### PR TITLE
[mlir][ArmSVE] Fix comment inconsistency for `pack_lhs` in `ArmSVE/pack-unpack-mmt4d.mlir` (NFC)

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/pack-unpack-mmt4d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/pack-unpack-mmt4d.mlir
@@ -119,9 +119,10 @@ func.func private @matmul(%A: tensor<7x16xi32>, %B: tensor<16x13xi32>, %C: tenso
 }
 
 //===----------------------------------------------------------------------===//
-// @matmul_via_mmt4d
+// @pack_lhs
 //
-// Implements matrix-multiplication via linalg.mmt4d
+// Implements packing for the A matrix (LHS) in matrix multiplication. The inner
+// tile size is fixed: 8 * 1.
 //===----------------------------------------------------------------------===//
 func.func private @pack_lhs(%A: tensor<7x16xi32>) -> tensor<1x16x8x1xi32> {
   %pad = arith.constant 0 : i32


### PR DESCRIPTION
This PR simply fix a comment inconsistency for `pack_lhs` in [ArmSVE/pack-unpack-mmt4d.mlir](https://github.com/llvm/llvm-project/compare/main...FedericoBruzzone:nfc-armsve?expand=1#diff-7be071860c440806b8dad954ed61946e7e9f27e032ed6044a704f0c0f70e4407) as identified in #208226.
