### PR TITLE
[AMDGPU] Testing cleanup in prep for true16 test upstreaming

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.div.fmas.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.div.fmas.ll
@@ -3,8 +3,8 @@
 ; RUN: llc -global-isel -mtriple=amdgpu8.03-amd-amdpal < %s | FileCheck --check-prefix=GFX8 %s
 ; RUN: llc -global-isel -mtriple=amdgpu10.10-amd-amdpal < %s | FileCheck --check-prefix=GFX10_W32 %s
 ; RUN: llc -global-isel -mtriple=amdgpu10.10-amd-amdpal -mattr=+wavefrontsize64 < %s | FileCheck --check-prefix=GFX10_W64 %s
-; RUN: llc -global-isel -mtriple=amdgpu11.00-amd-amdpal -mattr=-real-true16 -amdgpu-enable-delay-alu=0 < %s | FileCheck --check-prefixes=GFX11_W32 %s
-; RUN: llc -global-isel -mtriple=amdgpu11.00-amd-amdpal -mattr=-real-true16 -amdgpu-enable-delay-alu=0 -mattr=+wavefrontsize64 < %s | FileCheck --check-prefixes=GFX11_W64 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00-amd-amdpal -amdgpu-enable-delay-alu=0 < %s | FileCheck --check-prefixes=GFX11_W32 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00-amd-amdpal -amdgpu-enable-delay-alu=0 -mattr=+wavefrontsize64 < %s | FileCheck --check-prefixes=GFX11_W64 %s
 
 define float @v_div_fmas_f32(float %a, float %b, float %c, i1 %d) {
 ; GFX7-LABEL: v_div_fmas_f32:

--- a/llvm/test/CodeGen/AMDGPU/fadd.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fadd.f16.ll
@@ -146,33 +146,6 @@ define amdgpu_kernel void @fadd_f16(
 ; GFX11-FAKE16-GISEL-NEXT:    s_mov_b64 s[2:3], s[10:11]
 ; GFX11-FAKE16-GISEL-NEXT:    buffer_store_b16 v0, off, s[0:3], 0
 ; GFX11-FAKE16-GISEL-NEXT:    s_endpgm
-; GFX11-LABEL: fadd_f16:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    s_load_b128 s[4:7], s[0:1], 0x24
-; GFX11-NEXT:    s_load_b64 s[0:1], s[0:1], 0x34
-; GFX11-NEXT:    s_mov_b32 s11, 0x31016000
-; GFX11-NEXT:    s_mov_b32 s10, -1
-; GFX11-NEXT:    s_mov_b32 s3, s11
-; GFX11-NEXT:    s_mov_b32 s2, s10
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s8, s4
-; GFX11-NEXT:    s_mov_b32 s9, s5
-; GFX11-NEXT:    s_mov_b32 s4, s6
-; GFX11-NEXT:    s_mov_b32 s5, s7
-; GFX11-NEXT:    s_mov_b32 s6, s10
-; GFX11-NEXT:    s_mov_b32 s7, s11
-; GFX11-NEXT:    buffer_load_u16 v0, off, s[4:7], 0 glc dlc
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    buffer_load_u16 v1, off, s[0:3], 0 glc dlc
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_mov_b16_e32 v0.h, v1.l
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_add_f16_e32 v0.l, v0.l, v0.h
-; GFX11-NEXT:    buffer_store_b16 v0, off, s[8:11], 0
-; GFX11-NEXT:    s_nop 0
-; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
-; GFX11-NEXT:    s_endpgm
     ptr addrspace(1) %r,
     ptr addrspace(1) %a,
     ptr addrspace(1) %b) {
@@ -288,27 +261,6 @@ define amdgpu_kernel void @fadd_f16_imm_a(
 ; GFX11-FAKE16-GISEL-NEXT:    s_mov_b64 s[2:3], s[6:7]
 ; GFX11-FAKE16-GISEL-NEXT:    buffer_store_b16 v0, off, s[0:3], 0
 ; GFX11-FAKE16-GISEL-NEXT:    s_endpgm
-; GFX11-LABEL: fadd_f16_imm_a:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b128 s[0:3], s[0:1], 0x24
-; GFX11-NEXT:    s_mov_b32 s7, 0x31016000
-; GFX11-NEXT:    s_mov_b32 s6, -1
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s4, s0
-; GFX11-NEXT:    s_mov_b32 s5, s1
-; GFX11-NEXT:    s_mov_b32 s0, s2
-; GFX11-NEXT:    s_mov_b32 s1, s3
-; GFX11-NEXT:    s_mov_b32 s2, s6
-; GFX11-NEXT:    s_mov_b32 s3, s7
-; GFX11-NEXT:    buffer_load_u16 v0, off, s[0:3], 0
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_mov_b16_e32 v0.h, 0x3c00
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_add_f16_e32 v0.l, v0.l, v0.h
-; GFX11-NEXT:    buffer_store_b16 v0, off, s[4:7], 0
-; GFX11-NEXT:    s_nop 0
-; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
-; GFX11-NEXT:    s_endpgm
     ptr addrspace(1) %r,
     ptr addrspace(1) %b) {
 entry:
@@ -422,27 +374,6 @@ define amdgpu_kernel void @fadd_f16_imm_b(
 ; GFX11-FAKE16-GISEL-NEXT:    s_mov_b64 s[2:3], s[6:7]
 ; GFX11-FAKE16-GISEL-NEXT:    buffer_store_b16 v0, off, s[0:3], 0
 ; GFX11-FAKE16-GISEL-NEXT:    s_endpgm
-; GFX11-LABEL: fadd_f16_imm_b:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b128 s[0:3], s[0:1], 0x24
-; GFX11-NEXT:    s_mov_b32 s7, 0x31016000
-; GFX11-NEXT:    s_mov_b32 s6, -1
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s4, s0
-; GFX11-NEXT:    s_mov_b32 s5, s1
-; GFX11-NEXT:    s_mov_b32 s0, s2
-; GFX11-NEXT:    s_mov_b32 s1, s3
-; GFX11-NEXT:    s_mov_b32 s2, s6
-; GFX11-NEXT:    s_mov_b32 s3, s7
-; GFX11-NEXT:    buffer_load_u16 v0, off, s[0:3], 0
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_mov_b16_e32 v0.h, 0x4000
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_add_f16_e32 v0.l, v0.l, v0.h
-; GFX11-NEXT:    buffer_store_b16 v0, off, s[4:7], 0
-; GFX11-NEXT:    s_nop 0
-; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
-; GFX11-NEXT:    s_endpgm
     ptr addrspace(1) %r,
     ptr addrspace(1) %a) {
 entry:
@@ -591,26 +522,6 @@ define amdgpu_kernel void @fadd_v2f16(
 ; GFX11-FAKE16-GISEL-NEXT:    v_pk_add_f16 v0, v1, v0
 ; GFX11-FAKE16-GISEL-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-FAKE16-GISEL-NEXT:    s_endpgm
-; GFX11-LABEL: fadd_v2f16:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    s_load_b128 s[4:7], s[0:1], 0x24
-; GFX11-NEXT:    s_load_b64 s[8:9], s[0:1], 0x34
-; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX11-NEXT:    s_mov_b32 s3, 0x31016000
-; GFX11-NEXT:    s_mov_b32 s2, -1
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[6:7]
-; GFX11-NEXT:    global_load_b32 v0, v0, s[8:9]
-; GFX11-NEXT:    s_mov_b32 s0, s4
-; GFX11-NEXT:    s_mov_b32 s1, s5
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_pk_add_f16 v0, v1, v0
-; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
-; GFX11-NEXT:    s_nop 0
-; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
-; GFX11-NEXT:    s_endpgm
     ptr addrspace(1) %r,
     ptr addrspace(1) %a,
     ptr addrspace(1) %b) {
@@ -737,22 +648,6 @@ define amdgpu_kernel void @fadd_v2f16_imm_a(
 ; GFX11-FAKE16-GISEL-NEXT:    v_pk_add_f16 v0, 0x40003c00, v0
 ; GFX11-FAKE16-GISEL-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-FAKE16-GISEL-NEXT:    s_endpgm
-; GFX11-LABEL: fadd_v2f16_imm_a:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b128 s[0:3], s[0:1], 0x24
-; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX11-NEXT:    s_mov_b32 s7, 0x31016000
-; GFX11-NEXT:    s_mov_b32 s6, -1
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_b32 v0, v0, s[2:3]
-; GFX11-NEXT:    s_mov_b32 s4, s0
-; GFX11-NEXT:    s_mov_b32 s5, s1
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_pk_add_f16 v0, 0x40003c00, v0
-; GFX11-NEXT:    buffer_store_b32 v0, off, s[4:7], 0
-; GFX11-NEXT:    s_nop 0
-; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
-; GFX11-NEXT:    s_endpgm
     ptr addrspace(1) %r,
     ptr addrspace(1) %b) {
 entry:
@@ -876,22 +771,6 @@ define amdgpu_kernel void @fadd_v2f16_imm_b(
 ; GFX11-FAKE16-GISEL-NEXT:    v_pk_add_f16 v0, 0x3c004000, v0
 ; GFX11-FAKE16-GISEL-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-FAKE16-GISEL-NEXT:    s_endpgm
-; GFX11-LABEL: fadd_v2f16_imm_b:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b128 s[0:3], s[0:1], 0x24
-; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX11-NEXT:    s_mov_b32 s7, 0x31016000
-; GFX11-NEXT:    s_mov_b32 s6, -1
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_b32 v0, v0, s[2:3]
-; GFX11-NEXT:    s_mov_b32 s4, s0
-; GFX11-NEXT:    s_mov_b32 s5, s1
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_pk_add_f16 v0, 0x3c004000, v0
-; GFX11-NEXT:    buffer_store_b32 v0, off, s[4:7], 0
-; GFX11-NEXT:    s_nop 0
-; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
-; GFX11-NEXT:    s_endpgm
     ptr addrspace(1) %r,
     ptr addrspace(1) %a) {
 entry:

--- a/llvm/test/CodeGen/AMDGPU/strict_fsub.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/strict_fsub.f16.ll
@@ -249,20 +249,6 @@ define <2 x half> @v_constained_fsub_v2f16_fpexcept_strict(<2 x half> %x, <2 x h
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-GISEL-NEXT:    v_pk_add_f16 v0, v0, v1 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-SDAG-LABEL: v_constained_fsub_v2f16_fpexcept_strict:
-; GFX10PLUS-SDAG:       ; %bb.0:
-; GFX10PLUS-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v0, v0, v1
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v2, v3, v2
-; GFX10PLUS-SDAG-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10PLUS-SDAG-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-GISEL-LABEL: v_constained_fsub_v2f16_fpexcept_strict:
-; GFX10PLUS-GISEL:       ; %bb.0:
-; GFX10PLUS-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-GISEL-NEXT:    v_pk_add_f16 v0, v0, v1 neg_lo:[0,1] neg_hi:[0,1]
-; GFX10PLUS-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %val = call <2 x half> @llvm.experimental.constrained.fsub.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <2 x half> %val
 }
@@ -348,20 +334,6 @@ define <2 x half> @v_constained_fsub_v2f16_fpexcept_ignore(<2 x half> %x, <2 x h
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-GISEL-NEXT:    v_pk_add_f16 v0, v0, v1 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-SDAG-LABEL: v_constained_fsub_v2f16_fpexcept_ignore:
-; GFX10PLUS-SDAG:       ; %bb.0:
-; GFX10PLUS-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v0, v0, v1
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v2, v3, v2
-; GFX10PLUS-SDAG-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10PLUS-SDAG-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-GISEL-LABEL: v_constained_fsub_v2f16_fpexcept_ignore:
-; GFX10PLUS-GISEL:       ; %bb.0:
-; GFX10PLUS-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-GISEL-NEXT:    v_pk_add_f16 v0, v0, v1 neg_lo:[0,1] neg_hi:[0,1]
-; GFX10PLUS-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %val = call <2 x half> @llvm.experimental.constrained.fsub.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.ignore")
   ret <2 x half> %val
 }
@@ -447,20 +419,6 @@ define <2 x half> @v_constained_fsub_v2f16_fpexcept_maytrap(<2 x half> %x, <2 x 
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-GISEL-NEXT:    v_pk_add_f16 v0, v0, v1 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-SDAG-LABEL: v_constained_fsub_v2f16_fpexcept_maytrap:
-; GFX10PLUS-SDAG:       ; %bb.0:
-; GFX10PLUS-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v0, v0, v1
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v2, v3, v2
-; GFX10PLUS-SDAG-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10PLUS-SDAG-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-GISEL-LABEL: v_constained_fsub_v2f16_fpexcept_maytrap:
-; GFX10PLUS-GISEL:       ; %bb.0:
-; GFX10PLUS-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-GISEL-NEXT:    v_pk_add_f16 v0, v0, v1 neg_lo:[0,1] neg_hi:[0,1]
-; GFX10PLUS-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %val = call <2 x half> @llvm.experimental.constrained.fsub.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
   ret <2 x half> %val
 }
@@ -568,27 +526,6 @@ define <3 x half> @v_constained_fsub_v3f16_fpexcept_strict(<3 x half> %x, <3 x h
 ; GFX12-GISEL-NEXT:    v_pk_add_f16 v0, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    v_sub_f16_e32 v1.l, v1.l, v3.l
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-SDAG-LABEL: v_constained_fsub_v3f16_fpexcept_strict:
-; GFX10PLUS-SDAG:       ; %bb.0:
-; GFX10PLUS-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v0, v0, v2
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v1, v1, v3
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v2, v5, v4
-; GFX10PLUS-SDAG-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10PLUS-SDAG-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-GISEL-LABEL: v_constained_fsub_v3f16_fpexcept_strict:
-; GFX10PLUS-GISEL:       ; %bb.0:
-; GFX10PLUS-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10PLUS-GISEL-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v0, v0, v2
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v1, v1, v3
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v2, v4, v5
-; GFX10PLUS-GISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX10PLUS-GISEL-NEXT:    v_lshl_or_b32 v0, v2, 16, v0
-; GFX10PLUS-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %val = call <3 x half> @llvm.experimental.constrained.fsub.v3f16(<3 x half> %x, <3 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <3 x half> %val
 }
@@ -697,36 +634,6 @@ define <4 x half> @v_constained_fsub_v4f16_fpexcept_strict(<4 x half> %x, <4 x h
 ; GFX12-GISEL-NEXT:    v_pk_add_f16 v0, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    v_pk_add_f16 v1, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-SDAG-LABEL: v_constained_fsub_v4f16_fpexcept_strict:
-; GFX10PLUS-SDAG:       ; %bb.0:
-; GFX10PLUS-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX10PLUS-SDAG-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v1, v1, v3
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v0, v0, v2
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v2, v6, v5
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e32 v3, v7, v4
-; GFX10PLUS-SDAG-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10PLUS-SDAG-NEXT:    v_perm_b32 v1, v3, v1, 0x5040100
-; GFX10PLUS-SDAG-NEXT:    s_setpc_b64 s[30:31]
-; GFX10PLUS-GISEL-LABEL: v_constained_fsub_v4f16_fpexcept_strict:
-; GFX10PLUS-GISEL:       ; %bb.0:
-; GFX10PLUS-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10PLUS-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10PLUS-GISEL-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10PLUS-GISEL-NEXT:    v_lshrrev_b32_e32 v6, 16, v2
-; GFX10PLUS-GISEL-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v0, v0, v2
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v1, v1, v3
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v2, v4, v6
-; GFX10PLUS-GISEL-NEXT:    v_sub_f16_e32 v3, v5, v7
-; GFX10PLUS-GISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX10PLUS-GISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX10PLUS-GISEL-NEXT:    v_lshl_or_b32 v0, v2, 16, v0
-; GFX10PLUS-GISEL-NEXT:    v_lshl_or_b32 v1, v3, 16, v1
-; GFX10PLUS-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %val = call <4 x half> @llvm.experimental.constrained.fsub.v4f16(<4 x half> %x, <4 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <4 x half> %val
 }
@@ -865,19 +772,6 @@ define amdgpu_ps <2 x half> @s_constained_fsub_v2f16_fpexcept_strict(<2 x half> 
 ; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s0, s1, s0
 ; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX12-GISEL-NEXT:    ; return to shader part epilog
-; GFX10PLUS-SDAG-LABEL: s_constained_fsub_v2f16_fpexcept_strict:
-; GFX10PLUS-SDAG:       ; %bb.0:
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e64 v0, s2, s3
-; GFX10PLUS-SDAG-NEXT:    s_lshr_b32 s0, s3, 16
-; GFX10PLUS-SDAG-NEXT:    s_lshr_b32 s1, s2, 16
-; GFX10PLUS-SDAG-NEXT:    v_sub_f16_e64 v1, s1, s0
-; GFX10PLUS-SDAG-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX10PLUS-SDAG-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
-; GFX10PLUS-SDAG-NEXT:    ; return to shader part epilog
-; GFX10PLUS-GISEL-LABEL: s_constained_fsub_v2f16_fpexcept_strict:
-; GFX10PLUS-GISEL:       ; %bb.0:
-; GFX10PLUS-GISEL-NEXT:    v_pk_add_f16 v0, s2, s3 neg_lo:[0,1] neg_hi:[0,1]
-; GFX10PLUS-GISEL-NEXT:    ; return to shader part epilog
   %val = call <2 x half> @llvm.experimental.constrained.fsub.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <2 x half> %val
 }


### PR DESCRIPTION
[AMDGPU] Testing cleanup

Some small cleanup of a few tests in preparation for True16 test upstreaming, synchronizes with cleanups that already happened downstream

---

PR stack:
https://github.com/llvm/llvm-project/pull/209891
https://github.com/llvm/llvm-project/pull/209890
https://github.com/llvm/llvm-project/pull/209889
https://github.com/llvm/llvm-project/pull/209888 <- YOU ARE HERE
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>