### PR TITLE
[MCSchedule][NFC] Use constexpr for static constants

### DIFF
--- a/llvm/include/llvm/MC/MCSchedule.h
+++ b/llvm/include/llvm/MC/MCSchedule.h
@@ -274,7 +274,7 @@ struct MCSchedModel {
   // has a bandwidth limitation, then that can be naturally modeled by adding an
   // out-of-order processor resource.
   unsigned IssueWidth;
-  static const unsigned DefaultIssueWidth = 1;
+  static constexpr unsigned DefaultIssueWidth = 1;
 
   // MicroOpBufferSize is the number of micro-ops that the processor may buffer
   // for out-of-order execution.
@@ -291,7 +291,7 @@ struct MCSchedModel {
   // estimate of highly machine specific characteristics such as the register
   // renaming pool and reorder buffer.
   unsigned MicroOpBufferSize;
-  static const unsigned DefaultMicroOpBufferSize = 0;
+  static constexpr unsigned DefaultMicroOpBufferSize = 0;
 
   // LoopMicroOpBufferSize is the number of micro-ops that the processor may
   // buffer for optimized loop execution. More generally, this represents the
@@ -299,23 +299,23 @@ struct MCSchedModel {
   // unrolled to bring the count of micro-ops in the loop body closer to this
   // number.
   unsigned LoopMicroOpBufferSize;
-  static const unsigned DefaultLoopMicroOpBufferSize = 0;
+  static constexpr unsigned DefaultLoopMicroOpBufferSize = 0;
 
   // LoadLatency is the expected latency of load instructions.
   unsigned LoadLatency;
-  static const unsigned DefaultLoadLatency = 4;
+  static constexpr unsigned DefaultLoadLatency = 4;
 
   // HighLatency is the expected latency of "very high latency" operations.
   // See TargetInstrInfo::isHighLatencyDef().
   // By default, this is set to an arbitrarily high number of cycles
   // likely to have some impact on scheduling heuristics.
   unsigned HighLatency;
-  static const unsigned DefaultHighLatency = 10;
+  static constexpr unsigned DefaultHighLatency = 10;
 
   // MispredictPenalty is the typical number of extra cycles the processor
   // takes to recover from a branch misprediction.
   unsigned MispredictPenalty;
-  static const unsigned DefaultMispredictPenalty = 10;
+  static constexpr unsigned DefaultMispredictPenalty = 10;
 
   bool PostRAScheduler; // default value is false
 


### PR DESCRIPTION
Hopefully fixes a compilation error seen in llvm/llvm-project#203139.