### PR TITLE
TableGen: Deterministically order predicate groups by calling convention

### DIFF
--- a/llvm/test/TableGen/RuntimeLibcallEmitter-predicate-cc-sort.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-predicate-cc-sort.td
@@ -1,0 +1,38 @@
+// RUN: llvm-tblgen -gen-runtime-libcalls -I %p/../../include %s | FileCheck %s
+
+// Two groups share the same availability predicate but differ in calling
+// convention. The emitter must order them deterministically (by calling
+// convention name) so the generated output is stable.
+
+include "llvm/IR/RuntimeLibcallsImpl.td"
+
+def FUNC_AAPCS : RuntimeLibcall;
+def FUNC_DEFAULT : RuntimeLibcall;
+
+def impl_aapcs : RuntimeLibcallImpl<FUNC_AAPCS>;
+def impl_default : RuntimeLibcallImpl<FUNC_DEFAULT>;
+
+def isWin : RuntimeLibcallPredicate<[{TT.isOSWindows()}]>;
+
+def WinLibrary : SystemRuntimeLibrary<isWin,
+  (add LibcallsWithCC<(add impl_aapcs), ARM_AAPCS, isWin>,
+       LibcallImpls<(add impl_default), isWin>)
+>;
+
+// The ARM_AAPCS group sorts after the default-CC group (empty calling
+// convention name orders before "ARM_AAPCS").
+// CHECK: if (TT.isOSWindows()) {
+// CHECK:   static const RTLIB::LibcallImpl LibraryCalls_isWin[] = {
+// CHECK-NEXT:       RTLIB::impl_impl_default, // impl_default
+// CHECK-NEXT:   };
+// CHECK: for (const RTLIB::LibcallImpl Impl : LibraryCalls_isWin) {
+// CHECK-NEXT:   setAvailable(Impl);
+// CHECK-NEXT: }
+// CHECK: if (TT.isOSWindows()) {
+// CHECK:   static const RTLIB::LibcallImpl LibraryCalls_isWin_ARM_AAPCS[] = {
+// CHECK-NEXT:       RTLIB::impl_impl_aapcs, // impl_aapcs
+// CHECK-NEXT:   };
+// CHECK: for (const RTLIB::LibcallImpl Impl : LibraryCalls_isWin_ARM_AAPCS) {
+// CHECK-NEXT:   setAvailable(Impl);
+// CHECK-NEXT:   setLibcallImplCallingConv(Impl, CallingConv::ARM_AAPCS);
+// CHECK-NEXT: }

--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -446,7 +446,13 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
     llvm::sort(SortedPredicates, [](PredicateWithCC A, PredicateWithCC B) {
       StringRef AName = A.Predicate ? A.Predicate->getName() : "";
       StringRef BName = B.Predicate ? B.Predicate->getName() : "";
-      return AName < BName;
+      if (AName != BName)
+        return AName < BName;
+      // Break ties on the calling convention so predicates that share a name
+      // but differ in calling convention emit in a deterministic order.
+      StringRef ACC = A.CallingConv ? A.CallingConv->getName() : "";
+      StringRef BCC = B.CallingConv ? B.CallingConv->getName() : "";
+      return ACC < BCC;
     });
 
     for (PredicateWithCC Entry : SortedPredicates) {


### PR DESCRIPTION
The predicate-group sort in emitSystemRuntimeLibrarySetCalls keyed only on the
predicate name, so two groups sharing a predicate name but differing in calling
convention (e.g. isOSWindows with the default CC vs ARM_AAPCS) tied and could
emit in an unstable order. Break the tie on the calling convention name so the
generated output is deterministic.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>