### PR TITLE
[X86][APX] Add EVEX BMI opcodes to isDefConvertible

### DIFF
--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -4998,6 +4998,10 @@ bool X86InstrInfo::isRedundantFlagInstr(const MachineInstr &FlagI,
   }
 }
 
+#define CASE_EVEX(OP)                                                          \
+  case X86::OP:                                                                \
+  case X86::OP##_EVEX:
+
 /// Check whether the definition can be converted
 /// to remove a comparison against zero.
 inline static bool isDefConvertible(const MachineInstr &MI, bool &NoSignFlag,
@@ -5167,22 +5171,22 @@ inline static bool isDefConvertible(const MachineInstr &MI, bool &NoSignFlag,
   CASE_ND(OR32rm)
   CASE_ND(OR16rm)
   CASE_ND(OR8rm)
-  case X86::ANDN32rr:
-  case X86::ANDN32rm:
-  case X86::ANDN64rr:
-  case X86::ANDN64rm:
-  case X86::BLSI32rr:
-  case X86::BLSI32rm:
-  case X86::BLSI64rr:
-  case X86::BLSI64rm:
-  case X86::BLSMSK32rr:
-  case X86::BLSMSK32rm:
-  case X86::BLSMSK64rr:
-  case X86::BLSMSK64rm:
-  case X86::BLSR32rr:
-  case X86::BLSR32rm:
-  case X86::BLSR64rr:
-  case X86::BLSR64rm:
+  CASE_EVEX(ANDN32rr)
+  CASE_EVEX(ANDN32rm)
+  CASE_EVEX(ANDN64rr)
+  CASE_EVEX(ANDN64rm)
+  CASE_EVEX(BLSI32rr)
+  CASE_EVEX(BLSI32rm)
+  CASE_EVEX(BLSI64rr)
+  CASE_EVEX(BLSI64rm)
+  CASE_EVEX(BLSMSK32rr)
+  CASE_EVEX(BLSMSK32rm)
+  CASE_EVEX(BLSMSK64rr)
+  CASE_EVEX(BLSMSK64rm)
+  CASE_EVEX(BLSR32rr)
+  CASE_EVEX(BLSR32rm)
+  CASE_EVEX(BLSR64rr)
+  CASE_EVEX(BLSR64rm)
   case X86::BLCFILL32rr:
   case X86::BLCFILL32rm:
   case X86::BLCFILL64rr:
@@ -5211,10 +5215,10 @@ inline static bool isDefConvertible(const MachineInstr &MI, bool &NoSignFlag,
   case X86::BLSIC32rm:
   case X86::BLSIC64rr:
   case X86::BLSIC64rm:
-  case X86::BZHI32rr:
-  case X86::BZHI32rm:
-  case X86::BZHI64rr:
-  case X86::BZHI64rm:
+  CASE_EVEX(BZHI32rr)
+  CASE_EVEX(BZHI32rm)
+  CASE_EVEX(BZHI64rr)
+  CASE_EVEX(BZHI64rm)
   case X86::T1MSKC32rr:
   case X86::T1MSKC32rm:
   case X86::T1MSKC64rr:
@@ -5228,10 +5232,10 @@ inline static bool isDefConvertible(const MachineInstr &MI, bool &NoSignFlag,
     // overflow flag.
     ClearsOverflowFlag = true;
     return true;
-  case X86::BEXTR32rr:
-  case X86::BEXTR64rr:
-  case X86::BEXTR32rm:
-  case X86::BEXTR64rm:
+  CASE_EVEX(BEXTR32rr)
+  CASE_EVEX(BEXTR64rr)
+  CASE_EVEX(BEXTR32rm)
+  CASE_EVEX(BEXTR64rm)
   case X86::BEXTRI32ri:
   case X86::BEXTRI32mi:
   case X86::BEXTRI64ri:
@@ -5273,17 +5277,18 @@ static std::pair<X86::CondCode, unsigned> isUseDefConvertible(const MachineInstr
   case X86::BSR32rr:
   case X86::BSR64rr:
     return std::make_pair(X86::COND_E, 2U);
-  case X86::BLSI32rr:
-  case X86::BLSI64rr:
+  CASE_EVEX(BLSI32rr)
+  CASE_EVEX(BLSI64rr)
     return std::make_pair(X86::COND_AE, 1U);
-  case X86::BLSR32rr:
-  case X86::BLSR64rr:
-  case X86::BLSMSK32rr:
-  case X86::BLSMSK64rr:
+  CASE_EVEX(BLSR32rr)
+  CASE_EVEX(BLSR64rr)
+  CASE_EVEX(BLSMSK32rr)
+  CASE_EVEX(BLSMSK64rr)
     return std::make_pair(X86::COND_B, 1U);
     // TODO: TBM instructions.
   }
 }
+#undef CASE_EVEX
 
 /// Check if there exists an earlier instruction that
 /// operates on the same source operands and sets flags in the same way as

--- a/llvm/test/CodeGen/X86/bmi.ll
+++ b/llvm/test/CodeGen/X86/bmi.ll
@@ -92,7 +92,6 @@ define i1 @andn_cmp(i32 %x, i32 %y) {
 ; EGPR-LABEL: andn_cmp:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnl %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x40,0xf2,0xc6]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    sete %al # encoding: [0x0f,0x94,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %notx = xor i32 %x, -1
@@ -119,7 +118,6 @@ define i1 @and_cmp1(i32 %x, i32 %y) {
 ; EGPR-LABEL: and_cmp1:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnl %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x40,0xf2,0xc6]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    sete %al # encoding: [0x0f,0x94,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %and = and i32 %x, %y
@@ -144,7 +142,6 @@ define i1 @and_cmp2(i32 %x, i32 %y) {
 ; EGPR-LABEL: and_cmp2:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnl %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x40,0xf2,0xc6]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    setne %al # encoding: [0x0f,0x95,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %and = and i32 %y, %x
@@ -169,7 +166,6 @@ define i1 @and_cmp3(i32 %x, i32 %y) {
 ; EGPR-LABEL: and_cmp3:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnl %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x40,0xf2,0xc6]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    sete %al # encoding: [0x0f,0x94,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %and = and i32 %x, %y
@@ -194,7 +190,6 @@ define i1 @and_cmp4(i32 %x, i32 %y) {
 ; EGPR-LABEL: and_cmp4:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnl %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x40,0xf2,0xc6]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    setne %al # encoding: [0x0f,0x95,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %and = and i32 %y, %x
@@ -372,7 +367,6 @@ define i1 @andn_cmp_swap_ops(i64 %x, i64 %y) {
 ; EGPR-LABEL: andn_cmp_swap_ops:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnq %rsi, %rdi, %rax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xc0,0xf2,0xc6]
-; EGPR-NEXT:    testq %rax, %rax # encoding: [0x48,0x85,0xc0]
 ; EGPR-NEXT:    sete %al # encoding: [0x0f,0x94,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %notx = xor i64 %x, -1
@@ -428,7 +422,6 @@ define i1 @andn_cmp_i32_overflow(i32 %x, i32 %y) {
 ; EGPR-LABEL: andn_cmp_i32_overflow:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    andnl %edi, %esi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x48,0xf2,0xc7]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    setle %al # encoding: [0x0f,0x9e,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %noty = xor i32 %y, -1
@@ -693,7 +686,6 @@ define i32 @blsi32_z(i32 %a, i32 %b) nounwind {
 ; EGPR-LABEL: blsi32_z:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsil %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x78,0xf3,0xdf]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    cmovel %esi, %eax # encoding: [0x0f,0x44,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 0, %a
@@ -724,7 +716,6 @@ define i32 @blsi32_z2(i32 %a, i32 %b, i32 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    blsil %edi, %ecx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x70,0xf3,0xdf]
-; EGPR-NEXT:    testl %ecx, %ecx # encoding: [0x85,0xc9]
 ; EGPR-NEXT:    cmovnel %edx, %eax # encoding: [0x0f,0x45,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 0, %a
@@ -757,7 +748,6 @@ define i32 @blsi32_sle(i32 %a, i32 %b, i32 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    blsil %edi, %ecx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x70,0xf3,0xdf]
-; EGPR-NEXT:    testl %ecx, %ecx # encoding: [0x85,0xc9]
 ; EGPR-NEXT:    cmovgl %edx, %eax # encoding: [0x0f,0x4f,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 0, %a
@@ -830,7 +820,6 @@ define i64 @blsi64_z(i64 %a, i64 %b) nounwind {
 ; EGPR-LABEL: blsi64_z:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsiq %rdi, %rax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf8,0xf3,0xdf]
-; EGPR-NEXT:    testq %rax, %rax # encoding: [0x48,0x85,0xc0]
 ; EGPR-NEXT:    cmoveq %rsi, %rax # encoding: [0x48,0x0f,0x44,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 0, %a
@@ -872,7 +861,6 @@ define i64 @blsi64_z2(i64 %a, i64 %b, i64 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    blsiq %rdi, %rcx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf0,0xf3,0xdf]
-; EGPR-NEXT:    testq %rcx, %rcx # encoding: [0x48,0x85,0xc9]
 ; EGPR-NEXT:    cmovneq %rdx, %rax # encoding: [0x48,0x0f,0x45,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 0, %a
@@ -915,7 +903,6 @@ define i64 @blsi64_sle(i64 %a, i64 %b, i64 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    blsiq %rdi, %rcx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf0,0xf3,0xdf]
-; EGPR-NEXT:    testq %rcx, %rcx # encoding: [0x48,0x85,0xc9]
 ; EGPR-NEXT:    cmovgq %rdx, %rax # encoding: [0x48,0x0f,0x4f,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 0, %a
@@ -986,7 +973,6 @@ define i32 @blsmsk32_z(i32 %a, i32 %b) nounwind {
 ; EGPR-LABEL: blsmsk32_z:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsmskl %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x78,0xf3,0xd7]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    cmovel %esi, %eax # encoding: [0x0f,0x44,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 %a, 1
@@ -1047,7 +1033,6 @@ define i32 @blsmsk32_sle(i32 %a, i32 %b, i32 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    blsmskl %edi, %ecx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x70,0xf3,0xd7]
-; EGPR-NEXT:    testl %ecx, %ecx # encoding: [0x85,0xc9]
 ; EGPR-NEXT:    cmovgl %edx, %eax # encoding: [0x0f,0x4f,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 %a, 1
@@ -1120,7 +1105,6 @@ define i64 @blsmsk64_z(i64 %a, i64 %b) nounwind {
 ; EGPR-LABEL: blsmsk64_z:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsmskq %rdi, %rax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf8,0xf3,0xd7]
-; EGPR-NEXT:    testq %rax, %rax # encoding: [0x48,0x85,0xc0]
 ; EGPR-NEXT:    cmoveq %rsi, %rax # encoding: [0x48,0x0f,0x44,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 %a, 1
@@ -1204,7 +1188,6 @@ define i64 @blsmsk64_sle(i64 %a, i64 %b, i64 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    blsmskq %rdi, %rcx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf0,0xf3,0xd7]
-; EGPR-NEXT:    testq %rcx, %rcx # encoding: [0x48,0x85,0xc9]
 ; EGPR-NEXT:    cmovgq %rdx, %rax # encoding: [0x48,0x0f,0x4f,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 %a, 1
@@ -1275,7 +1258,6 @@ define i32 @blsr32_z(i32 %a, i32 %b) nounwind {
 ; EGPR-LABEL: blsr32_z:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsrl %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x78,0xf3,0xcf]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    cmovel %esi, %eax # encoding: [0x0f,0x44,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 %a, 1
@@ -1306,7 +1288,6 @@ define i32 @blsr32_z2(i32 %a, i32 %b, i32 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    blsrl %edi, %ecx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x70,0xf3,0xcf]
-; EGPR-NEXT:    testl %ecx, %ecx # encoding: [0x85,0xc9]
 ; EGPR-NEXT:    cmovnel %edx, %eax # encoding: [0x0f,0x45,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 %a, 1
@@ -1337,7 +1318,6 @@ define i32 @blsr32_sle(i32 %a, i32 %b, i32 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
 ; EGPR-NEXT:    blsrl %edi, %ecx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x70,0xf3,0xcf]
-; EGPR-NEXT:    testl %ecx, %ecx # encoding: [0x85,0xc9]
 ; EGPR-NEXT:    cmovgl %edx, %eax # encoding: [0x0f,0x4f,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i32 %a, 1
@@ -1410,7 +1390,6 @@ define i64 @blsr64_z(i64 %a, i64 %b) nounwind {
 ; EGPR-LABEL: blsr64_z:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsrq %rdi, %rax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf8,0xf3,0xcf]
-; EGPR-NEXT:    testq %rax, %rax # encoding: [0x48,0x85,0xc0]
 ; EGPR-NEXT:    cmoveq %rsi, %rax # encoding: [0x48,0x0f,0x44,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 %a, 1
@@ -1452,7 +1431,6 @@ define i64 @blsr64_z2(i64 %a, i64 %b, i64 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    blsrq %rdi, %rcx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf0,0xf3,0xcf]
-; EGPR-NEXT:    testq %rcx, %rcx # encoding: [0x48,0x85,0xc9]
 ; EGPR-NEXT:    cmovneq %rdx, %rax # encoding: [0x48,0x0f,0x45,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 %a, 1
@@ -1495,7 +1473,6 @@ define i64 @blsr64_sle(i64 %a, i64 %b, i64 %c) nounwind {
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    movq %rsi, %rax # encoding: [0x48,0x89,0xf0]
 ; EGPR-NEXT:    blsrq %rdi, %rcx # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf0,0xf3,0xcf]
-; EGPR-NEXT:    testq %rcx, %rcx # encoding: [0x48,0x85,0xc9]
 ; EGPR-NEXT:    cmovgq %rdx, %rax # encoding: [0x48,0x0f,0x4f,0xc2]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %t0 = sub i64 %a, 1
@@ -1875,7 +1852,6 @@ define void @pr42118_i32(i32 %x) {
 ; EGPR-LABEL: pr42118_i32:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsrl %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x78,0xf3,0xcf]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    je bar # TAILCALL
 ; EGPR-NEXT:    # encoding: [0x74,A]
 ; EGPR-NEXT:    # fixup A - offset: 1, value: bar, kind: FK_PCRel_1
@@ -1928,7 +1904,6 @@ define void @pr42118_i64(i64 %x) {
 ; EGPR-LABEL: pr42118_i64:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsrq %rdi, %rax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf8,0xf3,0xcf]
-; EGPR-NEXT:    testq %rax, %rax # encoding: [0x48,0x85,0xc0]
 ; EGPR-NEXT:    je bar # TAILCALL
 ; EGPR-NEXT:    # encoding: [0x74,A]
 ; EGPR-NEXT:    # fixup A - offset: 1, value: bar, kind: FK_PCRel_1
@@ -1967,8 +1942,7 @@ define i32 @blsi_cflag_32(i32 %x, i32 %y) nounwind {
 ; EGPR-LABEL: blsi_cflag_32:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsil %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x78,0xf3,0xdf]
-; EGPR-NEXT:    testl %edi, %edi # encoding: [0x85,0xff]
-; EGPR-NEXT:    cmovel %esi, %eax # encoding: [0x0f,0x44,0xc6]
+; EGPR-NEXT:    cmovael %esi, %eax # encoding: [0x0f,0x43,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %tobool = icmp eq i32 %x, 0
   %sub = sub nsw i32 0, %x
@@ -2012,8 +1986,7 @@ define i64 @blsi_cflag_64(i64 %x, i64 %y) nounwind {
 ; EGPR-LABEL: blsi_cflag_64:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    blsiq %rdi, %rax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0xf8,0xf3,0xdf]
-; EGPR-NEXT:    testq %rdi, %rdi # encoding: [0x48,0x85,0xff]
-; EGPR-NEXT:    cmoveq %rsi, %rax # encoding: [0x48,0x0f,0x44,0xc6]
+; EGPR-NEXT:    cmovaeq %rsi, %rax # encoding: [0x48,0x0f,0x43,0xc6]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %tobool = icmp eq i64 %x, 0
   %sub = sub nsw i64 0, %x

--- a/llvm/test/CodeGen/X86/bmi2.ll
+++ b/llvm/test/CodeGen/X86/bmi2.ll
@@ -68,7 +68,6 @@ define i1 @bzhi32_overflow(i32 %x, i32 %y) {
 ; EGPR-LABEL: bzhi32_overflow:
 ; EGPR:       # %bb.0:
 ; EGPR-NEXT:    bzhil %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x48,0xf5,0xc7]
-; EGPR-NEXT:    testl %eax, %eax # encoding: [0x85,0xc0]
 ; EGPR-NEXT:    setle %al # encoding: [0x0f,0x9e,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]
   %tmp = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %x, i32 %y)


### PR DESCRIPTION
To remove redundant test instructions.

Fixes: #207912

Assisted-by: Claude Sonnet 4.6