### PR TITLE
[libc] add net/if.h to the list of installed headers

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -21,6 +21,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.net_if
     libc.include.netinet_in
     libc.include.netinet_tcp
     libc.include.netinet_udp

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -21,6 +21,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.net_if
     libc.include.netinet_in
     libc.include.netinet_tcp
     libc.include.netinet_udp

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -21,6 +21,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.net_if
     libc.include.netinet_in
     libc.include.netinet_tcp
     libc.include.netinet_udp


### PR DESCRIPTION
on aarch64, riscv and x86_64.