### PR TITLE
[SystemZ/[z/OS] Guard source-epoch related testcase to 64-bit clang targets

### DIFF
--- a/clang/test/CodeGen/SystemZ/systemz-module.flags.c
+++ b/clang/test/CodeGen/SystemZ/systemz-module.flags.c
@@ -1,5 +1,5 @@
+//REQUIRES: clang-target-64-bits
+
 // RUN: %clang_cc1 -source-date-epoch 253402300799 -triple s390x-ibm-zos -emit-llvm -o - %s | FileCheck %s
 // CHECK: {{.*}}"zos_cu_language", !"C"}
 // CHECK: {{.*}}"zos_translation_time", i64 253402300799}
-
-// UNSUPPORTED: arm

--- a/clang/test/CodeGen/SystemZ/systemz-module.flags.c
+++ b/clang/test/CodeGen/SystemZ/systemz-module.flags.c
@@ -1,3 +1,5 @@
 // RUN: %clang_cc1 -source-date-epoch 253402300799 -triple s390x-ibm-zos -emit-llvm -o - %s | FileCheck %s
 // CHECK: {{.*}}"zos_cu_language", !"C"}
 // CHECK: {{.*}}"zos_translation_time", i64 253402300799}
+
+// REQUIRES: system-zos

--- a/clang/test/CodeGen/SystemZ/systemz-module.flags.c
+++ b/clang/test/CodeGen/SystemZ/systemz-module.flags.c
@@ -1,4 +1,4 @@
-//REQUIRES: clang-target-64-bits
+// REQUIRES: clang-target-64-bits
 
 // RUN: %clang_cc1 -source-date-epoch 253402300799 -triple s390x-ibm-zos -emit-llvm -o - %s | FileCheck %s
 // CHECK: {{.*}}"zos_cu_language", !"C"}

--- a/clang/test/CodeGen/SystemZ/systemz-module.flags.c
+++ b/clang/test/CodeGen/SystemZ/systemz-module.flags.c
@@ -2,4 +2,4 @@
 // CHECK: {{.*}}"zos_cu_language", !"C"}
 // CHECK: {{.*}}"zos_translation_time", i64 253402300799}
 
-// REQUIRES: system-zos
+// UNSUPPORTED: arm


### PR DESCRIPTION
This patch is to fix the error seen here:


```
******************** TEST 'Clang :: CodeGen/SystemZ/systemz-module.flags.c' FAILED ********************
Exit Code: 2
Command Output (stdout):
--
# RUN: at line 1
/home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/clang -cc1 -internal-isystem /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/lib/clang/24/include -nostdsysteminc -source-date-epoch 253402300799 -triple s390x-ibm-zos -emit-llvm -o - /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/CodeGen/SystemZ/systemz-module.flags.c | /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/FileCheck /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/CodeGen/SystemZ/systemz-module.flags.c
# executed command: /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/clang -cc1 -internal-isystem /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/lib/clang/24/include -nostdsysteminc -source-date-epoch 253402300799 -triple s390x-ibm-zos -emit-llvm -o - /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/CodeGen/SystemZ/systemz-module.flags.c
# .---command stderr------------
# | error: environment variable 'SOURCE_DATE_EPOCH' ('253402300799') must be a non-negative decimal integer <= 2147483647
# `-----------------------------
# error: command failed with exit status: 1
# executed command: /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/FileCheck /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/CodeGen/SystemZ/systemz-module.flags.c
# .---command stderr------------
# | FileCheck error: '<stdin>' is empty.
# | FileCheck command line:  /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/FileCheck /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/CodeGen/SystemZ/systemz-module.flags.c
# `-----------------------------
# error: command failed with exit status: 2
```