### PR TITLE
[lldb-mcp] Host managed debug sessions in-process

### DIFF
--- a/lldb/include/lldb/Protocol/MCP/Server.h
+++ b/lldb/include/lldb/Protocol/MCP/Server.h
@@ -96,6 +96,10 @@ struct ServerInfo {
   static llvm::Expected<ServerInfoHandle> Write(const ServerInfo &);
   /// Loads any server info saved in `~/.lldb`.
   static llvm::Expected<std::vector<ServerInfo>> Load();
+  /// Removes the registry entry for the instance with the given \p pid. The
+  /// handle removes it on a clean exit, so this only prunes one orphaned by a
+  /// crash.
+  static llvm::Error Remove(lldb::pid_t pid);
 };
 llvm::json::Value toJSON(const ServerInfo &);
 bool fromJSON(const llvm::json::Value &, ServerInfo &, llvm::json::Path);

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -60,6 +60,12 @@ bool lldb_protocol::mcp::fromJSON(const json::Value &V, ServerInfo &SM,
          O.mapOptional("pid", SM.pid);
 }
 
+/// Returns the on-disk registry path for the instance with the given \p pid.
+static FileSpec GetServerInfoPath(lldb::pid_t pid) {
+  return HostInfo::GetUserLLDBDir().CopyByAppendingPathComponent(
+      formatv("lldb-mcp-{0}.json", pid).str());
+}
+
 Expected<ServerInfoHandle> ServerInfo::Write(const ServerInfo &info) {
   // The file is written by the process that hosts the server, so stamp its pid
   // to keep it consistent with the filename below.
@@ -75,8 +81,7 @@ Expected<ServerInfoHandle> ServerInfo::Write(const ServerInfo &info) {
   if (error.Fail())
     return error.takeError();
 
-  FileSpec mcp_registry_entry_path = user_lldb_dir.CopyByAppendingPathComponent(
-      formatv("lldb-mcp-{0}.json", stamped.pid).str());
+  FileSpec mcp_registry_entry_path = GetServerInfoPath(stamped.pid);
 
   const File::OpenOptions flags = File::eOpenOptionWriteOnly |
                                   File::eOpenOptionCanCreate |
@@ -88,6 +93,15 @@ Expected<ServerInfoHandle> ServerInfo::Write(const ServerInfo &info) {
   if (llvm::Error error = (*file)->Write(buf.data(), num_bytes).takeError())
     return error;
   return ServerInfoHandle{mcp_registry_entry_path.GetPath()};
+}
+
+llvm::Error ServerInfo::Remove(lldb::pid_t pid) {
+  std::string path = GetServerInfoPath(pid).GetPath();
+  // A missing entry is not an error. sys::fs::remove already reports success
+  // when the file is gone.
+  if (std::error_code ec = sys::fs::remove(path))
+    return errorCodeToError(ec);
+  return llvm::Error::success();
 }
 
 Expected<std::vector<ServerInfo>> ServerInfo::Load() {

--- a/lldb/tools/lldb-mcp/CMakeLists.txt
+++ b/lldb/tools/lldb-mcp/CMakeLists.txt
@@ -3,15 +3,18 @@ add_lldb_tool(lldb-mcp
   Multiplexer.cpp
 
   LINK_COMPONENTS
-    Option
     Support
   LINK_LIBS
     liblldb
-    lldbUtility
     lldbHost
     lldbProtocolMCP
+    lldbUtility
   )
 
+# lldb-mcp hosts debug sessions in its own process. It drives the debug engine
+# through the public SB API in liblldb, but also links a few internal libraries
+# (transport, host) directly, so guard against liblldb interposing their
+# symbols, the same as lldb-dap.
 lldb_prevent_liblldb_symbol_interposition(lldb-mcp)
 
 if(APPLE)

--- a/lldb/tools/lldb-mcp/Multiplexer.cpp
+++ b/lldb/tools/lldb-mcp/Multiplexer.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Multiplexer.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -27,12 +28,16 @@ constexpr llvm::StringLiteral kServerName = "lldb-mcp";
 /// @{
 constexpr llvm::StringLiteral kToolCommand = "command";
 constexpr llvm::StringLiteral kToolSessionsList = "sessions_list";
+constexpr llvm::StringLiteral kToolSessionCreate = "session_create";
+constexpr llvm::StringLiteral kToolSessionClose = "session_close";
 /// @}
 
 /// Backend tool names, as exposed by the LLDB MCP server.
 /// @{
 constexpr llvm::StringLiteral kBackendToolCommand = "command";
 constexpr llvm::StringLiteral kBackendToolDebuggerList = "debugger_list";
+constexpr llvm::StringLiteral kBackendToolDebuggerCreate = "debugger_create";
+constexpr llvm::StringLiteral kBackendToolDebuggerDelete = "debugger_delete";
 /// @}
 
 /// Backend-local URI prefixes.
@@ -118,18 +123,23 @@ Multiplexer::Multiplexer(std::unique_ptr<MCPTransport> client_transport,
   });
 }
 
-void Multiplexer::AddBackend(lldb::pid_t pid, std::unique_ptr<Client> backend) {
-  // A backend that disconnects or errors mid-request will never answer its
-  // forwarded requests. Fail them so the client sees an error instead of
-  // waiting forever, since there is no request timeout.
-  Client *client = backend.get();
-  client->SetDisconnectHandler(
-      [client] { client->CancelPendingRequests("backend disconnected"); });
-  client->SetErrorHandler([client](llvm::Error error) {
+void Multiplexer::InstallBackendHandlers(lldb::pid_t pid, Client &backend) {
+  backend.SetDisconnectHandler([this, pid]() { RetireBackend(pid); });
+  backend.SetErrorHandler([this, pid](llvm::Error error) {
     consumeError(std::move(error));
-    client->CancelPendingRequests("backend transport error");
+    RetireBackend(pid);
   });
-  m_backends.push_back(Backend{pid, std::move(backend)});
+}
+
+void Multiplexer::AddBackend(lldb::pid_t pid, std::unique_ptr<Client> backend) {
+  InstallBackendHandlers(pid, *backend);
+  m_backends.push_back(Backend{pid, std::move(backend), /*local=*/false});
+}
+
+void Multiplexer::AddLocalBackend(lldb::pid_t pid,
+                                  std::unique_ptr<Client> backend) {
+  InstallBackendHandlers(pid, *backend);
+  m_backends.push_back(Backend{pid, std::move(backend), /*local=*/true});
 }
 
 llvm::Error Multiplexer::Run() {
@@ -146,24 +156,49 @@ llvm::Error Multiplexer::Run() {
   return m_client_transport->RegisterMessageHandler(*m_client_binder);
 }
 
-void Multiplexer::SetDisconnectHandler(llvm::unique_function<void()> handler) {
-  m_disconnect_handler = std::move(handler);
-}
-
 void Multiplexer::Shutdown() {
   for (Backend &backend : m_backends)
     backend.client->CancelPendingRequests("lldb-mcp is shutting down");
 }
 
+void Multiplexer::SetDisconnectHandler(llvm::unique_function<void()> handler) {
+  m_disconnect_handler = std::move(handler);
+}
+
 Client *Multiplexer::RouteToPid(lldb::pid_t pid) {
   for (Backend &backend : m_backends)
-    if (backend.pid == pid)
+    if (backend.pid == pid && backend.alive)
       return backend.client.get();
   return nullptr;
 }
 
-Client *Multiplexer::First() {
-  return m_backends.empty() ? nullptr : m_backends.front().client.get();
+Multiplexer::Backend *Multiplexer::LocalBackend() {
+  for (Backend &backend : m_backends)
+    if (backend.local && backend.alive)
+      return &backend;
+  return nullptr;
+}
+
+llvm::SmallVector<Multiplexer::Backend *> Multiplexer::LiveBackends() {
+  llvm::SmallVector<Backend *> live;
+  for (Backend &backend : m_backends)
+    if (backend.alive)
+      live.push_back(&backend);
+  return live;
+}
+
+void Multiplexer::RetireBackend(lldb::pid_t pid) {
+  for (Backend &backend : m_backends) {
+    if (backend.pid != pid)
+      continue;
+    if (!backend.alive)
+      return;
+    backend.alive = false;
+    // Fail any in-flight requests so a fanned-out aggregation or a routed call
+    // completes with an error instead of hanging.
+    backend.client->CancelPendingRequests("backend disconnected");
+    return;
+  }
 }
 
 Expected<InitializeResult>
@@ -196,7 +231,7 @@ Expected<ListToolsResult> Multiplexer::HandleToolsList() {
                 {"description",
                  "The debugger URI selecting the debug session, as reported by "
                  "sessions_list, e.g. lldb-mcp://instance/{pid}/debugger/{id}. "
-                 "Defaults to the first session."}}},
+                 "Defaults to the local session."}}},
        }},
       {"required", json::Array{"command"}},
   };
@@ -209,6 +244,30 @@ Expected<ListToolsResult> Multiplexer::HandleToolsList() {
   sessions_list.inputSchema = json::Object{{"type", "object"}};
   result.tools.push_back(std::move(sessions_list));
 
+  ToolDefinition session_create;
+  session_create.name = kToolSessionCreate;
+  session_create.description =
+      "Create a new in-process debug session and return its URI.";
+  session_create.inputSchema = json::Object{{"type", "object"}};
+  result.tools.push_back(std::move(session_create));
+
+  ToolDefinition session_close;
+  session_close.name = kToolSessionClose;
+  session_close.description =
+      "Close a debug session previously created with session_create.";
+  session_close.inputSchema = json::Object{
+      {"type", "object"},
+      {"properties",
+       json::Object{
+           {"session", json::Object{{"type", "string"},
+                                    {"description",
+                                     "The session URI to close, as returned by "
+                                     "session_create or sessions_list."}}},
+       }},
+      {"required", json::Array{"session"}},
+  };
+  result.tools.push_back(std::move(session_close));
+
   return result;
 }
 
@@ -218,6 +277,10 @@ void Multiplexer::HandleToolsCall(const CallToolParams &params,
     return HandleCommand(params, std::move(reply));
   if (params.name == kToolSessionsList)
     return HandleSessionsList(std::move(reply));
+  if (params.name == kToolSessionCreate)
+    return HandleSessionCreate(std::move(reply));
+  if (params.name == kToolSessionClose)
+    return HandleSessionClose(params, std::move(reply));
   reply(createStringError(formatv("no tool \"{0}\"", params.name)));
 }
 
@@ -234,8 +297,9 @@ void Multiplexer::HandleCommand(const CallToolParams &params,
 
   Client *backend = nullptr;
   if (debugger_arg.empty()) {
-    // Default to the first session, letting the backend pick its debugger.
-    backend = First();
+    // Default to the local session, letting the backend pick its debugger.
+    Backend *local = LocalBackend();
+    backend = local ? local->client.get() : nullptr;
     args.erase("debugger");
   } else {
     std::optional<RoutedURI> routed = ParseGlobalURI(debugger_arg);
@@ -256,7 +320,8 @@ void Multiplexer::HandleCommand(const CallToolParams &params,
 }
 
 void Multiplexer::HandleSessionsList(Reply<CallToolResult> reply) {
-  if (m_backends.empty())
+  llvm::SmallVector<Backend *> live = LiveBackends();
+  if (live.empty())
     return reply(makeTextResult(""));
 
   // All backends share the multiplexer's MainLoop, so these reply callbacks run
@@ -265,34 +330,31 @@ void Multiplexer::HandleSessionsList(Reply<CallToolResult> reply) {
     size_t remaining;
     // Keyed by pid so the aggregated output is deterministic.
     std::map<lldb::pid_t, std::string> texts;
-    std::string error;
     Reply<CallToolResult> reply;
   };
   auto state = std::make_shared<State>();
-  state->remaining = m_backends.size();
+  state->remaining = live.size();
   state->reply = std::move(reply);
 
-  for (Backend &backend : m_backends) {
-    lldb::pid_t pid = backend.pid;
+  for (Backend *backend : live) {
+    lldb::pid_t pid = backend->pid;
     CallToolParams params;
     params.name = kBackendToolDebuggerList;
-    backend.client->ToolsCall(
+    backend->client->ToolsCall(
         params, [state, pid](Expected<CallToolResult> result) {
+          // Best effort: a backend that fails or disconnected is simply omitted
+          // from the aggregate rather than failing the whole listing.
           if (result) {
             std::string text;
             for (const TextContent &content : result->content)
               text += RewriteURIsToGlobal(content.text, pid);
             state->texts[pid] = std::move(text);
-          } else if (state->error.empty()) {
-            state->error = toString(result.takeError());
           } else {
             consumeError(result.takeError());
           }
 
           if (--state->remaining != 0)
             return;
-          if (!state->error.empty())
-            return state->reply(createStringError(state->error));
           std::string combined;
           for (const auto &entry : state->texts)
             combined += entry.second;
@@ -301,8 +363,55 @@ void Multiplexer::HandleSessionsList(Reply<CallToolResult> reply) {
   }
 }
 
+void Multiplexer::HandleSessionCreate(Reply<CallToolResult> reply) {
+  Backend *local = LocalBackend();
+  if (!local)
+    return reply(createStringError("no in-process session host available"));
+
+  lldb::pid_t pid = local->pid;
+  CallToolParams params;
+  params.name = kBackendToolDebuggerCreate;
+  local->client->ToolsCall(
+      params,
+      [reply = std::move(reply), pid](Expected<CallToolResult> result) mutable {
+        if (!result)
+          return reply(result.takeError());
+        for (TextContent &content : result->content)
+          content.text = RewriteURIsToGlobal(content.text, pid);
+        reply(std::move(*result));
+      });
+}
+
+void Multiplexer::HandleSessionClose(const CallToolParams &params,
+                                     Reply<CallToolResult> reply) {
+  json::Object args;
+  if (params.arguments)
+    if (const json::Object *object = params.arguments->getAsObject())
+      args = *object;
+
+  std::optional<StringRef> session = args.getString("session");
+  if (!session || session->empty())
+    return reply(createStringError("session_close requires a \"session\" uri"));
+
+  std::optional<RoutedURI> routed = ParseGlobalURI(*session);
+  if (!routed)
+    return reply(
+        createStringError(formatv("malformed session uri \"{0}\"", *session)));
+
+  Backend *local = LocalBackend();
+  if (!local || routed->pid != local->pid)
+    return reply(
+        createStringError("can only close sessions that lldb-mcp created"));
+
+  CallToolParams delete_params;
+  delete_params.name = kBackendToolDebuggerDelete;
+  delete_params.arguments = json::Object{{"debugger", routed->local}};
+  local->client->ToolsCall(delete_params, std::move(reply));
+}
+
 void Multiplexer::HandleResourcesList(Reply<ListResourcesResult> reply) {
-  if (m_backends.empty())
+  llvm::SmallVector<Backend *> live = LiveBackends();
+  if (live.empty())
     return reply(ListResourcesResult{});
 
   // These reply callbacks run serially on the shared MainLoop thread, so this
@@ -310,17 +419,18 @@ void Multiplexer::HandleResourcesList(Reply<ListResourcesResult> reply) {
   struct State {
     size_t remaining;
     std::map<lldb::pid_t, std::vector<Resource>> resources;
-    std::string error;
     Reply<ListResourcesResult> reply;
   };
   auto state = std::make_shared<State>();
-  state->remaining = m_backends.size();
+  state->remaining = live.size();
   state->reply = std::move(reply);
 
-  for (Backend &backend : m_backends) {
-    lldb::pid_t pid = backend.pid;
-    backend.client->ResourcesList(
+  for (Backend *backend : live) {
+    lldb::pid_t pid = backend->pid;
+    backend->client->ResourcesList(
         [state, pid](Expected<ListResourcesResult> result) {
+          // Best effort: a failed or disconnected backend contributes no
+          // resources rather than failing the whole listing.
           if (result) {
             std::vector<Resource> rewritten;
             for (Resource resource : result->resources) {
@@ -328,16 +438,12 @@ void Multiplexer::HandleResourcesList(Reply<ListResourcesResult> reply) {
               rewritten.push_back(std::move(resource));
             }
             state->resources[pid] = std::move(rewritten);
-          } else if (state->error.empty()) {
-            state->error = toString(result.takeError());
           } else {
             consumeError(result.takeError());
           }
 
           if (--state->remaining != 0)
             return;
-          if (!state->error.empty())
-            return state->reply(createStringError(state->error));
           ListResourcesResult combined;
           for (auto &entry : state->resources)
             for (Resource &resource : entry.second)

--- a/lldb/tools/lldb-mcp/Multiplexer.h
+++ b/lldb/tools/lldb-mcp/Multiplexer.h
@@ -14,6 +14,7 @@
 #include "lldb/Protocol/MCP/Transport.h"
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include <memory>
@@ -45,14 +46,18 @@ std::optional<RoutedURI> ParseGlobalURI(llvm::StringRef uri);
 /// MCP servers, each reached through an mcp::Client and identified by the pid
 /// of its lldb instance.
 ///
+/// Backends are of two kinds. **Remote** backends are external lldb processes
+/// the user already runs, reached over sockets. The **local** backend is an
+/// embedded MCP server in this process that hosts the debug sessions the
+/// multiplexer creates. Managed sessions are its debuggers.
+///
 /// Requests answered locally (initialize, tools/list) are handled directly.
-/// Requests that list across instances (sessions_list, resources/list) fan out
-/// to every backend and aggregate. Requests that target one instance (command,
-/// resources/read) are routed by an instance-qualified URI of the form
-/// `lldb-mcp://instance/{pid}/debugger/{id}` (tools) or
-/// `lldb://instance/{pid}/debugger/{id}/target/{idx}` (resources). Backends
-/// only know their local `lldb-mcp://debugger/{id}` form, so URIs are rewritten
-/// in both directions.
+/// Listing requests (sessions_list, resources/list) fan out to every backend
+/// and aggregate. Targeted requests (command, resources/read) are routed by the
+/// pid parsed from an instance-qualified URI. Session management
+/// (session_create/session_close) operates on the local backend. Backends only
+/// know their local `lldb-mcp://debugger/{id}` form, so URIs are rewritten in
+/// both directions.
 class Multiplexer {
 public:
   template <typename T> using Reply = lldb_private::transport::Reply<T>;
@@ -61,10 +66,15 @@ public:
       std::unique_ptr<lldb_protocol::mcp::MCPTransport> client_transport,
       lldb_protocol::mcp::LogCallback log_callback = {});
 
-  /// Adds a backend identified by the pid of its lldb instance. The client must
-  /// already be running (see Client::Run). Takes ownership.
+  /// Adds a remote backend (an external lldb instance) identified by its pid.
+  /// The client must already be running (see Client::Run). Takes ownership.
   void AddBackend(lldb::pid_t pid,
                   std::unique_ptr<lldb_protocol::mcp::Client> backend);
+
+  /// Adds the local backend: the in-process embedded server that hosts managed
+  /// sessions. \p pid is this process's pid. Takes ownership.
+  void AddLocalBackend(lldb::pid_t pid,
+                       std::unique_ptr<lldb_protocol::mcp::Client> backend);
 
   /// Registers the client-facing handlers. Backends should be added first.
   llvm::Error Run();
@@ -80,6 +90,11 @@ private:
   struct Backend {
     lldb::pid_t pid;
     std::unique_ptr<lldb_protocol::mcp::Client> client;
+    /// True for the in-process backend that hosts managed sessions.
+    bool local = false;
+    /// Cleared when the backend disconnects. A dead backend is skipped by
+    /// routing and aggregation rather than left to hang a pending request.
+    bool alive = true;
   };
 
   /// Locally-answered requests.
@@ -96,6 +111,9 @@ private:
   void HandleCommand(const lldb_protocol::mcp::CallToolParams &params,
                      Reply<lldb_protocol::mcp::CallToolResult> reply);
   void HandleSessionsList(Reply<lldb_protocol::mcp::CallToolResult> reply);
+  void HandleSessionCreate(Reply<lldb_protocol::mcp::CallToolResult> reply);
+  void HandleSessionClose(const lldb_protocol::mcp::CallToolParams &params,
+                          Reply<lldb_protocol::mcp::CallToolResult> reply);
   void
   HandleResourcesList(Reply<lldb_protocol::mcp::ListResourcesResult> reply);
   void HandleResourcesRead(const lldb_protocol::mcp::ReadResourceParams &params,
@@ -107,10 +125,21 @@ private:
 
   void Log(llvm::StringRef message);
 
-  /// Returns the backend for \p pid, or nullptr if there is none.
+  /// Returns the backend for \p pid, or nullptr if there is none (or it is
+  /// no longer alive).
   lldb_protocol::mcp::Client *RouteToPid(lldb::pid_t pid);
-  /// Returns the first backend, or nullptr if there are none.
-  lldb_protocol::mcp::Client *First();
+  /// Returns the local (in-process) backend, or nullptr if there is none.
+  Backend *LocalBackend();
+  /// Returns the backends that are still alive, in registration order.
+  llvm::SmallVector<Backend *> LiveBackends();
+  /// Installs the disconnect and error handlers that retire the backend for
+  /// \p pid, so a dropped or erroring backend's in-flight requests are failed
+  /// rather than left hanging (there is no request timeout).
+  void InstallBackendHandlers(lldb::pid_t pid,
+                              lldb_protocol::mcp::Client &backend);
+  /// Marks the backend for \p pid dead and fails its in-flight requests, so a
+  /// backend that disconnects mid-request doesn't strand a pending reply.
+  void RetireBackend(lldb::pid_t pid);
 
   std::unique_ptr<lldb_protocol::mcp::MCPTransport> m_client_transport;
   lldb_protocol::mcp::MCPBinderUP m_client_binder;

--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -7,32 +7,31 @@
 //===----------------------------------------------------------------------===//
 
 #include "Multiplexer.h"
+#include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBError.h"
+#include "lldb/API/SBProtocolServer.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/File.h"
 #include "lldb/Host/FileSystem.h"
-#include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/MainLoop.h"
 #include "lldb/Host/MainLoopBase.h"
-#include "lldb/Host/ProcessLaunchInfo.h"
 #include "lldb/Host/Socket.h"
 #include "lldb/Protocol/MCP/Client.h"
 #include "lldb/Protocol/MCP/Server.h"
 #include "lldb/Protocol/MCP/Transport.h"
-#include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/UriParser.h"
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/WithColor.h"
-#include <chrono>
-#include <cstdlib>
 #include <memory>
-#include <thread>
 
 #if defined(_WIN32)
 #include <fcntl.h>
@@ -42,22 +41,15 @@ using namespace llvm;
 using namespace lldb;
 using namespace lldb_protocol::mcp;
 
-using lldb_private::Environment;
 using lldb_private::File;
-using lldb_private::FileSpec;
 using lldb_private::FileSystem;
-using lldb_private::Host;
+using lldb_private::HostInfo;
 using lldb_private::MainLoop;
 using lldb_private::MainLoopBase;
 using lldb_private::NativeFile;
+using lldb_private::Socket;
 
 namespace {
-
-#if defined(_WIN32)
-constexpr StringLiteral kDriverName = "lldb.exe";
-#else
-constexpr StringLiteral kDriverName = "lldb";
-#endif
 
 inline void exitWithError(llvm::Error Err, StringRef Prefix = "") {
   handleAllErrors(std::move(Err), [&](ErrorInfoBase &Info) {
@@ -66,61 +58,12 @@ inline void exitWithError(llvm::Error Err, StringRef Prefix = "") {
   std::exit(EXIT_FAILURE);
 }
 
-FileSpec driverPath() {
-  Environment host_env = Host::GetEnvironment();
-
-  // Check if an override for which lldb we're using exists, otherwise look next
-  // to the current binary.
-  std::string lldb_exe_path = host_env.lookup("LLDB_EXE_PATH");
-  auto &fs = FileSystem::Instance();
-  if (fs.Exists(lldb_exe_path))
-    return FileSpec(lldb_exe_path);
-
-  FileSpec lldb_exec_spec = lldb_private::HostInfo::GetProgramFileSpec();
-  lldb_exec_spec.SetFilename(kDriverName);
-  return lldb_exec_spec;
-}
-
-llvm::Error launch() {
-  FileSpec lldb_exec = driverPath();
-  lldb_private::ProcessLaunchInfo info;
-  info.SetMonitorProcessCallback(
-      &lldb_private::ProcessLaunchInfo::NoOpMonitorCallback);
-  info.SetExecutableFile(lldb_exec,
-                         /*add_exe_file_as_first_arg=*/true);
-  info.GetArguments().AppendArgument("-O");
-  info.GetArguments().AppendArgument("protocol start MCP");
-  return Host::LaunchProcess(info).takeError();
-}
-
-Expected<std::vector<ServerInfo>> loadOrStart(
-    // FIXME: This should become a CLI arg.
-    lldb_private::Timeout<std::micro> timeout = std::chrono::seconds(30)) {
-  using namespace std::chrono;
-  bool started = false;
-
-  const auto deadline = steady_clock::now() + *timeout;
-  while (steady_clock::now() < deadline) {
-    Expected<std::vector<ServerInfo>> servers = ServerInfo::Load();
-    if (!servers)
-      return servers.takeError();
-
-    if (servers->empty()) {
-      if (!started) {
-        started = true;
-        if (llvm::Error err = launch())
-          return std::move(err);
-      }
-
-      // FIXME: Can we use MainLoop to watch the directory?
-      std::this_thread::sleep_for(microseconds(250));
-      continue;
-    }
-
-    return std::move(*servers);
-  }
-
-  return createStringError("timed out waiting for MCP server to start");
+/// Returns a log callback that traces to stderr when LLDB_MCP_LOG is set in the
+/// environment, since stdout is reserved for the MCP protocol.
+lldb_protocol::mcp::LogCallback makeLogCallback() {
+  if (!std::getenv("LLDB_MCP_LOG"))
+    return {};
+  return [](StringRef message) { errs() << message << '\n'; };
 }
 
 /// Connects to the MCP server described by \p info and returns the connected
@@ -130,14 +73,14 @@ Expected<IOObjectSP> connectToServer(const ServerInfo &info) {
   if (!uri)
     return createStringError("invalid connection_uri");
 
-  std::optional<lldb_private::Socket::ProtocolModePair> protocol_and_mode =
-      lldb_private::Socket::GetProtocolAndMode(uri->scheme);
+  std::optional<Socket::ProtocolModePair> protocol_and_mode =
+      Socket::GetProtocolAndMode(uri->scheme);
   if (!protocol_and_mode)
     return createStringError("unknown protocol scheme");
 
   lldb_private::Status status;
-  std::unique_ptr<lldb_private::Socket> sock =
-      lldb_private::Socket::Create(protocol_and_mode->first, status);
+  std::unique_ptr<Socket> sock =
+      Socket::Create(protocol_and_mode->first, status);
   if (status.Fail())
     return status.takeError();
 
@@ -152,12 +95,26 @@ Expected<IOObjectSP> connectToServer(const ServerInfo &info) {
   return IOObjectSP(std::move(sock));
 }
 
-/// Returns a log callback that traces to stderr when LLDB_MCP_LOG is set in the
-/// environment, since stdout is reserved for the MCP protocol.
-lldb_protocol::mcp::LogCallback makeLogCallback() {
-  if (!std::getenv("LLDB_MCP_LOG"))
-    return {};
-  return [](StringRef message) { errs() << message << '\n'; };
+/// Connects to the server described by \p info and adds it to \p multiplexer,
+/// as the in-process local backend when \p local, otherwise as a remote one.
+llvm::Error connectBackend(lldb_mcp::Multiplexer &multiplexer, MainLoop &loop,
+                           const ServerInfo &info, bool local) {
+  Expected<IOObjectSP> io = connectToServer(info);
+  if (!io)
+    return io.takeError();
+
+  auto transport = std::make_unique<lldb_protocol::mcp::Transport>(
+      loop, *io, *io, makeLogCallback());
+  auto client = std::make_unique<lldb_protocol::mcp::Client>(
+      std::move(transport), makeLogCallback());
+  if (llvm::Error error = client->Run())
+    return error;
+
+  if (local)
+    multiplexer.AddLocalBackend(info.pid, std::move(client));
+  else
+    multiplexer.AddBackend(info.pid, std::move(client));
+  return llvm::Error::success();
 }
 
 } // namespace
@@ -184,26 +141,28 @@ int main(int argc, char *argv[]) {
   assert(result);
 #endif
 
-  lldb_private::FileSystem::Initialize();
-  lldb_private::HostInfo::Initialize();
-  if (llvm::Error error = lldb_private::Socket::Initialize())
-    exitWithError(std::move(error));
+  // Bring up the debug engine (through the public SB API) so lldb-mcp can host
+  // debug sessions in its own process.
+  SBDebugger::Initialize();
+  auto terminate_debugger = llvm::scope_exit([]() { SBDebugger::Terminate(); });
 
-  llvm::scope_exit cleanup([] {
-    lldb_private::Socket::Terminate();
-    lldb_private::HostInfo::Terminate();
-    lldb_private::FileSystem::Terminate();
+  // lldb-mcp also uses the host and transport libraries directly (which link as
+  // a separate copy from the one inside liblldb), so initialize the subsystems
+  // it needs itself.
+  FileSystem::Initialize();
+  HostInfo::Initialize();
+  if (llvm::Error error = Socket::Initialize())
+    exitWithError(std::move(error));
+  auto terminate_host = llvm::scope_exit([]() {
+    Socket::Terminate();
+    HostInfo::Terminate();
+    FileSystem::Terminate();
   });
 
   IOObjectSP input_sp = std::make_shared<NativeFile>(
       fileno(stdin), File::eOpenOptionReadOnly, NativeFile::Unowned);
-
   IOObjectSP output_sp = std::make_shared<NativeFile>(
       fileno(stdout), File::eOpenOptionWriteOnly, NativeFile::Unowned);
-
-  Expected<std::vector<ServerInfo>> servers = loadOrStart();
-  if (!servers)
-    exitWithError(servers.takeError());
 
   static MainLoop loop;
   sys::SetInterruptFunction([]() {
@@ -217,39 +176,48 @@ int main(int argc, char *argv[]) {
   lldb_mcp::Multiplexer multiplexer(std::move(client_transport),
                                     makeLogCallback());
 
-  // A stale registry entry left by a crashed instance fails to connect; skip it
-  // rather than aborting.
+  // Start an in-process MCP server that hosts our own debug sessions, and drive
+  // it as the local backend. This reuses the engine's MCP tools rather than
+  // reimplementing them.
+  const lldb::pid_t self_pid = llvm::sys::Process::getProcessId();
+  SBError sb_error;
+  SBProtocolServer protocol_server = SBProtocolServer::Create("MCP", sb_error);
+  if (sb_error.Fail())
+    exitWithError(createStringError(sb_error.GetCString()));
+  if (SBError error = protocol_server.Start("listen://[localhost]:0");
+      error.Fail())
+    exitWithError(createStringError(error.GetCString()));
+  const char *local_uri = protocol_server.GetConnectionURI();
+  if (!local_uri)
+    exitWithError(createStringError("in-process MCP server is not listening"));
+
+  ServerInfo local_info{local_uri, self_pid};
+  if (llvm::Error error =
+          connectBackend(multiplexer, loop, local_info, /*local=*/true))
+    exitWithError(std::move(error));
+
+  // Connect to every other discovered LLDB MCP server as a remote backend
+  // (skipping our own in-process one). A registry entry is written only after
+  // its server is listening, so an entry that fails to connect is from a
+  // crashed instance and gets pruned. A failed discovery is non-fatal.
   LogCallback log = makeLogCallback();
-  size_t connected = 0;
-  for (const ServerInfo &info : *servers) {
-    Expected<IOObjectSP> backend_io = connectToServer(info);
-    if (!backend_io) {
-      std::string reason = toString(backend_io.takeError());
-      if (log)
-        log(formatv("skipping unreachable MCP server (pid {0}): {1}", info.pid,
-                    reason)
-                .str());
-      continue;
+  if (Expected<std::vector<ServerInfo>> servers = ServerInfo::Load()) {
+    for (const ServerInfo &info : *servers) {
+      if (info.pid == self_pid)
+        continue;
+      if (llvm::Error error =
+              connectBackend(multiplexer, loop, info, /*local=*/false)) {
+        std::string reason = toString(std::move(error));
+        if (log)
+          log(formatv("pruning unreachable MCP server (pid {0}): {1}", info.pid,
+                      reason)
+                  .str());
+        consumeError(ServerInfo::Remove(info.pid));
+      }
     }
-
-    auto backend_transport = std::make_unique<lldb_protocol::mcp::Transport>(
-        loop, *backend_io, *backend_io, makeLogCallback());
-    auto backend = std::make_unique<lldb_protocol::mcp::Client>(
-        std::move(backend_transport), makeLogCallback());
-    if (llvm::Error error = backend->Run()) {
-      std::string reason = toString(std::move(error));
-      if (log)
-        log(formatv("skipping MCP server (pid {0}): {1}", info.pid, reason)
-                .str());
-      continue;
-    }
-
-    multiplexer.AddBackend(info.pid, std::move(backend));
-    ++connected;
+  } else {
+    consumeError(servers.takeError());
   }
-
-  if (connected == 0)
-    exitWithError(createStringError("failed to connect to any MCP server"));
 
   multiplexer.SetDisconnectHandler([]() { loop.RequestTermination(); });
   if (llvm::Error error = multiplexer.Run())
@@ -258,8 +226,9 @@ int main(int argc, char *argv[]) {
   if (llvm::Error error = loop.Run().takeError())
     exitWithError(std::move(error));
 
-  // The client is gone; fail any requests still in flight to a backend so their
-  // replies are satisfied rather than destroyed unanswered during teardown.
+  // The client disconnected. Fail any requests still in flight so abandoned
+  // replies are satisfied, then stop the in-process server.
   multiplexer.Shutdown();
+  protocol_server.Stop();
   return EXIT_SUCCESS;
 }

--- a/lldb/unittests/tools/lldb-mcp/MultiplexerTest.cpp
+++ b/lldb/unittests/tools/lldb-mcp/MultiplexerTest.cpp
@@ -88,6 +88,30 @@ public:
   }
 };
 
+/// A tool that mimics debugger_create by returning a fixed new debugger URI.
+class FakeDebuggerCreateTool : public Tool {
+public:
+  FakeDebuggerCreateTool() : Tool("debugger_create", "fake debugger_create") {}
+
+  llvm::Expected<CallToolResult> Call(const ToolArguments &) override {
+    CallToolResult result;
+    result.content.emplace_back(TextContent{{"lldb-mcp://debugger/2"}});
+    return result;
+  }
+};
+
+/// A tool that mimics debugger_delete.
+class FakeDebuggerDeleteTool : public Tool {
+public:
+  FakeDebuggerDeleteTool() : Tool("debugger_delete", "fake debugger_delete") {}
+
+  llvm::Expected<CallToolResult> Call(const ToolArguments &) override {
+    CallToolResult result;
+    result.content.emplace_back(TextContent{{"deleted"}});
+    return result;
+  }
+};
+
 class FakeResourceProvider : public ResourceProvider {
 public:
   using ResourceProvider::ResourceProvider;
@@ -134,20 +158,32 @@ public:
     EXPECT_THAT_ERROR(client->Run(), Succeeded());
   }
 
-  /// Adds a fake backend with a command tool labelled \p label.
+  /// Adds a fake remote backend with a command tool labelled \p label.
   void AddBackend(lldb::pid_t pid, std::string label) {
+    mux->AddBackend(pid, MakeBackend(std::move(label)));
+  }
+
+  /// Adds a fake local (in-process) backend that hosts managed sessions.
+  void AddLocalBackend(lldb::pid_t pid, std::string label) {
+    mux->AddLocalBackend(pid, MakeBackend(std::move(label)));
+  }
+
+  /// Builds a running fake backend client wired to a fake server.
+  std::unique_ptr<Client> MakeBackend(std::string label) {
     auto pair = TestTransport<ProtocolDescriptor>::createConnectedPair(loop);
 
     auto server = std::make_unique<Server>("fake", "0.1.0");
     server->AddTool(std::make_unique<FakeCommandTool>(std::move(label)));
     server->AddTool(std::make_unique<FakeDebuggerListTool>());
+    server->AddTool(std::make_unique<FakeDebuggerCreateTool>());
+    server->AddTool(std::make_unique<FakeDebuggerDeleteTool>());
     server->AddResourceProvider(std::make_unique<FakeResourceProvider>());
     EXPECT_THAT_ERROR(server->Accept(std::move(pair.second)), Succeeded());
 
     auto backend = std::make_unique<Client>(std::move(pair.first));
     EXPECT_THAT_ERROR(backend->Run(), Succeeded());
-    mux->AddBackend(pid, std::move(backend));
     servers.push_back(std::move(server));
+    return backend;
   }
 
   /// Adds a backend whose debugger_list tool always errors, to exercise the
@@ -162,6 +198,21 @@ public:
     auto backend = std::make_unique<Client>(std::move(pair.first));
     EXPECT_THAT_ERROR(backend->Run(), Succeeded());
     mux->AddBackend(pid, std::move(backend));
+    servers.push_back(std::move(server));
+  }
+
+  /// Adds a local backend whose debugger_create tool always errors, to exercise
+  /// the session_create failure path.
+  void AddLocalBackendWithFailingCreate(lldb::pid_t pid) {
+    auto pair = TestTransport<ProtocolDescriptor>::createConnectedPair(loop);
+
+    auto server = std::make_unique<Server>("fake", "0.1.0");
+    server->AddTool(std::make_unique<FakeFailingTool>("debugger_create"));
+    EXPECT_THAT_ERROR(server->Accept(std::move(pair.second)), Succeeded());
+
+    auto backend = std::make_unique<Client>(std::move(pair.first));
+    EXPECT_THAT_ERROR(backend->Run(), Succeeded());
+    mux->AddLocalBackend(pid, std::move(backend));
     servers.push_back(std::move(server));
   }
 
@@ -250,6 +301,10 @@ TEST(MultiplexerURITest, RewriteURIsToGlobal) {
   EXPECT_EQ(RewriteURIsToGlobal("no uris here", 1), "no uris here");
 }
 
+TEST_F(MultiplexerTest, RunWithoutBackendsFails) {
+  EXPECT_THAT_ERROR(mux->Run(), Failed());
+}
+
 TEST_F(MultiplexerTest, Initialize) {
   AddBackend(100, "A");
   Start();
@@ -273,7 +328,9 @@ TEST_F(MultiplexerTest, ToolsListIsUnifiedSurface) {
   std::vector<std::string> names;
   for (const ToolDefinition &tool : result->tools)
     names.push_back(tool.name);
-  EXPECT_THAT(names, testing::UnorderedElementsAre("command", "sessions_list"));
+  EXPECT_THAT(names,
+              testing::UnorderedElementsAre("command", "sessions_list",
+                                            "session_create", "session_close"));
 }
 
 TEST_F(MultiplexerTest, SessionsListAggregatesAcrossBackends) {
@@ -365,7 +422,7 @@ TEST_F(MultiplexerTest, ResourcesReadRoutesAndRewrites) {
   EXPECT_EQ(result->contents.front().text, "resource contents");
 }
 
-TEST_F(MultiplexerTest, SessionsListSurfacesBackendError) {
+TEST_F(MultiplexerTest, SessionsListOmitsErroringBackend) {
   AddBackend(100, "A");
   AddFailingBackend(200);
   Start();
@@ -374,9 +431,12 @@ TEST_F(MultiplexerTest, SessionsListSurfacesBackendError) {
         client->ToolsCall(CallToolParams{"sessions_list", {}},
                           std::move(reply));
       });
-  // One backend erroring fails the whole aggregation rather than silently
-  // dropping that instance's sessions.
-  EXPECT_THAT_EXPECTED(result, Failed());
+  // A backend that errors is dropped from the aggregate rather than failing the
+  // whole listing. The healthy backend's sessions still come back.
+  ASSERT_THAT_EXPECTED(result, Succeeded());
+  std::string text = commandText(*result);
+  EXPECT_THAT(text, testing::HasSubstr("lldb-mcp://instance/100/debugger/1"));
+  EXPECT_THAT(text, testing::Not(testing::HasSubstr("instance/200")));
 }
 
 TEST_F(MultiplexerTest, ResourcesReadMalformedURIErrors) {
@@ -462,6 +522,127 @@ TEST_F(MultiplexerTest, BackendDisconnectFailsPendingRequest) {
   EXPECT_THAT_ERROR(loop.Run().takeError(), Succeeded());
   ASSERT_TRUE(captured.has_value());
   EXPECT_THAT_EXPECTED(*captured, Failed());
+}
+
+TEST_F(MultiplexerTest, SessionCreateOnLocalBackend) {
+  AddLocalBackend(500, "local");
+  Start();
+
+  llvm::Expected<CallToolResult> created =
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        client->ToolsCall(CallToolParams{"session_create", {}},
+                          std::move(reply));
+      });
+  ASSERT_THAT_EXPECTED(created, Succeeded());
+  // The fake debugger_create yields debugger/2, rewritten to the global form.
+  EXPECT_THAT(commandText(*created),
+              testing::HasSubstr("lldb-mcp://instance/500/debugger/2"));
+}
+
+TEST_F(MultiplexerTest, SessionCreateRequiresLocalBackend) {
+  AddBackend(100, "A"); // Remote only, no local backend.
+  Start();
+  EXPECT_THAT_EXPECTED(
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        client->ToolsCall(CallToolParams{"session_create", {}},
+                          std::move(reply));
+      }),
+      Failed());
+}
+
+TEST_F(MultiplexerTest, SessionCloseOnLocalBackend) {
+  AddLocalBackend(500, "local");
+  Start();
+  llvm::Expected<CallToolResult> closed =
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        json::Object args{{"session", "lldb-mcp://instance/500/debugger/1"}};
+        client->ToolsCall(
+            CallToolParams{"session_close", json::Value(std::move(args))},
+            std::move(reply));
+      });
+  ASSERT_THAT_EXPECTED(closed, Succeeded());
+  EXPECT_THAT(commandText(*closed), testing::HasSubstr("deleted"));
+}
+
+TEST_F(MultiplexerTest, SessionCloseRejectsExternalSession) {
+  AddLocalBackend(500, "local");
+  AddBackend(100, "A"); // External, not managed by lldb-mcp.
+  Start();
+  llvm::Expected<CallToolResult> result =
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        json::Object args{{"session", "lldb-mcp://instance/100/debugger/1"}};
+        client->ToolsCall(
+            CallToolParams{"session_close", json::Value(std::move(args))},
+            std::move(reply));
+      });
+  EXPECT_THAT_EXPECTED(result, Failed());
+}
+
+TEST_F(MultiplexerTest, SessionCreateSurfacesBackendError) {
+  AddLocalBackendWithFailingCreate(500);
+  Start();
+  EXPECT_THAT_EXPECTED(
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        client->ToolsCall(CallToolParams{"session_create", {}},
+                          std::move(reply));
+      }),
+      Failed());
+}
+
+TEST_F(MultiplexerTest, SessionCloseMissingSessionErrors) {
+  AddLocalBackend(500, "local");
+  Start();
+  EXPECT_THAT_EXPECTED(
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        client->ToolsCall(CallToolParams{"session_close", {}},
+                          std::move(reply));
+      }),
+      Failed());
+}
+
+TEST_F(MultiplexerTest, SessionCloseMalformedURIErrors) {
+  AddLocalBackend(500, "local");
+  Start();
+  EXPECT_THAT_EXPECTED(
+      Capture<CallToolResult>([&](Client::Reply<CallToolResult> reply) {
+        // Not instance-qualified, so ParseGlobalURI rejects it.
+        json::Object args{{"session", "lldb-mcp://debugger/1"}};
+        client->ToolsCall(
+            CallToolParams{"session_close", json::Value(std::move(args))},
+            std::move(reply));
+      }),
+      Failed());
+}
+
+TEST_F(MultiplexerTest, SessionsListSurvivesBackendDisconnect) {
+  // A backend that never answers must not hang a fanned-out aggregation once it
+  // disconnects. The healthy backend's result still comes back.
+  TestTransport<ProtocolDescriptor> *silent = AddSilentBackend(200);
+  AddBackend(100, "A");
+  Start();
+
+  std::optional<llvm::Expected<CallToolResult>> captured;
+  client->ToolsCall(CallToolParams{"sessions_list", {}},
+                    [&](llvm::Expected<CallToolResult> result) {
+                      captured = std::move(result);
+                      loop.RequestTermination();
+                    });
+  // Disconnect the silent backend after the fan-out has been issued.
+  EXPECT_TRUE(loop.AddPendingCallback(
+      [silent](MainLoopBase &) { silent->SimulateClosed(); }));
+  EXPECT_TRUE(loop.AddCallback(
+      [](MainLoopBase &loop) {
+        loop.RequestTermination();
+        FAIL() << "sessions_list hung after a backend disconnected";
+      },
+      std::chrono::seconds(5)));
+  EXPECT_THAT_ERROR(loop.Run().takeError(), Succeeded());
+
+  ASSERT_TRUE(captured.has_value());
+  ASSERT_THAT_EXPECTED(*captured, Succeeded());
+  std::string text = commandText(**captured);
+  EXPECT_THAT(text, testing::HasSubstr("lldb-mcp://instance/100/debugger/1"));
+  EXPECT_THAT(text, testing::Not(testing::HasSubstr("instance/200")));
 }
 
 #endif // ifndef _WIN32


### PR DESCRIPTION
Let a client create and own debug sessions with session_create and session_close. Rather than spawn a separate lldb per session, lldb-mcp hosts them in its own process, communicating over a loopback socket to keep things uniform with external lldb instances.

The benefits of this approach are:

- There is no child-process machinery, so nothing needs to be spawned and cleaned up.
- It works without the need for an external lldb binary.
- It avoids the deadlock by reading stdin through a raw fd instead of the FILE* stdio path that previously hung the Debugger constructor contending on the REPL's stdin lock.
- The architecture stays uniform between in-process and external sessions.

The trade-off is no isolation, so an LLDB crash takes down lldb-mcp along with its proxied connections.

Assisted-by: Claude