### PR TITLE
[CI] Enable -Werror on Windows

### DIFF
--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -57,6 +57,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D CMAKE_MODULE_LINKER_FLAGS="/MANIFEST:NO" \
       -D CMAKE_SHARED_LINKER_FLAGS="/MANIFEST:NO" \
       -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
+      -D LLVM_ENABLE_WERROR=ON \
       "${runtime_cmake_args[@]}"
 
 start-group "ninja"


### PR DESCRIPTION
We use a recent clang-cl based toolchain which should be expected to build clang cleanly on Windows