### PR TITLE
[AMDGPU] Fix type of SIlds / AMDGPUISD::LDS node

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSelectionDAGInfo.cpp
@@ -51,8 +51,6 @@ void AMDGPUSelectionDAGInfo::verifyTargetNode(const SelectionDAG &DAG,
   case AMDGPUISD::ELSE:
   case AMDGPUISD::LOOP:
     // operand #1 must have type i1, but has type i32/i64
-  case AMDGPUISD::LDS:
-    // result #0 must have type i64 (iPTR), but has type i32
     return;
   }
   SelectionDAGGenTargetInfo::verifyTargetNode(DAG, N);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -275,7 +275,7 @@ def SIpc_add_rel_offset64 : SDNode<"AMDGPUISD::PC_ADD_REL_OFFSET64",
 >;
 
 def SIlds : SDNode<"AMDGPUISD::LDS",
-  SDTypeProfile<1, 1, [SDTCisVT<0, iPTR>, SDTCisSameAs<0,1>]>
+  SDTypeProfile<1, 1, [SDTCisVT<0, i32>, SDTCisSameAs<0,1>]>
 >;
 
 def SIload_d16_lo : SDNode<"AMDGPUISD::LOAD_D16_LO",


### PR DESCRIPTION
iPTR means i64 here, but this node operates on 32-bit LDS addresses.
