### PR TITLE
[lldb][test] Double the timeout for TestGuiSpawnThreads.py

### DIFF
--- a/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
+++ b/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
@@ -13,6 +13,10 @@ import sys
 
 @skipIfTargetDoesNotSupportThreads()
 class TestGuiSpawnThreadsTest(PExpectTest):
+    # This tests spawns threads, so low resources on the host may
+    # lead to the test program being stalled for a long time.
+    TIMEOUT = PExpectTest.TIMEOUT * 2
+
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
     @skipIfAsan


### PR DESCRIPTION
If the host machine is overloaded, spawning threads may be delayed due to lack of resources. I'm pretty sure this is the cause of failures in GitHub CI reported in
https://github.com/llvm/llvm-project/issues/209874.

For what the test is doing, we unfortunately cannot get around needing to wait on the test program.

We could perhaps come up with a lit mode that runs some tests in serial, but this is a larger project than I want to get into now.

For now, let's try doubling the timeout. This test is unlikely to fail for real, so if it's taking a long time, it'll be due to system resources. In 99% of cases, it'll pass in a few seconds still.