### PR TITLE
[clang][llvm] Call graph - drop generalized suffix

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3459,10 +3459,11 @@ void CodeGenModule::createIndirectFunctionTypeMD(const FunctionDecl *FD,
       F->getFunction().hasAddressTaken(nullptr, /*IgnoreCallbackUses=*/true,
                                        /*IgnoreAssumeLikeCalls=*/true,
                                        /*IgnoreLLVMUsed=*/false)) {
-    F->addMetadata(llvm::LLVMContext::MD_callgraph,
-                   *llvm::MDTuple::get(
-                       getLLVMContext(),
-                       {CreateMetadataIdentifierGeneralized(FD->getType())}));
+    F->addMetadata(
+        llvm::LLVMContext::MD_callgraph,
+        *llvm::MDTuple::get(
+            getLLVMContext(),
+            {CreateMetadataIdentifierForCallGraphType(FD->getType())}));
   }
 }
 
@@ -3494,15 +3495,11 @@ void CodeGenModule::createFunctionTypeMetadataForIcall(const FunctionDecl *FD,
 
 void CodeGenModule::createCalleeTypeMetadataForIcall(const QualType &QT,
                                                      llvm::CallBase *CB) {
-  // Only if needed for call graph section and only for indirect calls that are
-  // visible externally.
-  // TODO: Handle local linkage symbols so they are not left out of call graph
-  // reducing precision.
-  if (!CodeGenOpts.CallGraphSection || !CB->isIndirectCall() ||
-      !isExternallyVisible(QT->getLinkage()))
+  // Only if needed for call graph section and only for indirect calls
+  if (!CodeGenOpts.CallGraphSection || !CB->isIndirectCall())
     return;
 
-  llvm::Metadata *TypeIdMD = CreateMetadataIdentifierGeneralized(QT);
+  llvm::Metadata *TypeIdMD = CreateMetadataIdentifierForCallGraphType(QT);
   llvm::MDTuple *TypeTuple = llvm::MDTuple::get(getLLVMContext(), {TypeIdMD});
   llvm::MDTuple *MDN = llvm::MDNode::get(getLLVMContext(), {TypeTuple});
   CB->setMetadata(llvm::LLVMContext::MD_callee_type, MDN);
@@ -8575,9 +8572,8 @@ void CodeGenModule::EmitOMPThreadPrivateDecl(const OMPThreadPrivateDecl *D) {
   }
 }
 
-llvm::Metadata *
-CodeGenModule::CreateMetadataIdentifierImpl(QualType T, MetadataTypeMap &Map,
-                                            StringRef Suffix) {
+llvm::Metadata *CodeGenModule::CreateMetadataIdentifierImpl(
+    QualType T, MetadataTypeMap &Map, StringRef Suffix, bool ForceString) {
   if (auto *FnType = T->getAs<FunctionProtoType>())
     T = getContext().getFunctionType(
         FnType->getReturnType(), FnType->getParamTypes(),
@@ -8587,7 +8583,7 @@ CodeGenModule::CreateMetadataIdentifierImpl(QualType T, MetadataTypeMap &Map,
   if (InternalId)
     return InternalId;
 
-  if (isExternallyVisible(T->getLinkage())) {
+  if (ForceString || isExternallyVisible(T->getLinkage())) {
     std::string OutName;
     llvm::raw_string_ostream Out(OutName);
     getCXXABI().getMangleContext().mangleCanonicalTypeName(
@@ -8627,7 +8623,13 @@ CodeGenModule::CreateMetadataIdentifierForVirtualMemPtrType(QualType T) {
 
 llvm::Metadata *CodeGenModule::CreateMetadataIdentifierGeneralized(QualType T) {
   return CreateMetadataIdentifierImpl(T, GeneralizedMetadataIdMap,
-                                      ".generalized");
+                                      ".generalized", /*ForceString=*/false);
+}
+
+llvm::Metadata *
+CodeGenModule::CreateMetadataIdentifierForCallGraphType(QualType T) {
+  return CreateMetadataIdentifierImpl(T, CallGraphMetadataIdMap, ".generalized",
+                                      /*ForceString=*/true);
 }
 
 /// Returns whether this module needs the "all-vtables" type identifier.

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -8628,7 +8628,7 @@ llvm::Metadata *CodeGenModule::CreateMetadataIdentifierGeneralized(QualType T) {
 
 llvm::Metadata *
 CodeGenModule::CreateMetadataIdentifierForCallGraphType(QualType T) {
-  return CreateMetadataIdentifierImpl(T, CallGraphMetadataIdMap, ".generalized",
+  return CreateMetadataIdentifierImpl(T, CallGraphMetadataIdMap, "",
                                       /*ForceString=*/true);
 }
 

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -708,6 +708,7 @@ private:
   MetadataTypeMap MetadataIdMap;
   MetadataTypeMap VirtualMetadataIdMap;
   MetadataTypeMap GeneralizedMetadataIdMap;
+  MetadataTypeMap CallGraphMetadataIdMap;
 
   // Helps squashing blocks of TopLevelStmtDecl into a single llvm::Function
   // when used with -fincremental-extensions.
@@ -1753,6 +1754,11 @@ public:
   /// internal identifiers).
   llvm::Metadata *CreateMetadataIdentifierForType(QualType T);
 
+  /// Create a metadata identifier for the Call Graph Section.
+  /// This is a generalized type identifier that is guaranteed to be an
+  /// MDString.
+  llvm::Metadata *CreateMetadataIdentifierForCallGraphType(QualType T);
+
   /// Create a metadata identifier that is intended to be used to check virtual
   /// calls via a member function pointer.
   llvm::Metadata *CreateMetadataIdentifierForVirtualMemPtrType(QualType T);
@@ -2192,7 +2198,8 @@ private:
                                     llvm::AttrBuilder &FuncAttrs);
 
   llvm::Metadata *CreateMetadataIdentifierImpl(QualType T, MetadataTypeMap &Map,
-                                               StringRef Suffix);
+                                               StringRef Suffix,
+                                               bool ForceString = false);
 
   /// Emit deactivation symbols for any PFP fields whose offset is taken with
   /// offsetof.

--- a/clang/test/CodeGen/call-graph-section-callback.cpp
+++ b/clang/test/CodeGen/call-graph-section-callback.cpp
@@ -27,4 +27,4 @@ int takeCallbackAddress() {
     return 0;
 }
 
-// CHECK: [[F_CALLBACK]]   = !{!"_ZTSFviE.generalized"}
+// CHECK: [[F_CALLBACK]]   = !{!"_ZTSFviE"}

--- a/clang/test/CodeGen/call-graph-section-internal.cpp
+++ b/clang/test/CodeGen/call-graph-section-internal.cpp
@@ -1,9 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux -fexperimental-call-graph-section -disable-llvm-passes -emit-llvm -o - %s | FileCheck %s
 
-// Check that we do not generate callee_type metadata for indirect calls
+// Check that we generate callee_type metadata for indirect calls
 // to functions with internal linkage (e.g., types in anonymous namespaces),
-// as their callgraph metadata identifiers are distinct MDNodes instead of 
-// generalized strings, which would fail the LLVM Verifier.
+// using the generalized type metadata form.
 
 namespace {
 class a;
@@ -32,6 +31,8 @@ void test() {
 // CHECK-LABEL: define {{.*}} void @{{.*}}1a1dEv
 // CHECK:   %[[VFN:.*]] = getelementptr inbounds ptr, ptr %{{.*}}, i{{[0-9]+}} 0
 // CHECK:   %[[FP:.*]] = load ptr, ptr %[[VFN]], align {{[0-9]+}}
-// CHECK:   call void %[[FP]]({{.*}})
-// CHECK-NOT: !callee_type
+// CHECK:   call void %[[FP]]({{.*}}), !callee_type [[HEX_TYPE:![0-9]+]]
 // CHECK:   ret void
+
+// CHECK: [[HEX_TYPE]] = !{[[HEX_TYPE_INNER:![0-9]+]]}
+// CHECK: [[HEX_TYPE_INNER]] = !{!"_ZTSFvN12_GLOBAL__N_11aEE.generalized"}

--- a/clang/test/CodeGen/call-graph-section-internal.cpp
+++ b/clang/test/CodeGen/call-graph-section-internal.cpp
@@ -35,4 +35,4 @@ void test() {
 // CHECK:   ret void
 
 // CHECK: [[HEX_TYPE]] = !{[[HEX_TYPE_INNER:![0-9]+]]}
-// CHECK: [[HEX_TYPE_INNER]] = !{!"_ZTSFvN12_GLOBAL__N_11aEE.generalized"}
+// CHECK: [[HEX_TYPE_INNER]] = !{!"_ZTSFvN12_GLOBAL__N_11aEE"}

--- a/clang/test/CodeGen/call-graph-section-templates.cpp
+++ b/clang/test/CodeGen/call-graph-section-templates.cpp
@@ -44,12 +44,12 @@ public:
   T *(*fp)(T a, T *b, const T *c, T &d, const T &e);
 };
 
-// FT: [[F_TCLS2F1]] = !{!"_ZTSFvvE.generalized"}
-// FT: [[F_TCLS2F2]] = !{!"_ZTSFv4Cls1E.generalized"}
-// FT: [[F_TCLS2F3]] = !{!"_ZTSFvP4Cls1E.generalized"}
-// FT: [[F_TCLS2F4]] = !{!"_ZTSFvPK4Cls1E.generalized"}
-// FT: [[F_TCLS2F5]] = !{!"_ZTSFvR4Cls1E.generalized"}
-// FT: [[F_TCLS2F6]] = !{!"_ZTSFvRK4Cls1E.generalized"}
+// FT: [[F_TCLS2F1]] = !{!"_ZTSFvvE"}
+// FT: [[F_TCLS2F2]] = !{!"_ZTSFv4Cls1E"}
+// FT: [[F_TCLS2F3]] = !{!"_ZTSFvP4Cls1E"}
+// FT: [[F_TCLS2F4]] = !{!"_ZTSFvPK4Cls1E"}
+// FT: [[F_TCLS2F5]] = !{!"_ZTSFvR4Cls1E"}
+// FT: [[F_TCLS2F6]] = !{!"_ZTSFvRK4Cls1E"}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Callsites (check for indirect callsite operand bundles)
@@ -101,17 +101,17 @@ void foo() {
 // CST-LABEL: define {{.*}} @_Z6T_funcI4Cls1EPT_S1_S2_PKS1_RS1_RS3_(
 // CST-SAME: {{.*}} !callgraph [[F_TFUNC_CLS1:![0-9]+]]
 
-// CST: [[F_TCLS2F1]] = !{!"_ZTSFvvE.generalized"}
+// CST: [[F_TCLS2F1]] = !{!"_ZTSFvvE"}
 // CST: [[F_TFUNC_CLS1_CT]] = !{[[F_TFUNC_CLS1:![0-9]+]]}
-// CST: [[F_TFUNC_CLS1]] = !{!"_ZTSFP4Cls1S_S0_PKS_RS_RS1_E.generalized"}
+// CST: [[F_TFUNC_CLS1]] = !{!"_ZTSFP4Cls1S_S0_PKS_RS_RS1_E"}
 // CST: [[F_TCLS2F1_CT]] = !{[[F_TCLS2F1:![0-9]+]]}
 // CST: [[F_TCLS2F2_CT]] = !{[[F_TCLS2F2:![0-9]+]]}
-// CST: [[F_TCLS2F2]] = !{!"_ZTSFv4Cls1E.generalized"}
+// CST: [[F_TCLS2F2]] = !{!"_ZTSFv4Cls1E"}
 // CST: [[F_TCLS2F3_CT]] = !{[[F_TCLS2F3:![0-9]+]]}
-// CST: [[F_TCLS2F3]] = !{!"_ZTSFvP4Cls1E.generalized"}
+// CST: [[F_TCLS2F3]] = !{!"_ZTSFvP4Cls1E"}
 // CST: [[F_TCLS2F4_CT]] = !{[[F_TCLS2F4:![0-9]+]]}
-// CST: [[F_TCLS2F4]] = !{!"_ZTSFvPK4Cls1E.generalized"}
+// CST: [[F_TCLS2F4]] = !{!"_ZTSFvPK4Cls1E"}
 // CST: [[F_TCLS2F5_CT]] = !{[[F_TCLS2F5:![0-9]+]]}
-// CST: [[F_TCLS2F5]] = !{!"_ZTSFvR4Cls1E.generalized"}
+// CST: [[F_TCLS2F5]] = !{!"_ZTSFvR4Cls1E"}
 // CST: [[F_TCLS2F6_CT]] = !{[[F_TCLS2F6:![0-9]+]]}
-// CST: [[F_TCLS2F6]] = !{!"_ZTSFvRK4Cls1E.generalized"}
+// CST: [[F_TCLS2F6]] = !{!"_ZTSFvRK4Cls1E"}

--- a/clang/test/CodeGen/call-graph-section-virtual-methods.cpp
+++ b/clang/test/CodeGen/call-graph-section-virtual-methods.cpp
@@ -22,7 +22,7 @@ class Base {
     int vf(char *a) override { return 1; };
   };
   
-  // FT: [[F_TVF]] = !{!"_ZTSFiPcE.generalized"}
+  // FT: [[F_TVF]] = !{!"_ZTSFiPcE"}
   
   ////////////////////////////////////////////////////////////////////////////////
   // Callsites (check for indirect callsite operand bundles)
@@ -53,4 +53,4 @@ class Base {
   }
 
   // CST: [[F_TVF_CT]] = !{[[F_TVF:![0-9]+]]}
-  // CST: [[F_TVF]] = !{!"_ZTSFiPcE.generalized"}
+  // CST: [[F_TVF]] = !{!"_ZTSFiPcE"}

--- a/clang/test/CodeGen/call-graph-section.c
+++ b/clang/test/CodeGen/call-graph-section.c
@@ -74,20 +74,20 @@ void stf() {
   fp_stparam(St2, &St2);
 }
 
-// ITANIUM: [[F_TVOID]] = !{!"_ZTSFvE.generalized"}
+// ITANIUM: [[F_TVOID]] = !{!"_ZTSFvE"}
 // ITANIUM: [[F_TVOID_CT]] = !{[[F_TVOID:![0-9]+]]}
-// ITANIUM: [[F_TPRIMITIVE]] = !{!"_ZTSFicfdE.generalized"}
-// ITANIUM: [[F_TPTR]] = !{!"_ZTSFPiPcPfPdE.generalized"}
+// ITANIUM: [[F_TPRIMITIVE]] = !{!"_ZTSFicfdE"}
+// ITANIUM: [[F_TPTR]] = !{!"_ZTSFPiPcPfPdE"}
 // ITANIUM: [[F_TPRIMITIVE_CT]] = !{[[F_TPRIMITIVE:![0-9]+]]}
 // ITANIUM: [[F_TPTR_CT]] = !{[[F_TPTR:![0-9]+]]}
-// ITANIUM: [[F_TSTRUCT]] = !{!"_ZTSFv3st2PS_E.generalized"}
+// ITANIUM: [[F_TSTRUCT]] = !{!"_ZTSFv3st2PS_E"}
 // ITANIUM: [[F_TSTRUCT_CT]] = !{[[F_TSTRUCT:![0-9]+]]}
 
-// MS: [[F_TVOID]] = !{!"?6AX@Z.generalized"}
+// MS: [[F_TVOID]] = !{!"?6AX@Z"}
 // MS: [[F_TVOID_CT]] = !{[[F_TVOID:![0-9]+]]}
-// MS: [[F_TPRIMITIVE]] = !{!"?6AHDMN@Z.generalized"}
-// MS: [[F_TPTR]] = !{!"?6APEAHPEADPEAMPEAN@Z.generalized"}
+// MS: [[F_TPRIMITIVE]] = !{!"?6AHDMN@Z"}
+// MS: [[F_TPTR]] = !{!"?6APEAHPEADPEAMPEAN@Z"}
 // MS: [[F_TPRIMITIVE_CT]] = !{[[F_TPRIMITIVE:![0-9]+]]}
 // MS: [[F_TPTR_CT]] = !{[[F_TPTR:![0-9]+]]}
-// MS: [[F_TSTRUCT]] = !{!"?6AXUst2@@PEAU0@@Z.generalized"}
+// MS: [[F_TSTRUCT]] = !{!"?6AXUst2@@PEAU0@@Z"}
 // MS: [[F_TSTRUCT_CT]] = !{[[F_TSTRUCT:![0-9]+]]}

--- a/clang/test/CodeGen/call-graph-section.cpp
+++ b/clang/test/CodeGen/call-graph-section.cpp
@@ -57,15 +57,15 @@ public:
   void f9() const {}
 };
 
-// FT: [[F_TCLS1RECEIVER]] = !{!"_ZTSFPiPcPfE.generalized"}
-// FT: [[F_TCLS2F1]]   = !{!"_ZTSFicfdE.generalized"}
-// FT: [[F_TCLS2F2]]   = !{!"_ZTSFPiPcPfPdE.generalized"}
-// FT: [[F_TCLS2F3F4]] = !{!"_ZTSFv4Cls1E.generalized"}
-// FT: [[F_TCLS2F5]]   = !{!"_ZTSFvP4Cls1E.generalized"}
-// FT: [[F_TCLS2F6]]   = !{!"_ZTSFvPK4Cls1E.generalized"}
-// FT: [[F_TCLS2F7]]   = !{!"_ZTSFvR4Cls1E.generalized"}
-// FT: [[F_TCLS2F8]]   = !{!"_ZTSFvRK4Cls1E.generalized"}
-// FT: [[F_TCLS2F9]]   = !{!"_ZTSKFvvE.generalized"}
+// FT: [[F_TCLS1RECEIVER]] = !{!"_ZTSFPiPcPfE"}
+// FT: [[F_TCLS2F1]]   = !{!"_ZTSFicfdE"}
+// FT: [[F_TCLS2F2]]   = !{!"_ZTSFPiPcPfPdE"}
+// FT: [[F_TCLS2F3F4]] = !{!"_ZTSFv4Cls1E"}
+// FT: [[F_TCLS2F5]]   = !{!"_ZTSFvP4Cls1E"}
+// FT: [[F_TCLS2F6]]   = !{!"_ZTSFvPK4Cls1E"}
+// FT: [[F_TCLS2F7]]   = !{!"_ZTSFvR4Cls1E"}
+// FT: [[F_TCLS2F8]]   = !{!"_ZTSFvRK4Cls1E"}
+// FT: [[F_TCLS2F9]]   = !{!"_ZTSKFvvE"}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Callsites (check for indirect callsites' callee_type metadata )
@@ -120,28 +120,28 @@ void foo() {
 }
 
 // CST: [[F_TCLS1RECEIVER_CT]] = !{[[F_TCLS1RECEIVER:![0-9]+]]}
-// CST: [[F_TCLS1RECEIVER]] = !{!"_ZTSFPiPcPfE.generalized"}
+// CST: [[F_TCLS1RECEIVER]] = !{!"_ZTSFPiPcPfE"}
 
 // CST: [[F_TCLS2F1_CT]] = !{[[F_TCLS2F1:![0-9]+]]}
-// CST: [[F_TCLS2F1]]   = !{!"_ZTSFicfdE.generalized"}
+// CST: [[F_TCLS2F1]]   = !{!"_ZTSFicfdE"}
 
 // CST: [[F_TCLS2F2_CT]] = !{[[F_TCLS2F2:![0-9]+]]}
-// CST: [[F_TCLS2F2]]   = !{!"_ZTSFPiPcPfPdE.generalized"}
+// CST: [[F_TCLS2F2]]   = !{!"_ZTSFPiPcPfPdE"}
 
 // CST: [[F_TCLS2F3F4_CT]] = !{[[F_TCLS2F3F4:![0-9]+]]}
-// CST: [[F_TCLS2F3F4]] = !{!"_ZTSFv4Cls1E.generalized"}
+// CST: [[F_TCLS2F3F4]] = !{!"_ZTSFv4Cls1E"}
 
 // CST: [[F_TCLS2F5_CT]] = !{[[F_TCLS2F5:![0-9]+]]}
-// CST: [[F_TCLS2F5]]   = !{!"_ZTSFvP4Cls1E.generalized"}
+// CST: [[F_TCLS2F5]]   = !{!"_ZTSFvP4Cls1E"}
 
 // CST: [[F_TCLS2F6_CT]] = !{[[F_TCLS2F6:![0-9]+]]}
-// CST: [[F_TCLS2F6]]   = !{!"_ZTSFvPK4Cls1E.generalized"}
+// CST: [[F_TCLS2F6]]   = !{!"_ZTSFvPK4Cls1E"}
 
 // CST: [[F_TCLS2F7_CT]] = !{[[F_TCLS2F7:![0-9]+]]}
-// CST: [[F_TCLS2F7]]   = !{!"_ZTSFvR4Cls1E.generalized"}
+// CST: [[F_TCLS2F7]]   = !{!"_ZTSFvR4Cls1E"}
 
 // CST: [[F_TCLS2F8_CT]] = !{[[F_TCLS2F8:![0-9]+]]}
-// CST: [[F_TCLS2F8]]   = !{!"_ZTSFvRK4Cls1E.generalized"}
+// CST: [[F_TCLS2F8]]   = !{!"_ZTSFvRK4Cls1E"}
 
 // CST: [[F_TCLS2F9_CT]] = !{[[F_TCLS2F9:![0-9]+]]}
-// CST: [[F_TCLS2F9]]   = !{!"_ZTSKFvvE.generalized"}
+// CST: [[F_TCLS2F9]]   = !{!"_ZTSKFvvE"}

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1756,19 +1756,17 @@ void AsmPrinter::emitStackUsage(const MachineFunction &MF) {
     *StackUsageStream << "static\n";
 }
 
-/// Extracts a generalized numeric type identifier of a Function's type from
+/// Extracts a numeric type identifier of a Function's type from
 /// callgraph metadata. Returns null if metadata cannot be found.
 static ConstantInt *extractNumericCGTypeId(const Function &F) {
   SmallVector<MDNode *, 2> Types;
   F.getMetadata(LLVMContext::MD_callgraph, Types);
   for (const auto &Type : Types) {
     if (Type->getNumOperands() == 1 && isa<MDString>(Type->getOperand(0))) {
-      MDString *MDGeneralizedTypeId = cast<MDString>(Type->getOperand(0));
-      if (MDGeneralizedTypeId->getString().ends_with(".generalized")) {
-        uint64_t TypeIdVal = llvm::MD5Hash(MDGeneralizedTypeId->getString());
-        IntegerType *Int64Ty = Type::getInt64Ty(F.getContext());
-        return ConstantInt::get(Int64Ty, TypeIdVal);
-      }
+      MDString *MDTypeId = cast<MDString>(Type->getOperand(0));
+      uint64_t TypeIdVal = llvm::MD5Hash(MDTypeId->getString());
+      IntegerType *Int64Ty = Type::getInt64Ty(F.getContext());
+      return ConstantInt::get(Int64Ty, TypeIdVal);
     }
   }
   return nullptr;

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -759,7 +759,7 @@ MachineFunction::CallSiteInfo::CallSiteInfo(const CallBase &CB) {
   for (const MDOperand &Op : CalleeTypeList->operands()) {
     MDNode *TypeMD = cast<MDNode>(Op);
     MDString *TypeIdStr = cast<MDString>(TypeMD->getOperand(0));
-    // Compute numeric type id from generalized type id string
+    // Compute numeric type id from type id string
     uint64_t TypeIdVal = MD5Hash(TypeIdStr->getString());
     IntegerType *Int64Ty = Type::getInt64Ty(CB.getContext());
     CalleeTypeIds.push_back(

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5473,17 +5473,11 @@ void Verifier::visitCalleeTypeMetadata(Instruction &I, MDNode *MD) {
           Op);
     auto *CallgraphMD = cast<MDNode>(Op);
     Check(CallgraphMD->getNumOperands() == 1,
-          "Well-formed generalized callgraph metadata must contain exactly one "
+          "Well-formed callgraph metadata must contain exactly one "
           "operand",
           Op);
     Check(isa<MDString>(CallgraphMD->getOperand(0)),
           "The operand of callgraph metadata for functions must be an MDString",
-          Op);
-    Check(cast<MDString>(CallgraphMD->getOperand(0))
-              ->getString()
-              .ends_with(".generalized"),
-          "Only generalized callgraph metadata can be part of the callee_type "
-          "metadata list",
           Op);
   }
 }

--- a/llvm/test/CodeGen/ARM/call-graph-section-addrtaken.ll
+++ b/llvm/test/CodeGen/ARM/call-graph-section-addrtaken.ll
@@ -22,9 +22,9 @@ entry:
   ret void
 }
 
-!0 = !{!"_ZTSFvPFviEE.generalized"}
-!1 = !{!"_ZTSFivE.generalized"}
-!2 = !{!"_ZTSFviE.generalized"}
+!0 = !{!"_ZTSFvPFviEE"}
+!1 = !{!"_ZTSFivE"}
+!2 = !{!"_ZTSFviE"}
 
 ; CHECK: .section .llvm.callgraph,"o",%llvm_call_graph,.text
 ;; Version
@@ -33,6 +33,6 @@ entry:
 ; CHECK-NEXT: .byte   1
 ;; Function Entry PC
 ; CHECK-NEXT: .long _ZL10myCallbacki
-;; Function type ID -5212364466660467813
-; CHECK-NEXT: .long	1154849691
-; CHECK-NEXT: .long	3081369122
+;; Function type ID -8738933900360652027
+; CHECK-NEXT: .long 560098053
+; CHECK-NEXT: .long 2260275691

--- a/llvm/test/CodeGen/ARM/call-graph-section-assembly.ll
+++ b/llvm/test/CodeGen/ARM/call-graph-section-assembly.ll
@@ -29,11 +29,11 @@ entry:
 }
 
 !0 = !{!1}
-!1 = !{!"_ZTSFvE.generalized"}
+!1 = !{!"_ZTSFvE"}
 !2 = !{!3}
-!3 = !{!"_ZTSFicE.generalized"}
+!3 = !{!"_ZTSFicE"}
 !4 = !{!5}
-!5 = !{!"_ZTSFPvS_E.generalized"}
+!5 = !{!"_ZTSFPvS_"}
 
 ; CHECK: .section .llvm.callgraph,"o",%llvm_call_graph,.text
 ;; Version
@@ -54,9 +54,9 @@ entry:
 ;; Number of unique indirect target type IDs.
 ; CHECK-NEXT: .byte   3
 ;; Indirect type IDs.
-; CHECK-NEXT: .long 838288420
-; CHECK-NEXT: .long 1053552373
-; CHECK-NEXT: .long 1505527380
-; CHECK-NEXT: .long 814631809
-; CHECK-NEXT: .long 342417018
-; CHECK-NEXT: .long 2013108216
+; CHECK-NEXT: .long 3869454308
+; CHECK-NEXT: .long 1534046230
+; CHECK-NEXT: .long 1192513734
+; CHECK-NEXT: .long 33125428
+; CHECK-NEXT: .long 2609506087
+; CHECK-NEXT: .long 2269360106

--- a/llvm/test/CodeGen/ARM/call-graph-section-tailcall.ll
+++ b/llvm/test/CodeGen/ARM/call-graph-section-tailcall.ll
@@ -22,13 +22,13 @@ declare !callgraph !2 i32 @foo(i8 signext)
 
 declare !callgraph !2 i32 @bar(i8 signext)
 
-!0 = !{!"_ZTSFiPvcE.generalized"}
+!0 = !{!"_ZTSFiPvcE"}
 !1 = !{!2}
-!2 = !{!"_ZTSFicE.generalized"}
-!3 = !{!"_ZTSFiiE.generalized"}
+!2 = !{!"_ZTSFicE"}
+!3 = !{!"_ZTSFiiE"}
 
 ; CHECK:      Hex dump of section '.llvm.callgraph':
-; CHECK-NEXT: 0x00000000 00050000 00008e19 0b7f3326 e3000154
-; CHECK-NEXT: 0x00000010 86bc5981 4b8e3000 05000000 00a150b8
-;; Verify that the type id 0x308e4b8159bc8654 is in section.
-; CHECK-NEXT: 0x00000020 3e0cfe3c b2015486 bc59814b 8e30
+; CHECK-NEXT: 0x00000000 00050000 0000d4bf 88b60134 63f001c6
+; CHECK-NEXT: 0x00000010 50144734 74f90100 05000000 00423a34
+;; Verify that the type id 0x144734744701c650 is in section.
+; CHECK-NEXT: 0x00000020 855a01ce 4701c650 14473474 f901

--- a/llvm/test/CodeGen/ARM/call-graph-section.ll
+++ b/llvm/test/CodeGen/ARM/call-graph-section.ll
@@ -22,16 +22,16 @@ entry:
 
 ;; Check that the numeric type id (md5 hash) for the below type ids are emitted
 ;; to the callgraph section.
-!0 = !{!"_ZTSFvE.generalized"}
+!0 = !{!"_ZTSFvE"}
 !1 = !{!0}
-!2 = !{!"_ZTSFicE.generalized"}
+!2 = !{!"_ZTSFicE"}
 !3 = !{!2}
 !4 = !{!5}
-!5 = !{!"_ZTSFPvS_E.generalized"}
+!5 = !{!"_ZTSFPvS_"}
 
 ;; Make sure following type IDs are in call graph section
 ;; 0x5eecb3e2444f731f, 0x814b8e305486bc59, 0xf897fd777ade6814
 ; CHECK: Hex dump of section '.llvm.callgraph':
-; CHECK-NEXT: 0x00000000 00050000 00000000 00000000 00000324
-; CHECK-NEXT: 0x00000010 44f731f5 eecb3e54 86bc5981 4b8e307a
-; CHECK-NEXT: 0x00000020 de6814f8 97fd77
+; CHECK-NEXT: 0x00000000 00050000 00000000 00000000 000003e4
+; CHECK-NEXT: 0x00000010 2fa3e616 b06f5bc6 50144734 74f90127
+; CHECK-NEXT: 0x00000020 e7899bea af4387

--- a/llvm/test/CodeGen/X86/call-graph-section-addrtaken.ll
+++ b/llvm/test/CodeGen/X86/call-graph-section-addrtaken.ll
@@ -22,9 +22,9 @@ entry:
   ret void
 }
 
-!0 = !{!"_ZTSFvPFviEE.generalized"}
-!1 = !{!"_ZTSFivE.generalized"}
-!2 = !{!"_ZTSFviE.generalized"}
+!0 = !{!"_ZTSFvPFviEE"}
+!1 = !{!"_ZTSFivE"}
+!2 = !{!"_ZTSFviE"}
 
 ; CHECK: .section .llvm.callgraph,"o",@llvm_call_graph,.text
 ;; Version
@@ -34,4 +34,4 @@ entry:
 ;; Function Entry PC
 ; CHECK-NEXT: .quad   _ZL10myCallbacki
 ;; Function type ID
-; CHECK-NEXT: .quad   -5212364466660467813
+; CHECK-NEXT: .quad   -8738933900360652027

--- a/llvm/test/CodeGen/X86/call-graph-section-assembly.ll
+++ b/llvm/test/CodeGen/X86/call-graph-section-assembly.ll
@@ -29,11 +29,11 @@ entry:
 }
 
 !0 = !{!1}
-!1 = !{!"_ZTSFvE.generalized"}
+!1 = !{!"_ZTSFvE"}
 !2 = !{!3}
-!3 = !{!"_ZTSFicE.generalized"}
+!3 = !{!"_ZTSFicE"}
 !4 = !{!5}
-!5 = !{!"_ZTSFPvS_E.generalized"}
+!5 = !{!"_ZTSFPvS_"}
 
 ; CHECK: .section .llvm.callgraph,"o",@llvm_call_graph,.text
 ;; Version
@@ -53,6 +53,6 @@ entry:
 ;; Number of unique indirect target type IDs.
 ; CHECK-NEXT: .byte   3
 ;; Indirect type IDs.
-; CHECK-NEXT: .quad   4524972987496481828
-; CHECK-NEXT: .quad   3498816979441845844
-; CHECK-NEXT: .quad   8646233951371320954
+; CHECK-NEXT: .quad   6588678392271548388
+; CHECK-NEXT: .quad   142272631118516422
+; CHECK-NEXT: .quad   -8699916632982952153

--- a/llvm/test/CodeGen/X86/call-graph-section-tailcall.ll
+++ b/llvm/test/CodeGen/X86/call-graph-section-tailcall.ll
@@ -25,14 +25,14 @@ declare !callgraph !2 i32 @foo(i8 signext)
 
 declare !callgraph !2 i32 @bar(i8 signext)
 
-!0 = !{!"_ZTSFiPvcE.generalized"}
+!0 = !{!"_ZTSFiPvcE"}
 !1 = !{!2}
-!2 = !{!"_ZTSFicE.generalized"}
-!3 = !{!"_ZTSFiiE.generalized"}
+!2 = !{!"_ZTSFicE"}
+!3 = !{!"_ZTSFiiE"}
 
 ; CHECK: Hex dump of section '.llvm.callgraph':
-; CHECK-NEXT: 0x00000000 00050000 00000000 00008e19 0b7f3326
-; CHECK-NEXT: 0x00000010 e3000154 86bc5981 4b8e3000 05000000
-;; Verify that the type id 0x308e4b8159bc8654 is in section.
-; CHECK-NEXT: 0x00000020 00000000 00a150b8 3e0cfe3c b2015486
-; CHECK-NEXT: 0x00000030 bc59814b 8e30
+; CHECK-NEXT: 0x00000000 00050000 00000000 0000d4bf 88b60134
+; CHECK-NEXT: 0x00000010 63f001c6 50144734 74f90100 05000000
+;; Verify that the type id 0x144734744701c650 is in section.
+; CHECK-NEXT: 0x00000020 00000000 00423a34 855a01ce 4701c650
+; CHECK-NEXT: 0x00000030 14473474 f901

--- a/llvm/test/CodeGen/X86/call-graph-section.ll
+++ b/llvm/test/CodeGen/X86/call-graph-section.ll
@@ -25,16 +25,16 @@ entry:
 
 ;; Check that the numeric type id (md5 hash) for the below type ids are emitted
 ;; to the callgraph section.
-!0 = !{!"_ZTSFvE.generalized"}
+!0 = !{!"_ZTSFvE"}
 !1 = !{!0}
-!2 = !{!"_ZTSFicE.generalized"}
+!2 = !{!"_ZTSFicE"}
 !3 = !{!2}
 !4 = !{!5}
-!5 = !{!"_ZTSFPvS_E.generalized"}
+!5 = !{!"_ZTSFPvS_"}
 
 ;; Make sure following type IDs are in call graph section
 ;; 0x5eecb3e2444f731f, 0x814b8e305486bc59, 0xf897fd777ade6814
 ; CHECK:      Hex dump of section '.llvm.callgraph':
 ; CHECK-NEXT: 0x00000000 00050000 00000000 00000000 00000000
-; CHECK-NEXT: 0x00000010 00000324 44f731f5 eecb3e54 86bc5981
-; CHECK-NEXT: 0x00000020 4b8e307a de6814f8 97fd77
+; CHECK-NEXT: 0x00000010 000003e4 2fa3e616 b06f5bc6 50144734
+; CHECK-NEXT: 0x00000020 74f90127 e7899bea af4387

--- a/llvm/test/Verifier/callee-type-metadata.ll
+++ b/llvm/test/Verifier/callee-type-metadata.ll
@@ -1,7 +1,7 @@
 ;; Test if the callee_type metadata attached to indirect call sites adhere to the expected format.
 
 ; RUN: not llvm-as -disable-output < %s 2>&1 | FileCheck %s
-define i32 @_Z13call_indirectPFicEc(ptr %func, i8 signext %x) !type !0 {
+define i32 @_Z13call_indirectPFicEc(ptr %func, i8 signext %x) {
 entry:
   %func.addr = alloca ptr, align 8
   %x.addr = alloca i8, align 1
@@ -13,17 +13,13 @@ entry:
   %call = call i32 %fptr(i8 signext %x_val), !callee_type !0
   ; CHECK: The operand of callgraph metadata for functions must be an MDString
   %call1 = call i32 %fptr(i8 signext %x_val), !callee_type !2
-  ; CHECK: Well-formed generalized callgraph metadata must contain exactly one operand
+  ; CHECK: Well-formed callgraph metadata must contain exactly one operand
   %call2 = call i32 %fptr(i8 signext %x_val), !callee_type !4
-  ; CHECK: Only generalized callgraph metadata can be part of the callee_type metadata list
-  %call3 = call i32 %fptr(i8 signext %x_val), !callee_type !6
   ret i32 %call
 }
 
-!0 = !{i64 0, !"_ZTSFiPvcE.generalized"}
+!0 = !{i64 0, !"_ZTSFiPvcE"}
 !1 = !{!"_ZTSFicE"}
 !2 = !{!2}
 !3 = !{i64 1, !"_ZTSFicE"}
 !4 = !{!3}
-!5 = !{!"_ZTSFicE"}
-!6 = !{!5}


### PR DESCRIPTION
- **[clang] Emit call graph type metadata for internal linkage symbols**
- **[clang][llvm] Call graph - drop generalized suffix**
