### PR TITLE
[Github] symlink `llvm-tools` in libc container

### DIFF
--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -45,6 +45,7 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     sudo ./llvm.sh 23 && \
     rm llvm.sh
 
+# Install the LLVM testing tools, which the llvm.sh script above does not
 # include. This provides lit along with FileCheck, not, count and split-file,
 # which are required to run the libc test suites and some CIs like precommit
 # testing CI for libc-based compiler-rt builtins. The package only symlinks

--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -45,11 +45,14 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     sudo ./llvm.sh 23 && \
     rm llvm.sh
 
-# Install the LLVM testing tools, which the llvm.sh script above does not
-# include. This provides lit (as lit-23) along with FileCheck, not, count and
-# split-file, which are required to run the libc test suites and some CIs like
-# precommit testing CI for libc-based compiler-rt builtins. 
-RUN apt-get install -y llvm-23-tools
+# include. This provides lit along with FileCheck, not, count and split-file,
+# which are required to run the libc test suites and some CIs like precommit
+# testing CI for libc-based compiler-rt builtins. The package only symlinks
+# the tools into /usr/bin under versioned names (lit-23, FileCheck-23, ...),
+# so also symlink them under their canonical names.
+RUN apt-get install -y llvm-23-tools && \
+    ln -s -t /usr/bin $(dpkg -L llvm-23-tools | grep '^/usr/lib/llvm-23/bin/')
+
 
 # Install gmp and mpfr for cross compilation
 RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz && \


### PR DESCRIPTION
Missed thing in #210414. We need to symlink the LLVM tools that are under `/usr/lib/llvm-23/bin/` to avoid errors like this because the LLVM tools have a `-23` suffix when they're installed inside the container

```
# RUN: at line 2
/usr/bin/clang-23   -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta  -DCOMPILER_RT_HAS_FLOAT16 -nobuiltininc -I/__w/llvm-project/llvm-project/compiler-rt/include -idirafter /usr/lib/llvm-23/lib/clang/23/include -resource-dir=/__w/llvm-project/llvm-project/build/compiler-rt -Wl,-rpath,/__w/llvm-project/llvm-project/build/compiler-rt/lib/linux  -fno-builtin -I /__w/llvm-project/llvm-project/compiler-rt/lib/builtins -nodefaultlibs /__w/llvm-project/llvm-project/compiler-rt/test/builtins/Unit/aarch64/emupac.c -lm -Wl,--start-group /__w/llvm-project/llvm-project/build/compiler-rt/lib/linux/libclang_rt.builtins-aarch64.a -lc -Wl,--end-group -o /__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp
# executed command: /usr/bin/clang-23 -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -DCOMPILER_RT_HAS_FLOAT16 -nobuiltininc -I/__w/llvm-project/llvm-project/compiler-rt/include -idirafter /usr/lib/llvm-23/lib/clang/23/include -resource-dir=/__w/llvm-project/llvm-project/build/compiler-rt -Wl,-rpath,/__w/llvm-project/llvm-project/build/compiler-rt/lib/linux -fno-builtin -I /__w/llvm-project/llvm-project/compiler-rt/lib/builtins -nodefaultlibs /__w/llvm-project/llvm-project/compiler-rt/test/builtins/Unit/aarch64/emupac.c -lm -Wl,--start-group /__w/llvm-project/llvm-project/build/compiler-rt/lib/linux/libclang_rt.builtins-aarch64.a -lc -Wl,--end-group -o /__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp
# RUN: at line 3
/__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp 1
# executed command: /__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp 1
# RUN: at line 4
/__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp 2
# executed command: /__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp 2
# RUN: at line 5
not --crash  /__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp 3
# executed command: not --crash /__w/llvm-project/llvm-project/build/compiler-rt/test/builtins/Unit/AARCH64LinuxConfig/aarch64/Output/emupac.c.tmp 3
# .---command stderr------------
# | 'not': command not found
# `-----------------------------
```