### PR TITLE
[llvm] Add Trusty OSType

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -190,6 +190,9 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       default: // Assume MSVC for unknown environments
         return std::make_unique<MicrosoftARM64TargetInfo>(Triple, Opts);
       }
+    case llvm::Triple::Trusty:
+      return std::make_unique<TrustyTargetInfo<AArch64leTargetInfo>>(Triple,
+                                                                     Opts);
     default:
       return std::make_unique<AArch64leTargetInfo>(Triple, Opts);
     }
@@ -251,6 +254,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       default: // Assume MSVC for unknown environments
         return std::make_unique<MicrosoftARMleTargetInfo>(Triple, Opts);
       }
+    case llvm::Triple::Trusty:
+      return std::make_unique<TrustyTargetInfo<ARMleTargetInfo>>(Triple, Opts);
     default:
       return std::make_unique<ARMleTargetInfo>(Triple, Opts);
     }
@@ -693,6 +698,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::Serenity:
       return std::make_unique<SerenityTargetInfo<X86_64TargetInfo>>(Triple,
                                                                     Opts);
+    case llvm::Triple::Trusty:
+      return std::make_unique<TrustyTargetInfo<X86_64TargetInfo>>(Triple, Opts);
     default:
       return std::make_unique<X86_64TargetInfo>(Triple, Opts);
     }

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -1160,6 +1160,20 @@ public:
   }
 };
 
+// Trusty target
+template <typename Target>
+class LLVM_LIBRARY_VISIBILITY TrustyTargetInfo : public OSTargetInfo<Target> {
+protected:
+  void getOSDefines(const LangOptions &Opts, const llvm::Triple &Triple,
+                    MacroBuilder &Builder) const override {
+    Builder.defineMacro("__TRUSTY__");
+  }
+
+public:
+  TrustyTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
+      : OSTargetInfo<Target>(Triple, Opts) {}
+};
+
 } // namespace targets
 } // namespace clang
 #endif // LLVM_CLANG_LIB_BASIC_TARGETS_OSTARGETS_H

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -348,7 +348,8 @@ public:
     Firmware,
     QURT,
     H2,
-    LastOSType = H2
+    Trusty, // TEE OS for Android
+    LastOSType = Trusty
   };
   enum EnvironmentType {
     UnknownEnvironment,
@@ -859,6 +860,9 @@ public:
 
   /// Tests whether the OS is H2.
   bool isOSH2() const { return getOS() == Triple::H2; }
+
+  /// Tests whether the OS is Trusty.
+  bool isOSTrusty() const { return getOS() == Triple::Trusty; }
 
   /// Tests whether the OS uses the ELF binary format.
   bool isOSBinFormatELF() const { return getObjectFormat() == Triple::ELF; }

--- a/llvm/include/llvm/TargetParser/TripleName.def
+++ b/llvm/include/llvm/TargetParser/TripleName.def
@@ -87,6 +87,7 @@ TRIPLE_OS(ChipStar, "chipstar", "Generic")
 TRIPLE_OS(Firmware, "firmware", "Generic")
 TRIPLE_OS(QURT, "qurt", "Generic")
 TRIPLE_OS(H2, "h2", "Generic")
+TRIPLE_OS(Trusty, "trusty", "Generic")
 
 #undef TRIPLE_OS
 #undef TRIPLE_OS_ALIAS

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1483,6 +1483,24 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::spirv64, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ChipStar, T.getOS());
+
+  T = Triple("arm-unknown-trusty-musl");
+  EXPECT_EQ(Triple::arm, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Trusty, T.getOS());
+  EXPECT_EQ(Triple::Musl, T.getEnvironment());
+
+  T = Triple("aarch64-unknown-trusty-musl");
+  EXPECT_EQ(Triple::aarch64, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Trusty, T.getOS());
+  EXPECT_EQ(Triple::Musl, T.getEnvironment());
+
+  T = Triple("x86_64-unknown-trusty-musl");
+  EXPECT_EQ(Triple::x86_64, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Trusty, T.getOS());
+  EXPECT_EQ(Triple::Musl, T.getEnvironment());
 }
 
 TEST(TripleTest, EnumConstructor) {


### PR DESCRIPTION
Add an `OSType` variant for the [Trusty OS](https://source.android.com/docs/security/features/trusty), an operating system used to provide a trusted execution environment for Android devices.