### PR TITLE
[LLVM][CodeGen][SVE] Extend NEON->SVE splat imm isel to cover 64-bit vectors.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4711,41 +4711,48 @@ def : InstAlias<"pfalse\t$Pd", (PFALSE PPRorPNR8:$Pd), 0>;
 // Promote NEON operations to SVE when an SVE immediate form can be used.
 class PromoteNEONToSVEImm
   <SDNode Opc, ValueType VT, ComplexPattern ImmPat, Instruction SVEImmInst, ValueType ImmType>
-  : Pat<(Opc (VT V128:$Vm), (VT (ImmPat ImmType:$imm))),
+  : Pat<(Opc VT:$Vm, (VT (ImmPat ImmType:$imm))),
       (EXTRACT_SUBREG (SVEImmInst
-        (INSERT_SUBREG (IMPLICIT_DEF), (VT V128: $Vm), zsub), ImmType:$imm), zsub)>;
+        (INSERT_SUBREG (IMPLICIT_DEF), $Vm, NEONType<VT>.ZPRsubreg), ImmType:$imm), NEONType<VT>.ZPRsubreg)>;
+
 // Same as PromoteNEONToSVEImm but accepts immediates with a shift (for ADD/SUB).
 class PromoteNEONToSVEImmWithShift
   <SDNode Opc, ValueType VT, ComplexPattern ImmPat, Instruction SVEImmInst>
-  : Pat<(Opc (VT V128:$Vm), (VT (ImmPat i32:$imm, i32:$shift))),
+  : Pat<(Opc VT:$Vm, (VT (ImmPat i32:$imm, i32:$shift))),
       (EXTRACT_SUBREG (SVEImmInst
-        (INSERT_SUBREG (IMPLICIT_DEF), (VT V128: $Vm), zsub), i32:$imm, i32:$shift), zsub)>;
+        (INSERT_SUBREG (IMPLICIT_DEF), $Vm, NEONType<VT>.ZPRsubreg), i32:$imm, i32:$shift), NEONType<VT>.ZPRsubreg)>;
 
 let Predicates = [HasSVE_or_SME] in {
-  foreach VT = [v2i64, v4i32, v8i16, v16i8] in {
+  foreach VT = [v1i64, v2i64, v2i32, v4i32, v4i16, v8i16, v8i8, v16i8] in {
     // Logical operations
     def : PromoteNEONToSVEImm<and, VT, NEONSplatOfSVELogicalImmPat, AND_ZI_PSEUDO, i64>;
     def : PromoteNEONToSVEImm<xor, VT, NEONSplatOfSVELogicalImmPat, EOR_ZI_PSEUDO, i64>;
     def : PromoteNEONToSVEImm< or, VT, NEONSplatOfSVELogicalImmPat, ORR_ZI_PSEUDO, i64>;
   }
 
-  // Arith operations: ADD
-  def : PromoteNEONToSVEImmWithShift<add, v2i64, NEONSplatOfSVEAddSubImm, ADD_ZI_D_PSEUDO>;
-  def : PromoteNEONToSVEImmWithShift<add, v4i32, NEONSplatOfSVEAddSubImm, ADD_ZI_S_PSEUDO>;
-  def : PromoteNEONToSVEImmWithShift<add, v8i16, NEONSplatOfSVEAddSubImm, ADD_ZI_H_PSEUDO>;
-  def : PromoteNEONToSVEImmWithShift<add, v16i8, NEONSplatOfSVEAddSubImm, ADD_ZI_B_PSEUDO>;
+  foreach VT = [v1i64, v2i64] in {
+    def : PromoteNEONToSVEImmWithShift<add, VT, NEONSplatOfSVEAddSubImm, ADD_ZI_D_PSEUDO>;
+    def : PromoteNEONToSVEImmWithShift<sub, VT, NEONSplatOfSVEAddSubImm, SUB_ZI_D_PSEUDO>;
+    def : PromoteNEONToSVEImm<mul,          VT, NEONSplatOfSVEAddSubImm, MUL_ZI_D_PSEUDO, i32>;
+  }
 
-  // Arith operations: SUB
-  def : PromoteNEONToSVEImmWithShift<sub, v2i64, NEONSplatOfSVEAddSubImm, SUB_ZI_D_PSEUDO>;
-  def : PromoteNEONToSVEImmWithShift<sub, v4i32, NEONSplatOfSVEAddSubImm, SUB_ZI_S_PSEUDO>;
-  def : PromoteNEONToSVEImmWithShift<sub, v8i16, NEONSplatOfSVEAddSubImm, SUB_ZI_H_PSEUDO>;
-  def : PromoteNEONToSVEImmWithShift<sub, v16i8, NEONSplatOfSVEAddSubImm, SUB_ZI_B_PSEUDO>;
+  foreach VT = [v2i32, v4i32] in {
+    def : PromoteNEONToSVEImmWithShift<add, VT, NEONSplatOfSVEAddSubImm, ADD_ZI_S_PSEUDO>;
+    def : PromoteNEONToSVEImmWithShift<sub, VT, NEONSplatOfSVEAddSubImm, SUB_ZI_S_PSEUDO>;
+    def : PromoteNEONToSVEImm<mul,          VT, NEONSplatOfSVEArithSImm, MUL_ZI_S_PSEUDO, i32>;
+  }
 
-  // Arith operations: MUL
-  def : PromoteNEONToSVEImm<mul, v2i64, NEONSplatOfSVEAddSubImm, MUL_ZI_D_PSEUDO, i32>;
-  def : PromoteNEONToSVEImm<mul, v4i32, NEONSplatOfSVEArithSImm, MUL_ZI_S_PSEUDO, i32>;
-  def : PromoteNEONToSVEImm<mul, v8i16, NEONSplatOfSVEArithSImm, MUL_ZI_H_PSEUDO, i32>;
-  def : PromoteNEONToSVEImm<mul, v16i8, NEONSplatOfSVEArithSImm, MUL_ZI_B_PSEUDO, i32>;
+  foreach VT = [v4i16, v8i16] in {
+    def : PromoteNEONToSVEImmWithShift<add, VT, NEONSplatOfSVEAddSubImm, ADD_ZI_H_PSEUDO>;
+    def : PromoteNEONToSVEImmWithShift<sub, VT, NEONSplatOfSVEAddSubImm, SUB_ZI_H_PSEUDO>;
+    def : PromoteNEONToSVEImm<mul,          VT, NEONSplatOfSVEArithSImm, MUL_ZI_H_PSEUDO, i32>;
+  }
+
+  foreach VT = [v8i8, v16i8] in {
+    def : PromoteNEONToSVEImmWithShift<add, VT, NEONSplatOfSVEAddSubImm, ADD_ZI_B_PSEUDO>;
+    def : PromoteNEONToSVEImmWithShift<sub, VT, NEONSplatOfSVEAddSubImm, SUB_ZI_B_PSEUDO>;
+    def : PromoteNEONToSVEImm<mul,          VT, NEONSplatOfSVEArithSImm, MUL_ZI_B_PSEUDO, i32>;
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -31,6 +31,25 @@ class NEONType<ValueType VT> {
     v4bf16: nxv8bf16,
     v8bf16: nxv8bf16,
     untyped);
+
+  SubRegIndex ZPRsubreg = !switch(VT,
+    v8i8: dsub,
+    v16i8: zsub,
+    v4i16: dsub,
+    v8i16: zsub,
+    v2i32: dsub,
+    v4i32: zsub,
+    v1i64: dsub,
+    v2i64: zsub,
+    v4f16: dsub,
+    v8f16: zsub,
+    v2f32: dsub,
+    v4f32: zsub,
+    v1f64: dsub,
+    v2f64: zsub,
+    v4bf16: dsub,
+    v8bf16: zsub,
+    ?);
 }
 
 // Helper class to hold conversions of legal scalable vector types.

--- a/llvm/test/CodeGen/AArch64/aarch64-minmaxv.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-minmaxv.ll
@@ -1140,13 +1140,21 @@ entry:
 }
 
 define i8 @uminv_v2i8(<2 x i8> %a) {
-; CHECK-SD-LABEL: uminv_v2i8:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    movi d1, #0x0000ff000000ff
-; CHECK-SD-NEXT:    and v0.8b, v0.8b, v1.8b
-; CHECK-SD-NEXT:    uminp v0.2s, v0.2s, v0.2s
-; CHECK-SD-NEXT:    fmov w0, s0
-; CHECK-SD-NEXT:    ret
+; CHECK-SD-NOSVE-LABEL: uminv_v2i8:
+; CHECK-SD-NOSVE:       // %bb.0: // %entry
+; CHECK-SD-NOSVE-NEXT:    movi d1, #0x0000ff000000ff
+; CHECK-SD-NOSVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SD-NOSVE-NEXT:    uminp v0.2s, v0.2s, v0.2s
+; CHECK-SD-NOSVE-NEXT:    fmov w0, s0
+; CHECK-SD-NOSVE-NEXT:    ret
+;
+; CHECK-SD-SVE2-LABEL: uminv_v2i8:
+; CHECK-SD-SVE2:       // %bb.0: // %entry
+; CHECK-SD-SVE2-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SD-SVE2-NEXT:    and z0.s, z0.s, #0xff
+; CHECK-SD-SVE2-NEXT:    uminp v0.2s, v0.2s, v0.2s
+; CHECK-SD-SVE2-NEXT:    fmov w0, s0
+; CHECK-SD-SVE2-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: uminv_v2i8:
 ; CHECK-GI:       // %bb.0: // %entry
@@ -1255,13 +1263,21 @@ entry:
 }
 
 define i16 @uminv_v2i16(<2 x i16> %a) {
-; CHECK-SD-LABEL: uminv_v2i16:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    movi d1, #0x00ffff0000ffff
-; CHECK-SD-NEXT:    and v0.8b, v0.8b, v1.8b
-; CHECK-SD-NEXT:    uminp v0.2s, v0.2s, v0.2s
-; CHECK-SD-NEXT:    fmov w0, s0
-; CHECK-SD-NEXT:    ret
+; CHECK-SD-NOSVE-LABEL: uminv_v2i16:
+; CHECK-SD-NOSVE:       // %bb.0: // %entry
+; CHECK-SD-NOSVE-NEXT:    movi d1, #0x00ffff0000ffff
+; CHECK-SD-NOSVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SD-NOSVE-NEXT:    uminp v0.2s, v0.2s, v0.2s
+; CHECK-SD-NOSVE-NEXT:    fmov w0, s0
+; CHECK-SD-NOSVE-NEXT:    ret
+;
+; CHECK-SD-SVE2-LABEL: uminv_v2i16:
+; CHECK-SD-SVE2:       // %bb.0: // %entry
+; CHECK-SD-SVE2-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SD-SVE2-NEXT:    and z0.s, z0.s, #0xffff
+; CHECK-SD-SVE2-NEXT:    uminp v0.2s, v0.2s, v0.2s
+; CHECK-SD-SVE2-NEXT:    fmov w0, s0
+; CHECK-SD-SVE2-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: uminv_v2i16:
 ; CHECK-GI:       // %bb.0: // %entry
@@ -1530,13 +1546,21 @@ entry:
 }
 
 define i8 @umaxv_v2i8(<2 x i8> %a) {
-; CHECK-SD-LABEL: umaxv_v2i8:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    movi d1, #0x0000ff000000ff
-; CHECK-SD-NEXT:    and v0.8b, v0.8b, v1.8b
-; CHECK-SD-NEXT:    umaxp v0.2s, v0.2s, v0.2s
-; CHECK-SD-NEXT:    fmov w0, s0
-; CHECK-SD-NEXT:    ret
+; CHECK-SD-NOSVE-LABEL: umaxv_v2i8:
+; CHECK-SD-NOSVE:       // %bb.0: // %entry
+; CHECK-SD-NOSVE-NEXT:    movi d1, #0x0000ff000000ff
+; CHECK-SD-NOSVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SD-NOSVE-NEXT:    umaxp v0.2s, v0.2s, v0.2s
+; CHECK-SD-NOSVE-NEXT:    fmov w0, s0
+; CHECK-SD-NOSVE-NEXT:    ret
+;
+; CHECK-SD-SVE2-LABEL: umaxv_v2i8:
+; CHECK-SD-SVE2:       // %bb.0: // %entry
+; CHECK-SD-SVE2-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SD-SVE2-NEXT:    and z0.s, z0.s, #0xff
+; CHECK-SD-SVE2-NEXT:    umaxp v0.2s, v0.2s, v0.2s
+; CHECK-SD-SVE2-NEXT:    fmov w0, s0
+; CHECK-SD-SVE2-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: umaxv_v2i8:
 ; CHECK-GI:       // %bb.0: // %entry
@@ -1645,13 +1669,21 @@ entry:
 }
 
 define i16 @umaxv_v2i16(<2 x i16> %a) {
-; CHECK-SD-LABEL: umaxv_v2i16:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    movi d1, #0x00ffff0000ffff
-; CHECK-SD-NEXT:    and v0.8b, v0.8b, v1.8b
-; CHECK-SD-NEXT:    umaxp v0.2s, v0.2s, v0.2s
-; CHECK-SD-NEXT:    fmov w0, s0
-; CHECK-SD-NEXT:    ret
+; CHECK-SD-NOSVE-LABEL: umaxv_v2i16:
+; CHECK-SD-NOSVE:       // %bb.0: // %entry
+; CHECK-SD-NOSVE-NEXT:    movi d1, #0x00ffff0000ffff
+; CHECK-SD-NOSVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SD-NOSVE-NEXT:    umaxp v0.2s, v0.2s, v0.2s
+; CHECK-SD-NOSVE-NEXT:    fmov w0, s0
+; CHECK-SD-NOSVE-NEXT:    ret
+;
+; CHECK-SD-SVE2-LABEL: umaxv_v2i16:
+; CHECK-SD-SVE2:       // %bb.0: // %entry
+; CHECK-SD-SVE2-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SD-SVE2-NEXT:    and z0.s, z0.s, #0xffff
+; CHECK-SD-SVE2-NEXT:    umaxp v0.2s, v0.2s, v0.2s
+; CHECK-SD-SVE2-NEXT:    fmov w0, s0
+; CHECK-SD-SVE2-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: umaxv_v2i16:
 ; CHECK-GI:       // %bb.0: // %entry

--- a/llvm/test/CodeGen/AArch64/aarch64-smull.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-smull.ll
@@ -1645,10 +1645,10 @@ define <8 x i16> @umull_smaller_v8i16(<8 x i4> %src1, <8 x i16> %src2) {
 ;
 ; CHECK-SVE-LABEL: umull_smaller_v8i16:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v2.8b, #15
 ; CHECK-SVE-NEXT:    bic v1.8h, #255, lsl #8
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    and z0.b, z0.b, #0xf
 ; CHECK-SVE-NEXT:    xtn v1.8b, v1.8h
-; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v2.8b
 ; CHECK-SVE-NEXT:    umull v0.8h, v0.8b, v1.8b
 ; CHECK-SVE-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/bsl.ll
+++ b/llvm/test/CodeGen/AArch64/bsl.ll
@@ -338,9 +338,10 @@ define <4 x i8> @bsl_v4i8(<4 x i8> %0, <4 x i8> %1, <4 x i8> %2) {
 ;
 ; SVE2-LABEL: bsl_v4i8:
 ; SVE2:       // %bb.0:
-; SVE2-NEXT:    movi d3, #0xff00ff00ff00ff
+; SVE2-NEXT:    // kill: def $d2 killed $d2 def $z2
+; SVE2-NEXT:    movprfx z3, z2
+; SVE2-NEXT:    eor z3.h, z3.h, #0xff
 ; SVE2-NEXT:    and v0.8b, v2.8b, v0.8b
-; SVE2-NEXT:    eor v3.8b, v2.8b, v3.8b
 ; SVE2-NEXT:    and v1.8b, v1.8b, v3.8b
 ; SVE2-NEXT:    orr v0.8b, v0.8b, v1.8b
 ; SVE2-NEXT:    ret
@@ -364,12 +365,14 @@ define <4 x i8> @nbsl_v4i8(<4 x i8> %0, <4 x i8> %1, <4 x i8> %2) {
 ;
 ; SVE2-LABEL: nbsl_v4i8:
 ; SVE2:       // %bb.0:
-; SVE2-NEXT:    movi d3, #0xff00ff00ff00ff
+; SVE2-NEXT:    // kill: def $d2 killed $d2 def $z2
+; SVE2-NEXT:    movprfx z3, z2
+; SVE2-NEXT:    eor z3.h, z3.h, #0xff
 ; SVE2-NEXT:    and v0.8b, v2.8b, v0.8b
-; SVE2-NEXT:    eor v4.8b, v2.8b, v3.8b
-; SVE2-NEXT:    and v1.8b, v1.8b, v4.8b
+; SVE2-NEXT:    and v1.8b, v1.8b, v3.8b
 ; SVE2-NEXT:    orr v0.8b, v0.8b, v1.8b
-; SVE2-NEXT:    eor v0.8b, v0.8b, v3.8b
+; SVE2-NEXT:    eor z0.h, z0.h, #0xff
+; SVE2-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; SVE2-NEXT:    ret
   %4 = and <4 x i8> %2, %0
   %5 = xor <4 x i8> %2, splat (i8 -1)
@@ -392,11 +395,13 @@ define <4 x i8> @bsl1n_v4i8(<4 x i8> %0, <4 x i8> %1, <4 x i8> %2) {
 ;
 ; SVE2-LABEL: bsl1n_v4i8:
 ; SVE2:       // %bb.0:
-; SVE2-NEXT:    movi d3, #0xff00ff00ff00ff
-; SVE2-NEXT:    eor v0.8b, v0.8b, v3.8b
-; SVE2-NEXT:    eor v3.8b, v2.8b, v3.8b
-; SVE2-NEXT:    and v0.8b, v2.8b, v0.8b
+; SVE2-NEXT:    // kill: def $d0 killed $d0 def $z0
+; SVE2-NEXT:    // kill: def $d2 killed $d2 def $z2
+; SVE2-NEXT:    movprfx z3, z2
+; SVE2-NEXT:    eor z3.h, z3.h, #0xff
+; SVE2-NEXT:    eor z0.h, z0.h, #0xff
 ; SVE2-NEXT:    and v1.8b, v1.8b, v3.8b
+; SVE2-NEXT:    and v0.8b, v2.8b, v0.8b
 ; SVE2-NEXT:    orr v0.8b, v0.8b, v1.8b
 ; SVE2-NEXT:    ret
   %4 = xor <4 x i8> %0, splat (i8 -1)
@@ -419,10 +424,9 @@ define <4 x i8> @bsl2n_v4i8(<4 x i8> %0, <4 x i8> %1, <4 x i8> %2) {
 ;
 ; SVE2-LABEL: bsl2n_v4i8:
 ; SVE2:       // %bb.0:
-; SVE2-NEXT:    movi d3, #0xff00ff00ff00ff
 ; SVE2-NEXT:    orr v1.8b, v2.8b, v1.8b
 ; SVE2-NEXT:    and v0.8b, v2.8b, v0.8b
-; SVE2-NEXT:    eor v1.8b, v1.8b, v3.8b
+; SVE2-NEXT:    eor z1.h, z1.h, #0xff
 ; SVE2-NEXT:    orr v0.8b, v0.8b, v1.8b
 ; SVE2-NEXT:    ret
   %4 = and <4 x i8> %2, %0

--- a/llvm/test/CodeGen/AArch64/combine-storetomstore.ll
+++ b/llvm/test/CodeGen/AArch64/combine-storetomstore.ll
@@ -709,10 +709,10 @@ define void @test_masked_store_success_v64i8(<64 x i8> %x, ptr %ptr, <64 x i1> %
 define void @test_masked_store_success_invert_mask_v4i32(<4 x i32> %x, ptr %ptr, <4 x i1> %mask) {
 ; SVE-LABEL: test_masked_store_success_invert_mask_v4i32:
 ; SVE:       // %bb.0:
-; SVE-NEXT:    movi v2.4h, #1
+; SVE-NEXT:    // kill: def $d1 killed $d1 def $z1
 ; SVE-NEXT:    ptrue p0.s, vl4
 ; SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
-; SVE-NEXT:    eor v1.8b, v1.8b, v2.8b
+; SVE-NEXT:    eor z1.h, z1.h, #0x1
 ; SVE-NEXT:    ushll v1.4s, v1.4h, #0
 ; SVE-NEXT:    shl v1.4s, v1.4s, #31
 ; SVE-NEXT:    cmpne p1.s, p0/z, z1.s, #0

--- a/llvm/test/CodeGen/AArch64/imm-splat-ops.ll
+++ b/llvm/test/CodeGen/AArch64/imm-splat-ops.ll
@@ -2,14 +2,31 @@
 ; RUN: llc -mtriple=aarch64-none-linux-gnu -mattr=+neon < %s -o - | FileCheck %s --check-prefix=CHECK-NEON
 ; RUN: llc -mtriple=aarch64-none-linux-gnu -mattr=+sve < %s -o - | FileCheck %s --check-prefix=CHECK-SVE
 
-define <4 x i32> @and(<4 x i32> %a) {
-; CHECK-NEON-LABEL: and:
+define <2 x i32> @and_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: and_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    fmov v1.2s, #1.00000000
+; CHECK-NEON-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: and_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    fmov v1.2s, #1.00000000
+; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %and = and <2 x i32> %a, splat (i32 1065353216)
+  ret <2 x i32> %and
+}
+
+define <4 x i32> @and_v4i32(<4 x i32> %a) {
+; CHECK-NEON-LABEL: and_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
 ; CHECK-NEON-NEXT:    fmov v1.4s, #1.00000000
 ; CHECK-NEON-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEON-NEXT:    ret
 ;
-; CHECK-SVE-LABEL: and:
+; CHECK-SVE-LABEL: and_v4i32:
 ; CHECK-SVE:       // %bb.0: // %entry
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-SVE-NEXT:    and z0.s, z0.s, #0x3f800000
@@ -20,14 +37,31 @@ entry:
   ret <4 x i32> %and
 }
 
-define <4 x i32> @and_low_8(<4 x i32> %a) {
-; CHECK-NEON-LABEL: and_low_8:
+define <2 x i32> @and_low_8_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: and_low_8_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi d1, #0x0000ff000000ff
+; CHECK-NEON-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: and_low_8_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi d1, #0x0000ff000000ff
+; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %and = and <2 x i32> %a, splat (i32 255)
+  ret <2 x i32> %and
+}
+
+define <4 x i32> @and_low_8_v4i32(<4 x i32> %a) {
+; CHECK-NEON-LABEL: and_low_8_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
 ; CHECK-NEON-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; CHECK-NEON-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEON-NEXT:    ret
 ;
-; CHECK-SVE-LABEL: and_low_8:
+; CHECK-SVE-LABEL: and_low_8_v4i32:
 ; CHECK-SVE:       // %bb.0: // %entry
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-SVE-NEXT:    and z0.s, z0.s, #0xff
@@ -38,14 +72,31 @@ entry:
   ret <4 x i32> %and
 }
 
-define <4 x i32> @and_low_16(<4 x i32> %a) {
-; CHECK-NEON-LABEL: and_low_16:
+define <2 x i32> @and_low_16_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: and_low_16_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi d1, #0x00ffff0000ffff
+; CHECK-NEON-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: and_low_16_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi d1, #0x00ffff0000ffff
+; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %and = and <2 x i32> %a, splat (i32 65535)
+  ret <2 x i32> %and
+}
+
+define <4 x i32> @and_low_16_v4i32(<4 x i32> %a) {
+; CHECK-NEON-LABEL: and_low_16_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
 ; CHECK-NEON-NEXT:    movi v1.2d, #0x00ffff0000ffff
 ; CHECK-NEON-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEON-NEXT:    ret
 ;
-; CHECK-SVE-LABEL: and_low_16:
+; CHECK-SVE-LABEL: and_low_16_v4i32:
 ; CHECK-SVE:       // %bb.0: // %entry
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-SVE-NEXT:    and z0.s, z0.s, #0xffff
@@ -56,14 +107,33 @@ entry:
   ret <4 x i32> %and
 }
 
-define <2 x i64> @and_low_32(<2 x i64> %a) {
-; CHECK-NEON-LABEL: and_low_32:
+define <1 x i64> @and_low_32_v1i64(<1 x i64> %a) {
+; CHECK-NEON-LABEL: and_low_32_v1i64:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-NEON-NEXT:    mov v0.s[1], wzr
+; CHECK-NEON-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: and_low_32_v1i64:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-SVE-NEXT:    mov v0.s[1], wzr
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-SVE-NEXT:    ret
+entry:
+  %and = and <1 x i64> %a, splat (i64 4294967295)
+  ret <1 x i64> %and
+}
+
+define <2 x i64> @and_low_32_v2i64(<2 x i64> %a) {
+; CHECK-NEON-LABEL: and_low_32_v2i64:
 ; CHECK-NEON:       // %bb.0: // %entry
 ; CHECK-NEON-NEXT:    movi v1.2d, #0x000000ffffffff
 ; CHECK-NEON-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEON-NEXT:    ret
 ;
-; CHECK-SVE-LABEL: and_low_32:
+; CHECK-SVE-LABEL: and_low_32_v2i64:
 ; CHECK-SVE:       // %bb.0: // %entry
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-SVE-NEXT:    and z0.d, z0.d, #0xffffffff
@@ -74,14 +144,31 @@ entry:
   ret <2 x i64> %and
 }
 
-define <4 x i32> @xor(<4 x i32> %a) {
-; CHECK-NEON-LABEL: xor:
+define <2 x i32> @xor_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: xor_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.2s, #127
+; CHECK-NEON-NEXT:    eor v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: xor_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.2s, #127
+; CHECK-SVE-NEXT:    eor v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %and = xor <2 x i32> %a, splat (i32 127)
+  ret <2 x i32> %and
+}
+
+define <4 x i32> @xor_v4i32(<4 x i32> %a) {
+; CHECK-NEON-LABEL: xor_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
 ; CHECK-NEON-NEXT:    movi v1.4s, #127
 ; CHECK-NEON-NEXT:    eor v0.16b, v0.16b, v1.16b
 ; CHECK-NEON-NEXT:    ret
 ;
-; CHECK-SVE-LABEL: xor:
+; CHECK-SVE-LABEL: xor_v4i32:
 ; CHECK-SVE:       // %bb.0: // %entry
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-SVE-NEXT:    eor z0.s, z0.s, #0x7f
@@ -92,14 +179,31 @@ entry:
   ret <4 x i32> %and
 }
 
-define <4 x i32> @or(<4 x i32> %a) {
-; CHECK-NEON-LABEL: or:
+define <2 x i32> @or_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: or_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    mvni v1.2s, #127
+; CHECK-NEON-NEXT:    orr v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: or_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    mvni v1.2s, #127
+; CHECK-SVE-NEXT:    orr v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %or = or <2 x i32> %a, splat (i32 -128)
+  ret <2 x i32> %or
+}
+
+define <4 x i32> @or_v4i32(<4 x i32> %a) {
+; CHECK-NEON-LABEL: or_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
 ; CHECK-NEON-NEXT:    mvni v1.4s, #127
 ; CHECK-NEON-NEXT:    orr v0.16b, v0.16b, v1.16b
 ; CHECK-NEON-NEXT:    ret
 ;
-; CHECK-SVE-LABEL: or:
+; CHECK-SVE-LABEL: or_v4i32:
 ; CHECK-SVE:       // %bb.0: // %entry
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-SVE-NEXT:    orr z0.s, z0.s, #0xffffff80
@@ -108,6 +212,25 @@ define <4 x i32> @or(<4 x i32> %a) {
 entry:
   %or = or <4 x i32> %a, splat (i32 -128)
   ret <4 x i32> %or
+}
+
+define <1 x i64> @add_v1i64(<1 x i64> %a) {
+; CHECK-NEON-LABEL: add_v1i64:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    mov w8, #33 // =0x21
+; CHECK-NEON-NEXT:    fmov d1, x8
+; CHECK-NEON-NEXT:    add d0, d0, d1
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: add_v1i64:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    mov w8, #33 // =0x21
+; CHECK-SVE-NEXT:    fmov d1, x8
+; CHECK-SVE-NEXT:    add d0, d0, d1
+; CHECK-SVE-NEXT:    ret
+entry:
+  %add = add <1 x i64> %a, splat (i64 33)
+  ret <1 x i64> %add
 }
 
 define <2 x i64> @add_v2i64(<2 x i64> %a) {
@@ -129,6 +252,23 @@ entry:
   ret <2 x i64> %add
 }
 
+define <2 x i32> @add_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: add_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.2s, #1
+; CHECK-NEON-NEXT:    add v0.2s, v0.2s, v1.2s
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: add_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.2s, #1
+; CHECK-SVE-NEXT:    add v0.2s, v0.2s, v1.2s
+; CHECK-SVE-NEXT:    ret
+entry:
+  %add = add <2 x i32> %a, splat (i32 1)
+  ret <2 x i32> %add
+}
+
 define <4 x i32> @add_v4i32(<4 x i32> %a) {
 ; CHECK-NEON-LABEL: add_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -147,6 +287,23 @@ entry:
   ret <4 x i32> %add
 }
 
+define <4 x i16> @add_v4i16(<4 x i16> %a) {
+; CHECK-NEON-LABEL: add_v4i16:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.4h, #16
+; CHECK-NEON-NEXT:    add v0.4h, v0.4h, v1.4h
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: add_v4i16:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.4h, #16
+; CHECK-SVE-NEXT:    add v0.4h, v0.4h, v1.4h
+; CHECK-SVE-NEXT:    ret
+entry:
+  %add = add <4 x i16> %a, splat (i16 16)
+  ret <4 x i16> %add
+}
+
 define <8 x i16> @add_v8i16(<8 x i16> %a) {
 ; CHECK-NEON-LABEL: add_v8i16:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -163,6 +320,23 @@ define <8 x i16> @add_v8i16(<8 x i16> %a) {
 entry:
   %add = add <8 x i16> %a, splat (i16 16)
   ret <8 x i16> %add
+}
+
+define <8 x i8> @add_v8i8(<8 x i8> %a) {
+; CHECK-NEON-LABEL: add_v8i8:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.8b, #2
+; CHECK-NEON-NEXT:    add v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: add_v8i8:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.8b, #2
+; CHECK-SVE-NEXT:    add v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %add = add <8 x i8> %a, splat (i8 2)
+  ret <8 x i8> %add
 }
 
 define <16 x i8> @add_v16i8(<16 x i8> %a) {
@@ -202,6 +376,25 @@ entry:
   ret <4 x i32> %add
 }
 
+define <1 x i64> @sub_v1i64(<1 x i64> %a) {
+; CHECK-NEON-LABEL: sub_v1i64:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    mov w8, #64 // =0x40
+; CHECK-NEON-NEXT:    fmov d1, x8
+; CHECK-NEON-NEXT:    sub d0, d0, d1
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: sub_v1i64:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    mov w8, #64 // =0x40
+; CHECK-SVE-NEXT:    fmov d1, x8
+; CHECK-SVE-NEXT:    sub d0, d0, d1
+; CHECK-SVE-NEXT:    ret
+entry:
+  %sub = sub <1 x i64> %a, splat (i64 64)
+  ret <1 x i64> %sub
+}
+
 define <2 x i64> @sub_v2i64(<2 x i64> %a) {
 ; CHECK-NEON-LABEL: sub_v2i64:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -219,6 +412,23 @@ define <2 x i64> @sub_v2i64(<2 x i64> %a) {
 entry:
   %sub = sub <2 x i64> %a, splat (i64 64)
   ret <2 x i64> %sub
+}
+
+define <2 x i32> @sub_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: sub_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.2s, #2, lsl #8
+; CHECK-NEON-NEXT:    sub v0.2s, v0.2s, v1.2s
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: sub_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.2s, #2, lsl #8
+; CHECK-SVE-NEXT:    sub v0.2s, v0.2s, v1.2s
+; CHECK-SVE-NEXT:    ret
+entry:
+  %sub = sub <2 x i32> %a, splat (i32 512)
+  ret <2 x i32> %sub
 }
 
 define <4 x i32> @sub_v4i32(<4 x i32> %a) {
@@ -239,6 +449,23 @@ entry:
   ret <4 x i32> %sub
 }
 
+define <4 x i16> @sub_v4i16(<4 x i16> %a) {
+; CHECK-NEON-LABEL: sub_v4i16:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.4h, #99
+; CHECK-NEON-NEXT:    sub v0.4h, v0.4h, v1.4h
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: sub_v4i16:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.4h, #99
+; CHECK-SVE-NEXT:    sub v0.4h, v0.4h, v1.4h
+; CHECK-SVE-NEXT:    ret
+entry:
+  %sub = sub <4 x i16> %a, splat (i16 99)
+  ret <4 x i16> %sub
+}
+
 define <8 x i16> @sub_v8i16(<8 x i16> %a) {
 ; CHECK-NEON-LABEL: sub_v8i16:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -257,6 +484,23 @@ entry:
   ret <8 x i16> %sub
 }
 
+define <8 x i8> @sub_v8i8(<8 x i8> %a) {
+; CHECK-NEON-LABEL: sub_v8i8:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.8b, #7
+; CHECK-NEON-NEXT:    sub v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: sub_v8i8:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.8b, #7
+; CHECK-SVE-NEXT:    sub v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %sub = sub <8 x i8> %a, splat (i8 7)
+  ret <8 x i8> %sub
+}
+
 define <16 x i8> @sub_v16i8(<16 x i8> %a) {
 ; CHECK-NEON-LABEL: sub_v16i8:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -273,6 +517,27 @@ define <16 x i8> @sub_v16i8(<16 x i8> %a) {
 entry:
   %sub = sub <16 x i8> %a, splat (i8 7)
   ret <16 x i8> %sub
+}
+
+define <1 x i64> @mul_v1i64(<1 x i64> %a) {
+; CHECK-NEON-LABEL: mul_v1i64:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-NEON-NEXT:    fmov x9, d0
+; CHECK-NEON-NEXT:    mov w8, #123 // =0x7b
+; CHECK-NEON-NEXT:    mul x8, x9, x8
+; CHECK-NEON-NEXT:    fmov d0, x8
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: mul_v1i64:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    mul z0.d, z0.d, #123
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
+; CHECK-SVE-NEXT:    ret
+entry:
+  %mul = mul <1 x i64> %a, splat (i64 123)
+  ret <1 x i64> %mul
 }
 
 define <2 x i64> @mul_v2i64(<2 x i64> %a) {
@@ -298,6 +563,23 @@ entry:
   ret <2 x i64> %mul
 }
 
+define <2 x i32> @mul_v2i32(<2 x i32> %a) {
+; CHECK-NEON-LABEL: mul_v2i32:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.2s, #33
+; CHECK-NEON-NEXT:    mul v0.2s, v0.2s, v1.2s
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: mul_v2i32:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.2s, #33
+; CHECK-SVE-NEXT:    mul v0.2s, v0.2s, v1.2s
+; CHECK-SVE-NEXT:    ret
+entry:
+  %mul = mul <2 x i32> %a, splat (i32 33)
+  ret <2 x i32> %mul
+}
+
 define <4 x i32> @mul_v4i32(<4 x i32> %a) {
 ; CHECK-NEON-LABEL: mul_v4i32:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -316,6 +598,23 @@ entry:
   ret <4 x i32> %mul
 }
 
+define <4 x i16> @mul_v4i16(<4 x i16> %a) {
+; CHECK-NEON-LABEL: mul_v4i16:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    mvni v1.4h, #32
+; CHECK-NEON-NEXT:    mul v0.4h, v0.4h, v1.4h
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: mul_v4i16:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    mvni v1.4h, #32
+; CHECK-SVE-NEXT:    mul v0.4h, v0.4h, v1.4h
+; CHECK-SVE-NEXT:    ret
+entry:
+  %mul = mul <4 x i16> %a, splat (i16 -33)
+  ret <4 x i16> %mul
+}
+
 define <8 x i16> @mul_v8i16(<8 x i16> %a) {
 ; CHECK-NEON-LABEL: mul_v8i16:
 ; CHECK-NEON:       // %bb.0: // %entry
@@ -332,6 +631,23 @@ define <8 x i16> @mul_v8i16(<8 x i16> %a) {
 entry:
   %mul = mul <8 x i16> %a, splat (i16 -33)
   ret <8 x i16> %mul
+}
+
+define <8 x i8> @mul_v8i8(<8 x i8> %a) {
+; CHECK-NEON-LABEL: mul_v8i8:
+; CHECK-NEON:       // %bb.0: // %entry
+; CHECK-NEON-NEXT:    movi v1.8b, #253
+; CHECK-NEON-NEXT:    mul v0.8b, v0.8b, v1.8b
+; CHECK-NEON-NEXT:    ret
+;
+; CHECK-SVE-LABEL: mul_v8i8:
+; CHECK-SVE:       // %bb.0: // %entry
+; CHECK-SVE-NEXT:    movi v1.8b, #253
+; CHECK-SVE-NEXT:    mul v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    ret
+entry:
+  %mul = mul <8 x i8> %a, splat (i8 -3)
+  ret <8 x i8> %mul
 }
 
 define <16 x i8> @mul_v16i8(<16 x i8> %a) {

--- a/llvm/test/CodeGen/AArch64/imm-splat-ops.ll
+++ b/llvm/test/CodeGen/AArch64/imm-splat-ops.ll
@@ -11,8 +11,9 @@ define <2 x i32> @and_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: and_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    fmov v1.2s, #1.00000000
-; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    and z0.s, z0.s, #0x3f800000
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %and = and <2 x i32> %a, splat (i32 1065353216)
@@ -46,8 +47,9 @@ define <2 x i32> @and_low_8_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: and_low_8_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi d1, #0x0000ff000000ff
-; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    and z0.s, z0.s, #0xff
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %and = and <2 x i32> %a, splat (i32 255)
@@ -81,8 +83,9 @@ define <2 x i32> @and_low_16_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: and_low_16_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi d1, #0x00ffff0000ffff
-; CHECK-SVE-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    and z0.s, z0.s, #0xffff
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %and = and <2 x i32> %a, splat (i32 65535)
@@ -153,8 +156,9 @@ define <2 x i32> @xor_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: xor_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.2s, #127
-; CHECK-SVE-NEXT:    eor v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    eor z0.s, z0.s, #0x7f
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %and = xor <2 x i32> %a, splat (i32 127)
@@ -188,8 +192,9 @@ define <2 x i32> @or_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: or_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    mvni v1.2s, #127
-; CHECK-SVE-NEXT:    orr v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    orr z0.s, z0.s, #0xffffff80
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %or = or <2 x i32> %a, splat (i32 -128)
@@ -224,9 +229,9 @@ define <1 x i64> @add_v1i64(<1 x i64> %a) {
 ;
 ; CHECK-SVE-LABEL: add_v1i64:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    mov w8, #33 // =0x21
-; CHECK-SVE-NEXT:    fmov d1, x8
-; CHECK-SVE-NEXT:    add d0, d0, d1
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    add z0.d, z0.d, #33 // =0x21
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %add = add <1 x i64> %a, splat (i64 33)
@@ -261,8 +266,9 @@ define <2 x i32> @add_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: add_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.2s, #1
-; CHECK-SVE-NEXT:    add v0.2s, v0.2s, v1.2s
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    add z0.s, z0.s, #1 // =0x1
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %add = add <2 x i32> %a, splat (i32 1)
@@ -296,8 +302,9 @@ define <4 x i16> @add_v4i16(<4 x i16> %a) {
 ;
 ; CHECK-SVE-LABEL: add_v4i16:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.4h, #16
-; CHECK-SVE-NEXT:    add v0.4h, v0.4h, v1.4h
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    add z0.h, z0.h, #16 // =0x10
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %add = add <4 x i16> %a, splat (i16 16)
@@ -331,8 +338,9 @@ define <8 x i8> @add_v8i8(<8 x i8> %a) {
 ;
 ; CHECK-SVE-LABEL: add_v8i8:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.8b, #2
-; CHECK-SVE-NEXT:    add v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    add z0.b, z0.b, #2 // =0x2
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %add = add <8 x i8> %a, splat (i8 2)
@@ -386,9 +394,9 @@ define <1 x i64> @sub_v1i64(<1 x i64> %a) {
 ;
 ; CHECK-SVE-LABEL: sub_v1i64:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    mov w8, #64 // =0x40
-; CHECK-SVE-NEXT:    fmov d1, x8
-; CHECK-SVE-NEXT:    sub d0, d0, d1
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    sub z0.d, z0.d, #64 // =0x40
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %sub = sub <1 x i64> %a, splat (i64 64)
@@ -423,8 +431,9 @@ define <2 x i32> @sub_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: sub_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.2s, #2, lsl #8
-; CHECK-SVE-NEXT:    sub v0.2s, v0.2s, v1.2s
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    sub z0.s, z0.s, #512 // =0x200
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %sub = sub <2 x i32> %a, splat (i32 512)
@@ -458,8 +467,9 @@ define <4 x i16> @sub_v4i16(<4 x i16> %a) {
 ;
 ; CHECK-SVE-LABEL: sub_v4i16:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.4h, #99
-; CHECK-SVE-NEXT:    sub v0.4h, v0.4h, v1.4h
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    sub z0.h, z0.h, #99 // =0x63
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %sub = sub <4 x i16> %a, splat (i16 99)
@@ -493,8 +503,9 @@ define <8 x i8> @sub_v8i8(<8 x i8> %a) {
 ;
 ; CHECK-SVE-LABEL: sub_v8i8:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.8b, #7
-; CHECK-SVE-NEXT:    sub v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    sub z0.b, z0.b, #7 // =0x7
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %sub = sub <8 x i8> %a, splat (i8 7)
@@ -572,8 +583,9 @@ define <2 x i32> @mul_v2i32(<2 x i32> %a) {
 ;
 ; CHECK-SVE-LABEL: mul_v2i32:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.2s, #33
-; CHECK-SVE-NEXT:    mul v0.2s, v0.2s, v1.2s
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    mul z0.s, z0.s, #33
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %mul = mul <2 x i32> %a, splat (i32 33)
@@ -607,8 +619,9 @@ define <4 x i16> @mul_v4i16(<4 x i16> %a) {
 ;
 ; CHECK-SVE-LABEL: mul_v4i16:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    mvni v1.4h, #32
-; CHECK-SVE-NEXT:    mul v0.4h, v0.4h, v1.4h
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    mul z0.h, z0.h, #-33
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %mul = mul <4 x i16> %a, splat (i16 -33)
@@ -642,8 +655,9 @@ define <8 x i8> @mul_v8i8(<8 x i8> %a) {
 ;
 ; CHECK-SVE-LABEL: mul_v8i8:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    movi v1.8b, #253
-; CHECK-SVE-NEXT:    mul v0.8b, v0.8b, v1.8b
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-SVE-NEXT:    mul z0.b, z0.b, #-3
+; CHECK-SVE-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:
   %mul = mul <8 x i8> %a, splat (i8 -3)

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-int-to-fp.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-int-to-fp.ll
@@ -109,8 +109,8 @@ define void @ucvtf_v128i16_v128f16(ptr %a, ptr %b) vscale_range(16,0) #0 {
 define <2 x float> @ucvtf_v2i16_v2f32(<2 x i16> %op1) vscale_range(2,0) #0 {
 ; CHECK-LABEL: ucvtf_v2i16_v2f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi d1, #0x00ffff0000ffff
-; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-NEXT:    and z0.s, z0.s, #0xffff
 ; CHECK-NEXT:    ucvtf v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %res = uitofp <2 x i16> %op1 to <2 x float>
@@ -224,8 +224,8 @@ define <1 x double> @ucvtf_v1i16_v1f64(<1 x i16> %op1) vscale_range(2,0) #0 {
 define <2 x double> @ucvtf_v2i16_v2f64(<2 x i16> %op1) vscale_range(2,0) #0 {
 ; CHECK-LABEL: ucvtf_v2i16_v2f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi d1, #0x00ffff0000ffff
-; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-NEXT:    and z0.s, z0.s, #0xffff
 ; CHECK-NEXT:    ushll v0.2d, v0.2s, #0
 ; CHECK-NEXT:    ucvtf v0.2d, v0.2d
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sve-vector-compress.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-compress.ll
@@ -275,22 +275,21 @@ define <4 x double> @test_compress_v4f64_with_sve(<4 x double> %vec, <4 x i1> %m
 ; CHECK-NEXT:    sub sp, sp, #32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    ushll v2.4s, v2.4h, #0
-; CHECK-NEXT:    movi v4.2s, #1
+; CHECK-NEXT:    ptrue p0.d, vl2
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-NEXT:    mov x9, sp
-; CHECK-NEXT:    ptrue p0.d, vl2
 ; CHECK-NEXT:    ushll v3.2d, v2.2s, #0
-; CHECK-NEXT:    ushll2 v5.2d, v2.4s, #0
-; CHECK-NEXT:    and v2.8b, v2.8b, v4.8b
+; CHECK-NEXT:    ushll2 v4.2d, v2.4s, #0
+; CHECK-NEXT:    and z2.s, z2.s, #0x1
 ; CHECK-NEXT:    shl v3.2d, v3.2d, #63
-; CHECK-NEXT:    shl v4.2d, v5.2d, #63
+; CHECK-NEXT:    shl v4.2d, v4.2d, #63
 ; CHECK-NEXT:    addp v2.2s, v2.2s, v2.2s
 ; CHECK-NEXT:    cmpne p1.d, p0/z, z3.d, #0
 ; CHECK-NEXT:    cmpne p2.d, p0/z, z4.d, #0
 ; CHECK-NEXT:    fmov w8, s2
-; CHECK-NEXT:    compact z0.d, p1, z0.d
 ; CHECK-NEXT:    and x8, x8, #0x3
+; CHECK-NEXT:    compact z0.d, p1, z0.d
 ; CHECK-NEXT:    compact z1.d, p2, z1.d
 ; CHECK-NEXT:    lsl x8, x8, #3
 ; CHECK-NEXT:    str q0, [sp]


### PR DESCRIPTION
This extends https://github.com/llvm/llvm-project/issues/165559 to include 64-bit vectors.  I have a follow on PR to extend the support to include min/max operations.