### PR TITLE
[LLVM][ADT] Adding range-based test_all and test_any methods for BitVector

### DIFF
--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -483,6 +483,24 @@ public:
     return (*this)[Idx];
   }
 
+  /// Returns true if all bits in the range [Begin, End) are set.
+  bool test_all(unsigned Begin, unsigned End) const {
+    for (unsigned i = Begin; i < End; ++i) {
+      if (!test(i))
+        return false;
+    }
+    return true;
+  }
+
+  /// Returns true if any of the bits in the range [Begin, End) are set.
+  bool test_any(unsigned Begin, unsigned End) const {
+    for (unsigned i = Begin; i < End; ++i) {
+      if (test(i))
+        return true;
+    }
+    return false;
+  }
+
   // Push single bit to end of bitvector.
   void push_back(bool Val) {
     unsigned OldSize = Size;

--- a/llvm/include/llvm/ADT/SmallBitVector.h
+++ b/llvm/include/llvm/ADT/SmallBitVector.h
@@ -470,9 +470,28 @@ public:
     assert(!empty() && "Getting last element of empty vector.");
     return (*this)[size() - 1];
   }
-
+  
+  /// Returns true if bit \p Idx is set.
   bool test(unsigned Idx) const {
     return (*this)[Idx];
+  }
+
+  /// Returns true if all bits in the range [Begin, End) are set.
+  bool test_all(unsigned Begin, unsigned End) const {
+    for (unsigned i = Begin; i < End; ++i) {
+      if (!test(i))
+        return false;
+    }
+    return true;
+  }
+
+  /// Returns true if any of the bits in the range [Begin, End) are set.
+  bool test_any(unsigned Begin, unsigned End) const {
+    for (unsigned i = Begin; i < End; ++i) {
+      if (test(i))
+        return true;
+    }
+    return false;
   }
 
   // Push single bit to end of vector.

--- a/llvm/include/llvm/ADT/SmallBitVector.h
+++ b/llvm/include/llvm/ADT/SmallBitVector.h
@@ -470,7 +470,7 @@ public:
     assert(!empty() && "Getting last element of empty vector.");
     return (*this)[size() - 1];
   }
-  
+
   /// Returns true if bit \p Idx is set.
   bool test(unsigned Idx) const {
     return (*this)[Idx];

--- a/llvm/unittests/ADT/BitVectorTest.cpp
+++ b/llvm/unittests/ADT/BitVectorTest.cpp
@@ -199,6 +199,43 @@ TYPED_TEST(BitVectorTest, Equality) {
   EXPECT_TRUE(A == B);
 }
 
+TYPED_TEST(BitVectorTest, TestAllAndAny) {
+  TypeParam Vec;
+  Vec.resize(10);
+
+  // Empty range
+  EXPECT_TRUE(Vec.test_all(3, 3));
+  EXPECT_FALSE(Vec.test_any(3, 3));
+
+  Vec.set(2, 5);
+  EXPECT_TRUE(Vec.test_all(2, 5));
+  EXPECT_FALSE(Vec.test_all(2, 6));
+  EXPECT_FALSE(Vec.test_all(1, 5));
+  EXPECT_TRUE(Vec.test_any(2, 5));
+  EXPECT_TRUE(Vec.test_any(4, 5));
+  EXPECT_FALSE(Vec.test_any(0, 2));
+
+  Vec.set(7);
+  EXPECT_FALSE(Vec.test_all(0, Vec.size()));
+  EXPECT_TRUE(Vec.test_any(6, Vec.size()));
+  Vec.reset(7);
+
+  TypeParam LargeVec;
+  LargeVec.resize(80);
+  LargeVec.set(10, 30);
+  EXPECT_TRUE(LargeVec.test_any(10, 30));
+  EXPECT_FALSE(LargeVec.test_all(10, 35));
+  EXPECT_FALSE(LargeVec.test_any(0, 10));
+
+  LargeVec.set(30, 35);
+  EXPECT_TRUE(LargeVec.test_all(10, 35));
+
+  LargeVec.set(70);
+  EXPECT_TRUE(LargeVec.test_any(68, 72));
+  LargeVec.reset(70);
+  EXPECT_FALSE(LargeVec.test_any(68, 72));
+}
+
 TYPED_TEST(BitVectorTest, SimpleFindOpsMultiWord) {
   TypeParam A;
 


### PR DESCRIPTION
Just adding test_all and test_any utilities for [Small]BitVector ADT.