### PR TITLE
[Clang] Fixed auto parsing regression with brace initialization

### DIFF
--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3879,10 +3879,10 @@ void Parser::ParseDeclarationSpecifiers(
       // when a variable name matches a type brought in by a using-directive.
       if (DS.getTypeSpecType() == DeclSpec::TST_auto) {
         Token Next = NextToken();
-        if (Next.isOneOf(tok::equal, tok::l_paren, tok::l_square, tok::amp,
-                         tok::ampamp, tok::star, tok::coloncolon, tok::comma,
-                         tok::semi, tok::colon, tok::greater, tok::r_paren,
-                         tok::arrow))
+        if (Next.isOneOf(tok::equal, tok::l_paren, tok::l_square, tok::l_brace,
+                         tok::amp, tok::ampamp, tok::star, tok::coloncolon,
+                         tok::comma, tok::semi, tok::colon, tok::greater,
+                         tok::r_paren, tok::arrow))
           goto DoneWithDeclSpec;
       }
 

--- a/clang/test/CXX/dcl/dcl.spec/dcl.type/dcl.type.general/p2.cpp
+++ b/clang/test/CXX/dcl/dcl.spec/dcl.type/dcl.type.general/p2.cpp
@@ -1,0 +1,11 @@
+// RUN:  %clang_cc1 -std=c++2c -verify %s
+
+void func1() {
+  typedef float foo; // expected-note {{previous definition is here}}
+  auto foo{16};      // expected-error {{redefinition of 'foo' as different kind of symbol}}
+}
+
+typedef float bar;
+void func2() {
+  auto bar{16};
+}


### PR DESCRIPTION
The PR #208552 has introduced a regression where brace initialization was not taken into account `auto foo{12}`. It was also breaking `dcl.type.general` p2 rules, which is also now tested.