### PR TITLE
[analyzer] Fix StdVariantChecker crash on std::get with a non-ptr arg

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -226,8 +226,11 @@ private:
     if (ArgSVal.isUnknown())
       return false;
 
-    const auto &ArgType =
-        ArgSVal.getType(C.getASTContext())->getPointeeType().getTypePtr();
+    QualType SValType = ArgSVal.getType(C.getASTContext());
+    if (SValType.isNull() || !SValType->isPointerType())
+      return false;
+
+    const auto &ArgType = SValType->getPointeeType().getTypePtr();
     // We have to make sure that the argument is an std::variant.
     // There is another std::get with std::pair argument
     if (!isStdVariant(ArgType))

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -222,15 +222,7 @@ private:
   bool handleStdGetCall(const CallEvent &Call, CheckerContext &C) const {
     ProgramStateRef State = C.getState();
 
-    SVal ArgSVal = Call.getArgSVal(0);
-    if (ArgSVal.isUnknown())
-      return false;
-
-    QualType SValType = ArgSVal.getType(C.getASTContext());
-    if (SValType.isNull() || !SValType->isPointerType())
-      return false;
-
-    const auto &ArgType = SValType->getPointeeType().getTypePtr();
+    const auto *ArgType = Call.getArgExpr(0)->getType().getTypePtr();
     // We have to make sure that the argument is an std::variant.
     // There is another std::get with std::pair argument
     if (!isStdVariant(ArgType))

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -366,6 +366,10 @@ void unknownVal() {
   (void)std::get<int>(*(std::variant<int, float>*)(int)3.14f); // no crash
 }
 
+void concreteAddress() {
+  (void)std::get<int>(*(std::variant<int, char>*)11); // no crash
+}
+
 template <typename T>
 using MyVariant = std::variant<int, float>;
 


### PR DESCRIPTION
When `std::get` is called on a dereferenced integer-to-pointer cast, the checker `alpha.core.StdVariant` crashes. Minimal reproducer:

```
std::get<int>(*(std::variant<int, char> *)11);
```

Godbolt reproducer - https://godbolt.org/z/4EKe1PrKb

The root cause is that `StdVariantChecker::handleStdGetCall()` calls `SVal::getType()` on any non-unknown argument, then calls `getPointeeType()` on the result while assuming it is a pointer type. In the case of a concrete integer cast to a pointer and then dereferenced, it is modeled as `loc::ConcreteInt`, whose recovered type is an integer. `getPointeeType()` on such an input returns a null QualType, on which `getTypePtr()` crashes.

Fix the crash by using the argument's static type rather than recovering its SVal, eliminating the need to guard and call `getPointeeType()`.