### PR TITLE
[docs] Update the commit review admin task with process details

### DIFF
--- a/llvm/docs/AdminTasks.md
+++ b/llvm/docs/AdminTasks.md
@@ -1,5 +1,22 @@
 # LLVM Admin Tasks
 
+## Grant Commit Access
+
+- Frequency: Ongoing
+- Permissions: Admin
+- Description: An admin should periodically review the list of commit access requests.
+
+This can be done by searching for issues in the llvm-project repository which have the [`infra:commit-access-request` label].
+Any user that meets the [commit access requirements] should be added to the ['LLVM Committers' team].
+The admin should add a comment to the issue when an invite to join the team has been sent and then close the issue when the invite has been accepted.
+Admins should close issues after sending the invite and invite the requestor to reopen if there are issues.
+If there are insufficient votes and it has been over five days since the last update, admins should remove the `infra:commit-access-request` label.
+To reopen the request, someone with repository triage or write access must reapply the label to get it back on the dashboard.
+
+[`infra:commit-access-request` label]: https://github.com/llvm/llvm-project/issues/?q=is%3Aissue%20state%3Aopen%20label%3Ainfra%3Acommit-access-request
+[commit access requirements]: https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access
+['LLVM Committers' team]: https://github.com/orgs/llvm/teams/llvm-committers
+
 ## Commit Access Review
 
 - Frequency: Monthly
@@ -30,13 +47,3 @@ The issue should have the 'infra:commit-access' label and should use the same de
 The secrets are personal access tokens that are associated with the llvmbot GitHub account. An admin
 should log in to the llvmbot account, re-generate the personal access tokens and then copy the
 new values into the corresponding secret in the llvm-project repo's settings.
-
-## Grant Commit Access
-
-- Frequency: Ongoing
-- Permissions: Admin
-- Description: An admin should periodically review the list of commit access requests. This can be
-  done by searching for issues in the llvm-project repository which have the infra:commit-access-request
-  label. Any user that meets the [commit access requirements](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access)
-  should be added to the 'LLVM Committers' team. The admin should add a comment to the issue when
-  an invite to join the team has been sent and then close the issue when the invite has been accepted.

--- a/llvm/docs/AdminTasks.md
+++ b/llvm/docs/AdminTasks.md
@@ -10,7 +10,7 @@ This can be done by searching for issues in the llvm-project repository which ha
 Any user that meets the [commit access requirements] should be added to the ['LLVM Committers' team].
 The admin should add a comment to the issue when an invite to join the team has been sent and then close the issue when the invite has been accepted.
 Admins should close issues after sending the invite and invite the requestor to reopen if there are issues.
-If there are insufficient votes and it has been over five days since the last update, admins should remove the `infra:commit-access-request` label.
+If there are insufficient votes and it has been over two weeks since the last update, admins may remove the `infra:commit-access-request` label to take the request off the queue.
 To reopen the request, someone with repository triage or write access must reapply the label to get it back on the dashboard.
 
 [`infra:commit-access-request` label]: https://github.com/llvm/llvm-project/issues/?q=is%3Aissue%20state%3Aopen%20label%3Ainfra%3Acommit-access-request


### PR DESCRIPTION
As discussed in the infra area team meeting. Mostly this serves as a place to stash helpful links.

I invented the 5 day timeout. Let me know what you think is reasonable. It seems less than ideal that one needs issue tracker labelling privileges to reopen the issue, but I think that's accurate.