### PR TITLE
[VPlan] Migrate VPBuilder to VPInsertPt fully (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -25,13 +25,13 @@
 #define LLVM_TRANSFORMS_VECTORIZE_LOOPVECTORIZATIONPLANNER_H
 
 #include "VPlan.h"
-#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Support/InstructionCost.h"
 
 namespace {
 class GeneratedRTChecks;
-} // namespace
+}
 
 namespace llvm {
 
@@ -128,9 +128,11 @@ public:
     }
 
     VPBasicBlock *getBlock() const { return Block; }
+
     operator VPRecipeBase *() const {
       return Point == Block->end() ? nullptr : &*Point;
     }
+
     template <typename T> void insert(T &R) { return Block->insert(R, Point); }
   };
 
@@ -163,7 +165,8 @@ public:
   VPBuilder(VPBasicBlock *TheBB, VPBasicBlock::iterator IP)
       : InsertPt(TheBB, IP) {}
 
-  /// Get the recipe at the current point.
+  /// Get the recipe at the current insert point or nullptr if the insert point
+  /// is the end of the block.
   VPRecipeBase *getRecipe() const { return InsertPt; }
 
   /// Create a VPBuilder to insert after \p R.
@@ -172,12 +175,7 @@ public:
   }
 
   /// Sets the current insert point to a previously-saved location.
-  void restoreIP(VPInsertPoint IP) {
-    if (IP)
-      setInsertPoint(IP);
-    else
-      InsertPt.clear();
-  }
+  void restoreIP(VPInsertPoint IP) { InsertPt = IP; }
 
   /// Set the current insert point.
   void setInsertPoint(const VPInsertPoint &IP) {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -120,12 +120,6 @@ private:
     /// Returns true if this insert point is set.
     operator bool() const { return Block; }
 
-    /// Clears Block and Point.
-    void clear() {
-      Block = nullptr;
-      Point = {};
-    }
-
     VPBasicBlock *getBlock() const { return Block; }
 
     operator VPRecipeBase *() const {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -97,8 +97,7 @@ void reportVectorization(OptimizationRemarkEmitter *ORE, Loop *TheLoop,
 
 /// VPlan-based builder utility analogous to IRBuilder.
 class VPBuilder {
-public:
-  /// InsertPoint - A saved insertion point.
+private:
   class VPInsertPoint {
     VPBasicBlock *Block = nullptr;
     VPBasicBlock::iterator Point;
@@ -136,7 +135,6 @@ public:
     template <typename T> void insert(T &R) { return Block->insert(R, Point); }
   };
 
-private:
   VPInsertPoint InsertPt;
 
   /// Insert \p VPI in BB at InsertPt if BB is set.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -167,7 +167,7 @@ public:
 
   /// Get the recipe at the current insert point or nullptr if the insert point
   /// is the end of the block.
-  VPRecipeBase *getRecipe() const { return InsertPt; }
+  VPRecipeBase *getRecipeAtInsertPoint() const { return InsertPt; }
 
   /// Create a VPBuilder to insert after \p R.
   static VPBuilder getToInsertAfter(VPRecipeBase *R) {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -25,13 +25,13 @@
 #define LLVM_TRANSFORMS_VECTORIZE_LOOPVECTORIZATIONPLANNER_H
 
 #include "VPlan.h"
-#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Support/InstructionCost.h"
 
 namespace {
 class GeneratedRTChecks;
-}
+} // namespace
 
 namespace llvm {
 
@@ -97,13 +97,50 @@ void reportVectorization(OptimizationRemarkEmitter *ORE, Loop *TheLoop,
 
 /// VPlan-based builder utility analogous to IRBuilder.
 class VPBuilder {
-  VPBasicBlock *BB = nullptr;
-  VPBasicBlock::iterator InsertPt = VPBasicBlock::iterator();
+public:
+  /// InsertPoint - A saved insertion point.
+  class VPInsertPoint {
+    VPBasicBlock *Block = nullptr;
+    VPBasicBlock::iterator Point;
+
+  public:
+    /// Creates a new insertion point which doesn't point to anything.
+    VPInsertPoint() = default;
+
+    /// Creates a new insertion point to insert at \p Point in \p Block.
+    VPInsertPoint(VPBasicBlock *Block, VPBasicBlock::iterator Point)
+        : Block(Block), Point(Point) {}
+
+    /// Creates a new insertion point to insert before \p R.
+    VPInsertPoint(VPRecipeBase *R)
+        : Block(R->getParent()), Point(R->getIterator()) {}
+
+    /// Creates a new insertion point to insert at the end of \p Block.
+    VPInsertPoint(VPBasicBlock *Block) : Block(Block), Point(Block->end()) {}
+
+    /// Returns true if this insert point is set.
+    operator bool() const { return Block; }
+
+    /// Clears Block and Point.
+    void clear() {
+      Block = nullptr;
+      Point = {};
+    }
+
+    VPBasicBlock *getBlock() const { return Block; }
+    operator VPRecipeBase *() const {
+      return Point == Block->end() ? nullptr : &*Point;
+    }
+    template <typename T> void insert(T &R) { return Block->insert(R, Point); }
+  };
+
+private:
+  VPInsertPoint InsertPt;
 
   /// Insert \p VPI in BB at InsertPt if BB is set.
   template <typename T> T *tryInsertInstruction(T *R) {
-    if (BB)
-      BB->insert(R, InsertPt);
+    if (InsertPt)
+      InsertPt.insert(R);
     return R;
   }
 
@@ -117,87 +154,44 @@ class VPBuilder {
 
 public:
   VPlan &getPlan() const {
-    assert(getInsertBlock() && "Insert block must be set");
-    return *getInsertBlock()->getPlan();
+    assert(InsertPt && "Insert block must be set");
+    return *InsertPt.getBlock()->getPlan();
   }
 
   VPBuilder() = default;
-  VPBuilder(VPBasicBlock *InsertBB) { setInsertPoint(InsertBB); }
-  VPBuilder(VPRecipeBase *InsertPt) { setInsertPoint(InsertPt); }
-  VPBuilder(VPBasicBlock *TheBB, VPBasicBlock::iterator IP) {
-    setInsertPoint(TheBB, IP);
-  }
+  VPBuilder(const VPInsertPoint &IP) : InsertPt(IP) {}
+  VPBuilder(VPBasicBlock *TheBB, VPBasicBlock::iterator IP)
+      : InsertPt(TheBB, IP) {}
 
-  /// Clear the insertion point: created instructions will not be inserted into
-  /// a block.
-  void clearInsertionPoint() {
-    BB = nullptr;
-    InsertPt = VPBasicBlock::iterator();
-  }
-
-  VPBasicBlock *getInsertBlock() const { return BB; }
-  VPBasicBlock::iterator getInsertPoint() const { return InsertPt; }
+  /// Get the recipe at the current point.
+  VPRecipeBase *getRecipe() const { return InsertPt; }
 
   /// Create a VPBuilder to insert after \p R.
   static VPBuilder getToInsertAfter(VPRecipeBase *R) {
-    VPBuilder B;
-    B.setInsertPoint(R->getParent(), std::next(R->getIterator()));
-    return B;
+    return {R->getParent(), std::next(R->getIterator())};
   }
-
-  /// InsertPoint - A saved insertion point.
-  class VPInsertPoint {
-    VPBasicBlock *Block = nullptr;
-    VPBasicBlock::iterator Point;
-
-  public:
-    /// Creates a new insertion point which doesn't point to anything.
-    VPInsertPoint() = default;
-
-    /// Creates a new insertion point at the given location.
-    VPInsertPoint(VPBasicBlock *InsertBlock, VPBasicBlock::iterator InsertPoint)
-        : Block(InsertBlock), Point(InsertPoint) {}
-
-    /// Returns true if this insert point is set.
-    bool isSet() const { return Block != nullptr; }
-
-    VPBasicBlock *getBlock() const { return Block; }
-    VPBasicBlock::iterator getPoint() const { return Point; }
-  };
 
   /// Sets the current insert point to a previously-saved location.
   void restoreIP(VPInsertPoint IP) {
-    if (IP.isSet())
-      setInsertPoint(IP.getBlock(), IP.getPoint());
+    if (IP)
+      setInsertPoint(IP);
     else
-      clearInsertionPoint();
+      InsertPt.clear();
   }
 
-  /// This specifies that created VPInstructions should be appended to the end
-  /// of the specified block.
-  void setInsertPoint(VPBasicBlock *TheBB) {
-    assert(TheBB && "Attempting to set a null insert point");
-    BB = TheBB;
-    InsertPt = BB->end();
-  }
-
-  /// This specifies that created instructions should be inserted at the
-  /// specified point.
-  void setInsertPoint(VPBasicBlock *TheBB, VPBasicBlock::iterator IP) {
-    BB = TheBB;
+  /// Set the current insert point.
+  void setInsertPoint(const VPInsertPoint &IP) {
+    assert(IP && "Attempting to set a null insert point");
     InsertPt = IP;
   }
-
-  /// This specifies that created instructions should be inserted at the
-  /// specified point.
-  void setInsertPoint(VPRecipeBase *IP) {
-    BB = IP->getParent();
-    InsertPt = IP->getIterator();
+  void setInsertPoint(VPBasicBlock *TheBB, VPBasicBlock::iterator IP) {
+    assert(TheBB && "Attempting to set a null insert point");
+    InsertPt = VPInsertPoint(TheBB, IP);
   }
 
   /// Insert \p R at the current insertion point. Returns \p R unchanged.
   template <typename T> [[maybe_unused]] T *insert(T *R) {
-    BB->insert(R, InsertPt);
+    InsertPt.insert(R);
     return R;
   }
 
@@ -390,7 +384,7 @@ public:
   }
 
   VPValue *createElementCount(Type *Ty, ElementCount EC) {
-    VPlan &Plan = *getInsertBlock()->getPlan();
+    VPlan &Plan = getPlan();
     VPValue *RuntimeEC = Plan.getConstantInt(Ty, EC.getKnownMinValue());
     if (EC.isScalable()) {
       VPValue *VScale = createVScale(Ty);
@@ -564,17 +558,15 @@ public:
   /// the object is destroyed.
   class InsertPointGuard {
     VPBuilder &Builder;
-    VPBasicBlock *Block;
-    VPBasicBlock::iterator Point;
+    VPInsertPoint InsertPt;
 
   public:
-    InsertPointGuard(VPBuilder &B)
-        : Builder(B), Block(B.getInsertBlock()), Point(B.getInsertPoint()) {}
+    InsertPointGuard(VPBuilder &B) : Builder(B), InsertPt(B.InsertPt) {}
 
     InsertPointGuard(const InsertPointGuard &) = delete;
     InsertPointGuard &operator=(const InsertPointGuard &) = delete;
 
-    ~InsertPointGuard() { Builder.restoreIP(VPInsertPoint(Block, Point)); }
+    ~InsertPointGuard() { Builder.restoreIP(InsertPt); }
   };
 };
 

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1751,7 +1751,7 @@ bool VPlanTransforms::handleMaxMinNumReductions(VPlan &Plan) {
       if (DerivedIV->hasOneUse() && IsTC(DIVTC)) {
         auto *NewSel = MiddleBuilder.createSelect(
             AnyNaNLane, LoopRegion->getCanonicalIV(), DIVTC);
-        DerivedIV->moveAfter(MiddleBuilder.getRecipe());
+        DerivedIV->moveAfter(MiddleBuilder.getRecipeAtInsertPoint());
         DerivedIV->setOperand(1, NewSel);
         continue;
       }
@@ -2035,7 +2035,7 @@ static bool handleFirstArgMinOrMax(
         InductionDescriptor::IK_IntInduction,
         nullptr, // No FPBinOp for integer induction
         WideIV->getStartValue(), FinalCanIV, WideIV->getStepValue());
-    DerivedIVRecipe->insertBefore(Builder.getRecipe());
+    DerivedIVRecipe->insertBefore(Builder.getRecipeAtInsertPoint());
     FinalCanIV = DerivedIVRecipe;
   }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1751,7 +1751,7 @@ bool VPlanTransforms::handleMaxMinNumReductions(VPlan &Plan) {
       if (DerivedIV->hasOneUse() && IsTC(DIVTC)) {
         auto *NewSel = MiddleBuilder.createSelect(
             AnyNaNLane, LoopRegion->getCanonicalIV(), DIVTC);
-        DerivedIV->moveAfter(&*MiddleBuilder.getInsertPoint());
+        DerivedIV->moveAfter(MiddleBuilder.getRecipe());
         DerivedIV->setOperand(1, NewSel);
         continue;
       }
@@ -2035,7 +2035,7 @@ static bool handleFirstArgMinOrMax(
         InductionDescriptor::IK_IntInduction,
         nullptr, // No FPBinOp for integer induction
         WideIV->getStartValue(), FinalCanIV, WideIV->getStepValue());
-    DerivedIVRecipe->insertBefore(&*Builder.getInsertPoint());
+    DerivedIVRecipe->insertBefore(Builder.getRecipe());
     FinalCanIV = DerivedIVRecipe;
   }
 


### PR DESCRIPTION
There is already a VPInsertPoint in VPBuilder which is used just with InsertPointGuard. In order to share code, migrate VPBuilder to fully use VPInsertPoint as the canonical insertion point.