### PR TITLE
[lldb][Windows] Enforce Python 3.11

### DIFF
--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -68,9 +68,8 @@ else()
 endif()
 
 if (WIN32)
-  set(LLDB_RECOMMENDED_PYTHON "3.11")
-  if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
-    message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
-                    "is recommended and will be required from LLDB 24.")
+  set(LLDB_REQUIRED_PYTHON "3.11")
+  if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_REQUIRED_PYTHON}")
+    message(ERROR "Using Python ${Python3_VERSION}. Python ${LLDB_REQUIRED_PYTHON}+ is required.")
   endif()
 endif()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/191159 recommended Python 3.11 or later. Now that llvm 23 has branched, we can enforce Python 3.11 as the minimum requirement.