### PR TITLE
[InstCombine] Use getInsertionPointAfterDef to get sin/cos InsertPt.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1948,13 +1948,11 @@ static Value *foldSinAndCosToSinCos(IntrinsicInst *II, IRBuilderBase &B,
   // Insert sincos right after the argument definition.
   IRBuilderBase::InsertPointGuard Guard(B);
   if (auto *ArgInst = dyn_cast<Instruction>(Arg)) {
-    BasicBlock *ArgBB = ArgInst->getParent();
-    // Need skip whole PHIs if Arg is PHI to prevent insert in the middle
-    // of PHIs.
-    if (isa<PHINode>(ArgInst))
-      B.SetInsertPoint(ArgBB, ArgBB->getFirstInsertionPt());
-    else
-      B.SetInsertPoint(ArgBB, std::next(ArgInst->getIterator()));
+    std::optional<BasicBlock::iterator> InsertPt =
+        ArgInst->getInsertionPointAfterDef();
+    if (!InsertPt)
+      return nullptr;
+    B.SetInsertPoint(*InsertPt);
   } else {
     BasicBlock &EntryBB = II->getFunction()->getEntryBlock();
     B.SetInsertPoint(&EntryBB, EntryBB.begin());

--- a/llvm/test/Transforms/InstCombine/sincos.ll
+++ b/llvm/test/Transforms/InstCombine/sincos.ll
@@ -469,4 +469,51 @@ merge:
   ret float %res
 }
 
+define double @sincos_arg_is_invoke() personality ptr @__gxx_personality_v0 {
+; CHECK-LABEL: @sincos_arg_is_invoke(
+; CHECK-NEXT:    [[ANGLE:%.*]] = invoke double @foo()
+; CHECK-NEXT:            to label [[CONT:%.*]] unwind label [[LPAD:%.*]]
+; CHECK:       cont:
+; CHECK-NEXT:    [[SINCOS:%.*]] = call { double, double } @llvm.sincos.f64(double [[ANGLE]])
+; CHECK-NEXT:    [[SIN:%.*]] = extractvalue { double, double } [[SINCOS]], 0
+; CHECK-NEXT:    [[COS:%.*]] = extractvalue { double, double } [[SINCOS]], 1
+; CHECK-NEXT:    [[SUM:%.*]] = fadd double [[SIN]], [[COS]]
+; CHECK-NEXT:    ret double [[SUM]]
+; CHECK:       lpad:
+; CHECK-NEXT:    [[LP:%.*]] = landingpad { ptr, i32 }
+; CHECK-NEXT:            cleanup
+; CHECK-NEXT:    ret double 0.000000e+00
+;
+; CHECK-SHRINK-LABEL: @sincos_arg_is_invoke(
+; CHECK-SHRINK-NEXT:    [[ANGLE:%.*]] = invoke double @foo()
+; CHECK-SHRINK-NEXT:            to label [[CONT:%.*]] unwind label [[LPAD:%.*]]
+; CHECK-SHRINK:       cont:
+; CHECK-SHRINK-NEXT:    [[SINCOS:%.*]] = call { double, double } @llvm.sincos.f64(double [[ANGLE]])
+; CHECK-SHRINK-NEXT:    [[SIN:%.*]] = extractvalue { double, double } [[SINCOS]], 0
+; CHECK-SHRINK-NEXT:    [[COS:%.*]] = extractvalue { double, double } [[SINCOS]], 1
+; CHECK-SHRINK-NEXT:    [[SUM:%.*]] = fadd double [[SIN]], [[COS]]
+; CHECK-SHRINK-NEXT:    ret double [[SUM]]
+; CHECK-SHRINK:       lpad:
+; CHECK-SHRINK-NEXT:    [[LP:%.*]] = landingpad { ptr, i32 }
+; CHECK-SHRINK-NEXT:            cleanup
+; CHECK-SHRINK-NEXT:    ret double 0.000000e+00
+;
+  %angle = invoke double @foo()
+  to label %cont unwind label %lpad
+
+cont:
+  %s = call double @llvm.sin.f64(double %angle)
+  %c = call double @llvm.cos.f64(double %angle)
+  %sum = fadd double %s, %c
+  ret double %sum
+
+lpad:
+  %lp = landingpad { ptr, i32 }
+  cleanup
+  ret double 0.000000e+00
+}
+
+declare double @foo()
+declare i32 @__gxx_personality_v0(...)
+
 attributes #0 = { nounwind memory(none) }


### PR DESCRIPTION
The current logic added in https://github.com/llvm/llvm-project/pull/194616 
picks an incorrect insert point for the argument is an invoke.

Use getInsertionPointAfterDef and bail out if there is no such insert point.

Fixes crashes in the added tests.