### PR TITLE
[SystemZ] Enable clang-target-64-bits for s390x

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -393,7 +393,7 @@ if platform.system() not in ["Windows"]:
     config.available_features.add("can-remove-opened-file")
 
 # Features
-known_arches = ["x86_64", "mips64", "ppc64", "aarch64"]
+known_arches = ["x86_64", "mips64", "ppc64", "aarch64", "s390x"]
 if any(config.target_triple.startswith(x) for x in known_arches):
     config.available_features.add("clang-target-64-bits")
 


### PR DESCRIPTION
Enable clang-target-64-bits for s390x so we can enable tests like https://github.com/llvm/llvm-project/pull/210341