### PR TITLE
[compiler-rt] Fix asan_interceptors.cpp build warning -Wunused-template

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -178,6 +178,7 @@ DECLARE_REAL_AND_INTERCEPTOR(void, free, void*)
       *begin = *end = 0;                               \
     }
 
+#  if SANITIZER_INTERCEPT_MMAP
 template <class Mmap>
 static void* mmap_interceptor(Mmap real_mmap, void* addr, SIZE_T length,
                               int prot, int flags, int fd, OFF64_T offset) {
@@ -243,6 +244,7 @@ static int munmap_interceptor(Munmap real_munmap, void* addr, SIZE_T length) {
   }
   return real_munmap(addr, length);
 }
+#  endif  // SANITIZER_INTERCEPT_MMAP
 
 #  define COMMON_INTERCEPTOR_MMAP_IMPL(ctx, mmap, addr, length, prot, flags, \
                                        fd, offset)                           \


### PR DESCRIPTION
mmap_interceptor/munmap_interceptor template functions are instantiated in sanitizer_common_interceptors.inc only under `#if SANITIZER_INTERCEPT_MMAP`. Fix `unused function template 'mmap_interceptor'` warning on Windows, which is error under -Werror.