### PR TITLE
[libc][cmake] Remove proxy header XXX_macros -> XXX.h deps

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -34,7 +34,6 @@ add_proxy_header_library(
     math_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.math_macros
-    libc.include.math
 )
 
 add_proxy_header_library(
@@ -43,7 +42,6 @@ add_proxy_header_library(
     math_function_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.math_function_macros
-    libc.include.math
 )
 
 add_proxy_header_library(
@@ -51,7 +49,6 @@ add_proxy_header_library(
   HDRS
     errno_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.errno
     libc.include.llvm-libc-macros.error_number_macros
     libc.include.llvm-libc-macros.generic_error_number_macros
 )
@@ -65,7 +62,6 @@ add_proxy_header_library(
     .fcntl_overlay
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.fcntl_macros
-    libc.include.fcntl
 )
 
 add_proxy_header_library(
@@ -74,7 +70,6 @@ add_proxy_header_library(
     fenv_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.fenv_macros
-    libc.include.fenv
 )
 
 add_proxy_header_library(
@@ -82,7 +77,6 @@ add_proxy_header_library(
   HDRS
     inet-address-macros.h
   FULL_BUILD_DEPENDS
-    libc.include.arpa_inet
     libc.include.llvm-libc-macros.inet_address_macros
 )
 
@@ -91,7 +85,6 @@ add_proxy_header_library(
   HDRS
     net_if_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.net_if
     libc.include.llvm-libc-macros.net_if_macros
 )
 
@@ -100,7 +93,6 @@ add_proxy_header_library(
   HDRS
     netinet_in_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.netinet_in
     libc.include.llvm-libc-macros.netinet_in_macros
 )
 
@@ -110,7 +102,6 @@ add_proxy_header_library(
     pthread_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.pthread_macros
-    libc.include.pthread
 )
 
 add_proxy_header_library(
@@ -118,7 +109,6 @@ add_proxy_header_library(
   HDRS
     sched_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sched
     libc.include.llvm-libc-macros.sched_macros
 )
 
@@ -128,7 +118,6 @@ add_proxy_header_library(
     signal_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.signal_macros
-    libc.include.signal
 )
 
 add_header_library(stdlib_overlay HDRS stdlib_overlay.h)
@@ -140,7 +129,6 @@ add_proxy_header_library(
   DEPENDS
     .stdlib_overlay
   FULL_BUILD_DEPENDS
-    libc.include.stdlib
     libc.include.llvm-libc-macros.stdlib_macros
 )
 
@@ -154,7 +142,6 @@ add_proxy_header_library(
   DEPENDS
     .stdio_overlay
   FULL_BUILD_DEPENDS
-    libc.include.stdio
     libc.include.llvm-libc-macros.stdio_macros
     libc.include.llvm-libc-macros.file_seek_macros
 )
@@ -164,7 +151,6 @@ add_proxy_header_library(
   HDRS
     sys_epoll_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_epoll
     libc.include.llvm-libc-macros.sys_epoll_macros
 )
 
@@ -173,7 +159,6 @@ add_proxy_header_library(
   HDRS
     sys_ioctl_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_ioctl
     libc.include.llvm-libc-macros.sys_ioctl_macros
 )
 
@@ -182,7 +167,6 @@ add_proxy_header_library(
   HDRS
     sys_ipc_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_ipc
     libc.include.llvm-libc-macros.sys_ipc_macros
 )
 
@@ -191,7 +175,6 @@ add_proxy_header_library(
   HDRS
     sys_select_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_select
     libc.include.llvm-libc-macros.sys_select_macros
 )
 
@@ -200,7 +183,6 @@ add_proxy_header_library(
   HDRS
     sys_sem_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_sem
     libc.include.llvm-libc-macros.sys_sem_macros
 )
 
@@ -209,7 +191,6 @@ add_proxy_header_library(
   HDRS
     sys_socket_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_socket
     libc.include.llvm-libc-macros.sys_socket_macros
 )
 
@@ -218,7 +199,6 @@ add_proxy_header_library(
   HDRS
     sys_stat_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_stat
     libc.include.llvm-libc-macros.sys_stat_macros
 )
 
@@ -227,7 +207,6 @@ add_proxy_header_library(
   HDRS
     sys_mman_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_mman
     libc.include.llvm-libc-macros.sys_mman_macros
 )
 
@@ -236,7 +215,6 @@ add_proxy_header_library(
   HDRS
     sys_ptrace_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_ptrace
     libc.include.llvm-libc-macros.sys_ptrace_macros
 )
 
@@ -245,7 +223,6 @@ add_proxy_header_library(
   HDRS
     sys_time_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_time
     libc.include.llvm-libc-macros.sys_time_macros
 )
 
@@ -254,7 +231,6 @@ add_proxy_header_library(
   HDRS
     sys_wait_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.sys_wait
     libc.include.llvm-libc-macros.sys_wait_macros
 )
 
@@ -266,7 +242,6 @@ add_proxy_header_library(
   DEPENDS
     .unistd_overlay
   FULL_BUILD_DEPENDS
-    libc.include.unistd
     libc.include.llvm-libc-macros.unistd_macros
 )
 
@@ -283,7 +258,6 @@ add_proxy_header_library(
   DEPENDS
     ${windows_addtional_time_macros}
   FULL_BUILD_DEPENDS
-    libc.include.time
     libc.include.llvm-libc-macros.time_macros
 )
 
@@ -291,10 +265,8 @@ add_proxy_header_library(
   float_macros
   HDRS
     float_macros.h
-  DEPENDS
-    libc.include.llvm-libc-macros.float_macros
   FULL_BUILD_DEPENDS
-    libc.include.float
+    libc.include.llvm-libc-macros.float_macros
 )
 
 add_proxy_header_library(
@@ -302,7 +274,6 @@ add_proxy_header_library(
   HDRS
     limits_macros.h
   FULL_BUILD_DEPENDS
-    libc.include.limits
     libc.include.llvm-libc-macros.limits_macros
 )
 
@@ -312,7 +283,6 @@ add_proxy_header_library(
     link_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.link_macros
-    libc.include.link
 )
 
 add_proxy_header_library(
@@ -321,7 +291,6 @@ add_proxy_header_library(
     locale_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.locale_macros
-    libc.include.locale
 )
 
 add_proxy_header_library(
@@ -330,7 +299,6 @@ add_proxy_header_library(
     sys_auxv_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.sys_auxv_macros
-    libc.include.sys_auxv
 )
 
 add_proxy_header_library(
@@ -339,7 +307,6 @@ add_proxy_header_library(
     sys_resource_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.sys_resource_macros
-    libc.include.sys_resource
 )
 
 add_header_library(wchar_overlay HDRS wchar_overlay.h)
@@ -354,7 +321,6 @@ add_proxy_header_library(
     .wchar_overlay
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.wchar_macros
-    libc.include.wchar
 )
 
 # offsetof is a macro inside compiler resource header stddef.h
@@ -381,7 +347,6 @@ add_proxy_header_library(
     elf_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.elf_macros
-    libc.include.elf
 )
 
 add_gen_header(
@@ -446,7 +411,6 @@ add_proxy_header_library(
     regex_macros.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.regex_macros
-    libc.include.regex
 )
 
 add_subdirectory(types)


### PR DESCRIPTION
In the full build mode, these headers do not include the main XXX.h header, which makes sense, because they exist to allow us only to expose a part of it. They do include it in the overlay mode, but in this case, they are referring to the header from the libc being overlaid, which exists outside of the build system.

Also fix float_macros by moving
libc.include.llvm-libc-macros.float_macros from DEPENDS to FULL_BUILD_DEPENDS, as llvm-libc-macros/float-macros.h is only included under LIBC_FULL_BUILD.