### PR TITLE
[libc][bazel] Add missing hdr/*_macros deps to test targets

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
@@ -56,6 +56,7 @@ libc_test(
         "//libc:feraiseexcept",
         "//libc:fetestexcept",
         "//libc:hdr_fenv_macros",
+        "//libc:hdr_signal_macros",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
@@ -239,6 +239,7 @@ libc_test_library(
         "//libc:__support_macros_attributes",
         "//libc:__support_macros_properties_os",
         "//libc:hdr_stdint_proxy",
+        "//libc:hdr_sys_mman_macros",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/mman/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/mman/BUILD.bazel
@@ -43,6 +43,7 @@ libc_test(
         "//libc:__support_osutil_syscall",
         "//libc:getrlimit",
         "//libc:hdr_sys_mman_macros",
+        "//libc:hdr_sys_resource_macros",
         "//libc:madvise",
         "//libc:mincore",
         "//libc:mlock",
@@ -73,6 +74,7 @@ libc_test(
     name = "mprotect_test",
     srcs = ["linux/mprotect_test.cpp"],
     deps = [
+        "//libc:hdr_signal_macros",
         "//libc:hdr_sys_mman_macros",
         "//libc:mmap",
         "//libc:mprotect",
@@ -141,6 +143,7 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:hdr_sys_mman_macros",
+        "//libc:hdr_sys_stat_macros",
         "//libc:mmap",
         "//libc:munmap",
         "//libc:open",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/resource/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/resource/BUILD.bazel
@@ -17,8 +17,11 @@ libc_test(
         "//libc:__support_cpp_string_view",
         "//libc:close",
         "//libc:getrlimit",
+        "//libc:hdr_sys_resource_macros",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:setrlimit",
+        "//libc:types_struct_rlimit",
         "//libc:unlink",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -66,6 +66,7 @@ libc_test(
     deps = [
         "//libc:__support_cpp_scope",
         "//libc:close",
+        "//libc:hdr_sys_socket_macros",
         "//libc:recvfrom",
         "//libc:sendto",
         "//libc:socketpair",
@@ -106,6 +107,7 @@ libc_test(
     deps = [
         "//libc:__support_cpp_scope",
         "//libc:close",
+        "//libc:hdr_sys_socket_macros",
         "//libc:socket",
     ],
 )
@@ -138,6 +140,7 @@ libc_test(
     deps = [
         "//libc:__support_cpp_scope",
         "//libc:close",
+        "//libc:hdr_sys_socket_macros",
         "//libc:socketpair",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
@@ -16,6 +16,7 @@ libc_test(
     deps = [
         "//libc:access",
         "//libc:close",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:unlink",
     ],
@@ -27,6 +28,7 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:dup",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:read",
         "//libc:unlink",
@@ -40,6 +42,7 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:dup2",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:read",
         "//libc:unlink",
@@ -53,6 +56,7 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:dup3",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:read",
         "//libc:unlink",
@@ -67,6 +71,7 @@ libc_test(
         "//libc:__support_cpp_string_view",
         "//libc:close",
         "//libc:ftruncate",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:read",
         "//libc:unlink",
@@ -88,6 +93,7 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:fsync",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:pread",
         "//libc:pwrite",
@@ -102,6 +108,7 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:fsync",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:read",
         "//libc:remove",
@@ -114,6 +121,7 @@ libc_test(
     srcs = ["link_test.cpp"],
     deps = [
         "//libc:close",
+        "//libc:hdr_sys_stat_macros",
         "//libc:link",
         "//libc:open",
         "//libc:unlink",
@@ -134,6 +142,7 @@ libc_test(
     srcs = ["symlink_test.cpp"],
     deps = [
         "//libc:close",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:symlink",
         "//libc:unlink",
@@ -146,6 +155,7 @@ libc_test(
     deps = [
         "//libc:__support_cpp_string_view",
         "//libc:close",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:read",
         "//libc:truncate",
@@ -159,6 +169,7 @@ libc_test(
     srcs = ["unlink_test.cpp"],
     deps = [
         "//libc:close",
+        "//libc:hdr_sys_stat_macros",
         "//libc:open",
         "//libc:unlink",
     ],
@@ -185,6 +196,7 @@ libc_test(
     srcs = ["isatty_test.cpp"],
     deps = [
         "//libc:close",
+        "//libc:hdr_sys_stat_macros",
         "//libc:isatty",
         "//libc:open",
     ],


### PR DESCRIPTION
Commit b790c5cd2679 (#209449) switched several libc tests to include the hdr/*_macros.h proxy headers and updated the CMake build accordingly, but did not update the Bazel overlay. As a result, the Bazel libc test targets include hdr/*_macros.h (and, via shared headers, hdr/sys_mman_macros.h) without declaring the corresponding //libc:hdr_*_macros dependencies, breaking the Bazel build with 'file not found' / module layering errors.

Mirror the CMake dependency additions into the Bazel overlay so each test target that includes an hdr macro header depends on the matching //libc:hdr_*_macros (and //libc:types_struct_rlimit) target.

First found trying to land (#209747).

bazel changes assisted with: claude

cannot build with bazel locally so relying on CI to confirm green