### PR TITLE
[SelectionDAG] Allow constant UREM decomposition without high multiply

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8596,14 +8596,21 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
 
   APInt Divisor = CN->getAPIntValue();
 
-  // We depend on the UREM by constant optimization in DAGCombiner that requires
-  // high multiply.
-  if (!isOperationLegalOrCustom(ISD::MULHU, HiLoVT) &&
+  // The generated half-width UREM is normally optimized using high multiply.
+  // If the wide UREM libcall is unavailable, a legal or custom half-width
+  // UDIVREM can lower it instead.
+  bool CanDecomposeUREMWithoutMulHi =
+      Opcode == ISD::UREM &&
+      getLibcallImpl(RTLIB::getUREM(N->getValueType(0))) ==
+          RTLIB::Unsupported &&
+      isOperationLegalOrCustom(ISD::UDIVREM, HiLoVT);
+  if (!CanDecomposeUREMWithoutMulHi &&
+      !isOperationLegalOrCustom(ISD::MULHU, HiLoVT) &&
       !isOperationLegalOrCustom(ISD::UMUL_LOHI, HiLoVT))
     return false;
 
-  // Don't expand if optimizing for size.
-  if (DAG.shouldOptForSize())
+  // Prefer the smaller libcall when one is available.
+  if (DAG.shouldOptForSize() && !CanDecomposeUREMWithoutMulHi)
     return false;
 
   // Early out for 0 or 1 divisors.

--- a/llvm/test/CodeGen/AMDGPU/fshl-illegal-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/fshl-illegal-types.ll
@@ -1,0 +1,47 @@
+; RUN: llc -global-isel=0 -mtriple=amdgpu6.00 < %s | FileCheck %s --implicit-check-not=s_swappc_b64
+; RUN: llc -global-isel=0 -mtriple=amdgpu11.00 < %s | FileCheck %s --implicit-check-not=s_swappc_b64
+
+; The generated remainder and funnel-shift expansions are long and subject to
+; frequent changes. Check that SelectionDAG can lower variable funnel shifts
+; whose irregular types promote to i128 without requiring an i128 urem libcall.
+
+declare i65 @llvm.fshl.i65(i65, i65, i65)
+declare i66 @llvm.fshl.i66(i66, i66, i66)
+declare i67 @llvm.fshl.i67(i67, i67, i67)
+declare i68 @llvm.fshl.i68(i68, i68, i68)
+declare i127 @llvm.fshl.i127(i127, i127, i127)
+
+define i65 @fshl_i65(i65 %amt) {
+; CHECK-LABEL: fshl_i65:
+; CHECK:       s_setpc_b64
+  %result = call i65 @llvm.fshl.i65(i65 1, i65 0, i65 %amt)
+  ret i65 %result
+}
+
+define i66 @fshl_i66(i66 %amt) {
+; CHECK-LABEL: fshl_i66:
+; CHECK:       s_setpc_b64
+  %result = call i66 @llvm.fshl.i66(i66 1, i66 0, i66 %amt)
+  ret i66 %result
+}
+
+define i67 @fshl_i67(i67 %amt) {
+; CHECK-LABEL: fshl_i67:
+; CHECK:       s_setpc_b64
+  %result = call i67 @llvm.fshl.i67(i67 1, i67 0, i67 %amt)
+  ret i67 %result
+}
+
+define i68 @fshl_i68(i68 %amt) {
+; CHECK-LABEL: fshl_i68:
+; CHECK:       s_setpc_b64
+  %result = call i68 @llvm.fshl.i68(i68 1, i68 0, i68 %amt)
+  ret i68 %result
+}
+
+define i127 @fshl_i127(i127 %amt) {
+; CHECK-LABEL: fshl_i127:
+; CHECK:       s_setpc_b64
+  %result = call i127 @llvm.fshl.i127(i127 1, i127 0, i127 %amt)
+  ret i127 %result
+}

--- a/llvm/test/CodeGen/AMDGPU/urem-constant-i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/urem-constant-i128.ll
@@ -1,0 +1,48 @@
+; RUN: llc -global-isel=0 -mtriple=amdgpu6.00 < %s | FileCheck %s --implicit-check-not=s_swappc_b64
+; RUN: llc -global-isel=0 -mtriple=amdgpu11.00 < %s | FileCheck %s --implicit-check-not=s_swappc_b64
+
+; Check that AMDGPU legalizes constant i128 UREM without emitting a libcall.
+
+define i128 @urem_i128_65(i128 %src) {
+; CHECK-LABEL: urem_i128_65:
+; CHECK:       s_setpc_b64
+  %result = urem i128 %src, 65
+  ret i128 %result
+}
+
+define i128 @urem_i128_65_optsize(i128 %src) #0 {
+; CHECK-LABEL: urem_i128_65_optsize:
+; CHECK:       s_setpc_b64
+  %result = urem i128 %src, 65
+  ret i128 %result
+}
+
+define i128 @urem_i128_66(i128 %src) {
+; CHECK-LABEL: urem_i128_66:
+; CHECK:       s_setpc_b64
+  %result = urem i128 %src, 66
+  ret i128 %result
+}
+
+define i128 @urem_i128_67(i128 %src) {
+; CHECK-LABEL: urem_i128_67:
+; CHECK:       s_setpc_b64
+  %result = urem i128 %src, 67
+  ret i128 %result
+}
+
+define i128 @urem_i128_68(i128 %src) {
+; CHECK-LABEL: urem_i128_68:
+; CHECK:       s_setpc_b64
+  %result = urem i128 %src, 68
+  ret i128 %result
+}
+
+define i128 @urem_i128_127(i128 %src) {
+; CHECK-LABEL: urem_i128_127:
+; CHECK:       s_setpc_b64
+  %result = urem i128 %src, 127
+  ret i128 %result
+}
+
+attributes #0 = { optsize }


### PR DESCRIPTION
`SelectionDAG` may introduce a wide constant UREM when promoting funnel shifts on irregular integer types. On AMDGPU, an i65 `fshl` becomes an i128 remainder by 65; the existing decomposition is rejected because i64 `MULHU` and `UMUL_LOHI` are unavailable, after which legalization attempts the unsupported `__umodti3` libcall.

Allow the existing decomposition when the wide UREM libcall is unavailable and half-width `UDIVREM` is legal or custom. This lets AMDGPU finish through its custom i64 `UDIVREM`  lowering while preserving the existing libcall preference for targets with a usable wide libcall.
Fixes #197949