### PR TITLE
[CIR] Fix use-after-free in conditional-operator codegen

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2929,9 +2929,19 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
       yieldTy = branch.getType();
       cir::YieldOp::create(b, loc, branch);
     } else {
-      // If LHS or RHS is a throw or void expression we need to patch
-      // arms as to properly match yield types.
-      insertPoints.push_back(b.saveInsertionPoint());
+      // The branch produced no value. This happens both for void expressions
+      // (which fall through and still need a yield) and for expressions that
+      // don't fall through, such as a throw or a call to a [[noreturn]]
+      // function. A diverging arm leaves the insertion point in an empty,
+      // unreachable block that the enclosing lexical scope will erase as dead
+      // code; such an arm is already terminated and needs no yield. Recording
+      // its insertion point would leave a dangling reference to the erased
+      // block, which the patch-up loop below would later dereference. So only
+      // defer a yield for arms that actually fall through, mirroring the
+      // dead-block condition in LexicalScope::cleanup().
+      mlir::Block *curBlock = b.getInsertionBlock();
+      if (curBlock && (curBlock->isEntryBlock() || !curBlock->empty()))
+        insertPoints.push_back(b.saveInsertionPoint());
     }
   };
 


### PR DESCRIPTION
`ScalarExprEmitter::VisitAbstractConditionalOperator` lowers `cond ? a : b` to `cir.ternary`, emitting each arm inside a per-arm `LexicalScope`. When an arm produced no value it unconditionally saved that arm's insertion point to patch in a cir.yield afterwards. But a diverging arm (a `throw`, or a call to a `[[noreturn]]` function) is emitted as cir.throw + cir.unreachable followed by a fresh empty trailing block; `LexicalScope::cleanup()` then erases that empty, unreachable, non-entry block as dead code. The deferred patch-up loop later restored the saved insertion point onto the now-freed block and called `cir::YieldOp::create` on it, a use-after-free.

Only defer a yield for arms that actually fall through, mirroring the dead-block condition in LexicalScope::cleanup() (entry block, or non-empty block). Diverging arms are already terminated by cir.unreachable and need no yield.

The use-after-free was latent and usually benign until upstream commit 697bd9704894 ("Give each mlir::Block a stable ID within its parent region", #207617, 2026-07-08), which made MLIR block insertion dereference the parent region (region->nextBlockID++). That dereference happens during YieldOp::create on the freed block, turning the latent UAF into a reliable SIGSEGV. The pattern is pervasive in libc++ (discarded/void ternaries whose arm throws or calls __libcpp_verbose_abort via hardening asserts), which regressed the upstream libcxx CIR pass rate from ~79.5% to ~49.5% in prep for July progress report.