### PR TITLE
[Clang] Turn isSynthesizedAccessorStub() into checks from assertions

### DIFF
--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -4875,14 +4875,14 @@ Decl *SemaObjC::ActOnMethodDeclaration(
       if (auto *Setter = PropertyImpl->getSetterMethodDecl())
         if (Setter->getSelector() == Sel &&
             Setter->isInstanceMethod() == ObjCMethod->isInstanceMethod()) {
-          assert(Setter->isSynthesizedAccessorStub() && "autosynth stub expected");
-          PropertyImpl->setSetterMethodDecl(ObjCMethod);
+          if (Setter->isSynthesizedAccessorStub())
+            PropertyImpl->setSetterMethodDecl(ObjCMethod);
         }
       if (auto *Getter = PropertyImpl->getGetterMethodDecl())
         if (Getter->getSelector() == Sel &&
             Getter->isInstanceMethod() == ObjCMethod->isInstanceMethod()) {
-          assert(Getter->isSynthesizedAccessorStub() && "autosynth stub expected");
-          PropertyImpl->setGetterMethodDecl(ObjCMethod);
+          if (Getter->isSynthesizedAccessorStub())
+            PropertyImpl->setGetterMethodDecl(ObjCMethod);
           break;
         }
     }

--- a/clang/test/SemaObjC/property-duplicate-method-crash.m
+++ b/clang/test/SemaObjC/property-duplicate-method-crash.m
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-objc-root-class -Wno-objc-property-no-attribute %s
+
+@interface I
+@property (atomic) id atomic_prop; // expected-note {{property declared here}}
+@end
+
+@implementation I // expected-note {{implementation started here}}
+@synthesize atomic_prop, atomic_prop1; // expected-error {{property implementation must have its declaration in interface 'I' or one of its extensions}}
+
+- (id) atomic_prop { return 0; } // expected-note {{previous declaration is here}} \
+                                 // expected-warning {{writable atomic property 'atomic_prop' cannot pair a synthesized setter with a user defined getter}} \
+                                 // expected-note {{setter and getter must both be synthesized, or both be user defined, or the property must be nonatomic}}
+
+- (id) atomic_prop; // expected-error {{duplicate declaration of method 'atomic_prop'}}
+
+@end // expected-error {{expected method body}} \
+     // expected-error@17 {{missing '@end'}}


### PR DESCRIPTION
Turns out it was crashing on real code.

If the user writes two getter methods in the @implementation (which is invalid code), Clang will process the first one (replacing the stub) and then try to process the second one. On the second one, the getter is no longer a stub, breaking the invariant and causing the crash.

Resolves: https://github.com/llvm/llvm-project/issues/210129