### PR TITLE
[lldb][NFC] Remove Stream::Printf calls with constants in Plugins/

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1415,7 +1415,7 @@ bool DynamicLoaderDarwinKernel::ParseKextSummaries(
           if (image_info.GetModule()) {
             unloaded_module_list.AppendIfNeeded(image_info.GetModule());
           }
-          s->Printf(".");
+          s->PutCString(".");
           image_info.Clear();
           // should pull it out of the KextImageInfos vector but that would
           // mutate the list and invalidate the to_be_removed bool vector;
@@ -1427,7 +1427,7 @@ bool DynamicLoaderDarwinKernel::ParseKextSummaries(
   }
 
   if (load_kexts) {
-    s->Printf(" done.\n");
+    s->PutCString(" done.\n");
     if (kexts_failed_to_load.size() > 0 && number_of_new_kexts_being_added > 0) {
       s->Printf("Failed to load %d of %d kexts:\n",
                 (int)kexts_failed_to_load.size(),

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -898,9 +898,9 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
   StreamString ss;
 
   if (decl_name.isObjCZeroArgSelector()) {
-    ss.Printf("%s", decl_name.getAsString().c_str());
+    ss.PutCString(decl_name.getAsString().c_str());
   } else if (decl_name.isObjCOneArgSelector()) {
-    ss.Printf("%s", decl_name.getAsString().c_str());
+    ss.PutCString(decl_name.getAsString().c_str());
   } else {
     clang::Selector sel = decl_name.getObjCSelector();
 

--- a/lldb/source/Plugins/Instruction/ARM/EmulateInstructionARM.cpp
+++ b/lldb/source/Plugins/Instruction/ARM/EmulateInstructionARM.cpp
@@ -14355,7 +14355,7 @@ EmulateInstructionARM::GetInstructionCondition() {
 bool EmulateInstructionARM::TestEmulation(Stream &out_stream, ArchSpec &arch,
                                           OptionValueDictionary *test_data) {
   if (!test_data) {
-    out_stream.Printf("TestEmulation: Missing test data.\n");
+    out_stream.PutCString("TestEmulation: Missing test data.\n");
     return false;
   }
 
@@ -14368,7 +14368,7 @@ bool EmulateInstructionARM::TestEmulation(Stream &out_stream, ArchSpec &arch,
   uint32_t test_opcode;
   if ((value_sp.get() == nullptr) ||
       (value_sp->GetType() != OptionValue::eTypeUInt64)) {
-    out_stream.Printf("TestEmulation: Error reading opcode from test file.\n");
+    out_stream.PutCString("TestEmulation: Error reading opcode from test file.\n");
     return false;
   }
   test_opcode = value_sp->GetValueAs<uint64_t>().value_or(0);
@@ -14384,7 +14384,7 @@ bool EmulateInstructionARM::TestEmulation(Stream &out_stream, ArchSpec &arch,
     m_opcode_mode = eModeARM;
     m_opcode.SetOpcode32(test_opcode, endian::InlHostByteOrder());
   } else {
-    out_stream.Printf("TestEmulation:  Invalid arch.\n");
+    out_stream.PutCString("TestEmulation:  Invalid arch.\n");
     return false;
   }
 
@@ -14394,26 +14394,26 @@ bool EmulateInstructionARM::TestEmulation(Stream &out_stream, ArchSpec &arch,
   value_sp = test_data->GetValueForKey(before_key);
   if ((value_sp.get() == nullptr) ||
       (value_sp->GetType() != OptionValue::eTypeDictionary)) {
-    out_stream.Printf("TestEmulation:  Failed to find 'before' state.\n");
+    out_stream.PutCString("TestEmulation:  Failed to find 'before' state.\n");
     return false;
   }
 
   OptionValueDictionary *state_dictionary = value_sp->GetAsDictionary();
   if (!before_state.LoadStateFromDictionary(state_dictionary)) {
-    out_stream.Printf("TestEmulation:  Failed loading 'before' state.\n");
+    out_stream.PutCString("TestEmulation:  Failed loading 'before' state.\n");
     return false;
   }
 
   value_sp = test_data->GetValueForKey(after_key);
   if ((value_sp.get() == nullptr) ||
       (value_sp->GetType() != OptionValue::eTypeDictionary)) {
-    out_stream.Printf("TestEmulation:  Failed to find 'after' state.\n");
+    out_stream.PutCString("TestEmulation:  Failed to find 'after' state.\n");
     return false;
   }
 
   state_dictionary = value_sp->GetAsDictionary();
   if (!after_state.LoadStateFromDictionary(state_dictionary)) {
-    out_stream.Printf("TestEmulation: Failed loading 'after' state.\n");
+    out_stream.PutCString("TestEmulation: Failed loading 'after' state.\n");
     return false;
   }
 
@@ -14425,7 +14425,7 @@ bool EmulateInstructionARM::TestEmulation(Stream &out_stream, ArchSpec &arch,
 
   bool success = EvaluateInstruction(eEmulateInstructionOptionAutoAdvancePC);
   if (!success) {
-    out_stream.Printf("TestEmulation:  EvaluateInstruction() failed.\n");
+    out_stream.PutCString("TestEmulation:  EvaluateInstruction() failed.\n");
     return false;
   }
 

--- a/lldb/source/Plugins/Instruction/ARM/EmulationStateARM.cpp
+++ b/lldb/source/Plugins/Instruction/ARM/EmulationStateARM.cpp
@@ -245,11 +245,11 @@ bool EmulationStateARM::CompareState(EmulationStateARM &other_state,
   // other_state is the expected state. If it has memory, check it.
   if (!other_state.m_memory.empty() && m_memory != other_state.m_memory) {
     match = false;
-    out_stream.Printf("memory does not match\n");
-    out_stream.Printf("got memory:\n");
+    out_stream.PutCString("memory does not match\n");
+    out_stream.PutCString("got memory:\n");
     for (auto p : m_memory)
       out_stream.Printf("0x%08" PRIx64 ": 0x%08x\n", p.first, p.second);
-    out_stream.Printf("expected memory:\n");
+    out_stream.PutCString("expected memory:\n");
     for (auto p : other_state.m_memory)
       out_stream.Printf("0x%08" PRIx64 ": 0x%08x\n", p.first, p.second);
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -195,7 +195,7 @@ bool lldb_private::formatters::BlockPointerSummaryProvider(
   const char *child_value =
       qualified_child_representation_sp->GetValueAsCString();
 
-  s.Printf("%s", child_value);
+  s.PutCString(child_value);
 
   return true;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -69,7 +69,7 @@ static bool CharStringSummaryProvider(ValueObject &valobj, Stream &stream) {
   }
 
   if (!StringPrinter::ReadStringAndDumpToStream<ElemType>(options))
-    stream.Printf("Summary Unavailable");
+    stream.PutCString("Summary Unavailable");
 
   return true;
 }
@@ -155,7 +155,7 @@ bool lldb_private::formatters::WCharStringSummaryProvider(
     return StringPrinter::ReadStringAndDumpToStream<StringElementType::UTF32>(
         options);
   default:
-    stream.Printf("size for wchar_t is not valid");
+    stream.PutCString("size for wchar_t is not valid");
     return true;
   }
   return true;
@@ -210,7 +210,7 @@ bool lldb_private::formatters::WCharSummaryProvider(
     return StringPrinter::ReadBufferAndDumpToStream<StringElementType::UTF32>(
         options);
   default:
-    stream.Printf("size for wchar_t is not valid");
+    stream.PutCString("size for wchar_t is not valid");
     return true;
   }
   return true;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -75,7 +75,7 @@ bool lldb_private::formatters::LibCxxAtomicSummaryProvider(
     std::string summary;
     if (atomic_value->GetSummaryAsCString(summary, options) &&
         summary.size() > 0) {
-      stream.Printf("%s", summary.c_str());
+      stream.PutCString(summary.c_str());
       return true;
     }
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -162,7 +162,7 @@ bool LibcxxVariantSummaryProvider(ValueObject &valobj, Stream &stream,
     return false;
 
   if (validity == LibcxxVariantIndexValidity::NPos) {
-    stream.Printf(" No Value");
+    stream.PutCString(" No Value");
     return true;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -480,7 +480,7 @@ bool formatters::LibStdcppVariantSummaryProvider(
   auto npos_value = LibStdcppVariantNposValue(*index_bytes_or_err);
   auto index = index_obj->GetValueAsUnsigned(0);
   if (index == npos_value) {
-    stream.Printf(" No Value");
+    stream.PutCString(" No Value");
     return true;
   }
 
@@ -489,7 +489,7 @@ bool formatters::LibStdcppVariantSummaryProvider(
   if (!variant_type)
     return false;
   if (index >= variant_type.GetNumTemplateArguments(true)) {
-    stream.Printf(" <Invalid>");
+    stream.PutCString(" <Invalid>");
     return true;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
@@ -362,7 +362,7 @@ bool formatters::MsvcStlTreeIterSummaryProvider(
 
   MapEntry entry(node_sp.get());
   if (entry.is_nil()) {
-    stream.Printf("end");
+    stream.PutCString("end");
     return true;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
@@ -110,7 +110,7 @@ bool formatters::MsvcStlVariantSummaryProvider(
     return false;
 
   if (*index < 0) {
-    stream.Printf(" No Value");
+    stream.PutCString(" No Value");
     return true;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/CF.cpp
+++ b/lldb/source/Plugins/Language/ObjC/CF.cpp
@@ -186,35 +186,35 @@ bool lldb_private::formatters::CFBitVectorSummaryProvider(
     bool bit6 = (byte & 64) == 64;
     bool bit7 = (byte & 128) == 128;
     if (count) {
-      stream.Printf("%c", bit7 ? '1' : '0');
+      stream.PutChar(bit7 ? '1' : '0');
       count -= 1;
     }
     if (count) {
-      stream.Printf("%c", bit6 ? '1' : '0');
+      stream.PutChar(bit6 ? '1' : '0');
       count -= 1;
     }
     if (count) {
-      stream.Printf("%c", bit5 ? '1' : '0');
+      stream.PutChar(bit5 ? '1' : '0');
       count -= 1;
     }
     if (count) {
-      stream.Printf("%c", bit4 ? '1' : '0');
+      stream.PutChar(bit4 ? '1' : '0');
       count -= 1;
     }
     if (count) {
-      stream.Printf("%c", bit3 ? '1' : '0');
+      stream.PutChar(bit3 ? '1' : '0');
       count -= 1;
     }
     if (count) {
-      stream.Printf("%c", bit2 ? '1' : '0');
+      stream.PutChar(bit2 ? '1' : '0');
       count -= 1;
     }
     if (count) {
-      stream.Printf("%c", bit1 ? '1' : '0');
+      stream.PutChar(bit1 ? '1' : '0');
       count -= 1;
     }
     if (count)
-      stream.Printf("%c", bit0 ? '1' : '0');
+      stream.PutChar(bit0 ? '1' : '0');
   }
   return true;
 }

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -78,7 +78,7 @@ bool lldb_private::formatters::NSBundleSummaryProvider(
     bool was_nsstring_ok =
         NSStringSummaryProvider(*text, summary_stream, options);
     if (was_nsstring_ok && summary_stream.GetSize() > 0) {
-      stream.Printf("%s", summary_stream.GetData());
+      stream.PutCString(summary_stream.GetData());
       return true;
     }
   }
@@ -127,7 +127,7 @@ bool lldb_private::formatters::NSTimeZoneSummaryProvider(
     bool was_nsstring_ok =
         NSStringSummaryProvider(*text, summary_stream, options);
     if (was_nsstring_ok && summary_stream.GetSize() > 0) {
-      stream.Printf("%s", summary_stream.GetData());
+      stream.PutCString(summary_stream.GetData());
       return true;
     }
   }
@@ -176,7 +176,7 @@ bool lldb_private::formatters::NSNotificationSummaryProvider(
     bool was_nsstring_ok =
         NSStringSummaryProvider(*text, summary_stream, options);
     if (was_nsstring_ok && summary_stream.GetSize() > 0) {
-      stream.Printf("%s", summary_stream.GetData());
+      stream.PutCString(summary_stream.GetData());
       return true;
     }
   }
@@ -754,12 +754,12 @@ bool lldb_private::formatters::NSDecimalNumberSummaryProvider(
   const bool is_nan = is_negative && (length == 0);
 
   if (is_nan) {
-    stream.Printf("NaN");
+    stream.PutCString("NaN");
     return true;
   }
 
   if (length == 0) {
-    stream.Printf("0");
+    stream.PutCString("0");
     return true;
   }
 
@@ -769,7 +769,7 @@ bool lldb_private::formatters::NSDecimalNumberSummaryProvider(
     return false;
 
   if (is_negative)
-    stream.Printf("-");
+    stream.PutCString("-");
 
   stream.Printf("%" PRIu64 " x 10^%" PRIi8, mantissa, exponent);
   return true;
@@ -972,7 +972,7 @@ bool lldb_private::formatters::NSDateSummaryProvider(
   // The relative time in seconds from Cocoa Epoch to [NSDate distantPast].
   const double RelSecondsFromCocoaEpochToNSDateDistantPast = -63114076800;
   if (date_value == RelSecondsFromCocoaEpochToNSDateDistantPast) {
-    stream.Printf("0001-01-01 00:00:00 UTC");
+    stream.PutCString("0001-01-01 00:00:00 UTC");
     return true;
   }
 
@@ -1026,7 +1026,7 @@ bool lldb_private::formatters::ObjCClassSummaryProvider(
   if (ConstString cs = Mangled(class_name).GetDemangledName())
     class_name = cs;
 
-  stream.Printf("%s", class_name.AsCString("<unknown class>"));
+  stream.PutCString(class_name.AsCString("<unknown class>"));
   return true;
 }
 
@@ -1143,10 +1143,10 @@ bool lldb_private::formatters::ObjCBOOLSummaryProvider(
   int8_t value = (real_guy_sp->GetValueAsSigned(0) & 0xFF);
   switch (value) {
   case 0:
-    stream.Printf("NO");
+    stream.PutCString("NO");
     break;
   case 1:
-    stream.Printf("YES");
+    stream.PutCString("YES");
     break;
   default:
     stream.Printf("%d", value);
@@ -1217,7 +1217,7 @@ bool lldb_private::formatters::ObjCSELSummaryProvider(
   if (!valobj_sp)
     return false;
 
-  stream.Printf("%s", valobj_sp->GetSummaryAsCString());
+  stream.PutCString(valobj_sp->GetSummaryAsCString());
   return true;
 }
 

--- a/lldb/source/Plugins/Language/ObjC/CoreMedia.cpp
+++ b/lldb/source/Plugins/Language/ObjC/CoreMedia.cpp
@@ -53,17 +53,17 @@ bool lldb_private::formatters::CMTimeSummaryProvider(
   const unsigned int FlagIndefinite = 16;
 
   if (flags.AnySet(FlagIndefinite)) {
-    stream.Printf("indefinite");
+    stream.PutCString("indefinite");
     return true;
   }
 
   if (flags.AnySet(FlagPositiveInf)) {
-    stream.Printf("+oo");
+    stream.PutCString("+oo");
     return true;
   }
 
   if (flags.AnySet(FlagNegativeInf)) {
-    stream.Printf("-oo");
+    stream.PutCString("-oo");
     return true;
   }
 

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -108,14 +108,14 @@ bool lldb_private::formatters::NSException_SummaryProvider(
     return false;
 
   if (!reason_sp) {
-    stream.Printf("No reason");
+    stream.PutCString("No reason");
     return false;
   }
 
   StreamString reason_str_summary;
   if (NSStringSummaryProvider(*reason_sp, reason_str_summary, options) &&
       !reason_str_summary.Empty()) {
-    stream.Printf("%s", reason_str_summary.GetData());
+    stream.PutCString(reason_str_summary.GetData());
     return true;
   } else
     return false;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1073,7 +1073,7 @@ protected:
             std_out.Printf(" superclass = %s",
                            superclass->GetClassName().AsCString("<unknown>"));
           }
-          std_out.Printf("\n");
+          std_out.PutCString("\n");
           if (m_options.m_verbose) {
             for (size_t i = 0; i < iterator->second->GetNumIVars(); i++) {
               auto ivar = iterator->second->GetIVarAtIndex(i);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
@@ -45,7 +45,7 @@ AppleObjCTypeEncodingParser::AppleObjCTypeEncodingParser(
 std::string AppleObjCTypeEncodingParser::ReadStructName(llvm::StringRef &type) {
   StreamString buffer;
   while (!type.empty() && type.front() != '=')
-    buffer.Printf("%c", popChar(type));
+    buffer.PutChar(popChar(type));
 
   return std::string(buffer.GetString());
 }
@@ -57,7 +57,7 @@ AppleObjCTypeEncodingParser::ReadQuotedString(llvm::StringRef &type) {
 
   StreamString buffer;
   while (type.front() != '"') {
-    buffer.Printf("%c", popChar(type));
+    buffer.PutChar(popChar(type));
 
     if (type.empty())
       return std::nullopt;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
@@ -88,7 +88,7 @@ bool AppleThreadPlanStepThroughObjCTrampoline::
 void AppleThreadPlanStepThroughObjCTrampoline::GetDescription(
     Stream *s, lldb::DescriptionLevel level) {
   if (level == lldb::eDescriptionLevelBrief)
-    s->Printf("Step through ObjC trampoline");
+    s->PutCString("Step through ObjC trampoline");
   else {
     s->Printf("Stepping to implementation of ObjC method - obj: 0x%llx, isa: "
               "0x%" PRIx64 ", sel: 0x%" PRIx64,
@@ -286,7 +286,7 @@ void AppleThreadPlanStepThroughDirectDispatch::GetDescription(
     s->PutCString("Step through ObjC direct dispatch function.");
     break;
   default:
-    s->Printf("Step through ObjC direct dispatch using breakpoints: ");
+    s->PutCString("Step through ObjC direct dispatch using breakpoints: ");
     bool first = true;
     for (auto bkpt_sp : m_msgSend_bkpts) {
         if (!first) {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5327,7 +5327,7 @@ bool ObjectFileMachO::GetCorefileThreadExtraInfos(
 
       if (log) {
         StreamString logmsg;
-        logmsg.Printf("LC_NOTE 'process metadata' found: ");
+        logmsg.PutCString("LC_NOTE 'process metadata' found: ");
         dict->Dump(logmsg, /* pretty_print */ false);
         LLDB_LOGF(log, "%s", logmsg.GetData());
       }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -103,7 +103,7 @@ void PlatformAppleSimulator::GetStatus(Stream &strm) {
           developer_dir.c_str());
   const size_t num_devices = devices.GetNumDevices();
   if (num_devices) {
-    strm.Printf("Available devices:\n");
+    strm.PutCString("Available devices:\n");
     for (size_t i = 0; i < num_devices; ++i) {
       CoreSimulatorSupport::Device device = devices.GetDeviceAtIndex(i);
       strm << "   " << device.GetUDID() << ": " << device.GetName() << "\n";

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -243,21 +243,21 @@ PlatformDarwinKernel::~PlatformDarwinKernel() = default;
 void PlatformDarwinKernel::GetStatus(Stream &strm) {
   UpdateKextandKernelsLocalScan();
   Platform::GetStatus(strm);
-  strm.Printf(" Debug session type: ");
+  strm.PutCString(" Debug session type: ");
   if (m_ios_debug_session == eLazyBoolYes)
-    strm.Printf("iOS kernel debugging\n");
+    strm.PutCString("iOS kernel debugging\n");
   else if (m_ios_debug_session == eLazyBoolNo)
-    strm.Printf("Mac OS X kernel debugging\n");
+    strm.PutCString("Mac OS X kernel debugging\n");
   else
-    strm.Printf("unknown kernel debugging\n");
+    strm.PutCString("unknown kernel debugging\n");
 
-  strm.Printf("Directories searched recursively:\n");
+  strm.PutCString("Directories searched recursively:\n");
   const uint32_t num_kext_dirs = m_search_directories.size();
   for (uint32_t i = 0; i < num_kext_dirs; ++i) {
     strm.Printf("[%d] %s\n", i, m_search_directories[i].GetPath().c_str());
   }
 
-  strm.Printf("Directories not searched recursively:\n");
+  strm.PutCString("Directories not searched recursively:\n");
   const uint32_t num_kext_dirs_no_recursion =
       m_search_directories_no_recursing.size();
   for (uint32_t i = 0; i < num_kext_dirs_no_recursion; i++) {

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -81,7 +81,7 @@ static uint32_t chown_file(Platform *platform, const char *path,
     command.Printf("%d", uid);
   if (gid != UINT32_MAX)
     command.Printf(":%d", gid);
-  command.Printf("%s", path);
+  command.PutCString(path);
   int status;
   platform->RunShellCommand(command.GetData(), FileSpec(), &status, nullptr,
                             nullptr, nullptr, std::chrono::seconds(10));
@@ -277,14 +277,14 @@ std::string PlatformPOSIX::GetPlatformSpecificConnectionInformation() {
     stream.PutCString("rsync");
     if ((GetRSyncOpts() && *GetRSyncOpts()) ||
         (GetRSyncPrefix() && *GetRSyncPrefix()) || GetIgnoresRemoteHostname()) {
-      stream.Printf(", options: ");
+      stream.PutCString(", options: ");
       if (GetRSyncOpts() && *GetRSyncOpts())
         stream.Printf("'%s' ", GetRSyncOpts());
-      stream.Printf(", prefix: ");
+      stream.PutCString(", prefix: ");
       if (GetRSyncPrefix() && *GetRSyncPrefix())
         stream.Printf("'%s' ", GetRSyncPrefix());
       if (GetIgnoresRemoteHostname())
-        stream.Printf("ignore remote-hostname ");
+        stream.PutCString("ignore remote-hostname ");
     }
   }
   if (GetSupportsSSH()) {

--- a/lldb/source/Plugins/Process/MacOSX-Kernel/CommunicationKDP.cpp
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/CommunicationKDP.cpp
@@ -876,7 +876,7 @@ void CommunicationKDP::DumpPacket(Stream &s, const DataExtractor &packet) {
         } break;
 
         default:
-          s.Printf(" (add support for dumping this packet reply!!!");
+          s.PutCString(" (add support for dumping this packet reply!!!");
           break;
         }
       } else {

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -74,7 +74,7 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
   StreamString s;
   if (addr.GetDescription(s, target, eDescriptionLevelBrief))
     strm.Printf(" %s", s.GetString().data());
-  strm.Printf(".\n");
+  strm.PutCString(".\n");
 }
 
 std::optional<addr_t> StopInfoMachException::GetTagFaultAddress() const {
@@ -146,7 +146,7 @@ bool StopInfoMachException::DeterminePtrauthFailure(ExecutionContext &exe_ctx) {
   auto emit_ptrauth_prologue = [&](uint64_t at_address) {
     strm.Printf("EXC_BAD_ACCESS (code=%" PRIu64 ", address=0x%" PRIx64 ")\n",
                 m_exc_code, at_address);
-    strm.Printf("Note: Possible pointer authentication failure detected.\n");
+    strm.PutCString("Note: Possible pointer authentication failure detected.\n");
   };
 
   ABISP abi_sp = process.GetABI();
@@ -175,7 +175,7 @@ bool StopInfoMachException::DeterminePtrauthFailure(ExecutionContext &exe_ctx) {
         GetPtrauthInstructionInfo(target, arch, current_address);
     if (brk_ptrauth_info && brk_ptrauth_info->IsAuthenticated) {
       emit_ptrauth_prologue(bad_address);
-      strm.Printf("Found value that failed to authenticate ");
+      strm.PutCString("Found value that failed to authenticate ");
       DescribeAddressBriefly(strm, brk_address, target);
       m_description = std::string(strm.GetString());
       return true;
@@ -206,7 +206,7 @@ bool StopInfoMachException::DeterminePtrauthFailure(ExecutionContext &exe_ctx) {
         GetPtrauthInstructionInfo(target, arch, current_address);
     if (ptrauth_info && ptrauth_info->IsAuthenticated && ptrauth_info->IsLoad) {
       emit_ptrauth_prologue(bad_address);
-      strm.Printf("Found authenticated load instruction ");
+      strm.PutCString("Found authenticated load instruction ");
       DescribeAddressBriefly(strm, current_address, target);
       m_description = std::string(strm.GetString());
       return true;
@@ -236,7 +236,7 @@ bool StopInfoMachException::DeterminePtrauthFailure(ExecutionContext &exe_ctx) {
       if (blr_ptrauth_info && blr_ptrauth_info->IsAuthenticated &&
           blr_ptrauth_info->DoesBranch) {
         emit_ptrauth_prologue(bad_address);
-        strm.Printf("Found authenticated indirect branch ");
+        strm.PutCString("Found authenticated indirect branch ");
         DescribeAddressBriefly(strm, blr_address, target);
         m_description = std::string(strm.GetString());
         return true;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -2721,7 +2721,7 @@ void GDBRemoteCommunicationClient::TestPacketSpeed(const uint32_t num_packets,
       }
     }
     if (json)
-      strm.Printf("\n    ]\n  }\n}\n");
+      strm.PutCString("\n    ]\n  }\n}\n");
     else
       strm.EOL();
   }
@@ -2757,7 +2757,7 @@ bool GDBRemoteCommunicationClient::LaunchGDBServer(
     } else {
       // Make the GDB server we launch accept connections from any host since
       // we can't figure out the hostname
-      stream.Printf("host:*;");
+      stream.PutCString("host:*;");
     }
   }
   // give the process a few seconds to startup

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
@@ -228,7 +228,7 @@ GDBRemoteCommunicationServerCommon::Handle_qHostInfo(
     response.PutCString("watchpoint_exceptions_received:before;");
   } else {
     response.PutCString("ostype:macosx;");
-    response.Printf("watchpoint_exceptions_received:after;");
+    response.PutCString("watchpoint_exceptions_received:after;");
   }
 
 #else
@@ -238,9 +238,9 @@ GDBRemoteCommunicationServerCommon::Handle_qHostInfo(
       host_arch.GetMachine() == llvm::Triple::arm ||
       host_arch.GetMachine() == llvm::Triple::armeb || host_arch.IsMIPS() ||
       host_arch.GetTriple().isPPC64() || host_arch.GetTriple().isLoongArch())
-    response.Printf("watchpoint_exceptions_received:before;");
+    response.PutCString("watchpoint_exceptions_received:before;");
   else
-    response.Printf("watchpoint_exceptions_received:after;");
+    response.PutCString("watchpoint_exceptions_received:after;");
 #endif
 
   switch (endian::InlHostByteOrder()) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -1810,7 +1810,7 @@ GDBRemoteCommunication::PacketResult
 GDBRemoteCommunicationServerLLGS::Handle_vCont_actions(
     StringExtractorGDBRemote &packet) {
   StreamString response;
-  response.Printf("vCont;c;C;s;S;t");
+  response.PutCString("vCont;c;C;s;S;t");
 
   return SendPacketNoLock(response.GetString());
 }
@@ -3399,7 +3399,7 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
       response.Printf("\" ");
     }
 
-    response.Printf("/>\n");
+    response.PutCString("/>\n");
   }
 
   if (registers_count)
@@ -3455,7 +3455,7 @@ GDBRemoteCommunicationServerLLGS::ReadXferObject(llvm::StringRef object,
       response.Printf("l_addr=\"0x%" PRIx64 "\" ", library.base_addr);
       response.Printf("l_ld=\"0x%" PRIx64 "\" />", library.ld_addr);
     }
-    response.Printf("</library-list-svr4>");
+    response.PutCString("</library-list-svr4>");
     return MemoryBuffer::getMemBufferCopy(response.GetString(), __FUNCTION__);
   }
 
@@ -3465,15 +3465,15 @@ GDBRemoteCommunicationServerLLGS::ReadXferObject(llvm::StringRef object,
       return library_list.takeError();
 
     StreamString response;
-    response.Printf("<library-list>");
+    response.PutCString("<library-list>");
     for (auto const &library : *library_list) {
       response.Printf("<library name=\"%s\">",
                       XMLEncodeAttributeValue(library.name.c_str()).c_str());
       response.Printf("<section address=\"0x%" PRIx64 "\"/>",
                       library.base_addr);
-      response.Printf("</library>");
+      response.PutCString("</library>");
     }
-    response.Printf("</library-list>");
+    response.PutCString("</library-list>");
     return MemoryBuffer::getMemBufferCopy(response.GetString(), __FUNCTION__);
   }
 
@@ -3931,7 +3931,7 @@ GDBRemoteCommunicationServerLLGS::Handle_qWatchpointSupportInfo(
 
   StreamGDBRemote response;
   if (hw_debug_cap == std::nullopt)
-    response.Printf("num:0;");
+    response.PutCString("num:0;");
   else
     response.Printf("num:%d;", hw_debug_cap->second);
 

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -865,15 +865,15 @@ public:
     Stream &s = result.GetOutputStream();
     MinidumpParser &minidump = *process->m_minidump_parser;
     if (DumpDirectory()) {
-      s.Printf("RVA        SIZE       TYPE       StreamType\n");
-      s.Printf("---------- ---------- ---------- --------------------------\n");
+      s.PutCString("RVA        SIZE       TYPE       StreamType\n");
+      s.PutCString("---------- ---------- ---------- --------------------------\n");
       for (const auto &stream_desc : minidump.GetMinidumpFile().streams())
         s.Printf(
             "0x%8.8x 0x%8.8x 0x%8.8x %s\n", (uint32_t)stream_desc.Location.RVA,
             (uint32_t)stream_desc.Location.DataSize,
             (unsigned)(StreamType)stream_desc.Type,
             MinidumpParser::GetStreamTypeAsString(stream_desc.Type).data());
-      s.Printf("\n");
+      s.PutCString("\n");
     }
     auto DumpTextStream = [&](StreamType stream_type,
                               llvm::StringRef label) -> void {
@@ -895,7 +895,7 @@ public:
                            process->GetAddressByteSize());
         DumpDataExtractor(data, &s, 0, lldb::eFormatBytesWithASCII, 1,
                           bytes.size(), 16, 0, 0, 0);
-        s.Printf("\n\n");
+        s.PutCString("\n\n");
       }
     };
 
@@ -929,9 +929,9 @@ public:
                            process->GetAddressByteSize());
         lldb::offset_t offset = 0;
         uint32_t build_id = data.GetU32(&offset);
-        s.Printf("Facebook Build ID:\n");
+        s.PutCString("Facebook Build ID:\n");
         s.Printf("%u\n", build_id);
-        s.Printf("\n");
+        s.PutCString("\n");
       }
     }
     if (DumpFacebookVersionName())

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
@@ -107,7 +107,7 @@ size_t ProcessWasm::ReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
 llvm::Expected<std::vector<lldb::addr_t>>
 ProcessWasm::GetWasmCallStack(lldb::tid_t tid) {
   StreamString packet;
-  packet.Printf("qWasmCallStack:");
+  packet.PutCString("qWasmCallStack:");
   packet.Printf("%" PRIx64, tid);
 
   StringExtractorGDBRemote response;
@@ -142,10 +142,10 @@ ProcessWasm::GetWasmVariable(WasmVirtualRegisterKinds kind, int frame_index,
   StreamString packet;
   switch (kind) {
   case eWasmTagLocal:
-    packet.Printf("qWasmLocal:");
+    packet.PutCString("qWasmLocal:");
     break;
   case eWasmTagGlobal:
-    packet.Printf("qWasmGlobal:");
+    packet.PutCString("qWasmGlobal:");
     break;
   case eWasmTagOperandStack:
     packet.PutCString("qWasmStackValue:");

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -602,7 +602,7 @@ void ScriptInterpreterPythonImpl::IOHandlerInputComplete(IOHandler &io_handler,
       } else if (!batch_mode) {
         if (LockableStreamFileSP error_sp = io_handler.GetErrorStreamFileSP()) {
           LockedStreamFile locked_stream = error_sp->Lock();
-          locked_stream.Printf("Warning: No command attached to breakpoint.\n");
+          locked_stream.PutCString("Warning: No command attached to breakpoint.\n");
         }
       }
     }
@@ -624,7 +624,7 @@ void ScriptInterpreterPythonImpl::IOHandlerInputComplete(IOHandler &io_handler,
     } else if (!batch_mode) {
       if (LockableStreamFileSP error_sp = io_handler.GetErrorStreamFileSP()) {
         LockedStreamFile locked_stream = error_sp->Lock();
-        locked_stream.Printf("Warning: No command attached to breakpoint.\n");
+        locked_stream.PutCString("Warning: No command attached to breakpoint.\n");
       }
     }
     m_active_io_handler = eIOHandlerNone;
@@ -2524,7 +2524,7 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
   if (module_sp) {
     // everything went just great, now set the module object
     command_stream.Clear();
-    command_stream.Printf("%s", module_name.c_str());
+    command_stream.PutCString(module_name.c_str());
     void *module_pyobj = nullptr;
     if (ExecuteOneLineWithReturn(
             command_stream.GetData(),

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -537,21 +537,21 @@ void ManualDWARFIndex::Dump(Stream &s) {
   s.Format("Manual DWARF index for ({0}) '{1:F}':",
            m_module.GetArchitecture().GetArchitectureName(),
            m_module.GetObjectFile()->GetFileSpec());
-  s.Printf("\nFunction basenames:\n");
+  s.PutCString("\nFunction basenames:\n");
   m_set.function_basenames.Dump(&s);
-  s.Printf("\nFunction fullnames:\n");
+  s.PutCString("\nFunction fullnames:\n");
   m_set.function_fullnames.Dump(&s);
-  s.Printf("\nFunction methods:\n");
+  s.PutCString("\nFunction methods:\n");
   m_set.function_methods.Dump(&s);
-  s.Printf("\nFunction selectors:\n");
+  s.PutCString("\nFunction selectors:\n");
   m_set.function_selectors.Dump(&s);
-  s.Printf("\nObjective-C class selectors:\n");
+  s.PutCString("\nObjective-C class selectors:\n");
   m_set.objc_class_selectors.Dump(&s);
-  s.Printf("\nGlobals and statics:\n");
+  s.PutCString("\nGlobals and statics:\n");
   m_set.globals.Dump(&s);
-  s.Printf("\nTypes:\n");
+  s.PutCString("\nTypes:\n");
   m_set.types.Dump(&s);
-  s.Printf("\nNamespaces:\n");
+  s.PutCString("\nNamespaces:\n");
   m_set.namespaces.Dump(&s);
 }
 


### PR DESCRIPTION
`Stream::Printf` needs to call various other (variadic) functions, needs to parse the input string and potentially handle too-long format outputs. Calling in with a constant string is wasting a lot of instruction on doing nothing.

assisted-by: claude