### PR TITLE
[DebugInfo][NFC] Fix PDB/Native/LinePrinter.h build warning -Wmicrosoft-unqualified-friend

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/Native/LinePrinter.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/LinePrinter.h
@@ -47,9 +47,10 @@ namespace pdb {
 class ClassLayout;
 class PDBFile;
 class SymbolGroup;
+class WithColor;
 
 class LinePrinter {
-  friend class WithColor;
+  friend class pdb::WithColor;
 
 public:
   LLVM_ABI LinePrinter(int Indent, bool UseColor, raw_ostream &Stream,


### PR DESCRIPTION
Fix build warning on Windows, which is error under -Werror: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft-unqualified-friend]