### PR TITLE
[OpenMP][MLIR] RegionBranchOpInterface for TargetOp, TargetDataOp

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -222,7 +222,7 @@ def ParallelOp : OpenMP_Op<"parallel", traits = [
   let hasRegionVerifier = 1;
 }
 
-def TerminatorOp : OpenMP_Op<"terminator", [Terminator, Pure]> {
+def TerminatorOp : OpenMP_Op<"terminator", [Terminator, Pure, RegionBranchTerminatorOpInterface]> {
   let summary = "terminator for OpenMP regions";
   let description = [{
     A terminator operation for regions that appear in the body of OpenMP
@@ -1457,7 +1457,8 @@ def MapInfoOp : OpenMP_Op<"map.info", [AttrSizedOperandSegments]> {
 //===---------------------------------------------------------------------===//
 
 def TargetDataOp: OpenMP_Op<"target_data", traits = [
-    AttrSizedOperandSegments, DeclareOpInterfaceMethods<ComposableOpInterface>
+    AttrSizedOperandSegments, DeclareOpInterfaceMethods<ComposableOpInterface>,
+    DeclareOpInterfaceMethods<RegionBranchOpInterface>
   ], clauses = [
     OpenMP_DeviceClause, OpenMP_IfClause, OpenMP_MapClause,
     OpenMP_UseDeviceAddrClause, OpenMP_UseDevicePtrClause
@@ -1621,7 +1622,7 @@ def TargetUpdateOp: OpenMP_Op<"target_update", traits = [
 def TargetOp : OpenMP_Op<"target", traits = [
     AttrSizedOperandSegments, BlockArgOpenMPOpInterface,
     DeclareOpInterfaceMethods<ComposableOpInterface>, IsolatedFromAbove,
-    OutlineableOpenMPOpInterface
+    OutlineableOpenMPOpInterface, DeclareOpInterfaceMethods<RegionBranchOpInterface>
   ], clauses = [
     // TODO: Complete clause list (defaultmap, uses_allocators).
     OpenMP_AllocateClause, OpenMP_DependClause, OpenMP_DeviceClause,

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -1622,7 +1622,9 @@ def TargetUpdateOp: OpenMP_Op<"target_update", traits = [
 def TargetOp : OpenMP_Op<"target", traits = [
     AttrSizedOperandSegments, BlockArgOpenMPOpInterface,
     DeclareOpInterfaceMethods<ComposableOpInterface>, IsolatedFromAbove,
-    OutlineableOpenMPOpInterface, DeclareOpInterfaceMethods<RegionBranchOpInterface>
+    OutlineableOpenMPOpInterface, 
+    DeclareOpInterfaceMethods<RegionBranchOpInterface,
+      ["getEntrySuccessorOperands", "getSuccessorInputs"]>
   ], clauses = [
     // TODO: Complete clause list (defaultmap, uses_allocators).
     OpenMP_AllocateClause, OpenMP_DependClause, OpenMP_DeviceClause,

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -1621,10 +1621,10 @@ def TargetUpdateOp: OpenMP_Op<"target_update", traits = [
 
 def TargetOp : OpenMP_Op<"target", traits = [
     AttrSizedOperandSegments, BlockArgOpenMPOpInterface,
-    DeclareOpInterfaceMethods<ComposableOpInterface>, IsolatedFromAbove,
-    OutlineableOpenMPOpInterface, 
+    DeclareOpInterfaceMethods<ComposableOpInterface>,
     DeclareOpInterfaceMethods<RegionBranchOpInterface,
-      ["getEntrySuccessorOperands", "getSuccessorInputs"]>
+      ["getEntrySuccessorOperands", "getSuccessorInputs"]>,
+    IsolatedFromAbove, OutlineableOpenMPOpInterface
   ], clauses = [
     // TODO: Complete clause list (defaultmap, uses_allocators).
     OpenMP_AllocateClause, OpenMP_DependClause, OpenMP_DeviceClause,

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -2571,6 +2571,17 @@ LogicalResult TargetDataOp::verify() {
   return verifyMapClause(*this, getMapVars(), getMapIterated());
 }
 
+// Adapted from fir.if implementation.
+void TargetDataOp::getSuccessorRegions(
+  mlir::RegionBranchPoint point, 
+  llvm::SmallVectorImpl<::mlir::RegionSuccessor>& regions) {
+  if (!point.isParent()) {
+    regions.push_back(mlir::RegionSuccessor::parent());
+    return;
+  }
+  regions.push_back(mlir::RegionSuccessor(&getRegion()));
+}
+
 //===----------------------------------------------------------------------===//
 // TargetEnterDataOp
 //===----------------------------------------------------------------------===//
@@ -2851,6 +2862,17 @@ LogicalResult TargetOp::verifyRegions() {
   }
 
   return success();
+}
+
+// Copy from `TargetDataOp::getSuccessorRegions`
+void TargetOp::getSuccessorRegions(
+  mlir::RegionBranchPoint point, 
+  llvm::SmallVectorImpl<::mlir::RegionSuccessor>& regions) {
+  if (!point.isParent()) {
+    regions.push_back(mlir::RegionSuccessor::parent());
+    return;
+  }
+  regions.push_back(mlir::RegionSuccessor(&getRegion()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -2576,7 +2576,7 @@ void TargetDataOp::getSuccessorRegions(
   mlir::RegionBranchPoint point, 
   llvm::SmallVectorImpl<::mlir::RegionSuccessor>& regions) {
   if (!point.isParent()) {
-    regions.push_back(mlir::RegionSuccessor::parent());
+    regions.push_back(mlir::RegionSuccessor(getOperation()));
     return;
   }
   regions.push_back(mlir::RegionSuccessor(&getRegion()));
@@ -2869,7 +2869,7 @@ void TargetOp::getSuccessorRegions(
   mlir::RegionBranchPoint point, 
   llvm::SmallVectorImpl<::mlir::RegionSuccessor>& regions) {
   if (!point.isParent()) {
-    regions.push_back(mlir::RegionSuccessor::parent());
+    regions.push_back(mlir::RegionSuccessor(getOperation()));
     return;
   }
   regions.push_back(mlir::RegionSuccessor(&getRegion()));

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -2573,8 +2573,8 @@ LogicalResult TargetDataOp::verify() {
 
 // Adapted from fir.if implementation.
 void TargetDataOp::getSuccessorRegions(
-  mlir::RegionBranchPoint point, 
-  llvm::SmallVectorImpl<::mlir::RegionSuccessor>& regions) {
+    mlir::RegionBranchPoint point,
+    llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
   if (!point.isParent()) {
     regions.push_back(mlir::RegionSuccessor(getOperation()));
     return;
@@ -2866,8 +2866,8 @@ LogicalResult TargetOp::verifyRegions() {
 
 // Copy from `TargetDataOp::getSuccessorRegions`
 void TargetOp::getSuccessorRegions(
-  mlir::RegionBranchPoint point, 
-  llvm::SmallVectorImpl<::mlir::RegionSuccessor>& regions) {
+    mlir::RegionBranchPoint point,
+    llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
   if (!point.isParent()) {
     regions.push_back(mlir::RegionSuccessor(getOperation()));
     return;

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -2575,15 +2575,13 @@ LogicalResult TargetDataOp::verify() {
   return verifyMapClause(*this, getMapVars(), getMapIterated());
 }
 
-// Adapted from scf.if implementation.
 void TargetDataOp::getSuccessorRegions(
-    mlir::RegionBranchPoint point,
-    llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
   if (!point.isParent()) {
-    regions.push_back(mlir::RegionSuccessor(getOperation()));
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
-  regions.push_back(mlir::RegionSuccessor(&getRegion()));
+  regions.push_back(RegionSuccessor(&getRegion()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -2868,23 +2866,21 @@ LogicalResult TargetOp::verifyRegions() {
   return success();
 }
 
-void TargetOp::getSuccessorRegions(
-    mlir::RegionBranchPoint point,
-    llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
+void TargetOp::getSuccessorRegions(RegionBranchPoint point,
+                                   SmallVectorImpl<RegionSuccessor> &regions) {
   if (!point.isParent()) {
-    regions.push_back(mlir::RegionSuccessor(getOperation()));
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
-  regions.push_back(mlir::RegionSuccessor(&getRegion()));
+  regions.push_back(RegionSuccessor(&getRegion()));
 }
 
-OperandRange
-TargetOp::getEntrySuccessorOperands(mlir::RegionSuccessor successor) {
+OperandRange TargetOp::getEntrySuccessorOperands(RegionSuccessor successor) {
   assert(successor.getSuccessor() == &getRegion());
   return getHostEvalVars();
 }
 
-mlir::ValueRange TargetOp::getSuccessorInputs(mlir::RegionSuccessor successor) {
+mlir::ValueRange TargetOp::getSuccessorInputs(RegionSuccessor successor) {
   if (successor.isOperation())
     return {};
   assert(successor == &getRegion());

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/OpenMP/OpenMPClauseOperands.h"
+#include "mlir/Dialect/OpenMP/OpenMPInterfaces.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -22,6 +23,8 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
@@ -44,6 +47,7 @@
 #include "mlir/Dialect/OpenMP/OpenMPOpsEnums.cpp.inc"
 #include "mlir/Dialect/OpenMP/OpenMPOpsInterfaces.cpp.inc"
 #include "mlir/Dialect/OpenMP/OpenMPTypeInterfaces.cpp.inc"
+#include "mlir/Support/LLVM.h"
 
 using namespace mlir;
 using namespace mlir::omp;
@@ -2571,7 +2575,7 @@ LogicalResult TargetDataOp::verify() {
   return verifyMapClause(*this, getMapVars(), getMapIterated());
 }
 
-// Adapted from fir.if implementation.
+// Adapted from scf.if implementation.
 void TargetDataOp::getSuccessorRegions(
     mlir::RegionBranchPoint point,
     llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
@@ -2864,7 +2868,6 @@ LogicalResult TargetOp::verifyRegions() {
   return success();
 }
 
-// Copy from `TargetDataOp::getSuccessorRegions`
 void TargetOp::getSuccessorRegions(
     mlir::RegionBranchPoint point,
     llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
@@ -2873,6 +2876,20 @@ void TargetOp::getSuccessorRegions(
     return;
   }
   regions.push_back(mlir::RegionSuccessor(&getRegion()));
+}
+
+OperandRange
+TargetOp::getEntrySuccessorOperands(mlir::RegionSuccessor successor) {
+  assert(successor.getSuccessor() == &getRegion());
+  return getHostEvalVars();
+}
+
+mlir::ValueRange TargetOp::getSuccessorInputs(mlir::RegionSuccessor successor) {
+  if (successor.isOperation())
+    return {};
+  assert(successor == &getRegion());
+  return mlir::cast<BlockArgOpenMPOpInterface>(getOperation())
+      .getHostEvalBlockArgs();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This adds RegionBranchOpInterface support to `omp.target` and `omp.target_data`, and adds RegionBranchTerminatorOpInterface to `omp.terminator`.

Both `omp.target` and `omp.target_data` contain structured regions whose control flow enters the region and eventually returns to the parent operation. Without RegionBranchOpInterface, generic region-aware data-flow analyses cannot propagate lattice state across these region boundaries.

For example, an analysis that tracks the host and device states of mapped values cannot propagate its state into an `omp.target` region and back to the parent operation after a mapped value is modified and copied out.

Changes:
- Add RegionBranchOpInterface to omp.target.
- Add RegionBranchOpInterface to omp.target_data.
- Add RegionBranchTerminatorOpInterface to omp.terminator.
- Implement the corresponding region successor methods.

This was previously raised on [LLVM Discussion](https://discourse.llvm.org/t/mlir-openmp-should-omp-target-target-data-implement-regionbranchopinterface/91227).

Similar PR: https://github.com/llvm/llvm-project/pull/202418