### PR TITLE
[mlir][ods] Fix string interpolation at end of description

### DIFF
--- a/mlir/lib/TableGen/CodeGenHelpers.cpp
+++ b/mlir/lib/TableGen/CodeGenHelpers.cpp
@@ -157,18 +157,16 @@ std::string mlir::tblgen::buildErrorStreamingString(
 
     os << " << " << tgfmt(var, &ctx);
 
-    if (rest.empty())
-      break;
-
-    split = rest.split("{{");
-    if (split.second.empty() &&
-        errorStreamType == ErrorStreamType::InsideOpError) {
+    if (errorStreamType == ErrorStreamType::InsideOpError) {
       // To enable having part of string post, this adds a parenthesis before
       // the last string segment to match the existing one.
-      os << " << (\"" << split.first;
+      os << " << (\"";
     } else {
-      os << " << \"" << split.first;
+      os << " << \"";
     }
+
+    split = rest.split("{{");
+    os << split.first;
     msg = split.second;
   }
 

--- a/mlir/test/mlir-tblgen/constraint-unique.td
+++ b/mlir/test/mlir-tblgen/constraint-unique.td
@@ -17,7 +17,7 @@ def OtherType : Type<ATypePred, "another type">;
 
 def AnAttrPred : CPred<"attrPred($_self, $_op)">;
 def AnAttr : Attr<AnAttrPred, "an attribute (got {{reformat($_self)}})">;
-def OtherAttr : Attr<AnAttrPred, "another attribute">;
+def OtherAttr : Attr<AnAttrPred, "another attribute {{reformat($_self)}}">;
 
 def ASuccessorPred : CPred<"successorPred($_self, $_op)">;
 def ASuccessor : Successor<ASuccessorPred, "a successor">;
@@ -81,7 +81,7 @@ def OpC : NS_Op<"op_c"> {
 // CHECK:    static ::llvm::LogicalResult [[$O_ATTR_CONSTRAINT:__mlir_ods_local_attr_constraint.*]](
 // CHECK:      if (attr && !((attrPred(attr, *op))))
 // CHECK-NEXT:   return emitError() << "attribute '" << attrName
-// CHECK-NEXT:       << "' failed to satisfy constraint: another attribute";
+// CHECK-NEXT:       << "' failed to satisfy constraint: another attribute " << reformat(attr) << "";
 
 /// Test that a successor contraint was generated.
 // CHECK:    static ::llvm::LogicalResult [[$A_SUCCESSOR_CONSTRAINT:__mlir_ods_local_successor_constraint.*]](


### PR DESCRIPTION
Updates the error streaming string logic to handle the case where string interpolation used at the end of the description. Previously this could generate malformed code that would not compile e.g.:
```
"' failed to satisfy constraint: another attribute " << reformat(attr)";
```
With this change the above example would now generate:
```
"' failed to satisfy constraint: another attribute " << reformat(attr) << "";
```