### PR TITLE
[orc-rt] Fix WrapperFunctionBuffer empty range construction

### DIFF
--- a/orc-rt/include/orc-rt-c/WrapperFunction.h
+++ b/orc-rt/include/orc-rt-c/WrapperFunction.h
@@ -101,11 +101,13 @@ static inline orc_rt_WrapperFunctionBuffer
 orc_rt_CreateWrapperFunctionBufferFromRange(const char *Data, size_t Size) {
   orc_rt_WrapperFunctionBuffer B;
   B.Size = Size;
+  // If Size is 0 ValuePtr must be 0 or it is considered an out-of-band error.
+  B.Data.ValuePtr = 0;
   if (B.Size > sizeof(B.Data.Value)) {
     char *Tmp = (char *)malloc(Size);
     memcpy(Tmp, Data, Size);
     B.Data.ValuePtr = Tmp;
-  } else
+  } else if (Size != 0)
     memcpy(B.Data.Value, Data, Size);
   return B;
 }

--- a/orc-rt/test/unit/WrapperFunctionBufferTest.cpp
+++ b/orc-rt/test/unit/WrapperFunctionBufferTest.cpp
@@ -45,6 +45,12 @@ TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromRange) {
   EXPECT_EQ(B.getOutOfBandError(), nullptr);
 }
 
+TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromEmptyRangeIsEmpty) {
+  const char *Empty = "";
+  auto B = WrapperFunctionBuffer::copyFrom(Empty, 0);
+  EXPECT_TRUE(B.empty());
+}
+
 TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromCString) {
   auto B = WrapperFunctionBuffer::copyFrom(TestString);
   EXPECT_EQ(B.size(), strlen(TestString) + 1);


### PR DESCRIPTION
orc_rt_CreateWrapperFunctionBufferFromRange(const char *, size_t) left the constructed buffer's data member uninitialized when the size argument was zero. This could result in the returned buffer having a non-null data field and a zero size field, which is a (malformed) out-of-band error value, not an empty buffer.

Update orc_rt_CreateWrapperFunctionBufferFromRange to zero-initialize the data field so that the size == 0 case yields a correctly formed empty buffer.