### PR TITLE
[AMDGPU][True16] Select _t16 D16 loads/stores for FLAT/GLOBAL/SCRATCH

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -263,6 +263,12 @@ void AMDGPUDAGToDAGISelLegacy::getAnalysisUsage(AnalysisUsage &AU) const {
 
 bool AMDGPUDAGToDAGISel::matchLoadD16FromBuildVector(SDNode *N) const {
   assert(Subtarget->d16PreservesUnusedBits());
+  // In true16 mode the two 16-bit halves of a packed vector live in
+  // independent VGPR_16 registers, so building a vector from a pair of 16-bit
+  // loads is done with plain t16 loads and subregister inserts rather than the
+  // packed d16_hi/d16_lo loads.
+  if (Subtarget->useRealTrue16Insts())
+    return false;
   MVT VT = N->getValueType(0).getSimpleVT();
   if (VT != MVT::v2i16 && VT != MVT::v2f16)
     return false;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -3177,6 +3177,29 @@ void AMDGPUInstructionSelector::initM0(MachineInstr &I) const {
 bool AMDGPUInstructionSelector::selectG_LOAD_STORE_ATOMICRMW(
   MachineInstr &I) const {
   initM0(I);
+
+  // In true16 mode, a i8/i16 truncating store whose data operand is a
+  // 32-bit VGPR should feed the _t16 store pseudos, which take a 16-bit data
+  // operand. GISel cannot import the tablegen patterns that extract the low 16
+  // bits of a 32-bit source operand (they use EXTRACT_SUBREG on an input, which
+  // the pattern importer rejects), so copy the low half into a VGPR_16 here and
+  // let the imported i16 store patterns select the _t16 pseudo.
+  if (I.getOpcode() == AMDGPU::G_STORE && Subtarget->useRealTrue16Insts()) {
+    const MachineMemOperand *MMO = *I.memoperands_begin();
+    const LLT MemTy = MMO->getMemoryType();
+    Register DataReg = I.getOperand(0).getReg();
+    const RegisterBank *DataRB = RBI.getRegBank(DataReg, *MRI, TRI);
+    if (!MMO->isAtomic() && MemTy.isScalar() && MemTy.getSizeInBits() < 32 &&
+        RBI.getSizeInBits(DataReg, *MRI, TRI) == 32 && DataRB &&
+        DataRB->getID() == AMDGPU::VGPRRegBankID) {
+      Register Lo16 = MRI->createGenericVirtualRegister(LLT::scalar(16));
+      MRI->setRegBank(Lo16, RBI.getRegBank(AMDGPU::VGPRRegBankID));
+      BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(AMDGPU::COPY), Lo16)
+          .addReg(DataReg, {}, AMDGPU::lo16);
+      I.getOperand(0).setReg(Lo16);
+    }
+  }
+
   return selectImpl(I, *CoverageInfo);
 }
 

--- a/llvm/lib/Target/AMDGPU/FLATInstructions.td
+++ b/llvm/lib/Target/AMDGPU/FLATInstructions.td
@@ -1535,6 +1535,26 @@ class FlatStoreSignedPat <FLAT_Pseudo inst, SDPatternOperator node, ValueType vt
   (inst $vaddr, getVregSrcForVT<vt>.ret:$data, $offset)
 >;
 
+// True16 variants of the flat/global store patterns for a truncating store whose
+// value operand is a 32-bit VGPR.
+class FlatStorePat_t16_from_i32 <FLAT_Pseudo inst, SDPatternOperator node,
+                                 ValueType vt, SubRegIndex subreg = lo16> : GCNPat <
+  (node vt:$data, (FlatOffset i64:$vaddr, i32:$offset)),
+  (inst $vaddr, (i16 (EXTRACT_SUBREG $data, subreg)), $offset)
+>;
+
+class FlatStoreSignedPat_t16_from_i32 <FLAT_Pseudo inst, SDPatternOperator node,
+                                       ValueType vt, SubRegIndex subreg = lo16> : GCNPat <
+  (node vt:$data, (GlobalOffset i64:$vaddr, i32:$offset)),
+  (inst $vaddr, (i16 (EXTRACT_SUBREG $data, subreg)), $offset)
+>;
+
+class FlatStoreSaddrPat_t16_from_i32 <FLAT_Pseudo inst, SDPatternOperator node,
+                                      ValueType vt, SubRegIndex subreg = lo16> : GCNPat <
+  (node vt:$data, (GlobalSAddr (i64 SReg_64:$saddr), (i32 VGPROp_32:$voffset), i32:$offset, CPol:$cpol)),
+  (inst $voffset, (i16 (EXTRACT_SUBREG $data, subreg)), $saddr, $offset, $cpol)
+>;
+
 class FlatStoreSignedAtomicPat <FLAT_Pseudo inst, SDPatternOperator node,
                                 ValueType vt, ValueType data_vt = vt> : GCNPat <
   // atomic store follows atomic binop convention so the address comes
@@ -1696,6 +1716,24 @@ class ScratchStoreSVaddrPat <FLAT_Pseudo inst, SDPatternOperator node,
   (inst getVregSrcForVT<vt>.ret:$data, $vaddr, $saddr, $offset, $cpol)
 >;
 
+class ScratchStoreSignedPat_t16_from_i32 <FLAT_Pseudo inst, SDPatternOperator node,
+                                          ValueType vt, SubRegIndex subreg = lo16> : GCNPat <
+  (node vt:$data, (ScratchOffset (i32 VGPROp_32:$vaddr), i32:$offset)),
+  (inst (i16 (EXTRACT_SUBREG $data, subreg)), $vaddr, $offset)
+>;
+
+class ScratchStoreSaddrPat_t16_from_i32 <FLAT_Pseudo inst, SDPatternOperator node,
+                                         ValueType vt, SubRegIndex subreg = lo16> : GCNPat <
+  (node vt:$data, (ScratchSAddr (i32 SGPR_32:$saddr), i32:$offset)),
+  (inst (i16 (EXTRACT_SUBREG $data, subreg)), $saddr, $offset)
+>;
+
+class ScratchStoreSVaddrPat_t16_from_i32 <FLAT_Pseudo inst, SDPatternOperator node,
+                                          ValueType vt, SubRegIndex subreg = lo16> : GCNPat <
+  (node vt:$data, (ScratchSVAddr (i32 VGPROp_32:$vaddr), (i32 SGPR_32:$saddr), i32:$offset, CPol:$cpol)),
+  (inst (i16 (EXTRACT_SUBREG $data, subreg)), $vaddr, $saddr, $offset, $cpol)
+>;
+
 class ScratchLoadSVaddrPat_D16 <FLAT_Pseudo inst, SDPatternOperator node, ValueType vt> : GCNPat <
   (vt (node (ScratchSVAddr (i32 VGPROp_32:$vaddr), (i32 SGPR_32:$saddr), i32:$offset, CPol:$cpol), vt:$in)),
   (inst $vaddr, $saddr, $offset, $cpol, $in)
@@ -1709,6 +1747,42 @@ class ScratchLoadSVaddrPat_D16_t16 <FLAT_Pseudo inst, SDPatternOperator node, Va
 class ScratchLoadSVaddrPat_t16 <FLAT_Pseudo inst, SDPatternOperator node, ValueType vt> : GCNPat <
   (vt (node (ScratchSVAddr (i32 VGPROp_32:$vaddr), (i32 SGPR_32:$saddr), i32:$offset, CPol:$cpol))),
   (EXTRACT_SUBREG (inst $vaddr, $saddr, $offset, $cpol), lo16)
+>;
+
+class FlatLoadPat_D16_t16_pack <FLAT_Pseudo inst, SDPatternOperator node,
+                                 ValueType vt, SubRegIndex subreg> : GCNPat <
+  (node (FlatOffset (i64 VReg_64:$vaddr), i32:$offset), vt:$in),
+  (INSERT_SUBREG $in, (inst $vaddr, $offset, (i32 0)), subreg)
+>;
+
+class FlatSignedLoadPat_D16_t16_pack <FLAT_Pseudo inst, SDPatternOperator node,
+                                       ValueType vt, SubRegIndex subreg> : GCNPat <
+  (node (GlobalOffset (i64 VReg_64:$vaddr), i32:$offset), vt:$in),
+  (INSERT_SUBREG $in, (inst $vaddr, $offset, (i32 0)), subreg)
+>;
+
+class FlatLoadSaddrPat_D16_t16_pack <FLAT_Pseudo inst, SDPatternOperator node,
+                                      ValueType vt, SubRegIndex subreg> : GCNPat <
+  (node (GlobalSAddr (i64 SReg_64:$saddr), (i32 VGPROp_32:$voffset), i32:$offset, CPol:$cpol), vt:$in),
+  (INSERT_SUBREG $in, (inst $saddr, $voffset, $offset, $cpol), subreg)
+>;
+
+class ScratchLoadSignedPat_D16_t16_pack <FLAT_Pseudo inst, SDPatternOperator node,
+                                          ValueType vt, SubRegIndex subreg> : GCNPat <
+  (node (ScratchOffset (i32 VGPROp_32:$vaddr), i32:$offset), vt:$in),
+  (INSERT_SUBREG $in, (inst $vaddr, $offset, (i32 0)), subreg)
+>;
+
+class ScratchLoadSaddrPat_D16_t16_pack <FLAT_Pseudo inst, SDPatternOperator node,
+                                         ValueType vt, SubRegIndex subreg> : GCNPat <
+  (node (ScratchSAddr (i32 SGPR_32:$saddr), i32:$offset), vt:$in),
+  (INSERT_SUBREG $in, (inst $saddr, $offset, (i32 0)), subreg)
+>;
+
+class ScratchLoadSVaddrPat_D16_t16_pack <FLAT_Pseudo inst, SDPatternOperator node,
+                                          ValueType vt, SubRegIndex subreg> : GCNPat <
+  (node (ScratchSVAddr (i32 VGPROp_32:$vaddr), (i32 SGPR_32:$saddr), i32:$offset, CPol:$cpol), vt:$in),
+  (INSERT_SUBREG $in, (inst $vaddr, $saddr, $offset, $cpol), subreg)
 >;
 
 multiclass GlobalLoadLDSPats_M0<FLAT_Pseudo inst, SDPatternOperator node> {
@@ -1803,6 +1877,17 @@ multiclass GlobalFLATLoadPats_D16_t16<string inst, SDPatternOperator node, Value
   }
 }
 
+multiclass GlobalFLATLoadPats_D16_t16_pack<string inst, SDPatternOperator node,
+                                            ValueType vt, SubRegIndex subreg> {
+  def : FlatSignedLoadPat_D16_t16_pack<!cast<FLAT_Pseudo>(inst#"_t16"), node, vt, subreg> {
+    let AddedComplexity = 10;
+  }
+
+  def : FlatLoadSaddrPat_D16_t16_pack<!cast<FLAT_Pseudo>(inst#"_SADDR_t16"), node, vt, subreg> {
+    let AddedComplexity = 11;
+  }
+}
+
 multiclass GlobalFLATLoadPats_t16<FLAT_Pseudo inst, SDPatternOperator node, ValueType vt> {
   def : FlatSignedLoadPat_t16<inst, node, vt> {
     let AddedComplexity = 10;
@@ -1835,6 +1920,19 @@ multiclass GlobalFLATStorePats_D16_t16<string inst, SDPatternOperator node, Valu
 
   def : FlatStoreSaddrPat<!cast<FLAT_Pseudo>(inst#"_SADDR_t16"), node, vt> {
     let AddedComplexity = 11;
+  }
+}
+
+multiclass GlobalFLATStorePats_t16_from_i32<string inst, SDPatternOperator node,
+                                            ValueType vt, SubRegIndex subreg = lo16> {
+  // Complexity strictly above the plain GlobalFLATStorePats (main = 10,
+  // saddr = 11) so SDAG prefers the _t16 form.
+  def : FlatStoreSignedPat_t16_from_i32<!cast<FLAT_Pseudo>(inst#"_t16"), node, vt, subreg> {
+    let AddedComplexity = 12;
+  }
+
+  def : FlatStoreSaddrPat_t16_from_i32<!cast<FLAT_Pseudo>(inst#"_SADDR_t16"), node, vt, subreg> {
+    let AddedComplexity = 13;
   }
 }
 
@@ -1937,6 +2035,27 @@ multiclass ScratchFLATStorePats_D16_t16<string inst, SDPatternOperator node,
   }
 }
 
+// True16 variant of ScratchFLATStorePats for a truncating store from a 32-bit
+// value: extract the low 16 bits and select into the _t16 store pseudo
+// (SDAG-only).
+multiclass ScratchFLATStorePats_t16_from_i32<string inst, SDPatternOperator node,
+                                             ValueType vt, SubRegIndex subreg = lo16> {
+  // Complexity strictly above the plain ScratchFLATStorePats (main = 25,
+  // saddr = 26, svs = 27) so SDAG prefers the _t16 form under true16.
+  def : ScratchStoreSignedPat_t16_from_i32 <!cast<FLAT_Pseudo>(inst#"_t16"), node, vt, subreg> {
+    let AddedComplexity = 28;
+  }
+
+  def : ScratchStoreSaddrPat_t16_from_i32<!cast<FLAT_Pseudo>(inst#"_SADDR_t16"), node, vt, subreg> {
+    let AddedComplexity = 29;
+  }
+
+  def : ScratchStoreSVaddrPat_t16_from_i32<!cast<FLAT_Pseudo>(inst#"_SVS_t16"), node, vt, subreg> {
+    let SubtargetPredicate = HasFlatScratchSVSMode;
+    let AddedComplexity = 30;
+  }
+}
+
 multiclass ScratchFLATLoadPats_D16<FLAT_Pseudo inst, SDPatternOperator node, ValueType vt> {
   def : ScratchLoadSignedPat_D16 <inst, node, vt> {
     let AddedComplexity = 25;
@@ -1962,6 +2081,22 @@ multiclass ScratchFLATLoadPats_D16_t16<string inst, SDPatternOperator node, Valu
   }
 
   def : ScratchLoadSVaddrPat_D16_t16 <!cast<FLAT_Pseudo>(inst#"_SVS_t16"), node, vt> {
+    let SubtargetPredicate = HasFlatScratchSVSMode;
+    let AddedComplexity = 27;
+  }
+}
+
+multiclass ScratchFLATLoadPats_D16_t16_pack<string inst, SDPatternOperator node,
+                                             ValueType vt, SubRegIndex subreg> {
+  def : ScratchLoadSignedPat_D16_t16_pack <!cast<FLAT_Pseudo>(inst#"_t16"), node, vt, subreg> {
+    let AddedComplexity = 25;
+  }
+
+  def : ScratchLoadSaddrPat_D16_t16_pack<!cast<FLAT_Pseudo>(inst#"_SADDR_t16"), node, vt, subreg> {
+    let AddedComplexity = 26;
+  }
+
+  def : ScratchLoadSVaddrPat_D16_t16_pack <!cast<FLAT_Pseudo>(inst#"_SVS_t16"), node, vt, subreg> {
     let SubtargetPredicate = HasFlatScratchSVSMode;
     let AddedComplexity = 27;
   }
@@ -2011,6 +2146,16 @@ multiclass FlatLoadPats_D16_t16<FLAT_Pseudo inst, SDPatternOperator node, ValueT
   }
 }
 
+multiclass FlatLoadPats_D16_t16_pack<FLAT_Pseudo inst, SDPatternOperator node,
+                                      ValueType vt, SubRegIndex subreg> {
+  def : FlatLoadPat_D16_t16_pack <inst, node, vt, subreg>;
+
+  def : FlatLoadSaddrPat_D16_t16_pack<!cast<FLAT_Pseudo>(!cast<string>(inst)#"_SADDR"), node, vt, subreg> {
+    let AddedComplexity = 9;
+    let SubtargetPredicate = HasFlatGVSMode;
+  }
+}
+
 multiclass FlatLoadPats_t16<FLAT_Pseudo inst, SDPatternOperator node, ValueType vt> {
   def : FlatLoadPat_t16 <inst, node, vt> {
     let OtherPredicates = [HasFlatAddressSpace];
@@ -2038,6 +2183,21 @@ multiclass FlatStorePats_t16<FLAT_Pseudo inst, SDPatternOperator node, ValueType
 
   def : FlatStoreSaddrPat<!cast<FLAT_Pseudo>(!cast<string>(inst)#"_SADDR_t16"), node, vt> {
     let AddedComplexity = 9;
+    let SubtargetPredicate = HasFlatGVSMode;
+  }
+}
+
+multiclass FlatStorePats_t16_from_i32<FLAT_Pseudo inst, SDPatternOperator node,
+                                      ValueType vt, SubRegIndex subreg = lo16> {
+  // Complexity strictly above the plain FlatStorePats (main = 0, saddr = 9) so
+  // SDAG prefers the _t16 form under true16.
+  def : FlatStorePat_t16_from_i32 <!cast<FLAT_Pseudo>(!cast<string>(inst)#"_t16"), node, vt, subreg> {
+    let OtherPredicates = [HasFlatAddressSpace];
+    let AddedComplexity = 10;
+  }
+
+  def : FlatStoreSaddrPat_t16_from_i32<!cast<FLAT_Pseudo>(!cast<string>(inst)#"_SADDR_t16"), node, vt, subreg> {
+    let AddedComplexity = 11;
     let SubtargetPredicate = HasFlatGVSMode;
   }
 }
@@ -2108,8 +2268,16 @@ defm : FlatLoadPats <FLAT_LOAD_DWORDX2, atomic_load_nonext_64_flat, v4i16>;
 defm : FlatLoadPats <FLAT_LOAD_DWORDX2, atomic_load_nonext_64_flat, v2i32>;
 defm : FlatLoadPats <FLAT_LOAD_DWORDX4, atomic_load_nonext_128_flat, v4i32>;
 
-defm : FlatStorePats <FLAT_STORE_BYTE, truncstorei8_flat, i32>;
-defm : FlatStorePats <FLAT_STORE_SHORT, truncstorei16_flat, i32>;
+// The _t16 variants below use EXTRACT_SUBREG on a source operand and cannot
+// be imported by GISel).
+let True16Predicate = NotUseRealTrue16Insts in {
+  defm : FlatStorePats <FLAT_STORE_BYTE, truncstorei8_flat, i32>;
+  defm : FlatStorePats <FLAT_STORE_SHORT, truncstorei16_flat, i32>;
+}
+let True16Predicate = UseRealTrue16Insts in {
+  defm : FlatStorePats_t16_from_i32 <FLAT_STORE_BYTE, truncstorei8_flat, i32>;
+  defm : FlatStorePats_t16_from_i32 <FLAT_STORE_SHORT, truncstorei16_flat, i32>;
+}
 
 foreach vt = Reg32Types.types in {
 defm : FlatLoadPats <FLAT_LOAD_DWORD, load_flat, vt>;
@@ -2184,16 +2352,18 @@ let SubtargetPredicate = HasAtomicCondSubClampFlatInsts in {
 }
 } // end foreach as
 
-defm : FlatStorePats <FLAT_STORE_BYTE, truncstorei8_flat, i16>;
-defm : FlatStorePats <FLAT_STORE_SHORT, store_flat, i16>;
-
+// hi16 truncstores use the non-t16 *_D16_HI pseudos (VGPR_32 data) even
+// under true16. The natural true16 form would extract the hi16 subregister into
+// a VGPR_16 and use the _t16 store pseudo, but that approach
+// miscompiles uniform values today
 let OtherPredicates = [HasD16LoadStore] in {
-defm : FlatStorePats <FLAT_STORE_SHORT_D16_HI, truncstorei16_hi16_flat, i32>;
-defm : FlatStorePats <FLAT_STORE_BYTE_D16_HI, truncstorei8_hi16_flat, i32>;
+  defm : FlatStorePats <FLAT_STORE_SHORT_D16_HI, truncstorei16_hi16_flat, i32>;
+  defm : FlatStorePats <FLAT_STORE_BYTE_D16_HI, truncstorei8_hi16_flat, i32>;
 }
 
 let OtherPredicates = [D16PreservesUnusedBits] in {
 // TODO: Handle atomic loads
+let True16Predicate = NotUseRealTrue16Insts in {
 defm : FlatLoadPats_D16 <FLAT_LOAD_UBYTE_D16_HI, az_extloadi8_d16_hi_flat, v2i16>;
 defm : FlatLoadPats_D16 <FLAT_LOAD_UBYTE_D16_HI, az_extloadi8_d16_hi_flat, v2f16>;
 defm : FlatLoadPats_D16 <FLAT_LOAD_SBYTE_D16_HI, sextloadi8_d16_hi_flat, v2i16>;
@@ -2207,6 +2377,23 @@ defm : FlatLoadPats_D16 <FLAT_LOAD_SBYTE_D16, sextloadi8_d16_lo_flat, v2i16>;
 defm : FlatLoadPats_D16 <FLAT_LOAD_SBYTE_D16, sextloadi8_d16_lo_flat, v2f16>;
 defm : FlatLoadPats_D16 <FLAT_LOAD_SHORT_D16, load_d16_lo_flat, v2i16>;
 defm : FlatLoadPats_D16 <FLAT_LOAD_SHORT_D16, load_d16_lo_flat, v2f16>;
+} // End True16Predicate = NotUseRealTrue16Insts
+
+let True16Predicate = UseRealTrue16Insts in {
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_UBYTE_D16_t16, az_extloadi8_d16_hi_flat, v2i16, hi16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_UBYTE_D16_t16, az_extloadi8_d16_hi_flat, v2f16, hi16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SBYTE_D16_t16, sextloadi8_d16_hi_flat, v2i16, hi16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SBYTE_D16_t16, sextloadi8_d16_hi_flat, v2f16, hi16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SHORT_D16_t16, load_d16_hi_flat, v2i16, hi16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SHORT_D16_t16, load_d16_hi_flat, v2f16, hi16>;
+
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_UBYTE_D16_t16, az_extloadi8_d16_lo_flat, v2i16, lo16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_UBYTE_D16_t16, az_extloadi8_d16_lo_flat, v2f16, lo16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SBYTE_D16_t16, sextloadi8_d16_lo_flat, v2i16, lo16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SBYTE_D16_t16, sextloadi8_d16_lo_flat, v2f16, lo16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SHORT_D16_t16, load_d16_lo_flat, v2i16, lo16>;
+defm : FlatLoadPats_D16_t16_pack <FLAT_LOAD_SHORT_D16_t16, load_d16_lo_flat, v2f16, lo16>;
+} // End True16Predicate = UseRealTrue16Insts
 }
 
 defm : GlobalFLATLoadPats <GLOBAL_LOAD_UBYTE, atomic_load_aext_8_global, i32>;
@@ -2292,8 +2479,17 @@ defm : GlobalFLATLoadPats <GLOBAL_LOAD_DWORDX2, atomic_load_nonext_64_global, v2
 defm : GlobalFLATLoadPats <GLOBAL_LOAD_DWORDX2, atomic_load_nonext_64_global, v4i16>;
 defm : GlobalFLATLoadPats <GLOBAL_LOAD_DWORDX4, atomic_load_nonext_128_global, v4i32>;
 
-defm : GlobalFLATStorePats <GLOBAL_STORE_BYTE, truncstorei8_global, i32>;
-defm : GlobalFLATStorePats <GLOBAL_STORE_SHORT, truncstorei16_global, i32>;
+let OtherPredicates = [HasFlatGlobalInsts] in {
+  let True16Predicate = NotUseRealTrue16Insts in {
+  defm : GlobalFLATStorePats <GLOBAL_STORE_BYTE, truncstorei8_global, i32>;
+  defm : GlobalFLATStorePats <GLOBAL_STORE_SHORT, truncstorei16_global, i32>;
+  }
+  let True16Predicate = UseRealTrue16Insts in {
+  // SDAG only
+  defm : GlobalFLATStorePats_t16_from_i32 <"GLOBAL_STORE_BYTE", truncstorei8_global, i32>;
+  defm : GlobalFLATStorePats_t16_from_i32 <"GLOBAL_STORE_SHORT", truncstorei16_global, i32>;
+  }
+} // end OtherPredicates = [HasFlatGlobalInsts]
 defm : GlobalFLATStorePats <GLOBAL_STORE_DWORDX3, store_global, v3i32>;
 
 let OtherPredicates = [HasFlatGlobalInsts], True16Predicate = NotUseRealTrue16Insts in {
@@ -2310,13 +2506,16 @@ defm : GlobalFLATStorePats_D16_t16 <"GLOBAL_STORE_BYTE", atomic_store_8_global, 
 defm : GlobalFLATStorePats_D16_t16 <"GLOBAL_STORE_SHORT", atomic_store_16_global, i16>;
 }
 
+// See the flat hi16 truncstore comment above: these keep using the non-t16
+// *_D16_HI pseudos under true16 to avoid the uniform hi16 SGPR miscompile.
 let OtherPredicates = [HasD16LoadStore] in {
-defm : GlobalFLATStorePats <GLOBAL_STORE_SHORT_D16_HI, truncstorei16_hi16_global, i32>;
-defm : GlobalFLATStorePats <GLOBAL_STORE_BYTE_D16_HI, truncstorei8_hi16_global, i32>;
+  defm : GlobalFLATStorePats <GLOBAL_STORE_SHORT_D16_HI, truncstorei16_hi16_global, i32>;
+  defm : GlobalFLATStorePats <GLOBAL_STORE_BYTE_D16_HI, truncstorei8_hi16_global, i32>;
 }
 
 let OtherPredicates = [D16PreservesUnusedBits] in {
 // TODO: Handle atomic loads
+let True16Predicate = NotUseRealTrue16Insts in {
 defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_UBYTE_D16_HI, az_extloadi8_d16_hi_global, v2i16>;
 defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_UBYTE_D16_HI, az_extloadi8_d16_hi_global, v2f16>;
 defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_SBYTE_D16_HI, sextloadi8_d16_hi_global, v2i16>;
@@ -2330,6 +2529,23 @@ defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_SBYTE_D16, sextloadi8_d16_lo_global, 
 defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_SBYTE_D16, sextloadi8_d16_lo_global, v2f16>;
 defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_SHORT_D16, load_d16_lo_global, v2i16>;
 defm : GlobalFLATLoadPats_D16 <GLOBAL_LOAD_SHORT_D16, load_d16_lo_global, v2f16>;
+} // End True16Predicate = NotUseRealTrue16Insts
+
+let True16Predicate = UseRealTrue16Insts in {
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_UBYTE_D16", az_extloadi8_d16_hi_global, v2i16, hi16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_UBYTE_D16", az_extloadi8_d16_hi_global, v2f16, hi16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SBYTE_D16", sextloadi8_d16_hi_global, v2i16, hi16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SBYTE_D16", sextloadi8_d16_hi_global, v2f16, hi16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SHORT_D16", load_d16_hi_global, v2i16, hi16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SHORT_D16", load_d16_hi_global, v2f16, hi16>;
+
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_UBYTE_D16", az_extloadi8_d16_lo_global, v2i16, lo16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_UBYTE_D16", az_extloadi8_d16_lo_global, v2f16, lo16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SBYTE_D16", sextloadi8_d16_lo_global, v2i16, lo16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SBYTE_D16", sextloadi8_d16_lo_global, v2f16, lo16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SHORT_D16", load_d16_lo_global, v2i16, lo16>;
+defm : GlobalFLATLoadPats_D16_t16_pack <"GLOBAL_LOAD_SHORT_D16", load_d16_lo_global, v2f16, lo16>;
+} // End True16Predicate = UseRealTrue16Insts
 }
 
 defm : GlobalFLATStorePats <GLOBAL_STORE_BYTE, atomic_store_8_global, i32>;
@@ -2516,16 +2732,25 @@ defm : ScratchFLATLoadPats <SCRATCH_LOAD_DWORDX4, load_private, vt>;
 defm : ScratchFLATStorePats <SCRATCH_STORE_DWORDX4, store_private, vt>;
 }
 
+let True16Predicate = NotUseRealTrue16Insts in {
 defm : ScratchFLATStorePats <SCRATCH_STORE_BYTE, truncstorei8_private, i32>;
 defm : ScratchFLATStorePats <SCRATCH_STORE_SHORT, truncstorei16_private, i32>;
+}
+let True16Predicate = UseRealTrue16Insts in {
+defm : ScratchFLATStorePats_t16_from_i32 <"SCRATCH_STORE_BYTE", truncstorei8_private, i32>;
+defm : ScratchFLATStorePats_t16_from_i32 <"SCRATCH_STORE_SHORT", truncstorei16_private, i32>;
+}
 defm : ScratchFLATStorePats <SCRATCH_STORE_DWORDX3, store_private, v3i32>;
 
+// See the flat hi16 truncstore comment above: these keep using the non-t16
+// *_D16_HI pseudos under true16 to avoid the uniform hi16 SGPR miscompile.
 let OtherPredicates = [HasD16LoadStore, HasFlatScratchInsts, HasFlatScratchEnabled] in {
-defm : ScratchFLATStorePats <SCRATCH_STORE_SHORT_D16_HI, truncstorei16_hi16_private, i32>;
-defm : ScratchFLATStorePats <SCRATCH_STORE_BYTE_D16_HI, truncstorei8_hi16_private, i32>;
+  defm : ScratchFLATStorePats <SCRATCH_STORE_SHORT_D16_HI, truncstorei16_hi16_private, i32>;
+  defm : ScratchFLATStorePats <SCRATCH_STORE_BYTE_D16_HI, truncstorei8_hi16_private, i32>;
 }
 
 let OtherPredicates = [D16PreservesUnusedBits, HasFlatScratchInsts, HasFlatScratchEnabled] in {
+let True16Predicate = NotUseRealTrue16Insts in {
 defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_UBYTE_D16_HI, az_extloadi8_d16_hi_private, v2i16>;
 defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_UBYTE_D16_HI, az_extloadi8_d16_hi_private, v2f16>;
 defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_SBYTE_D16_HI, sextloadi8_d16_hi_private, v2i16>;
@@ -2539,6 +2764,23 @@ defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_SBYTE_D16, sextloadi8_d16_lo_privat
 defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_SBYTE_D16, sextloadi8_d16_lo_private, v2f16>;
 defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_SHORT_D16, load_d16_lo_private, v2i16>;
 defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_SHORT_D16, load_d16_lo_private, v2f16>;
+} // End True16Predicate = NotUseRealTrue16Insts
+
+let True16Predicate = UseRealTrue16Insts in {
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_UBYTE_D16", az_extloadi8_d16_hi_private, v2i16, hi16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_UBYTE_D16", az_extloadi8_d16_hi_private, v2f16, hi16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SBYTE_D16", sextloadi8_d16_hi_private, v2i16, hi16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SBYTE_D16", sextloadi8_d16_hi_private, v2f16, hi16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SHORT_D16", load_d16_hi_private, v2i16, hi16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SHORT_D16", load_d16_hi_private, v2f16, hi16>;
+
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_UBYTE_D16", az_extloadi8_d16_lo_private, v2i16, lo16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_UBYTE_D16", az_extloadi8_d16_lo_private, v2f16, lo16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SBYTE_D16", sextloadi8_d16_lo_private, v2i16, lo16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SBYTE_D16", sextloadi8_d16_lo_private, v2f16, lo16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SHORT_D16", load_d16_lo_private, v2i16, lo16>;
+defm : ScratchFLATLoadPats_D16_t16_pack <"SCRATCH_LOAD_SHORT_D16", load_d16_lo_private, v2f16, lo16>;
+} // End True16Predicate = UseRealTrue16Insts
 }
 
 } // End OtherPredicates = [HasFlatScratchInsts,HasFlatScratchEnabled]

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
@@ -1993,78 +1993,78 @@ define amdgpu_ps i48 @s_fshl_v2i24(i48 inreg %lhs.arg, i48 inreg %rhs.arg, i48 i
 ;
 ; GFX11-TRUE16-LABEL: s_fshl_v2i24:
 ; GFX11-TRUE16:       ; %bb.0:
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, s1
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v4, s3
-; GFX11-TRUE16-NEXT:    s_and_b32 s1, s2, 0xffff
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v3, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, s3
 ; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v0, off offset:16
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s2
-; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s5
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, s1
+; GFX11-TRUE16-NEXT:    s_and_b32 s1, s2, 0xffff
 ; GFX11-TRUE16-NEXT:    s_clause 0x4
-; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v0, off
-; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v1, off offset:20
-; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v2, off offset:4
+; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v2, off
+; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v0, off offset:20
+; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b16 off, v0, off offset:4
 ; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v3, off offset:8
-; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v4, off offset:12
+; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v1, off offset:12
 ; GFX11-TRUE16-NEXT:    s_clause 0xb
 ; GFX11-TRUE16-NEXT:    scratch_load_u8 v0, off, off offset:21
 ; GFX11-TRUE16-NEXT:    scratch_load_u8 v1, off, off offset:20
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v2, off, off offset:19
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v3, off, off offset:11
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v4, off, off offset:12
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v5, off, off offset:18
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v6, off, off offset:5
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v7, off, off offset:4
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v8, off, off offset:3
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v2, off, off offset:18
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v3, off, off offset:2
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v4, off, off offset:19
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v5, off, off offset:11
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v6, off, off offset:12
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v7, off, off offset:5
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v8, off, off offset:4
 ; GFX11-TRUE16-NEXT:    scratch_load_u8 v9, off, off offset:13
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v10, off, off offset:2
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v11, off, off offset:10
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v10, off, off offset:10
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v11, off, off offset:3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 8
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(11)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(10)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(9)
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_or3_b32 v0, v1, v2, v0
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(8)
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(7)
-; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v1, v4, 8, v3
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(6)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v5
+; GFX11-TRUE16-NEXT:    v_or3_b32 v0, v1, v4, v0
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v2, 0xffff, s4, v2
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(5)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v6
+; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v1, v6, 8, v5
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(4)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 8, v7
-; GFX11-TRUE16-NEXT:    v_mul_hi_u32 v0, 0xaaaaaab, v0
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0xffff, s4, v3
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 16, v7
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(3)
-; GFX11-TRUE16-NEXT:    v_or3_b32 v4, v5, v8, v4
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v6, 8, v8
+; GFX11-TRUE16-NEXT:    v_mul_hi_u32 v0, 0xaaaaaab, v0
+; GFX11-TRUE16-NEXT:    v_mul_hi_u32 v2, 0xaaaaaab, v2
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v7, v10, 24, s1
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v5, v11, 24, s1
+; GFX11-TRUE16-NEXT:    v_or3_b32 v5, v6, v11, v5
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0xffff, s0, v3
 ; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v1, v9, 24, v1
-; GFX11-TRUE16-NEXT:    v_mul_hi_u32 v3, 0xaaaaaab, v3
-; GFX11-TRUE16-NEXT:    v_lshl_add_u32 v0, v0, 3, v2
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v10
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v4, 1, v4
-; GFX11-TRUE16-NEXT:    v_alignbit_b32 v1, v8, v1, 1
-; GFX11-TRUE16-NEXT:    v_alignbit_b32 v5, s0, v5, 1
+; GFX11-TRUE16-NEXT:    v_lshl_add_u32 v0, v0, 3, v4
+; GFX11-TRUE16-NEXT:    v_lshl_add_u32 v2, v2, 3, s4
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 1, v5
+; GFX11-TRUE16-NEXT:    v_alignbit_b32 v4, s0, v7, 1
+; GFX11-TRUE16-NEXT:    v_alignbit_b32 v1, v11, v1, 1
 ; GFX11-TRUE16-NEXT:    v_not_b32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v2, 0xffff, s0, v2
-; GFX11-TRUE16-NEXT:    v_lshl_add_u32 v3, v3, 3, s4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_alignbit_b32 v0, v4, v1, v0.l
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 1, v2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v2, v3
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 8, v0
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 1, v3
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v2, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_alignbit_b32 v0, v5, v1, v0.l
+; GFX11-TRUE16-NEXT:    v_alignbit_b32 v1, v3, v4, v2.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_alignbit_b32 v1, v1, v5, v2.l
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v2, 8, v0
 ; GFX11-TRUE16-NEXT:    s_clause 0x4
-; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b8 off, v0, off offset:29
-; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v3, off offset:28
-; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, off offset:27
 ; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b8 off, v1, off offset:26
+; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b8 off, v0, off offset:29
 ; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v1, off offset:24
+; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v2, off offset:28
+; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, off offset:27
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    scratch_load_b32 v0, off, off offset:24
 ; GFX11-TRUE16-NEXT:    scratch_load_u16 v1, off, off offset:28

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
@@ -2012,78 +2012,78 @@ define amdgpu_ps i48 @s_fshr_v2i24(i48 inreg %lhs.arg, i48 inreg %rhs.arg, i48 i
 ;
 ; GFX11-TRUE16-LABEL: s_fshr_v2i24:
 ; GFX11-TRUE16:       ; %bb.0:
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, s5
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v4, s3
-; GFX11-TRUE16-NEXT:    s_and_b32 s1, s2, 0xffff
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, s3
 ; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v0, off
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v3, s2
-; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, s5
+; GFX11-TRUE16-NEXT:    s_and_b32 s1, s2, 0xffff
 ; GFX11-TRUE16-NEXT:    s_clause 0x4
-; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v0, off offset:16
-; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v1, off offset:4
-; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v2, off offset:20
+; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v2, off offset:16
+; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v0, off offset:4
+; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b16 off, v0, off offset:20
 ; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v3, off offset:8
-; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v4, off offset:12
+; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v1, off offset:12
 ; GFX11-TRUE16-NEXT:    s_clause 0xb
 ; GFX11-TRUE16-NEXT:    scratch_load_u8 v0, off, off offset:21
 ; GFX11-TRUE16-NEXT:    scratch_load_u8 v1, off, off offset:20
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v2, off, off offset:19
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v3, off, off offset:18
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v4, off, off offset:11
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v5, off, off offset:12
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v6, off, off offset:5
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v7, off, off offset:4
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v8, off, off offset:3
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v2, off, off offset:18
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v3, off, off offset:19
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v4, off, off offset:2
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v5, off, off offset:11
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v6, off, off offset:12
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v7, off, off offset:5
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v8, off, off offset:4
 ; GFX11-TRUE16-NEXT:    scratch_load_u8 v9, off, off offset:13
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v10, off, off offset:2
-; GFX11-TRUE16-NEXT:    scratch_load_u8 v11, off, off offset:10
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v10, off, off offset:10
+; GFX11-TRUE16-NEXT:    scratch_load_u8 v11, off, off offset:3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 8
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(11)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(10)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(9)
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_or3_b32 v0, v1, v2, v0
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(8)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 16, v3
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(6)
-; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v3, v5, 8, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_or3_b32 v0, v1, v3, v0
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0xffff, s4, v2
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(7)
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(5)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v6
+; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v4, v6, 8, v5
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(4)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 8, v7
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 16, v7
 ; GFX11-TRUE16-NEXT:    v_mul_hi_u32 v0, 0xaaaaaab, v0
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0xffff, s4, v1
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_mul_hi_u32 v1, 0xaaaaaab, v1
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(2)
-; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v3, v9, 24, v3
-; GFX11-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 24, v0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_sub_nc_u32_e32 v0, v2, v0
-; GFX11-TRUE16-NEXT:    v_mul_u32_u24_e32 v1, 24, v1
-; GFX11-TRUE16-NEXT:    v_or3_b32 v2, v5, v8, v4
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v10
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v6, 8, v8
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v2, 0xffff, s0, v2
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v5, v11, 24, s1
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v0, 8, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_or3_b32 v5, v6, v11, v5
+; GFX11-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 24, v0
+; GFX11-TRUE16-NEXT:    v_mul_u32_u24_e32 v1, 24, v1
+; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v4, v9, 24, v4
+; GFX11-TRUE16-NEXT:    v_sub_nc_u32_e32 v0, v3, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_sub_nc_u32_e32 v1, s4, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_alignbit_b32 v0, v2, v3, v0.l
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v2, 0xffff, s0, v4
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    v_lshl_or_b32 v3, v10, 24, s1
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v0, 8, v0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 8, v0
-; GFX11-TRUE16-NEXT:    v_alignbit_b32 v1, v2, v5, v1.l
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    v_alignbit_b32 v0, v5, v4, v0.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_alignbit_b32 v1, v2, v3, v1.l
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v2, 8, v0
 ; GFX11-TRUE16-NEXT:    s_clause 0x4
-; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b8 off, v0, off offset:29
-; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v3, off offset:28
-; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, off offset:27
 ; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b8 off, v1, off offset:26
+; GFX11-TRUE16-NEXT:    scratch_store_d16_hi_b8 off, v0, off offset:29
 ; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v1, off offset:24
+; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v2, off offset:28
+; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, off offset:27
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    scratch_load_b32 v0, off, off offset:24
 ; GFX11-TRUE16-NEXT:    scratch_load_u16 v1, off, off offset:28

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-flat.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-flat.mir
@@ -107,14 +107,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
-    ; GFX11-NEXT: FLAT_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16))
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX11-NEXT: FLAT_STORE_SHORT_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16))
     ;
     ; GFX12-LABEL: name: store_flat_s32_to_2
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
-    ; GFX12-NEXT: FLAT_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16))
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX12-NEXT: FLAT_STORE_SHORT_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16))
     %0:vgpr(p1) = COPY $vgpr0_vgpr1
     %1:vgpr(s32) = COPY $vgpr2
     G_STORE %1, %0 :: (store (s16), align 2, addrspace 0)
@@ -164,14 +166,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
-    ; GFX11-NEXT: FLAT_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8))
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX11-NEXT: FLAT_STORE_BYTE_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8))
     ;
     ; GFX12-LABEL: name: store_flat_s32_to_1
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
-    ; GFX12-NEXT: FLAT_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8))
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX12-NEXT: FLAT_STORE_BYTE_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8))
     %0:vgpr(p1) = COPY $vgpr0_vgpr1
     %1:vgpr(s32) = COPY $vgpr2
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 0)

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-global.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-global.mir
@@ -5,7 +5,7 @@
 # RUN: llc -amdgpu-global-isel-new-legality -mtriple=amdgpu8.03 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX8 %s
 # RUN: llc -amdgpu-global-isel-new-legality -mtriple=amdgpu9.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX9 %s
 # RUN: llc -amdgpu-global-isel-new-legality -mtriple=amdgpu10.10 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX10 %s
-# RUN: llc -amdgpu-global-isel-new-legality -mtriple=amdgpu11.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX10 %s
+# RUN: llc -amdgpu-global-isel-new-legality -mtriple=amdgpu11.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX11 %s
 # RUN: llc -amdgpu-global-isel-new-legality -mtriple=amdgpu12.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX12 %s
 
 ---
@@ -70,6 +70,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_s32_to_4
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_s32_to_4
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
@@ -145,12 +152,21 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s16), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_s32_to_2
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX11-NEXT: GLOBAL_STORE_SHORT_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec :: (store (s16), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_s32_to_2
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
-    ; GFX12-NEXT: GLOBAL_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s16), addrspace 1)
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX12-NEXT: GLOBAL_STORE_SHORT_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec :: (store (s16), addrspace 1)
     %0:vgpr(p1) = COPY $vgpr0_vgpr1
     %1:vgpr(s32) = COPY $vgpr2
     G_STORE %1, %0 :: (store (s16), align 2, addrspace 1)
@@ -219,12 +235,21 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s8), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_s32_to_1
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX11-NEXT: GLOBAL_STORE_BYTE_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec :: (store (s8), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_s32_to_1
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
-    ; GFX12-NEXT: GLOBAL_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s8), addrspace 1)
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY1]].lo16
+    ; GFX12-NEXT: GLOBAL_STORE_BYTE_t16 [[COPY]], [[COPY2]], 0, 0, implicit $exec :: (store (s8), addrspace 1)
     %0:vgpr(p1) = COPY $vgpr0_vgpr1
     %1:vgpr(s32) = COPY $vgpr2
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 1)
@@ -294,6 +319,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s64), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_s64
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (s64), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_s64
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
     ; GFX12-NEXT: {{  $}}
@@ -357,6 +389,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vgpr(p1) = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr(s128) = COPY $vgpr2_vgpr3_vgpr4_vgpr5
     ; GFX10-NEXT: G_STORE [[COPY1]](s128), [[COPY]](p1) :: (store (s128), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_s128
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr(p1) = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr(s128) = COPY $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: G_STORE [[COPY1]](s128), [[COPY]](p1) :: (store (s128), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_s128
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
@@ -433,6 +472,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x s32>), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_v2s32
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x s32>), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_v2s32
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
     ; GFX12-NEXT: {{  $}}
@@ -506,6 +552,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<4 x s32>), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_v4s32
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<4 x s32>), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_v4s32
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
@@ -582,6 +635,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x s16>), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_v2s16
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x s16>), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_v2s16
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
@@ -656,6 +716,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<4 x s16>), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_v4s16
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<4 x s16>), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_v4s16
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
@@ -732,6 +799,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<8 x s16>), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_v8s16
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<8 x s16>), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_v8s16
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
     ; GFX12-NEXT: {{  $}}
@@ -806,6 +880,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x s64>), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_v2s64
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x s64>), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_v2s64
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
@@ -882,6 +963,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (p1), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_p1
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (p1), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_p1
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
     ; GFX12-NEXT: {{  $}}
@@ -956,6 +1044,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x p1>), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_v2p1
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_128 = COPY $vgpr2_vgpr3_vgpr4_vgpr5
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX4 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x p1>), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_v2p1
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5
@@ -1032,6 +1127,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (p3), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_p3
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (p3), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_p3
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
@@ -1107,6 +1209,13 @@ body: |
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x p3>), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_v2p3
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store (<2 x p3>), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_v2p3
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
     ; GFX12-NEXT: {{  $}}
@@ -1180,6 +1289,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store monotonic (s32), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_atomic_global_s32
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store monotonic (s32), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_atomic_global_s32
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
@@ -1255,6 +1371,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
     ; GFX10-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store monotonic (s64), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_atomic_global_s64
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vreg_64 = COPY $vgpr2_vgpr3
+    ; GFX11-NEXT: GLOBAL_STORE_DWORDX2 [[COPY]], [[COPY1]], 0, 0, implicit $exec :: (store monotonic (s64), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_atomic_global_s64
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
@@ -1346,6 +1469,13 @@ body: |
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 2047, 0, implicit $exec :: (store (s32), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_s32_gep_2047
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[COPY]], [[COPY1]], 2047, 0, implicit $exec :: (store (s32), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_s32_gep_2047
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
@@ -1457,6 +1587,21 @@ body: |
     ; GFX10-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
     ; GFX10-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_s32_to_1_gep_24bit_max
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[V_MOV_B:%[0-9]+]]:vreg_64 = V_MOV_B64_PSEUDO 8388607, implicit $exec
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub0
+    ; GFX11-NEXT: [[COPY4:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub1
+    ; GFX11-NEXT: [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[COPY2]], [[COPY3]], 0, implicit $exec
+    ; GFX11-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+    ; GFX11-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_s32_to_1_gep_24bit_max
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
@@ -1582,6 +1727,21 @@ body: |
     ; GFX10-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
     ;
+    ; GFX11-LABEL: name: store_global_s32_to_1_gep_24bit_min
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[V_MOV_B:%[0-9]+]]:vreg_64 = V_MOV_B64_PSEUDO -8388608, implicit $exec
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub0
+    ; GFX11-NEXT: [[COPY4:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub1
+    ; GFX11-NEXT: [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[COPY2]], [[COPY3]], 0, implicit $exec
+    ; GFX11-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+    ; GFX11-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
+    ;
     ; GFX12-LABEL: name: store_global_s32_to_1_gep_24bit_min
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
@@ -1692,6 +1852,21 @@ body: |
     ; GFX10-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
     ; GFX10-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_s32_to_1_gep_2x_24bit_max
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[V_MOV_B:%[0-9]+]]:vreg_64 = V_MOV_B64_PSEUDO 16777214, implicit $exec
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub0
+    ; GFX11-NEXT: [[COPY4:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub1
+    ; GFX11-NEXT: [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[COPY2]], [[COPY3]], 0, implicit $exec
+    ; GFX11-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+    ; GFX11-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_s32_to_1_gep_2x_24bit_max
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
@@ -1825,6 +2000,21 @@ body: |
     ; GFX10-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
     ; GFX10-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
     ; GFX10-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
+    ;
+    ; GFX11-LABEL: name: store_global_s32_to_1_gep_2x_24bit_min
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[V_MOV_B:%[0-9]+]]:vreg_64 = V_MOV_B64_PSEUDO -16777215, implicit $exec
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub0
+    ; GFX11-NEXT: [[COPY4:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[V_MOV_B]].sub1
+    ; GFX11-NEXT: [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[COPY2]], [[COPY3]], 0, implicit $exec
+    ; GFX11-NEXT: [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, dead [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADDC_U32_e64 [[COPY4]], [[COPY5]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+    ; GFX11-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_ADD_CO_U32_e64_]], %subreg.sub0, [[V_ADDC_U32_e64_]], %subreg.sub1
+    ; GFX11-NEXT: GLOBAL_STORE_DWORD [[REG_SEQUENCE]], [[COPY1]], 0, 0, implicit $exec :: (store (s32), addrspace 1)
     ;
     ; GFX12-LABEL: name: store_global_s32_to_1_gep_2x_24bit_min
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-local.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-local.mir
@@ -4,7 +4,7 @@
 # RUN: llc -mtriple=amdgpu8.03 -run-pass=instruction-select -verify-machineinstrs  -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX7 %s
 # RUN: llc -mtriple=amdgpu9.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX9 %s
 # RUN: llc -mtriple=amdgpu10.10 -mattr=+cumode -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX10 %s
-# RUN: llc -mtriple=amdgpu11.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX9 %s
+# RUN: llc -mtriple=amdgpu11.00 -run-pass=instruction-select -verify-machineinstrs -global-isel-abort=0 -o - %s | FileCheck -check-prefix=GFX11 %s
 
 ---
 
@@ -27,6 +27,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B32 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s32), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s32_to_4
     ; GFX7: liveins: $vgpr0, $vgpr1
     ; GFX7-NEXT: {{  $}}
@@ -34,18 +35,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B32 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s32), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s32_to_4
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX9-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s32), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s32_to_4
     ; GFX10: liveins: $vgpr0, $vgpr1
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX10-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s32), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s32_to_4
+    ; GFX11: liveins: $vgpr0, $vgpr1
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
+    ; GFX11-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s32), addrspace 3)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p3) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s32), align 4, addrspace 3)
@@ -73,6 +83,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B16 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s16), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s32_to_2
     ; GFX7: liveins: $vgpr0, $vgpr1
     ; GFX7-NEXT: {{  $}}
@@ -80,18 +91,28 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B16 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s16), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s32_to_2
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX9-NEXT: DS_WRITE_B16_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s16), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s32_to_2
     ; GFX10: liveins: $vgpr0, $vgpr1
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX10-NEXT: DS_WRITE_B16_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s16), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s32_to_2
+    ; GFX11: liveins: $vgpr0, $vgpr1
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX11-NEXT: DS_WRITE_B16_t16 [[COPY1]], [[COPY2]], 0, 0, implicit $exec :: (store (s16), addrspace 3)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p3) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s16), align 2, addrspace 3)
@@ -119,6 +140,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B8 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s32_to_1
     ; GFX7: liveins: $vgpr0, $vgpr1
     ; GFX7-NEXT: {{  $}}
@@ -126,18 +148,28 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B8 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s32_to_1
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX9-NEXT: DS_WRITE_B8_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s32_to_1
     ; GFX10: liveins: $vgpr0, $vgpr1
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX10-NEXT: DS_WRITE_B8_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s32_to_1
+    ; GFX11: liveins: $vgpr0, $vgpr1
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX11-NEXT: DS_WRITE_B8_t16 [[COPY1]], [[COPY2]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p3) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s8), align 1, addrspace 3)
@@ -165,6 +197,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B32 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (<2 x s16>), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_v2s16
     ; GFX7: liveins: $vgpr0, $vgpr1
     ; GFX7-NEXT: {{  $}}
@@ -172,18 +205,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B32 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (<2 x s16>), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_v2s16
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX9-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<2 x s16>), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_v2s16
     ; GFX10: liveins: $vgpr0, $vgpr1
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX10-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<2 x s16>), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_v2s16
+    ; GFX11: liveins: $vgpr0, $vgpr1
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
+    ; GFX11-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<2 x s16>), addrspace 3)
     %0:vgpr(<2 x s16>) = COPY $vgpr0
     %1:vgpr(p3) = COPY $vgpr1
     G_STORE %0, %1 :: (store (<2 x s16>), align 4, addrspace 3)
@@ -211,6 +253,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B32 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (p3), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_p3
     ; GFX7: liveins: $vgpr0, $vgpr1
     ; GFX7-NEXT: {{  $}}
@@ -218,18 +261,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B32 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (p3), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_p3
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX9-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (p3), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_p3
     ; GFX10: liveins: $vgpr0, $vgpr1
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
     ; GFX10-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (p3), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_p3
+    ; GFX11: liveins: $vgpr0, $vgpr1
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
+    ; GFX11-NEXT: DS_WRITE_B32_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (p3), addrspace 3)
     %0:vgpr(p3) = COPY $vgpr0
     %1:vgpr(p3) = COPY $vgpr1
     G_STORE %0, %1 :: (store (p3), align 4, addrspace 3)
@@ -251,19 +303,28 @@ body: |
     ; GFX6-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B8 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $m0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s32_to_1_constant_4095
     ; GFX7: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX7-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B8 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $m0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s32_to_1_constant_4095
     ; GFX9: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX9-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX9-NEXT: DS_WRITE_B8_gfx9 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s32_to_1_constant_4095
     ; GFX10: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX10-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX10-NEXT: DS_WRITE_B8_gfx9 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s32_to_1_constant_4095
+    ; GFX11: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
+    ; GFX11-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX11-NEXT: DS_WRITE_B8_t16 [[V_MOV_B32_e32_]], [[COPY]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
     %0:vgpr(p3) = G_CONSTANT i32 4095
     %1:vgpr(s32) = G_CONSTANT i32 0
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 3)
@@ -290,19 +351,28 @@ body: |
     ; GFX6-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B8 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $m0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s32_to_1_constant_4096
     ; GFX7: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX7-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B8 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $m0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s32_to_1_constant_4096
     ; GFX9: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX9-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX9-NEXT: DS_WRITE_B8_gfx9 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s32_to_1_constant_4096
     ; GFX10: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX10-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
     ; GFX10-NEXT: DS_WRITE_B8_gfx9 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s32_to_1_constant_4096
+    ; GFX11: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
+    ; GFX11-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX11-NEXT: DS_WRITE_B8_t16 [[V_MOV_B32_e32_]], [[COPY]], 0, 0, implicit $exec :: (store (s8), addrspace 3)
     %0:vgpr(p3) = G_CONSTANT i32 4096
     %1:vgpr(s32) = G_CONSTANT i32 0
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 3)
@@ -330,6 +400,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr(p3) = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: G_STORE [[COPY]](s64), [[COPY1]](p3) :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s64_align4
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -339,6 +410,7 @@ body: |
     ; GFX7-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX7-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX7-NEXT: DS_WRITE2_B32 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $m0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s64_align4
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
@@ -347,6 +419,7 @@ body: |
     ; GFX9-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX9-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX9-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s64_align4
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
@@ -355,6 +428,15 @@ body: |
     ; GFX10-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX10-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX10-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s64_align4
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
     %0:vgpr(s64) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (s64), align 4, addrspace 3)
@@ -382,6 +464,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr(p3) = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: G_STORE [[COPY]](p1), [[COPY1]](p3) :: (store (p1), align 4, addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_p1_align4
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -391,6 +474,7 @@ body: |
     ; GFX7-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX7-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX7-NEXT: DS_WRITE2_B32 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $m0, implicit $exec :: (store (p1), align 4, addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_p1_align4
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
@@ -399,6 +483,7 @@ body: |
     ; GFX9-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX9-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX9-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (p1), align 4, addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_p1_align4
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
@@ -407,6 +492,15 @@ body: |
     ; GFX10-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX10-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX10-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (p1), align 4, addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_p1_align4
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (p1), align 4, addrspace 3)
     %0:vgpr(p1) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (p1), align 4, addrspace 3)
@@ -434,6 +528,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr(p3) = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: G_STORE [[COPY]](<2 x s32>), [[COPY1]](p3) :: (store (<2 x s32>), align 4, addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_v2s32_align4
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -443,6 +538,7 @@ body: |
     ; GFX7-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX7-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX7-NEXT: DS_WRITE2_B32 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $m0, implicit $exec :: (store (<2 x s32>), align 4, addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_v2s32_align4
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
@@ -451,6 +547,7 @@ body: |
     ; GFX9-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX9-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX9-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (<2 x s32>), align 4, addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_v2s32_align4
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
@@ -459,6 +556,15 @@ body: |
     ; GFX10-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX10-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX10-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (<2 x s32>), align 4, addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_v2s32_align4
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (<2 x s32>), align 4, addrspace 3)
     %0:vgpr(<2 x s32>) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (<2 x s32>), align 4, addrspace 3)
@@ -486,6 +592,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr(p3) = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: G_STORE [[COPY]](<4 x s16>), [[COPY1]](p3) :: (store (<4 x s16>), align 4, addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_v4s16_align4
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -495,6 +602,7 @@ body: |
     ; GFX7-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX7-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX7-NEXT: DS_WRITE2_B32 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $m0, implicit $exec :: (store (<4 x s16>), align 4, addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_v4s16_align4
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
@@ -503,6 +611,7 @@ body: |
     ; GFX9-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX9-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX9-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (<4 x s16>), align 4, addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_v4s16_align4
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
@@ -511,6 +620,15 @@ body: |
     ; GFX10-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX10-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX10-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (<4 x s16>), align 4, addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_v4s16_align4
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (<4 x s16>), align 4, addrspace 3)
     %0:vgpr(<4 x s16>) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (<4 x s16>), align 4, addrspace 3)
@@ -538,6 +656,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s64), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s64_align8
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -545,18 +664,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (s64), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s64_align8
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX9-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s64), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s64_align8
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s64), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s64_align8
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (s64), addrspace 3)
     %0:vgpr(s64) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (s64), align 8, addrspace 3)
@@ -584,6 +712,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (p1), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_p1_align8
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -591,18 +720,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (p1), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_p1_align8
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX9-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (p1), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_p1_align8
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (p1), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_p1_align8
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (p1), addrspace 3)
     %0:vgpr(p1) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (p1), align 8, addrspace 3)
@@ -630,6 +768,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (<2 x s32>), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_v2s32_align8
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -637,18 +776,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (<2 x s32>), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_v2s32_align8
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX9-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<2 x s32>), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_v2s32_align8
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<2 x s32>), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_v2s32_align8
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<2 x s32>), addrspace 3)
     %0:vgpr(<2 x s32>) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (<2 x s32>), align 8, addrspace 3)
@@ -676,6 +824,7 @@ body: |
     ; GFX6-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (<4 x s16>), addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_v4s16_align8
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -683,18 +832,27 @@ body: |
     ; GFX7-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX7-NEXT: $m0 = S_MOV_B32 -1
     ; GFX7-NEXT: DS_WRITE_B64 [[COPY1]], [[COPY]], 0, 0, implicit $m0, implicit $exec :: (store (<4 x s16>), addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_v4s16_align8
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX9-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX9-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<4 x s16>), addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_v4s16_align8
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
     ; GFX10-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
     ; GFX10-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
     ; GFX10-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<4 x s16>), addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_v4s16_align8
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: DS_WRITE_B64_gfx9 [[COPY1]], [[COPY]], 0, 0, implicit $exec :: (store (<4 x s16>), addrspace 3)
     %0:vgpr(<4 x s16>) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     G_STORE %0, %1 :: (store (<4 x s16>), align 8, addrspace 3)
@@ -724,6 +882,7 @@ body: |
     ; GFX6-NEXT: [[PTR_ADD:%[0-9]+]]:vgpr(p3) = G_PTR_ADD [[COPY1]], [[C]](s32)
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: G_STORE [[COPY]](s64), [[PTR_ADD]](p3) :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s64_align4_from_1_gep_1016
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -733,6 +892,7 @@ body: |
     ; GFX7-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX7-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX7-NEXT: DS_WRITE2_B32 [[COPY1]], [[COPY3]], [[COPY2]], 254, 255, 0, implicit $m0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s64_align4_from_1_gep_1016
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
@@ -741,6 +901,7 @@ body: |
     ; GFX9-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX9-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX9-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 254, 255, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s64_align4_from_1_gep_1016
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
@@ -749,6 +910,15 @@ body: |
     ; GFX10-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX10-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX10-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 254, 255, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s64_align4_from_1_gep_1016
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: DS_WRITE2_B32_gfx9 [[COPY1]], [[COPY3]], [[COPY2]], 254, 255, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
     %0:vgpr(s64) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     %2:vgpr(s32) = G_CONSTANT i32 1016
@@ -780,6 +950,7 @@ body: |
     ; GFX6-NEXT: [[PTR_ADD:%[0-9]+]]:vgpr(p3) = G_PTR_ADD [[COPY1]], [[C]](s32)
     ; GFX6-NEXT: $m0 = S_MOV_B32 -1
     ; GFX6-NEXT: G_STORE [[COPY]](s64), [[PTR_ADD]](p3) :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX7-LABEL: name: store_local_s64_align4_from_1_gep_1020
     ; GFX7: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX7-NEXT: {{  $}}
@@ -791,6 +962,7 @@ body: |
     ; GFX7-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX7-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX7-NEXT: DS_WRITE2_B32 [[V_ADD_CO_U32_e64_]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $m0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX9-LABEL: name: store_local_s64_align4_from_1_gep_1020
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
@@ -801,6 +973,7 @@ body: |
     ; GFX9-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX9-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX9-NEXT: DS_WRITE2_B32_gfx9 [[V_ADD_U32_e64_]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
     ; GFX10-LABEL: name: store_local_s64_align4_from_1_gep_1020
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
@@ -811,6 +984,17 @@ body: |
     ; GFX10-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
     ; GFX10-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
     ; GFX10-NEXT: DS_WRITE2_B32_gfx9 [[V_ADD_U32_e64_]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
+    ;
+    ; GFX11-LABEL: name: store_local_s64_align4_from_1_gep_1020
+    ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
+    ; GFX11-NEXT: {{  $}}
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vreg_64 = COPY $vgpr0_vgpr1
+    ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr2
+    ; GFX11-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 1020, implicit $exec
+    ; GFX11-NEXT: [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], [[V_MOV_B32_e32_]], 0, implicit $exec
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub1
+    ; GFX11-NEXT: [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
+    ; GFX11-NEXT: DS_WRITE2_B32_gfx9 [[V_ADD_U32_e64_]], [[COPY3]], [[COPY2]], 0, 1, 0, implicit $exec :: (store (s64), align 4, addrspace 3)
     %0:vgpr(s64) = COPY $vgpr0_vgpr1
     %1:vgpr(p3) = COPY $vgpr2
     %2:vgpr(s32) = G_CONSTANT i32 1020

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-private.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/inst-select-store-private.mir
@@ -88,14 +88,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX11-NEXT: SCRATCH_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_SHORT_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
     ;
     ; GFX12-LABEL: name: function_store_private_s32_to_2
     ; GFX12: liveins: $vgpr0, $vgpr1
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX12-NEXT: SCRATCH_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_SHORT_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p5) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s16), align 2, addrspace 5)
@@ -136,14 +138,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: function_store_private_s32_to_1
     ; GFX12: liveins: $vgpr0, $vgpr1
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p5) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s8), align 1, addrspace 5)
@@ -320,11 +324,13 @@ body: |
     ;
     ; GFX11-LABEL: name: function_store_private_s32_to_1_fi_offset_4095
     ; GFX11: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE_SADDR [[V_MOV_B32_e32_]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_SADDR_t16 [[COPY]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: function_store_private_s32_to_1_fi_offset_4095
     ; GFX12: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE_SADDR [[V_MOV_B32_e32_]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_SADDR_t16 [[COPY]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(p5) = G_FRAME_INDEX %stack.0
     %1:vgpr(s32) = G_CONSTANT i32 4095
     %2:vgpr(p5) = G_PTR_ADD %0, %1
@@ -360,12 +366,14 @@ body: |
     ; GFX11-LABEL: name: function_store_private_s32_to_1_constant_4095
     ; GFX11: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX11-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: function_store_private_s32_to_1_constant_4095
     ; GFX12: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX12-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(p5) = G_CONSTANT i32 4095
     %1:vgpr(s32) = G_CONSTANT i32 0
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 5)
@@ -401,12 +409,14 @@ body: |
     ; GFX11-LABEL: name: function_store_private_s32_to_1_constant_4096
     ; GFX11: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX11-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: function_store_private_s32_to_1_constant_4096
     ; GFX12: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX12-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(p5) = G_CONSTANT i32 4096
     %1:vgpr(s32) = G_CONSTANT i32 0
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 5)
@@ -493,14 +503,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX11-NEXT: SCRATCH_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_SHORT_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
     ;
     ; GFX12-LABEL: name: kernel_store_private_s32_to_2
     ; GFX12: liveins: $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX12-NEXT: SCRATCH_STORE_SHORT [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_SHORT_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16), addrspace 5)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p5) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s16), align 2, addrspace 5)
@@ -540,14 +552,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX11-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: kernel_store_private_s32_to_1
     ; GFX12: liveins: $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
     ; GFX12-NEXT: [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE [[COPY]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[COPY]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY2]], [[COPY1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(s32) = COPY $vgpr0
     %1:vgpr(p5) = COPY $vgpr1
     G_STORE %0, %1 :: (store (s8), align 1, addrspace 5)
@@ -728,13 +742,15 @@ body: |
     ; GFX11: liveins: $sgpr0_sgpr1_sgpr2_sgpr3
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE_SADDR [[V_MOV_B32_e32_]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_SADDR_t16 [[COPY]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: kernel_store_private_s32_to_1_fi_offset_4095
     ; GFX12: liveins: $sgpr0_sgpr1_sgpr2_sgpr3
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE_SADDR [[V_MOV_B32_e32_]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_SADDR_t16 [[COPY]], %stack.0, 4095, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(p5) = G_FRAME_INDEX %stack.0
     %1:vgpr(s32) = G_CONSTANT i32 4095
     %2:vgpr(p5) = G_PTR_ADD %0, %1
@@ -776,14 +792,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX11-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: kernel_store_private_s32_to_1_constant_4095
     ; GFX12: liveins: $sgpr0_sgpr1_sgpr2_sgpr3
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4095, implicit $exec
     ; GFX12-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(p5) = G_CONSTANT i32 4095
     %1:vgpr(s32) = G_CONSTANT i32 0
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 5)
@@ -825,14 +843,16 @@ body: |
     ; GFX11-NEXT: {{  $}}
     ; GFX11-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX11-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX11-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX11-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX11-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     ;
     ; GFX12-LABEL: name: kernel_store_private_s32_to_1_constant_4096
     ; GFX12: liveins: $sgpr0_sgpr1_sgpr2_sgpr3
     ; GFX12-NEXT: {{  $}}
     ; GFX12-NEXT: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
     ; GFX12-NEXT: [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX12-NEXT: SCRATCH_STORE_BYTE [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
+    ; GFX12-NEXT: [[COPY:%[0-9]+]]:vgpr_16 = COPY [[V_MOV_B32_e32_1]].lo16
+    ; GFX12-NEXT: SCRATCH_STORE_BYTE_t16 [[COPY]], [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s8), addrspace 5)
     %0:vgpr(p5) = G_CONSTANT i32 4096
     %1:vgpr(s32) = G_CONSTANT i32 0
     G_STORE %1, %0 :: (store (s8), align 1, addrspace 5)

--- a/llvm/test/CodeGen/AMDGPU/add_i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/add_i1.ll
@@ -40,16 +40,16 @@ define amdgpu_kernel void @add_var_var_i1(ptr addrspace(1) %out, ptr addrspace(1
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_u8 v1, v0, s[2:3] glc dlc
+; GFX11-NEXT:    global_load_u8 v0, v1, s[2:3] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    global_load_u8 v2, v0, s[4:5] glc dlc
+; GFX11-NEXT:    global_load_u8 v2, v1, s[4:5] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_xor_b32_e32 v1, v1, v2
+; GFX11-NEXT:    v_xor_b32_e32 v0, v0, v2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_and_b32_e32 v1, 1, v1
-; GFX11-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX11-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %a = load volatile i1, ptr addrspace(1) %in0
   %b = load volatile i1, ptr addrspace(1) %in1
@@ -94,19 +94,19 @@ define amdgpu_kernel void @add_var_imm_i1(ptr addrspace(1) %out, ptr addrspace(1
 ; GFX11-LABEL: add_var_imm_i1:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_u8 v1, v0, s[2:3] glc dlc
+; GFX11-NEXT:    global_load_u8 v0, v1, s[2:3] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_and_b32_e32 v1, 1, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v1
+; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v0
 ; GFX11-NEXT:    s_xor_b32 s2, vcc_lo, -1
 ; GFX11-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v1, s2
-; GFX11-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %a = load volatile i1, ptr addrspace(1) %in
   %add = add i1 %a, 1

--- a/llvm/test/CodeGen/AMDGPU/bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/bf16.ll
@@ -3981,72 +3981,139 @@ define void @test_call_v3bf16(<3 x bfloat> %in, ptr addrspace(5) %out) #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: test_call_v3bf16:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s2, s33
-; GFX11-NEXT:    s_mov_b32 s33, s32
-; GFX11-NEXT:    s_xor_saveexec_b32 s0, -1
-; GFX11-NEXT:    scratch_store_b32 off, v3, s33 ; 4-byte Folded Spill
-; GFX11-NEXT:    s_mov_b32 exec_lo, s0
-; GFX11-NEXT:    v_writelane_b32 v3, s30, 0
-; GFX11-NEXT:    s_add_i32 s32, s32, 16
-; GFX11-NEXT:    v_writelane_b32 v3, s31, 1
-; GFX11-NEXT:    s_getpc_b64 s[0:1]
-; GFX11-NEXT:    s_add_u32 s0, s0, test_arg_store_v2bf16@gotpcrel32@lo+4
-; GFX11-NEXT:    s_addc_u32 s1, s1, test_arg_store_v2bf16@gotpcrel32@hi+12
-; GFX11-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_swappc_b64 s[30:31], s[0:1]
-; GFX11-NEXT:    v_readlane_b32 s30, v3, 0
-; GFX11-NEXT:    scratch_store_b16 v2, v1, off offset:4 dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    scratch_store_b32 v2, v0, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    v_readlane_b32 s31, v3, 1
-; GFX11-NEXT:    s_mov_b32 s32, s33
-; GFX11-NEXT:    s_xor_saveexec_b32 s0, -1
-; GFX11-NEXT:    scratch_load_b32 v3, off, s33 ; 4-byte Folded Reload
-; GFX11-NEXT:    s_mov_b32 exec_lo, s0
-; GFX11-NEXT:    s_mov_b32 s33, s2
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11TRUE16-LABEL: test_call_v3bf16:
+; GFX11TRUE16:       ; %bb.0: ; %entry
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11TRUE16-NEXT:    s_mov_b32 s2, s33
+; GFX11TRUE16-NEXT:    s_mov_b32 s33, s32
+; GFX11TRUE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX11TRUE16-NEXT:    scratch_store_b32 off, v3, s33 ; 4-byte Folded Spill
+; GFX11TRUE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX11TRUE16-NEXT:    v_writelane_b32 v3, s30, 0
+; GFX11TRUE16-NEXT:    s_add_i32 s32, s32, 16
+; GFX11TRUE16-NEXT:    v_writelane_b32 v3, s31, 1
+; GFX11TRUE16-NEXT:    s_getpc_b64 s[0:1]
+; GFX11TRUE16-NEXT:    s_add_u32 s0, s0, test_arg_store_v2bf16@gotpcrel32@lo+4
+; GFX11TRUE16-NEXT:    s_addc_u32 s1, s1, test_arg_store_v2bf16@gotpcrel32@hi+12
+; GFX11TRUE16-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
+; GFX11TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11TRUE16-NEXT:    s_swappc_b64 s[30:31], s[0:1]
+; GFX11TRUE16-NEXT:    v_readlane_b32 s30, v3, 0
+; GFX11TRUE16-NEXT:    scratch_store_b32 v2, v0, off dlc
+; GFX11TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11TRUE16-NEXT:    scratch_store_b16 v2, v1, off offset:4 dlc
+; GFX11TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11TRUE16-NEXT:    v_readlane_b32 s31, v3, 1
+; GFX11TRUE16-NEXT:    s_mov_b32 s32, s33
+; GFX11TRUE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX11TRUE16-NEXT:    scratch_load_b32 v3, off, s33 ; 4-byte Folded Reload
+; GFX11TRUE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX11TRUE16-NEXT:    s_mov_b32 s33, s2
+; GFX11TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1250-LABEL: test_call_v3bf16:
-; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_mov_b32 s2, s33
-; GFX1250-NEXT:    s_mov_b32 s33, s32
-; GFX1250-NEXT:    s_xor_saveexec_b32 s0, -1
-; GFX1250-NEXT:    scratch_store_b32 off, v5, s33 nv ; 4-byte Folded Spill
-; GFX1250-NEXT:    s_wait_xcnt 0x0
-; GFX1250-NEXT:    s_mov_b32 exec_lo, s0
-; GFX1250-NEXT:    v_writelane_b32 v5, s30, 0
-; GFX1250-NEXT:    s_add_co_i32 s32, s32, 16
-; GFX1250-NEXT:    v_writelane_b32 v5, s31, 1
-; GFX1250-NEXT:    s_get_pc_i64 s[0:1]
-; GFX1250-NEXT:    s_add_nc_u64 s[0:1], s[0:1], test_arg_store_v2bf16@gotpcrel+4
-; GFX1250-NEXT:    v_mov_b32_e32 v4, v2
-; GFX1250-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0 nv
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_swap_pc_i64 s[30:31], s[0:1]
-; GFX1250-NEXT:    v_readlane_b32 s30, v5, 0
-; GFX1250-NEXT:    scratch_store_b16 v4, v1, off offset:4 scope:SCOPE_SYS
-; GFX1250-NEXT:    s_wait_storecnt 0x0
-; GFX1250-NEXT:    s_wait_xcnt 0x0
-; GFX1250-NEXT:    scratch_store_b32 v4, v0, off scope:SCOPE_SYS
-; GFX1250-NEXT:    s_wait_storecnt 0x0
-; GFX1250-NEXT:    v_readlane_b32 s31, v5, 1
-; GFX1250-NEXT:    s_mov_b32 s32, s33
-; GFX1250-NEXT:    s_wait_xcnt 0x0
-; GFX1250-NEXT:    s_xor_saveexec_b32 s0, -1
-; GFX1250-NEXT:    scratch_load_b32 v5, off, s33 nv ; 4-byte Folded Reload
-; GFX1250-NEXT:    s_wait_xcnt 0x0
-; GFX1250-NEXT:    s_mov_b32 exec_lo, s0
-; GFX1250-NEXT:    s_mov_b32 s33, s2
-; GFX1250-NEXT:    s_wait_loadcnt 0x0
-; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+; GFX11FAKE16-LABEL: test_call_v3bf16:
+; GFX11FAKE16:       ; %bb.0: ; %entry
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11FAKE16-NEXT:    s_mov_b32 s2, s33
+; GFX11FAKE16-NEXT:    s_mov_b32 s33, s32
+; GFX11FAKE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX11FAKE16-NEXT:    scratch_store_b32 off, v3, s33 ; 4-byte Folded Spill
+; GFX11FAKE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX11FAKE16-NEXT:    v_writelane_b32 v3, s30, 0
+; GFX11FAKE16-NEXT:    s_add_i32 s32, s32, 16
+; GFX11FAKE16-NEXT:    v_writelane_b32 v3, s31, 1
+; GFX11FAKE16-NEXT:    s_getpc_b64 s[0:1]
+; GFX11FAKE16-NEXT:    s_add_u32 s0, s0, test_arg_store_v2bf16@gotpcrel32@lo+4
+; GFX11FAKE16-NEXT:    s_addc_u32 s1, s1, test_arg_store_v2bf16@gotpcrel32@hi+12
+; GFX11FAKE16-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
+; GFX11FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11FAKE16-NEXT:    s_swappc_b64 s[30:31], s[0:1]
+; GFX11FAKE16-NEXT:    v_readlane_b32 s30, v3, 0
+; GFX11FAKE16-NEXT:    scratch_store_b16 v2, v1, off offset:4 dlc
+; GFX11FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11FAKE16-NEXT:    scratch_store_b32 v2, v0, off dlc
+; GFX11FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11FAKE16-NEXT:    v_readlane_b32 s31, v3, 1
+; GFX11FAKE16-NEXT:    s_mov_b32 s32, s33
+; GFX11FAKE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX11FAKE16-NEXT:    scratch_load_b32 v3, off, s33 ; 4-byte Folded Reload
+; GFX11FAKE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX11FAKE16-NEXT:    s_mov_b32 s33, s2
+; GFX11FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1250TRUE16-LABEL: test_call_v3bf16:
+; GFX1250TRUE16:       ; %bb.0: ; %entry
+; GFX1250TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250TRUE16-NEXT:    s_mov_b32 s2, s33
+; GFX1250TRUE16-NEXT:    s_mov_b32 s33, s32
+; GFX1250TRUE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1250TRUE16-NEXT:    scratch_store_b32 off, v5, s33 nv ; 4-byte Folded Spill
+; GFX1250TRUE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250TRUE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1250TRUE16-NEXT:    v_writelane_b32 v5, s30, 0
+; GFX1250TRUE16-NEXT:    s_add_co_i32 s32, s32, 16
+; GFX1250TRUE16-NEXT:    v_writelane_b32 v5, s31, 1
+; GFX1250TRUE16-NEXT:    s_get_pc_i64 s[0:1]
+; GFX1250TRUE16-NEXT:    s_add_nc_u64 s[0:1], s[0:1], test_arg_store_v2bf16@gotpcrel+4
+; GFX1250TRUE16-NEXT:    v_mov_b32_e32 v4, v2
+; GFX1250TRUE16-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0 nv
+; GFX1250TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250TRUE16-NEXT:    s_swap_pc_i64 s[30:31], s[0:1]
+; GFX1250TRUE16-NEXT:    v_readlane_b32 s30, v5, 0
+; GFX1250TRUE16-NEXT:    scratch_store_b32 v4, v0, off scope:SCOPE_SYS
+; GFX1250TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX1250TRUE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250TRUE16-NEXT:    scratch_store_b16 v4, v1, off offset:4 scope:SCOPE_SYS
+; GFX1250TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX1250TRUE16-NEXT:    v_readlane_b32 s31, v5, 1
+; GFX1250TRUE16-NEXT:    s_mov_b32 s32, s33
+; GFX1250TRUE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250TRUE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1250TRUE16-NEXT:    scratch_load_b32 v5, off, s33 nv ; 4-byte Folded Reload
+; GFX1250TRUE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250TRUE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1250TRUE16-NEXT:    s_mov_b32 s33, s2
+; GFX1250TRUE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250TRUE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1250FAKE16-LABEL: test_call_v3bf16:
+; GFX1250FAKE16:       ; %bb.0: ; %entry
+; GFX1250FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250FAKE16-NEXT:    s_mov_b32 s2, s33
+; GFX1250FAKE16-NEXT:    s_mov_b32 s33, s32
+; GFX1250FAKE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1250FAKE16-NEXT:    scratch_store_b32 off, v5, s33 nv ; 4-byte Folded Spill
+; GFX1250FAKE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250FAKE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1250FAKE16-NEXT:    v_writelane_b32 v5, s30, 0
+; GFX1250FAKE16-NEXT:    s_add_co_i32 s32, s32, 16
+; GFX1250FAKE16-NEXT:    v_writelane_b32 v5, s31, 1
+; GFX1250FAKE16-NEXT:    s_get_pc_i64 s[0:1]
+; GFX1250FAKE16-NEXT:    s_add_nc_u64 s[0:1], s[0:1], test_arg_store_v2bf16@gotpcrel+4
+; GFX1250FAKE16-NEXT:    v_mov_b32_e32 v4, v2
+; GFX1250FAKE16-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0 nv
+; GFX1250FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250FAKE16-NEXT:    s_swap_pc_i64 s[30:31], s[0:1]
+; GFX1250FAKE16-NEXT:    v_readlane_b32 s30, v5, 0
+; GFX1250FAKE16-NEXT:    scratch_store_b16 v4, v1, off offset:4 scope:SCOPE_SYS
+; GFX1250FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX1250FAKE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250FAKE16-NEXT:    scratch_store_b32 v4, v0, off scope:SCOPE_SYS
+; GFX1250FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX1250FAKE16-NEXT:    v_readlane_b32 s31, v5, 1
+; GFX1250FAKE16-NEXT:    s_mov_b32 s32, s33
+; GFX1250FAKE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250FAKE16-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1250FAKE16-NEXT:    scratch_load_b32 v5, off, s33 nv ; 4-byte Folded Reload
+; GFX1250FAKE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250FAKE16-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1250FAKE16-NEXT:    s_mov_b32 s33, s2
+; GFX1250FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %result = call <3 x bfloat> @test_arg_store_v2bf16(<3 x bfloat> %in)
   store volatile <3 x bfloat> %result, ptr addrspace(5) %out

--- a/llvm/test/CodeGen/AMDGPU/calling-conventions.ll
+++ b/llvm/test/CodeGen/AMDGPU/calling-conventions.ll
@@ -1421,24 +1421,43 @@ define amdgpu_ps void @ps_mesa_inreg_i16(i16 inreg %arg0) {
 ; VI-NEXT:    flat_store_short v[0:1], v0
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: ps_mesa_inreg_i16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_add_i32 s0, s0, s0
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: ps_mesa_inreg_i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: ps_mesa_inreg_i16:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_add_co_i32 s0, s0, s0
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: ps_mesa_inreg_i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: ps_mesa_inreg_i16:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: ps_mesa_inreg_i16:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX1250-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
   %add = add i16 %arg0, %arg0
   store i16 %add, ptr addrspace(1) poison
   ret void
@@ -1491,28 +1510,51 @@ define amdgpu_kernel void @amd_kernel_i8(i8 %arg0) {
 ; VI-NEXT:    flat_store_byte v[0:1], v0
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amd_kernel_i8:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_add_i32 s0, s0, s0
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amd_kernel_i8:
+; GFX11-TRUE16:       ; %bb.0: ; %entry
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amd_kernel_i8:
-; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_add_co_i32 s0, s0, s0
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amd_kernel_i8:
+; GFX11-FAKE16:       ; %bb.0: ; %entry
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amd_kernel_i8:
+; GFX1250-TRUE16:       ; %bb.0: ; %entry
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amd_kernel_i8:
+; GFX1250-FAKE16:       ; %bb.0: ; %entry
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX1250-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
 entry:
   %add = add i8 %arg0, %arg0
   store i8 %add, ptr addrspace(1) poison
@@ -1553,40 +1595,75 @@ define amdgpu_kernel void @amd_kernel_v2i8(<2 x i8> %arg0) {
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amd_kernel_v2i8:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_bfe_u32 s1, s0, 0x80008
-; GFX11-NEXT:    s_add_i32 s0, s0, s0
-; GFX11-NEXT:    s_add_i32 s1, s1, s1
-; GFX11-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX11-NEXT:    s_lshl_b32 s1, s1, 8
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    v_mov_b32_e32 v2, s0
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amd_kernel_v2i8:
+; GFX11-TRUE16:       ; %bb.0: ; %entry
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_bfe_u32 s1, s0, 0x80008
+; GFX11-TRUE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-TRUE16-NEXT:    s_add_i32 s1, s1, s1
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amd_kernel_v2i8:
-; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
-; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_bfe_u32 s1, s0, 0x80008
-; GFX1250-NEXT:    s_add_co_i32 s0, s0, s0
-; GFX1250-NEXT:    s_add_co_i32 s1, s1, s1
-; GFX1250-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX1250-NEXT:    s_lshl_b32 s1, s1, 8
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s0
-; GFX1250-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amd_kernel_v2i8:
+; GFX11-FAKE16:       ; %bb.0: ; %entry
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_bfe_u32 s1, s0, 0x80008
+; GFX11-FAKE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-FAKE16-NEXT:    s_add_i32 s1, s1, s1
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amd_kernel_v2i8:
+; GFX1250-TRUE16:       ; %bb.0: ; %entry
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b64_e32 v[2:3], 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_bfe_u32 s1, s0, 0x80008
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s1, s1, s1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-TRUE16-NEXT:    global_store_b16 v[2:3], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amd_kernel_v2i8:
+; GFX1250-FAKE16:       ; %bb.0: ; %entry
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b64_e32 v[0:1], 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_bfe_u32 s1, s0, 0x80008
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s1, s1, s1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1250-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
 entry:
   %add = add <2 x i8> %arg0, %arg0
   store <2 x i8> %add, ptr addrspace(1) null
@@ -1753,50 +1830,95 @@ define amdgpu_kernel void @amd_kernel_v3i8(<3 x i8> %arg0) {
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amd_kernel_v3i8:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 2 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v3, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_bfe_u32 s2, s0, 0x80008
-; GFX11-NEXT:    s_lshr_b32 s1, s0, 16
-; GFX11-NEXT:    s_add_i32 s0, s0, s0
-; GFX11-NEXT:    s_add_i32 s2, s2, s2
-; GFX11-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX11-NEXT:    s_lshl_b32 s2, s2, 8
-; GFX11-NEXT:    s_add_i32 s1, s1, s1
-; GFX11-NEXT:    s_or_b32 s0, s0, s2
-; GFX11-NEXT:    v_mov_b32_e32 v4, s1
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v5, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b8 v[0:1], v4, off
-; GFX11-NEXT:    global_store_b16 v[2:3], v5, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amd_kernel_v3i8:
+; GFX11-TRUE16:       ; %bb.0: ; %entry
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 2 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v4, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_bfe_u32 s2, s0, 0x80008
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-TRUE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, s2
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX11-TRUE16-NEXT:    s_add_i32 s1, s1, s1
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, s0
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    global_store_d16_hi_b16 v[3:4], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amd_kernel_v3i8:
-; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
-; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], 2
-; GFX1250-NEXT:    v_mov_b64_e32 v[2:3], 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_bfe_u32 s2, s0, 0x80008
-; GFX1250-NEXT:    s_lshr_b32 s1, s0, 16
-; GFX1250-NEXT:    s_add_co_i32 s0, s0, s0
-; GFX1250-NEXT:    s_add_co_i32 s2, s2, s2
-; GFX1250-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX1250-NEXT:    s_lshl_b32 s2, s2, 8
-; GFX1250-NEXT:    s_add_co_i32 s1, s1, s1
-; GFX1250-NEXT:    s_or_b32 s0, s0, s2
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, s0
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b8 v[0:1], v4, off
-; GFX1250-NEXT:    global_store_b16 v[2:3], v5, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amd_kernel_v3i8:
+; GFX11-FAKE16:       ; %bb.0: ; %entry
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 2 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v3, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_bfe_u32 s2, s0, 0x80008
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-FAKE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-FAKE16-NEXT:    s_add_i32 s2, s2, s2
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX11-FAKE16-NEXT:    s_add_i32 s1, s1, s1
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, s1
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v5, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v4, off
+; GFX11-FAKE16-NEXT:    global_store_b16 v[2:3], v5, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amd_kernel_v3i8:
+; GFX1250-TRUE16:       ; %bb.0: ; %entry
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b64_e32 v[2:3], 2
+; GFX1250-TRUE16-NEXT:    v_mov_b64_e32 v[4:5], 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_bfe_u32 s2, s0, 0x80008
+; GFX1250-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s2, s2, s2
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s1, s1, s1
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.h, s0
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_store_b8 v[2:3], v0, off
+; GFX1250-TRUE16-NEXT:    global_store_d16_hi_b16 v[4:5], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amd_kernel_v3i8:
+; GFX1250-FAKE16:       ; %bb.0: ; %entry
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b64_e32 v[0:1], 2
+; GFX1250-FAKE16-NEXT:    v_mov_b64_e32 v[2:3], 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_bfe_u32 s2, s0, 0x80008
+; GFX1250-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s2, s2, s2
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s2, s2, 8
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s1, s1, s1
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, s0
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_store_b8 v[0:1], v4, off
+; GFX1250-FAKE16-NEXT:    global_store_b16 v[2:3], v5, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
 entry:
   %add = add <3 x i8> %arg0, %arg0
   store <3 x i8> %add, ptr addrspace(1) null
@@ -1867,68 +1989,131 @@ define amdgpu_kernel void @amd_kernel_v5i8(<5 x i8> %arg0) {
 ; VI-NEXT:    flat_store_dword v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amd_kernel_v5i8:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 4 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v3, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX11-NEXT:    s_lshr_b32 s3, s0, 24
-; GFX11-NEXT:    s_add_i32 s4, s0, s0
-; GFX11-NEXT:    s_bfe_u32 s0, s0, 0x80008
-; GFX11-NEXT:    s_add_i32 s3, s3, s3
-; GFX11-NEXT:    s_add_i32 s0, s0, s0
-; GFX11-NEXT:    s_add_i32 s2, s2, s2
-; GFX11-NEXT:    s_and_b32 s4, s4, 0xff
-; GFX11-NEXT:    s_lshl_b32 s0, s0, 8
-; GFX11-NEXT:    s_lshl_b32 s3, s3, 8
-; GFX11-NEXT:    s_and_b32 s2, s2, 0xff
-; GFX11-NEXT:    s_or_b32 s0, s4, s0
-; GFX11-NEXT:    s_or_b32 s2, s2, s3
-; GFX11-NEXT:    s_and_b32 s0, s0, 0xffff
-; GFX11-NEXT:    s_lshl_b32 s2, s2, 16
-; GFX11-NEXT:    s_add_i32 s1, s1, s1
-; GFX11-NEXT:    s_or_b32 s0, s0, s2
-; GFX11-NEXT:    v_mov_b32_e32 v4, s1
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v5, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b8 v[0:1], v4, off
-; GFX11-NEXT:    global_store_b32 v[2:3], v5, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amd_kernel_v5i8:
+; GFX11-TRUE16:       ; %bb.0: ; %entry
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 4 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v4, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s0, 24
+; GFX11-TRUE16-NEXT:    s_add_i32 s4, s0, s0
+; GFX11-TRUE16-NEXT:    s_bfe_u32 s0, s0, 0x80008
+; GFX11-TRUE16-NEXT:    s_add_i32 s3, s3, s3
+; GFX11-TRUE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, s2
+; GFX11-TRUE16-NEXT:    s_and_b32 s4, s4, 0xff
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s0, s0, 8
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s3, s3, 8
+; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, 0xff
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s4, s0
+; GFX11-TRUE16-NEXT:    s_or_b32 s2, s2, s3
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 0xffff
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s2, s2, 16
+; GFX11-TRUE16-NEXT:    s_add_i32 s1, s1, s1
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v5, s0
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    global_store_b32 v[3:4], v5, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amd_kernel_v5i8:
-; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], 4
-; GFX1250-NEXT:    v_mov_b64_e32 v[2:3], 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX1250-NEXT:    s_lshr_b32 s3, s0, 24
-; GFX1250-NEXT:    s_add_co_i32 s4, s0, s0
-; GFX1250-NEXT:    s_bfe_u32 s0, s0, 0x80008
-; GFX1250-NEXT:    s_add_co_i32 s3, s3, s3
-; GFX1250-NEXT:    s_add_co_i32 s0, s0, s0
-; GFX1250-NEXT:    s_add_co_i32 s2, s2, s2
-; GFX1250-NEXT:    s_and_b32 s4, s4, 0xff
-; GFX1250-NEXT:    s_lshl_b32 s0, s0, 8
-; GFX1250-NEXT:    s_lshl_b32 s3, s3, 8
-; GFX1250-NEXT:    s_and_b32 s2, s2, 0xff
-; GFX1250-NEXT:    s_or_b32 s0, s4, s0
-; GFX1250-NEXT:    s_or_b32 s2, s2, s3
-; GFX1250-NEXT:    s_and_b32 s0, s0, 0xffff
-; GFX1250-NEXT:    s_lshl_b32 s2, s2, 16
-; GFX1250-NEXT:    s_add_co_i32 s1, s1, s1
-; GFX1250-NEXT:    s_or_b32 s0, s0, s2
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, s0
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b8 v[0:1], v4, off
-; GFX1250-NEXT:    global_store_b32 v[2:3], v5, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amd_kernel_v5i8:
+; GFX11-FAKE16:       ; %bb.0: ; %entry
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 4 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v3, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s3, s0, 24
+; GFX11-FAKE16-NEXT:    s_add_i32 s4, s0, s0
+; GFX11-FAKE16-NEXT:    s_bfe_u32 s0, s0, 0x80008
+; GFX11-FAKE16-NEXT:    s_add_i32 s3, s3, s3
+; GFX11-FAKE16-NEXT:    s_add_i32 s0, s0, s0
+; GFX11-FAKE16-NEXT:    s_add_i32 s2, s2, s2
+; GFX11-FAKE16-NEXT:    s_and_b32 s4, s4, 0xff
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s0, s0, 8
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s3, s3, 8
+; GFX11-FAKE16-NEXT:    s_and_b32 s2, s2, 0xff
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s4, s0
+; GFX11-FAKE16-NEXT:    s_or_b32 s2, s2, s3
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 0xffff
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s2, s2, 16
+; GFX11-FAKE16-NEXT:    s_add_i32 s1, s1, s1
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, s1
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v5, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v4, off
+; GFX11-FAKE16-NEXT:    global_store_b32 v[2:3], v5, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amd_kernel_v5i8:
+; GFX1250-TRUE16:       ; %bb.0: ; %entry
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b64_e32 v[2:3], 4
+; GFX1250-TRUE16-NEXT:    v_mov_b64_e32 v[4:5], 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX1250-TRUE16-NEXT:    s_lshr_b32 s3, s0, 24
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s4, s0, s0
+; GFX1250-TRUE16-NEXT:    s_bfe_u32 s0, s0, 0x80008
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s3, s3, s3
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s2, s2, s2
+; GFX1250-TRUE16-NEXT:    s_and_b32 s4, s4, 0xff
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s0, s0, 8
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s3, s3, 8
+; GFX1250-TRUE16-NEXT:    s_and_b32 s2, s2, 0xff
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s4, s0
+; GFX1250-TRUE16-NEXT:    s_or_b32 s2, s2, s3
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 0xffff
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s2, s2, 16
+; GFX1250-TRUE16-NEXT:    s_add_co_i32 s1, s1, s1
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX1250-TRUE16-NEXT:    v_mov_b32_e32 v1, s0
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_store_b8 v[2:3], v0, off
+; GFX1250-TRUE16-NEXT:    global_store_b32 v[4:5], v1, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amd_kernel_v5i8:
+; GFX1250-FAKE16:       ; %bb.0: ; %entry
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b64_e32 v[0:1], 4
+; GFX1250-FAKE16-NEXT:    v_mov_b64_e32 v[2:3], 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX1250-FAKE16-NEXT:    s_lshr_b32 s3, s0, 24
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s4, s0, s0
+; GFX1250-FAKE16-NEXT:    s_bfe_u32 s0, s0, 0x80008
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s3, s3, s3
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s0, s0, s0
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s2, s2, s2
+; GFX1250-FAKE16-NEXT:    s_and_b32 s4, s4, 0xff
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s0, s0, 8
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s3, s3, 8
+; GFX1250-FAKE16-NEXT:    s_and_b32 s2, s2, 0xff
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s4, s0
+; GFX1250-FAKE16-NEXT:    s_or_b32 s2, s2, s3
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 0xffff
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s2, s2, 16
+; GFX1250-FAKE16-NEXT:    s_add_co_i32 s1, s1, s1
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s2
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, s0
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_store_b8 v[0:1], v4, off
+; GFX1250-FAKE16-NEXT:    global_store_b32 v[2:3], v5, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
 entry:
   %add = add <5 x i8> %arg0, %arg0
   store <5 x i8> %add, ptr addrspace(1) null
@@ -4113,24 +4298,43 @@ define amdgpu_cs void @amdgpu_cs_inreg_i1(i1 inreg %arg0) {
 ; VI-NEXT:    flat_store_byte v[0:1], v0
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amdgpu_cs_inreg_i1:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_and_b32 s0, s0, 1
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amdgpu_cs_inreg_i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amdgpu_cs_inreg_i1:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_and_b32 s0, s0, 1
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amdgpu_cs_inreg_i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amdgpu_cs_inreg_i1:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amdgpu_cs_inreg_i1:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX1250-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
   store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
@@ -4192,64 +4396,123 @@ define amdgpu_cs void @amdgpu_cs_inreg_v8i1(<8 x i1> inreg %arg0) {
 ; VI-NEXT:    flat_store_byte v[0:1], v0
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amdgpu_cs_inreg_v8i1:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_and_b32 s6, s6, 1
-; GFX11-NEXT:    s_lshl_b32 s5, s5, 1
-; GFX11-NEXT:    s_and_b32 s4, s4, 1
-; GFX11-NEXT:    s_and_b32 s2, s2, 1
-; GFX11-NEXT:    s_lshl_b32 s1, s1, 1
-; GFX11-NEXT:    s_and_b32 s0, s0, 1
-; GFX11-NEXT:    s_lshl_b32 s7, s7, 3
-; GFX11-NEXT:    s_lshl_b32 s6, s6, 2
-; GFX11-NEXT:    s_or_b32 s4, s4, s5
-; GFX11-NEXT:    s_lshl_b32 s3, s3, 3
-; GFX11-NEXT:    s_lshl_b32 s2, s2, 2
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    s_or_b32 s5, s7, s6
-; GFX11-NEXT:    s_and_b32 s4, s4, 3
-; GFX11-NEXT:    s_or_b32 s1, s3, s2
-; GFX11-NEXT:    s_and_b32 s0, s0, 3
-; GFX11-NEXT:    s_or_b32 s2, s4, s5
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    s_lshl_b32 s1, s2, 4
-; GFX11-NEXT:    s_and_b32 s0, s0, 15
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amdgpu_cs_inreg_v8i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX11-TRUE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX11-TRUE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX11-TRUE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX11-TRUE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amdgpu_cs_inreg_v8i1:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_and_b32 s6, s6, 1
-; GFX1250-NEXT:    s_lshl_b32 s5, s5, 1
-; GFX1250-NEXT:    s_and_b32 s4, s4, 1
-; GFX1250-NEXT:    s_and_b32 s2, s2, 1
-; GFX1250-NEXT:    s_lshl_b32 s1, s1, 1
-; GFX1250-NEXT:    s_and_b32 s0, s0, 1
-; GFX1250-NEXT:    s_lshl_b32 s7, s7, 3
-; GFX1250-NEXT:    s_lshl_b32 s6, s6, 2
-; GFX1250-NEXT:    s_or_b32 s4, s4, s5
-; GFX1250-NEXT:    s_lshl_b32 s3, s3, 3
-; GFX1250-NEXT:    s_lshl_b32 s2, s2, 2
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    s_or_b32 s5, s7, s6
-; GFX1250-NEXT:    s_and_b32 s4, s4, 3
-; GFX1250-NEXT:    s_or_b32 s1, s3, s2
-; GFX1250-NEXT:    s_and_b32 s0, s0, 3
-; GFX1250-NEXT:    s_or_b32 s2, s4, s5
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    s_lshl_b32 s1, s2, 4
-; GFX1250-NEXT:    s_and_b32 s0, s0, 15
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amdgpu_cs_inreg_v8i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX11-FAKE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX11-FAKE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX11-FAKE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX11-FAKE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amdgpu_cs_inreg_v8i1:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX1250-TRUE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX1250-TRUE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX1250-TRUE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX1250-TRUE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amdgpu_cs_inreg_v8i1:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX1250-FAKE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX1250-FAKE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX1250-FAKE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX1250-FAKE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX1250-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
   store <8 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
@@ -4359,112 +4622,219 @@ define amdgpu_cs void @amdgpu_cs_inreg_v16i1(<16 x i1> inreg %arg0) {
 ; VI-NEXT:    flat_store_short v[0:1], v0
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: amdgpu_cs_inreg_v16i1:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_and_b32 s10, s10, 1
-; GFX11-NEXT:    s_lshl_b32 s9, s9, 1
-; GFX11-NEXT:    s_and_b32 s8, s8, 1
-; GFX11-NEXT:    s_and_b32 s6, s6, 1
-; GFX11-NEXT:    s_lshl_b32 s5, s5, 1
-; GFX11-NEXT:    s_and_b32 s4, s4, 1
-; GFX11-NEXT:    s_and_b32 s2, s2, 1
-; GFX11-NEXT:    s_lshl_b32 s1, s1, 1
-; GFX11-NEXT:    s_and_b32 s0, s0, 1
-; GFX11-NEXT:    s_and_b32 s14, s14, 1
-; GFX11-NEXT:    s_lshl_b32 s13, s13, 1
-; GFX11-NEXT:    s_and_b32 s12, s12, 1
-; GFX11-NEXT:    s_lshl_b32 s11, s11, 3
-; GFX11-NEXT:    s_lshl_b32 s10, s10, 2
-; GFX11-NEXT:    s_or_b32 s8, s8, s9
-; GFX11-NEXT:    s_lshl_b32 s7, s7, 3
-; GFX11-NEXT:    s_lshl_b32 s6, s6, 2
-; GFX11-NEXT:    s_or_b32 s4, s4, s5
-; GFX11-NEXT:    s_lshl_b32 s3, s3, 3
-; GFX11-NEXT:    s_lshl_b32 s2, s2, 2
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    s_lshl_b32 s15, s15, 3
-; GFX11-NEXT:    s_lshl_b32 s14, s14, 2
-; GFX11-NEXT:    s_or_b32 s12, s12, s13
-; GFX11-NEXT:    s_or_b32 s9, s11, s10
-; GFX11-NEXT:    s_and_b32 s8, s8, 3
-; GFX11-NEXT:    s_or_b32 s5, s7, s6
-; GFX11-NEXT:    s_and_b32 s4, s4, 3
-; GFX11-NEXT:    s_or_b32 s1, s3, s2
-; GFX11-NEXT:    s_and_b32 s0, s0, 3
-; GFX11-NEXT:    s_or_b32 s13, s15, s14
-; GFX11-NEXT:    s_and_b32 s12, s12, 3
-; GFX11-NEXT:    s_or_b32 s8, s8, s9
-; GFX11-NEXT:    s_or_b32 s2, s4, s5
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    s_or_b32 s10, s12, s13
-; GFX11-NEXT:    s_and_b32 s8, s8, 15
-; GFX11-NEXT:    s_lshl_b32 s1, s2, 4
-; GFX11-NEXT:    s_and_b32 s0, s0, 15
-; GFX11-NEXT:    s_lshl_b32 s9, s10, 12
-; GFX11-NEXT:    s_lshl_b32 s2, s8, 8
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    s_or_b32 s1, s9, s2
-; GFX11-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, s1
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: amdgpu_cs_inreg_v16i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_and_b32 s10, s10, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s9, s9, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s8, s8, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s14, s14, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s13, s13, 1
+; GFX11-TRUE16-NEXT:    s_and_b32 s12, s12, 1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s11, s11, 3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s10, s10, 2
+; GFX11-TRUE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX11-TRUE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s15, s15, 3
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s14, s14, 2
+; GFX11-TRUE16-NEXT:    s_or_b32 s12, s12, s13
+; GFX11-TRUE16-NEXT:    s_or_b32 s9, s11, s10
+; GFX11-TRUE16-NEXT:    s_and_b32 s8, s8, 3
+; GFX11-TRUE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX11-TRUE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX11-TRUE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX11-TRUE16-NEXT:    s_or_b32 s13, s15, s14
+; GFX11-TRUE16-NEXT:    s_and_b32 s12, s12, 3
+; GFX11-TRUE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX11-TRUE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    s_or_b32 s10, s12, s13
+; GFX11-TRUE16-NEXT:    s_and_b32 s8, s8, 15
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s9, s10, 12
+; GFX11-TRUE16-NEXT:    s_lshl_b32 s2, s8, 8
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    s_or_b32 s1, s9, s2
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: amdgpu_cs_inreg_v16i1:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_and_b32 s10, s10, 1
-; GFX1250-NEXT:    s_lshl_b32 s9, s9, 1
-; GFX1250-NEXT:    s_and_b32 s8, s8, 1
-; GFX1250-NEXT:    s_and_b32 s6, s6, 1
-; GFX1250-NEXT:    s_lshl_b32 s5, s5, 1
-; GFX1250-NEXT:    s_and_b32 s4, s4, 1
-; GFX1250-NEXT:    s_and_b32 s2, s2, 1
-; GFX1250-NEXT:    s_lshl_b32 s1, s1, 1
-; GFX1250-NEXT:    s_and_b32 s0, s0, 1
-; GFX1250-NEXT:    s_and_b32 s14, s14, 1
-; GFX1250-NEXT:    s_lshl_b32 s13, s13, 1
-; GFX1250-NEXT:    s_and_b32 s12, s12, 1
-; GFX1250-NEXT:    s_lshl_b32 s11, s11, 3
-; GFX1250-NEXT:    s_lshl_b32 s10, s10, 2
-; GFX1250-NEXT:    s_or_b32 s8, s8, s9
-; GFX1250-NEXT:    s_lshl_b32 s7, s7, 3
-; GFX1250-NEXT:    s_lshl_b32 s6, s6, 2
-; GFX1250-NEXT:    s_or_b32 s4, s4, s5
-; GFX1250-NEXT:    s_lshl_b32 s3, s3, 3
-; GFX1250-NEXT:    s_lshl_b32 s2, s2, 2
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    s_lshl_b32 s15, s15, 3
-; GFX1250-NEXT:    s_lshl_b32 s14, s14, 2
-; GFX1250-NEXT:    s_or_b32 s12, s12, s13
-; GFX1250-NEXT:    s_or_b32 s9, s11, s10
-; GFX1250-NEXT:    s_and_b32 s8, s8, 3
-; GFX1250-NEXT:    s_or_b32 s5, s7, s6
-; GFX1250-NEXT:    s_and_b32 s4, s4, 3
-; GFX1250-NEXT:    s_or_b32 s1, s3, s2
-; GFX1250-NEXT:    s_and_b32 s0, s0, 3
-; GFX1250-NEXT:    s_or_b32 s13, s15, s14
-; GFX1250-NEXT:    s_and_b32 s12, s12, 3
-; GFX1250-NEXT:    s_or_b32 s8, s8, s9
-; GFX1250-NEXT:    s_or_b32 s2, s4, s5
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    s_or_b32 s10, s12, s13
-; GFX1250-NEXT:    s_and_b32 s8, s8, 15
-; GFX1250-NEXT:    s_lshl_b32 s1, s2, 4
-; GFX1250-NEXT:    s_and_b32 s0, s0, 15
-; GFX1250-NEXT:    s_lshl_b32 s9, s10, 12
-; GFX1250-NEXT:    s_lshl_b32 s2, s8, 8
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    s_or_b32 s1, s9, s2
-; GFX1250-NEXT:    s_and_b32 s0, s0, 0xff
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-NEXT:    s_or_b32 s0, s0, s1
-; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: amdgpu_cs_inreg_v16i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_and_b32 s10, s10, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s9, s9, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s8, s8, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s14, s14, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s13, s13, 1
+; GFX11-FAKE16-NEXT:    s_and_b32 s12, s12, 1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s11, s11, 3
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s10, s10, 2
+; GFX11-FAKE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX11-FAKE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s15, s15, 3
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s14, s14, 2
+; GFX11-FAKE16-NEXT:    s_or_b32 s12, s12, s13
+; GFX11-FAKE16-NEXT:    s_or_b32 s9, s11, s10
+; GFX11-FAKE16-NEXT:    s_and_b32 s8, s8, 3
+; GFX11-FAKE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX11-FAKE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX11-FAKE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX11-FAKE16-NEXT:    s_or_b32 s13, s15, s14
+; GFX11-FAKE16-NEXT:    s_and_b32 s12, s12, 3
+; GFX11-FAKE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX11-FAKE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    s_or_b32 s10, s12, s13
+; GFX11-FAKE16-NEXT:    s_and_b32 s8, s8, 15
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s9, s10, 12
+; GFX11-FAKE16-NEXT:    s_lshl_b32 s2, s8, 8
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    s_or_b32 s1, s9, s2
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: amdgpu_cs_inreg_v16i1:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_and_b32 s10, s10, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s9, s9, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s8, s8, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s14, s14, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s13, s13, 1
+; GFX1250-TRUE16-NEXT:    s_and_b32 s12, s12, 1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s11, s11, 3
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s10, s10, 2
+; GFX1250-TRUE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX1250-TRUE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s15, s15, 3
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s14, s14, 2
+; GFX1250-TRUE16-NEXT:    s_or_b32 s12, s12, s13
+; GFX1250-TRUE16-NEXT:    s_or_b32 s9, s11, s10
+; GFX1250-TRUE16-NEXT:    s_and_b32 s8, s8, 3
+; GFX1250-TRUE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX1250-TRUE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX1250-TRUE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX1250-TRUE16-NEXT:    s_or_b32 s13, s15, s14
+; GFX1250-TRUE16-NEXT:    s_and_b32 s12, s12, 3
+; GFX1250-TRUE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX1250-TRUE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    s_or_b32 s10, s12, s13
+; GFX1250-TRUE16-NEXT:    s_and_b32 s8, s8, 15
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s9, s10, 12
+; GFX1250-TRUE16-NEXT:    s_lshl_b32 s2, s8, 8
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    s_or_b32 s1, s9, s2
+; GFX1250-TRUE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: amdgpu_cs_inreg_v16i1:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_and_b32 s10, s10, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s9, s9, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s8, s8, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s6, s6, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s5, s5, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s4, s4, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s1, s1, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s14, s14, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s13, s13, 1
+; GFX1250-FAKE16-NEXT:    s_and_b32 s12, s12, 1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s11, s11, 3
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s10, s10, 2
+; GFX1250-FAKE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s7, s7, 3
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s6, s6, 2
+; GFX1250-FAKE16-NEXT:    s_or_b32 s4, s4, s5
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s3, s3, 3
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s2, s2, 2
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s15, s15, 3
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s14, s14, 2
+; GFX1250-FAKE16-NEXT:    s_or_b32 s12, s12, s13
+; GFX1250-FAKE16-NEXT:    s_or_b32 s9, s11, s10
+; GFX1250-FAKE16-NEXT:    s_and_b32 s8, s8, 3
+; GFX1250-FAKE16-NEXT:    s_or_b32 s5, s7, s6
+; GFX1250-FAKE16-NEXT:    s_and_b32 s4, s4, 3
+; GFX1250-FAKE16-NEXT:    s_or_b32 s1, s3, s2
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 3
+; GFX1250-FAKE16-NEXT:    s_or_b32 s13, s15, s14
+; GFX1250-FAKE16-NEXT:    s_and_b32 s12, s12, 3
+; GFX1250-FAKE16-NEXT:    s_or_b32 s8, s8, s9
+; GFX1250-FAKE16-NEXT:    s_or_b32 s2, s4, s5
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    s_or_b32 s10, s12, s13
+; GFX1250-FAKE16-NEXT:    s_and_b32 s8, s8, 15
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s1, s2, 4
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 15
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s9, s10, 12
+; GFX1250-FAKE16-NEXT:    s_lshl_b32 s2, s8, 8
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    s_or_b32 s1, s9, s2
+; GFX1250-FAKE16-NEXT:    s_and_b32 s0, s0, 0xff
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    s_or_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX1250-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX1250-FAKE16-NEXT:    s_endpgm
   store <16 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/carryout-selection.ll
+++ b/llvm/test/CodeGen/AMDGPU/carryout-selection.ll
@@ -828,15 +828,16 @@ define amdgpu_kernel void @uaddo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_add_co_u32 v0, s4, s6, s7
+; GFX11-NEXT:    v_add_co_u32 v1, s4, s6, s7
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v1, v0, s[0:1]
-; GFX11-NEXT:    global_store_b8 v1, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v2, v1, s[0:1]
+; GFX11-NEXT:    global_store_b8 v2, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX1250-LABEL: uaddo32_vcc_user:
@@ -847,15 +848,16 @@ define amdgpu_kernel void @uaddo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1250-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_add_co_u32 v0, s4, s6, s7
+; GFX1250-NEXT:    v_add_co_u32 v1, s4, s6, s7
 ; GFX1250-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX1250-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b32 v1, v0, s[0:1]
-; GFX1250-NEXT:    global_store_b8 v1, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b32 v2, v1, s[0:1]
+; GFX1250-NEXT:    global_store_b8 v2, v0, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; GFX13-LABEL: uaddo32_vcc_user:
@@ -1033,14 +1035,14 @@ define amdgpu_kernel void @suaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX11-NEXT:    s_add_u32 s4, s4, s6
 ; GFX11-NEXT:    s_addc_u32 s5, s5, s7
 ; GFX11-NEXT:    s_cselect_b32 s6, -1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v0, s4
+; GFX11-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX11-NEXT:    s_and_b32 s4, s6, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s5
-; GFX11-NEXT:    v_mov_b32_e32 v3, s4
+; GFX11-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s5
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v2, v3, s[2:3]
+; GFX11-NEXT:    global_store_b64 v3, v[1:2], s[0:1]
+; GFX11-NEXT:    global_store_b8 v3, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX1250-LABEL: suaddo64:
@@ -1053,14 +1055,14 @@ define amdgpu_kernel void @suaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    s_add_co_u32 s0, s12, s14
 ; GFX1250-NEXT:    s_add_co_ci_u32 s1, s13, s15
 ; GFX1250-NEXT:    s_cselect_b32 s2, -1, 0
-; GFX1250-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v0, s0
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s0
 ; GFX1250-NEXT:    s_and_b32 s0, s2, exec_lo
 ; GFX1250-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v3, s0
+; GFX1250-NEXT:    v_mov_b32_e32 v3, s1
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s0
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[8:9]
-; GFX1250-NEXT:    global_store_b8 v2, v3, s[10:11]
+; GFX1250-NEXT:    global_store_b64 v1, v[2:3], s[8:9]
+; GFX1250-NEXT:    global_store_b8 v1, v0, s[10:11]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; GFX13-LABEL: suaddo64:
@@ -2144,15 +2146,16 @@ define amdgpu_kernel void @usubo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_sub_co_u32 v0, s4, s6, s7
+; GFX11-NEXT:    v_sub_co_u32 v1, s4, s6, s7
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v1, v0, s[0:1]
-; GFX11-NEXT:    global_store_b8 v1, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v2, v1, s[0:1]
+; GFX11-NEXT:    global_store_b8 v2, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX1250-LABEL: usubo32_vcc_user:
@@ -2163,15 +2166,16 @@ define amdgpu_kernel void @usubo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1250-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_sub_co_u32 v0, s4, s6, s7
+; GFX1250-NEXT:    v_sub_co_u32 v1, s4, s6, s7
 ; GFX1250-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX1250-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b32 v1, v0, s[0:1]
-; GFX1250-NEXT:    global_store_b8 v1, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b32 v2, v1, s[0:1]
+; GFX1250-NEXT:    global_store_b8 v2, v0, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; GFX13-LABEL: usubo32_vcc_user:
@@ -2349,14 +2353,14 @@ define amdgpu_kernel void @susubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX11-NEXT:    s_sub_u32 s4, s4, s6
 ; GFX11-NEXT:    s_subb_u32 s5, s5, s7
 ; GFX11-NEXT:    s_cselect_b32 s6, -1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v0, s4
+; GFX11-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX11-NEXT:    s_and_b32 s4, s6, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s5
-; GFX11-NEXT:    v_mov_b32_e32 v3, s4
+; GFX11-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s5
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v2, v3, s[2:3]
+; GFX11-NEXT:    global_store_b64 v3, v[1:2], s[0:1]
+; GFX11-NEXT:    global_store_b8 v3, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX1250-LABEL: susubo64:
@@ -2369,14 +2373,14 @@ define amdgpu_kernel void @susubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    s_sub_co_u32 s0, s12, s14
 ; GFX1250-NEXT:    s_sub_co_ci_u32 s1, s13, s15
 ; GFX1250-NEXT:    s_cselect_b32 s2, -1, 0
-; GFX1250-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v0, s0
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s0
 ; GFX1250-NEXT:    s_and_b32 s0, s2, exec_lo
 ; GFX1250-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v3, s0
+; GFX1250-NEXT:    v_mov_b32_e32 v3, s1
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s0
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[8:9]
-; GFX1250-NEXT:    global_store_b8 v2, v3, s[10:11]
+; GFX1250-NEXT:    global_store_b64 v1, v[2:3], s[8:9]
+; GFX1250-NEXT:    global_store_b8 v1, v0, s[10:11]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; GFX13-LABEL: susubo64:

--- a/llvm/test/CodeGen/AMDGPU/chain-hi-to-lo.ll
+++ b/llvm/test/CodeGen/AMDGPU/chain-hi-to-lo.ll
@@ -52,9 +52,9 @@ define <2 x half> @chain_hi_to_lo_private() {
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s0, 2
+; GFX11-TRUE16-NEXT:    s_mov_b32 s1, 0
 ; GFX11-TRUE16-NEXT:    scratch_load_d16_b16 v0, off, s0
-; GFX11-TRUE16-NEXT:    s_mov_b32 s0, 0
-; GFX11-TRUE16-NEXT:    scratch_load_d16_hi_b16 v0, off, s0
+; GFX11-TRUE16-NEXT:    scratch_load_d16_hi_b16 v0, off, s1
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -179,10 +179,9 @@ define <2 x half> @chain_hi_to_lo_arithmatic(ptr addrspace(5) %base, half %in) {
 ; GFX11-TRUE16-LABEL: chain_hi_to_lo_arithmatic:
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_add_f16_e32 v1.l, 1.0, v1.l
-; GFX11-TRUE16-NEXT:    scratch_load_d16_hi_b16 v1, v0, off
+; GFX11-TRUE16-NEXT:    scratch_load_d16_hi_b16 v0, v0, off
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-TRUE16-NEXT:    v_add_f16_e32 v0.l, 1.0, v1.l
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: chain_hi_to_lo_arithmatic:
@@ -228,9 +227,8 @@ define <2 x half> @chain_hi_to_lo_group() {
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX11-TRUE16-NEXT:    ds_load_u16_d16 v0, v1 offset:2
-; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    ds_load_u16_d16_hi v0, v1
+; GFX11-TRUE16-NEXT:    ds_load_u16_d16 v0, v1 offset:2
 ; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -277,7 +275,6 @@ define <2 x half> @chain_hi_to_lo_group_different_bases(ptr addrspace(3) %base_l
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    ds_load_u16_d16 v0, v0
-; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    ds_load_u16_d16_hi v0, v1
 ; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
@@ -329,10 +326,9 @@ define <2 x half> @chain_hi_to_lo_global() {
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, 2 :: v_dual_mov_b32 v1, 0
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v3, 0
 ; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v[0:1], off
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v[1:2], off
+; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v[2:3], off
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -460,12 +456,10 @@ define <2 x half> @chain_hi_to_lo_flat(ptr inreg %ptr) {
 ; GFX11-TRUE16-LABEL: chain_hi_to_lo_flat:
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s1
 ; GFX11-TRUE16-NEXT:    flat_load_d16_b16 v0, v[0:1] offset:2
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    flat_load_d16_hi_b16 v0, v[1:2]
+; GFX11-TRUE16-NEXT:    flat_load_d16_hi_b16 v0, v[2:3]
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -514,7 +508,6 @@ define <2 x half> @chain_hi_to_lo_flat_different_bases(ptr %base_lo, ptr %base_h
 ; GFX11-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    flat_load_d16_b16 v0, v[0:1]
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    flat_load_d16_hi_b16 v0, v[2:3]
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
@@ -679,11 +672,11 @@ define amdgpu_kernel void @vload2_private(ptr addrspace(1) nocapture readonly %i
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-TRUE16-NEXT:    scratch_store_b16 off, v0, off offset:4 dlc
 ; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    scratch_load_b32 v0, off, off
-; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v0.h
 ; GFX11-TRUE16-NEXT:    scratch_load_d16_hi_b16 v1, off, off offset:4
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v0.h
 ; GFX11-TRUE16-NEXT:    global_store_b64 v2, v[0:1], s[2:3]
 ; GFX11-TRUE16-NEXT:    s_endpgm
 ;
@@ -757,16 +750,28 @@ define <2 x i16> @chain_hi_to_lo_group_other_dep(ptr addrspace(3) %ptr) {
 ; GFX10-NEXT:    v_mov_b32_e32 v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: chain_hi_to_lo_group_other_dep:
-; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    ds_load_u16_d16_hi v1, v0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_pk_add_u16 v1, v1, 12 op_sel_hi:[1,0]
-; GFX11-NEXT:    ds_load_u16_d16 v1, v0 offset:2
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_mov_b32_e32 v0, v1
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: chain_hi_to_lo_group_other_dep:
+; GFX11-TRUE16:       ; %bb.0: ; %bb
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    ds_load_u16_d16_hi v1, v0
+; GFX11-TRUE16-NEXT:    ds_load_u16_d16 v0, v0 offset:2
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(1)
+; GFX11-TRUE16-NEXT:    v_pk_add_u16 v1, v1, 12 op_sel_hi:[1,0]
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.h
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: chain_hi_to_lo_group_other_dep:
+; GFX11-FAKE16:       ; %bb.0: ; %bb
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    ds_load_u16_d16_hi v1, v0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_pk_add_u16 v1, v1, 12 op_sel_hi:[1,0]
+; GFX11-FAKE16-NEXT:    ds_load_u16_d16 v1, v0 offset:2
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 bb:
   %gep_lo = getelementptr inbounds i16, ptr addrspace(3) %ptr, i64 1
   %load_lo = load i16, ptr addrspace(3) %gep_lo
@@ -888,16 +893,29 @@ define <2 x i16> @chain_hi_to_lo_private_other_dep(ptr addrspace(5) %ptr) {
 ; FLATSCR_GFX10-NEXT:    v_mov_b32_e32 v0, v1
 ; FLATSCR_GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: chain_hi_to_lo_private_other_dep:
-; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    scratch_load_d16_hi_b16 v1, v0, off
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_pk_add_u16 v1, v1, 12 op_sel_hi:[1,0]
-; GFX11-NEXT:    scratch_load_d16_b16 v1, v0, off offset:2
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_mov_b32_e32 v0, v1
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: chain_hi_to_lo_private_other_dep:
+; GFX11-TRUE16:       ; %bb.0: ; %bb
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    scratch_load_d16_hi_b16 v1, v0, off
+; GFX11-TRUE16-NEXT:    scratch_load_d16_b16 v0, v0, off offset:2
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-TRUE16-NEXT:    v_pk_add_u16 v1, v1, 12 op_sel_hi:[1,0]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.h
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: chain_hi_to_lo_private_other_dep:
+; GFX11-FAKE16:       ; %bb.0: ; %bb
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    scratch_load_d16_hi_b16 v1, v0, off
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_pk_add_u16 v1, v1, 12 op_sel_hi:[1,0]
+; GFX11-FAKE16-NEXT:    scratch_load_d16_b16 v1, v0, off offset:2
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 bb:
   %gep_lo = getelementptr inbounds i16, ptr addrspace(5) %ptr, i64 1
   %load_lo = load i16, ptr addrspace(5) %gep_lo
@@ -1119,3 +1137,5 @@ bb:
   %result = insertelement <2 x i16> %to.hi, i16 %load_lo, i32 0
   ret <2 x i16> %result
 }
+;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
+; GFX11: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/combine_andor_with_cmps.ll
+++ b/llvm/test/CodeGen/AMDGPU/combine_andor_with_cmps.ll
@@ -469,17 +469,29 @@ define i1 @test33(i32 %arg1, i32 %arg2) {
 }
 
 define amdgpu_gfx void @test34(i32 inreg %arg1, i32 inreg %arg2) {
-; GCN-LABEL: test34:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_min_i32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmpk_lt_i32 s0, 0x3e9
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test34:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_min_i32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmpk_lt_i32 s0, 0x3e9
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test34:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_min_i32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmpk_lt_i32 s0, 0x3e9
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp sle i32 %arg1, 1000
   %cmp2 = icmp sle i32 %arg2, 1000
   %or = or i1 %cmp1, %cmp2
@@ -488,17 +500,29 @@ define amdgpu_gfx void @test34(i32 inreg %arg1, i32 inreg %arg2) {
 }
 
 define amdgpu_gfx void @test35(i32 inreg %arg1, i32 inreg %arg2) {
-; GCN-LABEL: test35:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_max_i32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmpk_gt_i32 s0, 0x3e8
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test35:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_max_i32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmpk_gt_i32 s0, 0x3e8
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test35:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_max_i32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmpk_gt_i32 s0, 0x3e8
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp sgt i32 %arg1, 1000
   %cmp2 = icmp sgt i32 %arg2, 1000
   %or = or i1 %cmp1, %cmp2
@@ -507,17 +531,29 @@ define amdgpu_gfx void @test35(i32 inreg %arg1, i32 inreg %arg2) {
 }
 
 define amdgpu_gfx void @test36(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3) {
-; GCN-LABEL: test36:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_min_u32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmp_lt_u32 s0, s6
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test36:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_min_u32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmp_lt_u32 s0, s6
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test36:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_min_u32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmp_lt_u32 s0, s6
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp ult i32 %arg1, %arg3
   %cmp2 = icmp ult i32 %arg2, %arg3
   %or = or i1 %cmp1, %cmp2
@@ -526,17 +562,29 @@ define amdgpu_gfx void @test36(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3
 }
 
 define amdgpu_gfx void @test37(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3) {
-; GCN-LABEL: test37:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_max_i32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmp_ge_i32 s0, s6
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test37:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_max_i32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmp_ge_i32 s0, s6
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test37:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_max_i32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmp_ge_i32 s0, s6
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp sge i32 %arg1, %arg3
   %cmp2 = icmp sge i32 %arg2, %arg3
   %or = or i1 %cmp1, %cmp2
@@ -545,17 +593,29 @@ define amdgpu_gfx void @test37(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3
 }
 
 define amdgpu_gfx void @test38(i32 inreg %arg1, i32 inreg %arg2) {
-; GCN-LABEL: test38:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_max_u32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmpk_lt_u32 s0, 0x3e9
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test38:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_max_u32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmpk_lt_u32 s0, 0x3e9
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test38:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_max_u32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmpk_lt_u32 s0, 0x3e9
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp ule i32 %arg1, 1000
   %cmp2 = icmp ule i32 %arg2, 1000
   %and = and i1 %cmp1, %cmp2
@@ -564,17 +624,29 @@ define amdgpu_gfx void @test38(i32 inreg %arg1, i32 inreg %arg2) {
 }
 
 define amdgpu_gfx void @test39(i32 inreg %arg1, i32 inreg %arg2) {
-; GCN-LABEL: test39:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_min_i32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmpk_gt_i32 s0, 0x3e7
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test39:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_min_i32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmpk_gt_i32 s0, 0x3e7
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test39:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_min_i32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmpk_gt_i32 s0, 0x3e7
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp sge i32 %arg1, 1000
   %cmp2 = icmp sge i32 %arg2, 1000
   %and = and i1 %cmp1, %cmp2
@@ -583,17 +655,29 @@ define amdgpu_gfx void @test39(i32 inreg %arg1, i32 inreg %arg2) {
 }
 
 define amdgpu_gfx void @test40(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3) {
-; GCN-LABEL: test40:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_max_i32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmp_le_i32 s0, s6
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test40:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_max_i32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmp_le_i32 s0, s6
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test40:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_max_i32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmp_le_i32 s0, s6
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp sle i32 %arg1, %arg3
   %cmp2 = icmp sle i32 %arg2, %arg3
   %and = and i1 %cmp1, %cmp2
@@ -602,17 +686,29 @@ define amdgpu_gfx void @test40(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3
 }
 
 define amdgpu_gfx void @test41(i32 inreg %arg1, i32 inreg %arg2, i32 inreg %arg3) {
-; GCN-LABEL: test41:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_min_u32 s0, s4, s5
-; GCN-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GCN-NEXT:    s_cmp_ge_u32 s0, s6
-; GCN-NEXT:    s_cselect_b32 s0, 1, 0
-; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    global_store_b8 v[0:1], v2, off dlc
-; GCN-NEXT:    s_waitcnt_vscnt null, 0x0
-; GCN-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test41:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_min_u32 s0, s4, s5
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_cmp_ge_u32 s0, s6
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test41:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_min_u32 s0, s4, s5
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_cmp_ge_u32 s0, s6
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %cmp1 = icmp uge i32 %arg1, %arg3
   %cmp2 = icmp uge i32 %arg2, %arg3
   %and = and i1 %cmp1, %cmp2

--- a/llvm/test/CodeGen/AMDGPU/ctlz.ll
+++ b/llvm/test/CodeGen/AMDGPU/ctlz.ll
@@ -574,19 +574,33 @@ define amdgpu_kernel void @v_ctlz_i8(ptr addrspace(1) noalias %out, ptr addrspac
 ; GFX10-GISEL-NEXT:    global_store_byte v0, v1, s[0:1]
 ; GFX10-GISEL-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: v_ctlz_i8:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_u8 v1, v0, s[2:3]
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_clz_i32_u32_e32 v1, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_min_u32_e32 v1, 32, v1
-; GFX11-NEXT:    v_subrev_nc_u32_e32 v1, 24, v1
-; GFX11-NEXT:    global_store_b8 v0, v1, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: v_ctlz_i8:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    global_load_u8 v0, v1, s[2:3]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_clz_i32_u32_e32 v0, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 32, v0
+; GFX11-TRUE16-NEXT:    v_subrev_nc_u32_e32 v0, 24, v0
+; GFX11-TRUE16-NEXT:    global_store_b8 v1, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: v_ctlz_i8:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    global_load_u8 v1, v0, s[2:3]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_clz_i32_u32_e32 v1, v1
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 32, v1
+; GFX11-FAKE16-NEXT:    v_subrev_nc_u32_e32 v1, 24, v1
+; GFX11-FAKE16-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
   %val = load i8, ptr addrspace(1) %valptr
   %ctlz = call i8 @llvm.ctlz.i8(i8 %val, i1 false) nounwind readnone
   store i8 %ctlz, ptr addrspace(1) %out
@@ -2178,16 +2192,27 @@ define amdgpu_kernel void @v_ctlz_i8_sel_eq_neg1(ptr addrspace(1) noalias %out, 
 ; GFX10-GISEL-NEXT:    global_store_short v0, v1, s[0:1]
 ; GFX10-GISEL-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: v_ctlz_i16_sel_eq_neg1:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_u16 v1, v0, s[2:3]
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_clz_i32_u32_e32 v1, v1
-; GFX11-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: v_ctlz_i16_sel_eq_neg1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    global_load_u16 v0, v1, s[2:3]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_clz_i32_u32_e32 v0, v0
+; GFX11-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: v_ctlz_i16_sel_eq_neg1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    global_load_u16 v1, v0, s[2:3]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_clz_i32_u32_e32 v1, v1
+; GFX11-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
   %val = load i16, ptr addrspace(1) %valptr
   %ctlz = call i16 @llvm.ctlz.i16(i16 %val, i1 false) nounwind readnone
   %cmp = icmp eq i16 %val, 0

--- a/llvm/test/CodeGen/AMDGPU/cvt_f32_ubyte.ll
+++ b/llvm/test/CodeGen/AMDGPU/cvt_f32_ubyte.ll
@@ -1962,37 +1962,70 @@ define amdgpu_kernel void @load_v7i8_to_v7f32(ptr addrspace(1) noalias %out, ptr
 ; GFX9-NEXT:    global_store_dwordx3 v10, v[4:6], s[0:1] offset:16
 ; GFX9-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: load_v7i8_to_v7f32:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v7, 0 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-NEXT:    v_mov_b32_e32 v4, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 3, v0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_clause 0x5
-; GFX11-NEXT:    global_load_u8 v5, v0, s[2:3] offset:6
-; GFX11-NEXT:    global_load_u8 v1, v0, s[2:3] offset:3
-; GFX11-NEXT:    global_load_u8 v2, v0, s[2:3] offset:2
-; GFX11-NEXT:    global_load_u8 v6, v0, s[2:3] offset:1
-; GFX11-NEXT:    global_load_d16_b16 v4, v0, s[2:3] offset:4
-; GFX11-NEXT:    global_load_u8 v0, v0, s[2:3]
-; GFX11-NEXT:    s_waitcnt vmcnt(4)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v3, v1
-; GFX11-NEXT:    s_waitcnt vmcnt(3)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v2, v2
-; GFX11-NEXT:    s_waitcnt vmcnt(2)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v1, v6
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v6, v5
-; GFX11-NEXT:    s_waitcnt vmcnt(1)
-; GFX11-NEXT:    v_cvt_f32_ubyte1_e32 v5, v4
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v4, v4
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b96 v7, v[4:6], s[0:1] offset:16
-; GFX11-NEXT:    global_store_b128 v7, v[0:3], s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: load_v7i8_to_v7f32:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v8, 0 :: v_dual_lshlrev_b32 v1, 3, v0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_clause 0x5
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v1, s[2:3] offset:4
+; GFX11-TRUE16-NEXT:    global_load_u8 v2, v1, s[2:3] offset:6
+; GFX11-TRUE16-NEXT:    global_load_u8 v3, v1, s[2:3] offset:3
+; GFX11-TRUE16-NEXT:    global_load_u8 v4, v1, s[2:3] offset:2
+; GFX11-TRUE16-NEXT:    global_load_u8 v5, v1, s[2:3] offset:1
+; GFX11-TRUE16-NEXT:    global_load_u8 v7, v1, s[2:3]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(5)
+; GFX11-TRUE16-NEXT:    v_cvt_u32_u16_e32 v9, v0.l
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(4)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v6, v2
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v3, v3
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(2)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v2, v4
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v1, v5
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v0, v7
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte1_e32 v5, v9
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v4, v9
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b128 v8, v[0:3], s[0:1]
+; GFX11-TRUE16-NEXT:    global_store_b96 v8, v[4:6], s[0:1] offset:16
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: load_v7i8_to_v7f32:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v7, 0 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, 0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 3, v0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_clause 0x5
+; GFX11-FAKE16-NEXT:    global_load_u8 v5, v0, s[2:3] offset:6
+; GFX11-FAKE16-NEXT:    global_load_u8 v1, v0, s[2:3] offset:3
+; GFX11-FAKE16-NEXT:    global_load_u8 v2, v0, s[2:3] offset:2
+; GFX11-FAKE16-NEXT:    global_load_u8 v6, v0, s[2:3] offset:1
+; GFX11-FAKE16-NEXT:    global_load_d16_b16 v4, v0, s[2:3] offset:4
+; GFX11-FAKE16-NEXT:    global_load_u8 v0, v0, s[2:3]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(4)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v3, v1
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v2, v2
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(2)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v1, v6
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v6, v5
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte1_e32 v5, v4
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v4, v4
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b96 v7, v[4:6], s[0:1] offset:16
+; GFX11-FAKE16-NEXT:    global_store_b128 v7, v[0:3], s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %gep = getelementptr <7 x i8>, ptr addrspace(1) %in, i32 %tid
   %load = load <7 x i8>, ptr addrspace(1) %gep, align 1
@@ -3031,30 +3064,61 @@ define amdgpu_kernel void @cvt_f32_ubyte0_vector() local_unnamed_addr {
 ; GFX9-NEXT:    global_store_byte v[0:1], v0, off
 ; GFX9-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: cvt_f32_ubyte0_vector:
-; GFX11:       ; %bb.0: ; %entry
-; GFX11-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_clause 0x3
-; GFX11-NEXT:    global_load_u8 v1, v0, s[0:1] offset:3
-; GFX11-NEXT:    global_load_u8 v2, v0, s[0:1] offset:2
-; GFX11-NEXT:    global_load_u8 v3, v0, s[0:1] offset:1
-; GFX11-NEXT:    global_load_u8 v0, v0, s[0:1]
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt vmcnt(3)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v1, v1
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_fma_f32 v1, s0, v1, 0.5
-; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    s_clause 0x3
-; GFX11-NEXT:    global_store_b8 v[0:1], v2, off
-; GFX11-NEXT:    global_store_b8 v[0:1], v3, off
-; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX11-NEXT:    global_store_b8 v[0:1], v1, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: cvt_f32_ubyte0_vector:
+; GFX11-TRUE16:       ; %bb.0: ; %entry
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_clause 0x3
+; GFX11-TRUE16-NEXT:    global_load_u8 v1, v0, s[0:1] offset:3
+; GFX11-TRUE16-NEXT:    global_load_u8 v2, v0, s[0:1] offset:2
+; GFX11-TRUE16-NEXT:    global_load_u8 v3, v0, s[0:1] offset:1
+; GFX11-TRUE16-NEXT:    global_load_u8 v4, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_ubyte0_e32 v0, v1
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v3.l
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v0, s0, v0, 0.5
+; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v2.l
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v4.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v5.l
+; GFX11-TRUE16-NEXT:    s_clause 0x3
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v1, off
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v3, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: cvt_f32_ubyte0_vector:
+; GFX11-FAKE16:       ; %bb.0: ; %entry
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_clause 0x3
+; GFX11-FAKE16-NEXT:    global_load_u8 v1, v0, s[0:1] offset:3
+; GFX11-FAKE16-NEXT:    global_load_u8 v2, v0, s[0:1] offset:2
+; GFX11-FAKE16-NEXT:    global_load_u8 v3, v0, s[0:1] offset:1
+; GFX11-FAKE16-NEXT:    global_load_u8 v0, v0, s[0:1]
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v1, v1
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_fma_f32 v1, s0, v1, 0.5
+; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    s_clause 0x3
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v3, off
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v1, off
+; GFX11-FAKE16-NEXT:    s_endpgm
 entry:
   br label %for.body.i
 

--- a/llvm/test/CodeGen/AMDGPU/extract-i8-codegen.ll
+++ b/llvm/test/CodeGen/AMDGPU/extract-i8-codegen.ll
@@ -129,10 +129,11 @@ define void @extract_multiple_v4i8(ptr addrspace(1) %out) {
 ; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    v_mov_b32_e32 v2, 0
-; GFX12-NEXT:    ds_load_b32 v2, v2
+; GFX12-NEXT:    ds_load_b32 v3, v2
 ; GFX12-NEXT:    s_wait_dscnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.l, v3.l
 ; GFX12-NEXT:    s_clause 0x1
-; GFX12-NEXT:    global_store_d16_hi_b8 v[0:1], v2, off offset:2
+; GFX12-NEXT:    global_store_d16_hi_b8 v[0:1], v3, off offset:2
 ; GFX12-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX12-NEXT:    s_set_pc_i64 s[30:31]
   %ptr = getelementptr inbounds i8, ptr addrspace(3) @lds, i32 0

--- a/llvm/test/CodeGen/AMDGPU/flat-offset-bug.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat-offset-bug.ll
@@ -113,12 +113,14 @@ define amdgpu_kernel void @load_i16_lo(ptr %arg, ptr %out) {
 ; GFX11-LABEL: load_i16_lo:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX11-NEXT:    flat_load_d16_b16 v2, v[0:1] offset:8
-; GFX11-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s3
+; GFX11-NEXT:    flat_load_d16_b16 v0, v[0:1] offset:8
+; GFX11-NEXT:    v_mov_b32_e32 v1, s3
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_u16_e32 v2, v0.l
+; GFX11-NEXT:    v_mov_b32_e32 v0, s2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_pk_add_u16 v2, v2, v2
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX11-NEXT:    s_endpgm
@@ -166,12 +168,13 @@ define amdgpu_kernel void @load_i16_hi(ptr %arg, ptr %out) {
 ; GFX11-LABEL: load_i16_hi:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b16_e32 v2.l, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX11-NEXT:    flat_load_d16_hi_b16 v2, v[0:1] offset:8
-; GFX11-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s3
+; GFX11-NEXT:    flat_load_d16_b16 v0, v[0:1] offset:8
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v1, s3 :: v_dual_lshlrev_b32 v2, 16, v0
+; GFX11-NEXT:    v_mov_b32_e32 v0, s2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_pk_add_u16 v2, v2, v2
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX11-NEXT:    s_endpgm
@@ -219,12 +222,14 @@ define amdgpu_kernel void @load_half_lo(ptr %arg, ptr %out) {
 ; GFX11-LABEL: load_half_lo:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX11-NEXT:    flat_load_d16_b16 v2, v[0:1] offset:8
-; GFX11-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s3
+; GFX11-NEXT:    flat_load_d16_b16 v0, v[0:1] offset:8
+; GFX11-NEXT:    v_mov_b32_e32 v1, s3
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_u16_e32 v2, v0.l
+; GFX11-NEXT:    v_mov_b32_e32 v0, s2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_pk_add_f16 v2, v2, v2
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX11-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/flat-saddr-load.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat-saddr-load.ll
@@ -2332,16 +2332,26 @@ define amdgpu_ps <2 x half> @flat_load_saddr_i16_d16lo_zero_hi(ptr inreg %sbase,
 ; GFX1250-GISEL-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
 ; GFX1250-GISEL-TRUE16-NEXT:    ; return to shader part epilog
 ;
-; GFX1250-NOECC-LABEL: flat_load_saddr_i16_d16lo_zero_hi:
-; GFX1250-NOECC:       ; %bb.0:
-; GFX1250-NOECC-NEXT:    global_wb
-; GFX1250-NOECC-NEXT:    v_nop
-; GFX1250-NOECC-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NOECC-NEXT:    v_mov_b32_e32 v1, 0
-; GFX1250-NOECC-NEXT:    flat_load_d16_b16 v1, v0, s[2:3]
-; GFX1250-NOECC-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-NOECC-NEXT:    v_mov_b32_e32 v0, v1
-; GFX1250-NOECC-NEXT:    ; return to shader part epilog
+; GFX1250-NOECC-SDAG-TRUE16-LABEL: flat_load_saddr_i16_d16lo_zero_hi:
+; GFX1250-NOECC-SDAG-TRUE16:       ; %bb.0:
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    global_wb
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_nop
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    flat_load_d16_b16 v0, v0, s[2:3]
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    ; return to shader part epilog
+;
+; GFX1250-NOECC-SDAG-FAKE16-LABEL: flat_load_saddr_i16_d16lo_zero_hi:
+; GFX1250-NOECC-SDAG-FAKE16:       ; %bb.0:
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    global_wb
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    flat_load_d16_b16 v1, v0, s[2:3]
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    ; return to shader part epilog
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr %sbase, i64 %zext.offset
   %load = load i16, ptr %gep0
@@ -2391,16 +2401,26 @@ define amdgpu_ps <2 x half> @flat_load_saddr_i16_d16lo_zero_hi_immneg128(ptr inr
 ; GFX1250-GISEL-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
 ; GFX1250-GISEL-TRUE16-NEXT:    ; return to shader part epilog
 ;
-; GFX1250-NOECC-LABEL: flat_load_saddr_i16_d16lo_zero_hi_immneg128:
-; GFX1250-NOECC:       ; %bb.0:
-; GFX1250-NOECC-NEXT:    global_wb
-; GFX1250-NOECC-NEXT:    v_nop
-; GFX1250-NOECC-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NOECC-NEXT:    v_mov_b32_e32 v1, 0
-; GFX1250-NOECC-NEXT:    flat_load_d16_b16 v1, v0, s[2:3] offset:-128
-; GFX1250-NOECC-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-NOECC-NEXT:    v_mov_b32_e32 v0, v1
-; GFX1250-NOECC-NEXT:    ; return to shader part epilog
+; GFX1250-NOECC-SDAG-TRUE16-LABEL: flat_load_saddr_i16_d16lo_zero_hi_immneg128:
+; GFX1250-NOECC-SDAG-TRUE16:       ; %bb.0:
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    global_wb
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_nop
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    flat_load_d16_b16 v0, v0, s[2:3] offset:-128
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    ; return to shader part epilog
+;
+; GFX1250-NOECC-SDAG-FAKE16-LABEL: flat_load_saddr_i16_d16lo_zero_hi_immneg128:
+; GFX1250-NOECC-SDAG-FAKE16:       ; %bb.0:
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    global_wb
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    flat_load_d16_b16 v1, v0, s[2:3] offset:-128
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX1250-NOECC-SDAG-FAKE16-NEXT:    ; return to shader part epilog
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr %gep0, i64 -128
@@ -2926,10 +2946,9 @@ define amdgpu_ps <2 x half> @flat_load_saddr_i16_d16hi_zero_hi(ptr inreg %sbase,
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    global_wb
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_nop
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
-; GFX1250-NOECC-SDAG-TRUE16-NEXT:    flat_load_d16_hi_b16 v1, v0, s[2:3]
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    flat_load_d16_hi_b16 v0, v0, s[2:3]
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX1250-NOECC-SDAG-FAKE16-LABEL: flat_load_saddr_i16_d16hi_zero_hi:
@@ -2988,10 +3007,9 @@ define amdgpu_ps <2 x half> @flat_load_saddr_i16_d16hi_zero_hi_immneg128(ptr inr
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    global_wb
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_nop
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
-; GFX1250-NOECC-SDAG-TRUE16-NEXT:    flat_load_d16_hi_b16 v1, v0, s[2:3] offset:-128
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    flat_load_d16_hi_b16 v0, v0, s[2:3] offset:-128
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX1250-NOECC-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0
 ; GFX1250-NOECC-SDAG-TRUE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX1250-NOECC-SDAG-FAKE16-LABEL: flat_load_saddr_i16_d16hi_zero_hi_immneg128:

--- a/llvm/test/CodeGen/AMDGPU/flat-scratch-i8-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat-scratch-i8-i16.ll
@@ -149,18 +149,19 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_lo_v(ptr addrspace(5) %i
 ;
 ; GFX11-LABEL: test_scratch_load_i8_zext_to_d16_lo_v:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_add_nc_u32 v0, 1, v0
-; GFX11-NEXT:    scratch_load_d16_u8 v3, v0, off
+; GFX11-NEXT:    v_add_nc_u32_e32 v0, 1, v0
+; GFX11-NEXT:    scratch_load_d16_u8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_zext_to_d16_lo_v:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b32_e32 v3, 0xffff0000
-; GFX12-NEXT:    scratch_load_d16_u8 v3, v0, off offset:1
+; GFX12-NEXT:    scratch_load_d16_u8 v0, v0, off offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %gep = getelementptr i8, ptr addrspace(5) %in, i64 1
@@ -187,18 +188,19 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_lo_v(ptr addrspace(5) %i
 ;
 ; GFX11-LABEL: test_scratch_load_i8_sext_to_d16_lo_v:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_add_nc_u32 v0, 1, v0
-; GFX11-NEXT:    scratch_load_d16_i8 v3, v0, off
+; GFX11-NEXT:    v_add_nc_u32_e32 v0, 1, v0
+; GFX11-NEXT:    scratch_load_d16_i8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_sext_to_d16_lo_v:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b32_e32 v3, 0xffff0000
-; GFX12-NEXT:    scratch_load_d16_i8 v3, v0, off offset:1
+; GFX12-NEXT:    scratch_load_d16_i8 v0, v0, off offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %gep = getelementptr i8, ptr addrspace(5) %in, i64 1
@@ -225,18 +227,19 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_lo_v(ptr addrspace(5) %in, p
 ;
 ; GFX11-LABEL: test_scratch_load_i16_to_d16_lo_v:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_add_nc_u32 v0, 2, v0
-; GFX11-NEXT:    scratch_load_d16_b16 v3, v0, off
+; GFX11-NEXT:    v_add_nc_u32_e32 v0, 2, v0
+; GFX11-NEXT:    scratch_load_d16_b16 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i16_to_d16_lo_v:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b32_e32 v3, 0xffff0000
-; GFX12-NEXT:    scratch_load_d16_b16 v3, v0, off offset:2
+; GFX12-NEXT:    scratch_load_d16_b16 v0, v0, off offset:2
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %gep = getelementptr i16, ptr addrspace(5) %in, i64 1
@@ -264,18 +267,18 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_hi_v(ptr addrspace(5) %i
 ; GFX11-LABEL: test_scratch_load_i8_zext_to_d16_hi_v:
 ; GFX11:       ; %bb.0: ; %bb
 ; GFX11-NEXT:    v_add_nc_u32_e32 v0, 1, v0
-; GFX11-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX11-NEXT:    scratch_load_d16_hi_u8 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_hi_u8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_zext_to_d16_hi_v:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX12-NEXT:    scratch_load_d16_hi_u8 v3, v0, off offset:1
+; GFX12-NEXT:    scratch_load_d16_hi_u8 v0, v0, off offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %gep = getelementptr i8, ptr addrspace(5) %in, i64 1
@@ -303,18 +306,18 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_hi_v(ptr addrspace(5) %i
 ; GFX11-LABEL: test_scratch_load_i8_sext_to_d16_hi_v:
 ; GFX11:       ; %bb.0: ; %bb
 ; GFX11-NEXT:    v_add_nc_u32_e32 v0, 1, v0
-; GFX11-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX11-NEXT:    scratch_load_d16_hi_i8 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_hi_i8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_sext_to_d16_hi_v:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX12-NEXT:    scratch_load_d16_hi_i8 v3, v0, off offset:1
+; GFX12-NEXT:    scratch_load_d16_hi_i8 v0, v0, off offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %gep = getelementptr i8, ptr addrspace(5) %in, i64 1
@@ -342,18 +345,18 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_hi_v(ptr addrspace(5) %in, p
 ; GFX11-LABEL: test_scratch_load_i16_to_d16_hi_v:
 ; GFX11:       ; %bb.0: ; %bb
 ; GFX11-NEXT:    v_add_nc_u32_e32 v0, 2, v0
-; GFX11-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX11-NEXT:    scratch_load_d16_hi_b16 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_hi_b16 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i16_to_d16_hi_v:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX12-NEXT:    scratch_load_d16_hi_b16 v3, v0, off offset:2
+; GFX12-NEXT:    scratch_load_d16_hi_b16 v0, v0, off offset:2
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %gep = getelementptr i16, ptr addrspace(5) %in, i64 1
@@ -582,8 +585,8 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_lo_s(ptr addrspace(5) in
 ;
 ; GFX11-LABEL: test_scratch_load_i8_zext_to_d16_lo_s:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_mov_b32_e32 v2, 0xffff0000
 ; GFX11-NEXT:    s_add_i32 s0, s0, 1
+; GFX11-NEXT:    v_mov_b16_e32 v2.h, -1
 ; GFX11-NEXT:    scratch_load_d16_u8 v2, off, s0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
@@ -591,9 +594,9 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_lo_s(ptr addrspace(5) in
 ;
 ; GFX12-LABEL: test_scratch_load_i8_zext_to_d16_lo_s:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b32_e32 v2, 0xffff0000
 ; GFX12-NEXT:    scratch_load_d16_u8 v2, off, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.h, -1
 ; GFX12-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX12-NEXT:    s_endpgm
 bb:
@@ -621,8 +624,8 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_lo_s(ptr addrspace(5) in
 ;
 ; GFX11-LABEL: test_scratch_load_i8_sext_to_d16_lo_s:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_mov_b32_e32 v2, 0xffff0000
 ; GFX11-NEXT:    s_add_i32 s0, s0, 1
+; GFX11-NEXT:    v_mov_b16_e32 v2.h, -1
 ; GFX11-NEXT:    scratch_load_d16_i8 v2, off, s0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
@@ -630,9 +633,9 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_lo_s(ptr addrspace(5) in
 ;
 ; GFX12-LABEL: test_scratch_load_i8_sext_to_d16_lo_s:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b32_e32 v2, 0xffff0000
 ; GFX12-NEXT:    scratch_load_d16_i8 v2, off, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.h, -1
 ; GFX12-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX12-NEXT:    s_endpgm
 bb:
@@ -660,8 +663,8 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_lo_s(ptr addrspace(5) inreg 
 ;
 ; GFX11-LABEL: test_scratch_load_i16_to_d16_lo_s:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_mov_b32_e32 v2, 0xffff0000
 ; GFX11-NEXT:    s_add_i32 s0, s0, 2
+; GFX11-NEXT:    v_mov_b16_e32 v2.h, -1
 ; GFX11-NEXT:    scratch_load_d16_b16 v2, off, s0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
@@ -669,9 +672,9 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_lo_s(ptr addrspace(5) inreg 
 ;
 ; GFX12-LABEL: test_scratch_load_i16_to_d16_lo_s:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b32_e32 v2, 0xffff0000
 ; GFX12-NEXT:    scratch_load_d16_b16 v2, off, s0 offset:2
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.h, -1
 ; GFX12-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX12-NEXT:    s_endpgm
 bb:
@@ -699,8 +702,8 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_hi_s(ptr addrspace(5) in
 ;
 ; GFX11-LABEL: test_scratch_load_i8_zext_to_d16_hi_s:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX11-NEXT:    s_add_i32 s0, s0, 1
+; GFX11-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX11-NEXT:    scratch_load_d16_hi_u8 v2, off, s0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
@@ -708,9 +711,9 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_hi_s(ptr addrspace(5) in
 ;
 ; GFX12-LABEL: test_scratch_load_i8_zext_to_d16_hi_s:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX12-NEXT:    scratch_load_d16_hi_u8 v2, off, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX12-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX12-NEXT:    s_endpgm
 bb:
@@ -738,8 +741,8 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_hi_s(ptr addrspace(5) in
 ;
 ; GFX11-LABEL: test_scratch_load_i8_sext_to_d16_hi_s:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX11-NEXT:    s_add_i32 s0, s0, 1
+; GFX11-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX11-NEXT:    scratch_load_d16_hi_i8 v2, off, s0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
@@ -747,9 +750,9 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_hi_s(ptr addrspace(5) in
 ;
 ; GFX12-LABEL: test_scratch_load_i8_sext_to_d16_hi_s:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX12-NEXT:    scratch_load_d16_hi_i8 v2, off, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX12-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX12-NEXT:    s_endpgm
 bb:
@@ -777,8 +780,8 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_hi_s(ptr addrspace(5) inreg 
 ;
 ; GFX11-LABEL: test_scratch_load_i16_to_d16_hi_s:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX11-NEXT:    s_add_i32 s0, s0, 2
+; GFX11-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX11-NEXT:    scratch_load_d16_hi_b16 v2, off, s0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    flat_store_b32 v[0:1], v2
@@ -786,9 +789,9 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_hi_s(ptr addrspace(5) inreg 
 ;
 ; GFX12-LABEL: test_scratch_load_i16_to_d16_hi_s:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX12-NEXT:    scratch_load_d16_hi_b16 v2, off, s0 offset:2
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_mov_b16_e32 v2.l, -1
 ; GFX12-NEXT:    flat_store_b32 v[0:1], v2
 ; GFX12-NEXT:    s_endpgm
 bb:
@@ -1039,20 +1042,22 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_lo_svs(ptr addrspace(5) 
 ;
 ; GFX11-LABEL: test_scratch_load_i8_zext_to_d16_lo_svs:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_lshlrev_b32 v0, 2, v0
+; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add3_u32 v0, s0, v0, 1
-; GFX11-NEXT:    scratch_load_d16_u8 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_u8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_zext_to_d16_lo_svs:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_lshlrev_b32 v0, 2, v0
-; GFX12-NEXT:    scratch_load_d16_u8 v3, v0, s0 offset:1
+; GFX12-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX12-NEXT:    scratch_load_d16_u8 v0, v0, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %voffset4 = mul i32 %voffset, 4
@@ -1082,20 +1087,22 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_lo_svs(ptr addrspace(5) 
 ;
 ; GFX11-LABEL: test_scratch_load_i8_sext_to_d16_lo_svs:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_lshlrev_b32 v0, 2, v0
+; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add3_u32 v0, s0, v0, 1
-; GFX11-NEXT:    scratch_load_d16_i8 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_i8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_sext_to_d16_lo_svs:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_lshlrev_b32 v0, 2, v0
-; GFX12-NEXT:    scratch_load_d16_i8 v3, v0, s0 offset:1
+; GFX12-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX12-NEXT:    scratch_load_d16_i8 v0, v0, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %voffset4 = mul i32 %voffset, 4
@@ -1125,20 +1132,22 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_lo_svs(ptr addrspace(5) inre
 ;
 ; GFX11-LABEL: test_scratch_load_i16_to_d16_lo_svs:
 ; GFX11:       ; %bb.0: ; %bb
-; GFX11-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_lshlrev_b32 v0, 2, v0
+; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add3_u32 v0, s0, v0, 2
-; GFX11-NEXT:    scratch_load_d16_b16 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_b16 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i16_to_d16_lo_svs:
 ; GFX12:       ; %bb.0: ; %bb
-; GFX12-NEXT:    v_dual_mov_b32 v3, 0xffff0000 :: v_dual_lshlrev_b32 v0, 2, v0
-; GFX12-NEXT:    scratch_load_d16_b16 v3, v0, s0 offset:2
+; GFX12-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX12-NEXT:    scratch_load_d16_b16 v0, v0, s0 offset:2
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.h, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %voffset4 = mul i32 %voffset, 4
@@ -1169,21 +1178,21 @@ define amdgpu_ps void @test_scratch_load_i8_zext_to_d16_hi_svs(ptr addrspace(5) 
 ; GFX11-LABEL: test_scratch_load_i8_zext_to_d16_hi_svs:
 ; GFX11:       ; %bb.0: ; %bb
 ; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX11-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add3_u32 v0, s0, v0, 1
-; GFX11-NEXT:    scratch_load_d16_hi_u8 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_hi_u8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_zext_to_d16_hi_svs:
 ; GFX12:       ; %bb.0: ; %bb
 ; GFX12-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX12-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX12-NEXT:    scratch_load_d16_hi_u8 v3, v0, s0 offset:1
+; GFX12-NEXT:    scratch_load_d16_hi_u8 v0, v0, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %voffset4 = mul i32 %voffset, 4
@@ -1214,21 +1223,21 @@ define amdgpu_ps void @test_scratch_load_i8_sext_to_d16_hi_svs(ptr addrspace(5) 
 ; GFX11-LABEL: test_scratch_load_i8_sext_to_d16_hi_svs:
 ; GFX11:       ; %bb.0: ; %bb
 ; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX11-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add3_u32 v0, s0, v0, 1
-; GFX11-NEXT:    scratch_load_d16_hi_i8 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_hi_i8 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i8_sext_to_d16_hi_svs:
 ; GFX12:       ; %bb.0: ; %bb
 ; GFX12-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX12-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX12-NEXT:    scratch_load_d16_hi_i8 v3, v0, s0 offset:1
+; GFX12-NEXT:    scratch_load_d16_hi_i8 v0, v0, s0 offset:1
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %voffset4 = mul i32 %voffset, 4
@@ -1259,21 +1268,21 @@ define amdgpu_ps void @test_scratch_load_i16_to_d16_hi_svs(ptr addrspace(5) inre
 ; GFX11-LABEL: test_scratch_load_i16_to_d16_hi_svs:
 ; GFX11:       ; %bb.0: ; %bb
 ; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX11-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add3_u32 v0, s0, v0, 2
-; GFX11-NEXT:    scratch_load_d16_hi_b16 v3, v0, off
+; GFX11-NEXT:    scratch_load_d16_hi_b16 v0, v0, off
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    flat_store_b32 v[1:2], v3
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX11-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: test_scratch_load_i16_to_d16_hi_svs:
 ; GFX12:       ; %bb.0: ; %bb
 ; GFX12-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX12-NEXT:    v_mov_b16_e32 v3.l, -1
-; GFX12-NEXT:    scratch_load_d16_hi_b16 v3, v0, s0 offset:2
+; GFX12-NEXT:    scratch_load_d16_hi_b16 v0, v0, s0 offset:2
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
-; GFX12-NEXT:    flat_store_b32 v[1:2], v3
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, -1
+; GFX12-NEXT:    flat_store_b32 v[1:2], v0
 ; GFX12-NEXT:    s_endpgm
 bb:
   %voffset4 = mul i32 %voffset, 4

--- a/llvm/test/CodeGen/AMDGPU/flat-scratch-svs.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat-scratch-svs.ll
@@ -96,23 +96,44 @@ define amdgpu_kernel void @soff1_voff1(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff1_voff1:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_add_nc_u32 v0, s0, v0
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff1_voff1:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff1_voff1:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_add_nc_u32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff1_voff1:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -144,19 +165,35 @@ define amdgpu_kernel void @soff1_voff1(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff1_voff1:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff1_voff1:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 2
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff1_voff1:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff1 = mul i32 %soff, 1
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -255,26 +292,49 @@ define amdgpu_kernel void @soff1_voff2(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff1_voff2:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff1_voff2:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff1_voff2:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff1_voff2:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -310,21 +370,39 @@ define amdgpu_kernel void @soff1_voff2(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff1_voff2:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX12-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff1_voff2:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v2, 2, v1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff1_voff2:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff1 = mul i32 %soff, 1
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -423,26 +501,49 @@ define amdgpu_kernel void @soff1_voff4(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff1_voff4:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff1_voff4:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff1_voff4:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff1_voff4:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -478,21 +579,39 @@ define amdgpu_kernel void @soff1_voff4(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff1_voff4:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX12-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff1_voff4:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v2, 4, v1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff1_voff4:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff1 = mul i32 %soff, 1
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -596,26 +715,49 @@ define amdgpu_kernel void @soff2_voff1(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff2_voff1:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff2_voff1:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff2_voff1:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff2_voff1:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -649,20 +791,37 @@ define amdgpu_kernel void @soff2_voff1(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff2_voff1:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_mov_b32 v2, 2
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff2_voff1:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v1, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff2_voff1:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_mov_b32 v2, 2
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff2 = mul i32 %soff, 2
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -764,28 +923,53 @@ define amdgpu_kernel void @soff2_voff2(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff2_voff2:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff2_voff2:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff2_voff2:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff2_voff2:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -823,22 +1007,41 @@ define amdgpu_kernel void @soff2_voff2(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff2_voff2:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX12-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff2_voff2:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v2, 2, v1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff2_voff2:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff2 = mul i32 %soff, 2
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -940,28 +1143,53 @@ define amdgpu_kernel void @soff2_voff4(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff2_voff4:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff2_voff4:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff2_voff4:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff2_voff4:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -999,22 +1227,41 @@ define amdgpu_kernel void @soff2_voff4(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff2_voff4:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX12-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s0, s0, 1
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff2_voff4:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v2, 4, v1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff2_voff4:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 1
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff2 = mul i32 %soff, 2
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -1118,26 +1365,49 @@ define amdgpu_kernel void @soff4_voff1(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff4_voff1:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_lshl_b32 s0, s0, 2
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff4_voff1:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff4_voff1:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff4_voff1:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -1171,20 +1441,37 @@ define amdgpu_kernel void @soff4_voff1(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff4_voff1:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_mov_b32 v2, 2
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s0, s0, 2
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff4_voff1:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v1, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff4_voff1:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_mov_b32 v2, 2
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff4 = mul i32 %soff, 4
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -1286,28 +1573,53 @@ define amdgpu_kernel void @soff4_voff2(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff4_voff2:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_lshl_b32 s0, s0, 2
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff4_voff2:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff4_voff2:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff4_voff2:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -1345,22 +1657,41 @@ define amdgpu_kernel void @soff4_voff2(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff4_voff2:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX12-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s0, s0, 2
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff4_voff2:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v2, 2, v1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff4_voff2:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 2, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff4 = mul i32 %soff, 4
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -1459,28 +1790,53 @@ define amdgpu_kernel void @soff4_voff4(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff4_voff4:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v3, 4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_lshl_b32 s0, s0, 2
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v4, 1, v0
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, 4, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v4, v1, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v5, v2, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v3, off dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff4_voff4:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v3, 1, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v4, 2, v2
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v2, 4, v2
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v3, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v4, v0, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, off dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff4_voff4:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_mov_b32_e32 v3, 4
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_add_nc_u32 v5, 2, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v4, 1, v0
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, 4, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v4, v1, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v5, v2, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, off dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff4_voff4:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -1518,22 +1874,41 @@ define amdgpu_kernel void @soff4_voff4(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff4_voff4:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX12-GISEL-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s0, s0, 2
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff4_voff4:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 2
+; GFX12-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-GISEL-TRUE16-NEXT:    v_mul_u32_u24_e32 v2, 4, v1
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 4
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v0, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_d16_hi_b8 v2, v0, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v2, v1, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff4_voff4:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v3, 4
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-GISEL-FAKE16-NEXT:    v_mul_u32_u24_e32 v0, 4, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_lshl_b32 s0, s0, 2
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v2, s0 offset:2 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v3, s0 offset:4 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %soff4 = mul i32 %soff, 4
   %a = alloca i8, i32 64, align 4, addrspace(5)
@@ -1597,16 +1972,28 @@ define amdgpu_kernel void @soff1_voff1_negative(i32 %soff) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX11-GISEL-LABEL: soff1_voff1_negative:
-; GFX11-GISEL:       ; %bb.0: ; %bb
-; GFX11-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_add_nc_u32_e32 v0, s0, v0
-; GFX11-GISEL-NEXT:    scratch_store_b8 v0, v1, off offset:-1 dlc
-; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-GISEL-NEXT:    s_endpgm
+; GFX11-GISEL-TRUE16-LABEL: soff1_voff1_negative:
+; GFX11-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u32_e32 v1, s0, v0
+; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-GISEL-TRUE16-NEXT:    scratch_store_b8 v1, v0, off offset:-1 dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-GISEL-FAKE16-LABEL: soff1_voff1_negative:
+; GFX11-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX11-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u32_e32 v0, s0, v0
+; GFX11-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, off offset:-1 dlc
+; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-TRUE16-LABEL: soff1_voff1_negative:
 ; GFX12-SDAG-TRUE16:       ; %bb.0: ; %bb
@@ -1627,14 +2014,24 @@ define amdgpu_kernel void @soff1_voff1_negative(i32 %soff) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_storecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: soff1_voff1_negative:
-; GFX12-GISEL:       ; %bb.0: ; %bb
-; GFX12-GISEL-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    scratch_store_b8 v0, v1, s0 offset:-1 scope:SCOPE_SYS
-; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
-; GFX12-GISEL-NEXT:    s_endpgm
+; GFX12-GISEL-TRUE16-LABEL: soff1_voff1_negative:
+; GFX12-GISEL-TRUE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-TRUE16-NEXT:    v_and_b32_e32 v1, 0x3ff, v0
+; GFX12-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    scratch_store_b8 v1, v0, s0 offset:-1 scope:SCOPE_SYS
+; GFX12-GISEL-TRUE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-GISEL-FAKE16-LABEL: soff1_voff1_negative:
+; GFX12-GISEL-FAKE16:       ; %bb.0: ; %bb
+; GFX12-GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX12-GISEL-FAKE16-NEXT:    v_dual_mov_b32 v1, 1 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    scratch_store_b8 v0, v1, s0 offset:-1 scope:SCOPE_SYS
+; GFX12-GISEL-FAKE16-NEXT:    s_wait_storecnt 0x0
+; GFX12-GISEL-FAKE16-NEXT:    s_endpgm
 bb:
   %a = alloca [64 x i8], align 4, addrspace(5)
   %as = getelementptr i8, ptr addrspace(5) %a, i32 %soff
@@ -1645,9 +2042,7 @@ bb:
   ret void
 }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX11-GISEL-FAKE16: {{.*}}
-; GFX11-GISEL-TRUE16: {{.*}}
+; GFX11-GISEL: {{.*}}
 ; GFX11-SDAG: {{.*}}
-; GFX12-GISEL-FAKE16: {{.*}}
-; GFX12-GISEL-TRUE16: {{.*}}
+; GFX12-GISEL: {{.*}}
 ; GFX12-SDAG: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/fneg.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg.bf16.ll
@@ -987,19 +987,35 @@ define amdgpu_kernel void @v_extract_fneg_no_fold_v2bf16(ptr addrspace(1) %in) #
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: v_extract_fneg_no_fold_v2bf16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_b32 v0, v0, s[0:1]
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_d16_hi_b16 v[0:1], v0, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: v_extract_fneg_no_fold_v2bf16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    global_load_b32 v0, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v1, 0x80008000, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_d16_hi_b16 v[0:1], v1, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: v_extract_fneg_no_fold_v2bf16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    global_load_b32 v0, v0, s[0:1]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_d16_hi_b16 v[0:1], v0, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_endpgm
   %val = load <2 x bfloat>, ptr addrspace(1) %in
   %fneg = fsub <2 x bfloat> <bfloat -0.0, bfloat -0.0>, %val
   %elt0 = extractelement <2 x bfloat> %fneg, i32 0

--- a/llvm/test/CodeGen/AMDGPU/fneg.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg.f16.ll
@@ -759,19 +759,35 @@ define amdgpu_kernel void @v_extract_fneg_no_fold_v2f16(ptr addrspace(1) %in) #0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: v_extract_fneg_no_fold_v2f16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_b32 v0, v0, s[0:1]
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_d16_hi_b16 v[0:1], v0, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: v_extract_fneg_no_fold_v2f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    global_load_b32 v0, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v1, 0x80008000, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_d16_hi_b16 v[0:1], v1, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: v_extract_fneg_no_fold_v2f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    global_load_b32 v0, v0, s[0:1]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_d16_hi_b16 v[0:1], v0, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_endpgm
   %val = load <2 x half>, ptr addrspace(1) %in
   %fneg = fsub <2 x half> <half -0.0, half -0.0>, %val
   %elt0 = extractelement <2 x half> %fneg, i32 0

--- a/llvm/test/CodeGen/AMDGPU/fp_to_sint.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp_to_sint.ll
@@ -1121,13 +1121,14 @@ define amdgpu_kernel void @fp_to_uint_f32_to_i1(ptr addrspace(1) %out, float %in
 ; GFX11-SDAG-NEXT:    s_clause 0x1
 ; GFX11-SDAG-NEXT:    s_load_b32 s2, s[4:5], 0x2c
 ; GFX11-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_cmp_eq_f32_e64 s2, -1.0, s2
 ; GFX11-SDAG-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-SDAG-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX11-SDAG-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-SDAG-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-SDAG-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-SDAG-NEXT:    s_endpgm
 ;
 ; GFX11-GISEL-LABEL: fp_to_uint_f32_to_i1:
@@ -1204,13 +1205,14 @@ define amdgpu_kernel void @fp_to_uint_fabs_f32_to_i1(ptr addrspace(1) %out, floa
 ; GFX11-SDAG-NEXT:    s_clause 0x1
 ; GFX11-SDAG-NEXT:    s_load_b32 s2, s[4:5], 0x2c
 ; GFX11-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_cmp_eq_f32_e64 s2, -1.0, |s2|
 ; GFX11-SDAG-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-SDAG-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX11-SDAG-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-SDAG-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-SDAG-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-SDAG-NEXT:    s_endpgm
 ;
 ; GFX11-GISEL-LABEL: fp_to_uint_fabs_f32_to_i1:

--- a/llvm/test/CodeGen/AMDGPU/fp_to_uint.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp_to_uint.ll
@@ -892,13 +892,14 @@ define amdgpu_kernel void @fp_to_uint_f32_to_i1(ptr addrspace(1) %out, float %in
 ; GFX11-SDAG-NEXT:    s_clause 0x1
 ; GFX11-SDAG-NEXT:    s_load_b32 s2, s[4:5], 0x2c
 ; GFX11-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_cmp_eq_f32_e64 s2, 1.0, s2
 ; GFX11-SDAG-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-SDAG-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX11-SDAG-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-SDAG-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-SDAG-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-SDAG-NEXT:    s_endpgm
 ;
 ; GFX11-GISEL-LABEL: fp_to_uint_f32_to_i1:
@@ -975,13 +976,14 @@ define amdgpu_kernel void @fp_to_uint_fabs_f32_to_i1(ptr addrspace(1) %out, floa
 ; GFX11-SDAG-NEXT:    s_clause 0x1
 ; GFX11-SDAG-NEXT:    s_load_b32 s2, s[4:5], 0x2c
 ; GFX11-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_cmp_eq_f32_e64 s2, 1.0, |s2|
 ; GFX11-SDAG-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-SDAG-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX11-SDAG-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-SDAG-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-SDAG-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-SDAG-NEXT:    s_endpgm
 ;
 ; GFX11-GISEL-LABEL: fp_to_uint_fabs_f32_to_i1:

--- a/llvm/test/CodeGen/AMDGPU/freeze.ll
+++ b/llvm/test/CodeGen/AMDGPU/freeze.ll
@@ -6866,15 +6866,25 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-SDAG-LABEL: freeze_v3i16:
-; GFX11-SDAG:       ; %bb.0:
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-NEXT:    global_load_b64 v[0:1], v[0:1], off
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-SDAG-NEXT:    s_clause 0x1
-; GFX11-SDAG-NEXT:    global_store_b16 v[2:3], v1, off offset:4
-; GFX11-SDAG-NEXT:    global_store_b32 v[2:3], v0, off
-; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-SDAG-TRUE16-LABEL: freeze_v3i16:
+; GFX11-SDAG-TRUE16:       ; %bb.0:
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    global_load_b64 v[0:1], v[0:1], off
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    s_clause 0x1
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b32 v[2:3], v0, off
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b16 v[2:3], v1, off offset:4
+; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-SDAG-FAKE16-LABEL: freeze_v3i16:
+; GFX11-SDAG-FAKE16:       ; %bb.0:
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    global_load_b64 v[0:1], v[0:1], off
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    s_clause 0x1
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b16 v[2:3], v1, off offset:4
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b32 v[2:3], v0, off
+; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: freeze_v3i16:
 ; GFX11-GISEL:       ; %bb.0:
@@ -7543,15 +7553,25 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-SDAG-LABEL: freeze_v3f16:
-; GFX11-SDAG:       ; %bb.0:
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-NEXT:    global_load_b64 v[0:1], v[0:1], off
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-SDAG-NEXT:    s_clause 0x1
-; GFX11-SDAG-NEXT:    global_store_b16 v[2:3], v1, off offset:4
-; GFX11-SDAG-NEXT:    global_store_b32 v[2:3], v0, off
-; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-SDAG-TRUE16-LABEL: freeze_v3f16:
+; GFX11-SDAG-TRUE16:       ; %bb.0:
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    global_load_b64 v[0:1], v[0:1], off
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    s_clause 0x1
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b32 v[2:3], v0, off
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b16 v[2:3], v1, off offset:4
+; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-SDAG-FAKE16-LABEL: freeze_v3f16:
+; GFX11-SDAG-FAKE16:       ; %bb.0:
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    global_load_b64 v[0:1], v[0:1], off
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    s_clause 0x1
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b16 v[2:3], v1, off offset:4
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b32 v[2:3], v0, off
+; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: freeze_v3f16:
 ; GFX11-GISEL:       ; %bb.0:
@@ -8222,15 +8242,25 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-SDAG-LABEL: freeze_v3bf16:
-; GFX11-SDAG:       ; %bb.0:
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-NEXT:    global_load_b64 v[0:1], v[0:1], off
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-SDAG-NEXT:    s_clause 0x1
-; GFX11-SDAG-NEXT:    global_store_b16 v[2:3], v1, off offset:4
-; GFX11-SDAG-NEXT:    global_store_b32 v[2:3], v0, off
-; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-SDAG-TRUE16-LABEL: freeze_v3bf16:
+; GFX11-SDAG-TRUE16:       ; %bb.0:
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    global_load_b64 v[0:1], v[0:1], off
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    s_clause 0x1
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b32 v[2:3], v0, off
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b16 v[2:3], v1, off offset:4
+; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-SDAG-FAKE16-LABEL: freeze_v3bf16:
+; GFX11-SDAG-FAKE16:       ; %bb.0:
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    global_load_b64 v[0:1], v[0:1], off
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    s_clause 0x1
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b16 v[2:3], v1, off offset:4
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b32 v[2:3], v0, off
+; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: freeze_v3bf16:
 ; GFX11-GISEL:       ; %bb.0:
@@ -14793,14 +14823,23 @@ define void @freeze_i1_scc(i32 inreg %a, i32 inreg %b, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    global_store_byte v[0:1], v2, off
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-SDAG-LABEL: freeze_i1_scc:
-; GFX11-SDAG:       ; %bb.0:
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-NEXT:    s_cmp_eq_u32 s0, s1
-; GFX11-SDAG-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v2, s0
-; GFX11-SDAG-NEXT:    global_store_b8 v[0:1], v2, off
-; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-SDAG-TRUE16-LABEL: freeze_i1_scc:
+; GFX11-SDAG-TRUE16:       ; %bb.0:
+; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-TRUE16-NEXT:    s_cmp_eq_u32 s0, s1
+; GFX11-SDAG-TRUE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
+; GFX11-SDAG-TRUE16-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-SDAG-FAKE16-LABEL: freeze_i1_scc:
+; GFX11-SDAG-FAKE16:       ; %bb.0:
+; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s0, s1
+; GFX11-SDAG-FAKE16-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-SDAG-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: freeze_i1_scc:
 ; GFX11-GISEL:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/function-args-inreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-args-inreg.ll
@@ -13,14 +13,23 @@ define void @void_func_i1_inreg(i1 inreg %arg0) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: void_func_i1_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    s_and_b32 s0, s0, 1
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: void_func_i1_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: void_func_i1_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
@@ -211,14 +220,24 @@ define void @void_func_v3i16_inreg(<3 x i16> inreg %arg0) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: void_func_v3i16_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v1, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: void_func_v3i16_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, s0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b32 v[0:1], v1, off
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: void_func_v3i16_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v1, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    global_store_b32 v[0:1], v1, off
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   store <3 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
@@ -264,15 +283,25 @@ define void @void_func_v5i16_inreg(<5 x i16> inreg %arg0) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: void_func_v5i16_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v1, s1
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: void_func_v5i16_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, s0 :: v_dual_mov_b32 v2, s1
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    global_store_b64 v[0:1], v[1:2], off
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: void_func_v5i16_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v1, s1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    global_store_b64 v[0:1], v[0:1], off
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   store <5 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
@@ -947,14 +976,24 @@ define void @void_func_v3f16_inreg(<3 x half> inreg %arg0) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: void_func_v3f16_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v1, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: void_func_v3f16_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, s0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b32 v[0:1], v1, off
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: void_func_v3f16_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v1, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    global_store_b32 v[0:1], v1, off
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   store <3 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
@@ -1529,71 +1568,139 @@ define void @void_func_v32i32_i1_i8_i16_f32_inreg(<32 x i32> inreg %arg0, i1 inr
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: void_func_v32i32_i1_i8_i16_f32_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v2
-; GFX11-NEXT:    v_dual_mov_b32 v0, s24 :: v_dual_mov_b32 v1, s25
-; GFX11-NEXT:    v_dual_mov_b32 v2, s26 :: v_dual_mov_b32 v3, s27
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s40, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s41, v6
-; GFX11-NEXT:    v_dual_mov_b32 v4, s20 :: v_dual_mov_b32 v5, s21
-; GFX11-NEXT:    v_dual_mov_b32 v6, s22 :: v_dual_mov_b32 v7, s23
-; GFX11-NEXT:    v_readfirstlane_b32 s42, v13
-; GFX11-NEXT:    v_readfirstlane_b32 s20, v12
-; GFX11-NEXT:    v_readfirstlane_b32 s21, v11
-; GFX11-NEXT:    v_readfirstlane_b32 s22, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s14, v9
-; GFX11-NEXT:    v_readfirstlane_b32 s15, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v14
-; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    v_dual_mov_b32 v0, s16 :: v_dual_mov_b32 v1, s17
-; GFX11-NEXT:    v_dual_mov_b32 v2, s18 :: v_dual_mov_b32 v3, s19
-; GFX11-NEXT:    v_dual_mov_b32 v4, s0 :: v_dual_mov_b32 v5, s1
-; GFX11-NEXT:    v_dual_mov_b32 v6, s2 :: v_dual_mov_b32 v7, s3
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v15
-; GFX11-NEXT:    v_dual_mov_b32 v8, s22 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s20 :: v_dual_mov_b32 v11, s42
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v16
-; GFX11-NEXT:    v_dual_mov_b32 v12, s41 :: v_dual_mov_b32 v13, s40
-; GFX11-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v17
-; GFX11-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
-; GFX11-NEXT:    v_dual_mov_b32 v18, s11 :: v_dual_mov_b32 v19, s10
-; GFX11-NEXT:    s_and_b32 s0, s7, 1
-; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b128 v[0:1], v[12:15], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b128 v[0:1], v[16:19], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    v_dual_mov_b32 v0, s28 :: v_dual_mov_b32 v1, s29
-; GFX11-NEXT:    v_dual_mov_b32 v2, s9 :: v_dual_mov_b32 v3, s8
-; GFX11-NEXT:    v_dual_mov_b32 v4, s0 :: v_dual_mov_b32 v5, s6
-; GFX11-NEXT:    v_dual_mov_b32 v6, s5 :: v_dual_mov_b32 v7, s4
-; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b8 v[0:1], v4, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b8 v[0:1], v5, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b16 v[0:1], v6, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    global_store_b16 v[0:1], v7, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: void_func_v32i32_i1_i8_i16_f32_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s8, v1
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s9, v0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s12, v3
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s13, v2
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s24 :: v_dual_mov_b32 v1, s25
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, s26 :: v_dual_mov_b32 v3, s27
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s10, v5
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s11, v4
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s40, v7
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s41, v6
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v4, s20 :: v_dual_mov_b32 v5, s21
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v6, s22 :: v_dual_mov_b32 v7, s23
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s42, v13
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s20, v12
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s21, v11
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s22, v10
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s14, v9
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s15, v8
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[4:7], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s16 :: v_dual_mov_b32 v1, s17
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, s18 :: v_dual_mov_b32 v3, s19
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v4, s0 :: v_dual_mov_b32 v5, s1
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v6, s2 :: v_dual_mov_b32 v7, s3
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v8, s22 :: v_dual_mov_b32 v9, s21
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v10, s20 :: v_dual_mov_b32 v11, s42
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s5, v16
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v12, s41 :: v_dual_mov_b32 v13, s40
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s4, v17
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v18, s11 :: v_dual_mov_b32 v19, s10
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s7, 1
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[4:7], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[8:11], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[12:15], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[16:19], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, s28 :: v_dual_mov_b32 v1, s29
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, s9 :: v_dual_mov_b32 v3, s8
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.l, s0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.h, s6
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v5.l, s5
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v5.h, s4
+; GFX11-TRUE16-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[0:1], v4, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_d16_hi_b8 v[0:1], v4, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v5, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    global_store_d16_hi_b16 v[0:1], v5, off dlc
+; GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: void_func_v32i32_i1_i8_i16_f32_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s8, v1
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s9, v0
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s12, v3
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s13, v2
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, s24 :: v_dual_mov_b32 v1, s25
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, s26 :: v_dual_mov_b32 v3, s27
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s10, v5
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s11, v4
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s40, v7
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s41, v6
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v4, s20 :: v_dual_mov_b32 v5, s21
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v6, s22 :: v_dual_mov_b32 v7, s23
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s42, v13
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s20, v12
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s21, v11
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s22, v10
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s14, v9
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s15, v8
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[4:7], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, s16 :: v_dual_mov_b32 v1, s17
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, s18 :: v_dual_mov_b32 v3, s19
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v4, s0 :: v_dual_mov_b32 v5, s1
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v6, s2 :: v_dual_mov_b32 v7, s3
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v8, s22 :: v_dual_mov_b32 v9, s21
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v10, s20 :: v_dual_mov_b32 v11, s42
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s5, v16
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v12, s41 :: v_dual_mov_b32 v13, s40
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
+; GFX11-FAKE16-NEXT:    v_readfirstlane_b32 s4, v17
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v18, s11 :: v_dual_mov_b32 v19, s10
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s7, 1
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[4:7], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[8:11], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[12:15], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[16:19], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, s28 :: v_dual_mov_b32 v1, s29
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, s9 :: v_dual_mov_b32 v3, s8
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v4, s0 :: v_dual_mov_b32 v5, s6
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v6, s5 :: v_dual_mov_b32 v7, s4
+; GFX11-FAKE16-NEXT:    global_store_b128 v[0:1], v[0:3], off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v4, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v5, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v6, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v7, off dlc
+; GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   store volatile <32 x i32> %arg0, ptr addrspace(1) poison
   store volatile i1 %arg1, ptr addrspace(1) poison
   store volatile i8 %arg2, ptr addrspace(1) poison
@@ -2191,14 +2298,24 @@ define void @void_func_v3bf16_inreg(<3 x bfloat> inreg %arg0) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: void_func_v3bf16_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v1, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
-; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: void_func_v3bf16_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, s0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b32 v[0:1], v1, off
+; GFX11-TRUE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: void_func_v3bf16_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v1, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v0, off
+; GFX11-FAKE16-NEXT:    global_store_b32 v[0:1], v1, off
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   store <3 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/gfx-callable-argument-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/gfx-callable-argument-types.ll
@@ -182,33 +182,61 @@ define amdgpu_gfx void @test_call_external_void_func_i1_imm() #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: test_call_external_void_func_i1_imm:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s0, s33
-; GFX11-NEXT:    s_mov_b32 s33, s32
-; GFX11-NEXT:    s_or_saveexec_b32 s1, -1
-; GFX11-NEXT:    scratch_store_b32 off, v40, s33 ; 4-byte Folded Spill
-; GFX11-NEXT:    s_mov_b32 exec_lo, s1
-; GFX11-NEXT:    v_writelane_b32 v40, s0, 2
-; GFX11-NEXT:    s_add_i32 s32, s32, 16
-; GFX11-NEXT:    v_writelane_b32 v40, s30, 0
-; GFX11-NEXT:    v_writelane_b32 v40, s31, 1
-; GFX11-NEXT:    v_mov_b32_e32 v0, 1
-; GFX11-NEXT:    s_mov_b32 s1, external_void_func_i1@abs32@hi
-; GFX11-NEXT:    s_mov_b32 s0, external_void_func_i1@abs32@lo
-; GFX11-NEXT:    scratch_store_b8 off, v0, s32
-; GFX11-NEXT:    s_swappc_b64 s[30:31], s[0:1]
-; GFX11-NEXT:    v_readlane_b32 s30, v40, 0
-; GFX11-NEXT:    v_readlane_b32 s31, v40, 1
-; GFX11-NEXT:    s_mov_b32 s32, s33
-; GFX11-NEXT:    v_readlane_b32 s0, v40, 2
-; GFX11-NEXT:    s_or_saveexec_b32 s1, -1
-; GFX11-NEXT:    scratch_load_b32 v40, off, s33 ; 4-byte Folded Reload
-; GFX11-NEXT:    s_mov_b32 exec_lo, s1
-; GFX11-NEXT:    s_mov_b32 s33, s0
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test_call_external_void_func_i1_imm:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_mov_b32 s0, s33
+; GFX11-TRUE16-NEXT:    s_mov_b32 s33, s32
+; GFX11-TRUE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v40, s33 ; 4-byte Folded Spill
+; GFX11-TRUE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-TRUE16-NEXT:    v_writelane_b32 v40, s0, 2
+; GFX11-TRUE16-NEXT:    s_add_i32 s32, s32, 16
+; GFX11-TRUE16-NEXT:    v_writelane_b32 v40, s30, 0
+; GFX11-TRUE16-NEXT:    v_writelane_b32 v40, s31, 1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-TRUE16-NEXT:    s_mov_b32 s1, external_void_func_i1@abs32@hi
+; GFX11-TRUE16-NEXT:    s_mov_b32 s0, external_void_func_i1@abs32@lo
+; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, s32
+; GFX11-TRUE16-NEXT:    s_swappc_b64 s[30:31], s[0:1]
+; GFX11-TRUE16-NEXT:    v_readlane_b32 s30, v40, 0
+; GFX11-TRUE16-NEXT:    v_readlane_b32 s31, v40, 1
+; GFX11-TRUE16-NEXT:    s_mov_b32 s32, s33
+; GFX11-TRUE16-NEXT:    v_readlane_b32 s0, v40, 2
+; GFX11-TRUE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-TRUE16-NEXT:    scratch_load_b32 v40, off, s33 ; 4-byte Folded Reload
+; GFX11-TRUE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-TRUE16-NEXT:    s_mov_b32 s33, s0
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_call_external_void_func_i1_imm:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_mov_b32 s0, s33
+; GFX11-FAKE16-NEXT:    s_mov_b32 s33, s32
+; GFX11-FAKE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-FAKE16-NEXT:    scratch_store_b32 off, v40, s33 ; 4-byte Folded Spill
+; GFX11-FAKE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-FAKE16-NEXT:    v_writelane_b32 v40, s0, 2
+; GFX11-FAKE16-NEXT:    s_add_i32 s32, s32, 16
+; GFX11-FAKE16-NEXT:    v_writelane_b32 v40, s30, 0
+; GFX11-FAKE16-NEXT:    v_writelane_b32 v40, s31, 1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 1
+; GFX11-FAKE16-NEXT:    s_mov_b32 s1, external_void_func_i1@abs32@hi
+; GFX11-FAKE16-NEXT:    s_mov_b32 s0, external_void_func_i1@abs32@lo
+; GFX11-FAKE16-NEXT:    scratch_store_b8 off, v0, s32
+; GFX11-FAKE16-NEXT:    s_swappc_b64 s[30:31], s[0:1]
+; GFX11-FAKE16-NEXT:    v_readlane_b32 s30, v40, 0
+; GFX11-FAKE16-NEXT:    v_readlane_b32 s31, v40, 1
+; GFX11-FAKE16-NEXT:    s_mov_b32 s32, s33
+; GFX11-FAKE16-NEXT:    v_readlane_b32 s0, v40, 2
+; GFX11-FAKE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-FAKE16-NEXT:    scratch_load_b32 v40, off, s33 ; 4-byte Folded Reload
+; GFX11-FAKE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-FAKE16-NEXT:    s_mov_b32 s33, s0
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SCRATCH-LABEL: test_call_external_void_func_i1_imm:
 ; GFX10-SCRATCH:       ; %bb.0:
@@ -9844,33 +9872,61 @@ define amdgpu_gfx void @test_call_external_void_func_i1_imm_inreg() #0 {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX11-LABEL: test_call_external_void_func_i1_imm_inreg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s0, s33
-; GFX11-NEXT:    s_mov_b32 s33, s32
-; GFX11-NEXT:    s_or_saveexec_b32 s1, -1
-; GFX11-NEXT:    scratch_store_b32 off, v40, s33 ; 4-byte Folded Spill
-; GFX11-NEXT:    s_mov_b32 exec_lo, s1
-; GFX11-NEXT:    v_writelane_b32 v40, s0, 2
-; GFX11-NEXT:    s_add_i32 s32, s32, 16
-; GFX11-NEXT:    v_writelane_b32 v40, s30, 0
-; GFX11-NEXT:    v_writelane_b32 v40, s31, 1
-; GFX11-NEXT:    v_mov_b32_e32 v0, 1
-; GFX11-NEXT:    s_mov_b32 s1, external_void_func_i1_inreg@abs32@hi
-; GFX11-NEXT:    s_mov_b32 s0, external_void_func_i1_inreg@abs32@lo
-; GFX11-NEXT:    scratch_store_b8 off, v0, s32
-; GFX11-NEXT:    s_swappc_b64 s[30:31], s[0:1]
-; GFX11-NEXT:    v_readlane_b32 s30, v40, 0
-; GFX11-NEXT:    v_readlane_b32 s31, v40, 1
-; GFX11-NEXT:    s_mov_b32 s32, s33
-; GFX11-NEXT:    v_readlane_b32 s0, v40, 2
-; GFX11-NEXT:    s_or_saveexec_b32 s1, -1
-; GFX11-NEXT:    scratch_load_b32 v40, off, s33 ; 4-byte Folded Reload
-; GFX11-NEXT:    s_mov_b32 exec_lo, s1
-; GFX11-NEXT:    s_mov_b32 s33, s0
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GFX11-TRUE16-LABEL: test_call_external_void_func_i1_imm_inreg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_mov_b32 s0, s33
+; GFX11-TRUE16-NEXT:    s_mov_b32 s33, s32
+; GFX11-TRUE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v40, s33 ; 4-byte Folded Spill
+; GFX11-TRUE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-TRUE16-NEXT:    v_writelane_b32 v40, s0, 2
+; GFX11-TRUE16-NEXT:    s_add_i32 s32, s32, 16
+; GFX11-TRUE16-NEXT:    v_writelane_b32 v40, s30, 0
+; GFX11-TRUE16-NEXT:    v_writelane_b32 v40, s31, 1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 1
+; GFX11-TRUE16-NEXT:    s_mov_b32 s1, external_void_func_i1_inreg@abs32@hi
+; GFX11-TRUE16-NEXT:    s_mov_b32 s0, external_void_func_i1_inreg@abs32@lo
+; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, s32
+; GFX11-TRUE16-NEXT:    s_swappc_b64 s[30:31], s[0:1]
+; GFX11-TRUE16-NEXT:    v_readlane_b32 s30, v40, 0
+; GFX11-TRUE16-NEXT:    v_readlane_b32 s31, v40, 1
+; GFX11-TRUE16-NEXT:    s_mov_b32 s32, s33
+; GFX11-TRUE16-NEXT:    v_readlane_b32 s0, v40, 2
+; GFX11-TRUE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-TRUE16-NEXT:    scratch_load_b32 v40, off, s33 ; 4-byte Folded Reload
+; GFX11-TRUE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-TRUE16-NEXT:    s_mov_b32 s33, s0
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_call_external_void_func_i1_imm_inreg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_mov_b32 s0, s33
+; GFX11-FAKE16-NEXT:    s_mov_b32 s33, s32
+; GFX11-FAKE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-FAKE16-NEXT:    scratch_store_b32 off, v40, s33 ; 4-byte Folded Spill
+; GFX11-FAKE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-FAKE16-NEXT:    v_writelane_b32 v40, s0, 2
+; GFX11-FAKE16-NEXT:    s_add_i32 s32, s32, 16
+; GFX11-FAKE16-NEXT:    v_writelane_b32 v40, s30, 0
+; GFX11-FAKE16-NEXT:    v_writelane_b32 v40, s31, 1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 1
+; GFX11-FAKE16-NEXT:    s_mov_b32 s1, external_void_func_i1_inreg@abs32@hi
+; GFX11-FAKE16-NEXT:    s_mov_b32 s0, external_void_func_i1_inreg@abs32@lo
+; GFX11-FAKE16-NEXT:    scratch_store_b8 off, v0, s32
+; GFX11-FAKE16-NEXT:    s_swappc_b64 s[30:31], s[0:1]
+; GFX11-FAKE16-NEXT:    v_readlane_b32 s30, v40, 0
+; GFX11-FAKE16-NEXT:    v_readlane_b32 s31, v40, 1
+; GFX11-FAKE16-NEXT:    s_mov_b32 s32, s33
+; GFX11-FAKE16-NEXT:    v_readlane_b32 s0, v40, 2
+; GFX11-FAKE16-NEXT:    s_or_saveexec_b32 s1, -1
+; GFX11-FAKE16-NEXT:    scratch_load_b32 v40, off, s33 ; 4-byte Folded Reload
+; GFX11-FAKE16-NEXT:    s_mov_b32 exec_lo, s1
+; GFX11-FAKE16-NEXT:    s_mov_b32 s33, s0
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SCRATCH-LABEL: test_call_external_void_func_i1_imm_inreg:
 ; GFX10-SCRATCH:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/global-load-xcnt.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-load-xcnt.ll
@@ -146,19 +146,19 @@ define i16 @test_v7i16_load_store(ptr addrspace(1) %ptr1, ptr addrspace(1) %ptr2
 ; GCN-SDAG-REAL16-NEXT:    global_load_b128 v[4:7], v[0:1], off
 ; GCN-SDAG-REAL16-NEXT:    global_load_b128 v[8:11], v[2:3], off
 ; GCN-SDAG-REAL16-NEXT:    s_wait_xcnt 0x0
-; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[2:3], 12
-; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[12:13], 8
+; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[2:3], 8
+; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[12:13], 12
 ; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[14:15], 0
 ; GCN-SDAG-REAL16-NEXT:    s_wait_loadcnt 0x0
-; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v1, v7, v11
 ; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v0, v6, v10
+; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v1, v7, v11
 ; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v5, v5, v9
 ; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v4, v4, v8
 ; GCN-SDAG-REAL16-NEXT:    s_clause 0x2
-; GCN-SDAG-REAL16-NEXT:    global_store_b16 v[2:3], v1, off
-; GCN-SDAG-REAL16-NEXT:    global_store_b32 v[12:13], v0, off
+; GCN-SDAG-REAL16-NEXT:    global_store_b32 v[2:3], v0, off
+; GCN-SDAG-REAL16-NEXT:    global_store_b16 v[12:13], v1, off
 ; GCN-SDAG-REAL16-NEXT:    global_store_b64 v[14:15], v[4:5], off
-; GCN-SDAG-REAL16-NEXT:    s_wait_xcnt 0x1
+; GCN-SDAG-REAL16-NEXT:    s_wait_xcnt 0x2
 ; GCN-SDAG-REAL16-NEXT:    v_mov_b16_e32 v0.l, v0.h
 ; GCN-SDAG-REAL16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -483,35 +483,35 @@ define i64 @test_v16i64_load_store(ptr addrspace(1) %ptr_a, ptr addrspace(1) %pt
 }
 
 define amdgpu_kernel void @test_v7i16_load_store_kernel(ptr addrspace(1) %ptr1, ptr addrspace(1) %ptr2, ptr addrspace(1) %out) {
-; GCN-SDAG-LABEL: test_v7i16_load_store_kernel:
-; GCN-SDAG:       ; %bb.0:
-; GCN-SDAG-NEXT:    global_wb
-; GCN-SDAG-NEXT:    v_nop
-; GCN-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GCN-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0 nv
-; GCN-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
-; GCN-SDAG-NEXT:    s_wait_xcnt 0x0
-; GCN-SDAG-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10 nv
-; GCN-SDAG-NEXT:    v_mov_b64_e32 v[10:11], 8
-; GCN-SDAG-NEXT:    v_mov_b64_e32 v[12:13], 0
-; GCN-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GCN-SDAG-NEXT:    s_clause 0x1
-; GCN-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
-; GCN-SDAG-NEXT:    global_load_b128 v[4:7], v8, s[2:3] scale_offset
-; GCN-SDAG-NEXT:    s_wait_xcnt 0x0
-; GCN-SDAG-NEXT:    v_mov_b64_e32 v[8:9], 12
-; GCN-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GCN-SDAG-NEXT:    v_pk_add_u16 v3, v3, v7
-; GCN-SDAG-NEXT:    v_pk_add_u16 v2, v2, v6
-; GCN-SDAG-NEXT:    v_pk_add_u16 v1, v1, v5
-; GCN-SDAG-NEXT:    v_pk_add_u16 v0, v0, v4
-; GCN-SDAG-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-SDAG-NEXT:    s_clause 0x2
-; GCN-SDAG-NEXT:    global_store_b16 v[8:9], v3, off
-; GCN-SDAG-NEXT:    global_store_b32 v[10:11], v2, off
-; GCN-SDAG-NEXT:    global_store_b64 v[12:13], v[0:1], off
-; GCN-SDAG-NEXT:    global_store_d16_hi_b16 v4, v2, s[4:5]
-; GCN-SDAG-NEXT:    s_endpgm
+; GCN-SDAG-FAKE16-LABEL: test_v7i16_load_store_kernel:
+; GCN-SDAG-FAKE16:       ; %bb.0:
+; GCN-SDAG-FAKE16-NEXT:    global_wb
+; GCN-SDAG-FAKE16-NEXT:    v_nop
+; GCN-SDAG-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GCN-SDAG-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0 nv
+; GCN-SDAG-FAKE16-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GCN-SDAG-FAKE16-NEXT:    s_wait_xcnt 0x0
+; GCN-SDAG-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10 nv
+; GCN-SDAG-FAKE16-NEXT:    v_mov_b64_e32 v[10:11], 8
+; GCN-SDAG-FAKE16-NEXT:    v_mov_b64_e32 v[12:13], 0
+; GCN-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GCN-SDAG-FAKE16-NEXT:    s_clause 0x1
+; GCN-SDAG-FAKE16-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
+; GCN-SDAG-FAKE16-NEXT:    global_load_b128 v[4:7], v8, s[2:3] scale_offset
+; GCN-SDAG-FAKE16-NEXT:    s_wait_xcnt 0x0
+; GCN-SDAG-FAKE16-NEXT:    v_mov_b64_e32 v[8:9], 12
+; GCN-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GCN-SDAG-FAKE16-NEXT:    v_pk_add_u16 v3, v3, v7
+; GCN-SDAG-FAKE16-NEXT:    v_pk_add_u16 v2, v2, v6
+; GCN-SDAG-FAKE16-NEXT:    v_pk_add_u16 v1, v1, v5
+; GCN-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v4
+; GCN-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-SDAG-FAKE16-NEXT:    s_clause 0x2
+; GCN-SDAG-FAKE16-NEXT:    global_store_b16 v[8:9], v3, off
+; GCN-SDAG-FAKE16-NEXT:    global_store_b32 v[10:11], v2, off
+; GCN-SDAG-FAKE16-NEXT:    global_store_b64 v[12:13], v[0:1], off
+; GCN-SDAG-FAKE16-NEXT:    global_store_d16_hi_b16 v4, v2, s[4:5]
+; GCN-SDAG-FAKE16-NEXT:    s_endpgm
 ;
 ; GCN-GISEL-LABEL: test_v7i16_load_store_kernel:
 ; GCN-GISEL:       ; %bb.0:
@@ -550,6 +550,36 @@ define amdgpu_kernel void @test_v7i16_load_store_kernel(ptr addrspace(1) %ptr1, 
 ; GCN-GISEL-NEXT:    global_store_b16 v[20:21], v3, off
 ; GCN-GISEL-NEXT:    global_store_d16_hi_b16 v4, v2, s[4:5]
 ; GCN-GISEL-NEXT:    s_endpgm
+;
+; GCN-SDAG-REAL16-LABEL: test_v7i16_load_store_kernel:
+; GCN-SDAG-REAL16:       ; %bb.0:
+; GCN-SDAG-REAL16-NEXT:    global_wb
+; GCN-SDAG-REAL16-NEXT:    v_nop
+; GCN-SDAG-REAL16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GCN-SDAG-REAL16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0 nv
+; GCN-SDAG-REAL16-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GCN-SDAG-REAL16-NEXT:    s_wait_xcnt 0x0
+; GCN-SDAG-REAL16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10 nv
+; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[10:11], 12
+; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[12:13], 0
+; GCN-SDAG-REAL16-NEXT:    s_wait_kmcnt 0x0
+; GCN-SDAG-REAL16-NEXT:    s_clause 0x1
+; GCN-SDAG-REAL16-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
+; GCN-SDAG-REAL16-NEXT:    global_load_b128 v[4:7], v8, s[2:3] scale_offset
+; GCN-SDAG-REAL16-NEXT:    s_wait_xcnt 0x0
+; GCN-SDAG-REAL16-NEXT:    v_mov_b64_e32 v[8:9], 8
+; GCN-SDAG-REAL16-NEXT:    s_wait_loadcnt 0x0
+; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v2, v2, v6
+; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v3, v3, v7
+; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v1, v1, v5
+; GCN-SDAG-REAL16-NEXT:    v_pk_add_u16 v0, v0, v4
+; GCN-SDAG-REAL16-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-SDAG-REAL16-NEXT:    s_clause 0x2
+; GCN-SDAG-REAL16-NEXT:    global_store_b32 v[8:9], v2, off
+; GCN-SDAG-REAL16-NEXT:    global_store_b16 v[10:11], v3, off
+; GCN-SDAG-REAL16-NEXT:    global_store_b64 v[12:13], v[0:1], off
+; GCN-SDAG-REAL16-NEXT:    global_store_d16_hi_b16 v4, v2, s[4:5]
+; GCN-SDAG-REAL16-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %gep1 = getelementptr inbounds <7 x i16>, ptr addrspace(1) %ptr1, i32 %tid
   %gep2 = getelementptr inbounds <7 x i16>, ptr addrspace(1) %ptr2, i32 %tid

--- a/llvm/test/CodeGen/AMDGPU/global-saddr-load.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-saddr-load.ll
@@ -3996,21 +3996,35 @@ define amdgpu_ps <2 x half> @global_load_saddr_i16_d16lo_zero_hi(ptr addrspace(1
 ; GCN-NEXT:    v_mov_b32_e32 v0, v1
 ; GCN-NEXT:    ; return to shader part epilog
 ;
-; GFX11-LABEL: global_load_saddr_i16_d16lo_zero_hi:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_mov_b32_e32 v1, 0
-; GFX11-NEXT:    global_load_d16_b16 v1, v0, s[2:3]
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_mov_b32_e32 v0, v1
-; GFX11-NEXT:    ; return to shader part epilog
+; GFX11-TRUE16-LABEL: global_load_saddr_i16_d16lo_zero_hi:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v0, s[2:3]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX11-TRUE16-NEXT:    ; return to shader part epilog
 ;
-; GFX12-SDAG-LABEL: global_load_saddr_i16_d16lo_zero_hi:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v1, 0
-; GFX12-SDAG-NEXT:    global_load_d16_b16 v1, v0, s[2:3]
-; GFX12-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
+; GFX11-FAKE16-LABEL: global_load_saddr_i16_d16lo_zero_hi:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-FAKE16-NEXT:    global_load_d16_b16 v1, v0, s[2:3]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-FAKE16-NEXT:    ; return to shader part epilog
+;
+; GFX12-SDAG-TRUE16-LABEL: global_load_saddr_i16_d16lo_zero_hi:
+; GFX12-SDAG-TRUE16:       ; %bb.0:
+; GFX12-SDAG-TRUE16-NEXT:    global_load_d16_b16 v0, v0, s[2:3]
+; GFX12-SDAG-TRUE16-NEXT:    s_wait_loadcnt 0x0
+; GFX12-SDAG-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX12-SDAG-TRUE16-NEXT:    ; return to shader part epilog
+;
+; GFX12-SDAG-FAKE16-LABEL: global_load_saddr_i16_d16lo_zero_hi:
+; GFX12-SDAG-FAKE16:       ; %bb.0:
+; GFX12-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12-SDAG-FAKE16-NEXT:    global_load_d16_b16 v1, v0, s[2:3]
+; GFX12-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX12-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX12-GISEL-TRUE16-LABEL: global_load_saddr_i16_d16lo_zero_hi:
 ; GFX12-GISEL-TRUE16:       ; %bb.0:
@@ -4042,21 +4056,35 @@ define amdgpu_ps <2 x half> @global_load_saddr_i16_d16lo_zero_hi_immneg128(ptr a
 ; GCN-NEXT:    v_mov_b32_e32 v0, v1
 ; GCN-NEXT:    ; return to shader part epilog
 ;
-; GFX11-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_mov_b32_e32 v1, 0
-; GFX11-NEXT:    global_load_d16_b16 v1, v0, s[2:3] offset:-128
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_mov_b32_e32 v0, v1
-; GFX11-NEXT:    ; return to shader part epilog
+; GFX11-TRUE16-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v0, s[2:3] offset:-128
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX11-TRUE16-NEXT:    ; return to shader part epilog
 ;
-; GFX12-SDAG-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v1, 0
-; GFX12-SDAG-NEXT:    global_load_d16_b16 v1, v0, s[2:3] offset:-128
-; GFX12-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
+; GFX11-FAKE16-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-FAKE16-NEXT:    global_load_d16_b16 v1, v0, s[2:3] offset:-128
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-FAKE16-NEXT:    ; return to shader part epilog
+;
+; GFX12-SDAG-TRUE16-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
+; GFX12-SDAG-TRUE16:       ; %bb.0:
+; GFX12-SDAG-TRUE16-NEXT:    global_load_d16_b16 v0, v0, s[2:3] offset:-128
+; GFX12-SDAG-TRUE16-NEXT:    s_wait_loadcnt 0x0
+; GFX12-SDAG-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GFX12-SDAG-TRUE16-NEXT:    ; return to shader part epilog
+;
+; GFX12-SDAG-FAKE16-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
+; GFX12-SDAG-FAKE16:       ; %bb.0:
+; GFX12-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12-SDAG-FAKE16-NEXT:    global_load_d16_b16 v1, v0, s[2:3] offset:-128
+; GFX12-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX12-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX12-GISEL-TRUE16-LABEL: global_load_saddr_i16_d16lo_zero_hi_immneg128:
 ; GFX12-GISEL-TRUE16:       ; %bb.0:
@@ -4359,10 +4387,9 @@ define amdgpu_ps <2 x half> @global_load_saddr_i16_d16hi_zero_hi(ptr addrspace(1
 ;
 ; GFX11-TRUE16-LABEL: global_load_saddr_i16_d16hi_zero_hi:
 ; GFX11-TRUE16:       ; %bb.0:
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
-; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v1, v0, s[2:3]
+; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v0, s[2:3]
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0
 ; GFX11-TRUE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX11-FAKE16-LABEL: global_load_saddr_i16_d16hi_zero_hi:
@@ -4375,10 +4402,9 @@ define amdgpu_ps <2 x half> @global_load_saddr_i16_d16hi_zero_hi(ptr addrspace(1
 ;
 ; GFX12-SDAG-TRUE16-LABEL: global_load_saddr_i16_d16hi_zero_hi:
 ; GFX12-SDAG-TRUE16:       ; %bb.0:
-; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
-; GFX12-SDAG-TRUE16-NEXT:    global_load_d16_hi_b16 v1, v0, s[2:3]
+; GFX12-SDAG-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v0, s[2:3]
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_loadcnt 0x0
-; GFX12-SDAG-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0
 ; GFX12-SDAG-TRUE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX12-SDAG-FAKE16-LABEL: global_load_saddr_i16_d16hi_zero_hi:
@@ -4421,10 +4447,9 @@ define amdgpu_ps <2 x half> @global_load_saddr_i16_d16hi_zero_hi_immneg128(ptr a
 ;
 ; GFX11-TRUE16-LABEL: global_load_saddr_i16_d16hi_zero_hi_immneg128:
 ; GFX11-TRUE16:       ; %bb.0:
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
-; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v1, v0, s[2:3] offset:-128
+; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v0, s[2:3] offset:-128
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0
 ; GFX11-TRUE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX11-FAKE16-LABEL: global_load_saddr_i16_d16hi_zero_hi_immneg128:
@@ -4437,10 +4462,9 @@ define amdgpu_ps <2 x half> @global_load_saddr_i16_d16hi_zero_hi_immneg128(ptr a
 ;
 ; GFX12-SDAG-TRUE16-LABEL: global_load_saddr_i16_d16hi_zero_hi_immneg128:
 ; GFX12-SDAG-TRUE16:       ; %bb.0:
-; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
-; GFX12-SDAG-TRUE16-NEXT:    global_load_d16_hi_b16 v1, v0, s[2:3] offset:-128
+; GFX12-SDAG-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v0, s[2:3] offset:-128
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_loadcnt 0x0
-; GFX12-SDAG-TRUE16-NEXT:    v_mov_b32_e32 v0, v1
+; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0
 ; GFX12-SDAG-TRUE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX12-SDAG-FAKE16-LABEL: global_load_saddr_i16_d16hi_zero_hi_immneg128:

--- a/llvm/test/CodeGen/AMDGPU/half.ll
+++ b/llvm/test/CodeGen/AMDGPU/half.ll
@@ -35,15 +35,26 @@ define amdgpu_kernel void @load_f16_arg(ptr addrspace(1) %out, half %arg) #0 {
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: load_f16_arg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    s_load_b32 s2, s[4:5], 0x8
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX11-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: load_f16_arg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x8
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: load_f16_arg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x8
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX11-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
   store half %arg, ptr addrspace(1) %out
   ret void
 }
@@ -110,16 +121,27 @@ define amdgpu_kernel void @load_v3f16_arg(ptr addrspace(1) %out, <3 x half> %arg
 ; CIVI-NEXT:    flat_store_dword v[0:1], v5
 ; CIVI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: load_v3f16_arg:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s3
-; GFX11-NEXT:    v_mov_b32_e32 v2, s2
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v0, v1, s[0:1] offset:4
-; GFX11-NEXT:    global_store_b32 v0, v2, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: load_v3f16_arg:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s2
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s3
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX11-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1] offset:4
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: load_v3f16_arg:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s3
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1] offset:4
+; GFX11-FAKE16-NEXT:    global_store_b32 v0, v2, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
   store <3 x half> %arg, ptr addrspace(1) %out
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/image-load-d16-tfe.ll
+++ b/llvm/test/CodeGen/AMDGPU/image-load-d16-tfe.ll
@@ -509,9 +509,9 @@ define amdgpu_ps void @load_1d_v3f16_tfe_dmask7(<8 x i32> inreg %rsrc, i32 %s) {
 ; GFX11-NEXT:    v_mov_b32_e32 v3, v1
 ; GFX11-NEXT:    image_load v[1:3], v0, s[4:11] dmask:0x7 dim:SQ_RSRC_IMG_1D unorm tfe d16
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off dlc
-; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v1, off dlc
+; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-NEXT:    global_store_b16 v[0:1], v2, off dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v3, off dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0

--- a/llvm/test/CodeGen/AMDGPU/isel-amdgpu-cs-chain-preserve-cc.ll
+++ b/llvm/test/CodeGen/AMDGPU/isel-amdgpu-cs-chain-preserve-cc.ll
@@ -850,47 +850,97 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_half(half inre
 }
 
 define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_cc_bfloat(bfloat inreg %a, bfloat %b) {
-  ; DAGISEL-GFX11-WF32-LABEL: name: amdgpu_cs_chain_cc_bfloat
-  ; DAGISEL-GFX11-WF32: bb.0 (%ir-block.0):
-  ; DAGISEL-GFX11-WF32-NEXT:   liveins: $sgpr0, $vgpr8
-  ; DAGISEL-GFX11-WF32-NEXT: {{  $}}
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr8
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 16, [[COPY]], implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[S_LSHL_B32_:%[0-9]+]]:sreg_32 = S_LSHL_B32 [[COPY1]], 16, implicit-def dead $scc
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, killed [[S_LSHL_B32_]], 0, killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $mode, implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_BFE_U32_e64_:%[0-9]+]]:vgpr_32 = V_BFE_U32_e64 [[V_ADD_F32_e64_]], 16, 1, implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32767
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_ADD3_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD3_U32_e64 killed [[V_BFE_U32_e64_]], [[V_ADD_F32_e64_]], killed [[S_MOV_B32_]], implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 4194304
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_ADD_F32_e64_]], killed [[S_MOV_B32_1]], implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_CMP_U_F32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = nofpexcept V_CMP_U_F32_e64 0, [[V_ADD_F32_e64_]], 0, [[V_ADD_F32_e64_]], 0, implicit $mode, implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD3_U32_e64_]], 0, killed [[V_OR_B32_e64_]], killed [[V_CMP_U_F32_e64_]], implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_SHORT_D16_HI killed [[COPY2]], killed [[V_CNDMASK_B32_e64_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16) into `ptr poison`)
-  ; DAGISEL-GFX11-WF32-NEXT:   S_ENDPGM 0
+  ; DAGISEL-GFX11-WF32-TRUE16-LABEL: name: amdgpu_cs_chain_cc_bfloat
+  ; DAGISEL-GFX11-WF32-TRUE16: bb.0 (%ir-block.0):
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   liveins: $sgpr0, $vgpr8
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT: {{  $}}
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr8
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 16, [[COPY]], implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[S_LSHL_B32_:%[0-9]+]]:sreg_32 = S_LSHL_B32 [[COPY1]], 16, implicit-def dead $scc
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, killed [[S_LSHL_B32_]], 0, killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_BFE_U32_e64_:%[0-9]+]]:vgpr_32 = V_BFE_U32_e64 [[V_ADD_F32_e64_]], 16, 1, implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32767
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_ADD3_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD3_U32_e64 killed [[V_BFE_U32_e64_]], [[V_ADD_F32_e64_]], killed [[S_MOV_B32_]], implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 4194304
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_ADD_F32_e64_]], killed [[S_MOV_B32_1]], implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_CMP_U_F32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = nofpexcept V_CMP_U_F32_e64 0, [[V_ADD_F32_e64_]], 0, [[V_ADD_F32_e64_]], 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD3_U32_e64_]], 0, killed [[V_OR_B32_e64_]], killed [[V_CMP_U_F32_e64_]], implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[V_CNDMASK_B32_e64_]].hi16
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[V_MOV_B16_t16_e64_:%[0-9]+]]:vgpr_16 = V_MOV_B16_t16_e64 0, 0, 0, implicit $exec
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vgpr_32 = REG_SEQUENCE killed [[COPY2]], %subreg.lo16, killed [[V_MOV_B16_t16_e64_]], %subreg.hi16
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[COPY3:%[0-9]+]]:vgpr_16 = COPY [[REG_SEQUENCE]].lo16
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[DEF]]
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   FLAT_STORE_SHORT_t16 killed [[COPY4]], killed [[COPY3]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16) into `ptr poison`)
+  ; DAGISEL-GFX11-WF32-TRUE16-NEXT:   S_ENDPGM 0
   ;
-  ; DAGISEL-GFX11-WF64-LABEL: name: amdgpu_cs_chain_cc_bfloat
-  ; DAGISEL-GFX11-WF64: bb.0 (%ir-block.0):
-  ; DAGISEL-GFX11-WF64-NEXT:   liveins: $sgpr0, $vgpr8
-  ; DAGISEL-GFX11-WF64-NEXT: {{  $}}
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr8
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 16, [[COPY]], implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[S_LSHL_B32_:%[0-9]+]]:sreg_32 = S_LSHL_B32 [[COPY1]], 16, implicit-def dead $scc
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, killed [[S_LSHL_B32_]], 0, killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $mode, implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_BFE_U32_e64_:%[0-9]+]]:vgpr_32 = V_BFE_U32_e64 [[V_ADD_F32_e64_]], 16, 1, implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32767
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_ADD3_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD3_U32_e64 killed [[V_BFE_U32_e64_]], [[V_ADD_F32_e64_]], killed [[S_MOV_B32_]], implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 4194304
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_ADD_F32_e64_]], killed [[S_MOV_B32_1]], implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_CMP_U_F32_e64_:%[0-9]+]]:sreg_64_xexec = nofpexcept V_CMP_U_F32_e64 0, [[V_ADD_F32_e64_]], 0, [[V_ADD_F32_e64_]], 0, implicit $mode, implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD3_U32_e64_]], 0, killed [[V_OR_B32_e64_]], killed [[V_CMP_U_F32_e64_]], implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_SHORT_D16_HI killed [[COPY2]], killed [[V_CNDMASK_B32_e64_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16) into `ptr poison`)
-  ; DAGISEL-GFX11-WF64-NEXT:   S_ENDPGM 0
+  ; DAGISEL-GFX11-WF32-FAKE16-LABEL: name: amdgpu_cs_chain_cc_bfloat
+  ; DAGISEL-GFX11-WF32-FAKE16: bb.0 (%ir-block.0):
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   liveins: $sgpr0, $vgpr8
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT: {{  $}}
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr8
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 16, [[COPY]], implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[S_LSHL_B32_:%[0-9]+]]:sreg_32 = S_LSHL_B32 [[COPY1]], 16, implicit-def dead $scc
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, killed [[S_LSHL_B32_]], 0, killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_BFE_U32_e64_:%[0-9]+]]:vgpr_32 = V_BFE_U32_e64 [[V_ADD_F32_e64_]], 16, 1, implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32767
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_ADD3_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD3_U32_e64 killed [[V_BFE_U32_e64_]], [[V_ADD_F32_e64_]], killed [[S_MOV_B32_]], implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 4194304
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_ADD_F32_e64_]], killed [[S_MOV_B32_1]], implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_CMP_U_F32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = nofpexcept V_CMP_U_F32_e64 0, [[V_ADD_F32_e64_]], 0, [[V_ADD_F32_e64_]], 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD3_U32_e64_]], 0, killed [[V_OR_B32_e64_]], killed [[V_CMP_U_F32_e64_]], implicit $exec
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[DEF]]
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   FLAT_STORE_SHORT_D16_HI killed [[COPY2]], killed [[V_CNDMASK_B32_e64_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16) into `ptr poison`)
+  ; DAGISEL-GFX11-WF32-FAKE16-NEXT:   S_ENDPGM 0
+  ;
+  ; DAGISEL-GFX11-WF64-TRUE16-LABEL: name: amdgpu_cs_chain_cc_bfloat
+  ; DAGISEL-GFX11-WF64-TRUE16: bb.0 (%ir-block.0):
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   liveins: $sgpr0, $vgpr8
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT: {{  $}}
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr8
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 16, [[COPY]], implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[S_LSHL_B32_:%[0-9]+]]:sreg_32 = S_LSHL_B32 [[COPY1]], 16, implicit-def dead $scc
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, killed [[S_LSHL_B32_]], 0, killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_BFE_U32_e64_:%[0-9]+]]:vgpr_32 = V_BFE_U32_e64 [[V_ADD_F32_e64_]], 16, 1, implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32767
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_ADD3_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD3_U32_e64 killed [[V_BFE_U32_e64_]], [[V_ADD_F32_e64_]], killed [[S_MOV_B32_]], implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 4194304
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_ADD_F32_e64_]], killed [[S_MOV_B32_1]], implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_CMP_U_F32_e64_:%[0-9]+]]:sreg_64_xexec = nofpexcept V_CMP_U_F32_e64 0, [[V_ADD_F32_e64_]], 0, [[V_ADD_F32_e64_]], 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD3_U32_e64_]], 0, killed [[V_OR_B32_e64_]], killed [[V_CMP_U_F32_e64_]], implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[COPY2:%[0-9]+]]:vgpr_16 = COPY [[V_CNDMASK_B32_e64_]].hi16
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[V_MOV_B16_t16_e64_:%[0-9]+]]:vgpr_16 = V_MOV_B16_t16_e64 0, 0, 0, implicit $exec
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vgpr_32 = REG_SEQUENCE killed [[COPY2]], %subreg.lo16, killed [[V_MOV_B16_t16_e64_]], %subreg.hi16
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[COPY3:%[0-9]+]]:vgpr_16 = COPY [[REG_SEQUENCE]].lo16
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[DEF]]
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   FLAT_STORE_SHORT_t16 killed [[COPY4]], killed [[COPY3]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16) into `ptr poison`)
+  ; DAGISEL-GFX11-WF64-TRUE16-NEXT:   S_ENDPGM 0
+  ;
+  ; DAGISEL-GFX11-WF64-FAKE16-LABEL: name: amdgpu_cs_chain_cc_bfloat
+  ; DAGISEL-GFX11-WF64-FAKE16: bb.0 (%ir-block.0):
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   liveins: $sgpr0, $vgpr8
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT: {{  $}}
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr8
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 16, [[COPY]], implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[S_LSHL_B32_:%[0-9]+]]:sreg_32 = S_LSHL_B32 [[COPY1]], 16, implicit-def dead $scc
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, killed [[S_LSHL_B32_]], 0, killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_BFE_U32_e64_:%[0-9]+]]:vgpr_32 = V_BFE_U32_e64 [[V_ADD_F32_e64_]], 16, 1, implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32767
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_ADD3_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD3_U32_e64 killed [[V_BFE_U32_e64_]], [[V_ADD_F32_e64_]], killed [[S_MOV_B32_]], implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 4194304
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_ADD_F32_e64_]], killed [[S_MOV_B32_1]], implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_CMP_U_F32_e64_:%[0-9]+]]:sreg_64_xexec = nofpexcept V_CMP_U_F32_e64 0, [[V_ADD_F32_e64_]], 0, [[V_ADD_F32_e64_]], 0, implicit $mode, implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD3_U32_e64_]], 0, killed [[V_OR_B32_e64_]], killed [[V_CMP_U_F32_e64_]], implicit $exec
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[DEF]]
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   FLAT_STORE_SHORT_D16_HI killed [[COPY2]], killed [[V_CNDMASK_B32_e64_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s16) into `ptr poison`)
+  ; DAGISEL-GFX11-WF64-FAKE16-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF32-LABEL: name: amdgpu_cs_chain_cc_bfloat
   ; DAGISEL-GFX10-WF32: bb.0 (%ir-block.0):

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.add.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.add.ll
@@ -167,21 +167,21 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX1032GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s6, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_sext_i32_i16 s4, s6
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    s_mul_i32 s2, s4, s2
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s6, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s4, s6
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mul_i32 s2, s4, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -199,21 +199,21 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1132DAGISEL-NEXT:    s_mul_i32 s2, s2, s3
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s3, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mul_i32 s2, s2, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -231,6 +231,22 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s6, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s4, s6
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mul_i32 s4, s4, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -246,6 +262,22 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s3, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mul_i32 s2, s2, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -476,24 +508,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1164DAGISEL-LABEL: divergent_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
-; GFX1164DAGISEL-NEXT:    s_bitset0_b64 s[0:1], s3
-; GFX1164DAGISEL-NEXT:    s_add_i32 s2, s2, s4
-; GFX1164DAGISEL-NEXT:    s_cmp_lg_u64 s[0:1], 0
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1164DAGISEL-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_add_i32 s2, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1164GISEL-LABEL: divergent_value_i16:
 ; GFX1164GISEL:       ; %bb.0: ; %entry
@@ -514,24 +546,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1132DAGISEL-LABEL: divergent_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s1
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
-; GFX1132DAGISEL-NEXT:    s_bitset0_b32 s1, s2
-; GFX1132DAGISEL-NEXT:    s_add_i32 s0, s0, s3
-; GFX1132DAGISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1132DAGISEL-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
-; GFX1132DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_add_i32 s0, s0, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1132GISEL-LABEL: divergent_value_i16:
 ; GFX1132GISEL:       ; %bb.0: ; %entry
@@ -551,6 +583,44 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_add_i32 s2, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_add_i32 s0, s0, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ; GFX12DAGISEL-LABEL: divergent_value_i16:
 ; GFX12DAGISEL:       ; %bb.0: ; %entry
 ; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
@@ -5153,8 +5223,3 @@ entry:
 }
 
 attributes #0 = { nounwind }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX1132DAGISEL-FAKE16: {{.*}}
-; GFX1132DAGISEL-TRUE16: {{.*}}
-; GFX1164DAGISEL-FAKE16: {{.*}}
-; GFX1164DAGISEL-TRUE16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.and.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.and.ll
@@ -113,18 +113,18 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX10GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -139,17 +139,17 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -164,6 +164,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -176,6 +190,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -481,7 +509,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
 ; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -500,7 +528,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
 ; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
   entry:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.max.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.max.ll
@@ -113,18 +113,18 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX10GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -139,17 +139,17 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -164,6 +164,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -176,6 +190,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -390,24 +418,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1164DAGISEL-LABEL: divergent_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:    s_brev_b32 s2, 1
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
-; GFX1164DAGISEL-NEXT:    s_bitset0_b64 s[0:1], s3
-; GFX1164DAGISEL-NEXT:    s_max_i32 s2, s2, s4
-; GFX1164DAGISEL-NEXT:    s_cmp_lg_u64 s[0:1], 0
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1164DAGISEL-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_brev_b32 s2, 1
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_max_i32 s2, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1164GISEL-LABEL: divergent_value_i16:
 ; GFX1164GISEL:       ; %bb.0: ; %entry
@@ -428,24 +456,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1132DAGISEL-LABEL: divergent_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
-; GFX1132DAGISEL-NEXT:    s_brev_b32 s0, 1
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s1
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
-; GFX1132DAGISEL-NEXT:    s_bitset0_b32 s1, s2
-; GFX1132DAGISEL-NEXT:    s_max_i32 s0, s0, s3
-; GFX1132DAGISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1132DAGISEL-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
-; GFX1132DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_brev_b32 s0, 1
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_max_i32 s0, s0, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1132GISEL-LABEL: divergent_value_i16:
 ; GFX1132GISEL:       ; %bb.0: ; %entry
@@ -465,6 +493,44 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_brev_b32 s2, 1
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_max_i32 s2, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_brev_b32 s0, 1
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_max_i32 s0, s0, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %result = call i16 @llvm.amdgcn.wave.reduce.max.i16(i16 %in, i32 1)
   store i16 %result, ptr addrspace(1) %out
@@ -4217,8 +4283,3 @@ endif:
 }
 
 attributes #0 = { nounwind }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX1132DAGISEL-FAKE16: {{.*}}
-; GFX1132DAGISEL-TRUE16: {{.*}}
-; GFX1164DAGISEL-FAKE16: {{.*}}
-; GFX1164DAGISEL-TRUE16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.min.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.min.ll
@@ -113,18 +113,18 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX10GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -139,17 +139,17 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -164,6 +164,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -176,6 +190,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -390,24 +418,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1164DAGISEL-LABEL: divergent_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:    s_brev_b32 s2, -2
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
-; GFX1164DAGISEL-NEXT:    s_bitset0_b64 s[0:1], s3
-; GFX1164DAGISEL-NEXT:    s_min_i32 s2, s2, s4
-; GFX1164DAGISEL-NEXT:    s_cmp_lg_u64 s[0:1], 0
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1164DAGISEL-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_brev_b32 s2, -2
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_min_i32 s2, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1164GISEL-LABEL: divergent_value_i16:
 ; GFX1164GISEL:       ; %bb.0: ; %entry
@@ -428,24 +456,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1132DAGISEL-LABEL: divergent_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
-; GFX1132DAGISEL-NEXT:    s_brev_b32 s0, -2
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s1
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
-; GFX1132DAGISEL-NEXT:    s_bitset0_b32 s1, s2
-; GFX1132DAGISEL-NEXT:    s_min_i32 s0, s0, s3
-; GFX1132DAGISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1132DAGISEL-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
-; GFX1132DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_brev_b32 s0, -2
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_min_i32 s0, s0, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1132GISEL-LABEL: divergent_value_i16:
 ; GFX1132GISEL:       ; %bb.0: ; %entry
@@ -465,6 +493,44 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_brev_b32 s2, -2
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_min_i32 s2, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_brev_b32 s0, -2
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_min_i32 s0, s0, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %result = call i16 @llvm.amdgcn.wave.reduce.min.i16(i16 %in, i32 1)
   store i16 %result, ptr addrspace(1) %out
@@ -4217,8 +4283,3 @@ endif:
 }
 
 attributes #0 = { nounwind }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX1132DAGISEL-FAKE16: {{.*}}
-; GFX1132DAGISEL-TRUE16: {{.*}}
-; GFX1164DAGISEL-FAKE16: {{.*}}
-; GFX1164DAGISEL-TRUE16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.or.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.or.ll
@@ -113,18 +113,18 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX10GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -139,17 +139,17 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -164,6 +164,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -176,6 +190,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -481,7 +509,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
 ; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -500,7 +528,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
 ; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
   entry:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.sub.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.sub.ll
@@ -177,23 +177,23 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX1032GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s6, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_sext_i32_i16 s4, s6
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    s_sub_i32 s3, 0, s4
-; GFX1164DAGISEL-NEXT:    s_mul_i32 s2, s3, s2
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s6, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s4, s6
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_sub_i32 s3, 0, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mul_i32 s2, s3, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -213,22 +213,22 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1132DAGISEL-NEXT:    s_sub_i32 s2, 0, s2
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    s_mul_i32 s2, s2, s3
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s3, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_sub_i32 s2, 0, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mul_i32 s2, s2, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -248,6 +248,24 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s6, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s4, s6
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_sub_i32 s3, 0, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mul_i32 s3, s3, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -265,6 +283,24 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s3, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_sub_i32 s2, 0, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mul_i32 s2, s2, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -498,24 +534,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1164DAGISEL-LABEL: divergent_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
-; GFX1164DAGISEL-NEXT:    s_bitset0_b64 s[0:1], s3
-; GFX1164DAGISEL-NEXT:    s_sub_i32 s2, s2, s4
-; GFX1164DAGISEL-NEXT:    s_cmp_lg_u64 s[0:1], 0
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1164DAGISEL-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_sub_i32 s2, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1164GISEL-LABEL: divergent_value_i16:
 ; GFX1164GISEL:       ; %bb.0: ; %entry
@@ -536,24 +572,24 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX1132DAGISEL-LABEL: divergent_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
-; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s1
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
-; GFX1132DAGISEL-NEXT:    s_bitset0_b32 s1, s2
-; GFX1132DAGISEL-NEXT:    s_sub_i32 s0, s0, s3
-; GFX1132DAGISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
-; GFX1132DAGISEL-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
-; GFX1132DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_sub_i32 s0, s0, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1132GISEL-LABEL: divergent_value_i16:
 ; GFX1132GISEL:       ; %bb.0: ; %entry
@@ -573,6 +609,44 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_sub_i32 s2, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_sub_i32 s0, s0, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ; GFX12DAGISEL-LABEL: divergent_value_i16:
 ; GFX12DAGISEL:       ; %bb.0: ; %entry
 ; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
@@ -5286,8 +5360,3 @@ endif:
 }
 
 attributes #0 = { nounwind }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX1132DAGISEL-FAKE16: {{.*}}
-; GFX1132DAGISEL-TRUE16: {{.*}}
-; GFX1164DAGISEL-FAKE16: {{.*}}
-; GFX1164DAGISEL-TRUE16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.umax.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.umax.ll
@@ -113,18 +113,18 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX10GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -139,17 +139,17 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -164,6 +164,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -176,6 +190,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -493,7 +521,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
 ; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -512,7 +540,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
 ; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 entry:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.umin.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.umin.ll
@@ -113,18 +113,18 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX10GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -139,17 +139,17 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -164,6 +164,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -176,6 +190,20 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -481,7 +509,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
 ; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -500,7 +528,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
 ; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 entry:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.xor.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.xor.ll
@@ -177,23 +177,23 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1032GISEL-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX1032GISEL-NEXT:    s_endpgm
 ;
-; GFX1164DAGISEL-LABEL: uniform_value_i16:
-; GFX1164DAGISEL:       ; %bb.0: ; %entry
-; GFX1164DAGISEL-NEXT:    s_clause 0x1
-; GFX1164DAGISEL-NEXT:    s_load_b32 s6, s[4:5], 0x2c
-; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1164DAGISEL-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    s_and_b32 s2, s2, 1
-; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1164DAGISEL-NEXT:    s_and_b32 s3, s6, 0xffff
-; GFX1164DAGISEL-NEXT:    s_mul_i32 s2, s3, s2
-; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1164DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_endpgm
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s6, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_and_b32 s3, s6, 0xffff
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mul_i32 s2, s3, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1164GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -213,22 +213,22 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1132DAGISEL-LABEL: uniform_value_i16:
-; GFX1132DAGISEL:       ; %bb.0: ; %entry
-; GFX1132DAGISEL-NEXT:    s_clause 0x1
-; GFX1132DAGISEL-NEXT:    s_load_b32 s2, s[4:5], 0x2c
-; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
-; GFX1132DAGISEL-NEXT:    s_and_b32 s3, s3, 1
-; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX1132DAGISEL-NEXT:    s_and_b32 s2, s2, 0xffff
-; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1132DAGISEL-NEXT:    s_mul_i32 s2, s2, s3
-; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1132DAGISEL-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1132DAGISEL-NEXT:    s_endpgm
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s3, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_and_b32 s3, s3, 1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mul_i32 s2, s2, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-FAKE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
@@ -248,6 +248,24 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
 ;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s6, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bcnt1_i32_b64 s2, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_and_b32 s3, s6, 0xffff
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mul_i32 s3, s3, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
 ; GFX1164GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
 ; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
@@ -265,6 +283,24 @@ define amdgpu_kernel void @uniform_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
 ; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_i16:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s3, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_and_b32 s3, s3, 1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_and_b32 s2, s2, 0xffff
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mul_i32 s2, s2, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX1132GISEL-TRUE16-LABEL: uniform_value_i16:
 ; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
@@ -575,7 +611,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s2
 ; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -594,7 +630,7 @@ define void @divergent_value_i16(ptr addrspace(1) %out, i16 %in) {
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
 ; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
-; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s0
 ; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
   entry:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i1.ll
@@ -68,29 +68,46 @@ define amdgpu_kernel void @constant_load_i1(ptr addrspace(1) %out, ptr addrspace
 ; GFX12-LABEL: constant_load_i1:
 ; GFX12:       ; %bb.0:
 ; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    s_load_u8 s2, s[2:3], 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    s_and_b32 s2, s2, 1
 ; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX12-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX12-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX12-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX12-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: constant_load_i1:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_load_u8 s2, s[2:3], 0x0 nv
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_and_b32 s2, s2, 1
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX1250-NEXT:    global_store_b8 v0, v1, s[0:1]
-; GFX1250-NEXT:    s_endpgm
+; GFX1250-FAKE16-LABEL: constant_load_i1:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_load_u8 s2, s[2:3], 0x0 nv
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX1250-FAKE16-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX1250-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-REAL16-LABEL: constant_load_i1:
+; GFX1250-REAL16:       ; %bb.0:
+; GFX1250-REAL16-NEXT:    global_wb
+; GFX1250-REAL16-NEXT:    v_nop
+; GFX1250-REAL16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-REAL16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1250-REAL16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-REAL16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-REAL16-NEXT:    s_load_u8 s2, s[2:3], 0x0 nv
+; GFX1250-REAL16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-REAL16-NEXT:    s_and_b32 s2, s2, 1
+; GFX1250-REAL16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1250-REAL16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1250-REAL16-NEXT:    global_store_b8 v1, v0, s[0:1]
+; GFX1250-REAL16-NEXT:    s_endpgm
   %load = load i1, ptr addrspace(4) %in
   store i1 %load, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
@@ -265,18 +265,31 @@ define amdgpu_kernel void @constant_load_v3i16(ptr addrspace(1) %out, ptr addrsp
 ; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
-; GFX12-LABEL: constant_load_v3i16:
-; GFX12:       ; %bb.0: ; %entry
-; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_load_b64 s[2:3], s[2:3], 0x0
-; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s3
-; GFX12-NEXT:    v_mov_b32_e32 v2, s2
-; GFX12-NEXT:    s_clause 0x1
-; GFX12-NEXT:    global_store_b16 v0, v1, s[0:1] offset:4
-; GFX12-NEXT:    global_store_b32 v0, v2, s[0:1]
-; GFX12-NEXT:    s_endpgm
+; GFX12-TRUE16-LABEL: constant_load_v3i16:
+; GFX12-TRUE16:       ; %bb.0: ; %entry
+; GFX12-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_load_b64 s[2:3], s[2:3], 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s2
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s3
+; GFX12-TRUE16-NEXT:    s_clause 0x1
+; GFX12-TRUE16-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX12-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1] offset:4
+; GFX12-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-FAKE16-LABEL: constant_load_v3i16:
+; GFX12-FAKE16:       ; %bb.0: ; %entry
+; GFX12-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_load_b64 s[2:3], s[2:3], 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s3
+; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v2, s2
+; GFX12-FAKE16-NEXT:    s_clause 0x1
+; GFX12-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1] offset:4
+; GFX12-FAKE16-NEXT:    global_store_b32 v0, v2, s[0:1]
+; GFX12-FAKE16-NEXT:    s_endpgm
 entry:
   %ld = load <3 x i16>, ptr addrspace(4) %in
   store <3 x i16> %ld, ptr addrspace(1) %out
@@ -770,35 +783,27 @@ define amdgpu_kernel void @constant_load_v16i16_align2(ptr addrspace(4) %ptr0) #
 ; GFX12-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX12-TRUE16-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    s_clause 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v3, v8, s[0:1] offset:12
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v7, v8, s[0:1] offset:28
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v6, v8, s[0:1] offset:24
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v5, v8, s[0:1] offset:20
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v4, v8, s[0:1] offset:16
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v2, v8, s[0:1] offset:8
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v1, v8, s[0:1] offset:4
-; GFX12-TRUE16-NEXT:    global_load_d16_b16 v0, v8, s[0:1]
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v3, v8, s[0:1] offset:14
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v7, v8, s[0:1] offset:30
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v6, v8, s[0:1] offset:26
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v5, v8, s[0:1] offset:22
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v4, v8, s[0:1] offset:18
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v2, v8, s[0:1] offset:10
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v1, v8, s[0:1] offset:6
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x7
-; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v8, s[0:1] offset:2
-; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x0
-; GFX12-TRUE16-NEXT:    s_clause 0x1
-; GFX12-TRUE16-NEXT:    global_store_b128 v[0:1], v[4:7], off
+; GFX12-TRUE16-NEXT:    s_clause 0xf
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v3, v8, s[0:1] offset:30
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v3, v8, s[0:1] offset:28
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v2, v8, s[0:1] offset:26
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v2, v8, s[0:1] offset:24
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v1, v8, s[0:1] offset:22
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v1, v8, s[0:1] offset:20
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v8, s[0:1] offset:18
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v0, v8, s[0:1] offset:16
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v7, v8, s[0:1] offset:14
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v7, v8, s[0:1] offset:12
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v6, v8, s[0:1] offset:10
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v6, v8, s[0:1] offset:8
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v5, v8, s[0:1] offset:6
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v5, v8, s[0:1] offset:4
+; GFX12-TRUE16-NEXT:    global_load_d16_hi_b16 v4, v8, s[0:1] offset:2
+; GFX12-TRUE16-NEXT:    global_load_d16_b16 v4, v8, s[0:1]
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x8
 ; GFX12-TRUE16-NEXT:    global_store_b128 v[0:1], v[0:3], off
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt 0x0
+; GFX12-TRUE16-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX12-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX12-FAKE16-LABEL: constant_load_v16i16_align2:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i8.ll
@@ -302,17 +302,30 @@ define amdgpu_kernel void @constant_load_v3i8(ptr addrspace(1) %out, ptr addrspa
 ; EG-NEXT:     LSHR * T8.X, T0.W, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
-; GFX12-LABEL: constant_load_v3i8:
-; GFX12:       ; %bb.0: ; %entry
-; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_load_b32 s2, s[2:3], 0x0
-; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
-; GFX12-NEXT:    s_clause 0x1
-; GFX12-NEXT:    global_store_d16_hi_b8 v0, v1, s[0:1] offset:2
-; GFX12-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX12-NEXT:    s_endpgm
+; GFX12-TRUE16-LABEL: constant_load_v3i8:
+; GFX12-TRUE16:       ; %bb.0: ; %entry
+; GFX12-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_load_b32 s2, s[2:3], 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s2
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX12-TRUE16-NEXT:    s_clause 0x1
+; GFX12-TRUE16-NEXT:    global_store_d16_hi_b8 v1, v2, s[0:1] offset:2
+; GFX12-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX12-TRUE16-NEXT:    s_endpgm
+;
+; GFX12-FAKE16-LABEL: constant_load_v3i8:
+; GFX12-FAKE16:       ; %bb.0: ; %entry
+; GFX12-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_load_b32 s2, s[2:3], 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s2
+; GFX12-FAKE16-NEXT:    s_clause 0x1
+; GFX12-FAKE16-NEXT:    global_store_d16_hi_b8 v0, v1, s[0:1] offset:2
+; GFX12-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX12-FAKE16-NEXT:    s_endpgm
 entry:
   %ld = load <3 x i8>, ptr addrspace(4) %in
   store <3 x i8> %ld, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/max.ll
+++ b/llvm/test/CodeGen/AMDGPU/max.ll
@@ -274,15 +274,15 @@ define amdgpu_kernel void @v_test_imax_sge_i8(ptr addrspace(1) %out, ptr addrspa
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_load_i8 s4, s[2:3], 0x0
 ; GFX1250-NEXT:    s_load_i8 s5, s[6:7], 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_max_i32 s2, s4, s5
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1250-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1250-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; EG-LABEL: v_test_imax_sge_i8:
@@ -737,15 +737,15 @@ define amdgpu_kernel void @v_test_umax_uge_i8(ptr addrspace(1) %out, ptr addrspa
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_load_u8 s4, s[2:3], 0x0
 ; GFX1250-NEXT:    s_load_u8 s5, s[6:7], 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_max_u32 s2, s4, s5
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1250-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1250-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; EG-LABEL: v_test_umax_uge_i8:
@@ -1099,14 +1099,14 @@ define amdgpu_kernel void @s_test_imax_sge_i16(ptr addrspace(1) %out, [8 x i32],
 ; GFX1250-NEXT:    s_load_b32 s2, s[4:5], 0x70 nv
 ; GFX1250-NEXT:    s_load_b32 s3, s[4:5], 0x4c nv
 ; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_sext_i32_i16 s2, s2
 ; GFX1250-NEXT:    s_sext_i32_i16 s3, s3
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1250-NEXT:    s_max_i32 s2, s3, s2
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX1250-NEXT:    s_endpgm
 ;
 ; EG-LABEL: s_test_imax_sge_i16:

--- a/llvm/test/CodeGen/AMDGPU/min.ll
+++ b/llvm/test/CodeGen/AMDGPU/min.ll
@@ -568,40 +568,75 @@ define amdgpu_kernel void @s_test_imin_sle_i8(ptr addrspace(1) %out, [8 x i32], 
 ; GFX10-NEXT:    global_store_byte v0, v1, s[0:1]
 ; GFX10-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: s_test_imin_sle_i8:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_clause 0x2
-; GFX11-NEXT:    s_load_b32 s2, s[4:5], 0x4c
-; GFX11-NEXT:    s_load_b32 s3, s[4:5], 0x28
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_sext_i32_i8 s2, s2
-; GFX11-NEXT:    s_sext_i32_i8 s3, s3
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_min_i32 s2, s3, s2
-; GFX11-NEXT:    v_mov_b32_e32 v1, s2
-; GFX11-NEXT:    global_store_b8 v0, v1, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: s_test_imin_sle_i8:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_clause 0x2
+; GFX11-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x4c
+; GFX11-TRUE16-NEXT:    s_load_b32 s3, s[4:5], 0x28
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_sext_i32_i8 s2, s2
+; GFX11-TRUE16-NEXT:    s_sext_i32_i8 s3, s3
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_min_i32 s2, s3, s2
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-TRUE16-NEXT:    global_store_b8 v1, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: s_test_imin_sle_i8:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_clause 0x2
-; GFX1250-NEXT:    s_load_b32 s2, s[4:5], 0x4c nv
-; GFX1250-NEXT:    s_load_b32 s3, s[4:5], 0x28 nv
-; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_sext_i32_i8 s2, s2
-; GFX1250-NEXT:    s_sext_i32_i8 s3, s3
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-NEXT:    s_min_i32 s2, s3, s2
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1250-NEXT:    global_store_b8 v0, v1, s[0:1]
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: s_test_imin_sle_i8:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_clause 0x2
+; GFX11-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x4c
+; GFX11-FAKE16-NEXT:    s_load_b32 s3, s[4:5], 0x28
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_sext_i32_i8 s2, s2
+; GFX11-FAKE16-NEXT:    s_sext_i32_i8 s3, s3
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_min_i32 s2, s3, s2
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX11-FAKE16-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: s_test_imin_sle_i8:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_clause 0x2
+; GFX1250-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x4c nv
+; GFX1250-TRUE16-NEXT:    s_load_b32 s3, s[4:5], 0x28 nv
+; GFX1250-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_sext_i32_i8 s2, s2
+; GFX1250-TRUE16-NEXT:    s_sext_i32_i8 s3, s3
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    s_min_i32 s2, s3, s2
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1250-TRUE16-NEXT:    global_store_b8 v1, v0, s[0:1]
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: s_test_imin_sle_i8:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_clause 0x2
+; GFX1250-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x4c nv
+; GFX1250-FAKE16-NEXT:    s_load_b32 s3, s[4:5], 0x28 nv
+; GFX1250-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_sext_i32_i8 s2, s2
+; GFX1250-FAKE16-NEXT:    s_sext_i32_i8 s3, s3
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    s_min_i32 s2, s3, s2
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1250-FAKE16-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX1250-FAKE16-NEXT:    s_endpgm
   %cmp = icmp sle i8 %a, %b
   %val = select i1 %cmp, i8 %a, i8 %b
   store i8 %val, ptr addrspace(1) %out
@@ -2414,48 +2449,91 @@ define amdgpu_kernel void @v_test_umin_ule_v3i16(ptr addrspace(1) %out, ptr addr
 ; GFX10-NEXT:    global_store_dword v4, v0, s[0:1]
 ; GFX10-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: v_test_umin_ule_v3i16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
-; GFX11-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10
-; GFX11-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 3, v0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b64 v[0:1], v4, s[2:3]
-; GFX11-NEXT:    global_load_b64 v[2:3], v4, s[4:5]
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_pk_min_u16 v1, v1, v3
-; GFX11-NEXT:    v_pk_min_u16 v0, v0, v2
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v4, v1, s[0:1] offset:4
-; GFX11-NEXT:    global_store_b32 v4, v0, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: v_test_umin_ule_v3i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 3, v0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_load_b64 v[0:1], v4, s[2:3]
+; GFX11-TRUE16-NEXT:    global_load_b64 v[2:3], v4, s[4:5]
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-TRUE16-NEXT:    v_pk_min_u16 v0, v0, v2
+; GFX11-TRUE16-NEXT:    v_pk_min_u16 v1, v1, v3
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b32 v4, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    global_store_b16 v4, v1, s[0:1] offset:4
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: v_test_umin_ule_v3i16:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0 nv
-; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x10 nv
-; GFX1250-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_load_b64 v[0:1], v4, s[2:3] scale_offset
-; GFX1250-NEXT:    global_load_b64 v[2:3], v4, s[6:7] scale_offset
-; GFX1250-NEXT:    s_wait_xcnt 0x0
-; GFX1250-NEXT:    v_lshlrev_b32_e32 v4, 3, v4
-; GFX1250-NEXT:    s_wait_loadcnt 0x0
-; GFX1250-NEXT:    v_pk_min_u16 v1, v1, v3
-; GFX1250-NEXT:    v_pk_min_u16 v0, v0, v2
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v4, v1, s[0:1] offset:4
-; GFX1250-NEXT:    global_store_b32 v4, v0, s[0:1]
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: v_test_umin_ule_v3i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 3, v0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_load_b64 v[0:1], v4, s[2:3]
+; GFX11-FAKE16-NEXT:    global_load_b64 v[2:3], v4, s[4:5]
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-FAKE16-NEXT:    v_pk_min_u16 v1, v1, v3
+; GFX11-FAKE16-NEXT:    v_pk_min_u16 v0, v0, v2
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v4, v1, s[0:1] offset:4
+; GFX11-FAKE16-NEXT:    global_store_b32 v4, v0, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: v_test_umin_ule_v3i16:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0 nv
+; GFX1250-TRUE16-NEXT:    s_load_b64 s[6:7], s[4:5], 0x10 nv
+; GFX1250-TRUE16-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_load_b64 v[0:1], v4, s[2:3] scale_offset
+; GFX1250-TRUE16-NEXT:    global_load_b64 v[2:3], v4, s[6:7] scale_offset
+; GFX1250-TRUE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 3, v4
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_pk_min_u16 v0, v0, v2
+; GFX1250-TRUE16-NEXT:    v_pk_min_u16 v1, v1, v3
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_store_b32 v4, v0, s[0:1]
+; GFX1250-TRUE16-NEXT:    global_store_b16 v4, v1, s[0:1] offset:4
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: v_test_umin_ule_v3i16:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0 nv
+; GFX1250-FAKE16-NEXT:    s_load_b64 s[6:7], s[4:5], 0x10 nv
+; GFX1250-FAKE16-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_load_b64 v[0:1], v4, s[2:3] scale_offset
+; GFX1250-FAKE16-NEXT:    global_load_b64 v[2:3], v4, s[6:7] scale_offset
+; GFX1250-FAKE16-NEXT:    s_wait_xcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 3, v4
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_pk_min_u16 v1, v1, v3
+; GFX1250-FAKE16-NEXT:    v_pk_min_u16 v0, v0, v2
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_store_b16 v4, v1, s[0:1] offset:4
+; GFX1250-FAKE16-NEXT:    global_store_b32 v4, v0, s[0:1]
+; GFX1250-FAKE16-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %a.gep = getelementptr inbounds <3 x i16>, ptr addrspace(1) %a.ptr, i32 %tid
   %b.gep = getelementptr inbounds <3 x i16>, ptr addrspace(1) %b.ptr, i32 %tid
@@ -3092,44 +3170,83 @@ define amdgpu_kernel void @v_test_umin_ult_i32_multi_use(ptr addrspace(1) %out0,
 ; GFX10-NEXT:    global_store_byte v0, v2, s[2:3]
 ; GFX10-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: v_test_umin_ult_i32_multi_use:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s4, s[4:5], 0x0
-; GFX11-NEXT:    s_load_b32 s5, s[6:7], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_cmp_lt_u32 s4, s5
-; GFX11-NEXT:    s_cselect_b32 s4, s4, s5
-; GFX11-NEXT:    s_cselect_b32 s5, 1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v1, s4
-; GFX11-NEXT:    v_mov_b32_e32 v2, s5
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: v_test_umin_ult_i32_multi_use:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b256 s[0:7], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s4, s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    s_load_b32 s5, s[6:7], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_cmp_lt_u32 s4, s5
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s4, s4, s5
+; GFX11-TRUE16-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s5
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX11-TRUE16-NEXT:    global_store_b8 v1, v0, s[2:3]
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: v_test_umin_ult_i32_multi_use:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b256 s[8:15], s[4:5], 0x0 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_load_b32 s0, s[12:13], 0x0
-; GFX1250-NEXT:    s_load_b32 s1, s[14:15], 0x0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_cmp_lt_u32 s0, s1
-; GFX1250-NEXT:    s_cselect_b32 s0, s0, s1
-; GFX1250-NEXT:    s_cselect_b32 s1, 1, 0
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s0
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s1
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b32 v0, v1, s[8:9]
-; GFX1250-NEXT:    global_store_b8 v0, v2, s[10:11]
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: v_test_umin_ult_i32_multi_use:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b256 s[0:7], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s4, s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    s_load_b32 s5, s[6:7], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_cmp_lt_u32 s4, s5
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s4, s4, s5
+; GFX11-FAKE16-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, s4
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s5
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b32 v0, v1, s[0:1]
+; GFX11-FAKE16-NEXT:    global_store_b8 v0, v2, s[2:3]
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: v_test_umin_ult_i32_multi_use:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b256 s[8:15], s[4:5], 0x0 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_load_b32 s0, s[12:13], 0x0
+; GFX1250-TRUE16-NEXT:    s_load_b32 s1, s[14:15], 0x0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_cmp_lt_u32 s0, s1
+; GFX1250-TRUE16-NEXT:    s_cselect_b32 s0, s0, s1
+; GFX1250-TRUE16-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX1250-TRUE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s1
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_store_b32 v1, v2, s[8:9]
+; GFX1250-TRUE16-NEXT:    global_store_b8 v1, v0, s[10:11]
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: v_test_umin_ult_i32_multi_use:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b256 s[8:15], s[4:5], 0x0 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_load_b32 s0, s[12:13], 0x0
+; GFX1250-FAKE16-NEXT:    s_load_b32 s1, s[14:15], 0x0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_cmp_lt_u32 s0, s1
+; GFX1250-FAKE16-NEXT:    s_cselect_b32 s0, s0, s1
+; GFX1250-FAKE16-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v1, s0
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_store_b32 v0, v1, s[8:9]
+; GFX1250-FAKE16-NEXT:    global_store_b8 v0, v2, s[10:11]
+; GFX1250-FAKE16-NEXT:    s_endpgm
   %a = load i32, ptr addrspace(1) %aptr, align 4
   %b = load i32, ptr addrspace(1) %bptr, align 4
   %cmp = icmp ult i32 %a, %b
@@ -3268,22 +3385,22 @@ define amdgpu_kernel void @v_test_umin_ult_i16_multi_use(ptr addrspace(1) %out0,
 ; GFX11-TRUE16-LABEL: v_test_umin_ult_i16_multi_use:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_load_b256 s[0:7], s[4:5], 0x0
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
-; GFX11-TRUE16-NEXT:    global_load_d16_b16 v1, v0, s[6:7]
-; GFX11-TRUE16-NEXT:    global_load_d16_b16 v2, v0, s[4:5]
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v2, s[6:7]
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v1, v2, s[4:5]
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v0
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v2
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_lt_u32_e32 vcc_lo, v4, v3
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc_lo
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
-; GFX11-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX11-TRUE16-NEXT:    global_store_b8 v0, v2, s[2:3]
+; GFX11-TRUE16-NEXT:    global_store_b16 v2, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    global_store_b8 v2, v1, s[2:3]
 ; GFX11-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX11-FAKE16-LABEL: v_test_umin_ult_i16_multi_use:
@@ -3307,29 +3424,53 @@ define amdgpu_kernel void @v_test_umin_ult_i16_multi_use(ptr addrspace(1) %out0,
 ; GFX11-FAKE16-NEXT:    global_store_b8 v0, v2, s[2:3]
 ; GFX11-FAKE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: v_test_umin_ult_i16_multi_use:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b256 s[8:15], s[4:5], 0x0 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_load_u16 v1, v0, s[14:15]
-; GFX1250-NEXT:    global_load_u16 v2, v0, s[12:13]
-; GFX1250-NEXT:    s_wait_loadcnt 0x1
-; GFX1250-NEXT:    v_and_b32_e32 v3, 0xffff, v1
-; GFX1250-NEXT:    s_wait_loadcnt 0x0
-; GFX1250-NEXT:    v_and_b32_e32 v4, 0xffff, v2
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_cmp_lt_u32_e32 vcc_lo, v4, v3
-; GFX1250-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc_lo
-; GFX1250-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc_lo
-; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[8:9]
-; GFX1250-NEXT:    global_store_b8 v0, v2, s[10:11]
-; GFX1250-NEXT:    s_endpgm
+; GFX1250-TRUE16-LABEL: v_test_umin_ult_i16_multi_use:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b256 s[8:15], s[4:5], 0x0 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_load_u16 v0, v2, s[14:15]
+; GFX1250-TRUE16-NEXT:    global_load_u16 v1, v2, s[12:13]
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt 0x1
+; GFX1250-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v0
+; GFX1250-TRUE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v1
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-TRUE16-NEXT:    v_cmp_lt_u32_e32 vcc_lo, v4, v3
+; GFX1250-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
+; GFX1250-TRUE16-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc_lo
+; GFX1250-TRUE16-NEXT:    s_clause 0x1
+; GFX1250-TRUE16-NEXT:    global_store_b16 v2, v0, s[8:9]
+; GFX1250-TRUE16-NEXT:    global_store_b8 v2, v1, s[10:11]
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: v_test_umin_ult_i16_multi_use:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b256 s[8:15], s[4:5], 0x0 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_load_u16 v1, v0, s[14:15]
+; GFX1250-FAKE16-NEXT:    global_load_u16 v2, v0, s[12:13]
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt 0x1
+; GFX1250-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v1
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v2
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-FAKE16-NEXT:    v_cmp_lt_u32_e32 vcc_lo, v4, v3
+; GFX1250-FAKE16-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc_lo
+; GFX1250-FAKE16-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc_lo
+; GFX1250-FAKE16-NEXT:    s_clause 0x1
+; GFX1250-FAKE16-NEXT:    global_store_b16 v0, v1, s[8:9]
+; GFX1250-FAKE16-NEXT:    global_store_b8 v0, v2, s[10:11]
+; GFX1250-FAKE16-NEXT:    s_endpgm
   %a = load i16, ptr addrspace(1) %aptr, align 2
   %b = load i16, ptr addrspace(1) %bptr, align 2
   %cmp = icmp ult i16 %a, %b
@@ -4298,36 +4439,67 @@ define amdgpu_kernel void @s_test_imin_sle_i16(ptr addrspace(1) %out, i16 %a, i1
 ; GFX10-NEXT:    global_store_short v0, v1, s[0:1]
 ; GFX10-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: s_test_imin_sle_i16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    s_load_b32 s2, s[4:5], 0x8
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_ashr_i32 s3, s2, 16
-; GFX11-NEXT:    s_sext_i32_i16 s2, s2
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_min_i32 s2, s2, s3
-; GFX11-NEXT:    v_mov_b32_e32 v1, s2
-; GFX11-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: s_test_imin_sle_i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x8
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_ashr_i32 s3, s2, 16
+; GFX11-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_min_i32 s2, s2, s3
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    s_endpgm
 ;
-; GFX1250-LABEL: s_test_imin_sle_i16:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    global_wb
-; GFX1250-NEXT:    v_nop
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    s_load_b96 s[0:2], s[4:5], 0x0 nv
-; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    s_ashr_i32 s3, s2, 16
-; GFX1250-NEXT:    s_sext_i32_i16 s2, s2
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-NEXT:    s_min_i32 s2, s2, s3
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s2
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[0:1]
-; GFX1250-NEXT:    s_endpgm
+; GFX11-FAKE16-LABEL: s_test_imin_sle_i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x8
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_ashr_i32 s3, s2, 16
+; GFX11-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_min_i32 s2, s2, s3
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX11-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX11-FAKE16-NEXT:    s_endpgm
+;
+; GFX1250-TRUE16-LABEL: s_test_imin_sle_i16:
+; GFX1250-TRUE16:       ; %bb.0:
+; GFX1250-TRUE16-NEXT:    global_wb
+; GFX1250-TRUE16-NEXT:    v_nop
+; GFX1250-TRUE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-TRUE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x0 nv
+; GFX1250-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-TRUE16-NEXT:    s_ashr_i32 s3, s2, 16
+; GFX1250-TRUE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1250-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-TRUE16-NEXT:    s_min_i32 s2, s2, s3
+; GFX1250-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX1250-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1250-TRUE16-NEXT:    s_endpgm
+;
+; GFX1250-FAKE16-LABEL: s_test_imin_sle_i16:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    global_wb
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-FAKE16-NEXT:    s_load_b96 s[0:2], s[4:5], 0x0 nv
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    s_ashr_i32 s3, s2, 16
+; GFX1250-FAKE16-NEXT:    s_sext_i32_i16 s2, s2
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1250-FAKE16-NEXT:    s_min_i32 s2, s2, s3
+; GFX1250-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX1250-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1250-FAKE16-NEXT:    s_endpgm
   %cmp = icmp sle i16 %a, %b
   %val = select i1 %cmp, i16 %a, i16 %b
   store i16 %val, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/preload-kernargs.ll
+++ b/llvm/test/CodeGen/AMDGPU/preload-kernargs.ll
@@ -318,8 +318,9 @@ define amdgpu_kernel void @ptr1_v2i8_preload_arg(ptr addrspace(1) inreg %out, <2
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s4
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3]
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store <2 x i8> %in, ptr addrspace(1) %out
   ret void
@@ -553,11 +554,11 @@ define amdgpu_kernel void @v3i16_preload_arg(ptr addrspace(1) nocapture inreg %o
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s5
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s4
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s5
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3] offset:4
-; GFX1250-NEXT:    global_store_b32 v0, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b32 v1, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3] offset:4
 ; GFX1250-NEXT:    s_endpgm
   store <3 x i16> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -708,13 +709,13 @@ define amdgpu_kernel void @v5i8_preload_arg(ptr addrspace(1) nocapture inreg %ou
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_pack_lh_b32_b16 s0, 0, s4
 ; GFX1250-NEXT:    s_and_b32 s1, s4, 0xffff
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s5
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s5
 ; GFX1250-NEXT:    s_or_b32 s0, s1, s0
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s0
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b8 v0, v1, s[2:3] offset:4
-; GFX1250-NEXT:    global_store_b32 v0, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b8 v1, v0, s[2:3] offset:4
+; GFX1250-NEXT:    global_store_b32 v1, v2, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store <5 x i8> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -993,8 +994,9 @@ define amdgpu_kernel void @half_kernel_preload_arg(ptr addrspace(1) inreg %out, 
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s4
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3]
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store half %in, ptr addrspace(1) %out
   ret void
@@ -1034,8 +1036,9 @@ define amdgpu_kernel void @bfloat_kernel_preload_arg(ptr addrspace(1) inreg %out
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s4
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3]
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store bfloat %in, ptr addrspace(1) %out
   ret void
@@ -1119,11 +1122,11 @@ define amdgpu_kernel void @v3bfloat_kernel_preload_arg(ptr addrspace(1) inreg %o
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s5
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s4
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s5
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3] offset:4
-; GFX1250-NEXT:    global_store_b32 v0, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b32 v1, v2, s[2:3]
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3] offset:4
 ; GFX1250-NEXT:    s_endpgm
   store <3 x bfloat> %in, ptr addrspace(1) %out
   ret void
@@ -1222,13 +1225,14 @@ define amdgpu_kernel void @half_v7bfloat_kernel_preload_arg(ptr addrspace(1) inr
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v4, s4
-; GFX1250-NEXT:    v_dual_mov_b32 v5, s9 :: v_dual_mov_b32 v2, s8
-; GFX1250-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v4, s8
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.h, s9
+; GFX1250-NEXT:    v_dual_mov_b32 v2, s6 :: v_dual_mov_b32 v3, s7
 ; GFX1250-NEXT:    s_clause 0x2
-; GFX1250-NEXT:    global_store_b16 v3, v4, s[2:3]
-; GFX1250-NEXT:    global_store_b16 v3, v5, s[10:11] offset:12
-; GFX1250-NEXT:    global_store_b96 v3, v[0:2], s[10:11]
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
+; GFX1250-NEXT:    global_store_d16_hi_b16 v1, v0, s[10:11] offset:12
+; GFX1250-NEXT:    global_store_b96 v1, v[2:4], s[10:11]
 ; GFX1250-NEXT:    s_endpgm
   store half %in, ptr addrspace(1) %out
   store <7 x bfloat> %in2, ptr addrspace(1) %out2
@@ -1272,9 +1276,9 @@ define amdgpu_kernel void @i1_kernel_preload_arg(ptr addrspace(1) inreg %out, i1
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_and_b32 s0, s4, 1
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s0
-; GFX1250-NEXT:    global_store_b8 v0, v1, s[2:3]
+; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX1250-NEXT:    global_store_b8 v1, v0, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store i1 %in, ptr addrspace(1) %out
   ret void
@@ -1384,14 +1388,14 @@ define amdgpu_kernel void @v7i8_kernel_preload_arg(ptr addrspace(1) inreg %out, 
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_pack_lh_b32_b16 s0, 0, s4
 ; GFX1250-NEXT:    s_and_b32 s1, s4, 0xffff
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s5
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s5
 ; GFX1250-NEXT:    s_or_b32 s0, s1, s0
-; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s5
+; GFX1250-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX1250-NEXT:    s_clause 0x2
-; GFX1250-NEXT:    global_store_d16_hi_b8 v0, v1, s[2:3] offset:6
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3] offset:4
-; GFX1250-NEXT:    global_store_b32 v0, v2, s[2:3]
+; GFX1250-NEXT:    global_store_d16_hi_b8 v1, v2, s[2:3] offset:6
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3] offset:4
+; GFX1250-NEXT:    global_store_b32 v1, v3, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store <7 x i8> %in, ptr addrspace(1) %out
   ret void
@@ -1439,12 +1443,12 @@ define amdgpu_kernel void @v7half_kernel_preload_arg(ptr addrspace(1) inreg %out
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v4, s9
-; GFX1250-NEXT:    v_dual_mov_b32 v2, s8 :: v_dual_mov_b32 v0, s6
-; GFX1250-NEXT:    v_mov_b32_e32 v1, s7
+; GFX1250-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_mov_b32 v2, s8
+; GFX1250-NEXT:    v_mov_b16_e32 v3.l, s9
+; GFX1250-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v3, v4, s[2:3] offset:12
-; GFX1250-NEXT:    global_store_b96 v3, v[0:2], s[2:3]
+; GFX1250-NEXT:    global_store_b16 v4, v3, s[2:3] offset:12
+; GFX1250-NEXT:    global_store_b96 v4, v[0:2], s[2:3]
 ; GFX1250-NEXT:    s_endpgm
   store <7 x half> %in, ptr addrspace(1) %out
   ret void
@@ -1488,11 +1492,11 @@ define amdgpu_kernel void @i16_i32_kernel_preload_arg(ptr addrspace(1) inreg %ou
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s4
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s5
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3]
-; GFX1250-NEXT:    global_store_b32 v0, v2, s[6:7]
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
+; GFX1250-NEXT:    global_store_b32 v1, v2, s[6:7]
 ; GFX1250-NEXT:    s_endpgm
   store i16 %in, ptr addrspace(1) %out
   store i32 %in2, ptr addrspace(1) %out2
@@ -1542,12 +1546,12 @@ define amdgpu_kernel void @i16_v3i32_kernel_preload_arg(ptr addrspace(1) inreg %
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v4, s4
+; GFX1250-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_mov_b32 v2, s8
+; GFX1250-NEXT:    v_mov_b16_e32 v3.l, s4
 ; GFX1250-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
-; GFX1250-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v3, v4, s[2:3]
-; GFX1250-NEXT:    global_store_b96 v3, v[0:2], s[10:11]
+; GFX1250-NEXT:    global_store_b16 v4, v3, s[2:3]
+; GFX1250-NEXT:    global_store_b96 v4, v[0:2], s[10:11]
 ; GFX1250-NEXT:    s_endpgm
   store i16 %in, ptr addrspace(1) %out
   store <3 x i32> %in2, ptr addrspace(1) %out2
@@ -1590,10 +1594,11 @@ define amdgpu_kernel void @i16_i16_kernel_preload_arg(ptr addrspace(1) inreg %ou
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s4
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3]
-; GFX1250-NEXT:    global_store_d16_hi_b16 v0, v1, s[6:7]
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
+; GFX1250-NEXT:    global_store_d16_hi_b16 v1, v2, s[6:7]
 ; GFX1250-NEXT:    s_endpgm
   store i16 %in, ptr addrspace(1) %out
   store i16 %in2, ptr addrspace(1) %out2
@@ -1646,10 +1651,11 @@ define amdgpu_kernel void @i16_v2i8_kernel_preload_arg(ptr addrspace(1) inreg %o
 ; GFX1250-NEXT:    global_wb
 ; GFX1250-NEXT:    v_nop
 ; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s4
+; GFX1250-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX1250-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX1250-NEXT:    s_clause 0x1
-; GFX1250-NEXT:    global_store_b16 v0, v1, s[2:3]
-; GFX1250-NEXT:    global_store_d16_hi_b16 v0, v1, s[6:7]
+; GFX1250-NEXT:    global_store_b16 v1, v0, s[2:3]
+; GFX1250-NEXT:    global_store_d16_hi_b16 v1, v2, s[6:7]
 ; GFX1250-NEXT:    s_endpgm
   store i16 %in, ptr addrspace(1) %out
   store <2 x i8> %in2, ptr addrspace(1) %out2

--- a/llvm/test/CodeGen/AMDGPU/saddo.ll
+++ b/llvm/test/CodeGen/AMDGPU/saddo.ll
@@ -342,20 +342,20 @@ define amdgpu_kernel void @v_saddo_i32(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-LABEL: v_saddo_i32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_b32 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_b32 v0, v1, s[4:5]
+; GFX11-NEXT:    global_load_b32 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_add_nc_i32 v3, v1, v2 clamp
-; GFX11-NEXT:    v_add_nc_u32_e32 v1, v1, v2
+; GFX11-NEXT:    v_add_nc_i32 v3, v0, v2 clamp
+; GFX11-NEXT:    v_add_nc_u32_e32 v2, v0, v2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, v1, v3
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc_lo
+; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, v2, v3
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX11-NEXT:    global_store_b8 v1, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %a = load i32, ptr addrspace(1) %aptr, align 4
   %b = load i32, ptr addrspace(1) %bptr, align 4
@@ -474,15 +474,16 @@ define amdgpu_kernel void @s_saddo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_cmp_lt_i32 s7, 0
 ; GFX11-NEXT:    v_cmp_lt_i64_e64 s4, s[8:9], s[4:5]
 ; GFX11-NEXT:    s_cselect_b32 s5, -1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s9
+; GFX11-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s9
+; GFX11-NEXT:    v_mov_b32_e32 v1, s8
 ; GFX11-NEXT:    s_xor_b32 s4, s5, s4
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v0, s8 :: v_dual_mov_b32 v3, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v2, v3, s[2:3]
+; GFX11-NEXT:    global_store_b64 v3, v[1:2], s[0:1]
+; GFX11-NEXT:    global_store_b8 v3, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %sadd = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %a, i64 %b) nounwind
   %val = extractvalue { i64, i1 } %sadd, 0
@@ -612,7 +613,7 @@ define amdgpu_kernel void @v_saddo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s0, s0, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s0
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    global_store_b64 v6, v[4:5], s[4:5]
 ; GFX11-NEXT:    global_store_b8 v6, v0, s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/ssubo.ll
+++ b/llvm/test/CodeGen/AMDGPU/ssubo.ll
@@ -340,20 +340,20 @@ define amdgpu_kernel void @v_ssubo_i32(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-LABEL: v_ssubo_i32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_b32 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_b32 v0, v1, s[4:5]
+; GFX11-NEXT:    global_load_b32 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_sub_nc_i32 v3, v1, v2 clamp
-; GFX11-NEXT:    v_sub_nc_u32_e32 v1, v1, v2
+; GFX11-NEXT:    v_sub_nc_i32 v3, v0, v2 clamp
+; GFX11-NEXT:    v_sub_nc_u32_e32 v2, v0, v2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, v1, v3
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc_lo
+; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, v2, v3
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX11-NEXT:    global_store_b8 v1, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %a = load i32, ptr addrspace(1) %aptr, align 4
   %b = load i32, ptr addrspace(1) %bptr, align 4
@@ -470,18 +470,19 @@ define amdgpu_kernel void @s_ssubo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    v_cmp_lt_i64_e64 s8, s[4:5], s[6:7]
 ; GFX11-NEXT:    s_sub_u32 s4, s4, s6
 ; GFX11-NEXT:    s_subb_u32 s5, s5, s7
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s5
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(SALU_CYCLE_1)
+; GFX11-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s5
 ; GFX11-NEXT:    s_cmp_lt_i32 s5, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX11-NEXT:    s_cselect_b32 s6, -1, 0
 ; GFX11-NEXT:    s_xor_b32 s6, s8, s6
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s6, s6, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v3, s6
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s6
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v2, v3, s[2:3]
+; GFX11-NEXT:    global_store_b64 v3, v[1:2], s[0:1]
+; GFX11-NEXT:    global_store_b8 v3, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %ssub = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %a, i64 %b) nounwind
   %val = extractvalue { i64, i1 } %ssub, 0
@@ -612,7 +613,7 @@ define amdgpu_kernel void @v_ssubo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s0, s0, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s0
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    global_store_b64 v6, v[4:5], s[4:5]
 ; GFX11-NEXT:    global_store_b8 v6, v0, s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/store-weird-sizes.ll
+++ b/llvm/test/CodeGen/AMDGPU/store-weird-sizes.ll
@@ -143,18 +143,18 @@ define amdgpu_kernel void @local_store_i55(ptr addrspace(3) %ptr, i55 %arg) #0 {
 ; GFX11-TRUE16-LABEL: local_store_i55:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x8
 ; GFX11-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x0
-; GFX11-TRUE16-NEXT:    global_load_d16_hi_u8 v1, v0, s[4:5] offset:14
+; GFX11-TRUE16-NEXT:    global_load_d16_u8 v0, v0, s[4:5] offset:14
 ; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s3, s1, 0xffff
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v1, s2
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, s3, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, s2 :: v_dual_and_b32 v0, 0x7fffff, v0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v3, s0 :: v_dual_lshlrev_b32 v0, 16, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, s3, v0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0x7fffff, v0
 ; GFX11-TRUE16-NEXT:    ds_store_b8_d16_hi v1, v0 offset:6
 ; GFX11-TRUE16-NEXT:    ds_store_b16 v1, v2 offset:4
 ; GFX11-TRUE16-NEXT:    ds_store_b32 v1, v3

--- a/llvm/test/CodeGen/AMDGPU/sub_i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/sub_i1.ll
@@ -40,16 +40,16 @@ define amdgpu_kernel void @sub_var_var_i1(ptr addrspace(1) %out, ptr addrspace(1
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_u8 v1, v0, s[2:3] glc dlc
+; GFX11-NEXT:    global_load_u8 v0, v1, s[2:3] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    global_load_u8 v2, v0, s[4:5] glc dlc
+; GFX11-NEXT:    global_load_u8 v2, v1, s[4:5] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_xor_b32_e32 v1, v1, v2
+; GFX11-NEXT:    v_xor_b32_e32 v0, v0, v2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_and_b32_e32 v1, 1, v1
-; GFX11-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX11-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %a = load volatile i1, ptr addrspace(1) %in0
   %b = load volatile i1, ptr addrspace(1) %in1
@@ -94,19 +94,19 @@ define amdgpu_kernel void @sub_var_imm_i1(ptr addrspace(1) %out, ptr addrspace(1
 ; GFX11-LABEL: sub_var_imm_i1:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    global_load_u8 v1, v0, s[2:3] glc dlc
+; GFX11-NEXT:    global_load_u8 v0, v1, s[2:3] glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_and_b32_e32 v1, 1, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v1
+; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v0
 ; GFX11-NEXT:    s_xor_b32 s2, vcc_lo, -1
 ; GFX11-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v1, s2
-; GFX11-NEXT:    global_store_b8 v0, v1, s[0:1]
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX11-NEXT:    global_store_b8 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %a = load volatile i1, ptr addrspace(1) %in
   %sub = sub i1 %a, 1

--- a/llvm/test/CodeGen/AMDGPU/uaddo.ll
+++ b/llvm/test/CodeGen/AMDGPU/uaddo.ll
@@ -174,15 +174,16 @@ define amdgpu_kernel void @s_uaddo_i32(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_add_co_u32 v0, s4, s6, s7
+; GFX11-NEXT:    v_add_co_u32 v1, s4, s6, s7
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v1, v0, s[0:1]
-; GFX11-NEXT:    global_store_b8 v1, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v2, v1, s[0:1]
+; GFX11-NEXT:    global_store_b8 v2, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %uadd = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
   %val = extractvalue { i32, i1 } %uadd, 0
@@ -282,20 +283,20 @@ define amdgpu_kernel void @v_uaddo_i32(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-LABEL: v_uaddo_i32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_b32 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_b32 v0, v1, s[4:5]
+; GFX11-NEXT:    global_load_b32 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_add_co_u32 v1, s4, v1, v2
+; GFX11-NEXT:    v_add_co_u32 v2, s4, v0, v2
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX11-NEXT:    global_store_b8 v1, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -416,22 +417,22 @@ define amdgpu_kernel void @v_uaddo_i32_novcc(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-LABEL: v_uaddo_i32_novcc:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_b32 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_b32 v0, v1, s[4:5]
+; GFX11-NEXT:    global_load_b32 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_add_co_u32 v1, s4, v1, v2
+; GFX11-NEXT:    v_add_co_u32 v2, s4, v0, v2
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1] dlc
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX11-NEXT:    global_store_b32 v1, v2, s[0:1] dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3] dlc
+; GFX11-NEXT:    global_store_b8 v1, v0, s[2:3] dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
@@ -536,14 +537,14 @@ define amdgpu_kernel void @s_uaddo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_add_u32 s4, s4, s6
 ; GFX11-NEXT:    s_addc_u32 s5, s5, s7
 ; GFX11-NEXT:    s_cselect_b32 s6, -1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v0, s4
+; GFX11-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX11-NEXT:    s_and_b32 s4, s6, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s5
-; GFX11-NEXT:    v_mov_b32_e32 v3, s4
+; GFX11-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s5
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v2, v3, s[2:3]
+; GFX11-NEXT:    global_store_b64 v3, v[1:2], s[0:1]
+; GFX11-NEXT:    global_store_b8 v3, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %uadd = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
   %val = extractvalue { i64, i1 } %uadd, 0
@@ -653,15 +654,15 @@ define amdgpu_kernel void @v_uaddo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    global_load_b64 v[0:1], v4, s[4:5]
 ; GFX11-NEXT:    global_load_b64 v[2:3], v4, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
-; GFX11-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, v1, v3, vcc_lo
+; GFX11-NEXT:    v_add_co_u32 v2, vcc_lo, v0, v2
+; GFX11-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, v1, v3, vcc_lo
 ; GFX11-NEXT:    s_and_b32 s4, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v4, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v4, v2, s[2:3]
+; GFX11-NEXT:    global_store_b64 v4, v[2:3], s[0:1]
+; GFX11-NEXT:    global_store_b8 v4, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -766,21 +767,24 @@ define amdgpu_kernel void @v_uaddo_i16(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-LABEL: v_uaddo_i16:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_d16_b16 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_u16 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_d16_b16 v0, v2, s[4:5]
+; GFX11-NEXT:    global_load_u16 v1, v2, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_add_nc_u32_e32 v2, v1, v2
-; GFX11-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-NEXT:    v_add_nc_u32_e32 v1, v0, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_and_b32_e32 v3, 0xffff, v2
-; GFX11-NEXT:    v_cmp_lt_u32_e32 vcc_lo, v3, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc_lo
+; GFX11-NEXT:    v_and_b32_e32 v3, 0xffff, v1
+; GFX11-NEXT:    v_cmp_lt_u32_e32 vcc_lo, v3, v0
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, v1.l
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_mov_b16_e32 v1.l, v3.l
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v0, v2, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v1, s[2:3]
+; GFX11-NEXT:    global_store_b16 v2, v0, s[0:1]
+; GFX11-NEXT:    global_store_b8 v2, v1, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -1044,12 +1048,12 @@ define amdgpu_kernel void @s_uaddo_clamp_bit(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-NEXT:    s_load_b128 s[4:7], s[4:5], 0x24
 ; GFX11-NEXT:    s_and_b32 s0, s0, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s0
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
+; GFX11-NEXT:    v_mov_b16_e32 v1.l, s0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_store_b8 v1, v2, s[6:7]
+; GFX11-NEXT:    global_store_b32 v2, v0, s[4:5]
+; GFX11-NEXT:    global_store_b8 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_endpgm
 entry:
   %uadd = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
@@ -1199,7 +1203,7 @@ define amdgpu_kernel void @v_uaddo_clamp_bit(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v2.l, s4
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]

--- a/llvm/test/CodeGen/AMDGPU/use-t16-loads.ll
+++ b/llvm/test/CodeGen/AMDGPU/use-t16-loads.ll
@@ -1,0 +1,128 @@
+; RUN: llc -mtriple=amdgpu12.00 -mattr=+real-true16 -stop-after=finalize-isel < %s | FileCheck --check-prefix=GFX12 %s
+; RUN: llc -global-isel -mtriple=amdgpu12.00 -mattr=+real-true16 -stop-after=finalize-isel < %s | FileCheck --check-prefix=GFX12 %s
+
+; Check that only the _t16 suffixed forms of the loads are selected for both
+; the SelectionDAG and GlobalISel paths.
+
+define <8 x i16> @use_t16_global(i32 %off, ptr addrspace(1) %ptr) {
+; GFX12-LABEL: name: use_t16_global
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: GLOBAL_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+  %ext = zext i32 %off to i64
+  %gep = getelementptr inbounds nuw [2 x i8], ptr addrspace(1) %ptr, i64 %ext
+  %ld0 = load i16, ptr addrspace(1) %gep, align 2, !tbaa !0
+  %v0 = insertelement <8 x i16> poison, i16 %ld0, i64 0
+  %gep1 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 512
+  %ld1 = load i16, ptr addrspace(1) %gep1, align 2, !tbaa !0
+  %v1 = insertelement <8 x i16> %v0, i16 %ld1, i64 1
+  %gep2 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 1024
+  %ld2 = load i16, ptr addrspace(1) %gep2, align 2, !tbaa !0
+  %v2 = insertelement <8 x i16> %v1, i16 %ld2, i64 2
+  %gep3 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 1536
+  %ld3 = load i16, ptr addrspace(1) %gep3, align 2, !tbaa !0
+  %v3 = insertelement <8 x i16> %v2, i16 %ld3, i64 3
+  %gep4 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 2048
+  %ld4 = load i16, ptr addrspace(1) %gep4, align 2, !tbaa !0
+  %v4 = insertelement <8 x i16> %v3, i16 %ld4, i64 4
+  %gep5 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 2560
+  %ld5 = load i16, ptr addrspace(1) %gep5, align 2, !tbaa !0
+  %v5 = insertelement <8 x i16> %v4, i16 %ld5, i64 5
+  %gep6 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 3072
+  %ld6 = load i16, ptr addrspace(1) %gep6, align 2, !tbaa !0
+  %v6 = insertelement <8 x i16> %v5, i16 %ld6, i64 6
+  %gep7 = getelementptr inbounds nuw i8, ptr addrspace(1) %gep, i64 3584
+  %ld7 = load i16, ptr addrspace(1) %gep7, align 2, !tbaa !0
+  %v7 = insertelement <8 x i16> %v6, i16 %ld7, i64 7
+  %gep8 = getelementptr inbounds nuw [2 x i8], ptr addrspace(1) %ptr, i64 10
+  %ld8 = load i16, ptr addrspace(1) %gep8, align 2, !tbaa !0
+  %res = insertelement <8 x i16> %v6, i16 %ld8, i64 1
+  ret <8 x i16> %res
+}
+
+define <8 x i16> @use_t16_scratch(i32 %off, ptr addrspace(5) %ptr) {
+; GFX12-LABEL: name: use_t16_scratch
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: SCRATCH_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+  %gep = getelementptr inbounds nuw [2 x i8], ptr addrspace(5) %ptr, i32 %off
+  %ld0 = load i16, ptr addrspace(5) %gep, align 2, !tbaa !0
+  %v0 = insertelement <8 x i16> poison, i16 %ld0, i64 0
+  %gep1 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 512
+  %ld1 = load i16, ptr addrspace(5) %gep1, align 2, !tbaa !0
+  %v1 = insertelement <8 x i16> %v0, i16 %ld1, i64 1
+  %gep2 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 1024
+  %ld2 = load i16, ptr addrspace(5) %gep2, align 2, !tbaa !0
+  %v2 = insertelement <8 x i16> %v1, i16 %ld2, i64 2
+  %gep3 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 1536
+  %ld3 = load i16, ptr addrspace(5) %gep3, align 2, !tbaa !0
+  %v3 = insertelement <8 x i16> %v2, i16 %ld3, i64 3
+  %gep4 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 2048
+  %ld4 = load i16, ptr addrspace(5) %gep4, align 2, !tbaa !0
+  %v4 = insertelement <8 x i16> %v3, i16 %ld4, i64 4
+  %gep5 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 2560
+  %ld5 = load i16, ptr addrspace(5) %gep5, align 2, !tbaa !0
+  %v5 = insertelement <8 x i16> %v4, i16 %ld5, i64 5
+  %gep6 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 3072
+  %ld6 = load i16, ptr addrspace(5) %gep6, align 2, !tbaa !0
+  %v6 = insertelement <8 x i16> %v5, i16 %ld6, i64 6
+  %gep7 = getelementptr inbounds nuw i8, ptr addrspace(5) %gep, i32 3584
+  %ld7 = load i16, ptr addrspace(5) %gep7, align 2, !tbaa !0
+  %v7 = insertelement <8 x i16> %v6, i16 %ld7, i64 7
+  %gep8 = getelementptr inbounds nuw [2 x i8], ptr addrspace(5) %ptr, i32 10
+  %ld8 = load i16, ptr addrspace(5) %gep8, align 2, !tbaa !0
+  %res = insertelement <8 x i16> %v6, i16 %ld8, i64 1
+  ret <8 x i16> %res
+}
+
+define <8 x i16> @use_t16_flat(i32 %off, ptr %ptr) {
+; GFX12-LABEL: name: use_t16_flat
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+; GFX12: FLAT_LOAD_SHORT_D16_t16 %{{[0-9]+}}
+  %ext = zext i32 %off to i64
+  %gep = getelementptr inbounds nuw [2 x i8], ptr %ptr, i64 %ext
+  %ld0 = load i16, ptr %gep, align 2, !tbaa !0
+  %v0 = insertelement <8 x i16> poison, i16 %ld0, i64 0
+  %gep1 = getelementptr inbounds nuw i8, ptr %gep, i64 512
+  %ld1 = load i16, ptr %gep1, align 2, !tbaa !0
+  %v1 = insertelement <8 x i16> %v0, i16 %ld1, i64 1
+  %gep2 = getelementptr inbounds nuw i8, ptr %gep, i64 1024
+  %ld2 = load i16, ptr %gep2, align 2, !tbaa !0
+  %v2 = insertelement <8 x i16> %v1, i16 %ld2, i64 2
+  %gep3 = getelementptr inbounds nuw i8, ptr %gep, i64 1536
+  %ld3 = load i16, ptr %gep3, align 2, !tbaa !0
+  %v3 = insertelement <8 x i16> %v2, i16 %ld3, i64 3
+  %gep4 = getelementptr inbounds nuw i8, ptr %gep, i64 2048
+  %ld4 = load i16, ptr %gep4, align 2, !tbaa !0
+  %v4 = insertelement <8 x i16> %v3, i16 %ld4, i64 4
+  %gep5 = getelementptr inbounds nuw i8, ptr %gep, i64 2560
+  %ld5 = load i16, ptr %gep5, align 2, !tbaa !0
+  %v5 = insertelement <8 x i16> %v4, i16 %ld5, i64 5
+  %gep6 = getelementptr inbounds nuw i8, ptr %gep, i64 3072
+  %ld6 = load i16, ptr %gep6, align 2, !tbaa !0
+  %v6 = insertelement <8 x i16> %v5, i16 %ld6, i64 6
+  %gep7 = getelementptr inbounds nuw i8, ptr %gep, i64 3584
+  %ld7 = load i16, ptr %gep7, align 2, !tbaa !0
+  %v7 = insertelement <8 x i16> %v6, i16 %ld7, i64 7
+  %gep8 = getelementptr inbounds nuw [2 x i8], ptr %ptr, i64 10
+  %ld8 = load i16, ptr %gep8, align 2, !tbaa !0
+  %res = insertelement <8 x i16> %v6, i16 %ld8, i64 1
+  ret <8 x i16> %res
+}
+
+!0 = !{!1, !1, i64 0}
+!1 = !{!"omnipotent char", !2, i64 0}
+!2 = !{!"Simple C++ TBAA"}

--- a/llvm/test/CodeGen/AMDGPU/usubo.ll
+++ b/llvm/test/CodeGen/AMDGPU/usubo.ll
@@ -173,15 +173,16 @@ define amdgpu_kernel void @s_usubo_i32(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_sub_co_u32 v0, s4, s6, s7
+; GFX11-NEXT:    v_sub_co_u32 v1, s4, s6, s7
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v1, v0, s[0:1]
-; GFX11-NEXT:    global_store_b8 v1, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v2, v1, s[0:1]
+; GFX11-NEXT:    global_store_b8 v2, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %usub = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
   %val = extractvalue { i32, i1 } %usub, 0
@@ -281,20 +282,20 @@ define amdgpu_kernel void @v_usubo_i32(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-LABEL: v_usubo_i32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_b32 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_b32 v0, v1, s[4:5]
+; GFX11-NEXT:    global_load_b32 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_sub_co_u32 v1, s4, v1, v2
+; GFX11-NEXT:    v_sub_co_u32 v2, s4, v0, v2
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]
+; GFX11-NEXT:    global_store_b32 v1, v2, s[0:1]
+; GFX11-NEXT:    global_store_b8 v1, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -415,22 +416,22 @@ define amdgpu_kernel void @v_usubo_i32_novcc(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-LABEL: v_usubo_i32_novcc:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_b32 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_b32 v0, v1, s[4:5]
+; GFX11-NEXT:    global_load_b32 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_sub_co_u32 v1, s4, v1, v2
+; GFX11-NEXT:    v_sub_co_u32 v2, s4, v0, v2
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
-; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1] dlc
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
+; GFX11-NEXT:    global_store_b32 v1, v2, s[0:1] dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3] dlc
+; GFX11-NEXT:    global_store_b8 v1, v0, s[2:3] dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
@@ -535,14 +536,14 @@ define amdgpu_kernel void @s_usubo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    s_sub_u32 s4, s4, s6
 ; GFX11-NEXT:    s_subb_u32 s5, s5, s7
 ; GFX11-NEXT:    s_cselect_b32 s6, -1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v0, s4
+; GFX11-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX11-NEXT:    s_and_b32 s4, s6, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s5
-; GFX11-NEXT:    v_mov_b32_e32 v3, s4
+; GFX11-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s5
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v2, v3, s[2:3]
+; GFX11-NEXT:    global_store_b64 v3, v[1:2], s[0:1]
+; GFX11-NEXT:    global_store_b8 v3, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %usub = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
   %val = extractvalue { i64, i1 } %usub, 0
@@ -652,15 +653,15 @@ define amdgpu_kernel void @v_usubo_i64(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-NEXT:    global_load_b64 v[0:1], v4, s[4:5]
 ; GFX11-NEXT:    global_load_b64 v[2:3], v4, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_sub_co_u32 v0, vcc_lo, v0, v2
-; GFX11-NEXT:    v_sub_co_ci_u32_e32 v1, vcc_lo, v1, v3, vcc_lo
+; GFX11-NEXT:    v_sub_co_u32 v2, vcc_lo, v0, v2
+; GFX11-NEXT:    v_sub_co_ci_u32_e32 v3, vcc_lo, v1, v3, vcc_lo
 ; GFX11-NEXT:    s_and_b32 s4, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, s4
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b64 v4, v[0:1], s[0:1]
-; GFX11-NEXT:    global_store_b8 v4, v2, s[2:3]
+; GFX11-NEXT:    global_store_b64 v4, v[2:3], s[0:1]
+; GFX11-NEXT:    global_store_b8 v4, v0, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -765,21 +766,24 @@ define amdgpu_kernel void @v_usubo_i16(ptr addrspace(1) %out, ptr addrspace(1) %
 ; GFX11-LABEL: v_usubo_i16:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_load_d16_b16 v1, v0, s[4:5]
-; GFX11-NEXT:    global_load_u16 v2, v0, s[6:7]
+; GFX11-NEXT:    global_load_d16_b16 v0, v2, s[4:5]
+; GFX11-NEXT:    global_load_u16 v1, v2, s[6:7]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    v_sub_nc_u32_e32 v2, v1, v2
-; GFX11-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-NEXT:    v_sub_nc_u32_e32 v1, v0, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_and_b32_e32 v3, 0xffff, v2
-; GFX11-NEXT:    v_cmp_gt_u32_e32 vcc_lo, v3, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc_lo
+; GFX11-NEXT:    v_and_b32_e32 v3, 0xffff, v1
+; GFX11-NEXT:    v_cmp_gt_u32_e32 vcc_lo, v3, v0
+; GFX11-NEXT:    v_mov_b16_e32 v0.l, v1.l
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_mov_b16_e32 v1.l, v3.l
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v0, v2, s[0:1]
-; GFX11-NEXT:    global_store_b8 v0, v1, s[2:3]
+; GFX11-NEXT:    global_store_b16 v2, v0, s[0:1]
+; GFX11-NEXT:    global_store_b8 v2, v1, s[2:3]
 ; GFX11-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -1043,12 +1047,12 @@ define amdgpu_kernel void @s_usubo_clamp_bit(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-NEXT:    s_load_b128 s[4:7], s[4:5], 0x24
 ; GFX11-NEXT:    s_and_b32 s0, s0, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, s0
+; GFX11-NEXT:    v_mov_b32_e32 v2, 0
+; GFX11-NEXT:    v_mov_b16_e32 v1.l, s0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b32 v1, v0, s[4:5]
-; GFX11-NEXT:    global_store_b8 v1, v2, s[6:7]
+; GFX11-NEXT:    global_store_b32 v2, v0, s[4:5]
+; GFX11-NEXT:    global_store_b8 v2, v1, s[6:7]
 ; GFX11-NEXT:    s_endpgm
 entry:
   %usub = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
@@ -1199,7 +1203,7 @@ define amdgpu_kernel void @v_usubo_clamp_bit(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s4, 1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v2, s4
+; GFX11-NEXT:    v_mov_b16_e32 v2.l, s4
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX11-NEXT:    global_store_b8 v0, v2, s[2:3]

--- a/llvm/test/CodeGen/AMDGPU/widen-smrd-loads.ll
+++ b/llvm/test/CodeGen/AMDGPU/widen-smrd-loads.ll
@@ -34,19 +34,33 @@ define amdgpu_kernel void @widen_i16_constant_load(ptr addrspace(4) %arg) {
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: widen_i16_constant_load:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_addk_i32 s0, 0x3e7
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, 4
-; GFX11-NEXT:    v_mov_b32_e32 v2, s0
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: widen_i16_constant_load:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_addk_i32 s0, 0x3e7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, 4
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: widen_i16_constant_load:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_addk_i32 s0, 0x3e7
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, 4
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    s_endpgm
   %load = load i16, ptr addrspace(4) %arg, align 4
   %add = add i16 %load, 999
   %or = or i16 %add, 4
@@ -204,25 +218,44 @@ define amdgpu_kernel void @widen_i17_constant_load(ptr addrspace(4) %arg) {
 ; VI-NEXT:    flat_store_byte v[2:3], v0
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: widen_i17_constant_load:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    v_mov_b32_e32 v3, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_add_i32 s0, s0, 34
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, 4
-; GFX11-NEXT:    v_mov_b32_e32 v4, s0
-; GFX11-NEXT:    s_and_b32 s0, s0, 0x1ffff
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v5, s0
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    global_store_b16 v[0:1], v4, off
-; GFX11-NEXT:    global_store_d16_hi_b8 v[2:3], v5, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: widen_i17_constant_load:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 2 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v4, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_add_i32 s0, s0, 34
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, 4
+; GFX11-TRUE16-NEXT:    s_and_b32 s1, s0, 0x1ffff
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v5, s1
+; GFX11-TRUE16-NEXT:    s_clause 0x1
+; GFX11-TRUE16-NEXT:    global_store_d16_hi_b8 v[1:2], v5, off
+; GFX11-TRUE16-NEXT:    global_store_b16 v[3:4], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: widen_i17_constant_load:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v3, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_add_i32 s0, s0, 34
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, 4
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, s0
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 0x1ffff
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, 2 :: v_dual_mov_b32 v5, s0
+; GFX11-FAKE16-NEXT:    s_clause 0x1
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v4, off
+; GFX11-FAKE16-NEXT:    global_store_d16_hi_b8 v[2:3], v5, off
+; GFX11-FAKE16-NEXT:    s_endpgm
   %load = load i17, ptr addrspace(4) %arg, align 4
   %add = add i17 %load, 34
   %or = or i17 %add, 4
@@ -326,25 +359,45 @@ define amdgpu_kernel void @widen_v2i8_constant_load(ptr addrspace(4) %arg) {
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: widen_v2i8_constant_load:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0xc0c0104 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_and_b32 s0, s0, 0xffff
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_add_i32 s1, s0, 12
-; GFX11-NEXT:    s_or_b32 s1, s1, 4
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_perm_b32 v0, s1, s0, v0
-; GFX11-NEXT:    v_add_nc_u32_e32 v2, 0x2c00, v0
-; GFX11-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_or_b32_e32 v2, 0x300, v2
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: widen_v2i8_constant_load:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v0, 0xc0c0104 :: v_dual_mov_b32 v1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 0xffff
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_add_i32 s1, s0, 12
+; GFX11-TRUE16-NEXT:    s_or_b32 s1, s1, 4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_perm_b32 v0, s1, s0, v0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v0, 0x2c00, v0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, 0x300, v0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: widen_v2i8_constant_load:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0xc0c0104 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 0xffff
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_add_i32 s1, s0, 12
+; GFX11-FAKE16-NEXT:    s_or_b32 s1, s1, 4
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_perm_b32 v0, s1, s0, v0
+; GFX11-FAKE16-NEXT:    v_add_nc_u32_e32 v2, 0x2c00, v0
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, 0x300, v2
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    s_endpgm
   %load = load <2 x i8>, ptr addrspace(4) %arg, align 4
   %add = add <2 x i8> %load, <i8 12, i8 44>
   %or = or <2 x i8> %add, <i8 4, i8 3>
@@ -455,18 +508,31 @@ define amdgpu_kernel void @widen_i1_constant_load(ptr addrspace(4) %arg) {
 ; VI-NEXT:    flat_store_byte v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: widen_i1_constant_load:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_and_b32 s0, s0, 1
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v2, s0
-; GFX11-NEXT:    global_store_b8 v[0:1], v2, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: widen_i1_constant_load:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b8 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: widen_i1_constant_load:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    s_endpgm
   %load = load i1, ptr addrspace(4) %arg, align 4
   %and = and i1 %load, true
   store i1 %and, ptr addrspace(1) null
@@ -613,20 +679,35 @@ define amdgpu_kernel void @widen_i16_constant32_load(ptr addrspace(6) %arg) {
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: widen_i16_constant32_load:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b32 s0, s[4:5], 0x24
-; GFX11-NEXT:    s_mov_b32 s1, 0
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_addk_i32 s0, 0x3e7
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, 4
-; GFX11-NEXT:    v_mov_b32_e32 v2, s0
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: widen_i16_constant32_load:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    s_mov_b32 s1, 0
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_addk_i32 s0, 0x3e7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, 4
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: widen_i16_constant32_load:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    s_mov_b32 s1, 0
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_addk_i32 s0, 0x3e7
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, 4
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    s_endpgm
   %load = load i16, ptr addrspace(6) %arg, align 4
   %add = add i16 %load, 999
   %or = or i16 %add, 4
@@ -664,19 +745,33 @@ define amdgpu_kernel void @widen_i16_global_invariant_load(ptr addrspace(1) %arg
 ; VI-NEXT:    flat_store_short v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
-; GFX11-LABEL: widen_i16_global_invariant_load:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
-; GFX11-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_load_b32 s0, s[0:1], 0x0
-; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_addk_i32 s0, 0x3e7
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_or_b32 s0, s0, 1
-; GFX11-NEXT:    v_mov_b32_e32 v2, s0
-; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
-; GFX11-NEXT:    s_endpgm
+; GFX11-TRUE16-LABEL: widen_i16_global_invariant_load:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_addk_i32 s0, 0x3e7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    s_or_b32 s0, s0, 1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    global_store_b16 v[1:2], v0, off
+; GFX11-TRUE16-NEXT:    s_endpgm
+;
+; GFX11-FAKE16-LABEL: widen_i16_global_invariant_load:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_addk_i32 s0, 0x3e7
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-FAKE16-NEXT:    s_or_b32 s0, s0, 1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-FAKE16-NEXT:    s_endpgm
   %load = load i16, ptr addrspace(1) %arg, align 4, !invariant.load !0
   %add = add i16 %load, 999
   %or = or i16 %add, 1


### PR DESCRIPTION
In true16 mode, there previously were several isel patterns for 8 and 16-bit FLAT, GLOBAL and
SCRATCH loads and stores which selected into the non-t16 pseudo instructions, which take a 32-bit VGPR data operand. A mixture of t16 and non-t16 pseudos can cause the physical register liveness tracking in machine verifier to become inaccurate.
See https://github.com/llvm/llvm-project/pull/201004.

Add new selection patterns to use the _t16 pseudos in all cases except hi16 truncstore, which requires more changes.

globalisel can't import the EXTRACT_SUBREG patterns used in SDAG, so in CPP insert a copy of the stored argument to VGPR16, then select the _t16 suffixed pseudo instructions.

Assisted-by: Claude Code:claude-opus-4-8[1m]