### PR TITLE
[Flang] [OpenMP] Run `MarkDeclareTarget` pass again before `HostOpFiltering`

### DIFF
--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -464,6 +464,11 @@ void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
   pm.addPass(fir::createEmitMIFGlobalCtors());
 
   if (config.EnableOpenMP && !config.EnableOpenMPSimd) {
+    // Since some math operations may be converted to function calls by the
+    // ConvertMathToFuncs pass, we need to mark them with the omp.declare_target
+    // attribute if they're called from a target region.
+    pm.addPass(mlir::omp::createMarkDeclareTargetPass());
+
     // Remove all non target-related operations from host functions still
     // remaining at this point, if compiling for an OpenMP target device. This
     // is required before translating 'omp' dialect operations to LLVM IR.

--- a/flang/test/Fir/basic-program.fir
+++ b/flang/test/Fir/basic-program.fir
@@ -185,6 +185,7 @@ func.func @_QQmain() {
 // PASSES-NEXT: FIRToLLVMLowering
 // PASSES-NEXT: ReconcileUnrealizedCasts
 // PASSES-NEXT: EmitMIFGlobalCtors
+// PASSES-NEXT: MarkDeclareTargetPass
 // PASSES-NEXT:  HostOpFilteringPass
 // PASSES-NEXT: 'llvm.func' Pipeline
 // PASSES-NEXT:  StackToSharedPass

--- a/flang/test/Integration/OpenMP/declare-target-funcs.f90
+++ b/flang/test/Integration/OpenMP/declare-target-funcs.f90
@@ -1,0 +1,29 @@
+!===----------------------------------------------------------------------===!
+! This directory can be used to add Integration tests involving multiple
+! stages of the compiler (for eg. from Fortran to LLVM IR). It should not
+! contain executable tests. We should only add tests here sparingly and only
+! if there is no other way to test. Repeat this message in each test that is
+! added to this directory and sub-directories.
+!===----------------------------------------------------------------------===!
+
+!REQUIRES: amdgpu-registered-target
+!RUN: %flang_fc1 -triple amdgcn-amd-amdhsa -fopenmp -nogpulib -fopenmp-is-target-device -mmlir --mlir-print-ir-before-all -S %s -o /dev/null 2>&1 | FileCheck %s
+
+
+! This tests the fix for https://github.com/llvm/llvm-project/issues/209123
+! We are only interested in ensuring that functions used in target regions should have
+! the omp.declare_target attribute so the -omp-host-op-fitler pass doesn't crash.
+
+! CHECK-LABEL: IR Dump Before HostOpFilteringPass: omp-host-op-filter
+! CHECK: llvm.func{{.*}}@__mlir_math_ipowi_i32
+! CHECK-SAME: attributes{{.*}}omp.declare_target
+
+module m
+contains
+    subroutine s()
+      integer :: n1
+      real :: tmp1
+      !$omp declare target
+      tmp1 = 2**n1
+    end subroutine s
+end module

--- a/flang/test/Integration/OpenMP/declare-target-funcs.f90
+++ b/flang/test/Integration/OpenMP/declare-target-funcs.f90
@@ -12,11 +12,12 @@
 
 ! This tests the fix for https://github.com/llvm/llvm-project/issues/209123
 ! We are only interested in ensuring that functions used in target regions should have
-! the omp.declare_target attribute so the -omp-host-op-fitler pass doesn't crash.
+! the omp.declare_target attribute so the -omp-host-op-filter pass doesn't crash.
 
 ! CHECK-LABEL: IR Dump Before HostOpFilteringPass: omp-host-op-filter
 ! CHECK: llvm.func{{.*}}@__mlir_math_ipowi_i32
-! CHECK-SAME: attributes{{.*}}omp.declare_target
+! CHECK-SAME: attributes{{.*}}omp.declare_target{{.*}}device_type =
+! CHECK-NOT: (host)
 
 module m
 contains


### PR DESCRIPTION
Fixes #209123.

The power operation `math.ipowi` is converted to a function by `ConvertMathToFuncs`. When used in a target region, this pass runs well after `MarkDeclareTarget` which causes the newly created power function to not have the `omp.declare_target` attribute, which in turn trips up the `HostOpLowering` pass. Detailed investigation [here](https://github.com/llvm/llvm-project/issues/209123#issuecomment-4991765854).

Right now, I've just added a couple of lines to run `MarkDeclareTarget` again, before `HostOpFiltering`. Since I'm quite new to this, I'd like some help on whether this is acceptable, or should the `MarkDeclareTarget` pass be moved to after `ConvertMathToFuncs` and before `HostOpFiltering`.