### PR TITLE
[LFI][AArch64] Fix Segfault due to infinite recursion in LFI rewriter

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -301,8 +301,8 @@ void AArch64MCLFIRewriter::onLabel(const MCSymbol *, MCStreamer &Out) {
   // Flush a deferred LR guard before the label, since the label is a potential
   // branch target and code reached through it may use LR for control flow.
   if (DeferredLRGuard && LastSTI) {
-    emitAddMask(AArch64::LR, AArch64::LR, Out, *LastSTI);
     DeferredLRGuard = false;
+    emitAddMask(AArch64::LR, AArch64::LR, Out, *LastSTI);
   }
 
   // Invalidate guard state since the label is a potential branch target.
@@ -312,8 +312,8 @@ void AArch64MCLFIRewriter::onLabel(const MCSymbol *, MCStreamer &Out) {
 void AArch64MCLFIRewriter::finish(MCStreamer &Out) {
   // Flush a deferred LR guard at the end of the stream.
   if (DeferredLRGuard && LastSTI) {
-    emitAddMask(AArch64::LR, AArch64::LR, Out, *LastSTI);
     DeferredLRGuard = false;
+    emitAddMask(AArch64::LR, AArch64::LR, Out, *LastSTI);
   }
 }
 
@@ -948,8 +948,8 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
   // modified LR is sandboxed before it can be used to transfer control.
   if (DeferredLRGuard && (isReturn(Inst) || isIndirectBranch(Inst) ||
                           isCall(Inst) || isBranch(Inst))) {
-    emitAddMask(AArch64::LR, AArch64::LR, Out, STI);
     DeferredLRGuard = false;
+    emitAddMask(AArch64::LR, AArch64::LR, Out, STI);
   }
 
   // PAC authenticated branches/calls expand to authenticate + guarded branch.

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -298,11 +298,14 @@ MCRegister AArch64MCLFIRewriter::mayModifyReserved(const MCInst &Inst) const {
 }
 
 void AArch64MCLFIRewriter::onLabel(const MCSymbol *, MCStreamer &Out) {
+  if (Guard)
+    return;
+
   // Flush a deferred LR guard before the label, since the label is a potential
   // branch target and code reached through it may use LR for control flow.
   if (DeferredLRGuard && LastSTI) {
-    DeferredLRGuard = false;
     emitAddMask(AArch64::LR, AArch64::LR, Out, *LastSTI);
+    DeferredLRGuard = false;
   }
 
   // Invalidate guard state since the label is a potential branch target.
@@ -312,8 +315,8 @@ void AArch64MCLFIRewriter::onLabel(const MCSymbol *, MCStreamer &Out) {
 void AArch64MCLFIRewriter::finish(MCStreamer &Out) {
   // Flush a deferred LR guard at the end of the stream.
   if (DeferredLRGuard && LastSTI) {
-    DeferredLRGuard = false;
     emitAddMask(AArch64::LR, AArch64::LR, Out, *LastSTI);
+    DeferredLRGuard = false;
   }
 }
 
@@ -948,8 +951,8 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
   // modified LR is sandboxed before it can be used to transfer control.
   if (DeferredLRGuard && (isReturn(Inst) || isIndirectBranch(Inst) ||
                           isCall(Inst) || isBranch(Inst))) {
-    DeferredLRGuard = false;
     emitAddMask(AArch64::LR, AArch64::LR, Out, STI);
+    DeferredLRGuard = false;
   }
 
   // PAC authenticated branches/calls expand to authenticate + guarded branch.

--- a/llvm/test/MC/AArch64/LFI/debug-info.s
+++ b/llvm/test/MC/AArch64/LFI/debug-info.s
@@ -1,0 +1,13 @@
+// RUN: llvm-mc -triple aarch64_lfi -filetype=obj %s -o /dev/null
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// CHECK:      mov	x30, x0
+// CHECK:      add	x30, x27, w30, uxtw
+// CHECK:      next_func:
+// CHECK-NEXT: nop
+
+.file 1 "debug-info.s"
+mov x30, x0
+.loc 1 10 0
+next_func:
+  nop


### PR DESCRIPTION
When emitting a deferred LR guard, if debug info is enabled, the emission of the guard instruction can trigger temporary labels (e.g. for DWARF line entries), which recursively calls onLabel. Since DeferredLRGuard was only set to false after emission, the nested call would re-emit the guard, causing infinite recursion which leads to a SegFault due to stack overflow. This was detected compiling ubsan_minimal_handlers.cpp in compiler-rt. I fixed it by using the existing recursion guard (Guard).