### PR TITLE
[orc-rt] Add TaskGroup::TokenSource; drop raw group accessor

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -356,18 +356,18 @@ public:
   /// Session has already shut down, the callback will be called immediately.
   void addOnShutdown(OnShutdownFn OnShutdown);
 
-  /// Returns a reference to this Session's ManagedCodeTaskGroup.
+  /// Return a TokenSource for this Session's ManagedCodeTaskGroup.
   ///
   /// When calling code managed by a Session (e.g. JIT'd code, or library code
   /// loaded on behalf of JIT'd code), clients should hold a token for this
-  /// group. That token will prevent the Session from shutting down any Services
-  /// (and the Session itself) until tasks accessing managed code have
-  /// completed.
+  /// group, which can be constructed from the returned TokenSource. That token
+  /// will prevent the Session from shutting down any Services (and the Session
+  /// itself) until tasks accessing managed code have completed.
   ///
   /// Clients should prefer using the callManagedCodeSync and
   /// callManagedCodeAsync helpers to automatically acquire and hold a token
   /// for the duration of a call.
-  const std::shared_ptr<TaskGroup> &managedCodeTaskGroup() const {
+  TaskGroup::TokenSource managedCodeTokenSource() const {
     return ManagedCodeTaskGroup;
   }
 

--- a/orc-rt/include/orc-rt/TaskGroup.h
+++ b/orc-rt/include/orc-rt/TaskGroup.h
@@ -26,6 +26,24 @@ namespace orc_rt {
 /// all tasks have completed.
 class TaskGroup {
 public:
+  class Token;
+
+  /// A strong reference to a TaskGroup, used only to construct Tokens from it
+  /// (see Token). It exposes no operations of its own: acquisition lives on the
+  /// Token constructor so that Token remains the single point that knows the
+  /// acquire/release protocol. A TokenSource keeps the referenced TaskGroup
+  /// alive, but does not hold a Token and so does not prevent the group from
+  /// closing or completing.
+  class TokenSource {
+    friend class Token;
+
+  public:
+    TokenSource(std::shared_ptr<TaskGroup> TG) : TG(std::move(TG)) {}
+
+  private:
+    std::shared_ptr<TaskGroup> TG;
+  };
+
   /// Token represents the right to proceed with a task as part of a
   /// TaskGroup.
   ///
@@ -100,6 +118,12 @@ public:
       if (G && G->acquireToken())
         this->G = std::move(G);
     }
+
+    /// Construct a Token from the given TokenSource.
+    /// Note that this may fail if the TaskGroup has been closed. Clients must
+    /// check whether the resulting Token is valid (using operator bool())
+    /// before continuing with their task.
+    Token(const TokenSource &S) : Token(S.TG) {}
 
     /// Destroys this Token, potentially triggering task group completion if
     /// this Token represented the last running task in the TaskGroup.

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -444,7 +444,7 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
   ASSERT_FALSE(ShutdownOpIdx);
 
   // Take a managed code call token. This should succeed.
-  auto Tok = TaskGroup::Token(S.managedCodeTaskGroup());
+  auto Tok = TaskGroup::Token(S.managedCodeTokenSource());
   ASSERT_TRUE(Tok);
 
   // We expect shutdown to wait for any active managed calls to complete.
@@ -458,7 +458,7 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
 
   // The managed calls code group should have been closed. Assert that we
   // can't get a new token.
-  ASSERT_FALSE(TaskGroup::Token(S.managedCodeTaskGroup()));
+  ASSERT_FALSE(TaskGroup::Token(S.managedCodeTokenSource()));
 
   Tok = TaskGroup::Token(); // Reset token.
 

--- a/orc-rt/test/unit/TaskGroupTest.cpp
+++ b/orc-rt/test/unit/TaskGroupTest.cpp
@@ -304,6 +304,56 @@ TEST(TaskGroupTest, TokenKeepsTaskGroupAlive) {
   EXPECT_TRUE(Completed);
 }
 
+TEST(TaskGroupTest, TokenFromTokenSource) {
+  bool Completed = false;
+  auto TG = TaskGroup::Create();
+  TG->addOnComplete([&]() { Completed = true; });
+
+  TaskGroup::TokenSource TS(TG);
+  {
+    TaskGroup::Token T(TS);
+    EXPECT_TRUE(T);
+    TG->close();
+    EXPECT_FALSE(Completed);
+  }
+  EXPECT_TRUE(Completed);
+}
+
+TEST(TaskGroupTest, TokenFromClosedGroupViaTokenSource) {
+  auto TG = TaskGroup::Create();
+  TaskGroup::TokenSource TS(TG);
+  TG->close();
+  TaskGroup::Token T(TS);
+  EXPECT_FALSE(T);
+}
+
+// The point of the strong handle: it keeps the group alive so a later
+// acquisition attempt is well-defined even after the original ref is gone.
+TEST(TaskGroupTest, TokenSourceKeepsTaskGroupAlive) {
+  bool Completed = false;
+  auto TG = TaskGroup::Create();
+  TG->addOnComplete([&]() { Completed = true; });
+
+  TaskGroup::TokenSource TS(TG);
+  TG->close();
+  TG.reset(); // Only TS holds the group now.
+
+  TaskGroup::Token T(TS); // Group still exists; acquire fails only b/c closed.
+  EXPECT_FALSE(T);
+  EXPECT_TRUE(Completed); // Nothing kept a token, so it completed.
+}
+
+// A TokenSource is not a Token: holding one must not defer completion.
+TEST(TaskGroupTest, TokenSourceDoesNotHoldToken) {
+  bool Completed = false;
+  auto TG = TaskGroup::Create();
+  TG->addOnComplete([&]() { Completed = true; });
+
+  TaskGroup::TokenSource TS(TG); // Alive across the close below.
+  TG->close();
+  EXPECT_TRUE(Completed); // Completes immediately; TS holds no token.
+}
+
 TEST(TaskGroupTest, ConcurrentTokens) {
   for (int Iter = 0; Iter < 100; ++Iter) {
     std::atomic<int> Count{0};


### PR DESCRIPTION
Session::managedCodeTaskGroup() returned the raw
std::shared_ptr<TaskGroup> for the managed-code group, exposing the group's full interface -- including close() and addOnComplete() -- to callers, even though those operations are reserved for the Session.

Add TaskGroup::TokenSource, a strong handle whose sole role is to serve as an argument to the TaskGroup::Token constructor. Session now exposes managedCodeTokenSource() in its place, so clients can acquire tokens (to keep managed code alive across shutdown) without gaining the ability to close the group or register completion callbacks.