### PR TITLE
[RISCV][MC] Improve GPR Error Messages

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -397,7 +397,10 @@ def SP : GPRRegisterClass<(add X2)> {
 
 // Saved Registers from s0 to s7, for C.MVA01S07 instruction in Zcmp extension
 def SR07 : GPRRegisterClass<(add (sequence "X%u", 8, 9),
-                                 (sequence "X%u", 18, 23))>;
+                                 (sequence "X%u", 18, 23))> {
+  let DiagnosticType = "InvalidRegClassSR07";
+  let DiagnosticString = "register must be GPR from s0 to s7 (x8, x9 or x18-x23)";
+}
 
 def GPRX1X5 :  GPRRegisterClass<(add X1, X5)> {
   let DiagnosticType = "InvalidRegClassGPRX1X5";

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -319,7 +319,10 @@ def GPR : GPRRegisterClass<(add (sequence "X%u", 10, 17),
                                 (sequence "X%u", 28, 31),
                                 (sequence "X%u", 8, 9),
                                 (sequence "X%u", 18, 27),
-                                (sequence "X%u", 0, 4))>;
+                                (sequence "X%u", 0, 4))> {
+  let DiagnosticType = "InvalidRegClassGPR";
+  let DiagnosticString = "register must be a GPR";
+}
 
 def YGPR : RegisterClass<"RISCV", [YLenVT], 64,
                          (add (sequence "X%u_Y", 10, 17),
@@ -332,7 +335,10 @@ def YGPR : RegisterClass<"RISCV", [YLenVT], 64,
   let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_Y, 32, /*RVELimit=*/16>";
 }
 
-def GPRX0 : GPRRegisterClass<(add X0)>;
+def GPRX0 : GPRRegisterClass<(add X0)> {
+  let DiagnosticType = "InvalidRegClassGPRX0";
+  let DiagnosticString = "register must be zero (x0)";
+}
 
 def GPRX1 : GPRRegisterClass<(add X1)> {
   let DiagnosticType = "InvalidRegClassGPRX1";

--- a/llvm/test/MC/RISCV/corev/XCValu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCValu-invalid.s
@@ -2,13 +2,13 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
 cv.addrnr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addrnr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addrnr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addrnr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -26,13 +26,13 @@ cv.addun t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.addun t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addun t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addun 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -41,10 +41,10 @@ cv.addun t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.extbz t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extbz 0, t1
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extbz t0
 # CHECK-ERROR: too few operands for instruction
@@ -53,13 +53,13 @@ cv.extbz t0, t1, t2
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addnr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addnr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addnr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addnr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -77,10 +77,10 @@ cv.clipu t0, t1, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.clipu t0, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipu 0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -89,13 +89,13 @@ cv.clipu t0, t1, 0, 0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -104,10 +104,10 @@ cv.minu t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.abs 0, t1
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.abs t0
 # CHECK-ERROR: too few operands for instruction
@@ -125,13 +125,13 @@ cv.addrn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.addrn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addrn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addrn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -149,13 +149,13 @@ cv.suburn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.suburn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.suburn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.suburn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.suburn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -173,10 +173,10 @@ cv.clip t0, t1, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.clip t0, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clip 0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clip t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -185,13 +185,13 @@ cv.clip t0, t1, 0, 0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addunr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addunr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addunr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addunr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -209,13 +209,13 @@ cv.addurn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.addurn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addurn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addurn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -233,13 +233,13 @@ cv.subun t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.subun t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subun t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subun 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -257,13 +257,13 @@ cv.subn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.subn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -272,13 +272,13 @@ cv.subn t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrnr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrnr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrnr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrnr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -287,13 +287,13 @@ cv.subrnr t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.slet t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.slet t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.slet 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.slet t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -302,13 +302,13 @@ cv.slet t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.suburnr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.suburnr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.suburnr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.suburnr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -317,13 +317,13 @@ cv.suburnr t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -332,10 +332,10 @@ cv.maxu t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.extbs t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extbs 0, t1
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extbs t0
 # CHECK-ERROR: too few operands for instruction
@@ -344,10 +344,10 @@ cv.extbs t0, t1, t2
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.exths t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.exths 0, t1
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.exths t0
 # CHECK-ERROR: too few operands for instruction
@@ -356,13 +356,13 @@ cv.exths t0, t1, t2
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -371,13 +371,13 @@ cv.max t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subunr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subunr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subunr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subunr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -386,10 +386,10 @@ cv.subunr t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.exthz t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.exthz 0, t1
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.exthz t0
 # CHECK-ERROR: too few operands for instruction
@@ -398,13 +398,13 @@ cv.exthz t0, t1, t2
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clipur t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipur t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipur 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipur t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -413,13 +413,13 @@ cv.clipur t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addurnr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addurnr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addurnr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addurnr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -437,13 +437,13 @@ cv.addn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.addn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.addn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -461,13 +461,13 @@ cv.subrn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.subrn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -476,13 +476,13 @@ cv.subrn t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subnr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subnr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subnr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subnr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -491,13 +491,13 @@ cv.subnr t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clipr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipr t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipr 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clipr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -506,13 +506,13 @@ cv.clipr t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sletu t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sletu t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sletu 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sletu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -521,13 +521,13 @@ cv.sletu t0, t1, t2, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/XCVbi-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVbi-invalid.s
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 cv.beqimm 0, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.beqimm t0, t1, 0
 # CHECK-ERROR: immediate must be an integer in the range [-16, 15]
@@ -34,7 +34,7 @@ cv.beqimm t0, 0, -4098
 //===----------------------------------------------------------------------===//
 
 cv.bneimm 0, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.bneimm t0, t1, 0
 # CHECK-ERROR: immediate must be an integer in the range [-16, 15]

--- a/llvm/test/MC/RISCV/corev/XCVbitmanip-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVbitmanip-invalid.s
@@ -149,10 +149,10 @@ cv.extractr t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.extractr t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -161,10 +161,10 @@ cv.extractur t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.extractur t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractur t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractur t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -173,10 +173,10 @@ cv.insertr t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.insertr t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.insertr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.insertr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -185,10 +185,10 @@ cv.bclrr t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.bclrr t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.bclrr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.bclrr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -197,10 +197,10 @@ cv.bsetr t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.bsetr t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.bsetr t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.bsetr t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -209,10 +209,10 @@ cv.ror t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.ror t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.ror t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.ror t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -221,7 +221,7 @@ cv.ff1 t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.ff1 t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.ff1 t0, t1, 0
 # CHECK-ERROR: unexpected extra operand for instruction
@@ -233,7 +233,7 @@ cv.fl1 t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.fl1 t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.fl1 t0, t1, 0
 # CHECK-ERROR: unexpected extra operand for instruction
@@ -245,7 +245,7 @@ cv.clb t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.clb t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.clb t0, t1, 0
 # CHECK-ERROR: unexpected extra operand for instruction
@@ -257,7 +257,7 @@ cv.cnt t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.cnt t0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cnt t0, t1, 0
 # CHECK-ERROR: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/corev/XCVelw-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVelw-invalid.s
@@ -5,7 +5,7 @@ cv.elw t0, 0(0)
 # CHECK-ERROR: expected register
 
 cv.elw 0, 0(x6)
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.elw x12, 2048(x6)
 # CHECK-ERROR: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
@@ -20,7 +20,7 @@ cv.elw x12, x12(x6)
 # CHECK-ERROR: unexpected token
 
 cv.elw 0, 0(x6)
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.elw x0
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/XCVmac-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmac-invalid.s
@@ -2,13 +2,13 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
 cv.mac t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mac t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mac 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mac t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -26,13 +26,13 @@ cv.machhsn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.machhsn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhsn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhsn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -50,13 +50,13 @@ cv.machhsrn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.machhsrn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhsrn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhsrn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -74,13 +74,13 @@ cv.machhun t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.machhun t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhun t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhun 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -98,13 +98,13 @@ cv.machhurn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.machhurn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhurn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhurn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.machhurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -122,13 +122,13 @@ cv.macsn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.macsn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macsn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macsn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -146,13 +146,13 @@ cv.macsrn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.macsrn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macsrn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macsrn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -170,13 +170,13 @@ cv.macun t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.macun t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macun t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macun 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -194,13 +194,13 @@ cv.macurn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.macurn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macurn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macurn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.macurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -209,13 +209,13 @@ cv.macurn t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.msu t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.msu t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.msu 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.msu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -224,13 +224,13 @@ cv.msu t0, t1, t2, t4
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhs t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhs t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhs 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhs t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -248,13 +248,13 @@ cv.mulhhsn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulhhsn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhsn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhsn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -272,13 +272,13 @@ cv.mulhhsrn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulhhsrn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhsrn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhsrn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -287,13 +287,13 @@ cv.mulhhsrn t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhu t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhu t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhu 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -311,13 +311,13 @@ cv.mulhhun t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulhhun t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhun t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhun 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -335,13 +335,13 @@ cv.mulhhurn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulhhurn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhurn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhurn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulhhurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -350,13 +350,13 @@ cv.mulhhurn t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.muls t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.muls t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.muls 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.muls t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -374,13 +374,13 @@ cv.mulsn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulsn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulsn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulsn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -398,13 +398,13 @@ cv.mulsrn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulsrn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulsrn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulsrn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -413,13 +413,13 @@ cv.mulsrn t0, t1, t2, 0, a0
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulu t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulu t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulu 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulu t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -437,13 +437,13 @@ cv.mulun t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulun t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulun t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulun 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
@@ -461,13 +461,13 @@ cv.mulurn t0, t1, t2, a0
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
 
 cv.mulurn t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulurn t0, 0, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulurn 0, t1, t2, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.mulurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
@@ -5,26 +5,26 @@ cv.lb t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lb 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lb 0, (0), t2
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lb t0, (t1), -2049
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lb t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lb t0, (0), t1
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lb 0, (t1), t1
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lb t0
 # CHECK-ERROR: :[[@LINE-1]]:9: error: too few operands for instruction
@@ -39,26 +39,26 @@ cv.lbu t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lbu 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:8: error: register must be a GPR
 
 cv.lbu 0, (0), t0 
-# CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:8: error: register must be a GPR
 
 cv.lbu t0, (t1), -2049
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:18: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:18: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:18: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lbu t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:18: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:18: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:18: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lbu t0, (0), t1
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lbu 0, (t1), t1
-# CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:8: error: register must be a GPR
 
 cv.lbu t0
 # CHECK-ERROR: :[[@LINE-1]]:10: error: too few operands for instruction
@@ -73,19 +73,19 @@ cv.lh t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lh 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lh 0, (0), t2
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lh t0, (t1), -2049
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lh t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lh t0, (0), t1
@@ -95,7 +95,7 @@ cv.lh t0, t1(0)
 # CHECK-ERROR: :[[@LINE-1]]:14: error: expected GPR register
 
 cv.lh 0, (t1), t1
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lh t0
 # CHECK-ERROR: :[[@LINE-1]]:9: error: too few operands for instruction
@@ -110,19 +110,19 @@ cv.lhu t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lhu 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:8: error: register must be a GPR
 
 cv.lhu 0, 0(t1)
-# CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:8: error: register must be a GPR
 
 cv.lhu t0, (t1), -2049
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:18: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:18: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:18: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lhu t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:18: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:18: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:18: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lhu t0, (0), t1
@@ -147,19 +147,19 @@ cv.lw t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lw 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lw 0, (0), t2
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lw t0, (t1), -2049
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lw t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.lw t0, (0), t1
@@ -169,7 +169,7 @@ cv.lw t0, t1(0)
 # CHECK-ERROR: :[[@LINE-1]]:14: error: expected GPR register
 
 cv.lw 0, (t0), t1
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.lw t0
 # CHECK-ERROR: :[[@LINE-1]]:9: error: too few operands for instruction
@@ -184,21 +184,21 @@ cv.sb t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sb 0, (t0), 0
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.sb t0, 0(t1)
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sb t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.sb t0, (0), t1
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sb 0, (t1), t1
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.sb t0
 # CHECK-ERROR: :[[@LINE-1]]:9: error: too few operands for instruction
@@ -207,21 +207,21 @@ cv.sh t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sh 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.sh t0, 0(t1)
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sh t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.sh t0, (0), t1
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sh 0, (t1), t1
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.sh t0
 # CHECK-ERROR: :[[@LINE-1]]:9: error: too few operands for instruction
@@ -230,21 +230,21 @@ cv.sw t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sw 0, (t1), 0
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.sw t0, 0(t1)
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sw t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-2]]:17: note: register must be a GPR
 # CHECK-ERROR: :[[@LINE-3]]:17: note: immediate must be an integer in the range [-2048, 2047]
 
 cv.sw t0, (0), t1
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sw 0, (t1), t1
-# CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:7: error: register must be a GPR
 
 cv.sw t0
 # CHECK-ERROR: :[[@LINE-1]]:9: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/corev/XCVsimd-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVsimd-invalid.s
@@ -6,19 +6,19 @@
 //===----------------------------------------------------------------------===//
 
 cv.add.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -28,19 +28,19 @@ cv.add.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -50,19 +50,19 @@ cv.add.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -72,19 +72,19 @@ cv.add.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -94,10 +94,10 @@ cv.add.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -116,10 +116,10 @@ cv.add.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -138,19 +138,19 @@ cv.add.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -160,19 +160,19 @@ cv.sub.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -182,19 +182,19 @@ cv.sub.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -204,19 +204,19 @@ cv.sub.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -226,10 +226,10 @@ cv.sub.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -248,10 +248,10 @@ cv.sub.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -270,19 +270,19 @@ cv.sub.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avg.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -292,19 +292,19 @@ cv.avg.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avg.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -314,19 +314,19 @@ cv.avg.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avg.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -336,19 +336,19 @@ cv.avg.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avg.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -358,10 +358,10 @@ cv.avg.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avg.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -380,10 +380,10 @@ cv.avg.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avg.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avg.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -402,19 +402,19 @@ cv.avg.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avgu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -424,19 +424,19 @@ cv.avgu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avgu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -446,19 +446,19 @@ cv.avgu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avgu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -468,19 +468,19 @@ cv.avgu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avgu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -490,10 +490,10 @@ cv.avgu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avgu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -515,10 +515,10 @@ cv.avgu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.avgu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.avgu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -540,19 +540,19 @@ cv.avgu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.min.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -562,19 +562,19 @@ cv.min.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.min.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -584,19 +584,19 @@ cv.min.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.min.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -606,19 +606,19 @@ cv.min.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.min.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -628,10 +628,10 @@ cv.min.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.min.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -650,10 +650,10 @@ cv.min.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.min.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.min.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -672,19 +672,19 @@ cv.min.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.minu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -694,19 +694,19 @@ cv.minu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.minu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -716,19 +716,19 @@ cv.minu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.minu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -738,19 +738,19 @@ cv.minu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.minu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -760,10 +760,10 @@ cv.minu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.minu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -785,10 +785,10 @@ cv.minu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.minu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.minu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -810,19 +810,19 @@ cv.minu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.max.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -832,19 +832,19 @@ cv.max.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.max.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -854,19 +854,19 @@ cv.max.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.max.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -876,19 +876,19 @@ cv.max.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.max.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -898,10 +898,10 @@ cv.max.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.max.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -920,10 +920,10 @@ cv.max.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.max.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.max.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -942,19 +942,19 @@ cv.max.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.maxu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -964,19 +964,19 @@ cv.maxu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.maxu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -986,19 +986,19 @@ cv.maxu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.maxu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1008,19 +1008,19 @@ cv.maxu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.maxu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1030,10 +1030,10 @@ cv.maxu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.maxu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -1055,10 +1055,10 @@ cv.maxu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.maxu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.maxu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -1080,19 +1080,19 @@ cv.maxu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.srl.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1102,19 +1102,19 @@ cv.srl.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.srl.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1124,19 +1124,19 @@ cv.srl.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.srl.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1146,19 +1146,19 @@ cv.srl.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.srl.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1168,10 +1168,10 @@ cv.srl.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.srl.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 15]
@@ -1193,10 +1193,10 @@ cv.srl.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.srl.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.srl.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 7]
@@ -1218,19 +1218,19 @@ cv.srl.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sra.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1240,19 +1240,19 @@ cv.sra.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sra.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1262,19 +1262,19 @@ cv.sra.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sra.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1284,19 +1284,19 @@ cv.sra.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sra.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1306,10 +1306,10 @@ cv.sra.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sra.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 15]
@@ -1331,10 +1331,10 @@ cv.sra.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sra.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sra.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 7]
@@ -1356,19 +1356,19 @@ cv.sra.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sll.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1378,19 +1378,19 @@ cv.sll.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sll.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1400,19 +1400,19 @@ cv.sll.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sll.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1422,19 +1422,19 @@ cv.sll.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sll.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1444,10 +1444,10 @@ cv.sll.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sll.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 15]
@@ -1469,10 +1469,10 @@ cv.sll.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sll.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sll.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 7]
@@ -1494,19 +1494,19 @@ cv.sll.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.or.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1516,19 +1516,19 @@ cv.or.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.or.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1538,19 +1538,19 @@ cv.or.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.or.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1560,19 +1560,19 @@ cv.or.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.or.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1582,10 +1582,10 @@ cv.or.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.or.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -1604,10 +1604,10 @@ cv.or.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.or.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.or.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -1626,19 +1626,19 @@ cv.or.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.xor.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1648,19 +1648,19 @@ cv.xor.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.xor.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1670,19 +1670,19 @@ cv.xor.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.xor.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1692,19 +1692,19 @@ cv.xor.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.xor.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1714,10 +1714,10 @@ cv.xor.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.xor.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -1736,10 +1736,10 @@ cv.xor.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.xor.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.xor.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -1758,19 +1758,19 @@ cv.xor.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.and.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1780,19 +1780,19 @@ cv.and.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.and.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1802,19 +1802,19 @@ cv.and.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.and.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1824,19 +1824,19 @@ cv.and.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.and.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1846,10 +1846,10 @@ cv.and.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.and.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -1868,10 +1868,10 @@ cv.and.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.and.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.and.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -1890,10 +1890,10 @@ cv.and.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.abs.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.abs.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.abs.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
@@ -1912,10 +1912,10 @@ cv.abs.h t0, t1, 0
 //===----------------------------------------------------------------------===//
 
 cv.abs.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.abs.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.abs.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
@@ -1934,19 +1934,19 @@ cv.abs.b t0, t1, 0
 //===----------------------------------------------------------------------===//
 
 cv.dotup.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1956,19 +1956,19 @@ cv.dotup.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotup.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -1978,19 +1978,19 @@ cv.dotup.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotup.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2000,19 +2000,19 @@ cv.dotup.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotup.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2022,10 +2022,10 @@ cv.dotup.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotup.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2047,10 +2047,10 @@ cv.dotup.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotup.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotup.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2072,19 +2072,19 @@ cv.dotup.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotusp.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2094,19 +2094,19 @@ cv.dotusp.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotusp.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2116,19 +2116,19 @@ cv.dotusp.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotusp.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2138,19 +2138,19 @@ cv.dotusp.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotusp.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2160,10 +2160,10 @@ cv.dotusp.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotusp.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2182,10 +2182,10 @@ cv.dotusp.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotusp.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotusp.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2204,19 +2204,19 @@ cv.dotusp.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotsp.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2226,19 +2226,19 @@ cv.dotsp.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotsp.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2248,19 +2248,19 @@ cv.dotsp.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotsp.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2270,19 +2270,19 @@ cv.dotsp.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotsp.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2292,10 +2292,10 @@ cv.dotsp.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotsp.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2314,10 +2314,10 @@ cv.dotsp.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.dotsp.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.dotsp.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2336,19 +2336,19 @@ cv.dotsp.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotup.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2358,19 +2358,19 @@ cv.sdotup.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotup.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2380,19 +2380,19 @@ cv.sdotup.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotup.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2402,19 +2402,19 @@ cv.sdotup.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotup.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2424,10 +2424,10 @@ cv.sdotup.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotup.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2449,10 +2449,10 @@ cv.sdotup.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotup.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotup.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2474,19 +2474,19 @@ cv.sdotup.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotusp.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2496,19 +2496,19 @@ cv.sdotusp.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotusp.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2518,19 +2518,19 @@ cv.sdotusp.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotusp.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2540,19 +2540,19 @@ cv.sdotusp.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotusp.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2562,10 +2562,10 @@ cv.sdotusp.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotusp.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2584,10 +2584,10 @@ cv.sdotusp.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotusp.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotusp.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2606,19 +2606,19 @@ cv.sdotusp.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotsp.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2628,19 +2628,19 @@ cv.sdotsp.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotsp.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2650,19 +2650,19 @@ cv.sdotsp.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotsp.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2672,19 +2672,19 @@ cv.sdotsp.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotsp.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2694,10 +2694,10 @@ cv.sdotsp.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotsp.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2716,10 +2716,10 @@ cv.sdotsp.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sdotsp.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sdotsp.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -2738,10 +2738,10 @@ cv.sdotsp.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.extract.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extract.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extract.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2763,10 +2763,10 @@ cv.extract.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.extract.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extract.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extract.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2788,10 +2788,10 @@ cv.extract.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.extractu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractu.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2813,10 +2813,10 @@ cv.extractu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.extractu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.extractu.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2838,10 +2838,10 @@ cv.extractu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.insert.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.insert.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.insert.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2863,10 +2863,10 @@ cv.insert.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.insert.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.insert.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.insert.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2888,19 +2888,19 @@ cv.insert.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffle.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2910,19 +2910,19 @@ cv.shuffle.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffle.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -2932,10 +2932,10 @@ cv.shuffle.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffle.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2957,10 +2957,10 @@ cv.shuffle.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffleI0.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI0.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI0.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -2982,10 +2982,10 @@ cv.shuffleI0.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffleI1.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI1.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI1.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -3007,10 +3007,10 @@ cv.shuffleI1.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffleI2.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI2.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI2.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -3032,10 +3032,10 @@ cv.shuffleI2.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffleI3.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI3.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffleI3.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -3057,19 +3057,19 @@ cv.shuffleI3.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffle2.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle2.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3079,19 +3079,19 @@ cv.shuffle2.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.shuffle2.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle2.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.shuffle2.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3101,19 +3101,19 @@ cv.shuffle2.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.pack 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.pack t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3123,19 +3123,19 @@ cv.pack t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.pack.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.pack.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.pack.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3145,19 +3145,19 @@ cv.pack.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.packhi.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packhi.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packhi.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.packhi.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packhi.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packhi.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3167,19 +3167,19 @@ cv.packhi.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.packlo.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packlo.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packlo.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.packlo.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packlo.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.packlo.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3189,19 +3189,19 @@ cv.packlo.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpeq.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3211,19 +3211,19 @@ cv.cmpeq.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpeq.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3233,19 +3233,19 @@ cv.cmpeq.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpeq.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3255,19 +3255,19 @@ cv.cmpeq.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpeq.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3277,10 +3277,10 @@ cv.cmpeq.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpeq.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3299,10 +3299,10 @@ cv.cmpeq.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpeq.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpeq.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3321,19 +3321,19 @@ cv.cmpeq.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpne.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3343,19 +3343,19 @@ cv.cmpne.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpne.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3365,19 +3365,19 @@ cv.cmpne.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpne.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3387,19 +3387,19 @@ cv.cmpne.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpne.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3409,10 +3409,10 @@ cv.cmpne.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpne.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3431,10 +3431,10 @@ cv.cmpne.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpne.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpne.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3453,19 +3453,19 @@ cv.cmpne.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgt.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3475,19 +3475,19 @@ cv.cmpgt.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgt.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3497,19 +3497,19 @@ cv.cmpgt.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgt.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3519,19 +3519,19 @@ cv.cmpgt.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgt.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3541,10 +3541,10 @@ cv.cmpgt.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgt.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3563,10 +3563,10 @@ cv.cmpgt.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgt.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgt.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3585,19 +3585,19 @@ cv.cmpgt.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpge.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3607,19 +3607,19 @@ cv.cmpge.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpge.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3629,19 +3629,19 @@ cv.cmpge.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpge.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3651,19 +3651,19 @@ cv.cmpge.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpge.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3673,10 +3673,10 @@ cv.cmpge.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpge.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3695,10 +3695,10 @@ cv.cmpge.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpge.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpge.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3717,19 +3717,19 @@ cv.cmpge.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmplt.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3739,19 +3739,19 @@ cv.cmplt.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmplt.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3761,19 +3761,19 @@ cv.cmplt.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmplt.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3783,19 +3783,19 @@ cv.cmplt.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmplt.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3805,10 +3805,10 @@ cv.cmplt.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmplt.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3827,10 +3827,10 @@ cv.cmplt.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmplt.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmplt.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3849,19 +3849,19 @@ cv.cmplt.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmple.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3871,19 +3871,19 @@ cv.cmple.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmple.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3893,19 +3893,19 @@ cv.cmple.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmple.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3915,19 +3915,19 @@ cv.cmple.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmple.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -3937,10 +3937,10 @@ cv.cmple.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmple.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3959,10 +3959,10 @@ cv.cmple.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmple.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmple.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [-32, 31]
@@ -3981,19 +3981,19 @@ cv.cmple.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgtu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4003,19 +4003,19 @@ cv.cmpgtu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgtu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4025,19 +4025,19 @@ cv.cmpgtu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgtu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4047,19 +4047,19 @@ cv.cmpgtu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgtu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4069,10 +4069,10 @@ cv.cmpgtu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgtu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4094,10 +4094,10 @@ cv.cmpgtu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgtu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgtu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4119,19 +4119,19 @@ cv.cmpgtu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgeu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4141,19 +4141,19 @@ cv.cmpgeu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgeu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4163,19 +4163,19 @@ cv.cmpgeu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgeu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4185,19 +4185,19 @@ cv.cmpgeu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgeu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4207,10 +4207,10 @@ cv.cmpgeu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgeu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4232,10 +4232,10 @@ cv.cmpgeu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpgeu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpgeu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4257,19 +4257,19 @@ cv.cmpgeu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpltu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4279,19 +4279,19 @@ cv.cmpltu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpltu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4301,19 +4301,19 @@ cv.cmpltu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpltu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4323,19 +4323,19 @@ cv.cmpltu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpltu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4345,10 +4345,10 @@ cv.cmpltu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpltu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4370,10 +4370,10 @@ cv.cmpltu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpltu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpltu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4395,19 +4395,19 @@ cv.cmpltu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpleu.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4417,19 +4417,19 @@ cv.cmpleu.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpleu.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4439,19 +4439,19 @@ cv.cmpleu.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpleu.sc.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.h t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.h t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4461,19 +4461,19 @@ cv.cmpleu.sc.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpleu.sc.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.b t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sc.b t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4483,10 +4483,10 @@ cv.cmpleu.sc.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpleu.sci.h 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sci.h t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sci.h t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4508,10 +4508,10 @@ cv.cmpleu.sci.h t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cmpleu.sci.b 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sci.b t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cmpleu.sci.b t0, t1, t2, t3
 # CHECK-ERROR: immediate must be an integer in the range [0, 63]
@@ -4533,19 +4533,19 @@ cv.cmpleu.sci.b t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.r 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4555,19 +4555,19 @@ cv.cplxmul.r t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.i 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4577,19 +4577,19 @@ cv.cplxmul.i t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.r.div2 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div2 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div2 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div2 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4599,19 +4599,19 @@ cv.cplxmul.r.div2 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.i.div2 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div2 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div2 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div2 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4621,19 +4621,19 @@ cv.cplxmul.i.div2 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.r.div4 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div4 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div4 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div4 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4643,19 +4643,19 @@ cv.cplxmul.r.div4 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.i.div4 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div4 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div4 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div4 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4665,19 +4665,19 @@ cv.cplxmul.i.div4 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.r.div8 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div8 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div8 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.r.div8 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4687,19 +4687,19 @@ cv.cplxmul.r.div8 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxmul.i.div8 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div8 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div8 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxmul.i.div8 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4709,10 +4709,10 @@ cv.cplxmul.i.div8 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.cplxconj 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxconj t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.cplxconj t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
@@ -4731,19 +4731,19 @@ cv.cplxconj t0, t1, 0
 //===----------------------------------------------------------------------===//
 
 cv.subrotmj 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4753,19 +4753,19 @@ cv.subrotmj t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.subrotmj.div2 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div2 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div2 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div2 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4775,19 +4775,19 @@ cv.subrotmj.div2 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.subrotmj.div4 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div4 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div4 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div4 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4797,19 +4797,19 @@ cv.subrotmj.div4 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.subrotmj.div8 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div8 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div8 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.subrotmj.div8 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4819,19 +4819,19 @@ cv.subrotmj.div8 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.div2 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div2 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div2 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div2 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4841,19 +4841,19 @@ cv.add.div2 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.div4 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div4 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div4 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div4 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4863,19 +4863,19 @@ cv.add.div4 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.add.div8 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div8 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div8 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.add.div8 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4885,19 +4885,19 @@ cv.add.div8 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.div2 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div2 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div2 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div2 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div2 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4907,19 +4907,19 @@ cv.sub.div2 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.div4 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div4 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div4 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div4 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div4 t0, t1
 # CHECK-ERROR: too few operands for instruction
@@ -4929,19 +4929,19 @@ cv.sub.div4 t0, t1
 //===----------------------------------------------------------------------===//
 
 cv.sub.div8 0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div8 t0, 0, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div8 t0, t1, t2, t3
 # CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div8 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: register must be a GPR
 
 cv.sub.div8 t0, t1
 # CHECK-ERROR: too few operands for instruction

--- a/llvm/test/MC/RISCV/function-call-invalid.s
+++ b/llvm/test/MC/RISCV/function-call-invalid.s
@@ -9,7 +9,7 @@ call %hi(1234) # CHECK: :[[@LINE]]:6: error: operand must be a bare symbol name
 call %lo(1234) # CHECK: :[[@LINE]]:6: error: operand must be a bare symbol name
 call %hi(foo) # CHECK: :[[@LINE]]:6: error: operand must be a bare symbol name
 call %lo(foo) # CHECK: :[[@LINE]]:6: error: operand must be a bare symbol name
-call foo, bar # CHECK: :[[@LINE]]:6: error: invalid operand for instruction
+call foo, bar # CHECK: :[[@LINE]]:6: error: register must be a GPR
 call t0, %lo(foo) # CHECK: :[[@LINE]]:10: error: operand must be a bare symbol name
 call foo@pls # CHECK: :[[@LINE]]:10: error: @ (except the deprecated/ignored @plt) is disallowed
 call foo@3 # CHECK: :[[@LINE]]:10: error: @ (except the deprecated/ignored @plt) is disallowed

--- a/llvm/test/MC/RISCV/priv-invalid.s
+++ b/llvm/test/MC/RISCV/priv-invalid.s
@@ -7,7 +7,7 @@ sfence.vma zero, a1, a2 # CHECK: :[[@LINE]]:22: error: unexpected extra operand 
 sfence.vma a0, 0x10
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-2]]:16: note: unexpected extra operand for instruction
-# CHECK: :[[@LINE-3]]:16: note: invalid operand for instruction
+# CHECK: :[[@LINE-3]]:16: note: register must be a GPR
 
 sinval.vma zero, a1, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 

--- a/llvm/test/MC/RISCV/rv32d-invalid.s
+++ b/llvm/test/MC/RISCV/rv32d-invalid.s
@@ -6,8 +6,8 @@ fld ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsd ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Memory operand not formatted correctly
-fld ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fsd ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+fld ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fsd ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
 fld ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
@@ -18,4 +18,4 @@ fsgnjn.d fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for inst
 fadd.d a2, a1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
 
 # FP registers where integer regs are expected
-fcvt.wu.d ft2, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.wu.d ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32f-invalid.s
+++ b/llvm/test/MC/RISCV/rv32f-invalid.s
@@ -6,8 +6,8 @@ flw ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsw ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Memory operand not formatted correctly
-flw ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fsw ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+flw ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fsw ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
 flw ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
@@ -15,7 +15,7 @@ flw ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
 fsgnjn.s fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
 
 # Integer registers where FP regs are expected
-fmv.x.w fs7, a2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.x.w fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fmv.w.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rv32i-aliases-invalid.s
+++ b/llvm/test/MC/RISCV/rv32i-aliases-invalid.s
@@ -142,35 +142,35 @@ zext.w x3, x4
 
 sll x2, x3, 32
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 31]
 
 srl x2, x3, 32
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 31]
 
 sra x2, x3, 32
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 31]
 
 sll x2, x3, -1
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 31]
 
 srl x2, x3, -2
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 31]
 
 sra x2, x3, -3
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 31]
 
-addi x1, .      # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+addi x1, .      # CHECK: :[[@LINE]]:10: error: register must be a GPR
 
 foo:
   .space 4

--- a/llvm/test/MC/RISCV/rv32i-invalid.s
+++ b/llvm/test/MC/RISCV/rv32i-invalid.s
@@ -72,12 +72,12 @@ andi ra, sp, %pcrel_hi(123) # CHECK: :[[@LINE]]:14: error: operand must be a sym
 xori a2, a3, %hi(345) # CHECK: :[[@LINE]]:14: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 add a1, a2, (a3)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 add a1, a2, foo
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 ## uimm12
@@ -164,24 +164,24 @@ addi t0, sp, %modifer(255) # CHECK: :[[@LINE]]:15: error: invalid relocation spe
 addi t0, sp, %pltpcrel(255) # CHECK: :[[@LINE]]:14: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Use of operand modifier on register name
-addi t1, %lo(t2), 1 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+addi t1, %lo(t2), 1 # CHECK: :[[@LINE]]:10: error: register must be a GPR
 
 # Invalid mnemonics
 subs t0, t2, t1 # CHECK: :[[@LINE]]:1: error: unrecognized instruction mnemonic
 nandi t0, zero, 0 # CHECK: :[[@LINE]]:1: error: unrecognized instruction mnemonic
 
 # Invalid register names
-addi foo, sp, 10 # CHECK: :[[@LINE]]:6: error: invalid operand for instruction
-slti a10, a2, 0x20 # CHECK: :[[@LINE]]:6: error: invalid operand for instruction
-slt x32, s0, s0 # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+addi foo, sp, 10 # CHECK: :[[@LINE]]:6: error: register must be a GPR
+slti a10, a2, 0x20 # CHECK: :[[@LINE]]:6: error: register must be a GPR
+slt x32, s0, s0 # CHECK: :[[@LINE]]:5: error: register must be a GPR
 
 # RV64I mnemonics
 addiw a0, sp, 100 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set{{$}}
 sraw t0, s2, zero # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set{{$}}
 
 # Invalid operand types
-xori sp, 22, 220 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-sub t0, t2, 1 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+xori sp, 22, 220 # CHECK: :[[@LINE]]:10: error: register must be a GPR
+sub t0, t2, 1 # CHECK: :[[@LINE]]:13: error: register must be a GPR
 
 # Too many operands
 sltiu s2, s3, 0x50, 0x60 # CHECK: :[[@LINE]]:21: error: unexpected extra operand for instruction
@@ -209,7 +209,7 @@ clmul a0, a1, a2 # CHECK: :[[@LINE]]:1: error: instruction requires the followin
 bset a0, a1, a2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zbs' (Single-Bit Instructions){{$}}
 
 # Using floating point registers when integer registers are expected
-addi a2, ft0, 24 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+addi a2, ft0, 24 # CHECK: :[[@LINE]]:10: error: register must be a GPR
 
 # fence.tso accepts no operands
 fence.tso rw, rw # CHECK: :[[@LINE]]:11: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rv32q-invalid.s
+++ b/llvm/test/MC/RISCV/rv32q-invalid.s
@@ -6,8 +6,8 @@ flq ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsq ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Memory operand not formatted correctly
-flq ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fsq ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+flq ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fsq ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
 flq ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
@@ -18,4 +18,4 @@ fsgnjn.q fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for inst
 fadd.q a2, a1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
 
 # FP registers where integer regs are expected
-fcvt.wu.q ft2, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.wu.q ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32xqccmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv32xqccmp-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple=riscv32 -mattr=+xqccmp -M no-aliases -show-encoding < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK-ERROR %s
 
-# CHECK-ERROR: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:14: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 qc.cm.mvsa01 a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:14: error: rs1 and rs2 must be different
 qc.cm.mvsa01 s0, s0
 
-# CHECK-ERROR: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:14: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 qc.cm.mva01s a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:15: error: invalid register list, '{ra, s0-s10}' or '{x1, x8-x9, x18-x26}' is not supported

--- a/llvm/test/MC/RISCV/rv32zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zcmp-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple=riscv32 -mattr=zcmp -M no-aliases -show-encoding < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK-ERROR %s
 
-# CHECK-ERROR: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:11: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 cm.mvsa01 a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:11: error: rs1 and rs2 must be different
 cm.mvsa01 s0, s0
 
-# CHECK-ERROR: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:11: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 cm.mva01s a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:12: error: invalid register list, '{ra, s0-s10}' or '{x1, x8-x9, x18-x26}' is not supported

--- a/llvm/test/MC/RISCV/rv32zdinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zdinx-invalid.s
@@ -24,4 +24,4 @@ fmsub.d x10, x12, x14, x16, 0 # CHECK: :[[@LINE]]:29: error: operand must be a v
 fnmsub.d x10, x12, x14, x16, 0b111 # CHECK: :[[@LINE]]:30: error: operand must be a valid floating point rounding mode mnemonic
 
 # FP registers where integer regs are expected
-fcvt.wu.d ft2, a2 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.wu.d ft2, a2 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32zfh-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zfh-invalid.s
@@ -7,8 +7,8 @@ flh ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsh ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Memory operand not formatted correctly
-flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fsw ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fsw ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
 flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
@@ -16,7 +16,7 @@ flh ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
 fsgnjn.h fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
 
 # Integer registers where FP regs are expected
-fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
@@ -33,4 +33,4 @@ fnmsub.h f18, f19, f20, f21, 0b111 # CHECK: :[[@LINE]]:30: error: operand must b
 fadd.h a2, a1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
 
 # FP registers where integer regs are expected
-fcvt.wu.h ft2, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.wu.h ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32zhinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zhinx-invalid.s
@@ -21,4 +21,4 @@ fmsub.h x14, x15, x16, x17, 0 # CHECK: :[[@LINE]]:29: error: operand must be a v
 fnmsub.h x18, x19, x20, x21, 0b111 # CHECK: :[[@LINE]]:30: error: operand must be a valid floating point rounding mode mnemonic
 
 # FP registers where integer regs are expected
-fcvt.wu.h ft2, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.wu.h ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv64d-invalid.s
+++ b/llvm/test/MC/RISCV/rv64d-invalid.s
@@ -1,9 +1,9 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+d < %s 2>&1 | FileCheck %s
 
 # Integer registers where FP regs are expected
-fcvt.l.d ft0, a0 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.lu.d ft1, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-fmv.x.d ft2, a2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fcvt.l.d ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
+fcvt.lu.d ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
+fmv.x.d ft2, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fcvt.d.l a3, ft3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rv64f-invalid.s
+++ b/llvm/test/MC/RISCV/rv64f-invalid.s
@@ -1,8 +1,8 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+f < %s 2>&1 | FileCheck %s
 
 # Integer registers where FP regs are expected
-fcvt.l.s ft0, a0 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.lu.s ft1, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.l.s ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
+fcvt.lu.s ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fcvt.s.l a2, ft2 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rv64i-aliases-invalid.s
+++ b/llvm/test/MC/RISCV/rv64i-aliases-invalid.s
@@ -113,62 +113,62 @@ rdtimeh x28    # CHECK: :[[@LINE]]:1: error: instruction requires the following:
 
 sll x2, x3, 64
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 63]
 
 srl x2, x3, 64
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 63]
 
 sra x2, x3, 64
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 63]
 
 sll x2, x3, -1
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 63]
 
 srl x2, x3, -2
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 63]
 
 sra x2, x3, -3
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:13: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:13: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:13: note: immediate must be an integer in the range [0, 63]
 
 sllw x2, x3, 32
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:14: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:14: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:14: note: immediate must be an integer in the range [0, 31]
 
 srlw x2, x3, 32
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:14: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:14: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:14: note: immediate must be an integer in the range [0, 31]
 
 sraw x2, x3, 32
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:14: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:14: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:14: note: immediate must be an integer in the range [0, 31]
 
 sllw x2, x3, -1
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:14: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:14: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:14: note: immediate must be an integer in the range [0, 31]
 
 srlw x2, x3, -2
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:14: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:14: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:14: note: immediate must be an integer in the range [0, 31]
 
 sraw x2, x3, -3
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:14: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:14: note: register must be a GPR
 # CHECK: :[[@LINE-3]]:14: note: immediate must be an integer in the range [0, 31]
 
 foo:

--- a/llvm/test/MC/RISCV/rv64q-invalid.s
+++ b/llvm/test/MC/RISCV/rv64q-invalid.s
@@ -1,8 +1,8 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+q < %s 2>&1 | FileCheck %s
 
 # Integer registers where FP regs are expected
-fcvt.l.q ft0, a0 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.lu.q ft1, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.l.q ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
+fcvt.lu.q ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fcvt.q.l a3, ft3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rv64xqccmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64xqccmp-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple=riscv64 -mattr=xqccmp -M no-aliases -show-encoding < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK-ERROR %s
 
-# CHECK-ERROR: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:14: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 qc.cm.mvsa01 a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:14: error: rs1 and rs2 must be different
 qc.cm.mvsa01 s0, s0
 
-# CHECK-ERROR: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:14: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 qc.cm.mva01s a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:15: error: invalid register list, '{ra, s0-s10}' or '{x1, x8-x9, x18-x26}' is not supported

--- a/llvm/test/MC/RISCV/rv64xtheadfmemidx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64xtheadfmemidx-invalid.s
@@ -4,6 +4,6 @@
 th.flrd fa0, a1, a2, 5     # CHECK: :[[@LINE]]:22: error: immediate must be an integer in the range [0, 3]
 th.flrd a0, a1, a2, 3      # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
 th.flrw 0(fa0), a1, a2, 0  # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-th.flrw fa0, 4(a1), a2, 3  # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-th.fsrd fa0, a1, -1(a2), 0 # CHECK: :[[@LINE]]:18: error: invalid operand for instruction
+th.flrw fa0, 4(a1), a2, 3  # CHECK: :[[@LINE]]:14: error: register must be a GPR
+th.fsrd fa0, a1, -1(a2), 0 # CHECK: :[[@LINE]]:18: error: register must be a GPR
 th.fsrd fa0, a1, a2, -3    # CHECK: :[[@LINE]]:22: error: immediate must be an integer in the range [0, 3]

--- a/llvm/test/MC/RISCV/rv64xtheadmemidx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64xtheadmemidx-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+xtheadmemidx < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 -mattr=+xtheadmemidx < %s 2>&1 | FileCheck %s
 
-th.ldia		0(a0), (a1), 0, 0  # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+th.ldia		0(a0), (a1), 0, 0  # CHECK: :[[@LINE]]:10: error: register must be a GPR
 th.ldib		a0, 2(a1), 15, 1   # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
 th.lwia		a0, (a1), 30, 2    # CHECK: :[[@LINE]]:20: error: immediate must be an integer in the range [-16, 15]
 th.lwib		a0, (a1), -16, 43  # CHECK: :[[@LINE]]:25: error: immediate must be an integer in the range [0, 3]
 th.lhib		a0, (a1), -17, 3   # CHECK: :[[@LINE]]:20: error: immediate must be an integer in the range [-16, 15]
-th.lrb		-2(a0), a1, a2, 0  # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-th.lrw		a0, 3(a1), a2, 1   # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
-th.lrw		a0, a1, 4(a2), 2   # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
+th.lrb		-2(a0), a1, a2, 0  # CHECK: :[[@LINE]]:9: error: register must be a GPR
+th.lrw		a0, 3(a1), a2, 1   # CHECK: :[[@LINE]]:13: error: register must be a GPR
+th.lrw		a0, a1, 4(a2), 2   # CHECK: :[[@LINE]]:17: error: register must be a GPR
 th.lrh		a0, a1, a2, 5      # CHECK: :[[@LINE]]:21: error: immediate must be an integer in the range [0, 3]
 th.lrhu		a0, a1, a2, -1     # CHECK: :[[@LINE]]:22: error: immediate must be an integer in the range [0, 3]

--- a/llvm/test/MC/RISCV/rv64zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zcmp-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple=riscv64 -mattr=zcmp -M no-aliases -show-encoding < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK-ERROR %s
 
-# CHECK-ERROR: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:11: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 cm.mvsa01 a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:11: error: rs1 and rs2 must be different
 cm.mvsa01 s0, s0
 
-# CHECK-ERROR: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE+1]]:11: error: register must be GPR from s0 to s7 (x8, x9 or x18-x23)
 cm.mva01s a1, a2
 
 # CHECK-ERROR: :[[@LINE+1]]:12: error: invalid register list, '{ra, s0-s10}' or '{x1, x8-x9, x18-x26}' is not supported

--- a/llvm/test/MC/RISCV/rv64zdinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zdinx-invalid.s
@@ -6,10 +6,10 @@ ld a0, -2049(a1) # CHECK: :[[@LINE]]:8: error: operand must be a symbol with %lo
 
 # Invalid instructions
 fsd a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
-sd fa4, 64(sp) # CHECK: :[[@LINE]]:4: error: invalid operand for instruction
+sd fa4, 64(sp) # CHECK: :[[@LINE]]:4: error: register must be a GPR
 fmv.x.d t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.d.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # FP registers where integer regs are expected
-fcvt.d.l a3, ft3 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fcvt.d.lu a4, ft4 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
+fcvt.d.l a3, ft3 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fcvt.d.lu a4, ft4 # CHECK: :[[@LINE]]:15: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv64zfh-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zfh-invalid.s
@@ -7,8 +7,8 @@ flh ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsh ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Integer registers where FP regs are expected
-fcvt.l.h ft0, a0 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.lu.h ft1, a1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.l.h ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
+fcvt.lu.h ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fcvt.h.l a2, ft2 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rv64zfinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zfinx-invalid.s
@@ -9,5 +9,5 @@ fmv.x.w t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.w.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # FP registers where integer regs are expected
-fcvt.s.l a2, ft2 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fcvt.s.lu a3, ft3 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
+fcvt.s.l a2, ft2 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fcvt.s.lu a3, ft3 # CHECK: :[[@LINE]]:15: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv64zhinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zhinx-invalid.s
@@ -9,5 +9,5 @@ fmv.x.h t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.h.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # FP registers where integer regs are expected
-fcvt.h.l a2, ft2 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-fcvt.h.lu a3, ft3 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
+fcvt.h.l a2, ft2 # CHECK: :[[@LINE]]:14: error: register must be a GPR
+fcvt.h.lu a3, ft3 # CHECK: :[[@LINE]]:15: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rve-invalid.s
+++ b/llvm/test/MC/RISCV/rve-invalid.s
@@ -13,111 +13,111 @@
 .option push
 .option exact
 # CHECK-DIS: 00001837 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x16, 1
 # CHECK-DIS: 000028b7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x17, 2
 # CHECK-DIS: 00003937 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x18, 3
 # CHECK-DIS: 000049b7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x19, 4
 # CHECK-DIS: 00005a37 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x20, 5
 # CHECK-DIS: 00006ab7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x21, 6
 # CHECK-DIS: 00007b37 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x22, 7
 # CHECK-DIS: 00008bb7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x23, 8
 # CHECK-DIS: 00009c37 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x24, 9
 # CHECK-DIS: 0000acb7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x25, 10
 # CHECK-DIS: 0000bd37 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x26, 11
 # CHECK-DIS: 0000cdb7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x27, 12
 # CHECK-DIS: 0000de37 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x28, 13
 # CHECK-DIS: 0000eeb7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x29, 14
 # CHECK-DIS: 0000ff37 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x30, 15
 # CHECK-DIS: 00010fb7 <unknown>
-# CHECK: :[[@LINE+1]]:5: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:5: error: register must be a GPR
 lui x31, 16
 
 # CHECK-DIS: 00011817 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc a6, 17
 # CHECK-DIS: 00012897 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc a7, 18
 # CHECK-DIS: 00013917 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s2, 19
 # CHECK-DIS: 00014997 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s3, 20
 # CHECK-DIS: 00015a17 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s4, 21
 # CHECK-DIS: 00016a97 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s5, 22
 # CHECK-DIS: 00017b17 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s6, 23
 # CHECK-DIS: 00018b97 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s7, 24
 # CHECK-DIS: 00019c17 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s8, 25
 # CHECK-DIS: 0001ac97 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s9, 26
 # CHECK-DIS: 0001bd17 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s10, 27
 # CHECK-DIS: 0001cd97 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc s11, 28
 # CHECK-DIS: 0001de17 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc t3, 29
 # CHECK-DIS: 0001ee97 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc t4, 30
 # CHECK-DIS: 0001ff17 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc t5, 31
 # CHECK-DIS: 00020f97 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 auipc t6, 32
 .option pop
 
 # CHECK-DIS: 0f81 <unknown>
 # CHECK: :[[@LINE+3]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE+2]]:8: note: invalid operand for instruction
+# CHECK: :[[@LINE+2]]:8: note: register must be zero (x0)
 # CHECK: :[[@LINE+1]]:8: note: register must be a GPR excluding zero (x0)
 c.addi x31, 0
 # CHECK-DIS: 9846 <unknown>
-# CHECK: :[[@LINE+1]]:7: error: invalid operand for instruction
+# CHECK: :[[@LINE+1]]:7: error: register must be a GPR
 c.add x16, x17
 # CHECK-DIS: 8046 <unknown>
 # CHECK: :[[@LINE+1]]:10: error: register must be a GPR excluding zero (x0)

--- a/llvm/test/MC/RISCV/rvzfbfmin-invalid.s
+++ b/llvm/test/MC/RISCV/rvzfbfmin-invalid.s
@@ -9,14 +9,14 @@ flh ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsh ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Memory operand not formatted correctly
-flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
 flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
 flh ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
 
 # Integer registers where FP regs are expected
-fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rvzfhmin-invalid.s
+++ b/llvm/test/MC/RISCV/rvzfhmin-invalid.s
@@ -9,14 +9,14 @@ flh ft1, -2049(a0) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with 
 fsh ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Memory operand not formatted correctly
-flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
 flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
 flh ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
 
 # Integer registers where FP regs are expected
-fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
 fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/rvzicond-invalid.s
+++ b/llvm/test/MC/RISCV/rvzicond-invalid.s
@@ -2,13 +2,13 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+zicond < %s 2>&1 | FileCheck %s
 
 # Use of operand modifier on register name
-czero.eqz t1, %lo(t2), t3 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
+czero.eqz t1, %lo(t2), t3 # CHECK: :[[@LINE]]:15: error: register must be a GPR
 
 # Invalid register name
-czero.nez a4, a3, foo # CHECK: :[[@LINE]]:19: error: invalid operand for instruction
+czero.nez a4, a3, foo # CHECK: :[[@LINE]]:19: error: register must be a GPR
 
 # Invalid operand type
-czero.eqz t1, 2, t3 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
+czero.eqz t1, 2, t3 # CHECK: :[[@LINE]]:15: error: register must be a GPR
 
 # Too many operands
 czero.eqz t1, t2, t3, t4 # CHECK: :[[@LINE]]:23: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/tlsdesc.s
+++ b/llvm/test/MC/RISCV/tlsdesc.s
@@ -53,8 +53,8 @@ start:                                  # @start
 # ERR: :[[#@LINE-5]]:11: note: immediate must be an integer in the range [-2048, 2047]
 
 	addi a0, t0, %tlsdesc_add_lo(a_symbol)(a4) # ERR: :[[#@LINE]]:41: error: unexpected extra operand for instruction
-	addi a0, %tlsdesc_add_lo(a_symbol) # ERR: :[[#@LINE]]:11: error: invalid operand for instruction
-	addi x1, %tlsdesc_load_lo(a_symbol)(a0) # ERR: :[[#@LINE]]:11: error: invalid operand for instruction
+	addi a0, %tlsdesc_add_lo(a_symbol) # ERR: :[[#@LINE]]:11: error: register must be a GPR
+	addi x1, %tlsdesc_load_lo(a_symbol)(a0) # ERR: :[[#@LINE]]:11: error: register must be a GPR
 
 	jalr x5, 0(a1), %tlsdesc_hi(a_symbol)
 # ERR: :[[#@LINE-1]]:2: error: invalid instruction, any one of the following would fix this:

--- a/llvm/test/MC/RISCV/xmips-invalid.s
+++ b/llvm/test/MC/RISCV/xmips-invalid.s
@@ -20,7 +20,7 @@ mips.pref	8, 511(a0)
 # CHECK-FEATURE: error: instruction requires the following: 'Xmipscbop' (MIPS hardware prefetch)
 
 mips.ccmov x0, x1, 0x10
-# CHECK: error: invalid operand for instruction
+# CHECK: error: register must be a GPR
 
 mips.ccmov x10
 # CHECK: error: too few operands for instruction
@@ -32,7 +32,7 @@ mips.lwp x10, x11
 # CHECK: error: too few operands for instruction
 
 mips.ldp x9, 0x20
-# CHECK: error: invalid operand for instruction
+# CHECK: error: register must be a GPR
 
 mips.lwp x11, x12, 0(x13)
 # CHECK-FEATURE: error: instruction requires the following: 'Xmipslsp' (load and store pair instructions)
@@ -41,4 +41,4 @@ mips.swp x18, x19, 8(x2)
 # CHECK-FEATURE: error: instruction requires the following: 'Xmipslsp' (load and store pair instructions)
 
 mips.sdp 0x10, x3, 12(x4)
-# CHECK: error: invalid operand for instruction
+# CHECK: error: register must be a GPR

--- a/llvm/test/MC/RISCV/xqcibm-invalid.s
+++ b/llvm/test/MC/RISCV/xqcibm-invalid.s
@@ -192,7 +192,7 @@ qc.insbi x6, -10, 12, 65
 qc.insbi x6, -10, 12, 15
 
 
-# CHECK-PLUS: :[[@LINE+2]]:14: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insb x10, 7, 6, 31
 
@@ -216,7 +216,7 @@ qc.insb x10, x7, 6, 61
 qc.insb x10, x7, 6, 31
 
 
-# CHECK-PLUS: :[[@LINE+2]]:15: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:15: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbh x20, 12, 8, 12
 

--- a/llvm/test/MC/RISCV/xqcili-invalid.s
+++ b/llvm/test/MC/RISCV/xqcili-invalid.s
@@ -5,7 +5,7 @@
 # RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.li 9, 33554432
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/xqcilo-invalid.s
+++ b/llvm/test/MC/RISCV/xqcilo-invalid.s
@@ -4,8 +4,8 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcilo < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
-# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.lb 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
@@ -19,8 +19,8 @@ qc.e.lb x11, 33445562212(x10)
 qc.e.lb x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:10: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:10: error: register must be a GPR
 qc.e.lbu 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
@@ -34,8 +34,8 @@ qc.e.lbu x11, 33445562212(x10)
 qc.e.lbu x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.lh 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
@@ -49,8 +49,8 @@ qc.e.lh x11, 33445562212(x10)
 qc.e.lh x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:10: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:10: error: register must be a GPR
 qc.e.lhu 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
@@ -64,8 +64,8 @@ qc.e.lhu x11, 33445562212(x10)
 qc.e.lhu x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.lw 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
@@ -79,8 +79,8 @@ qc.e.lw x11, 33445562212(x10)
 qc.e.lw x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.sb 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
@@ -94,8 +94,8 @@ qc.e.sb x11, 33445562212(x10)
 qc.e.sb x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.sh 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
@@ -109,8 +109,8 @@ qc.e.sh x11, 33445562212(x10)
 qc.e.sh x11, 12(x10)
 
 
-# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR
+# CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR
 qc.e.sw 11, 12(x10)
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/xqcisim-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisim-invalid.s
@@ -66,7 +66,7 @@ qc.ppreg x10, x2
 # CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.ppreg
 
-# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+1]]:10: error: register must be a GPR
 qc.ppreg 23
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -79,7 +79,7 @@ qc.pputc x7, x3
 # CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pputc
 
-# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+1]]:10: error: register must be a GPR
 qc.pputc 34
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -92,7 +92,7 @@ qc.pputs x15, x18
 # CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pputs
 
-# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+1]]:10: error: register must be a GPR
 qc.pputs 45
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -105,7 +105,7 @@ qc.pexit x26, x23
 # CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pexit
 
-# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+1]]:10: error: register must be a GPR
 qc.pexit 78
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -118,7 +118,7 @@ qc.psyscall x11, x5
 # CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.psyscall
 
-# CHECK-PLUS: :[[@LINE+1]]:13: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+1]]:13: error: register must be a GPR
 qc.psyscall 98
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)

--- a/llvm/test/MC/RISCV/xqcisls-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisls-invalid.s
@@ -16,7 +16,7 @@ qc.lrb x5, x2, x4
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrb x5, x2, x4, 12
 
-# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrb x5, 2, x4, 4
 
@@ -36,7 +36,7 @@ qc.lrh x1, x12, x6
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrh x1, x12, x6, 22
 
-# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrh x1, 12, x6, 2
 
@@ -56,7 +56,7 @@ qc.lrw x15, x7, x14
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrw x15, x7, x14, 11
 
-# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:13: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrw x15, 7, x14, 1
 
@@ -76,7 +76,7 @@ qc.lrbu x9, x11, x4
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrbu x9, x11, x4, 37
 
-# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:13: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrbu x9, 11, x4, 7
 
@@ -96,7 +96,7 @@ qc.lrhu x16, x6, x10
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrhu x16, x6, x10, 44
 
-# CHECK-PLUS: :[[@LINE+2]]:14: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrhu x16, 6, x10, 4
 
@@ -116,7 +116,7 @@ qc.srb x0, x2, x8
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srb x0, x2, x8, 93
 
-# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srb x0, 2, x8, 3
 
@@ -136,7 +136,7 @@ qc.srh x13, x0, x20
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srh x13, x0, x20, 76
 
-# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:13: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srh x13, 0, x20, 6
 
@@ -156,7 +156,7 @@ qc.srw x17, x18, x19
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srw x17, x18, x19, 10
 
-# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:13: error: register must be a GPR
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srw x17, 18, x19, 0
 

--- a/llvm/test/MC/RISCV/xtheadcondmov-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadcondmov-invalid.s
@@ -3,7 +3,7 @@
 
 th.mveqz a0,a1        # CHECK: :[[@LINE]]:15: error: too few operands for instruction
 th.mveqz a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: unexpected extra operand for instruction
-th.mveqz a0,a1,1      # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+th.mveqz a0,a1,1      # CHECK: :[[@LINE]]:16: error: register must be a GPR
 th.mvnez a0,a1        # CHECK: :[[@LINE]]:15: error: too few operands for instruction
 th.mvnez a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: unexpected extra operand for instruction
-th.mvnez a0,a1,1      # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+th.mvnez a0,a1,1      # CHECK: :[[@LINE]]:16: error: register must be a GPR

--- a/llvm/test/MC/RISCV/xtheadmac-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadmac-invalid.s
@@ -1,7 +1,15 @@
-# RUN: not llvm-mc -triple riscv32 -mattr=+xtheadmac < %s 2>&1 | FileCheck %s
-# RUN: not llvm-mc -triple riscv64 -mattr=+xtheadmac < %s 2>&1 | FileCheck %s
+# RUN: not llvm-mc -triple riscv32 -mattr=+xtheadmac < %s 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-RV32 %s
+# RUN: not llvm-mc -triple riscv64 -mattr=+xtheadmac < %s 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-RV64 %s
 
-th.mula  t0, t1, 0(t2)  # CHECK: :[[@LINE]]:18: error: invalid operand for instruction
-th.muls  t0, 12, t2     # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-th.mulsh t0, t1, 34     # CHECK: :[[@LINE]]:18: error: invalid operand for instruction
-th.mulsw t0, -56, t2    # CHECK: :[[@LINE]]:{{1: error: invalid instruction|14: error: invalid operand for instruction}}
+th.mula  t0, t1, 0(t2)
+# CHECK: :[[@LINE-1]]:18: error: register must be a GPR
+
+th.muls  t0, 12, t2     
+# CHECK: :[[@LINE-1]]:14: error: register must be a GPR
+
+th.mulsh t0, t1, 34     
+# CHECK: :[[@LINE-1]]:18: error: register must be a GPR
+
+th.mulsw t0, -56, t2    
+# CHECK-RV64: :[[@LINE-1]]:14: error: register must be a GPR
+# CHECK-RV32: :[[@LINE-2]]:1: error: invalid instruction


### PR DESCRIPTION
- For the usual GPR RegClass
- For the GPRX0 RegClass as used by the `PseudoC_ADDI_NOP` instruction.

---

This PR was prepared with the help of AI.