### PR TITLE
[clang][bytecode] Check unions for members already being initialized

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -360,6 +360,16 @@ bool CheckActive(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
   if (!U.getFieldDesc()->isUnion())
     return true;
 
+  // Check if we're currently initializing another member of the same union.
+  if (WillActivate && !S.InitializingPtrs.empty()) {
+    if (PtrView B = S.InitializingPtrs.back();
+        B != Ptr.view() && !B.isRoot() && B.getBase() == U) {
+      S.FFDiag(S.Current->getSource(OpPC),
+               diag::note_constexpr_union_member_change_during_init);
+      return false;
+    }
+  }
+
   // When we will activate Ptr, check that none of the unions in its path have a
   // non-trivial default constructor.
   if (WillActivate) {
@@ -1990,10 +2000,19 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
   InterpFrame *FrameBefore = S.Current;
   S.Current = NewFrame;
 
+  bool RVO = false;
+  if (Func->hasRVO()) {
+    RVO = true;
+    Pointer RVOPtr = NewFrame->getRVOPtr();
+    S.InitializingPtrs.push_back(RVOPtr.view());
+  }
+
   InterpStateCCOverride CCOverride(S, Func->isImmediate());
   bool Success = Interpret(S);
-  // Remove initializing  block again.
+  // Remove initializing blocks again.
   if (InstancePtrTracked)
+    S.InitializingPtrs.pop_back();
+  if (RVO)
     S.InitializingPtrs.pop_back();
 
   if (!Success) {

--- a/clang/test/AST/ByteCode/cxx20.cpp
+++ b/clang/test/AST/ByteCode/cxx20.cpp
@@ -1531,3 +1531,22 @@ namespace SubPtr {
   }
   static_assert(dynAlloc() == 1);
 }
+
+namespace ActivatingDifferentUnionMember {
+  struct A { long x; };
+
+  union U;
+  constexpr A foo(U *up);
+
+  union U {
+    A a = foo(this); // both-note {{in call to 'foo(&u)'}}
+    int y;
+  };
+
+  constexpr A foo(U *up) {
+    up->y = 11; // both-note {{assignment would change active union member during the initialization of a different member}}
+    return {42};
+  }
+
+  constexpr U u = {}; // both-error {{must be initialized by a constant expression}}
+}


### PR DESCRIPTION
Add RVO pointers to the list of pointers being initialized, too, so we have the information in `CheckActive`.