### PR TITLE
Fix Unintialised char *CommentLexer resulting in potential UB.

### DIFF
--- a/clang/include/clang/AST/CommentLexer.h
+++ b/clang/include/clang/AST/CommentLexer.h
@@ -240,7 +240,7 @@ private:
 
   /// One past end pointer for the current comment.  For BCPL comments points
   /// to newline or BufferEnd, for C comments points to star in '*/'.
-  const char *CommentEnd{nullptr};
+  const char *CommentEnd = nullptr;
 
   SourceLocation FileLoc;
 

--- a/clang/include/clang/AST/CommentLexer.h
+++ b/clang/include/clang/AST/CommentLexer.h
@@ -240,7 +240,7 @@ private:
 
   /// One past end pointer for the current comment.  For BCPL comments points
   /// to newline or BufferEnd, for C comments points to star in '*/'.
-  const char *CommentEnd;
+  const char *CommentEnd{nullptr};
 
   SourceLocation FileLoc;
 


### PR DESCRIPTION
The patch intialised the  pointer to a .
Previously the pointer would have some garbage value which might have resulted in UB.

closes #210034