### PR TITLE
[libsycl] add explicit instantiations for event::get_profiling_info

### DIFF
--- a/libsycl/src/event.cpp
+++ b/libsycl/src/event.cpp
@@ -51,4 +51,13 @@ event::get_profiling_info() const {
                         "Profiling features are not supported.");
 }
 
+#define _LIBSYCL_EXPORT_GET_PROFILING_INFO(Desc)                               \
+  template _LIBSYCL_EXPORT                                                     \
+      detail::is_event_profiling_info_desc_t<info::event_profiling::Desc>      \
+      event::get_profiling_info<info::event_profiling::Desc>() const;
+_LIBSYCL_EXPORT_GET_PROFILING_INFO(command_submit)
+_LIBSYCL_EXPORT_GET_PROFILING_INFO(command_start)
+_LIBSYCL_EXPORT_GET_PROFILING_INFO(command_end)
+#undef _LIBSYCL_EXPORT_GET_PROFILING_INFO
+
 _LIBSYCL_END_NAMESPACE_SYCL

--- a/libsycl/unittests/event/event.cpp
+++ b/libsycl/unittests/event/event.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 using namespace sycl;
@@ -136,4 +137,25 @@ TEST(Event, GetWaitListWithSetKernelParametersAndLaunch) {
   EXPECT_CALL(Mock.get(), olSyncEvent(Dep1Impl->getHandle())).Times(1);
   EXPECT_CALL(Mock.get(), olSyncEvent(Dep2Impl->getHandle())).Times(1);
   event::wait(WaitList);
+}
+
+template <typename Param>
+void expectGetProfilingInfoThrows(const event &Event) {
+  try {
+    (void)Event.template get_profiling_info<Param>();
+    FAIL() << "Expected sycl::exception";
+  } catch (const exception &Ex) {
+    EXPECT_EQ(Ex.code(), make_error_code(errc::feature_not_supported));
+    EXPECT_THAT(std::string(Ex.what()),
+                HasSubstr("Profiling features are not supported."));
+  }
+}
+
+TEST(Event, GetProfilingInfoThrows) {
+  mock::MockWrapper Mock;
+  event Event;
+
+  expectGetProfilingInfoThrows<info::event_profiling::command_submit>(Event);
+  expectGetProfilingInfoThrows<info::event_profiling::command_start>(Event);
+  expectGetProfilingInfoThrows<info::event_profiling::command_end>(Event);
 }


### PR DESCRIPTION
Assisted by GH Copilot.