### PR TITLE
[NFC][test][ELF] Improve ppc32-ifunc-nonpreemptible-(no)pic.s

### DIFF
--- a/lld/test/ELF/ppc32-ifunc-nonpreemptible-nopic.s
+++ b/lld/test/ELF/ppc32-ifunc-nonpreemptible-nopic.s
@@ -3,6 +3,7 @@
 # RUN: ld.lld %t.o -o %t
 # RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-readelf -s %t | FileCheck --check-prefix=SYM %s
+# RUN: llvm-readelf -x .got.plt %t | FileCheck --check-prefix=HEX %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
 
 # RELOC:      .rela.dyn {
@@ -10,20 +11,30 @@
 # RELOC-NEXT: }
 
 # SYM: 10010100 0 FUNC GLOBAL DEFAULT {{.*}} func
-# HEX: 0x10020110 10010100
+
+# HEX:      Hex dump of section '.got.plt':
+# HEX-NEXT: 0x10020110 00000000 ....
 
 # CHECK:      Disassembly of section .text:
 # CHECK:      <.text>:
 # CHECK-NEXT: 100100e0: blr
 # CHECK:      <_start>:
-# CHECK-NEXT:   bl 0x100100f0
-# CHECK-NEXT:   lis 9, 4097
-# CHECK-NEXT:   addi 9, 9, 256
+# CHECK-NEXT:           bl 0x100100f0
+# CHECK-NEXT:           lis 9, 4097
+# CHECK-NEXT:           addi 9, 9, 256
 # CHECK-EMPTY:
 # CHECK-NEXT: <00000000.plt_call32.func>:
 ## 0x10020110 = 65536*4098+272
-# CHECK-NEXT:   lis 11, 4098
-# CHECK-NEXT:   lwz 11, 272(11)
+# CHECK-NEXT: 100100f0: lis 11, 4098
+# CHECK-NEXT:           lwz 11, 272(11)
+# CHECK-NEXT:           mtctr 11
+# CHECK-NEXT:           bctr
+# CHECK:      Disassembly of section .glink:
+# CHECK:      <func>:
+# CHECK-NEXT: 10010100: lis 11, 4098
+# CHECK-NEXT:           lwz 11, 272(11)
+# CHECK-NEXT:           mtctr 11
+# CHECK-NEXT:           bctr
 
 .text
 .globl func

--- a/lld/test/ELF/ppc32-ifunc-nonpreemptible-pic.s
+++ b/lld/test/ELF/ppc32-ifunc-nonpreemptible-pic.s
@@ -3,11 +3,11 @@
 # RUN: ld.lld -pie %t.o -o %t
 # RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-readelf -s %t | FileCheck --check-prefix=SYM %s
-# RUN: llvm-readelf -x .got2 %t | FileCheck --check-prefix=HEX %s
+# RUN: llvm-readelf -x .got2 -x .got.plt %t | FileCheck --check-prefix=HEX %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
 
-# RUN: ld.lld -pie %t.o -o %t --apply-dynamic-relocs
-# RUN: llvm-readelf -x .got2 %t | FileCheck --check-prefix=HEX2 %s
+# RUN: ld.lld -pie %t.o -o %t2 --apply-dynamic-relocs
+# RUN: llvm-readelf -x .got2 -x .got.plt %t2 | FileCheck --check-prefix=HEX2 %s
 
 # RELOC:      .rela.dyn {
 # RELOC-NEXT:   0x3022C R_PPC_RELATIVE - 0x101A0
@@ -15,11 +15,16 @@
 # RELOC-NEXT: }
 
 # SYM: 000101a0 0 FUNC GLOBAL DEFAULT {{.*}} func
+
 # HEX:      Hex dump of section '.got2':
 # HEX-NEXT: 0x0003022c 00000000 ....
+# HEX:      Hex dump of section '.got.plt':
+# HEX-NEXT: 0x00030230 00000000 ....
 
 # HEX2:      Hex dump of section '.got2':
 # HEX2-NEXT: 0x0003022c 000101a0 ....
+# HEX2:      Hex dump of section '.got.plt':
+# HEX2-NEXT: 0x00030230 00000000 ....
 
 .section .got2,"aw"
 .long func
@@ -28,14 +33,20 @@
 # CHECK:      <.text>:
 # CHECK-NEXT: 10188: blr
 # CHECK:      <_start>:
-# CHECK-NEXT:   bl 0x10190
+# CHECK-NEXT:        bl 0x10190
 # CHECK-EMPTY:
 # CHECK-NEXT: <00008000.got2.plt_pic32.func>:
-## 0x10020114 = 65536*4098+276
-# CHECK-NEXT:   lwz 11, -32764(30)
-# CHECK-NEXT:   mtctr 11
-# CHECK-NEXT:   bctr
-# CHECK-NEXT:   nop
+## 0x30230 - 0x3022c - 0x8000 = -32764
+# CHECK-NEXT: 10190: lwz 11, -32764(30)
+# CHECK-NEXT:        mtctr 11
+# CHECK-NEXT:        bctr
+# CHECK-NEXT:        nop
+# CHECK:      Disassembly of section .glink:
+# CHECK:      <func>:
+# CHECK-NEXT: 101a0: lwz 11, -32764(30)
+# CHECK-NEXT:        mtctr 11
+# CHECK-NEXT:        bctr
+# CHECK-NEXT:        nop
 
 .text
 .globl func


### PR DESCRIPTION
Firstly, the nopic test had an unused HEX check line when it should have
been checking .got.plt, and the pic test was only checking .got2, also
ignoring .got.plt.

Secondly, the indentation for instructions was inconsistent within a
single file.

Thirdly, neither test was actually checking the code for func's IPLT
entry in .glink, only that the symbol existed as a normal function that
wasn't the same as the resolver, and the nopic test wasn't even testing
the full contents of the PLT call stub, which was inconsistent with the
pic test.

Fourthly, the pic test used the same output file for two different
links, which can be confusing when debugging.

Finally, the comment at the start of the pic test's PLT call stub had no
bearing on the immediate in use, instead being the same as the nopic's
one with the 4 subtracted from both sides (presumably trying to account
for the nopic test not having the extra .got2 entry, but neglecting the
fact that it's not using absolute addressing, and even if it were, the
addresses are entirely different).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>