### PR TITLE
[clang-tidy][docs] Rewrite short check docs to Markdown

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/cleanup-ctad.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/cleanup-ctad.md
@@ -7,7 +7,7 @@ Suggests switching the initialization pattern of `absl::Cleanup`
 instances from the factory function to class template argument
 deduction (CTAD), in C++17 and higher.
 
-```c++
+```cpp
 auto c1 = absl::MakeCleanup([] {});
 
 const auto c2 = absl::MakeCleanup(std::function<void()>([] {}));
@@ -15,9 +15,8 @@ const auto c2 = absl::MakeCleanup(std::function<void()>([] {}));
 
 becomes
 
-```c++
+```cpp
 absl::Cleanup c1 = [] {};
 
 const absl::Cleanup c2 = std::function<void()>([] {});
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/cleanup-ctad.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/cleanup-ctad.md
@@ -1,22 +1,23 @@
-.. title:: clang-tidy - abseil-cleanup-ctad
+```{title} clang-tidy - abseil-cleanup-ctad
+```
 
-abseil-cleanup-ctad
-===================
+# abseil-cleanup-ctad
 
-Suggests switching the initialization pattern of ``absl::Cleanup``
+Suggests switching the initialization pattern of `absl::Cleanup`
 instances from the factory function to class template argument
 deduction (CTAD), in C++17 and higher.
 
-.. code-block:: c++
+```c++
+auto c1 = absl::MakeCleanup([] {});
 
-  auto c1 = absl::MakeCleanup([] {});
-
-  const auto c2 = absl::MakeCleanup(std::function<void()>([] {}));
+const auto c2 = absl::MakeCleanup(std::function<void()>([] {}));
+```
 
 becomes
 
-.. code-block:: c++
+```c++
+absl::Cleanup c1 = [] {};
 
-  absl::Cleanup c1 = [] {};
+const absl::Cleanup c2 = std::function<void()>([] {});
+```
 
-  const absl::Cleanup c2 = std::function<void()>([] {});

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-addition.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-addition.md
@@ -10,7 +10,7 @@ of a similar scale, and make that inference explicit.
 
 Examples:
 
-```c++
+```cpp
 // Original - Addition in the integer domain
 int x;
 absl::Time t;
@@ -19,4 +19,3 @@ int result = absl::ToUnixSeconds(t) + x;
 // Suggestion - Addition in the absl::Time domain
 int result = absl::ToUnixSeconds(t + absl::Seconds(x));
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-addition.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-addition.md
@@ -1,21 +1,22 @@
-.. title:: clang-tidy - abseil-duration-addition
+```{title} clang-tidy - abseil-duration-addition
+```
 
-abseil-duration-addition
-========================
+# abseil-duration-addition
 
-Checks for cases where addition should be performed in the ``absl::Time``
-domain. When adding two values, and one is known to be an ``absl::Time``,
-we can infer that the other should be interpreted as an ``absl::Duration``
+Checks for cases where addition should be performed in the `absl::Time`
+domain. When adding two values, and one is known to be an `absl::Time`,
+we can infer that the other should be interpreted as an `absl::Duration`
 of a similar scale, and make that inference explicit.
 
 Examples:
 
-.. code-block:: c++
+```c++
+// Original - Addition in the integer domain
+int x;
+absl::Time t;
+int result = absl::ToUnixSeconds(t) + x;
 
-  // Original - Addition in the integer domain
-  int x;
-  absl::Time t;
-  int result = absl::ToUnixSeconds(t) + x;
+// Suggestion - Addition in the absl::Time domain
+int result = absl::ToUnixSeconds(t + absl::Seconds(x));
+```
 
-  // Suggestion - Addition in the absl::Time domain
-  int result = absl::ToUnixSeconds(t + absl::Seconds(x));

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-factory-float.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-factory-float.md
@@ -13,7 +13,7 @@ superfluous casts.
 
 Examples:
 
-```c++
+```cpp
 // Original - Providing a floating-point literal.
 absl::Duration d = absl::Seconds(10.0);
 
@@ -27,4 +27,3 @@ absl::Duration d = absl::Seconds(static_cast<double>(10));
 // Suggested - Remove the explicit cast
 absl::Duration d = absl::Seconds(10);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-factory-float.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/duration-factory-float.md
@@ -1,10 +1,10 @@
-.. title:: clang-tidy - abseil-duration-factory-float
+```{title} clang-tidy - abseil-duration-factory-float
+```
 
-abseil-duration-factory-float
-=============================
+# abseil-duration-factory-float
 
 Checks for cases where the floating-point overloads of various
-``absl::Duration`` factory functions are called when the more-efficient
+`absl::Duration` factory functions are called when the more-efficient
 integer versions could be used instead.
 
 This check will not suggest fixes for literals which contain fractional
@@ -13,17 +13,18 @@ superfluous casts.
 
 Examples:
 
-.. code-block:: c++
+```c++
+// Original - Providing a floating-point literal.
+absl::Duration d = absl::Seconds(10.0);
 
-  // Original - Providing a floating-point literal.
-  absl::Duration d = absl::Seconds(10.0);
-
-  // Suggested - Use an integer instead.
-  absl::Duration d = absl::Seconds(10);
+// Suggested - Use an integer instead.
+absl::Duration d = absl::Seconds(10);
 
 
-  // Original - Explicitly casting to a floating-point type.
-  absl::Duration d = absl::Seconds(static_cast<double>(10));
+// Original - Explicitly casting to a floating-point type.
+absl::Duration d = absl::Seconds(static_cast<double>(10));
 
-  // Suggested - Remove the explicit cast
-  absl::Duration d = absl::Seconds(10);
+// Suggested - Remove the explicit cast
+absl::Duration d = absl::Seconds(10);
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/no-internal-dependencies.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/no-internal-dependencies.md
@@ -12,7 +12,7 @@ compatibility guidelines and may result in breakage. See
 
 The following cases will result in warnings:
 
-```c++
+```cpp
 absl::strings_internal::foo();
 // warning triggered on this line
 class foo {
@@ -22,4 +22,3 @@ class foo {
 absl::memory_internal::MakeUniqueResult();
 // warning triggered on this line
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/no-internal-dependencies.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/no-internal-dependencies.md
@@ -1,24 +1,25 @@
-.. title:: clang-tidy - abseil-no-internal-dependencies
+```{title} clang-tidy - abseil-no-internal-dependencies
+```
 
-abseil-no-internal-dependencies
-===============================
+# abseil-no-internal-dependencies
 
 Warns if code using Abseil depends on internal details. If something is in a
 namespace that includes the word "internal", code is not allowed to depend upon
 it because it's an implementation detail. They cannot friend it, include it,
 you mention it or refer to it in any way. Doing so violates Abseil's
 compatibility guidelines and may result in breakage. See
-https://abseil.io/about/compatibility for more information.
+<https://abseil.io/about/compatibility> for more information.
 
 The following cases will result in warnings:
 
-.. code-block:: c++
+```c++
+absl::strings_internal::foo();
+// warning triggered on this line
+class foo {
+  friend struct absl::container_internal::faa;
+  // warning triggered on this line
+};
+absl::memory_internal::MakeUniqueResult();
+// warning triggered on this line
+```
 
-  absl::strings_internal::foo();
-  // warning triggered on this line
-  class foo {
-    friend struct absl::container_internal::faa;
-    // warning triggered on this line
-  };
-  absl::memory_internal::MakeUniqueResult();
-  // warning triggered on this line

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/no-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/no-namespace.md
@@ -9,7 +9,7 @@ conflicts with Abseil's compatibility guidelines and may result in breakage.
 
 Any code that uses:
 
-```c++
+```cpp
 namespace absl {
  ...
 }
@@ -18,4 +18,3 @@ namespace absl {
 will be prompted with a warning.
 
 See [the full Abseil compatibility guidelines](https://abseil.io/about/compatibility) for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/no-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/no-namespace.md
@@ -1,21 +1,21 @@
-.. title:: clang-tidy - abseil-no-namespace
+```{title} clang-tidy - abseil-no-namespace
+```
 
-abseil-no-namespace
-===================
+# abseil-no-namespace
 
-Ensures code does not open ``namespace absl`` as that violates Abseil's
-compatibility guidelines. Code should not open ``namespace absl`` as that
+Ensures code does not open `namespace absl` as that violates Abseil's
+compatibility guidelines. Code should not open `namespace absl` as that
 conflicts with Abseil's compatibility guidelines and may result in breakage.
 
 Any code that uses:
 
-.. code-block:: c++
-
- namespace absl {
-  ...
- }
+```c++
+namespace absl {
+ ...
+}
+```
 
 will be prompted with a warning.
 
-See `the full Abseil compatibility guidelines <https://
-abseil.io/about/compatibility>`_ for more information.
+See [the full Abseil compatibility guidelines](https://abseil.io/about/compatibility) for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/redundant-strcat-calls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/redundant-strcat-calls.md
@@ -11,7 +11,7 @@ them makes the code smaller and faster.
 
 Examples:
 
-```c++
+```cpp
 std::string s = absl::StrCat("A", absl::StrCat("B", absl::StrCat("C", "D")));
 //before
 
@@ -24,4 +24,3 @@ absl::StrAppend(&s, absl::StrCat("E", "F", "G"));
 absl::StrAppend(&s, "E", "F", "G");
 //after
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/redundant-strcat-calls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/redundant-strcat-calls.md
@@ -1,26 +1,27 @@
-.. title:: clang-tidy - abseil-redundant-strcat-calls
+```{title} clang-tidy - abseil-redundant-strcat-calls
+```
 
-abseil-redundant-strcat-calls
-=============================
+# abseil-redundant-strcat-calls
 
-Suggests removal of unnecessary calls to ``absl::StrCat`` when the result is
-being passed to another call to ``absl::StrCat`` or ``absl::StrAppend``.
+Suggests removal of unnecessary calls to `absl::StrCat` when the result is
+being passed to another call to `absl::StrCat` or `absl::StrAppend`.
 
 The extra calls cause unnecessary temporary strings to be constructed. Removing
 them makes the code smaller and faster.
 
 Examples:
 
-.. code-block:: c++
+```c++
+std::string s = absl::StrCat("A", absl::StrCat("B", absl::StrCat("C", "D")));
+//before
 
-  std::string s = absl::StrCat("A", absl::StrCat("B", absl::StrCat("C", "D")));
-  //before
+std::string s = absl::StrCat("A", "B", "C", "D");
+//after
 
-  std::string s = absl::StrCat("A", "B", "C", "D");
-  //after
+absl::StrAppend(&s, absl::StrCat("E", "F", "G"));
+//before
 
-  absl::StrAppend(&s, absl::StrCat("E", "F", "G"));
-  //before
+absl::StrAppend(&s, "E", "F", "G");
+//after
+```
 
-  absl::StrAppend(&s, "E", "F", "G");
-  //after

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/str-cat-append.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/str-cat-append.md
@@ -9,10 +9,9 @@ Flags uses of `absl::StrCat()` to append to a `std::string`. Suggests
 The extra calls cause unnecessary temporary strings to be constructed. Removing
 them makes the code smaller and faster.
 
-```c++
+```cpp
 a = absl::StrCat(a, b); // Use absl::StrAppend(&a, b) instead.
 ```
 
 Does not diagnose cases where `absl::StrCat()` is used as a template
 argument for a functor.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/str-cat-append.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/str-cat-append.md
@@ -1,17 +1,18 @@
-.. title:: clang-tidy - abseil-str-cat-append
+```{title} clang-tidy - abseil-str-cat-append
+```
 
-abseil-str-cat-append
-=====================
+# abseil-str-cat-append
 
-Flags uses of ``absl::StrCat()`` to append to a ``std::string``. Suggests
-``absl::StrAppend()`` should be used instead.
+Flags uses of `absl::StrCat()` to append to a `std::string`. Suggests
+`absl::StrAppend()` should be used instead.
 
 The extra calls cause unnecessary temporary strings to be constructed. Removing
 them makes the code smaller and faster.
 
-.. code-block:: c++
+```c++
+a = absl::StrCat(a, b); // Use absl::StrAppend(&a, b) instead.
+```
 
-  a = absl::StrCat(a, b); // Use absl::StrAppend(&a, b) instead.
-
-Does not diagnose cases where ``absl::StrCat()`` is used as a template
+Does not diagnose cases where `absl::StrCat()` is used as a template
 argument for a functor.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/time-comparison.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/time-comparison.md
@@ -12,7 +12,7 @@ practice this is very rare, and still indicates a bug which should be fixed.
 
 Examples:
 
-```c++
+```cpp
 // Original - Comparison in the integer domain
 int x;
 absl::Time t;
@@ -21,4 +21,3 @@ if (x < absl::ToUnixSeconds(t)) ...
 // Suggested - Compare in the absl::Time domain instead
 if (absl::FromUnixSeconds(x) < t) ...
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/abseil/time-comparison.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/abseil/time-comparison.md
@@ -1,23 +1,24 @@
-.. title:: clang-tidy - abseil-time-comparison
+```{title} clang-tidy - abseil-time-comparison
+```
 
-abseil-time-comparison
-======================
+# abseil-time-comparison
 
-Prefer comparisons in the ``absl::Time`` domain instead of the integer domain.
+Prefer comparisons in the `absl::Time` domain instead of the integer domain.
 
-N.B.: In cases where an ``absl::Time`` is being converted to an integer,
+N.B.: In cases where an `absl::Time` is being converted to an integer,
 alignment may occur. If the comparison depends on this alignment, doing the
-comparison in the ``absl::Time`` domain may yield a different result. In
+comparison in the `absl::Time` domain may yield a different result. In
 practice this is very rare, and still indicates a bug which should be fixed.
 
 Examples:
 
-.. code-block:: c++
+```c++
+// Original - Comparison in the integer domain
+int x;
+absl::Time t;
+if (x < absl::ToUnixSeconds(t)) ...
 
-  // Original - Comparison in the integer domain
-  int x;
-  absl::Time t;
-  if (x < absl::ToUnixSeconds(t)) ...
+// Suggested - Compare in the absl::Time domain instead
+if (absl::FromUnixSeconds(x) < t) ...
+```
 
-  // Suggested - Compare in the absl::Time domain instead
-  if (absl::FromUnixSeconds(x) < t) ...

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/id-dependent-backward-branch.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/id-dependent-backward-branch.md
@@ -24,6 +24,4 @@ for (int i = 0; i < 100; ++i) {
 }
 ```
 
-Based on the [Altera SDK for OpenCL: Best Practices Guide][altera-guide].
-
-[altera-guide]: https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf
+Based on the [Altera SDK for OpenCL: Best Practices Guide](https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf).

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/id-dependent-backward-branch.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/id-dependent-backward-branch.md
@@ -6,7 +6,7 @@
 Finds ID-dependent variables and fields that are used within loops. This causes
 branches to occur inside the loops, and thus leads to performance degradation.
 
-```c++
+```cpp
 // The following code will produce a warning because this ID-dependent
 // variable is used in a loop condition statement.
 int ThreadID = get_local_id(0);
@@ -24,5 +24,6 @@ for (int i = 0; i < 100; ++i) {
 }
 ```
 
-Based on the [Altera SDK for OpenCL: Best Practices Guide](https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf).
+Based on the [Altera SDK for OpenCL: Best Practices Guide][altera-guide].
 
+[altera-guide]: https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/id-dependent-backward-branch.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/id-dependent-backward-branch.md
@@ -1,28 +1,28 @@
-.. title:: clang-tidy - altera-id-dependent-backward-branch
+```{title} clang-tidy - altera-id-dependent-backward-branch
+```
 
-altera-id-dependent-backward-branch
-===================================
+# altera-id-dependent-backward-branch
 
 Finds ID-dependent variables and fields that are used within loops. This causes
 branches to occur inside the loops, and thus leads to performance degradation.
 
-.. code-block:: c++
+```c++
+// The following code will produce a warning because this ID-dependent
+// variable is used in a loop condition statement.
+int ThreadID = get_local_id(0);
 
-  // The following code will produce a warning because this ID-dependent
-  // variable is used in a loop condition statement.
-  int ThreadID = get_local_id(0);
+// The following loop will produce a warning because the loop condition
+// statement depends on an ID-dependent variable.
+for (int i = 0; i < ThreadID; ++i) {
+  std::cout << i << std::endl;
+}
 
-  // The following loop will produce a warning because the loop condition
-  // statement depends on an ID-dependent variable.
-  for (int i = 0; i < ThreadID; ++i) {
-    std::cout << i << std::endl;
-  }
+// The following loop will not produce a warning, because the ID-dependent
+// variable is not used in the loop condition statement.
+for (int i = 0; i < 100; ++i) {
+  std::cout << ThreadID << std::endl;
+}
+```
 
-  // The following loop will not produce a warning, because the ID-dependent
-  // variable is not used in the loop condition statement.
-  for (int i = 0; i < 100; ++i) {
-    std::cout << ThreadID << std::endl;
-  }
+Based on the [Altera SDK for OpenCL: Best Practices Guide](https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf).
 
-Based on the `Altera SDK for OpenCL: Best Practices Guide
-<https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/kernel-name-restriction.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/kernel-name-restriction.md
@@ -10,6 +10,5 @@ Such kernel file names cause the offline compiler to generate intermediate
 design files that have the same names as certain internal files, which
 leads to a compilation error.
 
-Based on the `Guidelines for Naming the Kernel` section in the
+Based on the Guidelines for Naming the Kernel section in the
 [Intel FPGA SDK for OpenCL Pro Edition: Programming Guide](https://www.intel.com/content/www/us/en/programmable/documentation/mwh1391807965224.html#ewa1412973930963).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/altera/kernel-name-restriction.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/altera/kernel-name-restriction.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - altera-kernel-name-restriction
+```{title} clang-tidy - altera-kernel-name-restriction
+```
 
-altera-kernel-name-restriction
-==============================
+# altera-kernel-name-restriction
 
 Finds kernel files and include directives whose filename is `kernel.cl`,
 `Verilog.cl`, or `VHDL.cl`. The check is case insensitive.
@@ -11,5 +11,5 @@ design files that have the same names as certain internal files, which
 leads to a compilation error.
 
 Based on the `Guidelines for Naming the Kernel` section in the
-`Intel FPGA SDK for OpenCL Pro Edition: Programming Guide
-<https://www.intel.com/content/www/us/en/programmable/documentation/mwh1391807965224.html#ewa1412973930963>`_.
+[Intel FPGA SDK for OpenCL Pro Edition: Programming Guide](https://www.intel.com/content/www/us/en/programmable/documentation/mwh1391807965224.html#ewa1412973930963).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept.md
@@ -9,11 +9,10 @@ a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 accept(sockfd, addr, addrlen);
 
 // becomes
 
 accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - android-cloexec-accept
+```{title} clang-tidy - android-cloexec-accept
+```
 
-android-cloexec-accept
-======================
+# android-cloexec-accept
 
-The usage of ``accept()`` is not recommended, it's better to use ``accept4()``.
+The usage of `accept()` is not recommended, it's better to use `accept4()`.
 Without this flag, an opened sensitive file descriptor would remain open across
 a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+accept(sockfd, addr, addrlen);
 
-  accept(sockfd, addr, addrlen);
+// becomes
 
-  // becomes
+accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);
+```
 
-  accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept4.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept4.md
@@ -9,11 +9,10 @@ remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
 
 // becomes
 
 accept4(sockfd, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept4.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-accept4.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - android-cloexec-accept4
+```{title} clang-tidy - android-cloexec-accept4
+```
 
-android-cloexec-accept4
-=======================
+# android-cloexec-accept4
 
-``accept4()`` should include ``SOCK_CLOEXEC`` in its type argument to avoid the
+`accept4()` should include `SOCK_CLOEXEC` in its type argument to avoid the
 file descriptor leakage. Without this flag, an opened sensitive file would
 remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
 
-  accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
+// becomes
 
-  // becomes
+accept4(sockfd, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);
+```
 
-  accept4(sockfd, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-creat.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-creat.md
@@ -7,11 +7,10 @@ The usage of `creat()` is not recommended, it's better to use `open()`.
 
 Examples:
 
-```c++
+```cpp
 int fd = creat(path, mode);
 
 // becomes
 
 int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-creat.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-creat.md
@@ -1,16 +1,17 @@
-.. title:: clang-tidy - android-cloexec-creat
+```{title} clang-tidy - android-cloexec-creat
+```
 
-android-cloexec-creat
-=====================
+# android-cloexec-creat
 
-The usage of ``creat()`` is not recommended, it's better to use ``open()``.
+The usage of `creat()` is not recommended, it's better to use `open()`.
 
 Examples:
 
-.. code-block:: c++
+```c++
+int fd = creat(path, mode);
 
-  int fd = creat(path, mode);
+// becomes
 
-  // becomes
+int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);
+```
 
-  int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-dup.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-dup.md
@@ -9,11 +9,10 @@ remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 int fd = dup(oldfd);
 
 // becomes
 
 int fd = fcntl(oldfd, F_DUPFD_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-dup.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-dup.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - android-cloexec-dup
+```{title} clang-tidy - android-cloexec-dup
+```
 
-android-cloexec-dup
-===================
+# android-cloexec-dup
 
-The usage of ``dup()`` is not recommended, it's better to use ``fcntl()``,
+The usage of `dup()` is not recommended, it's better to use `fcntl()`,
 which can set the close-on-exec flag. Otherwise, an opened sensitive file would
 remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+int fd = dup(oldfd);
 
-  int fd = dup(oldfd);
+// becomes
 
-  // becomes
+int fd = fcntl(oldfd, F_DUPFD_CLOEXEC);
+```
 
-  int fd = fcntl(oldfd, F_DUPFD_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create.md
@@ -8,11 +8,10 @@ The usage of `epoll_create()` is not recommended, it's better to use
 
 Examples:
 
-```c++
+```cpp
 epoll_create(size);
 
 // becomes
 
 epoll_create1(EPOLL_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create.md
@@ -1,17 +1,18 @@
-.. title:: clang-tidy - android-cloexec-epoll-create
+```{title} clang-tidy - android-cloexec-epoll-create
+```
 
-android-cloexec-epoll-create
-============================
+# android-cloexec-epoll-create
 
-The usage of ``epoll_create()`` is not recommended, it's better to use
-``epoll_create1()``, which allows close-on-exec.
+The usage of `epoll_create()` is not recommended, it's better to use
+`epoll_create1()`, which allows close-on-exec.
 
 Examples:
 
-.. code-block:: c++
+```c++
+epoll_create(size);
 
-  epoll_create(size);
+// becomes
 
-  // becomes
+epoll_create1(EPOLL_CLOEXEC);
+```
 
-  epoll_create1(EPOLL_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create1.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create1.md
@@ -9,11 +9,10 @@ would remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 epoll_create1(0);
 
 // becomes
 
 epoll_create1(EPOLL_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create1.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-epoll-create1.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - android-cloexec-epoll-create1
+```{title} clang-tidy - android-cloexec-epoll-create1
+```
 
-android-cloexec-epoll-create1
-=============================
+# android-cloexec-epoll-create1
 
-``epoll_create1()`` should include ``EPOLL_CLOEXEC`` in its type argument to
+`epoll_create1()` should include `EPOLL_CLOEXEC` in its type argument to
 avoid the file descriptor leakage. Without this flag, an opened sensitive file
 would remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+epoll_create1(0);
 
-  epoll_create1(0);
+// becomes
 
-  // becomes
+epoll_create1(EPOLL_CLOEXEC);
+```
 
-  epoll_create1(EPOLL_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-fopen.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-fopen.md
@@ -4,15 +4,14 @@
 # android-cloexec-fopen
 
 `fopen()` should include `e` in their mode string; so `re` would be
-valid. This is equivalent to having set `FD_CLOEXEC on` that descriptor.
+valid. This is equivalent to having set `FD_CLOEXEC` on that descriptor.
 
 Examples:
 
-```c++
+```cpp
 fopen("fn", "r");
 
 // becomes
 
 fopen("fn", "re");
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-fopen.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-fopen.md
@@ -1,18 +1,18 @@
-.. title:: clang-tidy - android-cloexec-fopen
+```{title} clang-tidy - android-cloexec-fopen
+```
 
-android-cloexec-fopen
-=====================
+# android-cloexec-fopen
 
-``fopen()`` should include ``e`` in their mode string; so ``re`` would be
-valid. This is equivalent to having set ``FD_CLOEXEC on`` that descriptor.
+`fopen()` should include `e` in their mode string; so `re` would be
+valid. This is equivalent to having set `FD_CLOEXEC on` that descriptor.
 
 Examples:
 
-.. code-block:: c++
+```c++
+fopen("fn", "r");
 
-  fopen("fn", "r");
+// becomes
 
-  // becomes
-
-  fopen("fn", "re");
+fopen("fn", "re");
+```
 

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init.md
@@ -8,11 +8,10 @@ The usage of `inotify_init()` is not recommended, it's better to use
 
 Examples:
 
-```c++
+```cpp
 inotify_init();
 
 // becomes
 
 inotify_init1(IN_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init.md
@@ -1,17 +1,18 @@
-.. title:: clang-tidy - android-cloexec-inotify-init
+```{title} clang-tidy - android-cloexec-inotify-init
+```
 
-android-cloexec-inotify-init
-============================
+# android-cloexec-inotify-init
 
-The usage of ``inotify_init()`` is not recommended, it's better to use
-``inotify_init1()``.
+The usage of `inotify_init()` is not recommended, it's better to use
+`inotify_init1()`.
 
 Examples:
 
-.. code-block:: c++
+```c++
+inotify_init();
 
-  inotify_init();
+// becomes
 
-  // becomes
+inotify_init1(IN_CLOEXEC);
+```
 
-  inotify_init1(IN_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init1.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init1.md
@@ -10,7 +10,7 @@ lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 inotify_init1(IN_NONBLOCK);
 
 // becomes

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init1.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-inotify-init1.md
@@ -1,19 +1,20 @@
-.. title:: clang-tidy - android-cloexec-inotify-init1
+```{title} clang-tidy - android-cloexec-inotify-init1
+```
 
-android-cloexec-inotify-init1
-=============================
+# android-cloexec-inotify-init1
 
-``inotify_init1()`` should include ``IN_CLOEXEC`` in its type argument
+`inotify_init1()` should include `IN_CLOEXEC` in its type argument
 to avoid the file descriptor leakage. Without this flag, an opened
 sensitive file would remain open across a fork+exec to a
 lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+inotify_init1(IN_NONBLOCK);
 
-  inotify_init1(IN_NONBLOCK);
+// becomes
 
-  // becomes
+inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+```
 
-  inotify_init1(IN_NONBLOCK | IN_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-memfd-create.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-memfd-create.md
@@ -9,11 +9,10 @@ remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 memfd_create(name, MFD_ALLOW_SEALING);
 
 // becomes
 
 memfd_create(name, MFD_ALLOW_SEALING | MFD_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-memfd-create.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-memfd-create.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - android-cloexec-memfd-create
+```{title} clang-tidy - android-cloexec-memfd-create
+```
 
-android-cloexec-memfd-create
-============================
+# android-cloexec-memfd-create
 
-``memfd_create()`` should include ``MFD_CLOEXEC`` in its type argument to avoid
+`memfd_create()` should include `MFD_CLOEXEC` in its type argument to avoid
 the file descriptor leakage. Without this flag, an opened sensitive file would
 remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+memfd_create(name, MFD_ALLOW_SEALING);
 
-  memfd_create(name, MFD_ALLOW_SEALING);
+// becomes
 
-  // becomes
+memfd_create(name, MFD_ALLOW_SEALING | MFD_CLOEXEC);
+```
 
-  memfd_create(name, MFD_ALLOW_SEALING | MFD_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-open.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-open.md
@@ -11,7 +11,7 @@ sensitive data. Open-like functions including `open()`, `openat()`, and
 
 Examples:
 
-```c++
+```cpp
 open("filename", O_RDWR);
 open64("filename", O_RDWR);
 openat(0, "filename", O_RDWR);
@@ -22,4 +22,3 @@ open("filename", O_RDWR | O_CLOEXEC);
 open64("filename", O_RDWR | O_CLOEXEC);
 openat(0, "filename", O_RDWR | O_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-open.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-open.md
@@ -1,24 +1,25 @@
-.. title:: clang-tidy - android-cloexec-open
+```{title} clang-tidy - android-cloexec-open
+```
 
-android-cloexec-open
-====================
+# android-cloexec-open
 
 A common source of security bugs is code that opens a file without using the
-``O_CLOEXEC`` flag. Without that flag, an opened sensitive file would remain
+`O_CLOEXEC` flag. Without that flag, an opened sensitive file would remain
 open across a fork+exec to a lower-privileged SELinux domain, leaking that
-sensitive data. Open-like functions including ``open()``, ``openat()``, and
-``open64()`` should include ``O_CLOEXEC`` in their flags argument.
+sensitive data. Open-like functions including `open()`, `openat()`, and
+`open64()` should include `O_CLOEXEC` in their flags argument.
 
 Examples:
 
-.. code-block:: c++
+```c++
+open("filename", O_RDWR);
+open64("filename", O_RDWR);
+openat(0, "filename", O_RDWR);
 
-  open("filename", O_RDWR);
-  open64("filename", O_RDWR);
-  openat(0, "filename", O_RDWR);
+// becomes
 
-  // becomes
+open("filename", O_RDWR | O_CLOEXEC);
+open64("filename", O_RDWR | O_CLOEXEC);
+openat(0, "filename", O_RDWR | O_CLOEXEC);
+```
 
-  open("filename", O_RDWR | O_CLOEXEC);
-  open64("filename", O_RDWR | O_CLOEXEC);
-  openat(0, "filename", O_RDWR | O_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe.md
@@ -11,13 +11,13 @@ child process, potentially into a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 pipe(pipefd);
 ```
 
 Suggested replacement:
 
-```c++
+```cpp
 pipe2(pipefd, O_CLOEXEC);
 ```
 

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe.md
@@ -1,22 +1,23 @@
-.. title:: clang-tidy - android-cloexec-pipe
+```{title} clang-tidy - android-cloexec-pipe
+```
 
-android-cloexec-pipe
-====================
+# android-cloexec-pipe
 
-This check detects usage of ``pipe()``. Using ``pipe()`` is not recommended,
-``pipe2()`` is the suggested replacement. The check also adds the ``O_CLOEXEC``
+This check detects usage of `pipe()`. Using `pipe()` is not recommended,
+`pipe2()` is the suggested replacement. The check also adds the `O_CLOEXEC`
 flag that marks the file descriptor to be closed in child processes.
 Without this flag a sensitive file descriptor can be leaked to a
 child process, potentially into a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
-
-  pipe(pipefd);
+```c++
+pipe(pipefd);
+```
 
 Suggested replacement:
 
-.. code-block:: c++
+```c++
+pipe2(pipefd, O_CLOEXEC);
+```
 
-  pipe2(pipefd, O_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe2.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe2.md
@@ -11,13 +11,12 @@ potentially into a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 pipe2(pipefd, O_NONBLOCK);
 ```
 
 Suggested replacement:
 
-```c++
+```cpp
 pipe2(pipefd, O_NONBLOCK | O_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe2.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-pipe2.md
@@ -1,22 +1,23 @@
-.. title:: clang-tidy - android-cloexec-pipe2
+```{title} clang-tidy - android-cloexec-pipe2
+```
 
-android-cloexec-pipe2
-=====================
+# android-cloexec-pipe2
 
-This check ensures that ``pipe2()`` is called with the ``O_CLOEXEC`` flag.
-The check also adds the ``O_CLOEXEC`` flag that marks the file descriptor
+This check ensures that `pipe2()` is called with the `O_CLOEXEC` flag.
+The check also adds the `O_CLOEXEC` flag that marks the file descriptor
 to be closed in child processes.
 Without this flag a sensitive file descriptor can be leaked to a child process,
 potentially into a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
-
-  pipe2(pipefd, O_NONBLOCK);
+```c++
+pipe2(pipefd, O_NONBLOCK);
+```
 
 Suggested replacement:
 
-.. code-block:: c++
+```c++
+pipe2(pipefd, O_NONBLOCK | O_CLOEXEC);
+```
 
-  pipe2(pipefd, O_NONBLOCK | O_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-socket.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-socket.md
@@ -9,11 +9,10 @@ remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-```c++
+```cpp
 socket(domain, type, SOCK_STREAM);
 
 // becomes
 
 socket(domain, type, SOCK_STREAM | SOCK_CLOEXEC);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-socket.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/cloexec-socket.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - android-cloexec-socket
+```{title} clang-tidy - android-cloexec-socket
+```
 
-android-cloexec-socket
-======================
+# android-cloexec-socket
 
-``socket()`` should include ``SOCK_CLOEXEC`` in its type argument to avoid the
+`socket()` should include `SOCK_CLOEXEC` in its type argument to avoid the
 file descriptor leakage. Without this flag, an opened sensitive file would
 remain open across a fork+exec to a lower-privileged SELinux domain.
 
 Examples:
 
-.. code-block:: c++
+```c++
+socket(domain, type, SOCK_STREAM);
 
-  socket(domain, type, SOCK_STREAM);
+// becomes
 
-  // becomes
+socket(domain, type, SOCK_STREAM | SOCK_CLOEXEC);
+```
 
-  socket(domain, type, SOCK_STREAM | SOCK_CLOEXEC);

--- a/clang-tools-extra/docs/clang-tidy/checks/boost/use-to-string.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/boost/use-to-string.md
@@ -10,7 +10,7 @@ and replace it with calls to `std::to_string` and `std::to_wstring`.
 It doesn't replace conversion from floating points despite the `to_string`
 overloads, because it would change the behavior.
 
-```c++
+```cpp
 auto str = boost::lexical_cast<std::string>(42);
 auto wstr = boost::lexical_cast<std::wstring>(2137LL);
 
@@ -18,4 +18,3 @@ auto wstr = boost::lexical_cast<std::wstring>(2137LL);
 auto str = std::to_string(42);
 auto wstr = std::to_wstring(2137LL);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/boost/use-to-string.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/boost/use-to-string.md
@@ -1,22 +1,21 @@
-.. title:: clang-tidy - boost-use-to-string
+```{title} clang-tidy - boost-use-to-string
+```
 
-boost-use-to-string
-===================
+# boost-use-to-string
 
-This check finds conversion from integer type like ``int`` to
-``std::string`` or ``std::wstring`` using ``boost::lexical_cast``,
-and replace it with calls to ``std::to_string`` and ``std::to_wstring``.
+This check finds conversion from integer type like `int` to
+`std::string` or `std::wstring` using `boost::lexical_cast`,
+and replace it with calls to `std::to_string` and `std::to_wstring`.
 
-It doesn't replace conversion from floating points despite the ``to_string``
+It doesn't replace conversion from floating points despite the `to_string`
 overloads, because it would change the behavior.
 
+```c++
+auto str = boost::lexical_cast<std::string>(42);
+auto wstr = boost::lexical_cast<std::wstring>(2137LL);
 
-.. code-block:: c++
-
-    auto str = boost::lexical_cast<std::string>(42);
-    auto wstr = boost::lexical_cast<std::wstring>(2137LL);
-
-    // Will be changed to
-    auto str = std::to_string(42);
-    auto wstr = std::to_wstring(2137LL);
+// Will be changed to
+auto str = std::to_string(42);
+auto wstr = std::to_wstring(2137LL);
+```
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-if-condition.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-if-condition.md
@@ -13,7 +13,7 @@ including assignments that call an overloaded `operator=()`. The identified
 assignments violate
 [BARR group "Rule 8.2.c"](https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements).
 
-```c++
+```cpp
 int f = 3;
 if(f = 4) { // This is identified by both `Wparentheses` and this check - should it have been: `if (f == 4)` ?
   f = f + 1;
@@ -23,4 +23,3 @@ if((f == 5) || (f = 6)) { // the assignment here `(f = 6)` is identified by this
   f = f + 2;
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-if-condition.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-if-condition.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - bugprone-assignment-in-if-condition
+```{title} clang-tidy - bugprone-assignment-in-if-condition
+```
 
-bugprone-assignment-in-if-condition
-===================================
+# bugprone-assignment-in-if-condition
 
 Finds assignments within conditions of `if` statements.
 Such assignments are bug-prone because they may have been intended as
@@ -9,17 +9,18 @@ equality tests.
 
 This check finds all assignments within `if` conditions, including ones that
 are not flagged by `-Wparentheses` due to an extra set of parentheses, and
-including assignments that call an overloaded ``operator=()``. The identified
+including assignments that call an overloaded `operator=()`. The identified
 assignments violate
-`BARR group "Rule 8.2.c" <https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements>`_.
+[BARR group "Rule 8.2.c"](https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements).
 
-.. code-block:: c++
+```c++
+int f = 3;
+if(f = 4) { // This is identified by both `Wparentheses` and this check - should it have been: `if (f == 4)` ?
+  f = f + 1;
+}
 
-  int f = 3;
-  if(f = 4) { // This is identified by both `Wparentheses` and this check - should it have been: `if (f == 4)` ?
-    f = f + 1;
-  }
+if((f == 5) || (f = 6)) { // the assignment here `(f = 6)` is identified by this check, but not by `-Wparentheses`. Should it have been `(f == 6)` ?
+  f = f + 2;
+}
+```
 
-  if((f == 5) || (f = 6)) { // the assignment here `(f = 6)` is identified by this check, but not by `-Wparentheses`. Should it have been `(f == 6)` ?
-    f = f + 2;
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.md
@@ -7,7 +7,7 @@ Finds `pthread_kill` function calls when a thread is terminated by
 raising `SIGTERM` signal and the signal kills the entire process, not
 just the individual thread. Use any signal except `SIGTERM`.
 
-```c++
+```cpp
 pthread_kill(thread, SIGTERM);
 ```
 
@@ -15,4 +15,3 @@ This check corresponds to the CERT C Coding Standard rule
 [POS44-C. Do not use signals to terminate threads](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos44-c/).
 
 `cert-pos44-c` redirects here as an alias of this check.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.md
@@ -1,18 +1,18 @@
-.. title:: clang-tidy - bugprone-bad-signal-to-kill-thread
+```{title} clang-tidy - bugprone-bad-signal-to-kill-thread
+```
 
-bugprone-bad-signal-to-kill-thread
-==================================
+# bugprone-bad-signal-to-kill-thread
 
-Finds ``pthread_kill`` function calls when a thread is terminated by
-raising ``SIGTERM`` signal and the signal kills the entire process, not
-just the individual thread. Use any signal except ``SIGTERM``.
+Finds `pthread_kill` function calls when a thread is terminated by
+raising `SIGTERM` signal and the signal kills the entire process, not
+just the individual thread. Use any signal except `SIGTERM`.
 
-.. code-block:: c++
-
-    pthread_kill(thread, SIGTERM);
+```c++
+pthread_kill(thread, SIGTERM);
+```
 
 This check corresponds to the CERT C Coding Standard rule
-`POS44-C. Do not use signals to terminate threads
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos44-c/>`_.
+[POS44-C. Do not use signals to terminate threads](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos44-c/).
 
 `cert-pos44-c` redirects here as an alias of this check.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/bool-pointer-implicit-conversion.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/bool-pointer-implicit-conversion.md
@@ -8,10 +8,9 @@ Checks for conditions based on implicit conversion from a `bool` pointer to
 
 Example:
 
-```c++
+```cpp
 bool *p;
 if (p) {
   // Never used in a pointer-specific way.
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/bool-pointer-implicit-conversion.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/bool-pointer-implicit-conversion.md
@@ -1,16 +1,17 @@
-.. title:: clang-tidy - bugprone-bool-pointer-implicit-conversion
+```{title} clang-tidy - bugprone-bool-pointer-implicit-conversion
+```
 
-bugprone-bool-pointer-implicit-conversion
-=========================================
+# bugprone-bool-pointer-implicit-conversion
 
-Checks for conditions based on implicit conversion from a ``bool`` pointer to
-``bool``.
+Checks for conditions based on implicit conversion from a `bool` pointer to
+`bool`.
 
 Example:
 
-.. code-block:: c++
+```c++
+bool *p;
+if (p) {
+  // Never used in a pointer-specific way.
+}
+```
 
-  bool *p;
-  if (p) {
-    // Never used in a pointer-specific way.
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/command-processor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/command-processor.md
@@ -11,5 +11,6 @@ but does not actually attempt to execute a command.
 ## References
 
 This check corresponds to the CERT C Coding Standard rule
-[ENV33-C. Do not call system()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/).
+[ENV33-C. Do not call system()][ENV33-C].
 
+[ENV33-C]: https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/command-processor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/command-processor.md
@@ -11,6 +11,4 @@ but does not actually attempt to execute a command.
 ## References
 
 This check corresponds to the CERT C Coding Standard rule
-[ENV33-C. Do not call system()][ENV33-C].
-
-[ENV33-C]: https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/
+[ENV33-C. Do not call system()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/).

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/command-processor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/command-processor.md
@@ -1,16 +1,15 @@
-.. title:: clang-tidy - bugprone-command-processor
+```{title} clang-tidy - bugprone-command-processor
+```
 
-bugprone-command-processor
-==========================
+# bugprone-command-processor
 
-Flags calls to ``system()``, ``popen()``, and ``_popen()``, which
-execute a command processor. It does not flag calls to ``system()`` with a null
+Flags calls to `system()`, `popen()`, and `_popen()`, which
+execute a command processor. It does not flag calls to `system()` with a null
 pointer argument, as such a call checks for the presence of a command processor
 but does not actually attempt to execute a command.
 
-References
-----------
+## References
 
 This check corresponds to the CERT C Coding Standard rule
-`ENV33-C. Do not call system()
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/>`_.
+[ENV33-C. Do not call system()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.md
@@ -7,5 +7,6 @@ Finds assignments to the copied object and its direct or indirect members
 in copy constructors and copy assignment operators.
 
 This check corresponds to the CERT C Coding Standard rule
-[OOP58-CPP. Copy operations must not mutate the source object](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/).
+[OOP58-CPP. Copy operations must not mutate the source object][cert-oop58-cpp].
 
+[cert-oop58-cpp]: https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.md
@@ -7,6 +7,4 @@ Finds assignments to the copied object and its direct or indirect members
 in copy constructors and copy assignment operators.
 
 This check corresponds to the CERT C Coding Standard rule
-[OOP58-CPP. Copy operations must not mutate the source object][cert-oop58-cpp].
-
-[cert-oop58-cpp]: https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/
+[OOP58-CPP. Copy operations must not mutate the source object](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/).

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.md
@@ -1,11 +1,11 @@
-.. title:: clang-tidy - bugprone-copy-constructor-mutates-argument
+```{title} clang-tidy - bugprone-copy-constructor-mutates-argument
+```
 
-bugprone-copy-constructor-mutates-argument
-==========================================
+# bugprone-copy-constructor-mutates-argument
 
 Finds assignments to the copied object and its direct or indirect members
 in copy constructors and copy assignment operators.
 
 This check corresponds to the CERT C Coding Standard rule
-`OOP58-CPP. Copy operations must not mutate the source object
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/>`_.
+[OOP58-CPP. Copy operations must not mutate the source object](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.md
@@ -15,6 +15,4 @@ assume that the user provided the correct memory allocation).
 ## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-[MEM57-CPP. Avoid using default operator new for over-aligned types][mem57-cpp].
-
-[mem57-cpp]: https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/
+[MEM57-CPP. Avoid using default operator new for over-aligned types](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/).

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.md
@@ -15,5 +15,6 @@ assume that the user provided the correct memory allocation).
 ## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-[MEM57-CPP. Avoid using default operator new for over-aligned types](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/).
+[MEM57-CPP. Avoid using default operator new for over-aligned types][mem57-cpp].
 
+[mem57-cpp]: https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.md
@@ -1,20 +1,19 @@
-.. title:: clang-tidy - bugprone-default-operator-new-on-overaligned-type
+```{title} clang-tidy - bugprone-default-operator-new-on-overaligned-type
+```
 
-bugprone-default-operator-new-on-overaligned-type
-=================================================
+# bugprone-default-operator-new-on-overaligned-type
 
-Flags uses of default ``operator new`` where the type has extended
+Flags uses of default `operator new` where the type has extended
 alignment (an alignment greater than the fundamental alignment).
 
-The default ``operator new`` is guaranteed to provide the correct alignment
+The default `operator new` is guaranteed to provide the correct alignment
 if the requested alignment is less or equal to the fundamental alignment.
-Only cases are detected (by design) where the ``operator new`` is not
+Only cases are detected (by design) where the `operator new` is not
 user-defined and is not a placement new (the reason is that in these cases we
 assume that the user provided the correct memory allocation).
 
-References
-----------
+## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-`MEM57-CPP. Avoid using default operator new for over-aligned types
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/>`_.
+[MEM57-CPP. Avoid using default operator new for over-aligned types](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/dynamic-static-initializers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/dynamic-static-initializers.md
@@ -17,7 +17,7 @@ variable initialization will not cause problems.
 
 Consider the following code:
 
-```c
+```cpp
 int foo() {
   static int k = bar();
   return k;
@@ -27,4 +27,3 @@ int foo() {
 When synchronization of static initialization is disabled, if two threads both
 call `foo` for the first time, there is the possibility that `k` will be double
 initialized, creating a race condition.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/dynamic-static-initializers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/dynamic-static-initializers.md
@@ -1,14 +1,14 @@
-.. title:: clang-tidy - bugprone-dynamic-static-initializers
+```{title} clang-tidy - bugprone-dynamic-static-initializers
+```
 
-bugprone-dynamic-static-initializers
-====================================
+# bugprone-dynamic-static-initializers
 
 Finds instances of static variables that are dynamically initialized
 in header files.
 
 This can pose problems in certain multithreaded contexts. For example,
 when disabling compiler generated synchronization instructions for
-static variables initialized at runtime (e.g. by ``-fno-threadsafe-statics``),
+static variables initialized at runtime (e.g. by `-fno-threadsafe-statics`),
 even if a particular project takes the necessary precautions to prevent race
 conditions during initialization by providing their own synchronization, header
 files included from other projects may not. Therefore, such a check is helpful
@@ -17,13 +17,14 @@ variable initialization will not cause problems.
 
 Consider the following code:
 
-.. code-block:: c
-
-  int foo() {
-    static int k = bar();
-    return k;
-  }
+```c
+int foo() {
+  static int k = bar();
+  return k;
+}
+```
 
 When synchronization of static initialization is disabled, if two threads both
 call `foo` for the first time, there is the possibility that `k` will be double
 initialized, creating a race condition.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/float-loop-counter.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/float-loop-counter.md
@@ -1,13 +1,12 @@
-.. title:: clang-tidy - bugprone-float-loop-counter
+```{title} clang-tidy - bugprone-float-loop-counter
+```
 
-bugprone-float-loop-counter
-===========================
+# bugprone-float-loop-counter
 
-Flags ``for`` loops where the induction expression has a floating-point type.
+Flags `for` loops where the induction expression has a floating-point type.
 
-References
-----------
+## References
 
 This check corresponds to the CERT C Coding Standard rule
-`FLP30-C. Do not use floating-point variables as loop counters
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/floating-point-flp/flp30-c/>`_.
+[FLP30-C. Do not use floating-point variables as loop counters](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/floating-point-flp/flp30-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/forward-declaration-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/forward-declaration-namespace.md
@@ -9,7 +9,7 @@ The check inspects all unused forward declarations and checks if there is any
 declaration/definition with the same name existing, which could indicate that
 the forward declaration is in a potentially wrong namespace.
 
-```c++
+```cpp
 namespace na { struct A; }
 namespace nb { struct A {}; }
 nb::A a;
@@ -19,4 +19,3 @@ nb::A a;
 
 This check can only generate warnings, but it can't suggest a fix at this
 point.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/forward-declaration-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/forward-declaration-namespace.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - bugprone-forward-declaration-namespace
+```{title} clang-tidy - bugprone-forward-declaration-namespace
+```
 
-bugprone-forward-declaration-namespace
-======================================
+# bugprone-forward-declaration-namespace
 
 Checks if an unused forward declaration is in a wrong namespace.
 
@@ -9,13 +9,14 @@ The check inspects all unused forward declarations and checks if there is any
 declaration/definition with the same name existing, which could indicate that
 the forward declaration is in a potentially wrong namespace.
 
-.. code-block:: c++
-
-  namespace na { struct A; }
-  namespace nb { struct A {}; }
-  nb::A a;
-  // warning : no definition found for 'A', but a definition with the same name
-  // 'A' found in another namespace 'nb::'
+```c++
+namespace na { struct A; }
+namespace nb { struct A {}; }
+nb::A a;
+// warning : no definition found for 'A', but a definition with the same name
+// 'A' found in another namespace 'nb::'
+```
 
 This check can only generate warnings, but it can't suggest a fix at this
 point.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/inaccurate-erase.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/inaccurate-erase.md
@@ -13,7 +13,7 @@ removed due to using an inappropriate overload.
 
 For example, the following code erases only one element:
 
-```c++
+```cpp
 std::vector<int> xs;
 ...
 xs.erase(std::remove(xs.begin(), xs.end(), 10));
@@ -21,9 +21,8 @@ xs.erase(std::remove(xs.begin(), xs.end(), 10));
 
 Call the two-argument overload of `erase()` to remove the subrange:
 
-```c++
+```cpp
 std::vector<int> xs;
 ...
 xs.erase(std::remove(xs.begin(), xs.end(), 10), xs.end());
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/inaccurate-erase.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/inaccurate-erase.md
@@ -1,29 +1,29 @@
-.. title:: clang-tidy - bugprone-inaccurate-erase
+```{title} clang-tidy - bugprone-inaccurate-erase
+```
 
-bugprone-inaccurate-erase
-=========================
+# bugprone-inaccurate-erase
 
+Checks for inaccurate use of the `erase()` method.
 
-Checks for inaccurate use of the ``erase()`` method.
-
-Algorithms like ``remove()`` do not actually remove any element from the
+Algorithms like `remove()` do not actually remove any element from the
 container but return an iterator to the first redundant element at the end
 of the container. These redundant elements must be removed using the
-``erase()`` method. This check warns when not all of the elements will be
+`erase()` method. This check warns when not all of the elements will be
 removed due to using an inappropriate overload.
 
 For example, the following code erases only one element:
 
-.. code-block:: c++
+```c++
+std::vector<int> xs;
+...
+xs.erase(std::remove(xs.begin(), xs.end(), 10));
+```
 
-  std::vector<int> xs;
-  ...
-  xs.erase(std::remove(xs.begin(), xs.end(), 10));
+Call the two-argument overload of `erase()` to remove the subrange:
 
-Call the two-argument overload of ``erase()`` to remove the subrange:
+```c++
+std::vector<int> xs;
+...
+xs.erase(std::remove(xs.begin(), xs.end(), 10), xs.end());
+```
 
-.. code-block:: c++
-
-  std::vector<int> xs;
-  ...
-  xs.erase(std::remove(xs.begin(), xs.end(), 10), xs.end());

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/incorrect-roundings.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/incorrect-roundings.md
@@ -6,7 +6,7 @@
 Checks the usage of patterns known to produce incorrect rounding.
 Programmers often use:
 
-```
+```cpp
 (int)(double_expression + 0.5)
 ```
 
@@ -16,4 +16,3 @@ to round the double expression to an integer. The problem with this:
 2. It is incorrect. The number 0.499999975 (smallest representable float
    number below 0.5) rounds to 1.0. Even worse behavior for negative
    numbers where both -0.5f and -1.4f both round to 0.0.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/incorrect-roundings.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/incorrect-roundings.md
@@ -1,12 +1,14 @@
-.. title:: clang-tidy - bugprone-incorrect-roundings
+```{title} clang-tidy - bugprone-incorrect-roundings
+```
 
-bugprone-incorrect-roundings
-============================
+# bugprone-incorrect-roundings
 
 Checks the usage of patterns known to produce incorrect rounding.
-Programmers often use::
+Programmers often use:
 
-   (int)(double_expression + 0.5)
+```
+(int)(double_expression + 0.5)
+```
 
 to round the double expression to an integer. The problem with this:
 
@@ -14,3 +16,4 @@ to round the double expression to an integer. The problem with this:
 2. It is incorrect. The number 0.499999975 (smallest representable float
    number below 0.5) rounds to 1.0. Even worse behavior for negative
    numbers where both -0.5f and -1.4f both round to 0.0.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-parentheses.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-parentheses.md
@@ -1,8 +1,7 @@
-.. title:: clang-tidy - bugprone-macro-parentheses
+```{title} clang-tidy - bugprone-macro-parentheses
+```
 
-bugprone-macro-parentheses
-==========================
-
+# bugprone-macro-parentheses
 
 Finds macros that can have unexpected behavior due to missing parentheses.
 
@@ -19,5 +18,5 @@ with parentheses. This ensures that the argument value is calculated
 properly.
 
 This check corresponds to the CERT C Coding Standard rule
-`PRE02-C. Macro replacement lists should be parenthesized.
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/recommendations/preprocessor-pre/pre02-c/>`_
+[PRE02-C. Macro replacement lists should be parenthesized.](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/recommendations/preprocessor-pre/pre02-c/)
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-repeated-side-effects.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-repeated-side-effects.md
@@ -4,4 +4,3 @@
 # bugprone-macro-repeated-side-effects
 
 Checks for repeated argument with side effects in macros.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-repeated-side-effects.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-repeated-side-effects.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - bugprone-macro-repeated-side-effects
+```{title} clang-tidy - bugprone-macro-repeated-side-effects
+```
 
-bugprone-macro-repeated-side-effects
-====================================
-
+# bugprone-macro-repeated-side-effects
 
 Checks for repeated argument with side effects in macros.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/misplaced-pointer-arithmetic-in-alloc.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/misplaced-pointer-arithmetic-in-alloc.md
@@ -1,25 +1,25 @@
-.. title:: clang-tidy - bugprone-misplaced-pointer-arithmetic-in-alloc
+```{title} clang-tidy - bugprone-misplaced-pointer-arithmetic-in-alloc
+```
 
-bugprone-misplaced-pointer-arithmetic-in-alloc
-===============================================
+# bugprone-misplaced-pointer-arithmetic-in-alloc
 
 Finds cases where an integer expression is added to or subtracted from the
-result of a memory allocation function (``malloc()``, ``calloc()``,
-``realloc()``, ``alloca()``) instead of its argument. The check detects error
+result of a memory allocation function (`malloc()`, `calloc()`,
+`realloc()`, `alloca()`) instead of its argument. The check detects error
 cases even if one of these functions is called by a constant function pointer.
 
 Example code:
 
-.. code-block:: c
-
-  void bad_malloc(int n) {
-    char *p = (char*) malloc(n) + 10;
-  }
-
+```c
+void bad_malloc(int n) {
+  char *p = (char*) malloc(n) + 10;
+}
+```
 
 The suggested fix is to add the integer expression to the argument of
-``malloc`` and not to its result. In the example above the fix would be
+`malloc` and not to its result. In the example above the fix would be
 
-.. code-block:: c
+```c
+char *p = (char*) malloc(n + 10);
+```
 
-  char *p = (char*) malloc(n + 10);

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/multiple-statement-macro.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/multiple-statement-macro.md
@@ -9,9 +9,8 @@ ones will be executed unconditionally.
 
 Example:
 
-```c++
+```cpp
 #define INCREMENT_TWO(x, y) (x)++; (y)++
 if (do_increment)
   INCREMENT_TWO(a, b);  // (b)++ will be executed unconditionally.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/multiple-statement-macro.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/multiple-statement-macro.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - bugprone-multiple-statement-macro
+```{title} clang-tidy - bugprone-multiple-statement-macro
+```
 
-bugprone-multiple-statement-macro
-=================================
+# bugprone-multiple-statement-macro
 
 Detect multiple statement macros that are used in unbraced conditionals. Only
 the first statement of the macro will be inside the conditional and the other
@@ -9,8 +9,9 @@ ones will be executed unconditionally.
 
 Example:
 
-.. code-block:: c++
+```c++
+#define INCREMENT_TWO(x, y) (x)++; (y)++
+if (do_increment)
+  INCREMENT_TWO(a, b);  // (b)++ will be executed unconditionally.
+```
 
-  #define INCREMENT_TWO(x, y) (x)++; (y)++
-  if (do_increment)
-    INCREMENT_TWO(a, b);  // (b)++ will be executed unconditionally.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/no-escape.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/no-escape.md
@@ -10,11 +10,10 @@ with the `noescape` attribute is captured by one of these blocks.
 
 The following is an example of an invalid use of the `noescape` attribute.
 
-> ```objc
-> void foo(__attribute__((noescape)) int *p) {
->   dispatch_async(queue, ^{
->     *p = 123;
->   });
-> });
-> ```
-
+```objc
+void foo(__attribute__((noescape)) int *p) {
+  dispatch_async(queue, ^{
+    *p = 123;
+  });
+});
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/no-escape.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/no-escape.md
@@ -1,19 +1,20 @@
-.. title:: clang-tidy - bugprone-no-escape
+```{title} clang-tidy - bugprone-no-escape
+```
 
-bugprone-no-escape
-==================
+# bugprone-no-escape
 
-Finds pointers with the ``noescape`` attribute that are captured by an
-asynchronously-executed block. The block arguments in ``dispatch_async()`` and
-``dispatch_after()`` are guaranteed to escape, so it is an error if a pointer
-with the ``noescape`` attribute is captured by one of these blocks.
+Finds pointers with the `noescape` attribute that are captured by an
+asynchronously-executed block. The block arguments in `dispatch_async()` and
+`dispatch_after()` are guaranteed to escape, so it is an error if a pointer
+with the `noescape` attribute is captured by one of these blocks.
 
-The following is an example of an invalid use of the ``noescape`` attribute.
+The following is an example of an invalid use of the `noescape` attribute.
 
-  .. code-block:: objc
+> ```objc
+> void foo(__attribute__((noescape)) int *p) {
+>   dispatch_async(queue, ^{
+>     *p = 123;
+>   });
+> });
+> ```
 
-    void foo(__attribute__((noescape)) int *p) {
-      dispatch_async(queue, ^{
-        *p = 123;
-      });
-    });

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/parent-virtual-call.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/parent-virtual-call.md
@@ -6,7 +6,7 @@
 Detects and fixes calls to grand-...parent virtual methods instead of calls
 to overridden parent's virtual methods.
 
-```c++
+```cpp
 struct A {
   int virtual foo() {...}
 };
@@ -21,4 +21,3 @@ struct C: public B {
 // warning: qualified name A::foo refers to a member overridden in subclass; did you mean 'B'?  [bugprone-parent-virtual-call]
 };
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/parent-virtual-call.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/parent-virtual-call.md
@@ -1,23 +1,24 @@
-.. title:: clang-tidy - bugprone-parent-virtual-call
+```{title} clang-tidy - bugprone-parent-virtual-call
+```
 
-bugprone-parent-virtual-call
-============================
+# bugprone-parent-virtual-call
 
 Detects and fixes calls to grand-...parent virtual methods instead of calls
 to overridden parent's virtual methods.
 
-.. code-block:: c++
+```c++
+struct A {
+  int virtual foo() {...}
+};
 
-  struct A {
-    int virtual foo() {...}
-  };
+struct B: public A {
+  int foo() override {...}
+};
 
-  struct B: public A {
-    int foo() override {...}
-  };
+struct C: public B {
+  int foo() override { A::foo(); }
+//                     ^^^^^^^^
+// warning: qualified name A::foo refers to a member overridden in subclass; did you mean 'B'?  [bugprone-parent-virtual-call]
+};
+```
 
-  struct C: public B {
-    int foo() override { A::foo(); }
-  //                     ^^^^^^^^
-  // warning: qualified name A::foo refers to a member overridden in subclass; did you mean 'B'?  [bugprone-parent-virtual-call]
-  };

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/posix-return.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/posix-return.md
@@ -1,21 +1,22 @@
-.. title:: clang-tidy - bugprone-posix-return
+```{title} clang-tidy - bugprone-posix-return
+```
 
-bugprone-posix-return
-=====================
+# bugprone-posix-return
 
-Checks if any calls to ``pthread_*`` or ``posix_*`` functions
-(except ``posix_openpt``) expect negative return values. These functions return
-either ``0`` on success or an ``errno`` on failure, which is positive only.
+Checks if any calls to `pthread_*` or `posix_*` functions
+(except `posix_openpt`) expect negative return values. These functions return
+either `0` on success or an `errno` on failure, which is positive only.
 
 Example buggy usage looks like:
 
-.. code-block:: c
-
-  if (posix_fadvise(...) < 0) {
+```c
+if (posix_fadvise(...) < 0) {
+```
 
 This will never happen as the return value is always non-negative.
 A simple fix could be:
 
-.. code-block:: c
+```c
+if (posix_fadvise(...) > 0) {
+```
 
-  if (posix_fadvise(...) > 0) {

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-bitwise.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-bitwise.md
@@ -11,7 +11,7 @@ lead to undefined or implementation dependent behavior. In particular, right
 shift a signed integer is implementation dependent, while left shift a signed
 integer may result in undefined behavior.
 
-```c++
+```cpp
 int main(){
    int x = -4;
    int y = x >> 1; // y can be -2 or 2147483646
@@ -20,11 +20,9 @@ int main(){
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnorePositiveIntegerLiterals
+```{option} IgnorePositiveIntegerLiterals
 
-   If this option is set to `true`, the check will not warn on bitwise
-   operations with positive integer literals, e.g. ``~0``, ``2 << 1``, etc.
-   Default value is `false`.
+If this option is set to `true`, the check will not warn on bitwise
+operations with positive integer literals, e.g. `~0`, `2 << 1`, etc.
+Default value is `false`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-bitwise.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-bitwise.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - bugprone-signed-bitwise
+```{title} clang-tidy - bugprone-signed-bitwise
+```
 
-bugprone-signed-bitwise
-=======================
+# bugprone-signed-bitwise
 
 Finds uses of bitwise operations on signed integer types, which may lead to
 undefined or implementation defined behavior.
@@ -11,18 +11,20 @@ lead to undefined or implementation dependent behavior. In particular, right
 shift a signed integer is implementation dependent, while left shift a signed
 integer may result in undefined behavior.
 
-.. code-block:: c++
+```c++
+int main(){
+   int x = -4;
+   int y = x >> 1; // y can be -2 or 2147483646
+}
+```
 
-   int main(){
-      int x = -4;
-      int y = x >> 1; // y can be -2 or 2147483646
-   }
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: IgnorePositiveIntegerLiterals
 
    If this option is set to `true`, the check will not warn on bitwise
    operations with positive integer literals, e.g. ``~0``, ``2 << 1``, etc.
    Default value is `false`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-container.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-container.md
@@ -12,7 +12,7 @@ All class/struct types declared in namespace `std::` having a const
 
 Examples:
 
-```c++
+```cpp
 std::string s;
 int a = 47 + sizeof(s); // warning: sizeof() doesn't return the size of the container. Did you mean .size()?
 
@@ -24,4 +24,3 @@ int c = sizeof(array_of_strings) / sizeof(array_of_strings[0]); // no warning, d
 std::array<int, 3> std_array;
 int d = sizeof(std_array); // no warning, probably intended.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-container.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-container.md
@@ -1,26 +1,27 @@
-.. title:: clang-tidy - bugprone-sizeof-container
+```{title} clang-tidy - bugprone-sizeof-container
+```
 
-bugprone-sizeof-container
-=========================
+# bugprone-sizeof-container
 
-The check finds usages of ``sizeof`` on expressions of STL container types.
-Most likely the user wanted to use ``.size()`` instead.
+The check finds usages of `sizeof` on expressions of STL container types.
+Most likely the user wanted to use `.size()` instead.
 
-All class/struct types declared in namespace ``std::`` having a const
-``size()`` method are considered containers, with the exception of
-``std::bitset`` and ``std::array``.
+All class/struct types declared in namespace `std::` having a const
+`size()` method are considered containers, with the exception of
+`std::bitset` and `std::array`.
 
 Examples:
 
-.. code-block:: c++
+```c++
+std::string s;
+int a = 47 + sizeof(s); // warning: sizeof() doesn't return the size of the container. Did you mean .size()?
 
-  std::string s;
-  int a = 47 + sizeof(s); // warning: sizeof() doesn't return the size of the container. Did you mean .size()?
+int b = sizeof(std::string); // no warning, probably intended.
 
-  int b = sizeof(std::string); // no warning, probably intended.
+std::string array_of_strings[10];
+int c = sizeof(array_of_strings) / sizeof(array_of_strings[0]); // no warning, definitely intended.
 
-  std::string array_of_strings[10];
-  int c = sizeof(array_of_strings) / sizeof(array_of_strings[0]); // no warning, definitely intended.
+std::array<int, 3> std_array;
+int d = sizeof(std_array); // no warning, probably intended.
+```
 
-  std::array<int, 3> std_array;
-  int d = sizeof(std_array); // no warning, probably intended.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/spuriously-wake-up-functions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/spuriously-wake-up-functions.md
@@ -8,7 +8,7 @@ Finds `cnd_wait`, `cnd_timedwait`, `wait`, `wait_for`, or
 that checks whether a condition predicate holds or the function has a
 condition parameter.
 
-```c++
+```cpp
 if (condition_predicate) {
     condition.wait(lk);
 }
@@ -25,4 +25,3 @@ This check corresponds to the CERT C++ Coding Standard rule
 [CON54-CPP. Wrap functions that can spuriously wake up in a loop](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/concurrency-con/con54-cpp/).
 and CERT C Coding Standard rule
 [CON36-C. Wrap functions that can spuriously wake up in a loop](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/concurrency-con/con36-c/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/spuriously-wake-up-functions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/spuriously-wake-up-functions.md
@@ -1,29 +1,28 @@
-.. title:: clang-tidy - bugprone-spuriously-wake-up-functions
+```{title} clang-tidy - bugprone-spuriously-wake-up-functions
+```
 
-bugprone-spuriously-wake-up-functions
-=====================================
+# bugprone-spuriously-wake-up-functions
 
-Finds ``cnd_wait``, ``cnd_timedwait``, ``wait``, ``wait_for``, or
-``wait_until`` function calls when the function is not invoked from a loop
+Finds `cnd_wait`, `cnd_timedwait`, `wait`, `wait_for`, or
+`wait_until` function calls when the function is not invoked from a loop
 that checks whether a condition predicate holds or the function has a
 condition parameter.
 
-.. code-block:: c++
+```c++
+if (condition_predicate) {
+    condition.wait(lk);
+}
+```
 
-    if (condition_predicate) {
-        condition.wait(lk);
+```c
+if (condition_predicate) {
+    if (thrd_success != cnd_wait(&condition, &lock)) {
     }
-
-.. code-block:: c
-
-    if (condition_predicate) {
-        if (thrd_success != cnd_wait(&condition, &lock)) {
-        }
-    }
+}
+```
 
 This check corresponds to the CERT C++ Coding Standard rule
-`CON54-CPP. Wrap functions that can spuriously wake up in a loop
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/concurrency-con/con54-cpp/>`_.
+[CON54-CPP. Wrap functions that can spuriously wake up in a loop](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/concurrency-con/con54-cpp/).
 and CERT C Coding Standard rule
-`CON36-C. Wrap functions that can spuriously wake up in a loop
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/concurrency-con/con36-c/>`_.
+[CON36-C. Wrap functions that can spuriously wake up in a loop](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/concurrency-con/con36-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.md
@@ -8,7 +8,7 @@ implementation file, which often leads to hard-to-track-down ODR violations.
 
 Examples:
 
-```c++
+```cpp
 #include "Dinosaur.hpp"     // OK, .hpp files tend not to have definitions.
 #include "Pterodactyl.h"    // OK, .h files tend not to have definitions.
 #include "Velociraptor.cpp" // Warning, filename is suspicious.
@@ -17,10 +17,7 @@ Examples:
 
 ## Options
 
-```{eval-rst}
-.. option::  IgnoredRegex
-
-   A regular expression for the file name to be ignored by the check. Default
-   is empty string.
+```{option} IgnoredRegex
+A regular expression for the file name to be ignored by the check. Default
+is empty string.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-include.md
@@ -1,24 +1,26 @@
-.. title:: clang-tidy - bugprone-suspicious-include
+```{title} clang-tidy - bugprone-suspicious-include
+```
 
-bugprone-suspicious-include
-===========================
+# bugprone-suspicious-include
 
 The check detects various cases when an include refers to what appears to be an
 implementation file, which often leads to hard-to-track-down ODR violations.
 
 Examples:
 
-.. code-block:: c++
+```c++
+#include "Dinosaur.hpp"     // OK, .hpp files tend not to have definitions.
+#include "Pterodactyl.h"    // OK, .h files tend not to have definitions.
+#include "Velociraptor.cpp" // Warning, filename is suspicious.
+#include_next <stdio.c>     // Warning, filename is suspicious.
+```
 
-  #include "Dinosaur.hpp"     // OK, .hpp files tend not to have definitions.
-  #include "Pterodactyl.h"    // OK, .h files tend not to have definitions.
-  #include "Velociraptor.cpp" // Warning, filename is suspicious.
-  #include_next <stdio.c>     // Warning, filename is suspicious.
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option::  IgnoredRegex
 
    A regular expression for the file name to be ignored by the check. Default
    is empty string.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/terminating-continue.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/terminating-continue.md
@@ -7,7 +7,7 @@ Detects `do while` loops with a condition always evaluating to false that
 have a `continue` statement, as this `continue` terminates the loop
 effectively.
 
-```c++
+```cpp
 void f() {
 do {
   // some code
@@ -15,4 +15,3 @@ do {
   // some other code
 } while(false);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/terminating-continue.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/terminating-continue.md
@@ -1,17 +1,18 @@
-.. title:: clang-tidy - bugprone-terminating-continue
+```{title} clang-tidy - bugprone-terminating-continue
+```
 
-bugprone-terminating-continue
-=============================
+# bugprone-terminating-continue
 
-Detects ``do while`` loops with a condition always evaluating to false that
-have a ``continue`` statement, as this ``continue`` terminates the loop
+Detects `do while` loops with a condition always evaluating to false that
+have a `continue` statement, as this `continue` terminates the loop
 effectively.
 
-.. code-block:: c++
+```c++
+void f() {
+do {
+  // some code
+  continue; // terminating continue
+  // some other code
+} while(false);
+```
 
-  void f() {
-  do {
-    // some code
-    continue; // terminating continue
-    // some other code
-  } while(false);

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/throw-keyword-missing.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/throw-keyword-missing.md
@@ -10,7 +10,7 @@ that the programmer's intention was to throw that object.
 
 Example:
 
-```c++
+```cpp
 void f(int i) {
   if (i < 0) {
     // Exception is created but is not thrown.
@@ -18,4 +18,3 @@ void f(int i) {
   }
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/throw-keyword-missing.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/throw-keyword-missing.md
@@ -1,22 +1,21 @@
-.. title:: clang-tidy - bugprone-throw-keyword-missing
+```{title} clang-tidy - bugprone-throw-keyword-missing
+```
 
-bugprone-throw-keyword-missing
-==============================
+# bugprone-throw-keyword-missing
 
-Warns about a potentially missing ``throw`` keyword. If a temporary object
+Warns about a potentially missing `throw` keyword. If a temporary object
 is created, but the object's type derives from (or is the same as) a class
 that has 'EXCEPTION', 'Exception' or 'exception' in its name, we can assume
 that the programmer's intention was to throw that object.
 
 Example:
 
-.. code-block:: c++
-
-  void f(int i) {
-    if (i < 0) {
-      // Exception is created but is not thrown.
-      std::runtime_error("Unexpected argument");
-    }
+```c++
+void f(int i) {
+  if (i < 0) {
+    // Exception is created but is not thrown.
+    std::runtime_error("Unexpected argument");
   }
-
+}
+```
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/throwing-static-initialization.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/throwing-static-initialization.md
@@ -8,20 +8,18 @@ initializer for the object may throw an exception.
 
 ## Options
 
-```{eval-rst}
-.. option:: AllowedTypes
+```{option} AllowedTypes
 
   A semicolon-separated list of names of types that will be excluded from
   this check (declarations with matching type will be excluded). Regular
-  expressions are accepted, e.g. ``[Rr]ef(erence)?$`` matches every type with
-  suffix ``Ref``, ``ref``, ``Reference`` and ``reference``. If a name in the
+  expressions are accepted, e.g. `[Rr]ef(erence)?$` matches every type with
+  suffix `Ref`, `ref`, `Reference` and `reference`. If a name in the
   list contains the sequence `::`, it is matched against the qualified type
-  name (i.e. ``namespace::Type``), otherwise it is matched against only the
-  type name (i.e. ``Type``). Default is an empty string.
+  name (i.e. `namespace::Type`), otherwise it is matched against only the
+  type name (i.e. `Type`). Default is an empty string.
 ```
 
 ## References
 
 This check corresponds to the CERT C++ Coding Standard rule
 [ERR58-CPP. Handle all exceptions thrown before main() begins executing](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err58-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/throwing-static-initialization.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/throwing-static-initialization.md
@@ -1,14 +1,14 @@
-.. title:: clang-tidy - bugprone-throwing-static-initialization
+```{title} clang-tidy - bugprone-throwing-static-initialization
+```
 
-bugprone-throwing-static-initialization
-=======================================
+# bugprone-throwing-static-initialization
 
-Finds all ``static`` or ``thread_local`` variable declarations where the
+Finds all `static` or `thread_local` variable declarations where the
 initializer for the object may throw an exception.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: AllowedTypes
 
   A semicolon-separated list of names of types that will be excluded from
@@ -18,10 +18,10 @@ Options
   list contains the sequence `::`, it is matched against the qualified type
   name (i.e. ``namespace::Type``), otherwise it is matched against only the
   type name (i.e. ``Type``). Default is an empty string.
+```
 
-References
-----------
+## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-`ERR58-CPP. Handle all exceptions thrown before main() begins executing
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err58-cpp/>`_.
+[ERR58-CPP. Handle all exceptions thrown before main() begins executing](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err58-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/undelegated-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/undelegated-constructor.md
@@ -8,4 +8,3 @@ function call to another constructor of the same class.
 
 The user most likely meant to use a delegating constructor or base class
 initializer.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/undelegated-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/undelegated-constructor.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - bugprone-undelegated-constructor
+```{title} clang-tidy - bugprone-undelegated-constructor
+```
 
-bugprone-undelegated-constructor
-================================
+# bugprone-undelegated-constructor
 
 Finds creation of temporary objects in constructors that look like a
 function call to another constructor of the same class.
 
 The user most likely meant to use a delegating constructor or base class
 initializer.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/virtual-near-miss.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/virtual-near-miss.md
@@ -9,7 +9,7 @@ class.
 
 Example:
 
-```c++
+```cpp
 struct Base {
   virtual void func();
 };
@@ -19,4 +19,3 @@ struct Derived : Base {
   // warning: 'Derived::funk' has a similar name and the same signature as virtual method 'Base::func'; did you mean to override it?
 };
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/virtual-near-miss.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/virtual-near-miss.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - bugprone-virtual-near-miss
+```{title} clang-tidy - bugprone-virtual-near-miss
+```
 
-bugprone-virtual-near-miss
-==========================
+# bugprone-virtual-near-miss
 
 Warn if a function is a near miss (i.e. the name is very similar and
 the function signature is the same) to a virtual function from a base
@@ -9,13 +9,14 @@ class.
 
 Example:
 
-.. code-block:: c++
+```c++
+struct Base {
+  virtual void func();
+};
 
-  struct Base {
-    virtual void func();
-  };
+struct Derived : Base {
+  virtual void funk();
+  // warning: 'Derived::funk' has a similar name and the same signature as virtual method 'Base::func'; did you mean to override it?
+};
+```
 
-  struct Derived : Base {
-    virtual void funk();
-    // warning: 'Derived::funk' has a similar name and the same signature as virtual method 'Base::func'; did you mean to override it?
-  };

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/arr39-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/arr39-c.md
@@ -6,4 +6,3 @@
 The `cert-arr39-c` check is an alias, please see
 {doc}`bugprone-sizeof-expression <../bugprone/sizeof-expression>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/arr39-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/arr39-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-arr39-c
+```{title} clang-tidy - cert-arr39-c
+```
 
-cert-arr39-c
-============
+# cert-arr39-c
 
 The `cert-arr39-c` check is an alias, please see
-:doc:`bugprone-sizeof-expression <../bugprone/sizeof-expression>`
+{doc}`bugprone-sizeof-expression <../bugprone/sizeof-expression>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/con36-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/con36-c.md
@@ -4,7 +4,5 @@
 # cert-con36-c
 
 The `cert-con36-c` check is an alias, please see
-{doc}`bugprone-spuriously-wake-up-functions
-<../bugprone/spuriously-wake-up-functions>`
+{doc}`bugprone-spuriously-wake-up-functions <../bugprone/spuriously-wake-up-functions>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/con36-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/con36-c.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-con36-c
+```{title} clang-tidy - cert-con36-c
+```
 
-cert-con36-c
-============
+# cert-con36-c
 
 The `cert-con36-c` check is an alias, please see
-:doc:`bugprone-spuriously-wake-up-functions
+{doc}`bugprone-spuriously-wake-up-functions
 <../bugprone/spuriously-wake-up-functions>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/con54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/con54-cpp.md
@@ -4,7 +4,5 @@
 # cert-con54-cpp
 
 The `cert-con54-cpp` check is an alias, please see
-{doc}`bugprone-spuriously-wake-up-functions
-<../bugprone/spuriously-wake-up-functions>`
+{doc}`bugprone-spuriously-wake-up-functions <../bugprone/spuriously-wake-up-functions>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/con54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/con54-cpp.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-con54-cpp
+```{title} clang-tidy - cert-con54-cpp
+```
 
-cert-con54-cpp
-==============
+# cert-con54-cpp
 
 The `cert-con54-cpp` check is an alias, please see
-:doc:`bugprone-spuriously-wake-up-functions
+{doc}`bugprone-spuriously-wake-up-functions
 <../bugprone/spuriously-wake-up-functions>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/ctr56-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/ctr56-cpp.md
@@ -4,6 +4,5 @@
 # cert-ctr56-cpp
 
 The `cert-ctr56-cpp` check is an alias, please see
-{doc}`bugprone-pointer-arithmetic-on-polymorphic-object
-<../bugprone/pointer-arithmetic-on-polymorphic-object>` for more information.
-
+{doc}`bugprone-pointer-arithmetic-on-polymorphic-object <../bugprone/pointer-arithmetic-on-polymorphic-object>`
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/ctr56-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/ctr56-cpp.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-ctr56-cpp
+```{title} clang-tidy - cert-ctr56-cpp
+```
 
-cert-ctr56-cpp
-==============
+# cert-ctr56-cpp
 
 The `cert-ctr56-cpp` check is an alias, please see
-:doc:`bugprone-pointer-arithmetic-on-polymorphic-object
+{doc}`bugprone-pointer-arithmetic-on-polymorphic-object
 <../bugprone/pointer-arithmetic-on-polymorphic-object>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl03-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl03-c.md
@@ -4,5 +4,5 @@
 # cert-dcl03-c
 
 The `cert-dcl03-c` check is an alias, please see
-{doc}`misc-static-assert <../misc/static-assert>` for more information.
-
+{doc}`misc-static-assert <../misc/static-assert>`
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl03-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl03-c.md
@@ -1,7 +1,8 @@
-.. title:: clang-tidy - cert-dcl03-c
+```{title} clang-tidy - cert-dcl03-c
+```
 
-cert-dcl03-c
-============
+# cert-dcl03-c
 
 The `cert-dcl03-c` check is an alias, please see
-:doc:`misc-static-assert <../misc/static-assert>` for more information.
+{doc}`misc-static-assert <../misc/static-assert>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl16-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl16-c.md
@@ -4,6 +4,4 @@
 # cert-dcl16-c
 
 The `cert-dcl16-c` check is an alias, please see
-{doc}`readability-uppercase-literal-suffix
-<../readability/uppercase-literal-suffix>` for more information.
-
+{doc}`readability-uppercase-literal-suffix <../readability/uppercase-literal-suffix>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl16-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl16-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-dcl16-c
+```{title} clang-tidy - cert-dcl16-c
+```
 
-cert-dcl16-c
-============
+# cert-dcl16-c
 
 The `cert-dcl16-c` check is an alias, please see
-:doc:`readability-uppercase-literal-suffix
+{doc}`readability-uppercase-literal-suffix
 <../readability/uppercase-literal-suffix>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl37-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl37-c.md
@@ -6,4 +6,3 @@
 The `cert-dcl37-c` check is an alias, please see
 {doc}`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more
 information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl37-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl37-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-dcl37-c
+```{title} clang-tidy - cert-dcl37-c
+```
 
-cert-dcl37-c
-============
+# cert-dcl37-c
 
 The `cert-dcl37-c` check is an alias, please see
-:doc:`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more
+{doc}`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more
 information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.md
@@ -4,10 +4,8 @@
 # cert-dcl50-cpp
 
 The `cert-dcl50-cpp` check is an alias, please see
-{doc}`modernize-avoid-variadic-functions
-<../modernize/avoid-variadic-functions>`
+{doc}`modernize-avoid-variadic-functions <../modernize/avoid-variadic-functions>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [DCL50-CPP. Do not define a C-style variadic function](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl50-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cert-dcl50-cpp
+```{title} clang-tidy - cert-dcl50-cpp
+```
 
-cert-dcl50-cpp
-==============
+# cert-dcl50-cpp
 
 The `cert-dcl50-cpp` check is an alias, please see
-:doc:`modernize-avoid-variadic-functions
+{doc}`modernize-avoid-variadic-functions
 <../modernize/avoid-variadic-functions>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`DCL50-CPP. Do not define a C-style variadic function
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl50-cpp/>`_.
+[DCL50-CPP. Do not define a C-style variadic function](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl50-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl51-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl51-cpp.md
@@ -4,6 +4,4 @@
 # cert-dcl51-cpp
 
 The `cert-dcl51-cpp` check is an alias, please see
-{doc}`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more
-information.
-
+{doc}`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl51-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl51-cpp.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-dcl51-cpp
+```{title} clang-tidy - cert-dcl51-cpp
+```
 
-cert-dcl51-cpp
-==============
+# cert-dcl51-cpp
 
 The `cert-dcl51-cpp` check is an alias, please see
-:doc:`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more
+{doc}`bugprone-reserved-identifier <../bugprone/reserved-identifier>` for more
 information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl54-cpp.md
@@ -4,6 +4,4 @@
 # cert-dcl54-cpp
 
 The `cert-dcl54-cpp` check is an alias, please see
-{doc}`misc-new-delete-overloads <../misc/new-delete-overloads>` for more
-information.
-
+{doc}`misc-new-delete-overloads <../misc/new-delete-overloads>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl54-cpp.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-dcl54-cpp
+```{title} clang-tidy - cert-dcl54-cpp
+```
 
-cert-dcl54-cpp
-==============
+# cert-dcl54-cpp
 
 The `cert-dcl54-cpp` check is an alias, please see
-:doc:`misc-new-delete-overloads <../misc/new-delete-overloads>` for more
+{doc}`misc-new-delete-overloads <../misc/new-delete-overloads>` for more
 information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.md
@@ -4,10 +4,8 @@
 # cert-dcl58-cpp
 
 The `cert-dcl58-cpp` is an alias, please see
-{doc}`bugprone-std-namespace-modification
-<../bugprone/std-namespace-modification>`
+{doc}`bugprone-std-namespace-modification <../bugprone/std-namespace-modification>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [DCL58-CPP. Do not modify the standard namespaces](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl58-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cert-dcl58-cpp
+```{title} clang-tidy - cert-dcl58-cpp
+```
 
-cert-dcl58-cpp
-==============
+# cert-dcl58-cpp
 
 The `cert-dcl58-cpp` is an alias, please see
-:doc:`bugprone-std-namespace-modification
+{doc}`bugprone-std-namespace-modification
 <../bugprone/std-namespace-modification>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`DCL58-CPP. Do not modify the standard namespaces
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl58-cpp/>`_.
+[DCL58-CPP. Do not modify the standard namespaces](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl58-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl59-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl59-cpp.md
@@ -4,7 +4,5 @@
 # cert-dcl59-cpp
 
 The `cert-dcl59-cpp` check is an alias, please see
-{doc}`misc-anonymous-namespace-in-header
-<../misc/anonymous-namespace-in-header>`
+{doc}`misc-anonymous-namespace-in-header <../misc/anonymous-namespace-in-header>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl59-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl59-cpp.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-dcl59-cpp
+```{title} clang-tidy - cert-dcl59-cpp
+```
 
-cert-dcl59-cpp
-==============
+# cert-dcl59-cpp
 
 The `cert-dcl59-cpp` check is an alias, please see
-:doc:`misc-anonymous-namespace-in-header
+{doc}`misc-anonymous-namespace-in-header
 <../misc/anonymous-namespace-in-header>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.md
@@ -9,4 +9,3 @@ for more information.
 
 This check corresponds to the CERT C Coding Standard rule
 [ENV33-C. Do not call system()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - cert-env33-c
+```{title} clang-tidy - cert-env33-c
+```
 
-cert-env33-c
-============
+# cert-env33-c
 
 The `cert-env33-c` check is an alias, please see
-:doc:`bugprone-command-processor <../bugprone/command-processor>`
+{doc}`bugprone-command-processor <../bugprone/command-processor>`
 for more information.
 
 This check corresponds to the CERT C Coding Standard rule
-`ENV33-C. Do not call system()
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/>`_.
+[ENV33-C. Do not call system()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/environment-env/env33-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err09-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err09-cpp.md
@@ -4,8 +4,7 @@
 # cert-err09-cpp
 
 The `cert-err09-cpp` check is an alias, please see
-{doc}`misc-throw-by-value-catch-by-reference
-<../misc/throw-by-value-catch-by-reference>`
+{doc}`misc-throw-by-value-catch-by-reference <../misc/throw-by-value-catch-by-reference>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard recommendation
@@ -13,4 +12,3 @@ ERR09-CPP. Throw anonymous temporaries. However, all of the CERT
 recommendations have been removed from public view, and so their
 justification for the behavior of this check requires an account on
 their wiki to view.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err09-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err09-cpp.md
@@ -1,10 +1,10 @@
-.. title:: clang-tidy - cert-err09-cpp
+```{title} clang-tidy - cert-err09-cpp
+```
 
-cert-err09-cpp
-==============
+# cert-err09-cpp
 
 The `cert-err09-cpp` check is an alias, please see
-:doc:`misc-throw-by-value-catch-by-reference
+{doc}`misc-throw-by-value-catch-by-reference
 <../misc/throw-by-value-catch-by-reference>`
 for more information.
 
@@ -13,3 +13,4 @@ ERR09-CPP. Throw anonymous temporaries. However, all of the CERT
 recommendations have been removed from public view, and so their
 justification for the behavior of this check requires an account on
 their wiki to view.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err34-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err34-c.md
@@ -4,7 +4,5 @@
 # cert-err34-c
 
 The cert-err34-c check is an alias, please see
-{doc}`bugprone-unchecked-string-to-number-conversion
-<../bugprone/unchecked-string-to-number-conversion>`
+{doc}`bugprone-unchecked-string-to-number-conversion <../bugprone/unchecked-string-to-number-conversion>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err34-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err34-c.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-err34-c
+```{title} clang-tidy - cert-err34-c
+```
 
-cert-err34-c
-============
+# cert-err34-c
 
 The cert-err34-c check is an alias, please see
-:doc:`bugprone-unchecked-string-to-number-conversion
+{doc}`bugprone-unchecked-string-to-number-conversion
 <../bugprone/unchecked-string-to-number-conversion>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.md
@@ -9,4 +9,3 @@ for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [ERR52-CPP. Do not use setjmp() or longjmp()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err52-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - cert-err52-cpp
+```{title} clang-tidy - cert-err52-cpp
+```
 
-cert-err52-cpp
-==============
+# cert-err52-cpp
 
 The `cert-err52-cpp` check is an alias, please see
-:doc:`modernize-avoid-setjmp-longjmp <../modernize/avoid-setjmp-longjmp>`
+{doc}`modernize-avoid-setjmp-longjmp <../modernize/avoid-setjmp-longjmp>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`ERR52-CPP. Do not use setjmp() or longjmp()
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err52-cpp/>`_.
+[ERR52-CPP. Do not use setjmp() or longjmp()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err52-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err58-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err58-cpp.md
@@ -4,10 +4,8 @@
 # cert-err58-cpp
 
 The `cert-err58-cpp` check is an alias, please see
-{doc}`bugprone-throwing-static-initialization
-<../bugprone/throwing-static-initialization>`
+{doc}`bugprone-throwing-static-initialization <../bugprone/throwing-static-initialization>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [ERR58-CPP. Handle all exceptions thrown before main() begins executing](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err58-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err58-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err58-cpp.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cert-err58-cpp
+```{title} clang-tidy - cert-err58-cpp
+```
 
-cert-err58-cpp
-==============
+# cert-err58-cpp
 
 The `cert-err58-cpp` check is an alias, please see
-:doc:`bugprone-throwing-static-initialization
+{doc}`bugprone-throwing-static-initialization
 <../bugprone/throwing-static-initialization>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`ERR58-CPP. Handle all exceptions thrown before main() begins executing
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err58-cpp/>`_.
+[ERR58-CPP. Handle all exceptions thrown before main() begins executing](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err58-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.md
@@ -4,10 +4,8 @@
 # cert-err60-cpp
 
 The `cert-err60-cpp` check is an alias, please see
-{doc}`bugprone-exception-copy-constructor-throws
-<../bugprone/exception-copy-constructor-throws>`
+{doc}`bugprone-exception-copy-constructor-throws <../bugprone/exception-copy-constructor-throws>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [ERR60-CPP. Exception objects must be nothrow copy constructible](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err60-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cert-err60-cpp
+```{title} clang-tidy - cert-err60-cpp
+```
 
-cert-err60-cpp
-==============
+# cert-err60-cpp
 
 The `cert-err60-cpp` check is an alias, please see
-:doc:`bugprone-exception-copy-constructor-throws
+{doc}`bugprone-exception-copy-constructor-throws
 <../bugprone/exception-copy-constructor-throws>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`ERR60-CPP. Exception objects must be nothrow copy constructible
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err60-cpp/>`_.
+[ERR60-CPP. Exception objects must be nothrow copy constructible](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err60-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err61-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err61-cpp.md
@@ -4,7 +4,5 @@
 # cert-err61-cpp
 
 The `cert-err61-cpp` check is an alias, please see
-{doc}`misc-throw-by-value-catch-by-reference
-<../misc/throw-by-value-catch-by-reference>`
+{doc}`misc-throw-by-value-catch-by-reference <../misc/throw-by-value-catch-by-reference>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err61-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err61-cpp.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-err61-cpp
+```{title} clang-tidy - cert-err61-cpp
+```
 
-cert-err61-cpp
-==============
+# cert-err61-cpp
 
 The `cert-err61-cpp` check is an alias, please see
-:doc:`misc-throw-by-value-catch-by-reference
+{doc}`misc-throw-by-value-catch-by-reference
 <../misc/throw-by-value-catch-by-reference>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.md
@@ -4,6 +4,4 @@
 # cert-exp42-c
 
 The `cert-exp42-c` check is an alias, please see
-{doc}`bugprone-suspicious-memory-comparison
-<../bugprone/suspicious-memory-comparison>` for more information.
-
+{doc}`bugprone-suspicious-memory-comparison <../bugprone/suspicious-memory-comparison>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-exp42-c
+```{title} clang-tidy - cert-exp42-c
+```
 
-cert-exp42-c
-============
+# cert-exp42-c
 
 The `cert-exp42-c` check is an alias, please see
-:doc:`bugprone-suspicious-memory-comparison
+{doc}`bugprone-suspicious-memory-comparison
 <../bugprone/suspicious-memory-comparison>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.md
@@ -4,6 +4,4 @@
 # cert-exp45-c
 
 The `cert-exp45-c` check is an alias, please see
-{doc}`bugprone-assignment-in-selection-statement
-<../bugprone/assignment-in-selection-statement>` for more information.
-
+{doc}`bugprone-assignment-in-selection-statement <../bugprone/assignment-in-selection-statement>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-exp45-c
+```{title} clang-tidy - cert-exp45-c
+```
 
-cert-exp45-c
-============
+# cert-exp45-c
 
 The `cert-exp45-c` check is an alias, please see
-:doc:`bugprone-assignment-in-selection-statement
+{doc}`bugprone-assignment-in-selection-statement
 <../bugprone/assignment-in-selection-statement>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/fio38-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/fio38-c.md
@@ -4,8 +4,6 @@
 # cert-fio38-c
 
 The `cert-fio38-c` check is an alias, please see
-{doc}`misc-non-copyable-objects <../misc/non-copyable-objects>` for more
-information.
+{doc}`misc-non-copyable-objects <../misc/non-copyable-objects>` for more information.
 
 This check corresponds to CERT C++ Coding Standard rule [FIO38-C. Do not copy a FILE object](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/input-output-fio/fio38-c/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/fio38-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/fio38-c.md
@@ -1,11 +1,11 @@
-.. title:: clang-tidy - cert-fio38-c
+```{title} clang-tidy - cert-fio38-c
+```
 
-cert-fio38-c
-============
+# cert-fio38-c
 
 The `cert-fio38-c` check is an alias, please see
-:doc:`misc-non-copyable-objects <../misc/non-copyable-objects>` for more
+{doc}`misc-non-copyable-objects <../misc/non-copyable-objects>` for more
 information.
 
-This check corresponds to CERT C++ Coding Standard rule `FIO38-C. Do not copy a FILE object
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/input-output-fio/fio38-c/>`_.
+This check corresponds to CERT C++ Coding Standard rule [FIO38-C. Do not copy a FILE object](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/input-output-fio/fio38-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.md
@@ -9,4 +9,3 @@ for more information
 
 This check corresponds to the CERT C Coding Standard rule
 [FLP30-C. Do not use floating-point variables as loop counters](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/floating-point-flp/flp30-c/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - cert-flp30-c
+```{title} clang-tidy - cert-flp30-c
+```
 
-cert-flp30-c
-============
+# cert-flp30-c
 
 The `cert-flp30-c` check is an alias, please see
-:doc:`bugprone-float-loop-counter <../bugprone/float-loop-counter>`
+{doc}`bugprone-float-loop-counter <../bugprone/float-loop-counter>`
 for more information
 
 This check corresponds to the CERT C Coding Standard rule
-`FLP30-C. Do not use floating-point variables as loop counters
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/floating-point-flp/flp30-c/>`_.
+[FLP30-C. Do not use floating-point variables as loop counters](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/floating-point-flp/flp30-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.md
@@ -4,6 +4,4 @@
 # cert-flp37-c
 
 The `cert-flp37-c` check is an alias, please see
-{doc}`bugprone-suspicious-memory-comparison
-<../bugprone/suspicious-memory-comparison>` for more information.
-
+{doc}`bugprone-suspicious-memory-comparison <../bugprone/suspicious-memory-comparison>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-flp37-c
+```{title} clang-tidy - cert-flp37-c
+```
 
-cert-flp37-c
-============
+# cert-flp37-c
 
 The `cert-flp37-c` check is an alias, please see
-:doc:`bugprone-suspicious-memory-comparison
+{doc}`bugprone-suspicious-memory-comparison
 <../bugprone/suspicious-memory-comparison>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.md
@@ -4,6 +4,4 @@
 # cert-int09-c
 
 The `cert-int09-c` check is an alias, please see
-{doc}`readability-enum-initial-value <../readability/enum-initial-value>` for
-more information.
-
+{doc}`readability-enum-initial-value <../readability/enum-initial-value>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-int09-c
+```{title} clang-tidy - cert-int09-c
+```
 
-cert-int09-c
-============
+# cert-int09-c
 
 The `cert-int09-c` check is an alias, please see
-:doc:`readability-enum-initial-value <../readability/enum-initial-value>` for
+{doc}`readability-enum-initial-value <../readability/enum-initial-value>` for
 more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.md
@@ -4,10 +4,8 @@
 # cert-mem57-cpp
 
 The `cert-mem57-cpp` is an alias, please see
-{doc}`bugprone-default-operator-new-on-overaligned-type
-<../bugprone/default-operator-new-on-overaligned-type>`
+{doc}`bugprone-default-operator-new-on-overaligned-type <../bugprone/default-operator-new-on-overaligned-type>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [MEM57-CPP. Avoid using default operator new for over-aligned types](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cert-mem57-cpp
+```{title} clang-tidy - cert-mem57-cpp
+```
 
-cert-mem57-cpp
-==============
+# cert-mem57-cpp
 
 The `cert-mem57-cpp` is an alias, please see
-:doc:`bugprone-default-operator-new-on-overaligned-type
+{doc}`bugprone-default-operator-new-on-overaligned-type
 <../bugprone/default-operator-new-on-overaligned-type>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`MEM57-CPP. Avoid using default operator new for over-aligned types
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/>`_.
+[MEM57-CPP. Avoid using default operator new for over-aligned types](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc24-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc24-c.md
@@ -4,6 +4,4 @@
 # cert-msc24-c
 
 The `cert-msc24-c` check is an alias, please see
-{doc}`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more
-information.
-
+{doc}`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc24-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc24-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-msc24-c
+```{title} clang-tidy - cert-msc24-c
+```
 
-cert-msc24-c
-============
+# cert-msc24-c
 
 The `cert-msc24-c` check is an alias, please see
-:doc:`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more
+{doc}`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more
 information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.md
@@ -8,4 +8,3 @@ The `cert-msc30-c` check is an alias, please see
 
 This check corresponds to the CERT C Coding Standard rule
 [MSC30-C. Do not use the rand() function for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.md
@@ -1,11 +1,11 @@
-.. title:: clang-tidy - cert-msc30-c
+```{title} clang-tidy - cert-msc30-c
+```
 
-cert-msc30-c
-============
+# cert-msc30-c
 
 The `cert-msc30-c` check is an alias, please see
-:doc:`misc-predictable-rand <../misc/predictable-rand>` for more information.
+{doc}`misc-predictable-rand <../misc/predictable-rand>` for more information.
 
 This check corresponds to the CERT C Coding Standard rule
-`MSC30-C. Do not use the rand() function for generating pseudorandom numbers
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/>`_.
+[MSC30-C. Do not use the rand() function for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.md
@@ -9,4 +9,3 @@ for more information.
 
 This check corresponds to the CERT C Coding Standard rule
 [MSC32-C. Properly seed pseudorandom number generators](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc32-c/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - cert-msc32-c
+```{title} clang-tidy - cert-msc32-c
+```
 
-cert-msc32-c
-============
+# cert-msc32-c
 
 The `cert-msc32-c` check is an alias, please see
-:doc:`bugprone-random-generator-seed <../bugprone/random-generator-seed>`
+{doc}`bugprone-random-generator-seed <../bugprone/random-generator-seed>`
 for more information.
 
 This check corresponds to the CERT C Coding Standard rule
-`MSC32-C. Properly seed pseudorandom number generators
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc32-c/>`_.
+[MSC32-C. Properly seed pseudorandom number generators](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc32-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc33-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc33-c.md
@@ -4,6 +4,4 @@
 # cert-msc33-c
 
 The `cert-msc33-c` check is an alias, please see
-{doc}`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more
-information.
-
+{doc}`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc33-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc33-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-msc33-c
+```{title} clang-tidy - cert-msc33-c
+```
 
-cert-msc33-c
-============
+# cert-msc33-c
 
 The `cert-msc33-c` check is an alias, please see
-:doc:`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more
+{doc}`bugprone-unsafe-functions <../bugprone/unsafe-functions>` for more
 information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.md
@@ -8,4 +8,3 @@ The `cert-msc50-cpp` check is an alias, please see
 
 This check corresponds to the CERT C Coding Standard rule
 [MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.md
@@ -1,11 +1,11 @@
-.. title:: clang-tidy - cert-msc50-cpp
+```{title} clang-tidy - cert-msc50-cpp
+```
 
-cert-msc50-cpp
-==============
+# cert-msc50-cpp
 
 The `cert-msc50-cpp` check is an alias, please see
-:doc:`misc-predictable-rand <../misc/predictable-rand>` for more information.
+{doc}`misc-predictable-rand <../misc/predictable-rand>` for more information.
 
 This check corresponds to the CERT C Coding Standard rule
-`MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp>`_.
+[MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.md
@@ -4,10 +4,8 @@
 # cert-msc51-cpp
 
 The `cert-msc51-cpp` check is an alias, please see
-{doc}`bugprone-random-generator-seed
-<../bugprone/random-generator-seed>`
+{doc}`bugprone-random-generator-seed <../bugprone/random-generator-seed>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [MSC51-CPP. Ensure your random number generator is properly seeded](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc51-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cert-msc51-cpp
+```{title} clang-tidy - cert-msc51-cpp
+```
 
-cert-msc51-cpp
-==============
+# cert-msc51-cpp
 
 The `cert-msc51-cpp` check is an alias, please see
-:doc:`bugprone-random-generator-seed
+{doc}`bugprone-random-generator-seed
 <../bugprone/random-generator-seed>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`MSC51-CPP. Ensure your random number generator is properly seeded
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc51-cpp/>`_.
+[MSC51-CPP. Ensure your random number generator is properly seeded](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc51-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc54-cpp.md
@@ -6,4 +6,3 @@
 The `cert-msc54-cpp` check is an alias, please see
 {doc}`bugprone-signal-handler <../bugprone/signal-handler>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc54-cpp.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-msc54-cpp
+```{title} clang-tidy - cert-msc54-cpp
+```
 
-cert-msc54-cpp
-==============
+# cert-msc54-cpp
 
 The `cert-msc54-cpp` check is an alias, please see
-:doc:`bugprone-signal-handler <../bugprone/signal-handler>`
+{doc}`bugprone-signal-handler <../bugprone/signal-handler>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop11-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop11-cpp.md
@@ -3,7 +3,7 @@
 
 # cert-oop11-cpp
 
-The `cert-oop11-cpp check` is an alias, please see
+The `cert-oop11-cpp` check is an alias, please see
 {doc}`performance-move-constructor-init <../performance/move-constructor-init>`
 for more information.
 
@@ -12,4 +12,3 @@ OOP11-CPP. Do not copy-initialize members or base classes from a move
 constructor. However, all of the CERT recommendations have been removed from
 public view, and so their justification for the behavior of this check requires
 an account on their wiki to view.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop11-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop11-cpp.md
@@ -1,10 +1,10 @@
-.. title:: clang-tidy - cert-oop11-cpp
+```{title} clang-tidy - cert-oop11-cpp
+```
 
-cert-oop11-cpp
-==============
+# cert-oop11-cpp
 
 The `cert-oop11-cpp check` is an alias, please see
-:doc:`performance-move-constructor-init <../performance/move-constructor-init>`
+{doc}`performance-move-constructor-init <../performance/move-constructor-init>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard recommendation
@@ -12,3 +12,4 @@ OOP11-CPP. Do not copy-initialize members or base classes from a move
 constructor. However, all of the CERT recommendations have been removed from
 public view, and so their justification for the behavior of this check requires
 an account on their wiki to view.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop54-cpp.md
@@ -4,7 +4,5 @@
 # cert-oop54-cpp
 
 The `cert-oop54-cpp` check is an alias, please see
-{doc}`bugprone-unhandled-self-assignment
-<../bugprone/unhandled-self-assignment>`
+{doc}`bugprone-unhandled-self-assignment <../bugprone/unhandled-self-assignment>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop54-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop54-cpp.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-oop54-cpp
+```{title} clang-tidy - cert-oop54-cpp
+```
 
-cert-oop54-cpp
-==============
+# cert-oop54-cpp
 
 The `cert-oop54-cpp` check is an alias, please see
-:doc:`bugprone-unhandled-self-assignment
+{doc}`bugprone-unhandled-self-assignment
 <../bugprone/unhandled-self-assignment>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.md
@@ -4,11 +4,9 @@
 # cert-oop57-cpp
 
 The `cert-oop57-cpp` check is an alias, please see
-{doc}`bugprone-raw-memory-call-on-non-trivial-type
-<../bugprone/raw-memory-call-on-non-trivial-type>`
+{doc}`bugprone-raw-memory-call-on-non-trivial-type <../bugprone/raw-memory-call-on-non-trivial-type>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [OOP57-CPP. Prefer special member functions and overloaded operators to C
 Standard Library functions](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop57-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.md
@@ -1,14 +1,14 @@
-.. title:: clang-tidy - cert-oop57-cpp
+```{title} clang-tidy - cert-oop57-cpp
+```
 
-cert-oop57-cpp
-==============
+# cert-oop57-cpp
 
 The `cert-oop57-cpp` check is an alias, please see
-:doc:`bugprone-raw-memory-call-on-non-trivial-type
+{doc}`bugprone-raw-memory-call-on-non-trivial-type
 <../bugprone/raw-memory-call-on-non-trivial-type>`
 for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
-`OOP57-CPP. Prefer special member functions and overloaded operators to C
-Standard Library functions
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop57-cpp/>`_.
+[OOP57-CPP. Prefer special member functions and overloaded operators to C
+Standard Library functions](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop57-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop58-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop58-cpp.md
@@ -4,7 +4,5 @@
 # cert-oop58-cpp
 
 The `cert-oop58-cpp` check is an alias, please see
-{doc}`bugprone-copy-constructor-mutates-argument
-<../bugprone/copy-constructor-mutates-argument>`
+{doc}`bugprone-copy-constructor-mutates-argument <../bugprone/copy-constructor-mutates-argument>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop58-cpp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop58-cpp.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - cert-oop58-cpp
+```{title} clang-tidy - cert-oop58-cpp
+```
 
-cert-oop58-cpp
-==============
+# cert-oop58-cpp
 
 The `cert-oop58-cpp` check is an alias, please see
-:doc:`bugprone-copy-constructor-mutates-argument
+{doc}`bugprone-copy-constructor-mutates-argument
 <../bugprone/copy-constructor-mutates-argument>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/pos44-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/pos44-c.md
@@ -4,6 +4,4 @@
 # cert-pos44-c
 
 The `cert-pos44-c` check is an alias, please see
-{doc}`bugprone-bad-signal-to-kill-thread
-<../bugprone/bad-signal-to-kill-thread>` for more information.
-
+{doc}`bugprone-bad-signal-to-kill-thread <../bugprone/bad-signal-to-kill-thread>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/pos44-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/pos44-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-pos44-c
+```{title} clang-tidy - cert-pos44-c
+```
 
-cert-pos44-c
-============
+# cert-pos44-c
 
 The `cert-pos44-c` check is an alias, please see
-:doc:`bugprone-bad-signal-to-kill-thread
+{doc}`bugprone-bad-signal-to-kill-thread
 <../bugprone/bad-signal-to-kill-thread>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/pos47-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/pos47-c.md
@@ -4,6 +4,4 @@
 # cert-pos47-c
 
 The `cert-pos47-c` check is an alias, please see
-{doc}`concurrency-thread-canceltype-asynchronous
-<../concurrency/thread-canceltype-asynchronous>` for more information.
-
+{doc}`concurrency-thread-canceltype-asynchronous <../concurrency/thread-canceltype-asynchronous>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/pos47-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/pos47-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-pos47-c
+```{title} clang-tidy - cert-pos47-c
+```
 
-cert-pos47-c
-============
+# cert-pos47-c
 
 The `cert-pos47-c` check is an alias, please see
-:doc:`concurrency-thread-canceltype-asynchronous
+{doc}`concurrency-thread-canceltype-asynchronous
 <../concurrency/thread-canceltype-asynchronous>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/sig30-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/sig30-c.md
@@ -3,7 +3,4 @@
 
 # cert-sig30-c
 
-The `cert-sig30-c` check is an alias, please see
-{doc}`bugprone-signal-handler <../bugprone/signal-handler>`
-for more information.
-
+The `cert-sig30-c` check is an alias, please see {doc}`bugprone-signal-handler <../bugprone/signal-handler>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/sig30-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/sig30-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-sig30-c
+```{title} clang-tidy - cert-sig30-c
+```
 
-cert-sig30-c
-============
+# cert-sig30-c
 
 The `cert-sig30-c` check is an alias, please see
-:doc:`bugprone-signal-handler <../bugprone/signal-handler>`
+{doc}`bugprone-signal-handler <../bugprone/signal-handler>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/str34-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/str34-c.md
@@ -6,4 +6,3 @@
 The `cert-str34-c` check is an alias, please see
 {doc}`bugprone-signed-char-misuse <../bugprone/signed-char-misuse>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/str34-c.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/str34-c.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cert-str34-c
+```{title} clang-tidy - cert-str34-c
+```
 
-cert-str34-c
-============
+# cert-str34-c
 
 The `cert-str34-c` check is an alias, please see
-:doc:`bugprone-signed-char-misuse <../bugprone/signed-char-misuse>`
+{doc}`bugprone-signed-char-misuse <../bugprone/signed-char-misuse>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.md
@@ -10,7 +10,7 @@ type is set to asynchronous. Asynchronous cancellation type
 cancellation, a cancellation point in an asynchronous signal handler may still
 be acted upon and the effect is as if it was an asynchronous cancellation.
 
-```c++
+```cpp
 pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldtype);
 ```
 
@@ -18,4 +18,3 @@ This check corresponds to the CERT C Coding Standard rule
 [POS47-C. Do not use threads that can be canceled asynchronously](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos47-c/).
 
 `cert-pos47-c` redirects here as an alias of this check.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.md
@@ -1,21 +1,21 @@
-.. title:: clang-tidy - concurrency-thread-canceltype-asynchronous
+```{title} clang-tidy - concurrency-thread-canceltype-asynchronous
+```
 
-concurrency-thread-canceltype-asynchronous
-==========================================
+# concurrency-thread-canceltype-asynchronous
 
-Finds ``pthread_setcanceltype`` function calls where a thread's cancellation
+Finds `pthread_setcanceltype` function calls where a thread's cancellation
 type is set to asynchronous. Asynchronous cancellation type
-(``PTHREAD_CANCEL_ASYNCHRONOUS``) is generally unsafe, use type
-``PTHREAD_CANCEL_DEFERRED`` instead which is the default. Even with deferred
+(`PTHREAD_CANCEL_ASYNCHRONOUS`) is generally unsafe, use type
+`PTHREAD_CANCEL_DEFERRED` instead which is the default. Even with deferred
 cancellation, a cancellation point in an asynchronous signal handler may still
 be acted upon and the effect is as if it was an asynchronous cancellation.
 
-.. code-block:: c++
-
-  pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldtype);
+```c++
+pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldtype);
+```
 
 This check corresponds to the CERT C Coding Standard rule
-`POS47-C. Do not use threads that can be canceled asynchronously
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos47-c/>`_.
+[POS47-C. Do not use threads that can be canceled asynchronously](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos47-c/).
 
 `cert-pos47-c` redirects here as an alias of this check.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.md
@@ -6,4 +6,3 @@
 The `cppcoreguidelines-avoid-c-arrays` check is an alias, please see
 {doc}`modernize-avoid-c-arrays <../modernize/avoid-c-arrays>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cppcoreguidelines-avoid-c-arrays
+```{title} clang-tidy - cppcoreguidelines-avoid-c-arrays
+```
 
-cppcoreguidelines-avoid-c-arrays
-================================
+# cppcoreguidelines-avoid-c-arrays
 
 The `cppcoreguidelines-avoid-c-arrays` check is an alias, please see
-:doc:`modernize-avoid-c-arrays <../modernize/avoid-c-arrays>`
+{doc}`modernize-avoid-c-arrays <../modernize/avoid-c-arrays>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.md
@@ -6,4 +6,3 @@
 The `cppcoreguidelines-avoid-magic-numbers` check is an alias, please see
 {doc}`readability-magic-numbers <../readability/magic-numbers>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cppcoreguidelines-avoid-magic-numbers
+```{title} clang-tidy - cppcoreguidelines-avoid-magic-numbers
+```
 
-cppcoreguidelines-avoid-magic-numbers
-=====================================
+# cppcoreguidelines-avoid-magic-numbers
 
 The `cppcoreguidelines-avoid-magic-numbers` check is an alias, please see
-:doc:`readability-magic-numbers <../readability/magic-numbers>`
+{doc}`readability-magic-numbers <../readability/magic-numbers>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.md
@@ -9,7 +9,7 @@ parameters as values.
 
 Examples:
 
-```c++
+```cpp
 std::future<int> someCoroutine(int& val) {
   co_await ...;
   // When the coroutine is resumed, 'val' might no longer be valid.
@@ -19,4 +19,3 @@ std::future<int> someCoroutine(int& val) {
 
 This check implements [CP.53](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcoro-reference-parameters)
 from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - cppcoreguidelines-avoid-reference-coroutine-parameters
+```{title} clang-tidy - cppcoreguidelines-avoid-reference-coroutine-parameters
+```
 
-cppcoreguidelines-avoid-reference-coroutine-parameters
-======================================================
+# cppcoreguidelines-avoid-reference-coroutine-parameters
 
 Warns when a coroutine accepts reference parameters. After a coroutine suspend
 point, references could be dangling and no longer valid. Instead, pass
@@ -9,14 +9,14 @@ parameters as values.
 
 Examples:
 
-.. code-block:: c++
+```c++
+std::future<int> someCoroutine(int& val) {
+  co_await ...;
+  // When the coroutine is resumed, 'val' might no longer be valid.
+  if (val) ...
+}
+```
 
-  std::future<int> someCoroutine(int& val) {
-    co_await ...;
-    // When the coroutine is resumed, 'val' might no longer be valid.
-    if (val) ...
-  }
-
-This check implements `CP.53
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcoro-reference-parameters>`_
+This check implements [CP.53](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcoro-reference-parameters)
 from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.md
@@ -4,6 +4,4 @@
 # cppcoreguidelines-c-copy-assignment-signature
 
 The `cppcoreguidelines-c-copy-assignment-signature` check is an alias,
-please see {doc}`misc-unconventional-assign-operator
-<../misc/unconventional-assign-operator>` for more information.
-
+please see {doc}`misc-unconventional-assign-operator <../misc/unconventional-assign-operator>` for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cppcoreguidelines-c-copy-assignment-signature
+```{title} clang-tidy - cppcoreguidelines-c-copy-assignment-signature
+```
 
-cppcoreguidelines-c-copy-assignment-signature
-=============================================
+# cppcoreguidelines-c-copy-assignment-signature
 
 The `cppcoreguidelines-c-copy-assignment-signature` check is an alias,
-please see :doc:`misc-unconventional-assign-operator
+please see {doc}`misc-unconventional-assign-operator
 <../misc/unconventional-assign-operator>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-constructor.md
@@ -5,4 +5,3 @@
 
 This check is an alias for
 {doc}`misc-explicit-constructor <../misc/explicit-constructor>`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-constructor.md
@@ -1,7 +1,8 @@
-.. title:: clang-tidy - cppcoreguidelines-explicit-constructor
+```{title} clang-tidy - cppcoreguidelines-explicit-constructor
+```
 
-cppcoreguidelines-explicit-constructor
-======================================
+# cppcoreguidelines-explicit-constructor
 
 This check is an alias for
-:doc:`misc-explicit-constructor <../misc/explicit-constructor>`.
+{doc}`misc-explicit-constructor <../misc/explicit-constructor>`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.md
@@ -6,4 +6,3 @@
 The `cppcoreguidelines-explicit-virtual-functions` check is an alias,
 please see {doc}`modernize-use-override <../modernize/use-override>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cppcoreguidelines-explicit-virtual-functions
+```{title} clang-tidy - cppcoreguidelines-explicit-virtual-functions
+```
 
-cppcoreguidelines-explicit-virtual-functions
-============================================
+# cppcoreguidelines-explicit-virtual-functions
 
 The `cppcoreguidelines-explicit-virtual-functions` check is an alias,
-please see :doc:`modernize-use-override <../modernize/use-override>`
+please see {doc}`modernize-use-override <../modernize/use-override>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/interfaces-global-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/interfaces-global-init.md
@@ -1,13 +1,12 @@
-.. title:: clang-tidy - cppcoreguidelines-interfaces-global-init
+```{title} clang-tidy - cppcoreguidelines-interfaces-global-init
+```
 
-cppcoreguidelines-interfaces-global-init
-========================================
+# cppcoreguidelines-interfaces-global-init
 
 This check flags initializers of globals that access extern objects,
 and therefore can lead to order-of-initialization problems.
 
-This check implements `I.22
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#ri-global-init>`_
+This check implements [I.22](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#ri-global-init)
 from the C++ Core Guidelines.
 
 Note that currently this does not flag calls to non-constexpr functions, and

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-to-enum.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-to-enum.md
@@ -6,4 +6,3 @@
 The `cppcoreguidelines-macro-to-enum` check is an alias, please see
 {doc}`modernize-macro-to-enum <../modernize/macro-to-enum>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-to-enum.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-to-enum.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cppcoreguidelines-macro-to-enum
+```{title} clang-tidy - cppcoreguidelines-macro-to-enum
+```
 
-cppcoreguidelines-macro-to-enum
-===============================
+# cppcoreguidelines-macro-to-enum
 
 The `cppcoreguidelines-macro-to-enum` check is an alias, please see
-:doc:`modernize-macro-to-enum <../modernize/macro-to-enum>`
+{doc}`modernize-macro-to-enum <../modernize/macro-to-enum>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.md
@@ -9,4 +9,3 @@ from the C++ Core Guidelines.
 The `cppcoreguidelines-narrowing-conversions` check is an alias, please see
 {doc}`bugprone-narrowing-conversions <../bugprone/narrowing-conversions>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - cppcoreguidelines-narrowing-conversions
+```{title} clang-tidy - cppcoreguidelines-narrowing-conversions
+```
 
-cppcoreguidelines-narrowing-conversions
-=======================================
+# cppcoreguidelines-narrowing-conversions
 
-This check implements part of  `ES.46
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es46-avoid-lossy-narrowing-truncating-arithmetic-conversions>`_
+This check implements part of [ES.46](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es46-avoid-lossy-narrowing-truncating-arithmetic-conversions)
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-narrowing-conversions` check is an alias, please see
-:doc:`bugprone-narrowing-conversions <../bugprone/narrowing-conversions>`
+{doc}`bugprone-narrowing-conversions <../bugprone/narrowing-conversions>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.md
@@ -9,4 +9,3 @@ from the C++ Core Guidelines.
 The `cppcoreguidelines-noexcept-destructor` check is an alias, please see
 {doc}`performance-noexcept-destructor <../performance/noexcept-destructor>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.md
@@ -1,11 +1,12 @@
-.. title:: clang-tidy - cppcoreguidelines-noexcept-destructor
+```{title} clang-tidy - cppcoreguidelines-noexcept-destructor
+```
 
-cppcoreguidelines-noexcept-destructor
-=====================================
+# cppcoreguidelines-noexcept-destructor
 
-This check implements `C.37 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c37-make-destructors-noexcept>`_
+This check implements [C.37](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c37-make-destructors-noexcept)
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-noexcept-destructor` check is an alias, please see
-:doc:`performance-noexcept-destructor <../performance/noexcept-destructor>`
+{doc}`performance-noexcept-destructor <../performance/noexcept-destructor>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.md
@@ -7,6 +7,5 @@ This check implements [C.66](https://isocpp.github.io/CppCoreGuidelines/CppCoreG
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-noexcept-move-operations` check is an alias, please see
-{doc}`performance-noexcept-move-constructor
-<../performance/noexcept-move-constructor>` for more information.
-
+{doc}`performance-noexcept-move-constructor <../performance/noexcept-move-constructor>`
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.md
@@ -1,11 +1,12 @@
-.. title:: clang-tidy - cppcoreguidelines-noexcept-move-operations
+```{title} clang-tidy - cppcoreguidelines-noexcept-move-operations
+```
 
-cppcoreguidelines-noexcept-move-operations
-==========================================
+# cppcoreguidelines-noexcept-move-operations
 
-This check implements `C.66 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c66-make-move-operations-noexcept>`_
+This check implements [C.66](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c66-make-move-operations-noexcept)
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-noexcept-move-operations` check is an alias, please see
-:doc:`performance-noexcept-move-constructor
+{doc}`performance-noexcept-move-constructor
 <../performance/noexcept-move-constructor>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-swap.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-swap.md
@@ -3,12 +3,11 @@
 
 # cppcoreguidelines-noexcept-swap
 
-This check implements [C.83](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c83-for-value-like-types-consider-providing-a-noexcept-swap-function)
-, [C.84](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c84-a-swap-function-must-not-fail)
+This check implements [C.83](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c83-for-value-like-types-consider-providing-a-noexcept-swap-function),
+[C.84](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c84-a-swap-function-must-not-fail)
 and [C.85](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c85-make-swap-noexcept)
 from the C++ Core Guidelines.
 
-The `cppcoreguidelines-noexcept-swap check` is an alias, please see
+The `cppcoreguidelines-noexcept-swap` check is an alias, please see
 {doc}`performance-noexcept-swap <../performance/noexcept-swap>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-swap.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-swap.md
@@ -1,13 +1,14 @@
-.. title:: clang-tidy - cppcoreguidelines-noexcept-swap
+```{title} clang-tidy - cppcoreguidelines-noexcept-swap
+```
 
-cppcoreguidelines-noexcept-swap
-===============================
+# cppcoreguidelines-noexcept-swap
 
-This check implements `C.83 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c83-for-value-like-types-consider-providing-a-noexcept-swap-function>`_
-, `C.84 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c84-a-swap-function-must-not-fail>`_
-and `C.85 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c85-make-swap-noexcept>`_
+This check implements [C.83](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c83-for-value-like-types-consider-providing-a-noexcept-swap-function)
+, [C.84](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c84-a-swap-function-must-not-fail)
+and [C.85](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c85-make-swap-noexcept)
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-noexcept-swap check` is an alias, please see
-:doc:`performance-noexcept-swap <../performance/noexcept-swap>`
+{doc}`performance-noexcept-swap <../performance/noexcept-swap>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.md
@@ -4,6 +4,5 @@
 # cppcoreguidelines-non-private-member-variables-in-classes
 
 The `cppcoreguidelines-non-private-member-variables-in-classes` check is
-an alias, please see {doc}`misc-non-private-member-variables-in-classes
-<../misc/non-private-member-variables-in-classes>` for more information.
-
+an alias, please see {doc}`misc-non-private-member-variables-in-classes <../misc/non-private-member-variables-in-classes>`
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - cppcoreguidelines-non-private-member-variables-in-classes
+```{title} clang-tidy - cppcoreguidelines-non-private-member-variables-in-classes
+```
 
-cppcoreguidelines-non-private-member-variables-in-classes
-=========================================================
+# cppcoreguidelines-non-private-member-variables-in-classes
 
 The `cppcoreguidelines-non-private-member-variables-in-classes` check is
-an alias, please see :doc:`misc-non-private-member-variables-in-classes
+an alias, please see {doc}`misc-non-private-member-variables-in-classes
 <../misc/non-private-member-variables-in-classes>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.md
@@ -10,4 +10,3 @@ alternative to using pointers to access arrays.
 
 This rule is part of the [Bounds safety (Bounds 3)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-decay)
 profile from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-bounds-array-to-pointer-decay
+```{title} clang-tidy - cppcoreguidelines-pro-bounds-array-to-pointer-decay
+```
 
-cppcoreguidelines-pro-bounds-array-to-pointer-decay
-===================================================
+# cppcoreguidelines-pro-bounds-array-to-pointer-decay
 
 This check flags all array to pointer decays.
 
-Pointers should not be used as arrays. ``span<T>`` is a bounds-checked, safe
+Pointers should not be used as arrays. `span<T>` is a bounds-checked, safe
 alternative to using pointers to access arrays.
 
-This rule is part of the `Bounds safety (Bounds 3)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-decay>`_
+This rule is part of the [Bounds safety (Bounds 3)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-decay)
 profile from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.md
@@ -15,18 +15,15 @@ Optionally, this check can generate fixes using `gsl::at` for indexing.
 
 ## Options
 
-```{eval-rst}
-.. option:: GslHeader
+```{option} GslHeader
 
-   The check can generate fixes after this option has been set to the name of
-   the include file that contains ``gsl::at()``, e.g. `"gsl/gsl.h"`.
-   Default is an empty string.
+The check can generate fixes after this option has been set to the name of
+the include file that contains `gsl::at()`, e.g. `"gsl/gsl.h"`.
+Default is an empty string.
 ```
 
-```{eval-rst}
-.. option:: IncludeStyle
+```{option} IncludeStyle
 
-   A string specifying which include-style is used, `llvm` or `google`. Default
-   is `llvm`.
+A string specifying which include-style is used, `llvm` or `google`. Default
+is `llvm`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.md
@@ -1,29 +1,32 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-bounds-constant-array-index
+```{title} clang-tidy - cppcoreguidelines-pro-bounds-constant-array-index
+```
 
-cppcoreguidelines-pro-bounds-constant-array-index
-=================================================
+# cppcoreguidelines-pro-bounds-constant-array-index
 
 This check flags all array subscript expressions on static arrays and
-``std::arrays`` that either do not have a constant integer expression index or
-are out of bounds (for ``std::array``). For out-of-bounds checking of static
+`std::arrays` that either do not have a constant integer expression index or
+are out of bounds (for `std::array`). For out-of-bounds checking of static
 arrays, see the `-Warray-bounds` Clang diagnostic.
 
-This rule is part of the `Bounds safety (Bounds 2)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arrayindex>`_
+This rule is part of the [Bounds safety (Bounds 2)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arrayindex)
 profile from the C++ Core Guidelines.
 
-Optionally, this check can generate fixes using ``gsl::at`` for indexing.
+Optionally, this check can generate fixes using `gsl::at` for indexing.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: GslHeader
 
    The check can generate fixes after this option has been set to the name of
    the include file that contains ``gsl::at()``, e.g. `"gsl/gsl.h"`.
    Default is an empty string.
+```
 
+```{eval-rst}
 .. option:: IncludeStyle
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.md
@@ -15,10 +15,8 @@ profile from the C++ Core Guidelines.
 
 ## Options
 
-```{eval-rst}
-.. option:: AllowIncrementDecrementOperators
+```{option} AllowIncrementDecrementOperators
 
-   When enabled, the check will allow using the prefix/postfix increment or
-   decrement operators on pointers. Default is ``false``.
+When enabled, the check will allow using the prefix/postfix increment or
+decrement operators on pointers. Default is `false`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.md
@@ -1,23 +1,24 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-bounds-pointer-arithmetic
+```{title} clang-tidy - cppcoreguidelines-pro-bounds-pointer-arithmetic
+```
 
-cppcoreguidelines-pro-bounds-pointer-arithmetic
-===============================================
+# cppcoreguidelines-pro-bounds-pointer-arithmetic
 
 This check flags all usage of pointer arithmetic, because it could lead to an
 invalid pointer. Subtraction of two pointers is not flagged by this check.
 
 Pointers should only refer to single objects, and pointer arithmetic is fragile
-and easy to get wrong. ``span<T>`` is a bounds-checked, safe type for accessing
+and easy to get wrong. `span<T>` is a bounds-checked, safe type for accessing
 arrays of data.
 
-This rule is part of the `Bounds safety (Bounds 1)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arithmetic>`_
+This rule is part of the [Bounds safety (Bounds 1)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arithmetic)
 profile from the C++ Core Guidelines.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: AllowIncrementDecrementOperators
 
    When enabled, the check will allow using the prefix/postfix increment or
    decrement operators on pointers. Default is ``false``.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.md
@@ -16,4 +16,3 @@ This rule bans `(T)expression` only when used to perform an unsafe cast.
 
 This rule is part of the [Type safety (Type.4)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-cstylecast)
 profile from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.md
@@ -1,19 +1,19 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-type-cstyle-cast
+```{title} clang-tidy - cppcoreguidelines-pro-type-cstyle-cast
+```
 
-cppcoreguidelines-pro-type-cstyle-cast
-======================================
+# cppcoreguidelines-pro-type-cstyle-cast
 
-This check flags all use of C-style casts that perform a ``static_cast``
-downcast, ``const_cast``, or ``reinterpret_cast``.
+This check flags all use of C-style casts that perform a `static_cast`
+downcast, `const_cast`, or `reinterpret_cast`.
 
 Use of these casts can violate type safety and cause the program to access a
 variable that is actually of type X to be accessed as if it were of an
-unrelated type Z. Note that a C-style ``(T)expression`` cast means to perform
-the first of the following that is possible: a ``const_cast``, a
-``static_cast``, a ``static_cast`` followed by a ``const_cast``, a
-``reinterpret_cast``, or a ``reinterpret_cast`` followed by a ``const_cast``.
-This rule bans ``(T)expression`` only when used to perform an unsafe cast.
+unrelated type Z. Note that a C-style `(T)expression` cast means to perform
+the first of the following that is possible: a `const_cast`, a
+`static_cast`, a `static_cast` followed by a `const_cast`, a
+`reinterpret_cast`, or a `reinterpret_cast` followed by a `const_cast`.
+This rule bans `(T)expression` only when used to perform an unsafe cast.
 
-This rule is part of the `Type safety (Type.4)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-cstylecast>`_
+This rule is part of the [Type safety (Type.4)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-cstylecast)
 profile from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.md
@@ -11,4 +11,3 @@ unrelated type `Z`.
 
 This rule is part of the [Type safety (Type.1.1)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-reinterpretcast)
 profile from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.md
@@ -1,14 +1,14 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-type-reinterpret-cast
+```{title} clang-tidy - cppcoreguidelines-pro-type-reinterpret-cast
+```
 
-cppcoreguidelines-pro-type-reinterpret-cast
-===========================================
+# cppcoreguidelines-pro-type-reinterpret-cast
 
-This check flags all uses of ``reinterpret_cast`` in C++ code.
+This check flags all uses of `reinterpret_cast` in C++ code.
 
 Use of these casts can violate type safety and cause the program to access a
-variable that is actually of type ``X`` to be accessed as if it were of an
-unrelated type ``Z``.
+variable that is actually of type `X` to be accessed as if it were of an
+unrelated type `Z`.
 
-This rule is part of the `Type safety (Type.1.1)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-reinterpretcast>`_
+This rule is part of the [Type safety (Type.1.1)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-reinterpretcast)
 profile from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.md
@@ -16,10 +16,8 @@ profile from the C++ Core Guidelines.
 
 ## Options
 
-```{eval-rst}
-.. option:: StrictMode
+```{option} StrictMode
 
-  When set to `false`, no warnings are emitted for casts on non-polymorphic
-  types. Default is `true`.
+When set to `false`, no warnings are emitted for casts on non-polymorphic
+types. Default is `true`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.md
@@ -1,24 +1,25 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-type-static-cast-downcast
+```{title} clang-tidy - cppcoreguidelines-pro-type-static-cast-downcast
+```
 
-cppcoreguidelines-pro-type-static-cast-downcast
-===============================================
+# cppcoreguidelines-pro-type-static-cast-downcast
 
-This check flags all usages of ``static_cast``, where a base class is casted to
+This check flags all usages of `static_cast`, where a base class is casted to
 a derived class. In those cases, a fix-it is provided to convert the cast to a
-``dynamic_cast``.
+`dynamic_cast`.
 
 Use of these casts can violate type safety and cause the program to access a
-variable that is actually of type ``X`` to be accessed as if it were of an
-unrelated type ``Z``.
+variable that is actually of type `X` to be accessed as if it were of an
+unrelated type `Z`.
 
-This rule is part of the `Type safety (Type.2)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-downcast>`_
+This rule is part of the [Type safety (Type.2)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-downcast)
 profile from the C++ Core Guidelines.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: StrictMode
 
   When set to `false`, no warnings are emitted for casts on non-polymorphic
   types. Default is `true`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.md
@@ -14,4 +14,3 @@ get it right.
 
 This rule is part of the [Type safety (Type.7)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-unions)
 profile from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-type-union-access
+```{title} clang-tidy - cppcoreguidelines-pro-type-union-access
+```
 
-cppcoreguidelines-pro-type-union-access
-=======================================
+# cppcoreguidelines-pro-type-union-access
 
 This check flags all access to members of unions. Passing unions as a whole is
 not flagged.
@@ -12,6 +12,6 @@ had its destructor called. This is fragile because it cannot generally be
 enforced to be safe in the language and so relies on programmer discipline to
 get it right.
 
-This rule is part of the `Type safety (Type.7)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-unions>`_
+This rule is part of the [Type safety (Type.7)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-unions)
 profile from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.md
@@ -16,4 +16,3 @@ relies on programmer discipline to get it right.
 
 This rule is part of the [Type safety (Type.8)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-varargs)
 profile from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.md
@@ -1,10 +1,10 @@
-.. title:: clang-tidy - cppcoreguidelines-pro-type-vararg
+```{title} clang-tidy - cppcoreguidelines-pro-type-vararg
+```
 
-cppcoreguidelines-pro-type-vararg
-=================================
+# cppcoreguidelines-pro-type-vararg
 
 This check flags all calls to c-style vararg functions and all use of
-``va_arg``.
+`va_arg`.
 
 To allow for SFINAE use of vararg functions, a call is not flagged if a literal
 0 is passed as the only vararg argument or function is used in unevaluated
@@ -14,6 +14,6 @@ Passing to varargs assumes the correct type will be read. This is fragile
 because it cannot generally be enforced to be safe in the language and so
 relies on programmer discipline to get it right.
 
-This rule is part of the `Type safety (Type.8)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-varargs>`_
+This rule is part of the [Type safety (Type.8)](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-varargs)
 profile from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/slicing.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/slicing.md
@@ -8,7 +8,7 @@ derived object into a base object: the members of the derived object (both
 member variables and virtual member functions) will be discarded. This can be
 misleading especially for member function slicing, for example:
 
-```c++
+```cpp
 struct B { int a; virtual int f(); };
 struct D : B { int b; int f() override; };
 
@@ -23,4 +23,3 @@ use(d);  // Slice.
 This check implements [ES.63](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es63-dont-slice)
 and [C.145](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c145-access-polymorphic-objects-through-pointers-and-references)
 from the C++ Core Guidelines.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/slicing.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/slicing.md
@@ -1,27 +1,26 @@
-.. title:: clang-tidy - cppcoreguidelines-slicing
+```{title} clang-tidy - cppcoreguidelines-slicing
+```
 
-cppcoreguidelines-slicing
-=========================
+# cppcoreguidelines-slicing
 
 Flags slicing of member variables or vtable. Slicing happens when copying a
 derived object into a base object: the members of the derived object (both
 member variables and virtual member functions) will be discarded. This can be
 misleading especially for member function slicing, for example:
 
-.. code-block:: c++
+```c++
+struct B { int a; virtual int f(); };
+struct D : B { int b; int f() override; };
 
-  struct B { int a; virtual int f(); };
-  struct D : B { int b; int f() override; };
+void use(B b) {  // Missing reference, intended?
+  b.f();  // Calls B::f.
+}
 
-  void use(B b) {  // Missing reference, intended?
-    b.f();  // Calls B::f.
-  }
+D d;
+use(d);  // Slice.
+```
 
-  D d;
-  use(d);  // Slice.
-
-This check implements `ES.63
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es63-dont-slice>`_
-and `C.145
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c145-access-polymorphic-objects-through-pointers-and-references>`_
+This check implements [ES.63](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es63-dont-slice)
+and [C.145](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c145-access-polymorphic-objects-through-pointers-and-references)
 from the C++ Core Guidelines.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.md
@@ -9,4 +9,3 @@ from the C++ Core Guidelines.
 The `cppcoreguidelines-use-default-member-init` check is an alias, please see
 {doc}`modernize-use-default-member-init <../modernize/use-default-member-init>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.md
@@ -1,11 +1,12 @@
-.. title:: clang-tidy - cppcoreguidelines-use-default-member-init
+```{title} clang-tidy - cppcoreguidelines-use-default-member-init
+```
 
-cppcoreguidelines-use-default-member-init
-=========================================
+# cppcoreguidelines-use-default-member-init
 
-This check implements `C.48 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-in-class-initializer>`_
+This check implements [C.48](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-in-class-initializer)
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-use-default-member-init` check is an alias, please see
-:doc:`modernize-use-default-member-init <../modernize/use-default-member-init>`
+{doc}`modernize-use-default-member-init <../modernize/use-default-member-init>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/darwin/avoid-spinlock.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/darwin/avoid-spinlock.md
@@ -1,15 +1,16 @@
-.. title:: clang-tidy - darwin-avoid-spinlock
+```{title} clang-tidy - darwin-avoid-spinlock
+```
 
-darwin-avoid-spinlock
-=====================
+# darwin-avoid-spinlock
 
-Finds usages of ``OSSpinlock``, which is deprecated due to potential livelock
+Finds usages of `OSSpinlock`, which is deprecated due to potential livelock
 problems.
 
 This check will detect following function invocations:
 
-- ``OSSpinlockLock``
-- ``OSSpinlockTry``
-- ``OSSpinlockUnlock``
+- `OSSpinlockLock`
+- `OSSpinlockTry`
+- `OSSpinlockUnlock`
 
-The corresponding information about the problem of ``OSSpinlock``: https://blog.postmates.com/why-spinlocks-are-bad-on-ios-b69fc5221058
+The corresponding information about the problem of `OSSpinlock`: <https://blog.postmates.com/why-spinlocks-are-bad-on-ios-b69fc5221058>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/darwin/dispatch-once-nonstatic.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/darwin/dispatch-once-nonstatic.md
@@ -20,4 +20,3 @@ libdispatch requirements.
 See the discussion section of
 [Apple's dispatch_once documentation](https://developer.apple.com/documentation/dispatch/1447169-dispatch_once)
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/darwin/dispatch-once-nonstatic.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/darwin/dispatch-once-nonstatic.md
@@ -1,22 +1,23 @@
-.. title:: clang-tidy - darwin-dispatch-once-nonstatic
+```{title} clang-tidy - darwin-dispatch-once-nonstatic
+```
 
-darwin-dispatch-once-nonstatic
-==============================
+# darwin-dispatch-once-nonstatic
 
-Finds declarations of ``dispatch_once_t`` variables without static or global
-storage. The behavior of using ``dispatch_once_t`` predicates with automatic or
+Finds declarations of `dispatch_once_t` variables without static or global
+storage. The behavior of using `dispatch_once_t` predicates with automatic or
 dynamic storage is undefined by libdispatch, and should be avoided.
 
 It is a common pattern to have functions initialize internal static or global
 data once when the function runs, but programmers have been known to miss the
-static on the ``dispatch_once_t`` predicate, leading to an uninitialized flag
+static on the `dispatch_once_t` predicate, leading to an uninitialized flag
 value at the mercy of the stack.
 
-Programmers have also been known to make ``dispatch_once_t`` variables be
+Programmers have also been known to make `dispatch_once_t` variables be
 members of structs or classes, with the intent to lazily perform some expensive
 struct or class member initialization only once; however, this violates the
 libdispatch requirements.
 
 See the discussion section of
-`Apple's dispatch_once documentation <https://developer.apple.com/documentation/dispatch/1447169-dispatch_once>`_
+[Apple's dispatch_once documentation](https://developer.apple.com/documentation/dispatch/1447169-dispatch_once)
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-calls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-calls.md
@@ -7,17 +7,16 @@ Warns if a function or method is called with default arguments.
 
 For example, given the declaration:
 
-```c++
+```cpp
 int foo(int value = 5) { return value; }
 ```
 
 A function call expression that uses a default argument will be diagnosed.
 Calling it without defaults will not cause a warning:
 
-```c++
+```cpp
 foo();  // warning
 foo(0); // no warning
 ```
 
 See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-calls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-calls.md
@@ -1,22 +1,23 @@
-.. title:: clang-tidy - fuchsia-default-arguments-calls
+```{title} clang-tidy - fuchsia-default-arguments-calls
+```
 
-fuchsia-default-arguments-calls
-===============================
+# fuchsia-default-arguments-calls
 
 Warns if a function or method is called with default arguments.
 
 For example, given the declaration:
 
-.. code-block:: c++
-
-  int foo(int value = 5) { return value; }
+```c++
+int foo(int value = 5) { return value; }
+```
 
 A function call expression that uses a default argument will be diagnosed.
 Calling it without defaults will not cause a warning:
 
-.. code-block:: c++
+```c++
+foo();  // warning
+foo(0); // no warning
+```
 
-  foo();  // warning
-  foo(0); // no warning
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-declarations.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-declarations.md
@@ -7,11 +7,10 @@ Warns if a function or method is declared with default parameters.
 
 For example, the declaration:
 
-```c++
+```cpp
 int foo(int value = 5) { return value; }
 ```
 
 will cause a warning.
 
 See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-declarations.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-declarations.md
@@ -1,16 +1,17 @@
-.. title:: clang-tidy - fuchsia-default-arguments-declarations
+```{title} clang-tidy - fuchsia-default-arguments-declarations
+```
 
-fuchsia-default-arguments-declarations
-======================================
+# fuchsia-default-arguments-declarations
 
 Warns if a function or method is declared with default parameters.
 
 For example, the declaration:
 
-.. code-block:: c++
-
-  int foo(int value = 5) { return value; }
+```c++
+int foo(int value = 5) { return value; }
+```
 
 will cause a warning.
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/header-anon-namespaces.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/header-anon-namespaces.md
@@ -4,7 +4,5 @@
 # fuchsia-header-anon-namespaces
 
 The `fuchsia-header-anon-namespaces` check is an alias, please see
-{doc}`misc-anonymous-namespace-in-header
-<../misc/anonymous-namespace-in-header>`
+{doc}`misc-anonymous-namespace-in-header <../misc/anonymous-namespace-in-header>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/header-anon-namespaces.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/header-anon-namespaces.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - fuchsia-header-anon-namespaces
+```{title} clang-tidy - fuchsia-header-anon-namespaces
+```
 
-fuchsia-header-anon-namespaces
-==============================
+# fuchsia-header-anon-namespaces
 
 The `fuchsia-header-anon-namespaces` check is an alias, please see
-:doc:`misc-anonymous-namespace-in-header
+{doc}`misc-anonymous-namespace-in-header
 <../misc/anonymous-namespace-in-header>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - fuchsia-multiple-inheritance
+```{title} clang-tidy - fuchsia-multiple-inheritance
+```
 
-fuchsia-multiple-inheritance
-============================
+# fuchsia-multiple-inheritance
 
 The `fuchsia-multiple-inheritance` check is an alias, please See
-:doc:`misc-multiple-inheritance <../misc/multiple-inheritance>` for details.
+{doc}`misc-multiple-inheritance <../misc/multiple-inheritance>` for details.
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/overloaded-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/overloaded-operator.md
@@ -8,7 +8,7 @@ operators.
 
 For example:
 
-```c++
+```cpp
 int operator+(int);     // Warning
 
 B &operator=(const B &Other);  // No warning
@@ -16,4 +16,3 @@ B &operator=(B &&Other) // No warning
 ```
 
 See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/overloaded-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/overloaded-operator.md
@@ -1,18 +1,19 @@
-.. title:: clang-tidy - fuchsia-overloaded-operator
+```{title} clang-tidy - fuchsia-overloaded-operator
+```
 
-fuchsia-overloaded-operator
-===========================
+# fuchsia-overloaded-operator
 
 Warns if an operator is overloaded, except for the assignment (copy and move)
 operators.
 
 For example:
 
-.. code-block:: c++
+```c++
+int operator+(int);     // Warning
 
-  int operator+(int);     // Warning
+B &operator=(const B &Other);  // No warning
+B &operator=(B &&Other) // No warning
+```
 
-  B &operator=(const B &Other);  // No warning
-  B &operator=(B &&Other) // No warning
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/virtual-inheritance.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/virtual-inheritance.md
@@ -7,9 +7,8 @@ Warns if classes are defined with virtual inheritance.
 
 For example, classes should not be defined with virtual inheritance:
 
-```c++
+```cpp
 class B : public virtual A {};   // warning
 ```
 
 See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/virtual-inheritance.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/virtual-inheritance.md
@@ -1,14 +1,15 @@
-.. title:: clang-tidy - fuchsia-virtual-inheritance
+```{title} clang-tidy - fuchsia-virtual-inheritance
+```
 
-fuchsia-virtual-inheritance
-===========================
+# fuchsia-virtual-inheritance
 
 Warns if classes are defined with virtual inheritance.
 
 For example, classes should not be defined with virtual inheritance:
 
-.. code-block:: c++
+```c++
+class B : public virtual A {};   // warning
+```
 
-  class B : public virtual A {};   // warning
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-explicit-make-pair.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-explicit-make-pair.md
@@ -1,11 +1,12 @@
-.. title:: clang-tidy - google-build-explicit-make-pair
+```{title} clang-tidy - google-build-explicit-make-pair
+```
 
-google-build-explicit-make-pair
-===============================
+# google-build-explicit-make-pair
 
-Check that ``make_pair``'s template arguments are deduced.
+Check that `make_pair`'s template arguments are deduced.
 
-G++ 4.6 in C++11 mode fails badly if ``make_pair``'s template arguments are
+G++ 4.6 in C++11 mode fails badly if `make_pair`'s template arguments are
 specified explicitly, and such use isn't intended in any case.
 
 Corresponding cpplint.py check name: `build/explicit_make_pair`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-explicit-make-pair.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-explicit-make-pair.md
@@ -9,4 +9,3 @@ G++ 4.6 in C++11 mode fails badly if `make_pair`'s template arguments are
 specified explicitly, and such use isn't intended in any case.
 
 Corresponding cpplint.py check name: `build/explicit_make_pair`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.md
@@ -4,8 +4,7 @@
 # google-build-namespaces
 
 The `google-build-namespaces` check is an alias, please see
-{doc}`misc-anonymous-namespace-in-header
-<../misc/anonymous-namespace-in-header>`
+{doc}`misc-anonymous-namespace-in-header <../misc/anonymous-namespace-in-header>`
 for more information.
 
 Finds anonymous namespaces in headers.
@@ -13,4 +12,3 @@ Finds anonymous namespaces in headers.
 <https://google.github.io/styleguide/cppguide.html#Namespaces>
 
 Corresponding cpplint.py check name: `build/namespaces`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.md
@@ -1,15 +1,16 @@
-.. title:: clang-tidy - google-build-namespaces
+```{title} clang-tidy - google-build-namespaces
+```
 
-google-build-namespaces
-=======================
+# google-build-namespaces
 
 The `google-build-namespaces` check is an alias, please see
-:doc:`misc-anonymous-namespace-in-header
+{doc}`misc-anonymous-namespace-in-header
 <../misc/anonymous-namespace-in-header>`
 for more information.
 
 Finds anonymous namespaces in headers.
 
-https://google.github.io/styleguide/cppguide.html#Namespaces
+<https://google.github.io/styleguide/cppguide.html#Namespaces>
 
 Corresponding cpplint.py check name: `build/namespaces`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-using-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-using-namespace.md
@@ -11,10 +11,9 @@ The check implements the following rule of the
 > You may not use a using-directive to make all names from a namespace
 > available.
 
-```c++
+```cpp
 // Forbidden -- This pollutes the namespace.
 using namespace foo;
 ```
 
 Corresponding cpplint.py check name: `build/namespaces`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-using-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-using-namespace.md
@@ -1,19 +1,20 @@
-.. title:: clang-tidy - google-build-using-namespace
+```{title} clang-tidy - google-build-using-namespace
+```
 
-google-build-using-namespace
-============================
+# google-build-using-namespace
 
-Finds ``using namespace`` directives.
+Finds `using namespace` directives.
 
 The check implements the following rule of the
-`Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html#Namespaces>`_:
+[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Namespaces):
 
-  You may not use a using-directive to make all names from a namespace
-  available.
+> You may not use a using-directive to make all names from a namespace
+> available.
 
-.. code-block:: c++
-
-    // Forbidden -- This pollutes the namespace.
-    using namespace foo;
+```c++
+// Forbidden -- This pollutes the namespace.
+using namespace foo;
+```
 
 Corresponding cpplint.py check name: `build/namespaces`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/default-arguments.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/default-arguments.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - google-default-arguments
+```{title} clang-tidy - google-default-arguments
+```
 
-google-default-arguments
-========================
+# google-default-arguments
 
 Checks that default arguments are not given for virtual methods.
 
-See https://google.github.io/styleguide/cppguide.html#Default_Arguments
+See <https://google.github.io/styleguide/cppguide.html#Default_Arguments>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/default-arguments.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/default-arguments.md
@@ -6,4 +6,3 @@
 Checks that default arguments are not given for virtual methods.
 
 See <https://google.github.io/styleguide/cppguide.html#Default_Arguments>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/explicit-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/explicit-constructor.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - google-explicit-constructor
+```{title} clang-tidy - google-explicit-constructor
+```
 
-google-explicit-constructor
-===========================
+# google-explicit-constructor
 
 This check is an alias for
-:doc:`misc-explicit-constructor <../misc/explicit-constructor>`.
+{doc}`misc-explicit-constructor <../misc/explicit-constructor>`.
 
-See https://google.github.io/styleguide/cppguide.html#Explicit_Constructors
+See <https://google.github.io/styleguide/cppguide.html#Explicit_Constructors>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/global-names-in-headers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/global-names-in-headers.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - google-global-names-in-headers
+```{title} clang-tidy - google-global-names-in-headers
+```
 
-google-global-names-in-headers
-==============================
+# google-global-names-in-headers
 
 Flag global namespace pollution in header files. Right now it only triggers on
-``using`` declarations and directives.
+`using` declarations and directives.
 
 The relevant style guide section is
-https://google.github.io/styleguide/cppguide.html#Namespaces.
+<https://google.github.io/styleguide/cppguide.html#Namespaces>.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/global-names-in-headers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/global-names-in-headers.md
@@ -8,4 +8,3 @@ Flag global namespace pollution in header files. Right now it only triggers on
 
 The relevant style guide section is
 <https://google.github.io/styleguide/cppguide.html#Namespaces>.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/objc-avoid-nsobject-new.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/objc-avoid-nsobject-new.md
@@ -1,29 +1,29 @@
-.. title:: clang-tidy - google-objc-avoid-nsobject-new
+```{title} clang-tidy - google-objc-avoid-nsobject-new
+```
 
-google-objc-avoid-nsobject-new
-==============================
+# google-objc-avoid-nsobject-new
 
-Finds calls to ``+new`` or overrides of it, which are prohibited by the
+Finds calls to `+new` or overrides of it, which are prohibited by the
 Google Objective-C style guide.
 
-The Google Objective-C style guide forbids calling ``+new`` or overriding it in
-class implementations, preferring ``+alloc`` and ``-init`` methods to
+The Google Objective-C style guide forbids calling `+new` or overriding it in
+class implementations, preferring `+alloc` and `-init` methods to
 instantiate objects.
 
 An example:
 
-.. code-block:: objc
+```objc
+NSDate *now = [NSDate new];
+Foo *bar = [Foo new];
+```
 
-  NSDate *now = [NSDate new];
-  Foo *bar = [Foo new];
+Instead, code should use `+alloc`/`-init` or class factory methods.
 
-Instead, code should use ``+alloc``/``-init`` or class factory methods.
-
-.. code-block:: objc
-
-  NSDate *now = [NSDate date];
-  Foo *bar = [[Foo alloc] init];
+```objc
+NSDate *now = [NSDate date];
+Foo *bar = [[Foo alloc] init];
+```
 
 This check corresponds to the Google Objective-C Style Guide rule
-`Do Not Use +new
-<https://google.github.io/styleguide/objcguide.html#do-not-use-new>`_.
+[Do Not Use +new](https://google.github.io/styleguide/objcguide.html#do-not-use-new).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/objc-avoid-nsobject-new.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/objc-avoid-nsobject-new.md
@@ -26,4 +26,3 @@ Foo *bar = [[Foo alloc] init];
 
 This check corresponds to the Google Objective-C Style Guide rule
 [Do Not Use +new](https://google.github.io/styleguide/objcguide.html#do-not-use-new).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/objc-function-naming.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/objc-function-naming.md
@@ -1,27 +1,28 @@
-.. title:: clang-tidy - google-objc-function-naming
+```{title} clang-tidy - google-objc-function-naming
+```
 
-google-objc-function-naming
-===========================
+# google-objc-function-naming
 
 Finds function declarations in Objective-C files that do not follow the pattern
 described in the Google Objective-C Style Guide.
 
 The corresponding style guide rule can be found here:
-https://google.github.io/styleguide/objcguide.html#function-names
+<https://google.github.io/styleguide/objcguide.html#function-names>
 
 All function names should be in Pascal case. Functions whose storage class is
 not static should have an appropriate prefix.
 
 The following code sample does not follow this pattern:
 
-.. code-block:: objc
-
-  static bool is_positive(int i) { return i > 0; }
-  bool IsNegative(int i) { return i < 0; }
+```objc
+static bool is_positive(int i) { return i > 0; }
+bool IsNegative(int i) { return i < 0; }
+```
 
 The sample above might be corrected to the following code:
 
-.. code-block:: objc
+```objc
+static bool IsPositive(int i) { return i > 0; }
+bool *ABCIsNegative(int i) { return i < 0; }
+```
 
-  static bool IsPositive(int i) { return i > 0; }
-  bool *ABCIsNegative(int i) { return i < 0; }

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-braces-around-statements.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-braces-around-statements.md
@@ -4,7 +4,5 @@
 # google-readability-braces-around-statements
 
 The `google-readability-braces-around-statements` check is an alias, please see
-{doc}`readability-braces-around-statements
-<../readability/braces-around-statements>`
+{doc}`readability-braces-around-statements <../readability/braces-around-statements>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-braces-around-statements.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-braces-around-statements.md
@@ -1,9 +1,10 @@
-.. title:: clang-tidy - google-readability-braces-around-statements
+```{title} clang-tidy - google-readability-braces-around-statements
+```
 
-google-readability-braces-around-statements
-===========================================
+# google-readability-braces-around-statements
 
 The `google-readability-braces-around-statements` check is an alias, please see
-:doc:`readability-braces-around-statements
+{doc}`readability-braces-around-statements
 <../readability/braces-around-statements>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.md
@@ -1,14 +1,15 @@
-.. title:: clang-tidy - google-readability-casting
+```{title} clang-tidy - google-readability-casting
+```
 
-google-readability-casting
-==========================
+# google-readability-casting
 
 The `google-readability-casting` check is an alias, please see
-:doc:`modernize-avoid-c-style-cast <../modernize/avoid-c-style-cast>`
+{doc}`modernize-avoid-c-style-cast <../modernize/avoid-c-style-cast>`
 for more information.
 
 Finds usages of C-style casts.
 
-https://google.github.io/styleguide/cppguide.html#Casting
+<https://google.github.io/styleguide/cppguide.html#Casting>
 
 Corresponding cpplint.py check name: `readability/casting`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.md
@@ -12,4 +12,3 @@ Finds usages of C-style casts.
 <https://google.github.io/styleguide/cppguide.html#Casting>
 
 Corresponding cpplint.py check name: `readability/casting`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-function-size.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-function-size.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - google-readability-function-size
+```{title} clang-tidy - google-readability-function-size
+```
 
-google-readability-function-size
-================================
+# google-readability-function-size
 
 The `google-readability-function-size` check is an alias, please see
-:doc:`readability-function-size <../readability/function-size>` for more
+{doc}`readability-function-size <../readability/function-size>` for more
 information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-function-size.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-function-size.md
@@ -6,4 +6,3 @@
 The `google-readability-function-size` check is an alias, please see
 {doc}`readability-function-size <../readability/function-size>` for more
 information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-namespace-comments.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-namespace-comments.md
@@ -3,6 +3,5 @@
 
 # google-readability-namespace-comments
 
-The `google-readability-namespace-comments check` is an alias, please see
+The `google-readability-namespace-comments` check is an alias, please see
 {doc}`llvm-namespace-comment <../llvm/namespace-comment>` for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-namespace-comments.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-namespace-comments.md
@@ -1,7 +1,8 @@
-.. title:: clang-tidy - google-readability-namespace-comments
+```{title} clang-tidy - google-readability-namespace-comments
+```
 
-google-readability-namespace-comments
-=====================================
+# google-readability-namespace-comments
 
 The `google-readability-namespace-comments check` is an alias, please see
-:doc:`llvm-namespace-comment <../llvm/namespace-comment>` for more information.
+{doc}`llvm-namespace-comment <../llvm/namespace-comment>` for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-todo.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-todo.md
@@ -12,13 +12,11 @@ Corresponding cpplint.py check: `readability/todo`
 
 ## Options
 
-```{eval-rst}
-.. option:: Style
+```{option} Style
 
-   A string specifying the TODO style for fix-it hints. Accepted values are
-   `Hyphen` and `Parentheses`. Default is `Hyphen`.
+A string specifying the TODO style for fix-it hints. Accepted values are
+`Hyphen` and `Parentheses`. Default is `Hyphen`.
 
-   * `Hyphen` will format the fix-it as: ``// TODO: username - details``.
-   * `Parentheses` will format the fix-it as: ``// TODO(username): details``.
+* `Hyphen` will format the fix-it as: `// TODO: username - details`.
+* `Parentheses` will format the fix-it as: `// TODO(username): details`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-todo.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-todo.md
@@ -1,18 +1,18 @@
-.. title:: clang-tidy - google-readability-todo
+```{title} clang-tidy - google-readability-todo
+```
 
-google-readability-todo
-=======================
+# google-readability-todo
 
 Finds TODO comments without a username or bug number.
 
 The relevant style guide section is
-https://google.github.io/styleguide/cppguide.html#TODO_Comments.
+<https://google.github.io/styleguide/cppguide.html#TODO_Comments>.
 
 Corresponding cpplint.py check: `readability/todo`
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: Style
 
    A string specifying the TODO style for fix-it hints. Accepted values are
@@ -20,3 +20,5 @@ Options
 
    * `Hyphen` will format the fix-it as: ``// TODO: username - details``.
    * `Parentheses` will format the fix-it as: ``// TODO(username): details``.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-float.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-float.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - google-runtime-float
+```{title} clang-tidy - google-runtime-float
+```
 
-google-runtime-float
-====================
+# google-runtime-float
 
-Finds uses of ``long double`` and suggests against their use due to lack of
+Finds uses of `long double` and suggests against their use due to lack of
 portability.
 
 The corresponding style guide rule:
-https://google.github.io/styleguide/cppguide.html#Floating-Point_Types
+<https://google.github.io/styleguide/cppguide.html#Floating-Point_Types>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-float.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-float.md
@@ -8,4 +8,3 @@ portability.
 
 The corresponding style guide rule:
 <https://google.github.io/styleguide/cppguide.html#Floating-Point_Types>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-int.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-int.md
@@ -13,21 +13,14 @@ Corresponding cpplint.py check: `runtime/int`.
 
 ## Options
 
-```{eval-rst}
-.. option:: UnsignedTypePrefix
-
-   A string specifying the unsigned type prefix. Default is `uint`.
+```{option} UnsignedTypePrefix
+A string specifying the unsigned type prefix. Default is `uint`.
 ```
 
-```{eval-rst}
-.. option:: SignedTypePrefix
-
-   A string specifying the signed type prefix. Default is `int`.
+```{option} SignedTypePrefix
+A string specifying the signed type prefix. Default is `int`.
 ```
 
-```{eval-rst}
-.. option:: TypeSuffix
-
-   A string specifying the type suffix. Default is an empty string.
+```{option} TypeSuffix
+A string specifying the type suffix. Default is an empty string.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-int.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-int.md
@@ -1,27 +1,33 @@
-.. title:: clang-tidy - google-runtime-int
+```{title} clang-tidy - google-runtime-int
+```
 
-google-runtime-int
-==================
+# google-runtime-int
 
-Finds uses of ``short``, ``long`` and ``long long`` and suggest replacing them
-with ``u?intXX(_t)?``.
+Finds uses of `short`, `long` and `long long` and suggest replacing them
+with `u?intXX(_t)?`.
 
 The corresponding style guide rule:
-https://google.github.io/styleguide/cppguide.html#Integer_Types.
+<https://google.github.io/styleguide/cppguide.html#Integer_Types>.
 
 Corresponding cpplint.py check: `runtime/int`.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: UnsignedTypePrefix
 
    A string specifying the unsigned type prefix. Default is `uint`.
+```
 
+```{eval-rst}
 .. option:: SignedTypePrefix
 
    A string specifying the signed type prefix. Default is `int`.
+```
 
+```{eval-rst}
 .. option:: TypeSuffix
 
    A string specifying the type suffix. Default is an empty string.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-operator.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - google-runtime-operator
+```{title} clang-tidy - google-runtime-operator
+```
 
-google-runtime-operator
-=======================
+# google-runtime-operator
 
-Finds overloads of unary ``operator &``.
+Finds overloads of unary `operator &`.
 
-https://google.github.io/styleguide/cppguide.html#Operator_Overloading
+<https://google.github.io/styleguide/cppguide.html#Operator_Overloading>
 
 Corresponding cpplint.py check name: `runtime/operator`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/google/runtime-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/runtime-operator.md
@@ -8,4 +8,3 @@ Finds overloads of unary `operator &`.
 <https://google.github.io/styleguide/cppguide.html#Operator_Overloading>
 
 Corresponding cpplint.py check name: `runtime/operator`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/linuxkernel/must-check-errs.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/linuxkernel/must-check-errs.md
@@ -1,28 +1,29 @@
-.. title:: clang-tidy - linuxkernel-must-check-errs
+```{title} clang-tidy - linuxkernel-must-check-errs
+```
 
-linuxkernel-must-check-errs
-===========================
+# linuxkernel-must-check-errs
 
 Checks Linux kernel code to see if it uses the results from the functions in
-``linux/err.h``. Also checks to see if code uses the results from functions
+`linux/err.h`. Also checks to see if code uses the results from functions
 that directly return a value from one of these error functions.
 
-This is important in the Linux kernel because ``ERR_PTR``, ``PTR_ERR``,
-``IS_ERR``, ``IS_ERR_OR_NULL``, ``ERR_CAST``, and ``PTR_ERR_OR_ZERO`` return
+This is important in the Linux kernel because `ERR_PTR`, `PTR_ERR`,
+`IS_ERR`, `IS_ERR_OR_NULL`, `ERR_CAST`, and `PTR_ERR_OR_ZERO` return
 values must be checked, since positive pointers and negative error codes are
 being used in the same context. These functions are marked with
-``__attribute__((warn_unused_result))``, but some kernel versions do not have
+`__attribute__((warn_unused_result))`, but some kernel versions do not have
 this warning enabled for clang.
 
 Examples:
 
-.. code-block:: c
+```c
+/* Trivial unused call to an ERR function */
+PTR_ERR_OR_ZERO(some_function_call());
 
-  /* Trivial unused call to an ERR function */
-  PTR_ERR_OR_ZERO(some_function_call());
+/* A function that returns ERR_PTR. */
+void *fn() { ERR_PTR(-EINVAL); }
 
-  /* A function that returns ERR_PTR. */
-  void *fn() { ERR_PTR(-EINVAL); }
+/* An invalid use of fn. */
+fn();
+```
 
-  /* An invalid use of fn. */
-  fn();

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/else-after-return.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/else-after-return.md
@@ -1,9 +1,9 @@
-.. title:: clang-tidy - llvm-else-after-return
+```{title} clang-tidy - llvm-else-after-return
+```
 
-llvm-else-after-return
-======================
+# llvm-else-after-return
 
 The `llvm-else-after-return` check is an alias, please see
-:doc:`readability-else-after-return <../readability/else-after-return>`
+{doc}`readability-else-after-return <../readability/else-after-return>`
 for more information.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.md
@@ -1,6 +1,7 @@
-.. title:: clang-tidy - llvm-header-guard
+```{title} clang-tidy - llvm-header-guard
+```
 
-llvm-header-guard
-=================
+# llvm-header-guard
 
 Finds and fixes header guards that do not adhere to LLVM style.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.md
@@ -4,4 +4,3 @@
 # llvm-header-guard
 
 Finds and fixes header guards that do not adhere to LLVM style.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/include-order.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/include-order.md
@@ -1,9 +1,9 @@
-.. title:: clang-tidy - llvm-include-order
+```{title} clang-tidy - llvm-include-order
+```
 
-llvm-include-order
-==================
+# llvm-include-order
 
+Checks the correct order of `#includes`.
 
-Checks the correct order of ``#includes``.
+See <https://llvm.org/docs/CodingStandards.html#include-style>
 
-See https://llvm.org/docs/CodingStandards.html#include-style

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-register-over-unsigned.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-register-over-unsigned.md
@@ -9,7 +9,7 @@ them to use `Register`.
 Currently this works by finding all variables of unsigned integer type whose
 initializer begins with an implicit cast from `Register` to `unsigned`.
 
-```c++
+```cpp
 void example(MachineOperand &MO) {
   unsigned Reg = MO.getReg();
   ...
@@ -18,10 +18,9 @@ void example(MachineOperand &MO) {
 
 becomes:
 
-```c++
+```cpp
 void example(MachineOperand &MO) {
   Register Reg = MO.getReg();
   ...
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-register-over-unsigned.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/prefer-register-over-unsigned.md
@@ -1,27 +1,27 @@
-.. title:: clang-tidy - llvm-prefer-register-over-unsigned
+```{title} clang-tidy - llvm-prefer-register-over-unsigned
+```
 
-llvm-prefer-register-over-unsigned
-==================================
+# llvm-prefer-register-over-unsigned
 
-Finds historical use of ``unsigned`` to hold vregs and physregs and rewrites
-them to use ``Register``.
+Finds historical use of `unsigned` to hold vregs and physregs and rewrites
+them to use `Register`.
 
 Currently this works by finding all variables of unsigned integer type whose
-initializer begins with an implicit cast from ``Register`` to ``unsigned``.
+initializer begins with an implicit cast from `Register` to `unsigned`.
 
-.. code-block:: c++
-
-  void example(MachineOperand &MO) {
-    unsigned Reg = MO.getReg();
-    ...
-  }
+```c++
+void example(MachineOperand &MO) {
+  unsigned Reg = MO.getReg();
+  ...
+}
+```
 
 becomes:
 
-.. code-block:: c++
-
-  void example(MachineOperand &MO) {
-    Register Reg = MO.getReg();
-    ...
-  }
+```c++
+void example(MachineOperand &MO) {
+  Register Reg = MO.getReg();
+  ...
+}
+```
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/qualified-auto.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/qualified-auto.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - llvm-qualified-auto
+```{title} clang-tidy - llvm-qualified-auto
+```
 
-llvm-qualified-auto
-===================
+# llvm-qualified-auto
 
 The `llvm-qualified-auto check` is an alias, please see
-:doc:`readability-qualified-auto <../readability/qualified-auto>`
+{doc}`readability-qualified-auto <../readability/qualified-auto>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/qualified-auto.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/qualified-auto.md
@@ -6,4 +6,3 @@
 The `llvm-qualified-auto check` is an alias, please see
 {doc}`readability-qualified-auto <../readability/qualified-auto>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/use-new-mlir-op-builder.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/use-new-mlir-op-builder.md
@@ -8,13 +8,12 @@ and suggests using `T::create` instead.
 
 ## Example
 
-```c++
+```cpp
 builder.create<FooOp>(builder.getUnknownLoc(), "baz");
 ```
 
 Transforms to:
 
-```c++
+```cpp
 FooOp::create(builder, builder.getUnknownLoc(), "baz");
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/use-new-mlir-op-builder.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/use-new-mlir-op-builder.md
@@ -1,21 +1,20 @@
-.. title:: clang-tidy - llvm-use-new-mlir-op-builder
+```{title} clang-tidy - llvm-use-new-mlir-op-builder
+```
 
-llvm-mlir-op-builder
-====================
+# llvm-mlir-op-builder
 
-Checks for uses of MLIR's old/to be deprecated ``OpBuilder::create<T>`` form
-and suggests using ``T::create`` instead.
+Checks for uses of MLIR's old/to be deprecated `OpBuilder::create<T>` form
+and suggests using `T::create` instead.
 
-Example
--------
+## Example
 
-.. code-block:: c++
-
-  builder.create<FooOp>(builder.getUnknownLoc(), "baz");
-
+```c++
+builder.create<FooOp>(builder.getUnknownLoc(), "baz");
+```
 
 Transforms to:
 
-.. code-block:: c++
+```c++
+FooOp::create(builder, builder.getUnknownLoc(), "baz");
+```
 
-  FooOp::create(builder, builder.getUnknownLoc(), "baz");

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/callee-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/callee-namespace.md
@@ -5,7 +5,7 @@
 
 Checks all calls resolve to functions within correct namespace.
 
-```c++
+```cpp
 // Implementation inside the LIBC_NAMESPACE namespace.
 // Correct if:
 // - LIBC_NAMESPACE is a macro
@@ -26,4 +26,3 @@ strlen("world");
 
 } // namespace LIBC_NAMESPACE
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/callee-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/callee-namespace.md
@@ -1,28 +1,29 @@
-.. title:: clang-tidy - llvmlibc-callee-namespace
+```{title} clang-tidy - llvmlibc-callee-namespace
+```
 
-llvmlibc-callee-namespace
-====================================
+# llvmlibc-callee-namespace
 
 Checks all calls resolve to functions within correct namespace.
 
-.. code-block:: c++
+```c++
+// Implementation inside the LIBC_NAMESPACE namespace.
+// Correct if:
+// - LIBC_NAMESPACE is a macro
+// - LIBC_NAMESPACE expansion starts with `__llvm_libc`
+namespace LIBC_NAMESPACE {
 
-    // Implementation inside the LIBC_NAMESPACE namespace.
-    // Correct if:
-    // - LIBC_NAMESPACE is a macro
-    // - LIBC_NAMESPACE expansion starts with `__llvm_libc`
-    namespace LIBC_NAMESPACE {
+// Allow calls with the fully qualified name.
+LIBC_NAMESPACE::strlen("hello");
 
-    // Allow calls with the fully qualified name.
-    LIBC_NAMESPACE::strlen("hello");
+// Allow calls to compiler provided functions.
+(void)__builtin_abs(-1);
 
-    // Allow calls to compiler provided functions.
-    (void)__builtin_abs(-1);
+// Bare calls are allowed as long as they resolve to the correct namespace.
+strlen("world");
 
-    // Bare calls are allowed as long as they resolve to the correct namespace.
-    strlen("world");
+// Disallow calling into functions in the global namespace.
+::strlen("!");
 
-    // Disallow calling into functions in the global namespace.
-    ::strlen("!");
+} // namespace LIBC_NAMESPACE
+```
 
-    } // namespace LIBC_NAMESPACE

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - llvmlibc-inline-function-decl
+```{title} clang-tidy - llvmlibc-inline-function-decl
+```
 
-llvmlibc-inline-function-decl
-=============================
+# llvmlibc-inline-function-decl
 
 Checks that all implicitly and explicitly inline functions in header files are
-tagged with the ``LIBC_INLINE`` macro, except for functions implicit to classes
+tagged with the `LIBC_INLINE` macro, except for functions implicit to classes
 or deleted functions.
-See the `libc style guide <https://libc.llvm.org/dev/code_style.html>`_ for more
+See the [libc style guide](https://libc.llvm.org/dev/code_style.html) for more
 information about this macro.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.md
@@ -8,4 +8,3 @@ tagged with the `LIBC_INLINE` macro, except for functions implicit to classes
 or deleted functions.
 See the [libc style guide](https://libc.llvm.org/dev/code_style.html) for more
 information about this macro.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/anonymous-namespace-in-header.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/anonymous-namespace-in-header.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - misc-anonymous-namespace-in-header
+```{title} clang-tidy - misc-anonymous-namespace-in-header
+```
 
-misc-anonymous-namespace-in-header
-==================================
+# misc-anonymous-namespace-in-header
 
 Finds anonymous namespaces in headers.
 
@@ -10,11 +10,10 @@ violations because each translation unit including the header will get its
 own unique version of the symbols. This increases binary size and can cause
 confusing link-time errors.
 
-References
-----------
+## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-`DCL59-CPP. Do not define an unnamed namespace in a header file
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl59-cpp/>`_.
+[DCL59-CPP. Do not define an unnamed namespace in a header file](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl59-cpp/).
 
 Corresponding cpplint.py check name: `build/namespaces`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/anonymous-namespace-in-header.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/anonymous-namespace-in-header.md
@@ -16,4 +16,3 @@ This check corresponds to the CERT C++ Coding Standard rule
 [DCL59-CPP. Do not define an unnamed namespace in a header file](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl59-cpp/).
 
 Corresponding cpplint.py check name: `build/namespaces`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/confusable-identifiers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/confusable-identifiers.md
@@ -1,15 +1,16 @@
-.. title:: clang-tidy - misc-confusable-identifiers
+```{title} clang-tidy - misc-confusable-identifiers
+```
 
-misc-confusable-identifiers
-===========================
+# misc-confusable-identifiers
 
 Warn about confusable identifiers, i.e. identifiers that are visually close to
 each other, but use different Unicode characters. This detects a potential
-attack described in `CVE-2021-42574 <https://www.cve.org/CVERecord?id=CVE-2021-42574>`_.
+attack described in [CVE-2021-42574](https://www.cve.org/CVERecord?id=CVE-2021-42574).
 
 Example:
 
-.. code-block:: text
+```text
+int fo; // Initial character is U+0066 (LATIN SMALL LETTER F).
+int 𝐟o; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).
+```
 
-    int fo; // Initial character is U+0066 (LATIN SMALL LETTER F).
-    int 𝐟o; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.md
@@ -8,7 +8,7 @@ as described in the [Trojan Source](https://www.trojansource.codes) attack.
 
 Example:
 
-```c++
+```cpp
 #include <iostream>
 
 int main() {
@@ -19,4 +19,3 @@ int main() {
     return 0;
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.md
@@ -1,21 +1,22 @@
-.. title:: clang-tidy - misc-misleading-bidirectional
+```{title} clang-tidy - misc-misleading-bidirectional
+```
 
-misc-misleading-bidirectional
-=============================
+# misc-misleading-bidirectional
 
 Warns about unterminated bidirectional unicode sequence, detecting potential attack
-as described in the `Trojan Source <https://www.trojansource.codes>`_ attack.
+as described in the [Trojan Source](https://www.trojansource.codes) attack.
 
 Example:
 
-.. code-block:: c++
+```c++
+#include <iostream>
 
-    #include <iostream>
+int main() {
+    bool isAdmin = false;
+    /*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */
+        std::cout << "You are an admin.\n";
+    /* end admins only ‮ { ⁦*/
+    return 0;
+}
+```
 
-    int main() {
-        bool isAdmin = false;
-        /*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */
-            std::cout << "You are an admin.\n";
-        /* end admins only ‮ { ⁦*/
-        return 0;
-    }

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-identifier.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-identifier.md
@@ -1,23 +1,24 @@
-.. title:: clang-tidy - misc-misleading-identifier
+```{title} clang-tidy - misc-misleading-identifier
+```
 
-misc-misleading-identifier
-==========================
+# misc-misleading-identifier
 
 Finds identifiers that contain Unicode characters with right-to-left direction,
 which can be confusing as they may change the understanding of a whole
-statement line, as described in `Trojan Source <https://trojansource.codes>`_.
+statement line, as described in [Trojan Source](https://trojansource.codes).
 
 An example of such misleading code follows:
 
-.. code-block:: text
+```text
+#include <stdio.h>
 
-  #include <stdio.h>
+short int א = (short int)0;
+short int ג = (short int)12345;
 
-  short int א = (short int)0;
-  short int ג = (short int)12345;
+int main() {
+  int א = ג; // a local variable, set to zero?
+  printf("ג is %d\n", ג);
+  printf("א is %d\n", א);
+}
+```
 
-  int main() {
-    int א = ג; // a local variable, set to zero?
-    printf("ג is %d\n", ג);
-    printf("א is %d\n", א);
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/misplaced-const.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/misplaced-const.md
@@ -11,7 +11,7 @@ rather than the pointee.
 For instance, in the following code, the resulting type is `int * const`
 rather than `const int *`:
 
-```c++
+```cpp
 typedef int *int_ptr;
 void f(const int_ptr ptr) {
   *ptr = 0; // potentially quite unexpectedly the int can be modified here
@@ -23,4 +23,3 @@ The check does not diagnose when the underlying `typedef`/`using` type is a
 pointer to a `const` type or a function pointer type. This is because the
 `const` qualifier is less likely to be mistaken because it would be redundant
 (or disallowed) on the underlying pointee type.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/misplaced-const.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/misplaced-const.md
@@ -1,25 +1,26 @@
-.. title:: clang-tidy - misc-misplaced-const
+```{title} clang-tidy - misc-misplaced-const
+```
 
-misc-misplaced-const
-====================
+# misc-misplaced-const
 
-This check diagnoses when a ``const`` qualifier is applied to a ``typedef``/
-``using`` to a pointer type rather than to the pointee, because such constructs
-are often misleading to developers because the ``const`` applies to the pointer
+This check diagnoses when a `const` qualifier is applied to a `typedef`/
+`using` to a pointer type rather than to the pointee, because such constructs
+are often misleading to developers because the `const` applies to the pointer
 rather than the pointee.
 
-For instance, in the following code, the resulting type is ``int * const``
-rather than ``const int *``:
+For instance, in the following code, the resulting type is `int * const`
+rather than `const int *`:
 
-.. code-block:: c++
+```c++
+typedef int *int_ptr;
+void f(const int_ptr ptr) {
+  *ptr = 0; // potentially quite unexpectedly the int can be modified here
+  ptr = 0; // does not compile
+}
+```
 
-  typedef int *int_ptr;
-  void f(const int_ptr ptr) {
-    *ptr = 0; // potentially quite unexpectedly the int can be modified here
-    ptr = 0; // does not compile
-  }
-
-The check does not diagnose when the underlying ``typedef``/``using`` type is a
-pointer to a ``const`` type or a function pointer type. This is because the
-``const`` qualifier is less likely to be mistaken because it would be redundant
+The check does not diagnose when the underlying `typedef`/`using` type is a
+pointer to a `const` type or a function pointer type. This is because the
+`const` qualifier is less likely to be mistaken because it would be redundant
 (or disallowed) on the underlying pointee type.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/new-delete-overloads.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/new-delete-overloads.md
@@ -1,19 +1,19 @@
-.. title:: clang-tidy - misc-new-delete-overloads
+```{title} clang-tidy - misc-new-delete-overloads
+```
 
-misc-new-delete-overloads
-=========================
+# misc-new-delete-overloads
 
 `cert-dcl54-cpp` redirects here as an alias for this check.
 
-The check flags overloaded operator ``new()`` and operator ``delete()``
+The check flags overloaded operator `new()` and operator `delete()`
 functions that do not have a corresponding free store function defined within
 the same scope.
 For instance, the check will flag a class implementation of a non-placement
-operator ``new()`` when the class does not also define a non-placement operator
-``delete()`` function as well.
+operator `new()` when the class does not also define a non-placement operator
+`delete()` function as well.
 
 The check does not flag implicitly-defined operators, deleted or private
 operators, or placement operators.
 
-This check corresponds to CERT C++ Coding Standard rule `DCL54-CPP. Overload allocation and deallocation functions as a pair in the same scope
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl54-cpp/>`_.
+This check corresponds to CERT C++ Coding Standard rule [DCL54-CPP. Overload allocation and deallocation functions as a pair in the same scope](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl54-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/new-delete-overloads.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/new-delete-overloads.md
@@ -16,4 +16,3 @@ The check does not flag implicitly-defined operators, deleted or private
 operators, or placement operators.
 
 This check corresponds to CERT C++ Coding Standard rule [DCL54-CPP. Overload allocation and deallocation functions as a pair in the same scope](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl54-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/no-recursion.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/no-recursion.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - misc-no-recursion
+```{title} clang-tidy - misc-no-recursion
+```
 
-misc-no-recursion
-=================
+# misc-no-recursion
 
 Finds strongly connected functions (by analyzing the call graph for
 SCC's (Strongly Connected Components) that are loops),
@@ -10,14 +10,13 @@ and displays one example of a possible call graph loop (recursion).
 
 References:
 
-* CERT C++ Coding Standard rule `DCL56-CPP. Avoid cycles during initialization of static objects <https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl56-cpp/>`_.
-* JPL Institutional Coding Standard for the C Programming Language
+- CERT C++ Coding Standard rule [DCL56-CPP. Avoid cycles during initialization of static objects](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl56-cpp/).
+- JPL Institutional Coding Standard for the C Programming Language
   (JPL DOCID D-60411) rule `2.4 Do not use direct or indirect recursion`.
-* OpenCL Specification, Version 1.2 rule `6.9 Restrictions: i. Recursion is not supported. <https://www.khronos.org/registry/OpenCL/specs/opencl-1.2.pdf>`_.
+- OpenCL Specification, Version 1.2 rule [6.9 Restrictions: i. Recursion is not supported.](https://www.khronos.org/registry/OpenCL/specs/opencl-1.2.pdf).
 
+## Limitations
 
-Limitations
------------
+- The check does not handle calls done through function pointers
+- The check does not handle C++ destructors
 
-* The check does not handle calls done through function pointers
-* The check does not handle C++ destructors

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/non-copyable-objects.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/non-copyable-objects.md
@@ -1,16 +1,15 @@
-.. title:: clang-tidy - misc-non-copyable-objects
+```{title} clang-tidy - misc-non-copyable-objects
+```
 
-misc-non-copyable-objects
-=========================
+# misc-non-copyable-objects
 
 `cert-fio38-c` redirects here as an alias for this check.
 
 Flags dereferences and non-pointer declarations of objects that are
 not meant to be passed by value, such as C FILE objects or POSIX
-``pthread_mutex_t`` objects.
+`pthread_mutex_t` objects.
 
-References
-----------
+## References
 
-This check corresponds to CERT C++ Coding Standard rule `FIO38-C. Do not copy a FILE object
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/input-output-fio/fio38-c/>`_.
+This check corresponds to CERT C++ Coding Standard rule [FIO38-C. Do not copy a FILE object](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/input-output-fio/fio38-c/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.md
@@ -14,18 +14,15 @@ classes or class consumers.
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnoreClassesWithAllMemberVariablesBeingPublic
+```{option} IgnoreClassesWithAllMemberVariablesBeingPublic
 
-   When `true`, allows to completely ignore classes if **all** the member
-   variables in that class declared with a ``public`` access specifier.
-   Default is `false`.
+When `true`, allows to completely ignore classes if **all** the member
+variables in that class declared with a `public` access specifier.
+Default is `false`.
 ```
 
-```{eval-rst}
-.. option:: IgnorePublicMemberVariables
+```{option} IgnorePublicMemberVariables
 
-   When `true`, allows to ignore (not diagnose) **all** the member variables
-   declared with a ``public`` access specifier. Default is `false`.
+When `true`, allows to ignore (not diagnose) **all** the member variables
+declared with a `public` access specifier. Default is `false`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.md
@@ -1,27 +1,31 @@
-.. title:: clang-tidy - misc-non-private-member-variables-in-classes
+```{title} clang-tidy - misc-non-private-member-variables-in-classes
+```
 
-misc-non-private-member-variables-in-classes
-============================================
+# misc-non-private-member-variables-in-classes
 
 `cppcoreguidelines-non-private-member-variables-in-classes` redirects here
 as an alias for this check.
 
 Finds classes that contain non-static data members in addition to user-declared
 non-static member functions and diagnose all data members declared with a
-non-``public`` access specifier. The data members should be declared as
-``private`` and accessed through member functions instead of exposed to derived
+non-`public` access specifier. The data members should be declared as
+`private` and accessed through member functions instead of exposed to derived
 classes or class consumers.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: IgnoreClassesWithAllMemberVariablesBeingPublic
 
    When `true`, allows to completely ignore classes if **all** the member
    variables in that class declared with a ``public`` access specifier.
    Default is `false`.
+```
 
+```{eval-rst}
 .. option:: IgnorePublicMemberVariables
 
    When `true`, allows to ignore (not diagnose) **all** the member variables
    declared with a ``public`` access specifier. Default is `false`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/predictable-rand.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/predictable-rand.md
@@ -1,20 +1,18 @@
-.. title:: clang-tidy - misc-predictable-rand
+```{title} clang-tidy - misc-predictable-rand
+```
 
-misc-predictable-rand
-=====================
+# misc-predictable-rand
 
-Warns for the usage of ``std::rand()``. Pseudorandom number generators use
+Warns for the usage of `std::rand()`. Pseudorandom number generators use
 mathematical algorithms to produce a sequence of numbers with good
 statistical properties, but the numbers produced are not genuinely random.
-The ``std::rand()`` function takes a seed (number), runs a mathematical
+The `std::rand()` function takes a seed (number), runs a mathematical
 operation on it and returns the result. By manipulating the seed the result
 can be predictable.
 
-References
-----------
+## References
 
 This check corresponds to the CERT C Coding Standard rules
-`MSC30-C. Do not use the rand() function for generating pseudorandom numbers
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/>`_.
-`MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp/>`_.
+[MSC30-C. Do not use the rand() function for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/).
+[MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/predictable-rand.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/predictable-rand.md
@@ -15,4 +15,3 @@ can be predictable.
 This check corresponds to the CERT C Coding Standard rules
 [MSC30-C. Do not use the rand() function for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/).
 [MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/static-assert.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/static-assert.md
@@ -1,12 +1,13 @@
-.. title:: clang-tidy - misc-static-assert
+```{title} clang-tidy - misc-static-assert
+```
 
-misc-static-assert
-==================
+# misc-static-assert
 
 `cert-dcl03-c` redirects here as an alias for this check.
 
-Replaces ``assert()`` with ``static_assert()`` if the condition is evaluable
+Replaces `assert()` with `static_assert()` if the condition is evaluable
 at compile time.
 
-The condition of ``static_assert()`` is evaluated at compile time which is
+The condition of `static_assert()` is evaluated at compile time which is
 safer and more efficient.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/static-assert.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/static-assert.md
@@ -10,4 +10,3 @@ at compile time.
 
 The condition of `static_assert()` is evaluated at compile time which is
 safer and more efficient.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unconventional-assign-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unconventional-assign-operator.md
@@ -6,10 +6,9 @@
 Finds declarations of assign operators with the wrong return and/or argument
 types and definitions with good return type but wrong `return` statements.
 
-> - The return type must be `Class&`.
-> - The assignment may be from the class type by value, const lvalue
->   reference, non-const rvalue reference, or from a completely different
->   type (e.g. `int`).
-> - Private and deleted operators are ignored.
-> - The operator must always return `*this`.
-
+- The return type must be `Class&`.
+- The assignment may be from the class type by value, const lvalue
+  reference, non-const rvalue reference, or from a completely different
+  type (e.g. `int`).
+- Private and deleted operators are ignored.
+- The operator must always return `*this`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unconventional-assign-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unconventional-assign-operator.md
@@ -1,15 +1,15 @@
-.. title:: clang-tidy - misc-unconventional-assign-operator
+```{title} clang-tidy - misc-unconventional-assign-operator
+```
 
-misc-unconventional-assign-operator
-===================================
-
+# misc-unconventional-assign-operator
 
 Finds declarations of assign operators with the wrong return and/or argument
-types and definitions with good return type but wrong ``return`` statements.
+types and definitions with good return type but wrong `return` statements.
 
-  * The return type must be ``Class&``.
-  * The assignment may be from the class type by value, const lvalue
-    reference, non-const rvalue reference, or from a completely different
-    type (e.g. ``int``).
-  * Private and deleted operators are ignored.
-  * The operator must always return ``*this``.
+> - The return type must be `Class&`.
+> - The assignment may be from the class type by value, const lvalue
+>   reference, non-const rvalue reference, or from a completely different
+>   type (e.g. `int`).
+> - Private and deleted operators are ignored.
+> - The operator must always return `*this`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/uniqueptr-reset-release.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/uniqueptr-reset-release.md
@@ -7,7 +7,7 @@ Find and replace `unique_ptr::reset(release())` with `std::move()`.
 
 Example:
 
-```c++
+```cpp
 std::unique_ptr<Foo> x, y;
 x.reset(y.release()); -> x = std::move(y);
 ```
@@ -17,10 +17,8 @@ also be `std::unique_ptr<Foo>*`.
 
 ## Options
 
-```{eval-rst}
-.. option:: IncludeStyle
+```{option} IncludeStyle
 
-   A string specifying which include-style is used, `llvm` or `google`. Default
-   is `llvm`.
+A string specifying which include-style is used, `llvm` or `google`. Default
+is `llvm`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/uniqueptr-reset-release.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/uniqueptr-reset-release.md
@@ -1,24 +1,26 @@
-.. title:: clang-tidy - misc-uniqueptr-reset-release
+```{title} clang-tidy - misc-uniqueptr-reset-release
+```
 
-misc-uniqueptr-reset-release
-============================
+# misc-uniqueptr-reset-release
 
-Find and replace ``unique_ptr::reset(release())`` with ``std::move()``.
+Find and replace `unique_ptr::reset(release())` with `std::move()`.
 
 Example:
 
-.. code-block:: c++
+```c++
+std::unique_ptr<Foo> x, y;
+x.reset(y.release()); -> x = std::move(y);
+```
 
-  std::unique_ptr<Foo> x, y;
-  x.reset(y.release()); -> x = std::move(y);
+If `y` is already rvalue, `std::move()` is not added. `x` and `y` can
+also be `std::unique_ptr<Foo>*`.
 
-If ``y`` is already rvalue, ``std::move()`` is not added. ``x`` and ``y`` can
-also be ``std::unique_ptr<Foo>*``.
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: IncludeStyle
 
    A string specifying which include-style is used, `llvm` or `google`. Default
    is `llvm`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-alias-decls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-alias-decls.md
@@ -5,10 +5,9 @@
 
 Finds unused namespace alias declarations.
 
-```c++
+```cpp
 namespace my_namespace {
 class C {};
 }
 namespace unused_alias = ::my_namespace;
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-alias-decls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-alias-decls.md
@@ -1,14 +1,14 @@
-.. title:: clang-tidy - misc-unused-alias-decls
+```{title} clang-tidy - misc-unused-alias-decls
+```
 
-misc-unused-alias-decls
-=======================
-
+# misc-unused-alias-decls
 
 Finds unused namespace alias declarations.
 
-.. code-block:: c++
+```c++
+namespace my_namespace {
+class C {};
+}
+namespace unused_alias = ::my_namespace;
+```
 
-  namespace my_namespace {
-  class C {};
-  }
-  namespace unused_alias = ::my_namespace;

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-using-decls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-using-decls.md
@@ -12,9 +12,8 @@ option `HeaderFileExtensions`.
 
 Example:
 
-```c++
+```cpp
 // main.cpp
 namespace n { class C; }
 using n::C;  // Never actually used.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-using-decls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-using-decls.md
@@ -1,19 +1,20 @@
-.. title:: clang-tidy - misc-unused-using-decls
+```{title} clang-tidy - misc-unused-using-decls
+```
 
-misc-unused-using-decls
-=======================
+# misc-unused-using-decls
 
-Finds unused ``using`` declarations.
+Finds unused `using` declarations.
 
-Unused ``using`` declarations in header files will not be diagnosed
+Unused `using` declarations in header files will not be diagnosed
 since these using declarations are part of the header's public API.
 Allowed header file extensions can be configured via the global
 option `HeaderFileExtensions`.
 
 Example:
 
-.. code-block:: c++
+```c++
+// main.cpp
+namespace n { class C; }
+using n::C;  // Never actually used.
+```
 
-  // main.cpp
-  namespace n { class C; }
-  using n::C;  // Never actually used.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-setjmp-longjmp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-setjmp-longjmp.md
@@ -1,16 +1,15 @@
-.. title:: clang-tidy - modernize-avoid-setjmp-longjmp
+```{title} clang-tidy - modernize-avoid-setjmp-longjmp
+```
 
-modernize-avoid-setjmp-longjmp
-==============================
+# modernize-avoid-setjmp-longjmp
 
-Flags all call expressions involving ``setjmp()`` and
-``longjmp()`` in C++ code.
+Flags all call expressions involving `setjmp()` and
+`longjmp()` in C++ code.
 
-Exception handling with ``throw`` and ``catch`` should be used instead.
+Exception handling with `throw` and `catch` should be used instead.
 
-References
-----------
+## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-`ERR52-CPP. Do not use setjmp() or longjmp()
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err52-cpp/>`_.
+[ERR52-CPP. Do not use setjmp() or longjmp()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err52-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-setjmp-longjmp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-setjmp-longjmp.md
@@ -12,4 +12,3 @@ Exception handling with `throw` and `catch` should be used instead.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [ERR52-CPP. Do not use setjmp() or longjmp()](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err52-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - modernize-avoid-variadic-functions
+```{title} clang-tidy - modernize-avoid-variadic-functions
+```
 
-modernize-avoid-variadic-functions
-==================================
+# modernize-avoid-variadic-functions
 
 Find all function definitions (but not declarations) of C-style variadic
 functions.
@@ -9,10 +9,8 @@ functions.
 Instead of C-style variadic functions, C++ function parameter pack should be
 used.
 
-
-References
-----------
+## References
 
 This check corresponds to the CERT C++ Coding Standard rule
-`DCL50-CPP. Do not define a C-style variadic function
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl50-cpp/>`_.
+[DCL50-CPP. Do not define a C-style variadic function](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl50-cpp/).
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.md
@@ -13,4 +13,3 @@ used.
 
 This check corresponds to the CERT C++ Coding Standard rule
 [DCL50-CPP. Do not define a C-style variadic function](https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl50-cpp/).
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/deprecated-ios-base-aliases.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/deprecated-ios-base-aliases.md
@@ -1,17 +1,16 @@
-.. title:: clang-tidy - modernize-deprecated-ios-base-aliases
+```{title} clang-tidy - modernize-deprecated-ios-base-aliases
+```
 
-modernize-deprecated-ios-base-aliases
-=====================================
+# modernize-deprecated-ios-base-aliases
 
-Detects usage of the deprecated member types of ``std::ios_base`` and replaces
+Detects usage of the deprecated member types of `std::ios_base` and replaces
 those that have a non-deprecated equivalent.
 
-===================================  ===========================
-Deprecated member type               Replacement
-===================================  ===========================
-``std::ios_base::io_state``          ``std::ios_base::iostate``
-``std::ios_base::open_mode``         ``std::ios_base::openmode``
-``std::ios_base::seek_dir``          ``std::ios_base::seekdir``
-``std::ios_base::streamoff``
-``std::ios_base::streampos``
-===================================  ===========================
+| Deprecated member type     | Replacement               |
+| -------------------------- | ------------------------- |
+| `std::ios_base::io_state`  | `std::ios_base::iostate`  |
+| `std::ios_base::open_mode` | `std::ios_base::openmode` |
+| `std::ios_base::seek_dir`  | `std::ios_base::seekdir`  |
+| `std::ios_base::streamoff` |                           |
+| `std::ios_base::streampos` |                           |
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/deprecated-ios-base-aliases.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/deprecated-ios-base-aliases.md
@@ -13,4 +13,3 @@ those that have a non-deprecated equivalent.
 | `std::ios_base::seek_dir`  | `std::ios_base::seekdir`  |
 | `std::ios_base::streamoff` |                           |
 | `std::ios_base::streampos` |                           |
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/redundant-void-arg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/redundant-void-arg.md
@@ -1,19 +1,18 @@
-.. title:: clang-tidy - modernize-redundant-void-arg
+```{title} clang-tidy - modernize-redundant-void-arg
+```
 
-modernize-redundant-void-arg
-============================
+# modernize-redundant-void-arg
 
-Finds and removes redundant ``void`` argument lists.
+Finds and removes redundant `void` argument lists.
 Works in C++ and in C23 and up.
 
 Examples:
-  ===================================  ===========================
-  Initial code                         Code with applied fixes
-  ===================================  ===========================
-  ``int f(void);``                     ``int f();``
-  ``int (*f(void))(void);``            ``int (*f())();``
-  ``typedef int (*f_t(void))(void);``  ``typedef int (*f_t())();``
-  ``void (C::*p)(void);``              ``void (C::*p)();``
-  ``C::C(void) {}``                    ``C::C() {}``
-  ``C::~C(void) {}``                   ``C::~C() {}``
-  ===================================  ===========================
+: | Initial code                      | Code with applied fixes   |
+  | --------------------------------- | ------------------------- |
+  | `int f(void);`                    | `int f();`                |
+  | `int (*f(void))(void);`           | `int (*f())();`           |
+  | `typedef int (*f_t(void))(void);` | `typedef int (*f_t())();` |
+  | `void (C::*p)(void);`             | `void (C::*p)();`         |
+  | `C::C(void) {}`                   | `C::C() {}`               |
+  | `C::~C(void) {}`                  | `C::~C() {}`              |
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/redundant-void-arg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/redundant-void-arg.md
@@ -15,4 +15,3 @@ Examples:
   | `void (C::*p)(void);`             | `void (C::*p)();`         |
   | `C::C(void) {}`                   | `C::C() {}`               |
   | `C::~C(void) {}`                  | `C::~C() {}`              |
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/return-braced-init-list.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/return-braced-init-list.md
@@ -7,7 +7,7 @@ Replaces explicit calls to the constructor in a return with a braced
 initializer list. This way the return type is not needlessly duplicated in the
 function definition and the return statement.
 
-```c++
+```cpp
 Foo bar() {
   Baz baz;
   return Foo(baz);
@@ -20,4 +20,3 @@ Foo bar() {
   return {baz};
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/return-braced-init-list.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/return-braced-init-list.md
@@ -1,22 +1,23 @@
-.. title:: clang-tidy - modernize-return-braced-init-list
+```{title} clang-tidy - modernize-return-braced-init-list
+```
 
-modernize-return-braced-init-list
-=================================
+# modernize-return-braced-init-list
 
 Replaces explicit calls to the constructor in a return with a braced
 initializer list. This way the return type is not needlessly duplicated in the
 function definition and the return statement.
 
-.. code:: c++
+```c++
+Foo bar() {
+  Baz baz;
+  return Foo(baz);
+}
 
-  Foo bar() {
-    Baz baz;
-    return Foo(baz);
-  }
+// transforms to:
 
-  // transforms to:
+Foo bar() {
+  Baz baz;
+  return {baz};
+}
+```
 
-  Foo bar() {
-    Baz baz;
-    return {baz};
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/shrink-to-fit.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/shrink-to-fit.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - modernize-shrink-to-fit
+```{title} clang-tidy - modernize-shrink-to-fit
+```
 
-modernize-shrink-to-fit
-=======================
-
+# modernize-shrink-to-fit
 
 Replace copy and swap tricks on shrinkable containers with the
-``shrink_to_fit()`` method call.
+`shrink_to_fit()` method call.
 
-The ``shrink_to_fit()`` method is more readable and more effective than
+The `shrink_to_fit()` method is more readable and more effective than
 the copy and swap trick to reduce the capacity of a shrinkable container.
-Note that, the ``shrink_to_fit()`` method is only available in C++11 and up.
+Note that, the `shrink_to_fit()` method is only available in C++11 and up.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/shrink-to-fit.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/shrink-to-fit.md
@@ -9,4 +9,3 @@ Replace copy and swap tricks on shrinkable containers with the
 The `shrink_to_fit()` method is more readable and more effective than
 the copy and swap trick to reduce the capacity of a shrinkable container.
 Note that, the `shrink_to_fit()` method is only available in C++11 and up.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/unary-static-assert.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/unary-static-assert.md
@@ -11,7 +11,7 @@ The check is only applicable for C++17 and later code.
 
 The following code:
 
-```c++
+```cpp
 void f_textless(int a) {
   static_assert(sizeof(a) <= 10, "");
 }
@@ -19,9 +19,8 @@ void f_textless(int a) {
 
 is replaced by:
 
-```c++
+```cpp
 void f_textless(int a) {
   static_assert(sizeof(a) <= 10);
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/unary-static-assert.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/unary-static-assert.md
@@ -1,26 +1,27 @@
-.. title:: clang-tidy - modernize-unary-static-assert
+```{title} clang-tidy - modernize-unary-static-assert
+```
 
-modernize-unary-static-assert
-=============================
+# modernize-unary-static-assert
 
-The check diagnoses any ``static_assert`` declaration with an
+The check diagnoses any `static_assert` declaration with an
 empty string literal and provides a fix-it note to replace the
-declaration with a single-argument ``static_assert`` declaration.
+declaration with a single-argument `static_assert` declaration.
 
 The check is only applicable for C++17 and later code.
 
 The following code:
 
-.. code-block:: c++
-
-  void f_textless(int a) {
-    static_assert(sizeof(a) <= 10, "");
-  }
+```c++
+void f_textless(int a) {
+  static_assert(sizeof(a) <= 10, "");
+}
+```
 
 is replaced by:
 
-.. code-block:: c++
+```c++
+void f_textless(int a) {
+  static_assert(sizeof(a) <= 10);
+}
+```
 
-  void f_textless(int a) {
-    static_assert(sizeof(a) <= 10);
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-bool-literals.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-bool-literals.md
@@ -5,7 +5,7 @@
 
 Finds integer literals which are cast to `bool`.
 
-```c++
+```cpp
 bool p = 1;
 bool f = static_cast<bool>(1);
 std::ios_base::sync_with_stdio(0);
@@ -21,10 +21,8 @@ bool x = p ? true : false;
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnoreMacros
+```{option} IgnoreMacros
 
-   If set to `true`, the check will not give warnings inside macros. Default
-   is `true`.
+If set to `true`, the check will not give warnings inside macros. Default
+is `true`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-bool-literals.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-bool-literals.md
@@ -1,28 +1,30 @@
-.. title:: clang-tidy - modernize-use-bool-literals
+```{title} clang-tidy - modernize-use-bool-literals
+```
 
-modernize-use-bool-literals
-===========================
+# modernize-use-bool-literals
 
-Finds integer literals which are cast to ``bool``.
+Finds integer literals which are cast to `bool`.
 
-.. code-block:: c++
+```c++
+bool p = 1;
+bool f = static_cast<bool>(1);
+std::ios_base::sync_with_stdio(0);
+bool x = p ? 1 : 0;
 
-  bool p = 1;
-  bool f = static_cast<bool>(1);
-  std::ios_base::sync_with_stdio(0);
-  bool x = p ? 1 : 0;
+// transforms to
 
-  // transforms to
+bool p = true;
+bool f = true;
+std::ios_base::sync_with_stdio(false);
+bool x = p ? true : false;
+```
 
-  bool p = true;
-  bool f = true;
-  std::ios_base::sync_with_stdio(false);
-  bool x = p ? true : false;
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: IgnoreMacros
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default.md
@@ -1,9 +1,12 @@
-:orphan:
+---
+orphan: true
+---
 
-.. title:: clang-tidy - modernize-use-default
+```{title} clang-tidy - modernize-use-default
+```
 
-modernize-use-default
-=====================
+# modernize-use-default
 
 This check has been renamed to
-:doc:`modernize-use-equals-default <../modernize/use-equals-default>`.
+{doc}`modernize-use-equals-default <../modernize/use-equals-default>`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default.md
@@ -9,4 +9,3 @@ orphan: true
 
 This check has been renamed to
 {doc}`modernize-use-equals-default <../modernize/use-equals-default>`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.md
@@ -9,20 +9,15 @@ this will work with `std::string` and `std::string_view`.
 
 Covered scenarios:
 
-```{eval-rst}
-==================================================== =====================
-Expression                                           Replacement
----------------------------------------------------- ---------------------
-``u.find(v) == 0``                                   ``u.starts_with(v)``
-``u.find(v, 0) == 0``                                ``u.starts_with(v)``
-``u.find(v, 0, v.size()) == 0``                      ``u.starts_with(v)``
-``u.rfind(v, 0) != 0``                               ``!u.starts_with(v)``
-``u.rfind(v, 0, v.size()) != 0``                     ``!u.starts_with(v)``
-``u.compare(0, v.size(), v) == 0``                   ``u.starts_with(v)``
-``u.substr(0, v.size()) == v``                       ``u.starts_with(v)``
-``v != u.substr(0, v.size())``                       ``!u.starts_with(v)``
-``u.compare(u.size() - v.size(), v.size(), v) == 0`` ``u.ends_with(v)``
-``u.rfind(v) == u.size() - v.size()``                ``u.ends_with(v)``
-==================================================== =====================
-```
-
+| Expression | Replacement |
+| ---------- | ----------- |
+| `u.find(v) == 0` | `u.starts_with(v)` |
+| `u.find(v, 0) == 0` | `u.starts_with(v)` |
+| `u.find(v, 0, v.size()) == 0` | `u.starts_with(v)` |
+| `u.rfind(v, 0) != 0` | `!u.starts_with(v)` |
+| `u.rfind(v, 0, v.size()) != 0` | `!u.starts_with(v)` |
+| `u.compare(0, v.size(), v) == 0` | `u.starts_with(v)` |
+| `u.substr(0, v.size()) == v` | `u.starts_with(v)` |
+| `v != u.substr(0, v.size())` | `!u.starts_with(v)` |
+| `u.compare(u.size() - v.size(), v.size(), v) == 0` | `u.ends_with(v)` |
+| `u.rfind(v) == u.size() - v.size()` | `u.ends_with(v)` |

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.md
@@ -1,14 +1,15 @@
-.. title:: clang-tidy - modernize-use-starts-ends-with
+```{title} clang-tidy - modernize-use-starts-ends-with
+```
 
-modernize-use-starts-ends-with
-==============================
+# modernize-use-starts-ends-with
 
-Checks for common roundabout ways to express ``starts_with`` and ``ends_with``
+Checks for common roundabout ways to express `starts_with` and `ends_with`
 and suggests replacing with the simpler method when it is available. Notably,
-this will work with ``std::string`` and ``std::string_view``.
+this will work with `std::string` and `std::string_view`.
 
 Covered scenarios:
 
+```{eval-rst}
 ==================================================== =====================
 Expression                                           Replacement
 ---------------------------------------------------- ---------------------
@@ -23,3 +24,5 @@ Expression                                           Replacement
 ``u.compare(u.size() - v.size(), v.size(), v) == 0`` ``u.ends_with(v)``
 ``u.rfind(v) == u.size() - v.size()``                ``u.ends_with(v)``
 ==================================================== =====================
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.md
@@ -9,15 +9,15 @@ this will work with `std::string` and `std::string_view`.
 
 Covered scenarios:
 
-| Expression | Replacement |
-| ---------- | ----------- |
-| `u.find(v) == 0` | `u.starts_with(v)` |
-| `u.find(v, 0) == 0` | `u.starts_with(v)` |
-| `u.find(v, 0, v.size()) == 0` | `u.starts_with(v)` |
-| `u.rfind(v, 0) != 0` | `!u.starts_with(v)` |
-| `u.rfind(v, 0, v.size()) != 0` | `!u.starts_with(v)` |
-| `u.compare(0, v.size(), v) == 0` | `u.starts_with(v)` |
-| `u.substr(0, v.size()) == v` | `u.starts_with(v)` |
-| `v != u.substr(0, v.size())` | `!u.starts_with(v)` |
-| `u.compare(u.size() - v.size(), v.size(), v) == 0` | `u.ends_with(v)` |
-| `u.rfind(v) == u.size() - v.size()` | `u.ends_with(v)` |
+| Expression                                              | Replacement         |
+| ------------------------------------------------------- | ------------------- |
+| `u.find(v) == 0`                                        | `u.starts_with(v)`  |
+| `u.find(v, 0) == 0`                                     | `u.starts_with(v)`  |
+| `u.find(v, 0, v.size()) == 0`                           | `u.starts_with(v)`  |
+| `u.rfind(v, 0) != 0`                                    | `!u.starts_with(v)` |
+| `u.rfind(v, 0, v.size()) != 0`                          | `!u.starts_with(v)` |
+| `u.compare(0, v.size(), v) == 0`                        | `u.starts_with(v)`  |
+| `u.substr(0, v.size()) == v`                            | `u.starts_with(v)`  |
+| `v != u.substr(0, v.size())`                            | `!u.starts_with(v)` |
+| `u.compare(u.size() - v.size(), v.size(), v) == 0`      | `u.ends_with(v)`    |
+| `u.rfind(v) == u.size() - v.size()`                     | `u.ends_with(v)`    |

--- a/clang-tools-extra/docs/clang-tidy/checks/mpi/buffer-deref.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/mpi/buffer-deref.md
@@ -12,7 +12,7 @@ warning emitted.
 
 Examples:
 
-```c++
+```cpp
 // A double pointer is passed to the MPI function.
 char *buf;
 MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
@@ -25,4 +25,3 @@ MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
 short *buf[1];
 MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/mpi/buffer-deref.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/mpi/buffer-deref.md
@@ -1,27 +1,28 @@
-.. title:: clang-tidy - mpi-buffer-deref
+```{title} clang-tidy - mpi-buffer-deref
+```
 
-mpi-buffer-deref
-================
+# mpi-buffer-deref
 
 This check verifies if a buffer passed to an MPI (Message Passing Interface)
 function is sufficiently dereferenced. Buffers should be passed as a single
-pointer or array. As MPI function signatures specify ``void *`` for their
+pointer or array. As MPI function signatures specify `void *` for their
 buffer types, insufficiently dereferenced buffers can be passed, like for
 example as double pointers or multidimensional arrays, without a compiler
 warning emitted.
 
 Examples:
 
-.. code-block:: c++
+```c++
+// A double pointer is passed to the MPI function.
+char *buf;
+MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 
-   // A double pointer is passed to the MPI function.
-   char *buf;
-   MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+// A multidimensional array is passed to the MPI function.
+short buf[1][1];
+MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
 
-   // A multidimensional array is passed to the MPI function.
-   short buf[1][1];
-   MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
+// A pointer to an array is passed to the MPI function.
+short *buf[1];
+MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
+```
 
-   // A pointer to an array is passed to the MPI function.
-   short *buf[1];
-   MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);

--- a/clang-tools-extra/docs/clang-tidy/checks/mpi/type-mismatch.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/mpi/type-mismatch.md
@@ -11,7 +11,7 @@ of verification.
 
 Example:
 
-```c++
+```cpp
 // In this case, the buffer type matches MPI datatype.
 char buf;
 MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
@@ -20,4 +20,3 @@ MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 int buf;
 MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/mpi/type-mismatch.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/mpi/type-mismatch.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - mpi-type-mismatch
+```{title} clang-tidy - mpi-type-mismatch
+```
 
-mpi-type-mismatch
-=================
+# mpi-type-mismatch
 
 This check verifies if buffer type and MPI (Message Passing Interface)
 datatype pairs match for used MPI functions. All MPI datatypes defined
@@ -11,12 +11,13 @@ of verification.
 
 Example:
 
-.. code-block:: c++
+```c++
+// In this case, the buffer type matches MPI datatype.
+char buf;
+MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 
-  // In this case, the buffer type matches MPI datatype.
-  char buf;
-  MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+// In the following case, the buffer type does not match MPI datatype.
+int buf;
+MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+```
 
-  // In the following case, the buffer type does not match MPI datatype.
-  int buf;
-  MPI_Send(&buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/assert-equals.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/assert-equals.md
@@ -1,11 +1,12 @@
-.. title:: clang-tidy - objc-assert-equals
+```{title} clang-tidy - objc-assert-equals
+```
 
-objc-assert-equals
-==================
+# objc-assert-equals
 
 Finds improper usages of `XCTAssertEqual` and `XCTAssertNotEqual` and replaces
 them with `XCTAssertEqualObjects` or `XCTAssertNotEqualObjects`.
 
 This makes tests less fragile, as many improperly rely on pointer equality for
-strings that have equal values.  This assumption is not guaranteed by the
+strings that have equal values. This assumption is not guaranteed by the
 language.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/assert-equals.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/assert-equals.md
@@ -9,4 +9,3 @@ them with `XCTAssertEqualObjects` or `XCTAssertNotEqualObjects`.
 This makes tests less fragile, as many improperly rely on pointer equality for
 strings that have equal values. This assumption is not guaranteed by the
 language.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/avoid-nserror-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/avoid-nserror-init.md
@@ -1,13 +1,14 @@
-.. title:: clang-tidy - objc-avoid-nserror-init
+```{title} clang-tidy - objc-avoid-nserror-init
+```
 
-objc-avoid-nserror-init
-=======================
+# objc-avoid-nserror-init
 
-Finds improper initialization of ``NSError`` objects.
+Finds improper initialization of `NSError` objects.
 
 According to Apple developer document, we should always use factory method
-``errorWithDomain:code:userInfo:`` to create new NSError objects instead
-of ``[NSError alloc] init]``. Otherwise it will lead to a warning message
+`errorWithDomain:code:userInfo:` to create new NSError objects instead
+of `[NSError alloc] init]`. Otherwise it will lead to a warning message
 during runtime.
 
-The corresponding information about ``NSError`` creation: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html
+The corresponding information about `NSError` creation: <https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html>
+

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/avoid-nserror-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/avoid-nserror-init.md
@@ -11,4 +11,3 @@ of `[NSError alloc] init]`. Otherwise it will lead to a warning message
 during runtime.
 
 The corresponding information about `NSError` creation: <https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html>
-

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/dealloc-in-category.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/dealloc-in-category.md
@@ -1,13 +1,14 @@
-.. title:: clang-tidy - objc-dealloc-in-category
+```{title} clang-tidy - objc-dealloc-in-category
+```
 
-objc-dealloc-in-category
-========================
+# objc-dealloc-in-category
 
-Finds implementations of ``-dealloc`` in Objective-C categories. The category
-implementation will override any ``-dealloc`` in the class implementation,
+Finds implementations of `-dealloc` in Objective-C categories. The category
+implementation will override any `-dealloc` in the class implementation,
 potentially causing issues.
 
-Classes implement ``-dealloc`` to perform important actions to deallocate
-an object. If a category on the class implements ``-dealloc``, it will
+Classes implement `-dealloc` to perform important actions to deallocate
+an object. If a category on the class implements `-dealloc`, it will
 override the class's implementation and unexpected deallocation behavior
 may occur.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/dealloc-in-category.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/dealloc-in-category.md
@@ -11,4 +11,3 @@ Classes implement `-dealloc` to perform important actions to deallocate
 an object. If a category on the class implements `-dealloc`, it will
 override the class's implementation and unexpected deallocation behavior
 may occur.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.md
@@ -19,12 +19,10 @@ See <https://clang.llvm.org/docs/AttributeReference.html#objc-subclassing-restri
 
 ## Options
 
-```{eval-rst}
-.. option:: ForbiddenSuperClassNames
+```{option} ForbiddenSuperClassNames
 
-   Semicolon-separated list of names of Objective-C classes which
-   do not support subclassing.
+Semicolon-separated list of names of Objective-C classes which
+do not support subclassing.
 
-   Defaults to `ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView`.
+Defaults to `ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/forbidden-subclassing.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - objc-forbidden-subclassing
+```{title} clang-tidy - objc-forbidden-subclassing
+```
 
-objc-forbidden-subclassing
-==========================
+# objc-forbidden-subclassing
 
 Finds Objective-C classes which are subclasses of classes which are
 not designed to be subclassed.
@@ -9,20 +9,22 @@ not designed to be subclassed.
 By default, includes a list of Objective-C classes which are publicly
 documented as not supporting subclassing.
 
-.. note::
+:::{note}
+Instead of using this check, for code under your control, you should add
+`__attribute__((objc_subclassing_restricted))` before your `@interface`
+declarations to ensure the compiler prevents others from subclassing your
+Objective-C classes.
+See <https://clang.llvm.org/docs/AttributeReference.html#objc-subclassing-restricted>
+:::
 
-   Instead of using this check, for code under your control, you should add
-   ``__attribute__((objc_subclassing_restricted))`` before your ``@interface``
-   declarations to ensure the compiler prevents others from subclassing your
-   Objective-C classes.
-   See https://clang.llvm.org/docs/AttributeReference.html#objc-subclassing-restricted
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: ForbiddenSuperClassNames
 
    Semicolon-separated list of names of Objective-C classes which
    do not support subclassing.
 
    Defaults to `ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/missing-hash.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/missing-hash.md
@@ -1,16 +1,17 @@
-.. title:: clang-tidy - objc-missing-hash
+```{title} clang-tidy - objc-missing-hash
+```
 
-objc-missing-hash
-=================
+# objc-missing-hash
 
-Finds Objective-C implementations that implement ``-isEqual:`` without also
-appropriately implementing ``-hash``.
+Finds Objective-C implementations that implement `-isEqual:` without also
+appropriately implementing `-hash`.
 
 Apple documentation highlights that objects that are equal must have the same
 hash value:
-https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418795-isequal?language=objc
+<https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418795-isequal?language=objc>
 
-Note that the check only verifies the presence of ``-hash`` in scenarios where
+Note that the check only verifies the presence of `-hash` in scenarios where
 its omission could result in unexpected behavior. The verification of the
-implementation of ``-hash`` is the responsibility of the developer, e.g.,
+implementation of `-hash` is the responsibility of the developer, e.g.,
 through the addition of unit tests to verify the implementation.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/missing-hash.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/missing-hash.md
@@ -14,4 +14,3 @@ Note that the check only verifies the presence of `-hash` in scenarios where
 its omission could result in unexpected behavior. The verification of the
 implementation of `-hash` is the responsibility of the developer, e.g.,
 through the addition of unit tests to verify the implementation.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/objc/super-self.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/objc/super-self.md
@@ -1,12 +1,12 @@
-.. title:: clang-tidy - objc-super-self
+```{title} clang-tidy - objc-super-self
+```
 
-objc-super-self
-===============
+# objc-super-self
 
-Finds invocations of ``-self`` on super instances in initializers of subclasses
-of ``NSObject`` and recommends calling a superclass initializer instead.
+Finds invocations of `-self` on super instances in initializers of subclasses
+of `NSObject` and recommends calling a superclass initializer instead.
 
-Invoking ``-self`` on super instances in initializers is a common programmer
+Invoking `-self` on super instances in initializers is a common programmer
 error when the programmer's original intent is to call a superclass
 initializer. Failing to call a superclass initializer breaks initializer
 chaining and can result in invalid object initialization.

--- a/clang-tools-extra/docs/clang-tidy/checks/openmp/exception-escape.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/openmp/exception-escape.md
@@ -18,10 +18,8 @@ WARNING! This check may be expensive on large source files.
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnoredExceptions
+```{option} IgnoredExceptions
 
-   Comma-separated list containing type names which are not counted as thrown
-   exceptions in the check. Default value is an empty string.
+Comma-separated list containing type names which are not counted as thrown
+exceptions in the check. Default value is an empty string.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/openmp/exception-escape.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/openmp/exception-escape.md
@@ -1,25 +1,27 @@
-.. title:: clang-tidy - openmp-exception-escape
+```{title} clang-tidy - openmp-exception-escape
+```
 
-openmp-exception-escape
-=======================
+# openmp-exception-escape
 
 Analyzes OpenMP Structured Blocks and checks that no exception escapes
 out of the Structured Block it was thrown in.
 
 As per the OpenMP specification, a structured block is an executable statement,
 possibly compound, with a single entry at the top and a single exit at the
-bottom. Which means, ``throw`` may not be used to 'exit' out of the
+bottom. Which means, `throw` may not be used to 'exit' out of the
 structured block. If an exception is not caught in the same structured block
 it was thrown in, the behavior is undefined.
 
-FIXME: this check does not model SEH, ``setjmp``/``longjmp``.
+FIXME: this check does not model SEH, `setjmp`/`longjmp`.
 
 WARNING! This check may be expensive on large source files.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: IgnoredExceptions
 
    Comma-separated list containing type names which are not counted as thrown
    exceptions in the check. Default value is an empty string.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.md
@@ -1,8 +1,9 @@
-.. title:: clang-tidy - performance-faster-string-find
+```{title} clang-tidy - performance-faster-string-find
+```
 
-performance-faster-string-find
-==============================
+# performance-faster-string-find
 
 The `performance-faster-string-find` check is an alias, please see
-:doc:`performance-prefer-single-char-overloads <prefer-single-char-overloads>`
+{doc}`performance-prefer-single-char-overloads <prefer-single-char-overloads>`
 for more information.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.md
@@ -6,4 +6,3 @@
 The `performance-faster-string-find` check is an alias, please see
 {doc}`performance-prefer-single-char-overloads <prefer-single-char-overloads>`
 for more information.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-cast-in-loop.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-cast-in-loop.md
@@ -7,6 +7,4 @@ orphan: true
 
 # performance-implicit-cast-in-loop
 
-This check has been renamed to {doc}`performance-implicit-conversion-in-loop
-<../performance/implicit-conversion-in-loop>`.
-
+This check has been renamed to {doc}`performance-implicit-conversion-in-loop <../performance/implicit-conversion-in-loop>`.

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-cast-in-loop.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-cast-in-loop.md
@@ -1,10 +1,12 @@
-:orphan:
+---
+orphan: true
+---
 
-.. title:: clang-tidy - performance-implicit-cast-in-loop
+```{title} clang-tidy - performance-implicit-cast-in-loop
+```
 
-performance-implicit-cast-in-loop
-=================================
+# performance-implicit-cast-in-loop
 
-This check has been renamed to :doc:`performance-implicit-conversion-in-loop
+This check has been renamed to {doc}`performance-implicit-conversion-in-loop
 <../performance/implicit-conversion-in-loop>`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-conversion-in-loop.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-conversion-in-loop.md
@@ -10,7 +10,7 @@ result in expensive deep copies.
 
 Example:
 
-```c++
+```cpp
 map<int, vector<string>> my_map;
 for (const pair<int, vector<string>>& p : my_map) {}
 // The iterator type is in fact pair<const int, vector<string>>, which means
@@ -19,4 +19,3 @@ for (const pair<int, vector<string>>& p : my_map) {}
 
 The easiest solution is usually to use `const auto&` instead of writing the
 type manually.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-conversion-in-loop.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-conversion-in-loop.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - performance-implicit-conversion-in-loop
+```{title} clang-tidy - performance-implicit-conversion-in-loop
+```
 
-performance-implicit-conversion-in-loop
-=======================================
+# performance-implicit-conversion-in-loop
 
 This warning appears in a range-based loop with a loop variable of const ref
 type where the type of the variable does not match the one returned by the
@@ -10,12 +10,13 @@ result in expensive deep copies.
 
 Example:
 
-.. code-block:: c++
+```c++
+map<int, vector<string>> my_map;
+for (const pair<int, vector<string>>& p : my_map) {}
+// The iterator type is in fact pair<const int, vector<string>>, which means
+// that the compiler added a conversion, resulting in a copy of the vectors.
+```
 
-  map<int, vector<string>> my_map;
-  for (const pair<int, vector<string>>& p : my_map) {}
-  // The iterator type is in fact pair<const int, vector<string>>, which means
-  // that the compiler added a conversion, resulting in a copy of the vectors.
-
-The easiest solution is usually to use ``const auto&`` instead of writing the
+The easiest solution is usually to use `const auto&` instead of writing the
 type manually.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-algorithm.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-algorithm.md
@@ -9,7 +9,7 @@ Associative containers implement some of the algorithms as methods which
 should be preferred to the algorithms in the algorithm header. The methods
 can take advantage of the order of the elements.
 
-```c++
+```cpp
 std::set<int> s;
 auto it = std::find(s.begin(), s.end(), 43);
 
@@ -18,7 +18,7 @@ auto it = std::find(s.begin(), s.end(), 43);
 auto it = s.find(43);
 ```
 
-```c++
+```cpp
 std::set<int> s;
 auto c = std::count(s.begin(), s.end(), 43);
 
@@ -26,4 +26,3 @@ auto c = std::count(s.begin(), s.end(), 43);
 
 auto c = s.count(43);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-algorithm.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/inefficient-algorithm.md
@@ -1,8 +1,7 @@
-.. title:: clang-tidy - performance-inefficient-algorithm
+```{title} clang-tidy - performance-inefficient-algorithm
+```
 
-performance-inefficient-algorithm
-=================================
-
+# performance-inefficient-algorithm
 
 Warns on inefficient use of STL algorithms on associative containers.
 
@@ -10,20 +9,21 @@ Associative containers implement some of the algorithms as methods which
 should be preferred to the algorithms in the algorithm header. The methods
 can take advantage of the order of the elements.
 
-.. code-block:: c++
+```c++
+std::set<int> s;
+auto it = std::find(s.begin(), s.end(), 43);
 
-  std::set<int> s;
-  auto it = std::find(s.begin(), s.end(), 43);
+// becomes
 
-  // becomes
+auto it = s.find(43);
+```
 
-  auto it = s.find(43);
+```c++
+std::set<int> s;
+auto c = std::count(s.begin(), s.end(), 43);
 
-.. code-block:: c++
+// becomes
 
-  std::set<int> s;
-  auto c = std::count(s.begin(), s.end(), 43);
+auto c = s.count(43);
+```
 
-  // becomes
-
-  auto c = s.count(43);

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/move-constructor-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/move-constructor-init.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - performance-move-constructor-init
+```{title} clang-tidy - performance-move-constructor-init
+```
 
-performance-move-constructor-init
-=================================
+# performance-move-constructor-init
 
 "cert-oop11-cpp" redirects here as an alias for this check.
 
 The check flags user-defined move constructors that have a ctor-initializer
 initializing a member or base class through a copy constructor instead of a
 move constructor.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/move-constructor-init.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/move-constructor-init.md
@@ -8,4 +8,3 @@
 The check flags user-defined move constructors that have a ctor-initializer
 initializing a member or base class through a copy constructor instead of a
 move constructor.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-destructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-destructor.md
@@ -1,12 +1,13 @@
-.. title:: clang-tidy - performance-noexcept-destructor
+```{title} clang-tidy - performance-noexcept-destructor
+```
 
-performance-noexcept-destructor
-===============================
+# performance-noexcept-destructor
 
-The check flags user-defined destructors marked with ``noexcept(expr)``
-where ``expr`` evaluates to ``false`` (but is not a ``false`` literal itself).
+The check flags user-defined destructors marked with `noexcept(expr)`
+where `expr` evaluates to `false` (but is not a `false` literal itself).
 
-When a destructor is marked as ``noexcept``, it assures the compiler that
+When a destructor is marked as `noexcept`, it assures the compiler that
 no exceptions will be thrown during the destruction of an object, which
 allows the compiler to perform certain optimizations such as omitting
 exception handling code.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-destructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-destructor.md
@@ -10,4 +10,3 @@ When a destructor is marked as `noexcept`, it assures the compiler that
 no exceptions will be thrown during the destruction of an object, which
 allows the compiler to perform certain optimizations such as omitting
 exception handling code.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.md
@@ -1,13 +1,13 @@
-.. title:: clang-tidy - performance-noexcept-move-constructor
+```{title} clang-tidy - performance-noexcept-move-constructor
+```
 
-performance-noexcept-move-constructor
-=====================================
-
+# performance-noexcept-move-constructor
 
 The check flags user-defined move constructors and assignment operators not
-marked with ``noexcept`` or marked with ``noexcept(expr)`` where ``expr``
-evaluates to ``false`` (but is not a ``false`` literal itself).
+marked with `noexcept` or marked with `noexcept(expr)` where `expr`
+evaluates to `false` (but is not a `false` literal itself).
 
 Move constructors of all the types used with STL containers, for example,
-should be declared ``noexcept``. Otherwise STL may choose copy constructors
+should be declared `noexcept`. Otherwise STL may choose copy constructors
 instead. The same is valid for move assignment operations.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.md
@@ -10,4 +10,3 @@ evaluates to `false` (but is not a `false` literal itself).
 Move constructors of all the types used with STL containers, for example,
 should be declared `noexcept`. Otherwise STL may choose copy constructors
 instead. The same is valid for move assignment operations.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-swap.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-swap.md
@@ -1,13 +1,14 @@
-.. title:: clang-tidy - performance-noexcept-swap
+```{title} clang-tidy - performance-noexcept-swap
+```
 
-performance-noexcept-swap
-=========================
+# performance-noexcept-swap
 
 The check flags user-defined swap and iter_swap functions not marked with
-``noexcept`` or marked with ``noexcept(expr)`` where ``expr`` evaluates to
-``false`` (but is not a ``false`` literal itself).
+`noexcept` or marked with `noexcept(expr)` where `expr` evaluates to
+`false` (but is not a `false` literal itself).
 
-When a swap or iter_swap function is marked as ``noexcept``, it assures the
+When a swap or iter_swap function is marked as `noexcept`, it assures the
 compiler that no exceptions will be thrown during the swapping of two objects,
 which allows the compiler to perform certain optimizations such as omitting
 exception handling code.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-swap.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-swap.md
@@ -11,4 +11,3 @@ When a swap or iter_swap function is marked as `noexcept`, it assures the
 compiler that no exceptions will be thrown during the swapping of two objects,
 which allows the compiler to perform certain optimizations such as omitting
 exception handling code.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/trivially-destructible.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/trivially-destructible.md
@@ -6,11 +6,10 @@
 Finds types that could be made trivially-destructible by removing out-of-line
 defaulted destructor declarations.
 
-```c++
+```cpp
 struct A: TrivialType {
   ~A(); // Makes A non-trivially-destructible.
   TrivialType trivial_fields;
 };
 A::~A() = default;
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/trivially-destructible.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/trivially-destructible.md
@@ -1,15 +1,16 @@
-.. title:: clang-tidy - performance-trivially-destructible
+```{title} clang-tidy - performance-trivially-destructible
+```
 
-performance-trivially-destructible
-==================================
+# performance-trivially-destructible
 
 Finds types that could be made trivially-destructible by removing out-of-line
 defaulted destructor declarations.
 
-.. code-block:: c++
+```c++
+struct A: TrivialType {
+  ~A(); // Makes A non-trivially-destructible.
+  TrivialType trivial_fields;
+};
+A::~A() = default;
+```
 
-   struct A: TrivialType {
-     ~A(); // Makes A non-trivially-destructible.
-     TrivialType trivial_fields;
-   };
-   A::~A() = default;

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/type-promotion-in-math-fn.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/type-promotion-in-math-fn.md
@@ -10,7 +10,7 @@ For example, warns on `::sin(0.f)`, because this function's parameter is a
 double. You probably meant to call `std::sin(0.f)` (in C++), or `sinf(0.f)`
 (in C).
 
-```c++
+```cpp
 float a;
 asin(a);
 
@@ -19,4 +19,3 @@ asin(a);
 float a;
 std::asin(a);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/type-promotion-in-math-fn.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/type-promotion-in-math-fn.md
@@ -1,21 +1,22 @@
-.. title:: clang-tidy - performance-type-promotion-in-math-fn
+```{title} clang-tidy - performance-type-promotion-in-math-fn
+```
 
-performance-type-promotion-in-math-fn
-=====================================
+# performance-type-promotion-in-math-fn
 
-Finds calls to C math library functions (from ``math.h`` or, in C++, ``cmath``)
-with implicit ``float`` to ``double`` promotions.
+Finds calls to C math library functions (from `math.h` or, in C++, `cmath`)
+with implicit `float` to `double` promotions.
 
-For example, warns on ``::sin(0.f)``, because this function's parameter is a
-double. You probably meant to call ``std::sin(0.f)`` (in C++), or ``sinf(0.f)``
+For example, warns on `::sin(0.f)`, because this function's parameter is a
+double. You probably meant to call `std::sin(0.f)` (in C++), or `sinf(0.f)`
 (in C).
 
-.. code-block:: c++
+```c++
+float a;
+asin(a);
 
-  float a;
-  asin(a);
+// becomes
 
-  // becomes
+float a;
+std::asin(a);
+```
 
-  float a;
-  std::asin(a);

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/use-std-move.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/use-std-move.md
@@ -6,7 +6,7 @@
 Suggests insertion of `std::move(...)` to turn copy assignment operator calls
 into move assignment ones, when deemed valid and profitable.
 
-```c++
+```cpp
 void assign(std::vector<int>& out) {
   std::vector<int> some = make_vector();
   use_vector(some);
@@ -21,4 +21,3 @@ void assign(std::vector<int>& out) {
   out = std::move(some);
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/use-std-move.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/use-std-move.md
@@ -1,23 +1,24 @@
-.. title:: clang-tidy - performance-use-std-move
+```{title} clang-tidy - performance-use-std-move
+```
 
-performance-use-std-move
-========================
+# performance-use-std-move
 
-Suggests insertion of ``std::move(...)`` to turn copy assignment operator calls
+Suggests insertion of `std::move(...)` to turn copy assignment operator calls
 into move assignment ones, when deemed valid and profitable.
 
-.. code-block:: c++
+```c++
+void assign(std::vector<int>& out) {
+  std::vector<int> some = make_vector();
+  use_vector(some);
+  out = some;
+}
 
-  void assign(std::vector<int>& out) {
-    std::vector<int> some = make_vector();
-    use_vector(some);
-    out = some;
-  }
+// becomes
 
-  // becomes
+void assign(std::vector<int>& out) {
+  std::vector<int> some = make_vector();
+  use_vector(some);
+  out = std::move(some);
+}
+```
 
-  void assign(std::vector<int>& out) {
-    std::vector<int> some = make_vector();
-    use_vector(some);
-    out = std::move(some);
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/no-assembler.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/no-assembler.md
@@ -7,7 +7,6 @@ Checks for assembler statements. Use of inline assembly should be avoided
 since it ties to a specific CPU architecture and syntax making code that
 uses it non-portable across platforms.
 
-```c++
+```cpp
 asm("mov al, 2");  // warning: do not use assembler statements
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/portability/no-assembler.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/portability/no-assembler.md
@@ -1,12 +1,13 @@
-.. title:: clang-tidy - portability-no-assembler
+```{title} clang-tidy - portability-no-assembler
+```
 
-portability-no-assembler
-========================
+# portability-no-assembler
 
 Checks for assembler statements. Use of inline assembly should be avoided
 since it ties to a specific CPU architecture and syntax making code that
 uses it non-portable across platforms.
 
-.. code-block:: c++
+```c++
+asm("mov al, 2");  // warning: do not use assembler statements
+```
 
-   asm("mov al, 2");  // warning: do not use assembler statements

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.md
@@ -11,17 +11,15 @@ they should not be put there.
 
 Examples:
 
-```c++
+```cpp
 void f(const string);   // Bad: const is top level.
 void f(const string&);  // Good: const is not top level.
 ```
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnoreMacros
+```{option} IgnoreMacros
 
-   If set to `true`, the check will not give warnings inside macros. Default
-   is `true`.
+If set to `true`, the check will not give warnings inside macros. Default
+is `true`.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.md
@@ -1,25 +1,27 @@
-.. title:: clang-tidy - readability-avoid-const-params-in-decls
+```{title} clang-tidy - readability-avoid-const-params-in-decls
+```
 
-readability-avoid-const-params-in-decls
-=======================================
+# readability-avoid-const-params-in-decls
 
 Checks whether a function declaration has parameters that are top level
-``const``.
+`const`.
 
-``const`` values in declarations do not affect the signature of a function, so
+`const` values in declarations do not affect the signature of a function, so
 they should not be put there.
 
 Examples:
 
-.. code-block:: c++
+```c++
+void f(const string);   // Bad: const is top level.
+void f(const string&);  // Good: const is not top level.
+```
 
-  void f(const string);   // Bad: const is top level.
-  void f(const string&);  // Good: const is not top level.
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: IgnoreMacros
 
    If set to `true`, the check will not give warnings inside macros. Default
    is `true`.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-nested-conditional-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-nested-conditional-operator.md
@@ -11,9 +11,8 @@ several statements and stored the intermediate results in temporary variable.
 
 Examples:
 
-```c++
+```cpp
 int NestInConditional = (condition1 ? true1 : false1) ? true2 : false2;
 int NestInTrue = condition1 ? (condition2 ? true1 : false1) : false2;
 int NestInFalse = condition1 ? true1 : condition2 ? true2 : false1;
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-nested-conditional-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/avoid-nested-conditional-operator.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - readability-avoid-nested-conditional-operator
+```{title} clang-tidy - readability-avoid-nested-conditional-operator
+```
 
-readability-avoid-nested-conditional-operator
-=============================================
+# readability-avoid-nested-conditional-operator
 
 Identifies instances of nested conditional operators in the code.
 
@@ -11,8 +11,9 @@ several statements and stored the intermediate results in temporary variable.
 
 Examples:
 
-.. code-block:: c++
+```c++
+int NestInConditional = (condition1 ? true1 : false1) ? true2 : false2;
+int NestInTrue = condition1 ? (condition2 ? true1 : false1) : false2;
+int NestInFalse = condition1 ? true1 : condition2 ? true2 : false1;
+```
 
-  int NestInConditional = (condition1 ? true1 : false1) ? true2 : false2;
-  int NestInTrue = condition1 ? (condition2 ? true1 : false1) : false2;
-  int NestInFalse = condition1 ? true1 : condition2 ? true2 : false1;

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.md
@@ -14,10 +14,8 @@ pointer access does not perform an errant memory access.
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnoredContainers
+```{option} IgnoredContainers
 
-   Semicolon-separated list of containers regexp for which this check won't be
-   enforced. Default is an empty string.
+Semicolon-separated list of containers regexp for which this check won't be
+enforced. Default is an empty string.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.md
@@ -1,21 +1,23 @@
-.. title:: clang-tidy - readability-container-data-pointer
+```{title} clang-tidy - readability-container-data-pointer
+```
 
-readability-container-data-pointer
-==================================
+# readability-container-data-pointer
 
-Finds cases where code could use ``data()`` rather than the address of the
+Finds cases where code could use `data()` rather than the address of the
 element at index 0 in a container. This pattern is commonly used to materialize
-a pointer to the backing data of a container. ``std::vector`` and
-``std::string`` provide a ``data()`` accessor to retrieve the data pointer
+a pointer to the backing data of a container. `std::vector` and
+`std::string` provide a `data()` accessor to retrieve the data pointer
 which should be preferred.
 
 This also ensures that in the case that the container is empty, the data
 pointer access does not perform an errant memory access.
 
-Options
--------
+## Options
 
+```{eval-rst}
 .. option:: IgnoredContainers
 
    Semicolon-separated list of containers regexp for which this check won't be
    enforced. Default is an empty string.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/convert-member-functions-to-static.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/convert-member-functions-to-static.md
@@ -10,7 +10,5 @@ After applying modifications as suggested by the check, running the check again
 might find more opportunities to mark member functions `static`.
 
 After making a member function `static`, you might want to run the check
-{doc}`readability-static-accessed-through-instance
-<../readability/static-accessed-through-instance>` to replace calls like
+{doc}`readability-static-accessed-through-instance <../readability/static-accessed-through-instance>` to replace calls like
 `Instance.method()` by `Class::method()`.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/convert-member-functions-to-static.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/convert-member-functions-to-static.md
@@ -1,15 +1,16 @@
-.. title:: clang-tidy - readability-convert-member-functions-to-static
+```{title} clang-tidy - readability-convert-member-functions-to-static
+```
 
-readability-convert-member-functions-to-static
-==============================================
+# readability-convert-member-functions-to-static
 
-Finds non-static member functions that can be made ``static``
-because the functions don't use ``this``.
+Finds non-static member functions that can be made `static`
+because the functions don't use `this`.
 
 After applying modifications as suggested by the check, running the check again
-might find more opportunities to mark member functions ``static``.
+might find more opportunities to mark member functions `static`.
 
-After making a member function ``static``, you might want to run the check
-:doc:`readability-static-accessed-through-instance
+After making a member function `static`, you might want to run the check
+{doc}`readability-static-accessed-through-instance
 <../readability/static-accessed-through-instance>` to replace calls like
-``Instance.method()`` by ``Class::method()``.
+`Instance.method()` by `Class::method()`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/delete-null-pointer.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/delete-null-pointer.md
@@ -7,9 +7,8 @@ Checks the `if` statements where a pointer's existence is checked and
 then deletes the pointer.
 The check is unnecessary as deleting a null pointer has no effect.
 
-```c++
+```cpp
 int *p;
 if (p)
   delete p;
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/delete-null-pointer.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/delete-null-pointer.md
@@ -1,14 +1,15 @@
-.. title:: clang-tidy - readability-delete-null-pointer
+```{title} clang-tidy - readability-delete-null-pointer
+```
 
-readability-delete-null-pointer
-===============================
+# readability-delete-null-pointer
 
-Checks the ``if`` statements where a pointer's existence is checked and
+Checks the `if` statements where a pointer's existence is checked and
 then deletes the pointer.
 The check is unnecessary as deleting a null pointer has no effect.
 
-.. code:: c++
+```c++
+int *p;
+if (p)
+  delete p;
+```
 
-  int *p;
-  if (p)
-    delete p;

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-cast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-cast.md
@@ -7,6 +7,4 @@ orphan: true
 
 # readability-implicit-bool-cast
 
-This check has been renamed to {doc}`readability-implicit-bool-conversion
-<../readability/implicit-bool-conversion>`.
-
+This check has been renamed to {doc}`readability-implicit-bool-conversion <../readability/implicit-bool-conversion>`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-cast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-cast.md
@@ -1,9 +1,12 @@
-:orphan:
+---
+orphan: true
+---
 
-.. title:: clang-tidy - readability-implicit-bool-cast
+```{title} clang-tidy - readability-implicit-bool-cast
+```
 
-readability-implicit-bool-cast
-==============================
+# readability-implicit-bool-cast
 
-This check has been renamed to :doc:`readability-implicit-bool-conversion
+This check has been renamed to {doc}`readability-implicit-bool-conversion
 <../readability/implicit-bool-conversion>`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.md
@@ -16,13 +16,12 @@ more maintainable code.
 
 Before:
 
-```c++
+```cpp
 int x = 1 + 2 * 3 - 4 / 5;
 ```
 
 After:
 
-```c++
+```cpp
 int x = 1 + (2 * 3) - (4 / 5);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/math-missing-parentheses.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - readability-math-missing-parentheses
+```{title} clang-tidy - readability-math-missing-parentheses
+```
 
-readability-math-missing-parentheses
-====================================
+# readability-math-missing-parentheses
 
 Check for missing parentheses in mathematical expressions that involve
 operators of different priorities.
@@ -16,13 +16,13 @@ more maintainable code.
 
 Before:
 
-.. code-block:: c++
-
-  int x = 1 + 2 * 3 - 4 / 5;
-
+```c++
+int x = 1 + 2 * 3 - 4 / 5;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+int x = 1 + (2 * 3) - (4 / 5);
+```
 
-  int x = 1 + (2 * 3) - (4 / 5);

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/misplaced-array-index.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/misplaced-array-index.md
@@ -7,7 +7,7 @@ This check warns for unusual array index syntax.
 
 The following code has unusual array index syntax:
 
-```c++
+```cpp
 void f(int *X, int Y) {
   Y[X] = 0;
 }
@@ -15,13 +15,12 @@ void f(int *X, int Y) {
 
 becomes
 
-```c++
+```cpp
 void f(int *X, int Y) {
   X[Y] = 0;
 }
 ```
 
 The check warns about such unusual syntax for readability reasons:
-: - There are programmers that are not familiar with this unusual syntax.
-  - It is possible that variables are mixed up.
-
+:   - There are programmers that are not familiar with this unusual syntax.
+    - It is possible that variables are mixed up.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/misplaced-array-index.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/misplaced-array-index.md
@@ -1,27 +1,27 @@
-.. title:: clang-tidy - readability-misplaced-array-index
+```{title} clang-tidy - readability-misplaced-array-index
+```
 
-readability-misplaced-array-index
-=================================
+# readability-misplaced-array-index
 
 This check warns for unusual array index syntax.
 
 The following code has unusual array index syntax:
 
-.. code-block:: c++
-
-  void f(int *X, int Y) {
-    Y[X] = 0;
-  }
+```c++
+void f(int *X, int Y) {
+  Y[X] = 0;
+}
+```
 
 becomes
 
-.. code-block:: c++
-
-  void f(int *X, int Y) {
-    X[Y] = 0;
-  }
+```c++
+void f(int *X, int Y) {
+  X[Y] = 0;
+}
+```
 
 The check warns about such unusual syntax for readability reasons:
- * There are programmers that are not familiar with this unusual syntax.
- * It is possible that variables are mixed up.
+: - There are programmers that are not familiar with this unusual syntax.
+  - It is possible that variables are mixed up.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/misplaced-array-index.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/misplaced-array-index.md
@@ -22,5 +22,6 @@ void f(int *X, int Y) {
 ```
 
 The check warns about such unusual syntax for readability reasons:
-:   - There are programmers that are not familiar with this unusual syntax.
-    - It is possible that variables are mixed up.
+
+- There are programmers that are not familiar with this unusual syntax.
+- It is possible that variables are mixed up.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-function-ptr-dereference.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-function-ptr-dereference.md
@@ -7,7 +7,7 @@ Finds redundant dereferences of a function pointer.
 
 Before:
 
-```c++
+```cpp
 int f(int,int);
 int (*p)(int, int) = &f;
 
@@ -16,10 +16,9 @@ int i = (**p)(10, 50);
 
 After:
 
-```c++
+```cpp
 int f(int,int);
 int (*p)(int, int) = &f;
 
 int i = (*p)(10, 50);
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-function-ptr-dereference.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-function-ptr-dereference.md
@@ -1,24 +1,25 @@
-.. title:: clang-tidy - readability-redundant-function-ptr-dereference
+```{title} clang-tidy - readability-redundant-function-ptr-dereference
+```
 
-readability-redundant-function-ptr-dereference
-==============================================
+# readability-redundant-function-ptr-dereference
 
 Finds redundant dereferences of a function pointer.
 
 Before:
 
-.. code-block:: c++
+```c++
+int f(int,int);
+int (*p)(int, int) = &f;
 
-  int f(int,int);
-  int (*p)(int, int) = &f;
-
-  int i = (**p)(10, 50);
+int i = (**p)(10, 50);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+int f(int,int);
+int (*p)(int, int) = &f;
 
-  int f(int,int);
-  int (*p)(int, int) = &f;
+int i = (*p)(10, 50);
+```
 
-  int i = (*p)(10, 50);

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.md
@@ -7,7 +7,7 @@ Find and remove redundant calls to smart pointer's `.get()` method.
 
 Examples:
 
-```c++
+```cpp
 ptr.get()->Foo()  ==>  ptr->Foo()
 *ptr.get()  ==>  *ptr
 *ptr->get()  ==>  **ptr
@@ -16,10 +16,8 @@ if (ptr.get() == nullptr) ... => if (ptr == nullptr) ...
 
 ## Options
 
-```{eval-rst}
-.. option:: IgnoreMacros
+```{option} IgnoreMacros
 
-   If this option is set to `true` (default is `true`), the check will not warn
-   about calls inside macros.
+If this option is set to `true` (default is `true`), the check will not warn
+about calls inside macros.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.md
@@ -1,23 +1,25 @@
-.. title:: clang-tidy - readability-redundant-smartptr-get
+```{title} clang-tidy - readability-redundant-smartptr-get
+```
 
-readability-redundant-smartptr-get
-==================================
+# readability-redundant-smartptr-get
 
-Find and remove redundant calls to smart pointer's ``.get()`` method.
+Find and remove redundant calls to smart pointer's `.get()` method.
 
 Examples:
 
-.. code-block:: c++
+```c++
+ptr.get()->Foo()  ==>  ptr->Foo()
+*ptr.get()  ==>  *ptr
+*ptr->get()  ==>  **ptr
+if (ptr.get() == nullptr) ... => if (ptr == nullptr) ...
+```
 
-  ptr.get()->Foo()  ==>  ptr->Foo()
-  *ptr.get()  ==>  *ptr
-  *ptr->get()  ==>  **ptr
-  if (ptr.get() == nullptr) ... => if (ptr == nullptr) ...
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: IgnoreMacros
 
    If this option is set to `true` (default is `true`), the check will not warn
    about calls inside macros.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.md
@@ -8,15 +8,13 @@ Finds unnecessary calls to `std::string::c_str()` and
 
 ## Options
 
-```{eval-rst}
-.. option:: StringParameterFunctions
+```{option} StringParameterFunctions
 
-   A semicolon-separated list of regular expressions matching the
-   (fully qualified) names of function/method/operator, with the requirement
-   that any parameter currently accepting a ``const char*`` input should also
-   be able to accept ``std::string`` inputs, or proper overload candidates that
-   can do so should exist. This can be used to configure functions such as
-   ``fmt::format``, ``spdlog::logger::info``, or wrappers around these and
-   similar functions. The default value is the empty string.
+A semicolon-separated list of regular expressions matching the
+(fully qualified) names of function/method/operator, with the requirement
+that any parameter currently accepting a `const char*` input should also
+be able to accept `std::string` inputs, or proper overload candidates that
+can do so should exist. This can be used to configure functions such as
+`fmt::format`, `spdlog::logger::info`, or wrappers around these and
+similar functions. The default value is the empty string.
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-string-cstr.md
@@ -1,15 +1,14 @@
-.. title:: clang-tidy - readability-redundant-string-cstr
+```{title} clang-tidy - readability-redundant-string-cstr
+```
 
-readability-redundant-string-cstr
-=================================
+# readability-redundant-string-cstr
 
+Finds unnecessary calls to `std::string::c_str()` and
+`std::string::data()`.
 
-Finds unnecessary calls to ``std::string::c_str()`` and
-``std::string::data()``.
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: StringParameterFunctions
 
    A semicolon-separated list of regular expressions matching the
@@ -19,3 +18,5 @@ Options
    can do so should exist. This can be used to configure functions such as
    ``fmt::format``, ``spdlog::logger::info``, or wrappers around these and
    similar functions. The default value is the empty string.
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-subscript-expr.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-subscript-expr.md
@@ -9,17 +9,15 @@ single element, in which case simply calling `operator[]` suffice.
 
 Examples:
 
-```c++
+```cpp
 std::string s = ...;
 char c = s.data()[i];  // char c = s[i];
 ```
 
 ## Options
 
-```{eval-rst}
-.. option:: Types
+```{option} Types
 
-   The list of type(s) that triggers this check. Default is
-   `::std::basic_string;::std::basic_string_view;::std::vector;::std::array;::std::span`
+The list of type(s) that triggers this check. Default is
+`::std::basic_string;::std::basic_string_view;::std::vector;::std::array;::std::span`
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-subscript-expr.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/simplify-subscript-expr.md
@@ -1,23 +1,25 @@
-.. title:: clang-tidy - readability-simplify-subscript-expr
+```{title} clang-tidy - readability-simplify-subscript-expr
+```
 
-readability-simplify-subscript-expr
-===================================
+# readability-simplify-subscript-expr
 
 This check simplifies subscript expressions. Currently this covers calling
-``.data()`` and immediately doing an array subscript operation to obtain a
-single element, in which case simply calling ``operator[]`` suffice.
+`.data()` and immediately doing an array subscript operation to obtain a
+single element, in which case simply calling `operator[]` suffice.
 
 Examples:
 
-.. code-block:: c++
+```c++
+std::string s = ...;
+char c = s.data()[i];  // char c = s[i];
+```
 
-  std::string s = ...;
-  char c = s.data()[i];  // char c = s[i];
+## Options
 
-Options
--------
-
+```{eval-rst}
 .. option:: Types
 
    The list of type(s) that triggers this check. Default is
    `::std::basic_string;::std::basic_string_view;::std::vector;::std::array;::std::span`
+```
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/static-definition-in-anonymous-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/static-definition-in-anonymous-namespace.md
@@ -8,7 +8,7 @@ Finds static function and variable definitions in anonymous namespace.
 In this case, `static` is redundant, because anonymous namespace limits the
 visibility of definitions to a single translation unit.
 
-```c++
+```cpp
 namespace {
   static int a = 1; // Warning.
   static const int b = 1; // Warning.
@@ -19,4 +19,3 @@ namespace {
 ```
 
 The check will apply a fix by removing the redundant `static` qualifier.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/static-definition-in-anonymous-namespace.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/static-definition-in-anonymous-namespace.md
@@ -1,21 +1,22 @@
-.. title:: clang-tidy - readability-static-definition-in-anonymous-namespace
+```{title} clang-tidy - readability-static-definition-in-anonymous-namespace
+```
 
-readability-static-definition-in-anonymous-namespace
-====================================================
+# readability-static-definition-in-anonymous-namespace
 
 Finds static function and variable definitions in anonymous namespace.
 
-In this case, ``static`` is redundant, because anonymous namespace limits the
+In this case, `static` is redundant, because anonymous namespace limits the
 visibility of definitions to a single translation unit.
 
-.. code-block:: c++
-
-  namespace {
-    static int a = 1; // Warning.
-    static const int b = 1; // Warning.
-    namespace inner {
-      static int c = 1; // Warning.
-    }
+```c++
+namespace {
+  static int a = 1; // Warning.
+  static const int b = 1; // Warning.
+  namespace inner {
+    static int c = 1; // Warning.
   }
+}
+```
 
-The check will apply a fix by removing the redundant ``static`` qualifier.
+The check will apply a fix by removing the redundant `static` qualifier.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/use-std-min-max.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/use-std-min-max.md
@@ -10,7 +10,7 @@ additional stores compared to the original if statement.
 
 Before:
 
-```c++
+```cpp
 void foo() {
   int a = 2, b = 3;
   if (a < b)
@@ -20,10 +20,9 @@ void foo() {
 
 After:
 
-```c++
+```cpp
 void foo() {
   int a = 2, b = 3;
   a = std::max(a, b);
 }
 ```
-

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/use-std-min-max.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/use-std-min-max.md
@@ -1,29 +1,29 @@
-.. title:: clang-tidy - readability-use-std-min-max
+```{title} clang-tidy - readability-use-std-min-max
+```
 
-readability-use-std-min-max
-===========================
+# readability-use-std-min-max
 
 Replaces certain conditional statements with equivalent calls to
-``std::min`` or ``std::max``.
+`std::min` or `std::max`.
 Note: This may impact performance in critical code due to potential
 additional stores compared to the original if statement.
 
 Before:
 
-.. code-block:: c++
-
-  void foo() {
-    int a = 2, b = 3;
-    if (a < b)
-      a = b;
-  }
-
+```c++
+void foo() {
+  int a = 2, b = 3;
+  if (a < b)
+    a = b;
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() {
+  int a = 2, b = 3;
+  a = std::max(a, b);
+}
+```
 
-  void foo() {
-    int a = 2, b = 3;
-    a = std::max(a, b);
-  }

--- a/clang-tools-extra/docs/clang-tidy/checks/zircon/temporary-objects.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/zircon/temporary-objects.md
@@ -1,10 +1,11 @@
-.. title:: clang-tidy - zircon-temporary-objects
+```{title} clang-tidy - zircon-temporary-objects
+```
 
-zircon-temporary-objects
-========================
+# zircon-temporary-objects
 
-.. note::
+:::{note}
+The `zircon-temporary-objects` check has been deprecated and will be removed
+in 24th release of LLVM. Please use
+{doc}`fuchsia-temporary-objects <../fuchsia/temporary-objects>` instead.
+:::
 
-  The `zircon-temporary-objects` check has been deprecated and will be removed
-  in 24th release of LLVM. Please use
-  :doc:`fuchsia-temporary-objects <../fuchsia/temporary-objects>` instead.


### PR DESCRIPTION
Tracking issue: #201242
See the [migration guide] for more information. 

[migration guide]: https://llvm.org/docs/SphinxQuickstartTemplate.html#markdown-migration-guidelines

This is a stacked PR based on #210466  , which will be a standalone commit that
renames *.rst -> *.md before this PR lands for history preservation purposes.

I chose to do 308 files at once in this large batch because they were all short, i.e. less than 30 lines, so they all have very uncomplicated reST, which doesn't require much review, or fancy rewriting.

This was prepared with rst2myst plus LLM-assisted cleanup, and the changes are broken into two commits, mechanical, and LLM cleanup.

Please spot check my work and approve if it looks good. You can view the rendered HTML using the links in [this gist](https://gist.github.com/rnk/d5af78243f915fe0809cb878d95916d3) to confirm it renders properly.
