### PR TITLE
[libc][stdfix] Guard DiviFxTest shift edge cases against narrow IntType

### DIFF
--- a/libc/test/src/stdfix/DiviFxTest.h
+++ b/libc/test/src/stdfix/DiviFxTest.h
@@ -108,7 +108,8 @@ public:
 
     // Only valid when integral bits (excluding sign) exceed fraction bits.
     // Otherwise 1<<FRACTION_LEN may not fit in IntType.
-    if constexpr ((FXRep::INTEGRAL_LEN) > FXRep::FRACTION_LEN) {
+    if constexpr ((FXRep::INTEGRAL_LEN) > FXRep::FRACTION_LEN &&
+                  FXRep::FRACTION_LEN < cpp::numeric_limits<IntType>::digits) {
       constexpr IntType epsilon_result = static_cast<IntType>(1)
                                          << FXRep::FRACTION_LEN;
       EXPECT_EQ(func(1, epsilon), epsilon_result);
@@ -119,7 +120,8 @@ public:
       }
     }
 
-    if constexpr (has_integral) {
+    if constexpr (has_integral &&
+                  FXRep::INTEGRAL_LEN < cpp::numeric_limits<IntType>::digits) {
       constexpr IntType largest_positive =
           ((static_cast<IntType>(1) << FXRep::INTEGRAL_LEN) - 1);
       EXPECT_EQ(func(largest_positive, static_cast<FXType>(largest_positive)),


### PR DESCRIPTION
`1 << INTEGRAL_LEN`/`1 << FRACTION_LEN` assumed IntType always has enough bits which is false for long int / long accum on ILP32 targets. This PR adds guards to skip those checks when they don't fit.

Fixes riscv32 buildbot failure from #206115.