### PR TITLE
[libc] Fix size of struct sockaddr_storage

### DIFF
--- a/libc/include/llvm-libc-types/struct_sockaddr_storage.h
+++ b/libc/include/llvm-libc-types/struct_sockaddr_storage.h
@@ -15,10 +15,8 @@
 // protocol-specific address structures.
 struct __attribute__((may_alias)) sockaddr_storage {
   sa_family_t ss_family;
-  union {
-    char __ss_padding[128 - sizeof(sa_family_t)]; // Ensures size.
-    long __ss_align;                              // Ensures alignment.
-  };
+  char __ss_padding[128 - sizeof(sa_family_t) - sizeof(long)]; // Ensures size.
+  long __ss_align; // Ensures alignment.
 };
 
 #endif // LLVM_LIBC_TYPES_STRUCT_SOCKADDR_STORAGE_H

--- a/libc/test/src/sys/socket/linux/sockaddr_storage_test.cpp
+++ b/libc/test/src/sys/socket/linux/sockaddr_storage_test.cpp
@@ -18,6 +18,7 @@ sa_family_t test_sockaddr_aliasing(struct sockaddr_storage *ss,
                                    struct sockaddr_un *sun);
 
 TEST_F(LlvmLibcSockaddrStorageTest, SizeAndAlignment) {
+  static_assert(sizeof(struct sockaddr_storage) == 128);
   // TODO: Add other sockaddr_* types as they are defined.
   static_assert(sizeof(struct sockaddr_un) <= sizeof(struct sockaddr_storage));
   static_assert(alignof(struct sockaddr_un) <=


### PR DESCRIPTION
My cleverness with the union backfired as it introduced an (architecture-specific) padding between before it. Drop the union to avoid that.

This probably wouldn't break much as the structure exists just to allocate space (and this made it larger), but we should fix it nonetheless.