### PR TITLE
Ensure that we properly propagate template decl attributes to redecls

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -121,6 +121,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 ### Attribute Changes in Clang
 
+- Clang now properly propagates attributes on class and variable templates to their redeclarations, which will result in redeclarations not interfering with diagnostics. (#GH101469)
+
 ### Improvements to Clang's diagnostics
 
 ### Improvements to Clang's time-trace

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -121,7 +121,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 ### Attribute Changes in Clang
 
-- Clang now properly propagates attributes on class and variable templates to their redeclarations, which will result in redeclarations not interfering with diagnostics. (#GH101469)
+- Clang now properly propagates attributes on class and variable templates to their redeclarations, which will result in redeclarations not interfering with diagnostics. (#GH209812)
 
 ### Improvements to Clang's diagnostics
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4768,7 +4768,11 @@ void Sema::MergeVarDecl(VarDecl *New, LookupResult &Previous) {
     New->setInvalidDecl();
   }
 
+  if (NewTemplate && OldTemplate)
+    mergeDeclAttributes(NewTemplate, OldTemplate);
+
   mergeDeclAttributes(New, Old);
+
   // Warn if an already-defined variable is made a weak_import in a subsequent
   // declaration
   if (New->hasAttr<WeakImportAttr>())

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2288,8 +2288,10 @@ DeclResult Sema::CheckClassTemplate(
 
   ProcessDeclAttributeList(S, NewClass, Attr);
 
-  if (PrevClassTemplate)
+  if (PrevClassTemplate) {
+    mergeDeclAttributes(NewTemplate, PrevClassTemplate);
     mergeDeclAttributes(NewClass, PrevClassTemplate->getTemplatedDecl());
+  }
 
   AddPushedVisibilityAttribute(NewClass);
   inferGslOwnerPointerAttribute(NewClass);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2539,6 +2539,8 @@ Decl *TemplateDeclInstantiator::VisitVarTemplateDecl(VarTemplateDecl *D) {
   }
 
   Owner->addDecl(Inst);
+  SemaRef.InstantiateAttrsForDecl(TemplateArgs, D, Inst, LateAttrs,
+                                  StartingScope);
 
   if (!PrevVarTemplate) {
     // Queue up any out-of-line partial specializations of this member

--- a/clang/test/SemaCXX/attr-no-specializations.cpp
+++ b/clang/test/SemaCXX/attr-no-specializations.cpp
@@ -60,3 +60,25 @@ template <class T>
 [[clang::no_specializations]] void func(); // expected-note {{marked 'clang::no_specializations' here}}
 
 template <> void func<int>(); // expected-error {{'func' cannot be specialized}}
+
+namespace DeclBetween {
+template <class T>
+[[clang::no_specializations]] void func(); // expected-note {{marked 'clang::no_specializations' here}}
+template<class t> void func(){}
+template <> void func<int>(); // expected-error {{'func' cannot be specialized}}
+
+template<typename T>
+struct HasVarDecl {
+template<typename U> static int var_decl[[clang::no_specializations]];// expected-note {{marked 'clang::no_specializations' here}}
+};
+
+template<typename T>
+template<typename U> int HasVarDecl<T>::var_decl = 5;
+template<>
+template<>
+int HasVarDecl<int>::var_decl<int>; // expected-error{{'var_decl' cannot be specialized}}
+
+template<typename> struct [[clang::no_specializations]] ClassTempl; // expected-note {{marked 'clang::no_specializations' here}}
+template<typename> struct ClassTempl { };
+template<> struct ClassTempl<int> { }; // expected-error{{'ClassTempl' cannot be specialized}}
+};


### PR DESCRIPTION
Variable and class templates weren't forwarding their declaration attributes that were attached directly to them (at the moment, the only one I could find that had this issue is the no_specialization attr). The result was that intermediate redeclarations would prevent the diagnostics from happening.

This patch ensures we propagate them properly for variable and class templates.  It seems our function templates already do the right thing.

Fixes: #209812