### PR TITLE
[libc] Add struct group_req, struct group_source_req, and related socket options

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -521,6 +521,24 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  struct_group_req
+  HDRS
+    struct_group_req.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_group_req
+    libc.include.netinet_in
+)
+
+add_proxy_header_library(
+  struct_group_source_req
+  HDRS
+    struct_group_source_req.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_group_source_req
+    libc.include.netinet_in
+)
+
+add_proxy_header_library(
   struct_ip_opts
   HDRS
     struct_ip_opts.h

--- a/libc/hdr/types/struct_group_req.h
+++ b/libc/hdr/types/struct_group_req.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy header for struct group_req.
+///
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_GROUP_REQ_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_GROUP_REQ_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_group_req.h"
+
+#else
+
+#include <netinet/in.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_GROUP_REQ_H

--- a/libc/hdr/types/struct_group_source_req.h
+++ b/libc/hdr/types/struct_group_source_req.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy header for struct group_source_req.
+///
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_GROUP_SOURCE_REQ_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_GROUP_SOURCE_REQ_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_group_source_req.h"
+
+#else
+
+#include <netinet/in.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_GROUP_SOURCE_REQ_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -939,6 +939,8 @@ add_header_macro(
     .llvm-libc-types.in_addr_t
     .llvm-libc-types.in_port_t
     .llvm-libc-types.sa_family_t
+    .llvm-libc-types.struct_group_req
+    .llvm-libc-types.struct_group_source_req
     .llvm-libc-types.struct_sockaddr_in
     .llvm-libc-types.struct_sockaddr_in6
     .llvm-libc-types.struct_in_addr

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -225,6 +225,22 @@ add_header(
     libc.include.llvm-libc-macros.stdint_macros
 )
 add_header(struct_sockaddr_storage HDR struct_sockaddr_storage.h DEPENDS .sa_family_t)
+add_header(
+  struct_group_req
+  HDR
+    struct_group_req.h
+  DEPENDS
+    .struct_sockaddr_storage
+    libc.include.llvm-libc-macros.stdint_macros
+)
+add_header(
+  struct_group_source_req
+  HDR
+    struct_group_source_req.h
+  DEPENDS
+    .struct_sockaddr_storage
+    libc.include.llvm-libc-macros.stdint_macros
+)
 add_header(struct_sockaddr_un HDR struct_sockaddr_un.h DEPENDS .sa_family_t)
 add_header(struct_ifreq HDR struct_ifreq.h DEPENDS libc.include.llvm-libc-macros.net_if_macros .struct_sockaddr)
 add_header(struct_iovec HDR struct_iovec.h DEPENDS .size_t)

--- a/libc/include/llvm-libc-types/struct_group_req.h
+++ b/libc/include/llvm-libc-types/struct_group_req.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of struct group_req.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_GROUP_REQ_H
+#define LLVM_LIBC_TYPES_STRUCT_GROUP_REQ_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "struct_sockaddr_storage.h"
+
+struct group_req {
+  uint32_t gr_interface;
+  // NB: Architecture-specific padding.
+  struct sockaddr_storage gr_group;
+};
+
+#endif // LLVM_LIBC_TYPES_STRUCT_GROUP_REQ_H

--- a/libc/include/llvm-libc-types/struct_group_source_req.h
+++ b/libc/include/llvm-libc-types/struct_group_source_req.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of struct group_source_req.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_GROUP_SOURCE_REQ_H
+#define LLVM_LIBC_TYPES_STRUCT_GROUP_SOURCE_REQ_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "struct_sockaddr_storage.h"
+
+struct group_source_req {
+  uint32_t gsr_interface;
+  // NB: Architecture-specific padding.
+  struct sockaddr_storage gsr_group;
+  struct sockaddr_storage gsr_source;
+};
+
+#endif // LLVM_LIBC_TYPES_STRUCT_GROUP_SOURCE_REQ_H

--- a/libc/include/netinet/in.yaml
+++ b/libc/include/netinet/in.yaml
@@ -100,6 +100,18 @@ macros:
     macro_value: 40 # struct ip_mreq_source
   - macro_name: IP_MSFILTER
     macro_value: 41 # struct ip_msfilter
+  - macro_name: MCAST_JOIN_GROUP
+    macro_value: 42 # struct group_req
+  - macro_name: MCAST_BLOCK_SOURCE
+    macro_value: 43 # struct group_source_req
+  - macro_name: MCAST_UNBLOCK_SOURCE
+    macro_value: 44 # struct group_source_req
+  - macro_name: MCAST_LEAVE_GROUP
+    macro_value: 45 # struct group_req
+  - macro_name: MCAST_JOIN_SOURCE_GROUP
+    macro_value: 46 # struct group_source_req
+  - macro_name: MCAST_LEAVE_SOURCE_GROUP
+    macro_value: 47 # struct group_source_req
   - macro_name: IP_MULTICAST_ALL
     macro_value: 49 # int
   - macro_name: IP_LOCAL_PORT_RANGE
@@ -153,6 +165,8 @@ types:
   - type_name: in_addr_t
   - type_name: struct_sockaddr_in
   - type_name: struct_sockaddr_in6
+  - type_name: struct_group_req
+  - type_name: struct_group_source_req
   - type_name: struct_in_addr
   - type_name: struct_in6_addr
   - type_name: struct_ipv6_mreq

--- a/libc/test/src/netinet/CMakeLists.txt
+++ b/libc/test/src/netinet/CMakeLists.txt
@@ -8,6 +8,8 @@ add_libc_unittest(
     in_test.cpp
   DEPENDS
     libc.hdr.netinet_in_macros
+    libc.hdr.types.struct_group_req
+    libc.hdr.types.struct_group_source_req
     libc.hdr.types.struct_in6_addr
     libc.hdr.types.struct_ip_mreq
     libc.hdr.types.struct_ip_mreq_source

--- a/libc/test/src/netinet/in_test.cpp
+++ b/libc/test/src/netinet/in_test.cpp
@@ -17,6 +17,8 @@
 #include "test/UnitTest/Test.h"
 
 #include "hdr/netinet_in_macros.h"
+#include "hdr/types/struct_group_req.h"
+#include "hdr/types/struct_group_source_req.h"
 #include "hdr/types/struct_in6_addr.h"
 #include "hdr/types/struct_ip_mreq.h"
 #include "hdr/types/struct_ip_mreq_source.h"
@@ -136,4 +138,21 @@ TEST(LlvmLibcNetinetInTest, IpOptionLayout) {
             static_cast<size_t>(0));
   EXPECT_EQ(offsetof(struct ipv6_mreq, ipv6mr_interface),
             static_cast<size_t>(16));
+}
+
+TEST(LlvmLibcNetinetInTest, GroupSourceOptionLayout) {
+  // 64 bit structures contain a padding after the interface field.
+  constexpr size_t INTERFACE_PADDING = sizeof(long) - sizeof(uint32_t);
+  EXPECT_EQ(sizeof(struct group_req), 132 + INTERFACE_PADDING);
+  EXPECT_EQ(sizeof(struct group_source_req), 260 + INTERFACE_PADDING);
+
+  EXPECT_EQ(offsetof(struct group_req, gr_interface), static_cast<size_t>(0));
+  EXPECT_EQ(offsetof(struct group_req, gr_group), 4 + INTERFACE_PADDING);
+
+  EXPECT_EQ(offsetof(struct group_source_req, gsr_interface),
+            static_cast<size_t>(0));
+  EXPECT_EQ(offsetof(struct group_source_req, gsr_group),
+            4 + INTERFACE_PADDING);
+  EXPECT_EQ(offsetof(struct group_source_req, gsr_source),
+            132 + INTERFACE_PADDING);
 }


### PR DESCRIPTION
Add definitions for struct group_req and struct group_source_req in llvm-libc-types and wire them into <netinet/in.h>.

Also define the multicast socket options using these structs:
- MCAST_JOIN_GROUP
- MCAST_LEAVE_GROUP
- MCAST_BLOCK_SOURCE
- MCAST_UNBLOCK_SOURCE
- MCAST_JOIN_SOURCE_GROUP
- MCAST_LEAVE_SOURCE_GROUP

Add layout assertions for struct group_req and struct group_source_req to the netinet/in.h unit test.

Assisted by Gemini.