### PR TITLE
[RISCV][P-ext] Remove redundant shuffle lowering for packed widening high-half convert.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -6512,49 +6512,6 @@ SDValue RISCVTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
   if (Subtarget.hasStdExtP() && !Subtarget.hasVInstructions()) {
     ArrayRef<int> Mask = SVN->getMask();
 
-    // Match the IR produced by the packed widening high-half convert header
-    // intrinsics:
-    //   shufflevector zeroinitializer, src, <0, N, 1, N+1, ...>
-    //   bitcast to the widened vector type
-    // This places each source element in the high half of the widened element.
-    // Lower it to PZIP with a zero first operand and let tablegen select
-    // pwcvth.* via zip*p/wzip*p.
-    auto IsWidenHighMask = [&](unsigned SrcNumElts) {
-      for (unsigned I = 0; I != SrcNumElts; ++I)
-        if (Mask[2 * I] != (int)I || Mask[2 * I + 1] != (int)(NumElts + I))
-          return false;
-      return true;
-    };
-
-    SDValue Src = V2;
-    if (V2.getOpcode() == ISD::CONCAT_VECTORS && V2.getOperand(1).isUndef())
-      Src = V2.getOperand(0);
-    MVT SrcVT = Src.getSimpleValueType();
-    if (Subtarget.isRV32() &&
-        ISD::isConstantSplatVectorAllZeros(V1.getNode()) &&
-        SrcVT.getVectorNumElements() * 2 == NumElts &&
-        V2.getSimpleValueType().getVectorNumElements() == NumElts) {
-      unsigned SrcNumElts = SrcVT.getVectorNumElements();
-      if (IsWidenHighMask(SrcNumElts) &&
-          (SrcVT == MVT::v4i8 || SrcVT == MVT::v2i16)) {
-        Src =
-            DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, Src, DAG.getUNDEF(SrcVT));
-        return DAG.getNode(RISCVISD::PZIP, DL, VT, DAG.getConstant(0, DL, VT),
-                           Src);
-      }
-    }
-
-    if (ISD::isConstantSplatVectorAllZeros(V1.getNode()) &&
-        V2.getSimpleValueType() == VT &&
-        (VT == MVT::v8i8 || VT == MVT::v4i16)) {
-      unsigned SrcNumElts = NumElts / 2;
-      if (IsWidenHighMask(SrcNumElts)) {
-        Src = V2;
-        return DAG.getNode(RISCVISD::PZIP, DL, VT, DAG.getConstant(0, DL, VT),
-                           Src);
-      }
-    }
-
     // Select an element reverse shuffle to VECTOR_REVERSE. The tablegen
     // patterns select rev8/rev16/ppairoe.* from VECTOR_REVERSE.
     // Reverse of the low L lanes, higher lanes poison. L == NumElts is a plain


### PR DESCRIPTION
The more general lowerVECTOR_SHUFFLEAsPZip can handle this case.