### PR TITLE
[lldb] Truncate an over-wide symbol address in the IR interpreter

### DIFF
--- a/lldb/source/Expression/IRInterpreter.cpp
+++ b/lldb/source/Expression/IRInterpreter.cpp
@@ -267,7 +267,12 @@ public:
         lldb::addr_t addr = m_execution_unit.FindSymbol(name, missing_weak);
         if (addr == LLDB_INVALID_ADDRESS)
           return false;
-        value = APInt(m_target_data.getPointerSizeInBits(), addr);
+        // A resolved symbol address may be wider than a target pointer when we
+        // store extra information in the high bits, such as an address-space
+        // tag. Truncate to the pointer width rather than asserting. When the
+        // address already fits this is a no-op.
+        value = APInt(m_target_data.getPointerSizeInBits(), addr,
+                      /*isSigned=*/false, /*implicitTrunc=*/true);
         return true;
       }
       break;


### PR DESCRIPTION
IRInterpreter::ResolveConstantValue built a pointer-width APInt directly from the address returned by FindSymbol. That address can be wider than a target pointer, because lldb records extra information in the high bits on some targets, such as the code/memory address-space tag on WebAssembly.

A 32-bit pointer then cannot hold the tagged address and the APInt constructor asserts, aborting the debugger when a function-valued expression is evaluated (for example `expr main`).

Truncate to the pointer width instead of asserting, matching the idiom already used in DWARFExpression. On targets whose addresses fit in a pointer this is a no-op.