### PR TITLE
[lldb][NFC] Remove Stream::Printf calls with constants in Commands/

### DIFF
--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -503,7 +503,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
       }
     }
   } else {
-    error_stream.Printf("error: unknown error\n");
+    error_stream.PutCString("error: unknown error\n");
   }
 
   return (success != eExpressionSetupError &&

--- a/lldb/source/Commands/CommandObjectHelp.cpp
+++ b/lldb/source/Commands/CommandObjectHelp.cpp
@@ -128,7 +128,7 @@ void CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
           for (size_t match_idx = 0; match_idx < num_matches; match_idx++) {
             s.Printf("\n\t%s", matches.GetStringAtIndex(match_idx));
           }
-          s.Printf("\n");
+          s.PutCString("\n");
           result.AppendError(s.GetString());
           return;
         } else if (!sub_cmd_obj) {

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -212,7 +212,7 @@ public:
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
-    ostrm.Printf("Available platforms:\n");
+    ostrm.PutCString("Available platforms:\n");
 
     PlatformSP host_platform_sp(Platform::GetHostPlatform());
     ostrm.Format("{0}: {1}\n", host_platform_sp->GetPluginName(),

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1610,8 +1610,8 @@ public:
   Options *GetOptions() override { return &m_options; }
 
   void PrintSignalHeader(Stream &str) {
-    str.Printf("NAME         PASS   STOP   NOTIFY  DESCRIPTION\n");
-    str.Printf("===========  =====  =====  ======  ===================\n");
+    str.PutCString("NAME         PASS   STOP   NOTIFY  DESCRIPTION\n");
+    str.PutCString("===========  =====  =====  ======  ===================\n");
   }
 
   void PrintSignal(Stream &str, int32_t signo, llvm::StringRef sig_name,
@@ -1633,7 +1633,7 @@ public:
         str.PutCString(sig_description);
       }
     }
-    str.Printf("\n");
+    str.PutCString("\n");
   }
 
   void PrintSignalInformation(Stream &str, Args &signal_args,

--- a/lldb/source/Commands/CommandObjectScripting.cpp
+++ b/lldb/source/Commands/CommandObjectScripting.cpp
@@ -317,7 +317,7 @@ private:
     const std::string separator(
         std::min<uint64_t>(GetDebugger().GetTerminalWidth(), 80), '-');
 
-    s.Printf("Available scripted extension templates:");
+    s.PutCString("Available scripted extension templates:");
 
     auto print_field = [&](llvm::StringRef key, llvm::StringRef value,
                            const std::string &value_color = std::string()) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -100,7 +100,7 @@ static void DumpTargetInfo(uint32_t target_idx, Target *target,
 
   uint32_t properties = 0;
   if (target_arch.IsValid()) {
-    strm.Printf(" ( arch=");
+    strm.PutCString(" ( arch=");
     target_arch.DumpTriple(strm.AsRawOstream());
     properties++;
   }
@@ -1460,7 +1460,7 @@ static void DumpDwoFilesTable(Stream &strm,
     if (dict->GetValueForKeyAsInteger("dwo_id", dwo_id))
       strm.Printf("0x%16.16" PRIx64 " ", dwo_id);
     else
-      strm.Printf("0x???????????????? ");
+      strm.PutCString("0x???????????????? ");
 
     llvm::StringRef error;
     if (dict->GetValueForKeyAsString("error", error))

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -359,7 +359,7 @@ protected:
 
         // Get provider metadata for header.
         if (provider_id == 0) {
-          strm.Printf(": Base Unwinder ===\n");
+          strm.PutCString(": Base Unwinder ===\n");
         } else {
           // Find the descriptor in the provider chain.
           const auto &provider_chain = thread->GetProviderChainIds();
@@ -380,7 +380,7 @@ protected:
           if (provider_priority.has_value()) {
             strm.Printf(" (priority: %u)", *provider_priority);
           }
-          strm.Printf(" ===\n");
+          strm.PutCString(" ===\n");
 
           if (!provider_desc.empty()) {
             strm.Printf("Description: %s\n", provider_desc.c_str());
@@ -401,7 +401,7 @@ protected:
             selected_frame_marker);
 
         if (num_frames == 0) {
-          strm.Printf("(No frames available)\n");
+          strm.PutCString("(No frames available)\n");
         }
       }
 
@@ -1633,7 +1633,7 @@ public:
         return false;
       }
     } else
-      strm.Printf("(no siginfo)\n");
+      strm.PutCString("(no siginfo)\n");
     strm.PutChar('\n');
 
     return true;

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -251,11 +251,12 @@ public:
               }
             } else {
               LockedStreamFile locked_stream = error_sp->Lock();
-              locked_stream.Printf("error: unable to generate a function.\n");
+              locked_stream.PutCString(
+                  "error: unable to generate a function.\n");
             }
           } else {
             LockedStreamFile locked_stream = error_sp->Lock();
-            locked_stream.Printf("error: no script interpreter.\n");
+            locked_stream.PutCString("error: no script interpreter.\n");
           }
         } else {
           LockedStreamFile locked_stream = error_sp->Lock();
@@ -485,18 +486,18 @@ protected:
                     }
                   } else {
                     LockedStreamFile locked_stream = error_sp->Lock();
-                    locked_stream.Printf("error: invalid type name.\n");
+                    locked_stream.PutCString("error: invalid type name.\n");
                     break;
                   }
                 }
               }
             } else {
               LockedStreamFile locked_stream = error_sp->Lock();
-              locked_stream.Printf("error: unable to generate a class.\n");
+              locked_stream.PutCString("error: unable to generate a class.\n");
             }
           } else {
             LockedStreamFile locked_stream = error_sp->Lock();
-            locked_stream.Printf("error: no script interpreter.\n");
+            locked_stream.PutCString("error: no script interpreter.\n");
           }
         } else {
           LockedStreamFile locked_stream = error_sp->Lock();

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -931,7 +931,7 @@ protected:
       if (var_sp->GetScope() == eValueTypeVariableLocal)
         watch_sp->SetupVariableWatchpointDisabler(m_exe_ctx.GetFrameSP());
     }
-    output_stream.Printf("Watchpoint created: ");
+    output_stream.PutCString("Watchpoint created: ");
     watch_sp->GetDescription(&output_stream, lldb::eDescriptionLevelFull);
     output_stream.EOL();
     result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -1105,7 +1105,7 @@ protected:
     if (watch_sp) {
       watch_sp->SetWatchSpec(std::string(expr));
       Stream &output_stream = result.GetOutputStream();
-      output_stream.Printf("Watchpoint created: ");
+      output_stream.PutCString("Watchpoint created: ");
       watch_sp->GetDescription(&output_stream, lldb::eDescriptionLevelFull);
       output_stream.EOL();
       result.SetStatus(eReturnStatusSuccessFinishResult);

--- a/lldb/source/Commands/CommandOptionArgumentTable.cpp
+++ b/lldb/source/Commands/CommandOptionArgumentTable.cpp
@@ -297,7 +297,7 @@ llvm::StringRef arch_helper() {
     StringList archs;
 
     ArchSpec::ListSupportedArchNames(archs);
-    g_archs_help.Printf("These are the supported architecture names:\n");
+    g_archs_help.PutCString("These are the supported architecture names:\n");
     archs.Join("\n", g_archs_help);
   }
   return g_archs_help.GetString();


### PR DESCRIPTION
`Stream::Printf` needs to call various other (variadic) functions, needs to parse the input string and potentially handle too-long format outputs. Calling in with a constant string is wasting a lot of instruction on doing nothing.

assisted-by: claude