### PR TITLE
[bazel][libc] Add layering deps

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -27,6 +27,7 @@ libc_test_library(
         "//libc:types_size_t",
         "//libc:types_socklen_t",
         "//libc:types_struct_sockaddr_un",
+        "//libc/test/UnitTest:LibcUnitTest",
     ],
 )
 


### PR DESCRIPTION
Not sure why CI didn't catch it, but c5837b469c6d6f35eb0822cd9ebd7c2aa7e2ab75 adds some targets that are broken when layering checks are enabled.