### PR TITLE
[clang] Match MSVC ABI for over-aligned base tail padding on Arm64

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -429,9 +429,9 @@ features cannot lower the translation-unit ABI level;
 #### Windows Support
 
 - Fixed a bug where Clang did not match the MSVC ABI on Arm64 when an
-  over-aligned, non-standard-layout base class is followed by another base
-  class. MSVC on Arm64 (but not Arm64EC or x64) reuses the tail padding of the
-  over-aligned base for the subsequent base; Clang now does the same.
+  over-aligned base class is followed by another base class. MSVC on Arm64 (but
+  not Arm64EC or x64) reuses the tail padding of the over-aligned base for the
+  subsequent base; Clang now does the same.
   ([#210174](https://github.com/llvm/llvm-project/issues/210174))
 
 #### LoongArch Support

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -428,6 +428,12 @@ features cannot lower the translation-unit ABI level;
 
 #### Windows Support
 
+- Fixed a bug where Clang did not match the MSVC ABI on Arm64 when an
+  over-aligned, non-standard-layout base class is followed by another base
+  class. MSVC on Arm64 (but not Arm64EC or x64) reuses the tail padding of the
+  over-aligned base for the subsequent base; Clang now does the same.
+  ([#210174](https://github.com/llvm/llvm-project/issues/210174))
+
 #### LoongArch Support
 
 #### RISC-V Support

--- a/clang/include/clang/AST/RecordLayout.h
+++ b/clang/include/clang/AST/RecordLayout.h
@@ -97,6 +97,12 @@ private:
     /// which is the alignment of the object without virtual bases.
     CharUnits NonVirtualAlignment;
 
+    /// NonRequiredNVAlignment - The non-virtual alignment (in chars) of an
+    /// object ignoring any over-alignment imposed via `alignas` /
+    /// `__declspec(align)` (i.e. the record's required alignment) on the record
+    /// or its bases.
+    CharUnits NonRequiredNVAlignment;
+
     /// PreferredNVAlignment - The preferred non-virtual alignment (in chars) of
     /// an object, which is the preferred alignment of the object without
     /// virtual bases.
@@ -164,6 +170,7 @@ private:
                   CharUnits datasize, ArrayRef<uint64_t> fieldoffsets,
                   CharUnits nonvirtualsize, CharUnits nonvirtualalignment,
                   CharUnits preferrednvalignment,
+                  CharUnits nonrequirednvalignment,
                   CharUnits SizeOfLargestEmptySubobject,
                   const CXXRecordDecl *PrimaryBase, bool IsPrimaryBaseVirtual,
                   const CXXRecordDecl *BaseSharingVBPtr,
@@ -220,6 +227,15 @@ public:
     assert(CXXInfo && "Record layout does not have C++ specific info!");
 
     return CXXInfo->NonVirtualAlignment;
+  }
+
+  /// getNonRequiredNVAlignment - Get the non-virtual alignment (in chars) of an
+  /// object ignoring over-alignment imposed via `alignas` / `__declspec(align)`
+  /// on the object or its bases. Only meaningful for the Microsoft ABI.
+  CharUnits getNonRequiredNVAlignment() const {
+    assert(CXXInfo && "Record layout does not have C++ specific info!");
+
+    return CXXInfo->NonRequiredNVAlignment;
   }
 
   /// getPreferredNVAlignment - Get the preferred non-virtual alignment (in

--- a/clang/lib/AST/RecordLayout.cpp
+++ b/clang/lib/AST/RecordLayout.cpp
@@ -57,7 +57,7 @@ ASTRecordLayout::ASTRecordLayout(
       PreferredAlignment(preferredAlignment),
       UnadjustedAlignment(unadjustedAlignment),
       RequiredAlignment(requiredAlignment),
-      CXXInfo(new(Ctx) CXXRecordLayoutInfo) {
+      CXXInfo(new (Ctx) CXXRecordLayoutInfo) {
   FieldOffsets.append(Ctx, fieldoffsets.begin(), fieldoffsets.end());
 
   CXXInfo->PrimaryBase.setPointer(PrimaryBase);

--- a/clang/lib/AST/RecordLayout.cpp
+++ b/clang/lib/AST/RecordLayout.cpp
@@ -48,16 +48,16 @@ ASTRecordLayout::ASTRecordLayout(
     CharUnits requiredAlignment, bool hasOwnVFPtr, bool hasExtendableVFPtr,
     CharUnits vbptroffset, CharUnits datasize, ArrayRef<uint64_t> fieldoffsets,
     CharUnits nonvirtualsize, CharUnits nonvirtualalignment,
-    CharUnits preferrednvalignment, CharUnits SizeOfLargestEmptySubobject,
-    const CXXRecordDecl *PrimaryBase, bool IsPrimaryBaseVirtual,
-    const CXXRecordDecl *BaseSharingVBPtr, bool EndsWithZeroSizedObject,
-    bool LeadsWithZeroSizedBase, const BaseOffsetsMapTy &BaseOffsets,
-    const VBaseOffsetsMapTy &VBaseOffsets)
+    CharUnits preferrednvalignment, CharUnits nonrequirednvalignment,
+    CharUnits SizeOfLargestEmptySubobject, const CXXRecordDecl *PrimaryBase,
+    bool IsPrimaryBaseVirtual, const CXXRecordDecl *BaseSharingVBPtr,
+    bool EndsWithZeroSizedObject, bool LeadsWithZeroSizedBase,
+    const BaseOffsetsMapTy &BaseOffsets, const VBaseOffsetsMapTy &VBaseOffsets)
     : Size(size), DataSize(datasize), Alignment(alignment),
       PreferredAlignment(preferredAlignment),
       UnadjustedAlignment(unadjustedAlignment),
       RequiredAlignment(requiredAlignment),
-      CXXInfo(new (Ctx) CXXRecordLayoutInfo) {
+      CXXInfo(new(Ctx) CXXRecordLayoutInfo) {
   FieldOffsets.append(Ctx, fieldoffsets.begin(), fieldoffsets.end());
 
   CXXInfo->PrimaryBase.setPointer(PrimaryBase);
@@ -65,6 +65,7 @@ ASTRecordLayout::ASTRecordLayout(
   CXXInfo->NonVirtualSize = nonvirtualsize;
   CXXInfo->NonVirtualAlignment = nonvirtualalignment;
   CXXInfo->PreferredNVAlignment = preferrednvalignment;
+  CXXInfo->NonRequiredNVAlignment = nonrequirednvalignment;
   CXXInfo->SizeOfLargestEmptySubobject = SizeOfLargestEmptySubobject;
   CXXInfo->BaseOffsets = BaseOffsets;
   CXXInfo->VBaseOffsets = VBaseOffsets;

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -2717,7 +2717,7 @@ MicrosoftRecordLayoutBuilder::getAdjustedElementInfo(
   // alignment attributes.
   auto TInfo =
       Context.getTypeInfoInChars(FD->getType()->getUnqualifiedDesugaredType());
-  ElementInfo Info{TInfo.Width, TInfo.Align};
+  ElementInfo Info{TInfo.Width, TInfo.Align, CharUnits::Zero()};
   // Respect align attributes on the field.
   CharUnits DirectFieldAlignment =
       Context.toCharUnitsFromBits(FD->getMaxAlignment());

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -2547,6 +2547,11 @@ struct MicrosoftRecordLayoutBuilder {
   struct ElementInfo {
     CharUnits Size;
     CharUnits Alignment;
+    /// The alignment to use when updating the enclosing record's alignment.
+    /// This differs from Alignment only on targets that reuse over-aligned tail
+    /// padding, where over-alignment applied directly to a field must not raise
+    /// the record's alignment (only its required alignment).
+    CharUnits NonRequiredAlignment;
   };
   typedef llvm::DenseMap<const CXXRecordDecl *, CharUnits> BaseOffsetsMapTy;
   MicrosoftRecordLayoutBuilder(const ASTContext &Context,
@@ -2700,6 +2705,7 @@ MicrosoftRecordLayoutBuilder::getAdjustedElementInfo(
   Alignment = std::max(Alignment, BaseAlignment);
   RequiredAlignment = std::max(RequiredAlignment, Layout.getRequiredAlignment());
   Info.Alignment = std::max(Info.Alignment, Layout.getRequiredAlignment());
+  Info.NonRequiredAlignment = Info.Alignment;
   Info.Size = Layout.getNonVirtualSize();
   return Info;
 }
@@ -2713,35 +2719,54 @@ MicrosoftRecordLayoutBuilder::getAdjustedElementInfo(
       Context.getTypeInfoInChars(FD->getType()->getUnqualifiedDesugaredType());
   ElementInfo Info{TInfo.Width, TInfo.Align};
   // Respect align attributes on the field.
-  CharUnits FieldRequiredAlignment =
+  CharUnits DirectFieldAlignment =
       Context.toCharUnitsFromBits(FD->getMaxAlignment());
+  // The portion of the field's required alignment that comes from its type
+  // rather than from over-alignment applied directly to the field.
+  CharUnits FieldTypeRequiredAlignment = CharUnits::Zero();
   // Respect align attributes on the type.
   if (Context.isAlignmentRequired(FD->getType()))
-    FieldRequiredAlignment = std::max(
-        Context.getTypeAlignInChars(FD->getType()), FieldRequiredAlignment);
+    FieldTypeRequiredAlignment = Context.getTypeAlignInChars(FD->getType());
   // Respect attributes applied to subobjects of the field.
   if (FD->isBitField())
     // For some reason __declspec align impacts alignment rather than required
     // alignment when it is applied to bitfields.
-    Info.Alignment = std::max(Info.Alignment, FieldRequiredAlignment);
+    Info.Alignment =
+        std::max(Info.Alignment,
+                 std::max(DirectFieldAlignment, FieldTypeRequiredAlignment));
   else {
     if (const auto *RT = FD->getType()
                              ->getBaseElementTypeUnsafe()
                              ->getAsCanonical<RecordType>()) {
       auto const &Layout = Context.getASTRecordLayout(RT->getDecl());
       EndsWithZeroSizedObject = Layout.endsWithZeroSizedObject();
-      FieldRequiredAlignment = std::max(FieldRequiredAlignment,
-                                        Layout.getRequiredAlignment());
+      FieldTypeRequiredAlignment =
+          std::max(FieldTypeRequiredAlignment, Layout.getRequiredAlignment());
     }
     // Capture required alignment as a side-effect.
-    RequiredAlignment = std::max(RequiredAlignment, FieldRequiredAlignment);
+    RequiredAlignment =
+        std::max(RequiredAlignment,
+                 std::max(DirectFieldAlignment, FieldTypeRequiredAlignment));
   }
   // Respect pragma pack, attribute pack and declspec align
   if (!MaxFieldAlignment.isZero())
     Info.Alignment = std::min(Info.Alignment, MaxFieldAlignment);
   if (FD->hasAttr<PackedAttr>())
     Info.Alignment = CharUnits::One();
-  Info.Alignment = std::max(Info.Alignment, FieldRequiredAlignment);
+  // The alignment used to update the record's alignment excludes over-alignment
+  // applied directly to the field; the alignment used for placement includes
+  // it.  On targets that don't reuse over-aligned tail padding the two are the
+  // same.
+  Info.NonRequiredAlignment =
+      std::max(Info.Alignment, FieldTypeRequiredAlignment);
+  Info.Alignment = std::max(Info.NonRequiredAlignment, DirectFieldAlignment);
+  // Bitfields are excluded: over-alignment applied directly to a bitfield
+  // raises the record's alignment (not its required alignment) and is immune to
+  // #pragma pack, so it must not be stripped here.  Stripping it would drop
+  // that alignment when #pragma pack clamps the bitfield's natural alignment
+  // below the over-alignment.
+  if (!reuseOveralignedBaseTailPadding() || FD->isBitField())
+    Info.NonRequiredAlignment = Info.Alignment;
   return Info;
 }
 
@@ -2994,7 +3019,7 @@ void MicrosoftRecordLayoutBuilder::layoutField(const FieldDecl *FD) {
   }
   LastFieldIsNonZeroWidthBitfield = false;
   ElementInfo Info = getAdjustedElementInfo(FD);
-  Alignment = std::max(Alignment, Info.Alignment);
+  Alignment = std::max(Alignment, Info.NonRequiredAlignment);
 
   const CXXRecordDecl *FieldClass = FD->getType()->getAsCXXRecordDecl();
   bool IsOverlappingEmptyField = FD->isPotentiallyOverlapping() &&
@@ -3073,7 +3098,7 @@ void MicrosoftRecordLayoutBuilder::layoutBitField(const FieldDecl *FD) {
         llvm::alignDown(FieldBitOffset, Context.toBits(Info.Alignment)) +
         Context.toBits(Info.Size));
     Size = std::max(Size, NewSize);
-    Alignment = std::max(Alignment, Info.Alignment);
+    Alignment = std::max(Alignment, Info.NonRequiredAlignment);
   } else if (IsUnion) {
     placeFieldAtOffset(CharUnits::Zero());
     Size = std::max(Size, Info.Size);
@@ -3085,7 +3110,7 @@ void MicrosoftRecordLayoutBuilder::layoutBitField(const FieldDecl *FD) {
         Context.toBits(DataSize) - RemainingBitsInField;
     placeFieldAtOffset(FieldOffset);
     Size = FieldOffset + Info.Size;
-    Alignment = std::max(Alignment, Info.Alignment);
+    Alignment = std::max(Alignment, Info.NonRequiredAlignment);
     RemainingBitsInField = Context.toBits(Info.Size) - Width;
     ::CheckFieldPadding(Context, IsUnion, Context.toBits(FieldOffset),
                         UnpaddedFieldOffsetInBits, FD);
@@ -3117,7 +3142,7 @@ MicrosoftRecordLayoutBuilder::layoutZeroWidthBitField(const FieldDecl *FD) {
     placeFieldAtOffset(FieldOffset);
     RemainingBitsInField = 0;
     Size = FieldOffset;
-    Alignment = std::max(Alignment, Info.Alignment);
+    Alignment = std::max(Alignment, Info.NonRequiredAlignment);
     ::CheckFieldPadding(Context, IsUnion, Context.toBits(FieldOffset),
                         UnpaddedFieldOffsetInBits, FD);
   }

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -2590,6 +2590,13 @@ public:
   /// __declspec(align) into account.  It also updates RequiredAlignment as a
   /// side effect because it is most convenient to do so here.
   ElementInfo getAdjustedElementInfo(const FieldDecl *FD);
+  /// Returns true if this target reuses the tail padding of an over-aligned
+  /// base class for a subsequent base.  MSVC does this on Arm64, but not on
+  /// Arm64EC (which follows the x64 layout rules) or x64.
+  bool reuseOveralignedBaseTailPadding() const {
+    const llvm::Triple &Triple = Context.getTargetInfo().getTriple();
+    return Triple.isAArch64() && !Triple.isWindowsArm64EC();
+  }
   /// Places a field at an offset in CharUnits.
   void placeFieldAtOffset(CharUnits FieldOffset) {
     FieldOffsets.push_back(Context.toBits(FieldOffset));
@@ -2618,6 +2625,9 @@ public:
   /// The alignment that this record must obey.  This is imposed by
   /// __declspec(align()) on the record itself or one of its fields or bases.
   CharUnits RequiredAlignment;
+  /// The alignment of the record ignoring any over-alignment imposed via
+  /// __declspec(align()) / alignas on the record or its bases.
+  CharUnits NonRequiredAlignment;
   /// The size of the allocation of the currently active bitfield.
   /// This value isn't meaningful unless LastFieldIsNonZeroWidthBitfield
   /// is true.
@@ -2678,7 +2688,16 @@ MicrosoftRecordLayoutBuilder::getAdjustedElementInfo(
   // Respect required alignment, this is necessary because we may have adjusted
   // the alignment in the case of pragma pack.  Note that the required alignment
   // doesn't actually apply to the struct alignment at this point.
-  Alignment = std::max(Alignment, Info.Alignment);
+  // When reusing a base's tail padding, fold in the base's alignment ignoring
+  // any over-alignment it imposes, so that over-alignment contributes to the
+  // record's size but not to the alignment its tail padding is rounded to.
+  CharUnits BaseAlignment = Info.Alignment;
+  if (reuseOveralignedBaseTailPadding()) {
+    BaseAlignment = Layout.getNonRequiredNVAlignment();
+    if (!MaxFieldAlignment.isZero())
+      BaseAlignment = std::min(BaseAlignment, MaxFieldAlignment);
+  }
+  Alignment = std::max(Alignment, BaseAlignment);
   RequiredAlignment = std::max(RequiredAlignment, Layout.getRequiredAlignment());
   Info.Alignment = std::max(Info.Alignment, Layout.getRequiredAlignment());
   Info.Size = Layout.getNonVirtualSize();
@@ -2764,6 +2783,7 @@ void MicrosoftRecordLayoutBuilder::initializeLayout(const RecordDecl *RD) {
   IsUnion = RD->isUnion();
   Size = CharUnits::Zero();
   Alignment = CharUnits::One();
+  NonRequiredAlignment = CharUnits::One();
   // In 64-bit mode we always perform an alignment step after laying out vbases.
   // In 32-bit mode we do not.  The check to see if we need to perform alignment
   // checks the RequiredAlignment field and performs alignment if it isn't 0.
@@ -3235,6 +3255,10 @@ void MicrosoftRecordLayoutBuilder::finalizeLayout(const RecordDecl *RD) {
   // Respect required alignment.  Note that in 32-bit mode Required alignment
   // may be 0 and cause size not to be updated.
   DataSize = Size;
+  // Capture the alignment before folding in the required alignment; this is the
+  // record's alignment ignoring any over-alignment imposed via alignas /
+  // __declspec(align).
+  NonRequiredAlignment = Alignment;
   if (!RequiredAlignment.isZero()) {
     Alignment = std::max(Alignment, RequiredAlignment);
     auto RoundingAlignment = Alignment;
@@ -3406,10 +3430,10 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
           Builder.Alignment, Builder.RequiredAlignment, Builder.HasOwnVFPtr,
           Builder.HasOwnVFPtr || Builder.PrimaryBase, Builder.VBPtrOffset,
           Builder.DataSize, Builder.FieldOffsets, Builder.NonVirtualSize,
-          Builder.Alignment, Builder.Alignment, CharUnits::Zero(),
-          Builder.PrimaryBase, false, Builder.SharedVBPtrBase,
-          Builder.EndsWithZeroSizedObject, Builder.LeadsWithZeroSizedBase,
-          Builder.Bases, Builder.VBases);
+          Builder.Alignment, Builder.Alignment, Builder.NonRequiredAlignment,
+          CharUnits::Zero(), Builder.PrimaryBase, false,
+          Builder.SharedVBPtrBase, Builder.EndsWithZeroSizedObject,
+          Builder.LeadsWithZeroSizedBase, Builder.Bases, Builder.VBases);
     } else {
       MicrosoftRecordLayoutBuilder Builder(*this, /*EmptySubobjects=*/nullptr);
       Builder.layout(D);
@@ -3442,7 +3466,7 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
           Builder.Alignment, Builder.HasOwnVFPtr, RD->isDynamicClass(),
           CharUnits::fromQuantity(-1), DataSize, Builder.FieldOffsets,
           NonVirtualSize, Builder.NonVirtualAlignment,
-          Builder.PreferredNVAlignment,
+          Builder.PreferredNVAlignment, Builder.NonVirtualAlignment,
           EmptySubobjects.SizeOfLargestEmptySubobject, Builder.PrimaryBase,
           Builder.PrimaryBaseIsVirtual, nullptr, false, false, Builder.Bases,
           Builder.VBases);

--- a/clang/test/Layout/ms-arm64-aligned-base-tail-padding.cpp
+++ b/clang/test/Layout/ms-arm64-aligned-base-tail-padding.cpp
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -fno-rtti -triple aarch64-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN:            | FileCheck %s -check-prefix CHECK-ARM64
+// RUN: %clang_cc1 -fno-rtti -triple arm64ec-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN:            | FileCheck %s -check-prefix CHECK-X64
+// RUN: %clang_cc1 -fno-rtti -triple x86_64-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN:            | FileCheck %s -check-prefix CHECK-X64
+
+// On Arm64 (but not Arm64EC or x64), MSVC reuses the tail padding of an
+// over-aligned base class for a subsequent base class.
+
+struct alignas(16) Type {
+  long long a, b, c;
+};
+struct Empty {};
+struct Mid : Type {};
+struct Node { void *next; };
+
+// The over-aligned base's tail padding is reused for the following base only on
+// Arm64.
+struct Derived : Mid, Node {};
+
+int a = sizeof(Derived);
+
+// CHECK-ARM64-LABEL:  0 | struct Derived
+// CHECK-ARM64-NEXT:   0 |   struct Mid (base)
+// CHECK-ARM64-NEXT:   0 |     struct Type (base)
+// CHECK-ARM64:       24 |   struct Node (base)
+// CHECK-ARM64-NEXT:  24 |     void * next
+// CHECK-ARM64-NEXT:     | [sizeof=32, align=16,
+// CHECK-ARM64-NEXT:     |  nvsize=32, nvalign=16]
+
+// CHECK-X64-LABEL:  0 | struct Derived
+// CHECK-X64-NEXT:   0 |   struct Mid (base)
+// CHECK-X64-NEXT:   0 |     struct Type (base)
+// CHECK-X64:       32 |   struct Node (base)
+// CHECK-X64-NEXT:  32 |     void * next
+// CHECK-X64-NEXT:     | [sizeof=48, align=16,
+// CHECK-X64-NEXT:     |  nvsize=48, nvalign=16]

--- a/clang/test/Layout/ms-arm64-aligned-base-tail-padding.cpp
+++ b/clang/test/Layout/ms-arm64-aligned-base-tail-padding.cpp
@@ -1,17 +1,17 @@
-// RUN: %clang_cc1 -fno-rtti -triple aarch64-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN: %clang_cc1 -fno-rtti -fms-extensions -triple aarch64-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
 // RUN:            | FileCheck %s -check-prefix CHECK-ARM64
-// RUN: %clang_cc1 -fno-rtti -triple arm64ec-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN: %clang_cc1 -fno-rtti -fms-extensions -triple arm64ec-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
 // RUN:            | FileCheck %s -check-prefix CHECK-X64
-// RUN: %clang_cc1 -fno-rtti -triple x86_64-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN: %clang_cc1 -fno-rtti -fms-extensions -triple x86_64-windows-msvc -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
 // RUN:            | FileCheck %s -check-prefix CHECK-X64
 
 // On Arm64 (but not Arm64EC or x64), MSVC reuses the tail padding of an
-// over-aligned base class for a subsequent base class.
+// over-aligned base class for a subsequent base class.  This holds whether the
+// over-alignment comes from the record itself or from one of its fields.
 
 struct alignas(16) Type {
   long long a, b, c;
 };
-struct Empty {};
 struct Mid : Type {};
 struct Node { void *next; };
 
@@ -36,3 +36,72 @@ int a = sizeof(Derived);
 // CHECK-X64-NEXT:  32 |     void * next
 // CHECK-X64-NEXT:     | [sizeof=48, align=16,
 // CHECK-X64-NEXT:     |  nvsize=48, nvalign=16]
+
+// The over-alignment can also come from `alignas` on an individual field rather
+// than from the record itself; the tail padding is reused the same way.
+struct FieldOver {
+  alignas(16) long long a;
+  long long b, c;
+};
+struct FieldMid : FieldOver {};
+struct FieldDerived : FieldMid, Node {};
+
+int b = sizeof(FieldDerived);
+
+// CHECK-ARM64-LABEL:  0 | struct FieldDerived
+// CHECK-ARM64-NEXT:   0 |   struct FieldMid (base)
+// CHECK-ARM64-NEXT:   0 |     struct FieldOver (base)
+// CHECK-ARM64:       24 |   struct Node (base)
+// CHECK-ARM64-NEXT:  24 |     void * next
+// CHECK-ARM64-NEXT:     | [sizeof=32, align=16,
+// CHECK-ARM64-NEXT:     |  nvsize=32, nvalign=16]
+
+// CHECK-X64-LABEL:  0 | struct FieldDerived
+// CHECK-X64-NEXT:   0 |   struct FieldMid (base)
+// CHECK-X64-NEXT:   0 |     struct FieldOver (base)
+// CHECK-X64:       32 |   struct Node (base)
+// CHECK-X64-NEXT:  32 |     void * next
+// CHECK-X64-NEXT:     | [sizeof=48, align=16,
+// CHECK-X64-NEXT:     |  nvsize=48, nvalign=16]
+
+// Reusing tail padding must not affect placement of an over-aligned base that
+// follows another base: padding is still inserted so it lands at its required
+// alignment.
+struct PadBefore : Node, Type {};
+
+int c = sizeof(PadBefore);
+
+// CHECK-ARM64-LABEL:  0 | struct PadBefore
+// CHECK-ARM64-NEXT:   0 |   struct Node (base)
+// CHECK-ARM64-NEXT:   0 |     void * next
+// CHECK-ARM64-NEXT:  16 |   struct Type (base)
+// CHECK-ARM64:          | [sizeof=48, align=16,
+
+// CHECK-X64-LABEL:  0 | struct PadBefore
+// CHECK-X64-NEXT:   0 |   struct Node (base)
+// CHECK-X64-NEXT:   0 |     void * next
+// CHECK-X64-NEXT:  16 |   struct Type (base)
+// CHECK-X64:          | [sizeof=48, align=16,
+
+// Over-alignment applied directly to a bitfield via __declspec(align) raises
+// the record's alignment (rather than its required alignment) and is immune to
+// #pragma pack.  The over-aligned base tail-padding reuse above does not apply
+// to bitfields, so this is left unchanged by that transformation and is handled
+// identically on every target.
+#pragma pack(2)
+struct BitfieldAlign {
+  __declspec(align(16)) long long a : 8;
+};
+#pragma pack()
+
+int d = sizeof(BitfieldAlign);
+
+// CHECK-ARM64-LABEL:      0 | struct BitfieldAlign
+// CHECK-ARM64-NEXT:   0:0-7 |   long long a
+// CHECK-ARM64-NEXT:         | [sizeof=8, align=16,
+// CHECK-ARM64-NEXT:         |  nvsize=8, nvalign=16]
+
+// CHECK-X64-LABEL:      0 | struct BitfieldAlign
+// CHECK-X64-NEXT:   0:0-7 |   long long a
+// CHECK-X64-NEXT:         | [sizeof=8, align=16,
+// CHECK-X64-NEXT:         |  nvsize=8, nvalign=16]


### PR DESCRIPTION
When targeting aarch64-pc-windows-msvc, clang laid out a base following an over-aligned, non-standard-layout base at the wrong offset. MSVC on Arm64 reuses the over-aligned base's tail padding for the subsequent base, but clang rounded the base up to a full slot, so the two disagreed on member offsets, breaking interop between clang- and MSVC-built binaries.

Fix: store each record's natural non-virtual alignment (excluding `alignas`/`__declspec(align)` over-alignment) as `getNonRequiredNVAlignment()`, and on Arm64 fold in a base's natural alignment rather than its full alignment. This is gated to Arm64 only; Arm64EC and x64 follow the x64 rule (no reuse) and are unchanged.

Validated against MSVC (Hostx64\arm64\cl.exe /d1reportSingleClassLayout): clang now matches MSVC Arm64 exactly for the reduced repro, the original polymorphic case (vftable + empty base + template), and a range of probe cases covering natural vs. over-alignment padding and field vs. base reuse. Arm64EC and x64 output is byte-identical to before.

Fixes #210174