### PR TITLE
AMDGPU: Use subarch triples in more unit tests

### DIFF
--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -8156,8 +8156,8 @@ TEST_F(OpenMPIRBuilderTest, registerTargetGlobalVariable) {
   OpenMPIRBuilderConfig Config(false, false, false, false, false, false, false);
   OMPBuilder.setConfig(Config);
 
-  std::vector<llvm::Triple> TargetTriple;
-  TargetTriple.emplace_back("amdgcn-amd-amdhsa");
+  std::vector<llvm::Triple> TargetTriple = {Triple(
+      Triple::amdgpu, Triple::AMDGPUSubArch700, Triple::AMD, Triple::AMDHSA)};
 
   TargetRegionEntryInfo EntryInfo("", 42, 4711, 17);
   std::vector<GlobalVariable *> RefsGathered;

--- a/llvm/unittests/FuzzMutate/StrategiesTest.cpp
+++ b/llvm/unittests/FuzzMutate/StrategiesTest.cpp
@@ -775,7 +775,7 @@ TEST(AllStrategies, SpecialTerminator) {
 
 TEST(AllStrategies, AMDGCNLegalAddrspace) {
   StringRef Source = "\n\
-    target triple = \"amdgcn-amd-amdhsa\"\n\
+    target triple = \"amdgpu7.00-amd-amdhsa\"\n\
     ; minimum values required by the fuzzer (e.g., default addrspace for allocas and globals)\n\
     target datalayout = \"A5-G1\"\n\
     define amdgpu_gfx void @strict_wwm_amdgpu_cs_main(<4 x i32> inreg %desc, i32 %index) {\n\

--- a/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
@@ -31,7 +31,7 @@ protected:
 
   AMDGPUMCExprTest() {
 
-    TM = createAMDGPUTargetMachine("amdgpu10.10--amdpal", "", "");
+    TM = createAMDGPUTargetMachine(Triple("amdgpu10.10--amdpal"), "", "");
 
     LLVMCtx = std::make_unique<LLVMContext>();
     M = std::make_unique<Module>("Module", *LLVMCtx);

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
@@ -28,8 +28,7 @@ void AMDGPUTestBase::SetUpTestSuite() { initializeAMDGPUTarget(); }
 void AMDGPUCodeGenTestBase::SetUpTestSuite() { initializeAMDGPUTarget(); }
 
 std::unique_ptr<GCNTargetMachine>
-createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
-  Triple TT(TStr);
+createAMDGPUTargetMachine(const Triple &TT, StringRef CPU, StringRef FS) {
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T)
@@ -116,17 +115,17 @@ static bool testAndRecord(std::stringstream &Table, const GCNSubtarget &ST,
 
 static void testGPRLimits(const char *RegName, bool TestW32W64,
                           TestFuncTy test) {
-  SmallVector<StringRef> CPUs;
-  AMDGPU::fillValidArchListAMDGCN(CPUs);
-
   std::map<std::string, SmallVector<std::string>> TablePerCPUs;
-  for (auto CPUName : CPUs) {
-    auto CanonCPUName =
-        AMDGPU::getArchNameAMDGCN(AMDGPU::parseArchAMDGCN(CPUName));
+  for (unsigned SubArch = Triple::FirstAMDGPUSubArch;
+       SubArch <= Triple::LastAMDGPUSubArch; ++SubArch) {
+    auto SubArchType = static_cast<Triple::SubArchType>(SubArch);
+    StringRef CanonCPUName = AMDGPU::getArchNameFromSubArch(SubArchType);
+
+    Triple TT(Triple::amdgpu, SubArchType);
 
     auto *FS = &EmptyFS;
     while (true) {
-      auto TM = createAMDGPUTargetMachine("amdgcn-amd-", CPUName, FS->first);
+      auto TM = createAMDGPUTargetMachine(TT, /*CPU=*/"", FS->first);
       if (!TM)
         break;
 
@@ -159,19 +158,20 @@ static void testGPRLimits(const char *RegName, bool TestW32W64,
   EXPECT_TRUE(ErrStr.empty()) << ErrStr;
 }
 
-static void testDynamicVGPRLimits(StringRef CPUName, StringRef FS,
-                                  TestFuncTy test) {
-  auto TM = createAMDGPUTargetMachine("amdgcn-amd-", CPUName, FS);
+static void testDynamicVGPRLimits(llvm::Triple::SubArchType SubArch,
+                                  StringRef FS, TestFuncTy test) {
+  Triple TT(Triple::amdgpu, SubArch);
+  auto TM = createAMDGPUTargetMachine(TT, /*CPU=*/"", FS);
   ASSERT_TRUE(TM) << "No target machine";
 
-  GCNSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
-                  std::string(TM->getTargetFeatureString()), *TM);
+  GCNSubtarget ST(TT, TM->getTargetCPU(), FS, *TM);
 
+  StringRef ArchName = AMDGPU::getArchNameFromSubArch(SubArch);
   auto testWithBlockSize = [&](unsigned DynamicVGPRBlockSize) {
     std::stringstream Table;
     bool Success = testAndRecord(Table, ST, test, DynamicVGPRBlockSize);
     EXPECT_TRUE(Success && !PrintCpuRegLimits)
-        << CPUName << " dynamic VGPR block size " << DynamicVGPRBlockSize
+        << ArchName << " dynamic VGPR block size " << DynamicVGPRBlockSize
         << ":\nOcc    MinVGPR        MaxVGPR\n"
         << Table.str() << '\n';
     // In dVGPR mode, max VGPR limits do not depend on occupancy:
@@ -206,7 +206,7 @@ TEST_F(AMDGPUTestBase, TestVGPRLimitsPerOccupancy) {
 
   testGPRLimits("VGPR", true, test);
 
-  testDynamicVGPRLimits("gfx1200", "+wavefrontsize32", test);
+  testDynamicVGPRLimits(Triple::AMDGPUSubArch1200, "+wavefrontsize32", test);
 }
 
 TEST_F(AMDGPUTestBase, TestSGPRLimitsPerOccupancy) {
@@ -226,15 +226,17 @@ TEST_F(AMDGPUTestBase, TestSGPRLimitsPerOccupancy) {
   testGPRLimits("SGPR", false, test);
 }
 
-static void testAbsoluteLimits(StringRef CPUName, StringRef FS,
+static void testAbsoluteLimits(llvm::Triple::SubArchType SubArch, StringRef FS,
                                unsigned DynamicVGPRBlockSize,
                                unsigned ExpectedMinOcc, unsigned ExpectedMaxOcc,
                                unsigned ExpectedMaxVGPRs) {
-  auto TM = createAMDGPUTargetMachine("amdgcn-amd-", CPUName, FS);
+  Triple TT(Triple::amdgpu, SubArch);
+  auto TM = createAMDGPUTargetMachine(TT, /*CPU=*/"", FS);
   ASSERT_TRUE(TM) << "No target machine";
 
-  GCNSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
-                  std::string(TM->getTargetFeatureString()), *TM);
+  GCNSubtarget ST(TT, TM->getTargetCPU(), FS, *TM);
+
+  StringRef ArchName = AMDGPU::getArchNameFromSubArch(SubArch);
 
   // Test function without attributes.
   LLVMContext Context;
@@ -250,24 +252,28 @@ static void testAbsoluteLimits(StringRef CPUName, StringRef FS,
     Func->addFnAttr("amdgpu-dynamic-vgpr-block-size", DVGPRBlockSize);
 
   auto Range = ST.getWavesPerEU(*Func);
-  EXPECT_EQ(ExpectedMinOcc, Range.first) << CPUName << ' ' << FS;
-  EXPECT_EQ(ExpectedMaxOcc, Range.second) << CPUName << ' ' << FS;
-  EXPECT_EQ(ExpectedMaxVGPRs, ST.getMaxNumVGPRs(*Func)) << CPUName << ' ' << FS;
+  EXPECT_EQ(ExpectedMinOcc, Range.first) << ArchName << ' ' << FS;
+  EXPECT_EQ(ExpectedMaxOcc, Range.second) << ArchName << ' ' << FS;
+  EXPECT_EQ(ExpectedMaxVGPRs, ST.getMaxNumVGPRs(*Func))
+      << ArchName << ' ' << FS;
   EXPECT_EQ(ExpectedMaxVGPRs, ST.getAddressableNumVGPRs(DynamicVGPRBlockSize))
-      << CPUName << ' ' << FS;
+      << ArchName << ' ' << FS;
 
   // Function with requested 'amdgpu-waves-per-eu' in a valid range.
   Func->addFnAttr("amdgpu-waves-per-eu", "10,12");
   Range = ST.getWavesPerEU(*Func);
-  EXPECT_EQ(10u, Range.first) << CPUName << ' ' << FS;
-  EXPECT_EQ(12u, Range.second) << CPUName << ' ' << FS;
+  EXPECT_EQ(10u, Range.first) << ArchName << ' ' << FS;
+  EXPECT_EQ(12u, Range.second) << ArchName << ' ' << FS;
 }
 
 TEST_F(AMDGPUTestBase, TestOccupancyAbsoluteLimits) {
-  // CPUName, Features, DynamicVGPRBlockSize; Expected MinOcc, MaxOcc, MaxVGPRs
-  testAbsoluteLimits("gfx1200", "+wavefrontsize32", 0, 1, 16, 256);
-  testAbsoluteLimits("gfx1200", "+wavefrontsize32", 16, 1, 16, 128);
-  testAbsoluteLimits("gfx1200", "+wavefrontsize32", 32, 1, 16, 256);
+  // SubArch, Features, DynamicVGPRBlockSize; Expected MinOcc, MaxOcc, MaxVGPRs
+  testAbsoluteLimits(Triple::AMDGPUSubArch1200, "+wavefrontsize32", 0, 1, 16,
+                     256);
+  testAbsoluteLimits(Triple::AMDGPUSubArch1200, "+wavefrontsize32", 16, 1, 16,
+                     128);
+  testAbsoluteLimits(Triple::AMDGPUSubArch1200, "+wavefrontsize32", 32, 1, 16,
+                     256);
 }
 
 static const char *printSubReg(const TargetRegisterInfo &TRI, unsigned SubReg) {
@@ -275,7 +281,7 @@ static const char *printSubReg(const TargetRegisterInfo &TRI, unsigned SubReg) {
 }
 
 TEST_F(AMDGPUTestBase, TestReverseComposeSubRegIndices) {
-  auto TM = createAMDGPUTargetMachine("amdgpu9.00-amd-", "", "");
+  auto TM = createAMDGPUTargetMachine(Triple("amdgpu9.00-amd-"), "", "");
   if (!TM)
     return;
   GCNSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
@@ -352,7 +358,7 @@ TEST_F(AMDGPUTestBase, TestReverseComposeSubRegIndices) {
 
 TEST_F(AMDGPUTestBase, TestGetNamedOperandIdx) {
   std::unique_ptr<const GCNTargetMachine> TM =
-      createAMDGPUTargetMachine("amdgpu9.00-amd-", "", "");
+      createAMDGPUTargetMachine(Triple("amdgpu9.00-amd-"), "", "");
   if (!TM)
     return;
   const MCInstrInfo *MCII = TM->getMCInstrInfo();

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.h
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.h
@@ -19,10 +19,11 @@
 namespace llvm {
 class GCNTargetMachine;
 class StringRef;
+class Triple;
 } // end namespace llvm
 
 std::unique_ptr<llvm::GCNTargetMachine>
-createAMDGPUTargetMachine(std::string TStr, llvm::StringRef CPU,
+createAMDGPUTargetMachine(const llvm::Triple &TT, llvm::StringRef CPU,
                           llvm::StringRef FS);
 
 class AMDGPUTestBase : public testing::Test {

--- a/llvm/unittests/Target/AMDGPU/CSETest.cpp
+++ b/llvm/unittests/Target/AMDGPU/CSETest.cpp
@@ -16,7 +16,7 @@
 using namespace llvm;
 
 TEST_F(AMDGPUTestBase, TestCSEForRegisterClassOrBankAndLLT) {
-  auto TM = createAMDGPUTargetMachine("amdgpu11.00-amd-", "", "");
+  auto TM = createAMDGPUTargetMachine(Triple("amdgpu11.00-amd-"), "", "");
   if (!TM)
     GTEST_SKIP();
 

--- a/llvm/unittests/Target/AMDGPU/DwarfRegMappings.cpp
+++ b/llvm/unittests/Target/AMDGPU/DwarfRegMappings.cpp
@@ -13,9 +13,10 @@
 using namespace llvm;
 
 TEST_F(AMDGPUTestBase, TestWave64DwarfRegMapping) {
-  for (auto Triple : {"amdgpu10.10-amd-", "amdgpu10.10-amd-amdhsa",
-                      "amdgpu10.10-amd-amdpal"}) {
-    auto TM = createAMDGPUTargetMachine(Triple, "", "+wavefrontsize64");
+  for (StringRef TripleStr : {"amdgpu10.10-amd-", "amdgpu10.10-amd-amdhsa",
+                              "amdgpu10.10-amd-amdpal"}) {
+    auto TM =
+        createAMDGPUTargetMachine(Triple(TripleStr), "", "+wavefrontsize64");
     if (TM) {
       GCNSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                       std::string(TM->getTargetFeatureString()), *TM);
@@ -53,9 +54,10 @@ TEST_F(AMDGPUTestBase, TestWave64DwarfRegMapping) {
 }
 
 TEST_F(AMDGPUTestBase, TestWave32DwarfRegMapping) {
-  for (auto Triple : {"amdgpu10.10-amd-", "amdgpu10.10-amd-amdhsa",
-                      "amdgpu10.10-amd-amdpal"}) {
-    auto TM = createAMDGPUTargetMachine(Triple, "", "+wavefrontsize32");
+  for (StringRef TripleStr : {"amdgpu10.10-amd-", "amdgpu10.10-amd-amdhsa",
+                              "amdgpu10.10-amd-amdpal"}) {
+    auto TM =
+        createAMDGPUTargetMachine(Triple(TripleStr), "", "+wavefrontsize32");
     if (TM) {
       GCNSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
                       std::string(TM->getTargetFeatureString()), *TM);

--- a/llvm/unittests/Target/AMDGPU/ExecMayBeModifiedBeforeAnyUse.cpp
+++ b/llvm/unittests/Target/AMDGPU/ExecMayBeModifiedBeforeAnyUse.cpp
@@ -14,7 +14,7 @@
 using namespace llvm;
 
 TEST_F(AMDGPUTestBase, ExecMayBeModifiedBeforeAnyUse) {
-  auto TM = createAMDGPUTargetMachine("amdgpu9.06-amd-", "", "");
+  auto TM = createAMDGPUTargetMachine(Triple("amdgpu9.06-amd-"), "", "");
   if (!TM)
     GTEST_SKIP();
 

--- a/llvm/unittests/Target/AMDGPU/PALMetadata.cpp
+++ b/llvm/unittests/Target/AMDGPU/PALMetadata.cpp
@@ -34,7 +34,7 @@ protected:
   AMDGPUPALMetadata MD;
 
   PALMetadata() {
-    TM = createAMDGPUTargetMachine("amdgpu10.10--amdpal", "", "");
+    TM = createAMDGPUTargetMachine(Triple("amdgpu10.10--amdpal"), "", "");
 
     Ctx = std::make_unique<LLVMContext>();
     M = std::make_unique<Module>("Module", *Ctx);

--- a/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
@@ -40,7 +40,6 @@ static UniformityInfo computeUniformity(const TargetTransformInfo *TTI,
 TEST_F(AMDGPUTestBase, NewValueIsConservativelyDivergent) {
 
   StringRef ModuleString = R"(
-  target triple = "amdgcn-unknown-amdhsa"
   define amdgpu_kernel void @test(i32 inreg %a, i32 inreg %b) {
     %add = add i32 %a, %b
     ret void
@@ -54,8 +53,8 @@ TEST_F(AMDGPUTestBase, NewValueIsConservativelyDivergent) {
   Function *F = M->getFunction("test");
   ASSERT_TRUE(F);
 
-  auto TM =
-      createAMDGPUTargetMachine("amdgpu10.10-amd-", "", "+wavefrontsize32");
+  auto TM = createAMDGPUTargetMachine(Triple("amdgpu10.10-amd-"), "",
+                                      "+wavefrontsize32");
   ASSERT_TRUE(TM);
   TargetTransformInfo TTI = TM->getTargetTransformInfo(*F);
 

--- a/llvm/unittests/Transforms/Utils/CodeExtractorTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CodeExtractorTest.cpp
@@ -746,7 +746,7 @@ TEST(CodeExtractor, OpenMPAggregateArgs) {
   SMDiagnostic Err;
   std::unique_ptr<Module> M(parseAssemblyString(R"ir(
     target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
-    target triple = "amdgcn-amd-amdhsa"
+    target triple = "amdgpu7.00-amd-amdhsa"
 
     define void @foo(ptr %0) {
       %2= alloca ptr, align 8, addrspace(5)


### PR DESCRIPTION
Avoid looking up the target by the cpu name with the legacy
amdgcn name.

Co-authored-by: Claude (Claude-Opus-4.8)