### PR TITLE
[flang][cuda] Use managed allocation for saved locals

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10619,7 +10619,9 @@ void DeclarationVisitor::SetImplicitCUDADataAttr(Symbol &symbol) {
   // COMMON objects may not carry managed/unified attributes.
   if (cudaEnabled && (cudaManaged || cudaUnified) && !object->commonBlock()) {
     const Scope &owner{symbol.owner()};
-    const bool unifiedAllowed{!IsCUDADeviceContext(&owner) &&
+    const bool isSavedLocal{
+        owner.kind() == Scope::Kind::Subprogram && IsSaved(symbol)};
+    const bool unifiedAllowed{!isSavedLocal && !IsCUDADeviceContext(&owner) &&
         (owner.IsDerivedType() || owner.kind() == Scope::Kind::MainProgram ||
             owner.kind() == Scope::Kind::Subprogram)};
     object->set_cudaDataAttr(cudaUnified && unifiedAllowed

--- a/flang/test/Lower/CUDA/cuda-implicit-managed-alloc.cuf
+++ b/flang/test/Lower/CUDA/cuda-implicit-managed-alloc.cuf
@@ -20,6 +20,8 @@ contains
   subroutine mod_sub()
     real, allocatable :: loc_arr(:)
     real, pointer :: loc_ptr(:)
+    real, allocatable, save :: saved_arr(:)
+    real, pointer, save :: saved_ptr(:)
   end subroutine
   subroutine common_sub()
     real, pointer :: com_ptr(:)
@@ -42,6 +44,13 @@ end program
 ! UNI: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
 ! MAN: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
 
+! Saved subprogram locals use Managed because their static descriptors cannot
+! be registered as Unified device symbols.
+! UNI: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMmFmod_subEsaved_arr"}
+! UNI: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEsaved_ptr"}
+! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMmFmod_subEsaved_arr"}
+! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEsaved_ptr"}
+
 ! Main-program local: Unified under -gpu=unified, Managed under
 ! -gpu=managed.
 ! UNI: hlfir.declare {{.*}} {data_attr = #cuf.cuda<unified>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFEprog_arr"}
@@ -54,9 +63,18 @@ end program
 ! MAN: fir.global @_QMmEmod_arr {data_attr = #cuf.cuda<managed>}
 ! MAN: fir.global @_QMmEmod_ptr {data_attr = #cuf.cuda<managed>}
 
+! UNI: fir.global internal @_QMmFmod_subEsaved_arr {data_attr = #cuf.cuda<managed>}
+! UNI: fir.global internal @_QMmFmod_subEsaved_ptr {data_attr = #cuf.cuda<managed>}
+! MAN: fir.global internal @_QMmFmod_subEsaved_arr {data_attr = #cuf.cuda<managed>}
+! MAN: fir.global internal @_QMmFmod_subEsaved_ptr {data_attr = #cuf.cuda<managed>}
+
 ! Derived-type components: Unified under -gpu=unified, Managed under
 ! -gpu=managed. Checked via the symbol table.
 ! UNI-SYM: comp_arr, ALLOCATABLE {{.*}} cudaDataAttr: Unified
 ! UNI-SYM: comp_ptr, POINTER {{.*}} cudaDataAttr: Unified
 ! MAN-SYM: comp_arr, ALLOCATABLE {{.*}} cudaDataAttr: Managed
 ! MAN-SYM: comp_ptr, POINTER {{.*}} cudaDataAttr: Managed
+! UNI-SYM: saved_arr, ALLOCATABLE, SAVE {{.*}} cudaDataAttr: Managed
+! UNI-SYM: saved_ptr, POINTER, SAVE {{.*}} cudaDataAttr: Managed
+! MAN-SYM: saved_arr, ALLOCATABLE, SAVE {{.*}} cudaDataAttr: Managed
+! MAN-SYM: saved_ptr, POINTER, SAVE {{.*}} cudaDataAttr: Managed

--- a/flang/test/Lower/CUDA/cuda-implicit-managed-alloc.cuf
+++ b/flang/test/Lower/CUDA/cuda-implicit-managed-alloc.cuf
@@ -40,16 +40,16 @@ end program
 ! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMmFmod_subEloc_arr"}
 ! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEloc_ptr"}
 
-! COMMON-block pointer: unattributed, CUDA attributes may not appear in COMMON.
-! UNI: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
-! MAN: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
-
 ! Saved subprogram locals use Managed because their static descriptors cannot
 ! be registered as Unified device symbols.
 ! UNI: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMmFmod_subEsaved_arr"}
 ! UNI: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEsaved_ptr"}
 ! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMmFmod_subEsaved_arr"}
 ! MAN: hlfir.declare {{.*}} {data_attr = #cuf.cuda<managed>, fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFmod_subEsaved_ptr"}
+
+! COMMON-block pointer: unattributed, CUDA attributes may not appear in COMMON.
+! UNI: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
+! MAN: hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFcommon_subEcom_ptr"}
 
 ! Main-program local: Unified under -gpu=unified, Managed under
 ! -gpu=managed.


### PR DESCRIPTION
Example:
```fortran
subroutine work
  real, allocatable, save :: q(:)
  allocate(q(10))
end
```

`SAVE` gives the local allocatable descriptor static storage. Implicitly attributing it as Unified causes allocation to look it up as a registered CUDA global, but no device symbol is registered for the descriptor.

Fix: use Managed attribution for saved subprogram-local allocatables and pointers, avoiding the invalid CUDA symbol lookup.
