### PR TITLE
[flang][cuda] Add option to flag descriptor I/O as error

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -584,8 +584,13 @@ def CUFDeviceFuncTransform
   let dependentDialects = ["mlir::gpu::GPUDialect",
                            "mlir::cf::ControlFlowDialect",
                            "mlir::NVVM::NVVMDialect"];
-  let options = [Option<"computeCap", "compute-capability", "int",
-                        /*default=*/"0", "CUDA compute capability version">];
+  let options =
+      [Option<"computeCap", "compute-capability", "int",
+              /*default=*/"0", "CUDA compute capability version">,
+       Option<"checkioOutputDescriptor", "check-io-output-descriptor", "bool",
+              /*default=*/"false",
+              "Report an error if device code contains a call to "
+              "descriptor I/O">];
 }
 
 def CUFFunctionRewrite : Pass<"cuf-function-rewrite", ""> {

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
@@ -254,6 +254,25 @@ class CUFDeviceFuncTransform
       });
     });
 
+    // Optionally report an error when device code calls the runtime function
+    // _FortranAioOutputDescriptor, which is not supported on the device.
+    if (checkioOutputDescriptor) {
+      constexpr llvm::StringRef aioOutputDescriptor =
+          "_FortranAioOutputDescriptor";
+      auto checkForAioOutputDescriptor = [&](fir::CallOp op) {
+        if (op.getCallee() && op.getCallee()->getLeafReference().getValue() ==
+                                  aioOutputDescriptor) {
+          op.emitError("descriptor I/O is not supported in device code");
+          signalPassFailure();
+        }
+      };
+      for (auto funcOp : deviceFuncs)
+        funcOp.walk(checkForAioOutputDescriptor);
+      mod.walk([&](cuf::KernelOp kernelOp) {
+        kernelOp.walk(checkForAioOutputDescriptor);
+      });
+    }
+
     for (auto funcOp : funcsToClone)
       gpuModSymTab.insert(funcOp->clone());
 

--- a/flang/test/Fir/CUDA/cuda-device-func-transform-aio.mlir
+++ b/flang/test/Fir/CUDA/cuda-device-func-transform-aio.mlir
@@ -1,0 +1,35 @@
+// Without the option, calls to _FortranAioOutputDescriptor in device code are
+// not reported and the pass succeeds.
+// RUN: fir-opt --split-input-file --cuf-transform-device-func %s | FileCheck %s
+
+// With the option enabled, such calls trigger an error and pass failure.
+// RUN: fir-opt --split-input-file --cuf-transform-device-func="check-aio-output-descriptor=true" \
+// RUN:   --verify-diagnostics %s
+
+func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1
+
+func.func @_QPsub_aio_device(%arg0: !fir.ref<i8>, %arg1: !fir.box<none>) attributes {cuf.proc_attr = #cuf.cuda_proc<device>} {
+  // expected-error@+1 {{descriptor I/O is not supported in device code}}
+  %0 = fir.call @_FortranAioOutputDescriptor(%arg0, %arg1) : (!fir.ref<i8>, !fir.box<none>) -> i1
+  return
+}
+
+// CHECK-LABEL: gpu.module @cuda_device_mod
+// CHECK: gpu.func @_QPsub_aio_device
+
+// -----
+
+func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1
+
+func.func @_QPsub_aio_host(%arg0: !fir.ref<i8>, %arg1: !fir.box<none>) {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  cuf.kernel<<<%c1_i32, %c1_i32>>> (%iv : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
+    // expected-error@+1 {{call to _FortranAioOutputDescriptor is not supported in device code}}
+    %0 = fir.call @_FortranAioOutputDescriptor(%arg0, %arg1) : (!fir.ref<i8>, !fir.box<none>) -> i1
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @_QPsub_aio_host

--- a/flang/test/Fir/CUDA/cuda-device-func-transform-aio.mlir
+++ b/flang/test/Fir/CUDA/cuda-device-func-transform-aio.mlir
@@ -3,7 +3,7 @@
 // RUN: fir-opt --split-input-file --cuf-transform-device-func %s | FileCheck %s
 
 // With the option enabled, such calls trigger an error and pass failure.
-// RUN: fir-opt --split-input-file --cuf-transform-device-func="check-aio-output-descriptor=true" \
+// RUN: fir-opt --split-input-file --cuf-transform-device-func="check-io-output-descriptor=true" \
 // RUN:   --verify-diagnostics %s
 
 func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1
@@ -25,7 +25,7 @@ func.func @_QPsub_aio_host(%arg0: !fir.ref<i8>, %arg1: !fir.box<none>) {
   %c1 = arith.constant 1 : index
   %c1_i32 = arith.constant 1 : i32
   cuf.kernel<<<%c1_i32, %c1_i32>>> (%iv : index) = (%c1 : index) to (%c1 : index) step (%c1 : index) {
-    // expected-error@+1 {{call to _FortranAioOutputDescriptor is not supported in device code}}
+    // expected-error@+1 {{descriptor I/O is not supported in device code}}
     %0 = fir.call @_FortranAioOutputDescriptor(%arg0, %arg1) : (!fir.ref<i8>, !fir.box<none>) -> i1
     "fir.end"() : () -> ()
   }


### PR DESCRIPTION
Descriptor I/O is too expensive in some compilation mode (nordc). Add ability to emit an error if they are found in device code. 