### PR TITLE
[NFC][test][ELF] Check DSO's ifunc2 is in .iplt in aarch64-ifunc-bti.s

### DIFF
--- a/lld/test/ELF/aarch64-ifunc-bti.s
+++ b/lld/test/ELF/aarch64-ifunc-bti.s
@@ -49,8 +49,10 @@
 # CHECK-NEXT:                   br      x17
 # CHECK-NEXT:                   nop
 
+# SHARED: Disassembly of section .iplt:
+# SHARED-EMPTY:
 ## The address of ifunc2 (STT_FUNC) escapes, so it must have `bti c`.
-# SHARED:      <ifunc2>:
+# SHARED-NEXT: <ifunc2>:
 # SHARED-NEXT:    bti     c
 
 # SHARED:         nop


### PR DESCRIPTION
This mirror's the PIE's CHECK lines, which were already stricter.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>