### PR TITLE
[clang] fix a crash for uses of a pseudo-destructor of enum without definition

### DIFF
--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -41,7 +41,7 @@ static CXXRecordDecl *getCurrentInstantiationOf(QualType T,
 
 DeclContext *Sema::computeDeclContext(QualType T) {
   if (!T->isDependentType())
-    if (auto *D = T->getAsTagDecl())
+    if (auto *D = T->getAsRecordDecl())
       return D;
   return ::getCurrentInstantiationOf(T, CurContext);
 }

--- a/clang/test/SemaTemplate/destructor-template.cpp
+++ b/clang/test/SemaTemplate/destructor-template.cpp
@@ -119,3 +119,10 @@ X::typo<T>::typ0::~typ0() {} // expected-error {{no member named 'typ0'}} \
                              // expected-error {{no type named 'typ0'}}
 
 }
+
+namespace GH209908 {
+  template <class T> using X = decltype(T().~E());
+  // expected-error@-1 {{undeclared identifier 'E' in destructor name}}
+  enum E : int;
+  using Z = X<E>; // expected-note {{requested here}}
+} // namespace GH209908


### PR DESCRIPTION
Lookup for the destuctor name in the object type only applies to record types.

Since this will be backported, there are no release notes.

Fixes #209808