### PR TITLE
[ObjC] Sort constant NSDictionary keys by UTF-16 code unit

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3716,6 +3716,10 @@ def warn_nsdictionary_duplicate_key : Warning<
   InGroup<DiagGroup<"objc-dictionary-duplicate-keys">>;
 def note_nsdictionary_duplicate_key_here : Note<
   "previous equal key is here">;
+def warn_objc_dictionary_ill_formed_utf8_key : Warning<
+  "dictionary key is ill-formed as UTF-8 and will be truncated in a static "
+  "constant dictionary, so it may not be found at runtime">,
+  InGroup<DiagGroup<"objc-dictionary-invalid-utf8-key">>;
 def err_swift_param_attr_not_swiftcall : Error<
   "'%0' parameter can only be used with swiftcall%select{ or swiftasynccall|}1 "
   "calling convention%select{|s}1">;

--- a/clang/lib/CodeGen/CGObjCMacConstantLiteralUtil.h
+++ b/clang/lib/CodeGen/CGObjCMacConstantLiteralUtil.h
@@ -21,6 +21,8 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/Support/ConvertUTF.h"
+#include <algorithm>
 #include <numeric>
 
 namespace clang {
@@ -107,26 +109,38 @@ public:
     SmallVector<size_t, 16> ElementIndicies(NumElements);
     std::iota(ElementIndicies.begin(), ElementIndicies.end(), 0);
 
+    // Precompute the UTF-16 form of each string key. The runtime stores keys as
+    // UTF-16 and looks them up by UTF-16 code-unit order, so we must sort by the
+    // same order here. Sorting by the raw UTF-8 bytes instead would diverge for
+    // keys mixing characters in U+E000..U+FFFF with astral characters
+    // (U+10000..U+10FFFF), because UTF-16 encodes the latter with lead
+    // surrogates (0xD800..0xDBFF) that sort *below* 0xE000 -- causing the
+    // runtime's lookup to miss keys that are actually present.
+    SmallVector<SmallVector<llvm::UTF16, 16>, 16> KeysUTF16(NumElements);
+    for (size_t I = 0; I < NumElements; ++I) {
+      Expr *const K = E->getKeyValueElement(I).Key->IgnoreImpCasts();
+      auto *SL = dyn_cast<ObjCStringLiteral>(K);
+      assert(SL && "Non-constant literals should not be sorted to "
+                   "maintain existing behavior");
+      // NOTE: Using the `StringLiteral->getString()` since it checks that
+      //       `chars` are 1 byte
+      StringRef KS = SL->getString()->getString();
+      bool OK = llvm::convertUTF8ToUTF16String(KS, KeysUTF16[I]);
+      (void)OK;
+      assert(OK && "constant dictionary key is not well-formed UTF-8");
+    }
+
     // Now perform the sorts and shift the indicies as needed
     std::stable_sort(
         ElementIndicies.begin(), ElementIndicies.end(),
-        [E, O](size_t LI, size_t RI) {
-          Expr *const LK = E->getKeyValueElement(LI).Key->IgnoreImpCasts();
-          Expr *const RK = E->getKeyValueElement(RI).Key->IgnoreImpCasts();
-
-          if (!isa<ObjCStringLiteral>(LK) || !isa<ObjCStringLiteral>(RK))
-            llvm_unreachable("Non-constant literals should not be sorted to "
-                             "maintain existing behavior");
-
-          // NOTE: Using the `StringLiteral->getString()` since it checks that
-          //       `chars` are 1 byte
-          StringRef LKS = cast<ObjCStringLiteral>(LK)->getString()->getString();
-          StringRef RKS = cast<ObjCStringLiteral>(RK)->getString()->getString();
-
-          // Do an alpha sort to aid in with de-dupe at link time
-          // `O(log n)` worst case lookup at runtime supported by `Foundation`
+        [O, &KeysUTF16](size_t LI, size_t RI) {
+          // Sort by UTF-16 code unit to match the runtime's lookup order. This
+          // is a deterministic total order, so it still aids link-time de-dupe,
+          // and it supports the runtime's `O(log n)` worst-case lookup.
           if (O == Options::Sorted)
-            return LKS < RKS;
+            return std::lexicographical_compare(
+                KeysUTF16[LI].begin(), KeysUTF16[LI].end(),
+                KeysUTF16[RI].begin(), KeysUTF16[RI].end());
           llvm_unreachable("Unexpected `NSDictionaryBuilder::Options given");
         });
 

--- a/clang/lib/CodeGen/CGObjCMacConstantLiteralUtil.h
+++ b/clang/lib/CodeGen/CGObjCMacConstantLiteralUtil.h
@@ -116,6 +116,16 @@ public:
     // (U+10000..U+10FFFF), because UTF-16 encodes the latter with lead
     // surrogates (0xD800..0xDBFF) that sort *below* 0xE000 -- causing the
     // runtime's lookup to miss keys that are actually present.
+    //
+    // A key need not be well-formed UTF-8: string literals with invalid or
+    // partial sequences are legal in the AST (Sema warns about them separately;
+    // see warn_objc_dictionary_ill_formed_utf8_key). We deliberately mirror the
+    // constant CFString emitter (CodeGenModule::GetConstantCFStringEntry), which
+    // runs ConvertUTF8toUTF16 with strictConversion and keeps whatever prefix
+    // converts successfully, so we sort by exactly the code units the string is
+    // stored and looked up as. Any trailing bytes that fail to convert are
+    // dropped from the sort key; this cannot crash and yields a valid
+    // strict-weak ordering regardless of well-formedness.
     SmallVector<SmallVector<llvm::UTF16, 16>, 16> KeysUTF16(NumElements);
     for (size_t I = 0; I < NumElements; ++I) {
       Expr *const K = E->getKeyValueElement(I).Key->IgnoreImpCasts();
@@ -125,9 +135,14 @@ public:
       // NOTE: Using the `StringLiteral->getString()` since it checks that
       //       `chars` are 1 byte
       StringRef KS = SL->getString()->getString();
-      bool OK = llvm::convertUTF8ToUTF16String(KS, KeysUTF16[I]);
-      (void)OK;
-      assert(OK && "constant dictionary key is not well-formed UTF-8");
+      SmallVectorImpl<llvm::UTF16> &Dst = KeysUTF16[I];
+      Dst.resize(KS.size()); // UTF-16 needs <= as many code units as UTF-8.
+      const llvm::UTF8 *SrcPtr = reinterpret_cast<const llvm::UTF8 *>(KS.data());
+      llvm::UTF16 *DstPtr = Dst.data();
+      llvm::ConvertUTF8toUTF16(&SrcPtr, SrcPtr + KS.size(), &DstPtr,
+                               DstPtr + Dst.size(), llvm::strictConversion);
+      // ConvertUTF8toUTF16 advances DstPtr to the end of the converted prefix.
+      Dst.truncate(DstPtr - Dst.data());
     }
 
     // Now perform the sorts and shift the indicies as needed

--- a/clang/lib/CodeGen/CGObjCMacConstantLiteralUtil.h
+++ b/clang/lib/CodeGen/CGObjCMacConstantLiteralUtil.h
@@ -20,9 +20,10 @@
 #include "clang/AST/Type.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ConvertUTF.h"
-#include <algorithm>
 #include <numeric>
 
 namespace clang {
@@ -146,16 +147,15 @@ public:
     }
 
     // Now perform the sorts and shift the indicies as needed
-    std::stable_sort(
-        ElementIndicies.begin(), ElementIndicies.end(),
-        [O, &KeysUTF16](size_t LI, size_t RI) {
+    llvm::stable_sort(
+        ElementIndicies, [O, &KeysUTF16](size_t LI, size_t RI) {
           // Sort by UTF-16 code unit to match the runtime's lookup order. This
           // is a deterministic total order, so it still aids link-time de-dupe,
           // and it supports the runtime's `O(log n)` worst-case lookup.
+          // ArrayRef::operator< is a lexicographic code-unit comparison.
           if (O == Options::Sorted)
-            return std::lexicographical_compare(
-                KeysUTF16[LI].begin(), KeysUTF16[LI].end(),
-                KeysUTF16[RI].begin(), KeysUTF16[RI].end());
+            return ArrayRef<llvm::UTF16>(KeysUTF16[LI]) <
+                   ArrayRef<llvm::UTF16>(KeysUTF16[RI]);
           llvm_unreachable("Unexpected `NSDictionaryBuilder::Options given");
         });
 

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -1035,6 +1035,36 @@ CheckObjCDictionaryLiteralDuplicateKeys(Sema &S,
   }
 }
 
+/// Warn about string keys of a constant dictionary literal that are not
+/// well-formed UTF-8. When a dictionary is emitted as a static constant, its
+/// keys are stored and looked up as UTF-16, and the CFString emitter truncates
+/// each key at the first ill-formed byte. A truncated key generally cannot be
+/// found at runtime as written, so flag it -- mirroring the diagnostic emitted
+/// for ill-formed UTF-8 when boxing a string (warn_objc_boxing_invalid_utf8_string).
+static void
+CheckObjCDictionaryLiteralUTF8Keys(Sema &S, ObjCDictionaryLiteral *Literal) {
+  // Only constant dictionaries store/truncate keys as UTF-16; ordinary runtime
+  // dictionaries keep the original NSString unchanged.
+  if (!Literal->isExpressibleAsConstantInitializer())
+    return;
+  if (Literal->isValueDependent() || Literal->isTypeDependent())
+    return;
+
+  for (unsigned Idx = 0, End = Literal->getNumElements(); Idx != End; ++Idx) {
+    Expr *Key = Literal->getKeyValueElement(Idx).Key->IgnoreParenImpCasts();
+    auto *StrLit = dyn_cast<ObjCStringLiteral>(Key);
+    if (!StrLit)
+      continue;
+    StringRef Bytes = StrLit->getString()->getBytes();
+    const llvm::UTF8 *Begin = Bytes.bytes_begin();
+    const llvm::UTF8 *End2 = Bytes.bytes_end();
+    if (!llvm::isLegalUTF8String(&Begin, End2))
+      S.Diag(StrLit->getExprLoc(),
+             diag::warn_objc_dictionary_ill_formed_utf8_key)
+          << StrLit->getSourceRange();
+  }
+}
+
 ExprResult SemaObjC::BuildObjCDictionaryLiteral(
     SourceRange SR, MutableArrayRef<ObjCDictionaryElement> Elements) {
   ASTContext &Context = getASTContext();
@@ -1246,6 +1276,7 @@ ExprResult SemaObjC::BuildObjCDictionaryLiteral(
       ExpressibleAsConstantInitLiteral, SR);
 
   CheckObjCDictionaryLiteralDuplicateKeys(SemaRef, DictionaryLiteral);
+  CheckObjCDictionaryLiteralUTF8Keys(SemaRef, DictionaryLiteral);
 
   return SemaRef.MaybeBindToTemporary(DictionaryLiteral);
 }

--- a/clang/test/CodeGenObjC/objc-constant-dictionary-key-order.m
+++ b/clang/test/CodeGenObjC/objc-constant-dictionary-key-order.m
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macosx11.0.0 -fobjc-runtime=macosx-11.0.0 -fobjc-constant-literals -fconstant-nsnumber-literals -fconstant-nsarray-literals -fconstant-nsdictionary-literals -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-ios14.0 -fobjc-runtime=ios-14.0 -fobjc-constant-literals -fconstant-nsnumber-literals -fconstant-nsarray-literals -fconstant-nsdictionary-literals -emit-llvm -o - %s | FileCheck %s
+
+// The constant dictionary emitter sorts string keys by UTF-16 code unit, which
+// is the order the runtime uses to look them up. This matters for keys that mix
+// the BMP above the surrogate range (U+E000..U+FFFF) with astral characters
+// (U+10000..U+10FFFF): UTF-16 encodes astral characters with lead surrogates
+// (0xD800..0xDBFF) that sort *below* 0xE000, which is the opposite of their
+// UTF-8 byte order. Sorting by UTF-16 here keeps compile-time emission and
+// runtime lookup consistent so the keys can be found.
+
+#if __LP64__
+typedef unsigned long NSUInteger;
+#else
+typedef unsigned int NSUInteger;
+#endif
+
+@interface NSNumber
++ (NSNumber *)numberWithInt:(int)value;
+@end
+
+@interface NSDictionary
++ (id)dictionaryWithObjects:(const id[])objects forKeys:(const id[])keys count:(NSUInteger)cnt;
+@end
+
+// The emoji U+1F600 is stored as the UTF-16 surrogate pair <0xD83D, 0xDE00>.
+// CHECK: @.str = private unnamed_addr constant [3 x i16] [i16 -10179, i16 -8704, i16 0], section "__TEXT,__ustring"
+// CHECK: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { ptr @__CFConstantStringClassReference, i32 {{[0-9]+}}, ptr @.str, i64 2 }
+
+// The Private Use Area character U+E000 is a single UTF-16 code unit <0xE000>.
+// CHECK: @.str.2 = private unnamed_addr constant [2 x i16] [i16 -8192, i16 0], section "__TEXT,__ustring"
+// CHECK: @_unnamed_cfstring_.3 = private global %struct.__NSConstantString_tag { ptr @__CFConstantStringClassReference, i32 {{[0-9]+}}, ptr @.str.2, i64 1 }
+
+// The emitted keys array is ordered by UTF-16 code unit: the emoji's lead
+// surrogate 0xD83D sorts before the PUA's 0xE000, so @_unnamed_cfstring_ (emoji)
+// comes first even though its UTF-8 bytes (F0 9F 98 80) are greater than the
+// PUA's (EE 80 80). This matches the runtime's UTF-16 lookup order.
+// CHECK: @_unnamed_array_storage = internal unnamed_addr constant [2 x ptr] [ptr @_unnamed_cfstring_, ptr @_unnamed_cfstring_.3]
+// CHECK: @_unnamed_nsdictionary_ = private constant %struct.__builtin_NSDictionary { ptr @"OBJC_CLASS_$_NSConstantDictionary", i64 1, i64 2, ptr @_unnamed_array_storage, ptr @_unnamed_array_storage.5 }
+
+static NSDictionary *const diverges = @{
+    @"\U0001F600" : @1,
+    @"\uE000" : @2,
+};
+
+const void *use(void) { return (const void *)diverges; }

--- a/clang/test/SemaObjC/objc-constant-dictionary-invalid-utf8-key.m
+++ b/clang/test/SemaObjC/objc-constant-dictionary-invalid-utf8-key.m
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -fsyntax-only -triple arm64-apple-ios14.0 -fobjc-runtime=ios-14.0 -fobjc-constant-literals -fconstant-nsnumber-literals -fconstant-nsarray-literals -fconstant-nsdictionary-literals -Wno-CFString-literal -verify %s
+
+// A constant dictionary stores and looks up its keys as UTF-16, truncating any
+// key at the first ill-formed UTF-8 byte. Warn when that happens, since the
+// truncated key generally cannot be found at runtime.
+
+#if __LP64__
+typedef unsigned long NSUInteger;
+#else
+typedef unsigned int NSUInteger;
+#endif
+
+@interface NSNumber
++ (NSNumber *)numberWithInt:(int)value;
+@end
+
+@interface NSDictionary
++ (id)dictionaryWithObjects:(const id[])objects forKeys:(const id[])keys count:(NSUInteger)cnt;
+@end
+
+// Ill-formed UTF-8 key (a lone 0xFF continuation byte) in a constant dictionary.
+static NSDictionary *const bad = @{
+    @"\xff" : @1, // expected-warning {{dictionary key is ill-formed as UTF-8 and will be truncated in a static constant dictionary, so it may not be found at runtime}}
+    @"ok" : @2,
+};
+
+// Well-formed keys (including non-ASCII and astral) must NOT warn.
+static NSDictionary *const good = @{
+    @"ascii" : @1,
+    @"café" : @2,
+    @"\U0001F600" : @3,
+};
+
+// A runtime (non-constant) dictionary keeps the original NSString and is not
+// truncated, so it must NOT warn even with an ill-formed key.
+NSDictionary *runtime(NSNumber *n) {
+  return @{
+      @"\xff" : n,
+      @"ok" : n,
+  };
+}


### PR DESCRIPTION
## Summary

When an Objective-C dictionary literal is emitted as a static constant (`-fconstant-nsdictionary-literals`), its string keys are sorted at compile time and the runtime performs an `O(log n)` lookup over them. The runtime stores and compares keys as **UTF-16**, but the emitter sorted them by their raw **UTF-8 bytes**.

These two orders agree across almost the entire Unicode range, but they diverge when two keys' first differing character has one side in **U+E000..U+FFFF** (the BMP above the surrogate range) and the other in **U+10000..U+10FFFF** (the supplementary planes). UTF-16 encodes supplementary characters using lead surrogates in `0xD800..0xDBFF`, which sort *below* `0xE000` — the opposite of their UTF-8 byte order. When keys diverge, the runtime's lookup can fail to find a key that is actually present in the dictionary (e.g. a dictionary mixing an emoji key with a Private Use Area key).

This patch sorts the keys by UTF-16 code unit so the compile-time order matches the runtime's lookup order.

## Which runtimes are affected

This primarily affects the **iOS** runtime, whose `NSConstantDictionary` lookup is order-based (the UTF-16 `O(log n)` search described above) and therefore depends on the emitted key order being correct. The **macOS** runtime is *not* affected: its constant-dictionary lookup is hash-based (`CFStringHashNSString`), so key order is irrelevant to correctness there. Sorting by UTF-16 keeps macOS correct as well (a hash lookup doesn't care about order) while fixing the iOS lookup, so this is the right fix for both.

## Why this is safe

- **No-op for the common case.** ASCII and any text below U+E000 already sorted identically under UTF-8 and UTF-16, so the emitted layout of existing dictionaries does not change.
- **Still a deterministic total order**, so link-time de-duplication of identical constant dictionaries is preserved.
- **No ABI impact.** The affected globals — the dictionary struct, its key/object arrays, and the key strings — all have `private`/`internal` linkage and are never exported. Even when a constant dictionary appears in a public header behind an `inline` (`linkonce_odr`) accessor, the accessor is byte-identical regardless of key order and the private payload is re-emitted per translation unit rather than shared. Only the internal element order of the private key array changes, and only for dictionaries containing the divergent key class described above.

## Testing

New test `clang/test/CodeGenObjC/objc-constant-dictionary-key-order.m` checks that an emoji key (U+1F600) sorts before a Private Use Area key (U+E000) — i.e. UTF-16 order, the opposite of UTF-8 byte order. Passes on x86_64 and arm64. The existing `objc2-constant-collection-literals.m` continues to pass unchanged, confirming the common case is untouched.

The fix was also verified end to end against the real runtime: a static-constant dictionary mixing astral and BMP-high keys missed several present keys before the change and finds all of them after, both on the iOS simulator and on a physical iOS device.

[Assisted-by](https://t.ly/Dkjjk): Opus 4.8
