### PR TITLE
[ADT] Introduce SetVector::reserve (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -62,10 +62,6 @@ class SetVector {
   using const_arg_type =
       typename const_pointer_or_const_ref<typename Set::key_type>::type;
 
-  template <typename Container>
-  using check_has_member_reserve_t =
-      decltype(std::declval<Container>().reserve(std::declval<size_t>()));
-
 public:
   using value_type = typename Vector::value_type;
   using key_type = typename Set::key_type;
@@ -108,10 +104,8 @@ public:
 
   /// Reserve space in the SetVector if supported by the underlying containers.
   void reserve(size_type Size) {
-    if constexpr (is_detected<check_has_member_reserve_t, vector_type>::value)
-      vector_.reserve(Size);
-    if constexpr (is_detected<check_has_member_reserve_t, set_type>::value)
-      set_.reserve(Size);
+    vector_.reserve(Size);
+    set_.reserve(Size);
   }
 
   /// Get an iterator to the beginning of the SetVector.

--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -62,6 +62,10 @@ class SetVector {
   using const_arg_type =
       typename const_pointer_or_const_ref<typename Set::key_type>::type;
 
+  template <typename Container>
+  using check_has_member_reserve_t =
+      decltype(std::declval<Container>().reserve(std::declval<size_t>()));
+
 public:
   using value_type = typename Vector::value_type;
   using key_type = typename Set::key_type;
@@ -101,6 +105,14 @@ public:
 
   /// Determine the number of elements in the SetVector.
   [[nodiscard]] size_type size() const { return vector_.size(); }
+
+  /// Reserve space in the SetVector if supported by the underlying containers.
+  void reserve(size_type Size) {
+    if constexpr (is_detected<check_has_member_reserve_t, vector_type>::value)
+      vector_.reserve(Size);
+    if constexpr (is_detected<check_has_member_reserve_t, set_type>::value)
+      set_.reserve(Size);
+  }
 
   /// Get an iterator to the beginning of the SetVector.
   [[nodiscard]] iterator begin() { return vector_.begin(); }

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -4097,6 +4097,7 @@ PreservedAnalyses AttributorPass::run(Module &M, ModuleAnalysisManager &AM) {
   AnalysisGetter AG(FAM);
 
   SetVector<Function *> Functions;
+  Functions.reserve(M.size());
   for (Function &F : M)
     Functions.insert(&F);
 
@@ -4120,6 +4121,7 @@ PreservedAnalyses AttributorCGSCCPass::run(LazyCallGraph::SCC &C,
   AnalysisGetter AG(FAM);
 
   SetVector<Function *> Functions;
+  Functions.reserve(C.size());
   for (LazyCallGraph::Node &N : C)
     Functions.insert(&N.getFunction());
 
@@ -4149,6 +4151,7 @@ PreservedAnalyses AttributorLightPass::run(Module &M,
   AnalysisGetter AG(FAM, /* CachedOnly */ true);
 
   SetVector<Function *> Functions;
+  Functions.reserve(M.size());
   for (Function &F : M)
     Functions.insert(&F);
 


### PR DESCRIPTION
This patch introduces SetVector::reserve to allocate capacity in the
underlying containers.

We also adopt SetVector::reserve across Attributor.cpp where the exact
number of unique functions being inserted is known ahead of time.

Assisted-by: Antigravity
