### PR TITLE
[clang][HLSL] Fix assertion crash on forward-declared record in hasConstantBufferLayout (#198349)

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -5187,6 +5187,8 @@ static bool hasConstantBufferLayout(QualType QT) {
     return false;
 
   if (const auto *RD = Ty->getAsCXXRecordDecl()) {
+    if (!RD->hasDefinition())
+      return false;
     for (const auto *FD : RD->fields()) {
       if (hasConstantBufferLayout(FD->getType()))
         return true;


### PR DESCRIPTION
hasConstantBufferLayout iterates fields and accesses base class info of CXXRecordDecl
without checking hasDefinition(), causing an assertion:

  Assertion `DD && "queried property of class with no definition"' failed.

This is triggered when clangd opens HLSL files whose compile_commands.json has
`-x hlsl` without a DXIL/SPIR-V target triple. In this state, HLSL builtin
types like SamplerState exist as forward-declared CXXRecordDecls without
HLSLResourceAttr, bypassing the isHLSLResourceRecord() early return.

Fix: add hasDefinition() guard before accessing record fields and bases.

Fixes #198349.
Assisted by: claude code.