### PR TITLE
[libc] Implement alloca.h header

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -1,4 +1,5 @@
 set(TARGET_PUBLIC_HEADERS
+    libc.include.alloca
     libc.include.arpa_inet
     libc.include.assert
     libc.include.byteswap

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -1,4 +1,5 @@
 set(TARGET_PUBLIC_HEADERS
+    libc.include.alloca
     libc.include.complex
     libc.include.cpio
     libc.include.ctype

--- a/libc/config/linux/i386/headers.txt
+++ b/libc/config/linux/i386/headers.txt
@@ -1,4 +1,5 @@
 set(TARGET_PUBLIC_HEADERS
+  libc.include.alloca
   libc.include.assert
   libc.include.cpio
 )

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -1,4 +1,5 @@
 set(TARGET_PUBLIC_HEADERS
+    libc.include.alloca
     libc.include.arpa_inet
     libc.include.assert
     libc.include.byteswap

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -1,4 +1,5 @@
 set(TARGET_PUBLIC_HEADERS
+    libc.include.alloca
     libc.include.arpa_inet
     libc.include.assert
     libc.include.byteswap

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -212,6 +212,16 @@ add_header_macro(
 )
 
 add_header_macro(
+  alloca
+  ../libc/include/alloca.yaml
+  alloca.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.alloca_macros
+    .llvm-libc-types.size_t
+)
+
+add_header_macro(
   assert
   ../libc/include/assert.yaml
   assert.h

--- a/libc/include/alloca.yaml
+++ b/libc/include/alloca.yaml
@@ -1,0 +1,11 @@
+header: alloca.h
+standards:
+  - gnu
+macros:
+  - macro_name: alloca
+    macro_header: alloca-macros.h
+types:
+  - type_name: size_t
+enums: []
+objects: []
+functions: []

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -459,3 +459,9 @@ else()
       _LIBC_MODULAR_FORMAT_PRINTF.h
   )
 endif()
+
+add_macro_header(
+  alloca_macros
+  HDR
+    alloca-macros.h
+)

--- a/libc/include/llvm-libc-macros/alloca-macros.h
+++ b/libc/include/llvm-libc-macros/alloca-macros.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines the alloca macro.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_ALLOCA_MACROS_H
+#define LLVM_LIBC_MACROS_ALLOCA_MACROS_H
+
+#define alloca(size) __builtin_alloca(size)
+
+#endif // LLVM_LIBC_MACROS_ALLOCA_MACROS_H

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -2,6 +2,16 @@ add_custom_target(libc_include_tests)
 add_dependencies(check-libc libc_include_tests-build)
 
 add_libc_test(
+  alloca_test
+  SUITE
+    libc_include_tests
+  SRCS
+    alloca_test.cpp
+  DEPENDS
+    libc.include.llvm-libc-macros.alloca_macros
+)
+
+add_libc_test(
   assert_test
   SUITE
     libc_include_tests

--- a/libc/test/include/alloca_test.cpp
+++ b/libc/test/include/alloca_test.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for alloca.
+///
+//===----------------------------------------------------------------------===//
+
+#include "test/UnitTest/Test.h"
+
+#include "include/llvm-libc-macros/alloca-macros.h"
+
+TEST(LlvmLibcAllocaTest, Basic) {
+  // Ensure the macro is defined.
+#ifndef alloca
+  FAIL() << "alloca macro is not defined";
+#endif
+
+  // Allocate some memory on the stack.
+  void *ptr = alloca(10);
+  ASSERT_NE(ptr, static_cast<void *>(nullptr));
+
+  // Write to it to make sure it's valid memory.
+  char *char_ptr = static_cast<char *>(ptr);
+  for (int i = 0; i < 10; ++i) {
+    char_ptr[i] = static_cast<char>(i);
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(char_ptr[i], static_cast<char>(i));
+  }
+}


### PR DESCRIPTION
Implemented the alloca.h header for LLVM libc.

* libc/include/llvm-libc-macros/alloca-macros.h: Defined alloca macro using __builtin_alloca.
* libc/include/alloca.yaml: Added header specification.
* libc/include/CMakeLists.txt, libc/include/llvm-libc-macros/CMakeLists.txt: Registered the new header and macro targets.
* libc/config/linux/*/headers.txt: Enabled the header for Linux targets (x86_64, aarch64, arm, i386, riscv).
* libc/test/include/alloca_test.cpp, libc/test/include/CMakeLists.txt: Added and registered functional unit tests.

Tested by running the new unit and hermetic tests.

Assisted-by: Automated tooling, human reviewed.