### PR TITLE
[flang][cuda] Skip implicit managed/unified attribution for COMMON objects

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10616,7 +10616,8 @@ void DeclarationVisitor::SetImplicitCUDADataAttr(Symbol &symbol) {
   // program, or component) so generic resolution still selects the
   // unified specific; fall back to Managed elsewhere (module scope,
   // device subprograms), which uses the same allocator.
-  if (cudaEnabled && (cudaManaged || cudaUnified)) {
+  // COMMON objects may not carry managed/unified attributes.
+  if (cudaEnabled && (cudaManaged || cudaUnified) && !object->commonBlock()) {
     const Scope &owner{symbol.owner()};
     const bool unifiedAllowed{!IsCUDADeviceContext(&owner) &&
         (owner.IsDerivedType() || owner.kind() == Scope::Kind::MainProgram ||

--- a/flang/test/Lower/CUDA/cuda-implicit-managed-alloc.cuf
+++ b/flang/test/Lower/CUDA/cuda-implicit-managed-alloc.cuf
@@ -21,6 +21,10 @@ contains
     real, allocatable :: loc_arr(:)
     real, pointer :: loc_ptr(:)
   end subroutine
+  subroutine common_sub()
+    real, pointer :: com_ptr(:)
+    common /blk/ com_ptr
+  end subroutine
 end module
 
 program p
@@ -33,6 +37,10 @@ end program
 ! UNI: hlfir.declare {{.*}} {data_attr = #cuf.cuda<unified>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEloc_ptr"}
 ! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMmFmod_subEloc_arr"}
 ! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEloc_ptr"}
+
+! COMMON-block pointer: unattributed, CUDA attributes may not appear in COMMON.
+! UNI: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
+! MAN: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
 
 ! Main-program local: Unified under -gpu=unified, Managed under
 ! -gpu=managed.


### PR DESCRIPTION
Objects in Fortran `COMMON` blocks may not carry `ATTRIBUTES(MANAGED)` or `ATTRIBUTES(UNIFIED)`.  The implicit attribution added in [#209292](https://github.com/llvm/llvm-project/pull/209292) did not account for this, causing a spurious semantic error when a pointer in a `COMMON` block was implicitly attributed. This change adds a `!object->commonBlock()` guard to `SetImplicitCUDADataAttr` so that COMMON members are left unattributed.