### PR TITLE
[NFC] Refactor when selecting x86-64 EH encoding to be less prone to error

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -122,7 +122,7 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
                                              const TargetMachine &TgtM) {
   TargetLoweringObjectFile::Initialize(Ctx, TgtM);
 
-  CodeModel::Model CM = TgtM.getCodeModel();
+  const CodeModel::Model CM = TgtM.getCodeModel();
   InitializeELF(TgtM.Options.UseInitArray);
 
   switch (TgtM.getTargetTriple().getArch()) {
@@ -150,29 +150,37 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
                               dwarf::DW_EH_PE_sdata4
                         : dwarf::DW_EH_PE_absptr;
     break;
-  case Triple::x86_64:
-    if (TgtM.Options.MCOptions.LargeEHEncoding)
-      CM = CodeModel::Large;
+  case Triple::x86_64: {
+    // The large EH encoding forces 64-bit-wide EH pointers regardless of the
+    // code model, so treat it like the Large code model when selecting
+    // encodings below.
+    const CodeModel::Model EHCM =
+        TgtM.Options.MCOptions.LargeEHEncoding ? CodeModel::Large : CM;
     if (isPositionIndependent()) {
-      PersonalityEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
-        ((CM == CodeModel::Small || CM == CodeModel::Medium)
-         ? dwarf::DW_EH_PE_sdata4 : dwarf::DW_EH_PE_sdata8);
+      PersonalityEncoding =
+          dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
+          ((EHCM == CodeModel::Small || EHCM == CodeModel::Medium)
+               ? dwarf::DW_EH_PE_sdata4
+               : dwarf::DW_EH_PE_sdata8);
       LSDAEncoding = dwarf::DW_EH_PE_pcrel |
-        (CM == CodeModel::Small
-         ? dwarf::DW_EH_PE_sdata4 : dwarf::DW_EH_PE_sdata8);
+                     (EHCM == CodeModel::Small ? dwarf::DW_EH_PE_sdata4
+                                               : dwarf::DW_EH_PE_sdata8);
       TTypeEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
-        ((CM == CodeModel::Small || CM == CodeModel::Medium)
-         ? dwarf::DW_EH_PE_sdata4 : dwarf::DW_EH_PE_sdata8);
+                      ((EHCM == CodeModel::Small || EHCM == CodeModel::Medium)
+                           ? dwarf::DW_EH_PE_sdata4
+                           : dwarf::DW_EH_PE_sdata8);
     } else {
       PersonalityEncoding =
-        (CM == CodeModel::Small || CM == CodeModel::Medium)
-        ? dwarf::DW_EH_PE_udata4 : dwarf::DW_EH_PE_absptr;
-      LSDAEncoding = (CM == CodeModel::Small)
-        ? dwarf::DW_EH_PE_udata4 : dwarf::DW_EH_PE_absptr;
-      TTypeEncoding = (CM == CodeModel::Small)
-        ? dwarf::DW_EH_PE_udata4 : dwarf::DW_EH_PE_absptr;
+          (EHCM == CodeModel::Small || EHCM == CodeModel::Medium)
+              ? dwarf::DW_EH_PE_udata4
+              : dwarf::DW_EH_PE_absptr;
+      LSDAEncoding = (EHCM == CodeModel::Small) ? dwarf::DW_EH_PE_udata4
+                                                : dwarf::DW_EH_PE_absptr;
+      TTypeEncoding = (EHCM == CodeModel::Small) ? dwarf::DW_EH_PE_udata4
+                                                 : dwarf::DW_EH_PE_absptr;
     }
     break;
+  }
   case Triple::hexagon:
     PersonalityEncoding = dwarf::DW_EH_PE_absptr;
     LSDAEncoding = dwarf::DW_EH_PE_absptr;


### PR DESCRIPTION
Apply suggestion from https://github.com/llvm/llvm-project/pull/174508#discussion_r3589397222

Use a case-scoped local (EHCM) rather than mutating the object file's code model, so only the EH encoding selection is affected.