### PR TITLE
[SPIRV] Fix legalization of widened cbuffer vector loads

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -138,9 +138,27 @@ class SPIRVLegalizePointerCastImpl {
         return AssignValue;
     }
 
-    assert(TargetType->getNumElements() < SourceType->getNumElements());
-    SmallVector<int> Mask(/* Size= */ TargetType->getNumElements());
-    for (unsigned I = 0; I < TargetType->getNumElements(); ++I)
+    auto *AssignVecTy = cast<FixedVectorType>(AssignValue->getType());
+    const unsigned NumTarget = TargetType->getNumElements();
+    const unsigned NumSource = AssignVecTy->getNumElements();
+
+    // Optimizations may widen a narrow load to cover padding (e.g., loading a
+    // <1 x float> column as <4 x float>). Since extra lanes read trailing
+    // padding, insert only the valid lanes into a poison vector to avoid poison
+    // scalars.
+    if (NumTarget > NumSource) {
+      Value *Result = PoisonValue::get(TargetType);
+      buildAssignType(B, TargetType, Result);
+      for (unsigned I = 0; I < NumSource; ++I) {
+        Value *Scalar = extractScalarFromVector(B, AssignValue, I);
+        Result = makeInsertElement(B, Result, Scalar, I);
+      }
+      return Result;
+    }
+
+    assert(NumTarget < NumSource);
+    SmallVector<int> Mask(/* Size= */ NumTarget);
+    for (unsigned I = 0; I < NumTarget; ++I)
       Mask[I] = I;
     Value *Output = B.CreateShuffleVector(AssignValue, AssignValue, Mask);
     buildAssignType(B, TargetType, Output);
@@ -425,6 +443,22 @@ class SPIRVLegalizePointerCastImpl {
     Value *NewI = B.CreateIntrinsic(Intrinsic::spv_extractelt, {Types}, {Args});
     buildAssignType(B, ElementType, NewI);
     return NewI;
+  }
+
+  // Extracts scalar element |Index| from |Vector|. A <1 x T> vector shares its
+  // SPIR-V type with the scalar T, so a plain extractelement would be invalid;
+  // bridge it with spv_bitcast instead.
+  Value *extractScalarFromVector(IRBuilder<> &B, Value *Vector,
+                                 unsigned Index) {
+    auto *VecTy = cast<FixedVectorType>(Vector->getType());
+    Type *ElemTy = VecTy->getElementType();
+    if (VecTy->getNumElements() == 1) {
+      Value *Scalar =
+          B.CreateIntrinsic(Intrinsic::spv_bitcast, {ElemTy, VecTy}, {Vector});
+      buildAssignType(B, ElemTy, Scalar);
+      return Scalar;
+    }
+    return makeExtractElement(B, ElemTy, Vector, Index);
   }
 
   // Stores the given Src vector operand into the Dst vector, adjusting the size

--- a/llvm/test/CodeGen/SPIRV/passes/SPIRVLegalizePointerCast.ll
+++ b/llvm/test/CodeGen/SPIRV/passes/SPIRVLegalizePointerCast.ll
@@ -59,4 +59,20 @@ entry:
   ret void
 }
 
+@WIDEN = external addrspace(12) global <{ <1 x float>, target("spirv.Padding", 12), <1 x float> }>, align 4
+
+define spir_func void @widen() #0 {
+; CHECK-LABEL: define spir_func void @widen(
+; CHECK-NOT: call {{.*}}@llvm.spv.ptrcast
+; CHECK: call ptr addrspace(12) {{.*}}@llvm.spv.gep.p12.p12(i1 false, ptr addrspace(12) @WIDEN, i32 0, i32 0)
+; CHECK: load <1 x float>, ptr addrspace(12)
+; CHECK: call float @llvm.spv.bitcast.f32.v1f32(<1 x float>
+; CHECK: call <4 x float> @llvm.spv.insertelt.v4f32.v4f32.f32.i32(<4 x float> poison, float
+entry:
+  %v = load <4 x float>, ptr addrspace(12) @WIDEN, align 4
+  %x = extractelement <4 x float> %v, i32 0
+  store float %x, ptr addrspace(10) @OUT, align 4
+  ret void
+}
+
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
fixes #191070

In the SPIR-V backend an optimization has widened a narrow cbuffer load into a wider vector load that reads trailing padding (e.g. a <1 x float> float1x4 column loaded as <4 x float>). loadVectorFromVector only handled down-casts and asserts when the target has more elements than the source.

We need to handle the widening case by loading the available lanes and inserting them into a poison target vector, leaving the padding lanes as poison.

Assisted by Claude Opus 4.8