### PR TITLE
CodeGen: Rename LibcallLoweringModuleAnalysisResult to ModuleLibcallLoweringInfo

### DIFF
--- a/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
+++ b/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
@@ -78,7 +78,7 @@ public:
 };
 
 /// Record a mapping from subtarget to LibcallLoweringInfo.
-class LibcallLoweringModuleAnalysisResult {
+class ModuleLibcallLoweringInfo {
 private:
   using LibcallLoweringMap =
       DenseMap<const TargetSubtargetInfo *, LibcallLoweringInfo>;
@@ -86,8 +86,8 @@ private:
   const RTLIB::RuntimeLibcallsInfo *RTLCI = nullptr;
 
 public:
-  LibcallLoweringModuleAnalysisResult() = default;
-  LibcallLoweringModuleAnalysisResult(RTLIB::RuntimeLibcallsInfo &RTLCI)
+  ModuleLibcallLoweringInfo() = default;
+  ModuleLibcallLoweringInfo(RTLIB::RuntimeLibcallsInfo &RTLCI)
       : RTLCI(&RTLCI) {}
 
   void init(const RTLIB::RuntimeLibcallsInfo *RT) { RTLCI = RT; }
@@ -114,16 +114,16 @@ private:
   friend AnalysisInfoMixin<LibcallLoweringModuleAnalysis>;
   LLVM_ABI static AnalysisKey Key;
 
-  LibcallLoweringModuleAnalysisResult LibcallLoweringMap;
+  ModuleLibcallLoweringInfo LibcallLoweringMap;
 
 public:
-  using Result = LibcallLoweringModuleAnalysisResult;
+  using Result = ModuleLibcallLoweringInfo;
 
   LLVM_ABI Result run(Module &M, ModuleAnalysisManager &);
 };
 
 class LLVM_ABI LibcallLoweringInfoWrapper : public ImmutablePass {
-  LibcallLoweringModuleAnalysisResult Result;
+  ModuleLibcallLoweringInfo Result;
   RuntimeLibraryInfoWrapper *RuntimeLibcallsWrapper = nullptr;
 
 public:
@@ -135,7 +135,7 @@ public:
     return getResult(M).getLibcallLowering(Subtarget);
   }
 
-  const LibcallLoweringModuleAnalysisResult &getResult(const Module &M) {
+  const ModuleLibcallLoweringInfo &getResult(const Module &M) {
     if (!Result)
       Result.init(&RuntimeLibcallsWrapper->getRTLCI(M));
     return Result;

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -151,8 +151,7 @@ private:
   bool processAtomicInstr(Instruction *I);
 
 public:
-  bool run(Function &F,
-           const LibcallLoweringModuleAnalysisResult &LibcallResult,
+  bool run(Function &F, const ModuleLibcallLoweringInfo &LibcallResult,
            const TargetMachine *TM);
 };
 
@@ -455,9 +454,9 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
   return false;
 }
 
-bool AtomicExpandImpl::run(
-    Function &F, const LibcallLoweringModuleAnalysisResult &LibcallResult,
-    const TargetMachine *TM) {
+bool AtomicExpandImpl::run(Function &F,
+                           const ModuleLibcallLoweringInfo &LibcallResult,
+                           const TargetMachine *TM) {
   const auto *Subtarget = TM->getSubtargetImpl(F);
   if (!Subtarget->enableAtomicExpand())
     return false;
@@ -496,7 +495,7 @@ bool AtomicExpandLegacy::runOnFunction(Function &F) {
     return false;
   auto *TM = &TPC->getTM<TargetMachine>();
 
-  const LibcallLoweringModuleAnalysisResult &LibcallResult =
+  const ModuleLibcallLoweringInfo &LibcallResult =
       getAnalysis<LibcallLoweringInfoWrapper>().getResult(*F.getParent());
   AtomicExpandImpl AE;
   return AE.run(F, LibcallResult, TM);
@@ -510,7 +509,7 @@ PreservedAnalyses AtomicExpandPass::run(Function &F,
                                         FunctionAnalysisManager &FAM) {
   auto &MAMProxy = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
 
-  const LibcallLoweringModuleAnalysisResult *LibcallResult =
+  const ModuleLibcallLoweringInfo *LibcallResult =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(*F.getParent());
 
   if (!LibcallResult) {

--- a/llvm/lib/CodeGen/DwarfEHPrepare.cpp
+++ b/llvm/lib/CodeGen/DwarfEHPrepare.cpp
@@ -388,7 +388,7 @@ PreservedAnalyses DwarfEHPreparePass::run(Function &F,
 
   auto &MAMProxy = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
 
-  const LibcallLoweringModuleAnalysisResult *LibcallLowering =
+  const ModuleLibcallLoweringInfo *LibcallLowering =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(*F.getParent());
 
   if (!LibcallLowering) {

--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -1459,7 +1459,7 @@ PreservedAnalyses ExpandIRInstsPass::run(Function &F,
 
   auto &MAMProxy = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
 
-  const LibcallLoweringModuleAnalysisResult *LibcallLowering =
+  const ModuleLibcallLoweringInfo *LibcallLowering =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(*F.getParent());
 
   if (!LibcallLowering) {

--- a/llvm/lib/CodeGen/LibcallLoweringInfo.cpp
+++ b/llvm/lib/CodeGen/LibcallLoweringInfo.cpp
@@ -34,7 +34,7 @@ LibcallLoweringInfo::LibcallLoweringInfo(
 
 AnalysisKey LibcallLoweringModuleAnalysis::Key;
 
-bool LibcallLoweringModuleAnalysisResult::invalidate(
+bool ModuleLibcallLoweringInfo::invalidate(
     Module &, const PreservedAnalyses &PA,
     ModuleAnalysisManager::Invalidator &) {
   // Passes that change the runtime libcall set must explicitly invalidate this
@@ -43,7 +43,7 @@ bool LibcallLoweringModuleAnalysisResult::invalidate(
   return !PAC.preservedWhenStateless();
 }
 
-LibcallLoweringModuleAnalysisResult
+ModuleLibcallLoweringInfo
 LibcallLoweringModuleAnalysis::run(Module &M, ModuleAnalysisManager &MAM) {
   LibcallLoweringMap.init(&MAM.getResult<RuntimeLibraryAnalysis>(M));
   return LibcallLoweringMap;

--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -59,7 +59,7 @@ namespace {
 
 struct PreISelIntrinsicLowering {
   const TargetMachine *TM;
-  const LibcallLoweringModuleAnalysisResult &ModuleLibcalls;
+  const ModuleLibcallLoweringInfo &ModuleLibcalls;
   const function_ref<TargetTransformInfo &(Function &)> LookupTTI;
   const function_ref<TargetLibraryInfo &(Function &)> LookupTLI;
 
@@ -70,7 +70,7 @@ struct PreISelIntrinsicLowering {
 
   explicit PreISelIntrinsicLowering(
       const TargetMachine *TM_,
-      const LibcallLoweringModuleAnalysisResult &ModuleLibcalls_,
+      const ModuleLibcallLoweringInfo &ModuleLibcalls_,
       function_ref<TargetTransformInfo &(Function &)> LookupTTI_,
       function_ref<TargetLibraryInfo &(Function &)> LookupTLI_,
       bool UseMemIntrinsicLibFunc_ = true)
@@ -241,9 +241,9 @@ bool PreISelIntrinsicLowering::shouldExpandMemIntrinsicWithSize(
   return SizeVal > Threshold || Threshold == 0;
 }
 
-static bool
-canEmitLibcall(const LibcallLoweringModuleAnalysisResult &ModuleLowering,
-               const TargetMachine *TM, Function *F, RTLIB::Libcall LC) {
+static bool canEmitLibcall(const ModuleLibcallLoweringInfo &ModuleLowering,
+                           const TargetMachine *TM, Function *F,
+                           RTLIB::Libcall LC) {
   // TODO: Should this consider the address space of the memcpy?
   if (!TM)
     return true;
@@ -252,9 +252,8 @@ canEmitLibcall(const LibcallLoweringModuleAnalysisResult &ModuleLowering,
   return Lowering.getLibcallImpl(LC) != RTLIB::Unsupported;
 }
 
-static bool
-canEmitMemcpy(const LibcallLoweringModuleAnalysisResult &ModuleLowering,
-              const TargetMachine *TM, Function *F) {
+static bool canEmitMemcpy(const ModuleLibcallLoweringInfo &ModuleLowering,
+                          const TargetMachine *TM, Function *F) {
   // TODO: Should this consider the address space of the memcpy?
   if (!TM)
     return true;
@@ -847,7 +846,7 @@ public:
   }
 
   bool runOnModule(Module &M) override {
-    const LibcallLoweringModuleAnalysisResult &ModuleLibcalls =
+    const ModuleLibcallLoweringInfo &ModuleLibcalls =
         getAnalysis<LibcallLoweringInfoWrapper>().getResult(M);
 
     auto LookupTTI = [this](Function &F) -> TargetTransformInfo & {
@@ -885,7 +884,7 @@ ModulePass *llvm::createPreISelIntrinsicLoweringPass() {
 
 PreservedAnalyses
 PreISelIntrinsicLoweringPass::run(Module &M, ModuleAnalysisManager &MAM) {
-  const LibcallLoweringModuleAnalysisResult &LibcallLowering =
+  const ModuleLibcallLoweringInfo &LibcallLowering =
       MAM.getResult<LibcallLoweringModuleAnalysis>(M);
 
   auto &FAM = MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();

--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -970,7 +970,7 @@ PreservedAnalyses SafeStackPass::run(Function &F,
   auto &SE = FAM.getResult<ScalarEvolutionAnalysis>(F);
 
   auto &MAMProxy = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
-  const LibcallLoweringModuleAnalysisResult *LibcallLowering =
+  const ModuleLibcallLoweringInfo *LibcallLowering =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(*F.getParent());
 
   if (!LibcallLowering) {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -502,7 +502,7 @@ void SelectionDAGISel::initializeAnalysisResults(
   MachineModuleInfo &MMI =
       MAMP.getCachedResult<MachineModuleAnalysis>(*Fn.getParent())->getMMI();
 
-  const LibcallLoweringModuleAnalysisResult *LibcallResult =
+  const ModuleLibcallLoweringInfo *LibcallResult =
       MAMP.getCachedResult<LibcallLoweringModuleAnalysis>(*Fn.getParent());
   if (!LibcallResult) {
     reportFatalUsageError("'" + LibcallLoweringModuleAnalysis::name() +

--- a/llvm/lib/CodeGen/StackProtector.cpp
+++ b/llvm/lib/CodeGen/StackProtector.cpp
@@ -134,7 +134,7 @@ PreservedAnalyses StackProtectorPass::run(Function &F,
   }
 
   auto &MAMProxy = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
-  const LibcallLoweringModuleAnalysisResult *LibcallLowering =
+  const ModuleLibcallLoweringInfo *LibcallLowering =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(*F.getParent());
 
   if (!LibcallLowering) {

--- a/llvm/lib/Target/AArch64/GISel/AArch64O0PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64O0PreLegalizerCombiner.cpp
@@ -197,7 +197,7 @@ AArch64O0PreLegalizerCombinerPass::run(MachineFunction &MF,
   const AArch64Subtarget &ST = MF.getSubtarget<AArch64Subtarget>();
   auto &MAMProxy =
       MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF);
-  const LibcallLoweringModuleAnalysisResult *LibcallResult =
+  const ModuleLibcallLoweringInfo *LibcallResult =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(
           *MF.getFunction().getParent());
   if (!LibcallResult)

--- a/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
@@ -918,7 +918,7 @@ AArch64PreLegalizerCombinerPass::run(MachineFunction &MF,
   const AArch64Subtarget &ST = MF.getSubtarget<AArch64Subtarget>();
   auto &MAMProxy =
       MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF);
-  const LibcallLoweringModuleAnalysisResult *LibcallResult =
+  const ModuleLibcallLoweringInfo *LibcallResult =
       MAMProxy.getCachedResult<LibcallLoweringModuleAnalysis>(
           *MF.getFunction().getParent());
   if (!LibcallResult)


### PR DESCRIPTION
Avoid putting pass manager flavored naming in this class. This is analagous to
TargetLibraryInfo's TargetLibraryInfoImpl.

Co-authored-by: Claude (Claude Opus 4.8) <noreply@anthropic.com>