### PR TITLE
Add fallback type for Constrained placeholders other than plain auto.

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -145,6 +145,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 #### Bug Fixes to C++ Support
 
+-Fixed an issue where we tried to compare invalid NTTPs for variable declarations, which ended up in hitting an assertion with a constrained non-plain-auto NTTP, which we don't quite implement yet. (#GH208658)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1316,6 +1316,7 @@ bool Sema::AttachTypeConstraint(AutoTypeLoc TL,
         << NewConstrainedParm->getTypeSourceInfo()
                ->getTypeLoc()
                .getSourceRange();
+    NewConstrainedParm->setType(TL.getType());
     return true;
   }
   // FIXME: Concepts: This should be the type of the placeholder, but this is
@@ -8281,13 +8282,6 @@ static bool MatchTemplateParameterKind(
     if (Kind != Sema::TPL_TemplateTemplateParmMatch ||
         (!OldNTTP->getType()->isDependentType() &&
          !NewNTTP->getType()->isDependentType())) {
-
-      // Matching against an invalid declaration is going to be rife with
-      // errors, particularly when `getUnconstrainedType` isn't really valid
-      // there. Just treat these as otherwise invalid.
-      if (OldNTTP->isInvalidDecl() || NewNTTP->isInvalidDecl())
-        return false;
-
       // C++20 [temp.over.link]p6:
       //   Two [non-type] template-parameters are equivalent [if] they have
       //   equivalent types ignoring the use of type-constraints for

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -8281,6 +8281,13 @@ static bool MatchTemplateParameterKind(
     if (Kind != Sema::TPL_TemplateTemplateParmMatch ||
         (!OldNTTP->getType()->isDependentType() &&
          !NewNTTP->getType()->isDependentType())) {
+
+      // Matching against an invalid declaration is going to be rife with
+      // errors, particularly when `getUnconstrainedType` isn't really valid
+      // there. Just treat these as otherwise invalid.
+      if (OldNTTP->isInvalidDecl() || NewNTTP->isInvalidDecl())
+        return false;
+
       // C++20 [temp.over.link]p6:
       //   Two [non-type] template-parameters are equivalent [if] they have
       //   equivalent types ignoring the use of type-constraints for

--- a/clang/test/CXX/temp/temp.param/p10-2a.cpp
+++ b/clang/test/CXX/temp/temp.param/p10-2a.cpp
@@ -141,3 +141,10 @@ using j2 = J<'a', nullptr>;
 template<OneOf<char, int> auto &x>
 // expected-error@-1 {{constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet}}
 using K = int;
+
+namespace GH208658 {
+template <class> concept C = true;
+template <auto &x> using A = int;
+template <C auto &x> using A = int;
+// expected-error@-1 {{constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet}}
+}

--- a/clang/test/CXX/temp/temp.param/p10-2a.cpp
+++ b/clang/test/CXX/temp/temp.param/p10-2a.cpp
@@ -147,4 +147,14 @@ template <class> concept C = true;
 template <auto &x> using A = int;
 template <C auto &x> using A = int;
 // expected-error@-1 {{constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet}}
+// expected-error@-2 {{template non-type parameter has a different type 'C auto' in template redeclaration}}
+// expected-note@-4 {{previous non-type template parameter with type 'auto &' is here}}
+
+template <C auto &x> using B = int;
+// expected-error@-1 {{constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet}}
+template <auto &x> using B = int;
+template <C auto &x> using B = int;
+// expected-error@-1 {{constrained placeholder types other than simple 'auto' on non-type template parameters not supported yet}}
+// expected-error@-2 {{template non-type parameter has a different type 'C auto' in template redeclaration}}
+// expected-note@-4 {{previous non-type template parameter with type 'auto &' is here}}
 }


### PR DESCRIPTION
We were diagnosing this and leave the type in place, but that broke invariants when 
looking it up later.  This patch just sets a fallback type to just the 'auto' (or a supported
type at least) instead, so that we gracefully continue.

Fixes: #208658