### PR TITLE
[Webkit Checkers][SaferCpp] Fix MemoryUnsafeCastChecker to precisely exclude `*this` casts

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -98,7 +98,7 @@ static decltype(auto) hasTypePointingTo(DeclarationMatcher DeclM) {
 // Matches `this` or `*this`, but not member accesses like `this->m_field`.
 static decltype(auto) isThisOrDerefThis() {
   return ignoringParenImpCasts(anyOf(
-     cxxThisExpr(),
+      cxxThisExpr(),
       unaryOperator(hasOperatorName("*"),
                     hasUnaryOperand(ignoringParenImpCasts(cxxThisExpr())))));
 }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -97,10 +97,10 @@ static decltype(auto) hasTypePointingTo(DeclarationMatcher DeclM) {
 
 // Matches `this` or `*this`, but not member accesses like `this->m_field`.
 static decltype(auto) isThisOrDerefThis() {
-  return ignoringParenImpCasts(
-      anyOf(cxxThisExpr(),
-            unaryOperator(hasOperatorName("*"),
-                          hasUnaryOperand(ignoringParenImpCasts(cxxThisExpr())))));
+  return ignoringParenImpCasts(anyOf(
+     cxxThisExpr(),
+      unaryOperator(hasOperatorName("*"),
+                    hasUnaryOperand(ignoringParenImpCasts(cxxThisExpr())))));
 }
 
 void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -95,6 +95,14 @@ static decltype(auto) hasTypePointingTo(DeclarationMatcher DeclM) {
   return hasType(pointerType(pointee(hasDeclaration(DeclM))));
 }
 
+// Matches `this` or `*this`, but not member accesses like `this->m_field`.
+static decltype(auto) isThisOrDerefThis() {
+  return ignoringParenImpCasts(
+      anyOf(cxxThisExpr(),
+            unaryOperator(hasOperatorName("*"),
+                          hasUnaryOperand(ignoringParenImpCasts(cxxThisExpr())))));
+}
+
 void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
                                                AnalysisManager &AM,
                                                BugReporter &BR) const {
@@ -120,7 +128,7 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
             hasType(hasUnqualifiedDesugaredType(recordType(hasDeclaration(
                 decl(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
                          .bind(DerivedNode)))))),
-            unless(anyOf(hasSourceExpression(hasDescendant(cxxThisExpr())),
+            unless(anyOf(hasSourceExpression(isThisOrDerefThis()),
                          hasType(templateTypeParmDecl()))));
   auto MatchExprPtrVoidCast = allOf(
       anyOf(hasSourceExpression(explicitCastExpr(

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -88,6 +88,30 @@ AST_MATCHER_P(StringLiteral, mentionsBoundType, std::string, BindingID) {
     return true;
   });
 }
+
+// Matches a cast whose previously-bound BaseID node is a class template
+// specialization and whose previously-bound DerivedID node is one of that
+// specialization's type template arguments, i.e. the CRTP pattern
+// `class Derived : Base<Derived>`.
+AST_MATCHER_P2(Expr, isCRTPCast, std::string, BaseID, std::string,
+               DerivedID) {
+  return Builder->removeBindings([this](const BoundNodesMap &Nodes) {
+    const auto *Base = Nodes.getNodeAs<CXXRecordDecl>(this->BaseID);
+    const auto *Derived = Nodes.getNodeAs<CXXRecordDecl>(this->DerivedID);
+    const auto *CTSD =
+        Base ? dyn_cast<ClassTemplateSpecializationDecl>(Base) : nullptr;
+    if (!CTSD || !Derived)
+      return true;
+    for (const TemplateArgument &Arg : CTSD->getTemplateArgs().asArray()) {
+      if (Arg.getKind() != TemplateArgument::Type)
+        continue;
+      QualType ArgType = Arg.getAsType();
+      if (!ArgType.isNull() && ArgType->getAsCXXRecordDecl() == Derived)
+        return false;
+    }
+    return true;
+  });
+}
 } // end namespace ast_matchers
 } // end namespace clang
 
@@ -114,8 +138,9 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
       hasSourceExpression(hasTypePointingTo(cxxRecordDecl().bind(BaseNode))),
       hasTypePointingTo(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
                             .bind(DerivedNode)),
-      unless(anyOf(hasSourceExpression(cxxThisExpr()),
-                   hasTypePointingTo(templateTypeParmDecl()))));
+      unless(anyOf(hasTypePointingTo(templateTypeParmDecl()),
+                   allOf(hasSourceExpression(cxxThisExpr()),
+                         isCRTPCast(BaseNode, DerivedNode)))));
   auto MatchExprPtrObjC = allOf(
       hasSourceExpression(ignoringImpCasts(hasType(objcObjectPointerType(
           pointee(hasDeclaration(objcInterfaceDecl().bind(BaseNode))))))),
@@ -128,8 +153,9 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
             hasType(hasUnqualifiedDesugaredType(recordType(hasDeclaration(
                 decl(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
                          .bind(DerivedNode)))))),
-            unless(anyOf(hasSourceExpression(isThisOrDerefThis()),
-                         hasType(templateTypeParmDecl()))));
+            unless(anyOf(hasType(templateTypeParmDecl()),
+                         allOf(hasSourceExpression(isThisOrDerefThis()),
+                               isCRTPCast(BaseNode, DerivedNode)))));
   auto MatchExprPtrVoidCast = allOf(
       anyOf(hasSourceExpression(explicitCastExpr(
                 hasType(pointerType(pointee(voidType()))),

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -93,8 +93,7 @@ AST_MATCHER_P(StringLiteral, mentionsBoundType, std::string, BindingID) {
 // specialization and whose previously-bound DerivedID node is one of that
 // specialization's type template arguments, i.e. the CRTP pattern
 // `class Derived : Base<Derived>`.
-AST_MATCHER_P2(Expr, isCRTPCast, std::string, BaseID, std::string,
-               DerivedID) {
+AST_MATCHER_P2(Expr, isCRTPCast, std::string, BaseID, std::string, DerivedID) {
   return Builder->removeBindings([this](const BoundNodesMap &Nodes) {
     const auto *Base = Nodes.getNodeAs<CXXRecordDecl>(this->BaseID);
     const auto *Derived = Nodes.getNodeAs<CXXRecordDecl>(this->DerivedID);

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast-cxxthis.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast-cxxthis.cpp
@@ -1,0 +1,44 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.MemoryUnsafeCastChecker -verify %s
+
+#include "mock-types.h"
+
+struct Base : RefCountable { virtual ~Base() {} };
+struct Derived : Base { int extra; };
+
+struct S {
+  Base& m_ref;
+
+  void f() {
+    // this->m_ref contains CXXThisExpr as descendant -> suppressed
+    auto& dref = static_cast<Derived&>(this->m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    // Pointer equivalent using exact match — IS flagged:
+    auto* dptr = static_cast<Derived*>(&this->m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+
+  void f_reinterpret() {
+    auto& dref = reinterpret_cast<Derived&>(this->m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = reinterpret_cast<Derived*>(&this->m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+
+  void f_dynamic() {
+    auto& dref = dynamic_cast<Derived&>(this->m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = dynamic_cast<Derived*>(&this->m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+
+  void f_cstyle() {
+    auto& dref = (Derived&)this->m_ref;
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = (Derived*)&this->m_ref;
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+};

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast-cxxthis.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast-cxxthis.cpp
@@ -42,3 +42,60 @@ struct S {
     // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
   }
 };
+
+// Member access with an implicit `this`
+struct S2 {
+  Base& m_ref;
+
+  void f() {
+    auto& dref = static_cast<Derived&>(m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = static_cast<Derived*>(&m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+
+  void f_reinterpret() {
+    auto& dref = reinterpret_cast<Derived&>(m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = reinterpret_cast<Derived*>(&m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+
+  void f_dynamic() {
+    auto& dref = dynamic_cast<Derived&>(m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = dynamic_cast<Derived*>(&m_ref);
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+
+  void f_cstyle() {
+    auto& dref = (Derived&)m_ref;
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+    auto* dptr = (Derived*)&m_ref;
+    // expected-warning@-1 {{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  }
+};
+
+// A cast of `this` to an unrelated
+// further-derived class is still an unsafe downcast and must be flagged.
+struct T1 : Derived {
+  void bogus_ptr();
+};
+struct GrandchildPtr : T1 { int more; };
+void T1::bogus_ptr() {
+  auto* g = static_cast<GrandchildPtr*>(this);
+  // expected-warning@-1 {{Unsafe cast from base type 'T1' to derived type 'GrandchildPtr'}}
+}
+
+struct T2 : Derived {
+  void bogus_ref();
+};
+struct GrandchildRef : T2 { int more; };
+void T2::bogus_ref() {
+  auto& g = static_cast<GrandchildRef&>(*this);
+  // expected-warning@-1 {{Unsafe cast from base type 'T2' to derived type 'GrandchildRef'}}
+}

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.cpp
@@ -254,6 +254,9 @@ public:
   void initializeWeakPtrFactory() const {
     auto &this_to_T = static_cast<const WeakPtrFactoryType&>(*this);
   }
+  void initializeWeakPtrFactoryReinterpret() const {
+    auto &this_to_T = reinterpret_cast<const WeakPtrFactoryType&>(*this);
+  }
 };
 
 template<typename T>

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.cpp
@@ -255,7 +255,8 @@ public:
     auto &this_to_T = static_cast<const WeakPtrFactoryType&>(*this);
   }
   void initializeWeakPtrFactoryReinterpret() const {
-    auto &this_to_T = reinterpret_cast<const WeakPtrFactoryType&>(*this);
+    auto &this_to_T = reinterpret_cast<const SomeArrayClass&>(*this);
+    // expected-warning@-1{{Unsafe cast from type 'CanMakeWeakPtrBase' to an unrelated type 'SomeArrayClass'}}
   }
 };
 
@@ -266,4 +267,5 @@ class EventLoop : public CanMakeWeakPtr<EventLoop> { };
 
 void test_this_to_template_ref(EventLoop *ptr) {
   ptr->initializeWeakPtrFactory();
+  ptr->initializeWeakPtrFactoryReinterpret();
 };


### PR DESCRIPTION
Exclude casts precisely matching `this` and `*this` (through parens/implicit casts), without matching member accesses like `this->m_field`.

rdar://173770064