### PR TITLE
[AMDGPU] Lower uniform uaddsat.i32 to SALU insts

### DIFF
--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -2078,6 +2078,10 @@ let AddedComplexity = 20 in {
 // Higher complexity to prefer scalar over VALU patterns for uniform values.
 let AddedComplexity = 20 in {
   def : GCNPat<
+    (i32 (UniformBinFrag<uaddsat> i32:$src0, i32:$src1)),
+    (S_ADD_U32 (S_MIN_U32 $src0, (S_NOT_B32 $src1)), $src1)
+  >;
+  def : GCNPat<
     (i32 (UniformBinFrag<usubsat> i32:$src0, i32:$src1)),
     (S_SUB_I32 (S_MAX_U32 $src0, $src1), $src1)
   >;

--- a/llvm/test/CodeGen/AMDGPU/add-max.ll
+++ b/llvm/test/CodeGen/AMDGPU/add-max.ll
@@ -50,9 +50,13 @@ define amdgpu_ps float @add_max_u32_sss(i32 inreg %a, i32 inreg %b, i32 inreg %c
 ; SDAG-NEXT:    global_wb
 ; SDAG-NEXT:    v_nop
 ; SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; SDAG-NEXT:    v_add_nc_u32_e64 v0, s0, s1 clamp
-; SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-NEXT:    v_max_u32_e32 v0, s2, v0
+; SDAG-NEXT:    s_not_b32 s3, s1
+; SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; SDAG-NEXT:    s_min_u32 s0, s0, s3
+; SDAG-NEXT:    s_add_co_u32 s0, s0, s1
+; SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; SDAG-NEXT:    s_max_u32 s0, s0, s2
+; SDAG-NEXT:    v_mov_b32_e32 v0, s0
 ; SDAG-NEXT:    ; return to shader part epilog
 ;
 ; GISEL-LABEL: add_max_u32_sss:

--- a/llvm/test/CodeGen/AMDGPU/uaddsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/uaddsat.ll
@@ -105,6 +105,57 @@ define i16 @v_uaddsat_i16(i16 %lhs, i16 %rhs) {
   ret i16 %result
 }
 
+define i32 @s_uaddsat_i32(i32 inreg %lhs, i32 inreg %rhs) {
+; GFX6-LABEL: s_uaddsat_i32:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    s_not_b32 s4, s17
+; GFX6-NEXT:    s_min_u32 s4, s16, s4
+; GFX6-NEXT:    s_add_i32 s4, s4, s17
+; GFX6-NEXT:    v_mov_b32_e32 v0, s4
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: s_uaddsat_i32:
+; GFX8:       ; %bb.0:
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    s_not_b32 s4, s17
+; GFX8-NEXT:    s_min_u32 s4, s16, s4
+; GFX8-NEXT:    s_add_u32 s4, s4, s17
+; GFX8-NEXT:    v_mov_b32_e32 v0, s4
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: s_uaddsat_i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_not_b32 s4, s17
+; GFX9-NEXT:    s_min_u32 s4, s16, s4
+; GFX9-NEXT:    s_add_u32 s4, s4, s17
+; GFX9-NEXT:    v_mov_b32_e32 v0, s4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX10-LABEL: s_uaddsat_i32:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    s_not_b32 s4, s17
+; GFX10-NEXT:    s_min_u32 s4, s16, s4
+; GFX10-NEXT:    s_add_u32 s4, s4, s17
+; GFX10-NEXT:    v_mov_b32_e32 v0, s4
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: s_uaddsat_i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    s_not_b32 s2, s1
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-NEXT:    s_min_u32 s0, s0, s2
+; GFX11-NEXT:    s_add_u32 s0, s0, s1
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+  %result = call i32 @llvm.uadd.sat.i32(i32 %lhs, i32 %rhs)
+  ret i32 %result
+}
+
 define i32 @v_uaddsat_i32(i32 %lhs, i32 %rhs) {
 ; GFX6-LABEL: v_uaddsat_i32:
 ; GFX6:       ; %bb.0:


### PR DESCRIPTION
Map uaddsat.i32(i32 %a, i32 %b) to the following:

```
s_not_b32 s4, s17          ; s17 = %b
s_min_u32 s4, s16, s4      ; s16 = %a
s_add_u32 s4, s4, s17
```
