### PR TITLE
[lldb] Fix TestSBValueSetTypeSyntheticOverride with libstdc++

### DIFF
--- a/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py
+++ b/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py
@@ -16,14 +16,6 @@ class TestCase(TestBase):
 
         frame = thread.GetFrameAtIndex(0)
 
-        # CXX runtime synthetic can be overridden
-        vec = frame.FindVariable("vec")
-
-        # GNU libstdc++'s std::vector doesn't have a CXXSyntheticChildren implementation
-        # Use the fact that GetTypeSynthetic() only returns scripted SCPs to filter
-        if vec.IsSynthetic() and vec.GetTypeSynthetic() is None:
-            self.checkOverride(vec, before=None)
-
         # Python synthetic can be overridden
         foo = frame.FindVariable("foo")
         self.assertTrue(foo.IsSynthetic())

--- a/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py
+++ b/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py
@@ -18,8 +18,11 @@ class TestCase(TestBase):
 
         # CXX runtime synthetic can be overridden
         vec = frame.FindVariable("vec")
-        self.assertTrue(vec.IsSynthetic())
-        self.checkOverride(vec, before=None)
+
+        # GNU libstdc++'s std::vector doesn't have a CXXSyntheticChildren implementation
+        # Use the fact that GetTypeSynthetic() only returns scripted SCPs to filter
+        if vec.IsSynthetic() and vec.GetTypeSynthetic() is None:
+            self.checkOverride(vec, before=None)
 
         # Python synthetic can be overridden
         foo = frame.FindVariable("foo")

--- a/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py
+++ b/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py
@@ -16,6 +16,17 @@ class TestCase(TestBase):
 
         frame = thread.GetFrameAtIndex(0)
 
+        # CXX runtime synthetic can be overridden
+        vec = frame.FindVariable("vec")
+        self.assertTrue(vec.IsSynthetic())
+
+        # On some platforms the synthetic child provider implementation of
+        # std::vector is not native, in other words it's scripted
+        #
+        # This test can't reliably tell the difference, so skip checking
+        # the 'before' implementation typename check
+        self.checkOverride(vec, before=None, skip_before_impl_check=True)
+
         # Python synthetic can be overridden
         foo = frame.FindVariable("foo")
         self.assertTrue(foo.IsSynthetic())
@@ -26,19 +37,20 @@ class TestCase(TestBase):
         self.assertFalse(bar.IsSynthetic())
         self.checkOverride(bar, before=None)
 
-    def checkOverride(self, value, before):
+    def checkOverride(self, value, before, skip_before_impl_check=False):
         foo = lldb.SBTypeSynthetic.CreateWithClassName(f"foo_bar_synths.FooSynthetic")
         bar = lldb.SBTypeSynthetic.CreateWithClassName(f"foo_bar_synths.BarSynthetic")
 
         # Target the static (non synthetic) ValueObject
         static = value.GetNonSyntheticValue()
 
-        impl_before = static.GetSyntheticValue().GetTypeSyntheticImplementation()
-        if not before:
-            self.assertIsNone(impl_before)
-        else:
-            self.assertIsNotNone(impl_before)
-            self.assertEqual(type(impl_before).__name__, before)
+        if not skip_before_impl_check:
+            impl_before = static.GetSyntheticValue().GetTypeSyntheticImplementation()
+            if not before:
+                self.assertIsNone(impl_before)
+            else:
+                self.assertIsNotNone(impl_before)
+                self.assertEqual(type(impl_before).__name__, before)
 
         static.SetTypeSynthetic(bar)
         self.assertEqual(static.GetTypeSynthetic(), bar)


### PR DESCRIPTION
My test added in #209056 assumed that a `CXXSyntheticChildren` implementation for `std::vector` is readily available on all platforms, that is not the case.

Do the simplest thing and remove this part of the test for now.

Fixes: https://lab.llvm.org/buildbot/#/builders/59/builds/35839
```
FAIL: test (TestSBValueSetTypeSyntheticOverride.TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tcwg-buildbot/worker/lldb-aarch64-ubuntu/llvm-project/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py", line 22, in test
    self.checkOverride(vec, before=None)
  File "/home/tcwg-buildbot/worker/lldb-aarch64-ubuntu/llvm-project/lldb/test/API/python_api/sbvalue_set_type_synthetic_override/TestSBValueSetTypeSyntheticOverride.py", line 43, in checkOverride
    self.assertIsNone(impl_before)
AssertionError: <lldb.formatters.cpp.gnu_libstdcpp.StdVectorSynthProvider object at 0xfb088f787bb0> is not None
```