### PR TITLE
[Clang][Sema] Don't delay the access check when computing implicit deletion

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -334,6 +334,10 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   `[](Types... = args...) {}`). Clang now diagnoses the illegal default
   argument instead of asserting. (#GH210714)
 
+- Fixed a crash when computing the implicit deletion of a defaulted comparison
+  operator required an access check that ran while an enclosing declaration
+  was still being parsed. (#GH210692)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaAccess.cpp
+++ b/clang/lib/Sema/SemaAccess.cpp
@@ -21,6 +21,7 @@
 #include "clang/Sema/DelayedDiagnostic.h"
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/Lookup.h"
+#include "llvm/ADT/ScopeExit.h"
 
 using namespace clang;
 using namespace sema;
@@ -1611,6 +1612,16 @@ bool Sema::isMemberAccessibleForDeletion(CXXRecordDecl *NamingClass,
 
   // Suppress diagnostics.
   Entity.setDiag(Diag);
+
+  // Deletion checking can run while we are inside an enclosing
+  // delayed-diagnostics scope (e.g. when parsing a later declaration whose
+  // initializer requires explaining why a defaulted comparison operator is
+  // deleted). CheckAccess would then return AR_delayed, but the result must be
+  // known immediately here. Force an undelayed check, mirroring CheckEnableIf.
+  llvm::scope_exit UndelayDiags(
+      [&, CurrentState(DelayedDiagnostics.pushUndelayed())] {
+        DelayedDiagnostics.popUndelayed(CurrentState);
+      });
 
   switch (CheckAccess(*this, Loc, Entity)) {
   case AR_accessible: return true;

--- a/clang/lib/Sema/SemaAccess.cpp
+++ b/clang/lib/Sema/SemaAccess.cpp
@@ -1613,11 +1613,10 @@ bool Sema::isMemberAccessibleForDeletion(CXXRecordDecl *NamingClass,
   // Suppress diagnostics.
   Entity.setDiag(Diag);
 
-  // Deletion checking can run while we are inside an enclosing
+  // We don't want to delay access checking even we are inside an enclosing
   // delayed-diagnostics scope (e.g. when parsing a later declaration whose
   // initializer requires explaining why a defaulted comparison operator is
-  // deleted). CheckAccess would then return AR_delayed, but the result must be
-  // known immediately here. Force an undelayed check, mirroring CheckEnableIf.
+  // deleted)
   llvm::scope_exit UndelayDiags(
       [&, CurrentState(DelayedDiagnostics.pushUndelayed())] {
         DelayedDiagnostics.popUndelayed(CurrentState);

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -66,14 +66,14 @@ struct MutCheck : MutOnly {
 };
 }
 
-namespace immediate_deletion_check  {
+namespace immediate_deletion_check {
 struct HasPrivateSpaceship {
 private:
   std::strong_ordering operator<=>(const HasPrivateSpaceship &) const; // expected-note 2 {{declared private here}}
 };
 
 struct S {
-  HasPrivateSpaceship member; // expected-note 2 {{because it would invoke a private 'operator<=>' member of 'immediate_deletion_check ::HasPrivateSpaceship' to compare member 'member'}}
+  HasPrivateSpaceship member; // expected-note 2 {{because it would invoke a private 'operator<=>' member of 'immediate_deletion_check::HasPrivateSpaceship' to compare member 'member'}}
   auto operator<=>(const S &) const = default; // expected-warning {{explicitly defaulted three-way comparison operator is implicitly deleted}} expected-note {{replace 'default' with 'delete'}} expected-note {{explicitly defaulted function was implicitly deleted here}}
 };
 

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -67,10 +67,6 @@ struct MutCheck : MutOnly {
 }
 
 namespace immediate_deletion_check  {
-// Explaining why a defaulted comparison operator is deleted can run while we
-// are parsing a later declaration, i.e. inside an enclosing delayed-diagnostics
-// scope. The access check for the deleted-ness computation must produce an
-// immediate answer rather than being delayed. Previously this crashed.
 struct HasPrivateSpaceship {
 private:
   std::strong_ordering operator<=>(const HasPrivateSpaceship &) const; // expected-note 2 {{declared private here}}

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -66,7 +66,7 @@ struct MutCheck : MutOnly {
 };
 }
 
-namespace delayed_deletion_check {
+namespace immediate_deletion_check  {
 // Explaining why a defaulted comparison operator is deleted can run while we
 // are parsing a later declaration, i.e. inside an enclosing delayed-diagnostics
 // scope. The access check for the deleted-ness computation must produce an
@@ -77,7 +77,7 @@ private:
 };
 
 struct S {
-  HasPrivateSpaceship member; // expected-note 2 {{because it would invoke a private 'operator<=>' member of 'delayed_deletion_check::HasPrivateSpaceship' to compare member 'member'}}
+  HasPrivateSpaceship member; // expected-note 2 {{because it would invoke a private 'operator<=>' member of 'immediate_deletion_check ::HasPrivateSpaceship' to compare member 'member'}}
   auto operator<=>(const S &) const = default; // expected-warning {{explicitly defaulted three-way comparison operator is implicitly deleted}} expected-note {{replace 'default' with 'delete'}} expected-note {{explicitly defaulted function was implicitly deleted here}}
 };
 

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -65,3 +65,21 @@ struct MutCheck : MutOnly {
   // bool operator==(this MutCheck, MutCheck) = default;
 };
 }
+
+namespace delayed_deletion_check {
+// Explaining why a defaulted comparison operator is deleted can run while we
+// are parsing a later declaration, i.e. inside an enclosing delayed-diagnostics
+// scope. The access check for the deleted-ness computation must produce an
+// immediate answer rather than being delayed. Previously this crashed.
+struct HasPrivateSpaceship {
+private:
+  std::strong_ordering operator<=>(const HasPrivateSpaceship &) const; // expected-note 2 {{declared private here}}
+};
+
+struct S {
+  HasPrivateSpaceship member; // expected-note 2 {{because it would invoke a private 'operator<=>' member of 'delayed_deletion_check::HasPrivateSpaceship' to compare member 'member'}}
+  auto operator<=>(const S &) const = default; // expected-warning {{explicitly defaulted three-way comparison operator is implicitly deleted}} expected-note {{replace 'default' with 'delete'}} expected-note {{explicitly defaulted function was implicitly deleted here}}
+};
+
+bool b = (S{} < S{}); // expected-error {{object of type 'S' cannot be compared because its 'operator<=>' is implicitly deleted}}
+}


### PR DESCRIPTION
Sema::isMemberAccessibleForDeletion treats AR_delayed as unreachable, but CheckAccess returns AR_delayed whenever it runs inside an enclosing delayed-diagnostics scope. That happens when deletion checking runs synchronously while parsing a later declaration -- e.g. while explaining why a defaulted operator<=> is deleted for an expression in that declaration's initializer. The caller cannot consume a delayed diagnostic, so letting CheckAccess delay always hits
llvm_unreachable("cannot delay =delete computation") and crashes.

Force an immediate answer by wrapping the CheckAccess call in DelayedDiagnostics.pushUndelayed()/popUndelayed() via llvm::scope_exit, mirroring the existing Sema::CheckEnableIf pattern in SemaOverload.cpp.

Fixes https://github.com/llvm/llvm-project/issues/210692

Co-authored - Claude-Sonnet