### PR TITLE
[clang] Expose MC target options through -mllvm

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -39,6 +39,7 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/LTO/LTOBackend.h"
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/OffloadBinary.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -98,6 +99,9 @@
 #include <optional>
 using namespace clang;
 using namespace llvm;
+
+// Register MC target-option flags so they're reachable via -mllvm.
+static llvm::mc::RegisterMCTargetOptionsFlags MCTargetOptionsFlags;
 
 #define HANDLE_EXTENSION(Ext)                                                  \
   llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
@@ -502,6 +506,9 @@ static bool initTargetOptions(const CompilerInstance &CI,
     Options.SwiftAsyncFramePointer = SwiftAsyncFramePointerMode::Never;
     break;
   }
+
+  // Seed from -mllvm first; clang's own flags below take precedence.
+  Options.MCOptions = llvm::mc::InitMCTargetOptionsFromFlags();
 
   Options.MCOptions.SplitDwarfFile = CodeGenOpts.SplitDwarfFile;
   Options.MCOptions.EmitDwarfUnwind = CodeGenOpts.getEmitDwarfUnwind();

--- a/clang/test/CodeGen/mllvm-mc-target-options.c
+++ b/clang/test/CodeGen/mllvm-mc-target-options.c
@@ -1,0 +1,28 @@
+// REQUIRES: x86-registered-target
+///
+/// Clang registers LLVM's machine-code target options (via
+/// RegisterMCTargetOptionsFlags) so they can be set through -mllvm. An MC option
+/// that has no dedicated clang flag takes effect directly; an MC option that also
+/// has a clang flag is governed by the clang flag, which takes precedence over
+/// -mllvm.
+
+/// -asm-show-inst has no clang flag, so -mllvm controls it and the emitted
+/// assembly gains <MCInst ...> comments.
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -S %s -o - \
+// RUN:   | FileCheck %s --check-prefix=NO-SHOW-INST
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -S -mllvm -asm-show-inst %s -o - \
+// RUN:   | FileCheck %s --check-prefix=SHOW-INST
+// NO-SHOW-INST-NOT: <MCInst
+// SHOW-INST: <MCInst
+
+/// -x86-relax-relocations also has a clang flag (-mrelax-relocations), which wins
+/// over -mllvm: with -mrelax-relocations=no the GOT load keeps its non-relaxable
+/// relocation even though -mllvm -x86-relax-relocations requests relaxation.
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -mrelocation-model pic \
+// RUN:   -mrelax-relocations=no -mllvm -x86-relax-relocations -emit-obj %s -o %t
+// RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=PRECEDENCE
+// PRECEDENCE:     R_X86_64_GOTPCREL foo
+// PRECEDENCE-NOT: R_X86_64_REX_GOTPCRELX foo
+
+extern int foo;
+int *f(void) { return &foo; }

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -37,6 +37,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
@@ -63,6 +64,9 @@ using namespace clang;
 using namespace clang::options;
 using namespace llvm;
 using namespace llvm::opt;
+
+// Register MC target-option flags so they're reachable via -mllvm.
+static llvm::mc::RegisterMCTargetOptionsFlags MCTargetOptionsFlags;
 
 namespace {
 
@@ -463,7 +467,8 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
   std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(Opts.Triple));
   assert(MRI && "Unable to create target register info!");
 
-  MCTargetOptions MCOptions;
+  // Seed from -mllvm first; clang's own flags below take precedence.
+  MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
   MCOptions.MCRelaxAll = Opts.RelaxAll;
   MCOptions.EmitDwarfUnwind = Opts.EmitDwarfUnwind;
   MCOptions.EmitCompactUnwindNonCanonical = Opts.EmitCompactUnwindNonCanonical;


### PR DESCRIPTION
Clang never instantiated RegisterMCTargetOptionsFlags, so LLVM's machine-code target options (`-mllvm`) were not reachable from clang.

This made certain flags such as `-large-eh-encoding` (MCTargetOptions::LargeEHEncoding) impossible to set in clang.

Register the flags in the cc1 codegen path and in the integrated assembler, then seed MCTargetOptions before applying clang's own settings with proper precendence for matching flags.

Value precedence: clang's driver flags stay authoritative. The seed runs first and clang's flag-derived assignments overwrite whatever they cover, so -mllvm only contributes Absent any -mllvm flags the seed equals a default-constructed MCTargetOptions, so existing behavior is unchanged.

This change would supersede https://github.com/llvm/llvm-project/pull/187583