### PR TITLE
[NFC][ELF] Remove unused R_TLS*_HINT RelExprs

### DIFF
--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -72,11 +72,9 @@ enum RelExpr {
   R_TLSGD_GOT,
   R_TLSGD_GOTPLT,
   R_TLSGD_PC,
-  R_TLSIE_HINT,
   R_TLSLD_GOT,
   R_TLSLD_GOTPLT,
   R_TLSLD_GOT_OFF,
-  R_TLSLD_HINT,
   R_TLSLD_PC,
 
   // The following is abstract relocation types used for only one target.


### PR DESCRIPTION
As of 5e87f8147d68 ("[ELF] Add target-specific relocation scanning for
PPC32 (#181517)") these are never generated, and as of 46d29d43ba8e
("[ELF] Remove unused handleTlsRelocation (#184951)") these are not even
handled anywhere.