### PR TITLE
[GlobalISel][AArch64] Add more memcpy and memmove tests (NFC)

### DIFF
--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-memcpy.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-memcpy.mir
@@ -10,6 +10,10 @@
   define void @test_memcpy2_const_minsize() #3 { entry: unreachable }
   define void @test_memcpy3_const_arrays_unaligned() #4 { entry: unreachable }
   define void @test_memcpy_addrspace() #5 { entry: unreachable }
+  define void @test_memcpy_load_store_offsets_1() #6 { entry: unreachable }
+  define void @test_memcpy_load_store_offsets_2() #7 { entry: unreachable }
+  define void @test_memcpy_load_store_offsets_volatile_1() #8 { entry: unreachable }
+  define void @test_memcpy_load_store_offsets_volatile_2() #9 { entry: unreachable }
 
   attributes #2 = { optsize }
   attributes #3 = { minsize }
@@ -281,4 +285,120 @@ body:             |
     G_MEMCPY %0(p1), %1(p2), %2(s64), 1 :: (store (s8), align 4, addrspace 1), (load (s8), align 4, addrspace 2)
     RET_ReallyLR
 
+...
+---
+name:            test_memcpy_load_store_offsets_1
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memcpy_load_store_offsets_1
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i16) = G_LOAD [[COPY1]](p0) :: (load (s16), align 8)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i16), [[COPY]](p0) :: (store (s16), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](i64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD]](p0) :: (load (s8) from unknown-address + 2, align 2)
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](i64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i8), [[PTR_ADD1]](p0) :: (store (s8) into unknown-address + 2, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 3
+    G_MEMCPY %0(p0), %1(p0), %2(i64), 0 :: (store (s8), align 8), (load (s8), align 8)
+    RET_ReallyLR
+
+...
+---
+name:            test_memcpy_load_store_offsets_2
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memcpy_load_store_offsets_2
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[COPY1]](p0) :: (load (s32), align 8)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i32), [[COPY]](p0) :: (store (s32), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 3
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](i64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from unknown-address + 3, align 1)
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](i64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i32), [[PTR_ADD1]](p0) :: (store (s32) into unknown-address + 3, align 1)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 7
+    G_MEMCPY %0(p0), %1(p0), %2(i64), 0 :: (store (s8), align 8), (load (s8), align 8)
+    RET_ReallyLR
+
+...
+---
+name:            test_memcpy_load_store_offsets_volatile_1
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memcpy_load_store_offsets_volatile_1
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i16) = G_LOAD [[COPY1]](p0) :: (volatile load (s16), align 8)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i16), [[COPY]](p0) :: (volatile store (s16), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](i64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD]](p0) :: (volatile load (s8) from unknown-address + 2, align 2)
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](i64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i8), [[PTR_ADD1]](p0) :: (volatile store (s8) into unknown-address + 2, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 3
+    G_MEMCPY %0(p0), %1(p0), %2(i64), 0 :: (volatile store (s8), align 8), (volatile load (s8), align 8)
+    RET_ReallyLR
+
+...
+---
+name:            test_memcpy_load_store_offsets_volatile_2
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memcpy_load_store_offsets_volatile_2
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[COPY1]](p0) :: (volatile load (s32), align 8)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i32), [[COPY]](p0) :: (volatile store (s32), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 4
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](i64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i16) = G_LOAD [[PTR_ADD]](p0) :: (volatile load (s16) from unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](i64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i16), [[PTR_ADD1]](p0) :: (volatile store (s16) into unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 6
+    ; CHECK-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C1]](i64)
+    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD2]](p0) :: (volatile load (s8) from unknown-address + 6, align 2)
+    ; CHECK-NEXT: [[PTR_ADD3:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](i64)
+    ; CHECK-NEXT: G_STORE [[LOAD2]](i8), [[PTR_ADD3]](p0) :: (volatile store (s8) into unknown-address + 6, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 7
+    G_MEMCPY %0(p0), %1(p0), %2(i64), 0 :: (volatile store (s8), align 8), (volatile load (s8), align 8)
+    RET_ReallyLR
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-memmove.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-memmove.mir
@@ -9,6 +9,10 @@
   define void @test_memmove3_const_toolarge() { entry: unreachable }
   define void @test_memmove4_const_unaligned() { entry: unreachable }
   define void @test_memmove_addrspace() { entry: unreachable }
+  define void @test_memmove_load_store_offsets_1() { entry: unreachable }
+  define void @test_memmove_load_store_offsets_2() { entry: unreachable }
+  define void @test_memmove_load_store_offsets_volatile_1() { entry: unreachable }
+  define void @test_memmove_load_store_offsets_volatile_2() { entry: unreachable }
 ...
 ---
 name:            test_memmove1
@@ -196,4 +200,131 @@ body:             |
     G_MEMMOVE %0(p1), %1(p2), %2(s64), 1 :: (store (s8), align 4, addrspace 1), (load (s8), align 4, addrspace 2)
     RET_ReallyLR
 
+...
+---
+name:            test_memmove_load_store_offsets_1
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memmove_load_store_offsets_1
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i16) = G_LOAD [[COPY1]](p0) :: (load (s16), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](s64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD]](p0) :: (load (s8) from unknown-address + 2, align 2)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i16), [[COPY]](p0) :: (store (s16), align 8)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](s64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i8), [[PTR_ADD1]](p0) :: (store (s8) into unknown-address + 2, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 3
+    G_MEMMOVE %0(p0), %1(p0), %2(i64), 0 :: (store (s8), align 8), (load (s8), align 8)
+    RET_ReallyLR
+
+...
+---
+name:            test_memmove_load_store_offsets_2
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memmove_load_store_offsets_2
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[COPY1]](p0) :: (load (s32), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](s64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i16) = G_LOAD [[PTR_ADD]](p0) :: (load (s16) from unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 6
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C1]](s64)
+    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD1]](p0) :: (load (s8) from unknown-address + 6, align 2)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i32), [[COPY]](p0) :: (store (s32), align 8)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; CHECK-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](s64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i16), [[PTR_ADD2]](p0) :: (store (s16) into unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 6
+    ; CHECK-NEXT: [[PTR_ADD3:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C3]](s64)
+    ; CHECK-NEXT: G_STORE [[LOAD2]](i8), [[PTR_ADD3]](p0) :: (store (s8) into unknown-address + 6, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 7
+    G_MEMMOVE %0(p0), %1(p0), %2(i64), 0 :: (store (s8), align 8), (load (s8), align 8)
+    RET_ReallyLR
+
+...
+---
+name:            test_memmove_load_store_offsets_volatile_1
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memmove_load_store_offsets_volatile_1
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i16) = G_LOAD [[COPY1]](p0) :: (volatile load (s16), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](s64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD]](p0) :: (volatile load (s8) from unknown-address + 2, align 2)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i16), [[COPY]](p0) :: (volatile store (s16), align 8)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C1]](s64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i8), [[PTR_ADD1]](p0) :: (volatile store (s8) into unknown-address + 2, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 3
+    G_MEMMOVE %0(p0), %1(p0), %2(i64), 0 :: (volatile store (s8), align 8), (volatile load (s8), align 8)
+    RET_ReallyLR
+
+...
+---
+name:            test_memmove_load_store_offsets_volatile_2
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: test_memmove_load_store_offsets_volatile_2
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x1
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[COPY1]](p0) :: (volatile load (s32), align 8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](s64)
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(i16) = G_LOAD [[PTR_ADD]](p0) :: (volatile load (s16) from unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 6
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C1]](s64)
+    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(i8) = G_LOAD [[PTR_ADD1]](p0) :: (volatile load (s8) from unknown-address + 6, align 2)
+    ; CHECK-NEXT: G_STORE [[LOAD]](i32), [[COPY]](p0) :: (volatile store (s32), align 8)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; CHECK-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](s64)
+    ; CHECK-NEXT: G_STORE [[LOAD1]](i16), [[PTR_ADD2]](p0) :: (volatile store (s16) into unknown-address + 4, align 4)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 6
+    ; CHECK-NEXT: [[PTR_ADD3:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C3]](s64)
+    ; CHECK-NEXT: G_STORE [[LOAD2]](i8), [[PTR_ADD3]](p0) :: (volatile store (s8) into unknown-address + 6, align 2)
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:_(p0) = COPY $x0
+    %1:_(p0) = COPY $x1
+    %2:_(i64) = G_CONSTANT i64 7
+    G_MEMMOVE %0(p0), %1(p0), %2(i64), 0 :: (volatile store (s8), align 8), (volatile load (s8), align 8)
+    RET_ReallyLR
 ...

--- a/llvm/test/CodeGen/AArch64/aarch64-mops.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-mops.ll
@@ -932,6 +932,88 @@ entry:
   ret void
 }
 
+define void @memcpy_7(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-LABEL: memcpy_7:
+; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-NEXT:    ldur w8, [x1, #3]
+; GISel-WITHOUT-MOPS-NEXT:    stur w8, [x0, #3]
+; GISel-WITHOUT-MOPS-NEXT:    ret
+;
+; GISel-MOPS-LABEL: memcpy_7:
+; GISel-MOPS:       // %bb.0: // %entry
+; GISel-MOPS-NEXT:    ldr w8, [x1]
+; GISel-MOPS-NEXT:    str w8, [x0]
+; GISel-MOPS-NEXT:    ldur w8, [x1, #3]
+; GISel-MOPS-NEXT:    stur w8, [x0, #3]
+; GISel-MOPS-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memcpy_7:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memcpy_7:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 false)
+  ret void
+}
+
+define void @memcpy_7_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-LABEL: memcpy_7_volatile:
+; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-NEXT:    ldrh w8, [x1, #4]
+; GISel-WITHOUT-MOPS-NEXT:    strh w8, [x0, #4]
+; GISel-WITHOUT-MOPS-NEXT:    ldrb w8, [x1, #6]
+; GISel-WITHOUT-MOPS-NEXT:    strb w8, [x0, #6]
+; GISel-WITHOUT-MOPS-NEXT:    ret
+;
+; GISel-MOPS-LABEL: memcpy_7_volatile:
+; GISel-MOPS:       // %bb.0: // %entry
+; GISel-MOPS-NEXT:    ldr w8, [x1]
+; GISel-MOPS-NEXT:    str w8, [x0]
+; GISel-MOPS-NEXT:    ldrh w8, [x1, #4]
+; GISel-MOPS-NEXT:    strh w8, [x0, #4]
+; GISel-MOPS-NEXT:    ldrb w8, [x1, #6]
+; GISel-MOPS-NEXT:    strb w8, [x0, #6]
+; GISel-MOPS-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memcpy_7_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memcpy_7_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 true)
+  ret void
+}
+
 define void @memcpy_10(ptr %dst, ptr %src, i32 %value) {
 ; GISel-WITHOUT-MOPS-LABEL: memcpy_10:
 ; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
@@ -1202,7 +1284,6 @@ entry:
   ret void
 }
 
-
 define void @memcpy_inline_0(ptr %dst, ptr %src, i32 %value) {
 ; GISel-WITHOUT-MOPS-LABEL: memcpy_inline_0:
 ; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
@@ -1242,6 +1323,88 @@ define void @memcpy_inline_0_volatile(ptr %dst, ptr %src, i32 %value) {
 ; SDAG-MOPS-O2-NEXT:    ret
 entry:
   call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 0, i1 true)
+  ret void
+}
+
+define void @memcpy_inline_7(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-LABEL: memcpy_inline_7:
+; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-NEXT:    ldur w8, [x1, #3]
+; GISel-WITHOUT-MOPS-NEXT:    stur w8, [x0, #3]
+; GISel-WITHOUT-MOPS-NEXT:    ret
+;
+; GISel-MOPS-LABEL: memcpy_inline_7:
+; GISel-MOPS:       // %bb.0: // %entry
+; GISel-MOPS-NEXT:    ldr w8, [x1]
+; GISel-MOPS-NEXT:    str w8, [x0]
+; GISel-MOPS-NEXT:    ldur w8, [x1, #3]
+; GISel-MOPS-NEXT:    stur w8, [x0, #3]
+; GISel-MOPS-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memcpy_inline_7:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memcpy_inline_7:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 false)
+  ret void
+}
+
+define void @memcpy_inline_7_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-LABEL: memcpy_inline_7_volatile:
+; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-NEXT:    ldrh w8, [x1, #4]
+; GISel-WITHOUT-MOPS-NEXT:    strh w8, [x0, #4]
+; GISel-WITHOUT-MOPS-NEXT:    ldrb w8, [x1, #6]
+; GISel-WITHOUT-MOPS-NEXT:    strb w8, [x0, #6]
+; GISel-WITHOUT-MOPS-NEXT:    ret
+;
+; GISel-MOPS-LABEL: memcpy_inline_7_volatile:
+; GISel-MOPS:       // %bb.0: // %entry
+; GISel-MOPS-NEXT:    ldr w8, [x1]
+; GISel-MOPS-NEXT:    str w8, [x0]
+; GISel-MOPS-NEXT:    ldrh w8, [x1, #4]
+; GISel-MOPS-NEXT:    strh w8, [x0, #4]
+; GISel-MOPS-NEXT:    ldrb w8, [x1, #6]
+; GISel-MOPS-NEXT:    strb w8, [x0, #6]
+; GISel-MOPS-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memcpy_inline_7_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memcpy_inline_7_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 true)
   ret void
 }
 
@@ -1868,6 +2031,132 @@ entry:
   ret void
 }
 
+define void @memmove_7(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_7:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_7:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_7:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_7:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_7:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_7:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 true)
+  ret void
+}
+
+define void @memmove_7_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_7_volatile:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_7_volatile:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_7_volatile:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_7_volatile:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_7_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_7_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 false)
+  ret void
+}
+
 define void @memmove_10(ptr %dst, ptr %src, i32 %value) {
 ; GISel-WITHOUT-MOPS-O0-LABEL: memmove_10:
 ; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
@@ -2167,5 +2456,401 @@ define void @memmove_n_volatile(ptr %dst, ptr %src, i64 %size, i32 %value) {
 ; SDAG-MOPS-O2-NEXT:    ret
 entry:
   call void @llvm.memmove.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 %size, i1 true)
+  ret void
+}
+
+define void @memmove_inline_0(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-LABEL: memmove_inline_0:
+; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-NEXT:    ret
+;
+; GISel-MOPS-LABEL: memmove_inline_0:
+; GISel-MOPS:       // %bb.0: // %entry
+; GISel-MOPS-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_0:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_0:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 0, i1 false)
+  ret void
+}
+
+define void @memmove_inline_0_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-LABEL: memmove_inline_0_volatile:
+; GISel-WITHOUT-MOPS:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-NEXT:    ret
+;
+; GISel-MOPS-LABEL: memmove_inline_0_volatile:
+; GISel-MOPS:       // %bb.0: // %entry
+; GISel-MOPS-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_0_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_0_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 0, i1 true)
+  ret void
+}
+
+define void @memmove_inline_7(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_inline_7:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_inline_7:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_inline_7:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_inline_7:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_7:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_7:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldur w8, [x1, #3]
+; SDAG-MOPS-O2-NEXT:    ldr w9, [x1]
+; SDAG-MOPS-O2-NEXT:    stur w8, [x0, #3]
+; SDAG-MOPS-O2-NEXT:    str w9, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 false)
+  ret void
+}
+
+define void @memmove_inline_7_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_inline_7_volatile:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_inline_7_volatile:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_inline_7_volatile:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    ldr w10, [x1]
+; GISel-MOPS-O0-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O0-NEXT:    ldrb w8, [x1, #6]
+; GISel-MOPS-O0-NEXT:    str w10, [x0]
+; GISel-MOPS-O0-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O0-NEXT:    strb w8, [x0, #6]
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_inline_7_volatile:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    ldr w8, [x1]
+; GISel-MOPS-O3-NEXT:    ldrh w9, [x1, #4]
+; GISel-MOPS-O3-NEXT:    ldrb w10, [x1, #6]
+; GISel-MOPS-O3-NEXT:    str w8, [x0]
+; GISel-MOPS-O3-NEXT:    strh w9, [x0, #4]
+; GISel-MOPS-O3-NEXT:    strb w10, [x0, #6]
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_7_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_7_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldr w8, [x1]
+; SDAG-MOPS-O2-NEXT:    ldrh w9, [x1, #4]
+; SDAG-MOPS-O2-NEXT:    ldrb w10, [x1, #6]
+; SDAG-MOPS-O2-NEXT:    strb w10, [x0, #6]
+; SDAG-MOPS-O2-NEXT:    strh w9, [x0, #4]
+; SDAG-MOPS-O2-NEXT:    str w8, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 7, i1 true)
+  ret void
+}
+
+define void @memmove_inline_10(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_inline_10:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr x9, [x1]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrh w8, [x1, #8]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str x9, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strh w8, [x0, #8]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_inline_10:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr x8, [x1]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrh w9, [x1, #8]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strh w9, [x0, #8]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_inline_10:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    ldr x9, [x1]
+; GISel-MOPS-O0-NEXT:    ldrh w8, [x1, #8]
+; GISel-MOPS-O0-NEXT:    str x9, [x0]
+; GISel-MOPS-O0-NEXT:    strh w8, [x0, #8]
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_inline_10:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    ldr x8, [x1]
+; GISel-MOPS-O3-NEXT:    ldrh w9, [x1, #8]
+; GISel-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-MOPS-O3-NEXT:    strh w9, [x0, #8]
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_10:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrh w8, [x1, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr x9, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w8, [x0, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str x9, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_10:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldrh w8, [x1, #8]
+; SDAG-MOPS-O2-NEXT:    ldr x9, [x1]
+; SDAG-MOPS-O2-NEXT:    strh w8, [x0, #8]
+; SDAG-MOPS-O2-NEXT:    str x9, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 10, i1 false)
+  ret void
+}
+
+define void @memmove_inline_10_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_inline_10_volatile:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr x9, [x1]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldrh w8, [x1, #8]
+; GISel-WITHOUT-MOPS-O0-NEXT:    str x9, [x0]
+; GISel-WITHOUT-MOPS-O0-NEXT:    strh w8, [x0, #8]
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_inline_10_volatile:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr x8, [x1]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldrh w9, [x1, #8]
+; GISel-WITHOUT-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-WITHOUT-MOPS-O3-NEXT:    strh w9, [x0, #8]
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_inline_10_volatile:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    ldr x9, [x1]
+; GISel-MOPS-O0-NEXT:    ldrh w8, [x1, #8]
+; GISel-MOPS-O0-NEXT:    str x9, [x0]
+; GISel-MOPS-O0-NEXT:    strh w8, [x0, #8]
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_inline_10_volatile:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    ldr x8, [x1]
+; GISel-MOPS-O3-NEXT:    ldrh w9, [x1, #8]
+; GISel-MOPS-O3-NEXT:    str x8, [x0]
+; GISel-MOPS-O3-NEXT:    strh w9, [x0, #8]
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_10_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr x8, [x1]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldrh w9, [x1, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    strh w9, [x0, #8]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str x8, [x0]
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_10_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    ldr x8, [x1]
+; SDAG-MOPS-O2-NEXT:    ldrh w9, [x1, #8]
+; SDAG-MOPS-O2-NEXT:    strh w9, [x0, #8]
+; SDAG-MOPS-O2-NEXT:    str x8, [x0]
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 10, i1 true)
+  ret void
+}
+
+define void @memmove_inline_300(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_inline_300:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; GISel-WITHOUT-MOPS-O0-NEXT:    .cfi_def_cfa_offset 16
+; GISel-WITHOUT-MOPS-O0-NEXT:    .cfi_offset w30, -16
+; GISel-WITHOUT-MOPS-O0-NEXT:    mov w8, #300 // =0x12c
+; GISel-WITHOUT-MOPS-O0-NEXT:    mov w2, w8
+; GISel-WITHOUT-MOPS-O0-NEXT:    bl memmove
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_inline_300:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; GISel-WITHOUT-MOPS-O3-NEXT:    .cfi_def_cfa_offset 16
+; GISel-WITHOUT-MOPS-O3-NEXT:    .cfi_offset w30, -16
+; GISel-WITHOUT-MOPS-O3-NEXT:    mov w2, #300 // =0x12c
+; GISel-WITHOUT-MOPS-O3-NEXT:    bl memmove
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_inline_300:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    mov w8, #300 // =0x12c
+; GISel-MOPS-O0-NEXT:    // kill: def $x8 killed $w8
+; GISel-MOPS-O0-NEXT:    cpyp [x0]!, [x1]!, x8!
+; GISel-MOPS-O0-NEXT:    cpym [x0]!, [x1]!, x8!
+; GISel-MOPS-O0-NEXT:    cpye [x0]!, [x1]!, x8!
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_inline_300:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    mov w8, #300 // =0x12c
+; GISel-MOPS-O3-NEXT:    cpyp [x0]!, [x1]!, x8!
+; GISel-MOPS-O3-NEXT:    cpym [x0]!, [x1]!, x8!
+; GISel-MOPS-O3-NEXT:    cpye [x0]!, [x1]!, x8!
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_300:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; SDAG-WITHOUT-MOPS-O2-NEXT:    .cfi_def_cfa_offset 16
+; SDAG-WITHOUT-MOPS-O2-NEXT:    .cfi_offset w30, -16
+; SDAG-WITHOUT-MOPS-O2-NEXT:    mov w2, #300 // =0x12c
+; SDAG-WITHOUT-MOPS-O2-NEXT:    bl memmove
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_300:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    mov w8, #300 // =0x12c
+; SDAG-MOPS-O2-NEXT:    cpyp [x0]!, [x1]!, x8!
+; SDAG-MOPS-O2-NEXT:    cpym [x0]!, [x1]!, x8!
+; SDAG-MOPS-O2-NEXT:    cpye [x0]!, [x1]!, x8!
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 300, i1 false)
+  ret void
+}
+
+define void @memmove_inline_300_volatile(ptr %dst, ptr %src, i32 %value) {
+; GISel-WITHOUT-MOPS-O0-LABEL: memmove_inline_300_volatile:
+; GISel-WITHOUT-MOPS-O0:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O0-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; GISel-WITHOUT-MOPS-O0-NEXT:    .cfi_def_cfa_offset 16
+; GISel-WITHOUT-MOPS-O0-NEXT:    .cfi_offset w30, -16
+; GISel-WITHOUT-MOPS-O0-NEXT:    mov w8, #300 // =0x12c
+; GISel-WITHOUT-MOPS-O0-NEXT:    mov w2, w8
+; GISel-WITHOUT-MOPS-O0-NEXT:    bl memmove
+; GISel-WITHOUT-MOPS-O0-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; GISel-WITHOUT-MOPS-O0-NEXT:    ret
+;
+; GISel-WITHOUT-MOPS-O3-LABEL: memmove_inline_300_volatile:
+; GISel-WITHOUT-MOPS-O3:       // %bb.0: // %entry
+; GISel-WITHOUT-MOPS-O3-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; GISel-WITHOUT-MOPS-O3-NEXT:    .cfi_def_cfa_offset 16
+; GISel-WITHOUT-MOPS-O3-NEXT:    .cfi_offset w30, -16
+; GISel-WITHOUT-MOPS-O3-NEXT:    mov w2, #300 // =0x12c
+; GISel-WITHOUT-MOPS-O3-NEXT:    bl memmove
+; GISel-WITHOUT-MOPS-O3-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; GISel-WITHOUT-MOPS-O3-NEXT:    ret
+;
+; GISel-MOPS-O0-LABEL: memmove_inline_300_volatile:
+; GISel-MOPS-O0:       // %bb.0: // %entry
+; GISel-MOPS-O0-NEXT:    mov w8, #300 // =0x12c
+; GISel-MOPS-O0-NEXT:    // kill: def $x8 killed $w8
+; GISel-MOPS-O0-NEXT:    cpyp [x0]!, [x1]!, x8!
+; GISel-MOPS-O0-NEXT:    cpym [x0]!, [x1]!, x8!
+; GISel-MOPS-O0-NEXT:    cpye [x0]!, [x1]!, x8!
+; GISel-MOPS-O0-NEXT:    ret
+;
+; GISel-MOPS-O3-LABEL: memmove_inline_300_volatile:
+; GISel-MOPS-O3:       // %bb.0: // %entry
+; GISel-MOPS-O3-NEXT:    mov w8, #300 // =0x12c
+; GISel-MOPS-O3-NEXT:    cpyp [x0]!, [x1]!, x8!
+; GISel-MOPS-O3-NEXT:    cpym [x0]!, [x1]!, x8!
+; GISel-MOPS-O3-NEXT:    cpye [x0]!, [x1]!, x8!
+; GISel-MOPS-O3-NEXT:    ret
+;
+; SDAG-WITHOUT-MOPS-O2-LABEL: memmove_inline_300_volatile:
+; SDAG-WITHOUT-MOPS-O2:       // %bb.0: // %entry
+; SDAG-WITHOUT-MOPS-O2-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; SDAG-WITHOUT-MOPS-O2-NEXT:    .cfi_def_cfa_offset 16
+; SDAG-WITHOUT-MOPS-O2-NEXT:    .cfi_offset w30, -16
+; SDAG-WITHOUT-MOPS-O2-NEXT:    mov w2, #300 // =0x12c
+; SDAG-WITHOUT-MOPS-O2-NEXT:    bl memmove
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; SDAG-WITHOUT-MOPS-O2-NEXT:    ret
+;
+; SDAG-MOPS-O2-LABEL: memmove_inline_300_volatile:
+; SDAG-MOPS-O2:       // %bb.0: // %entry
+; SDAG-MOPS-O2-NEXT:    mov w8, #300 // =0x12c
+; SDAG-MOPS-O2-NEXT:    cpyp [x0]!, [x1]!, x8!
+; SDAG-MOPS-O2-NEXT:    cpym [x0]!, [x1]!, x8!
+; SDAG-MOPS-O2-NEXT:    cpye [x0]!, [x1]!, x8!
+; SDAG-MOPS-O2-NEXT:    ret
+entry:
+  call void @llvm.memmove.inline.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 300, i1 true)
   ret void
 }


### PR DESCRIPTION
Test inlined memcpy and memmove operations with multiple loads/stores with different sizes.

New IR tests added for size 7 to check which one of load/store sequences
we generate:

- 4 + 2 + 1 bytes
- 4 + 4 bytes (4 bytes at offset, 4 bytes at offset + 3)

We also didn't have the `memcpy_inline_...` tests for the
`memmove.inline` intrinsic. I've copied all `memcpy_inline_...` tests
for `memmove.inline`, with the exception of sizes 65, 64, and 63, as I'm
not sure whether they're useful. (the same edge cases are already
checked in tests with sizes 10 and 7)

List of all IR tests added:

- memcpy_7
- memcpy_7_volatile
- memcpy_inline_7
- memcpy_inline_7_volatile
- memmove_7
- memmove_7_volatile
- memmove_inline_0
- memmove_inline_0_volatile
- memmove_inline_7
- memmove_inline_7_volatile
- memmove_inline_10
- memmove_inline_10_volatile
- memmove_inline_300
- memmove_inline_300_volatile