### PR TITLE
[clang-tidy][docs] Remove obsolete doc8 instructions. NFC.

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/Contributing.rst
+++ b/clang-tools-extra/docs/clang-tidy/Contributing.rst
@@ -466,24 +466,7 @@ generator and create HTML documentation files in the
 ``tools/clang/tools/extra/docs/html`` directory in your build tree.
 Make sure that your check is correctly shown in the release notes and the list
 of checks. Make sure that the formatting and structure of your check's
-documentation look correct: there is no trailing whitespaces and lines are no
-longer than 80 characters.
-
-To validate your files, please use ``doc8`` as described below.
-
-Clang-Tidy uses `doc8 <https://pypi.org/project/doc8/>`_ to check ``.rst``
-files for formatting consistency. You can install ``doc8`` with ``pip``:
-
-.. code-block:: console
-
-  $ pip install doc8
-
-To run ``doc8`` on the modified documentations:
-
-.. code-block:: console
-
-  $ git diff --name-only HEAD -- clang-tools-extra/docs/clang-tidy/ | grep "\.rst$" | xargs -r doc8
-
+documentation look correct and contain no trailing whitespace.
 
 Registering your Check
 ----------------------

--- a/clang-tools-extra/docs/clang-tidy/Contributing.rst
+++ b/clang-tools-extra/docs/clang-tidy/Contributing.rst
@@ -465,8 +465,7 @@ Building the target ``docs-clang-tools-html`` will run the Sphinx documentation
 generator and create HTML documentation files in the
 ``tools/clang/tools/extra/docs/html`` directory in your build tree.
 Make sure that your check is correctly shown in the release notes and the list
-of checks. Make sure that the formatting and structure of your check's
-documentation look correct and contain no trailing whitespace.
+of checks, and that its documentation is formatted and structured correctly.
 
 Registering your Check
 ----------------------


### PR DESCRIPTION
Remove the doc8 setup and invocation instructions from the contributing guide as clang-tidy documentation transitions to Markdown.

Part of https://github.com/llvm/llvm-project/issues/201242