### PR TITLE
[DirectX] Fix `--dx-embed-debug` flag dependency

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -41,11 +41,7 @@ using namespace llvm::mcdxbc;
 
 static cl::opt<bool> ShaderHashDependsOnSource(
     "dx-Zss", cl::desc("Compute Shader Hash considering source information"));
-cl::opt<std::string> PdbDebugPath(
-    "dx-pdb-path",
-    cl::desc("Write debug information to the given file, or automatically "
-             "named file in directory when ending in '/'"),
-    cl::value_desc("filename"));
+extern cl::opt<std::string> PdbDebugPath;
 extern cl::opt<bool> SourceInDebugModule;
 
 namespace {

--- a/llvm/lib/Target/DirectX/DXILWriter/DXILWriterPass.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILWriterPass.cpp
@@ -38,7 +38,11 @@ using namespace llvm::dxil;
 
 extern cl::opt<bool> EmbedDebug;
 extern cl::opt<bool> StripDebug;
-extern cl::opt<std::string> PdbDebugPath;
+cl::opt<std::string> PdbDebugPath(
+    "dx-pdb-path",
+    cl::desc("Write debug information to the given file, or automatically "
+             "named file in directory when ending in '/'"),
+    cl::value_desc("filename"));
 cl::opt<bool> SourceInDebugModule(
     "dx-source-in-debug-module",
     cl::desc("Embed source code into debug module on DirectX target"),


### PR DESCRIPTION
This patch moves the definition of `cl::opt<std::string> PdbDebugPath` from `DXContainerGlobals.cpp` to `DXILWriter/DXILWriterPass.cpp`, reversing the dependency.
Fixes the layering violation in #204166.