### PR TITLE
[clang][bytecode] Fix tail padding with __builtin_object_size

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2299,11 +2299,9 @@ static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
 
 static std::optional<unsigned> computeFullDescSize(const ASTContext &ASTCtx,
                                                    const Descriptor *Desc) {
-  if (Desc->isPrimitive())
+  if (Desc->isPrimitive() || Desc->isArray())
     return ASTCtx.getTypeSizeInChars(Desc->getType()).getQuantity();
-  if (Desc->isArray())
-    return ASTCtx.getTypeSizeInChars(Desc->getElemQualType()).getQuantity() *
-           Desc->getNumElems();
+
   if (Desc->isRecord()) {
     // Can't use Descriptor::getType() as that may return a pointer type. Look
     // at the decl directly.

--- a/clang/test/AST/ByteCode/builtin-object-size.cpp
+++ b/clang/test/AST/ByteCode/builtin-object-size.cpp
@@ -55,3 +55,17 @@ namespace InvalidBase {
   constexpr size_t bos_dtor = __builtin_object_size(&(T&)(T&&)invalid_base_2(), 0); // expected-error {{must be initialized by a constant expression}} \
                                                                                     // expected-note {{non-literal type 'T'}}
 }
+
+namespace Padding {
+  typedef long double LongDouble3Vec __attribute__((ext_vector_type(3)));
+  void foo() {
+      LongDouble3Vec v1, v2;
+#if __SIZEOF_SIZE_T__ == 8
+#if !defined(_WIN32)
+      static_assert(__builtin_object_size(&v1, 0) == 64);
+#else
+      static_assert(__builtin_object_size(&v1, 0) == 32);
+#endif
+#endif
+  }
+}


### PR DESCRIPTION
This fixes the new libcxx/atomics/builtin_clear_padding.pass.cpp