### PR TITLE
[clang][TCE] Fix ordering of OpenCL address space mappings

### DIFF
--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -35,10 +35,10 @@ static const unsigned TCEOpenCLAddrSpaceMap[] = {
     3, // opencl_local
     2, // opencl_constant
     0, // opencl_private
-    1, // opencl_global_device
-    1, // opencl_global_host
     // FIXME: generic has to be added to the target
     0, // opencl_generic
+    1, // opencl_global_device
+    1, // opencl_global_host
     0, // cuda_device
     0, // cuda_constant
     0, // cuda_shared


### PR DESCRIPTION
opencl_global_device and opencl_global_host are defined after opencl_generic in LangAS, but commit
8d27be8dbaffce0519ac41173d51923fc2524b1b inserted them before opencl_generic in the TCE address space map.

Fix the order to restore the intended mappings.