### PR TITLE
[Clang] [Sema] Added a check for `NameInfo` not being empty after template instantiation

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -154,6 +154,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 #### Miscellaneous Bug Fixes
 
 #### Miscellaneous Clang Crashes Fixed
+- Fixed a crash when instantiating an invalid dependent friend destructor declaration in a class template. (#GH210610)
 
 ### OpenACC Specific Changes
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -154,7 +154,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 #### Miscellaneous Bug Fixes
 
 #### Miscellaneous Clang Crashes Fixed
-- Fixed a crash when instantiating an invalid dependent friend destructor declaration in a class template. (#GH210610)
+- Fixed a crash when instantiating an invalid dependent friend destructor declaration in a class template. (#GH210234)
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3287,7 +3287,10 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
         TrailingRequiresClause);
     Method->setRangeEnd(Constructor->getEndLoc());
   } else if (CXXDestructorDecl *Destructor = dyn_cast<CXXDestructorDecl>(D)) {
-    Method = CXXDestructorDecl::Create(
+      if (NameInfo.getName().getNameKind() != DeclarationName::NameKind::CXXDestructorName) {
+          return nullptr;
+      }
+      Method = CXXDestructorDecl::Create(
         SemaRef.Context, Record, StartLoc, NameInfo, T, TInfo,
         Destructor->UsesFPIntrin(), Destructor->isInlineSpecified(), false,
         Destructor->getConstexprKind(), TrailingRequiresClause);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3287,10 +3287,11 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
         TrailingRequiresClause);
     Method->setRangeEnd(Constructor->getEndLoc());
   } else if (CXXDestructorDecl *Destructor = dyn_cast<CXXDestructorDecl>(D)) {
-      if (NameInfo.getName().getNameKind() != DeclarationName::NameKind::CXXDestructorName) {
-          return nullptr;
-      }
-      Method = CXXDestructorDecl::Create(
+    if (NameInfo.getName().getNameKind() !=
+        DeclarationName::NameKind::CXXDestructorName)
+      return nullptr;
+
+    Method = CXXDestructorDecl::Create(
         SemaRef.Context, Record, StartLoc, NameInfo, T, TInfo,
         Destructor->UsesFPIntrin(), Destructor->isInlineSpecified(), false,
         Destructor->getConstexprKind(), TrailingRequiresClause);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3271,6 +3271,11 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
   DeclarationNameInfo NameInfo
     = SemaRef.SubstDeclarationNameInfo(D->getNameInfo(), TemplateArgs);
 
+  // Check if the substitution of template args failed
+  // leading to an empty DeclarationNameInfo.
+  if (!NameInfo.getName())
+    return nullptr;
+
   if (FunctionRewriteKind != RewriteKind::None)
     adjustForRewrite(FunctionRewriteKind, D, T, TInfo, NameInfo);
 
@@ -3287,10 +3292,6 @@ Decl *TemplateDeclInstantiator::VisitCXXMethodDecl(
         TrailingRequiresClause);
     Method->setRangeEnd(Constructor->getEndLoc());
   } else if (CXXDestructorDecl *Destructor = dyn_cast<CXXDestructorDecl>(D)) {
-    if (NameInfo.getName().getNameKind() !=
-        DeclarationName::NameKind::CXXDestructorName)
-      return nullptr;
-
     Method = CXXDestructorDecl::Create(
         SemaRef.Context, Record, StartLoc, NameInfo, T, TInfo,
         Destructor->UsesFPIntrin(), Destructor->isInlineSpecified(), false,

--- a/clang/test/SemaTemplate/friend.cpp
+++ b/clang/test/SemaTemplate/friend.cpp
@@ -181,7 +181,7 @@ namespace InstQualifier1 {
   }
 } // namespace InstQualifier1
 
-namespace invalid_function_name_in_template_instantiation {
+namespace GH210234 {
   template <typename T>
   struct D {
     friend T::S::~ffl_fusion(); // expected-error {{no type named 'ffl_fusion'}}

--- a/clang/test/SemaTemplate/friend.cpp
+++ b/clang/test/SemaTemplate/friend.cpp
@@ -180,3 +180,16 @@ namespace InstQualifier1 {
     };
   }
 } // namespace InstQualifier1
+
+namespace invalid_function_name_in_template_instantiation {
+  template <typename T>
+  struct D {
+    friend T::S::~ffl_fusion(); // expected-error {{no type named 'ffl_fusion'}}
+  };
+
+  struct Q {
+    struct S { ~S(); };
+  };
+
+  template struct D<Q>; // expected-note {{in instantiation of template class}}
+} // namespace invalid_function_name_in_template_instantiation


### PR DESCRIPTION
Fixes #210234 

As per my investigation (mostly following stack traces and dumping variable values), a default empty `DeclarationNameInfo` was being returned after template substitution [over here](https://github.com/llvm/llvm-project/blob/c45b4e4d00bed488d6ece5608560561732ae5b9e/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp#L3270).

```cpp
// D-.>getNameInfo() has actual data here
 
 DeclarationNameInfo NameInfo
    = SemaRef.SubstDeclarationNameInfo(D->getNameInfo(), TemplateArgs);

// NameInfo has default values
```

This was being passed on directly to `CXXDestructorDecl::Create` leading to the assertion being hit. This PR adds a check that ensures `NameInfo` actually contains a valid destructor name before constructing a `CXXDestructorDecl`. This fixes the assertion being hit in the reproducer from the linked issue.