### PR TITLE
Fix SCC enter block collection in BPI

### DIFF
--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -391,7 +391,7 @@ void BPIConstruction::SccInfo::getSccEnterBlocks(
     if (isSCCHeader(BB, SccNum))
       for (const auto *Pred : predecessors(BB))
         if (getSCCNum(Pred) != SccNum)
-          Enters.push_back(const_cast<BasicBlock *>(BB));
+          Enters.push_back(const_cast<BasicBlock *>(Pred));
   }
 }
 

--- a/llvm/test/Analysis/BranchProbabilityInfo/loop.ll
+++ b/llvm/test/Analysis/BranchProbabilityInfo/loop.ll
@@ -722,4 +722,34 @@ exit:
 }
 
 
+; Check that a cold irreducible loop propagates its estimated weight through
+; the blocks entering the SCC.
+define void @test19(i1 %arg, i1 %arg2, i1 %arg3, i1 %arg4) {
+; CHECK: edge %entry -> %dispatch probability is 0x078780e3 / 0x80000000 = 5.88%
+; CHECK: edge %entry -> %exit probability is 0x78787f1d / 0x80000000 = 94.12% [HOT edge]
 
+entry:
+  br i1 %arg, label %dispatch, label %exit
+
+dispatch:
+  br i1 %arg2, label %entry1, label %entry2
+
+entry1:
+  br label %loop1
+
+entry2:
+  br label %loop2
+
+loop1:
+  br i1 %arg3, label %loop2, label %cold
+
+loop2:
+  br i1 %arg4, label %loop1, label %cold
+
+cold:
+  call void @cold()
+  br label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
 Fixes incorrect SCC enter-block collection in BPI, getSccEnterBlocks is documented to collect blocks outside an SCC that have edges into the SCC. It was instead adding the SCC header block itself, which
 prevented estimated cold loop weights from propagating to the actual predecessor entering the irreducible SCC.