### PR TITLE
[LLVM] Use kwargs for ShTest constructor

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -26,7 +26,7 @@ extra_substitutions = extra_substitutions = (
     if config.enable_profcheck
     else []
 )
-config.test_format = lit.formats.ShTest(extra_substitutions)
+config.test_format = lit.formats.ShTest(extra_substitutions=extra_substitutions)
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.


### PR DESCRIPTION
Since extra_substitutions is not the first argument (although it will be soon).

Fixes https://lab.llvm.org/buildbot/#/builders/223/builds/7170.

This was broken by 3f46a5e91cdf2ade1d8ca350f4a57af8221407ea.