### PR TITLE
[NFC][ELF] Avoid need to copy Symbol in replaceWithDefined

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -243,16 +243,15 @@ static SmallPtrSet<SharedSymbol *, 4> getSymbolsAt(Ctx &ctx, SharedSymbol &ss) {
 // location.
 static void replaceWithDefined(Ctx &ctx, Symbol &sym, SectionBase &sec,
                                uint64_t value, uint64_t size) {
-  Symbol old = sym;
+  uint16_t versionId = sym.versionId;
   Defined(ctx, sym.file, StringRef(), sym.binding, sym.stOther, sym.type, value,
           size, &sec)
       .overwrite(sym);
 
-  sym.versionId = old.versionId;
+  sym.versionId = versionId;
   sym.isUsedInRegularObj = true;
   // A copy relocated alias may need a GOT entry.
-  sym.flags.store(old.flags.load(std::memory_order_relaxed) & NEEDS_GOT,
-                  std::memory_order_relaxed);
+  sym.flags.fetch_and(NEEDS_GOT, std::memory_order_relaxed);
 }
 
 // Reserve space in .bss or .bss.rel.ro for copy relocation.


### PR DESCRIPTION
Firstly, by overwriting the symbol, it will have its existing flags, so
there is no need to copy them back; all we need to do is mask out the
other bits on the existing symbol.

Secondly, copying the whole symbol just to preserve the symbol version
that gets cleared by Defined::overwrite is a waste; just copy the single
member to reinstate it.