### PR TITLE
[CIR][NVPTX] Add support for binary atomic builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -163,11 +163,10 @@ static Address checkAtomicAlignment(CIRGenFunction &cgf, const CallExpr *e) {
 
 /// Utility to insert an atomic instruction based on Intrinsic::ID
 /// and the expression node.
-static mlir::Value makeBinaryAtomicValue(
-    CIRGenFunction &cgf, cir::AtomicFetchKind kind, const CallExpr *expr,
-    mlir::Type *originalArgType = nullptr,
-    mlir::Value *emittedArgValue = nullptr,
-    cir::MemOrder ordering = cir::MemOrder::SequentiallyConsistent) {
+mlir::Value CIRGenFunction::makeBinaryAtomicValue(
+    cir::AtomicFetchKind kind, const CallExpr *expr, mlir::Type *originalArgType,
+    mlir::Value *emittedArgValue, cir::MemOrder ordering) {
+  CIRGenFunction &cgf = *this;
 
   QualType type = expr->getType();
   QualType ptrType = expr->getArg(0)->getType();
@@ -224,7 +223,7 @@ static mlir::Value makeBinaryAtomicValue(
 static RValue emitBinaryAtomic(CIRGenFunction &cgf,
                                cir::AtomicFetchKind atomicOpkind,
                                const CallExpr *e) {
-  return RValue::get(makeBinaryAtomicValue(cgf, atomicOpkind, e));
+  return RValue::get(cgf.makeBinaryAtomicValue(atomicOpkind, e));
 }
 
 template <typename BinOp>
@@ -234,8 +233,8 @@ static RValue emitBinaryAtomicPost(CIRGenFunction &cgf,
   mlir::Value emittedArgValue;
   mlir::Type originalArgType;
   clang::QualType typ = e->getType();
-  mlir::Value result = makeBinaryAtomicValue(
-      cgf, atomicOpkind, e, &originalArgType, &emittedArgValue);
+  mlir::Value result = cgf.makeBinaryAtomicValue(
+      atomicOpkind, e, &originalArgType, &emittedArgValue);
   clang::CIRGen::CIRGenBuilderTy &builder = cgf.getBuilder();
   result = BinOp::create(builder, result.getLoc(), result, emittedArgValue);
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -163,9 +163,11 @@ static Address checkAtomicAlignment(CIRGenFunction &cgf, const CallExpr *e) {
 
 /// Utility to insert an atomic instruction based on Intrinsic::ID
 /// and the expression node.
-mlir::Value CIRGenFunction::makeBinaryAtomicValue(
-    cir::AtomicFetchKind kind, const CallExpr *expr, mlir::Type *originalArgType,
-    mlir::Value *emittedArgValue, cir::MemOrder ordering) {
+mlir::Value CIRGenFunction::makeBinaryAtomicValue(cir::AtomicFetchKind kind,
+                                                  const CallExpr *expr,
+                                                  mlir::Type *originalArgType,
+                                                  mlir::Value *emittedArgValue,
+                                                  cir::MemOrder ordering) {
   CIRGenFunction &cgf = *this;
 
   QualType type = expr->getType();

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -88,7 +88,6 @@ CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId, const CallExpr *expr) {
   case NVPTX::BI__nvvm_atom_max_gen_ui:
   case NVPTX::BI__nvvm_atom_max_gen_ul:
   case NVPTX::BI__nvvm_atom_max_gen_ull:
-    // The unsigned operand type makes this lower to `umax`.
     return makeBinaryAtomicValue(cir::AtomicFetchKind::Max, expr,
                                  /*originalArgType=*/nullptr,
                                  /*emittedArgValue=*/nullptr,
@@ -103,7 +102,6 @@ CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId, const CallExpr *expr) {
   case NVPTX::BI__nvvm_atom_min_gen_ui:
   case NVPTX::BI__nvvm_atom_min_gen_ul:
   case NVPTX::BI__nvvm_atom_min_gen_ull:
-    // The unsigned operand type makes this lower to `umin`.
     return makeBinaryAtomicValue(cir::AtomicFetchKind::Min, expr,
                                  /*originalArgType=*/nullptr,
                                  /*emittedArgValue=*/nullptr,

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -39,10 +39,10 @@ CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId, const CallExpr *expr) {
   case NVPTX::BI__nvvm_atom_add_gen_i:
   case NVPTX::BI__nvvm_atom_add_gen_l:
   case NVPTX::BI__nvvm_atom_add_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Add, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_sub_gen_i:
   case NVPTX::BI__nvvm_atom_sub_gen_l:
   case NVPTX::BI__nvvm_atom_sub_gen_ll:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -46,31 +46,31 @@ CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId, const CallExpr *expr) {
   case NVPTX::BI__nvvm_atom_sub_gen_i:
   case NVPTX::BI__nvvm_atom_sub_gen_l:
   case NVPTX::BI__nvvm_atom_sub_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Sub, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_and_gen_i:
   case NVPTX::BI__nvvm_atom_and_gen_l:
   case NVPTX::BI__nvvm_atom_and_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::And, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_or_gen_i:
   case NVPTX::BI__nvvm_atom_or_gen_l:
   case NVPTX::BI__nvvm_atom_or_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Or, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_xor_gen_i:
   case NVPTX::BI__nvvm_atom_xor_gen_l:
   case NVPTX::BI__nvvm_atom_xor_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Xor, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_xchg_gen_i:
   case NVPTX::BI__nvvm_atom_xchg_gen_l:
   case NVPTX::BI__nvvm_atom_xchg_gen_ll:
@@ -81,31 +81,33 @@ CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId, const CallExpr *expr) {
   case NVPTX::BI__nvvm_atom_max_gen_i:
   case NVPTX::BI__nvvm_atom_max_gen_l:
   case NVPTX::BI__nvvm_atom_max_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Max, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_max_gen_ui:
   case NVPTX::BI__nvvm_atom_max_gen_ul:
   case NVPTX::BI__nvvm_atom_max_gen_ull:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    // The unsigned operand type makes this lower to `umax`.
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Max, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_min_gen_i:
   case NVPTX::BI__nvvm_atom_min_gen_l:
   case NVPTX::BI__nvvm_atom_min_gen_ll:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Min, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_min_gen_ui:
   case NVPTX::BI__nvvm_atom_min_gen_ul:
   case NVPTX::BI__nvvm_atom_min_gen_ull:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    // The unsigned operand type makes this lower to `umin`.
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::Min, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_cas_gen_us:
   case NVPTX::BI__nvvm_atom_cas_gen_i:
   case NVPTX::BI__nvvm_atom_cas_gen_l:
@@ -122,15 +124,15 @@ CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId, const CallExpr *expr) {
                      getContext().BuiltinInfo.getName(builtinId));
     return mlir::Value{};
   case NVPTX::BI__nvvm_atom_inc_gen_ui:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::UIncWrap, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_atom_dec_gen_ui:
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented NVPTX builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    return makeBinaryAtomicValue(cir::AtomicFetchKind::UDecWrap, expr,
+                                 /*originalArgType=*/nullptr,
+                                 /*emittedArgValue=*/nullptr,
+                                 cir::MemOrder::Relaxed);
   case NVPTX::BI__nvvm_ldg_c:
   case NVPTX::BI__nvvm_ldg_sc:
   case NVPTX::BI__nvvm_ldg_c2:

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1648,6 +1648,12 @@ public:
       const Expr *memOrder, bool isStore, bool isLoad, bool isFence,
       llvm::function_ref<void(cir::MemOrder)> emitAtomicOp);
 
+  mlir::Value makeBinaryAtomicValue(
+      cir::AtomicFetchKind kind, const clang::CallExpr *expr,
+      mlir::Type *originalArgType = nullptr,
+      mlir::Value *emittedArgValue = nullptr,
+      cir::MemOrder ordering = cir::MemOrder::SequentiallyConsistent);
+
   mlir::LogicalResult emitAttributedStmt(const AttributedStmt &s);
 
   AutoVarEmission emitAutoVarAlloca(const clang::VarDecl &d,

--- a/clang/test/CIR/CodeGenCUDA/builtins-nvvm-atomic.cu
+++ b/clang/test/CIR/CodeGenCUDA/builtins-nvvm-atomic.cu
@@ -1,0 +1,37 @@
+#include "Inputs/cuda.h"
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -target-cpu sm_80 -x cuda \
+// RUN:            -fcuda-is-device -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -target-cpu sm_80 -x cuda \
+// RUN:            -fcuda-is-device -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -target-cpu sm_80 -x cuda \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// CIR-LABEL: @_Z19test_atom_add_gen_iPii
+// CIR: cir.atomic.fetch add relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z19test_atom_add_gen_iPii
+// LLVM: atomicrmw add ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_add_gen_i(int *p, int val) {
+  __nvvm_atom_add_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_add_gen_lPll
+// CIR: cir.atomic.fetch add relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_add_gen_lPll
+// LLVM: atomicrmw add ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_add_gen_l(long *p, long val) {
+  __nvvm_atom_add_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_add_gen_llPxx
+// CIR: cir.atomic.fetch add relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z20test_atom_add_gen_llPxx
+// LLVM: atomicrmw add ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_add_gen_ll(long long *p, long long val) {
+  __nvvm_atom_add_gen_ll(p, val);
+}

--- a/clang/test/CIR/CodeGenCUDA/builtins-nvvm-atomic.cu
+++ b/clang/test/CIR/CodeGenCUDA/builtins-nvvm-atomic.cu
@@ -35,3 +35,195 @@ __device__ void test_atom_add_gen_l(long *p, long val) {
 __device__ void test_atom_add_gen_ll(long long *p, long long val) {
   __nvvm_atom_add_gen_ll(p, val);
 }
+
+// CIR-LABEL: @_Z19test_atom_sub_gen_iPii
+// CIR: cir.atomic.fetch sub relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z19test_atom_sub_gen_iPii
+// LLVM: atomicrmw sub ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_sub_gen_i(int *p, int val) {
+  __nvvm_atom_sub_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_sub_gen_lPll
+// CIR: cir.atomic.fetch sub relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_sub_gen_lPll
+// LLVM: atomicrmw sub ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_sub_gen_l(long *p, long val) {
+  __nvvm_atom_sub_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_sub_gen_llPxx
+// CIR: cir.atomic.fetch sub relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z20test_atom_sub_gen_llPxx
+// LLVM: atomicrmw sub ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_sub_gen_ll(long long *p, long long val) {
+  __nvvm_atom_sub_gen_ll(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_and_gen_iPii
+// CIR: cir.atomic.fetch and relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z19test_atom_and_gen_iPii
+// LLVM: atomicrmw and ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_and_gen_i(int *p, int val) {
+  __nvvm_atom_and_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_and_gen_lPll
+// CIR: cir.atomic.fetch and relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_and_gen_lPll
+// LLVM: atomicrmw and ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_and_gen_l(long *p, long val) {
+  __nvvm_atom_and_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_and_gen_llPxx
+// CIR: cir.atomic.fetch and relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z20test_atom_and_gen_llPxx
+// LLVM: atomicrmw and ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_and_gen_ll(long long *p, long long val) {
+  __nvvm_atom_and_gen_ll(p, val);
+}
+
+// CIR-LABEL: @_Z18test_atom_or_gen_iPii
+// CIR: cir.atomic.fetch or relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z18test_atom_or_gen_iPii
+// LLVM: atomicrmw or ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_or_gen_i(int *p, int val) {
+  __nvvm_atom_or_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z18test_atom_or_gen_lPll
+// CIR: cir.atomic.fetch or relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z18test_atom_or_gen_lPll
+// LLVM: atomicrmw or ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_or_gen_l(long *p, long val) {
+  __nvvm_atom_or_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_or_gen_llPxx
+// CIR: cir.atomic.fetch or relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_or_gen_llPxx
+// LLVM: atomicrmw or ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_or_gen_ll(long long *p, long long val) {
+  __nvvm_atom_or_gen_ll(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_xor_gen_iPii
+// CIR: cir.atomic.fetch xor relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z19test_atom_xor_gen_iPii
+// LLVM: atomicrmw xor ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_xor_gen_i(int *p, int val) {
+  __nvvm_atom_xor_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_xor_gen_lPll
+// CIR: cir.atomic.fetch xor relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_xor_gen_lPll
+// LLVM: atomicrmw xor ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_xor_gen_l(long *p, long val) {
+  __nvvm_atom_xor_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_xor_gen_llPxx
+// CIR: cir.atomic.fetch xor relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z20test_atom_xor_gen_llPxx
+// LLVM: atomicrmw xor ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_xor_gen_ll(long long *p, long long val) {
+  __nvvm_atom_xor_gen_ll(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_max_gen_iPii
+// CIR: cir.atomic.fetch max relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z19test_atom_max_gen_iPii
+// LLVM: atomicrmw max ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_max_gen_i(int *p, int val) {
+  __nvvm_atom_max_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_max_gen_lPll
+// CIR: cir.atomic.fetch max relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_max_gen_lPll
+// LLVM: atomicrmw max ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_max_gen_l(long *p, long val) {
+  __nvvm_atom_max_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_max_gen_llPxx
+// CIR: cir.atomic.fetch max relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z20test_atom_max_gen_llPxx
+// LLVM: atomicrmw max ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_max_gen_ll(long long *p, long long val) {
+  __nvvm_atom_max_gen_ll(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_max_gen_uiPjj
+// CIR: cir.atomic.fetch max relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!u32i>, !u32i) -> !u32i
+// LLVM-LABEL: @_Z20test_atom_max_gen_uiPjj
+// LLVM: atomicrmw umax ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_max_gen_ui(unsigned *p, unsigned val) {
+  __nvvm_atom_max_gen_ui(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_max_gen_ulPmm
+// CIR: cir.atomic.fetch max relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!u64i>, !u64i) -> !u64i
+// LLVM-LABEL: @_Z20test_atom_max_gen_ulPmm
+// LLVM: atomicrmw umax ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_max_gen_ul(unsigned long *p, unsigned long val) {
+  __nvvm_atom_max_gen_ul(p, val);
+}
+
+// CIR-LABEL: @_Z21test_atom_max_gen_ullPyy
+// CIR: cir.atomic.fetch max relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!u64i>, !u64i) -> !u64i
+// LLVM-LABEL: @_Z21test_atom_max_gen_ullPyy
+// LLVM: atomicrmw umax ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_max_gen_ull(unsigned long long *p, unsigned long long val) {
+  __nvvm_atom_max_gen_ull(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_min_gen_iPii
+// CIR: cir.atomic.fetch min relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s32i>, !s32i) -> !s32i
+// LLVM-LABEL: @_Z19test_atom_min_gen_iPii
+// LLVM: atomicrmw min ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_min_gen_i(int *p, int val) {
+  __nvvm_atom_min_gen_i(p, val);
+}
+
+// CIR-LABEL: @_Z19test_atom_min_gen_lPll
+// CIR: cir.atomic.fetch min relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z19test_atom_min_gen_lPll
+// LLVM: atomicrmw min ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_min_gen_l(long *p, long val) {
+  __nvvm_atom_min_gen_l(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_min_gen_llPxx
+// CIR: cir.atomic.fetch min relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+// LLVM-LABEL: @_Z20test_atom_min_gen_llPxx
+// LLVM: atomicrmw min ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_min_gen_ll(long long *p, long long val) {
+  __nvvm_atom_min_gen_ll(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_min_gen_uiPjj
+// CIR: cir.atomic.fetch min relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!u32i>, !u32i) -> !u32i
+// LLVM-LABEL: @_Z20test_atom_min_gen_uiPjj
+// LLVM: atomicrmw umin ptr %{{.*}}, i32 %{{.*}} monotonic, align 4
+__device__ void test_atom_min_gen_ui(unsigned *p, unsigned val) {
+  __nvvm_atom_min_gen_ui(p, val);
+}
+
+// CIR-LABEL: @_Z20test_atom_min_gen_ulPmm
+// CIR: cir.atomic.fetch min relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!u64i>, !u64i) -> !u64i
+// LLVM-LABEL: @_Z20test_atom_min_gen_ulPmm
+// LLVM: atomicrmw umin ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_min_gen_ul(unsigned long *p, unsigned long val) {
+  __nvvm_atom_min_gen_ul(p, val);
+}
+
+// CIR-LABEL: @_Z21test_atom_min_gen_ullPyy
+// CIR: cir.atomic.fetch min relaxed syncscope(system) fetch_first %{{.*}}, %{{.*}} : (!cir.ptr<!u64i>, !u64i) -> !u64i
+// LLVM-LABEL: @_Z21test_atom_min_gen_ullPyy
+// LLVM: atomicrmw umin ptr %{{.*}}, i64 %{{.*}} monotonic, align 8
+__device__ void test_atom_min_gen_ull(unsigned long long *p, unsigned long long val) {
+  __nvvm_atom_min_gen_ull(p, val);
+}


### PR DESCRIPTION
Adds codegen support for the following NVVM binary atomic builtins: add, sub, and, or, xor, min, umin, max and max.

These are lowered to the corresponding CIR `cir.atomic.fetch` operations and subsequently lowered to LLVM `atomicrmw` instructions.