### PR TITLE
[lldb] Remove unused method DynamicLoaderDarwin::ImageInfo::FindSegment

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -904,16 +904,6 @@ lldb_private::ArchSpec DynamicLoaderDarwin::ImageInfo::GetArchitecture() const {
   return arch_spec;
 }
 
-const DynamicLoaderDarwin::Segment *
-DynamicLoaderDarwin::ImageInfo::FindSegment(ConstString name) const {
-  const size_t num_segments = segments.size();
-  for (size_t i = 0; i < num_segments; ++i) {
-    if (segments[i].name == name)
-      return &segments[i];
-  }
-  return nullptr;
-}
-
 // Dump an image info structure to the file handle provided.
 void DynamicLoaderDarwin::ImageInfo::PutToLog(Log *log) const {
   if (!log)

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
@@ -169,8 +169,6 @@ protected:
 
     lldb_private::ArchSpec GetArchitecture() const;
 
-    const Segment *FindSegment(lldb_private::ConstString name) const;
-
     void PutToLog(lldb_private::Log *log) const;
 
     typedef std::vector<ImageInfo> collection;


### PR DESCRIPTION
This method is unused.