### PR TITLE
[clang][bytecode] long double on arm64 darwin is 8 bytes (NFC)

### DIFF
--- a/clang/test/AST/ByteCode/builtin-object-size.cpp
+++ b/clang/test/AST/ByteCode/builtin-object-size.cpp
@@ -61,7 +61,7 @@ namespace Padding {
   void foo() {
       LongDouble3Vec v1, v2;
 #if __SIZEOF_SIZE_T__ == 8
-#if !defined(_WIN32)
+#if __SIZEOF_LONG_DOUBLE__ == 16
       static_assert(__builtin_object_size(&v1, 0) == 64);
 #else
       static_assert(__builtin_object_size(&v1, 0) == 32);


### PR DESCRIPTION
This test was failing on arm64 darwin targets. Generalise the #if so that the win32 branch is also taken by arm64 darwin.

rdar://182340494