### PR TITLE
[HIPSPV] Preserve device debug info requested via -g

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
+++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
@@ -112,6 +112,19 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
     TrArgs.push_back("--spirv-ext=+all");
   }
 
+  // Preserve debug info requested via -g into the emitted SPIR-V using the
+  // NonSemantic.Shader.DebugInfo form. Downstream consumers such as Intel's IGC
+  // and gdb-oneapi use it to map device code back to source lines and local
+  // variables; the translator's default OpenCL.DebugInfo.100 form is not
+  // sufficient for that. Emitting the NonSemantic debug instructions requires
+  // the SPV_KHR_non_semantic_info extension. The translator accumulates
+  // --spirv-ext across occurrences, so this augments the list set above.
+  if (const Arg *A = Args.getLastArg(options::OPT_g_Group);
+      A && !A->getOption().matches(options::OPT_g0)) {
+    TrArgs.push_back("--spirv-ext=+SPV_KHR_non_semantic_info");
+    TrArgs.push_back("--spirv-debug-info-version=nonsemantic-shader-200");
+  }
+
   InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
   SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
 }
@@ -333,10 +346,16 @@ VersionTuple HIPSPVToolChain::computeMSVCVersion(const Driver *D,
 void HIPSPVToolChain::adjustDebugInfoKind(
     llvm::codegenoptions::DebugInfoKind &DebugInfoKind,
     const llvm::opt::ArgList &Args) const {
-  // Debug info generation is disabled for SPIRV-LLVM-Translator
-  // which currently aborts on the presence of DW_OP_LLVM_convert.
-  // TODO: Enable debug info when the SPIR-V backend arrives.
-  DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
+  // Historically device debug info was force-disabled here because the
+  // SPIRV-LLVM-Translator aborted on DW_OP_LLVM_convert debug expressions. The
+  // translator now lowers that operation, so honor the debug level the user
+  // requested (e.g. via -g) and let it flow into the emitted SPIR-V.
+  // constructLinkAndEmitSpirvCommand() enables the NonSemantic.Shader.DebugInfo
+  // form at translation time so downstream tools (e.g. gdb-oneapi) can consume
+  // it. Leaving DebugInfoKind untouched keeps the default (no -g) behavior,
+  // since the driver defaults it to NoDebugInfo.
+  (void)DebugInfoKind;
+  (void)Args;
 }
 
 LTOKind HIPSPVToolChain::getLTOMode(const llvm::opt::ArgList &Args,

--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
+++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
@@ -117,11 +117,23 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
   // and gdb-oneapi use it to map device code back to source lines and local
   // variables; the translator's default OpenCL.DebugInfo.100 form is not
   // sufficient for that. Emitting the NonSemantic debug instructions requires
-  // the SPV_KHR_non_semantic_info extension. The translator accumulates
-  // --spirv-ext across occurrences, so this augments the list set above.
+  // the SPV_KHR_non_semantic_info extension.
+  //
+  // SPV_INTEL_optnone carries the optnone function attribute, which Clang
+  // attaches to every function at -O0, through to the consumer as the
+  // OptNoneEXT function control. Without it the attribute is silently dropped
+  // in translation and the device compiler is free to optimize the kernel, so a
+  // debugger reports arguments and locals as <optimized out> even though the
+  // debug info itself is present. At -O1 and above no optnone attribute exists
+  // and the extension has no effect. It is redundant for the +all list above
+  // but required for the restricted chipStar one.
+  //
+  // The translator accumulates --spirv-ext across occurrences, so this augments
+  // the list set above.
   if (const Arg *A = Args.getLastArg(options::OPT_g_Group);
       A && !A->getOption().matches(options::OPT_g0)) {
-    TrArgs.push_back("--spirv-ext=+SPV_KHR_non_semantic_info");
+    TrArgs.push_back("--spirv-ext=+SPV_KHR_non_semantic_info"
+                     ",+SPV_INTEL_optnone");
     TrArgs.push_back("--spirv-debug-info-version=nonsemantic-shader-200");
   }
 

--- a/clang/test/Driver/hipspv-toolchain.hip
+++ b/clang/test/Driver/hipspv-toolchain.hip
@@ -141,7 +141,7 @@
 
 //      DEBUG: {{".*llvm-spirv"}} "--spirv-max-version=1.2"
 // DEBUG-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
-// DEBUG-SAME: "--spirv-ext=+SPV_KHR_non_semantic_info"
+// DEBUG-SAME: "--spirv-ext=+SPV_KHR_non_semantic_info,+SPV_INTEL_optnone"
 // DEBUG-SAME: "--spirv-debug-info-version=nonsemantic-shader-200"
 
 // RUN: %clang -### --no-default-config -o %t.dummy.img \
@@ -151,4 +151,5 @@
 
 //      NODEBUG: {{".*llvm-spirv"}}
 // NODEBUG-NOT: SPV_KHR_non_semantic_info
+// NODEBUG-NOT: SPV_INTEL_optnone
 // NODEBUG-NOT: spirv-debug-info-version

--- a/clang/test/Driver/hipspv-toolchain.hip
+++ b/clang/test/Driver/hipspv-toolchain.hip
@@ -129,3 +129,26 @@
 // RUN: | FileCheck -DVERSION=%llvm-version-major --check-prefix=VERSIONED %s
 
 // VERSIONED: {{.*}}llvm-spirv-[[VERSION]]
+
+//-----------------------------------------------------------------------------
+// Check that -g preserves device debug info by requesting the
+// NonSemantic.Shader.DebugInfo form (and the extension it depends on) from the
+// translator, and that no debug flags are emitted without -g.
+// RUN: %clang -### --no-default-config -g -o %t.dummy.img \
+// RUN:   --target=spirv64-unknown-chipstar %t.dummy.o \
+// RUN:   --hip-path="%S/Inputs/hipspv" \
+// RUN: 2>&1 | FileCheck %s --check-prefix=DEBUG
+
+//      DEBUG: {{".*llvm-spirv"}} "--spirv-max-version=1.2"
+// DEBUG-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+// DEBUG-SAME: "--spirv-ext=+SPV_KHR_non_semantic_info"
+// DEBUG-SAME: "--spirv-debug-info-version=nonsemantic-shader-200"
+
+// RUN: %clang -### --no-default-config -o %t.dummy.img \
+// RUN:   --target=spirv64-unknown-chipstar %t.dummy.o \
+// RUN:   --hip-path="%S/Inputs/hipspv" \
+// RUN: 2>&1 | FileCheck %s --check-prefix=NODEBUG
+
+//      NODEBUG: {{".*llvm-spirv"}}
+// NODEBUG-NOT: SPV_KHR_non_semantic_info
+// NODEBUG-NOT: spirv-debug-info-version


### PR DESCRIPTION
`HIPSPVToolChain::adjustDebugInfoKind()` unconditionally forces `NoDebugInfo`, so compiling HIP device code for SPIR-V with `-g` produces device code with no debug metadata at all. Debuggers such as Intel's gdb-oneapi cannot resolve source lines or local variables in offloaded kernels as a result.

The comment there attributes the force-disable to the SPIRV-LLVM-Translator aborting on `DW_OP_LLVM_convert`; the translator now lowers that operation, so the workaround is no longer needed.

This PR:
- stops clobbering the requested debug level in `adjustDebugInfoKind()`, letting `-g` flow into device codegen;
- when `-g` (and not `-g0`) is given, requests debug info in the NonSemantic.Shader.DebugInfo form from the translator (`--spirv-debug-info-version=nonsemantic-shader-200`) and enables the required `SPV_KHR_non_semantic_info` extension. The translator accumulates `--spirv-ext` across occurrences, so this augments the extension list already selected.

The default (no `-g`) SPIR-V output is unchanged. A driver test covers both the `-g` and no-`-g` cases.

Draft: opened for feedback and CI. I have not yet been able to validate end-to-end on hardware (compile `-g -O0`, break in-kernel under gdb-oneapi, inspect locals); doing so is in progress. Feedback on whether `adjustDebugInfoKind()` should be dropped entirely rather than left as a no-op override is welcome.


Reported downstream: CHIP-SPV/chipStar#1004
