### PR TITLE
[offload-arch] Fix amdgpu HIP DLL search path on Windows

### DIFF
--- a/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
+++ b/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
@@ -236,7 +236,8 @@ void primeLibraryLoad(StringRef Path,
   // Other paths here use '/' for consistency, but LoadLibraryExW's altered
   // search path needs '\\' to locate dependencies relative to the DLL.
   //
-  // See https://learn.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw
+  // See
+  // https://learn.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw
   // "If the string specifies a fully qualified path, the function searches only
   //  that path for the module. When specifying a path, be sure to use
   //  backslashes (\), not forward slashes (/)."

--- a/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
+++ b/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
@@ -221,9 +221,12 @@ static std::pair<std::string, bool> findNewestHIPDLL() {
 }
 
 #ifdef _WIN32
+using LoadLibraryExWFn = decltype(&::LoadLibraryExW);
+
 // Pre-load DLL with LOAD_WITH_ALTERED_SEARCH_PATH so transitive deps
 // resolve from its directory. Pinned so getPermanentLibrary reuses it.
-static void primeLibraryLoad(StringRef Path) {
+void primeLibraryLoad(StringRef Path,
+                      LoadLibraryExWFn Loader = &::LoadLibraryExW) {
   // One DLL primed per process; subsequent calls are no-ops.
   // Not thread-safe, but offload-arch is single-threaded.
   static HMODULE PinnedModule = nullptr;
@@ -244,8 +247,8 @@ static void primeLibraryLoad(StringRef Path) {
   if (!convertUTF8ToUTF16String(NativePath, WPath))
     return;
   WPath.push_back(0);
-  PinnedModule = LoadLibraryExW(reinterpret_cast<LPCWSTR>(WPath.data()),
-                                nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+  PinnedModule = Loader(reinterpret_cast<LPCWSTR>(WPath.data()), nullptr,
+                        LOAD_WITH_ALTERED_SEARCH_PATH);
   DWORD Err = GetLastError();
   if (!PinnedModule && Verbose)
     WithColor::note() << "priming LoadLibraryExW failed for " << Path

--- a/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
+++ b/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
@@ -229,8 +229,19 @@ static void primeLibraryLoad(StringRef Path) {
   static HMODULE PinnedModule = nullptr;
   if (PinnedModule || !sys::path::is_absolute(Path))
     return;
+
+  // Other paths here use '/' for consistency, but LoadLibraryExW's altered
+  // search path needs '\\' to locate dependencies relative to the DLL.
+  //
+  // See https://learn.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw
+  // "If the string specifies a fully qualified path, the function searches only
+  //  that path for the module. When specifying a path, be sure to use
+  //  backslashes (\), not forward slashes (/)."
+  SmallString<256> NativePath;
+  sys::path::native(Path, NativePath, sys::path::Style::windows_backslash);
+
   SmallVector<UTF16, 256> WPath;
-  if (!convertUTF8ToUTF16String(Path, WPath))
+  if (!convertUTF8ToUTF16String(NativePath, WPath))
     return;
   WPath.push_back(0);
   PinnedModule = LoadLibraryExW(reinterpret_cast<LPCWSTR>(WPath.data()),

--- a/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
+++ b/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
@@ -221,12 +221,9 @@ static std::pair<std::string, bool> findNewestHIPDLL() {
 }
 
 #ifdef _WIN32
-using LoadLibraryExWFn = decltype(&::LoadLibraryExW);
-
 // Pre-load DLL with LOAD_WITH_ALTERED_SEARCH_PATH so transitive deps
 // resolve from its directory. Pinned so getPermanentLibrary reuses it.
-void primeLibraryLoad(StringRef Path,
-                      LoadLibraryExWFn Loader = &::LoadLibraryExW) {
+static void primeLibraryLoad(StringRef Path) {
   // One DLL primed per process; subsequent calls are no-ops.
   // Not thread-safe, but offload-arch is single-threaded.
   static HMODULE PinnedModule = nullptr;
@@ -248,8 +245,8 @@ void primeLibraryLoad(StringRef Path,
   if (!convertUTF8ToUTF16String(NativePath, WPath))
     return;
   WPath.push_back(0);
-  PinnedModule = Loader(reinterpret_cast<LPCWSTR>(WPath.data()), nullptr,
-                        LOAD_WITH_ALTERED_SEARCH_PATH);
+  PinnedModule = LoadLibraryExW(reinterpret_cast<LPCWSTR>(WPath.data()),
+                                nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
   DWORD Err = GetLastError();
   if (!PinnedModule && Verbose)
     WithColor::note() << "priming LoadLibraryExW failed for " << Path

--- a/clang/unittests/offload-arch/OffloadArchTest.cpp
+++ b/clang/unittests/offload-arch/OffloadArchTest.cpp
@@ -13,10 +13,17 @@
 #include <algorithm>
 #include <string>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 // Defined in AMDGPUArchByHIP.cpp (non-static, compiled into this test).
 #ifdef _WIN32
+using LoadLibraryExWFn = decltype(&::LoadLibraryExW);
+
 bool compareVersions(llvm::StringRef A, llvm::StringRef B);
 llvm::SmallVector<std::string, 8> getCandidateBinPaths(llvm::StringRef ExeDir);
+void primeLibraryLoad(llvm::StringRef Path, LoadLibraryExWFn Loader);
 #endif
 
 using namespace llvm;
@@ -24,6 +31,37 @@ using namespace llvm;
 cl::opt<bool> Verbose("offload-arch-test-verbose", cl::Hidden, cl::init(false));
 
 #ifdef _WIN32
+
+// --- primeLibraryLoad ---
+
+namespace {
+std::wstring CapturedPath;
+HANDLE CapturedFile;
+DWORD CapturedFlags;
+
+HMODULE WINAPI mockLoadLibraryExW(LPCWSTR Path, HANDLE File, DWORD Flags) {
+  CapturedPath = Path;
+  CapturedFile = File;
+  CapturedFlags = Flags;
+  return reinterpret_cast<HMODULE>(1);
+}
+} // namespace
+
+TEST(PrimeLibraryLoad, UsesWindowsBackslashes) {
+  CapturedPath.clear();
+  CapturedFile = reinterpret_cast<HANDLE>(1);
+  CapturedFlags = 0;
+
+  primeLibraryLoad("C:/rocm\\bin/amdhip64_7.dll", mockLoadLibraryExW);
+
+  // The underlying LoadLibraryExW function should be called with backslashes,
+  // not forward slashes to ensure that it can discover and load dependent
+  // DLLs in the same directory.
+  EXPECT_EQ(CapturedPath, L"C:\\rocm\\bin\\amdhip64_7.dll");
+  EXPECT_EQ(CapturedPath.find(L'/'), std::wstring::npos);
+  EXPECT_EQ(CapturedFile, nullptr);
+  EXPECT_EQ(CapturedFlags, LOAD_WITH_ALTERED_SEARCH_PATH);
+}
 
 // --- compareVersions ---
 

--- a/clang/unittests/offload-arch/OffloadArchTest.cpp
+++ b/clang/unittests/offload-arch/OffloadArchTest.cpp
@@ -13,17 +13,10 @@
 #include <algorithm>
 #include <string>
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 // Defined in AMDGPUArchByHIP.cpp (non-static, compiled into this test).
 #ifdef _WIN32
-using LoadLibraryExWFn = decltype(&::LoadLibraryExW);
-
 bool compareVersions(llvm::StringRef A, llvm::StringRef B);
 llvm::SmallVector<std::string, 8> getCandidateBinPaths(llvm::StringRef ExeDir);
-void primeLibraryLoad(llvm::StringRef Path, LoadLibraryExWFn Loader);
 #endif
 
 using namespace llvm;
@@ -31,37 +24,6 @@ using namespace llvm;
 cl::opt<bool> Verbose("offload-arch-test-verbose", cl::Hidden, cl::init(false));
 
 #ifdef _WIN32
-
-// --- primeLibraryLoad ---
-
-namespace {
-std::wstring CapturedPath;
-HANDLE CapturedFile;
-DWORD CapturedFlags;
-
-HMODULE WINAPI mockLoadLibraryExW(LPCWSTR Path, HANDLE File, DWORD Flags) {
-  CapturedPath = Path;
-  CapturedFile = File;
-  CapturedFlags = Flags;
-  return reinterpret_cast<HMODULE>(1);
-}
-} // namespace
-
-TEST(PrimeLibraryLoad, UsesWindowsBackslashes) {
-  CapturedPath.clear();
-  CapturedFile = reinterpret_cast<HANDLE>(1);
-  CapturedFlags = 0;
-
-  primeLibraryLoad("C:/rocm\\bin/amdhip64_7.dll", mockLoadLibraryExW);
-
-  // The underlying LoadLibraryExW function should be called with backslashes,
-  // not forward slashes to ensure that it can discover and load dependent
-  // DLLs in the same directory.
-  EXPECT_EQ(CapturedPath, L"C:\\rocm\\bin\\amdhip64_7.dll");
-  EXPECT_EQ(CapturedPath.find(L'/'), std::wstring::npos);
-  EXPECT_EQ(CapturedFile, nullptr);
-  EXPECT_EQ(CapturedFlags, LOAD_WITH_ALTERED_SEARCH_PATH);
-}
 
 // --- compareVersions ---
 


### PR DESCRIPTION
## Motivation

This follows up on https://github.com/llvm/llvm-project/pull/194063 to fix https://github.com/ROCm/TheRock/issues/6571, where `offload-arch` distributed as part of ROCm has been failing with:
```diff
 D:\projects\TheRock (main -> upstream)
 λ .\build\dist\rocm\lib\llvm\bin\offload-arch.exe --verbose
 Found HIP runtime: D:/projects/TheRock/build/dist/rocm/bin/amdhip64_7.dll
-note: priming LoadLibraryExW failed for D:/projects/TheRock/build/dist/rocm/bin/amdhip64_7.dll (error 126)
 Failed to load D:/projects/TheRock/build/dist/rocm/bin/amdhip64_7.dll: D:/projects/TheRock/build/dist/rocm/bin/amdhip64_7.dll:  Can't open: The specified module could not be found.  (0x7E)
 Failed to 'dlopen' libcuda.so.1
 Unable to load library 'libze_loader.so': libze_loader.so: Can't open: The specified module could not be found.  (0x7E)
```

## Fix details

The relevant code path in offload-arch is this:
```c++
int printGPUsByHIP() {
  auto [DynamicHIPPath, IsFallback] = findNewestHIPDLL();
  // Prime DLL load so transitive deps resolve from its directory.
  primeLibraryLoad(DynamicHIPPath);
  // ... then load the library and use it
```

Here's where the relevant files are located on disk in both build and package directories:
```
rocm/
    bin/
        amdhip64_7.dll
        rocm_kpack.dll    (amdhip64_7.dll newly depends on this!)
    lib/
        llvm/
            bin/
                offload-arch.exe
```

The documentation for the [`LoadLibraryExW`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw) API that this code was calling says:
> If the string specifies a fully qualified path, the function searches only that path for the module. When specifying a path, be sure to use backslashes (`\`), not forward slashes (`/`). For more information about paths, see [Naming Files, Paths, and Namespaces](https://learn.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file).

the `primeLibraryLoad()` function has been receiving a path with forward slashes in it though, leading to the `error 126`.

## Testing performed

* Built `offload-arch` with and without this fix and ran it locally on Windows
* Added new unit tests asserting that `LoadLibraryExW` is called with backslashes and not forward slashes (we could add more "real" tests that actually exercise library loading but I'm not sure if LLVM unit tests are the right spot for that)
* Ran a "real" test that uses `offload-arch` to list GPUs, compile some code, and run a printf function over in TheRock: https://github.com/ROCm/TheRock/blob/a20ab791d74c94354704b791a85343babb83409b/tests/test_rocm_sanity.py#L85-L154 (this test was disabled back in https://github.com/ROCm/TheRock/pull/5346 due to suspected machine issues, now we'll be able to re-enable it)