### PR TITLE
[LLD][ELF] handle unnamed section group signatures

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -695,7 +695,25 @@ StringRef ObjFile<ELFT>::getShtGroupSignature(ArrayRef<Elf_Shdr> sections,
   if (sec.sh_info >= symbols.size())
     Fatal(ctx) << this << ": invalid symbol index";
   const typename ELFT::Sym &sym = symbols[sec.sh_info];
-  return CHECK2(sym.getName(this->stringTable), this);
+  StringRef signature = CHECK2(sym.getName(this->stringTable), this);
+  if (!signature.empty() || sym.getType() != STT_SECTION)
+    return signature;
+
+  // GNU as may use an unnamed STT_SECTION symbol as a group signature.
+  ArrayRef<Elf_Word> shndx;
+  if (sym.st_shndx == SHN_XINDEX) {
+    for (const Elf_Shdr &section : sections) {
+      if (section.sh_type != SHT_SYMTAB_SHNDX || section.sh_link != sec.sh_link)
+        continue;
+      shndx = CHECK2(getObj().getSHNDXTable(section, sections), this);
+      break;
+    }
+  }
+  uint32_t sectionIndex =
+      CHECK2(getObj().getSectionIndex(sym, symbols, shndx), this);
+  if (sectionIndex == 0 || sectionIndex >= sections.size())
+    Fatal(ctx) << this << ": invalid section index: " << sectionIndex;
+  return CHECK2(getObj().getSectionName(sections[sectionIndex]), this);
 }
 
 template <class ELFT>

--- a/lld/test/ELF/sht-group-signature-section.test
+++ b/lld/test/ELF/sht-group-signature-section.test
@@ -1,0 +1,73 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: ld.lld -r %t.o -o %t
+# RUN: llvm-readobj --sections %t | FileCheck %s
+
+# CHECK-DAG: Name: .text.direct.a
+# CHECK-DAG: Name: .text.direct.b
+# CHECK-DAG: Name: .text.xindex.a
+# CHECK-DAG: Name: .text.xindex.b
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name: .group.direct.a
+    Type: SHT_GROUP
+    Link: .symtab
+    Info: 1
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.direct.a
+  - Name: .text.direct.a
+    Type: SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+  - Name: .group.direct.b
+    Type: SHT_GROUP
+    Link: .symtab
+    Info: 2
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.direct.b
+  - Name: .text.direct.b
+    Type: SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+  - Name: .group.xindex.a
+    Type: SHT_GROUP
+    Link: .symtab
+    Info: 3
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.xindex.a
+  - Name: .text.xindex.a
+    Type: SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+  - Name: .group.xindex.b
+    Type: SHT_GROUP
+    Link: .symtab
+    Info: 4
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.xindex.b
+  - Name: .text.xindex.b
+    Type: SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+  - Name: .symtab_shndx
+    Type: SHT_SYMTAB_SHNDX
+    Link: .symtab
+    Entries: [ 0, 0, 0, 6, 8 ]
+Symbols:
+  - Name: ""
+    Type: STT_SECTION
+    Section: .text.direct.a
+  - Name: ""
+    Type: STT_SECTION
+    Section: .text.direct.b
+  - Name: ""
+    Type: STT_SECTION
+    Index: SHN_XINDEX
+  - Name: ""
+    Type: STT_SECTION
+    Index: SHN_XINDEX


### PR DESCRIPTION
GNU as may use an unnamed STT_SECTION symbol as a COMDAT group signature. LLD treated every such signature as empty and discarded unrelated constructor and destructor groups as duplicates.

Use the referenced section name, as GNU BFD does. Handle SHN_XINDEX while resolving the referenced section.