### PR TITLE
[clang] Use key-value initialization for LangASMap (NFCI)

### DIFF
--- a/clang/include/clang/Basic/AddressSpaces.h
+++ b/clang/include/clang/Basic/AddressSpaces.h
@@ -15,7 +15,10 @@
 #ifndef LLVM_CLANG_BASIC_ADDRESSSPACES_H
 #define LLVM_CLANG_BASIC_ADDRESSSPACES_H
 
+#include <array>
 #include <cassert>
+#include <initializer_list>
+#include <utility>
 
 namespace clang {
 
@@ -76,7 +79,20 @@ enum class LangAS : unsigned {
 
 /// The type of a lookup table which maps from language-specific address spaces
 /// to target-specific ones.
-using LangASMap = unsigned[(unsigned)LangAS::FirstTargetAddressSpace];
+class LangASMap {
+  std::array<unsigned, (unsigned)LangAS::FirstTargetAddressSpace> Map{};
+
+public:
+  constexpr LangASMap() = default;
+
+  constexpr LangASMap(
+      std::initializer_list<std::pair<LangAS, unsigned>> Mappings) {
+    for (auto [LanguageAS, TargetAS] : Mappings)
+      Map[(unsigned)LanguageAS] = TargetAS;
+  }
+
+  constexpr unsigned operator[](LangAS AS) const { return Map[(unsigned)AS]; }
+};
 
 /// \return whether \p AS is a target-specific address space rather than a
 /// clang AST address space

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1701,7 +1701,7 @@ public:
   unsigned getTargetAddressSpace(LangAS AS) const {
     if (isTargetAddressSpace(AS))
       return toTargetAddressSpace(AS);
-    return getAddressSpaceMap()[(unsigned)AS];
+    return getAddressSpaceMap()[AS];
   }
 
   /// Determine whether the given pointer-authentication key is valid.

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -24,37 +24,37 @@
 #include <cstdlib>
 using namespace clang;
 
-static const LangASMap DefaultAddrSpaceMap = {0};
+static const LangASMap DefaultAddrSpaceMap;
 // The fake address space map must have a distinct entry for each
 // language-specific address space.
 static const LangASMap FakeAddrSpaceMap = {
-    0,  // Default
-    1,  // opencl_global
-    3,  // opencl_local
-    2,  // opencl_constant
-    0,  // opencl_private
-    4,  // opencl_generic
-    5,  // opencl_global_device
-    6,  // opencl_global_host
-    7,  // cuda_device
-    8,  // cuda_constant
-    9,  // cuda_shared
-    1,  // sycl_global
-    5,  // sycl_global_device
-    6,  // sycl_global_host
-    3,  // sycl_local
-    0,  // sycl_private
-    10, // ptr32_sptr
-    11, // ptr32_uptr
-    12, // ptr64
-    13, // hlsl_groupshared
-    14, // hlsl_constant
-    15, // hlsl_private
-    16, // hlsl_device
-    17, // hlsl_input
-    18, // hlsl_output
-    19, // hlsl_push_constant
-    20, // wasm_funcref
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 1},
+    {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 4},
+    {LangAS::opencl_global_device, 5},
+    {LangAS::opencl_global_host, 6},
+    {LangAS::cuda_device, 7},
+    {LangAS::cuda_constant, 8},
+    {LangAS::cuda_shared, 9},
+    {LangAS::sycl_global, 1},
+    {LangAS::sycl_global_device, 5},
+    {LangAS::sycl_global_host, 6},
+    {LangAS::sycl_local, 3},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 10},
+    {LangAS::ptr32_uptr, 11},
+    {LangAS::ptr64, 12},
+    {LangAS::hlsl_groupshared, 13},
+    {LangAS::hlsl_constant, 14},
+    {LangAS::hlsl_private, 15},
+    {LangAS::hlsl_device, 16},
+    {LangAS::hlsl_input, 17},
+    {LangAS::hlsl_output, 18},
+    {LangAS::hlsl_push_constant, 19},
+    {LangAS::wasm_funcref, 20},
 };
 
 // TargetInfo Constructor.

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -24,10 +24,10 @@
 #include <cstdlib>
 using namespace clang;
 
-static const LangASMap DefaultAddrSpaceMap;
+static constexpr LangASMap DefaultAddrSpaceMap;
 // The fake address space map must have a distinct entry for each
 // language-specific address space.
-static const LangASMap FakeAddrSpaceMap = {
+static constexpr LangASMap FakeAddrSpaceMap = {
     {LangAS::Default, 0},
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -24,7 +24,7 @@ namespace targets {
 
 enum AArch64AddrSpace { ptr32_sptr = 270, ptr32_uptr = 271, ptr64 = 272 };
 
-static const LangASMap ARM64AddrSpaceMap = {
+static constexpr LangASMap ARM64AddrSpaceMap = {
     {LangAS::ptr32_sptr, static_cast<unsigned>(AArch64AddrSpace::ptr32_sptr)},
     {LangAS::ptr32_uptr, static_cast<unsigned>(AArch64AddrSpace::ptr32_uptr)},
     {LangAS::ptr64, static_cast<unsigned>(AArch64AddrSpace::ptr64)},

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -25,33 +25,9 @@ namespace targets {
 enum AArch64AddrSpace { ptr32_sptr = 270, ptr32_uptr = 271, ptr64 = 272 };
 
 static const LangASMap ARM64AddrSpaceMap = {
-    {LangAS::Default, 0},
-    {LangAS::opencl_global, 0},
-    {LangAS::opencl_local, 0},
-    {LangAS::opencl_constant, 0},
-    {LangAS::opencl_private, 0},
-    {LangAS::opencl_generic, 0},
-    {LangAS::opencl_global_device, 0},
-    {LangAS::opencl_global_host, 0},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
     {LangAS::ptr32_sptr, static_cast<unsigned>(AArch64AddrSpace::ptr32_sptr)},
     {LangAS::ptr32_uptr, static_cast<unsigned>(AArch64AddrSpace::ptr32_uptr)},
     {LangAS::ptr64, static_cast<unsigned>(AArch64AddrSpace::ptr64)},
-    {LangAS::hlsl_groupshared, 0},
-    {LangAS::hlsl_constant, 0},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
-    {LangAS::wasm_funcref, 0},
 };
 
 using AArch64FeatureSet = llvm::SmallDenseSet<StringRef, 32>;

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -24,34 +24,34 @@ namespace targets {
 
 enum AArch64AddrSpace { ptr32_sptr = 270, ptr32_uptr = 271, ptr64 = 272 };
 
-static const unsigned ARM64AddrSpaceMap[] = {
-    0, // Default
-    0, // opencl_global
-    0, // opencl_local
-    0, // opencl_constant
-    0, // opencl_private
-    0, // opencl_generic
-    0, // opencl_global_device
-    0, // opencl_global_host
-    0, // cuda_device
-    0, // cuda_constant
-    0, // cuda_shared
-    0, // sycl_global
-    0, // sycl_global_device
-    0, // sycl_global_host
-    0, // sycl_local
-    0, // sycl_private
-    static_cast<unsigned>(AArch64AddrSpace::ptr32_sptr),
-    static_cast<unsigned>(AArch64AddrSpace::ptr32_uptr),
-    static_cast<unsigned>(AArch64AddrSpace::ptr64),
-    0, // hlsl_groupshared
-    0, // hlsl_constant
-    0, // hlsl_private
-    0, // hlsl_device
-    0, // hlsl_input
-    0, // hlsl_output
-    0, // hlsl_push_constant
-    0, // wasm_funcref
+static const LangASMap ARM64AddrSpaceMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 0},
+    {LangAS::opencl_local, 0},
+    {LangAS::opencl_constant, 0},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 0},
+    {LangAS::opencl_global_device, 0},
+    {LangAS::opencl_global_host, 0},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, static_cast<unsigned>(AArch64AddrSpace::ptr32_sptr)},
+    {LangAS::ptr32_uptr, static_cast<unsigned>(AArch64AddrSpace::ptr32_uptr)},
+    {LangAS::ptr64, static_cast<unsigned>(AArch64AddrSpace::ptr64)},
+    {LangAS::hlsl_groupshared, 0},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 0},
 };
 
 using AArch64FeatureSet = llvm::SmallDenseSet<StringRef, 32>;

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -28,34 +28,34 @@ namespace targets {
 // getPointerWidthV().
 
 const LangASMap AMDGPUTargetInfo::AMDGPUAddrSpaceMap = {
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // Default
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global
-    llvm::AMDGPUAS::LOCAL_ADDRESS,    // opencl_local
-    llvm::AMDGPUAS::CONSTANT_ADDRESS, // opencl_constant
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // opencl_private
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // opencl_generic
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global_device
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global_host
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // cuda_device
-    llvm::AMDGPUAS::CONSTANT_ADDRESS, // cuda_constant
-    llvm::AMDGPUAS::LOCAL_ADDRESS,    // cuda_shared
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // sycl_global
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // sycl_global_device
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // sycl_global_host
-    llvm::AMDGPUAS::LOCAL_ADDRESS,    // sycl_local
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // sycl_private
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // ptr32_sptr
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // ptr32_uptr
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // ptr64
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // hlsl_groupshared
-    llvm::AMDGPUAS::CONSTANT_ADDRESS, // hlsl_constant
+    {LangAS::Default, llvm::AMDGPUAS::FLAT_ADDRESS},
+    {LangAS::opencl_global, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::opencl_local, llvm::AMDGPUAS::LOCAL_ADDRESS},
+    {LangAS::opencl_constant, llvm::AMDGPUAS::CONSTANT_ADDRESS},
+    {LangAS::opencl_private, llvm::AMDGPUAS::PRIVATE_ADDRESS},
+    {LangAS::opencl_generic, llvm::AMDGPUAS::FLAT_ADDRESS},
+    {LangAS::opencl_global_device, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::opencl_global_host, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::cuda_device, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::cuda_constant, llvm::AMDGPUAS::CONSTANT_ADDRESS},
+    {LangAS::cuda_shared, llvm::AMDGPUAS::LOCAL_ADDRESS},
+    {LangAS::sycl_global, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::sycl_global_device, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::sycl_global_host, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::sycl_local, llvm::AMDGPUAS::LOCAL_ADDRESS},
+    {LangAS::sycl_private, llvm::AMDGPUAS::PRIVATE_ADDRESS},
+    {LangAS::ptr32_sptr, llvm::AMDGPUAS::FLAT_ADDRESS},
+    {LangAS::ptr32_uptr, llvm::AMDGPUAS::FLAT_ADDRESS},
+    {LangAS::ptr64, llvm::AMDGPUAS::FLAT_ADDRESS},
+    {LangAS::hlsl_groupshared, llvm::AMDGPUAS::FLAT_ADDRESS},
+    {LangAS::hlsl_constant, llvm::AMDGPUAS::CONSTANT_ADDRESS},
     // FIXME(pr/122103): hlsl_private -> PRIVATE is wrong, but at least this
     // will break loudly.
-    llvm::AMDGPUAS::PRIVATE_ADDRESS, // hlsl_private
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,  // hlsl_device
-    llvm::AMDGPUAS::PRIVATE_ADDRESS, // hlsl_input
-    llvm::AMDGPUAS::PRIVATE_ADDRESS, // hlsl_output
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,  // hlsl_push_constant
+    {LangAS::hlsl_private, llvm::AMDGPUAS::PRIVATE_ADDRESS},
+    {LangAS::hlsl_device, llvm::AMDGPUAS::GLOBAL_ADDRESS},
+    {LangAS::hlsl_input, llvm::AMDGPUAS::PRIVATE_ADDRESS},
+    {LangAS::hlsl_output, llvm::AMDGPUAS::PRIVATE_ADDRESS},
+    {LangAS::hlsl_push_constant, llvm::AMDGPUAS::GLOBAL_ADDRESS},
 };
 
 } // namespace targets

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -21,14 +21,10 @@ namespace clang {
 namespace targets {
 
 static const LangASMap DirectXAddrSpaceMap = {
-    {LangAS::opencl_global, 1},
-    {LangAS::opencl_local, 3},
-    {LangAS::opencl_constant, 2},
-    {LangAS::opencl_generic, 4},
-    {LangAS::opencl_global_device, 5},
-    {LangAS::opencl_global_host, 6},
-    {LangAS::hlsl_groupshared, 3},
-    {LangAS::hlsl_constant, 2},
+    {LangAS::opencl_global, 1},        {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},      {LangAS::opencl_generic, 4},
+    {LangAS::opencl_global_device, 5}, {LangAS::opencl_global_host, 6},
+    {LangAS::hlsl_groupshared, 3},     {LangAS::hlsl_constant, 2},
 };
 
 class LLVM_LIBRARY_VISIBILITY DirectXTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -20,35 +20,35 @@
 namespace clang {
 namespace targets {
 
-static const unsigned DirectXAddrSpaceMap[] = {
-    0, // Default
-    1, // opencl_global
-    3, // opencl_local
-    2, // opencl_constant
-    0, // opencl_private
-    4, // opencl_generic
-    5, // opencl_global_device
-    6, // opencl_global_host
-    0, // cuda_device
-    0, // cuda_constant
-    0, // cuda_shared
+static const LangASMap DirectXAddrSpaceMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 1},
+    {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 4},
+    {LangAS::opencl_global_device, 5},
+    {LangAS::opencl_global_host, 6},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
     // SYCL address space values for this map are dummy
-    0, // sycl_global
-    0, // sycl_global_device
-    0, // sycl_global_host
-    0, // sycl_local
-    0, // sycl_private
-    0, // ptr32_sptr
-    0, // ptr32_uptr
-    0, // ptr64
-    3, // hlsl_groupshared
-    2, // hlsl_constant
-    0, // hlsl_private
-    0, // hlsl_device
-    0, // hlsl_input
-    0, // hlsl_output
-    0, // hlsl_push_constant
-    0, // wasm_funcref
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 0},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 3},
+    {LangAS::hlsl_constant, 2},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 0},
 };
 
 class LLVM_LIBRARY_VISIBILITY DirectXTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -20,7 +20,7 @@
 namespace clang {
 namespace targets {
 
-static const LangASMap DirectXAddrSpaceMap = {
+static constexpr LangASMap DirectXAddrSpaceMap = {
     {LangAS::opencl_global, 1},        {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},      {LangAS::opencl_generic, 4},
     {LangAS::opencl_global_device, 5}, {LangAS::opencl_global_host, 6},

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -21,34 +21,14 @@ namespace clang {
 namespace targets {
 
 static const LangASMap DirectXAddrSpaceMap = {
-    {LangAS::Default, 0},
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},
-    {LangAS::opencl_private, 0},
     {LangAS::opencl_generic, 4},
     {LangAS::opencl_global_device, 5},
     {LangAS::opencl_global_host, 6},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    // SYCL address space values for this map are dummy
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
-    {LangAS::ptr32_uptr, 0},
-    {LangAS::ptr64, 0},
     {LangAS::hlsl_groupshared, 3},
     {LangAS::hlsl_constant, 2},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
-    {LangAS::wasm_funcref, 0},
 };
 
 class LLVM_LIBRARY_VISIBILITY DirectXTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -25,11 +25,9 @@ namespace clang {
 namespace targets {
 
 static const LangASMap NVPTXAddrSpaceMap = {
-    {LangAS::Default, 0},
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 4},
-    {LangAS::opencl_private, 0},
     // FIXME: generic has to be added to the target
     {LangAS::opencl_generic, 0},
     {LangAS::opencl_global_device, 1},
@@ -41,18 +39,6 @@ static const LangASMap NVPTXAddrSpaceMap = {
     {LangAS::sycl_global_device, 1},
     {LangAS::sycl_global_host, 1},
     {LangAS::sycl_local, 3},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
-    {LangAS::ptr32_uptr, 0},
-    {LangAS::ptr64, 0},
-    {LangAS::hlsl_groupshared, 0},
-    {LangAS::hlsl_constant, 0},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
-    {LangAS::wasm_funcref, 0},
 };
 
 /// The DWARF address class. Taken from

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -24,7 +24,7 @@
 namespace clang {
 namespace targets {
 
-static const LangASMap NVPTXAddrSpaceMap = {
+static constexpr LangASMap NVPTXAddrSpaceMap = {
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 4},

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -24,35 +24,35 @@
 namespace clang {
 namespace targets {
 
-static const unsigned NVPTXAddrSpaceMap[] = {
-    0, // Default
-    1, // opencl_global
-    3, // opencl_local
-    4, // opencl_constant
-    0, // opencl_private
+static const LangASMap NVPTXAddrSpaceMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 1},
+    {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 4},
+    {LangAS::opencl_private, 0},
     // FIXME: generic has to be added to the target
-    0, // opencl_generic
-    1, // opencl_global_device
-    1, // opencl_global_host
-    1, // cuda_device
-    4, // cuda_constant
-    3, // cuda_shared
-    1, // sycl_global
-    1, // sycl_global_device
-    1, // sycl_global_host
-    3, // sycl_local
-    0, // sycl_private
-    0, // ptr32_sptr
-    0, // ptr32_uptr
-    0, // ptr64
-    0, // hlsl_groupshared
-    0, // hlsl_constant
-    0, // hlsl_private
-    0, // hlsl_device
-    0, // hlsl_input
-    0, // hlsl_output
-    0, // hlsl_push_constant
-    0, // wasm_funcref
+    {LangAS::opencl_generic, 0},
+    {LangAS::opencl_global_device, 1},
+    {LangAS::opencl_global_host, 1},
+    {LangAS::cuda_device, 1},
+    {LangAS::cuda_constant, 4},
+    {LangAS::cuda_shared, 3},
+    {LangAS::sycl_global, 1},
+    {LangAS::sycl_global_device, 1},
+    {LangAS::sycl_global_host, 1},
+    {LangAS::sycl_local, 3},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 0},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 0},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 0},
 };
 
 /// The DWARF address class. Taken from

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -29,26 +29,12 @@ namespace targets {
 
 // Used by both the SPIR and SPIR-V targets.
 static const LangASMap SPIRDefIsPrivMap = {
-    {LangAS::Default, 0},
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},
-    {LangAS::opencl_private, 0},
     {LangAS::opencl_generic, 4},
     {LangAS::opencl_global_device, 5},
     {LangAS::opencl_global_host, 6},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    // SYCL address space values for this map are dummy
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
-    {LangAS::ptr32_uptr, 0},
-    {LangAS::ptr64, 0},
     {LangAS::hlsl_groupshared, 3},
     {LangAS::hlsl_constant, 12},
     {LangAS::hlsl_private, 10},
@@ -56,7 +42,6 @@ static const LangASMap SPIRDefIsPrivMap = {
     {LangAS::hlsl_input, 7},
     {LangAS::hlsl_output, 8},
     {LangAS::hlsl_push_constant, 13},
-    {LangAS::wasm_funcref, 0},
 };
 
 // Used by both the SPIR and SPIR-V targets.
@@ -65,7 +50,6 @@ static const LangASMap SPIRDefIsGenMap = {
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},
-    {LangAS::opencl_private, 0},
     {LangAS::opencl_generic, 4},
     {LangAS::opencl_global_device, 5},
     {LangAS::opencl_global_host, 6},
@@ -81,18 +65,12 @@ static const LangASMap SPIRDefIsGenMap = {
     {LangAS::sycl_global_device, 5},
     {LangAS::sycl_global_host, 6},
     {LangAS::sycl_local, 3},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
-    {LangAS::ptr32_uptr, 0},
-    {LangAS::ptr64, 0},
     {LangAS::hlsl_groupshared, 3},
-    {LangAS::hlsl_constant, 0},
     {LangAS::hlsl_private, 10},
     {LangAS::hlsl_device, 11},
     {LangAS::hlsl_input, 7},
     {LangAS::hlsl_output, 8},
     {LangAS::hlsl_push_constant, 13},
-    {LangAS::wasm_funcref, 0},
 };
 
 // Base class for SPIR and SPIR-V target info.

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -29,18 +29,12 @@ namespace targets {
 
 // Used by both the SPIR and SPIR-V targets.
 static const LangASMap SPIRDefIsPrivMap = {
-    {LangAS::opencl_global, 1},
-    {LangAS::opencl_local, 3},
-    {LangAS::opencl_constant, 2},
-    {LangAS::opencl_generic, 4},
-    {LangAS::opencl_global_device, 5},
-    {LangAS::opencl_global_host, 6},
-    {LangAS::hlsl_groupshared, 3},
-    {LangAS::hlsl_constant, 12},
-    {LangAS::hlsl_private, 10},
-    {LangAS::hlsl_device, 11},
-    {LangAS::hlsl_input, 7},
-    {LangAS::hlsl_output, 8},
+    {LangAS::opencl_global, 1},        {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},      {LangAS::opencl_generic, 4},
+    {LangAS::opencl_global_device, 5}, {LangAS::opencl_global_host, 6},
+    {LangAS::hlsl_groupshared, 3},     {LangAS::hlsl_constant, 12},
+    {LangAS::hlsl_private, 10},        {LangAS::hlsl_device, 11},
+    {LangAS::hlsl_input, 7},           {LangAS::hlsl_output, 8},
     {LangAS::hlsl_push_constant, 13},
 };
 

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -28,7 +28,7 @@ namespace clang {
 namespace targets {
 
 // Used by both the SPIR and SPIR-V targets.
-static const LangASMap SPIRDefIsPrivMap = {
+static constexpr LangASMap SPIRDefIsPrivMap = {
     {LangAS::opencl_global, 1},        {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},      {LangAS::opencl_generic, 4},
     {LangAS::opencl_global_device, 5}, {LangAS::opencl_global_host, 6},
@@ -39,7 +39,7 @@ static const LangASMap SPIRDefIsPrivMap = {
 };
 
 // Used by both the SPIR and SPIR-V targets.
-static const LangASMap SPIRDefIsGenMap = {
+static constexpr LangASMap SPIRDefIsGenMap = {
     {LangAS::Default, 4},
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -28,71 +28,71 @@ namespace clang {
 namespace targets {
 
 // Used by both the SPIR and SPIR-V targets.
-static const unsigned SPIRDefIsPrivMap[] = {
-    0, // Default
-    1, // opencl_global
-    3, // opencl_local
-    2, // opencl_constant
-    0, // opencl_private
-    4, // opencl_generic
-    5, // opencl_global_device
-    6, // opencl_global_host
-    0, // cuda_device
-    0, // cuda_constant
-    0, // cuda_shared
+static const LangASMap SPIRDefIsPrivMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 1},
+    {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 4},
+    {LangAS::opencl_global_device, 5},
+    {LangAS::opencl_global_host, 6},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
     // SYCL address space values for this map are dummy
-    0,  // sycl_global
-    0,  // sycl_global_device
-    0,  // sycl_global_host
-    0,  // sycl_local
-    0,  // sycl_private
-    0,  // ptr32_sptr
-    0,  // ptr32_uptr
-    0,  // ptr64
-    3,  // hlsl_groupshared
-    12, // hlsl_constant
-    10, // hlsl_private
-    11, // hlsl_device
-    7,  // hlsl_input
-    8,  // hlsl_output
-    13, // hlsl_push_constant
-    0,  // wasm_funcref
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 0},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 3},
+    {LangAS::hlsl_constant, 12},
+    {LangAS::hlsl_private, 10},
+    {LangAS::hlsl_device, 11},
+    {LangAS::hlsl_input, 7},
+    {LangAS::hlsl_output, 8},
+    {LangAS::hlsl_push_constant, 13},
+    {LangAS::wasm_funcref, 0},
 };
 
 // Used by both the SPIR and SPIR-V targets.
-static const unsigned SPIRDefIsGenMap[] = {
-    4, // Default
-    1, // opencl_global
-    3, // opencl_local
-    2, // opencl_constant
-    0, // opencl_private
-    4, // opencl_generic
-    5, // opencl_global_device
-    6, // opencl_global_host
+static const LangASMap SPIRDefIsGenMap = {
+    {LangAS::Default, 4},
+    {LangAS::opencl_global, 1},
+    {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 4},
+    {LangAS::opencl_global_device, 5},
+    {LangAS::opencl_global_host, 6},
     // cuda_* address space mapping is intended for HIPSPV (HIP to SPIR-V
     // translation). This mapping is enabled when the language mode is HIP.
-    1, // cuda_device
+    {LangAS::cuda_device, 1},
     // cuda_constant pointer can be casted to default/"flat" pointer, but in
     // SPIR-V casts between constant and generic pointers are not allowed. For
     // this reason cuda_constant is mapped to SPIR-V CrossWorkgroup.
-    1,  // cuda_constant
-    3,  // cuda_shared
-    1,  // sycl_global
-    5,  // sycl_global_device
-    6,  // sycl_global_host
-    3,  // sycl_local
-    0,  // sycl_private
-    0,  // ptr32_sptr
-    0,  // ptr32_uptr
-    0,  // ptr64
-    3,  // hlsl_groupshared
-    0,  // hlsl_constant
-    10, // hlsl_private
-    11, // hlsl_device
-    7,  // hlsl_input
-    8,  // hlsl_output
-    13, // hlsl_push_constant
-    0,  // wasm_funcref
+    {LangAS::cuda_constant, 1},
+    {LangAS::cuda_shared, 3},
+    {LangAS::sycl_global, 1},
+    {LangAS::sycl_global_device, 5},
+    {LangAS::sycl_global_host, 6},
+    {LangAS::sycl_local, 3},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 0},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 3},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 10},
+    {LangAS::hlsl_device, 11},
+    {LangAS::hlsl_input, 7},
+    {LangAS::hlsl_output, 8},
+    {LangAS::hlsl_push_constant, 13},
+    {LangAS::wasm_funcref, 0},
 };
 
 // Base class for SPIR and SPIR-V target info.

--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -21,34 +21,34 @@
 namespace clang {
 namespace targets {
 
-static const unsigned ZOSAddressMap[] = {
-    0, // Default
-    0, // opencl_global
-    0, // opencl_local
-    0, // opencl_constant
-    0, // opencl_private
-    0, // opencl_generic
-    0, // opencl_global_device
-    0, // opencl_global_host
-    0, // cuda_device
-    0, // cuda_constant
-    0, // cuda_shared
-    0, // sycl_global
-    0, // sycl_global_device
-    0, // sycl_global_host
-    0, // sycl_local
-    0, // sycl_private
-    0, // ptr32_sptr
-    1, // ptr32_uptr
-    0, // ptr64
-    0, // hlsl_groupshared
-    0, // hlsl_constant
-    0, // hlsl_private
-    0, // hlsl_device
-    0, // hlsl_input
-    0, // hlsl_output
-    0, // hlsl_push_constant
-    0  // wasm_funcref
+static const LangASMap ZOSAddressMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 0},
+    {LangAS::opencl_local, 0},
+    {LangAS::opencl_constant, 0},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 0},
+    {LangAS::opencl_global_device, 0},
+    {LangAS::opencl_global_host, 0},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 1},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 0},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 0},
 };
 
 class LLVM_LIBRARY_VISIBILITY SystemZTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -21,7 +21,7 @@
 namespace clang {
 namespace targets {
 
-static const LangASMap ZOSAddressMap = {
+static constexpr LangASMap ZOSAddressMap = {
     {LangAS::ptr32_uptr, 1},
 };
 

--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -22,33 +22,7 @@ namespace clang {
 namespace targets {
 
 static const LangASMap ZOSAddressMap = {
-    {LangAS::Default, 0},
-    {LangAS::opencl_global, 0},
-    {LangAS::opencl_local, 0},
-    {LangAS::opencl_constant, 0},
-    {LangAS::opencl_private, 0},
-    {LangAS::opencl_generic, 0},
-    {LangAS::opencl_global_device, 0},
-    {LangAS::opencl_global_host, 0},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
     {LangAS::ptr32_uptr, 1},
-    {LangAS::ptr64, 0},
-    {LangAS::hlsl_groupshared, 0},
-    {LangAS::hlsl_constant, 0},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
-    {LangAS::wasm_funcref, 0},
 };
 
 class LLVM_LIBRARY_VISIBILITY SystemZTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -29,35 +29,35 @@ namespace targets {
 // target processor and program binary. TCE co-design environment is
 // publicly available in http://tce.cs.tut.fi
 
-static const unsigned TCEOpenCLAddrSpaceMap[] = {
-    0, // Default
-    1, // opencl_global
-    3, // opencl_local
-    2, // opencl_constant
-    0, // opencl_private
+static const LangASMap TCEOpenCLAddrSpaceMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 1},
+    {LangAS::opencl_local, 3},
+    {LangAS::opencl_constant, 2},
+    {LangAS::opencl_private, 0},
     // FIXME: generic has to be added to the target
-    0, // opencl_generic
-    1, // opencl_global_device
-    1, // opencl_global_host
-    0, // cuda_device
-    0, // cuda_constant
-    0, // cuda_shared
-    0, // sycl_global
-    0, // sycl_global_device
-    0, // sycl_global_host
-    0, // sycl_local
-    0, // sycl_private
-    0, // ptr32_sptr
-    0, // ptr32_uptr
-    0, // ptr64
-    0, // hlsl_groupshared
-    0, // hlsl_constant
-    0, // hlsl_private
-    0, // hlsl_device
-    0, // hlsl_input
-    0, // hlsl_output
-    0, // hlsl_push_constant
-    0, // wasm_funcref
+    {LangAS::opencl_generic, 0},
+    {LangAS::opencl_global_device, 1},
+    {LangAS::opencl_global_host, 1},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 0},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 0},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 0},
 };
 
 class LLVM_LIBRARY_VISIBILITY TCETargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -29,7 +29,7 @@ namespace targets {
 // target processor and program binary. TCE co-design environment is
 // publicly available in http://tce.cs.tut.fi
 
-static const LangASMap TCEOpenCLAddrSpaceMap = {
+static constexpr LangASMap TCEOpenCLAddrSpaceMap = {
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -30,34 +30,13 @@ namespace targets {
 // publicly available in http://tce.cs.tut.fi
 
 static const LangASMap TCEOpenCLAddrSpaceMap = {
-    {LangAS::Default, 0},
     {LangAS::opencl_global, 1},
     {LangAS::opencl_local, 3},
     {LangAS::opencl_constant, 2},
-    {LangAS::opencl_private, 0},
     // FIXME: generic has to be added to the target
     {LangAS::opencl_generic, 0},
     {LangAS::opencl_global_device, 1},
     {LangAS::opencl_global_host, 1},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
-    {LangAS::ptr32_uptr, 0},
-    {LangAS::ptr64, 0},
-    {LangAS::hlsl_groupshared, 0},
-    {LangAS::hlsl_constant, 0},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
-    {LangAS::wasm_funcref, 0},
 };
 
 class LLVM_LIBRARY_VISIBILITY TCETargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -21,7 +21,7 @@
 namespace clang {
 namespace targets {
 
-static const LangASMap WebAssemblyAddrSpaceMap = {
+static constexpr LangASMap WebAssemblyAddrSpaceMap = {
     {LangAS::wasm_funcref, 20},
 };
 

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -21,34 +21,34 @@
 namespace clang {
 namespace targets {
 
-static const unsigned WebAssemblyAddrSpaceMap[] = {
-    0,  // Default
-    0,  // opencl_global
-    0,  // opencl_local
-    0,  // opencl_constant
-    0,  // opencl_private
-    0,  // opencl_generic
-    0,  // opencl_global_device
-    0,  // opencl_global_host
-    0,  // cuda_device
-    0,  // cuda_constant
-    0,  // cuda_shared
-    0,  // sycl_global
-    0,  // sycl_global_device
-    0,  // sycl_global_host
-    0,  // sycl_local
-    0,  // sycl_private
-    0,  // ptr32_sptr
-    0,  // ptr32_uptr
-    0,  // ptr64
-    0,  // hlsl_groupshared
-    0,  // hlsl_constant
-    0,  // hlsl_private
-    0,  // hlsl_device
-    0,  // hlsl_input
-    0,  // hlsl_output
-    0,  // hlsl_push_constant
-    20, // wasm_funcref
+static const LangASMap WebAssemblyAddrSpaceMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 0},
+    {LangAS::opencl_local, 0},
+    {LangAS::opencl_constant, 0},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 0},
+    {LangAS::opencl_global_device, 0},
+    {LangAS::opencl_global_host, 0},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 0},
+    {LangAS::ptr32_uptr, 0},
+    {LangAS::ptr64, 0},
+    {LangAS::hlsl_groupshared, 0},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 20},
 };
 
 class LLVM_LIBRARY_VISIBILITY WebAssemblyTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -22,32 +22,6 @@ namespace clang {
 namespace targets {
 
 static const LangASMap WebAssemblyAddrSpaceMap = {
-    {LangAS::Default, 0},
-    {LangAS::opencl_global, 0},
-    {LangAS::opencl_local, 0},
-    {LangAS::opencl_constant, 0},
-    {LangAS::opencl_private, 0},
-    {LangAS::opencl_generic, 0},
-    {LangAS::opencl_global_device, 0},
-    {LangAS::opencl_global_host, 0},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
-    {LangAS::ptr32_sptr, 0},
-    {LangAS::ptr32_uptr, 0},
-    {LangAS::ptr64, 0},
-    {LangAS::hlsl_groupshared, 0},
-    {LangAS::hlsl_constant, 0},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
     {LangAS::wasm_funcref, 20},
 };
 

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -26,33 +26,9 @@ namespace clang {
 namespace targets {
 
 static const LangASMap X86AddrSpaceMap = {
-    {LangAS::Default, 0},
-    {LangAS::opencl_global, 0},
-    {LangAS::opencl_local, 0},
-    {LangAS::opencl_constant, 0},
-    {LangAS::opencl_private, 0},
-    {LangAS::opencl_generic, 0},
-    {LangAS::opencl_global_device, 0},
-    {LangAS::opencl_global_host, 0},
-    {LangAS::cuda_device, 0},
-    {LangAS::cuda_constant, 0},
-    {LangAS::cuda_shared, 0},
-    {LangAS::sycl_global, 0},
-    {LangAS::sycl_global_device, 0},
-    {LangAS::sycl_global_host, 0},
-    {LangAS::sycl_local, 0},
-    {LangAS::sycl_private, 0},
     {LangAS::ptr32_sptr, 270},
     {LangAS::ptr32_uptr, 271},
     {LangAS::ptr64, 272},
-    {LangAS::hlsl_groupshared, 0},
-    {LangAS::hlsl_constant, 0},
-    {LangAS::hlsl_private, 0},
-    {LangAS::hlsl_device, 0},
-    {LangAS::hlsl_input, 0},
-    {LangAS::hlsl_output, 0},
-    {LangAS::hlsl_push_constant, 0},
-    {LangAS::wasm_funcref, 0},
 };
 
 // X86 target abstract base class; x86-32 and x86-64 are very close, so

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -25,7 +25,7 @@
 namespace clang {
 namespace targets {
 
-static const LangASMap X86AddrSpaceMap = {
+static constexpr LangASMap X86AddrSpaceMap = {
     {LangAS::ptr32_sptr, 270},
     {LangAS::ptr32_uptr, 271},
     {LangAS::ptr64, 272},

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -25,34 +25,34 @@
 namespace clang {
 namespace targets {
 
-static const unsigned X86AddrSpaceMap[] = {
-    0,   // Default
-    0,   // opencl_global
-    0,   // opencl_local
-    0,   // opencl_constant
-    0,   // opencl_private
-    0,   // opencl_generic
-    0,   // opencl_global_device
-    0,   // opencl_global_host
-    0,   // cuda_device
-    0,   // cuda_constant
-    0,   // cuda_shared
-    0,   // sycl_global
-    0,   // sycl_global_device
-    0,   // sycl_global_host
-    0,   // sycl_local
-    0,   // sycl_private
-    270, // ptr32_sptr
-    271, // ptr32_uptr
-    272, // ptr64
-    0,   // hlsl_groupshared
-    0,   // hlsl_constant
-    0,   // hlsl_private
-    0,   // hlsl_device
-    0,   // hlsl_input
-    0,   // hlsl_output
-    0,   // hlsl_push_constant
-    0,   // wasm_funcref
+static const LangASMap X86AddrSpaceMap = {
+    {LangAS::Default, 0},
+    {LangAS::opencl_global, 0},
+    {LangAS::opencl_local, 0},
+    {LangAS::opencl_constant, 0},
+    {LangAS::opencl_private, 0},
+    {LangAS::opencl_generic, 0},
+    {LangAS::opencl_global_device, 0},
+    {LangAS::opencl_global_host, 0},
+    {LangAS::cuda_device, 0},
+    {LangAS::cuda_constant, 0},
+    {LangAS::cuda_shared, 0},
+    {LangAS::sycl_global, 0},
+    {LangAS::sycl_global_device, 0},
+    {LangAS::sycl_global_host, 0},
+    {LangAS::sycl_local, 0},
+    {LangAS::sycl_private, 0},
+    {LangAS::ptr32_sptr, 270},
+    {LangAS::ptr32_uptr, 271},
+    {LangAS::ptr64, 272},
+    {LangAS::hlsl_groupshared, 0},
+    {LangAS::hlsl_constant, 0},
+    {LangAS::hlsl_private, 0},
+    {LangAS::hlsl_device, 0},
+    {LangAS::hlsl_input, 0},
+    {LangAS::hlsl_output, 0},
+    {LangAS::hlsl_push_constant, 0},
+    {LangAS::wasm_funcref, 0},
 };
 
 // X86 target abstract base class; x86-32 and x86-64 are very close, so


### PR DESCRIPTION
The original implementation requires each target to list a value for every LangAS in exact enum order.  This forces targets to specify mappings for unrelated address spaces and makes it easy to introduce ordering bugs, such as the one fixed in 4479f3397f827291c51698fbaa685b1a9493467a.

Address this by introducing a class that supports order-independent key-value initialization and defaults unspecified entries to 0.

---

Depends on:
* https://github.com/llvm/llvm-project/pull/210244
* https://github.com/llvm/llvm-project/pull/210253