### PR TITLE
[ConstraintElim] Fix integer overflow when negating constraint

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -1816,7 +1816,8 @@ void ConstraintInfo::addFactImpl(CmpInst::Predicate Pred, Value *A, Value *B,
   if (R.isEq()) {
     // Also add the inverted constraint for equality constraints.
     for (auto &Coeff : R.Coefficients)
-      Coeff *= -1;
+      if (MulOverflow(Coeff, int64_t(-1), Coeff))
+        return;
     CSToUse.addVariableRowFill(R.Coefficients);
 
     DFSInStack.emplace_back(NumIn, NumOut, R.IsSigned,

--- a/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
+++ b/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
@@ -104,3 +104,29 @@ entry:
   %c = icmp ult i64 %i4, %lim
   ret i1 %c
 }
+
+define i1 @eq_inverted_normal_coeff(i64 %a, i64 %b) {
+; CHECK-LABEL: define i1 @eq_inverted_normal_coeff(
+; CHECK-SAME: i64 [[A:%.*]], i64 [[B:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[A]], [[B]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[THEN:%.*]], label [[ELSE:%.*]]
+; CHECK:       then:
+; CHECK-NEXT:    [[RES:%.*]] = and i1 true, true
+; CHECK-NEXT:    ret i1 [[RES]]
+; CHECK:       else:
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %cmp = icmp eq i64 %a, %b
+  br i1 %cmp, label %then, label %else
+
+then:
+  %t.1 = icmp uge i64 %a, %b
+  %t.2 = icmp ule i64 %a, %b
+  %res = and i1 %t.1, %t.2
+  ret i1 %res
+
+else:
+  ret i1 false
+}


### PR DESCRIPTION
Negating a coefficient (e.g. INT64_MIN) can overflow; skip adding the inverted constraint if it wraps.

Fixes an UBSan failure for the added test.