### PR TITLE
clang: Remove unnecessary cstdlib include

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -110,7 +110,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/RISCVISAInfo.h"
-#include <cstdlib> // ::getenv
 #include <map>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
The comment says it's needed for getenv, but this file does
not directly use getenv; it uses sys::Process::GetEnv.