### PR TITLE
[flang][OpenACC] Allow blanks around ':' in more clause separators

### DIFF
--- a/flang/lib/Parser/openacc-parsers.cpp
+++ b/flang/lib/Parser/openacc-parsers.cpp
@@ -50,8 +50,8 @@ TYPE_PARSER(construct<AccObjectListWithReduction>(
 
 // 2.16 (3249) wait-argument is:
 //   [devnum : int-expr :] [queues :] int-expr-list
-TYPE_PARSER(construct<AccWaitArgument>(maybe("DEVNUM:" >> scalarIntExpr / ":"),
-    "QUEUES:" >> nonemptyList(scalarIntExpr) || nonemptyList(scalarIntExpr)))
+TYPE_PARSER(construct<AccWaitArgument>(maybe("DEVNUM :" >> scalarIntExpr / ":"),
+    "QUEUES :" >> nonemptyList(scalarIntExpr) || nonemptyList(scalarIntExpr)))
 
 // 2.9 (1984-1986) size-expr is one of:
 //   * (represented as an empty std::optional<ScalarIntExpr>)
@@ -97,7 +97,7 @@ TYPE_PARSER(
 
 // 2.9.1 collapse
 TYPE_PARSER(construct<AccCollapseArg>(
-    "FORCE:"_tok >> pure(true) || pure(false), scalarIntConstantExpr))
+    "FORCE :"_tok >> pure(true) || pure(false), scalarIntConstantExpr))
 
 // 2.5.15 Reduction, F'2023 R1131, and CUF reduction-op
 // Operator for reduction
@@ -137,8 +137,8 @@ TYPE_PARSER(sourced(
 
 // Modifier for copyin, copyout, cache and create
 TYPE_PARSER(sourced(construct<AccDataModifier>(
-    first("ZERO:" >> pure(AccDataModifier::Modifier::Zero),
-        "READONLY:" >> pure(AccDataModifier::Modifier::ReadOnly)))))
+    first("ZERO :" >> pure(AccDataModifier::Modifier::Zero),
+        "READONLY :" >> pure(AccDataModifier::Modifier::ReadOnly)))))
 
 // Combined directives
 TYPE_PARSER(sourced(construct<AccCombinedDirective>(

--- a/flang/test/Parser/acc-unparse.f90
+++ b/flang/test/Parser/acc-unparse.f90
@@ -33,6 +33,14 @@ subroutine acc_loop()
   end do
 !CHECK: !$ACC LOOP COLLAPSE(FORCE:2_4)
 
+! Blanks are permitted around the ':' separator of a collapse force modifier.
+  !$acc loop collapse(force : 2)
+  do i = 1, 10
+    do j = 1, 10
+    end do
+  end do
+!CHECK: !$ACC LOOP COLLAPSE(FORCE:2_4)
+
   !$acc loop gang
   do i = 1, 10
     a(i) = i
@@ -106,6 +114,23 @@ subroutine acc_loop()
   end do
 ! CHECK: !$ACC LOOP GANG(NUM:gangnum)
 
+end subroutine
+
+! Blanks are permitted around the ':' separators of a wait-argument
+! (devnum/queues) and of copy/create data modifiers (zero/readonly).
+subroutine acc_clause_spaces()
+  integer :: i
+  real :: a(10), b(10)
+
+!CHECK-LABEL: SUBROUTINE acc_clause_spaces
+
+  !$acc wait(devnum : 1 : 2, 3)
+!CHECK: !$ACC WAIT(DEVNUM:1_4:2_4,3_4)
+
+  !$acc data copyin(readonly : a) create(zero : b)
+!CHECK: !$ACC DATA COPYIN(READONLY:a) CREATE(ZERO:b)
+  !$acc end data
+!CHECK: !$ACC END DATA
 end subroutine
 
 subroutine routine1()


### PR DESCRIPTION
Several OpenACC clause parsers glue a keyword directly to its `:` separator in the token string (`"DEVNUM:"`, `"QUEUES:"`, `"FORCE:"`, `"ZERO:"`, `"READONLY:"`). A blank in a `TokenStringMatch` pattern is the only place a blank is accepted between characters of the token, so these spellings rejected an otherwise valid separating space, e.g.

```fortran
!$acc wait(devnum : 1 : 2, 3)
!$acc loop collapse(force : 2)
!$acc data copyin(readonly : a) create(zero : b)
```

This moves the blank in each token string to before the `:` so zero or more blanks are accepted on either side of the separator, matching free-form Fortran's treatment of blanks and the spec grammar (which writes these with spaces around the `:`). It mirrors the earlier fix for the gang `static`/`dim`/`num` arguments.

Parser/unparse coverage is added for the spaced spellings of the wait `devnum`/`queues` argument, the collapse `force` modifier, and the `zero` and `readonly` data modifiers.

Assisted-by: AI