### PR TITLE
[lldb][NFC] Remove Stream::Printf calls with constant strings in Target/*

### DIFF
--- a/lldb/source/Target/DynamicRegisterInfo.cpp
+++ b/lldb/source/Target/DynamicRegisterInfo.cpp
@@ -765,19 +765,19 @@ void DynamicRegisterInfo::Dump(Stream &s) const {
     if (m_regs[i].alt_name)
       s.Printf(", alt-name = %s", m_regs[i].alt_name);
     if (m_regs[i].value_regs) {
-      s.Printf(", value_regs = [ ");
+      s.PutCString(", value_regs = [ ");
       for (size_t j = 0; m_regs[i].value_regs[j] != LLDB_INVALID_REGNUM; ++j) {
         s.Printf("%s ", m_regs[m_regs[i].value_regs[j]].name);
       }
-      s.Printf("]");
+      s.PutCString("]");
     }
     if (m_regs[i].invalidate_regs) {
-      s.Printf(", invalidate_regs = [ ");
+      s.PutCString(", invalidate_regs = [ ");
       for (size_t j = 0; m_regs[i].invalidate_regs[j] != LLDB_INVALID_REGNUM;
            ++j) {
         s.Printf("%s ", m_regs[m_regs[i].invalidate_regs[j]].name);
       }
-      s.Printf("]");
+      s.PutCString("]");
     }
     s.EOL();
   }
@@ -791,7 +791,7 @@ void DynamicRegisterInfo::Dump(Stream &s) const {
     for (size_t idx = 0; idx < m_sets[i].num_registers; ++idx) {
       s.Printf("%s ", m_regs[m_sets[i].registers[idx]].name);
     }
-    s.Printf("]\n");
+    s.PutCString("]\n");
   }
 }
 

--- a/lldb/source/Target/LanguageRuntime.cpp
+++ b/lldb/source/Target/LanguageRuntime.cpp
@@ -135,7 +135,7 @@ public:
 
     SetActualResolver();
     if (m_actual_resolver_sp) {
-      s->Printf(" using: ");
+      s->PutCString(" using: ");
       m_actual_resolver_sp->GetDescription(s);
     } else
       s->Printf(" the correct runtime exception handler will be determined "

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -345,7 +345,7 @@ void Platform::GetStatus(Stream &strm) {
   ArchSpec arch(GetSystemArchitecture());
   if (arch.IsValid()) {
     if (!arch.GetTriple().str().empty()) {
-      strm.Printf("    Triple: ");
+      strm.PutCString("    Triple: ");
       arch.DumpTriple(strm.AsRawOstream());
       strm.EOL();
     }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -925,9 +925,9 @@ bool Process::HandleProcessStateChangedEvent(
           if (target_idx != UINT32_MAX)
             stream->Printf("Target %d: (", target_idx);
           else
-            stream->Printf("Target <unknown index>: (");
+            stream->PutCString("Target <unknown index>: (");
           process_sp->GetTarget().Dump(stream, eDescriptionLevelBrief);
-          stream->Printf(") stopped.\n");
+          stream->PutCString(") stopped.\n");
         }
       }
 
@@ -5930,7 +5930,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
               Thread *thread = thread_list.GetThreadAtIndex(thread_index).get();
 
               if (!thread) {
-                ts.Printf("<?> ");
+                ts.PutCString("<?> ");
                 continue;
               }
 
@@ -5941,7 +5941,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
               if (register_context)
                 ts.Printf("[ip 0x%" PRIx64 "] ", register_context->GetPC());
               else
-                ts.Printf("[ip unknown] ");
+                ts.PutCString("[ip unknown] ");
 
               // Show the private stop info here, the public stop info will be
               // from the last natural stop.
@@ -5951,7 +5951,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
                 if (stop_desc)
                   ts.PutCString(stop_desc);
               }
-              ts.Printf(">");
+              ts.PutCString(">");
             }
 
             event_explanation = ts.GetData();
@@ -6057,7 +6057,7 @@ void Process::GetStatus(Stream &strm, bool is_verbose) {
                   exit_description ? exit_description : "");
     } else {
       if (state == eStateConnected)
-        strm.Printf("Connected to remote target.\n");
+        strm.PutCString("Connected to remote target.\n");
       else {
         strm.Printf("Process %" PRIu64 " %s\n", GetID(), StateAsCString(state));
         if (auto core_args = GetCoreFileArgs(); core_args && is_verbose)

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -644,7 +644,7 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
       m_frames[curr_frame_idx] = prev_frame_sp;
 
 #if defined(DEBUG_STACK_FRAMES)
-      s.Printf("\n    Copying previous frame to current frame");
+      s.PutCString("\n    Copying previous frame to current frame");
 #endif
     }
     // We are done with the old stack frame list, we can release it now.

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -250,7 +250,7 @@ public:
             }
           }
 
-          strm.Printf("breakpoint ");
+          strm.PutCString("breakpoint ");
           m_async_stopped_locs.GetDescription(&strm, eDescriptionLevelBrief);
           m_description = std::string(strm.GetString());
         } else {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4147,8 +4147,8 @@ void Target::ClearDummySignals(Args &signal_names) {
 }
 
 void Target::PrintDummySignals(Stream &strm, Args &signal_args) {
-  strm.Printf("NAME         PASS     STOP     NOTIFY\n");
-  strm.Printf("===========  =======  =======  =======\n");
+  strm.PutCString("NAME         PASS     STOP     NOTIFY\n");
+  strm.PutCString("===========  =======  =======  =======\n");
 
   auto str_for_lazy = [] (LazyBool lazy) -> const char * {
     switch (lazy) {

--- a/lldb/source/Target/TargetList.cpp
+++ b/lldb/source/Target/TargetList.cpp
@@ -205,7 +205,7 @@ Status TargetList::CreateTargetInternal(
             error_strm.PutCString(platform_name);
             platform_set.insert(platform_name);
           }
-          error_strm.Printf("), specify an architecture to disambiguate");
+          error_strm.PutCString("), specify an architecture to disambiguate");
           error = Status(error_strm.GetString().str());
           return error;
         }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -2156,21 +2156,21 @@ bool Thread::GetDescription(Stream &strm, lldb::DescriptionLevel level,
                             bool print_json_thread, bool print_json_stopinfo) {
   const bool stop_format = false;
   DumpUsingSettingsFormat(strm, 0, stop_format);
-  strm.Printf("\n");
+  strm.PutCString("\n");
 
   StructuredData::ObjectSP thread_info = GetExtendedInfo();
 
   if (print_json_thread || print_json_stopinfo) {
     if (thread_info && print_json_thread) {
       thread_info->Dump(strm);
-      strm.Printf("\n");
+      strm.PutCString("\n");
     }
 
     if (print_json_stopinfo && m_stop_info_sp) {
       StructuredData::ObjectSP stop_info = m_stop_info_sp->GetExtendedInfo();
       if (stop_info) {
         stop_info->Dump(strm);
-        strm.Printf("\n");
+        strm.PutCString("\n");
       }
     }
 
@@ -2201,7 +2201,7 @@ bool Thread::GetDescription(Stream &strm, lldb::DescriptionLevel level,
     bool printed_breadcrumb = false;
     if (breadcrumb && breadcrumb->GetType() == eStructuredDataTypeDictionary) {
       if (printed_activity)
-        strm.Printf("\n");
+        strm.PutCString("\n");
       StructuredData::Dictionary *breadcrumb_dict =
           breadcrumb->GetAsDictionary();
       StructuredData::ObjectSP breadcrumb_text =
@@ -2215,7 +2215,7 @@ bool Thread::GetDescription(Stream &strm, lldb::DescriptionLevel level,
     }
     if (messages && messages->GetType() == eStructuredDataTypeArray) {
       if (printed_breadcrumb)
-        strm.Printf("\n");
+        strm.PutCString("\n");
       StructuredData::Array *messages_array = messages->GetAsArray();
       const size_t msg_count = messages_array->GetSize();
       if (msg_count > 0) {

--- a/lldb/source/Target/ThreadPlanBase.cpp
+++ b/lldb/source/Target/ThreadPlanBase.cpp
@@ -47,7 +47,7 @@ ThreadPlanBase::ThreadPlanBase(Thread &thread)
 ThreadPlanBase::~ThreadPlanBase() = default;
 
 void ThreadPlanBase::GetDescription(Stream *s, lldb::DescriptionLevel level) {
-  s->Printf("Base thread plan.");
+  s->PutCString("Base thread plan.");
 }
 
 bool ThreadPlanBase::ValidatePlan(Stream *error) { return true; }

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -231,7 +231,7 @@ void ThreadPlanCallFunction::DidPop() { DoTakedown(PlanSucceeded()); }
 
 void ThreadPlanCallFunction::GetDescription(Stream *s, DescriptionLevel level) {
   if (level == eDescriptionLevelBrief) {
-    s->Printf("Function call thread plan");
+    s->PutCString("Function call thread plan");
   } else {
     s->Printf("Thread plan to call 0x%" PRIx64,
               m_function_addr.GetLoadAddress(&GetTarget()));

--- a/lldb/source/Target/ThreadPlanCallFunctionUsingABI.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunctionUsingABI.cpp
@@ -47,7 +47,7 @@ ThreadPlanCallFunctionUsingABI::~ThreadPlanCallFunctionUsingABI() = default;
 void ThreadPlanCallFunctionUsingABI::GetDescription(Stream *s,
                                                     DescriptionLevel level) {
   if (level == eDescriptionLevelBrief) {
-    s->Printf("Function call thread plan using ABI instead of JIT");
+    s->PutCString("Function call thread plan using ABI instead of JIT");
   } else {
     s->Printf("Thread plan to call 0x%" PRIx64 " using ABI instead of JIT",
               m_function_addr.GetLoadAddress(&GetTarget()));

--- a/lldb/source/Target/ThreadPlanCallUserExpression.cpp
+++ b/lldb/source/Target/ThreadPlanCallUserExpression.cpp
@@ -48,7 +48,7 @@ ThreadPlanCallUserExpression::~ThreadPlanCallUserExpression() = default;
 void ThreadPlanCallUserExpression::GetDescription(
     Stream *s, lldb::DescriptionLevel level) {
   if (level == eDescriptionLevelBrief)
-    s->Printf("User Expression thread plan");
+    s->PutCString("User Expression thread plan");
   else
     ThreadPlanCallFunction::GetDescription(s, level);
 }

--- a/lldb/source/Target/ThreadPlanRunToAddress.cpp
+++ b/lldb/source/Target/ThreadPlanRunToAddress.cpp
@@ -89,30 +89,30 @@ void ThreadPlanRunToAddress::GetDescription(Stream *s,
 
   if (level == lldb::eDescriptionLevelBrief) {
     if (num_addresses == 0) {
-      s->Printf("run to address with no addresses given.");
+      s->PutCString("run to address with no addresses given.");
       return;
     } else if (num_addresses == 1)
-      s->Printf("run to address: ");
+      s->PutCString("run to address: ");
     else
-      s->Printf("run to addresses: ");
+      s->PutCString("run to addresses: ");
 
     for (size_t i = 0; i < num_addresses; i++) {
       DumpAddress(s->AsRawOstream(), m_addresses[i], sizeof(addr_t));
-      s->Printf(" ");
+      s->PutCString(" ");
     }
   } else {
     if (num_addresses == 0) {
-      s->Printf("run to address with no addresses given.");
+      s->PutCString("run to address with no addresses given.");
       return;
     } else if (num_addresses == 1)
-      s->Printf("Run to address: ");
+      s->PutCString("Run to address: ");
     else {
-      s->Printf("Run to addresses: ");
+      s->PutCString("Run to addresses: ");
     }
 
     for (size_t i = 0; i < num_addresses; i++) {
       if (num_addresses > 1) {
-        s->Printf("\n");
+        s->PutCString("\n");
         s->Indent();
       }
 
@@ -123,7 +123,7 @@ void ThreadPlanRunToAddress::GetDescription(Stream *s,
       if (breakpoint)
         breakpoint->Dump(s);
       else
-        s->Printf("but the breakpoint has been deleted.");
+        s->PutCString("but the breakpoint has been deleted.");
     }
   }
 }
@@ -131,7 +131,7 @@ void ThreadPlanRunToAddress::GetDescription(Stream *s,
 bool ThreadPlanRunToAddress::ValidatePlan(Stream *error) {
   if (m_could_not_resolve_hw_bp) {
     if (error)
-      error->Printf("Could not set hardware breakpoint(s)");
+      error->PutCString("Could not set hardware breakpoint(s)");
     return false;
   }
 
@@ -142,9 +142,9 @@ bool ThreadPlanRunToAddress::ValidatePlan(Stream *error) {
     if (m_break_ids[i] == LLDB_INVALID_BREAK_ID) {
       all_bps_good = false;
       if (error) {
-        error->Printf("Could not set breakpoint for address: ");
+        error->PutCString("Could not set breakpoint for address: ");
         DumpAddress(error->AsRawOstream(), m_addresses[i], sizeof(addr_t));
-        error->Printf("\n");
+        error->PutCString("\n");
       }
     }
   }

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -464,7 +464,7 @@ void ThreadPlanStackMap::DumpPlans(Stream &strm,
         strm.Printf("thread #%u: tid = 0x%4.4" PRIx64 "\n", index_id, tid);
         strm.IndentMore();
         strm.Indent();
-        strm.Printf("No active thread plans\n");
+        strm.PutCString("No active thread plans\n");
         strm.IndentLess();
         return;
       }
@@ -507,7 +507,7 @@ bool ThreadPlanStackMap::DumpPlansForTID(Stream &strm, lldb::tid_t tid,
       strm.Printf("thread #%u: tid = 0x%4.4" PRIx64 "\n", index_id, tid);
       strm.IndentMore();
       strm.Indent();
-      strm.Printf("No active thread plans\n");
+      strm.PutCString("No active thread plans\n");
       strm.IndentLess();
       return true;
     }

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -99,15 +99,15 @@ void ThreadPlanStepInRange::GetDescription(Stream *s,
   };
 
   if (level == lldb::eDescriptionLevelBrief) {
-    s->Printf("step in");
+    s->PutCString("step in");
     PrintFailureIfAny();
     return;
   }
 
-  s->Printf("Stepping in");
+  s->PutCString("Stepping in");
   bool printed_line_info = false;
   if (m_addr_context.line_entry.IsValid()) {
-    s->Printf(" through line ");
+    s->PutCString(" through line ");
     m_addr_context.line_entry.DumpStopContext(s, false);
     printed_line_info = true;
   }
@@ -116,7 +116,7 @@ void ThreadPlanStepInRange::GetDescription(Stream *s,
     s->Format(" targeting {0}", m_step_into_target);
 
   if (!printed_line_info || level == eDescriptionLevelVerbose) {
-    s->Printf(" using ranges:");
+    s->PutCString(" using ranges:");
     DumpRanges(s);
   }
 

--- a/lldb/source/Target/ThreadPlanStepInstruction.cpp
+++ b/lldb/source/Target/ThreadPlanStepInstruction.cpp
@@ -60,21 +60,21 @@ void ThreadPlanStepInstruction::GetDescription(Stream *s,
 
   if (level == lldb::eDescriptionLevelBrief) {
     if (m_step_over)
-      s->Printf("instruction step over");
+      s->PutCString("instruction step over");
     else
-      s->Printf("instruction step into");
+      s->PutCString("instruction step into");
 
     PrintFailureIfAny();
   } else {
-    s->Printf("Stepping one instruction past ");
+    s->PutCString("Stepping one instruction past ");
     DumpAddress(s->AsRawOstream(), m_instruction_addr, sizeof(addr_t));
     if (!m_start_has_symbol)
-      s->Printf(" which has no symbol");
+      s->PutCString(" which has no symbol");
 
     if (m_step_over)
-      s->Printf(" stepping over calls");
+      s->PutCString(" stepping over calls");
     else
-      s->Printf(" stepping into calls");
+      s->PutCString(" stepping into calls");
 
     PrintFailureIfAny();
   }

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -235,14 +235,14 @@ ThreadPlanStepOut::~ThreadPlanStepOut() {
 void ThreadPlanStepOut::GetDescription(Stream *s,
                                        lldb::DescriptionLevel level) {
   if (level == lldb::eDescriptionLevelBrief)
-    s->Printf("step out");
+    s->PutCString("step out");
   else {
     if (m_step_out_to_inline_plan_sp)
-      s->Printf("Stepping out to inlined frame so we can walk through it.");
+      s->PutCString("Stepping out to inlined frame so we can walk through it.");
     else if (m_step_through_inline_plan_sp)
-      s->Printf("Stepping out by stepping through inlined function.");
+      s->PutCString("Stepping out by stepping through inlined function.");
     else {
-      s->Printf("Stepping out from ");
+      s->PutCString("Stepping out from ");
       Address tmp_address;
       if (tmp_address.SetLoadAddress(m_step_from_insn, &GetTarget())) {
         tmp_address.Dump(s, &m_process, Address::DumpStyleResolvedDescription,
@@ -255,7 +255,7 @@ void ThreadPlanStepOut::GetDescription(Stream *s,
       // be multiple copies of the
       // same function on the stack.
 
-      s->Printf(" returning to frame at ");
+      s->PutCString(" returning to frame at ");
       if (tmp_address.SetLoadAddress(m_return_addr, &GetTarget())) {
         tmp_address.Dump(s, &m_process, Address::DumpStyleResolvedDescription,
                          Address::DumpStyleLoadAddress);
@@ -271,9 +271,9 @@ void ThreadPlanStepOut::GetDescription(Stream *s,
   if (m_stepped_past_frames.empty())
     return;
 
-  s->Printf("\n");
+  s->PutCString("\n");
   for (StackFrameSP frame_sp : m_stepped_past_frames) {
-    s->Printf("Stepped out past: ");
+    s->PutCString("Stepped out past: ");
     frame_sp->DumpUsingSettingsFormat(s);
   }
 }

--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -55,21 +55,21 @@ void ThreadPlanStepOverRange::GetDescription(Stream *s,
   };
 
   if (level == lldb::eDescriptionLevelBrief) {
-    s->Printf("step over");
+    s->PutCString("step over");
     PrintFailureIfAny();
     return;
   }
 
-  s->Printf("Stepping over");
+  s->PutCString("Stepping over");
   bool printed_line_info = false;
   if (m_addr_context.line_entry.IsValid()) {
-    s->Printf(" line ");
+    s->PutCString(" line ");
     m_addr_context.line_entry.DumpStopContext(s, false);
     printed_line_info = true;
   }
 
   if (!printed_line_info || level == eDescriptionLevelVerbose) {
-    s->Printf(" using ranges: ");
+    s->PutCString(" using ranges: ");
     DumpRanges(s);
   }
 

--- a/lldb/source/Target/ThreadPlanStepThrough.cpp
+++ b/lldb/source/Target/ThreadPlanStepThrough.cpp
@@ -112,7 +112,7 @@ void ThreadPlanStepThrough::LookForPlanToStepThroughFromCurrentPC() {
 void ThreadPlanStepThrough::GetDescription(Stream *s,
                                            lldb::DescriptionLevel level) {
   if (level == lldb::eDescriptionLevelBrief)
-    s->Printf("Step through");
+    s->PutCString("Step through");
   else {
     s->PutCString("Stepping through trampoline code from: ");
     DumpAddress(s->AsRawOstream(), m_start_address, sizeof(addr_t));

--- a/lldb/source/Target/ThreadPlanStepUntil.cpp
+++ b/lldb/source/Target/ThreadPlanStepUntil.cpp
@@ -96,9 +96,9 @@ void ThreadPlanStepUntil::Clear() {
 void ThreadPlanStepUntil::GetDescription(Stream *s,
                                          lldb::DescriptionLevel level) {
   if (level == lldb::eDescriptionLevelBrief) {
-    s->Printf("step until");
+    s->PutCString("step until");
     if (m_stepped_out)
-      s->Printf(" - stepped out");
+      s->PutCString(" - stepped out");
   } else {
     if (m_until_points.size() == 1)
       s->Printf("Stepping from address 0x%" PRIx64 " until we reach 0x%" PRIx64

--- a/lldb/source/Target/ThreadPlanTracer.cpp
+++ b/lldb/source/Target/ThreadPlanTracer.cpp
@@ -69,7 +69,7 @@ void ThreadPlanTracer::Log() {
   if (StreamSP stream_sp = GetLogStreamSP()) {
     GetThread().GetStackFrameAtIndex(0)->Dump(stream_sp.get(), show_frame_index,
                                               show_fullpaths);
-    stream_sp->Printf("\n");
+    stream_sp->PutCString("\n");
     stream_sp->Flush();
   }
 }


### PR DESCRIPTION
`Stream::Printf` needs to call various other (variadic) functions, needs to parse the input string and potentially handle too-long format outputs. Calling in with a constant string is wasting a lot of instruction on doing nothing.

assisted-by: claude