### PR TITLE
[BPF] Use FETCH atomic instruction for monotonic atomicrmw when the result is used

### DIFF
--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -1008,57 +1008,8 @@ let Constraints = "$dst = $val" in {
   def XFXORD : XFALU64<BPF_DW, BPF_XOR, "u64", "xor">;
 }
 
-let Predicates = [BPFHasALU32] in {
-    foreach P = [// add
-                 [atomic_load_add_i32_monotonic,  XADDW32],
-                 [atomic_load_add_i32_acquire,   XFADDW32],
-                 [atomic_load_add_i32_release,   XFADDW32],
-                 [atomic_load_add_i32_acq_rel,   XFADDW32],
-                 [atomic_load_add_i32_seq_cst,   XFADDW32],
-                 // and
-                 [atomic_load_and_i32_monotonic,  XANDW32],
-                 [atomic_load_and_i32_acquire,   XFANDW32],
-                 [atomic_load_and_i32_release,   XFANDW32],
-                 [atomic_load_and_i32_acq_rel,   XFANDW32],
-                 [atomic_load_and_i32_seq_cst,   XFANDW32],
-                 // or
-                 [atomic_load_or_i32_monotonic,   XORW32],
-                 [atomic_load_or_i32_acquire,    XFORW32],
-                 [atomic_load_or_i32_release,    XFORW32],
-                 [atomic_load_or_i32_acq_rel,    XFORW32],
-                 [atomic_load_or_i32_seq_cst,    XFORW32],
-                 // xor
-                 [atomic_load_xor_i32_monotonic,  XXORW32],
-                 [atomic_load_xor_i32_acquire,   XFXORW32],
-                 [atomic_load_xor_i32_release,   XFXORW32],
-                 [atomic_load_xor_i32_acq_rel,   XFXORW32],
-                 [atomic_load_xor_i32_seq_cst,   XFXORW32],
-                ] in {
-      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, GPR32:$val)>;
-    }
-
-    // atomic_load_sub can be represented as a neg followed
-    // by an atomic_load_add.
-    foreach P = [[atomic_load_sub_i32_monotonic,  XADDW32],
-                 [atomic_load_sub_i32_acquire,   XFADDW32],
-                 [atomic_load_sub_i32_release,   XFADDW32],
-                 [atomic_load_sub_i32_acq_rel,   XFADDW32],
-                 [atomic_load_sub_i32_seq_cst,   XFADDW32],
-                ] in {
-      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, (NEG_32 GPR32:$val))>;
-    }
-}
-
-foreach P = [[atomic_load_sub_i64_monotonic,  XADDD],
-             [atomic_load_sub_i64_acquire,   XFADDD],
-             [atomic_load_sub_i64_release,   XFADDD],
-             [atomic_load_sub_i64_acq_rel,   XFADDD],
-             [atomic_load_sub_i64_seq_cst,   XFADDD],
-            ] in {
-  def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
-}
-
-// Borrow the idea from X86InstrFragments.td
+// Borrow the idea from X86InstrFragments.td: split each monotonic atomic RMW
+// pattern on whether its result value is used.
 class binop_no_use<SDPatternOperator operator>
       : PatFrag<(ops node:$A, node:$B),
                 (operator node:$A, node:$B),
@@ -1069,11 +1020,71 @@ class binop_has_use<SDPatternOperator operator>
                 (operator node:$A, node:$B),
                 [{ return !SDValue(N, 0).use_empty(); }]>;
 
-foreach op = [add, and, or, xor] in {
+foreach op = [add, sub, and, or, xor] in {
 def atomic_load_ # op # _i64_monotonic_nu:
     binop_no_use <!cast<SDPatternOperator>("atomic_load_"#op# _i64_monotonic)>;
 def atomic_load_ # op # _i64_monotonic_hu:
     binop_has_use<!cast<SDPatternOperator>("atomic_load_"#op# _i64_monotonic)>;
+def atomic_load_ # op # _i32_monotonic_nu:
+    binop_no_use <!cast<SDPatternOperator>("atomic_load_"#op# _i32_monotonic)>;
+def atomic_load_ # op # _i32_monotonic_hu:
+    binop_has_use<!cast<SDPatternOperator>("atomic_load_"#op# _i32_monotonic)>;
+}
+
+let Predicates = [BPFHasALU32] in {
+    foreach P = [// add
+                 [atomic_load_add_i32_monotonic_nu, XADDW32],
+                 [atomic_load_add_i32_monotonic_hu, XFADDW32],
+                 [atomic_load_add_i32_acquire,   XFADDW32],
+                 [atomic_load_add_i32_release,   XFADDW32],
+                 [atomic_load_add_i32_acq_rel,   XFADDW32],
+                 [atomic_load_add_i32_seq_cst,   XFADDW32],
+                 // and
+                 [atomic_load_and_i32_monotonic_nu, XANDW32],
+                 [atomic_load_and_i32_monotonic_hu, XFANDW32],
+                 [atomic_load_and_i32_acquire,   XFANDW32],
+                 [atomic_load_and_i32_release,   XFANDW32],
+                 [atomic_load_and_i32_acq_rel,   XFANDW32],
+                 [atomic_load_and_i32_seq_cst,   XFANDW32],
+                 // or
+                 [atomic_load_or_i32_monotonic_nu,  XORW32],
+                 [atomic_load_or_i32_monotonic_hu, XFORW32],
+                 [atomic_load_or_i32_acquire,    XFORW32],
+                 [atomic_load_or_i32_release,    XFORW32],
+                 [atomic_load_or_i32_acq_rel,    XFORW32],
+                 [atomic_load_or_i32_seq_cst,    XFORW32],
+                 // xor
+                 [atomic_load_xor_i32_monotonic_nu, XXORW32],
+                 [atomic_load_xor_i32_monotonic_hu, XFXORW32],
+                 [atomic_load_xor_i32_acquire,   XFXORW32],
+                 [atomic_load_xor_i32_release,   XFXORW32],
+                 [atomic_load_xor_i32_acq_rel,   XFXORW32],
+                 [atomic_load_xor_i32_seq_cst,   XFXORW32],
+                ] in {
+      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, GPR32:$val)>;
+    }
+
+    // atomic_load_sub can be represented as a neg followed
+    // by an atomic_load_add.
+    foreach P = [[atomic_load_sub_i32_monotonic_nu, XADDW32],
+                 [atomic_load_sub_i32_monotonic_hu, XFADDW32],
+                 [atomic_load_sub_i32_acquire,   XFADDW32],
+                 [atomic_load_sub_i32_release,   XFADDW32],
+                 [atomic_load_sub_i32_acq_rel,   XFADDW32],
+                 [atomic_load_sub_i32_seq_cst,   XFADDW32],
+                ] in {
+      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, (NEG_32 GPR32:$val))>;
+    }
+}
+
+foreach P = [[atomic_load_sub_i64_monotonic_nu, XADDD],
+             [atomic_load_sub_i64_monotonic_hu, XFADDD],
+             [atomic_load_sub_i64_acquire,   XFADDD],
+             [atomic_load_sub_i64_release,   XFADDD],
+             [atomic_load_sub_i64_acq_rel,   XFADDD],
+             [atomic_load_sub_i64_seq_cst,   XFADDD],
+            ] in {
+  def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
 }
 
 let Predicates = [BPFHasALU32] in {

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -955,6 +955,8 @@ let Predicates = [BPFNoALU32] in {
             (XADDW ADDRri:$addr, GPR:$val)>;
   def : Pat<(atomic_load_add_i64 ADDRri:$addr, GPR:$val),
             (XADDD ADDRri:$addr, GPR:$val)>;
+  def : Pat<(atomic_load_sub_i64_monotonic ADDRri:$addr, GPR:$val),
+            (XADDD ADDRri:$addr, (NEG_64 GPR:$val))>;
 }
 
 // Atomic Fetch-and-<add, and, or, xor> operations
@@ -1077,9 +1079,14 @@ let Predicates = [BPFHasALU32] in {
     }
 }
 
-foreach P = [[atomic_load_sub_i64_monotonic_nu, XADDD],
-             [atomic_load_sub_i64_monotonic_hu, XFADDD],
-             [atomic_load_sub_i64_acquire,   XFADDD],
+let Predicates = [BPFHasALU32] in {
+  foreach P = [[atomic_load_sub_i64_monotonic_nu, XADDD],
+               [atomic_load_sub_i64_monotonic_hu, XFADDD]] in {
+    def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1] ADDRri:$addr, (NEG_64 GPR:$val))>;
+  }
+}
+
+foreach P = [[atomic_load_sub_i64_acquire,   XFADDD],
              [atomic_load_sub_i64_release,   XFADDD],
              [atomic_load_sub_i64_acq_rel,   XFADDD],
              [atomic_load_sub_i64_seq_cst,   XFADDD],

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -1047,16 +1047,6 @@ let Predicates = [BPFHasALU32] in {
                 ] in {
       def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, (NEG_32 GPR32:$val))>;
     }
-
-    foreach P = [// add
-                 [atomic_load_add_i64_monotonic,  XADDD],
-                 [atomic_load_add_i64_acquire,   XFADDD],
-                 [atomic_load_add_i64_release,   XFADDD],
-                 [atomic_load_add_i64_acq_rel,   XFADDD],
-                 [atomic_load_add_i64_seq_cst,   XFADDD],
-                ] in {
-      def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, GPR:$val)>;
-    }
 }
 
 foreach P = [[atomic_load_sub_i64_monotonic,  XADDD],
@@ -1084,6 +1074,19 @@ def atomic_load_ # op # _i64_monotonic_nu:
     binop_no_use <!cast<SDPatternOperator>("atomic_load_"#op# _i64_monotonic)>;
 def atomic_load_ # op # _i64_monotonic_hu:
     binop_has_use<!cast<SDPatternOperator>("atomic_load_"#op# _i64_monotonic)>;
+}
+
+let Predicates = [BPFHasALU32] in {
+  foreach P = [// add
+              [atomic_load_add_i64_monotonic_nu, XADDD],
+              [atomic_load_add_i64_monotonic_hu, XFADDD],
+              [atomic_load_add_i64_acquire,   XFADDD],
+              [atomic_load_add_i64_release,   XFADDD],
+              [atomic_load_add_i64_acq_rel,   XFADDD],
+              [atomic_load_add_i64_seq_cst,   XFADDD],
+            ] in {
+    def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, GPR:$val)>;
+  }
 }
 
 foreach P = [// and

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -955,6 +955,8 @@ let Predicates = [BPFNoALU32] in {
             (XADDW ADDRri:$addr, GPR:$val)>;
   def : Pat<(atomic_load_add_i64 ADDRri:$addr, GPR:$val),
             (XADDD ADDRri:$addr, GPR:$val)>;
+  // No atomic fetch on non-ALU32 CPUs: lower a used-result relaxed sub to plain
+  // XADDD rather than the ALU32-only XFADDD.
   def : Pat<(atomic_load_sub_i64_monotonic ADDRri:$addr, GPR:$val),
             (XADDD ADDRri:$addr, (NEG_64 GPR:$val))>;
 }
@@ -1077,25 +1079,8 @@ let Predicates = [BPFHasALU32] in {
                 ] in {
       def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, (NEG_32 GPR32:$val))>;
     }
-}
 
-let Predicates = [BPFHasALU32] in {
-  foreach P = [[atomic_load_sub_i64_monotonic_nu, XADDD],
-               [atomic_load_sub_i64_monotonic_hu, XFADDD]] in {
-    def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1] ADDRri:$addr, (NEG_64 GPR:$val))>;
-  }
-}
-
-foreach P = [[atomic_load_sub_i64_acquire,   XFADDD],
-             [atomic_load_sub_i64_release,   XFADDD],
-             [atomic_load_sub_i64_acq_rel,   XFADDD],
-             [atomic_load_sub_i64_seq_cst,   XFADDD],
-            ] in {
-  def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
-}
-
-let Predicates = [BPFHasALU32] in {
-  foreach P = [// add
+    foreach P = [// add
               [atomic_load_add_i64_monotonic_nu, XADDD],
               [atomic_load_add_i64_monotonic_hu, XFADDD],
               [atomic_load_add_i64_acquire,   XFADDD],
@@ -1105,6 +1090,16 @@ let Predicates = [BPFHasALU32] in {
             ] in {
     def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, GPR:$val)>;
   }
+}
+
+foreach P = [[atomic_load_sub_i64_monotonic_nu, XADDD],
+             [atomic_load_sub_i64_monotonic_hu, XFADDD],
+             [atomic_load_sub_i64_acquire,   XFADDD],
+             [atomic_load_sub_i64_release,   XFADDD],
+             [atomic_load_sub_i64_acq_rel,   XFADDD],
+             [atomic_load_sub_i64_seq_cst,   XFADDD],
+            ] in {
+  def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
 }
 
 foreach P = [// and

--- a/llvm/test/CodeGen/BPF/atomics_mem_order_v3.ll
+++ b/llvm/test/CodeGen/BPF/atomics_mem_order_v3.ll
@@ -201,7 +201,7 @@ define dso_local i32 @test_fetch_add_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) += w3
+; CHECK-NEXT:    w3 = atomic_fetch_add((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_add((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -323,7 +323,7 @@ define dso_local i32 @test_fetch_sub_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w2 = -w2
 ; CHECK-NEXT:    w3 = w2
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) += w3
+; CHECK-NEXT:    w3 = atomic_fetch_add((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = w2
 ; CHECK-NEXT:    w0 = atomic_fetch_add((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -385,7 +385,7 @@ define dso_local i64 @test_fetch_sub_64_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:    r2 = 10
 ; CHECK-NEXT:    r2 = -r2
 ; CHECK-NEXT:    r3 = r2
-; CHECK-NEXT:    lock *(u64 *)(r1 + 0) += r3
+; CHECK-NEXT:    r3 = atomic_fetch_add((u64 *)(r1 + 0), r3)
 ; CHECK-NEXT:    r0 = r2
 ; CHECK-NEXT:    r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)
 ; CHECK-NEXT:    r0 += r3
@@ -445,7 +445,7 @@ define dso_local i32 @test_fetch_and_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) &= w3
+; CHECK-NEXT:    w3 = atomic_fetch_and((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_and((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -565,7 +565,7 @@ define dso_local i32 @test_fetch_or_32_ret(ptr nocapture noundef %i) local_unnam
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) |= w3
+; CHECK-NEXT:    w3 = atomic_fetch_or((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_or((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -685,7 +685,7 @@ define dso_local i32 @test_fetch_xor_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) ^= w3
+; CHECK-NEXT:    w3 = atomic_fetch_xor((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_xor((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3

--- a/llvm/test/CodeGen/BPF/atomics_mem_order_v3.ll
+++ b/llvm/test/CodeGen/BPF/atomics_mem_order_v3.ll
@@ -261,7 +261,7 @@ define dso_local i64 @test_fetch_add_64_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    r2 = 10
 ; CHECK-NEXT:    r3 = 10
-; CHECK-NEXT:    lock *(u64 *)(r1 + 0) += r3
+; CHECK-NEXT:    r3 = atomic_fetch_add((u64 *)(r1 + 0), r3)
 ; CHECK-NEXT:    r0 = 10
 ; CHECK-NEXT:    r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)
 ; CHECK-NEXT:    r0 += r3


### PR DESCRIPTION
For BPF, a monotonic atomicrmw selected the non-fetch instruction regardless of whether the result was used. The non-fetch form discards the old value, so the result was wrong if used.

Fix makes ISel select the fetch form when the result is used and the non-fetch form otherwise via the binop_no_use / binop_has_use PatFrags. This was already done for the i64 and/or/xor patterns, applied it to the remaining monotonic patterns: i64 add and sub, and all i32 ops (add/sub/and/or/xor).

Fixes #210280

Assisted-by: Claude (Anthropic)