### PR TITLE
[llvm-objcopy][COFF] Support --rename-section

### DIFF
--- a/llvm/docs/CommandGuide/llvm-objcopy.rst
+++ b/llvm/docs/CommandGuide/llvm-objcopy.rst
@@ -177,6 +177,13 @@ multiple file formats.
  For MachO objects, ``<section>`` must be formatted as
  ``<segment name>,<section name>``.
 
+.. option:: --rename-section <old>=<new>[,<flag>,...]
+
+ Rename sections called ``<old>`` to ``<new>`` in the output, and apply any
+ specified ``<flag>`` values. See :option:`--set-section-flags` for a list of
+ supported flags. Can be specified multiple times to rename multiple sections.
+ Supported for ELF and COFF.
+
 .. option:: --set-section-alignment <section>=<align>
 
  Set the alignment of section ``<section>`` to ``<align>``. Can be specified
@@ -498,12 +505,6 @@ them.
 
  Remove notes of integer type ``<type>`` and name ``<name>`` from SHT_NOTE
  sections that are not in a segment. Can be specified multiple times.
-
-.. option:: --rename-section <old>=<new>[,<flag>,...]
-
- Rename sections called ``<old>`` to ``<new>`` in the output, and apply any
- specified ``<flag>`` values. See :option:`--set-section-flags` for a list of
- supported flags. Can be specified multiple times to rename multiple sections.
 
 .. option:: --set-section-type <section>=<type>
 

--- a/llvm/lib/ObjCopy/COFF/COFFObjcopy.cpp
+++ b/llvm/lib/ObjCopy/COFF/COFFObjcopy.cpp
@@ -309,6 +309,29 @@ static Error handleArgs(const CommonConfig &Config,
     if (Error E = addGnuDebugLink(Obj, Config.AddGnuDebugLink))
       return E;
 
+  if (!Config.SectionsToRename.empty()) {
+    for (Section &Sec : Obj.getMutableSections()) {
+      auto It = Config.SectionsToRename.find(Sec.Name);
+      if (It == Config.SectionsToRename.end())
+        continue;
+
+      const SectionRename &SR = It->second;
+      StringRef OldName = Sec.Name;
+      StringRef NewName = SR.NewName;
+
+      // Update section-definition symbols that still share the section's name.
+      for (Symbol &Sym : Obj.getMutableSymbols()) {
+        if (Sym.Name == OldName && Sym.TargetSectionId == Sec.UniqueId)
+          Sym.Name = NewName;
+      }
+
+      Sec.Name = NewName;
+      if (SR.NewFlags)
+        Sec.Header.Characteristics =
+            flagsToCharacteristics(*SR.NewFlags, Sec.Header.Characteristics);
+    }
+  }
+
   if (COFFConfig.Subsystem || COFFConfig.MajorSubsystemVersion ||
       COFFConfig.MinorSubsystemVersion) {
     if (!Obj.IsPE)

--- a/llvm/lib/ObjCopy/ConfigManager.cpp
+++ b/llvm/lib/ObjCopy/ConfigManager.cpp
@@ -26,7 +26,7 @@ Expected<const COFFConfig &> ConfigManager::getCOFFConfig() const {
       !Common.AllocSectionsPrefix.empty() || !Common.KeepSection.empty() ||
       !Common.SymbolsToGlobalize.empty() || !Common.SymbolsToKeep.empty() ||
       !Common.SymbolsToLocalize.empty() || !Common.SymbolsToWeaken.empty() ||
-      !Common.SymbolsToKeepGlobal.empty() || !Common.SectionsToRename.empty() ||
+      !Common.SymbolsToKeepGlobal.empty() ||
       !Common.SetSectionAlignment.empty() || !Common.SetSectionType.empty() ||
       Common.ExtractDWO || Common.StripDWO || Common.StripNonAlloc ||
       Common.StripSections || Common.Weaken ||

--- a/llvm/test/tools/llvm-objcopy/COFF/rename-section-and-update.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/rename-section-and-update.test
@@ -1,0 +1,56 @@
+## --update-section / --add-section / --set-section-flags match the original
+## name and run before --rename-section.
+
+# RUN: yaml2obj %s -o %t
+# RUN: echo DEADBEEF > %t.sec
+
+## --update-section then rename:
+# RUN: echo -n AAAB > %t.diff
+# RUN: llvm-objcopy --update-section=.foo=%t.diff --rename-section=.foo=.bar %t %t.1
+# RUN: llvm-readobj --sections --section-data %t.1 | FileCheck %s --check-prefix=UPDATE
+
+# UPDATE:      Name: .bar
+# UPDATE:      SectionData (
+# UPDATE-NEXT:   0000: 41414142
+# UPDATE-NEXT: )
+
+## --add-section then rename:
+# RUN: llvm-objcopy --add-section=.new=%t.sec --rename-section=.new=.renamed %t %t.2
+# RUN: llvm-readobj --sections --section-data %t.2 | FileCheck %s --check-prefix=ADD
+
+# ADD:      Name: .foo
+# ADD:      Name: .renamed
+# ADD:      SectionData (
+# ADD-NEXT:   0000: {{.*}}DEADBEEF{{.*}}
+# ADD-NEXT: )
+
+## --set-section-flags then rename (flags applied under original name):
+# RUN: llvm-objcopy --set-section-flags=.foo=code --rename-section=.foo=.bar %t %t.3
+# RUN: llvm-readobj --sections %t.3 | FileCheck %s --check-prefix=FLAGS
+
+# FLAGS:      Name: .bar
+# FLAGS:      Characteristics [
+# FLAGS-NEXT:   IMAGE_SCN_ALIGN_4BYTES
+# FLAGS-NEXT:   IMAGE_SCN_CNT_CODE
+# FLAGS-NEXT:   IMAGE_SCN_MEM_EXECUTE
+# FLAGS-NEXT:   IMAGE_SCN_MEM_READ
+# FLAGS-NEXT:   IMAGE_SCN_MEM_WRITE
+# FLAGS-NEXT: ]
+
+## Conflict: --set-section-flags on rename destination is rejected (CLI).
+# RUN: not llvm-objcopy --rename-section=.foo=.bar --set-section-flags=.bar=alloc %t %t.4 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CONFLICT
+
+# CONFLICT: --set-section-flags=.bar conflicts with --rename-section=.foo=.bar
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name:            .foo
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     '41414141'
+symbols:
+...

--- a/llvm/test/tools/llvm-objcopy/COFF/rename-section-dollar.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/rename-section-dollar.test
@@ -1,0 +1,30 @@
+## Renaming to a $ grouping name changes only the logical name.
+## LLVM does not apply GNU PE known-name characteristic forcing;
+## characteristics are not touched unless flags are given.
+
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-objcopy --rename-section=.foo=.rdata$1 %t %t2
+# RUN: llvm-readobj --sections --section-data %t2 | FileCheck %s
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name:            .foo
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       4
+    SectionData:     '01020304'
+symbols:
+...
+
+# CHECK:      Name: .rdata$1
+# CHECK:      Characteristics [
+# CHECK-NEXT:   IMAGE_SCN_ALIGN_4BYTES
+# CHECK-NEXT:   IMAGE_SCN_CNT_INITIALIZED_DATA
+# CHECK-NEXT:   IMAGE_SCN_MEM_READ
+# CHECK-NEXT:   IMAGE_SCN_MEM_WRITE
+# CHECK-NEXT: ]
+# CHECK:      SectionData (
+# CHECK-NEXT:   0000: 01020304
+# CHECK-NEXT: )

--- a/llvm/test/tools/llvm-objcopy/COFF/rename-section-flags.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/rename-section-flags.test
@@ -1,0 +1,72 @@
+# RUN: yaml2obj %s -o %t
+
+## Single flags via --rename-section (same mapping as --set-section-flags).
+# RUN: llvm-objcopy --rename-section=.foo=.bar,alloc %t %t.alloc
+# RUN: llvm-readobj --sections %t.alloc | FileCheck %s --check-prefixes=CHECK,UNINITDATA,READ,WRITE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,load %t %t.load
+# RUN: llvm-readobj --sections %t.load | FileCheck %s --check-prefixes=CHECK,READ,WRITE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,noload %t %t.noload
+# RUN: llvm-readobj --sections %t.noload | FileCheck %s --check-prefixes=CHECK,READ,WRITE,REMOVE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,readonly %t %t.readonly
+# RUN: llvm-readobj --sections %t.readonly | FileCheck %s --check-prefixes=CHECK,READ
+# RUN: llvm-objcopy --rename-section=.foo=.bar,exclude %t %t.exclude
+# RUN: llvm-readobj --sections %t.exclude | FileCheck %s --check-prefixes=CHECK,READ,WRITE,REMOVE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,debug %t %t.debug
+# RUN: llvm-readobj --sections %t.debug | FileCheck %s --check-prefixes=CHECK,INITDATA,DISCARDABLE,READ,WRITE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,code %t %t.code
+# RUN: llvm-readobj --sections %t.code | FileCheck %s --check-prefixes=CHECK,CODE,EXECUTE,READ,WRITE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,data %t %t.data
+# RUN: llvm-readobj --sections %t.data | FileCheck %s --check-prefixes=CHECK,INITDATA,READ,WRITE
+# RUN: llvm-objcopy --rename-section=.foo=.bar,share %t %t.share
+# RUN: llvm-readobj --sections %t.share | FileCheck %s --check-prefixes=CHECK,READ,SHARED,WRITE
+
+## Multiple flags:
+# RUN: llvm-objcopy --rename-section=.foo=.bar,alloc,readonly,share %t %t.alloc_ro_share
+# RUN: llvm-readobj --sections %t.alloc_ro_share | FileCheck %s --check-prefixes=CHECK,UNINITDATA,READ,SHARED
+# RUN: llvm-objcopy --rename-section=.foo=.bar,alloc,code %t %t.alloc_code
+# RUN: llvm-readobj --sections %t.alloc_code | FileCheck %s --check-prefixes=CHECK,CODE,UNINITDATA,EXECUTE,READ,WRITE
+
+## No flags: preserve original characteristics (contents are never dropped).
+# RUN: llvm-objcopy --rename-section=.foo=.bar %t %t.none
+# RUN: llvm-readobj --sections --section-data %t.none | FileCheck %s --check-prefixes=PRESERVE,PRESERVE-DATA
+
+## Invalid flag:
+# RUN: not llvm-objcopy --rename-section=.foo=.bar,xyzzy %t %t.xyzzy 2>&1 | FileCheck %s --check-prefix=BAD-FLAG
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name:            .foo
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     'DEADBEEF'
+symbols:
+...
+
+# CHECK:            Name: .bar
+# CHECK:            Characteristics [
+# CHECK-NEXT:         IMAGE_SCN_ALIGN_4BYTES
+# CODE-NEXT:          IMAGE_SCN_CNT_CODE
+# INITDATA-NEXT:      IMAGE_SCN_CNT_INITIALIZED_DATA
+# UNINITDATA-NEXT:    IMAGE_SCN_CNT_UNINITIALIZED_DATA
+# REMOVE-NEXT:        IMAGE_SCN_LNK_REMOVE
+# DISCARDABLE-NEXT:   IMAGE_SCN_MEM_DISCARDABLE
+# EXECUTE-NEXT:       IMAGE_SCN_MEM_EXECUTE
+# READ-NEXT:          IMAGE_SCN_MEM_READ
+# SHARED-NEXT:        IMAGE_SCN_MEM_SHARED
+# WRITE-NEXT:         IMAGE_SCN_MEM_WRITE
+# CHECK-NEXT:       ]
+
+# PRESERVE:            Name: .bar
+# PRESERVE:            Characteristics [
+# PRESERVE-NEXT:         IMAGE_SCN_ALIGN_4BYTES
+# PRESERVE-NEXT:         IMAGE_SCN_CNT_INITIALIZED_DATA
+# PRESERVE-NEXT:         IMAGE_SCN_MEM_READ
+# PRESERVE-NEXT:       ]
+# PRESERVE-DATA:       SectionData (
+# PRESERVE-DATA-NEXT:    0000: DEADBEEF
+# PRESERVE-DATA-NEXT:  )
+
+# BAD-FLAG: unrecognized section flag 'xyzzy'. Flags supported for GNU compatibility: alloc, load, noload, readonly, exclude, debug, code, data, rom, share, contents, merge, strings

--- a/llvm/test/tools/llvm-objcopy/COFF/rename-section-long-name.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/rename-section-long-name.test
@@ -1,0 +1,44 @@
+## Long section names (>8 bytes) go into the COFF string table.
+
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-objcopy --rename-section=.text=.longsectionname %t %t2
+# RUN: llvm-readobj --sections --symbols --string-table %t2 | FileCheck %s
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     '90'
+symbols:
+  - Name:            .text
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          1
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          1
+...
+
+# CHECK:      Name: .longsectionname
+# CHECK:      Characteristics [
+# CHECK-NEXT:   IMAGE_SCN_ALIGN_16BYTES
+# CHECK-NEXT:   IMAGE_SCN_CNT_CODE
+# CHECK-NEXT:   IMAGE_SCN_MEM_EXECUTE
+# CHECK-NEXT:   IMAGE_SCN_MEM_READ
+# CHECK-NEXT: ]
+
+# CHECK:      Name: .longsectionname
+# CHECK-NEXT: Value: 0
+# CHECK-NEXT: Section: .longsectionname
+
+# CHECK:      StringTable {
+# CHECK:        .longsectionname

--- a/llvm/test/tools/llvm-objcopy/COFF/rename-section-reloc.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/rename-section-reloc.test
@@ -1,0 +1,64 @@
+## Renaming a section also renames its section-definition symbol. Relocations
+## that target that symbol stay valid (they use symbol indices, not names).
+
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-objcopy --rename-section=.text=.text2 %t %t2
+# RUN: llvm-readobj --sections --relocations --symbols %t2 | FileCheck %s
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     '9090'
+  - Name:            .debug_info
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_DISCARDABLE, IMAGE_SCN_MEM_READ ]
+    Alignment:       1
+    SectionData:     '0000000000000000'
+    Relocations:
+      - VirtualAddress:  0
+        SymbolName:      .text
+        Type:            IMAGE_REL_AMD64_ADDR64
+symbols:
+  - Name:            .text
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          2
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          1
+  - Name:            .debug_info
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 1
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          2
+...
+
+# CHECK:      Name: .text2
+# CHECK:      Name: .debug_info
+
+# CHECK:      Relocations [
+# CHECK-NEXT:   Section (2) .debug_info {
+# CHECK-NEXT:     0x0 IMAGE_REL_AMD64_ADDR64 .text2 (0)
+# CHECK-NEXT:   }
+# CHECK-NEXT: ]
+
+# CHECK:      Name: .text2
+# CHECK-NEXT: Value: 0
+# CHECK-NEXT: Section: .text2
+# CHECK:      Name: .debug_info

--- a/llvm/test/tools/llvm-objcopy/COFF/rename-section.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/rename-section.test
@@ -1,0 +1,101 @@
+# RUN: yaml2obj %s -o %t
+
+## Basic rename: section header, contents, alignment, and section symbol.
+# RUN: llvm-objcopy --rename-section=.foo=.bar %t %t2
+# RUN: llvm-readobj --sections --section-data --symbols %t2 | FileCheck %s
+
+## Bad format / multiple renames of the same source (CLI, format-agnostic).
+# RUN: not llvm-objcopy --rename-section=.foo.bar --rename-section=.foo=.other %t %t2 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=BAD-FORMAT
+# RUN: not llvm-objcopy --rename-section=.foo=.bar --rename-section=.foo=.other %t %t2 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=MULTIPLE-RENAMES
+
+## Section renames do not chain in one invocation.
+# RUN: llvm-objcopy --rename-section=.foo=.bar --rename-section=.bar=.baz %t %t3
+# RUN: cmp %t2 %t3
+
+## Renaming a nonexistent section is a silent no-op.
+# RUN: llvm-objcopy --rename-section=.missing=.other %t %t4
+# RUN: cmp %t %t4
+
+## Empty new name is allowed (matches LLVM ELF and COFF --add-section).
+# RUN: llvm-objcopy --rename-section=.foo= %t %t5
+# RUN: llvm-readobj --sections %t5 | FileCheck %s --check-prefix=EMPTY-NAME
+
+## PE executable smoke: rename a section header when there are no symbols.
+# RUN: yaml2obj %p/Inputs/x86_64-exe.yaml -o %t.exe
+# RUN: llvm-objcopy --rename-section=.rdata=.rodata %t.exe %t.exe2
+# RUN: llvm-readobj --sections %t.exe2 | FileCheck %s --check-prefix=PE
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name:            .foo
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     'C3C3C3C3'
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     '90'
+symbols:
+  - Name:            .foo
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          4
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          1
+  - Name:            .text
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          1
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          2
+  - Name:            main
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+...
+
+# CHECK:      Name: .bar
+# CHECK:      Characteristics [
+# CHECK-NEXT:   IMAGE_SCN_ALIGN_4BYTES
+# CHECK-NEXT:   IMAGE_SCN_CNT_INITIALIZED_DATA
+# CHECK-NEXT:   IMAGE_SCN_MEM_READ
+# CHECK-NEXT: ]
+# CHECK:      SectionData (
+# CHECK-NEXT:   0000: C3C3C3C3
+# CHECK-NEXT: )
+# CHECK:      Name: .text
+
+# CHECK:      Name: .bar
+# CHECK-NEXT: Value: 0
+# CHECK-NEXT: Section: .bar
+# CHECK:      Name: .text
+# CHECK:      Name: main
+
+# BAD-FORMAT: bad format for --rename-section: missing '='
+# MULTIPLE-RENAMES: multiple renames of section '.foo'
+
+# EMPTY-NAME: Name: (00 00 00 00 00 00 00 00)
+
+# PE: Name: .text
+# PE: Name: .rodata
+# PE: Name: .data
+# PE: Name: .pdata


### PR DESCRIPTION
* Implement `--rename-section` for COFF objects.
* Move its documentation from the ELF-specific section to the generic options section.
* Add tests based on the existing COFF and ELF tests.


Assisted-by: Cursor Grok 4.5 (the tests)

Apart from lit tests, I have tested it on one project that currently requires GNU ObjCopy.
