### PR TITLE
[lldb][Windows] Reuse preloaded exe module on launch

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -660,9 +660,8 @@ void ProcessWindows::OnDebuggerConnected(lldb::addr_t image_base) {
         GetTarget().GetOrCreateModule(module_spec, /*notify=*/true, &error);
     if (!module)
       return;
+    GetTarget().SetExecutableModule(module, eLoadDependentsNo);
   }
-
-  GetTarget().SetExecutableModule(module, eLoadDependentsNo);
 
   if (auto dyld = GetDynamicLoader())
     dyld->OnLoadModule(module, ModuleSpec(), image_base);

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -645,22 +645,21 @@ void ProcessWindows::OnDebuggerConnected(lldb::addr_t image_base) {
   LLDB_LOG(log, "Debugger connected to process {0}.  Image base = {1:x}",
            debugger->GetProcess().GetProcessId(), image_base);
 
-  ModuleSP module;
-  // During attach, we won't have the executable module, so find it now.
-  const DWORD pid = debugger->GetProcess().GetProcessId();
-  const std::string file_name = GetProcessExecutableName(pid);
-  if (file_name.empty()) {
-    return;
-  }
-
-  FileSpec executable_file(file_name);
-  FileSystem::Instance().Resolve(executable_file);
-  ModuleSpec module_spec(executable_file);
-  Status error;
-  module =
-      GetTarget().GetOrCreateModule(module_spec, true /* notify */, &error);
+  ModuleSP module = GetTarget().GetExecutableModule();
   if (!module) {
-    return;
+    const DWORD pid = debugger->GetProcess().GetProcessId();
+    const std::string file_name = GetProcessExecutableName(pid);
+    if (file_name.empty())
+      return;
+
+    FileSpec executable_file(file_name);
+    FileSystem::Instance().Resolve(executable_file);
+    ModuleSpec module_spec(executable_file);
+    Status error;
+    module =
+        GetTarget().GetOrCreateModule(module_spec, /*notify=*/true, &error);
+    if (!module)
+      return;
   }
 
   GetTarget().SetExecutableModule(module, eLoadDependentsNo);


### PR DESCRIPTION
# Brief

Recreating the module everytime causes the path to be canonicalized. This does not work well with subst drives, because the newly created module will not have the correct drive path, causing breakpoints to be unresolved.


# Description
`ProcessWindows::OnDebuggerConnected` derives the executable module from `GetModuleFileNameExW` on every connect. This returns the process image's *real* path, so when the target is created via a subst'd or mapped drive (e.g. `S:\...\a.out`, where `S:` is subst for `C:\S`) it comes back as `C:\S\...\a.out`. `GetOrCreateModule` then fails to match the module LLDB had already preloaded and creates a duplicate instead. The duplicate leaves the original module's breakpoint location orphaned unresolved while the new module's location is resolved, so a source line breakpoint reports two locations with only one resolved. Generic tests that assert exactly one resolved location fail with `"2 != 1"` and `"Expecting 1 locations, got 2"`.

# Fix
This patch fixes this by first attempting to reuse the existing module if it exists. In practice, LLDB only looks for the executable during attach.

This is a problem in Swiftlang where we run our tests with a subst drive. The impacted tests are:
- `lang/c/{array_types,function_types,set_values,enum_types,anonymous,forward,local_variables}`
- `lang/cpp/{class_types,inlines}`
- `commands/{apropos/with-process,command/nested_alias,memory/write}`
- `functionalities/{memory/find,dead-strip,memory/holes}`
- `commands/expression/entry-bp`