### PR TITLE
[lldb-dap][test] Avoid a hang on a test failure

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1646,7 +1646,11 @@ class DebugCommunication(object):
 
     def terminate(self):
         if self.socket:
-            self.socket.shutdown(socket.SHUT_RDWR)
+            try:
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                # Ignore "already disconnected" errors.
+                pass
         self.send.close()
         if self._recv_thread.is_alive():
             self._recv_thread.join()

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -205,11 +205,13 @@ class DebugCommunication(object):
         send: BinaryIO,
         init_commands: Optional[List[str]] = None,
         spawn_helper: Optional[SpawnHelperCallback] = None,
+        socket: Optional[socket.socket] = None,
     ):
         self._log = Log()
         self.send = send
         self.recv = recv
         self.spawn_helper = spawn_helper
+        self.socket = socket
 
         # Packets that have been received and processed but have not yet been
         # requested by a test case.
@@ -1643,6 +1645,8 @@ class DebugCommunication(object):
         return self._send_recv(command_dict)
 
     def terminate(self):
+        if self.socket:
+            self.socket.shutdown(socket.SHUT_RDWR)
         self.send.close()
         if self._recv_thread.is_alive():
             self._recv_thread.join()
@@ -1706,6 +1710,7 @@ class DebugAdapterServer(DebugCommunication):
                 s.makefile("wb"),
                 init_commands,
                 spawn_helper,
+                socket=s,
             )
             self.connection = connection
         else:


### PR DESCRIPTION
Tests in `TestDAP_server.py` create `DebugAdapterServer`, passing a connection string. `DebugAdapterServer.__init__()` creates a socket and passes the associated input and output streams to its parent class, `DebugCommunication`. `DAPTestCaseBase.launch()`, which is called from `TestDAP_server.run_debug_session()`, adds a teardown hook that eventually calls `DebugCommunication.terminate()`. If the socket is not closed when this hook executes, it waits indefinitely for the receiving thread to join.

In the normal case, when a test passes, the connection is closed by calling `self.dap_server.request_disconnect()` at the end of `TestDAP_server.run_debug_session()`. If a test fails, the cleanup hook is called while the connection is still active, which results in a hang. This can be reproduced by removing the call to `request_disconnect()` or by changing the condition in the `assertEqual()` on the previous line.

The fix passes the opened socket to 'DebugCommunication' and closes the socket explicitly in 'DebugCommunication.terminate()'.