### PR TITLE
[clang][OpenMP][test] Specify libomp flag

### DIFF
--- a/clang/test/Driver/openmp-invalid-target-id.c
+++ b/clang/test/Driver/openmp-invalid-target-id.c
@@ -3,7 +3,7 @@
 //
 // Legacy mode (-fopenmp-targets,-Xopenmp-target,-march) tests for TargetID
 //
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908xnack \
@@ -11,7 +11,7 @@
 
 // NOPLUS-L: error: invalid target ID 'gfx908xnack'
 
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:xnack+ \
@@ -19,7 +19,7 @@
 
 // ORDER-L: error: invalid target ID 'gfx908:xnack+:xnack+'
 
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:unknown+ \
@@ -29,7 +29,7 @@
 
 // UNK-L: error: invalid target ID 'gfx900+xnack'
 
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:sramecc+:unknown+ \
@@ -38,7 +38,7 @@
 
 // MIXED-L: error: invalid target ID 'gfx900+xnack'
 
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900:sramecc+ \
@@ -46,7 +46,7 @@
 
 // UNSUP-L: error: invalid target ID 'gfx900:sramecc+'
 
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900:xnack \
@@ -54,7 +54,7 @@
 
 // NOSIGN-L: error: invalid target ID 'gfx900:xnack'
 
-// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900+xnack \
@@ -70,21 +70,21 @@
 // Offload-arch mode (--offload-arch) tests for TargetID
 //
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx908xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS %s
 
 // NOPLUS: error: failed to deduce triple for target architecture 'gfx908xnack'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx900 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx900 \
 // RUN:   --offload-arch=gfx908:xnack+:xnack+ \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=ORDER %s
 
 // ORDER: error: invalid target ID 'gfx908:xnack+:xnack+'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx908:unknown+ \
 // RUN:   --offload-arch=gfx908+sramecc+unknown \
 // RUN:   --offload-arch=gfx900+xnack \
@@ -93,7 +93,7 @@
 // UNK: error: failed to deduce triple for target architecture 'gfx900+xnack'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx908:sramecc+:unknown+ \
 // RUN:   --offload-arch=gfx900+xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=MIXED %s
@@ -101,28 +101,28 @@
 // MIXED: error: failed to deduce triple for target architecture 'gfx900+xnack'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx900:sramecc+ \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=UNSUP %s
 
 // UNSUP: error: invalid target ID 'gfx900:sramecc+'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx900:xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=NOSIGN %s
 
 // NOSIGN: error: invalid target ID 'gfx900:xnack'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx900+xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=NOCOLON %s
 
 // NOCOLON: error: failed to deduce triple for target architecture 'gfx900+xnack'
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
-// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   -fopenmp=libomp --offload-arch=gfx908 \
 // RUN:   --offload-arch=gfx908:xnack+ \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=COMBO %s
 


### PR DESCRIPTION
The test added in #209740 assumes that `-fopenmp=libomp` is the default value, and does not work when the build is configured w/ `libgomp` as the default instead.