### PR TITLE
[flang][OpenACC] Allow blanks around ':' in a gang-arg

### DIFF
--- a/flang/lib/Parser/openacc-parsers.cpp
+++ b/flang/lib/Parser/openacc-parsers.cpp
@@ -85,11 +85,11 @@ TYPE_PARSER(construct<AccTileExprList>(nonemptyList(Parser<AccTileExpr>{})))
 //   dim:int-expr
 //   static:size-expr
 TYPE_PARSER(sourced(construct<AccGangArg>(construct<AccGangArg::Static>(
-                        "STATIC: " >> Parser<AccSizeExpr>{})) ||
+                        "STATIC :" >> Parser<AccSizeExpr>{})) ||
     construct<AccGangArg>(
-        construct<AccGangArg::Dim>("DIM: " >> scalarIntExpr)) ||
+        construct<AccGangArg::Dim>("DIM :" >> scalarIntExpr)) ||
     construct<AccGangArg>(
-        construct<AccGangArg::Num>(maybe("NUM: "_tok) >> scalarIntExpr))))
+        construct<AccGangArg::Num>(maybe("NUM :"_tok) >> scalarIntExpr))))
 
 // 2.9 gang-arg-list
 TYPE_PARSER(

--- a/flang/test/Parser/acc-unparse.f90
+++ b/flang/test/Parser/acc-unparse.f90
@@ -75,6 +75,37 @@ subroutine acc_loop()
   end do
 ! CHECK: !$ACC LOOP GANG(STATIC:gangstatic,DIM:gangdim)
 
+! Spaces are permitted around the ':' separator of a gang-arg.
+  !$acc loop gang(static :gangStatic)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP GANG(STATIC:gangstatic)
+
+  !$acc loop gang(static : gangStatic)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP GANG(STATIC:gangstatic)
+
+  !$acc loop gang(static : *)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP GANG(STATIC:*)
+
+  !$acc loop gang(dim : gangDim)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP GANG(DIM:gangdim)
+
+  !$acc loop gang(num : gangNum)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP GANG(NUM:gangnum)
+
 end subroutine
 
 subroutine routine1()


### PR DESCRIPTION
The parsers for the STATIC, DIM, and NUM forms of an OpenACC gang-arg used the token strings "STATIC: ", "DIM: ", and "NUM: ", none of which permit a blank between the keyword and the ':' separator. A space in a TokenStringMatch pattern is the only place a blank is accepted in the source (outside the leading/trailing skip), so a directive such as

    !$acc loop gang(static : 1)

was rejected with "expected end of OpenACC directive", even though free-form Fortran allows optional blanks around the separator.

Move the blank in each token string to before the ':' ("STATIC :", etc.) so zero or more blanks are accepted on either side of the separator. The _tok form keeps the blank optional, so the no-space spelling still parses without a warning.

Add parser/unparse coverage for the spaced spellings of the static, dim, and num gang arguments.