### PR TITLE
[mlir][AMDGPU] Diagnose unsupported packed fp8 conversions

### DIFF
--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3046,6 +3046,9 @@ LogicalResult PackedTrunc2xFp8OpLowering::matchAndRewrite(
   else if (typeIsExpectedFp8ForChipset(chipset, resultElemType))
     result = ROCDL::CvtPkFp8F32Op::create(rewriter, loc, i32, sourceA, sourceB,
                                           existing, op.getWordIndex());
+  else
+    return op.emitOpError(
+        "no truncation to result type available on given chipset");
 
   result = rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(
       op, getTypeConverter()->convertType(resultType), result);
@@ -3080,6 +3083,9 @@ LogicalResult PackedStochRoundFp8OpLowering::matchAndRewrite(
   else if (typeIsExpectedFp8ForChipset(chipset, resultElemType))
     result = ROCDL::CvtSrFp8F32Op::create(rewriter, loc, i32, source, stoch,
                                           existing, op.getStoreIndex());
+  else
+    return op.emitOpError(
+        "no stochastic rounding to result type available on given chipset");
 
   result = rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(
       op, getTypeConverter()->convertType(resultType), result);

--- a/mlir/test/Conversion/AMDGPUToROCDL/packed-trunc-invalid.mlir
+++ b/mlir/test/Conversion/AMDGPUToROCDL/packed-trunc-invalid.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt %s --convert-amdgpu-to-rocdl=chipset=gfx942 --split-input-file --verify-diagnostics
+
+func.func @packed_trunc_ocp_type_requires_ocp_chipset(%arg0: f32) {
+  // expected-error@below {{'amdgpu.packed_trunc_2xfp8' op no truncation to result type available on given chipset}}
+  // expected-error@below {{failed to legalize operation 'amdgpu.packed_trunc_2xfp8'}}
+  %0 = amdgpu.packed_trunc_2xfp8 %arg0, undef into undef[word 0] : f32 to vector<4xf8E4M3FN>
+  return
+}
+
+// -----
+
+func.func @packed_stoch_round_ocp_type_requires_ocp_chipset(%arg0: f32,
+                                                            %arg1: i32) {
+  // expected-error@below {{'amdgpu.packed_stoch_round_fp8' op no stochastic rounding to result type available on given chipset}}
+  // expected-error@below {{failed to legalize operation 'amdgpu.packed_stoch_round_fp8'}}
+  %0 = amdgpu.packed_stoch_round_fp8 %arg0 + %arg1 into undef[0] : f32 to vector<4xf8E4M3FN>
+  return
+}


### PR DESCRIPTION
## Summary

Fixes #210266.

`amdgpu.packed_trunc_2xfp8` could crash during AMDGPU-to-ROCDL conversion when the result
element type does not match the selected chipset. For example, `gfx942` expects FNUZ fp8
types, but the reproducer uses the OCP `f8E4M3FN` type. The lowering failed to create an
intrinsic result and later tried to bitcast a null value.

This patch diagnoses unsupported packed fp8 conversions instead of crashing. It also adds
the same guard for `amdgpu.packed_stoch_round_fp8`, which had the same unchecked result
path.

## Tests

```sh
ninja -C build mlir-opt FileCheck count not
build/bin/llvm-lit -v mlir/test/Conversion/AMDGPUToROCDL/packed-trunc-invalid.mlir
build/bin/llvm-lit -v mlir/test/Conversion/AMDGPUToROCDL/8-bit-floats.mlir mlir/test/
Conversion/AMDGPUToROCDL/8-bit-floats-ocp.mlir mlir/test/Conversion/AMDGPUToROCDL/packed-
trunc-invalid.mlir
build/bin/llvm-lit -v mlir/test/Conversion/AMDGPUToROCDL

