### PR TITLE
[RISCV][P-ext] Make undef vectors Legal.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -632,6 +632,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
         setOperationAction(ISD::BSWAP, VT, Legal);
       }
     }
+    setOperationAction(ISD::UNDEF, VTs, Legal);
     setOperationAction(ISD::SPLAT_VECTOR, VTs, Legal);
     setOperationAction(ISD::BUILD_VECTOR, VTs, Legal);
     setOperationAction(ISD::SCALAR_TO_VECTOR, VTs, Legal);
@@ -668,6 +669,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
         }
       }
 
+      setOperationAction(ISD::UNDEF, P64VecVTs, Legal);
       setOperationAction({ISD::LOAD, ISD::STORE}, P64VecVTs, Custom);
       setOperationAction(ISD::BITCAST, P64VecVTs, Custom);
       setOperationAction({ISD::ADD, ISD::SUB}, P64VecVTs, Legal);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -2820,6 +2820,18 @@ let append Predicates = [IsRV64] in {
   def : Pat<(v4i16 (riscv_punzipo (v4i16 GPR:$rs1), (v4i16 GPR:$rs2))),
             (UNZIP16HP GPR:$rs1, GPR:$rs2)>;
 
+  // Match undef to X0 to avoid false dependency.
+  // FIXME: Match operand 0 too?
+  // FIXME: Enable BreakFalseDep pass?
+  def : Pat<(v8i8 (riscv_punzipe (v8i8 GPR:$rs1), (v8i8 undef))),
+            (UNZIP8P GPR:$rs1, (v8i8 X0))>;
+  def : Pat<(v8i8 (riscv_punzipo (v8i8 GPR:$rs1), (v8i8 undef))),
+            (UNZIP8HP GPR:$rs1, (v8i8 X0))>;
+  def : Pat<(v4i16 (riscv_punzipe (v4i16 GPR:$rs1), (v4i16 undef))),
+            (UNZIP16P GPR:$rs1, (v4i16 X0))>;
+  def : Pat<(v4i16 (riscv_punzipo (v4i16 GPR:$rs1), (v4i16 undef))),
+            (UNZIP16HP GPR:$rs1, (v4i16 X0))>;
+
   // Packed zip.
   def : Pat<(v8i8 (riscv_pzip (v8i8 GPR:$rs1), (v8i8 GPR:$rs2))),
             (ZIP8P GPR:$rs1, GPR:$rs2)>;

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -2734,30 +2734,15 @@ define <2 x i16> @test_psabs_v2i16(<2 x i16> %a) {
 }
 
 define <4 x i8> @test_undef_v4i8() {
-; RV32-LABEL: test_undef_v4i8:
-; RV32:       # %bb.0:
-; RV32-NEXT:    li a0, 0
-; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    ppaire.db a0, a0, a0
-; RV32-NEXT:    pack a0, a0, a1
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_undef_v4i8:
-; RV64:       # %bb.0:
-; RV64-NEXT:    li a0, 0
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_undef_v4i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   ret <4 x i8> undef
 }
 
 define <2 x i16> @test_undef_v2i16() {
-; RV32-LABEL: test_undef_v2i16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    pack a0, zero, zero
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_undef_v2i16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    li a0, 0
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_undef_v2i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   ret <2 x i16> undef
 }

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -2732,3 +2732,32 @@ define <2 x i16> @test_psabs_v2i16(<2 x i16> %a) {
   %res = call <2 x i16> @llvm.riscv.psabs.v2i16(<2 x i16> %a)
   ret <2 x i16> %res
 }
+
+define <4 x i8> @test_undef_v4i8() {
+; RV32-LABEL: test_undef_v4i8:
+; RV32:       # %bb.0:
+; RV32-NEXT:    li a0, 0
+; RV32-NEXT:    li a1, 0
+; RV32-NEXT:    ppaire.db a0, a0, a0
+; RV32-NEXT:    pack a0, a0, a1
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_undef_v4i8:
+; RV64:       # %bb.0:
+; RV64-NEXT:    li a0, 0
+; RV64-NEXT:    ret
+  ret <4 x i8> undef
+}
+
+define <2 x i16> @test_undef_v2i16() {
+; RV32-LABEL: test_undef_v2i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pack a0, zero, zero
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_undef_v2i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    li a0, 0
+; RV64-NEXT:    ret
+  ret <2 x i16> undef
+}

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -5999,43 +5999,22 @@ define <2 x i32> @test_return_zero() {
 }
 
 define <8 x i8> @test_undef_v8i8() {
-; RV32-LABEL: test_undef_v8i8:
-; RV32:       # %bb.0:
-; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    li a0, 0
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_undef_v8i8:
-; RV64:       # %bb.0:
-; RV64-NEXT:    li a0, 0
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_undef_v8i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   ret <8 x i8> undef
 }
 
 define <4 x i16> @test_undef_v4i16() {
-; RV32-LABEL: test_undef_v4i16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    li a0, 0
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_undef_v4i16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    li a0, 0
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_undef_v4i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   ret <4 x i16> undef
 }
 
 define <2 x i32> @test_undef_v2i32() {
-; RV32-LABEL: test_undef_v2i32:
-; RV32:       # %bb.0:
-; RV32-NEXT:    li a1, 0
-; RV32-NEXT:    li a0, 0
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_undef_v2i32:
-; RV64:       # %bb.0:
-; RV64-NEXT:    li a0, 0
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_undef_v2i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   ret <2 x i32> undef
 }

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -5997,3 +5997,45 @@ define <2 x i32> @test_return_zero() {
 ; RV64-NEXT:    ret
   ret <2 x i32> splat (i32 0)
 }
+
+define <8 x i8> @test_undef_v8i8() {
+; RV32-LABEL: test_undef_v8i8:
+; RV32:       # %bb.0:
+; RV32-NEXT:    li a1, 0
+; RV32-NEXT:    li a0, 0
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_undef_v8i8:
+; RV64:       # %bb.0:
+; RV64-NEXT:    li a0, 0
+; RV64-NEXT:    ret
+  ret <8 x i8> undef
+}
+
+define <4 x i16> @test_undef_v4i16() {
+; RV32-LABEL: test_undef_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    li a1, 0
+; RV32-NEXT:    li a0, 0
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_undef_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    li a0, 0
+; RV64-NEXT:    ret
+  ret <4 x i16> undef
+}
+
+define <2 x i32> @test_undef_v2i32() {
+; RV32-LABEL: test_undef_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    li a1, 0
+; RV32-NEXT:    li a0, 0
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_undef_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    li a0, 0
+; RV64-NEXT:    ret
+  ret <2 x i32> undef
+}


### PR DESCRIPTION
Add a few additional isel patterns to avoid false dependencies. We may want to enable the BreakFalseDep pass in the future.