### PR TITLE
[Clang][RISCV] Add P extension reinterpret cast intrinsics

### DIFF
--- a/clang/lib/Headers/riscv_packed_simd.h
+++ b/clang/lib/Headers/riscv_packed_simd.h
@@ -188,6 +188,12 @@ typedef uint32_t uint32x2_t __attribute__((__vector_size__(8)));
     return builtin(__rd, __rs1, __rs2);                                        \
   }
 
+#define __packed_reinterpret(name, rty, ty)                                    \
+  static __inline__ rty __DEFAULT_FN_ATTRS __riscv_preinterpret_##name(        \
+      ty __x) {                                                                \
+    return __builtin_bit_cast(rty, __x);                                       \
+  }
+
 // clang-format off: macro call sites have no trailing semicolons, which
 // confuses clang-format into a deeply nested expression.
 
@@ -599,6 +605,96 @@ __packed_psabs(psabs_i16x2, int16x2_t, __builtin_riscv_psabs_i16x2)
 __packed_psabs(psabs_i8x8, int8x8_t, __builtin_riscv_psabs_i8x8)
 __packed_psabs(psabs_i16x4, int16x4_t, __builtin_riscv_psabs_i16x4)
 
+/* Reinterpret Casts, Packed <-> Scalar (32-bit) */
+__packed_reinterpret(u8x4_u32, uint32_t, uint8x4_t)
+__packed_reinterpret(u16x2_u32, uint32_t, uint16x2_t)
+__packed_reinterpret(i8x4_u32, uint32_t, int8x4_t)
+__packed_reinterpret(i16x2_u32, uint32_t, int16x2_t)
+__packed_reinterpret(u8x4_i32, int32_t, uint8x4_t)
+__packed_reinterpret(u16x2_i32, int32_t, uint16x2_t)
+__packed_reinterpret(i8x4_i32, int32_t, int8x4_t)
+__packed_reinterpret(i16x2_i32, int32_t, int16x2_t)
+__packed_reinterpret(u32_u8x4, uint8x4_t, uint32_t)
+__packed_reinterpret(u32_u16x2, uint16x2_t, uint32_t)
+__packed_reinterpret(u32_i8x4, int8x4_t, uint32_t)
+__packed_reinterpret(u32_i16x2, int16x2_t, uint32_t)
+__packed_reinterpret(i32_u8x4, uint8x4_t, int32_t)
+__packed_reinterpret(i32_u16x2, uint16x2_t, int32_t)
+__packed_reinterpret(i32_i8x4, int8x4_t, int32_t)
+__packed_reinterpret(i32_i16x2, int16x2_t, int32_t)
+
+/* Reinterpret Casts, Packed <-> Scalar (64-bit) */
+__packed_reinterpret(u8x8_u64, uint64_t, uint8x8_t)
+__packed_reinterpret(u16x4_u64, uint64_t, uint16x4_t)
+__packed_reinterpret(u32x2_u64, uint64_t, uint32x2_t)
+__packed_reinterpret(i8x8_u64, uint64_t, int8x8_t)
+__packed_reinterpret(i16x4_u64, uint64_t, int16x4_t)
+__packed_reinterpret(i32x2_u64, uint64_t, int32x2_t)
+__packed_reinterpret(u8x8_i64, int64_t, uint8x8_t)
+__packed_reinterpret(u16x4_i64, int64_t, uint16x4_t)
+__packed_reinterpret(u32x2_i64, int64_t, uint32x2_t)
+__packed_reinterpret(i8x8_i64, int64_t, int8x8_t)
+__packed_reinterpret(i16x4_i64, int64_t, int16x4_t)
+__packed_reinterpret(i32x2_i64, int64_t, int32x2_t)
+__packed_reinterpret(u64_u8x8, uint8x8_t, uint64_t)
+__packed_reinterpret(u64_u16x4, uint16x4_t, uint64_t)
+__packed_reinterpret(u64_u32x2, uint32x2_t, uint64_t)
+__packed_reinterpret(u64_i8x8, int8x8_t, uint64_t)
+__packed_reinterpret(u64_i16x4, int16x4_t, uint64_t)
+__packed_reinterpret(u64_i32x2, int32x2_t, uint64_t)
+__packed_reinterpret(i64_u8x8, uint8x8_t, int64_t)
+__packed_reinterpret(i64_u16x4, uint16x4_t, int64_t)
+__packed_reinterpret(i64_u32x2, uint32x2_t, int64_t)
+__packed_reinterpret(i64_i8x8, int8x8_t, int64_t)
+__packed_reinterpret(i64_i16x4, int16x4_t, int64_t)
+__packed_reinterpret(i64_i32x2, int32x2_t, int64_t)
+
+/* Reinterpret Casts, Packed <-> Packed (32-bit) */
+__packed_reinterpret(i8x4_u8x4, uint8x4_t, int8x4_t)
+__packed_reinterpret(u16x2_u8x4, uint8x4_t, uint16x2_t)
+__packed_reinterpret(i16x2_u8x4, uint8x4_t, int16x2_t)
+__packed_reinterpret(u8x4_i8x4, int8x4_t, uint8x4_t)
+__packed_reinterpret(u16x2_i8x4, int8x4_t, uint16x2_t)
+__packed_reinterpret(i16x2_i8x4, int8x4_t, int16x2_t)
+__packed_reinterpret(u8x4_u16x2, uint16x2_t, uint8x4_t)
+__packed_reinterpret(i8x4_u16x2, uint16x2_t, int8x4_t)
+__packed_reinterpret(i16x2_u16x2, uint16x2_t, int16x2_t)
+__packed_reinterpret(u8x4_i16x2, int16x2_t, uint8x4_t)
+__packed_reinterpret(i8x4_i16x2, int16x2_t, int8x4_t)
+__packed_reinterpret(u16x2_i16x2, int16x2_t, uint16x2_t)
+
+/* Reinterpret Casts, Packed <-> Packed (64-bit) */
+__packed_reinterpret(i8x8_u8x8, uint8x8_t, int8x8_t)
+__packed_reinterpret(u16x4_u8x8, uint8x8_t, uint16x4_t)
+__packed_reinterpret(i16x4_u8x8, uint8x8_t, int16x4_t)
+__packed_reinterpret(u32x2_u8x8, uint8x8_t, uint32x2_t)
+__packed_reinterpret(i32x2_u8x8, uint8x8_t, int32x2_t)
+__packed_reinterpret(u8x8_i8x8, int8x8_t, uint8x8_t)
+__packed_reinterpret(u16x4_i8x8, int8x8_t, uint16x4_t)
+__packed_reinterpret(i16x4_i8x8, int8x8_t, int16x4_t)
+__packed_reinterpret(u32x2_i8x8, int8x8_t, uint32x2_t)
+__packed_reinterpret(i32x2_i8x8, int8x8_t, int32x2_t)
+__packed_reinterpret(u8x8_u16x4, uint16x4_t, uint8x8_t)
+__packed_reinterpret(i8x8_u16x4, uint16x4_t, int8x8_t)
+__packed_reinterpret(i16x4_u16x4, uint16x4_t, int16x4_t)
+__packed_reinterpret(u32x2_u16x4, uint16x4_t, uint32x2_t)
+__packed_reinterpret(i32x2_u16x4, uint16x4_t, int32x2_t)
+__packed_reinterpret(u8x8_i16x4, int16x4_t, uint8x8_t)
+__packed_reinterpret(i8x8_i16x4, int16x4_t, int8x8_t)
+__packed_reinterpret(u16x4_i16x4, int16x4_t, uint16x4_t)
+__packed_reinterpret(u32x2_i16x4, int16x4_t, uint32x2_t)
+__packed_reinterpret(i32x2_i16x4, int16x4_t, int32x2_t)
+__packed_reinterpret(u8x8_u32x2, uint32x2_t, uint8x8_t)
+__packed_reinterpret(i8x8_u32x2, uint32x2_t, int8x8_t)
+__packed_reinterpret(u16x4_u32x2, uint32x2_t, uint16x4_t)
+__packed_reinterpret(i16x4_u32x2, uint32x2_t, int16x4_t)
+__packed_reinterpret(i32x2_u32x2, uint32x2_t, int32x2_t)
+__packed_reinterpret(u8x8_i32x2, int32x2_t, uint8x8_t)
+__packed_reinterpret(i8x8_i32x2, int32x2_t, int8x8_t)
+__packed_reinterpret(u16x4_i32x2, int32x2_t, uint16x4_t)
+__packed_reinterpret(i16x4_i32x2, int32x2_t, int16x4_t)
+__packed_reinterpret(u32x2_i32x2, int32x2_t, uint32x2_t)
+
 // clang-format on
 
 #undef __packed_splat2
@@ -635,6 +731,7 @@ __packed_psabs(psabs_i16x4, int16x4_t, __builtin_riscv_psabs_i16x4)
 #undef __packed_unzipo4
 #undef __packed_abdsum
 #undef __packed_abdsum_acc
+#undef __packed_reinterpret
 #undef __DEFAULT_FN_ATTRS
 
 #if defined(__cplusplus)

--- a/clang/test/CodeGen/RISCV/rvp-intrinsics.c
+++ b/clang/test/CodeGen/RISCV/rvp-intrinsics.c
@@ -7193,3 +7193,1077 @@ int32x2_t test_pwcvth_i32x2(int16x2_t rs1) {
 uint32x2_t test_pwcvth_u32x2(uint16x2_t rs1) {
   return __riscv_pwcvth_u32x2(rs1);
 }
+
+/* Reinterpret Casts, Packed <-> Scalar (32-bit) */
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u8x4_u32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_u8x4_u32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint32_t test_preinterpret_u8x4_u32(uint8x4_t x) {
+  return __riscv_preinterpret_u8x4_u32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u16x2_u32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_u16x2_u32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint32_t test_preinterpret_u16x2_u32(uint16x2_t x) {
+  return __riscv_preinterpret_u16x2_u32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i8x4_u32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_i8x4_u32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint32_t test_preinterpret_i8x4_u32(int8x4_t x) {
+  return __riscv_preinterpret_i8x4_u32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i16x2_u32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_i16x2_u32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint32_t test_preinterpret_i16x2_u32(int16x2_t x) {
+  return __riscv_preinterpret_i16x2_u32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u8x4_i32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_u8x4_i32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int32_t test_preinterpret_u8x4_i32(uint8x4_t x) {
+  return __riscv_preinterpret_u8x4_i32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u16x2_i32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_u16x2_i32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int32_t test_preinterpret_u16x2_i32(uint16x2_t x) {
+  return __riscv_preinterpret_u16x2_i32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i8x4_i32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_i8x4_i32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int32_t test_preinterpret_i8x4_i32(int8x4_t x) {
+  return __riscv_preinterpret_i8x4_i32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i16x2_i32(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local signext i32 @test_preinterpret_i16x2_i32(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int32_t test_preinterpret_i16x2_i32(int16x2_t x) {
+  return __riscv_preinterpret_i16x2_i32(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u32_u8x4(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u32_u8x4(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+uint8x4_t test_preinterpret_u32_u8x4(uint32_t x) {
+  return __riscv_preinterpret_u32_u8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u32_u16x2(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u32_u16x2(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+uint16x2_t test_preinterpret_u32_u16x2(uint32_t x) {
+  return __riscv_preinterpret_u32_u16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u32_i8x4(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u32_i8x4(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+int8x4_t test_preinterpret_u32_i8x4(uint32_t x) {
+  return __riscv_preinterpret_u32_i8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u32_i16x2(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u32_i16x2(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+int16x2_t test_preinterpret_u32_i16x2(uint32_t x) {
+  return __riscv_preinterpret_u32_i16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i32_u8x4(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i32_u8x4(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+uint8x4_t test_preinterpret_i32_u8x4(int32_t x) {
+  return __riscv_preinterpret_i32_u8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i32_u16x2(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i32_u16x2(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+uint16x2_t test_preinterpret_i32_u16x2(int32_t x) {
+  return __riscv_preinterpret_i32_u16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i32_i8x4(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i32_i8x4(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+int8x4_t test_preinterpret_i32_i8x4(int32_t x) {
+  return __riscv_preinterpret_i32_i8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i32_i16x2(
+// RV32-SAME: i32 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i32_i16x2(
+// RV64-SAME: i32 noundef signext [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X]]
+//
+int16x2_t test_preinterpret_i32_i16x2(int32_t x) {
+  return __riscv_preinterpret_i32_i16x2(x);
+}
+
+/* Reinterpret Casts, Packed <-> Scalar (64-bit) */
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_u64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_u64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint64_t test_preinterpret_u8x8_u64(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_u64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_u64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_u64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint64_t test_preinterpret_u16x4_u64(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_u64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_u64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_u64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint64_t test_preinterpret_u32x2_u64(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_u64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_u64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_u64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint64_t test_preinterpret_i8x8_u64(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_u64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_u64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_u64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint64_t test_preinterpret_i16x4_u64(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_u64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_u64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_u64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint64_t test_preinterpret_i32x2_u64(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_u64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_i64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_i64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int64_t test_preinterpret_u8x8_i64(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_i64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_i64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_i64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int64_t test_preinterpret_u16x4_i64(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_i64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_i64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_i64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int64_t test_preinterpret_u32x2_i64(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_i64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_i64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_i64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int64_t test_preinterpret_i8x8_i64(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_i64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_i64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_i64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int64_t test_preinterpret_i16x4_i64(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_i64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_i64(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_i64(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int64_t test_preinterpret_i32x2_i64(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_i64(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u64_u8x8(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u64_u8x8(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+uint8x8_t test_preinterpret_u64_u8x8(uint64_t x) {
+  return __riscv_preinterpret_u64_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u64_u16x4(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u64_u16x4(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+uint16x4_t test_preinterpret_u64_u16x4(uint64_t x) {
+  return __riscv_preinterpret_u64_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u64_u32x2(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u64_u32x2(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+uint32x2_t test_preinterpret_u64_u32x2(uint64_t x) {
+  return __riscv_preinterpret_u64_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u64_i8x8(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u64_i8x8(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+int8x8_t test_preinterpret_u64_i8x8(uint64_t x) {
+  return __riscv_preinterpret_u64_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u64_i16x4(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u64_i16x4(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+int16x4_t test_preinterpret_u64_i16x4(uint64_t x) {
+  return __riscv_preinterpret_u64_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u64_i32x2(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u64_i32x2(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+int32x2_t test_preinterpret_u64_i32x2(uint64_t x) {
+  return __riscv_preinterpret_u64_i32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i64_u8x8(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i64_u8x8(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+uint8x8_t test_preinterpret_i64_u8x8(int64_t x) {
+  return __riscv_preinterpret_i64_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i64_u16x4(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i64_u16x4(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+uint16x4_t test_preinterpret_i64_u16x4(int64_t x) {
+  return __riscv_preinterpret_i64_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i64_u32x2(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i64_u32x2(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+uint32x2_t test_preinterpret_i64_u32x2(int64_t x) {
+  return __riscv_preinterpret_i64_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i64_i8x8(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i64_i8x8(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+int8x8_t test_preinterpret_i64_i8x8(int64_t x) {
+  return __riscv_preinterpret_i64_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i64_i16x4(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i64_i16x4(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+int16x4_t test_preinterpret_i64_i16x4(int64_t x) {
+  return __riscv_preinterpret_i64_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i64_i32x2(
+// RV32-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i64_i32x2(
+// RV64-SAME: i64 noundef [[X:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X]]
+//
+int32x2_t test_preinterpret_i64_i32x2(int64_t x) {
+  return __riscv_preinterpret_i64_i32x2(x);
+}
+
+/* Reinterpret Casts, Packed <-> Packed (32-bit) */
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i8x4_u8x4(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i8x4_u8x4(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint8x4_t test_preinterpret_i8x4_u8x4(int8x4_t x) {
+  return __riscv_preinterpret_i8x4_u8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u16x2_u8x4(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u16x2_u8x4(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint8x4_t test_preinterpret_u16x2_u8x4(uint16x2_t x) {
+  return __riscv_preinterpret_u16x2_u8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i16x2_u8x4(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i16x2_u8x4(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint8x4_t test_preinterpret_i16x2_u8x4(int16x2_t x) {
+  return __riscv_preinterpret_i16x2_u8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u8x4_i8x4(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u8x4_i8x4(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int8x4_t test_preinterpret_u8x4_i8x4(uint8x4_t x) {
+  return __riscv_preinterpret_u8x4_i8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u16x2_i8x4(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u16x2_i8x4(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int8x4_t test_preinterpret_u16x2_i8x4(uint16x2_t x) {
+  return __riscv_preinterpret_u16x2_i8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i16x2_i8x4(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i16x2_i8x4(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int8x4_t test_preinterpret_i16x2_i8x4(int16x2_t x) {
+  return __riscv_preinterpret_i16x2_i8x4(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u8x4_u16x2(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u8x4_u16x2(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint16x2_t test_preinterpret_u8x4_u16x2(uint8x4_t x) {
+  return __riscv_preinterpret_u8x4_u16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i8x4_u16x2(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i8x4_u16x2(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint16x2_t test_preinterpret_i8x4_u16x2(int8x4_t x) {
+  return __riscv_preinterpret_i8x4_u16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i16x2_u16x2(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i16x2_u16x2(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+uint16x2_t test_preinterpret_i16x2_u16x2(int16x2_t x) {
+  return __riscv_preinterpret_i16x2_u16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u8x4_i16x2(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u8x4_i16x2(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int16x2_t test_preinterpret_u8x4_i16x2(uint8x4_t x) {
+  return __riscv_preinterpret_u8x4_i16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_i8x4_i16x2(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_i8x4_i16x2(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int16x2_t test_preinterpret_i8x4_i16x2(int8x4_t x) {
+  return __riscv_preinterpret_i8x4_i16x2(x);
+}
+// RV32-LABEL: define dso_local i32 @test_preinterpret_u16x2_i16x2(
+// RV32-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i32 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i32 @test_preinterpret_u16x2_i16x2(
+// RV64-SAME: i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i32 [[X_COERCE]]
+//
+int16x2_t test_preinterpret_u16x2_i16x2(uint16x2_t x) {
+  return __riscv_preinterpret_u16x2_i16x2(x);
+}
+
+/* Reinterpret Casts, Packed <-> Packed (64-bit) */
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_u8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_u8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint8x8_t test_preinterpret_i8x8_u8x8(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_u8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_u8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint8x8_t test_preinterpret_u16x4_u8x8(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_u8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_u8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint8x8_t test_preinterpret_i16x4_u8x8(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_u8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_u8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint8x8_t test_preinterpret_u32x2_u8x8(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_u8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_u8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint8x8_t test_preinterpret_i32x2_u8x8(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_u8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_i8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_i8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int8x8_t test_preinterpret_u8x8_i8x8(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_i8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_i8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int8x8_t test_preinterpret_u16x4_i8x8(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_i8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_i8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int8x8_t test_preinterpret_i16x4_i8x8(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_i8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_i8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int8x8_t test_preinterpret_u32x2_i8x8(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_i8x8(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_i8x8(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int8x8_t test_preinterpret_i32x2_i8x8(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_i8x8(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_u16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_u16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint16x4_t test_preinterpret_u8x8_u16x4(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_u16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_u16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint16x4_t test_preinterpret_i8x8_u16x4(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_u16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_u16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint16x4_t test_preinterpret_i16x4_u16x4(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_u16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_u16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint16x4_t test_preinterpret_u32x2_u16x4(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_u16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_u16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint16x4_t test_preinterpret_i32x2_u16x4(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_u16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_i16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_i16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int16x4_t test_preinterpret_u8x8_i16x4(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_i16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_i16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int16x4_t test_preinterpret_i8x8_i16x4(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_i16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_i16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int16x4_t test_preinterpret_u16x4_i16x4(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_i16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_i16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int16x4_t test_preinterpret_u32x2_i16x4(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_i16x4(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_i16x4(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int16x4_t test_preinterpret_i32x2_i16x4(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_i16x4(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_u32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_u32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint32x2_t test_preinterpret_u8x8_u32x2(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_u32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_u32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint32x2_t test_preinterpret_i8x8_u32x2(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_u32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_u32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint32x2_t test_preinterpret_u16x4_u32x2(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_u32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_u32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint32x2_t test_preinterpret_i16x4_u32x2(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i32x2_u32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i32x2_u32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+uint32x2_t test_preinterpret_i32x2_u32x2(int32x2_t x) {
+  return __riscv_preinterpret_i32x2_u32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u8x8_i32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u8x8_i32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int32x2_t test_preinterpret_u8x8_i32x2(uint8x8_t x) {
+  return __riscv_preinterpret_u8x8_i32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i8x8_i32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i8x8_i32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int32x2_t test_preinterpret_i8x8_i32x2(int8x8_t x) {
+  return __riscv_preinterpret_i8x8_i32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u16x4_i32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u16x4_i32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int32x2_t test_preinterpret_u16x4_i32x2(uint16x4_t x) {
+  return __riscv_preinterpret_u16x4_i32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_i16x4_i32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_i16x4_i32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int32x2_t test_preinterpret_i16x4_i32x2(int16x4_t x) {
+  return __riscv_preinterpret_i16x4_i32x2(x);
+}
+// RV32-LABEL: define dso_local i64 @test_preinterpret_u32x2_i32x2(
+// RV32-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    ret i64 [[X_COERCE]]
+//
+// RV64-LABEL: define dso_local i64 @test_preinterpret_u32x2_i32x2(
+// RV64-SAME: i64 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    ret i64 [[X_COERCE]]
+//
+int32x2_t test_preinterpret_u32x2_i32x2(uint32x2_t x) {
+  return __riscv_preinterpret_u32x2_i32x2(x);
+}


### PR DESCRIPTION
Implement the "Reinterpret casts" section of the RISC-V P extension
intrinsic spec in `riscv_packed_simd.h`.

The 82 `__riscv_preinterpret_<from>_<to>` intrinsics provide
bit-pattern-preserving conversions between packed types and equal-width
scalars, and between equal-width packed types. They generate no
instructions; each is a `__builtin_bit_cast`. Tests cover every
intrinsic on both RV32 and RV64.
