### PR TITLE
[mlir-tblgen] Emit named result indices

### DIFF
--- a/mlir/test/mlir-tblgen/op-result.td
+++ b/mlir/test/mlir-tblgen/op-result.td
@@ -14,6 +14,9 @@ def OpA : NS_Op<"one_normal_result_op", []> {
   let results = (outs I32:$result);
 }
 
+// DECL-LABEL: class OpA : {{.*}} {
+// DECL: static constexpr int odsIndex_result = 0;
+
 // CHECK-LABEL: void OpA::build
 // CHECK:         ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands
 // CHECK:         assert(resultTypes.size() == 1u && "mismatched number of return types");
@@ -23,6 +26,10 @@ def OpB : NS_Op<"same_input_output_type_op", [SameOperandsAndResultType]> {
   let arguments = (ins I32:$x);
   let results = (outs I32:$y);
 }
+
+// DECL-LABEL: class OpB : {{.*}} {
+// DECL: static constexpr int odsIndex_x = 0;
+// DECL: static constexpr int odsIndex_y = 0;
 
 // CHECK-LABEL: OpB definitions
 // CHECK: void OpB::build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type y, ::mlir::Value x)
@@ -38,6 +45,10 @@ def OpB : NS_Op<"same_input_output_type_op", [SameOperandsAndResultType]> {
 def OpC : NS_Op<"three_normal_result_op", []> {
   let results = (outs I32:$x, /*unnamed*/I32, I32:$z);
 }
+
+// DECL-LABEL: class OpC : {{.*}} {
+// DECL: static constexpr int odsIndex_x = 0;
+// DECL: static constexpr int odsIndex_z = 2;
 
 // CHECK-LABEL: OpC definitions
 // CHECK:       void OpC::build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type x, ::mlir::Type resultType1, ::mlir::Type z)

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -2175,7 +2175,8 @@ generateNamedOperandGetters(const Operator &op, Class &opClass,
                     "'SameVariadicOperandSize' traits");
   }
 
-  // Print the ods names so they don't need to be hardcoded in the source.
+  // Print the ODS indices of operands so they don't need to be hardcoded in the
+  // source.
   for (int i = 0; i != numOperands; ++i) {
     const auto &operand = op.getOperand(i);
     if (operand.name.empty())
@@ -2387,6 +2388,17 @@ void OpEmitter::genNamedResultGetters() {
     PrintFatalError(op.getLoc(),
                     "op cannot have both 'AttrSizedResultSegments' and "
                     "'SameVariadicResultSize' traits");
+  }
+
+  // Print the ODS indices of results so they don't need to be hardcoded in the
+  // source.
+  for (int i = 0; i != numResults; ++i) {
+    const auto &result = op.getResult(i);
+    if (result.name.empty())
+      continue;
+
+    opClass.declare<Field>("static constexpr int",
+                           Twine("odsIndex_") + result.name + " = " + Twine(i));
   }
 
   // Build the initializer string for the result segment size attribute.


### PR DESCRIPTION
similar to https://github.com/llvm/llvm-project/pull/146839

useful for cases such as being able to programmatically update the result segment sizes or clone an operation via `OperationState` while editing just a few results, programmatically