### PR TITLE
[NFC][BoundsSafety] Re-order some checks in `Sema::CheckCountedByAttrOnField`

### DIFF
--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -103,7 +103,7 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
   // only `PointeeTy->isStructureTypeWithFlexibleArrayMember()` is reachable
   // when `FieldTy->isArrayType()`.
   bool ShouldWarn = false;
-  if (PointeeTy->isAlwaysIncompleteType() && !CountInBytes) {
+  if (!CountInBytes && PointeeTy->isAlwaysIncompleteType()) {
     // In general using `counted_by` or `counted_by_or_null` on
     // pointers where the pointee is an incomplete type are problematic. This is
     // because it isn't possible to compute the pointer's bounds without knowing
@@ -152,8 +152,8 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::SIZELESS;
   } else if (PointeeTy->isFunctionType()) {
     InvalidTypeKind = CountedByInvalidPointeeTypeKind::FUNCTION;
-  } else if (PointeeTy->isStructureTypeWithFlexibleArrayMember() &&
-             !CountInBytes) {
+  } else if (!CountInBytes &&
+             PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
     if (FieldTy->isArrayType() && !getLangOpts().BoundsSafety) {
       // This is a workaround for the Linux kernel that has already adopted
       // `counted_by` on a FAM where the pointee is a struct with a FAM. This


### PR DESCRIPTION
This is post-merge feedback for #209603
(4b455a91141d59ace3a29870c885f5f5e4ff0506).