### PR TITLE
[clang-tidy] suggest std::in_range in modernize-use-integer-sign-comparison

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "UseIntegerSignComparisonCheck.h"
+#include "../utils/ASTUtils.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/NestedNameSpecifier.h"
+#include "clang/AST/Type.h"
+#include "clang/AST/TypeLoc.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Lex/Lexer.h"
 
@@ -29,6 +34,9 @@ static bool isActualCharType(const QualType &Ty) {
 
 namespace {
 AST_MATCHER(QualType, isActualChar) { return isActualCharType(Node); }
+AST_MATCHER(Expr, hasSideEffects) {
+  return Node.HasSideEffects(Finder->getASTContext());
+}
 } // namespace
 
 static BindableMatcher<Stmt> intCastExpression(bool IsSigned,
@@ -51,6 +59,31 @@ static BindableMatcher<Stmt> intCastExpression(bool IsSigned,
 
   return expr(anyOf(ImplicitCastExpr, CStyleCastExpr, StaticCastExpr,
                     FunctionalCastExpr));
+}
+
+/// Extract the source text of the first template argument from a
+/// numeric_limits<T>::min/max/lowest() call expression, preserving typedef
+/// aliases as written (e.g. int32_t rather than the canonical int).
+static StringRef getLimitsTypeSourceText(const CallExpr *CE,
+                                         const SourceManager &SM,
+                                         const LangOptions &LangOpts) {
+  const Expr *Callee = CE->getCallee()->IgnoreImplicit();
+  NestedNameSpecifierLoc QualLoc;
+  if (const auto *DRE = dyn_cast<DeclRefExpr>(Callee))
+    QualLoc = DRE->getQualifierLoc();
+  else if (const auto *ME = dyn_cast<MemberExpr>(Callee))
+    QualLoc = ME->getQualifierLoc();
+  if (!QualLoc.getNestedNameSpecifier())
+    return {};
+  TypeLoc TL = QualLoc.getAsTypeLoc();
+  if (TL.isNull())
+    return {};
+  auto TSTL = TL.getAs<TemplateSpecializationTypeLoc>();
+  if (TSTL.isNull() || TSTL.getNumArgs() == 0)
+    return {};
+  return Lexer::getSourceText(
+      CharSourceRange::getTokenRange(TSTL.getArgLoc(0).getSourceRange()),
+      SM, LangOpts);
 }
 
 static StringRef parseOpCode(BinaryOperator::Opcode Code) {
@@ -91,7 +124,9 @@ void UseIntegerSignComparisonCheck::registerMatchers(MatchFinder *Finder) {
   const auto UnSignedIntCastExpr = intCastExpression(false);
 
   // Flag all operators "==", "<=", ">=", "<", ">", "!="
-  // that are used between signed/unsigned
+  // that are used between signed/unsigned integers.  Range-check
+  // sub-comparisons (e.g. val >= limits::min()) are filtered in
+  // onEndOfTranslationUnit() after the in_range matches are collected.
   const auto CompareOperator =
       binaryOperator(hasAnyOperatorName("==", "<=", ">=", "<", ">", "!="),
                      hasOperands(SignedIntCastExpr, UnSignedIntCastExpr),
@@ -99,6 +134,63 @@ void UseIntegerSignComparisonCheck::registerMatchers(MatchFinder *Finder) {
           .bind("intComparison");
 
   Finder->addMatcher(CompareOperator, this);
+
+  // Match manual integer range checks using std::numeric_limits that can be
+  // replaced with std::in_range / q20::in_range.
+  auto IntType = qualType(hasCanonicalType(qualType(
+      anyOf(isSignedInteger(), isUnsignedInteger()), unless(isActualChar()),
+      unless(booleanType()), unless(enumType()))));
+
+  // Matches "A op B" or the equivalent "B rev_op A", capturing oriented
+  // comparisons without listing every commutative variant separately.
+  const auto Ordered = [](const char *Op, const char *RevOp, const auto &A,
+                           const auto &B) {
+    return binaryOperator(
+        anyOf(allOf(hasOperatorName(Op), hasLHS(ignoringParenImpCasts(A)),
+                    hasRHS(ignoringParenImpCasts(B))),
+              allOf(hasOperatorName(RevOp), hasLHS(ignoringParenImpCasts(B)),
+                    hasRHS(ignoringParenImpCasts(A)))));
+  };
+
+  // Matches std::numeric_limits<T>::<Names>(), binding the template arg type.
+  const auto LimitsCall = [&](auto Names, StringRef TypeBind) {
+    return callExpr(
+        argumentCountIs(0),
+        callee(cxxMethodDecl(
+            Names, ofClass(classTemplateSpecializationDecl(
+                       hasName("numeric_limits"), isInStdNamespace(),
+                       hasTemplateArgument(
+                           0, refersToType(IntType.bind(TypeBind))))))));
+  };
+
+  auto LimitsMin =
+      LimitsCall(hasAnyName("min", "lowest"), "MinType").bind("LimitsMinExpr");
+  auto LimitsMax = LimitsCall(hasName("max"), "MaxType");
+  auto ValueLower =
+      expr(hasType(IntType), unless(hasSideEffects())).bind("ValueFromLower");
+  auto ValueUpper =
+      expr(hasType(IntType), unless(hasSideEffects())).bind("ValueFromUpper");
+
+  // Form 1: val >= min() && val <= max() (and commutative/swapped variants)
+  Finder->addMatcher(
+      binaryOperator(hasOperatorName("&&"),
+                     hasOperands(ignoringParenImpCasts(Ordered(">=", "<=", ValueLower, LimitsMin)),
+                                 ignoringParenImpCasts(Ordered("<=", ">=", ValueUpper, LimitsMax))),
+                     unless(isInTemplateInstantiation()))
+          .bind("RangeCheck"),
+      this);
+
+  // Form 2: !(val < min() || val > max()) (and commutative/swapped variants)
+  Finder->addMatcher(
+      unaryOperator(
+          hasOperatorName("!"),
+          hasUnaryOperand(ignoringParenImpCasts(binaryOperator(
+              hasOperatorName("||"),
+              hasOperands(ignoringParenImpCasts(Ordered("<", ">", ValueLower, LimitsMin)),
+                          ignoringParenImpCasts(Ordered(">", "<", ValueUpper, LimitsMax)))))),
+          unless(isInTemplateInstantiation()))
+          .bind("RangeCheck"),
+      this);
 }
 
 void UseIntegerSignComparisonCheck::registerPPCallbacks(
@@ -108,6 +200,69 @@ void UseIntegerSignComparisonCheck::registerPPCallbacks(
 
 void UseIntegerSignComparisonCheck::check(
     const MatchFinder::MatchResult &Result) {
+  StringRef CmpNamespace;
+  StringRef CmpHeader;
+  if (getLangOpts().CPlusPlus20) {
+    CmpHeader = "<utility>";
+    CmpNamespace = "std::";
+  } else if (getLangOpts().CPlusPlus17 && EnableQtSupport) {
+    CmpHeader = "<QtCore/q20utility.h>";
+    CmpNamespace = "q20::";
+  }
+
+  // Handle in_range pattern (val >= min && val <= max, or negated form).
+  if (const auto *Matched = Result.Nodes.getNodeAs<Expr>("RangeCheck")) {
+    const auto *ValueLower = Result.Nodes.getNodeAs<Expr>("ValueFromLower");
+    const auto *ValueUpper = Result.Nodes.getNodeAs<Expr>("ValueFromUpper");
+    const auto *MinTypePtr = Result.Nodes.getNodeAs<QualType>("MinType");
+    const auto *MaxTypePtr = Result.Nodes.getNodeAs<QualType>("MaxType");
+    if (!ValueLower || !ValueUpper || !MinTypePtr || !MaxTypePtr)
+      return;
+
+    if (Result.Context->getCanonicalType(*MinTypePtr) !=
+        Result.Context->getCanonicalType(*MaxTypePtr))
+      return;
+
+    if (!utils::areStatementsIdentical(ValueLower, ValueUpper, *Result.Context,
+                                       /*Canonical=*/true))
+      return;
+
+    const SourceManager &SM = *Result.SourceManager;
+    StringRef ValueText = Lexer::getSourceText(
+        CharSourceRange::getTokenRange(SM.getSpellingLoc(ValueLower->getBeginLoc()),
+                                       SM.getSpellingLoc(ValueLower->getEndLoc())),
+        SM, getLangOpts());
+    if (ValueText.empty())
+      return;
+
+    std::string TypeStr;
+    if (const auto *MinCall =
+            Result.Nodes.getNodeAs<CallExpr>("LimitsMinExpr")) {
+      StringRef Written = getLimitsTypeSourceText(MinCall, SM, getLangOpts());
+      if (!Written.empty())
+        TypeStr = Written.str();
+    }
+    if (TypeStr.empty())
+      TypeStr = MinTypePtr->getAsString(Result.Context->getPrintingPolicy());
+
+    // Record the source range so onEndOfTranslationUnit() can suppress any
+    // sign-comparison diagnostics for the sub-comparisons.
+    SrcMgr = Result.SourceManager;
+    RangeCheckRanges.push_back(Matched->getSourceRange());
+
+    auto Diag = diag(Matched->getBeginLoc(),
+                     "use '%0in_range' instead of manual range check")
+                << CmpNamespace;
+    if (!Matched->getBeginLoc().isMacroID() && !Matched->getEndLoc().isMacroID()) {
+      std::string Replacement =
+          (CmpNamespace + "in_range<" + TypeStr + ">(" + ValueText + ")").str();
+      Diag << FixItHint::CreateReplacement(Matched->getSourceRange(), Replacement)
+           << IncludeInserter.createIncludeInsertion(
+                  SM.getFileID(Matched->getBeginLoc()), CmpHeader);
+    }
+    return;
+  }
+
   const auto *SignedCastExpression =
       Result.Nodes.getNodeAs<ImplicitCastExpr>("sIntCastExpression");
   assert(SignedCastExpression);
@@ -124,32 +279,18 @@ void UseIntegerSignComparisonCheck::check(
       Result.Nodes.getNodeAs<BinaryOperator>("intComparison");
   assert(BinaryOp);
 
-  const Expr *LHS = BinaryOp->getLHS()->IgnoreImpCasts();
-  const Expr *RHS = BinaryOp->getRHS()->IgnoreImpCasts();
-  const Expr *SubExprLHS = nullptr;
-  const Expr *SubExprRHS = nullptr;
-  SourceRange R1(LHS->getBeginLoc());
-  SourceRange R2(BinaryOp->getOperatorLoc());
-  SourceRange R3(Lexer::getLocForEndOfToken(
-      RHS->getEndLoc(), 0, *Result.SourceManager, getLangOpts()));
-  if (const auto *LHSCast = dyn_cast<ExplicitCastExpr>(LHS)) {
-    SubExprLHS = LHSCast->getSubExpr();
-    R1.setEnd(SubExprLHS->getBeginLoc().getLocWithOffset(-1));
-    R2.setBegin(Lexer::getLocForEndOfToken(
-        SubExprLHS->getEndLoc(), 0, *Result.SourceManager, getLangOpts()));
+  SrcMgr = Result.SourceManager;
+  PendingCmps.push_back({BinaryOp});
+}
+
+void UseIntegerSignComparisonCheck::onEndOfTranslationUnit() {
+  if (PendingCmps.empty()) {
+    RangeCheckRanges.clear();
+    return;
   }
-  if (const auto *RHSCast = dyn_cast<ExplicitCastExpr>(RHS)) {
-    SubExprRHS = RHSCast->getSubExpr();
-    R2.setEnd(SubExprRHS->getBeginLoc().getLocWithOffset(-1));
-    R3.setBegin(Lexer::getLocForEndOfToken(
-        SubExprRHS->getEndLoc(), 0, *Result.SourceManager, getLangOpts()));
-  }
-  const DiagnosticBuilder Diag =
-      diag(BinaryOp->getBeginLoc(),
-           "comparison between 'signed' and 'unsigned' integers");
+
   StringRef CmpNamespace;
   StringRef CmpHeader;
-
   if (getLangOpts().CPlusPlus20) {
     CmpHeader = "<utility>";
     CmpNamespace = "std::";
@@ -158,16 +299,55 @@ void UseIntegerSignComparisonCheck::check(
     CmpNamespace = "q20::";
   }
 
-  // Prefer modernize-use-integer-sign-comparison when C++20 is available!
-  Diag << FixItHint::CreateReplacement(
-      CharSourceRange(R1, SubExprLHS != nullptr),
-      Twine(CmpNamespace + parseOpCode(BinaryOp->getOpcode()) + "(").str());
-  Diag << FixItHint::CreateReplacement(R2, ",");
-  Diag << FixItHint::CreateReplacement(CharSourceRange::getCharRange(R3), ")");
+  for (const auto &Pending : PendingCmps) {
+    const auto *BinaryOp = Pending.BinaryOp;
+    SourceLocation BOpLoc = BinaryOp->getBeginLoc();
 
-  // If there is no include for cmp_{*} functions, we'll add it.
-  Diag << IncludeInserter.createIncludeInsertion(
-      Result.SourceManager->getFileID(BinaryOp->getBeginLoc()), CmpHeader);
+    // Skip sub-comparisons that are part of a recognized range check; those
+    // are already covered by an in_range diagnostic.
+    bool InRangeCheck =
+        llvm::any_of(RangeCheckRanges, [&](const SourceRange &RR) {
+          return !SrcMgr->isBeforeInTranslationUnit(BOpLoc, RR.getBegin()) &&
+                 !SrcMgr->isBeforeInTranslationUnit(RR.getEnd(), BOpLoc);
+        });
+    if (InRangeCheck)
+      continue;
+
+    const Expr *LHS = BinaryOp->getLHS()->IgnoreImpCasts();
+    const Expr *RHS = BinaryOp->getRHS()->IgnoreImpCasts();
+    const Expr *SubExprLHS = nullptr;
+    const Expr *SubExprRHS = nullptr;
+    SourceRange R1(LHS->getBeginLoc());
+    SourceRange R2(BinaryOp->getOperatorLoc());
+    SourceRange R3(Lexer::getLocForEndOfToken(
+        RHS->getEndLoc(), 0, *SrcMgr, getLangOpts()));
+    if (const auto *LHSCast = dyn_cast<ExplicitCastExpr>(LHS)) {
+      SubExprLHS = LHSCast->getSubExpr();
+      R1.setEnd(SubExprLHS->getBeginLoc().getLocWithOffset(-1));
+      R2.setBegin(Lexer::getLocForEndOfToken(SubExprLHS->getEndLoc(), 0,
+                                              *SrcMgr, getLangOpts()));
+    }
+    if (const auto *RHSCast = dyn_cast<ExplicitCastExpr>(RHS)) {
+      SubExprRHS = RHSCast->getSubExpr();
+      R2.setEnd(SubExprRHS->getBeginLoc().getLocWithOffset(-1));
+      R3.setBegin(Lexer::getLocForEndOfToken(SubExprRHS->getEndLoc(), 0,
+                                              *SrcMgr, getLangOpts()));
+    }
+    const DiagnosticBuilder Diag =
+        diag(BinaryOp->getBeginLoc(),
+             "comparison between 'signed' and 'unsigned' integers");
+    Diag << FixItHint::CreateReplacement(
+        CharSourceRange(R1, SubExprLHS != nullptr),
+        Twine(CmpNamespace + parseOpCode(BinaryOp->getOpcode()) + "(").str());
+    Diag << FixItHint::CreateReplacement(R2, ",");
+    Diag << FixItHint::CreateReplacement(CharSourceRange::getCharRange(R3), ")");
+    Diag << IncludeInserter.createIncludeInsertion(
+        SrcMgr->getFileID(BinaryOp->getBeginLoc()), CmpHeader);
+  }
+
+  PendingCmps.clear();
+  RangeCheckRanges.clear();
+  SrcMgr = nullptr;
 }
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.h
@@ -15,8 +15,8 @@
 
 namespace clang::tidy::modernize {
 
-/// Replace comparisons between signed and unsigned integers with their safe
-/// C++20 ``std::cmp_*`` alternative, if available.
+/// Replace comparisons between signed and unsigned integers with ``std::cmp_*``
+/// and manual numeric_limits range checks with ``std::in_range``.
 ///
 /// For the user-facing documentation see:
 /// https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-integer-sign-comparison.html
@@ -29,6 +29,7 @@ public:
                            Preprocessor *ModuleExpanderPP) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void onEndOfTranslationUnit() override;
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus20 || (LangOpts.CPlusPlus17 && EnableQtSupport);
   }
@@ -36,6 +37,15 @@ public:
 private:
   utils::IncludeInserter IncludeInserter;
   const bool EnableQtSupport;
+
+  // Two-pass state for sign-comparison diagnostics: collect during check(),
+  // emit in onEndOfTranslationUnit() after filtering out range-check children.
+  struct PendingSignCmp {
+    const BinaryOperator *BinaryOp;
+  };
+  llvm::SmallVector<PendingSignCmp, 8> PendingCmps;
+  llvm::SmallVector<SourceRange, 4> RangeCheckRanges;
+  const SourceManager *SrcMgr = nullptr;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
@@ -3,13 +3,18 @@
 modernize-use-integer-sign-comparison
 =====================================
 
-Replace comparisons between signed and unsigned integers with their safe
-C++20 ``std::cmp_*`` alternative, if available.
+Modernizes integer comparisons using C++20 (or Qt's C++17 backport) safe
+comparison utilities from ``<utility>``:
 
-The check provides a replacement only for C++20 or later, otherwise
-it highlights the problem and expects the user to fix it manually.
+- Replaces comparisons between signed and unsigned integers with
+  ``std::cmp_*`` alternatives.
+- Replaces manual integer range checks using ``std::numeric_limits`` with
+  ``std::in_range``.
 
-Examples of fixes created by the check:
+Both transformations correctly handle signed/unsigned boundaries without
+the implicit conversion pitfalls of the original code.
+
+**Sign comparison** — replaces mixed-sign comparisons:
 
 .. code-block:: c++
 
@@ -27,6 +32,35 @@ becomes
     return std::cmp_equal(a, b);
   }
 
+The check provides a replacement only for C++20 or later, otherwise
+it highlights the problem and expects the user to fix it manually.
+
+**Range check** — replaces manual ``numeric_limits`` range checks:
+
+.. code-block:: c++
+
+  #include <limits>
+  bool fits_in_int(long val) {
+    return val >= std::numeric_limits<int>::min() &&
+           val <= std::numeric_limits<int>::max();
+  }
+
+becomes
+
+.. code-block:: c++
+
+  #include <limits>
+  #include <utility>
+  bool fits_in_int(long val) {
+    return std::in_range<int>(val);
+  }
+
+The check also recognizes negated forms such as
+``!(val < std::numeric_limits<T>::min() || val > std::numeric_limits<T>::max())``,
+commutative variants of the comparison operators, and ``lowest()`` as
+equivalent to ``min()`` for integer types. Typedef aliases are preserved
+in the fix-it (e.g. ``int32_t`` rather than ``int``).
+
 Options
 -------
 
@@ -37,5 +71,5 @@ Options
 
 .. option:: EnableQtSupport
 
-  Makes C++17 ``q20::cmp_*`` alternative available for Qt-based
-  applications. Default is `false`.
+  Makes C++17 ``q20::cmp_*`` and ``q20::in_range`` alternatives available
+  for Qt-based applications. Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison.cpp
@@ -2,6 +2,15 @@
 
 // CHECK-FIXES: #include <utility>
 
+namespace std {
+template <class T>
+struct numeric_limits {
+  static constexpr T min() noexcept;
+  static constexpr T lowest() noexcept;
+  static constexpr T max() noexcept;
+};
+} // namespace std
+
 // The code that triggers the check
 #define MAX_MACRO(a, b) (a < b) ? b : a
 
@@ -125,4 +134,177 @@ int AllComparisons() {
     TemplateFuncParameters(uVar, sVar);
 
     return 0;
+}
+
+// ---- in_range: positive tests ----
+
+bool canonical(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range' instead of manual range check [modernize-use-integer-sign-comparison]
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return val >= std::numeric_limits<int>::min() && val <= std::numeric_limits<int>::max();
+}
+
+bool commutative_min_lhs(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return std::numeric_limits<int>::min() <= val && val <= std::numeric_limits<int>::max();
+}
+
+bool commutative_max_lhs(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return val >= std::numeric_limits<int>::min() && std::numeric_limits<int>::max() >= val;
+}
+
+bool swapped_and_operands(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return val <= std::numeric_limits<int>::max() && val >= std::numeric_limits<int>::min();
+}
+
+bool with_lowest(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return val >= std::numeric_limits<int>::lowest() && val <= std::numeric_limits<int>::max();
+}
+
+bool negated_form(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return !(val < std::numeric_limits<int>::min() || val > std::numeric_limits<int>::max());
+}
+
+bool negated_swapped_or(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return !(val > std::numeric_limits<int>::max() || val < std::numeric_limits<int>::min());
+}
+
+bool short_type(int val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<short>(val);
+  return val >= std::numeric_limits<short>::min() && val <= std::numeric_limits<short>::max();
+}
+
+// typedef aliases must be preserved in the fix-it
+using int32_t = int;
+using uint16_t = unsigned short;
+
+bool typedef_signed(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int32_t>(val);
+  return val >= std::numeric_limits<int32_t>::min() && val <= std::numeric_limits<int32_t>::max();
+}
+
+bool long_long_type(long long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int>(val);
+  return val >= std::numeric_limits<int>::min() && val <= std::numeric_limits<int>::max();
+}
+
+bool signed_char_type(int val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<signed char>(val);
+  return val >= std::numeric_limits<signed char>::min() && val <= std::numeric_limits<signed char>::max();
+}
+
+template <typename T>
+bool template_value(T val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<int>::min() && val <= std::numeric_limits<int>::max();
+}
+bool instantiate_template() { return template_value(42L); }
+
+// ---- in_range: negative tests (should NOT trigger) ----
+
+bool mismatched_types(long val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<int>::min() && val <= std::numeric_limits<short>::max();
+}
+
+bool different_values(long val1, long val2) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val1 >= std::numeric_limits<int>::min() && val2 <= std::numeric_limits<int>::max();
+}
+
+bool float_type(double val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<float>::min() && val <= std::numeric_limits<float>::max();
+}
+
+bool bool_type(int val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<bool>::min() && val <= std::numeric_limits<bool>::max();
+}
+
+bool char_type(int val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<char>::min() && val <= std::numeric_limits<char>::max();
+}
+
+enum MyEnum { A, B };
+bool enum_type(int val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<MyEnum>::min() && val <= std::numeric_limits<MyEnum>::max();
+}
+
+bool wrong_operators(long val) {
+  // CHECK-MESSAGES-NOT: warning:
+  return val >= std::numeric_limits<int>::min() && val >= std::numeric_limits<int>::max();
+}
+
+// Side-effecting value expression: should NOT trigger (unsafe to collapse two
+// calls into one, since doing so would change the number of calls).
+int counter();
+bool side_effects(long) {
+  // CHECK-MESSAGES-NOT: warning:
+  return counter() >= std::numeric_limits<int>::min() && counter() <= std::numeric_limits<int>::max();
+}
+
+// Range check inside a macro body: diagnostic fires but no fix-it (the
+// replacement range spans a macro expansion).
+#define FITS_IN_INT(v) \
+  (v) >= std::numeric_limits<int>::min() && (v) <= std::numeric_limits<int>::max()
+
+bool in_macro_body(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:{{.*}}warning: use 'std::in_range'
+  // CHECK-FIXES-NOT: std::in_range
+  return FITS_IN_INT(val);
+}
+
+// ---- cmp_* vs in_range interaction ----
+
+// When val and T have opposite signedness (the canonical in_range use case),
+// the individual sub-comparisons are themselves signed/unsigned comparisons
+// that would trigger cmp_* warnings. The in_range pattern takes priority:
+// only the in_range diagnostic should fire, not cmp_* for each sub-expression.
+//
+// long vs unsigned long: same bit-width, so the usual arithmetic conversion
+// promotes long to unsigned long -- a genuine signed/unsigned comparison.
+bool fits_in_ulong(long val) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<unsigned long>(val);
+  return val >= std::numeric_limits<unsigned long>::min() && val <= std::numeric_limits<unsigned long>::max();
+}
+// The two sub-comparisons above must NOT produce cmp_* warnings;
+// they are suppressed by the two-pass range-check filter in onEndOfTranslationUnit().
+
+// Fix 1: a standalone signed/unsigned comparison that involves a numeric_limits
+// call but is NOT part of a range check must still warn with cmp_*.
+// uval (unsigned long) > min() (int): the int return value is implicitly cast
+// to unsigned long, so CompareOperator fires and the warning must not be
+// suppressed just because one operand is a numeric_limits call.
+bool standalone_limits_cmp(unsigned long uval) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: comparison between 'signed' and 'unsigned' integers
+  // CHECK-FIXES: return std::cmp_greater(uval , std::numeric_limits<int>::min());
+  return uval > std::numeric_limits<int>::min();
+}
+
+// Fix 3: object-style call lim.min() must preserve the typedef alias in the
+// fix-it via the MemberExpr callee path in getLimitsTypeSourceText.
+bool object_style_limits(long val) {
+  std::numeric_limits<int32_t> lim;
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::in_range'
+  // CHECK-FIXES: return std::in_range<int32_t>(val);
+  return val >= lim.std::numeric_limits<int32_t>::min() && val <= lim.std::numeric_limits<int32_t>::max();
 }


### PR DESCRIPTION
Assisted-by: Claude
Resolves: #190665