### PR TITLE
[lldb][NFC] Remove Stream::Printf calls with constant strings in Interpreter/*

### DIFF
--- a/lldb/source/Interpreter/CommandAlias.cpp
+++ b/lldb/source/Interpreter/CommandAlias.cpp
@@ -144,7 +144,7 @@ void CommandAlias::GetAliasExpansion(StreamString &help_string) const {
   help_string.Printf("'%*s", (int)command_name.size(), command_name.data());
 
   if (!m_option_args_sp) {
-    help_string.Printf("'");
+    help_string.PutCString("'");
     return;
   }
 
@@ -165,7 +165,7 @@ void CommandAlias::GetAliasExpansion(StreamString &help_string) const {
     }
   }
 
-  help_string.Printf("'");
+  help_string.PutCString("'");
 }
 
 bool CommandAlias::IsDashDashCommand() {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1856,7 +1856,7 @@ CommandObject *CommandInterpreter::BuildAliasResult(
       (alias_name_str != cmd_args.GetArgumentAtIndex(0)))
     cmd_args.Unshift(alias_name_str);
 
-  result_str.Printf("%s", alias_cmd_obj->GetCommandName().str().c_str());
+  result_str.PutCString(alias_cmd_obj->GetCommandName());
 
   if (!option_arg_vector_sp.get()) {
     alias_result = std::string(result_str.GetString());
@@ -1879,10 +1879,10 @@ CommandObject *CommandInterpreter::BuildAliasResult(
       continue;
 
     if (value_type != OptionParser::eOptionalArgument)
-      result_str.Printf(" ");
+      result_str.PutCString(" ");
     int index = GetOptionArgumentPosition(value.c_str());
     if (index == 0)
-      result_str.Printf("%s", value.c_str());
+      result_str.PutCString(value);
     else if (static_cast<size_t>(index) >= cmd_args.GetArgumentCount()) {
 
       result.AppendErrorWithFormat("Not enough arguments provided; you "
@@ -1914,7 +1914,7 @@ CommandObject *CommandInterpreter::BuildAliasResult(
             strlen(cmd_args.GetArgumentAtIndex(index)) + len_fudge);
       }
       if (quote_char == '\0')
-        result_str.Printf("%s", cmd_args.GetArgumentAtIndex(index));
+        result_str.PutCString(cmd_args.GetArgumentAtIndex(index));
       else
         result_str.Printf("%c%s%c", quote_char, entry.c_str(), quote_char);
     }
@@ -3367,7 +3367,7 @@ void CommandInterpreter::PrintCommandOutput(IOHandler &io_handler,
   LockedStreamFile stream_file = stream->Lock();
   if (had_output &&
       INTERRUPT_REQUESTED(GetDebugger(), "Interrupted dumping command output"))
-    stream_file.Printf("\n... Interrupted.\n");
+    stream_file.PutCString("\n... Interrupted.\n");
   stream_file.Flush();
 }
 
@@ -3751,7 +3751,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
     std::string alias_result;
     cmd_obj =
         BuildAliasResult(full_name, scratch_command, alias_result, result);
-    revised_command_line.Printf("%s", alias_result.c_str());
+    revised_command_line.PutCString(alias_result);
     if (cmd_obj) {
       wants_raw_input = cmd_obj->WantsRawCommandString();
     }
@@ -3772,10 +3772,10 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       } else {
         if (cmd_obj) {
           llvm::StringRef cmd_name = cmd_obj->GetCommandName();
-          revised_command_line.Printf("%s", cmd_name.str().c_str());
+          revised_command_line.PutCString(cmd_name);
           wants_raw_input = cmd_obj->WantsRawCommandString();
         } else {
-          revised_command_line.Printf("%s", next_word.c_str());
+          revised_command_line.PutCString(next_word);
         }
       }
     } else {
@@ -3787,7 +3787,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
           // restart rather than append to the revised_command_line.
           llvm::StringRef sub_cmd_name = sub_cmd_obj->GetCommandName();
           revised_command_line.Clear();
-          revised_command_line.Printf("%s", sub_cmd_name.str().c_str());
+          revised_command_line.PutCString(sub_cmd_name);
           cmd_obj = sub_cmd_obj;
           wants_raw_input = cmd_obj->WantsRawCommandString();
         } else {

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -561,7 +561,7 @@ void CommandObject::GetFormattedCommandArguments(Stream &str,
   int num_args = m_arguments.size();
   for (int i = 0; i < num_args; ++i) {
     if (i > 0)
-      str.Printf(" ");
+      str.PutCString(" ");
     CommandArgumentEntry arg_entry =
         opt_set_mask == LLDB_OPT_SET_ALL
             ? m_arguments[i]
@@ -612,8 +612,8 @@ void CommandObject::GetFormattedCommandArguments(Stream &str,
       StreamString names;
       for (int j = 0; j < num_alternatives; ++j) {
         if (j > 0)
-          names.Printf(" | ");
-        names.Printf("%s", GetArgumentName(arg_entry[j].arg_type));
+          names.PutCString(" | ");
+        names.PutCString(GetArgumentName(arg_entry[j].arg_type));
       }
 
       std::string name_str = std::string(names.GetString());

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -24,7 +24,7 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
     const bool one_line = dump_mask & eDumpOptionCommand;
     const uint32_t size = m_current_value.GetSize();
     if (dump_mask & (eDumpOptionType | eDumpOptionDefaultValue)) {
-      strm.Printf(" =");
+      strm.PutCString(" =");
       if (dump_mask & eDumpOptionDefaultValue && !m_current_value.IsEmpty()) {
         DefaultValueFormat label(strm);
         strm.PutCString("empty");

--- a/lldb/source/Interpreter/OptionValueLanguage.cpp
+++ b/lldb/source/Interpreter/OptionValueLanguage.cpp
@@ -59,7 +59,7 @@ Status OptionValueLanguage::SetValueFromString(llvm::StringRef value,
     } else {
       StreamString error_strm;
       error_strm.Printf("invalid language type '%s', ", value.str().c_str());
-      error_strm.Printf("valid values are:\n");
+      error_strm.PutCString("valid values are:\n");
       for (int bit : languages_for_types.bitvector.set_bits()) {
         auto language = (LanguageType)bit;
         error_strm.Printf("    %s\n",

--- a/lldb/source/Interpreter/OptionValuePathMappings.cpp
+++ b/lldb/source/Interpreter/OptionValuePathMappings.cpp
@@ -30,7 +30,7 @@ void OptionValuePathMappings::DumpValue(const ExecutionContext *exe_ctx,
     strm.Printf("(%s)", GetTypeAsCString());
   if (dump_mask & eDumpOptionValue) {
     if (dump_mask & (eDumpOptionType | eDumpOptionDefaultValue)) {
-      strm.Printf(" =");
+      strm.PutCString(" =");
       if (dump_mask & eDumpOptionDefaultValue && !m_path_mappings.IsEmpty()) {
         DefaultValueFormat label(strm);
         strm.PutCString("empty");

--- a/lldb/source/Interpreter/OptionValueRegex.cpp
+++ b/lldb/source/Interpreter/OptionValueRegex.cpp
@@ -22,8 +22,7 @@ void OptionValueRegex::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
     if (m_regex.IsValid()) {
-      llvm::StringRef regex_text = m_regex.GetText();
-      strm.Printf("%s", regex_text.str().c_str());
+      strm.PutCString(m_regex.GetText());
     }
     if (dump_mask & eDumpOptionDefaultValue &&
         m_regex.GetText() != m_default_regex_str &&

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -376,7 +376,7 @@ void Options::GenerateOptionUsage(Stream &strm, CommandObject &cmd,
     uint32_t num_option_sets = GetRequiredOptions().size();
     for (uint32_t opt_set = 0; opt_set < num_option_sets; ++opt_set) {
       if (opt_set > 0)
-        strm.Printf("\n");
+        strm.PutCString("\n");
       strm.Indent(name);
 
       // Different option sets may require different args.
@@ -432,7 +432,7 @@ void Options::GenerateOptionUsage(Stream &strm, CommandObject &cmd,
 
       if (args_str.GetSize() > 0) {
         if (cmd.WantsRawCommandString())
-          strm.Printf(" --");
+          strm.PutCString(" --");
         strm << " " << args_str.GetString();
       }
     }
@@ -447,7 +447,7 @@ void Options::GenerateOptionUsage(Stream &strm, CommandObject &cmd,
   }
 
   if (!only_print_args) {
-    strm.Printf("\n\n");
+    strm.PutCString("\n\n");
 
     // Now print out all the detailed information about the various options:
     // long form, short form and help text:
@@ -494,11 +494,11 @@ void Options::GenerateOptionUsage(Stream &strm, CommandObject &cmd,
         OutputFormattedUsageText(strm, opt_def, screen_width, use_color);
       if (!opt_def.enum_values.empty()) {
         strm.Indent();
-        strm.Printf("Values: ");
+        strm.PutCString("Values: ");
         bool is_first = true;
         for (const auto &enum_value : opt_def.enum_values) {
           if (is_first) {
-            strm.Printf("%s", enum_value.string_value);
+            strm.PutCString(enum_value.string_value);
             is_first = false;
           }
           else


### PR DESCRIPTION
`Stream::Printf` needs to call various other (variadic) functions, needs to parse the input string and potentially handle too-long format outputs. Calling in with a constant string is wasting a lot of instruction on doing nothing.

assisted-by: claude