### PR TITLE
[LTO] Sort DefinedGlobals in LTO cache key

### DIFF
--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -304,12 +304,14 @@ std::string llvm::computeLTOCacheKey(
     }
   };
 
-  // Include the hash for the linkage type to reflect internalization and weak
-  // resolution, and collect any used type identifier resolutions.
+  // Sort the defined globals by GUID to be independent of the insertion order,
+  // which may depend on the order that modules are added.
   SmallVector<std::pair<GlobalValue::GUID, GlobalValueSummary *>>
       SortedDefinedGlobals(DefinedGlobals.begin(), DefinedGlobals.end());
   llvm::sort(SortedDefinedGlobals, llvm::less_first());
   for (auto &GS : SortedDefinedGlobals) {
+    // Include the hash for the linkage type to reflect internalization and weak
+    // resolution, and collect any used type identifier resolutions.
     GlobalValue::LinkageTypes Linkage = GS.second->linkage();
     Hasher.update(
         ArrayRef<uint8_t>((const uint8_t *)&Linkage, sizeof(Linkage)));

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -306,7 +306,10 @@ std::string llvm::computeLTOCacheKey(
 
   // Include the hash for the linkage type to reflect internalization and weak
   // resolution, and collect any used type identifier resolutions.
-  for (auto &GS : DefinedGlobals) {
+  SmallVector<std::pair<GlobalValue::GUID, GlobalValueSummary *>>
+      SortedDefinedGlobals(DefinedGlobals.begin(), DefinedGlobals.end());
+  llvm::sort(SortedDefinedGlobals, llvm::less_first());
+  for (auto &GS : SortedDefinedGlobals) {
     GlobalValue::LinkageTypes Linkage = GS.second->linkage();
     Hasher.update(
         ArrayRef<uint8_t>((const uint8_t *)&Linkage, sizeof(Linkage)));

--- a/llvm/test/ThinLTO/X86/Inputs/cache-defined-globals-order.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/cache-defined-globals-order.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define linkonce_odr void @shared29() {
+  ret void
+}

--- a/llvm/test/ThinLTO/X86/cache-defined-globals-order.ll
+++ b/llvm/test/ThinLTO/X86/cache-defined-globals-order.ll
@@ -1,0 +1,27 @@
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: opt -module-hash -module-summary %s -o %t/t.bc
+; RUN: opt -module-hash -module-summary %S/Inputs/cache-defined-globals-order.ll -o %t/a.bc
+
+; Tests that the LTO cache key is insensitive to the order of the modules.
+; The linkonce_odr function @shared29 is defined in both t.bc and a.bc, so
+; it gets a different position in the combined index depending on which
+; module is processed first, which results in a different insertion order
+; for DefinedGlobals.
+
+; RUN: llvm-lto2 run -cache-dir %t/cache -o %t.o %t/t.bc %t/a.bc -r=%t/t.bc,main,plx -r=%t/t.bc,shared29,plx -r=%t/a.bc,shared29,lx
+; RUN: ls %t/cache | count 2
+
+; RUN: llvm-lto2 run -cache-dir %t/cache -o %t.o %t/a.bc %t/t.bc -r=%t/t.bc,main,plx -r=%t/t.bc,shared29,plx -r=%t/a.bc,shared29,lx
+; RUN: ls %t/cache | count 2
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @main() {
+  call void @shared29()
+  ret void
+}
+
+define linkonce_odr void @shared29() {
+  ret void
+}


### PR DESCRIPTION
Sort the DefindeGlobals by GUID when computing the LTO cache key, to avoid making the cache key dependent on the insertion order. This fixes large compile-time regressions in rust incremental builds.

Alternatively one could make collectDefinedGVSummariesPerModule() work on the sortedRange(), but as that is also used in other places, it probably makes sense to sort locally.

The issue was introduced in 760bb06cb3cd98832f1e4e7a4eaebd98b66d2bdd.