### PR TITLE
[libc] Replace sys/select.h, sys/utsname.h and sys/wait.h includes with proxy headers

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -187,6 +187,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  sys_select_macros
+  HDRS
+    sys_select_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.sys_select
+    libc.include.llvm-libc-macros.sys_select_macros
+)
+
+add_proxy_header_library(
   sys_sem_macros
   HDRS
     sys_sem_macros.h
@@ -238,6 +247,15 @@ add_proxy_header_library(
   FULL_BUILD_DEPENDS
     libc.include.sys_time
     libc.include.llvm-libc-macros.sys_time_macros
+)
+
+add_proxy_header_library(
+  sys_wait_macros
+  HDRS
+    sys_wait_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.sys_wait
+    libc.include.llvm-libc-macros.sys_wait_macros
 )
 
 add_header_library(unistd_overlay HDRS unistd_overlay.h)

--- a/libc/hdr/sys_select_macros.h
+++ b/libc/hdr/sys_select_macros.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from sys/select.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_SYS_SELECT_MACROS_H
+#define LLVM_LIBC_HDR_SYS_SELECT_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/sys-select-macros.h"
+
+#else // Overlay mode
+
+#include <sys/select.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_SYS_SELECT_MACROS_H

--- a/libc/hdr/sys_wait_macros.h
+++ b/libc/hdr/sys_wait_macros.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from sys/wait.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_SYS_WAIT_MACROS_H
+#define LLVM_LIBC_HDR_SYS_WAIT_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/sys-wait-macros.h"
+
+#else // Overlay mode
+
+#include <sys/wait.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_SYS_WAIT_MACROS_H

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -221,6 +221,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  fd_set
+  HDRS
+    fd_set.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.fd_set
+    libc.include.sys_select
+)
+
+add_proxy_header_library(
   fenv_t
   HDRS
     fenv_t.h
@@ -602,6 +611,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  struct_utsname
+  HDRS
+    struct_utsname.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_utsname
+    libc.include.sys_utsname
+)
+
+add_proxy_header_library(
   sa_family_t
   HDRS
     sa_family_t.h
@@ -734,6 +752,15 @@ add_proxy_header_library(
     struct_rlimit.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.struct_rlimit
+    libc.include.sys_resource
+)
+
+add_proxy_header_library(
+  struct_rusage
+  HDRS
+    struct_rusage.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_rusage
     libc.include.sys_resource
 )
 

--- a/libc/hdr/types/fd_set.h
+++ b/libc/hdr/types/fd_set.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy for fd_set.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_FD_SET_H
+#define LLVM_LIBC_HDR_TYPES_FD_SET_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/fd_set.h"
+
+#else // Overlay mode
+
+#include <sys/select.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_FD_SET_H

--- a/libc/hdr/types/struct_rusage.h
+++ b/libc/hdr/types/struct_rusage.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy for struct rusage.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_RUSAGE_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_RUSAGE_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_rusage.h"
+
+#else // Overlay mode
+
+#include <sys/resource.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_RUSAGE_H

--- a/libc/hdr/types/struct_utsname.h
+++ b/libc/hdr/types/struct_utsname.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy for struct utsname.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_UTSNAME_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_UTSNAME_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_utsname.h"
+
+#else // Overlay mode
+
+#include <sys/utsname.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_UTSNAME_H

--- a/libc/src/sys/select/linux/CMakeLists.txt
+++ b/libc/src/sys/select/linux/CMakeLists.txt
@@ -5,8 +5,13 @@ add_entrypoint_object(
   HDRS
     ../select.h
   DEPENDS
-    libc.include.sys_select
+    libc.hdr.types.fd_set
+    libc.hdr.types.sigset_t
+    libc.hdr.types.size_t
+    libc.hdr.types.struct_timespec
+    libc.hdr.types.struct_timeval
     libc.include.sys_syscall
+    libc.src.__support.CPP.limits
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/sys/select/linux/select.cpp
+++ b/libc/src/sys/select/linux/select.cpp
@@ -9,14 +9,13 @@
 #include "src/sys/select/select.h"
 
 #include "hdr/types/sigset_t.h"
+#include "hdr/types/size_t.h"
 #include "hdr/types/struct_timespec.h"
 #include "src/__support/CPP/limits.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-
-#include "hdr/types/size_t.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sys/select/select.h
+++ b/libc/src/sys/select/select.h
@@ -9,8 +9,9 @@
 #ifndef LLVM_LIBC_SRC_SYS_SELECT_SELECT_H
 #define LLVM_LIBC_SRC_SYS_SELECT_SELECT_H
 
+#include "hdr/types/fd_set.h"
+#include "hdr/types/struct_timeval.h"
 #include "src/__support/macros/config.h"
-#include <sys/select.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/utsname/linux/CMakeLists.txt
+++ b/libc/src/sys/utsname/linux/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../uname.h
   DEPENDS
-    libc.include.sys_utsname
+    libc.hdr.types.struct_utsname
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno

--- a/libc/src/sys/utsname/linux/uname.cpp
+++ b/libc/src/sys/utsname/linux/uname.cpp
@@ -8,13 +8,12 @@
 
 #include "src/sys/utsname/uname.h"
 
+#include "hdr/types/struct_utsname.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include <sys/syscall.h> // For syscall numbers.
-#include <sys/utsname.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/utsname/uname.h
+++ b/libc/src/sys/utsname/uname.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_UTSNAME_UNAME_H
 #define LLVM_LIBC_SRC_SYS_UTSNAME_UNAME_H
 
+#include "hdr/types/struct_utsname.h"
 #include "src/__support/macros/config.h"
-#include <sys/utsname.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/wait/linux/CMakeLists.txt
+++ b/libc/src/sys/wait/linux/CMakeLists.txt
@@ -6,9 +6,10 @@ add_entrypoint_object(
     ../wait.h
   DEPENDS
     libc.hdr.signal_macros
+    libc.hdr.sys_wait_macros
     libc.hdr.types.pid_t
     libc.hdr.types.siginfo_t
-    libc.include.sys_wait
+    libc.hdr.types.struct_rusage
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -22,8 +23,10 @@ add_entrypoint_object(
     ../wait4.h
   DEPENDS
     libc.hdr.signal_macros
+    libc.hdr.sys_wait_macros
+    libc.hdr.types.pid_t
     libc.hdr.types.siginfo_t
-    libc.include.sys_wait
+    libc.hdr.types.struct_rusage
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -37,9 +40,10 @@ add_entrypoint_object(
     ../waitpid.h
   DEPENDS
     libc.hdr.signal_macros
+    libc.hdr.sys_wait_macros
     libc.hdr.types.pid_t
     libc.hdr.types.siginfo_t
-    libc.include.sys_wait
+    libc.hdr.types.struct_rusage
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno

--- a/libc/src/sys/wait/wait4.h
+++ b/libc/src/sys/wait/wait4.h
@@ -9,8 +9,9 @@
 #ifndef LLVM_LIBC_SRC_SYS_WAIT_WAIT4_H
 #define LLVM_LIBC_SRC_SYS_WAIT_WAIT4_H
 
+#include "hdr/types/pid_t.h"
+#include "hdr/types/struct_rusage.h"
 #include "src/__support/macros/config.h"
-#include <sys/wait.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/wait/wait4Impl.h
+++ b/libc/src/sys/wait/wait4Impl.h
@@ -16,9 +16,11 @@
 #include "src/__support/macros/config.h"
 
 #include "hdr/signal_macros.h"
+#include "hdr/sys_wait_macros.h"
+#include "hdr/types/pid_t.h"
 #include "hdr/types/siginfo_t.h"
+#include "hdr/types/struct_rusage.h"
 #include <sys/syscall.h> // For syscall numbers.
-#include <sys/wait.h>
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -235,10 +235,11 @@ add_entrypoint_object(
     ../gethostname.h
   DEPENDS
     libc.hdr.types.size_t
+    libc.hdr.types.struct_utsname
     libc.include.sys_syscall
-    libc.include.sys_utsname
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
+    libc.src.string.string_utils
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/linux/gethostname.cpp
+++ b/libc/src/unistd/linux/gethostname.cpp
@@ -9,6 +9,7 @@
 #include "src/unistd/gethostname.h"
 
 #include "hdr/types/size_t.h"
+#include "hdr/types/struct_utsname.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
@@ -16,7 +17,6 @@
 #include "src/string/string_utils.h"
 
 #include <sys/syscall.h> // For syscall numbers.
-#include <sys/utsname.h>
 
 namespace LIBC_NAMESPACE_DECL {
 


### PR DESCRIPTION
I'm replacing system includes of <sys/select.h>, <sys/utsname.h>, and <sys/wait.h> in non-test and non-proxy code with granular proxy headers.

- add proxy headers for sys/select.h and sys/wait.h macros as well as fd_set, struct rusage, and struct utsname types
- switch select, uname, gethostname, and wait4 internal headers and implementations to include the proxy headers instead of system headers
- update cmake dependencies for the affected entry points

Assisted by Gemini.