### PR TITLE
[mlir][acc] Add attribute for redundant execution marking

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGAttributes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGAttributes.td
@@ -91,4 +91,15 @@ def OpenACC_GPUParallelDimsAttr : OpenACC_Attr<"GPUParallelDims", "par_dims"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def OpenACC_GPUBlockRedundantAttr
+    : OpenACC_Attr<"GPUBlockRedundant", "gpu_block_redundant"> {
+  let summary = "Loop runs redundantly across all thread blocks.";
+  let description = [{
+    Marks an op that executes redundantly on every thread block and therefore
+    must not be assigned block/grid-level work-sharing. Only thread-level
+    parallelism may be assigned, and during GPU code generation its enclosing
+    block dimensions are treated as active (not predicated away).
+  }];
+}
+
 #endif // OPENACCCG_ATTRIBUTES

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsCG.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsCG.h
@@ -95,6 +95,16 @@ void updateParDimsAttr(Operation *op, GPUParallelDimsAttr attr);
 /// Copy parallel dimensions from \p from to \p to.
 void copyParDimsAttr(Operation *from, Operation *to);
 
+/// Return whether \p op is marked with the `acc.gpu_block_redundant` attribute,
+/// i.e. it executes redundantly across all thread blocks. Such an op must not
+/// be assigned block/grid-level work-sharing; only thread-level parallelism may
+/// apply, and its enclosing block dimensions are treated as active (not
+/// predicated).
+bool hasGPUBlockRedundantAttr(Operation *op);
+
+/// Mark \p op with the `acc.gpu_block_redundant` attribute.
+void setGPUBlockRedundantAttr(Operation *op);
+
 /// Create a gang dim 1 GPUParallelDimsAttr based on the mapping policy.
 inline GPUParallelDimsAttr
 getGangDim1ParDimsAttr(MLIRContext *ctx, ACCToGPUMappingPolicy &policy) {

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -246,16 +246,21 @@ getAccRoutineCallParDim(CallOpInterface callOp,
 /// Collects parallel dimensions from enclosing loops and the compute region.
 static SmallVector<GPUParallelDimAttr> getAncestorParDims(Operation *op) {
   SmallVector<GPUParallelDimAttr> parDimsArray;
+  ComputeRegionOp computeRegion = op->getParentOfType<ComputeRegionOp>();
+  assert(computeRegion && "missing enclosing acc.compute_region");
   scf::ParallelOp parentLoop = op->getParentOfType<scf::ParallelOp>();
   while (parentLoop) {
     if (GPUParallelDimsAttr parDimsAttr = getParDimsAttr(parentLoop))
       for (GPUParallelDimAttr parDim : parDimsAttr.getArray())
         insertParDim(parDimsArray, parDim);
+    // A block-redundant loop executes on every block, so its enclosing block
+    // dimensions are active ancestors that must not be predicated away.
+    if (hasGPUBlockRedundantAttr(parentLoop))
+      for (GPUParallelDimAttr parDim : computeRegion.getLaunchParDims())
+        insertParDim(parDimsArray, parDim);
     parentLoop = parentLoop->getParentOfType<scf::ParallelOp>();
   }
 
-  ComputeRegionOp computeRegion = op->getParentOfType<ComputeRegionOp>();
-  assert(computeRegion && "missing enclosing acc.compute_region");
   if (GPUParallelDimsAttr parDimsAttr = getParDimsAttr(computeRegion))
     for (GPUParallelDimAttr parDim : parDimsAttr.getArray())
       insertParDim(parDimsArray, parDim);

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
@@ -208,6 +208,15 @@ void updateParDimsAttr(Operation *op, GPUParallelDimsAttr attr) {
 
 #undef ACC_OP_WITH_PAR_DIMS_LIST
 
+bool hasGPUBlockRedundantAttr(Operation *op) {
+  return op->hasAttrOfType<GPUBlockRedundantAttr>(GPUBlockRedundantAttr::name);
+}
+
+void setGPUBlockRedundantAttr(Operation *op) {
+  op->setAttr(GPUBlockRedundantAttr::name,
+              GPUBlockRedundantAttr::get(op->getContext()));
+}
+
 void copyParDimsAttr(Operation *from, Operation *to) {
   assert(hasParDimsAttr(from) &&
          "expected parallel dimensions attribute to already be set");

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant.mlir
@@ -1,0 +1,38 @@
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
+
+// A loop parallelized at the vector (thread_x) level and marked
+// `acc.gpu_block_redundant` runs redundantly on every thread block. Because the
+// block dimension is redundant (all blocks execute) and thread_x is the active
+// worksharing dimension, there is no inactive parallel dimension left to
+// serialize on, so a predicate_region inside the loop must lower without any
+// blockIdx/threadIdx predication (no scf.if / arith.cmpi guard on the store).
+
+// CHECK-LABEL: func.func @block_redundant_vector_no_predicate
+// CHECK:         gpu.launch
+// CHECK-NOT:     acc.predicate_region
+// CHECK-NOT:     scf.if
+// CHECK-NOT:     arith.cmpi
+// CHECK:         memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<32xi32>
+
+func.func @block_redundant_vector_no_predicate(%arg0: memref<32xi32>) {
+  %c32 = arith.constant 32 : index
+  %par_bx = acc.par_width %c32 {par_dim = #acc.par_dim<block_x>}
+  %par_tx = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    acc.compute_region launch(%grid = %par_bx, %block = %par_tx)
+        ins(%arg10 = %arg0) : (memref<32xi32>) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c32_0 = arith.constant 32 : index
+      scf.parallel (%i) = (%c0) to (%c32_0) step (%c1) {
+        acc.predicate_region {
+          %c42 = arith.constant 42 : i32
+          memref.store %c42, %arg10[%i] : memref<32xi32>
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[thread_x]>, acc.gpu_block_redundant = #acc.gpu_block_redundant}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}


### PR DESCRIPTION
Adds `acc.gpu_block_redundant` attribute for correct gang-redundant lowering.

OpenACC gang-redundant regions execute on every gang rather than partitioning work across gangs. When lowering to the GPU dialect, such regions must not be assigned block-level par dims; only thread-level parallelism applies. This marks loops with this attribute to ensure proper execution and to avoid incorrect predication.