### PR TITLE
[NFC][LSR] Remove duplicate debug expression update

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -6858,7 +6858,6 @@ static void updateDVIWithLocation(T &DbgVal, Value *Location,
                                     "contain any DW_OP_llvm_arg operands.");
   DbgVal.setRawLocation(ValueAsMetadata::get(Location));
   DbgVal.setExpression(DIExpression::get(DbgVal.getContext(), Ops));
-  DbgVal.setExpression(DIExpression::get(DbgVal.getContext(), Ops));
 }
 
 /// Overwrite DVI with locations placed into a DIArglist.


### PR DESCRIPTION
Remove duplicate debug expression update updateDVIWithLocation assigned the same DIExpression twice so let's just remove the redundant call.

Tested via make check.

Assisted by AI.