### PR TITLE
[mlir][NVVM] Diagnose non-NVVM target ops before serialization

### DIFF
--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -760,6 +760,20 @@ NVVMTargetAttrImpl::serializeToObject(Attribute attribute, Operation *module,
     module->emitError("Module must be a GPU module.");
     return std::nullopt;
   }
+
+  // Reject operations from other GPU target dialects.
+  WalkResult foreignOp = module->walk([&](Operation *op) {
+    StringRef dialect = op->getDialect()->getNamespace();
+    if (dialect == "rocdl" || dialect == "xevm") {
+      op->emitError() << "'" << op->getName() << "' from '" << dialect
+                      << "' dialect is not compatible with the NVVM target";
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  if (foreignOp.wasInterrupted())
+    return std::nullopt;
+
   NVPTXSerializer serializer(*module, cast<NVVMTargetAttr>(attribute), options);
   serializer.init();
   std::optional<SmallVector<char, 0>> result = serializer.run();

--- a/mlir/test/Dialect/GPU/module-to-binary-invalid.mlir
+++ b/mlir/test/Dialect/GPU/module-to-binary-invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --gpu-module-to-binary --verify-diagnostics
+// RUN: mlir-opt %s --gpu-module-to-binary --verify-diagnostics --split-input-file
 
 module attributes {gpu.container_module} {
   // expected-error @below {{the module has no target attributes}}
@@ -6,6 +6,32 @@ module attributes {gpu.container_module} {
     llvm.func @kernel(%arg0: i32, %arg1: !llvm.ptr,
         %arg2: !llvm.ptr, %arg3: i64, %arg4: i64,
         %arg5: i64) attributes {gpu.kernel} {
+      llvm.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module} {
+  // expected-error @below {{An error happened while serializing the module}}
+  gpu.module @kernel_module_nvvm_rocdl_op [#nvvm.target] {
+    llvm.func @kernel() attributes {gpu.kernel} {
+      // expected-error @below {{'rocdl.workitem.id.x' from 'rocdl' dialect is not compatible with the NVVM target}}
+      %tx = rocdl.workitem.id.x : i32
+      llvm.return
+    }
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module} {
+  // expected-error @below {{An error happened while serializing the module}}
+  gpu.module @kernel_module_nvvm_rocdl_barrier [#nvvm.target] {
+    llvm.func @kernel() attributes {gpu.kernel} {
+      // expected-error @below {{'rocdl.barrier' from 'rocdl' dialect is not compatible with the NVVM target}}
+      rocdl.barrier
       llvm.return
     }
   }


### PR DESCRIPTION
When a gpu.module targeted with #nvvm.target contains operations from other GPU target dialects (e.g. rocdl, xevm), those ops are translated to their LLVM intrinsics (e.g. llvm.amdgcn.*)

Add a walk at the top of NVVMTargetAttrImpl::serializeToObject that rejects operations from foreign GPU target dialects with a clear diagnostic before any LLVM IR is produced

This PR fixes #205274