### PR TITLE
[libcxx][test] Fix build failure from typo in #171785

### DIFF
--- a/libcxx/test/libcxx-03/strings/basic.string/string.capacity/allocation_size.pass.cpp
+++ b/libcxx/test/libcxx-03/strings/basic.string/string.capacity/allocation_size.pass.cpp
@@ -18,7 +18,7 @@
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
 static const std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 #else
-static const std::size_t alginment = 8;
+static const std::size_t alignment = 8;
 #endif
 
 int main(int, char**) {

--- a/libcxx/test/libcxx-03/strings/basic.string/string.capacity/max_size.pass.cpp
+++ b/libcxx/test/libcxx-03/strings/basic.string/string.capacity/max_size.pass.cpp
@@ -20,7 +20,7 @@
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
 static const std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 #else
-static const std::size_t alginment = 8;
+static const std::size_t alignment = 8;
 #endif
 
 template <class = int>


### PR DESCRIPTION
If `__STDCPP_DEFAULT_NEW_ALIGNMENT__` is not defined, these tests will fail to build due to a typo that was added in #171785.