### PR TITLE
[mlir][acc] Lower per-thread array reductions correctly

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -364,6 +364,10 @@ static Value castPointerLikeTypeIfNeeded(OpBuilder &builder, Location loc,
   return value;
 }
 
+/// Walks back from a memref use to its defining `acc.private_local`, if any,
+/// looking through view/cast ops.
+static acc::PrivateLocalOp getPrivateLocalForMemref(Value memref);
+
 /// Returns the sole user of \p v, or null if it has zero or multiple uses.
 static Operation *getOnlyUser(Value v) {
   if (!v.hasOneUse())
@@ -523,7 +527,8 @@ private:
   void createGPUAllReduceOp(Location loc, Value input, Value memref,
                             arith::AtomicRMWKind kind,
                             mlir::acc::GPUParallelDimsAttr parDimsAttr,
-                            ValueRange indices = {});
+                            ValueRange indices = {},
+                            bool isPerThreadPrivateTarget = false);
 
   /// Finish lowering a deferred `acc.reduction_accumulate`.
   void postprocessAccumulateOp(acc::ReductionAccumulateOp op);
@@ -1236,6 +1241,25 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
         }
       }
     }
+    // A dynamically-shaped privatization is materialized as a strided view whose
+    // type does not reveal its parallel scope. Keep its own par_dims active so
+    // the view is materialized (and predicated) per owning thread/block.
+    // Statically-shaped privatizations are left to the stack-fit decision
+    // so only do this for dynamic shapes.
+    acc::PrivateType privTy =
+        cast<acc::PrivateType>(privateLocalOp.getPrivatized().getType());
+    MemRefType baseTy = getPrivateBaseMemRefType(
+        privTy.getBaseTy(), computeRegion->getParentOfType<ModuleOp>());
+    if (!baseTy.hasStaticShape()) {
+      mlir::acc::GPUParallelDimsAttr ownParDims =
+          mlir::acc::getParDimsAttr(privateLocalOp);
+      if (!ownParDims)
+        ownParDims =
+            getPrivatizeOp(privateLocalOp, computeRegion).getParDimsAttr();
+      if (ownParDims)
+        for (mlir::acc::GPUParallelDimAttr parDim : ownParDims.getArray())
+          mlir::acc::insertParDim(ancestorParDims, parDim);
+    }
   }
 
   bool hasBlock = false;
@@ -1247,18 +1271,31 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       mlir::acc::GPUParallelDimAttr::threadXDim(ctx);
   if (block) {
     block->walk([&](Operation *op) {
-      // Check stores to acc.private_local - add the privatize's par_dims
-      // as active dims so predication is correct for per-worker/gang memory.
-      if (memref::StoreOp storeOp = dyn_cast<memref::StoreOp>(op)) {
-        if (auto privateLocalOp =
-                storeOp.getMemref().getDefiningOp<acc::PrivateLocalOp>()) {
-          acc::PrivatizeOp privatizeOp =
-              getPrivatizeOp(privateLocalOp, computeRegion);
-          if (mlir::acc::GPUParallelDimsAttr parDimsAttr =
-                  privatizeOp.getParDimsAttr()) {
+      // Writes to acc.private_local must keep the privatization's par_dims
+      // active so the write runs on all owning threads instead of being
+      // predicated to a single lane.
+      auto addPrivateStoreParDims = [&](Value target) {
+        if (auto privateLocalOp = getPrivateLocalForMemref(target)) {
+          // The privatization par_dims may be recorded on the private_local
+          // itself (acc.par_dims attribute) or on its privatize; prefer the
+          // private_local's.
+          mlir::acc::GPUParallelDimsAttr parDimsAttr =
+              mlir::acc::getParDimsAttr(privateLocalOp);
+          if (!parDimsAttr)
+            parDimsAttr =
+                getPrivatizeOp(privateLocalOp, computeRegion).getParDimsAttr();
+          if (parDimsAttr)
             for (auto parDim : parDimsAttr.getArray())
               mlir::acc::insertParDim(ancestorParDims, parDim);
-          }
+        }
+      };
+      if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
+        SmallVector<MemoryEffects::EffectInstance> effects;
+        memEffects.getEffects(effects);
+        for (const MemoryEffects::EffectInstance &effect : effects) {
+          if (isa<MemoryEffects::Write>(effect.getEffect()) &&
+              effect.getValue())
+            addPrivateStoreParDims(effect.getValue());
         }
       }
       // Consider ACC routine calls; routine calls should be predicated up to
@@ -2948,7 +2985,8 @@ void ACCCGToGPULowering::constructAtomicAccumulation(
 
 void ACCCGToGPULowering::createGPUAllReduceOp(
     Location loc, Value input, Value memref, arith::AtomicRMWKind kind,
-    mlir::acc::GPUParallelDimsAttr parDimsAttr, ValueRange indices) {
+    mlir::acc::GPUParallelDimsAttr parDimsAttr, ValueRange indices,
+    bool isPerThreadPrivateTarget) {
   gpu::AllReduceOperationAttr attr = gpu::AllReduceOperationAttr::get(
       computeRegion->getContext(), getAllReduceOperation(kind));
   auto allReduceOp = gpu::AllReduceOp::create(rewriter, loc, input, attr, true);
@@ -2983,8 +3021,10 @@ void ACCCGToGPULowering::createGPUAllReduceOp(
   // value on all threads, so each can safely store to its own copy.
   // Detect per-thread storage by walking through conversion ops to
   // find the underlying allocation.
-  bool isPerThreadPrivate = isa_and_nonnull<memref::AllocaOp>(
-      unwrapMemRefConversion(memref).getDefiningOp());
+  bool isPerThreadPrivate =
+      isPerThreadPrivateTarget ||
+      isa_and_nonnull<memref::AllocaOp>(
+          unwrapMemRefConversion(memref).getDefiningOp());
   // combine
   scf::IfOp ifOp;
   if (predicate && !isPerThreadPrivate) {
@@ -3248,10 +3288,25 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
     return;
   }
 
-  // Per-element gpu.all_reduce is only correct for a per-thread alloca; mirror
-  // processPrivateLocal's stack-fit decision rather than inspect the memref.
-  bool isPerThreadPrivate =
-      canUseStackAlloca(memrefTy, loc, options.maxThreadPrivateStack);
+  // Per-element gpu.all_reduce is only correct when each thread owns its own
+  // accumulator copy. For a statically-shaped accumulator, classify from the
+  // operand: an explicit shared allocation is block-shared regardless of size,
+  // and anything else (a per-thread stack alloca, or a view over one) is
+  // per-thread when it fits the per-thread stack budget and block-shared when
+  // it is too large. For a dynamically-shaped accumulator the type conveys no
+  // size, so classify from par_dims (which the producer sets to the reduction's
+  // actual parallel scope): a thread dimension means per-thread storage.
+  bool isPerThreadPrivate;
+  if (memrefTy.hasStaticShape()) {
+    Operation *rootOp = unwrapMemRefConversion(memref).getDefiningOp();
+    isPerThreadPrivate =
+        !isa_and_nonnull<memref::AllocOp>(rootOp) &&
+        canUseStackAlloca(memrefTy, loc, options.maxThreadPrivateStack);
+  } else {
+    isPerThreadPrivate = llvm::any_of(
+        op.getParDims().getArray(),
+        [](mlir::acc::GPUParallelDimAttr d) { return d.isThreadX(); });
+  }
   if (!isPerThreadPrivate) {
     // Block-shared accumulator: no-op only when the accumulate spans a block
     // dim (threads distribute distinct elements, so the block partial is in
@@ -3275,19 +3330,19 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
                                       v);
   };
 
-  Value lb = boundsOp.getLowerbound()
-                 ? toIndex(boundsOp.getLowerbound())
-                 : arith::ConstantIndexOp::create(rewriter, loc, 0);
-  Value step = boundsOp.getStride()
-                   ? toIndex(boundsOp.getStride())
-                   : arith::ConstantIndexOp::create(rewriter, loc, 1);
+  Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
-  // Exclusive upper bound: prefer extent (count of elements), fall back to the
-  // inclusive upperbound.
+  Value lb =
+      boundsOp.getLowerbound() ? toIndex(boundsOp.getLowerbound()) : zero;
+  Value step = boundsOp.getStride() ? toIndex(boundsOp.getStride()) : one;
+  // Exclusive upper bound. `extent` counts elements, so the span is
+  // `extent * step` (for the common unit-stride case step is 1); fall back to
+  // the inclusive upperbound when no extent is given.
   Value ub;
   if (boundsOp.getExtent()) {
-    ub =
-        arith::AddIOp::create(rewriter, loc, lb, toIndex(boundsOp.getExtent()));
+    Value span = arith::MulIOp::create(rewriter, loc,
+                                       toIndex(boundsOp.getExtent()), step);
+    ub = arith::AddIOp::create(rewriter, loc, lb, span);
   } else {
     assert(boundsOp.getUpperbound() &&
            "acc.bounds must specify an extent or upperbound");
@@ -3303,7 +3358,8 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
     Value iv = forOp.getInductionVar();
     Value elem = memref::LoadOp::create(rewriter, loc, memref, ValueRange{iv});
     createGPUAllReduceOp(loc, elem, memref, kind, op.getParDims(),
-                         ValueRange{iv});
+                         ValueRange{iv},
+                         /*isPerThreadPrivateTarget=*/true);
   }
 
   eraseDeadBounds();

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1241,11 +1241,11 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
         }
       }
     }
-    // A dynamically-shaped privatization is materialized as a strided view whose
-    // type does not reveal its parallel scope. Keep its own par_dims active so
-    // the view is materialized (and predicated) per owning thread/block.
-    // Statically-shaped privatizations are left to the stack-fit decision
-    // so only do this for dynamic shapes.
+    // A dynamically-shaped privatization is materialized as a strided view
+    // whose type does not reveal its parallel scope. Keep its own par_dims
+    // active so the view is materialized (and predicated) per owning
+    // thread/block. Statically-shaped privatizations are left to the stack-fit
+    // decision so only do this for dynamic shapes.
     acc::PrivateType privTy =
         cast<acc::PrivateType>(privateLocalOp.getPrivatized().getType());
     MemRefType baseTy = getPrivateBaseMemRefType(
@@ -3021,10 +3021,9 @@ void ACCCGToGPULowering::createGPUAllReduceOp(
   // value on all threads, so each can safely store to its own copy.
   // Detect per-thread storage by walking through conversion ops to
   // find the underlying allocation.
-  bool isPerThreadPrivate =
-      isPerThreadPrivateTarget ||
-      isa_and_nonnull<memref::AllocaOp>(
-          unwrapMemRefConversion(memref).getDefiningOp());
+  bool isPerThreadPrivate = isPerThreadPrivateTarget ||
+                            isa_and_nonnull<memref::AllocaOp>(
+                                unwrapMemRefConversion(memref).getDefiningOp());
   // combine
   scf::IfOp ifOp;
   if (predicate && !isPerThreadPrivate) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -62,3 +62,75 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
   acc.copyout accPtr(%0 : memref<2xi32>) to varPtr(%arg0 : memref<2xi32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
   return
 }
+
+// CHECK-LABEL: func.func @array_reduction_small_shared
+// CHECK: memref.alloc() : memref<2xi32>
+// CHECK-NOT: gpu.all_reduce
+// CHECK-NOT: acc.reduction_accumulate_array
+func.func @array_reduction_small_shared() {
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
+    %c2 = arith.constant 2 : index
+    %shared = memref.alloc() : memref<2xi32>
+    %bounds = acc.bounds extent(%c2 : index)
+    acc.reduction_accumulate_array %shared bounds(%bounds) <add>
+        : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+    memref.dealloc %shared : memref<2xi32>
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// CHECK-LABEL: func.func @array_reduction_strided_extent
+// CHECK: gpu.launch
+// CHECK: %[[LB:.*]] = arith.constant 1 : index
+// CHECK: %[[STEP:.*]] = arith.constant 2 : index
+// CHECK: %[[EXTENT:.*]] = arith.constant 3 : index
+// CHECK: %[[SPAN:.*]] = arith.muli %[[EXTENT]], %[[STEP]] : index
+// CHECK: %[[UB:.*]] = arith.addi %[[LB]], %[[SPAN]] : index
+// CHECK: scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]]
+func.func @array_reduction_strided_extent() {
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
+    %c1_b = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %local = memref.alloca() : memref<8xi32>
+    %bounds = acc.bounds lowerbound(%c1_b : index) extent(%c3 : index)
+        stride(%c2 : index)
+    acc.reduction_accumulate_array %local bounds(%bounds) <add>
+        : memref<8xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// A dynamically-shaped accumulator (a strided view whose type conveys no size)
+// is classified per-thread from par_dims: a thread dimension means per-thread
+// storage, so lowering emits the per-element gpu.all_reduce.
+//
+// CHECK-LABEL: func.func @array_reduction_dynamic_par_dims
+// CHECK: scf.for
+// CHECK: gpu.all_reduce add
+func.func @array_reduction_dynamic_par_dims(%buf: memref<?xi32>, %n: index) {
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg0 = %buf, %ext = %n) : (memref<?xi32>, index) {
+    %view = memref.reinterpret_cast %arg0 to offset: [0], sizes: [%ext], strides: [1]
+        : memref<?xi32> to memref<?xi32, strided<[1]>>
+    %bounds = acc.bounds extent(%ext : index)
+    acc.reduction_accumulate_array %view bounds(%bounds) <add>
+        : memref<?xi32, strided<[1]>>
+        {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}


### PR DESCRIPTION
Lowering an acc.reduction_accumulate_array to a per-element gpu.all_reduce is only valid when each thread owns its own accumulator copy. This was inferred from the memref's static size, which was wrong for dynamically-shaped accumulators and for storage seen through descriptor or strided views.

Per-thread accumulators that fit the local stack budget are materialized in stack memory; anything larger, or gang-scoped, is materialized in shared memory. Classify from that: a stack alloca (or a view over one) within the budget is per-thread, a shared allocation is block-shared, and a dynamically-shaped accumulator is classified from its par_dims. Materialization and predication follow the same rule, and writes to a privatization are recognized through views/casts so per-thread setup runs on every owning thread.