### PR TITLE
[BOLT][RISCV] Support the TLS global-dynamic relocation

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -571,6 +571,7 @@ static bool isGOTRISCV(uint32_t Type) {
     return false;
   case ELF::R_RISCV_GOT_HI20:
   case ELF::R_RISCV_TLS_GOT_HI20:
+  case ELF::R_RISCV_TLS_GD_HI20:
     return true;
   }
 }
@@ -609,6 +610,7 @@ static bool isTLSRISCV(uint32_t Type) {
   default:
     return false;
   case ELF::R_RISCV_TLS_GOT_HI20:
+  case ELF::R_RISCV_TLS_GD_HI20:
   case ELF::R_RISCV_TPREL_HI20:
   case ELF::R_RISCV_TPREL_ADD:
   case ELF::R_RISCV_TPREL_LO12_I:

--- a/bolt/test/RISCV/reloc-tls.s
+++ b/bolt/test/RISCV/reloc-tls.s
@@ -1,6 +1,6 @@
 // RUN: llvm-mc -triple riscv64 -filetype obj -o %t.o %s
 // RUN: ld.lld --emit-relocs -o %t %t.o
-// RUN: llvm-bolt --print-cfg --print-only=tls_le,tls_ie -o %t.null %t \
+// RUN: llvm-bolt --print-cfg --print-only=tls_le,tls_ie,tls_gd -o %t.null %t \
 // RUN:    | FileCheck %s
 
 // CHECK-LABEL: Binary Function "tls_le{{.*}}" after building cfg {
@@ -13,6 +13,11 @@
 // CHECK-LABEL: .LBB01
 // CHECK:      auipc a0, %pcrel_hi(__BOLT_got_zero+{{[0-9]+}})
 // CHECK-NEXT: ld a0, %pcrel_lo(.Ltmp0)(a0)
+
+// CHECK-LABEL: Binary Function "tls_gd" after building cfg {
+// CHECK-LABEL: .LBB02
+// CHECK:      auipc a0, %pcrel_hi(__BOLT_got_zero+{{[0-9]+}})
+// CHECK-NEXT: addi a0, a0, %pcrel_lo(.Ltmp1)
     .text
     .globl tls_le, _start
     .p2align 2
@@ -33,6 +38,23 @@ tls_ie:
     la.tls.ie a0, i
     ret
     .size tls_ie, .-tls_ie
+
+    .globl tls_gd
+    .p2align 2
+tls_gd:
+    nop
+1:
+    auipc a0, %tls_gd_pcrel_hi(i)
+    addi a0, a0, %pcrel_lo(1b)
+    call __tls_get_addr
+    ret
+    .size tls_gd, .-tls_gd
+
+    .globl __tls_get_addr
+    .p2align 2
+__tls_get_addr:
+    ret
+    .size __tls_get_addr, .-__tls_get_addr
 
     .section .tbss,"awT",@nobits
     .type i,@object


### PR DESCRIPTION
This patch adds BOLT support for the RISC-V TLS global-dynamic relocation `R_RISCV_TLS_GD_HI20`. Classifying it as both a **TLS relocation** and a **GOT-style relocation** allows BOLT to preserve the relocation, recover the actual GOT entry address from the linked instructions, and symbolize the instruction pair.

The RISC-V TLS relocation test is extended to cover a global-dynamic sequence and verify that BOLT reconstructs the `AUIPC`/`PCREL_LO12` pair correctly.