### PR TITLE
[libc++] Run macOS CI on self-hosted runners instead of Github ones

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -198,9 +198,13 @@ jobs:
       matrix:
         include:
         - config: generic-cxx03
+          xcode-version: 26.5
         - config: generic-cxx23
+          xcode-version: 26.5
         - config: generic-modules
+          xcode-version: 26.5
         - config: apple-configuration
+          xcode-version: 26.5
         # TODO: These jobs are intended to test back-deployment (building against ToT libc++ but running against an
         #       older system-provided libc++.dylib). Doing this properly would require building the test suite on a
         #       recent macOS using a recent Clang (hence recent Xcode), and then running the actual test suite on an
@@ -212,14 +216,16 @@ jobs:
         #       macOS versions as a way to avoid rotting that configuration, but it doesn't provide a lot of additional
         #       coverage.
         - config: apple-system
+          xcode-version: 26.5
         - config: apple-system-hardened
+          xcode-version: 26.5
     runs-on: ["self-hosted", "macOS", "apple-runners"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Select Xcode
-        run: echo "DEVELOPER_DIR=/Applications/Xcode_26.5.app/Contents/Developer" >> $GITHUB_ENV
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer" >> $GITHUB_ENV
       - name: Install Ninja and CMake
         run: |
           brew install ninja cmake

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -198,13 +198,9 @@ jobs:
       matrix:
         include:
         - config: generic-cxx03
-          os: macos-26
         - config: generic-cxx23
-          os: macos-26
         - config: generic-modules
-          os: macos-26
         - config: apple-configuration
-          os: macos-26
         # TODO: These jobs are intended to test back-deployment (building against ToT libc++ but running against an
         #       older system-provided libc++.dylib). Doing this properly would require building the test suite on a
         #       recent macOS using a recent Clang (hence recent Xcode), and then running the actual test suite on an
@@ -216,18 +212,15 @@ jobs:
         #       macOS versions as a way to avoid rotting that configuration, but it doesn't provide a lot of additional
         #       coverage.
         - config: apple-system
-          os: macos-26
         - config: apple-system-hardened
-          os: macos-26
-    runs-on: ${{ matrix.os }}
+    runs-on: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
-          xcode-version: '26.4'
+      - name: Install Ninja and CMake
+        run: |
+          brew install ninja cmake
       - name: Build and test
         run: |
           python3 -m venv .venv

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -218,6 +218,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Select Xcode
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_26.5.app/Contents/Developer" >> $GITHUB_ENV
       - name: Install Ninja and CMake
         run: |
           brew install ninja cmake

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -213,7 +213,7 @@ jobs:
         #       coverage.
         - config: apple-system
         - config: apple-system-hardened
-    runs-on: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
+    runs-on: ["self-hosted", "macOS", "apple-runners"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
This should increase our capacity and allow better turn around times, and potentially unblock additional test coverage.

Note that this change implies that the self-hosted runners provide a version of Xcode that is supported by libc++ (the latest released one), which is currently the case.