### PR TITLE
[analyzer] Fix crash in RegionStoreManager::bindArray

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -2729,6 +2729,12 @@ RegionStoreManager::bindArray(LimitedRegionBindingsConstRef B,
   if (isa<nonloc::SymbolVal, UnknownVal, UndefinedVal>(Init))
     return bindAggregate(B, R, Init);
 
+  // We may get non-CompoundVal accidentally due to imprecise cast logic or
+  // that we are binding symbolic array value. Kill the element values, and if
+  // the value is symbolic go and bind it as a "default" binding.
+  if (!isa<nonloc::CompoundVal>(Init))
+    return bindAggregate(B, R, UnknownVal());
+
   // Remaining case: explicit compound values.
   const nonloc::CompoundVal& CV = Init.castAs<nonloc::CompoundVal>();
   nonloc::CompoundVal::iterator VI = CV.begin(), VE = CV.end();

--- a/clang/test/Analysis/gh-issue-210183.cpp
+++ b/clang/test/Analysis/gh-issue-210183.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -std=c++17 -verify %s
+
+// https://github.com/llvm/llvm-project/issues/210183
+// Don't crash when binding a value that isn't a CompoundVal (e.g. a pointer
+// reinterpreted as an integer via a template-induced round trip) to a region
+// of array type.
+
+// expected-no-diagnostics
+
+template <typename T>
+class Span {
+public:
+  template <int N>
+  Span(T (&arr)[N]) : ptr_(arr) {}
+  T *data() { return ptr_; }
+  T *ptr_;
+};
+
+class Decoder {
+public:
+  template <typename TInput, typename TOutput>
+  auto decodeOne(TInput input, TOutput output) {
+    using InPtr_t = decltype(input.data());
+    InPtr_t inPtr = input.data();
+    using OutPtr_t = decltype(output.data());
+    OutPtr_t outPtr = output.data();
+    int scratch[1];
+    scratch[0] = *inPtr;
+    int value = scratch[0];
+    *outPtr = value;
+  }
+};
+
+void test() {
+  char buffer[1];
+  Span<char> span(buffer);
+  Decoder decoder;
+  decoder.decodeOne(span, span);
+}


### PR DESCRIPTION
[analyzer] Fix crash in RegionStoreManager::bindArray on non-CompoundVal init

bindArray() unconditionally cast its Init value to nonloc::CompoundVal without first checking that it actually was one, unlike its siblings bindStruct() and bindVector(), which both guard the same cast and fall back to bindAggregate(UnknownVal()) otherwise.

When a pointer value gets modeled as a nonloc::LocAsInteger (e.g. via a type-punning round trip through template-deduced pointer types), it can reach bindArray() as the Init for an array-typed region and hit the unchecked castAs&lt;nonloc::CompoundVal&gt;(), which asserts in a debug build and segfaults in a release build.

Add the missing guard, mirroring the existing bindStruct()/bindVector() handling, and add a regression test reduced from the crashing report.

Fixes #210183