### PR TITLE
[analyzer] Make pointer/null comparison commutative for addresses of fields of symbolic regions

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
@@ -861,7 +861,7 @@ SVal SimpleSValBuilder::evalBinOpLL(ProgramStateRef state,
 
     // If one of the operands is a symbol and the other is a constant,
     // build an expression for use by the constraint manager.
-    if (SymbolRef rSym = rhs.getAsLocSymbol()) {
+    if (SymbolRef rSym = rhs.getAsLocSymbol(true)) {
       if (op == BO_Cmp)
         return UnknownVal();
 

--- a/clang/test/Analysis/issue-206798.cpp
+++ b/clang/test/Analysis/issue-206798.cpp
@@ -1,0 +1,43 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
+
+struct S {
+  int n;
+};
+struct T {
+  S s;
+};
+
+// &r->s is the address of a field of a symbolic region, so it is symbol-based.
+// A swapped null check (`nullptr == p`) must build the same constraint as the
+// usual `p == nullptr`; otherwise the analyzer contradicts itself and reports a
+// null dereference that cannot happen.
+int gh206798_swapped(T *r) {
+  S *p = &r->s;
+  if (!p) {
+  }
+  if (nullptr == p)
+    return 0;
+  return p->n; // no-warning: p is known non-null after the check
+}
+
+int gh206798_normal(T *r) {
+  S *p = &r->s;
+  if (!p) {
+  }
+  if (p == nullptr)
+    return 0;
+  return p->n; // no-warning: p is known non-null after the check
+}
+
+// A genuine null dereference must still be flagged in either order.
+int stillReportsRealBug_swapped(S *p) {
+  if (nullptr == p)
+    return p->n; // expected-warning{{Access to field 'n' results in a dereference of a null pointer (loaded from variable 'p')}}
+  return 0;
+}
+
+int stillReportsRealBug_normal(S *p) {
+  if (p == nullptr)
+    return p->n; // expected-warning{{Access to field 'n' results in a dereference of a null pointer (loaded from variable 'p')}}
+  return 0;
+}


### PR DESCRIPTION
Fixes #206798

A reversed ("Yoda") null check `nullptr == p` produced a false
`core.NullDereference` when `p` is the address of a field of a symbolic
region (e.g. `&r->s`). The canonical form `p == nullptr` worked fine.