### PR TITLE
[lldb][bazel] Add PlatformWasm plugin library to the Bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -716,6 +716,38 @@ cc_library(
     ],
 )
 
+gentbl_cc_library(
+    name = "PlatformWasmProperties",
+    strip_include_prefix = "Platform/WebAssembly",
+    tbl_outs = {
+        "Platform/WebAssembly/PlatformWasmProperties.inc": ["-gen-lldb-property-defs"],
+        "Platform/WebAssembly/PlatformWasmPropertiesEnum.inc": ["-gen-lldb-property-enum-defs"],
+    },
+    tblgen = "//lldb:lldb-tblgen",
+    td_file = "Platform/WebAssembly/PlatformWasmProperties.td",
+    deps = ["//lldb:CoreTdFiles"],
+)
+
+cc_library(
+    name = "PluginPlatformWasm",
+    srcs = glob(["Platform/WebAssembly/*.cpp"]),
+    hdrs = glob(["Platform/WebAssembly/*.h"]),
+    includes = [".."],
+    deps = [
+        ":PlatformWasmProperties",
+        ":PluginPlatformGDB",
+        ":PluginProcessWasm",
+        "//lldb:Core",
+        "//lldb:CoreHeaders",
+        "//lldb:Headers",
+        "//lldb:Host",
+        "//lldb:Target",
+        "//lldb:TargetHeaders",
+        "//lldb:Utility",
+        "//llvm:Support",
+    ],
+)
+
 cc_library(
     name = "PluginPlatformGDB",
     srcs = glob(["Platform/gdb-server/*.cpp"]),


### PR DESCRIPTION
Adds the PluginPlatformWasm cc_library plus its PlatformWasmProperties gentbl_cc_library (settings .td, modeled on PlatformQemuUserProperties) to the lldb Bazel overlay. Deps mirror
source/Plugins/Platform/WebAssembly/CMakeLists.txt (lldbCore, lldbHost, lldbTarget, lldbUtility, Support) plus the :PluginPlatformGDB and :PluginProcessWasm plugin deps its GDB-remote/Web-Inspector sources use. The library is intentionally left out of DEFAULT_PLUGINS.

bazel rule assisted with: claude

Can confirm this library will convert to BUCK internally at Meta and build with buck2 where we do have in the default plugin list. I left it out here, unless there's a desire to add it in.