### PR TITLE
release-23.x: [Sema][Serialization] Emit unused local typedefs in a deterministic order

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -951,6 +951,9 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Fixed a assertion when `__block` is used on global variables in C mode. (#GH183974)
 - Added missing AST nodes representing the `decltype` specifiers in destructor call to AST.
 - Fixed a missing ODR violation diagnostic introduced by the inline assembly string or clobber list. (#GH198616)
+- Fixed a non-deterministic ordering of unused local typedefs that made
+  serialized PCH/AST files and `-Wunused-local-typedef` diagnostics
+  non-reproducible across runs. (#GH209639)
 
 #### Miscellaneous Bug Fixes
 

--- a/clang/include/clang/Sema/ExternalSemaSource.h
+++ b/clang/include/clang/Sema/ExternalSemaSource.h
@@ -141,7 +141,7 @@ public:
   /// be invoked multiple times; the external source should take care not to
   /// introduce the same declarations repeatedly.
   virtual void ReadUnusedLocalTypedefNameCandidates(
-      llvm::SmallSetVector<const TypedefNameDecl *, 4> &Decls) {}
+      llvm::SmallPtrSetImpl<const TypedefNameDecl *> &Decls) {}
 
   /// Read the set of referenced selectors known to the
   /// external Sema source.

--- a/clang/include/clang/Sema/MultiplexExternalSemaSource.h
+++ b/clang/include/clang/Sema/MultiplexExternalSemaSource.h
@@ -301,7 +301,7 @@ public:
   /// be invoked multiple times; the external source should take care not to
   /// introduce the same declarations repeatedly.
   void ReadUnusedLocalTypedefNameCandidates(
-      llvm::SmallSetVector<const TypedefNameDecl *, 4> &Decls) override;
+      llvm::SmallPtrSetImpl<const TypedefNameDecl *> &Decls) override;
 
   /// Read the set of referenced selectors known to the
   /// external Sema source.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3609,8 +3609,13 @@ public:
       ExtnameUndeclaredIdentifiers;
 
   /// Set containing all typedefs that are likely unused.
-  llvm::SmallSetVector<const TypedefNameDecl *, 4>
+  llvm::SmallPtrSet<const TypedefNameDecl *, 4>
       UnusedLocalTypedefNameCandidates;
+
+  /// Store UnusedLocalTypedefNameCandidates in \p Sorted in a deterministic
+  /// order.
+  void getSortedUnusedLocalTypedefNameCandidates(
+      SmallVectorImpl<const TypedefNameDecl *> &Sorted) const;
 
   typedef LazyVector<const DeclaratorDecl *, ExternalSemaSource,
                      &ExternalSemaSource::ReadUnusedFileScopedDecls, 2, 2>

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -2317,7 +2317,7 @@ public:
   void ReadExtVectorDecls(SmallVectorImpl<TypedefNameDecl *> &Decls) override;
 
   void ReadUnusedLocalTypedefNameCandidates(
-      llvm::SmallSetVector<const TypedefNameDecl *, 4> &Decls) override;
+      llvm::SmallPtrSetImpl<const TypedefNameDecl *> &Decls) override;
 
   void ReadDeclsToCheckForDeferredDiags(
       llvm::SmallSetVector<Decl *, 4> &Decls) override;

--- a/clang/lib/Sema/MultiplexExternalSemaSource.cpp
+++ b/clang/lib/Sema/MultiplexExternalSemaSource.cpp
@@ -303,7 +303,7 @@ void MultiplexExternalSemaSource::ReadDeclsToCheckForDeferredDiags(
 }
 
 void MultiplexExternalSemaSource::ReadUnusedLocalTypedefNameCandidates(
-    llvm::SmallSetVector<const TypedefNameDecl *, 4> &Decls) {
+    llvm::SmallPtrSetImpl<const TypedefNameDecl *> &Decls) {
   for(size_t i = 0; i < Sources.size(); ++i)
     Sources[i]->ReadUnusedLocalTypedefNameCandidates(Decls);
 }

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1192,11 +1192,26 @@ static bool IsRecordFullyDefined(const CXXRecordDecl *RD,
   return Complete;
 }
 
+void Sema::getSortedUnusedLocalTypedefNameCandidates(
+    SmallVectorImpl<const TypedefNameDecl *> &Sorted) const {
+  // The candidates are collected while iterating a Scope's SmallPtrSet, so sort
+  // by source location for a deterministic order.
+  Sorted.assign(UnusedLocalTypedefNameCandidates.begin(),
+                UnusedLocalTypedefNameCandidates.end());
+  llvm::sort(Sorted,
+             [](const TypedefNameDecl *LHS, const TypedefNameDecl *RHS) {
+               return LHS->getLocation().getRawEncoding() <
+                      RHS->getLocation().getRawEncoding();
+             });
+}
+
 void Sema::emitAndClearUnusedLocalTypedefWarnings() {
   if (ExternalSource)
     ExternalSource->ReadUnusedLocalTypedefNameCandidates(
         UnusedLocalTypedefNameCandidates);
-  for (const TypedefNameDecl *TD : UnusedLocalTypedefNameCandidates) {
+  SmallVector<const TypedefNameDecl *, 4> Sorted;
+  getSortedUnusedLocalTypedefNameCandidates(Sorted);
+  for (const TypedefNameDecl *TD : Sorted) {
     if (TD->isReferenced())
       continue;
     Diag(TD->getLocation(), diag::warn_unused_local_typedef)

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -9721,7 +9721,7 @@ void ASTReader::ReadExtVectorDecls(SmallVectorImpl<TypedefNameDecl *> &Decls) {
 }
 
 void ASTReader::ReadUnusedLocalTypedefNameCandidates(
-    llvm::SmallSetVector<const TypedefNameDecl *, 4> &Decls) {
+    llvm::SmallPtrSetImpl<const TypedefNameDecl *> &Decls) {
   for (unsigned I = 0, N = UnusedLocalTypedefNameCandidates.size(); I != N;
        ++I) {
     TypedefNameDecl *D = dyn_cast_or_null<TypedefNameDecl>(

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -5796,8 +5796,11 @@ void ASTWriter::PrepareWritingSpecialDecls(Sema &SemaRef) {
     for (unsigned I = 0, N = SemaRef.VTableUses.size(); I != N; ++I)
       GetDeclRef(SemaRef.VTableUses[I].first);
 
-  // Writing all of the UnusedLocalTypedefNameCandidates.
-  for (const TypedefNameDecl *TD : SemaRef.UnusedLocalTypedefNameCandidates)
+  // Writing all of the UnusedLocalTypedefNameCandidates in a deterministic
+  // order.
+  SmallVector<const TypedefNameDecl *, 4> UnusedLocalTypedefs;
+  SemaRef.getSortedUnusedLocalTypedefNameCandidates(UnusedLocalTypedefs);
+  for (const TypedefNameDecl *TD : UnusedLocalTypedefs)
     GetDeclRef(TD);
 
   // Writing all of pending implicit instantiations.
@@ -5924,9 +5927,12 @@ void ASTWriter::WriteSpecialDeclRecords(Sema &SemaRef) {
     Stream.EmitRecord(VTABLE_USES, VTableUses);
   }
 
-  // Write the record containing potentially unused local typedefs.
+  // Write the record containing potentially unused local typedefs, in a
+  // deterministic order.
   RecordData UnusedLocalTypedefNameCandidates;
-  for (const TypedefNameDecl *TD : SemaRef.UnusedLocalTypedefNameCandidates)
+  SmallVector<const TypedefNameDecl *, 4> SortedCandidates;
+  SemaRef.getSortedUnusedLocalTypedefNameCandidates(SortedCandidates);
+  for (const TypedefNameDecl *TD : SortedCandidates)
     AddEmittedDeclRef(TD, UnusedLocalTypedefNameCandidates);
   if (!UnusedLocalTypedefNameCandidates.empty())
     Stream.EmitRecord(UNUSED_LOCAL_TYPEDEF_NAME_CANDIDATES,

--- a/clang/test/PCH/unused-local-typedef-determinism.cpp
+++ b/clang/test/PCH/unused-local-typedef-determinism.cpp
@@ -1,0 +1,115 @@
+// Check that emitting a PCH is deterministic even when a scope contains many
+// unused local typedefs. These are collected into
+// Sema::UnusedLocalTypedefNameCandidates while iterating a Scope's SmallPtrSet
+// (a pointer-order, run-to-run unstable container) and are then serialized into
+// the AST file, so without a stable order the two PCHs below would differ.
+//
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %clang_cc1 -x c++-header %s -emit-pch -o %t/a.pch
+// RUN: %clang_cc1 -x c++-header %s -emit-pch -o %t/b.pch
+// RUN: cmp %t/a.pch %t/b.pch
+
+inline void f() {
+  // Enough typedefs to exceed the small storage of Scope::DeclSetTy.
+  typedef int t000;
+  typedef int t001;
+  typedef int t002;
+  typedef int t003;
+  typedef int t004;
+  typedef int t005;
+  typedef int t006;
+  typedef int t007;
+  typedef int t008;
+  typedef int t009;
+  typedef int t010;
+  typedef int t011;
+  typedef int t012;
+  typedef int t013;
+  typedef int t014;
+  typedef int t015;
+  typedef int t016;
+  typedef int t017;
+  typedef int t018;
+  typedef int t019;
+  typedef int t020;
+  typedef int t021;
+  typedef int t022;
+  typedef int t023;
+  typedef int t024;
+  typedef int t025;
+  typedef int t026;
+  typedef int t027;
+  typedef int t028;
+  typedef int t029;
+  typedef int t030;
+  typedef int t031;
+  typedef int t032;
+  typedef int t033;
+  typedef int t034;
+  typedef int t035;
+  typedef int t036;
+  typedef int t037;
+  typedef int t038;
+  typedef int t039;
+  typedef int t040;
+  typedef int t041;
+  typedef int t042;
+  typedef int t043;
+  typedef int t044;
+  typedef int t045;
+  typedef int t046;
+  typedef int t047;
+  typedef int t048;
+  typedef int t049;
+  typedef int t050;
+  typedef int t051;
+  typedef int t052;
+  typedef int t053;
+  typedef int t054;
+  typedef int t055;
+  typedef int t056;
+  typedef int t057;
+  typedef int t058;
+  typedef int t059;
+  typedef int t060;
+  typedef int t061;
+  typedef int t062;
+  typedef int t063;
+  typedef int t064;
+  typedef int t065;
+  typedef int t066;
+  typedef int t067;
+  typedef int t068;
+  typedef int t069;
+  typedef int t070;
+  typedef int t071;
+  typedef int t072;
+  typedef int t073;
+  typedef int t074;
+  typedef int t075;
+  typedef int t076;
+  typedef int t077;
+  typedef int t078;
+  typedef int t079;
+  typedef int t080;
+  typedef int t081;
+  typedef int t082;
+  typedef int t083;
+  typedef int t084;
+  typedef int t085;
+  typedef int t086;
+  typedef int t087;
+  typedef int t088;
+  typedef int t089;
+  typedef int t090;
+  typedef int t091;
+  typedef int t092;
+  typedef int t093;
+  typedef int t094;
+  typedef int t095;
+  typedef int t096;
+  typedef int t097;
+  typedef int t098;
+  typedef int t099;
+}

--- a/clang/test/SemaCXX/warn-unused-local-typedef-deterministic-order.cpp
+++ b/clang/test/SemaCXX/warn-unused-local-typedef-deterministic-order.cpp
@@ -1,0 +1,212 @@
+// Verify that -Wunused-local-typedef diagnostics are emitted in a deterministic
+// (source) order even when a scope contains many unused local typedefs. The
+// candidates are collected while iterating a Scope's DeclsInScope, which is a
+// SmallPtrSet, so without sorting the order would depend on pointer values and
+// vary across runs.
+//
+// RUN: %clang_cc1 %s -fsyntax-only -Wunused-local-typedef 2>&1 | FileCheck %s
+
+inline void f() {
+  // Enough typedefs to exceed the small storage of Scope::DeclSetTy.
+  typedef int t000;
+  typedef int t001;
+  typedef int t002;
+  typedef int t003;
+  typedef int t004;
+  typedef int t005;
+  typedef int t006;
+  typedef int t007;
+  typedef int t008;
+  typedef int t009;
+  typedef int t010;
+  typedef int t011;
+  typedef int t012;
+  typedef int t013;
+  typedef int t014;
+  typedef int t015;
+  typedef int t016;
+  typedef int t017;
+  typedef int t018;
+  typedef int t019;
+  typedef int t020;
+  typedef int t021;
+  typedef int t022;
+  typedef int t023;
+  typedef int t024;
+  typedef int t025;
+  typedef int t026;
+  typedef int t027;
+  typedef int t028;
+  typedef int t029;
+  typedef int t030;
+  typedef int t031;
+  typedef int t032;
+  typedef int t033;
+  typedef int t034;
+  typedef int t035;
+  typedef int t036;
+  typedef int t037;
+  typedef int t038;
+  typedef int t039;
+  typedef int t040;
+  typedef int t041;
+  typedef int t042;
+  typedef int t043;
+  typedef int t044;
+  typedef int t045;
+  typedef int t046;
+  typedef int t047;
+  typedef int t048;
+  typedef int t049;
+  typedef int t050;
+  typedef int t051;
+  typedef int t052;
+  typedef int t053;
+  typedef int t054;
+  typedef int t055;
+  typedef int t056;
+  typedef int t057;
+  typedef int t058;
+  typedef int t059;
+  typedef int t060;
+  typedef int t061;
+  typedef int t062;
+  typedef int t063;
+  typedef int t064;
+  typedef int t065;
+  typedef int t066;
+  typedef int t067;
+  typedef int t068;
+  typedef int t069;
+  typedef int t070;
+  typedef int t071;
+  typedef int t072;
+  typedef int t073;
+  typedef int t074;
+  typedef int t075;
+  typedef int t076;
+  typedef int t077;
+  typedef int t078;
+  typedef int t079;
+  typedef int t080;
+  typedef int t081;
+  typedef int t082;
+  typedef int t083;
+  typedef int t084;
+  typedef int t085;
+  typedef int t086;
+  typedef int t087;
+  typedef int t088;
+  typedef int t089;
+  typedef int t090;
+  typedef int t091;
+  typedef int t092;
+  typedef int t093;
+  typedef int t094;
+  typedef int t095;
+  typedef int t096;
+  typedef int t097;
+  typedef int t098;
+  typedef int t099;
+}
+
+// CHECK: warning: unused typedef 't000'
+// CHECK: warning: unused typedef 't001'
+// CHECK: warning: unused typedef 't002'
+// CHECK: warning: unused typedef 't003'
+// CHECK: warning: unused typedef 't004'
+// CHECK: warning: unused typedef 't005'
+// CHECK: warning: unused typedef 't006'
+// CHECK: warning: unused typedef 't007'
+// CHECK: warning: unused typedef 't008'
+// CHECK: warning: unused typedef 't009'
+// CHECK: warning: unused typedef 't010'
+// CHECK: warning: unused typedef 't011'
+// CHECK: warning: unused typedef 't012'
+// CHECK: warning: unused typedef 't013'
+// CHECK: warning: unused typedef 't014'
+// CHECK: warning: unused typedef 't015'
+// CHECK: warning: unused typedef 't016'
+// CHECK: warning: unused typedef 't017'
+// CHECK: warning: unused typedef 't018'
+// CHECK: warning: unused typedef 't019'
+// CHECK: warning: unused typedef 't020'
+// CHECK: warning: unused typedef 't021'
+// CHECK: warning: unused typedef 't022'
+// CHECK: warning: unused typedef 't023'
+// CHECK: warning: unused typedef 't024'
+// CHECK: warning: unused typedef 't025'
+// CHECK: warning: unused typedef 't026'
+// CHECK: warning: unused typedef 't027'
+// CHECK: warning: unused typedef 't028'
+// CHECK: warning: unused typedef 't029'
+// CHECK: warning: unused typedef 't030'
+// CHECK: warning: unused typedef 't031'
+// CHECK: warning: unused typedef 't032'
+// CHECK: warning: unused typedef 't033'
+// CHECK: warning: unused typedef 't034'
+// CHECK: warning: unused typedef 't035'
+// CHECK: warning: unused typedef 't036'
+// CHECK: warning: unused typedef 't037'
+// CHECK: warning: unused typedef 't038'
+// CHECK: warning: unused typedef 't039'
+// CHECK: warning: unused typedef 't040'
+// CHECK: warning: unused typedef 't041'
+// CHECK: warning: unused typedef 't042'
+// CHECK: warning: unused typedef 't043'
+// CHECK: warning: unused typedef 't044'
+// CHECK: warning: unused typedef 't045'
+// CHECK: warning: unused typedef 't046'
+// CHECK: warning: unused typedef 't047'
+// CHECK: warning: unused typedef 't048'
+// CHECK: warning: unused typedef 't049'
+// CHECK: warning: unused typedef 't050'
+// CHECK: warning: unused typedef 't051'
+// CHECK: warning: unused typedef 't052'
+// CHECK: warning: unused typedef 't053'
+// CHECK: warning: unused typedef 't054'
+// CHECK: warning: unused typedef 't055'
+// CHECK: warning: unused typedef 't056'
+// CHECK: warning: unused typedef 't057'
+// CHECK: warning: unused typedef 't058'
+// CHECK: warning: unused typedef 't059'
+// CHECK: warning: unused typedef 't060'
+// CHECK: warning: unused typedef 't061'
+// CHECK: warning: unused typedef 't062'
+// CHECK: warning: unused typedef 't063'
+// CHECK: warning: unused typedef 't064'
+// CHECK: warning: unused typedef 't065'
+// CHECK: warning: unused typedef 't066'
+// CHECK: warning: unused typedef 't067'
+// CHECK: warning: unused typedef 't068'
+// CHECK: warning: unused typedef 't069'
+// CHECK: warning: unused typedef 't070'
+// CHECK: warning: unused typedef 't071'
+// CHECK: warning: unused typedef 't072'
+// CHECK: warning: unused typedef 't073'
+// CHECK: warning: unused typedef 't074'
+// CHECK: warning: unused typedef 't075'
+// CHECK: warning: unused typedef 't076'
+// CHECK: warning: unused typedef 't077'
+// CHECK: warning: unused typedef 't078'
+// CHECK: warning: unused typedef 't079'
+// CHECK: warning: unused typedef 't080'
+// CHECK: warning: unused typedef 't081'
+// CHECK: warning: unused typedef 't082'
+// CHECK: warning: unused typedef 't083'
+// CHECK: warning: unused typedef 't084'
+// CHECK: warning: unused typedef 't085'
+// CHECK: warning: unused typedef 't086'
+// CHECK: warning: unused typedef 't087'
+// CHECK: warning: unused typedef 't088'
+// CHECK: warning: unused typedef 't089'
+// CHECK: warning: unused typedef 't090'
+// CHECK: warning: unused typedef 't091'
+// CHECK: warning: unused typedef 't092'
+// CHECK: warning: unused typedef 't093'
+// CHECK: warning: unused typedef 't094'
+// CHECK: warning: unused typedef 't095'
+// CHECK: warning: unused typedef 't096'
+// CHECK: warning: unused typedef 't097'
+// CHECK: warning: unused typedef 't098'
+// CHECK: warning: unused typedef 't099'

--- a/lldb/source/Plugins/ExpressionParser/Clang/ASTUtils.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ASTUtils.h
@@ -563,7 +563,7 @@ public:
   }
 
   void ReadUnusedLocalTypedefNameCandidates(
-      llvm::SmallSetVector<const clang::TypedefNameDecl *, 4> &Decls) override {
+      llvm::SmallPtrSetImpl<const clang::TypedefNameDecl *> &Decls) override {
     for (auto &Source : Sources)
       Source->ReadUnusedLocalTypedefNameCandidates(Decls);
   }


### PR DESCRIPTION
This is cherry-picking #209639 for 23.x release. 

Sema::UnusedLocalTypedefNameCandidates is populated while iterating a Scope's DeclsInScope, which is a SmallPtrSet whose iteration order depends on pointer values and is therefore not stable across runs. The candidates are serialized into the AST file -- both to assign declaration IDs and to write the UNUSED_LOCAL_TYPEDEF_NAME_CANDIDATES record -- and are also used to emit the deferred -Wunused-local-typedef warnings, so neither the emitted PCH/AST file nor the diagnostics were reproducible. With deterministic compilation caching this surfaces as a "cache poisoned" error, because two builds of the same PCH produce different bytes.

Sort the candidates by source location at the point they are consumed, via Sema::getSortedUnusedLocalTypedefNameCandidates(), so that both the diagnostics and the serialized declarations are deterministic.