### PR TITLE
[clang] Use 0 for wasm_funcref in non-Wasm address space maps (NFCI)

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -51,9 +51,7 @@ static const unsigned ARM64AddrSpaceMap[] = {
     0, // hlsl_input
     0, // hlsl_output
     0, // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0, // wasm_funcref
 };
 
 using AArch64FeatureSet = llvm::SmallDenseSet<StringRef, 32>;

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -48,9 +48,7 @@ static const unsigned DirectXAddrSpaceMap[] = {
     0, // hlsl_input
     0, // hlsl_output
     0, // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0, // wasm_funcref
 };
 
 class LLVM_LIBRARY_VISIBILITY DirectXTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -52,9 +52,7 @@ static const unsigned NVPTXAddrSpaceMap[] = {
     0, // hlsl_input
     0, // hlsl_output
     0, // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0, // wasm_funcref
 };
 
 /// The DWARF address class. Taken from

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -56,9 +56,7 @@ static const unsigned SPIRDefIsPrivMap[] = {
     7,  // hlsl_input
     8,  // hlsl_output
     13, // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0,  // wasm_funcref
 };
 
 // Used by both the SPIR and SPIR-V targets.
@@ -94,9 +92,7 @@ static const unsigned SPIRDefIsGenMap[] = {
     7,  // hlsl_input
     8,  // hlsl_output
     13, // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0,  // wasm_funcref
 };
 
 // Base class for SPIR and SPIR-V target info.

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -57,9 +57,7 @@ static const unsigned TCEOpenCLAddrSpaceMap[] = {
     0, // hlsl_input
     0, // hlsl_output
     0, // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0, // wasm_funcref
 };
 
 class LLVM_LIBRARY_VISIBILITY TCETargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -52,9 +52,7 @@ static const unsigned X86AddrSpaceMap[] = {
     0,   // hlsl_input
     0,   // hlsl_output
     0,   // hlsl_push_constant
-    // Wasm address space values for this target are dummy values,
-    // as it is only enabled for Wasm targets.
-    20, // wasm_funcref
+    0,   // wasm_funcref
 };
 
 // X86 target abstract base class; x86-32 and x86-64 are very close, so


### PR DESCRIPTION
The __funcref keyword is only supported by the WebAssembly target, so the wasm_funcref entries in other targets' address space maps are unused.

Use 0 for these entries, which is consistent with other unsupported address spaces.