### PR TITLE
[lldb][NFC] Remove various Stream::Printf calls with constants

### DIFF
--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -224,7 +224,7 @@ public:
     if (m_arch.IsValid()) {
       if (dumped_something)
         strm.PutCString(", ");
-      strm.Printf("arch = ");
+      strm.PutCString("arch = ");
       m_arch.DumpTriple(strm.AsRawOstream());
       dumped_something = true;
     }

--- a/lldb/source/API/SBAddressRangeList.cpp
+++ b/lldb/source/API/SBAddressRangeList.cpp
@@ -85,7 +85,7 @@ bool SBAddressRangeList::GetDescription(SBStream &description,
     if (is_first) {
       is_first = false;
     } else {
-      stream.Printf(", ");
+      stream.PutCString(", ");
     }
     GetAddressRangeAtIndex(i).GetDescription(description, target);
   }

--- a/lldb/source/API/SBMemoryRegionInfo.cpp
+++ b/lldb/source/API/SBMemoryRegionInfo.cpp
@@ -169,7 +169,7 @@ bool SBMemoryRegionInfo::GetDescription(SBStream &description) {
   strm.Printf(m_opaque_up->GetReadable() ? "R" : "-");
   strm.Printf(m_opaque_up->GetWritable() ? "W" : "-");
   strm.Printf(m_opaque_up->GetExecutable() ? "X" : "-");
-  strm.Printf("]");
+  strm.PutCString("]");
 
   return true;
 }

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -988,7 +988,7 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
       // don't generally know how to set them until the target is run.
       if (m_resolver_sp->getResolverID() !=
           BreakpointResolver::ExceptionResolver)
-        s->Printf(", locations = 0 (pending)");
+        s->PutCString(", locations = 0 (pending)");
     }
 
     m_options.GetDescription(s, level);
@@ -1000,7 +1000,7 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
       if (!m_name_list.empty()) {
         s->EOL();
         s->Indent();
-        s->Printf("Names:");
+        s->PutCString("Names:");
         s->EOL();
         s->IndentMore();
         for (llvm::StringRef name : m_name_list.keys()) {
@@ -1017,7 +1017,7 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
   case lldb::eDescriptionLevelInitial:
     s->Printf("Breakpoint %i: ", GetID());
     if (num_locations == 0) {
-      s->Printf("no locations (pending).");
+      s->PutCString("no locations (pending).");
     } else if (num_locations == 1 && !show_locations) {
       // There is only one location, so we'll just print that location
       // information.
@@ -1045,9 +1045,9 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
   if (show_locations && level != lldb::eDescriptionLevelBrief) {
     if ((display_type & eDisplayHeader) != 0) {
       if ((display_type & eDisplayFacade) != 0)
-        s->Printf("Facade locations:\n");
+        s->PutCString("Facade locations:\n");
       else
-        s->Printf("Implementation Locations\n");
+        s->PutCString("Implementation Locations\n");
     }
     s->IndentMore();
     for (size_t i = 0; i < num_locations; ++i) {

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -653,8 +653,8 @@ void BreakpointLocation::GetDescription(Stream *s,
   if (!is_scripted_desc) {
     if (m_address.IsSectionOffset() &&
         (level == eDescriptionLevelFull || level == eDescriptionLevelInitial))
-      s->Printf(", ");
-    s->Printf("address = ");
+      s->PutCString(", ");
+    s->PutCString("address = ");
 
     ExecutionContextScope *exe_scope = nullptr;
     Target *target = &m_owner.GetTarget();
@@ -677,7 +677,7 @@ void BreakpointLocation::GetDescription(Stream *s,
           resolved_address.CalculateSymbolContextSymbol();
       if (resolved_symbol) {
         if (level == eDescriptionLevelFull || level == eDescriptionLevelInitial)
-          s->Printf(", ");
+          s->PutCString(", ");
         else if (level == lldb::eDescriptionLevelVerbose) {
           s->EOL();
           s->Indent();

--- a/lldb/source/Breakpoint/BreakpointLocationList.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocationList.cpp
@@ -207,7 +207,7 @@ void BreakpointLocationList::GetDescription(Stream *s,
   collection::iterator pos, end = m_locations.end();
 
   for (pos = m_locations.begin(); pos != end; ++pos) {
-    s->Printf(" ");
+    s->PutCString(" ");
     (*pos)->GetDescription(s, level);
   }
 }

--- a/lldb/source/Breakpoint/BreakpointOptions.cpp
+++ b/lldb/source/Breakpoint/BreakpointOptions.cpp
@@ -522,10 +522,10 @@ void BreakpointOptions::GetDescription(Stream *s,
     s->Printf("%sabled ", m_enabled ? "en" : "dis");
 
     if (m_one_shot)
-      s->Printf("one-shot ");
+      s->PutCString("one-shot ");
 
     if (m_auto_continue)
-      s->Printf("auto-continue ");
+      s->PutCString("auto-continue ");
 
     if (m_thread_spec_up)
       m_thread_spec_up->GetDescription(s, level);

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -405,12 +405,12 @@ void BreakpointResolverName::GetDescription(Stream *s) {
       s->Printf("name = '%s'", unique_lookups[0].GetCString());
     else {
       size_t num_names = unique_lookups.size();
-      s->Printf("names = {");
+      s->PutCString("names = {");
       for (size_t i = 0; i < num_names; i++) {
         s->Printf("%s'%s'", (i == 0 ? "" : ", "),
                   unique_lookups[i].GetCString());
       }
-      s->Printf("}");
+      s->PutCString("}");
     }
   }
   if (m_language != eLanguageTypeUnknown) {

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -279,7 +279,7 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
   if (m_watch_read && !m_watch_modify && !m_watch_write)
     return printed_anything;
 
-  s->Printf("\n");
+  s->PutCString("\n");
   s->Printf("Watchpoint %u hit:\n", GetID());
 
   StreamString values_ss;
@@ -310,7 +310,7 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
 
   if (m_new_value_sp) {
     if (values_ss.GetSize())
-      values_ss.Printf("\n");
+      values_ss.PutCString("\n");
 
     if (auto *new_value_cstr = m_new_value_sp->GetValueAsCString())
       values_ss.Printf("new value: %s", new_value_cstr);
@@ -334,7 +334,7 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
   }
 
   if (values_ss.GetSize()) {
-    s->Printf("%s", values_ss.GetData());
+    s->PutCString(values_ss.GetData());
     printed_anything = true;
   }
 
@@ -364,7 +364,7 @@ void Watchpoint::DumpWithLevel(Stream *s,
       if (ProcessSP process_sp = m_target.GetProcessSP()) {
         auto &resourcelist = process_sp->GetWatchpointResourceList();
         size_t idx = 0;
-        s->Printf("\n    watchpoint resources:");
+        s->PutCString("\n    watchpoint resources:");
         for (WatchpointResourceSP &wpres : resourcelist.Sites()) {
           if (wpres->ConstituentsContains(this)) {
             s->Printf("\n       #%zu: ", idx);

--- a/lldb/source/Breakpoint/WatchpointList.cpp
+++ b/lldb/source/Breakpoint/WatchpointList.cpp
@@ -213,7 +213,7 @@ void WatchpointList::GetDescription(Stream *s, lldb::DescriptionLevel level) {
   wp_collection::iterator pos, end = m_watchpoints.end();
 
   for (pos = m_watchpoints.begin(); pos != end; ++pos) {
-    s->Printf(" ");
+    s->PutCString(" ");
     (*pos)->Dump(s);
   }
 }

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -1085,7 +1085,7 @@ OptionValueSP Instruction::ReadDictionary(FILE *in_file, Stream &out_stream) {
 
 bool Instruction::TestEmulation(Stream &out_stream, const char *file_name) {
   if (!file_name) {
-    out_stream.Printf("Instruction::TestEmulation:  Missing file_name.");
+    out_stream.PutCString("Instruction::TestEmulation:  Missing file_name.");
     return false;
   }
   FILE *test_file = FileSystem::Instance().Fopen(file_name, "r");
@@ -1157,9 +1157,9 @@ bool Instruction::TestEmulation(Stream &out_stream, const char *file_name) {
         insn_emulator_up->TestEmulation(out_stream, arch, data_dictionary);
 
   if (success)
-    out_stream.Printf("Emulation test succeeded.");
+    out_stream.PutCString("Emulation test succeeded.");
   else
-    out_stream.Printf("Emulation test failed.");
+    out_stream.PutCString("Emulation test failed.");
 
   return success;
 }

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -161,7 +161,7 @@ static lldb::offset_t DumpInstructions(const DataExtractor &DE, Stream *s,
         s->Printf("failed to decode instructions at 0x%" PRIx64 ".", addr);
     }
   } else
-    s->Printf("invalid target");
+    s->PutCString("invalid target");
 
   return offset;
 }
@@ -174,31 +174,31 @@ static bool TryDumpSpecialEscapedChar(Stream &s, const char c) {
   switch (c) {
   case '\033':
     // Common non-standard escape code for 'escape'.
-    s.Printf("\\e");
+    s.PutCString("\\e");
     return true;
   case '\a':
-    s.Printf("\\a");
+    s.PutCString("\\a");
     return true;
   case '\b':
-    s.Printf("\\b");
+    s.PutCString("\\b");
     return true;
   case '\f':
-    s.Printf("\\f");
+    s.PutCString("\\f");
     return true;
   case '\n':
-    s.Printf("\\n");
+    s.PutCString("\\n");
     return true;
   case '\r':
-    s.Printf("\\r");
+    s.PutCString("\\r");
     return true;
   case '\t':
-    s.Printf("\\t");
+    s.PutCString("\\t");
     return true;
   case '\v':
-    s.Printf("\\v");
+    s.PutCString("\\v");
     return true;
   case '\0':
-    s.Printf("\\0");
+    s.PutCString("\\0");
     return true;
   default:
     return false;
@@ -484,7 +484,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
       const uint64_t ch = DE.GetMaxU64Bitfield(&offset, item_byte_size,
                                                item_bit_size, item_bit_offset);
       if (llvm::isPrint(ch))
-        s->Printf("%c", (char)ch);
+        s->PutChar((char)ch);
       else if (item_format != eFormatCharPrintable) {
         if (!TryDumpSpecialEscapedChar(*s, ch)) {
           if (item_byte_size == 1)
@@ -554,7 +554,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
       const char *cstr = DE.GetCStr(&offset);
 
       if (!cstr) {
-        s->Printf("NULL");
+        s->PutCString("NULL");
         offset = LLDB_INVALID_OFFSET;
       } else {
         s->PutChar('\"');
@@ -747,14 +747,14 @@ lldb::offset_t lldb_private::DumpDataExtractor(
         llvm::APFloat ap_float(DE.GetFloat(&offset));
         ap_float.convertToHexString(float_cstr, 0, false,
                                     llvm::APFloat::rmNearestTiesToEven);
-        s->Printf("%s", float_cstr);
+        s->PutCString(float_cstr);
         break;
       } else if (sizeof(double) == item_byte_size) {
         char float_cstr[256];
         llvm::APFloat ap_float(DE.GetDouble(&offset));
         ap_float.convertToHexString(float_cstr, 0, false,
                                     llvm::APFloat::rmNearestTiesToEven);
-        s->Printf("%s", float_cstr);
+        s->PutCString(float_cstr);
         break;
       } else {
         s->Printf("error: unsupported byte size (%" PRIu64

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -356,7 +356,7 @@ ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
   } else {
     if (force_symbol_search) {
       lldb::StreamUP s = target.GetDebugger().GetAsyncErrorStream();
-      s->Printf("Unable to find file");
+      s->PutCString("Unable to find file");
       if (!name.empty())
         s->Printf(" %s", name.str().c_str());
       if (uuid.IsValid())
@@ -367,7 +367,7 @@ ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
         else
           s->Printf(" at address 0x%" PRIx64, value);
       }
-      s->Printf("\n");
+      s->PutCString("\n");
     }
     LLDB_LOGF(log,
               "Unable to find binary %s with UUID %s and load it at "

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -437,7 +437,7 @@ void FormatEntity::Entry::Dump(Stream &s, int depth) const {
   if (number != 0)
     s.Printf("number = %" PRIu64 " (0x%" PRIx64 "), ", number, number);
   if (deref)
-    s.Printf("deref = true, ");
+    s.PutCString("deref = true, ");
   s.EOL();
   for (const auto &children : children_stack) {
     for (const auto &child : children)
@@ -461,7 +461,7 @@ static bool RunScriptFormatKeyword(Stream &s, const SymbolContext *sc,
       if (script_interpreter->RunScriptFormatKeyword(script_function_name, t,
                                                      script_output, error) &&
           error.Success()) {
-        s.Printf("%s", script_output.c_str());
+        s.PutCString(script_output.c_str());
         return true;
       } else {
         s.Printf("<error: %s>", error.AsCString());
@@ -2049,12 +2049,12 @@ bool FormatEntity::Formatter::Format(const Entry &entry, Stream &s,
           Address pc;
           pc.SetLoadAddress(pc_loadaddr, m_exe_ctx->GetTargetPtr());
           if (pc == *m_addr) {
-            s.Printf("-> ");
+            s.PutCString("-> ");
             return true;
           }
         }
       }
-      s.Printf("   ");
+      s.PutCString("   ");
       return true;
     }
     return false;

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -134,9 +134,9 @@ IOHandlerConfirm::IOHandlerConfirm(Debugger &debugger, llvm::StringRef prompt,
   StreamString prompt_stream;
   prompt_stream.PutCString(prompt);
   if (m_default_response)
-    prompt_stream.Printf(": [Y/n] ");
+    prompt_stream.PutCString(": [Y/n] ");
   else
-    prompt_stream.Printf(": [y/N] ");
+    prompt_stream.PutCString(": [y/N] ");
 
   SetPrompt(prompt_stream.GetString());
 }
@@ -359,7 +359,7 @@ bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
     if (prompt && prompt[0]) {
       if (m_output_sp) {
         LockedStreamFile locked_stream = m_output_sp->Lock();
-        locked_stream.Printf("%s", prompt);
+        locked_stream.PutCString(prompt);
       }
     }
   }

--- a/lldb/source/Core/IOHandlerCursesGUI.cpp
+++ b/lldb/source/Core/IOHandlerCursesGUI.cpp
@@ -7254,7 +7254,7 @@ public:
           else if (mnemonic != nullptr && operands != nullptr)
             strm.Printf("%-8s %s", mnemonic, operands);
           else if (mnemonic != nullptr)
-            strm.Printf("%s", mnemonic);
+            strm.PutCString(mnemonic);
 
           int right_pad = 1;
           window.PutCStringTruncated(

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -403,7 +403,7 @@ void Mangled::DumpDebug(Stream *s) const {
   s->Printf("%*p: Mangled mangled = ", static_cast<int>(sizeof(void *) * 2),
             static_cast<const void *>(this));
   m_mangled.DumpDebug(s);
-  s->Printf(", demangled = ");
+  s->PutCString(", demangled = ");
   m_demangled.DumpDebug(s);
 }
 

--- a/lldb/source/Core/SearchFilter.cpp
+++ b/lldb/source/Core/SearchFilter.cpp
@@ -555,7 +555,7 @@ void SearchFilterByModuleList::Search(Searcher &searcher) {
 void SearchFilterByModuleList::GetDescription(Stream *s) {
   size_t num_modules = m_module_spec_list.GetSize();
   if (num_modules == 1) {
-    s->Printf(", module = ");
+    s->PutCString(", module = ");
     s->PutCString(
         m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().nonEmptyOr(
             "<Unknown>"));
@@ -775,7 +775,7 @@ void SearchFilterByModuleListAndCU::Search(Searcher &searcher) {
 void SearchFilterByModuleListAndCU::GetDescription(Stream *s) {
   size_t num_modules = m_module_spec_list.GetSize();
   if (num_modules == 1) {
-    s->Printf(", module = ");
+    s->PutCString(", module = ");
     s->PutCString(
         m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().nonEmptyOr(
             "<Unknown>"));

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -296,12 +296,12 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
         // Display caret cursor.
         std::string src_line;
         last_file_sp->GetLine(line, src_line);
-        s->Printf("    \t");
+        s->PutCString("    \t");
         // Insert a space for every non-tab character in the source line.
         for (size_t i = 0; i + 1 < column && i < src_line.length(); ++i)
           s->PutChar(src_line[i] == '\t' ? '\t' : ' ');
         // Now add the caret.
-        s->Printf("^\n");
+        s->PutCString("^\n");
       }
       if (this_line_size == 0) {
         m_last_line = UINT32_MAX;

--- a/lldb/source/DataFormatters/FormattersHelpers.cpp
+++ b/lldb/source/DataFormatters/FormattersHelpers.cpp
@@ -131,7 +131,7 @@ lldb_private::formatters::GetArrayAddressOrPointerValue(ValueObject &valobj) {
 void lldb_private::formatters::DumpCxxSmartPtrPointerSummary(
     Stream &stream, ValueObject &ptr, const TypeSummaryOptions &options) {
   if (ptr.GetValueAsUnsigned(0) == 0) {
-    stream.Printf("nullptr");
+    stream.PutCString("nullptr");
     return;
   }
 

--- a/lldb/source/DataFormatters/StringPrinter.cpp
+++ b/lldb/source/DataFormatters/StringPrinter.cpp
@@ -263,9 +263,9 @@ static bool DumpEncodedBufferToStream(
   assert(dump_options.GetStream() && "need a Stream to print the string to");
   Stream &stream(*dump_options.GetStream());
   if (dump_options.GetPrefixToken() != nullptr)
-    stream.Printf("%s", dump_options.GetPrefixToken());
+    stream.PutCString(dump_options.GetPrefixToken());
   if (dump_options.GetQuote() != 0)
-    stream.Printf("%c", dump_options.GetQuote());
+    stream.PutChar(dump_options.GetQuote());
   auto data(dump_options.GetData());
   auto source_size(dump_options.GetSourceSize());
   if (data.GetByteSize() && data.GetDataStart() && data.GetDataEnd()) {
@@ -358,20 +358,20 @@ static bool DumpEncodedBufferToStream(
           return false;
 
         for (unsigned c = 0; c < printable_size; c++)
-          stream.Printf("%c", *(printable_bytes + c));
+          stream.PutChar(*(printable_bytes + c));
         utf8_data_ptr = (uint8_t *)next_data;
       } else {
-        stream.Printf("%c", *utf8_data_ptr);
+        stream.PutChar(*utf8_data_ptr);
         utf8_data_ptr++;
       }
     }
   }
   if (dump_options.GetQuote() != 0)
-    stream.Printf("%c", dump_options.GetQuote());
+    stream.PutChar(dump_options.GetQuote());
   if (dump_options.GetSuffixToken() != nullptr)
-    stream.Printf("%s", dump_options.GetSuffixToken());
+    stream.PutCString(dump_options.GetSuffixToken());
   if (dump_options.GetIsTruncated())
-    stream.Printf("...");
+    stream.PutCString("...");
   return true;
 }
 

--- a/lldb/source/DataFormatters/TypeCategory.cpp
+++ b/lldb/source/DataFormatters/TypeCategory.cpp
@@ -297,7 +297,7 @@ std::string TypeCategoryImpl::GetDescription() {
   StreamString stream;
   stream.Printf("%s (%s", GetName(), (IsEnabled() ? "enabled" : "disabled"));
   StreamString lang_stream;
-  lang_stream.Printf(", applicable for language(s): ");
+  lang_stream.PutCString(", applicable for language(s): ");
   bool print_lang = false;
   for (size_t idx = 0; idx < GetNumLanguages(); idx++) {
     const lldb::LanguageType lang = GetLanguageAtIndex(idx);

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -84,7 +84,7 @@ std::string TypeFilterImpl::GetDescription() {
     sstr.Printf("    %s\n", GetExpressionPathAtIndex(i));
   }
 
-  sstr.Printf("}");
+  sstr.PutCString("}");
   return std::string(sstr.GetString());
 }
 

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -346,7 +346,7 @@ void ValueObjectPrinter::PrintDecl() {
     if (!varName.Empty())
       m_stream->Printf("%s =", varName.GetData());
     else if (ShouldShowName())
-      m_stream->Printf(" =");
+      m_stream->PutCString(" =");
   }
 }
 
@@ -447,7 +447,7 @@ bool ValueObjectPrinter::PrintValueAndSummaryIfNeeded(bool &value_printed,
       // combination means "could not resolve a type" and the default failure
       // mode is quite ugly
       if (!m_compiler_type.IsValid()) {
-        m_stream->Printf(" <could not resolve type>");
+        m_stream->PutCString(" <could not resolve type>");
         return false;
       }
 

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -306,7 +306,7 @@ bool lldb_private::formatters::VectorTypeSummaryProvider(
     const char *child_value = child_sp->GetValueAsCString();
     if (child_value && *child_value) {
       if (first) {
-        s.Printf("%s", child_value);
+        s.PutCString(child_value);
         first = false;
       } else {
         s.Printf(", %s", child_value);

--- a/lldb/source/Expression/IRInterpreter.cpp
+++ b/lldb/source/Expression/IRInterpreter.cpp
@@ -135,7 +135,7 @@ public:
   std::string SummarizeValue(const Value *value) {
     lldb_private::StreamString ss;
 
-    ss.Printf("%s", PrintValue(value).c_str());
+    ss.PutCString(PrintValue(value).c_str());
 
     ValueMap::iterator i = m_values.find(value);
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -352,14 +352,14 @@ public:
                        m_persistent_variable_sp->GetName());
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -369,14 +369,14 @@ public:
     }
 
     {
-      dump_stream.Printf("Target:\n");
+      dump_stream.PutCString("Target:\n");
 
       lldb::addr_t target_address;
 
       map.ReadPointerFromMemory(&target_address, load_addr, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DataBufferHeap data(
             llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
@@ -390,7 +390,7 @@ public:
             err);
 
         if (!err.Success()) {
-          dump_stream.Printf("  <could not be read>\n");
+          dump_stream.PutCString("  <could not be read>\n");
         } else {
           DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                        target_address);
@@ -687,14 +687,14 @@ public:
     lldb::addr_t ptr = LLDB_INVALID_ADDRESS;
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DataExtractor extractor(data.GetBytes(), data.GetByteSize(),
                                 map.GetByteOrder(), map.GetAddressByteSize());
@@ -711,13 +711,13 @@ public:
     }
 
     if (m_temporary_allocation == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("Points to process memory:\n");
+      dump_stream.PutCString("Points to process memory:\n");
     } else {
-      dump_stream.Printf("Temporary allocation:\n");
+      dump_stream.PutCString("Temporary allocation:\n");
     }
 
     if (ptr == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("  <could not be be found>\n");
+      dump_stream.PutCString("  <could not be be found>\n");
     } else {
       DataBufferHeap data(m_temporary_allocation_size, 0);
 
@@ -725,7 +725,7 @@ public:
                      m_temporary_allocation_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -1118,14 +1118,14 @@ public:
     lldb::addr_t ptr = LLDB_INVALID_ADDRESS;
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DataExtractor extractor(data.GetBytes(), data.GetByteSize(),
                                 map.GetByteOrder(), map.GetAddressByteSize());
@@ -1142,13 +1142,13 @@ public:
     }
 
     if (m_temporary_allocation == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("Points to process memory:\n");
+      dump_stream.PutCString("Points to process memory:\n");
     } else {
-      dump_stream.Printf("Temporary allocation:\n");
+      dump_stream.PutCString("Temporary allocation:\n");
     }
 
     if (ptr == LLDB_INVALID_ADDRESS) {
-      dump_stream.Printf("  <could not be be found>\n");
+      dump_stream.PutCString("  <could not be be found>\n");
     } else {
       DataBufferHeap data(m_temporary_allocation_size, 0);
 
@@ -1156,7 +1156,7 @@ public:
                      m_temporary_allocation_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -1283,14 +1283,14 @@ public:
                        m_symbol.GetName());
 
     {
-      dump_stream.Printf("Pointer:\n");
+      dump_stream.PutCString("Pointer:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);
@@ -1450,14 +1450,14 @@ public:
                        m_register_info.name);
 
     {
-      dump_stream.Printf("Value:\n");
+      dump_stream.PutCString("Value:\n");
 
       DataBufferHeap data(m_size, 0);
 
       map.ReadMemory(data.GetBytes(), load_addr, m_size, err);
 
       if (!err.Success()) {
-        dump_stream.Printf("  <could not be read>\n");
+        dump_stream.PutCString("  <could not be read>\n");
       } else {
         DumpHexBytes(&dump_stream, data.GetBytes(), data.GetByteSize(), 16,
                      load_addr);

--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -99,7 +99,7 @@ void REPL::IOHandlerActivated(IOHandler &io_handler, bool interactive) {
   if (process_sp && process_sp->IsAlive())
     return;
   LockedStreamFile locked_stream = io_handler.GetErrorStreamFileSP()->Lock();
-  locked_stream.Printf("REPL requires a running target process.\n");
+  locked_stream.PutCString("REPL requires a running target process.\n");
   io_handler.SetIsDone(true);
 }
 
@@ -397,7 +397,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
               locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_FG_COLOR_RED));
               locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_BOLD));
             }
-            locked_error_stream.Printf("Execution interrupted. ");
+            locked_error_stream.PutCString("Execution interrupted. ");
             if (useColors)
               locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
             locked_error_stream.Printf(
@@ -429,7 +429,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
             break;
 
           case lldb::eExpressionTimedOut:
-            locked_error_stream.Printf("error: timeout\n");
+            locked_error_stream.PutCString("error: timeout\n");
             if (error.AsCString())
               locked_error_stream.Printf("error: %s\n", error.AsCString());
             break;

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -359,7 +359,7 @@ bool ProcessLaunchInfo::ConvertArgumentsForLaunchingInShell(
         // There should only be one argument that is the shell command itself
         // to be used as is
         if (argv[0] && !argv[1])
-          shell_command.Printf("%s", argv[0]);
+          shell_command.PutCString(argv[0]);
         else
           return false;
       } else {

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -89,7 +89,7 @@ bool SymbolContext::DumpStopContext(
     SymbolContext inline_parent_sc;
     Address inline_parent_addr;
     if (!show_function_name) {
-      s->Printf("<");
+      s->PutCString("<");
       dumped_something = true;
     } else {
       ConstString name;
@@ -168,7 +168,7 @@ bool SymbolContext::DumpStopContext(
     }
   } else if (symbol != nullptr) {
     if (!show_function_name) {
-      s->Printf("<");
+      s->PutCString("<");
       dumped_something = true;
     } else if (symbol->GetName()) {
       dumped_something = true;
@@ -1127,7 +1127,7 @@ void SymbolContextSpecifier::GetDescription(
   char path_str[PATH_MAX + 1];
 
   if (m_type == eNothingSpecified) {
-    s->Printf("Nothing specified.\n");
+    s->PutCString("Nothing specified.\n");
   }
 
   if (m_type == eModuleSpecified) {
@@ -1148,11 +1148,11 @@ void SymbolContextSpecifier::GetDescription(
       if (m_type == eLineEndSpecified)
         s->Printf("to line %" PRIu64 "", (uint64_t)m_end_line);
       else
-        s->Printf("to end");
+        s->PutCString("to end");
     } else if (m_type == eLineEndSpecified) {
       s->Printf(" from start to line %" PRIu64 "", (uint64_t)m_end_line);
     }
-    s->Printf(".\n");
+    s->PutCString(".\n");
   }
 
   if (m_type == eLineStartSpecified) {
@@ -1161,8 +1161,8 @@ void SymbolContextSpecifier::GetDescription(
     if (m_type == eLineEndSpecified)
       s->Printf("to line %" PRIu64 "", (uint64_t)m_end_line);
     else
-      s->Printf("to end");
-    s->Printf(".\n");
+      s->PutCString("to end");
+    s->PutCString(".\n");
   } else if (m_type == eLineEndSpecified) {
     s->Printf("From start to line %" PRIu64 ".\n", (uint64_t)m_end_line);
   }

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1201,9 +1201,9 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
   ModuleSP module_sp;
   if (CheckModule(module_sp)) {
     if (m_dynamic_type.IsValid()) {
-      strm.Printf("Dynamic:\n");
+      strm.PutCString("Dynamic:\n");
       m_dynamic_type.DumpTypeDescription(&strm);
-      strm.Printf("\nStatic:\n");
+      strm.PutCString("\nStatic:\n");
     }
     m_static_type.DumpTypeDescription(&strm);
   } else {

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -241,11 +241,11 @@ void UnwindPlan::Row::Dump(Stream &s, const UnwindPlan *unwind_plan,
   m_cfa_value.Dump(s, unwind_plan, thread);
 
   if (!m_afa_value.IsUnspecified()) {
-    s.Printf(" AFA=");
+    s.PutCString(" AFA=");
     m_afa_value.Dump(s, unwind_plan, thread);
   }
 
-  s.Printf(" => ");
+  s.PutCString(" => ");
   for (collection::const_iterator idx = m_register_locations.begin();
        idx != m_register_locations.end(); ++idx) {
     DumpRegisterName(s, unwind_plan, thread, idx->first);
@@ -512,40 +512,40 @@ void UnwindPlan::Dump(Stream &s, Thread *thread, lldb::addr_t base_addr) const {
     s.Printf("This UnwindPlan originally sourced from %s\n",
              m_source_name.GetCString());
   }
-  s.Printf("This UnwindPlan is sourced from the compiler: ");
+  s.PutCString("This UnwindPlan is sourced from the compiler: ");
   switch (m_plan_is_sourced_from_compiler) {
   case eLazyBoolYes:
-    s.Printf("yes.\n");
+    s.PutCString("yes.\n");
     break;
   case eLazyBoolNo:
-    s.Printf("no.\n");
+    s.PutCString("no.\n");
     break;
   case eLazyBoolCalculate:
-    s.Printf("not specified.\n");
+    s.PutCString("not specified.\n");
     break;
   }
-  s.Printf("This UnwindPlan is valid at all instruction locations: ");
+  s.PutCString("This UnwindPlan is valid at all instruction locations: ");
   switch (m_plan_is_valid_at_all_instruction_locations) {
   case eLazyBoolYes:
-    s.Printf("yes.\n");
+    s.PutCString("yes.\n");
     break;
   case eLazyBoolNo:
-    s.Printf("no.\n");
+    s.PutCString("no.\n");
     break;
   case eLazyBoolCalculate:
-    s.Printf("not specified.\n");
+    s.PutCString("not specified.\n");
     break;
   }
-  s.Printf("This UnwindPlan is for a trap handler function: ");
+  s.PutCString("This UnwindPlan is for a trap handler function: ");
   switch (m_plan_is_for_signal_trap) {
   case eLazyBoolYes:
-    s.Printf("yes.\n");
+    s.PutCString("yes.\n");
     break;
   case eLazyBoolNo:
-    s.Printf("no.\n");
+    s.PutCString("no.\n");
     break;
   case eLazyBoolCalculate:
-    s.Printf("not specified.\n");
+    s.PutCString("not specified.\n");
     break;
   }
   if (!m_plan_valid_ranges.empty()) {

--- a/lldb/source/Utility/Event.cpp
+++ b/lldb/source/Utility/Event.cpp
@@ -77,7 +77,7 @@ void Event::Dump(Stream *s) const {
     m_data_sp->Dump(s);
     s->PutChar('}');
   } else
-    s->Printf("<NULL>");
+    s->PutCString("<NULL>");
 }
 
 void Event::DoOnRemoval() {

--- a/lldb/source/Utility/ProcessInfo.cpp
+++ b/lldb/source/Utility/ProcessInfo.cpp
@@ -140,7 +140,7 @@ void ProcessInstanceInfo::Dump(Stream &s, UserIDResolver &resolver) const {
   s.Format("{0}", m_environment);
 
   if (m_arch.IsValid()) {
-    s.Printf("   arch = ");
+    s.PutCString("   arch = ");
     m_arch.DumpTriple(s.AsRawOstream());
     s.EOL();
   }

--- a/lldb/source/Utility/StructuredData.cpp
+++ b/lldb/source/Utility/StructuredData.cpp
@@ -197,7 +197,7 @@ void StructuredData::Boolean::GetDescription(lldb_private::Stream &s) const {
 }
 
 void StructuredData::String::GetDescription(lldb_private::Stream &s) const {
-  s.Printf("%s", m_value.empty() ? "\"\"" : m_value.c_str());
+  s.PutCString(m_value.empty() ? "\"\"" : m_value.c_str());
 }
 
 void StructuredData::Array::GetDescription(lldb_private::Stream &s) const {
@@ -283,7 +283,7 @@ void StructuredData::Dictionary::GetDescription(lldb_private::Stream &s) const {
 }
 
 void StructuredData::Null::GetDescription(lldb_private::Stream &s) const {
-  s.Printf("NULL");
+  s.PutCString("NULL");
 }
 
 void StructuredData::Generic::GetDescription(lldb_private::Stream &s) const {

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -983,7 +983,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
       if ((bytes_read = data.GetByteSize()) > 0) {
         total_bytes_read = bytes_read;
         for (size_t offset = 0; offset < bytes_read; offset++)
-          s.Printf("%c", *data.PeekData(offset, 1));
+          s.PutChar(*data.PeekData(offset, 1));
         if (capped_data)
           was_capped = true;
       }
@@ -1015,7 +1015,7 @@ ValueObject::ReadPointedString(lldb::WritableDataBufferSP &buffer_sp,
           len = cstr_len;
 
         for (size_t offset = 0; offset < bytes_read; offset++)
-          s.Printf("%c", *data.PeekData(offset, 1));
+          s.PutChar(*data.PeekData(offset, 1));
 
         if (len < k_max_buf_size)
           break;


### PR DESCRIPTION
`Stream::Printf` needs to call various other (variadic) functions, needs to parse the input string and potentially handle too-long format outputs. Calling in with a constant string is wasting a lot of instruction on doing nothing.

assisted-by: claude