### PR TITLE
[SCEV] Reach MatchRangeCheckIdiom through zext in LoopGuards worklist

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -16114,6 +16114,9 @@ void ScalarEvolution::LoopGuards::collectFromBlock(
     //  'max(a, b) <= c'   ->   '(a <= c) and (b <= c)',
     //  'max(a, b) <  c'   ->   '(a <  c) and (b <  c)'.
 
+    // Preserve the original RHS before it is adjusted by the switch below.
+    const SCEV *OrigRHS = RHS;
+
     // We cannot express strict predicates in SCEV, so instead we replace them
     // with non-strict ones against plus or minus one of RHS depending on the
     // predicate.
@@ -16153,12 +16156,34 @@ void ScalarEvolution::LoopGuards::collectFromBlock(
       append_range(Worklist, S->operands());
     };
 
+    // Look through `zext(X) <upred> RHS` and retry the idiom in X's type
+    // when truncating RHS is lossless.
+    auto TryMatchIdiomThroughZExt = [&](const SCEV *From) {
+      const SCEV *X;
+      if (!ICmpInst::isUnsigned(Predicate) ||
+          !match(From, m_scev_ZExt(m_SCEV(X))))
+        return false;
+
+      // The rewrite is only valid if truncating RHS is lossless,
+      // i.e. every possible value of RHS fits in X's type.
+      unsigned NarrowBits = SE.getTypeSizeInBits(X->getType());
+      if (SE.getUnsignedRange(OrigRHS).getActiveBits() > NarrowBits)
+        return false;
+
+      const SCEV *NarrowRHS = SE.getTruncateExpr(OrigRHS, X->getType());
+      return MatchRangeCheckIdiom(Predicate, X, NarrowRHS);
+    };
+
     while (!Worklist.empty()) {
       const SCEV *From = Worklist.pop_back_val();
       if (isa<SCEVConstant>(From))
         continue;
       if (!Visited.insert(From).second)
         continue;
+
+      if (TryMatchIdiomThroughZExt(From))
+        continue;
+
       const SCEV *FromRewritten = GetMaybeRewritten(From);
       const SCEV *To = nullptr;
 

--- a/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
+++ b/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
@@ -1700,7 +1700,7 @@ exit:
   ret void
 }
 
-; TODO: The guard `zext i32 (-1 + %len) to i64 ult 4` implies that
+; The guard `zext i32 (-1 + %len) to i64 ult 4` implies that
 ; `%len` is in [1, 5).
 define void @range_check_idiom_through_zext(i32 %len) {
 ; CHECK-LABEL: 'range_check_idiom_through_zext'
@@ -1710,12 +1710,12 @@ define void @range_check_idiom_through_zext(i32 %len) {
 ; CHECK-NEXT:    %len.wide = zext i32 %len.off to i64
 ; CHECK-NEXT:    --> (zext i32 (-1 + %len) to i64) U: [0,4294967296) S: [0,4294967296)
 ; CHECK-NEXT:    %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
-; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,-2147483648) S: [0,-2147483648) Exits: (-1 + %len) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,4) S: [0,4) Exits: (-1 + %len) LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:    %iv.next = add nuw nsw i32 %iv, 1
-; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,-2147483648) S: [1,-2147483648) Exits: %len LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,5) S: [1,5) Exits: %len LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:  Determining loop execution counts for: @range_check_idiom_through_zext
 ; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + %len)
-; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 -2
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 3
 ; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + %len)
 ; CHECK-NEXT:  Loop %loop: Trip multiple is 1
 ;


### PR DESCRIPTION
For unsigned guards of the form `zext(X) <upred> RHS`, retry the idiom
on `(X, trunc(RHS))` when `RHS` fits in the narrow type.

Related to https://github.com/llvm/llvm-project/issues/208778

Alive2 proof: https://alive2.llvm.org/ce/z/zcdv_2

Built on top of: https://github.com/llvm/llvm-project/pull/210387