### PR TITLE
[TableGen][GISel] Fix Matcher Creation for C++23 libc++

### DIFF
--- a/llvm/utils/TableGen/Common/GlobalISel/MatchTable/Matchers.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/MatchTable/Matchers.cpp
@@ -649,6 +649,13 @@ Error RuleMatcher::defineComplexSubOperand(StringRef SymbolicName,
   return Error::success();
 }
 
+InstructionMatcher &
+RuleMatcher::allocateInstructionMatcher(StringRef SymbolicName,
+                                        bool AllowNumOpsCheck) {
+  return *InsnMatchers.emplace_back(std::make_unique<InstructionMatcher>(
+      *this, InsnMatchers.size(), SymbolicName, AllowNumOpsCheck));
+}
+
 InstructionMatcher &RuleMatcher::addInstructionMatcher(StringRef SymbolicName) {
   auto &Res = allocateInstructionMatcher(SymbolicName);
   Roots.push_back(&Res);

--- a/llvm/utils/TableGen/Common/GlobalISel/MatchTable/Matchers.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/MatchTable/Matchers.h
@@ -373,10 +373,7 @@ protected:
   friend class InstructionOperandMatcher;
 
   InstructionMatcher &allocateInstructionMatcher(StringRef SymbolicName,
-                                                 bool AllowNumOpsCheck = true) {
-    return *InsnMatchers.emplace_back(std::make_unique<InstructionMatcher>(
-        *this, InsnMatchers.size(), SymbolicName, AllowNumOpsCheck));
-  }
+                                                 bool AllowNumOpsCheck = true);
 
 public:
   RuleMatcher(ArrayRef<SMLoc> SrcLoc, bool UsesRecordOperand = true);


### PR DESCRIPTION
libc++ in C++23 mode evaluates make_unique eagerly, which requires InstructionMatcher to be defined at the constexpr call to make_unique. Currently, it's defined later in the file.

This patch moves the call to make_unique to the C++ file so that InstructionMatcher is fully defined at time of instantiation.