### PR TITLE
[flang][Lower][OpenMP] Fix reduction on array sections aborting in lowering

### DIFF
--- a/flang/lib/Lower/Support/ReductionProcessor.cpp
+++ b/flang/lib/Lower/Support/ReductionProcessor.cpp
@@ -387,7 +387,11 @@ bool ReductionProcessor::isExpressionLoweredAsReductionObject(
   if (!object || !object->ref())
     return false;
   const SomeExpr &expr = *object->ref();
-  return evaluate::IsArrayElement(expr);
+  // Only genuine single array elements (rank 0) are lowered via the element
+  // path. Array sections such as a(2:96) and vector subscripts have rank > 0;
+  // lowering them here produces an unsupported sequence type and aborts in
+  // PrivateReductionUtils. Let them fall back to the boxed whole-array path.
+  return evaluate::IsArrayElement(expr) && expr.Rank() == 0;
 }
 
 template <typename ParentDeclOpType>

--- a/flang/test/Lower/OpenMP/reduction-array-section.f90
+++ b/flang/test/Lower/OpenMP/reduction-array-section.f90
@@ -1,0 +1,39 @@
+! Regression test for reductions on array *sections* (e.g. a(2:96)).
+!
+! An array section has rank > 0, so it must be lowered using the boxed
+! whole-array reduction (@add_reduction_byref_box_*) and the section applied
+! via hlfir.designate inside the region. It must NOT be routed through the
+! single-element path (uniq_name = "omp.reduction.element"), which only supports
+! rank-0 references and otherwise aborts in PrivateReductionUtils with
+! "creating reduction/privatization init region for unsupported type".
+
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s --implicit-check-not=omp.reduction.element
+
+subroutine reduction_array_section(a, n)
+  integer :: a(100), n
+!$omp parallel do reduction(+: a(2:96))
+  do i = 1, n
+    a(2:96) = a(2:96) + i
+  end do
+end subroutine
+
+! CHECK: omp.declare_reduction @[[RED:add_reduction_byref_box_100xi32]] : !fir.ref<!fir.box<!fir.array<100xi32>>>
+
+! CHECK-LABEL: func.func @_QPreduction_array_section
+! CHECK: omp.wsloop {{.*}} reduction(byref @[[RED]] %{{[0-9]+}} -> %[[ARG:.*]] : !fir.ref<!fir.box<!fir.array<100xi32>>>) {
+! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG]] {uniq_name = "_QFreduction_array_sectionEa"}
+! CHECK: %[[BOX:.*]] = fir.load %[[DECL]]#0 : !fir.ref<!fir.box<!fir.array<100xi32>>>
+! CHECK: hlfir.designate %[[BOX]] (%c2:%c96:%c1) {{.*}} -> !fir.ref<!fir.array<95xi32>>
+
+subroutine reduction_array_section_simd(a, n)
+  integer :: a(100), n
+!$omp parallel do simd reduction(+: a(2:96))
+  do i = 1, n
+    a(2:96) = a(2:96) + i
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPreduction_array_section_simd
+! CHECK: omp.wsloop reduction(byref @[[RED]] %{{[0-9]+}} -> %[[WSARG:.*]] : !fir.ref<!fir.box<!fir.array<100xi32>>>) {
+! CHECK: omp.simd {{.*}} reduction(byref @[[RED]] %[[WSARG]] -> %[[SIMDARG:.*]] : !fir.ref<!fir.box<!fir.array<100xi32>>>) {
+! CHECK: hlfir.declare %[[SIMDARG]] {uniq_name = "_QFreduction_array_section_simdEa"}

--- a/flang/test/Lower/OpenMP/reduction-array-section.f90
+++ b/flang/test/Lower/OpenMP/reduction-array-section.f90
@@ -1,3 +1,5 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s --implicit-check-not=omp.reduction.element
+
 ! Regression test for reductions on array *sections* (e.g. a(2:96)).
 !
 ! An array section has rank > 0, so it must be lowered using the boxed
@@ -6,8 +8,6 @@
 ! single-element path (uniq_name = "omp.reduction.element"), which only supports
 ! rank-0 references and otherwise aborts in PrivateReductionUtils with
 ! "creating reduction/privatization init region for unsupported type".
-
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s --implicit-check-not=omp.reduction.element
 
 subroutine reduction_array_section(a, n)
   integer :: a(100), n


### PR DESCRIPTION
**Summary**

This regression was introduced by #196094, which added a special lowering path for reductions on a single array element, such as `a(2)`.

The problem is that Flang also treated an array section like `a(2:96)` as if it were a single element. Because of this, the section was sent to a code path that only supports scalar elements.

That path produced an array type that the reduction initialization code could not handle, so Flang reached a `TODO` and aborted with a “not yet implemented” error.

**Fix**


The fix is to use the special element path only when the expression has rank 0, which means it represents one single value. Array sections have rank greater than 0, so they should continue through the existing boxed-array path.





Fixes : [209462](https://github.com/llvm/llvm-project/issues/209462)