### PR TITLE
[CIR] Recognize loop distribution candidates

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -36,6 +36,7 @@ std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createLoopDistributionPass();
 
 void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -207,6 +207,20 @@ def LibOpt : Pass<"cir-lib-opt"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def LoopDistribution : Pass<"cir-loop-distribution"> {
+  let summary = "Distribute buried reductions for profitable interchange";
+  let description = [{
+    Distribute structured CIR nests where a reduction is buried behind
+    statements in an enclosing loop, then interchange the exposed reduction
+    nest when doing so makes its innermost memory accesses contiguous while
+    preserving the reduction order.
+  }];
+  let constructor = "mlir::createLoopDistributionPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+  let statistics = [Statistic<"numCandidates", "num-candidates",
+                              "Number of loop distribution candidates">];
+}
+
 def CallConvLowering : Pass<"cir-call-conv-lowering", "mlir::ModuleOp"> {
   let summary = "Lower CIR function signatures and call sites to match target ABI";
   let description = [{

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_library(MLIRCIRTransforms
   GotoSolver.cpp
   IdiomRecognizer.cpp
   LibOpt.cpp
+  LoopDistribution.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/LoopDistribution.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoopDistribution.cpp
@@ -1,0 +1,240 @@
+//===- LoopDistribution.cpp - Distribute reduction loops -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Distribute buried reductions and interchange the exposed loop nest.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+using namespace mlir;
+
+namespace mlir {
+#define GEN_PASS_DEF_LOOPDISTRIBUTION
+#include "clang/CIR/Dialect/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+struct CountedLoop {
+  cir::ForOp op;
+  mlir::Value ivSlot;
+};
+
+// Target CIRGen's raw form, where IVs load from allocas and addresses compare
+// by SSA identity.
+static std::optional<CountedLoop> recognizeCountedLoop(cir::ForOp loop) {
+  if (!loop.getCond().hasOneBlock() || !loop.getStep().hasOneBlock())
+    return std::nullopt;
+  auto condition = mlir::dyn_cast_or_null<cir::ConditionOp>(
+      loop.getCond().front().getTerminator());
+  if (!condition)
+    return std::nullopt;
+  auto cmp = condition.getCondition().getDefiningOp<cir::CmpOp>();
+  if (!cmp || cmp.getKind() != cir::CmpOpKind::lt)
+    return std::nullopt;
+  auto ivLoad = cmp.getLhs().getDefiningOp<cir::LoadOp>();
+  if (!ivLoad || !ivLoad.getAddr().getDefiningOp<cir::AllocaOp>())
+    return std::nullopt;
+
+  mlir::Value ivSlot = ivLoad.getAddr();
+  bool stepWritesIV = false;
+  for (auto store : loop.getStep().front().getOps<cir::StoreOp>())
+    stepWritesIV |= store.getAddr() == ivSlot;
+  if (!stepWritesIV)
+    return std::nullopt;
+
+  bool bodyWritesIV = false;
+  loop.getBody().walk(
+      [&](cir::StoreOp store) { bodyWritesIV |= store.getAddr() == ivSlot; });
+  if (bodyWritesIV)
+    return std::nullopt;
+  return CountedLoop{loop, ivSlot};
+}
+
+static void peelAddress(mlir::Value address,
+                        llvm::SmallVectorImpl<mlir::Value> &indices) {
+  while (true) {
+    if (auto element = address.getDefiningOp<cir::GetElementOp>()) {
+      indices.push_back(element.getIndex());
+      address = element.getBase();
+      continue;
+    }
+    if (auto stride = address.getDefiningOp<cir::PtrStrideOp>()) {
+      indices.push_back(stride.getStride());
+      address = stride.getBase();
+      continue;
+    }
+    return;
+  }
+}
+
+template <typename Predicate>
+static bool valueContainsLoad(mlir::Value value, Predicate predicate) {
+  llvm::SmallVector<mlir::Value, 8> worklist{value};
+  llvm::SmallPtrSet<mlir::Operation *, 8> visited;
+  while (!worklist.empty()) {
+    mlir::Operation *def = worklist.pop_back_val().getDefiningOp();
+    if (!def || !visited.insert(def).second)
+      continue;
+    if (auto load = mlir::dyn_cast<cir::LoadOp>(def))
+      if (predicate(load))
+        return true;
+    llvm::append_range(worklist, def->getOperands());
+  }
+  return false;
+}
+
+// Checks whether a backward slice loads an IV slot or accumulator address.
+static bool valueLoadsFrom(mlir::Value value, mlir::Value address) {
+  return valueContainsLoad(
+      value, [&](cir::LoadOp load) { return load.getAddr() == address; });
+}
+
+static bool containsLoop(mlir::Operation *op) {
+  bool found = false;
+  op->walk([&](cir::ForOp) { found = true; });
+  return found;
+}
+
+static std::optional<CountedLoop> recognizeLoopScope(cir::ScopeOp scope) {
+  cir::ForOp loop;
+  for (mlir::Operation &op : scope.getScopeRegion().front())
+    if (auto candidate = mlir::dyn_cast<cir::ForOp>(op)) {
+      if (loop)
+        return std::nullopt;
+      loop = candidate;
+    }
+  if (!loop)
+    return std::nullopt;
+  return recognizeCountedLoop(loop);
+}
+
+struct DistributionCandidate {
+  CountedLoop outer;
+  CountedLoop reduction;
+};
+
+// Structural matcher for the reduction idiom.
+static std::optional<DistributionCandidate>
+recognizeCandidate(cir::ScopeOp outerScope) {
+  std::optional<CountedLoop> outer = recognizeLoopScope(outerScope);
+  if (!outer)
+    return std::nullopt;
+
+  cir::ScopeOp bodyScope;
+  for (mlir::Operation &op : outer->op.getBody().front()) {
+    if (mlir::isa<cir::YieldOp>(op))
+      continue;
+    auto scope = mlir::dyn_cast<cir::ScopeOp>(op);
+    if (!scope || bodyScope)
+      return std::nullopt;
+    bodyScope = scope;
+  }
+  if (!bodyScope)
+    return std::nullopt;
+
+  cir::ScopeOp reductionScope;
+  bool hasSurroundingStatement = false;
+  for (mlir::Operation &op : bodyScope.getScopeRegion().front()) {
+    auto scope = mlir::dyn_cast<cir::ScopeOp>(op);
+    if (scope && containsLoop(scope)) {
+      if (reductionScope)
+        return std::nullopt;
+      reductionScope = scope;
+    } else if (mlir::isa<cir::ForOp>(op)) {
+      return std::nullopt;
+    } else if (!mlir::isa<cir::YieldOp>(op)) {
+      hasSurroundingStatement = true;
+    }
+  }
+  if (!reductionScope || !hasSurroundingStatement)
+    return std::nullopt;
+
+  std::optional<CountedLoop> reduction = recognizeLoopScope(reductionScope);
+  if (!reduction)
+    return std::nullopt;
+  bool hasNestedLoop = false;
+  reduction->op.getBody().walk(
+      [&](cir::ForOp loop) { hasNestedLoop |= loop != reduction->op; });
+  if (hasNestedLoop)
+    return std::nullopt;
+
+  cir::StoreOp accumulatorStore;
+  bool multipleStores = false;
+  reduction->op.getBody().walk([&](cir::StoreOp store) {
+    llvm::SmallVector<mlir::Value, 4> indices;
+    peelAddress(store.getAddr(), indices);
+    if (indices.empty() || llvm::any_of(indices, [&](mlir::Value index) {
+          return valueLoadsFrom(index, reduction->ivSlot);
+        }))
+      return;
+    if (accumulatorStore)
+      multipleStores = true;
+    else
+      accumulatorStore = store;
+  });
+  // Compound assignments reuse one address SSA value; otherwise this misses.
+  if (!accumulatorStore || multipleStores ||
+      !valueLoadsFrom(accumulatorStore.getValue(), accumulatorStore.getAddr()))
+    return std::nullopt;
+
+  return DistributionCandidate{*outer, *reduction};
+}
+
+static bool isProfitable(DistributionCandidate candidate) {
+  bool profitable = false;
+  candidate.reduction.op.getBody().walk([&](cir::LoadOp load) {
+    llvm::SmallVector<mlir::Value, 4> indices;
+    peelAddress(load.getAddr(), indices);
+    if (indices.size() < 2)
+      return;
+    bool variesWithReduction = llvm::any_of(indices, [&](mlir::Value index) {
+      return valueLoadsFrom(index, candidate.reduction.ivSlot);
+    });
+    // indices.front() is the innermost subscript, the one the interchange
+    // makes contiguous.
+    if (variesWithReduction &&
+        valueLoadsFrom(indices.front(), candidate.outer.ivSlot))
+      profitable = true;
+  });
+  return profitable;
+}
+
+struct LoopDistributionPass
+    : public impl::LoopDistributionBase<LoopDistributionPass> {
+  using impl::LoopDistributionBase<LoopDistributionPass>::LoopDistributionBase;
+
+  void runOnOperation() override {
+    // Report each recognized candidate.
+    getOperation()->walk([&](cir::FuncOp function) {
+      function.walk([&](cir::ScopeOp scope) {
+        std::optional<DistributionCandidate> candidate =
+            recognizeCandidate(scope);
+        if (!candidate || !isProfitable(*candidate))
+          return;
+        ++numCandidates;
+        scope.emitRemark() << "loop distribution candidate in function '"
+                           << function.getSymName() << "'";
+      });
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createLoopDistributionPass() {
+  return std::make_unique<LoopDistributionPass>();
+}

--- a/clang/test/CIR/Transforms/loop-distribution-opportunities-stats.c
+++ b/clang/test/CIR/Transforms/loop-distribution-opportunities-stats.c
@@ -1,0 +1,7 @@
+// REQUIRES: asserts
+// RUN: %clang_cc1 -fclangir -emit-cir %S/loop-distribution-opportunities.c \
+// RUN:   -o - | cir-opt -cir-loop-distribution -mlir-disable-threading \
+// RUN:   -mlir-pass-statistics -o /dev/null 2>&1 | FileCheck %s
+
+// CHECK: LoopDistribution
+// CHECK: (S) 1 num-candidates - Number of loop distribution candidates

--- a/clang/test/CIR/Transforms/loop-distribution-opportunities.c
+++ b/clang/test/CIR/Transforms/loop-distribution-opportunities.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -fclangir -emit-cir %s -o - | \
+// RUN:   cir-opt -cir-loop-distribution -o /dev/null 2>&1 | \
+// RUN:   FileCheck %s --implicit-check-not=remark:
+
+double A[8][4], B[4][8], C[4][4], D[4][4];
+
+void candidate(void) {
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j) {
+      C[i][j] = 0;
+      for (int k = 0; k < 8; ++k)
+        C[i][j] += A[k][i] * A[k][j];
+    }
+}
+
+void perfect_strided_nest(void) {
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      for (int k = 0; k < 8; ++k)
+        C[i][j] += A[k][i] * A[k][j];
+}
+
+void already_unit_stride(void) {
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j) {
+      D[i][j] = 0;
+      for (int k = 0; k < 8; ++k)
+        D[i][j] += B[i][k] * B[j][k];
+    }
+}
+
+// CHECK: remark: loop distribution candidate in function 'candidate'

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -40,6 +40,9 @@ int main(int argc, char **argv) {
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createCIRSimplifyPass();
   });
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createLoopDistributionPass();
+  });
 
   mlir::PassPipelineRegistration<CIRToLLVMPipelineOptions> pipeline(
       "cir-to-llvm", "",


### PR DESCRIPTION
This patch adds a `cir-loop-distribution` pass that recognizes and reports a loop reduction idiom. The pass will eventually distribute the loop around the reduction and interchange the nest so the innermost memory accesses become contiguous, but this patch implements only the recognition step and does not modify the IR.

The idiom is a counted reduction loop that sits among other statements inside an enclosing counted loop, where the reduction reads a strided access such as `A[k][i] * A[k][j]`. In the motivating PolyBench kernels (covariance, correlation, 2mm, 3mm, and doitgen), LLVM `-O3` leaves this pattern strided and unvectorized.

The pass is registered only for `cir-opt`. The Clang driver flag is added in a later patch, once the transform exists, so no flag ships without an effect.

The transform is built incrementally over the following patches.
  1. Recognize and report candidates (this patch)
  2. Interchange a perfect reduction nest
  3. Support affine and nonzero loop starts
  4. Distribute an imperfect nest to expose the interchange
  5. Support the covariance transpose epilogue
  6. Handle restrict pointer bases on the direct path
  7. Version two pointer bases with constant extents
  8. Version dynamic and multiple base cases
  9. Recognize flat linearized indexing

The pass is tested with `cir-opt`, checking candidate remarks, the pass statistic, and negative cases for perfect nests and nests that are already unit stride. The CIR transform suite passes 66/66.