### PR TITLE
[OpenACC] emit NYI for multi-rank or non-memref type array reduction

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -3205,8 +3205,10 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
 
   Value memref = mapping.lookupOrDefault(op.getMemref());
   MemRefType memrefTy = dyn_cast<MemRefType>(memref.getType());
-  assert(memrefTy && memrefTy.getRank() == 1 &&
-         "array reduction accumulate expects a rank-1 memref");
+  if (!memref || memrefTy.getRank() != 1) {
+    (void)accSupport.emitNYI(loc,
+                             "reduction: multi-rank MemRefTy or non-MemRefTy");
+  }
 
   FailureOr<arith::AtomicRMWKind> kindOr = getReductionKind(
       op.getReductionOperator(), memrefTy.getElementType(), loc);

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -3205,9 +3205,11 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
 
   Value memref = mapping.lookupOrDefault(op.getMemref());
   MemRefType memrefTy = dyn_cast<MemRefType>(memref.getType());
-  if (!memref || memrefTy.getRank() != 1) {
-    (void)accSupport.emitNYI(loc,
-                             "reduction: multi-rank MemRefTy or non-MemRefTy");
+  if (!memref) {
+    (void)accSupport.emitNYI(loc, "reduction: non-MemRefTy accumulate array");
+  }
+  if (memrefTy.getRank() != 1) {
+    (void)accSupport.emitNYI(loc, "reduction: multi-rank accumulate array");
   }
 
   FailureOr<arith::AtomicRMWKind> kindOr = getReductionKind(

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -3205,12 +3205,10 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
 
   Value memref = mapping.lookupOrDefault(op.getMemref());
   MemRefType memrefTy = dyn_cast<MemRefType>(memref.getType());
-  if (!memref) {
+  if (!memref)
     (void)accSupport.emitNYI(loc, "reduction: non-MemRefTy accumulate array");
-  }
-  if (memrefTy.getRank() != 1) {
+  if (memrefTy.getRank() != 1)
     (void)accSupport.emitNYI(loc, "reduction: multi-rank accumulate array");
-  }
 
   FailureOr<arith::AtomicRMWKind> kindOr = getReductionKind(
       op.getReductionOperator(), memrefTy.getElementType(), loc);


### PR DESCRIPTION
This should be an NYI and not an assertion