### PR TITLE
[Clang] Ensure correct template parameter depth for abbreviated templates

### DIFF
--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2534,6 +2534,12 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
     if (BitfieldSize.isInvalid())
       SkipUntil(tok::comma, StopAtSemi | StopBeforeMatch);
   } else if (Tok.is(tok::kw_requires)) {
+    TemplateParameterDepthRAII CurTemplateDepthTracker(TemplateParameterDepth);
+    // With abbreviated function templates - we need to explicitly add depth to
+    // account for the implicit template parameter list induced by the template.
+    if (DeclaratorInfo.getTemplateParameterLists().empty() &&
+        DeclaratorInfo.getInventedTemplateParameterList())
+      ++CurTemplateDepthTracker;
     ParseTrailingRequiresClauseWithScope(DeclaratorInfo);
   } else {
     ParseOptionalCXX11VirtSpecifierSeq(

--- a/clang/test/SemaCXX/constexpr-late-instantiation.cpp
+++ b/clang/test/SemaCXX/constexpr-late-instantiation.cpp
@@ -1,5 +1,10 @@
-// RUN: %clang_cc1 %s -fsyntax-only -verify
-// RUN: %clang_cc1 %s -fexperimental-new-constant-interpreter -fsyntax-only -verify
+// RUN: %clang_cc1 %s -std=c++14 -fsyntax-only -verify
+// RUN: %clang_cc1 %s -std=c++20 -fsyntax-only -verify
+// RUN: %clang_cc1 %s -std=c++2c -fsyntax-only -verify
+
+// RUN: %clang_cc1 %s -std=c++14 -fsyntax-only -fexperimental-new-constant-interpreter -verify
+// RUN: %clang_cc1 %s -std=c++20 -fsyntax-only -fexperimental-new-constant-interpreter -verify
+// RUN: %clang_cc1 %s -std=c++2c -fsyntax-only -fexperimental-new-constant-interpreter -verify
 
 template <typename T>
 constexpr T foo(T a);   // expected-note {{declared here}}
@@ -14,3 +19,28 @@ template <typename T>
 constexpr T foo(T a) {
   return a;
 }
+
+#if __cplusplus > 202002L
+
+namespace GH115118 {
+
+struct foo {
+    // expected-note@-1 2{{while}}
+    foo(const foo&) = default;
+    foo(auto)
+        requires([]<int = 0>() -> bool { return true; }())
+        // expected-error@-1 {{non-constant expression}}
+        // expected-note@-2 {{undefined function}} \
+        // expected-note@-2 {{declared}}
+    {}
+};
+
+// FIXME: This will be fixed by https://github.com/llvm/llvm-project/pull/205557
+struct bar {
+    // expected-note@-1 {{while}}
+    foo x; // check that the lambda gets instantiated.
+};
+
+}  // namespace GH115118
+
+#endif


### PR DESCRIPTION
This fixes another case of member functions where we overlooked template depths when only abbreviated template parameters are involved.

This mirrors previous fix cfb25203c25f, but I don't intend to put it in ParseTrailingRequiresClause because we might want the similar fix for e.g. noexcept expressions, so let's keep it inline for future refactor.

The example comes from #205557.