### PR TITLE
[SLP]Drop nsw when shl by BW-1 is converted to mul

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -23519,6 +23519,18 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
           });
         }))
       I->setHasNoSignedWrap(/*b=*/false);
+    // shl nsw X, BW-1 is not equivalent to mul nsw X, INT_MIN: shl nsw never
+    // poisons at X = -1 (shifted-out bits match the sign bit), but mul nsw
+    // does. A shl lane converted to mul this way must drop nsw.
+    if (!MinBWs.contains(E) && Opcode == Instruction::Mul &&
+        any_of(UniqueInsts, [&](Value *V) {
+          auto *SI = cast<Instruction>(V);
+          if (SI->getOpcode() != Instruction::Shl)
+            return false;
+          const auto *CI = dyn_cast<ConstantInt>(SI->getOperand(1));
+          return CI && CI->getValue() == CI->getBitWidth() - 1;
+        }))
+      I->setHasNoSignedWrap(/*b=*/false);
     if (auto *ICmp = dyn_cast<ICmpInst>(I); ICmp && It == MinBWs.end())
       ICmp->setSameSign(/*B=*/false);
     return I;

--- a/llvm/test/Transforms/SLPVectorizer/X86/mul-shl-nsw-intmin.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/mul-shl-nsw-intmin.ll
@@ -61,7 +61,7 @@ define void @shl_bw1_converted_to_mul(ptr %p, i32 %x, i32 %y) {
 ; CHECK-LABEL: @shl_bw1_converted_to_mul(
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i32> poison, i32 [[X:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x i32> [[TMP1]], i32 [[Y:%.*]], i64 1
-; CHECK-NEXT:    [[TMP3:%.*]] = mul nsw <2 x i32> [[TMP2]], <i32 3, i32 -2147483648>
+; CHECK-NEXT:    [[TMP3:%.*]] = mul <2 x i32> [[TMP2]], <i32 3, i32 -2147483648>
 ; CHECK-NEXT:    store <2 x i32> [[TMP3]], ptr [[P:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
shl nsw X, BW-1 is valid at X = -1, but mul X, INT_MIN is not nsw-safe
there. Drop nsw on the vector mul when a shl lane with shift amount
BW-1 is unified into mul during opcode interchange.

Fixes #210093
