### PR TITLE
[lldb/script] Add type hints to scripted extension base classes

### DIFF
--- a/lldb/examples/python/templates/operating_system.py
+++ b/lldb/examples/python/templates/operating_system.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from typing import Any, Optional
 
 import lldb
 import struct
@@ -39,7 +40,10 @@ class OperatingSystem(ScriptedThread):
         described by the dictionary returned from a call to the get_register_info() method.
     """
 
-    def __init__(self, process):
+    registers: dict[str, Any]
+    threads: list[dict]
+
+    def __init__(self, process: lldb.SBProcess):
         """Initialization needs a valid lldb.SBProcess object. This plug-in
         will get created after a live process is valid and has stopped for the
         first time.
@@ -52,7 +56,7 @@ class OperatingSystem(ScriptedThread):
         self.registers = self.register_info
         self.threads = []
 
-    def create_thread(self, tid, context):
+    def create_thread(self, tid: int, context: int) -> Optional[dict]:
         """Lazily create an operating system thread using a thread information
         dictionary and an optional operating system thread context address.
         This method is called manually, using the SBAPI
@@ -69,7 +73,7 @@ class OperatingSystem(ScriptedThread):
         return None
 
     @abstractmethod
-    def get_thread_info(self):
+    def get_thread_info(self) -> list[dict]:
         """Get the list of operating system threads. This method gets called
         automatically every time the process stops and it needs to update its
         thread list.
@@ -83,7 +87,7 @@ class OperatingSystem(ScriptedThread):
         pass
 
     @abstractmethod
-    def get_register_data(self, tid):
+    def get_register_data(self, tid: int) -> str:
         """Get the operating system thread register context for given a thread
         id. This method is called when unwinding the stack of one of the
         operating system threads.
@@ -96,8 +100,8 @@ class OperatingSystem(ScriptedThread):
         """
         pass
 
-    def get_register_context(self):
+    def get_register_context(self) -> Optional[str]:
         pass
 
-    def get_stop_reason(self):
+    def get_stop_reason(self) -> Optional[dict[str, Any]]:
         pass

--- a/lldb/examples/python/templates/scripted_breakpoint.py
+++ b/lldb/examples/python/templates/scripted_breakpoint.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional
 
 import lldb
 
@@ -8,8 +9,11 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
     The base class for a scripted breakpoint resolver.
     """
 
+    bkpt: lldb.SBBreakpoint
+    args: lldb.SBStructuredData
+
     @abstractmethod
-    def __init__(self, bkpt, args):
+    def __init__(self, bkpt: lldb.SBBreakpoint, args: lldb.SBStructuredData):
         """Construct a scripted breakpoint resolver.
 
         Args:
@@ -20,7 +24,7 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         self.bkpt = bkpt
         self.args = args
 
-    def overrides_resolver(self, resolver_data):
+    def overrides_resolver(self, resolver_data: lldb.SBStructuredData) -> bool:
         """Decide, from the incoming resolver options, whether this
         breakpoint should have its resolver replaced by this class. When
         `True`, this class's `__callback__` picks locations for this
@@ -38,7 +42,7 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         """
         return False
 
-    def set_breakpoint(self, bkpt):
+    def set_breakpoint(self, bkpt: lldb.SBBreakpoint) -> None:
         """Called once the underlying breakpoint has been fully created and
         associated to this resolver.
 
@@ -48,7 +52,7 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def __callback__(self, sym_ctx):
+    def __callback__(self, sym_ctx: lldb.SBSymbolContext) -> None:
         """Called once per symbol context matched by the search depth
         returned by `__get_depth__`. Set breakpoint locations here by calling
         `AddLocation` on the resolver's breakpoint.
@@ -58,7 +62,7 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         """
         pass
 
-    def __get_depth__(self):
+    def __get_depth__(self) -> int:
         """The search depth at which `__callback__` will be called.
 
         Returns:
@@ -67,7 +71,7 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         """
         return lldb.eSearchDepthModule
 
-    def get_short_help(self):
+    def get_short_help(self) -> Optional[str]:
         """A one-line description of this resolver, shown by `breakpoint list`.
 
         Returns:
@@ -75,7 +79,9 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         """
         pass
 
-    def was_hit(self, frame, bp_loc):
+    def was_hit(
+        self, frame: lldb.SBFrame, bp_loc: lldb.SBBreakpointLocation
+    ) -> lldb.SBBreakpointLocation:
         """Called when a location owned by this resolver is hit, to allow
         overriding which location is reported as hit.
 
@@ -90,7 +96,9 @@ class ScriptedBreakpointResolver(metaclass=ABCMeta):
         """
         return bp_loc
 
-    def get_location_description(self, bp_loc, level):
+    def get_location_description(
+        self, bp_loc: lldb.SBBreakpointLocation, level: int
+    ) -> Optional[str]:
         """Customize the description used when printing a breakpoint location
         owned by this resolver.
 

--- a/lldb/examples/python/templates/scripted_frame_provider.py
+++ b/lldb/examples/python/templates/scripted_frame_provider.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional, Union
 
 import lldb
 
@@ -65,8 +66,14 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
         construction.
     """
 
+    input_frames: lldb.SBFrameList
+    args: lldb.SBStructuredData
+    thread: lldb.SBThread
+    target: lldb.SBTarget
+    process: lldb.SBProcess
+
     @staticmethod
-    def applies_to_thread(thread):
+    def applies_to_thread(thread: lldb.SBThread) -> bool:
         """Determine if this frame provider should be used for a given thread.
 
         This static method is called before creating an instance of the frame
@@ -94,7 +101,7 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def get_description():
+    def get_description() -> str:
         """Get a description of this frame provider.
 
         This method should return a human-readable string describing what
@@ -115,7 +122,7 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
         pass
 
     @staticmethod
-    def get_priority():
+    def get_priority() -> Optional[int]:
         """Get the priority of this frame provider.
 
         This static method is called to determine the evaluation order when
@@ -142,7 +149,7 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
         """
         return None  # Default/lowest priority
 
-    def __init__(self, input_frames, args):
+    def __init__(self, input_frames: lldb.SBFrameList, args: lldb.SBStructuredData):
         """Construct a scripted frame provider.
 
         Args:
@@ -170,7 +177,9 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
             self.args = args
 
     @abstractmethod
-    def get_frame_at_index(self, index):
+    def get_frame_at_index(
+        self, index: int
+    ) -> Union["lldb.plugins.scripted_process.ScriptedFrame", int, dict, None]:
         """Get a single stack frame at the given index.
 
         This method is called lazily when a specific frame is needed in the

--- a/lldb/examples/python/templates/scripted_hook.py
+++ b/lldb/examples/python/templates/scripted_hook.py
@@ -14,8 +14,11 @@ class ScriptedHook(metaclass=ABCMeta):
     registered via `target hook add -P`.
     """
 
+    target: lldb.SBTarget
+    args: lldb.SBStructuredData
+
     @abstractmethod
-    def __init__(self, target, args):
+    def __init__(self, target: lldb.SBTarget, args: lldb.SBStructuredData):
         """Construct a scripted hook.
 
         Args:
@@ -26,7 +29,7 @@ class ScriptedHook(metaclass=ABCMeta):
         self.target = target
         self.args = args
 
-    def handle_module_loaded(self, stream):
+    def handle_module_loaded(self, stream: lldb.SBStream) -> None:
         """Called whenever a module is loaded into the target.
 
         Args:
@@ -35,7 +38,7 @@ class ScriptedHook(metaclass=ABCMeta):
         """
         pass
 
-    def handle_module_unloaded(self, stream):
+    def handle_module_unloaded(self, stream: lldb.SBStream) -> None:
         """Called whenever a module is unloaded from the target.
 
         Args:
@@ -45,7 +48,9 @@ class ScriptedHook(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def handle_stop(self, exe_ctx, stream):
+    def handle_stop(
+        self, exe_ctx: lldb.SBExecutionContext, stream: lldb.SBStream
+    ) -> bool:
         """Called whenever the process stops, before control is returned to
         the user.
 

--- a/lldb/examples/python/templates/scripted_platform.py
+++ b/lldb/examples/python/templates/scripted_platform.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional
 
 import lldb
 
@@ -12,10 +13,10 @@ class ScriptedPlatform(metaclass=ABCMeta):
     overwritten by the inheriting class.
     """
 
-    processes = None
+    processes: Optional[dict[int, dict]] = None
 
     @abstractmethod
-    def __init__(self, exe_ctx, args):
+    def __init__(self, exe_ctx: lldb.SBExecutionContext, args: lldb.SBStructuredData):
         """Construct a scripted platform.
 
         Args:
@@ -26,7 +27,7 @@ class ScriptedPlatform(metaclass=ABCMeta):
         processes = []
 
     @abstractmethod
-    def list_processes(self):
+    def list_processes(self) -> dict[int, dict]:
         """Get a list of processes that are running or that can be attached to on the platform.
 
         .. code-block:: python
@@ -50,7 +51,7 @@ class ScriptedPlatform(metaclass=ABCMeta):
         """
         pass
 
-    def get_process_info(self, pid):
+    def get_process_info(self, pid: int) -> Optional[dict]:
         """Get the dictionary describing the process.
 
         Returns:
@@ -60,7 +61,7 @@ class ScriptedPlatform(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def attach_to_process(self, attach_info):
+    def attach_to_process(self, attach_info: lldb.SBAttachInfo) -> lldb.SBError:
         """Attach to a process.
 
         Args:
@@ -72,7 +73,7 @@ class ScriptedPlatform(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def launch_process(self, launch_info):
+    def launch_process(self, launch_info: lldb.SBLaunchInfo) -> lldb.SBError:
         """Launch a process.
 
         Args:
@@ -84,7 +85,7 @@ class ScriptedPlatform(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def kill_process(self, pid):
+    def kill_process(self, pid: int) -> lldb.SBError:
         """Kill a process.
 
         Args:

--- a/lldb/examples/python/templates/scripted_process.py
+++ b/lldb/examples/python/templates/scripted_process.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Any, Optional, Union
 
 import lldb
 import json, struct, signal
@@ -12,14 +13,20 @@ class ScriptedProcess(metaclass=ABCMeta):
     overwritten by the inheriting class.
     """
 
-    capabilities = None
-    memory_regions = None
-    loaded_images = None
-    threads = None
-    metadata = None
+    capabilities: Optional[dict[str, bool]] = None
+    memory_regions: Optional[list[lldb.SBMemoryRegionInfo]] = None
+    loaded_images: Optional[list[dict]] = None
+    threads: Optional[dict[int, "lldb.plugins.scripted_process.ScriptedThread"]] = None
+    metadata: Optional[dict[str, Any]] = None
+
+    target: lldb.SBTarget
+    args: lldb.SBStructuredData
+    arch: str
+    dbg: lldb.SBDebugger
+    pid: int
 
     @abstractmethod
-    def __init__(self, exe_ctx, args):
+    def __init__(self, exe_ctx: lldb.SBExecutionContext, args: lldb.SBStructuredData):
         """Construct a scripted process.
 
         Args:
@@ -45,7 +52,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         self.capabilities = {}
         self.pid = 42
 
-    def get_capabilities(self):
+    def get_capabilities(self) -> dict[str, bool]:
         """Get a dictionary containing the process capabilities.
 
         Returns:
@@ -55,7 +62,9 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return self.capabilities
 
-    def get_memory_region_containing_address(self, addr):
+    def get_memory_region_containing_address(
+        self, addr: int
+    ) -> Optional[lldb.SBMemoryRegionInfo]:
         """Get the memory region for the scripted process, containing a
             specific address.
 
@@ -69,7 +78,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return None
 
-    def get_threads_info(self):
+    def get_threads_info(self) -> dict[int, "lldb.plugins.scripted_process.ScriptedThread"]:
         """Get the dictionary describing the process' Scripted Threads.
 
         Returns:
@@ -80,7 +89,9 @@ class ScriptedProcess(metaclass=ABCMeta):
         return self.threads
 
     @abstractmethod
-    def read_memory_at_address(self, addr, size, error):
+    def read_memory_at_address(
+        self, addr: int, size: int, error: lldb.SBError
+    ) -> lldb.SBData:
         """Get a memory buffer from the scripted process at a certain address,
             of a certain size.
 
@@ -95,7 +106,9 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         pass
 
-    def write_memory_at_address(self, addr, data, error):
+    def write_memory_at_address(
+        self, addr: int, data: lldb.SBData, error: lldb.SBError
+    ) -> int:
         """Write a buffer to the scripted process memory.
 
         Args:
@@ -112,7 +125,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         )
         return 0
 
-    def get_loaded_images(self):
+    def get_loaded_images(self) -> Optional[list[dict]]:
         """Get the list of loaded images for the scripted process.
 
         .. code-block:: python
@@ -131,7 +144,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return self.loaded_images
 
-    def get_process_id(self):
+    def get_process_id(self) -> int:
         """Get the scripted process identifier.
 
         Returns:
@@ -139,7 +152,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return self.pid
 
-    def launch(self):
+    def launch(self) -> lldb.SBError:
         """Simulate the scripted process launch.
 
         Returns:
@@ -147,7 +160,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return lldb.SBError()
 
-    def attach(self, attach_info):
+    def attach(self, attach_info: lldb.SBAttachInfo) -> lldb.SBError:
         """Simulate the scripted process attach.
 
         Args:
@@ -159,7 +172,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return lldb.SBError()
 
-    def resume(self, should_stop=True):
+    def resume(self, should_stop: bool = True) -> lldb.SBError:
         """Simulate the scripted process resume.
 
         Args:
@@ -181,7 +194,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         return lldb.SBError()
 
     @abstractmethod
-    def is_alive(self):
+    def is_alive(self) -> bool:
         """Check if the scripted process is alive.
 
         Returns:
@@ -190,7 +203,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_scripted_thread_plugin(self):
+    def get_scripted_thread_plugin(self) -> str:
         """Get scripted thread plugin name.
 
         Returns:
@@ -198,7 +211,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return None
 
-    def get_process_metadata(self):
+    def get_process_metadata(self) -> Optional[dict[str, Any]]:
         """Get some metadata for the scripted process.
 
         Returns:
@@ -207,7 +220,9 @@ class ScriptedProcess(metaclass=ABCMeta):
         """
         return self.metadata
 
-    def create_breakpoint(self, addr, error):
+    def create_breakpoint(
+        self, addr: int, error: lldb.SBError
+    ) -> Union[lldb.SBBreakpoint, bool]:
         """Create a breakpoint in the scripted process from an address.
             This is mainly used with interactive scripted process debugging.
 
@@ -233,8 +248,28 @@ class ScriptedThread(metaclass=ABCMeta):
     overwritten by the inheriting class.
     """
 
+    target: lldb.SBTarget
+    arch: str
+    originating_process: Union["lldb.plugins.scripted_process.ScriptedProcess", lldb.SBProcess]
+    process: lldb.SBProcess
+    args: lldb.SBStructuredData
+    idx: int
+    tid: int
+    name: str
+    queue: str
+    state: int
+    stop_reason: dict[str, Any]
+    register_info: dict[str, Any]
+    register_ctx: dict[str, int]
+    frames: list[dict]
+    extended_info: list[dict]
+
     @abstractmethod
-    def __init__(self, process, args):
+    def __init__(
+        self,
+        process: Union["lldb.plugins.scripted_process.ScriptedProcess", lldb.SBProcess],
+        args: Optional[lldb.SBStructuredData],
+    ):
         """Construct a scripted thread.
 
         Args:
@@ -272,7 +307,7 @@ class ScriptedThread(metaclass=ABCMeta):
             self.process = self.target.GetProcess()
             self.get_register_info()
 
-    def get_thread_idx(self):
+    def get_thread_idx(self) -> int:
         """Get the scripted thread index.
 
         Returns:
@@ -280,7 +315,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         return self.idx
 
-    def get_thread_id(self):
+    def get_thread_id(self) -> int:
         """Get the scripted thread identifier.
 
         Returns:
@@ -288,7 +323,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         return self.tid
 
-    def get_name(self):
+    def get_name(self) -> str:
         """Get the scripted thread name.
 
         Returns:
@@ -296,7 +331,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         return self.name
 
-    def get_state(self):
+    def get_state(self) -> int:
         """Get the scripted thread state type.
 
         .. code-block:: python
@@ -313,7 +348,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         return lldb.eStateStopped
 
-    def get_queue(self):
+    def get_queue(self) -> str:
         """Get the scripted thread associated queue name.
             This method is optional.
 
@@ -323,7 +358,7 @@ class ScriptedThread(metaclass=ABCMeta):
         return self.queue
 
     @abstractmethod
-    def get_stop_reason(self):
+    def get_stop_reason(self) -> dict[str, Any]:
         """Get the dictionary describing the stop reason type with some data.
             This method is optional.
 
@@ -333,7 +368,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         pass
 
-    def get_stackframes(self):
+    def get_stackframes(self) -> list[dict]:
         """Get the list of stack frames for the scripted thread.
 
         .. code-block:: python
@@ -351,7 +386,20 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         return self.frames
 
-    def get_register_info(self):
+    def get_register_info(self) -> dict[str, Any]:
+        """Get the register info dictionary describing the scripted thread's
+        registers. Lazily populated on first call from a per-architecture
+        general-purpose register layout keyed off `self.arch`.
+
+        Returns:
+            Dict: The register info dictionary with `sets` and `registers`
+            keys. `sets` is a list of register set names and `registers`
+            is a list of register descriptions.
+
+        Raises:
+            ValueError: If `self.arch` is not one of the architectures
+                the base class ships a register layout for.
+        """
         if self.register_info is None:
             self.register_info = dict()
             if "x86_64" in self.arch:
@@ -371,7 +419,7 @@ class ScriptedThread(metaclass=ABCMeta):
         return self.register_info
 
     @abstractmethod
-    def get_register_context(self):
+    def get_register_context(self) -> str:
         """Get the scripted thread register context
 
         Returns:
@@ -379,7 +427,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         pass
 
-    def get_extended_info(self):
+    def get_extended_info(self) -> list[dict]:
         """Get scripted thread extended information.
 
         Returns:
@@ -388,7 +436,7 @@ class ScriptedThread(metaclass=ABCMeta):
         """
         return self.extended_info
 
-    def get_scripted_frame_plugin(self):
+    def get_scripted_frame_plugin(self) -> Optional[str]:
         """Get scripted frame plugin name.
 
         Returns:
@@ -405,8 +453,22 @@ class ScriptedFrame(metaclass=ABCMeta):
     overwritten by the inheriting class.
     """
 
+    target: lldb.SBTarget
+    arch: str
+    originating_thread: Union["lldb.plugins.scripted_process.ScriptedThread", lldb.SBThread]
+    thread: lldb.SBThread
+    process: lldb.SBProcess
+    args: lldb.SBStructuredData
+    id: int
+    name: str
+    register_info: dict[str, Any]
+    register_ctx: dict[str, int]
+    variables: list[lldb.SBValue]
+
     @abstractmethod
-    def __init__(self, thread, args):
+    def __init__(
+        self, thread: Union["lldb.plugins.scripted_process.ScriptedThread", lldb.SBThread], args: lldb.SBStructuredData
+    ):
         """Construct a scripted frame.
 
         Args:
@@ -439,7 +501,7 @@ class ScriptedFrame(metaclass=ABCMeta):
             self.get_register_info()
 
     @abstractmethod
-    def get_id(self):
+    def get_id(self) -> int:
         """Get the scripted frame identifier.
 
         Returns:
@@ -447,7 +509,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         pass
 
-    def get_pc(self):
+    def get_pc(self) -> Optional[int]:
         """Get the scripted frame address.
 
         Returns:
@@ -455,7 +517,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return None
 
-    def get_symbol_context(self):
+    def get_symbol_context(self) -> Optional[lldb.SBSymbolContext]:
         """Get the scripted frame symbol context.
 
         Returns:
@@ -463,7 +525,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return None
 
-    def is_inlined(self):
+    def is_inlined(self) -> bool:
         """Check if the scripted frame is inlined.
 
         Returns:
@@ -471,7 +533,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return False
 
-    def is_artificial(self):
+    def is_artificial(self) -> bool:
         """Check if the scripted frame is artificial.
 
         Returns:
@@ -479,7 +541,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return True
 
-    def is_hidden(self):
+    def is_hidden(self) -> bool:
         """Check if the scripted frame is hidden.
 
         Returns:
@@ -487,7 +549,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return False
 
-    def get_function_name(self):
+    def get_function_name(self) -> str:
         """Get the scripted frame function name.
 
         Returns:
@@ -495,7 +557,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return self.name
 
-    def get_display_function_name(self):
+    def get_display_function_name(self) -> str:
         """Get the scripted frame display function name.
 
         Returns:
@@ -503,7 +565,9 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return self.get_function_name()
 
-    def get_variables(self, filters):
+    def get_variables(
+        self, filters: lldb.SBVariablesOptions
+    ) -> Optional[lldb.SBValueList]:
         """Get the scripted thread state type.
 
         Args:
@@ -514,7 +578,21 @@ class ScriptedFrame(metaclass=ABCMeta):
         """
         return None
 
-    def get_register_info(self):
+    def get_register_info(self) -> dict[str, Any]:
+        """Get the register info dictionary describing the scripted frame's
+        registers. Delegates to the originating scripted thread when there
+        is one; otherwise lazily populates a per-architecture
+        general-purpose register layout keyed off `self.arch`.
+
+        Returns:
+            Dict: The register info dictionary with `sets` and `registers`
+            keys. `sets` is a list of register set names and `registers`
+            is a list of register descriptions.
+
+        Raises:
+            ValueError: If `self.arch` is not one of the architectures
+                the base class ships a register layout for.
+        """
         if self.register_info is None:
             if isinstance(self.originating_thread, ScriptedThread):
                 self.register_info = self.originating_thread.get_register_info()
@@ -544,7 +622,7 @@ class ScriptedFrame(metaclass=ABCMeta):
         return self.register_info
 
     @abstractmethod
-    def get_register_context(self):
+    def get_register_context(self) -> str:
         """Get the scripted thread register context
 
         Returns:
@@ -553,10 +631,25 @@ class ScriptedFrame(metaclass=ABCMeta):
         pass
 
 class PassthroughScriptedProcess(ScriptedProcess):
+    """A reference `ScriptedProcess` subclass that forwards every request to
+    a "driving" process running in another target of the same debugger.
+    Useful as a starting point when the extension only needs to reshape or
+    filter data from a real underlying process."""
+
     driving_target = None
     driving_process = None
 
-    def __init__(self, exe_ctx, args, launched_driving_process=True):
+    def __init__(
+        self,
+        exe_ctx: lldb.SBExecutionContext,
+        args: lldb.SBStructuredData,
+        launched_driving_process: bool = True,
+    ):
+        """Construct a passthrough scripted process by looking up the driving
+        target's index in `args["driving_target_idx"]` and (unless
+        `launched_driving_process` is `False`) mirroring its threads and
+        loaded images into `self`.
+        """
         super().__init__(exe_ctx, args)
 
         self.driving_target = None
@@ -591,14 +684,18 @@ class PassthroughScriptedProcess(ScriptedProcess):
                     )
                     self.loaded_images.append({"path": path, "load_addr": load_addr})
 
-    def get_memory_region_containing_address(self, addr):
+    def get_memory_region_containing_address(
+        self, addr: int
+    ) -> Optional[lldb.SBMemoryRegionInfo]:
         mem_region = lldb.SBMemoryRegionInfo()
         error = self.driving_process.GetMemoryRegionInfo(addr, mem_region)
         if error.Fail():
             return None
         return mem_region
 
-    def read_memory_at_address(self, addr, size, error):
+    def read_memory_at_address(
+        self, addr: int, size: int, error: lldb.SBError
+    ) -> lldb.SBData:
         data = lldb.SBData()
         bytes_read = self.driving_process.ReadMemory(addr, size, error)
 
@@ -614,23 +711,33 @@ class PassthroughScriptedProcess(ScriptedProcess):
 
         return data
 
-    def write_memory_at_address(self, addr, data, error):
+    def write_memory_at_address(
+        self, addr: int, data: lldb.SBData, error: lldb.SBError
+    ) -> int:
         return self.driving_process.WriteMemory(
             addr, bytearray(data.uint8.all()), error
         )
 
-    def get_process_id(self):
+    def get_process_id(self) -> int:
         return self.driving_process.GetProcessID()
 
-    def is_alive(self):
+    def is_alive(self) -> bool:
         return True
 
-    def get_scripted_thread_plugin(self):
+    def get_scripted_thread_plugin(self) -> str:
         return f"{PassthroughScriptedThread.__module__}.{PassthroughScriptedThread.__name__}"
 
 
 class PassthroughScriptedThread(ScriptedThread):
-    def __init__(self, process, args):
+    """A reference `ScriptedThread` subclass that forwards every request to
+    a specific thread of a driving process. See `PassthroughScriptedProcess`
+    for the process-side counterpart."""
+
+    def __init__(
+        self,
+        process: Union["lldb.plugins.scripted_process.ScriptedProcess", lldb.SBProcess],
+        args: lldb.SBStructuredData,
+    ):
         super().__init__(process, args)
         driving_target_idx = args.GetValueForKey("driving_target_idx")
         thread_idx = args.GetValueForKey("thread_idx")
@@ -656,13 +763,13 @@ class PassthroughScriptedThread(ScriptedThread):
         if self.driving_thread:
             self.id = self.driving_thread.GetThreadID()
 
-    def get_thread_id(self):
+    def get_thread_id(self) -> int:
         return self.id
 
-    def get_name(self):
+    def get_name(self) -> str:
         return f"{PassthroughScriptedThread.__name__}.thread-{self.idx}"
 
-    def get_stop_reason(self):
+    def get_stop_reason(self) -> dict:
         stop_reason = {"type": lldb.eStopReasonInvalid, "data": {}}
 
         if (
@@ -687,7 +794,7 @@ class PassthroughScriptedThread(ScriptedThread):
 
         return stop_reason
 
-    def get_register_context(self):
+    def get_register_context(self) -> Optional[str]:
         if not self.driving_thread or self.driving_thread.GetNumFrames() == 0:
             return None
         frame = self.driving_thread.GetFrameAtIndex(0)

--- a/lldb/examples/python/templates/scripted_thread_plan.py
+++ b/lldb/examples/python/templates/scripted_thread_plan.py
@@ -9,6 +9,8 @@ class ScriptedThreadPlan:
 
     """
 
+    thread_plan: lldb.SBThreadPlan
+
     def __init__(self, thread_plan: lldb.SBThreadPlan):
         """Initialization needs a valid lldb.SBThreadPlan object. This plug-in will get created after a live process is valid and has stopped.
 


### PR DESCRIPTION
This patch adds type annotations to every method (parameters and return types) and every `self.<name>` attribute of the scripted extension base classes shipped under `lldb/examples/python/templates/`. Extension authors reading the base classes -- or an IDE navigating them -- can now see the `lldb.SB*` contract each method exposes without having to cross-reference the docstring.

`scripting extension generate` also picks the annotations up: derived class docstrings advertise each inherited attribute together with its declared type, and the generated method signatures carry their parameter and return annotations too.

The classes covered are `ScriptedProcess`, `ScriptedThread`, `ScriptedFrame`, `PassthroughScriptedProcess`,
`PassthroughScriptedThread`, `ScriptedFrameProvider`, `ScriptedBreakpointResolver`, `ScriptedThreadPlan`, `ScriptedHook`, `ScriptedPlatform`, and `OperatingSystem`.