### PR TITLE
[AMDGPU] Avoid errors with 24-bit div/rem

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -2015,13 +2015,12 @@ SDValue AMDGPUTargetLowering::SplitVectorStore(SDValue Op,
 }
 
 // This is a shortcut for integer division because we have fast i32<->f32
-// conversions, and fast f32 reciprocal instructions. The fractional part of a
-// float is enough to accurately represent up to a 24-bit integer.
-SDValue AMDGPUTargetLowering::LowerDIVREM24(SDValue Op, SelectionDAG &DAG,
-                                            bool Sign) const {
+// conversions, and fast f32 reciprocal instructions.
+SDValue AMDGPUTargetLowering::LowerDIVREMToFloat(SDValue Op, SelectionDAG &DAG,
+                                                 bool Sign) const {
   SDLoc DL(Op);
   EVT VT = Op.getValueType();
-  assert(VT == MVT::i32 && "LowerDIVREM24 expects an i32");
+  assert(VT == MVT::i32 && "LowerDIVREMToFloat expects an i32");
 
   SDValue LHS = Op.getOperand(0);
   SDValue RHS = Op.getOperand(1);
@@ -2038,10 +2037,7 @@ SDValue AMDGPUTargetLowering::LowerDIVREM24(SDValue Op, SelectionDAG &DAG,
   } else {
     KnownBits LHSKnown = DAG.computeKnownBits(LHS);
     KnownBits RHSKnown = DAG.computeKnownBits(RHS);
-    APInt U24Max = APInt::getLowBitsSet(32, 24);
-    if (LHSKnown.getMaxValue().ugt(U24Max) ||
-        RHSKnown.getMaxValue().ugt(U24Max))
-      return SDValue();
+
     LHSSignBits = LHSKnown.countMinLeadingZeros();
     RHSSignBits = RHSKnown.countMinLeadingZeros();
   }
@@ -2051,6 +2047,14 @@ SDValue AMDGPUTargetLowering::LowerDIVREM24(SDValue Op, SelectionDAG &DAG,
   unsigned DivBits = BitSize - SignBits;
   if (Sign)
     ++DivBits;
+
+  // In order to avoid problems due to 1 ulp accuracy issues with v_rcp_f32,
+  // limit LowerDIVREMToFloat to:
+  //   [-0x400000,0x3FFFFF] for Sign
+  //   [ 0x000000,0x3FFFFF] for !Sign
+  // This matches what is done in expandDivRemToFloatImpl.
+  if (DivBits > (Sign ? 23 : 22))
+    return SDValue();
 
   ISD::NodeType ToFp = Sign ? ISD::SINT_TO_FP : ISD::UINT_TO_FP;
   ISD::NodeType ToInt = Sign ? ISD::FP_TO_SINT : ISD::FP_TO_UINT;
@@ -2370,7 +2374,7 @@ SDValue AMDGPUTargetLowering::LowerUDIVREM(SDValue Op,
   }
 
   if (VT == MVT::i32) {
-    if (SDValue Res = LowerDIVREM24(Op, DAG, false))
+    if (SDValue Res = LowerDIVREMToFloat(Op, DAG, false))
       return Res;
   }
 
@@ -2425,7 +2429,7 @@ SDValue AMDGPUTargetLowering::LowerSDIVREM(SDValue Op,
   SDValue NegOne = DAG.getAllOnesConstant(DL, VT);
 
   if (VT == MVT::i32) {
-    if (SDValue Res = LowerDIVREM24(Op, DAG, true))
+    if (SDValue Res = LowerDIVREMToFloat(Op, DAG, true))
       return Res;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
@@ -182,7 +182,7 @@ protected:
   SDValue LowerSTORE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSDIVREM(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerUDIVREM(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerDIVREM24(SDValue Op, SelectionDAG &DAG, bool sign) const;
+  SDValue LowerDIVREMToFloat(SDValue Op, SelectionDAG &DAG, bool sign) const;
   void LowerUDIVREM64(SDValue Op, SelectionDAG &DAG,
                                     SmallVectorImpl<SDValue> &Results) const;
 

--- a/llvm/test/CodeGen/AMDGPU/div-rem-fast-path.ll
+++ b/llvm/test/CodeGen/AMDGPU/div-rem-fast-path.ll
@@ -104,26 +104,38 @@ define amdgpu_kernel void @udiv_i32_and_i24_fast_path(ptr addrspace(1) %out, i32
 ; GFX950-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX950-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX950-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX950-NEXT:    s_load_dword s3, s[4:5], 0x2c
-; GFX950-NEXT:    s_mov_b32 s2, 0xffffff
+; GFX950-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX950-NEXT:    s_mov_b32 s3, 0xffffff
 ; GFX950-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX950-NEXT:    s_and_b32 s5, s3, s2
-; GFX950-NEXT:    s_mov_b32 s3, 1
-; GFX950-NEXT:    s_or_b32 s4, s5, s3
-; GFX950-NEXT:    v_cvt_f32_u32_e64 v2, s5
-; GFX950-NEXT:    v_cvt_f32_u32_e64 v3, s4
-; GFX950-NEXT:    v_rcp_f32_e64 v1, v3
+; GFX950-NEXT:    s_and_b32 s4, s2, s3
+; GFX950-NEXT:    s_mov_b32 s2, 1
+; GFX950-NEXT:    s_or_b32 s5, s4, s2
+; GFX950-NEXT:    s_mov_b32 s3, 0
+; GFX950-NEXT:    s_sub_i32 s3, s3, s5
+; GFX950-NEXT:    v_cvt_f32_u32_e32 v1, s5
+; GFX950-NEXT:    v_rcp_iflag_f32_e32 v1, v1
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_mul_f32_e64 v1, v2, v1
-; GFX950-NEXT:    v_trunc_f32_e64 v1, v1
-; GFX950-NEXT:    v_fma_f32 v2, -v1, v3, v2
-; GFX950-NEXT:    v_cmp_ge_f32_e64 s[6:7], |v2|, |v3|
-; GFX950-NEXT:    s_mov_b32 s4, 0
-; GFX950-NEXT:    s_and_b64 s[6:7], s[6:7], exec
-; GFX950-NEXT:    s_cselect_b32 s3, s3, s4
-; GFX950-NEXT:    v_cvt_u32_f32_e64 v1, v1
-; GFX950-NEXT:    v_add_u32_e64 v1, v1, s3
-; GFX950-NEXT:    v_and_b32_e64 v1, v1, s2
+; GFX950-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
+; GFX950-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_readfirstlane_b32 s6, v1
+; GFX950-NEXT:    s_mul_i32 s6, s3, s6
+; GFX950-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX950-NEXT:    s_mul_hi_u32 s6, s3, s6
+; GFX950-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX950-NEXT:    s_add_i32 s3, s3, s6
+; GFX950-NEXT:    s_mul_hi_u32 s6, s4, s3
+; GFX950-NEXT:    s_add_i32 s3, s6, s2
+; GFX950-NEXT:    s_mul_i32 s7, s6, s5
+; GFX950-NEXT:    s_sub_i32 s7, s4, s7
+; GFX950-NEXT:    s_sub_i32 s4, s7, s5
+; GFX950-NEXT:    s_cmp_ge_u32 s7, s5
+; GFX950-NEXT:    s_cselect_b32 s4, s4, s7
+; GFX950-NEXT:    s_cselect_b32 s3, s3, s6
+; GFX950-NEXT:    s_add_i32 s2, s3, s2
+; GFX950-NEXT:    s_cmp_ge_u32 s4, s5
+; GFX950-NEXT:    s_cselect_b32 s2, s2, s3
+; GFX950-NEXT:    v_mov_b32_e32 v1, s2
 ; GFX950-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX950-NEXT:    s_endpgm
 ;
@@ -135,25 +147,36 @@ define amdgpu_kernel void @udiv_i32_and_i24_fast_path(ptr addrspace(1) %out, i32
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX90A-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX90A-NEXT:    s_load_dword s3, s[4:5], 0x2c
-; GFX90A-NEXT:    s_mov_b32 s2, 0xffffff
+; GFX90A-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX90A-NEXT:    s_mov_b32 s3, 0xffffff
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    s_and_b32 s5, s3, s2
-; GFX90A-NEXT:    s_mov_b32 s3, 1
-; GFX90A-NEXT:    s_or_b32 s4, s5, s3
-; GFX90A-NEXT:    v_cvt_f32_u32_e64 v2, s5
-; GFX90A-NEXT:    v_cvt_f32_u32_e64 v3, s4
-; GFX90A-NEXT:    v_rcp_f32_e64 v1, v3
-; GFX90A-NEXT:    v_mul_f32_e64 v1, v2, v1
-; GFX90A-NEXT:    v_trunc_f32_e64 v1, v1
-; GFX90A-NEXT:    v_mad_f32 v2, -v1, v3, v2
-; GFX90A-NEXT:    v_cmp_ge_f32_e64 s[6:7], |v2|, |v3|
-; GFX90A-NEXT:    s_mov_b32 s4, 0
-; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
-; GFX90A-NEXT:    s_cselect_b32 s3, s3, s4
-; GFX90A-NEXT:    v_cvt_u32_f32_e64 v1, v1
-; GFX90A-NEXT:    v_add_u32_e64 v1, v1, s3
-; GFX90A-NEXT:    v_and_b32_e64 v1, v1, s2
+; GFX90A-NEXT:    s_and_b32 s4, s2, s3
+; GFX90A-NEXT:    s_mov_b32 s2, 1
+; GFX90A-NEXT:    s_or_b32 s5, s4, s2
+; GFX90A-NEXT:    s_mov_b32 s3, 0
+; GFX90A-NEXT:    s_sub_i32 s3, s3, s5
+; GFX90A-NEXT:    v_cvt_f32_u32_e32 v1, s5
+; GFX90A-NEXT:    v_rcp_iflag_f32_e32 v1, v1
+; GFX90A-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
+; GFX90A-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX90A-NEXT:    v_readfirstlane_b32 s6, v1
+; GFX90A-NEXT:    s_mul_i32 s6, s3, s6
+; GFX90A-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX90A-NEXT:    s_mul_hi_u32 s6, s3, s6
+; GFX90A-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX90A-NEXT:    s_add_i32 s3, s3, s6
+; GFX90A-NEXT:    s_mul_hi_u32 s6, s4, s3
+; GFX90A-NEXT:    s_add_i32 s3, s6, s2
+; GFX90A-NEXT:    s_mul_i32 s7, s6, s5
+; GFX90A-NEXT:    s_sub_i32 s7, s4, s7
+; GFX90A-NEXT:    s_sub_i32 s4, s7, s5
+; GFX90A-NEXT:    s_cmp_ge_u32 s7, s5
+; GFX90A-NEXT:    s_cselect_b32 s4, s4, s7
+; GFX90A-NEXT:    s_cselect_b32 s3, s3, s6
+; GFX90A-NEXT:    s_add_i32 s2, s3, s2
+; GFX90A-NEXT:    s_cmp_ge_u32 s4, s5
+; GFX90A-NEXT:    s_cselect_b32 s2, s2, s3
+; GFX90A-NEXT:    v_mov_b32_e32 v1, s2
 ; GFX90A-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX90A-NEXT:    s_endpgm
   %dividend = and i32 %input, u0xffffff
@@ -445,28 +468,36 @@ define amdgpu_kernel void @urem_i32_and_i24_fast_path(ptr addrspace(1) %out, i32
 ; GFX950-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX950-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX950-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX950-NEXT:    s_load_dword s3, s[4:5], 0x2c
-; GFX950-NEXT:    s_mov_b32 s2, 0xffffff
+; GFX950-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX950-NEXT:    s_mov_b32 s3, 0xffffff
 ; GFX950-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX950-NEXT:    s_and_b32 s3, s3, s2
-; GFX950-NEXT:    s_mov_b32 s5, 1
-; GFX950-NEXT:    s_or_b32 s4, s3, s5
-; GFX950-NEXT:    v_cvt_f32_u32_e64 v2, s3
-; GFX950-NEXT:    v_cvt_f32_u32_e64 v3, s4
-; GFX950-NEXT:    v_rcp_f32_e64 v1, v3
+; GFX950-NEXT:    s_and_b32 s2, s2, s3
+; GFX950-NEXT:    s_mov_b32 s3, 1
+; GFX950-NEXT:    s_or_b32 s4, s2, s3
+; GFX950-NEXT:    s_mov_b32 s3, 0
+; GFX950-NEXT:    s_sub_i32 s3, s3, s4
+; GFX950-NEXT:    v_cvt_f32_u32_e32 v1, s4
+; GFX950-NEXT:    v_rcp_iflag_f32_e32 v1, v1
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_mul_f32_e64 v1, v2, v1
-; GFX950-NEXT:    v_trunc_f32_e64 v1, v1
-; GFX950-NEXT:    v_fma_f32 v2, -v1, v3, v2
-; GFX950-NEXT:    v_cmp_ge_f32_e64 s[8:9], |v2|, |v3|
-; GFX950-NEXT:    s_mov_b32 s6, 0
-; GFX950-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX950-NEXT:    s_cselect_b32 s5, s5, s6
-; GFX950-NEXT:    v_cvt_u32_f32_e64 v1, v1
-; GFX950-NEXT:    v_add_u32_e64 v1, v1, s5
-; GFX950-NEXT:    v_mul_lo_u32 v1, v1, s4
-; GFX950-NEXT:    v_sub_u32_e64 v1, s3, v1
-; GFX950-NEXT:    v_and_b32_e64 v1, v1, s2
+; GFX950-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
+; GFX950-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_readfirstlane_b32 s5, v1
+; GFX950-NEXT:    s_mul_i32 s5, s3, s5
+; GFX950-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX950-NEXT:    s_mul_hi_u32 s5, s3, s5
+; GFX950-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX950-NEXT:    s_add_i32 s3, s3, s5
+; GFX950-NEXT:    s_mul_hi_u32 s3, s2, s3
+; GFX950-NEXT:    s_mul_i32 s3, s3, s4
+; GFX950-NEXT:    s_sub_i32 s3, s2, s3
+; GFX950-NEXT:    s_sub_i32 s2, s3, s4
+; GFX950-NEXT:    s_cmp_ge_u32 s3, s4
+; GFX950-NEXT:    s_cselect_b32 s3, s2, s3
+; GFX950-NEXT:    s_sub_i32 s2, s3, s4
+; GFX950-NEXT:    s_cmp_ge_u32 s3, s4
+; GFX950-NEXT:    s_cselect_b32 s2, s2, s3
+; GFX950-NEXT:    v_mov_b32_e32 v1, s2
 ; GFX950-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX950-NEXT:    s_endpgm
 ;
@@ -478,27 +509,34 @@ define amdgpu_kernel void @urem_i32_and_i24_fast_path(ptr addrspace(1) %out, i32
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX90A-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX90A-NEXT:    s_load_dword s3, s[4:5], 0x2c
-; GFX90A-NEXT:    s_mov_b32 s2, 0xffffff
+; GFX90A-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX90A-NEXT:    s_mov_b32 s3, 0xffffff
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    s_and_b32 s3, s3, s2
-; GFX90A-NEXT:    s_mov_b32 s5, 1
-; GFX90A-NEXT:    s_or_b32 s4, s3, s5
-; GFX90A-NEXT:    v_cvt_f32_u32_e64 v2, s3
-; GFX90A-NEXT:    v_cvt_f32_u32_e64 v3, s4
-; GFX90A-NEXT:    v_rcp_f32_e64 v1, v3
-; GFX90A-NEXT:    v_mul_f32_e64 v1, v2, v1
-; GFX90A-NEXT:    v_trunc_f32_e64 v1, v1
-; GFX90A-NEXT:    v_mad_f32 v2, -v1, v3, v2
-; GFX90A-NEXT:    v_cmp_ge_f32_e64 s[8:9], |v2|, |v3|
-; GFX90A-NEXT:    s_mov_b32 s6, 0
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX90A-NEXT:    s_cselect_b32 s5, s5, s6
-; GFX90A-NEXT:    v_cvt_u32_f32_e64 v1, v1
-; GFX90A-NEXT:    v_add_u32_e64 v1, v1, s5
-; GFX90A-NEXT:    v_mul_lo_u32 v1, v1, s4
-; GFX90A-NEXT:    v_sub_u32_e64 v1, s3, v1
-; GFX90A-NEXT:    v_and_b32_e64 v1, v1, s2
+; GFX90A-NEXT:    s_and_b32 s2, s2, s3
+; GFX90A-NEXT:    s_mov_b32 s3, 1
+; GFX90A-NEXT:    s_or_b32 s4, s2, s3
+; GFX90A-NEXT:    s_mov_b32 s3, 0
+; GFX90A-NEXT:    s_sub_i32 s3, s3, s4
+; GFX90A-NEXT:    v_cvt_f32_u32_e32 v1, s4
+; GFX90A-NEXT:    v_rcp_iflag_f32_e32 v1, v1
+; GFX90A-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
+; GFX90A-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX90A-NEXT:    v_readfirstlane_b32 s5, v1
+; GFX90A-NEXT:    s_mul_i32 s5, s3, s5
+; GFX90A-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX90A-NEXT:    s_mul_hi_u32 s5, s3, s5
+; GFX90A-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX90A-NEXT:    s_add_i32 s3, s3, s5
+; GFX90A-NEXT:    s_mul_hi_u32 s3, s2, s3
+; GFX90A-NEXT:    s_mul_i32 s3, s3, s4
+; GFX90A-NEXT:    s_sub_i32 s3, s2, s3
+; GFX90A-NEXT:    s_sub_i32 s2, s3, s4
+; GFX90A-NEXT:    s_cmp_ge_u32 s3, s4
+; GFX90A-NEXT:    s_cselect_b32 s3, s2, s3
+; GFX90A-NEXT:    s_sub_i32 s2, s3, s4
+; GFX90A-NEXT:    s_cmp_ge_u32 s3, s4
+; GFX90A-NEXT:    s_cselect_b32 s2, s2, s3
+; GFX90A-NEXT:    v_mov_b32_e32 v1, s2
 ; GFX90A-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX90A-NEXT:    s_endpgm
   %dividend = and i32 %input, u0xffffff

--- a/llvm/test/CodeGen/AMDGPU/sdiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv.ll
@@ -2010,43 +2010,53 @@ define amdgpu_kernel void @v_sdiv_i24(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @6
-; EG-NEXT:    ALU 29, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 39, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_8 T1.X, T0.X, 6, #1
 ; EG-NEXT:     VTX_READ_16 T2.X, T0.X, 0, #1
-; EG-NEXT:     VTX_READ_16 T3.X, T0.X, 4, #1
-; EG-NEXT:     VTX_READ_8 T0.X, T0.X, 2, #1
+; EG-NEXT:     VTX_READ_8 T3.X, T0.X, 2, #1
+; EG-NEXT:     VTX_READ_16 T0.X, T0.X, 4, #1
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
 ; EG-NEXT:     BFE_INT * T0.W, T1.X, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHL * T1.W, PV.W, literal.x,
+; EG-NEXT:     LSHL * T0.W, PV.W, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T2.W, T0.X, 0.0, literal.x,
-; EG-NEXT:     OR_INT * T1.W, T3.X, PV.W,
+; EG-NEXT:     OR_INT * T0.W, T0.X, PV.W,
+; EG-NEXT:     SETGT_INT * T1.W, 0.0, PV.W,
+; EG-NEXT:     BFE_INT T2.W, T3.X, 0.0, literal.x,
+; EG-NEXT:     ADD_INT * T0.W, T0.W, PV.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHL T3.W, PV.W, literal.x,
-; EG-NEXT:     INT_TO_FLT * T0.X, PS,
+; EG-NEXT:     LSHL T2.W, PV.W, literal.x,
+; EG-NEXT:     XOR_INT * T0.W, PS, T1.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     OR_INT T1.W, T2.X, PV.W,
-; EG-NEXT:     RECIP_IEEE * T0.Y, PS,
-; EG-NEXT:     INT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T1.W, PS, T0.Y,
-; EG-NEXT:     TRUNC T1.W, PV.W,
-; EG-NEXT:     XOR_INT * T0.W, T2.W, T0.W,
-; EG-NEXT:     ASHR T0.W, PS, literal.x,
-; EG-NEXT:     MULADD_IEEE * T2.W, -PV.W, T0.X, T0.Z,
-; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
-; EG-NEXT:     TRUNC T0.Z, T1.W,
-; EG-NEXT:     SETGE T1.W, |PS|, |T0.X|,
-; EG-NEXT:     OR_INT * T0.W, PV.W, 1,
-; EG-NEXT:     CNDE T0.W, PV.W, 0.0, PS,
-; EG-NEXT:     FLT_TO_INT * T1.W, PV.Z,
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, 0.0, PS,
+; EG-NEXT:     OR_INT T2.W, T2.X, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.X, PS,
+; EG-NEXT:     SETGT_INT T3.W, 0.0, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PV.Z, PS,
+; EG-NEXT:     ADD_INT T2.W, T2.W, PV.W,
+; EG-NEXT:     MULHI * T0.Y, T0.X, PS,
+; EG-NEXT:     ADD_INT T4.W, T0.X, PS,
+; EG-NEXT:     XOR_INT * T2.W, PV.W, T3.W,
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T2.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T4.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T5.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T2.W, PV.W, T2.W, PS,
+; EG-NEXT:     CNDE_INT * T4.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T5.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.W, PS, T4.W, PV.W, BS:VEC_102/SCL_221
+; EG-NEXT:     XOR_INT * T1.W, T3.W, T1.W,
+; EG-NEXT:     XOR_INT * T0.W, PV.W, PS,
+; EG-NEXT:     SUB_INT * T0.W, PV.W, T1.W,
 ; EG-NEXT:     LSHL * T0.W, PV.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     ASHR T0.X, PV.W, literal.x,

--- a/llvm/test/CodeGen/AMDGPU/sdivrem24.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdivrem24.ll
@@ -43,10 +43,8 @@ define amdgpu_kernel void @sdiv24_i16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; FUNC-LABEL: {{^}}sdiv24_i32:
 ; SI-NOT: v_cvt_i32_f32
 
-; EG: INT_TO_FLT
-; EG-DAG: INT_TO_FLT
-; EG-DAG: RECIP_IEEE
-; EG: FLT_TO_INT
+; EG-NOT: INT_TO_FLT
+; EG-NOT: RECIP_IEEE
 define amdgpu_kernel void @sdiv24_i32(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
@@ -155,10 +153,8 @@ define amdgpu_kernel void @srem24_i16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; FUNC-LABEL: {{^}}srem24_i32:
 ; SI-NOT: v_cvt_i32_f32
 
-; EG: INT_TO_FLT
-; EG-DAG: INT_TO_FLT
-; EG-DAG: RECIP_IEEE
-; EG: FLT_TO_INT
+; EG-NOT: INT_TO_FLT
+; EG-NOT: RECIP_IEEE
 define amdgpu_kernel void @srem24_i32(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
@@ -265,8 +261,8 @@ define amdgpu_kernel void @no_srem25_i25_i24_i32(ptr addrspace(1) %out, ptr addr
 ; FUNC-LABEL: {{^}}srem25_i24_i11_i32:
 ; SI-NOT: v_cvt_f32_i32
 
-; EG: INT_TO_FLT
-; EG: RECIP_IEEE
+; EG-NOT: INT_TO_FLT
+; EG-NOT: RECIP_IEEE
 define amdgpu_kernel void @srem25_i24_i11_i32(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
@@ -283,8 +279,8 @@ define amdgpu_kernel void @srem25_i24_i11_i32(ptr addrspace(1) %out, ptr addrspa
 ; FUNC-LABEL: {{^}}srem25_i11_i24_i32:
 ; SI-NOT: v_cvt_f32_i32
 
-; EG: INT_TO_FLT
-; EG: RECIP_IEEE
+; EG-NOT: INT_TO_FLT
+; EG-NOT: RECIP_IEEE
 define amdgpu_kernel void @srem25_i11_i24_i32(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4

--- a/llvm/test/CodeGen/AMDGPU/sdivrem64.r600.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdivrem64.r600.ll
@@ -100,29 +100,29 @@ define amdgpu_kernel void @test_srem3264(ptr addrspace(1) %out, i64 %x, i64 %y) 
   ret void
 }
 
-;EG-LABEL: {{^}}test_sdiv2464:
+;EG-LABEL: {{^}}test_sdiv2364:
 ;EG: INT_TO_FLT
 ;EG: INT_TO_FLT
 ;EG: FLT_TO_INT
 ;EG-NOT: RECIP_UINT
 ;EG-NOT: BFE_UINT
-define amdgpu_kernel void @test_sdiv2464(ptr addrspace(1) %out, i64 %x, i64 %y) {
-  %1 = ashr i64 %x, 40
-  %2 = ashr i64 %y, 40
+define amdgpu_kernel void @test_sdiv2364(ptr addrspace(1) %out, i64 %x, i64 %y) {
+  %1 = ashr i64 %x, 41
+  %2 = ashr i64 %y, 41
   %result = sdiv i64 %1, %2
   store i64 %result, ptr addrspace(1) %out
   ret void
 }
 
-;EG-LABEL: {{^}}test_srem2464:
+;EG-LABEL: {{^}}test_srem2364:
 ;EG: INT_TO_FLT
 ;EG: INT_TO_FLT
 ;EG: FLT_TO_INT
 ;EG-NOT: RECIP_UINT
 ;EG-NOT: BFE_UINT
-define amdgpu_kernel void @test_srem2464(ptr addrspace(1) %out, i64 %x, i64 %y) {
-  %1 = ashr i64 %x, 40
-  %2 = ashr i64 %y, 40
+define amdgpu_kernel void @test_srem2364(ptr addrspace(1) %out, i64 %x, i64 %y) {
+  %1 = ashr i64 %x, 41
+  %2 = ashr i64 %y, 41
   %result = srem i64 %1, %2
   store i64 %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/udiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/udiv.ll
@@ -1861,7 +1861,7 @@ define amdgpu_kernel void @v_udiv_i23(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @6
-; EG-NEXT:    ALU 20, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 23, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -1875,25 +1875,28 @@ define amdgpu_kernel void @v_udiv_i23(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:    ALU clause starting at 15:
 ; EG-NEXT:     LSHL * T0.W, T1.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     OR_INT T0.W, T0.X, PV.W,
-; EG-NEXT:     LSHL * T1.W, T3.X, literal.x,
+; EG-NEXT:     OR_INT * T0.W, T0.X, PV.W,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.X, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PV.W, PS,
+; EG-NEXT:     LSHL T1.W, T3.X, literal.x,
+; EG-NEXT:     MULHI * T0.Y, T0.X, PS,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.X, PV.W,
-; EG-NEXT:     OR_INT T0.W, T2.X, T1.W,
-; EG-NEXT:     RECIP_IEEE * T0.Y, PS,
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.Y,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.X, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.X,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    8388607(1.175494e-38), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT T2.W, T0.X, PS,
+; EG-NEXT:     OR_INT * T1.W, T2.X, PV.W,
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T1.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i23, ptr addrspace(1) %in, i23 1
   %num = load i23, ptr addrspace(1) %in
   %den = load i23, ptr addrspace(1) %den_ptr
@@ -2107,7 +2110,7 @@ define amdgpu_kernel void @v_udiv_i24(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @6
-; EG-NEXT:    ALU 20, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 23, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -2121,25 +2124,28 @@ define amdgpu_kernel void @v_udiv_i24(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:    ALU clause starting at 15:
 ; EG-NEXT:     LSHL * T0.W, T1.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     OR_INT T0.W, T0.X, PV.W,
-; EG-NEXT:     LSHL * T1.W, T3.X, literal.x,
+; EG-NEXT:     OR_INT * T0.W, T0.X, PV.W,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.X, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PV.W, PS,
+; EG-NEXT:     LSHL T1.W, T3.X, literal.x,
+; EG-NEXT:     MULHI * T0.Y, T0.X, PS,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.X, PV.W,
-; EG-NEXT:     OR_INT T0.W, T2.X, T1.W,
-; EG-NEXT:     RECIP_IEEE * T0.Y, PS,
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.Y,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.X, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.X,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    16777215(2.350989e-38), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT T2.W, T0.X, PS,
+; EG-NEXT:     OR_INT * T1.W, T2.X, PV.W,
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T1.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i24, ptr addrspace(1) %in, i24 1
   %num = load i24, ptr addrspace(1) %in
   %den = load i24, ptr addrspace(1) %den_ptr

--- a/llvm/test/CodeGen/AMDGPU/udivrem24.ll
+++ b/llvm/test/CodeGen/AMDGPU/udivrem24.ll
@@ -573,7 +573,7 @@ define amdgpu_kernel void @udiv23_i32(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -584,23 +584,26 @@ define amdgpu_kernel void @udiv23_i32(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    8388607(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Y, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T0.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    8388607(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.X,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.Y, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.Y,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    8388607(1.175494e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4
@@ -688,7 +691,7 @@ define amdgpu_kernel void @udiv24_i32(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -699,23 +702,26 @@ define amdgpu_kernel void @udiv24_i32(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    16777215(2.350989e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Y, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T0.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    16777215(2.350989e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.X,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.Y, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.Y,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    16777215(2.350989e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4
@@ -803,7 +809,7 @@ define amdgpu_kernel void @no_udiv24_u23_u24_i32(ptr addrspace(1) %out, ptr addr
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -814,23 +820,26 @@ define amdgpu_kernel void @no_udiv24_u23_u24_i32(ptr addrspace(1) %out, ptr addr
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    16777215(2.350989e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Y, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T0.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    8388607(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.X,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.Y, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.Y,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    16777215(2.350989e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4
@@ -918,7 +927,7 @@ define amdgpu_kernel void @no_udiv24_u24_u23_i32(ptr addrspace(1) %out, ptr addr
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -929,23 +938,26 @@ define amdgpu_kernel void @no_udiv24_u24_u23_i32(ptr addrspace(1) %out, ptr addr
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    8388607(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Y, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T0.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    16777215(2.350989e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.X,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.Y, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.Y,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    16777215(2.350989e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4
@@ -1591,7 +1603,7 @@ define amdgpu_kernel void @urem24_i32(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 20, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 19, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -1602,25 +1614,24 @@ define amdgpu_kernel void @urem24_i32(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    16777215(2.350989e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T1.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    16777215(2.350989e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.W, PV.W,
-; EG-NEXT:     MUL_IEEE * T1.W, PS, T1.X,
-; EG-NEXT:     TRUNC * T1.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T0.W, -PV.W, T0.Z, T0.W,
-; EG-NEXT:     TRUNC * T1.W, PV.W,
-; EG-NEXT:     SETGE * T0.W, |PV.W|, T0.Z,
-; EG-NEXT:     CNDE T0.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.Z, T1.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     MULLO_INT * T0.Y, PV.W, T0.Y,
-; EG-NEXT:     SUB_INT * T0.W, T0.X, PS,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    16777215(2.350989e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.X, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT * T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PV.W, T1.W, PS,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4
@@ -2038,7 +2049,7 @@ define amdgpu_kernel void @test_udiv24_u16_u23_i32(ptr addrspace(1) %out, ptr ad
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -2049,23 +2060,26 @@ define amdgpu_kernel void @test_udiv24_u16_u23_i32(ptr addrspace(1) %out, ptr ad
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    8388607(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Y, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T0.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.X,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.Y, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.Y,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    8388607(1.175494e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4
@@ -2153,7 +2167,7 @@ define amdgpu_kernel void @test_udiv24_u23_u16_i32(ptr addrspace(1) %out, ptr ad
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
@@ -2164,23 +2178,26 @@ define amdgpu_kernel void @test_udiv24_u23_u16_i32(ptr addrspace(1) %out, ptr ad
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     AND_INT * T0.W, T0.Y, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Y, PV.W,
-; EG-NEXT:     AND_INT T0.W, T0.X, literal.x,
-; EG-NEXT:     RECIP_IEEE * T0.X, PS,
+; EG-NEXT:     SUB_INT T1.W, 0.0, PV.W,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.W, PS,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T1.W, T0.Y, PS,
+; EG-NEXT:     AND_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    8388607(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     UINT_TO_FLT * T0.Z, PV.W,
-; EG-NEXT:     MUL_IEEE * T0.W, PS, T0.X,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     MULADD_IEEE T1.W, -PV.W, T0.Y, T0.Z,
-; EG-NEXT:     TRUNC * T0.W, PV.W,
-; EG-NEXT:     SETGE * T1.W, |PV.W|, T0.Y,
-; EG-NEXT:     CNDE T1.W, PV.W, 0.0, literal.x,
-; EG-NEXT:     FLT_TO_UINT * T0.X, T0.W,
-; EG-NEXT:    1(1.401298e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, PS, PV.W,
-; EG-NEXT:     AND_INT T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
-; EG-NEXT:    8388607(1.175494e-38), 2(2.802597e-45)
+; EG-NEXT:     MULHI * T0.X, PS, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T0.W,
+; EG-NEXT:     SUB_INT * T1.W, T2.W, PS,
+; EG-NEXT:     ADD_INT T0.Z, T0.X, 1,
+; EG-NEXT:     SETGE_UINT T2.W, PV.W, T0.W,
+; EG-NEXT:     SUB_INT * T3.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T1.W, PV.W, T1.W, PS,
+; EG-NEXT:     CNDE_INT * T2.W, PV.W, T0.X, PV.Z,
+; EG-NEXT:     ADD_INT T3.W, PS, 1,
+; EG-NEXT:     SETGE_UINT * T0.W, PV.W, T0.W,
+; EG-NEXT:     CNDE_INT T0.X, PS, T2.W, PV.W,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %den_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
   %num = load i32, ptr addrspace(1) %in, align 4
   %den = load i32, ptr addrspace(1) %den_ptr, align 4

--- a/llvm/test/CodeGen/AMDGPU/udivrem64.r600.ll
+++ b/llvm/test/CodeGen/AMDGPU/udivrem64.r600.ll
@@ -100,29 +100,29 @@ define amdgpu_kernel void @test_urem3264(ptr addrspace(1) %out, i64 %x, i64 %y) 
   ret void
 }
 
-;EG-LABEL: {{^}}test_udiv2364:
+;EG-LABEL: {{^}}test_udiv2264:
 ;EG: UINT_TO_FLT
 ;EG: UINT_TO_FLT
 ;EG: FLT_TO_UINT
 ;EG-NOT: RECIP_UINT
 ;EG-NOT: BFE_UINT
-define amdgpu_kernel void @test_udiv2364(ptr addrspace(1) %out, i64 %x, i64 %y) {
-  %1 = lshr i64 %x, 41
-  %2 = lshr i64 %y, 41
+define amdgpu_kernel void @test_udiv2264(ptr addrspace(1) %out, i64 %x, i64 %y) {
+  %1 = lshr i64 %x, 42
+  %2 = lshr i64 %y, 42
   %result = udiv i64 %1, %2
   store i64 %result, ptr addrspace(1) %out
   ret void
 }
 
-;EG-LABEL: {{^}}test_urem2364:
+;EG-LABEL: {{^}}test_urem2264:
 ;EG: UINT_TO_FLT
 ;EG: UINT_TO_FLT
 ;EG: FLT_TO_UINT
 ;EG-NOT: RECIP_UINT
 ;EG-NOT: BFE_UINT
-define amdgpu_kernel void @test_urem2364(ptr addrspace(1) %out, i64 %x, i64 %y) {
-  %1 = lshr i64 %x, 41
-  %2 = lshr i64 %y, 41
+define amdgpu_kernel void @test_urem2264(ptr addrspace(1) %out, i64 %x, i64 %y) {
+  %1 = lshr i64 %x, 42
+  %2 = lshr i64 %y, 42
   %result = urem i64 %1, %2
   store i64 %result, ptr addrspace(1) %out
   ret void


### PR DESCRIPTION
Avoid errors when using floating-point reciprocal to calculate Y/X when Y = (0x7FFFFF/X)*X-1.  Limit expansion to 23-bit signed and 22-bit unsigned to avoid this issue.

This change is analogous to the change done in https://github.com/llvm/llvm-project/pull/202753, but in AMDGPUISelLowering.cpp.