### PR TITLE
[InstCombine] Fix invalid fshl -> lshr fold when shift is vector with constant zero lane

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2668,7 +2668,9 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
 
       // fshl(0, X, C) --> lshr X, (BW-C)
       // fshl(undef, X, C) --> lshr X, (BW-C)
-      if (match(Op0, m_ZeroInt()) || match(Op0, m_Undef()))
+      // Similar to fshr -> fshl fold above, this is only valid if C is not zero
+      if ((match(Op0, m_ZeroInt()) || match(Op0, m_Undef())) &&
+          isKnownNonZero(ShAmtC, SQ.getWithInstruction(II)))
         return BinaryOperator::CreateLShr(Op1,
                                           ConstantExpr::getSub(WidthC, ShAmtC));
 

--- a/llvm/test/Transforms/InstCombine/fsh.ll
+++ b/llvm/test/Transforms/InstCombine/fsh.ll
@@ -1072,6 +1072,15 @@ define <2 x i32> @fshr_vec_zero_elem(<2 x i32> %x, <2 x i32> %y) {
   ret <2 x i32> %fsh
 }
 
+define <2 x i32> @fshl_vec_zero_elem(<2 x i32> %x) {
+; CHECK-LABEL: @fshl_vec_zero_elem(
+; CHECK-NEXT:    [[FSH:%.*]] = call <2 x i32> @llvm.fshl.v2i32(<2 x i32> zeroinitializer, <2 x i32> [[X:%.*]], <2 x i32> <i32 2, i32 0>)
+; CHECK-NEXT:    ret <2 x i32> [[FSH]]
+;
+  %fsh = call <2 x i32> @llvm.fshl.v2i32(<2 x i32> zeroinitializer, <2 x i32> %x, <2 x i32> <i32 2, i32 0>)
+  ret <2 x i32> %fsh
+}
+
 define i16 @fshl_i16_shl(i16 %x, i16 %y) {
 ; CHECK-LABEL: @fshl_i16_shl(
 ; CHECK-NEXT:  entry:


### PR DESCRIPTION
For vectors, this is not valid if a subset of the lanes are constant zero. Doing this fold introduces poison in those lanes. A similar fix was done for fshr in 46957a138dea339799059ea5bf032e40042ff185 however the same issue seems to apply to fshl

Fixes https://github.com/llvm/llvm-project/issues/210605