### PR TITLE
[orc-rt] Session::OnCallControllerReturnFn, comments. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/InProcessControllerAccess.h
+++ b/orc-rt/include/orc-rt/InProcessControllerAccess.h
@@ -107,13 +107,13 @@ public:
 
   void disconnect() override;
 
-  void callController(OnCallHandlerCompleteFn OnComplete, HandlerTag T,
+  void callController(OnControllerCallReturnFn OnComplete, HandlerTag T,
                       WrapperFunctionBuffer ArgBytes) override;
   void sendWrapperResult(uint64_t CallId,
                          WrapperFunctionBuffer ResultBytes) override;
 
 private:
-  uint64_t registerPendingHandler(OnCallHandlerCompleteFn OnComplete);
+  uint64_t registerPendingHandler(OnControllerCallReturnFn OnComplete);
   void doDisconnect();
 
   void callWrapper(uint64_t CallId, void *Fn,
@@ -133,7 +133,8 @@ private:
   std::mutex M;
   uint64_t NextPendingCall = 0;
 
-  using PendingCallsMap = std::unordered_map<uint64_t, OnCallHandlerCompleteFn>;
+  using PendingCallsMap =
+      std::unordered_map<uint64_t, OnControllerCallReturnFn>;
   PendingCallsMap PendingCalls;
 };
 

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -106,6 +106,10 @@ public:
   using OnDetachFn = move_only_function<void()>;
   using OnShutdownFn = move_only_function<void()>;
 
+  /// Return value callback used to return results from callController.
+  using OnControllerCallReturnFn =
+      move_only_function<void(WrapperFunctionBuffer)>;
+
   /// Callback used by the Session to run incoming wrapper-function calls.
   ///
   /// A ManagedCodeTaskGroup token is created for each call to this callback,
@@ -119,8 +123,6 @@ public:
       orc_rt_WrapperFunction Fn, WrapperFunctionBuffer ArgBytes)>;
 
   using HandlerTag = void *;
-  using OnCallHandlerCompleteFn =
-      move_only_function<void(WrapperFunctionBuffer)>;
 
   /// Provides access to the controller.
   class ControllerAccess {
@@ -131,7 +133,7 @@ public:
 
   protected:
     using HandlerTag = Session::HandlerTag;
-    using OnCallHandlerCompleteFn = Session::OnCallHandlerCompleteFn;
+    using OnControllerCallReturnFn = Session::OnControllerCallReturnFn;
 
     ControllerAccess(Session &S) : S(S) {}
 
@@ -179,7 +181,7 @@ public:
     void reportError(Error Err) { S.reportError(std::move(Err)); }
 
     /// Call the handler in the controller associated with the given tag.
-    virtual void callController(OnCallHandlerCompleteFn OnComplete,
+    virtual void callController(OnControllerCallReturnFn OnComplete,
                                 HandlerTag T,
                                 WrapperFunctionBuffer ArgBytes) = 0;
 
@@ -418,7 +420,7 @@ public:
   /// This method can be called directly, but is expected to be more commonly
   /// called via WrapperFunction::call using a CallViaSession object (returned
   /// by the callViaSession method).
-  void callController(OnCallHandlerCompleteFn OnComplete, HandlerTag T,
+  void callController(OnControllerCallReturnFn OnComplete, HandlerTag T,
                       WrapperFunctionBuffer ArgBytes) {
     if (auto TmpCA = std::atomic_load(&CA))
       TmpCA->callController(std::move(OnComplete), T, std::move(ArgBytes));
@@ -435,7 +437,7 @@ public:
   public:
     CallViaSession(Session &S, HandlerTag T) : S(S), T(T) {}
 
-    void operator()(OnCallHandlerCompleteFn &&HandleResult,
+    void operator()(OnControllerCallReturnFn &&HandleResult,
                     WrapperFunctionBuffer ArgBytes) {
       S.callController(std::move(HandleResult), T, std::move(ArgBytes));
     }

--- a/orc-rt/lib/executor/InProcessControllerAccess.cpp
+++ b/orc-rt/lib/executor/InProcessControllerAccess.cpp
@@ -201,7 +201,7 @@ void InProcessControllerAccess::disconnect() {
 }
 
 void InProcessControllerAccess::callController(
-    OnCallHandlerCompleteFn OnComplete, HandlerTag T,
+    OnControllerCallReturnFn OnComplete, HandlerTag T,
     WrapperFunctionBuffer ArgBytes) {
   assert(C && "callController called before connect");
   if (C->EnterMessageScope(C)) {
@@ -223,7 +223,7 @@ void InProcessControllerAccess::sendWrapperResult(
 }
 
 uint64_t InProcessControllerAccess::registerPendingHandler(
-    OnCallHandlerCompleteFn OnComplete) {
+    OnControllerCallReturnFn OnComplete) {
   std::scoped_lock<std::mutex> Lock(M);
   PendingCalls[NextPendingCall] = std::move(OnComplete);
   return NextPendingCall++;
@@ -259,7 +259,7 @@ void InProcessControllerAccess::callWrapperEntry(
 void InProcessControllerAccess::returnJITDispatchResult(
     uint64_t CallId, orc_rt_WrapperFunctionBuffer ResultBytes) {
 
-  OnCallHandlerCompleteFn OnComplete;
+  OnControllerCallReturnFn OnComplete;
   {
     std::scoped_lock<std::mutex> Lock(M);
     auto I = PendingCalls.find(CallId);

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -130,7 +130,7 @@ public:
     notifyDisconnected();
   }
 
-  void callController(OnCallHandlerCompleteFn OnComplete, HandlerTag T,
+  void callController(OnControllerCallReturnFn OnComplete, HandlerTag T,
                       WrapperFunctionBuffer ArgBytes) override {
     // Simulate a call to the controller by running the requested function via
     // the test-supplied Post hook (or inline, if no hook was provided).
@@ -163,7 +163,7 @@ public:
   void sendWrapperResult(uint64_t CallId,
                          WrapperFunctionBuffer ResultBytes) override {
     // Respond to a simulated call by the controller.
-    OnCallHandlerCompleteFn OnComplete;
+    OnControllerCallReturnFn OnComplete;
     {
       std::scoped_lock<std::mutex> Lock(M);
       if (Shutdown) {
@@ -192,7 +192,7 @@ public:
       ShutdownCV.notify_all();
   }
 
-  void callFromController(OnCallHandlerCompleteFn OnComplete,
+  void callFromController(OnControllerCallReturnFn OnComplete,
                           orc_rt_WrapperFunction Fn,
                           WrapperFunctionBuffer ArgBytes) {
     size_t CId = 0;
@@ -263,7 +263,7 @@ private:
   bool Shutdown = false;
   size_t Outstanding = 0;
   size_t CallId = 0;
-  std::unordered_map<size_t, OnCallHandlerCompleteFn> Pending;
+  std::unordered_map<size_t, OnControllerCallReturnFn> Pending;
   std::condition_variable ShutdownCV;
   OnConnectFn OnConnect;
 };
@@ -273,7 +273,7 @@ public:
   CallViaMockControllerAccess(MockControllerAccess &CA,
                               orc_rt_WrapperFunction Fn)
       : CA(CA), Fn(Fn) {}
-  void operator()(Session::OnCallHandlerCompleteFn OnComplete,
+  void operator()(Session::OnControllerCallReturnFn OnComplete,
                   WrapperFunctionBuffer ArgBytes) {
     CA.callFromController(std::move(OnComplete), Fn, std::move(ArgBytes));
   }


### PR DESCRIPTION
Rename Session::OnCallHandlerCompleteFn to
Session::OnControllerCallReturnFn and add a comment to clarify its purpose: This callback is used to handle retured values from calls to the controller.