### PR TITLE
[BOLT] Add fdata symbols mode

### DIFF
--- a/bolt/docs/profiles.md
+++ b/bolt/docs/profiles.md
@@ -163,6 +163,15 @@ perf2bolt ./binary -p perf.data -o perf.preagg --profile-format=preagg
 # Symbolized profiles
 The profiles accepted by llvm-bolt. fdata is the legacy format, YAML is the rich (metadata-enabled) format.
 
+As local symbol names are not guaranteed to be unique, BOLT disambiguates them with suffixes:
+- short form `<name>/<id>`,
+- long form `<name>/<file>/<id>`, where `<file>` is the containing debug file symbol.
+
+(Debug file symbols can be preserved when stripping debug information using `--keep-file-symbols`).
+
+As such, symbolized profiles are not expected to be produced by external tools, except the **symbols** fdata
+format mode which accepts names without suffixes but matches all aliases.
+
 ## fdata format
 
 Plaintext, space-separated branch profile format written by `perf2bolt` and
@@ -198,6 +207,19 @@ Requires `no_lbr` header followed by an optional event name:
 no_lbr <event_name>
 <is_sym> <sym> <off> <count>
 ```
+
+### Symbols mode format
+
+Requires `symbols` header, followed by a list of (mangled) symbol names:
+
+```
+symbols
+main
+BZ2_compressBlock
+```
+
+Each line matches all aliases of the symbol, each matching function is assigned
+an execution count of `1`.
 
 ### Special headers
 

--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -350,6 +350,15 @@ protected:
   ///
   std::error_code parseInNoLBRMode();
 
+  /// When "symbols" is the first line of the file, activate Symbols mode. Each
+  /// subsequent line contains a single symbol name (no counts or offsets).
+  ///
+  /// symbols                          # First line of fdata file
+  /// main
+  /// BZ2_compressBlock
+  ///
+  std::error_code parseInSymbolsMode();
+
   /// Return branch data matching one of the names in \p FuncNames.
   FuncBranchData *
   getBranchDataForNames(const std::vector<StringRef> &FuncNames);
@@ -457,7 +466,7 @@ protected:
   ErrorOr<BasicSampleInfo> parseSampleInfo();
   ErrorOr<MemInfo> parseMemInfo();
   ErrorOr<bool> maybeParseNoLBRFlag();
-  ErrorOr<bool> maybeParseBATFlag();
+  ErrorOr<bool> maybeParseFlag(StringRef Flag);
   bool hasBranchData();
   bool hasMemData();
 
@@ -474,6 +483,7 @@ protected:
   FuncsToMemDataMapTy FuncsToMemData;
   bool NoLBRMode{false};
   bool BATMode{false};
+  bool SymbolsMode{false};
   StringSet<> EventNames;
   static const char FieldSeparator = ' ';
 

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -14,6 +14,7 @@
 #include "bolt/Profile/DataReader.h"
 #include "bolt/Core/BinaryFunction.h"
 #include "bolt/Passes/MCF.h"
+#include "bolt/Utils/NameResolver.h"
 #include "bolt/Utils/Utils.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -242,6 +243,22 @@ Error DataReader::preprocessProfile(BinaryContext &BC) {
 
   if (opts::DumpData)
     dump();
+
+  if (SymbolsMode) {
+    for (auto &BFI : BC.getBinaryFunctions()) {
+      BinaryFunction &Function = BFI.second;
+      for (StringRef Name : Function.getNames()) {
+        auto It = NamesToBranches.find(NameResolver::restore(Name));
+        if (It == NamesToBranches.end())
+          continue;
+        setBranchData(Function, &It->second);
+        It->second.setEntryCounts(Function);
+        It->second.Used = true;
+        break;
+      }
+    }
+    return Error::success();
+  }
 
   if (collectedInBoltedBinary())
     outs() << "BOLT-INFO: profile collection done on a binary already "
@@ -1038,6 +1055,19 @@ ErrorOr<BasicSampleInfo> DataReader::parseSampleInfo() {
   return BasicSampleInfo(std::move(Address), Occurrences);
 }
 
+/// Return if \p Flag line was present in the line.
+ErrorOr<bool> DataReader::maybeParseFlag(StringRef Flag) {
+  if (!ParsingBuf.consume_front(Flag))
+    return false;
+  Col += Flag.size();
+
+  if (!checkAndConsumeNewLine()) {
+    reportError((Twine("malformed ") + Flag + " line").str());
+    return make_error_code(llvm::errc::io_error);
+  }
+  return true;
+}
+
 ErrorOr<bool> DataReader::maybeParseNoLBRFlag() {
   if (!ParsingBuf.consume_front("no_lbr"))
     return false;
@@ -1055,18 +1085,6 @@ ErrorOr<bool> DataReader::maybeParseNoLBRFlag() {
 
   if (!checkAndConsumeNewLine()) {
     reportError("malformed no_lbr line");
-    return make_error_code(llvm::errc::io_error);
-  }
-  return true;
-}
-
-ErrorOr<bool> DataReader::maybeParseBATFlag() {
-  if (!ParsingBuf.consume_front("boltedcollection"))
-    return false;
-  Col += 16;
-
-  if (!checkAndConsumeNewLine()) {
-    reportError("malformed boltedcollection line");
     return make_error_code(llvm::errc::io_error);
   }
   return true;
@@ -1138,6 +1156,25 @@ std::error_code DataReader::parseInNoLBRMode() {
   return std::error_code();
 }
 
+std::error_code DataReader::parseInSymbolsMode() {
+  while (!ParsingBuf.empty()) {
+    ErrorOr<StringRef> NameOrErr = parseString('\n');
+    if (std::error_code EC = NameOrErr.getError())
+      return EC;
+    StringRef Name = NameOrErr.get();
+    if (Name.empty())
+      continue;
+    // Use branch entry data rather since basic samples only apply in no_lbr
+    // mode.
+    FuncBranchData &FBD = NamesToBranches.try_emplace(Name, Name).first->second;
+    FBD.EntryData.emplace_back(Location(0),
+                               Location(/*IsSymbol=*/true, Name, 0),
+                               /*Mispreds=*/0, /*Branches=*/1);
+  }
+
+  return std::error_code();
+}
+
 std::error_code DataReader::parse() {
   auto GetOrCreateFuncEntry = [&](StringRef Name) {
     return NamesToBranches.try_emplace(Name, Name).first;
@@ -1149,12 +1186,21 @@ std::error_code DataReader::parse() {
 
   Col = 0;
   Line = 1;
+  ErrorOr<bool> SymbolsFlagOrErr = maybeParseFlag("symbols");
+  if (!SymbolsFlagOrErr)
+    return SymbolsFlagOrErr.getError();
+  SymbolsMode = *SymbolsFlagOrErr;
+
+  // Symbols mode ignores other headers.
+  if (SymbolsMode)
+    return parseInSymbolsMode();
+
   ErrorOr<bool> FlagOrErr = maybeParseNoLBRFlag();
   if (!FlagOrErr)
     return FlagOrErr.getError();
   NoLBRMode = *FlagOrErr;
 
-  ErrorOr<bool> BATFlagOrErr = maybeParseBATFlag();
+  ErrorOr<bool> BATFlagOrErr = maybeParseFlag("boltedcollection");
   if (!BATFlagOrErr)
     return BATFlagOrErr.getError();
   BATMode = *BATFlagOrErr;

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -1055,19 +1055,6 @@ ErrorOr<BasicSampleInfo> DataReader::parseSampleInfo() {
   return BasicSampleInfo(std::move(Address), Occurrences);
 }
 
-/// Return if \p Flag line was present in the line.
-ErrorOr<bool> DataReader::maybeParseFlag(StringRef Flag) {
-  if (!ParsingBuf.consume_front(Flag))
-    return false;
-  Col += Flag.size();
-
-  if (!checkAndConsumeNewLine()) {
-    reportError((Twine("malformed ") + Flag + " line").str());
-    return make_error_code(llvm::errc::io_error);
-  }
-  return true;
-}
-
 ErrorOr<bool> DataReader::maybeParseNoLBRFlag() {
   if (!ParsingBuf.consume_front("no_lbr"))
     return false;
@@ -1085,6 +1072,19 @@ ErrorOr<bool> DataReader::maybeParseNoLBRFlag() {
 
   if (!checkAndConsumeNewLine()) {
     reportError("malformed no_lbr line");
+    return make_error_code(llvm::errc::io_error);
+  }
+  return true;
+}
+
+/// Return if \p Flag line was present in the line.
+ErrorOr<bool> DataReader::maybeParseFlag(StringRef Flag) {
+  if (!ParsingBuf.consume_front(Flag))
+    return false;
+  Col += Flag.size();
+
+  if (!checkAndConsumeNewLine()) {
+    reportError((Twine("malformed ") + Flag + " line").str());
     return make_error_code(llvm::errc::io_error);
   }
   return true;

--- a/bolt/test/X86/profile-symbols-mode.s
+++ b/bolt/test/X86/profile-symbols-mode.s
@@ -1,0 +1,71 @@
+# Test the 'symbols' fdata subformat. Each line lists a single symbol name.
+# Matching functions (compared against restored names, i.e. with the local
+# symbol disambiguation suffix stripped) receive an execution count of 1.
+#
+# main.s and other.s each define a local function named loc. Local names are not
+# unique, so BOLT disambiguates them as loc/1 and loc/2 (with long-form aliases
+# loc/main.c/N and loc/other.c/N from the file symbols). A single "loc" entry in
+# the symbols profile matches both via the restored name. foo (global) is also
+# listed; bar (global) is omitted and stays cold.
+
+# REQUIRES: system-linux
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: %clang %cflags %t/main.s %t/other.s -o %t/main.exe -Wl,-q
+# RUN: llvm-bolt %t/main.exe --data %t/symbols.fdata -o %t/main.bolt \
+# RUN:     --print-cfg 2>&1 | FileCheck %s
+
+# foo and both loc functions (matched by the same restored name) each receive an
+# execution count of 1.
+# CHECK: Binary Function "foo"
+# CHECK: Exec Count  : 1
+# CHECK: Binary Function "loc/1
+# CHECK: Exec Count  : 1
+# CHECK: Binary Function "loc/2
+# CHECK: Exec Count  : 1
+
+#--- main.s
+    .file "main.c"
+    .text
+    .globl _start
+    .type _start, %function
+_start:
+    call foo
+    call bar
+    retq
+    .size _start, .-_start
+
+    .globl foo
+    .type foo, %function
+foo:
+    retq
+    .size foo, .-foo
+
+# First local symbol named loc.
+    .local loc
+    .type loc, %function
+loc:
+    retq
+    .size loc, .-loc
+
+    .globl bar
+    .type bar, %function
+bar:
+    retq
+    .size bar, .-bar
+
+#--- other.s
+    .file "other.c"
+    .text
+# Second local symbol also named loc; BOLT disambiguates it from the one in
+# main.s as loc/2.
+    .local loc
+    .type loc, %function
+loc:
+    retq
+    .size loc, .-loc
+
+#--- symbols.fdata
+symbols
+foo
+loc


### PR DESCRIPTION
Add a new fdata profile mode accepting symbol names as-is.

It addresses the UX gap surfaced by #208313 that all methods of selecting
functions to process (symbolized profile types, `-funcs*` options) expect
disambiguated local symbols. 

Introduce fdata mode activated by a `symbols` header line, where each subsequent
line is a (mangled) symbol name. The names are matched against restored function
names (with disambiguation suffix stripped), and every matching function gets an
execution count of 1. 

This can be used to drive selective instrumentation (`--instrument-hot-only`) or
basic linker-script style optimizations.

Symbols are stored as branch entry data so matching reuses the existing default
branch profile path.

Test Plan:
Update docs/profiles.md and add profile-symbols-mode.s