### PR TITLE
[NFC] [rtsan] Cleanup env for lit tests

### DIFF
--- a/compiler-rt/test/rtsan/deduplicate_errors.cpp
+++ b/compiler-rt/test/rtsan/deduplicate_errors.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: env RTSAN_OPTIONS="halt_on_error=false,print_stats_on_exit=true" %run %t 2>&1 | FileCheck %s
-// RUN: env RTSAN_OPTIONS="halt_on_error=false,suppress_equal_stacks=false" %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUPLICATES
+// RUN: %env_rtsan_opts="halt_on_error=false,print_stats_on_exit=true" %run %t 2>&1 | FileCheck %s
+// RUN: %env_rtsan_opts="halt_on_error=false,suppress_equal_stacks=false" %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUPLICATES
 
 // UNSUPPORTED: ios
 

--- a/compiler-rt/test/rtsan/lit.cfg.py
+++ b/compiler-rt/test/rtsan/lit.cfg.py
@@ -4,7 +4,7 @@ import os
 config.name = "RTSAN" + config.name_suffix
 
 
-default_rtsan_opts = "atexit_sleep_ms=0"
+default_rtsan_opts = ""
 
 if config.target_os == "Darwin":
     # On Darwin, we default to `abort_on_error=1`, which would make tests run

--- a/compiler-rt/test/rtsan/unrecognized_flags.cpp
+++ b/compiler-rt/test/rtsan/unrecognized_flags.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: env RTSAN_OPTIONS="verbosity=1,asdf=1" %run %t 2>&1 | FileCheck %s
+// RUN: %env_rtsan_opts="verbosity=1,asdf=1" %run %t 2>&1 | FileCheck %s
 // UNSUPPORTED: ios
 
 // Intent: Make sure we are respecting some basic common flags


### PR DESCRIPTION
This matches the style of our other tests, and may make it easier for others to maintain downstream if they override the `env_rtsan_opts` variable with special platform specific options.