### PR TITLE
[LIT][NFC] Fix double slash in GoogleTest format test names

### DIFF
--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import math
 import os
@@ -14,9 +16,17 @@ kIsWindows = sys.platform in ["win32", "cygwin"]
 
 
 class GoogleTest(TestFormat):
-    def __init__(self, test_sub_dirs, test_suffix, run_under=[], test_prefix=None):
+    def __init__(
+        self,
+        test_sub_dirs: str | None,
+        test_suffix: str,
+        run_under=[],
+        test_prefix=None,
+    ):
         self.seen_executables = set()
-        self.test_sub_dirs = str(test_sub_dirs).split(";")
+        # Split on ";" can create [''] when test_sub_dirs is empty string,
+        # which causes leading slashes in test paths. Filter empty strings.
+        self.test_sub_dirs = [d for d in str(test_sub_dirs).split(";") if d] or ["."]
 
         # On Windows, assume tests will also end in '.exe'.
         exe_suffix = str(test_suffix)
@@ -27,6 +37,17 @@ class GoogleTest(TestFormat):
         self.test_suffixes = {exe_suffix, test_suffix + ".py"}
         self.test_prefixes = {test_prefix} if test_prefix else None
         self.run_under = run_under
+
+    def _make_test_path(
+        self, path_in_suite: tuple, subdir: str, fn: str, *extra: str, litConfig=None
+    ) -> tuple:
+        """Construct test path, omitting '.' subdirectory."""
+        components = () if subdir == "." else (subdir,)
+        test_path = path_in_suite + components + (fn,) + extra
+        if litConfig and litConfig.debug:
+            subdir_display = "." if subdir == "." else repr(subdir)
+            litConfig.note(f"GoogleTest path: {test_path} (subdir={subdir_display})")
+        return test_path
 
     def get_num_tests(self, path, litConfig, localConfig):
         list_test_cmd = self.prepareCmd(
@@ -80,11 +101,13 @@ class GoogleTest(TestFormat):
 
                         # Create one lit test for each shard.
                         for idx in range(nshard):
-                            testPath = path_in_suite + (
+                            testPath = self._make_test_path(
+                                path_in_suite,
                                 subdir,
                                 fn,
                                 str(idx),
                                 str(nshard),
+                                litConfig=litConfig,
                             )
                             json_file = (
                                 "-".join(
@@ -106,7 +129,9 @@ class GoogleTest(TestFormat):
                                 gtest_json_file=json_file,
                             )
                     else:
-                        testPath = path_in_suite + (subdir, fn)
+                        testPath = self._make_test_path(
+                            path_in_suite, subdir, fn, litConfig=litConfig
+                        )
                         json_file = (
                             "-".join(
                                 [

--- a/llvm/utils/lit/tests/Inputs/googletest-empty-subdir/device-test.py
+++ b/llvm/utils/lit/tests/Inputs/googletest-empty-subdir/device-test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Mock GoogleTest executable for testing lit GoogleTest format.
+
+Simulates GoogleTest discovery (--gtest_list_tests) and execution
+with JSON output. Used by googletest-empty-subdir.py test.
+"""
+
+import os
+import sys
+
+# Number of parts to split GTEST_OUTPUT format ("json:/path/to/file.json")
+# Split at first colon only to handle paths with colons (e.g., Windows C:\\path)
+PROTOCOL_MAX_SPLIT = 1
+
+if len(sys.argv) == 3 and sys.argv[1] == "--gtest_list_tests":
+    if sys.argv[2] != "--gtest_filter=-*DISABLED_*":
+        raise ValueError(f"unexpected argument: {sys.argv[2]}")
+    print(
+        """\
+FirstTest.
+  subTestA
+  subTestB
+SecondTest.
+  subTestC"""
+    )
+    sys.exit(0)
+elif len(sys.argv) != 1:
+    # sharding and json output are specified using environment variables
+    raise ValueError(f"unexpected argument: {' '.join(sys.argv[1:])!r}")
+
+if "GTEST_OUTPUT" not in os.environ:
+    raise ValueError("missing environment variable: GTEST_OUTPUT")
+
+if not os.environ["GTEST_OUTPUT"].startswith("json:"):
+    raise ValueError(f"must emit json output: {os.environ['GTEST_OUTPUT']}")
+
+output = """\
+{
+"random_seed": 123,
+"testsuites": [
+    {
+        "name": "FirstTest",
+        "testsuite": [
+            {
+                "name": "subTestA",
+                "result": "COMPLETED",
+                "time": "0.001s"
+            },
+            {
+                "name": "subTestB",
+                "result": "COMPLETED",
+                "time": "0.001s",
+                "failures": [
+                    {
+                        "failure": "Test intentionally fails",
+                        "type": ""
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "SecondTest",
+        "testsuite": [
+            {
+                "name": "subTestC",
+                "result": "COMPLETED",
+                "time": "0.001s"
+            }
+        ]
+    }
+]
+}"""
+
+json_filename = os.environ["GTEST_OUTPUT"].split(":", PROTOCOL_MAX_SPLIT)[1]
+with open(json_filename, "w", encoding="utf-8") as f:
+    print("[ RUN      ] FirstTest.subTestA", flush=True)
+    print("[       OK ] FirstTest.subTestA (1 ms)", flush=True)
+    print("[ RUN      ] FirstTest.subTestB", flush=True)
+    print("Test intentionally fails", file=sys.stderr, flush=True)
+    print("[  FAILED  ] FirstTest.subTestB (1 ms)", flush=True)
+    print("[ RUN      ] SecondTest.subTestC", flush=True)
+    print("[       OK ] SecondTest.subTestC (1 ms)", flush=True)
+    f.write(output)
+
+sys.exit(1)

--- a/llvm/utils/lit/tests/Inputs/googletest-empty-subdir/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/googletest-empty-subdir/lit.cfg
@@ -1,0 +1,5 @@
+import lit.formats
+
+config.name = "googletest-empty-subdir"
+# Tests empty test_sub_dirs to verify no leading/double slashes in names
+config.test_format = lit.formats.GoogleTest("", "-test")

--- a/llvm/utils/lit/tests/googletest-empty-subdir.py
+++ b/llvm/utils/lit/tests/googletest-empty-subdir.py
@@ -1,0 +1,9 @@
+# Check that empty test_sub_dirs produces clean test names without double slashes.
+
+# RUN: not %{lit} -v --no-gtest-sharding %{inputs}/googletest-empty-subdir | FileCheck %s
+
+# CHECK: FAIL: googletest-empty-subdir :: device-test.py
+# CHECK: *** TEST 'googletest-empty-subdir :: device-test.py' FAILED ***
+
+# CHECK: Failed Tests (1):
+# CHECK-NEXT:   googletest-empty-subdir :: FirstTest/subTestB


### PR DESCRIPTION
An empty test_sub_dirs results in an empty path component when constructing test names, producing a double slash (//), e.g. `Suite :: device//device-test/Name`.

Fix: Filter out empty strings and use `['.']` as the default for `test_sub_dirs`, while omitting `'.'` when constructing test paths. This produces consistent test names such as `Suite :: device/device-test/Name`.

This change improves test name consistency, which is needed for automated CI test result collection and analysis.