### PR TITLE
[sanitizer_common] fix shadowed ret hiding symbolizer read failures.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_internal.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_internal.h
@@ -96,6 +96,9 @@ class SymbolizerProcess {
   InternalMmapVector<char> &GetBuff() { return buffer_; }
 
  private:
+  // Grants the regression test access to input_fd_ and ReadFromSymbolizer().
+  friend class Symbolizer_ReadFromSymbolizerReportsEofAsFailure_Test;
+
   virtual bool ReachedEndOfOutput(const char *buffer, uptr length) const {
     UNIMPLEMENTED();
   }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp
@@ -555,8 +555,8 @@ bool SymbolizerProcess::ReadFromSymbolizer() {
     uptr size_before = buffer_.size();
     buffer_.resize(size_before + max_length);
     buffer_.resize(buffer_.capacity());
-    bool ret = ReadFromFile(input_fd_, &buffer_[size_before],
-                            buffer_.size() - size_before, &just_read);
+    ret = ReadFromFile(input_fd_, &buffer_[size_before],
+                       buffer_.size() - size_before, &just_read);
 
     if (!ret)
       just_read = 0;

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_symbolizer_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_symbolizer_test.cpp
@@ -68,4 +68,28 @@ TEST(Symbolizer, DemangleSwiftAndCXX) {
 }
 #endif
 
+#if SANITIZER_POSIX
+namespace {
+class TestSymbolizerProcess final : public SymbolizerProcess {
+ public:
+  TestSymbolizerProcess() : SymbolizerProcess("/invalid/symbolizer/path") {}
+
+ private:
+  bool ReachedEndOfOutput(const char*, uptr) const override { return true; }
+};
+}  // namespace
+
+// A symbolizer that closes its stdout yields a 0-byte (EOF) read. That must be
+// reported as a failure, not silently accepted as success. Regression test for
+// the shadowed `ret` in SymbolizerProcess::ReadFromSymbolizer.
+TEST(Symbolizer, ReadFromSymbolizerReportsEofAsFailure) {
+  fd_t fd = OpenFile("/dev/null", RdOnly);
+  ASSERT_NE(fd, kInvalidFd);
+  TestSymbolizerProcess symbolizer;
+  symbolizer.input_fd_ = fd;
+  EXPECT_FALSE(symbolizer.ReadFromSymbolizer());
+  CloseFile(fd);
+}
+#endif  // SANITIZER_POSIX
+
 }  // namespace __sanitizer


### PR DESCRIPTION
The inner `bool ret` from ReadFromFile shadowed the outer one that is returned, so a dead/closed symbolizer (0-byte read or read error) was reported as success: SendCommand never restarted the crashed process, and the addr2line path aborted on a CHECK over an empty buffer. Regression from acfeb1a6c244. Add a regression test that feeds an EOF fd through ReadFromSymbolizer and expects failure.