### PR TITLE
[BOLT] Support --lite selection with basic sample profiles

### DIFF
--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -275,10 +275,12 @@ Error DataReader::preprocessProfile(BinaryContext &BC) {
       FuncData->setEntryCounts(Function);
       FuncData->Used = true;
     }
-    if (NoLBRMode)
+    if (NoLBRMode) {
       if (FuncBasicSampleData *SampleData =
-              getFuncBasicSampleData(Function.getNames()))
+              getFuncBasicSampleData(Function.getNames())) {
         Function.setExecutionCount(SampleData->getSamples());
+      }
+    }
   }
 
   for (auto &BFI : BC.getBinaryFunctions()) {

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -275,6 +275,10 @@ Error DataReader::preprocessProfile(BinaryContext &BC) {
       FuncData->setEntryCounts(Function);
       FuncData->Used = true;
     }
+    if (NoLBRMode)
+      if (FuncBasicSampleData *SampleData =
+              getFuncBasicSampleData(Function.getNames()))
+        Function.setExecutionCount(SampleData->getSamples());
   }
 
   for (auto &BFI : BC.getBinaryFunctions()) {

--- a/bolt/test/X86/nolbr.s
+++ b/bolt/test/X86/nolbr.s
@@ -12,8 +12,6 @@
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
 # RUN: llvm-bolt %t.exe -o %t.out --data %t.fdata --dyno-stats -ba \
 # RUN:    --print-only=_start 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT
-# RUN: llvm-bolt %t.exe -o %t.lite.out --data %t.fdata --lite \
-# RUN:    --lite-threshold-count=1 -v=1 2>&1 | FileCheck %s --check-prefix=CHECK-LITE
 ## Check that invalid fdata is detected.
 # RUN: cp %t.fdata %t.invalid.fdata
 # RUN: echo "invalid" >> %t.invalid.fdata
@@ -24,12 +22,10 @@
 # CHECK-FDATA-NEXT: 1 _start [[#]] 1
 
 # CHECK-BOLT: BOLT-INFO: pre-processing profile using branch profile reader
+# CHECK-BOLT-NOT: BOLT-INFO: skipping processing _start per user request
 # CHECK-BOLT: BOLT-INFO: operating with basic samples profiling data (no brstack).
 # CHECK-BOLT: BOLT-INFO: 1 out of 1 functions in the binary (100.0%) have non-empty execution profile
 # CHECK-BOLT-NOT: WARNING: invalid profile data detected
-
-# CHECK-LITE-NOT: BOLT-INFO: skipping processing _start per user request
-# CHECK-LITE: BOLT-INFO: operating with basic samples profiling data (no brstack).
 
 # CHECK-WARN: WARNING: invalid profile data detected at line {{[0-9]+}}. Possibly corrupted profile.
 

--- a/bolt/test/X86/nolbr.s
+++ b/bolt/test/X86/nolbr.s
@@ -12,6 +12,8 @@
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
 # RUN: llvm-bolt %t.exe -o %t.out --data %t.fdata --dyno-stats -ba \
 # RUN:    --print-only=_start 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-bolt %t.exe -o %t.lite.out --data %t.fdata --lite \
+# RUN:    --lite-threshold-count=1 -v=1 2>&1 | FileCheck %s --check-prefix=CHECK-LITE
 ## Check that invalid fdata is detected.
 # RUN: cp %t.fdata %t.invalid.fdata
 # RUN: echo "invalid" >> %t.invalid.fdata
@@ -25,6 +27,9 @@
 # CHECK-BOLT: BOLT-INFO: operating with basic samples profiling data (no brstack).
 # CHECK-BOLT: BOLT-INFO: 1 out of 1 functions in the binary (100.0%) have non-empty execution profile
 # CHECK-BOLT-NOT: WARNING: invalid profile data detected
+
+# CHECK-LITE-NOT: BOLT-INFO: skipping processing _start per user request
+# CHECK-LITE: BOLT-INFO: operating with basic samples profiling data (no brstack).
 
 # CHECK-WARN: WARNING: invalid profile data detected at line {{[0-9]+}}. Possibly corrupted profile.
 


### PR DESCRIPTION
Seed function execution counts from no-LBR basic samples during profile preprocessing, allowing `--lite` threshold selection to identify profiled functions. Add coverage for lite-mode processing of no-LBR fdata.