### PR TITLE
[fakeflang] Also detect CMakeTestGNU.c

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -27,7 +27,9 @@ set(FLANG_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../flang")
 # LLVM's requirement is only CMake 3.20, teach CMake 3.20-3.23 how to use Flang.
 if (CMAKE_VERSION VERSION_LESS "3.24")
   cmake_path(GET CMAKE_Fortran_COMPILER STEM _Fortran_COMPILER_STEM)
-  if (_Fortran_COMPILER_STEM STREQUAL "flang-new" OR _Fortran_COMPILER_STEM STREQUAL "flang")
+  if (_Fortran_COMPILER_STEM STREQUAL "flang-new" OR
+      _Fortran_COMPILER_STEM STREQUAL "flang" OR
+      _Fortran_COMPILER_STEM STREQUAL "fakeflang")
     include(CMakeForceCompiler)
     CMAKE_FORCE_Fortran_COMPILER("${CMAKE_Fortran_COMPILER}" "LLVMFlang")
 

--- a/flang/test/Driver/fakeflang.F
+++ b/flang/test/Driver/fakeflang.F
@@ -3,6 +3,7 @@
 ! RUN: rm -rf %t
 ! RUN: mkdir -p %t
 ! RUN: cp %s %t/CMakeFortranCompilerId.F
+! RUN: cp %s %t/CMakeTestGNU.c
 ! RUN: cp %s %t/compiletest.F
 ! RUN: cd %t
 
@@ -16,6 +17,11 @@
 
 ! RUN: fakeflang -v -c -cpp -E --target=x86_64-pc-windows-msvc CMakeFortranCompilerId.F 2>&1 | FileCheck %s --check-prefix=FAKEWARNING
 ! RUN: FileCheck %s --input-file=a.out --check-prefixes=CHECK,MSVC --match-full-lines
+! RUN: rm a.out
+
+! CMakeTestGNU.c is a fallback used by CMake
+! RUN: fakeflang -E CMakeTestGNU.c --target=aarch64-linux-gnu 2>&1 | FileCheck %s --check-prefix=FAKEWARNING
+! RUN: FileCheck %s --input-file=a.out --check-prefixes=CHECK,GNU --match-full-lines
 ! RUN: rm a.out
 
 ! FLANG_BOOTSTRAP_PROBE forces probe mode

--- a/flang/tools/fakeflang/fakeflang.cpp
+++ b/flang/tools/fakeflang/fakeflang.cpp
@@ -67,7 +67,8 @@ static bool isCompilerIdProbe(llvm::ArrayRef<const char *> OrigArgs) {
     return true;
 
   return llvm::any_of(OrigArgs, [](const char *Arg) {
-    return llvm::sys::path::filename(Arg) == "CMakeFortranCompilerId.F";
+    llvm::StringRef fname = llvm::sys::path::filename(Arg);
+    return fname == "CMakeFortranCompilerId.F" || fname == "CMakeTestGNU.c";
   });
 }
 

--- a/runtimes/cmake/config-Fortran.cmake
+++ b/runtimes/cmake/config-Fortran.cmake
@@ -90,7 +90,9 @@ if (CMAKE_Fortran_COMPILER)
   # Workarounds for older versions of CMake not recognizing FLang. Hence, we
   # cannot use CMAKE_Fortran_COMPILER_ID.
   cmake_path(GET CMAKE_Fortran_COMPILER STEM _Fortran_COMPILER_STEM)
-  if (_Fortran_COMPILER_STEM STREQUAL "flang-new" OR _Fortran_COMPILER_STEM STREQUAL "flang")
+  if (_Fortran_COMPILER_STEM STREQUAL "flang-new" OR
+      _Fortran_COMPILER_STEM STREQUAL "flang" OR
+      _Fortran_COMPILER_STEM STREQUAL "fakeflang")
     # CMake 3.24 is the first version of CMake that directly recognizes Flang.
     # LLVM's requirement is only CMake 3.20, teach CMake 3.20-3.23 how to use Flang, if used.
     if (CMAKE_VERSION VERSION_LESS "3.24")


### PR DESCRIPTION
Two fixes when using CMake < 3.28 after #209482:

 * In addition to `flang`, also recognize `fakeflang` to determine whether any workaround for CMake not completely supporting Flang is needed. `fakeflang` is used as a shim in #209482.

 * For CMake < 3.24, CMake does not recognize Flang at all and tries other methods to detect the compiler, including the file `CMakeTestGNU.c`. Make `fakeflang` recognize it as a probe attempt.

This should fix the [openmp-offload-amdgpu-clang-flang](https://lab.llvm.org/buildbot/#/builders/67) buildbot. The buildbot is currently upgrade to a newer CMake version, and the minimum required version of CMake will become 3.31 soon anyway.