### PR TITLE
[libcxx] Mark test unsupported in clang-24

### DIFF
--- a/libcxx/test/libcxx/atomics/builtin_clear_padding.pass.cpp
+++ b/libcxx/test/libcxx/atomics/builtin_clear_padding.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03
 // UNSUPPORTED: gcc
-// UNSUPPORTED: clang-19, clang-20, clang-21, clang-22, clang-23, apple-clang-17, apple-clang-21
+// UNSUPPORTED: clang-19, clang-20, clang-21, clang-22, clang-23, clang-24, apple-clang-17, apple-clang-21
 
 // ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated-volatile -Wno-dynamic-class-memaccess
 


### PR DESCRIPTION
After the version bump, we started seeing this test fail. For now mark it unsupported in newer LLVM versions, until the underlying issue can be addressed. More details can be found in  #209787.