### PR TITLE
[libc++] Remove some adjacent_view::begin() benchmarks

### DIFF
--- a/libcxx/test/benchmarks/adjacent_view_begin.bench.cpp
+++ b/libcxx/test/benchmarks/adjacent_view_begin.bench.cpp
@@ -28,13 +28,6 @@ void BM_adjacent_full(benchmark::State& state) {
 }
 
 BENCHMARK(BM_adjacent_full<2>)->Name("rng::adjacent_view::begin()/2 (full view)");
-BENCHMARK(BM_adjacent_full<3>)->Name("rng::adjacent_view::begin()/3 (full view)");
-BENCHMARK(BM_adjacent_full<4>)->Name("rng::adjacent_view::begin()/4 (full view)");
-BENCHMARK(BM_adjacent_full<5>)->Name("rng::adjacent_view::begin()/5 (full view)");
-BENCHMARK(BM_adjacent_full<6>)->Name("rng::adjacent_view::begin()/6 (full view)");
-BENCHMARK(BM_adjacent_full<7>)->Name("rng::adjacent_view::begin()/7 (full view)");
-BENCHMARK(BM_adjacent_full<8>)->Name("rng::adjacent_view::begin()/8 (full view)");
-BENCHMARK(BM_adjacent_full<9>)->Name("rng::adjacent_view::begin()/9 (full view)");
 BENCHMARK(BM_adjacent_full<10>)->Name("rng::adjacent_view::begin()/10 (full view)");
 BENCHMARK(BM_adjacent_full<100>)->Name("rng::adjacent_view::begin()/100 (full view)");
 BENCHMARK(BM_adjacent_full<1000>)->Name("rng::adjacent_view::begin()/1000 (full view)");
@@ -49,16 +42,6 @@ void BM_adjacent_empty(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_adjacent_empty<2>)->Name("rng::adjacent_view::begin()/2 (empty view)");
-BENCHMARK(BM_adjacent_empty<3>)->Name("rng::adjacent_view::begin()/3 (empty view)");
-BENCHMARK(BM_adjacent_empty<4>)->Name("rng::adjacent_view::begin()/4 (empty view)");
-BENCHMARK(BM_adjacent_empty<5>)->Name("rng::adjacent_view::begin()/5 (empty view)");
-BENCHMARK(BM_adjacent_empty<6>)->Name("rng::adjacent_view::begin()/6 (empty view)");
-BENCHMARK(BM_adjacent_empty<7>)->Name("rng::adjacent_view::begin()/7 (empty view)");
-BENCHMARK(BM_adjacent_empty<8>)->Name("rng::adjacent_view::begin()/8 (empty view)");
-BENCHMARK(BM_adjacent_empty<9>)->Name("rng::adjacent_view::begin()/9 (empty view)");
-BENCHMARK(BM_adjacent_empty<10>)->Name("rng::adjacent_view::begin()/10 (empty view)");
-BENCHMARK(BM_adjacent_empty<100>)->Name("rng::adjacent_view::begin()/100 (empty view)");
 BENCHMARK(BM_adjacent_empty<1000>)->Name("rng::adjacent_view::begin()/1000 (empty view)");
 
 } // namespace


### PR DESCRIPTION
Benchmarking a bunch of very similar values has rather little benefit, since they behave essentially the same.
