### PR TITLE
[CIR] Fix a pair of CIR Build failures:

### DIFF
--- a/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
@@ -315,9 +315,8 @@ void trap2() {
 
 // OGCG-LABEL: define{{.*}} void @_Z5trap2v
 // OGCG:         call void @llvm.trap()
-// OGCG-NEXT:    call void @_Z2f1v()
-// OGCG:         ret void
-// OGCG:       }
+// OGCG-NEXT:    unreachable
+// OGCG-NEXT:  }
 
 void *test_alloca(unsigned long n) {
   return __builtin_alloca(n);

--- a/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
+++ b/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x hlsl -finclude-default-header -triple spirv-unknown-vulkan-compute %s \
+// RUN: %clang_cc1 -x hlsl -finclude-default-header -triple spirv-unknown-vulkan-library %s \
 // RUN:   -fclangir -emit-cir -disable-llvm-passes -verify
 
 // expected-error@*:* {{ClangIR code gen Not Yet Implemented: processing of type: ConstantMatrix}}


### PR DESCRIPTION
HLSL added a bunch of diagnostics for entry functions that messed with the matrix test, see here: https://github.com/llvm/llvm-project/pull/184892/

The solution is to just mark the test as a library triple.

Builtin-trap stopped translating in classic codegen, so the call after it is now missing (and there is an unreachable after it),w hich actually better matches our behavior see:
https://github.com/llvm/llvm-project/pull/197789

This patch fixes both tests.