### PR TITLE
[flang][AIX] Diagnose unsupported OBJECT_MODE setting and -maix32 option

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -826,6 +826,9 @@ def err_drv_cannot_mix_options : Error<"cannot specify '%1' along with '%0'">;
 def err_drv_invalid_object_mode : Error<
   "OBJECT_MODE setting %0 is not recognized and is not a valid setting">;
 
+def err_drv_compile_mode_unsupported : Error<
+  "the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64">;
+
 def err_roptr_requires_data_sections: Error<"-mxcoff-roptr is supported only with -fdata-sections">;
 def err_roptr_cannot_build_shared: Error<"-mxcoff-roptr is not supported with -shared">;
 

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -826,8 +826,8 @@ def err_drv_cannot_mix_options : Error<"cannot specify '%1' along with '%0'">;
 def err_drv_invalid_object_mode : Error<
   "OBJECT_MODE setting %0 is not recognized and is not a valid setting">;
 
-def err_drv_compile_mode_unsupported : Error<
-  "the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64">;
+def err_drv_compile_mode_unsupported_aix : Error<
+  "32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64">;
 
 def err_roptr_requires_data_sections: Error<"-mxcoff-roptr is supported only with -fdata-sections">;
 def err_roptr_cannot_build_shared: Error<"-mxcoff-roptr is not supported with -shared">;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -745,12 +745,17 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
     } else if (A->getOption().matches(options::OPT_m32) ||
                A->getOption().matches(options::OPT_maix32)) {
       if (D.IsFlangMode()) {
-        // On AIX, flang assumes 32-bit mode compile by default
-        if (!Target.isOSAIX()) {
-          D.Diag(diag::err_drv_unsupported_opt_for_target)
-              << A->getAsString(Args) << Target.str();
-        } else if (llvm::sys::Process::GetEnv("OBJECT_MODE")) {
+        // Flang does not support 32-bit compilation.
+        // On an AIX host, -m32/-maix32 is always an error.
+        // On a non-AIX host, it is an error only when targeting AIX.
+        llvm::Triple HostTriple(D.getTargetTriple());
+        if (HostTriple.isOSAIX() || Target.isOSAIX()) {
           D.Diag(diag::err_drv_compile_mode_unsupported);
+        } else {
+          AT = Target.get32BitArchVariant().getArch();
+          if (AT == llvm::Triple::ppcle)
+            D.Diag(diag::err_drv_unsupported_opt_for_target)
+                << A->getAsString(Args) << Target.str();
         }
       } else {
         AT = Target.get32BitArchVariant().getArch();

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -675,21 +675,37 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
       StringRef ObjectMode = *ObjectModeValue;
       llvm::Triple::ArchType AT = llvm::Triple::UnknownArch;
 
-      // Silently accept '32_64' and 'any'
-      const bool OtherAllowedMode =
-          ObjectMode == "32_64" || ObjectMode == "any";
-      if (ObjectMode == "64") {
-        AT = Target.get64BitArchVariant().getArch();
-      } else if (ObjectMode == "32") {
-        AT = Target.get32BitArchVariant().getArch();
-      } else if (!OtherAllowedMode) {
-        D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
+      if (D.IsFlangMode()) {
+        bool HasMaix = Args.hasArg(options::OPT_maix32, options::OPT_maix64,
+                                   options::OPT_m32, options::OPT_m64);
+        if (!HasMaix) {
+          if (ObjectMode == "64") {
+            AT = Target.get64BitArchVariant().getArch();
+          } else {
+            D.Diag(diag::err_drv_compile_mode_unsupported);
+            AT = Target.get32BitArchVariant().getArch();
+          }
+        }
+      } else {
+        // Silently accept '32_64' and 'any'
+        const bool OtherAllowedMode =
+            ObjectMode == "32_64" || ObjectMode == "any";
+        if (ObjectMode == "64") {
+          AT = Target.get64BitArchVariant().getArch();
+        } else if (ObjectMode == "32") {
+          AT = Target.get32BitArchVariant().getArch();
+        } else if (!OtherAllowedMode) {
+          D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
+        }
       }
 
       if (AT != llvm::Triple::UnknownArch && AT != Target.getArch()) {
         Target.setArch(AT);
         Target = llvm::Triple(Target.normalize());
       }
+    } else if (D.IsFlangMode() &&
+               !Args.hasArg(options::OPT_maix64, options::OPT_m64)) {
+      D.Diag(diag::err_drv_compile_mode_unsupported);
     }
   }
 #endif
@@ -728,9 +744,14 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
         Target.setEnvironment(llvm::Triple::GNUX32);
     } else if (A->getOption().matches(options::OPT_m32) ||
                A->getOption().matches(options::OPT_maix32)) {
-      if (D.IsFlangMode() && !Target.isOSAIX()) {
-        D.Diag(diag::err_drv_unsupported_opt_for_target)
-            << A->getAsString(Args) << Target.str();
+      if (D.IsFlangMode()) {
+        // On AIX, flang assumes 32-bit mode compile by default
+        if (!Target.isOSAIX()) {
+          D.Diag(diag::err_drv_unsupported_opt_for_target)
+              << A->getAsString(Args) << Target.str();
+        } else if (llvm::sys::Process::GetEnv("OBJECT_MODE")) {
+          D.Diag(diag::err_drv_compile_mode_unsupported);
+        }
       } else {
         AT = Target.get32BitArchVariant().getArch();
         if (Target.getEnvironment() == llvm::Triple::GNUX32)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -681,11 +681,10 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
         } else if (ObjectMode == "32" || ObjectMode == "32_64" ||
                    ObjectMode == "any") {
           // OBJECT_MODE setting can be overridden by -maix64/-m64
-          if (Args.hasArg(options::OPT_maix64, options::OPT_m64)) {
+          if (Args.hasArg(options::OPT_maix64, options::OPT_m64))
             AT = Target.get64BitArchVariant().getArch();
-          } else {
+          else
             D.Diag(diag::err_drv_compile_mode_unsupported_aix);
-          }
         } else {
           D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
         }
@@ -693,13 +692,12 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
         // Silently accept '32_64' and 'any'
         const bool OtherAllowedMode =
             ObjectMode == "32_64" || ObjectMode == "any";
-        if (ObjectMode == "64") {
+        if (ObjectMode == "64")
           AT = Target.get64BitArchVariant().getArch();
-        } else if (ObjectMode == "32") {
+        else if (ObjectMode == "32")
           AT = Target.get32BitArchVariant().getArch();
-        } else if (!OtherAllowedMode) {
+        else if (!OtherAllowedMode)
           D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
-        }
       }
 
       if (AT != llvm::Triple::UnknownArch && AT != Target.getArch()) {
@@ -708,8 +706,8 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
       }
     } else if (D.IsFlangMode() &&
                !Args.hasArg(options::OPT_maix64, options::OPT_m64)) {
-      // For flang on AIX, if OBJECT_MODE is unset and compile
-      // without -maix64/-m64 issue an error.
+      // For flang on AIX, if OBJECT_MODE is unset and neither
+      // -maix64 nor -m64 is specified, issue an error.
       D.Diag(diag::err_drv_compile_mode_unsupported_aix);
     }
   }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -754,7 +754,7 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
           D.Diag(diag::err_drv_compile_mode_unsupported_aix);
         } else {
           D.Diag(diag::err_drv_unsupported_opt_for_target)
-            << A->getAsString(Args) << Target.str();
+              << A->getAsString(Args) << Target.str();
         }
       } else {
         AT = Target.get32BitArchVariant().getArch();

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -676,15 +676,18 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
       llvm::Triple::ArchType AT = llvm::Triple::UnknownArch;
 
       if (D.IsFlangMode()) {
-        bool HasMaix = Args.hasArg(options::OPT_maix32, options::OPT_maix64,
-                                   options::OPT_m32, options::OPT_m64);
-        if (!HasMaix) {
-          if (ObjectMode == "64") {
+        if (ObjectMode == "64") {
+          AT = Target.get64BitArchVariant().getArch();
+        } else if (ObjectMode == "32" || ObjectMode == "32_64" ||
+                   ObjectMode == "any") {
+          // OBJECT_MODE setting can be overridden by -maix64/-m64
+          if (Args.hasArg(options::OPT_maix64, options::OPT_m64)) {
             AT = Target.get64BitArchVariant().getArch();
           } else {
-            D.Diag(diag::err_drv_compile_mode_unsupported);
-            AT = Target.get32BitArchVariant().getArch();
+            D.Diag(diag::err_drv_compile_mode_unsupported_aix);
           }
+        } else {
+          D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
         }
       } else {
         // Silently accept '32_64' and 'any'
@@ -705,7 +708,9 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
       }
     } else if (D.IsFlangMode() &&
                !Args.hasArg(options::OPT_maix64, options::OPT_m64)) {
-      D.Diag(diag::err_drv_compile_mode_unsupported);
+      // For flang on AIX, if OBJECT_MODE is unset and compile
+      // without -maix64/-m64 issue an error.
+      D.Diag(diag::err_drv_compile_mode_unsupported_aix);
     }
   }
 #endif
@@ -745,17 +750,11 @@ static llvm::Triple computeTargetTriple(const Driver &D, StringRef TargetTriple,
     } else if (A->getOption().matches(options::OPT_m32) ||
                A->getOption().matches(options::OPT_maix32)) {
       if (D.IsFlangMode()) {
-        // Flang does not support 32-bit compilation.
-        // On an AIX host, -m32/-maix32 is always an error.
-        // On a non-AIX host, it is an error only when targeting AIX.
-        llvm::Triple HostTriple(D.getTargetTriple());
-        if (HostTriple.isOSAIX() || Target.isOSAIX()) {
-          D.Diag(diag::err_drv_compile_mode_unsupported);
+        if (Target.isOSAIX()) {
+          D.Diag(diag::err_drv_compile_mode_unsupported_aix);
         } else {
-          AT = Target.get32BitArchVariant().getArch();
-          if (AT == llvm::Triple::ppcle)
-            D.Diag(diag::err_drv_unsupported_opt_for_target)
-                << A->getAsString(Args) << Target.str();
+          D.Diag(diag::err_drv_unsupported_opt_for_target)
+            << A->getAsString(Args) << Target.str();
         }
       } else {
         AT = Target.get32BitArchVariant().getArch();

--- a/flang-rt/test/lit.cfg.py
+++ b/flang-rt/test/lit.cfg.py
@@ -111,4 +111,4 @@ if config.flang_rt_fortran_modules:
 # Tools that support OBJECT_MODE default to 32-bit on AIX. Set
 # OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
 if "system-aix" in config.available_features:
-    config.environment["OBJECT_MODE"] = "any"
+    config.environment["OBJECT_MODE"] = "64"

--- a/flang-rt/test/lit.cfg.py
+++ b/flang-rt/test/lit.cfg.py
@@ -108,7 +108,6 @@ if config.flang_rt_experimental_offload_support == "CUDA":
 if config.flang_rt_fortran_modules:
     config.available_features.add("fortran-modules")
 
-# Tools that support OBJECT_MODE default to 32-bit on AIX. Set
-# OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
+# Set OBJECT_MODE=64 as tools on AIX default to 32-bit.
 if "system-aix" in config.available_features:
     config.environment["OBJECT_MODE"] = "64"

--- a/flang/test/Driver/aix-object-mode.f90
+++ b/flang/test/Driver/aix-object-mode.f90
@@ -1,0 +1,21 @@
+! Check Flang on AIX OBJECT_MODE handling and -maix* flag behavior.
+!REQUIRES: system-aix
+
+!RUN: env -u OBJECT_MODE not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+!RUN: env OBJECT_MODE=32 not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+!RUN: env OBJECT_MODE=32_64 not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+!RUN: env OBJECT_MODE=any not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+!RUN: env OBJECT_MODE=64 %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
+
+!RUN: not %flang -maix32 -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+!RUN: env OBJECT_MODE=64 not %flang -maix32 -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+!RUN: env OBJECT_MODE=32 %flang -maix64 -print-target-triple 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
+
+!MODE-64BIT: powerpc64-ibm-aix
+!MAIX32-ERROR: error: the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64

--- a/flang/test/Driver/aix-object-mode.f90
+++ b/flang/test/Driver/aix-object-mode.f90
@@ -1,21 +1,24 @@
 ! Check Flang on AIX OBJECT_MODE handling and -maix* flag behavior.
 !REQUIRES: system-aix
 
-!RUN: env -u OBJECT_MODE not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+!RUN: env -u OBJECT_MODE not %flang %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-!RUN: env OBJECT_MODE=32 not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+!RUN: env OBJECT_MODE=32 not %flang %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-!RUN: env OBJECT_MODE=32_64 not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+!RUN: env OBJECT_MODE=32_64 not %flang %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-!RUN: env OBJECT_MODE=any not %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+!RUN: env OBJECT_MODE=any not %flang %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-!RUN: env OBJECT_MODE=64 %flang -print-target-triple 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
+!RUN: env OBJECT_MODE=64 %flang -print-target-triple %s 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
 
-!RUN: not %flang -maix32 -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+!RUN: not %flang -maix32 %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-!RUN: env OBJECT_MODE=64 not %flang -maix32 -print-target-triple 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+!RUN: env OBJECT_MODE=64 not %flang -maix32 %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-!RUN: env OBJECT_MODE=32 %flang -maix64 -print-target-triple 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
+!RUN: env OBJECT_MODE=32 %flang -maix64 -print-target-triple %s 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
 
 !MODE-64BIT: powerpc64-ibm-aix
 !MAIX32-ERROR: error: the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64
+
+program main
+end

--- a/flang/test/Driver/aix-object-mode.f90
+++ b/flang/test/Driver/aix-object-mode.f90
@@ -1,4 +1,4 @@
-! Check Flang on AIX OBJECT_MODE handling and -maix* flag behavior.
+! Check Flang on AIX OBJECT_MODE handling with -maix* setting.
 !REQUIRES: system-aix
 
 !RUN: env -u OBJECT_MODE not %flang %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
@@ -11,14 +11,18 @@
 
 !RUN: env OBJECT_MODE=64 %flang -print-target-triple %s 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
 
-!RUN: not %flang -maix32 %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
-
 !RUN: env OBJECT_MODE=64 not %flang -maix32 %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
 !RUN: env OBJECT_MODE=32 %flang -maix64 -print-target-triple %s 2>&1 | FileCheck -check-prefix=MODE-64BIT %s
 
+!RUN: env OBJECT_MODE=7 not %flang %s 2>&1 | FileCheck -check-prefix=OBJECT-MODE-INVALID-ERROR %s
+
+!RUN: env OBJECT_MODE='' not %flang %s 2>&1 | FileCheck -check-prefix=OBJECT-MODE-EMPTY-ERROR %s
+
+!OBJECT-MODE-INVALID-ERROR: error: OBJECT_MODE setting 7 is not recognized and is not a valid setting
+!OBJECT-MODE-EMPTY-ERROR: error: OBJECT_MODE setting is not recognized and is not a valid setting
 !MODE-64BIT: powerpc64-ibm-aix
-!MAIX32-ERROR: error: the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64
+!MAIX32-ERROR: error: 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64
 
 program main
 end

--- a/flang/test/Driver/m32-option.f90
+++ b/flang/test/Driver/m32-option.f90
@@ -1,14 +1,14 @@
 ! Check support of -m32.
-! RUN: %flang -target powerpc-ibm-aix -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
-! RUN: %flang -target powerpc64-ibm-aix -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
-! RUN: %flang -target powerpc-ibm-aix -maix32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
-! RUN: %flang -target powerpc64-ibm-aix -maix32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
+! RUN: not %flang -target powerpc-ibm-aix -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32-AIX-ERROR %s
+! RUN: not %flang -target powerpc64-ibm-aix -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32-AIX-ERROR %s
+! RUN: not %flang -target powerpc-ibm-aix -maix32 -### - %s 2>&1 | FileCheck -check-prefix=M32-AIX-ERROR %s
+! RUN: not %flang -target powerpc64-ibm-aix -maix32 -### - %s 2>&1 | FileCheck -check-prefix=M32-AIX-ERROR %s
 ! RUN: %flang -target powerpc-ibm-aix -maix64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
 ! RUN: %flang -target powerpc64-ibm-aix -maix64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
 ! RUN: not %flang -target powerpc64le-unknown-linux-gnu -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32-ERROR %s
 ! RUN: not %flang -target powerpc64le-unknown-linux-gnu -maix32 -### - %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-! M32: "-triple" "powerpc-ibm-aix{{.*}}"
+! M32-AIX-ERROR: error: the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64
 ! M64: "-triple" "powerpc64-ibm-aix{{.*}}"
 ! M32-ERROR: error: unsupported option '-m32' for target 'powerpc64le-unknown-linux-gnu'
 ! MAIX32-ERROR: error: unsupported option '-maix32' for target 'powerpc64le-unknown-linux-gnu'

--- a/flang/test/Driver/m32-option.f90
+++ b/flang/test/Driver/m32-option.f90
@@ -8,7 +8,7 @@
 ! RUN: not %flang -target powerpc64le-unknown-linux-gnu -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32-ERROR %s
 ! RUN: not %flang -target powerpc64le-unknown-linux-gnu -maix32 -### - %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
 
-! M32-AIX-ERROR: error: the 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64
+! M32-AIX-ERROR: error: 32-bit compile mode is not supported. Use OBJECT_MODE=64, -maix64 or -m64
 ! M64: "-triple" "powerpc64-ibm-aix{{.*}}"
 ! M32-ERROR: error: unsupported option '-m32' for target 'powerpc64le-unknown-linux-gnu'
 ! MAIX32-ERROR: error: unsupported option '-maix32' for target 'powerpc64le-unknown-linux-gnu'

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -271,3 +271,8 @@ if config.flang_runtime_f128_math_lib:
     )
 else:
     config.substitutions.append(("%f128-lib", "NONE"))
+
+# Tools that support OBJECT_MODE default to 32-bit on AIX. Set
+# OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
+if "system-aix" in config.available_features:
+    config.environment["OBJECT_MODE"] = "64"

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -272,7 +272,6 @@ if config.flang_runtime_f128_math_lib:
 else:
     config.substitutions.append(("%f128-lib", "NONE"))
 
-# Tools that support OBJECT_MODE default to 32-bit on AIX. Set
-# OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
+# Set OBJECT_MODE=64 as tools on AIX default to 32-bit.
 if "system-aix" in config.available_features:
     config.environment["OBJECT_MODE"] = "64"


### PR DESCRIPTION
This patch is to align flang's default behavior to the other tools in toolchain on AIX. Flang assumes 32-bit compile by default. The compile mode can be overridden by setting environment variable OBJECT_MODE=64 or specifying the -maix64 option.