### PR TITLE
[ManagedStatic][NFC] Fix the comment for ManagedStaticBase::isConstructed

### DIFF
--- a/llvm/include/llvm/Support/ManagedStatic.h
+++ b/llvm/include/llvm/Support/ManagedStatic.h
@@ -69,7 +69,7 @@ public:
   constexpr ManagedStaticBase() = default;
 #endif
 
-  /// isConstructed - Return true if this object has not been created yet.
+  /// isConstructed - Return true if this object has already been created.
   bool isConstructed() const { return Ptr != nullptr; }
 
   LLVM_ABI void destroy() const;


### PR DESCRIPTION
The comment said that the function returns true if the object has `not` been created yet, but it returns `Ptr != nullptr`, which means the opposite - `true` if the object has been created.