### PR TITLE
Add missing BigArchive container plugin to lldb's bazel build

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -618,6 +618,7 @@ cc_library(
         "//lldb:Host",
         "//lldb:Symbol",
         "//lldb:SymbolHeaders",
+        "//lldb:Utility",
         "//llvm:Support",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -609,6 +609,20 @@ cc_library(
 )
 
 cc_library(
+    name = "PluginObjectContainerBigArchive",
+    srcs = glob(["ObjectContainer/Big-Archive/*.cpp"]),
+    hdrs = glob(["ObjectContainer/Big-Archive/*.h"]),
+    includes = [".."],
+    deps = [
+        "//lldb:Core",
+        "//lldb:Host",
+        "//lldb:Symbol",
+        "//lldb:SymbolHeaders",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "PluginObjectContainerMachOFileset",
     srcs = glob(["ObjectContainer/Mach-O-Fileset/*.cpp"]),
     hdrs = glob(["ObjectContainer/Mach-O-Fileset/*.h"]),

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
@@ -51,6 +51,7 @@ DEFAULT_PLUGINS = [
     "MemoryHistoryASan",
     "ObjCLanguage",
     "ObjCPlusPlusLanguage",
+    "ObjectContainerBigArchive",
     "ObjectContainerBSDArchive",
     "ObjectContainerMachOArchive",
     "ObjectContainerMachOFileset",


### PR DESCRIPTION
Another missing plugin and its libraries in the LLDB bazel build.  Based this one on source/Plugins/ObjectContainer/Big-Archive/CMakeLists.txt and its dependecies ( {}.cpp & {}.h)

waiting on CI to confirm bazel is correct as cannot build locally.

Can confirm this library will convert to BUCK internally at Meta and build with buck2 where we do have in the default plugin list.

bazel rule assisted with: claude