### PR TITLE
Don't eagerly load all declarations in a class when defining a special member function.

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -410,6 +410,10 @@ public:
   /// a C++ class.
   bool isCXXInstanceMember() const;
 
+  // Determine whether this declaration is a direct or indirect field. For use
+  // with filtered_decl_iterator.
+  bool isDirectOrIndirectFieldDecl() const;
+
   /// Determine if the declaration obeys the reserved identifier rules of the
   /// given language.
   ReservedIdentifierStatus isReserved(const LangOptions &LangOpts) const;
@@ -4601,6 +4605,24 @@ public:
   // Whether there are any fields (non-static data members) in this record.
   bool noload_field_empty() const {
     return noload_field_begin() == noload_field_end();
+  }
+
+  // Iterator access to direct or indirect field members. The field iterator
+  // only visits the non-static data members of this class, ignoring any static
+  // data members, functions, constructors, destructors, etc.
+  using direct_or_indirect_field_iterator =
+      filtered_decl_iterator<NamedDecl,
+                             &NamedDecl::isDirectOrIndirectFieldDecl>;
+  using direct_or_indirect_field_range =
+      llvm::iterator_range<direct_or_indirect_field_iterator>;
+
+  direct_or_indirect_field_range direct_or_indirect_fields() const {
+    return direct_or_indirect_field_range(direct_or_indirect_field_begin(),
+                                          direct_or_indirect_field_end());
+  }
+  direct_or_indirect_field_iterator direct_or_indirect_field_begin() const;
+  direct_or_indirect_field_iterator direct_or_indirect_field_end() const {
+    return direct_or_indirect_field_iterator(decl_iterator());
   }
 
   /// Note that the definition of this type is now complete.

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1128,6 +1128,14 @@ bool NamedDecl::isPlaceholderVar(const LangOptions &LangOpts) const {
   return false;
 }
 
+static bool isDirectOrIndirectFieldDeclKind(Decl::Kind K) {
+  return FieldDecl::classofKind(K) || IndirectFieldDecl::classofKind(K);
+}
+
+bool NamedDecl::isDirectOrIndirectFieldDecl() const {
+  return isDirectOrIndirectFieldDeclKind(getKind());
+}
+
 ReservedIdentifierStatus
 NamedDecl::isReserved(const LangOptions &LangOpts) const {
   const IdentifierInfo *II = getIdentifier();
@@ -5280,6 +5288,15 @@ RecordDecl::field_iterator RecordDecl::field_begin() const {
   return field_iterator(decl_iterator(FirstDecl));
 }
 
+RecordDecl::direct_or_indirect_field_iterator
+RecordDecl::direct_or_indirect_field_begin() const {
+  if (hasExternalLexicalStorage() && !hasLoadedFieldsFromExternalStorage())
+    LoadFieldsFromExternalStorage();
+  if (RecordDecl *D = getDefinition(); D && D != this)
+    return D->direct_or_indirect_field_begin();
+  return direct_or_indirect_field_iterator(decl_iterator(FirstDecl));
+}
+
 RecordDecl::field_iterator RecordDecl::noload_field_begin() const {
   return field_iterator(decl_iterator(getDefinitionOrSelf()->FirstDecl));
 }
@@ -5333,14 +5350,13 @@ void RecordDecl::LoadFieldsFromExternalStorage() const {
 
   SmallVector<Decl*, 64> Decls;
   setHasLoadedFieldsFromExternalStorage(true);
-  Source->FindExternalLexicalDecls(this, [](Decl::Kind K) {
-    return FieldDecl::classofKind(K) || IndirectFieldDecl::classofKind(K);
-  }, Decls);
+  Source->FindExternalLexicalDecls(this, isDirectOrIndirectFieldDeclKind,
+                                   Decls);
 
 #ifndef NDEBUG
   // Check that all decls we got were FieldDecls.
   for (unsigned i=0, e=Decls.size(); i != e; ++i)
-    assert(isa<FieldDecl>(Decls[i]) || isa<IndirectFieldDecl>(Decls[i]));
+    assert(cast<NamedDecl>(Decls[i])->isDirectOrIndirectFieldDecl());
 #endif
 
   if (Decls.empty())

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4127,7 +4127,7 @@ namespace {
     llvm::SmallPtrSet<ValueDecl*, 4> UninitializedFields;
 
     // At the beginning, all fields are uninitialized.
-    for (auto *I : RD->decls()) {
+    for (auto *I : RD->direct_or_indirect_fields()) {
       if (auto *FD = dyn_cast<FieldDecl>(I)) {
         UninitializedFields.insert(FD);
       } else if (auto *IFD = dyn_cast<IndirectFieldDecl>(I)) {
@@ -5586,7 +5586,7 @@ bool Sema::SetCtorInitializers(CXXConstructorDecl *Constructor, bool AnyErrors,
   }
 
   // Fields.
-  for (auto *Mem : ClassDecl->decls()) {
+  for (auto *Mem : ClassDecl->direct_or_indirect_fields()) {
     if (auto *F = dyn_cast<FieldDecl>(Mem)) {
       // C++ [class.bit]p2:
       //   A declaration for a bit-field that omits the identifier declares an

--- a/clang/test/OpenMP/declare_target_ast_print.cpp
+++ b/clang/test/OpenMP/declare_target_ast_print.cpp
@@ -215,19 +215,17 @@ struct C {
 // CHECK-NEXT: #pragma omp end declare target
 
 // CHECK: template<> struct C<int>
-  T t;
-// CHECK-NEXT: int t;
   static T ts;
-// CHECK-NEXT: #pragma omp declare target
+// CHECK: #pragma omp declare target
 // CHECK-NEXT: static int ts;
-// CHECK: #pragma omp end declare target
+// CHECK-NEXT: #pragma omp end declare target
 
   C(T t) : t(t) {
   }
 // CHECK: #pragma omp declare target
 // CHECK-NEXT: C(int t) : t(t) {
 // CHECK-NEXT: }
-// CHECK: #pragma omp end declare target
+// CHECK-NEXT: #pragma omp end declare target
 
   T foo() {
     return t;
@@ -236,7 +234,11 @@ struct C {
 // CHECK-NEXT: int foo() {
 // CHECK-NEXT: return this->t;
 // CHECK-NEXT: }
-// CHECK: #pragma omp end declare target
+// CHECK-NEXT: #pragma omp end declare target
+
+// Not inside a #pragma omp declare target.
+// CHECK-NEXT: int t;
+  T t;
 };
 
 template<class T>

--- a/clang/test/PCH/Inputs/cxx-method.h
+++ b/clang/test/PCH/Inputs/cxx-method.h
@@ -3,7 +3,14 @@ struct S {
 
   S();
   S(const S&);
+  S &operator=(const S&);
+
+  void doNotDeserialize();
 
   operator const char*();
   operator char*();
+};
+
+struct Trivial {
+  void doNotDeserialize();
 };

--- a/clang/test/PCH/cxx-method.cpp
+++ b/clang/test/PCH/cxx-method.cpp
@@ -1,7 +1,21 @@
 // RUN: %clang_cc1 -x c++ -include %S/Inputs/cxx-method.h -verify %s
 // RUN: %clang_cc1 -x c++ -emit-pch %S/Inputs/cxx-method.h -o %t
-// RUN: %clang_cc1 -include-pch %t -verify %s
+// RUN: %clang_cc1 -include-pch %t -verify %s -error-on-deserialized-decl doNotDeserialize -ast-dump
 // expected-no-diagnostics
+
+// Calling constructors should not cause doNotDeserialize to be deserialized.
+S s;
+S s2(s);
+
+// Implicitly defining special member functions should not cause
+// doNotDeserialize to be deserialized.
+Trivial t;
+Trivial t2(t);
+
+void assign() {
+  s = s2;
+  t = t2;
+}
 
 void S::m(int x) { }
 


### PR DESCRIPTION
Add an accessor to walk the fields and indirect fields of a class without deserializing everything, and use it instead of walking over all of `decls()` in a couple of places within the implicit definition of a special member function. We already have machinery to only import those parts of the class without importing everything else, but we weren't using it here.

This allows us to use classes with implicit special members from an imported PCH or module without importing all the declarations in the class.