### PR TITLE
[libc++] Update release runners to the image that was used on main at the branch point

### DIFF
--- a/libcxx/utils/ci/images/libcxx_release_runners.txt
+++ b/libcxx/utils/ci/images/libcxx_release_runners.txt
@@ -1,1 +1,1 @@
-ghcr.io/llvm/libcxx-linux-builder:e8753c0de90d3aaa60361b5354588fa29fef9228
+ghcr.io/llvm/libcxx-linux-builder:6d3cf7f436a01f4622fb660e413a4020209777b8


### PR DESCRIPTION
This will allow retaining a stable image for CI throughout the whole LLVM 23 release.