### PR TITLE
[libc++] Remove redundant benchmarks for lexicographical_compare_three_way

### DIFF
--- a/libcxx/test/benchmarks/algorithms/lexicographical_compare_three_way.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/lexicographical_compare_three_way.bench.cpp
@@ -13,50 +13,6 @@
 #include "benchmark/benchmark.h"
 #include "test_iterators.h"
 
-static void BM_lexicographical_compare_three_way_slow_path(benchmark::State& state) {
-  auto size = state.range(0);
-  std::vector<int> v1;
-  v1.resize(size);
-  // v2 is identical except for the last value.
-  // This means, that `lexicographical_compare_three_way` actually has to
-  // compare the complete vector and cannot bail out early.
-  std::vector<int> v2 = v1;
-  v2.back() += 1;
-  int* b1 = v1.data();
-  int* e1 = b1 + v1.size();
-  int* b2 = v2.data();
-  int* e2 = b2 + v2.size();
-
-  for (auto _ : state) {
-    auto cmp = std::compare_three_way();
-    benchmark::DoNotOptimize(std::__lexicographical_compare_three_way_slow_path(b1, e1, b2, e2, cmp));
-  }
-}
-
-BENCHMARK(BM_lexicographical_compare_three_way_slow_path)->RangeMultiplier(4)->Range(1, 1 << 20);
-
-static void BM_lexicographical_compare_three_way_fast_path(benchmark::State& state) {
-  auto size = state.range(0);
-  std::vector<int> v1;
-  v1.resize(size);
-  // v2 is identical except for the last value.
-  // This means, that `lexicographical_compare_three_way` actually has to
-  // compare the complete vector and cannot bail out early.
-  std::vector<int> v2 = v1;
-  v2.back() += 1;
-  int* b1 = v1.data();
-  int* e1 = b1 + v1.size();
-  int* b2 = v2.data();
-  int* e2 = b2 + v2.size();
-
-  for (auto _ : state) {
-    auto cmp = std::compare_three_way();
-    benchmark::DoNotOptimize(std::__lexicographical_compare_three_way_fast_path(b1, e1, b2, e2, cmp));
-  }
-}
-
-BENCHMARK(BM_lexicographical_compare_three_way_fast_path)->RangeMultiplier(4)->Range(1, 1 << 20);
-
 template <class IteratorT>
 static void BM_lexicographical_compare_three_way(benchmark::State& state) {
   auto size = state.range(0);


### PR DESCRIPTION
We already test the `_slow_path` and `_fast_path` functions through the generic `BM_lexicographical_compare_three_way`. We don't need to benchmark them again.
