### PR TITLE
[clang] Do not compute typo-correction suggestions for disabled diagnostics

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -515,6 +515,21 @@ void Preprocessor::SuggestTypoedDirective(const Token &Tok,
   // directives.
   if (getLangOpts().AsmPreprocessor) return;
 
+  // A known non-conditional directive (e.g. #include or #define inside a
+  // skipped conditional block) is not a typo of a conditional don't scan
+  // it. #elifdef/#elifndef stay eligible so that pre-C23/C++23 code still
+  // gets the "did you mean #elif" suggestion.
+  if (tok::PPKeywordKind K = getIdentifierInfo(Directive)->getPPKeywordID();
+      K != tok::pp_not_keyword && K != tok::pp_elifdef &&
+      K != tok::pp_elifndef)
+    return;
+
+  // The scan only feeds this diagnostic; skip it when the diagnostic is
+  // disabled at this location (e.g. -w).
+  if (getDiagnostics().isIgnored(diag::warn_pp_invalid_directive,
+                                 Tok.getLocation()))
+    return;
+
   std::vector<StringRef> Candidates = {
       "if", "ifdef", "ifndef", "elif", "else", "endif"
   };

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -520,8 +520,7 @@ void Preprocessor::SuggestTypoedDirective(const Token &Tok,
   // it. #elifdef/#elifndef stay eligible so that pre-C23/C++23 code still
   // gets the "did you mean #elif" suggestion.
   if (tok::PPKeywordKind K = getIdentifierInfo(Directive)->getPPKeywordID();
-      K != tok::pp_not_keyword && K != tok::pp_elifdef &&
-      K != tok::pp_elifndef)
+      K != tok::pp_not_keyword && K != tok::pp_elifdef && K != tok::pp_elifndef)
     return;
 
   // The scan only feeds this diagnostic; skip it when the diagnostic is

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -325,8 +325,8 @@ static bool warnByDefaultOnWrongCase(StringRef Include) {
 ///
 /// \returns a similar string if exists. If no similar string exists,
 /// returns std::nullopt.
-static std::optional<StringRef>
-findSimilarStr(StringRef LHS, const std::vector<StringRef> &Candidates) {
+static std::optional<StringRef> findSimilarStr(StringRef LHS,
+                                               ArrayRef<StringRef> Candidates) {
   // We need to check if `Candidates` has the exact case-insensitive string
   // because the Levenshtein distance match does not care about it.
   for (StringRef C : Candidates) {
@@ -515,25 +515,23 @@ void Preprocessor::SuggestTypoedDirective(const Token &Tok,
   // directives.
   if (getLangOpts().AsmPreprocessor) return;
 
-  // A known non-conditional directive (e.g. #include or #define inside a
-  // skipped conditional block) is not a typo of a conditional don't scan
-  // it. #elifdef/#elifndef stay eligible so that pre-C23/C++23 code still
-  // gets the "did you mean #elif" suggestion.
-  if (tok::PPKeywordKind K = getIdentifierInfo(Directive)->getPPKeywordID();
-      K != tok::pp_not_keyword && K != tok::pp_elifdef && K != tok::pp_elifndef)
-    return;
-
   // The scan only feeds this diagnostic; skip it when the diagnostic is
   // disabled at this location (e.g. -w).
   if (getDiagnostics().isIgnored(diag::warn_pp_invalid_directive,
                                  Tok.getLocation()))
     return;
 
-  std::vector<StringRef> Candidates = {
-      "if", "ifdef", "ifndef", "elif", "else", "endif"
-  };
-  if (LangOpts.C23 || LangOpts.CPlusPlus23)
-    Candidates.insert(Candidates.end(), {"elifdef", "elifndef"});
+  // A known directive (e.g. #include or #define inside a skipped conditional
+  // block) is not a typo of a conditional; don't scan it.
+  if (getIdentifierInfo(Directive)->getPPKeywordID() != tok::pp_not_keyword)
+    return;
+
+  static constexpr StringRef AllCandidates[] = {
+      "if", "ifdef", "ifndef", "elif", "else", "endif", "elifdef", "elifndef"};
+  ArrayRef<StringRef> Candidates(AllCandidates);
+  // #elifdef/#elifndef are only suggested in C23/C++23 and later.
+  if (!LangOpts.C23 && !LangOpts.CPlusPlus23)
+    Candidates = Candidates.drop_back(2);
 
   if (std::optional<StringRef> Sugg = findSimilarStr(Directive, Candidates)) {
     // Directive cannot be coming from macro.

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -515,15 +515,15 @@ void Preprocessor::SuggestTypoedDirective(const Token &Tok,
   // directives.
   if (getLangOpts().AsmPreprocessor) return;
 
+  // A known directive (e.g. #include or #define inside a skipped conditional
+  // block) is not a typo of a conditional; don't scan it.
+  if (getIdentifierInfo(Directive)->getPPKeywordID() != tok::pp_not_keyword)
+    return;
+
   // The scan only feeds this diagnostic; skip it when the diagnostic is
   // disabled at this location (e.g. -w).
   if (getDiagnostics().isIgnored(diag::warn_pp_invalid_directive,
                                  Tok.getLocation()))
-    return;
-
-  // A known directive (e.g. #include or #define inside a skipped conditional
-  // block) is not a typo of a conditional; don't scan it.
-  if (getIdentifierInfo(Directive)->getPPKeywordID() != tok::pp_not_keyword)
     return;
 
   static constexpr StringRef AllCandidates[] = {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8637,6 +8637,12 @@ void Sema::checkUnusedDeclAttributes(Declarator &D) {
 
 void Sema::DiagnoseUnknownAttribute(const ParsedAttr &AL) {
   SourceRange NR = AL.getNormalizedRange();
+  // Skip the expensive spelling-list typo-correction scan when the
+  // diagnostics it feeds are disabled at this location.
+  if (Diags.isIgnored(diag::warn_unknown_attribute_ignored, NR.getBegin()) &&
+      Diags.isIgnored(diag::warn_unknown_attribute_ignored_suggestion,
+                      NR.getBegin()))
+    return;
   StringRef ScopeName = AL.getNormalizedScopeName();
   std::optional<StringRef> CorrectedScopeName =
       AL.tryGetCorrectedScopeName(ScopeName);


### PR DESCRIPTION
While benchmarking I noticed that Boost.MPL compiles with ~1.2% more instructions
after #140629.
clang spends a fair amount of time computing typo-correction
suggestions for diagnostics that are never emitted, for example Boost doesn't contain any
typos, so all of this work produces nothing.

We can easily avoid this overhead by checking `isIgnored()` before computing
suggestions, and by not treating known non-conditional directives as typos.

You can see the improvement here:
https://llvm-compile-time-tracker.com/compare.php?from=49de424f45389cb757c3cc8c50daf38d024e2314&to=89a68cd24f9fabf15897d7b20b77bb5b0bfb9c16&stat=instructions%3Au
