### PR TITLE
[CIR] Fixup conversion of const unions/structs of unions

### DIFF
--- a/clang/include/clang/CIR/LoweringHelpers.h
+++ b/clang/include/clang/CIR/LoweringHelpers.h
@@ -13,6 +13,7 @@
 #define LLVM_CLANG_CIR_LOWERINGHELPERS_H
 
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 
@@ -42,6 +43,18 @@ std::optional<mlir::Attribute>
 lowerConstRecordAttr(cir::ConstRecordAttr constRecord,
                      const mlir::TypeConverter *converter,
                      mlir::ModuleOp moduleOp = {});
+
+/// Adjust \p llvmType (the converted type of \p init) to the concrete LLVM type
+/// a global constant initialized with \p init actually lowers to. This differs
+/// from a plain type conversion for flexible-array-member and union
+/// initializers, and the adjustment recurses through nested aggregates. Returns
+/// \p llvmType unchanged when no adjustment is needed. This is the single
+/// source of truth for the shape of a lowered record constant; the
+/// value-producing paths (the insertvalue visitor and lowerConstRecordAttr)
+/// conform to it.
+mlir::Type adjustGlobalTypeForInit(mlir::Type llvmType, mlir::Attribute init,
+                                   const mlir::TypeConverter &converter,
+                                   const mlir::DataLayout &dataLayout);
 
 mlir::Value getConstAPInt(mlir::OpBuilder &bld, mlir::Location loc,
                           mlir::Type typ, const llvm::APInt &val);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -570,84 +570,11 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
   return result;
 }
 
-// Figure out if we want mark the new struct 'packed' if it isn't already. IF
-// it is already, we have to keep that behavior. We pack it with logic similar
-// to classic codegen, though will end up missing cases, since we don't want to
-// change the type other than the FAM.
-// We can do so if:
-// 1- Packing it won't change any of the field offsets.
-// 2- the non-padded struct would add padding beyond the
-// flexible array member.  We don't pack if the flexible array member manages
-// to not cause trailing padding.
-static bool shouldPackFAMStruct(const mlir::DataLayout &dataLayout,
-                                llvm::ArrayRef<mlir::Type> members) {
-  uint64_t maxAlign = 1;
-  uint64_t totalSize = 0;
-  for (mlir::Type member : members) {
-    uint64_t align = dataLayout.getTypeABIAlignment(member);
-    maxAlign = std::max(maxAlign, align);
-    uint64_t size = dataLayout.getTypeSize(member).getFixedValue();
-
-    if (llvm::alignTo(totalSize, align) != totalSize)
-      return false;
-
-    totalSize += size;
-  }
-  return llvm::alignTo(totalSize, maxAlign) != totalSize;
-}
-
-// CIR supports flexible-array-members in its struct types. That is, a
-// zero-length array as the last element, which can be initialized with an
-// arbitrary number of elements. A ConstRecordAttr can be created with one of
-// these, and our verifier allows it.  However, the LLVM implementation does NOT
-// permit this. So we have to replace this type in LLVM with special struct for
-// this value.
-// This function is used to adjust  any place we could run into a
-// ConstRecordAttr (that is, a global?) that is initialized. It'll return the
-// type value unchanged if this isn't a flexible array member case.
-static mlir::Type
-adjustGlobalTypeForFlexibleArrayInit(mlir::Type llvmType, mlir::Attribute init,
-                                     const mlir::TypeConverter &converter,
-                                     const mlir::DataLayout &dataLayout) {
-  // This only applies to ConstRecordAttr initialization.
-  auto constRecord = mlir::dyn_cast_if_present<cir::ConstRecordAttr>(init);
-  if (!constRecord)
-    return llvmType;
-
-  // If this isn't of struct-type, or doesn't have any members, there is nothing
-  // to do.
-  auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(llvmType);
-  if (!structTy || structTy.getBody().empty())
-    return llvmType;
-
-  // If this isn't a zero-sized array, it isn't a flexible array member.
-  auto fam = dyn_cast<mlir::LLVM::LLVMArrayType>(structTy.getBody().back());
-  if (!fam || fam.getNumElements() != 0)
-    return llvmType;
-
-  llvm::ArrayRef<mlir::Attribute> initMembers =
-      constRecord.getMembers().getValue();
-  mlir::Type lastInitType = cast<mlir::TypedAttr>(initMembers.back()).getType();
-
-  // Don't touch it if we don't need to do non-zero elements.
-  if (cast<cir::ArrayType>(lastInitType).getSize() == 0)
-    return llvmType;
-
-  llvm::SmallVector<mlir::Type> newBody{structTy.getBody()};
-  newBody[newBody.size() - 1] = converter.convertType(lastInitType);
-
-  bool packed = structTy.isPacked() || shouldPackFAMStruct(dataLayout, newBody);
-
-  return mlir::LLVM::LLVMStructType::getLiteral(structTy.getContext(), newBody,
-                                                packed);
-}
-
 /// ConstRecord visitor.
 mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstRecordAttr constRecord) {
   mlir::Type llvmTy = converter->convertType(constRecord.getType());
   mlir::DataLayout dataLayout(parentOp->getParentOfType<mlir::ModuleOp>());
-  llvmTy = adjustGlobalTypeForFlexibleArrayInit(llvmTy, constRecord, *converter,
-                                                dataLayout);
+  llvmTy = adjustGlobalTypeForInit(llvmTy, constRecord, *converter, dataLayout);
   const mlir::Location loc = parentOp->getLoc();
   mlir::Value result = mlir::LLVM::UndefOp::create(rewriter, loc, llvmTy);
 
@@ -2538,8 +2465,8 @@ void CIRToLLVMGlobalOpLowering::setupRegionInitializedLLVMGlobalOp(
   // Keep the global's type in sync with the value built by CIRAttrToValue: a
   // flexible array member initializer requires an oversized anonymous struct.
   if (std::optional<mlir::Attribute> init = op.getInitialValue())
-    llvmType = adjustGlobalTypeForFlexibleArrayInit(
-        llvmType, *init, *getTypeConverter(), dataLayout);
+    llvmType = adjustGlobalTypeForInit(llvmType, *init, *getTypeConverter(),
+                                       dataLayout);
 
   // FIXME: These default values are placeholders until the the equivalent
   //        attributes are available on cir.global ops. This duplicates code
@@ -2615,8 +2542,8 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
   // record's declared type, so the global must use an oversized anonymous
   // struct instead.
   if (init.has_value())
-    llvmType = adjustGlobalTypeForFlexibleArrayInit(
-        llvmType, *init, *getTypeConverter(), dataLayout);
+    llvmType = adjustGlobalTypeForInit(llvmType, *init, *getTypeConverter(),
+                                       dataLayout);
 
   // FIXME: These default values are placeholders until the the equivalent
   //        attributes are available on cir.global ops.

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -13,7 +13,9 @@
 #include "clang/CIR/LoweringHelpers.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 
 static unsigned getIntOrBoolBitWidth(mlir::Type ty) {
   if (auto intTy = mlir::dyn_cast<cir::IntType>(ty))
@@ -314,6 +316,165 @@ lowerConstRecordMemberAttr(mlir::Attribute attr,
   return lowerPointerElementAttr(attr, ctx, moduleOp, converter);
 }
 
+// Figure out if we want mark the new struct 'packed' if it isn't already. IF
+// it is already, we have to keep that behavior. We pack it with logic similar
+// to classic codegen, though will end up missing cases, since we don't want to
+// change the type other than the FAM.
+// We can do so if:
+// 1- Packing it won't change any of the field offsets.
+// 2- the non-padded struct would add padding beyond the
+// flexible array member.  We don't pack if the flexible array member manages
+// to not cause trailing padding.
+static bool shouldPackFAMStruct(const mlir::DataLayout &dataLayout,
+                                llvm::ArrayRef<mlir::Type> members) {
+  uint64_t maxAlign = 1;
+  uint64_t totalSize = 0;
+  for (mlir::Type member : members) {
+    uint64_t align = dataLayout.getTypeABIAlignment(member);
+    maxAlign = std::max(maxAlign, align);
+    uint64_t size = dataLayout.getTypeSize(member).getFixedValue();
+
+    if (llvm::alignTo(totalSize, align) != totalSize)
+      return false;
+
+    totalSize += size;
+  }
+  return llvm::alignTo(totalSize, maxAlign) != totalSize;
+}
+
+// CIR supports flexible-array-members in its struct types. That is, a
+// zero-length array as the last element, which can be initialized with an
+// arbitrary number of elements. A ConstRecordAttr can be created with one of
+// these, and our verifier allows it.  However, the LLVM implementation does NOT
+// permit this. So we have to replace this type in LLVM with special struct for
+// this value.
+//
+// Additionally, the struct itself could contain a struct with a FAM or a union
+// that needed adjustment, so it recurses to check those.  If no such type has
+// been found/no adjustment needed, this returns the type unchanged.
+static mlir::Type adjustGlobalStructTypeForInit(
+    mlir::LLVM::LLVMStructType structTy, cir::ConstRecordAttr constRecord,
+    const mlir::TypeConverter &converter, const mlir::DataLayout &dataLayout) {
+
+  llvm::ArrayRef<mlir::Attribute> initMembers =
+      constRecord.getMembers().getValue();
+  llvm::SmallVector<mlir::Type> newBody{structTy.getBody()};
+  bool changed = false;
+
+  // Recursively adjust each member. A member that is itself a union (or a
+  // struct containing one) lowers to a type that differs from its declared
+  // field type, and this struct has to adopt that adjusted type so the
+  // enclosing insertvalue chain type-checks.
+  for (auto [idx, member] : llvm::enumerate(initMembers)) {
+    if (idx >= newBody.size())
+      break;
+    mlir::Type adjusted =
+        adjustGlobalTypeForInit(newBody[idx], member, converter, dataLayout);
+    if (adjusted != newBody[idx]) {
+      newBody[idx] = adjusted;
+      changed = true;
+    }
+  }
+
+  // CIR supports flexible-array-members in its struct types. That is, a
+  // zero-length array as the last element, which can be initialized with an
+  // arbitrary number of elements. A ConstRecordAttr can be created with one of
+  // these, and our verifier allows it. However, the LLVM implementation does
+  // NOT permit this, so we widen that trailing member to the initializer's
+  // array type (packing the struct if that changes the layout).
+  bool packed = structTy.isPacked();
+  if (auto fam =
+          mlir::dyn_cast<mlir::LLVM::LLVMArrayType>(structTy.getBody().back());
+      fam && fam.getNumElements() == 0) {
+    mlir::Type lastInitType =
+        mlir::cast<mlir::TypedAttr>(initMembers.back()).getType();
+    if (mlir::cast<cir::ArrayType>(lastInitType).getSize() != 0) {
+      newBody.back() = converter.convertType(lastInitType);
+      packed = packed || shouldPackFAMStruct(dataLayout, newBody);
+      changed = true;
+    }
+  }
+
+  if (!changed)
+    return structTy;
+
+  return mlir::LLVM::LLVMStructType::getLiteral(structTy.getContext(), newBody,
+                                                packed);
+}
+
+// A union constant only initializes its active member, but a union is lowered
+// to its most-aligned member (its 'storage' type), which need not be the
+// initialized one -- e.g. `union { char buf[16]; long cap; }` stores as `long`
+// (higher alignment) but may be initialized through `buf`. So the storage type
+// (and thus structTy) generally can't hold the active member's value. Rebuild
+// an anonymous struct `{ <active member>, [pad x i8] }` that holds the active
+// member followed by enough byte padding to span the union's full allocated
+// size, mirroring classic codegen.
+static mlir::Type adjustGlobalUnionTypeForInit(
+    mlir::LLVM::LLVMStructType structTy, cir::ConstRecordAttr constRecord,
+    const mlir::TypeConverter &converter, const mlir::DataLayout &dataLayout) {
+
+  auto unionTy = mlir::cast<cir::UnionType>(constRecord.getType());
+
+  // Unions can only initialize one field, so this has to be sizeof-one.
+  assert(constRecord.getMembers().size() == 1);
+  mlir::Attribute member = constRecord.getMembers()[0];
+  mlir::Type memberTy =
+      converter.convertType(mlir::cast<mlir::TypedAttr>(member).getType());
+
+  // The active member may itself need adjusting (e.g. it is a nested union, or
+  // a struct containing one), so recurse before using its type below.
+  memberTy = adjustGlobalTypeForInit(memberTy, member, converter, dataLayout);
+
+  // The converted union type is { storage, [padding] }, where storage is the
+  // union's most-aligned member. When the active member IS that storage type,
+  // the converted type already describes this initializer exactly (the pad we
+  // would compute equals the union's declared pad), so there is nothing to do.
+  if (memberTy == structTy.getBody().front())
+    return structTy;
+
+  uint64_t unionSize = dataLayout.getTypeSize(unionTy).getFixedValue();
+  uint64_t initSize = dataLayout.getTypeSize(memberTy).getFixedValue();
+  assert(initSize <= unionSize && "union initializer larger than the union");
+
+  llvm::SmallVector<mlir::Type> newBody;
+  newBody.push_back(memberTy);
+
+  // Fill the rest of the union's allocated size with byte padding.
+  if (initSize < unionSize)
+    newBody.push_back(mlir::LLVM::LLVMArrayType::get(
+        mlir::IntegerType::get(structTy.getContext(), 8),
+        unionSize - initSize));
+
+  return mlir::LLVM::LLVMStructType::getLiteral(structTy.getContext(), newBody,
+                                                unionTy.getPacked());
+}
+
+// Apply various adjustments required for struct/union types.
+mlir::Type adjustGlobalTypeForInit(mlir::Type llvmType, mlir::Attribute init,
+                                   const mlir::TypeConverter &converter,
+                                   const mlir::DataLayout &dataLayout) {
+  // Conversions for both only happen if we have a record init.
+  auto constRecord = mlir::dyn_cast_if_present<cir::ConstRecordAttr>(init);
+  if (!constRecord)
+    return llvmType;
+
+  // If this isn't of struct-type, or doesn't have any members, there is nothing
+  // to do.
+  auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(llvmType);
+  if (!structTy || structTy.getBody().empty())
+    return llvmType;
+
+  // Structs can have a flexible array member, adjust that.
+  if (mlir::isa<cir::StructType>(constRecord.getType()))
+    return adjustGlobalStructTypeForInit(structTy, constRecord, converter,
+                                         dataLayout);
+  if (mlir::isa<cir::UnionType>(constRecord.getType()))
+    return adjustGlobalUnionTypeForInit(structTy, constRecord, converter,
+                                        dataLayout);
+  return llvmType;
+}
+
 std::optional<mlir::Attribute>
 lowerConstRecordAttr(cir::ConstRecordAttr constRecord,
                      const mlir::TypeConverter *converter,
@@ -333,15 +494,19 @@ lowerConstRecordAttr(cir::ConstRecordAttr constRecord,
     loweredMembers.push_back(*lowered);
   }
 
-  // For a union, the CIR representation is a single field. However, if the
-  // union has padding, we would have added that as an LLVM field, so make sure
-  // we have a corresponding undef for that spot.
-  if (auto unionTy = mlir::dyn_cast<cir::UnionType>(constRecord.getType());
-      unionTy && unionTy.getPadded()) {
-    assert(loweredMembers.size() == 1);
-    loweredMembers.push_back(
-        mlir::LLVM::UndefAttr::get(constRecord.getContext()));
-  }
+  // The lowered LLVM type may have more fields than the CIR record has members
+  // -- e.g. a union lowers to { active-member, [pad x i8] } (see
+  // adjustGlobalTypeForInit, the single source of truth for the shape). Fill
+  // any such synthesized (padding) fields with undef so this ArrayAttr has
+  // exactly one entry per LLVM field, matching the type the global is declared
+  // with.
+  mlir::Type adjustedTy = adjustGlobalTypeForInit(
+      converter->convertType(constRecord.getType()), constRecord, *converter,
+      mlir::DataLayout(moduleOp));
+  if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(adjustedTy))
+    while (loweredMembers.size() < structTy.getBody().size())
+      loweredMembers.push_back(
+          mlir::LLVM::UndefAttr::get(constRecord.getContext()));
 
   return mlir::ArrayAttr::get(constRecord.getContext(), loweredMembers);
 }

--- a/clang/test/CIR/CodeGen/anonymous-nested-init.c
+++ b/clang/test/CIR/CodeGen/anonymous-nested-init.c
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
-// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM,LLVMCIR
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM,OGCG
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 // Anonymous struct as a field.
 struct StructWithAnon {
@@ -22,8 +22,7 @@ struct StructWithAnonUnion g_anon_union = { {.f = 1.5f}, 42 };
 
 // CIR: cir.global external @g_anon_union = #cir.const_record<{#cir.const_record<{#cir.fp<1.500000e+00> : !cir.float}> : !rec_anon2E1, #cir.int<42> : !s32i}> : !rec_StructWithAnonUnion
 // Union lowering chooses to lower this as an int instead of a float since the storage type is 'int', but active type is 'float'.
-// LLVMCIR: @g_anon_union = global %struct.StructWithAnonUnion { %union{{.*}} { i32 1069547520 }, i32 42 }
-// OGCG:    @g_anon_union = global { { float }, i32 } { { float } { float 1.500000e+00 }, i32 42 }
+// LLVM:    @g_anon_union = global { { float }, i32 } { { float } { float 1.500000e+00 }, i32 42 }
 
 struct StructWithAnonBitfields {
   int leading;

--- a/clang/test/CIR/CodeGen/record-with-padded-union.cpp
+++ b/clang/test/CIR/CodeGen/record-with-padded-union.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
-// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: FileCheck --check-prefix=LLVM,LLVMCIR --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM,OGCG --input-file=%t.ll %s
 
 struct SSO {
   char *p;
@@ -21,6 +21,25 @@ struct SSO {
 // LLVM: %struct.SSO = type { ptr, i64, %union.anon{{.*}} }
 // LLVM: %union.anon{{.*}} = type { i64, [8 x i8] }
 
+SSO s1 {nullptr, 1, {.local{}}};
+// CIR: cir.global external @s1 = #cir.const_record<{#cir.ptr<null> : !cir.ptr<!s8i>, #cir.int<1> : !u64i, #cir.const_record<{#cir.zero : !cir.array<!s8i x 16>}> : !rec_anon2E0}> : !rec_SSO
+// LLVM: @s1 = global { ptr, i64, { [16 x i8] } } { ptr null, i64 1, { [16 x i8] } zeroinitializer }
+SSO s2 {nullptr, 1, {'a', 'b', 'c', 'd'}};
+// CIR: cir.global external @s2 = #cir.const_record<{#cir.ptr<null> : !cir.ptr<!s8i>, #cir.int<1> : !u64i, #cir.const_record<{#cir.const_array<[#cir.int<97> : !s8i, #cir.int<98> : !s8i, #cir.int<99> : !s8i, #cir.int<100> : !s8i], trailing_zeros> : !cir.array<!s8i x 16>}> : !rec_anon2E0}> : !rec_SSO
+// LLVMCIR: @s2 = global { ptr, i64, { [16 x i8] } } { ptr null, i64 1, { [16 x i8] } { [16 x i8] c"abcd\00\00\00\00\00\00\00\00\00\00\00\00" } }
+// OGCG:    @s2 = global { ptr, i64, { <{ i8, i8, i8, i8, [12 x i8] }> } } { ptr null, i64 1, { <{ i8, i8, i8, i8, [12 x i8] }> } { <{ i8, i8, i8, i8, [12 x i8] }> <{ i8 97, i8 98, i8 99, i8 100, [12 x i8] zeroinitializer }> } }
+
+struct SSO2 {
+  char *p;
+  union {
+    char buf[16];
+    long cap;
+  };
+  constexpr SSO2() : p(buf), buf{} {}
+} str;
+// CIR: cir.global external @str = #cir.const_record<{#cir.global_view<@str, [1 : i32]> : !cir.ptr<!s8i>, #cir.const_record<{#cir.zero : !cir.array<!s8i x 16>}> : !rec_anon2E1}> : !rec_SSO2
+// LLVM: @str = global { ptr, { [16 x i8] } } { ptr getelementptr {{.*}}(i8, ptr @str, i64 8), { [16 x i8] } zeroinitializer }
+
 extern "C" SSO *last_of_three() {
   SSO *p = new SSO[3];
   return &p[2];
@@ -30,3 +49,5 @@ extern "C" SSO *last_of_three() {
 // LLVM-LABEL: define {{.*}}@last_of_three
 // LLVM: call {{.*}}@_Znam(i64 noundef 96)
 // LLVM: getelementptr{{.*}}%struct.SSO, ptr %{{.+}}, i64 2
+
+


### PR DESCRIPTION
Now that we represent a union as all of the fields, it is possible for the non-storage type to be initialized, so the fact that we were lowering the types as storage in 1 way for the constant type, but filling it with our actual value was wrong.

This patch makes sure we create a literal struct type for LLVM for union types where they don't match, which generally matches the OGCG implementation/output.

I've also generalized the work for the FAM to do this conversion, and moved it to LoweringHelpers, so that our ConstantRecord lowering can use it too.

This patch fixes up a couple uses of std::string initializers where they fit in the SSO.

Note: I was assisted in this by Claude Opus. I did plenty of self-review on this as it was being generated, and a post-review, but hopefully I didn't miss anything.