### PR TITLE
[VPlan] Retire LVP::hasTailFolded (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -969,10 +969,6 @@ public:
   /// loop. Asserts that the VPlan decision matches the legacy cost model.
   bool requiresScalarEpilogue(VPlan &Plan, ElementCount VF) const;
 
-  /// Returns true if \p Plan folds the tail by masking. Asserts that the
-  /// VPlan-based decision matches the legacy cost model.
-  bool hasTailFolded(const VPlan &Plan) const;
-
   /// Attach the runtime checks of \p RTChecks to \p Plan.
   void attachRuntimeChecks(VPlan &Plan, GeneratedRTChecks &RTChecks,
                            bool HasBranchWeights) const;

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3617,7 +3617,8 @@ std::unique_ptr<VPlan> LoopVectorizationPlanner::selectBestEpiloguePlan(
     }
 
     if (Result.Width.isScalar() ||
-        isMoreProfitable(NextVF, Result, MaxTripCount, !hasTailFolded(MainPlan),
+        isMoreProfitable(NextVF, Result, MaxTripCount,
+                         !MainPlan.hasTailFolded(),
                          /*IsEpilogue*/ true)) {
       Result = NextVF;
       BestPlan = &CurrentPlan;
@@ -5669,7 +5670,7 @@ LoopVectorizationPlanner::precomputeCosts(VPlan &Plan, ElementCount VF,
     // TODO: Remove this code after stepping away from the legacy cost model and
     // adding code to simplify VPlans before calculating their costs.
     auto TC = getSmallConstantTripCount(PSE.getSE(), OrigLoop);
-    if (TC == VF && !hasTailFolded(Plan))
+    if (TC == VF && !Plan.hasTailFolded())
       addFullyUnrolledInstructionsToIgnore(OrigLoop, Legal->getInductionVars(),
                                            CostCtx.SkipCostComputation);
 
@@ -5966,7 +5967,7 @@ DenseMap<const SCEV *, Value *> LoopVectorizationPlanner::executePlan(
   RUN_VPLAN_PASS(VPlanTransforms::convertEVLExitCond, BestVPlan);
   // Regions are dissolved after optimizing for VF and UF, which completely
   // removes unneeded loop regions first.
-  const bool HasTailFolded = hasTailFolded(BestVPlan);
+  const bool HasTailFolded = BestVPlan.hasTailFolded();
   RUN_VPLAN_PASS(VPlanTransforms::dissolveLoopRegions, BestVPlan);
   // Expand BranchOnTwoConds after dissolution, when latch has direct access to
   // its successors.
@@ -7121,13 +7122,6 @@ bool LoopVectorizationPlanner::requiresScalarEpilogue(VPlan &Plan,
   return Result;
 }
 
-bool LoopVectorizationPlanner::hasTailFolded(const VPlan &Plan) const {
-  bool Result = Plan.hasTailFolded();
-  assert(CM.foldTailByMasking() == Result &&
-         "CM.foldTailByMasking and the VPlan-based check must agree");
-  return Result;
-}
-
 void LoopVectorizationPlanner::addMinimumIterationCheck(
     VPlan &Plan, ElementCount VF, unsigned UF,
     ElementCount MinProfitableTripCount) const {
@@ -7137,7 +7131,7 @@ void LoopVectorizationPlanner::addMinimumIterationCheck(
           : nullptr;
   RUN_VPLAN_PASS(VPlanTransforms::addMinimumIterationCheck, Plan, VF, UF,
                  MinProfitableTripCount, requiresScalarEpilogue(Plan, VF),
-                 hasTailFolded(Plan), OrigLoop, BranchWeights,
+                 Plan.hasTailFolded(), OrigLoop, BranchWeights,
                  OrigLoop->getLoopPredecessor()->getTerminator()->getDebugLoc(),
                  PSE, Plan.getEntry());
 }


### PR DESCRIPTION
LVP::hasTailFolded incldued an assert that hasTailFOlded matches the VPlan version. No divergence surfaced, so remove the assert as planned.