### PR TITLE
[clang-tidy] Extend bugprone-narrowing-conversions with time_t narrowing option

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 
+#include <algorithm>
 #include <cstdint>
 
 using namespace clang::ast_matchers;
@@ -243,24 +244,7 @@ static bool getFloatingConstantExprValue(const ASTContext &Context,
   return true;
 }
 
-namespace {
-
-struct IntegerRange {
-  bool contains(const IntegerRange &From) const {
-    return llvm::APSInt::compareValues(Lower, From.Lower) <= 0 &&
-           llvm::APSInt::compareValues(Upper, From.Upper) >= 0;
-  }
-
-  bool contains(const llvm::APSInt &Value) const {
-    return llvm::APSInt::compareValues(Lower, Value) <= 0 &&
-           llvm::APSInt::compareValues(Upper, Value) >= 0;
-  }
-
-  llvm::APSInt Lower;
-  llvm::APSInt Upper;
-};
-
-bool hasTimeTTypedef(QualType QT) {
+static bool hasTimeTTypedef(QualType QT) {
   while (true) {
     const auto *T = QT.getTypePtrOrNull();
     if (!T)
@@ -283,8 +267,7 @@ bool hasTimeTTypedef(QualType QT) {
   return false;
 }
 
-bool exprMentionsTimeT(const Expr *E) {
-
+static bool exprMentionsTimeT(const Expr *E) {
   if (!E)
     return false;
 
@@ -293,14 +276,28 @@ bool exprMentionsTimeT(const Expr *E) {
   if (hasTimeTTypedef(E->getType()))
     return true;
 
-  for (const Stmt *Child : E->children()) {
-    if (const auto *ChildExpr = dyn_cast_or_null<Expr>(Child))
-      if (exprMentionsTimeT(ChildExpr))
-        return true;
+  return std::any_of(E->child_begin(), E->child_end(), [](const Stmt *Child) {
+    const auto *ChildExpr = dyn_cast_or_null<Expr>(Child);
+    return ChildExpr && exprMentionsTimeT(ChildExpr);
+  });
+}
+
+namespace {
+
+struct IntegerRange {
+  bool contains(const IntegerRange &From) const {
+    return llvm::APSInt::compareValues(Lower, From.Lower) <= 0 &&
+           llvm::APSInt::compareValues(Upper, From.Upper) >= 0;
   }
 
-  return false;
-}
+  bool contains(const llvm::APSInt &Value) const {
+    return llvm::APSInt::compareValues(Lower, Value) <= 0 &&
+           llvm::APSInt::compareValues(Upper, Value) >= 0;
+  }
+
+  llvm::APSInt Lower;
+  llvm::APSInt Upper;
+};
 
 } // namespace
 

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
@@ -55,7 +55,8 @@ NarrowingConversionsCheck::NarrowingConversionsCheck(StringRef Name,
       WarnWithinTemplateInstantiation(
           Options.get("WarnWithinTemplateInstantiation", false)),
       WarnOnEquivalentBitWidth(Options.get("WarnOnEquivalentBitWidth", true)),
-      WarnOnTimeTNarrowingConversion(Options.get("WarnOnTimeTNarrowingConversion", false)),
+      WarnOnTimeTNarrowingConversion(
+          Options.get("WarnOnTimeTNarrowingConversion", false)),
       IgnoreConversionFromTypes(Options.get("IgnoreConversionFromTypes", "")),
       PedanticMode(Options.get("PedanticMode", false)) {}
 
@@ -70,7 +71,8 @@ void NarrowingConversionsCheck::storeOptions(
   Options.store(Opts, "WarnWithinTemplateInstantiation",
                 WarnWithinTemplateInstantiation);
   Options.store(Opts, "WarnOnEquivalentBitWidth", WarnOnEquivalentBitWidth);
-  Options.store(Opts, "WarnOnTimeTNarrowingConversion", WarnOnTimeTNarrowingConversion);
+  Options.store(Opts, "WarnOnTimeTNarrowingConversion",
+                WarnOnTimeTNarrowingConversion);
   Options.store(Opts, "IgnoreConversionFromTypes", IgnoreConversionFromTypes);
   Options.store(Opts, "PedanticMode", PedanticMode);
 }
@@ -457,8 +459,8 @@ void NarrowingConversionsCheck::diagTimeTConversion(SourceLocation SourceLoc,
       << getUnqualifiedType(Rhs) << getUnqualifiedType(Lhs);
 }
 
-void NarrowingConversionsCheck::handleTimeTOnlyCast(
-    const ASTContext &Context, const CastExpr &Cast) {
+void NarrowingConversionsCheck::handleTimeTOnlyCast(const ASTContext &Context,
+                                                    const CastExpr &Cast) {
   const Expr &Lhs = Cast;
   const Expr &Rhs = *Cast.getSubExprAsWritten();
 
@@ -469,9 +471,10 @@ void NarrowingConversionsCheck::handleTimeTOnlyCast(
   handleTimeTConversion(Context, SourceLoc, Lhs, Rhs);
 }
 
-void NarrowingConversionsCheck::handleTimeTConversion(
-  const ASTContext &Context, SourceLocation SourceLoc,
-  const Expr &Lhs, const Expr &Rhs) {
+void NarrowingConversionsCheck::handleTimeTConversion(const ASTContext &Context,
+                                                      SourceLocation SourceLoc,
+                                                      const Expr &Lhs,
+                                                      const Expr &Rhs) {
   if (!WarnOnTimeTNarrowingConversion)
     return;
 
@@ -756,7 +759,8 @@ void NarrowingConversionsCheck::check(const MatchFinder::MatchResult &Result) {
     handleBinaryOperator(*Result.Context, *Op);
   else if (const auto *Cast = Result.Nodes.getNodeAs<ImplicitCastExpr>("cast"))
     handleImplicitCast(*Result.Context, *Cast);
-  else if (const auto *ECast = Result.Nodes.getNodeAs<ExplicitCastExpr>("explicit_cast"))
+  else if (const auto *ECast =
+               Result.Nodes.getNodeAs<ExplicitCastExpr>("explicit_cast"))
     handleTimeTOnlyCast(*Result.Context, *ECast);
   else
     llvm_unreachable("must be binary operator or cast expression");

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
@@ -55,6 +55,7 @@ NarrowingConversionsCheck::NarrowingConversionsCheck(StringRef Name,
       WarnWithinTemplateInstantiation(
           Options.get("WarnWithinTemplateInstantiation", false)),
       WarnOnEquivalentBitWidth(Options.get("WarnOnEquivalentBitWidth", true)),
+      WarnOnTimeTNarrowingConversion(Options.get("WarnOnTimeTNarrowingConversion", false)),
       IgnoreConversionFromTypes(Options.get("IgnoreConversionFromTypes", "")),
       PedanticMode(Options.get("PedanticMode", false)) {}
 
@@ -69,6 +70,7 @@ void NarrowingConversionsCheck::storeOptions(
   Options.store(Opts, "WarnWithinTemplateInstantiation",
                 WarnWithinTemplateInstantiation);
   Options.store(Opts, "WarnOnEquivalentBitWidth", WarnOnEquivalentBitWidth);
+  Options.store(Opts, "WarnOnTimeTNarrowingConversion", WarnOnTimeTNarrowingConversion);
   Options.store(Opts, "IgnoreConversionFromTypes", IgnoreConversionFromTypes);
   Options.store(Opts, "PedanticMode", PedanticMode);
 }
@@ -184,6 +186,24 @@ void NarrowingConversionsCheck::registerMatchers(MatchFinder *Finder) {
           unless(hasOperatorName("=")))
           .bind("binary_op"),
       this);
+
+  // Explicit casts are checked only in the time_t narrowing mode,
+  // so the default behavior of this check remains unchanged.
+  if (WarnOnTimeTNarrowingConversion) {
+    Finder->addMatcher(
+        traverse(
+            TK_AsIs,
+            explicitCastExpr(
+                hasDestinationType(hasUnqualifiedDesugaredType(builtinType())),
+                hasSourceExpression(
+                    expr(hasType(hasUnqualifiedDesugaredType(builtinType())))),
+                unless(hasSourceExpression(IsCeilFloorCallExpr)),
+                WarnWithinTemplateInstantiation
+                    ? stmt()
+                    : stmt(unless(isInTemplateInstantiation())))
+                .bind("explicit_cast")),
+        this);
+  }
 }
 
 static const BuiltinType *getBuiltinType(const Expr &E) {
@@ -237,6 +257,48 @@ struct IntegerRange {
   llvm::APSInt Lower;
   llvm::APSInt Upper;
 };
+
+bool hasTimeTTypedef(QualType QT) {
+  while (true) {
+    const auto *T = QT.getTypePtrOrNull();
+    if (!T)
+      return false;
+
+    if (const auto *TT = dyn_cast<TypedefType>(T)) {
+      const auto *TD = TT->getDecl();
+      if (TD->getName() == "time_t" || TD->getName() == "__time_t")
+        return true;
+    }
+
+    QualType NextInChain = QT->getLocallyUnqualifiedSingleStepDesugaredType();
+    NextInChain = NextInChain.getNonReferenceType().getUnqualifiedType();
+    if (NextInChain == QT)
+      break;
+
+    QT = NextInChain;
+  }
+
+  return false;
+}
+
+bool exprMentionsTimeT(const Expr *E) {
+
+  if (!E)
+    return false;
+
+  E = E->IgnoreParenImpCasts();
+
+  if (hasTimeTTypedef(E->getType()))
+    return true;
+
+  for (const Stmt *Child : E->children()) {
+    if (const auto *ChildExpr = dyn_cast_or_null<Expr>(Child))
+      if (exprMentionsTimeT(ChildExpr))
+        return true;
+  }
+
+  return false;
+}
 
 } // namespace
 
@@ -385,6 +447,54 @@ void NarrowingConversionsCheck::diagNarrowTypeOrConstant(
     diagNarrowConstant(SourceLoc, Lhs, Rhs);
   else
     diagNarrowType(SourceLoc, Lhs, Rhs);
+}
+
+void NarrowingConversionsCheck::diagTimeTConversion(SourceLocation SourceLoc,
+                                                    const Expr &Lhs,
+                                                    const Expr &Rhs) {
+  diag(SourceLoc,
+       "conversion from %0 to %1 may not preserve the full range of time_t")
+      << getUnqualifiedType(Rhs) << getUnqualifiedType(Lhs);
+}
+
+void NarrowingConversionsCheck::handleTimeTOnlyCast(
+    const ASTContext &Context, const CastExpr &Cast) {
+  const Expr &Lhs = Cast;
+  const Expr &Rhs = *Cast.getSubExprAsWritten();
+
+  if (Lhs.isInstantiationDependent() || Rhs.isInstantiationDependent())
+    return;
+
+  const SourceLocation SourceLoc = Cast.getExprLoc();
+  handleTimeTConversion(Context, SourceLoc, Lhs, Rhs);
+}
+
+void NarrowingConversionsCheck::handleTimeTConversion(
+  const ASTContext &Context, SourceLocation SourceLoc,
+  const Expr &Lhs, const Expr &Rhs) {
+  if (!WarnOnTimeTNarrowingConversion)
+    return;
+
+  if (!exprMentionsTimeT(&Rhs))
+    return;
+
+  const BuiltinType *FromType = getBuiltinType(Rhs);
+  const BuiltinType *ToType = getBuiltinType(Lhs);
+
+  if (!FromType || !ToType)
+    return;
+
+  if (!ToType->isInteger() || !FromType->isInteger())
+    return;
+
+  // Usually not useful for Y2038. Keep bool conversions quiet.
+  if (ToType->getKind() == BuiltinType::Bool)
+    return;
+
+  if (isWideEnoughToHold(Context, *FromType, *ToType))
+    return;
+
+  diagTimeTConversion(SourceLoc, Lhs, Rhs);
 }
 
 void NarrowingConversionsCheck::handleIntegralCast(const ASTContext &Context,
@@ -572,6 +682,10 @@ void NarrowingConversionsCheck::handleConditionalOperatorArgument(
 
 void NarrowingConversionsCheck::handleImplicitCast(
     const ASTContext &Context, const ImplicitCastExpr &Cast) {
+  if (WarnOnTimeTNarrowingConversion) {
+    handleTimeTOnlyCast(Context, Cast);
+    return;
+  }
   if (Cast.getExprLoc().isMacroID())
     return;
   const Expr &Lhs = Cast;
@@ -626,6 +740,12 @@ void NarrowingConversionsCheck::handleBinaryOperator(const ASTContext &Context,
   const Expr &Rhs = *Op.getRHS();
   if (Lhs.isInstantiationDependent() || Rhs.isInstantiationDependent())
     return;
+
+  if (WarnOnTimeTNarrowingConversion) {
+    handleTimeTConversion(Context, Op.getExprLoc(), Lhs, Rhs);
+    return;
+  }
+
   if (handleConditionalOperator(Context, Lhs, Rhs))
     return;
   handleBinaryOperator(Context, Rhs.getBeginLoc(), Lhs, Rhs);
@@ -636,6 +756,8 @@ void NarrowingConversionsCheck::check(const MatchFinder::MatchResult &Result) {
     handleBinaryOperator(*Result.Context, *Op);
   else if (const auto *Cast = Result.Nodes.getNodeAs<ImplicitCastExpr>("cast"))
     handleImplicitCast(*Result.Context, *Cast);
+  else if (const auto *ECast = Result.Nodes.getNodeAs<ExplicitCastExpr>("explicit_cast"))
+    handleTimeTOnlyCast(*Result.Context, *ECast);
   else
     llvm_unreachable("must be binary operator or cast expression");
 }

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.h
@@ -53,6 +53,9 @@ private:
                                 SourceLocation SourceLoc, const Expr &Lhs,
                                 const Expr &Rhs);
 
+  void diagTimeTConversion(SourceLocation SourceLoc, const Expr &Lhs,
+                           const Expr &Rhs);
+
   void handleIntegralCast(const ASTContext &Context, SourceLocation SourceLoc,
                           const Expr &Lhs, const Expr &Rhs);
 
@@ -79,6 +82,10 @@ private:
   void handleFloatingCast(const ASTContext &Context, SourceLocation SourceLoc,
                           const Expr &Lhs, const Expr &Rhs);
 
+  void handleTimeTConversion(const ASTContext &Context,
+                             SourceLocation SourceLoc, const Expr &Lhs,
+                             const Expr &Rhs);
+
   void handleBinaryOperator(const ASTContext &Context, SourceLocation SourceLoc,
                             const Expr &Lhs, const Expr &Rhs);
 
@@ -93,6 +100,8 @@ private:
   void handleBinaryOperator(const ASTContext &Context,
                             const BinaryOperator &Op);
 
+  void handleTimeTOnlyCast(const ASTContext &Context, const CastExpr &Cast);
+
   bool isWarningInhibitedByEquivalentSize(const ASTContext &Context,
                                           const BuiltinType &FromType,
                                           const BuiltinType &ToType) const;
@@ -102,6 +111,7 @@ private:
   const bool WarnOnFloatingPointNarrowingConversion;
   const bool WarnWithinTemplateInstantiation;
   const bool WarnOnEquivalentBitWidth;
+  const bool WarnOnTimeTNarrowingConversion;
   const StringRef IgnoreConversionFromTypes;
   const bool PedanticMode;
 };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -114,7 +114,7 @@ Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Improved :doc:`bugprone-narrowing-conversions
-  <clang-tidy/checks/bugprone-narrowing-conversions>` check by adding the
+  <clang-tidy/checks/bugprone/narrowing-conversions>` check by adding the
   ``WarnOnTimeTNarrowingConversion`` option to diagnose conversions from
   ``time_t`` values to integer types that may not preserve the full range of
   ``time_t``. This option is disabled by the default.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -133,6 +133,12 @@ Changes in existing checks
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious
   trailing semicolons and lost comments when the ``if`` body has no braces.
 
+- Improved :doc:`bugprone-narrowing-conversions
+  <clang-tidy/checks/bugprone/narrowing-conversions>` check by adding the
+  :option:`WarnOnTimeTNarrowingConversion` option to diagnose conversions from
+  ``time_t`` values to integer types that may not preserve the full range of
+  ``time_t``. This option is disabled by default.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -113,6 +113,12 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`bugprone-narrowing-conversions
+  <clang-tidy/checks/bugprone-narrowing-conversions>` check by adding the
+  ``WarnOnTimeTNarrowingConversion`` option to diagnose conversions from
+  ``time_t`` values to integer types that may not preserve the full range of
+  ``time_t``. This option is disabled by the default.
+
 - Improved :doc:`cppcoreguidelines-pro-type-member-init
   <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
   ``std::array`` the same as built-in arrays when `IgnoreArrays` option is enabled.
@@ -132,12 +138,6 @@ Changes in existing checks
 - Improved :doc:`readability-use-std-min-max
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious
   trailing semicolons and lost comments when the ``if`` body has no braces.
-
-- Improved :doc:`bugprone-narrowing-conversions
-  <clang-tidy/checks/bugprone/narrowing-conversions>` check by adding the
-  :option:`WarnOnTimeTNarrowingConversion` option to diagnose conversions from
-  ``time_t`` values to integer types that may not preserve the full range of
-  ``time_t``. This option is disabled by default.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/narrowing-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/narrowing-conversions.rst
@@ -15,14 +15,18 @@ We flag narrowing conversions from:
    if WarnOnIntegerNarrowingConversion Option is set,
  - an integer to a narrower floating-point (e.g. ``uint64_t`` to ``float``)
    if WarnOnIntegerToFloatingPointNarrowingConversion Option is set,
+ - a ``time_t`` value, or and expression involving ``time_t``, to an integer
+   type that may not preserve the full range of ``time_t`` if
+   WarnOnTimeTNarrowingConversion Option is set,
  - a floating-point to an integer (e.g. ``double`` to ``int``),
  - a floating-point to a narrower floating-point (e.g. ``double`` to ``float``)
    if WarnOnFloatingPointNarrowingConversion Option is set.
 
 This check will flag:
  - All narrowing conversions that are not marked by an explicit cast (c-style
-   or ``static_cast``). For example: ``int i = 0; i += 0.1;``,
-   ``void f(int); f(0.1);``,
+   or ``static_cast``), except conversions from ``time_t`` when
+   WarnOnTimeTNarrowingConversion Option is set. For example:
+   ``int i = 0; i += 0.1;``, ``void f(int); f(0.1);``,
  - All applications of binary operators with a narrowing conversions.
    For example: ``int i; i+= 0.1;``.
 
@@ -103,6 +107,23 @@ Options
     When `true`, the check will warn on assigning a floating point constant
     to an integer value even if the floating point value is exactly
     representable in the destination type (e.g. ``int i = 1.0;``).
+    `false` by default.
+
+.. option:: WarnOnTimeTNarrowingConversion
+
+    When `true`, the check will warn on conversion from ``time_t`` or a
+    typedef of ``time_t`` to an integer type that may not preserve the full
+    range of ``time_t``. This includes explicit casts.
+
+    This option is intended to help audit code for Y2038-related truncation
+    issues. For example:
+
+    .. code-block:: c++
+
+      time_t t = time(nullptr);
+      int i = t;
+      uint32_t u32 = (uint32_t)t;
+
     `false` by default.
 
 FAQ

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/narrowing-conversions-time-t.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/narrowing-conversions-time-t.cpp
@@ -2,7 +2,7 @@
 // RUN: bugprone-narrowing-conversions %t -- \
 // RUN: -config='{CheckOptions: {bugprone-narrowing-conversions.WarnOnTimeTNarrowingConversion: true}}'
 
-typedef long time_t;
+typedef long long time_t;
 typedef time_t mytime;
 typedef mytime opaque_time;
 
@@ -33,46 +33,46 @@ void ignore(int i, long l, double d) {
 void implicit(time_t t) {
 
     int32_t i32 = t;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:19: warning: conversion from 'time_t' (aka 'long') to 'int32_t' (aka 'int') may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:19: warning: conversion from 'time_t' (aka 'long long') to 'int32_t' (aka 'int') may not preserve the full range of time_t
 
     uint32_t u32 = t;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:20: warning: conversion from 'time_t' (aka 'long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:20: warning: conversion from 'time_t' (aka 'long long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
 
     takes_int(t);
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:15: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:15: warning: conversion from 'time_t' (aka 'long long') to 'int' may not preserve the full range of time_t
 
     bool b = t;
 }
 
 void explicit_test(time_t t) {
     int i = (int)t;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long long') to 'int' may not preserve the full range of time_t
 
     int32_t i32 = (int32_t)t;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:19: warning: conversion from 'time_t' (aka 'long') to 'int32_t' (aka 'int') may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:19: warning: conversion from 'time_t' (aka 'long long') to 'int32_t' (aka 'int') may not preserve the full range of time_t
 
     short s = (short)t;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:15: warning: conversion from 'time_t' (aka 'long') to 'short' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:15: warning: conversion from 'time_t' (aka 'long long') to 'short' may not preserve the full range of time_t
 
     int c = static_cast<int>(t);
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long long') to 'int' may not preserve the full range of time_t
 
     int j = int(t);
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long long') to 'int' may not preserve the full range of time_t
 }
 
 void misc(std::time_t t, int offset) {
     int i = t;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'std::time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'std::time_t' (aka 'long long') to 'int' may not preserve the full range of time_t
 
     opaque_time op = time(nullptr);
     uint32_t u32 = (uint32_t)op;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:20: warning: conversion from 'opaque_time' (aka 'long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:20: warning: conversion from 'opaque_time' (aka 'long long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
 
     int oper = t + offset;
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:16: warning: conversion from 'std::time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:16: warning: conversion from 'std::time_t' (aka 'long long') to 'int' may not preserve the full range of time_t
 
 #define TO_UINT32(arg) ((uint32_t)(arg))
     uint32_t trunc = TO_UINT32(t);
-    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:22: warning: conversion from 'std::time_t' (aka 'long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:22: warning: conversion from 'std::time_t' (aka 'long long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/narrowing-conversions-time-t.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/narrowing-conversions-time-t.cpp
@@ -1,0 +1,78 @@
+// RUN: %check_clang_tidy -check-suffix=DEFAULT %s \
+// RUN: bugprone-narrowing-conversions %t -- \
+// RUN: -config='{CheckOptions: {bugprone-narrowing-conversions.WarnOnTimeTNarrowingConversion: true}}'
+
+typedef long time_t;
+typedef time_t mytime;
+typedef mytime opaque_time;
+
+namespace std {
+    using ::time_t;
+}
+
+using int32_t = int;
+using uint32_t = unsigned int;
+using int64_t = long;
+using uint64_t = unsigned long;
+
+time_t time(time_t *);
+
+void takes_int(int);
+int returns_int(float f) {
+    return f;
+}
+
+void ignore(int i, long l, double d) {
+    short s1 = i;
+    short s2 = (short)i;
+    int i1 = l, i2 = (int)l;
+    float f = d;
+    takes_int(l);
+}
+
+void implicit(time_t t) {
+
+    int32_t i32 = t;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:19: warning: conversion from 'time_t' (aka 'long') to 'int32_t' (aka 'int') may not preserve the full range of time_t
+
+    uint32_t u32 = t;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:20: warning: conversion from 'time_t' (aka 'long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
+
+    takes_int(t);
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:15: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+
+    bool b = t;
+}
+
+void explicit_test(time_t t) {
+    int i = (int)t;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+
+    int32_t i32 = (int32_t)t;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:19: warning: conversion from 'time_t' (aka 'long') to 'int32_t' (aka 'int') may not preserve the full range of time_t
+
+    short s = (short)t;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:15: warning: conversion from 'time_t' (aka 'long') to 'short' may not preserve the full range of time_t
+
+    int c = static_cast<int>(t);
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+
+    int j = int(t);
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+}
+
+void misc(std::time_t t, int offset) {
+    int i = t;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:13: warning: conversion from 'std::time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+
+    opaque_time op = time(nullptr);
+    uint32_t u32 = (uint32_t)op;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:20: warning: conversion from 'opaque_time' (aka 'long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
+
+    int oper = t + offset;
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:16: warning: conversion from 'std::time_t' (aka 'long') to 'int' may not preserve the full range of time_t
+
+#define TO_UINT32(arg) ((uint32_t)(arg))
+    uint32_t trunc = TO_UINT32(t);
+    // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:22: warning: conversion from 'std::time_t' (aka 'long') to 'uint32_t' (aka 'unsigned int') may not preserve the full range of time_t
+}


### PR DESCRIPTION
This PR extends `bugprone-narrowing-conversion` with a new `WarnOnTimeTNarrowingConversion` option. When enabled, the check diagnoses conversions from `time_t` values to integer types that may not preserve the full range of `time_t`. This is intended to help with Y2038-related audits.

This follows the motivation discussed in the LLVM Discourse [RFC](https://discourse.llvm.org/t/rfc-y2038-check-for-lossy-time-t-conversions/91060).