### PR TITLE
[SampleProfile] Support MD5-based ProfileSymbolList

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1697,28 +1697,25 @@ public:
   }
 
   bool contains(StringRef Name) const {
-    return Syms.count(Name) || ColdGUIDTable.contains(llvm::MD5Hash(Name));
+    return IsMD5 ? ColdGUIDTable.contains(llvm::MD5Hash(Name))
+                 : Syms.count(Name);
   }
 
   void merge(const ProfileSymbolList &List) {
-    assert(List.ColdGUIDTable.empty() &&
+    assert(!List.IsMD5 &&
            "Merging pre-hashed MD5 ProfileSymbolList not yet implemented");
     for (auto Sym : List.Syms)
       add(Sym, true);
   }
 
-  unsigned size() const {
-    assert((ColdGUIDTable.empty() || Syms.empty()) &&
-           "Mixed string/GUID ProfileSymbolList size not yet implemented");
-    return Syms.size() + ColdGUIDTable.size();
-  }
+  unsigned size() const { return IsMD5 ? ColdGUIDTable.size() : Syms.size(); }
   void reserve(size_t Size) { Syms.reserve(Size); }
 
   void setToCompress(bool TC) { ToCompress = TC; }
   bool toCompress() { return ToCompress; }
 
   std::vector<uint64_t> collectGUIDs() const {
-    assert(ColdGUIDTable.empty() &&
+    assert(!IsMD5 &&
            "Collecting GUIDs from existing MD5 table not yet implemented");
     std::vector<uint64_t> Keys;
     Keys.reserve(Syms.size());
@@ -1729,17 +1726,23 @@ public:
   }
 
   void setColdGUIDTable(EytzingerTableSpan<support::ulittle64_t> Table) {
+    assert(Syms.empty() &&
+           "Setting ColdGUIDTable shadows existing strings in Syms");
     ColdGUIDTable = Table;
+    IsMD5 = true;
   }
   EytzingerTableSpan<support::ulittle64_t> getColdGUIDTable() const {
+    assert(IsMD5 && "Retrieving ColdGUIDTable from non-MD5 ProfileSymbolList");
     return ColdGUIDTable;
   }
+  bool isMD5() const { return IsMD5; }
 
   LLVM_ABI std::error_code read(const uint8_t *Data, uint64_t ListSize);
   LLVM_ABI std::error_code write(raw_ostream &OS);
   LLVM_ABI void dump(raw_ostream &OS = dbgs()) const;
 
 private:
+  bool IsMD5 = false;
   // Determine whether or not to compress the symbol list when
   // writing it into profile. The variable is unused when the symbol
   // list is read from an existing profile.

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Eytzinger.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -208,6 +209,10 @@ enum class SecNameTableFlags : uint32_t {
   // the suffix when doing profile matching when seeing the flag.
   SecFlagUniqSuffix = (1 << 2)
 };
+enum class SecProfileSymbolListFlags : uint32_t {
+  SecFlagInValid = 0,
+  SecFlagMD5 = (1 << 0)
+};
 enum class SecProfSummaryFlags : uint32_t {
   SecFlagInValid = 0,
   /// SecFlagPartial means the profile is for common/shared code.
@@ -253,6 +258,9 @@ static inline void verifySecFlag(SecType Type, SecFlagType Flag) {
   switch (Type) {
   case SecNameTable:
     IsFlagLegal = std::is_same<SecNameTableFlags, SecFlagType>();
+    break;
+  case SecProfileSymbolList:
+    IsFlagLegal = std::is_same<SecProfileSymbolListFlags, SecFlagType>();
     break;
   case SecProfSummary:
     IsFlagLegal = std::is_same<SecProfSummaryFlags, SecFlagType>();
@@ -1688,18 +1696,44 @@ public:
     Syms.insert(Name.copy(Allocator));
   }
 
-  bool contains(StringRef Name) { return Syms.count(Name); }
+  bool contains(StringRef Name) const {
+    return Syms.count(Name) || ColdGUIDTable.contains(llvm::MD5Hash(Name));
+  }
 
   void merge(const ProfileSymbolList &List) {
+    assert(List.ColdGUIDTable.empty() &&
+           "Merging pre-hashed MD5 ProfileSymbolList not yet implemented");
     for (auto Sym : List.Syms)
       add(Sym, true);
   }
 
-  unsigned size() { return Syms.size(); }
+  unsigned size() const {
+    assert((ColdGUIDTable.empty() || Syms.empty()) &&
+           "Mixed string/GUID ProfileSymbolList size not yet implemented");
+    return Syms.size() + ColdGUIDTable.size();
+  }
   void reserve(size_t Size) { Syms.reserve(Size); }
 
   void setToCompress(bool TC) { ToCompress = TC; }
   bool toCompress() { return ToCompress; }
+
+  std::vector<uint64_t> collectGUIDs() const {
+    assert(ColdGUIDTable.empty() &&
+           "Collecting GUIDs from existing MD5 table not yet implemented");
+    std::vector<uint64_t> Keys;
+    Keys.reserve(Syms.size());
+    llvm::append_range(Keys, llvm::map_range(Syms, llvm::MD5Hash));
+    llvm::sort(Keys);
+    Keys.erase(llvm::unique(Keys), Keys.end());
+    return Keys;
+  }
+
+  void setColdGUIDTable(EytzingerTableSpan<support::ulittle64_t> Table) {
+    ColdGUIDTable = Table;
+  }
+  EytzingerTableSpan<support::ulittle64_t> getColdGUIDTable() const {
+    return ColdGUIDTable;
+  }
 
   LLVM_ABI std::error_code read(const uint8_t *Data, uint64_t ListSize);
   LLVM_ABI std::error_code write(raw_ostream &OS);
@@ -1711,6 +1745,7 @@ private:
   // list is read from an existing profile.
   bool ToCompress = false;
   DenseSet<StringRef> Syms;
+  EytzingerTableSpan<support::ulittle64_t> ColdGUIDTable;
   BumpPtrAllocator Allocator;
 };
 

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -1032,7 +1032,9 @@ protected:
                                    SampleProfileMap &Profiles);
   std::error_code readNameTableSec(bool IsMD5, bool FixedLengthMD5);
   std::error_code readCSNameTableSec();
-  std::error_code readProfileSymbolList();
+  std::error_code readProfileSymbolList(bool IsMD5);
+  std::error_code readStringBasedProfileSymbolList();
+  std::error_code readMD5ProfileSymbolList();
 
   std::error_code readHeader() override;
   std::error_code verifySPMagic(uint64_t Magic) override = 0;

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROFWRITER_H
 #define LLVM_PROFILEDATA_SAMPLEPROFWRITER_H
 
+#include "llvm/ADT/Eytzinger.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ProfileSummary.h"
@@ -416,6 +417,8 @@ protected:
   std::error_code writeNameTableSection(const SampleProfileMap &ProfileMap);
   std::error_code writeFuncOffsetTable();
   std::error_code writeProfileSymbolListSection();
+  std::error_code writeStringBasedProfileSymbolListSection();
+  std::error_code writeMD5ProfileSymbolListSection();
 
   SectionLayout SecLayout = DefaultLayout;
   // Specifiy the order of sections in section header table. Note

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -909,7 +909,8 @@ std::error_code SampleProfileReaderExtBinaryBase::readOneSection(
     break;
   }
   case SecProfileSymbolList:
-    if (std::error_code EC = readProfileSymbolList())
+    if (std::error_code EC = readProfileSymbolList(
+            hasSecFlag(Entry, SecProfileSymbolListFlags::SecFlagMD5)))
       return EC;
     break;
   default:
@@ -1135,7 +1136,29 @@ std::error_code SampleProfileReaderExtBinaryBase::readFuncProfiles() {
   return sampleprof_error::success;
 }
 
-std::error_code SampleProfileReaderExtBinaryBase::readProfileSymbolList() {
+std::error_code
+SampleProfileReaderExtBinaryBase::readProfileSymbolList(bool IsMD5) {
+  if (IsMD5)
+    return readMD5ProfileSymbolList();
+  return readStringBasedProfileSymbolList();
+}
+
+std::error_code SampleProfileReaderExtBinaryBase::readMD5ProfileSymbolList() {
+  size_t Size = End - Data;
+  if (Size % sizeof(uint64_t) != 0)
+    return sampleprof_error::truncated;
+  const auto *Table = reinterpret_cast<const support::ulittle64_t *>(Data);
+  size_t NumEntries = Size / sizeof(uint64_t);
+  if (!ProfSymList)
+    ProfSymList = std::make_unique<ProfileSymbolList>();
+  ProfSymList->setColdGUIDTable(
+      EytzingerTableSpan<support::ulittle64_t>(Table, NumEntries));
+  Data = End;
+  return sampleprof_error::success;
+}
+
+std::error_code
+SampleProfileReaderExtBinaryBase::readStringBasedProfileSymbolList() {
   if (!ProfSymList)
     ProfSymList = std::make_unique<ProfileSymbolList>();
 
@@ -1588,6 +1611,10 @@ static std::string getSecFlagsStr(const SecHdrTableEntry &Entry) {
       Flags.append("probe,");
     if (hasSecFlag(Entry, SecFuncMetadataFlags::SecFlagHasAttribute))
       Flags.append("attr,");
+    break;
+  case SecProfileSymbolList:
+    if (hasSecFlag(Entry, SecProfileSymbolListFlags::SecFlagMD5))
+      Flags.append("md5,");
     break;
   default:
     break;

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -434,7 +434,7 @@ SampleProfileWriterExtBinaryBase::writeProfileSymbolListSection() {
 
 std::error_code
 SampleProfileWriterExtBinaryBase::writeStringBasedProfileSymbolListSection() {
-  assert((!ProfSymList || ProfSymList->getColdGUIDTable().empty()) &&
+  assert((!ProfSymList || !ProfSymList->isMD5()) &&
          "Writing string-based ProfileSymbolListSection from MD5 table "
          "not yet implemented");
   if (ProfSymList && ProfSymList->size() > 0)
@@ -448,7 +448,7 @@ std::error_code
 SampleProfileWriterExtBinaryBase::writeMD5ProfileSymbolListSection() {
   if (!ProfSymList || ProfSymList->size() == 0)
     return sampleprof_error::success;
-  assert(ProfSymList->getColdGUIDTable().empty() &&
+  assert(!ProfSymList->isMD5() &&
          "Writing MD5 ProfileSymbolListSection from existing MD5 "
          "table not yet implemented");
 

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -49,6 +49,11 @@ static cl::opt<uint64_t> RequestedVersion(
     "sample-profile-format-version", cl::init(DefaultVersion), cl::Hidden,
     cl::desc("Format version to write for extensible binary profiles"));
 
+static cl::opt<bool>
+    WriteMD5ProfSymList("md5-prof-sym-list", cl::init(false), cl::Hidden,
+                        cl::desc("Write ProfileSymbolList (Cold Symbols) as "
+                                 "64-bit MD5 hashes in Eytzinger layout"));
+
 namespace llvm {
 namespace support {
 namespace endian {
@@ -422,10 +427,39 @@ std::error_code SampleProfileWriterExtBinaryBase::writeCSNameTableSection() {
 
 std::error_code
 SampleProfileWriterExtBinaryBase::writeProfileSymbolListSection() {
+  if (WriteMD5ProfSymList)
+    return writeMD5ProfileSymbolListSection();
+  return writeStringBasedProfileSymbolListSection();
+}
+
+std::error_code
+SampleProfileWriterExtBinaryBase::writeStringBasedProfileSymbolListSection() {
+  assert((!ProfSymList || ProfSymList->getColdGUIDTable().empty()) &&
+         "Writing string-based ProfileSymbolListSection from MD5 table "
+         "not yet implemented");
   if (ProfSymList && ProfSymList->size() > 0)
     if (std::error_code EC = ProfSymList->write(*OutputStream))
       return EC;
 
+  return sampleprof_error::success;
+}
+
+std::error_code
+SampleProfileWriterExtBinaryBase::writeMD5ProfileSymbolListSection() {
+  if (!ProfSymList || ProfSymList->size() == 0)
+    return sampleprof_error::success;
+  assert(ProfSymList->getColdGUIDTable().empty() &&
+         "Writing MD5 ProfileSymbolListSection from existing MD5 "
+         "table not yet implemented");
+
+  auto &OS = *OutputStream;
+  std::vector<uint64_t> Keys = ProfSymList->collectGUIDs();
+
+  auto Table =
+      llvm::EytzingerTable<support::ulittle64_t>::create(std::move(Keys));
+
+  OS.write(reinterpret_cast<const char *>(Table.data()),
+           Table.size() * sizeof(support::ulittle64_t));
   return sampleprof_error::success;
 }
 
@@ -448,6 +482,8 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
   if (Type == SecProfSummary && ExtBinaryWriteVTableTypeProf)
     addSectionFlag(SecProfSummary,
                    SecProfSummaryFlags::SecFlagHasVTableTypeProf);
+  if (Type == SecProfileSymbolList && WriteMD5ProfSymList)
+    addSectionFlag(SecProfileSymbolList, SecProfileSymbolListFlags::SecFlagMD5);
 
   uint64_t SectionStart = markSectionStart(Type, LayoutIdx);
   switch (Type) {

--- a/llvm/test/tools/llvm-profdata/profile-symbol-list.test
+++ b/llvm/test/tools/llvm-profdata/profile-symbol-list.test
@@ -8,6 +8,12 @@
 
 ; NOSYMLIST: ProfileSymbolListSection {{.*}} Size: 0
 
+;; Verify that -md5-prof-sym-list records the md5 section flag for ProfileSymbolListSection.
+; RUN: llvm-profdata merge -sample -extbinary -md5-prof-sym-list -prof-sym-list=%S/Inputs/profile-symbol-list-1.text %S/Inputs/sample-profile.proftext -o %t.md5.output
+; RUN: llvm-profdata show -sample -show-sec-info-only %t.md5.output | FileCheck %s -check-prefix=MD5
+
+; MD5: ProfileSymbolListSection - Offset: {{.*}}, Size: {{.*}}, Flags: {{{.*}}md5}
+
 ;; Generate two SampleFDO binary profiles and merge them.
 ;; Tests that the vtable counters in the merged profile are the aggregated
 ;; result from both sources.

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -476,6 +476,18 @@ TEST_F(SampleProfTest, roundtrip_md5_ext_binary_profile) {
   testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, true);
 }
 
+TEST_F(SampleProfTest, roundtrip_eytzinger_ext_binary_profile) {
+  const char *Args[] = {"SampleProfTest", "--md5-prof-sym-list=true"};
+  cl::ResetAllOptionOccurrences();
+  cl::ParseCommandLineOptions(2, Args, StringRef(), &llvm::nulls());
+
+  testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, false);
+
+  const char *ArgsFalse[] = {"SampleProfTest", "--md5-prof-sym-list=false"};
+  cl::ResetAllOptionOccurrences();
+  cl::ParseCommandLineOptions(2, ArgsFalse, StringRef(), &llvm::nulls());
+}
+
 TEST_F(SampleProfTest, remap_text_profile) {
   testRoundTrip(SampleProfileFormat::SPF_Text, true, false);
 }
@@ -685,6 +697,22 @@ TEST_F(SampleProfTest, SampleProfileFormatVersion105) {
   auto Buffer = writeRawHeaderToBuffer(105);
   auto ReadVersionOrErr = readVersionFromBuffer(Buffer);
   EXPECT_EQ(ReadVersionOrErr.getError(), sampleprof_error::unsupported_version);
+}
+
+TEST_F(SampleProfTest, ProfileSymbolListMD5) {
+  std::vector<uint64_t> Keys = {FunctionId("foo").getHashCode(),
+                                FunctionId("bar").getHashCode()};
+  auto Table =
+      llvm::EytzingerTable<support::ulittle64_t>::create(std::move(Keys));
+
+  ProfileSymbolList List;
+  List.setColdGUIDTable(
+      EytzingerTableSpan<support::ulittle64_t>(Table.data(), Table.size()));
+
+  EXPECT_TRUE(List.contains("foo"));
+  EXPECT_TRUE(List.contains("bar"));
+  EXPECT_FALSE(List.contains("baz"));
+  EXPECT_EQ(2u, List.size());
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
This patch speeds up sample profile loading by introducing an
MD5-based ProfileSymbolList (cold symbol list) in extensible binary
profiles.

The sample profile loader spends about a third of its time on loading
and decoding the symbol names in the Profile Symbol List section, yet
we use them only for membership checking purposes via
ProfileSymbolList::contains.

This patch teaches the writer to emit the section as an array of
64-bit GUIDs in the Eytzinger layout.  The reader checks the
SecFlagMD5 section flag and sets up an EytzingerTableSpan
pointing into the mmap memory.  This achieves both space efficiency
and runtime efficiency.

The new flag, md5-prof-sym-list, is off by default for now.

Profile merging is supported only from strings to an MD5-based
Eytzinger array.

RFC:
https://discourse.llvm.org/t/rfc-faster-sample-profile-loading/90957/7

Assisted-by: Antitygravity
