### PR TITLE
[NFC][test][AliasSet] Canonicalise memset.ll's overload suffices

### DIFF
--- a/llvm/test/Analysis/AliasSet/memset.ll
+++ b/llvm/test/Analysis/AliasSet/memset.ll
@@ -27,7 +27,7 @@ entry:
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, LocationSize::precise(1))
 define void @test_atomic_known_size(ptr noalias %d) {
 entry:
-  call void @llvm.memset.element.unordered.atomic.p0.i32(ptr align 1 %d, i8 0, i64 1, i32 1)
+  call void @llvm.memset.element.unordered.atomic.p0.i64(ptr align 1 %d, i8 0, i64 1, i32 1)
   ret void
 }
 
@@ -36,13 +36,13 @@ entry:
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, unknown after)
 define void @test_atomic_unknown_size(ptr noalias %d, i64 %len) {
 entry:
-  call void @llvm.memset.element.unordered.atomic.p0.i32(ptr align 1 %d, i8 0, i64 %len, i32 1)
+  call void @llvm.memset.element.unordered.atomic.p0.i64(ptr align 1 %d, i8 0, i64 %len, i32 1)
   ret void
 }
 
 declare void @llvm.memset.p0.i64(ptr %dest, i8 %val,
-                                   i64 %len, i1 %isvolatile)
-declare void @llvm.memset.element.unordered.atomic.p0.i32(ptr %dest,
-                                                            i8 %value,
-                                                            i64 %len,
-                                                            i32 %element_size)
+                                 i64 %len, i1 %isvolatile)
+declare void @llvm.memset.element.unordered.atomic.p0.i64(ptr %dest,
+                                                          i8 %value,
+                                                          i64 %len,
+                                                          i32 %element_size)


### PR DESCRIPTION
The second overload suffix here corresponds to the type of the length,
the third argument, which is an i64 not an i32. Canonicalise this to
avoid confusion from inconsistency.

Whilst here, fix the whitespace used to align the arguments in the
intrinsic declarations, a remnant of losing the two characters in "i8"
when migrating to opaque pointers.

Fixes: 9f0916129024 ("[AST] Add test coverage of memsets")
Fixes: ac924305793c ("[AliasSet] Convert tests to opaque pointers (NFC)")