### PR TITLE
[lldb][test] Handle potential compiler differences in TestEmptyFuncThreadStepOut.py

### DIFF
--- a/lldb/test/API/functionalities/thread/finish-from-empty-func/TestEmptyFuncThreadStepOut.py
+++ b/lldb/test/API/functionalities/thread/finish-from-empty-func/TestEmptyFuncThreadStepOut.py
@@ -41,7 +41,6 @@ class FinishFromEmptyFunctionTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("bt")
 
-        correct_stepped_out_line = line_number("main.c", "leaving main")
         return_statement_line = line_number("main.c", "return 0")
         safety_bp = target.BreakpointCreateByLocation(
             lldb.SBFileSpec("main.c"), return_statement_line
@@ -54,9 +53,19 @@ class FinishFromEmptyFunctionTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("bt")
 
-        frame = thread.GetSelectedFrame()
-        self.assertEqual(
-            frame.line_entry.GetLine(),
-            correct_stepped_out_line,
+        # Compilers may generate source locations differently, so we expect to
+        # either be:
+        # * On the line of the second done() call, or -
+        # * On the puts() line below.
+        #
+        # If we reach the return statement, we did not step out correctly.
+        stepped_out_lines = [
+            line_number("main.c", "leaving main"),
+            line_number("main.c", "Second call to done"),
+        ]
+
+        self.assertIn(
+            thread.GetSelectedFrame().line_entry.GetLine(),
+            stepped_out_lines,
             "Step-out lost control of execution, ran too far",
         )

--- a/lldb/test/API/functionalities/thread/finish-from-empty-func/main.c
+++ b/lldb/test/API/functionalities/thread/finish-from-empty-func/main.c
@@ -3,7 +3,7 @@ void done() {}
 int main() {
   puts("in main");
   done(); // Set breakpoint here
-  done();
+  done(); // Second call to done
   puts("leaving main");
   return 0;
 }


### PR DESCRIPTION
Fixes #195958

It was reported that this test sometimes failed in CI because lldb would step out to line 6 instead of line 7.

Jim Ingham expained on the issue that both could be valid locations (https://github.com/llvm/llvm-project/issues/195958#issuecomment-4384269846).

There's no garauntee that "step out" would go to the source line after the call you step out of. All it does is go to the first location outside of the call. If the compiler so chose, that could be on the same line as the call.

I was not able to reproduce this failure mode, but I think it was happening in CI before, and is possible. So I've made the test accept line 6 or 7. Anything further than that we've gone too far and the test will fail.