### PR TITLE
Remove Signum_match template and its implementation

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -3119,46 +3119,6 @@ m_c_FMul(const LHS &L, const RHS &R) {
   return BinaryOp_match<LHS, RHS, Instruction::FMul, true>(L, R);
 }
 
-template <typename Opnd_t> struct Signum_match {
-  Opnd_t Val;
-  Signum_match(const Opnd_t &V) : Val(V) {}
-
-  template <typename OpTy> bool match(OpTy *V) const {
-    unsigned TypeSize = V->getType()->getScalarSizeInBits();
-    if (TypeSize == 0)
-      return false;
-
-    unsigned ShiftWidth = TypeSize - 1;
-    Value *Op;
-
-    // This is the representation of signum we match:
-    //
-    //  signum(x) == (x >> 63) | (-x >>u 63)
-    //
-    // An i1 value is its own signum, so it's correct to match
-    //
-    //  signum(x) == (x >> 0)  | (-x >>u 0)
-    //
-    // for i1 values.
-
-    auto LHS = m_AShr(m_Value(Op), m_SpecificInt(ShiftWidth));
-    auto RHS = m_LShr(m_Neg(m_Deferred(Op)), m_SpecificInt(ShiftWidth));
-    auto Signum = m_c_Or(LHS, RHS);
-
-    return Signum.match(V) && Val.match(Op);
-  }
-};
-
-/// Matches a signum pattern.
-///
-/// signum(x) =
-///      x >  0  ->  1
-///      x == 0  ->  0
-///      x <  0  -> -1
-template <typename Val_t> inline Signum_match<Val_t> m_Signum(const Val_t &V) {
-  return Signum_match<Val_t>(V);
-}
-
 template <int Ind, typename Opnd_t> struct ExtractValue_match {
   Opnd_t Val;
   ExtractValue_match(const Opnd_t &V) : Val(V) {}

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4672,14 +4672,25 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
 
   if (Value *Res = FoldOrOfSelectSmaxToAbs(I, Builder))
     return replaceInstUsesWith(I, Res);
-
-  // signum: or (ashr X, BW-1), zext (icmp ne|sgt X, 0) --> scmp(X, 0)
+  
   // The ashr already supplies -1 for negative X, so any predicate that
   // produces 1 for positive X and 0 for X == 0 yields the same result here.
   {
     Value *X;
     CmpPredicate SignPred;
     unsigned BitWidth = Ty->getScalarSizeInBits();
+
+    // or (ashr X, BW-1), (lshr (-X), BW-1) --> scmp(X, 0)
+    if (match(&I,
+              m_c_Or(m_AShr(m_Value(X), m_SpecificIntAllowPoison(BitWidth - 1)),
+                     m_LShr(m_Neg(m_Deferred(X)),
+                            m_SpecificIntAllowPoison(BitWidth - 1)))) &&
+        (Op0->hasOneUse() || Op1->hasOneUse()))
+      return replaceInstUsesWith(
+          I, Builder.CreateIntrinsic(Ty, Intrinsic::scmp,
+                                     {X, Constant::getNullValue(Ty)}));
+
+    // or (ashr X, BW-1), zext (icmp ne|sgt X, 0) --> scmp(X, 0)
     if (match(&I,
               m_c_Or(m_AShr(m_Value(X), m_SpecificIntAllowPoison(BitWidth - 1)),
                      m_ZExt(m_ICmp(SignPred, m_Deferred(X), m_ZeroInt())))) &&

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -1462,14 +1462,6 @@ Instruction *InstCombinerImpl::foldICmpTruncConstant(ICmpInst &Cmp,
       return new ICmpInst(Pred, X, ConstantInt::get(SrcTy, C.zext(SrcBits)));
   }
 
-  if (C.isOne() && C.getBitWidth() > 1) {
-    // icmp slt trunc(signum(V)) 1 --> icmp slt V, 1
-    Value *V = nullptr;
-    if (Pred == ICmpInst::ICMP_SLT && match(X, m_Signum(m_Value(V))))
-      return new ICmpInst(ICmpInst::ICMP_SLT, V,
-                          ConstantInt::get(V->getType(), 1));
-  }
-
   // TODO: Handle non-equality predicates.
   Value *Y;
   const APInt *Pow2;
@@ -2084,14 +2076,6 @@ Instruction *InstCombinerImpl::foldICmpOrConstant(ICmpInst &Cmp,
                                                   BinaryOperator *Or,
                                                   const APInt &C) {
   ICmpInst::Predicate Pred = Cmp.getPredicate();
-  if (C.isOne()) {
-    // icmp slt signum(V) 1 --> icmp slt V, 1
-    Value *V = nullptr;
-    if (Pred == ICmpInst::ICMP_SLT && match(Or, m_Signum(m_Value(V))))
-      return new ICmpInst(ICmpInst::ICMP_SLT, V,
-                          ConstantInt::get(V->getType(), 1));
-  }
-
   Value *OrOp0 = Or->getOperand(0), *OrOp1 = Or->getOperand(1);
 
   // (icmp eq/ne (or disjoint x, C0), C1)

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2386,3 +2386,75 @@ define i32 @signum_i32_or_wrong_ext(i32 %x) {
   %r = or i32 %signbit, %sgt0ext
   ret i32 %r
 }
+
+; (-X) lshr (bitwidth - 1) | ashr (X) (bitwidth - 1)
+
+define i32 @signum_i32_lshr(i32 %x) {
+; CHECK-LABEL: @signum_i32_lshr(
+; CHECK-NEXT:    [[SIGN:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X]]
+; CHECK-NEXT:    [[LSHR:%.*]] = lshr i32 [[NEG]], 31
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGN]], [[LSHR]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %sign = ashr i32 %x, 31
+  %neg = sub i32 0, %x
+  %lshr = lshr i32 %neg, 31
+  %r = or i32 %sign, %lshr
+  ret i32 %r
+}
+
+define i32 @signum_i32_lshr_commuted(i32 %x) {
+; CHECK-LABEL: @signum_i32_lshr_commuted(
+; CHECK-NEXT:    [[SIGN:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X]]
+; CHECK-NEXT:    [[LSHR:%.*]] = lshr i32 [[NEG]], 31
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[LSHR]], [[SIGN]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %sign = ashr i32 %x, 31
+  %neg = sub i32 0, %x
+  %lshr = lshr i32 %neg, 31
+  %r = or i32 %lshr, %sign
+  ret i32 %r
+}
+
+; Negative tests
+
+define i32 @signum_i32_lshr_multi_use_both(i32 %x) {
+; CHECK-LABEL: @signum_i32_lshr_multi_use_both(
+; CHECK-NEXT:    [[SIGN:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X]]
+; CHECK-NEXT:    [[LSHR:%.*]] = lshr i32 [[NEG]], 31
+; CHECK-NEXT:    call void @use(i32 [[SIGN]])
+; CHECK-NEXT:    call void @use(i32 [[LSHR]])
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGN]], [[LSHR]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %sign = ashr i32 %x, 31
+  %neg = sub i32 0, %x
+  %lshr = lshr i32 %neg, 31
+  call void @use(i32 %sign)
+  call void @use(i32 %lshr)
+  %r = or i32 %sign, %lshr
+  ret i32 %r
+}
+
+define i32 @signum_i32_lshr_commuted_multi_use_both(i32 %x) {
+; CHECK-LABEL: @signum_i32_lshr_commuted_multi_use_both(
+; CHECK-NEXT:    [[SIGN:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X]]
+; CHECK-NEXT:    [[LSHR:%.*]] = lshr i32 [[NEG]], 31
+; CHECK-NEXT:    call void @use(i32 [[SIGN]])
+; CHECK-NEXT:    call void @use(i32 [[LSHR]])
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[LSHR]], [[SIGN]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %sign = ashr i32 %x, 31
+  %neg = sub i32 0, %x
+  %lshr = lshr i32 %neg, 31
+  call void @use(i32 %sign)
+  call void @use(i32 %lshr)
+  %r = or i32 %lshr, %sign
+  ret i32 %r
+}

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2391,10 +2391,7 @@ define i32 @signum_i32_or_wrong_ext(i32 %x) {
 
 define i32 @signum_i32_lshr(i32 %x) {
 ; CHECK-LABEL: @signum_i32_lshr(
-; CHECK-NEXT:    [[SIGN:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X]]
-; CHECK-NEXT:    [[LSHR:%.*]] = lshr i32 [[NEG]], 31
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGN]], [[LSHR]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %sign = ashr i32 %x, 31
@@ -2406,10 +2403,7 @@ define i32 @signum_i32_lshr(i32 %x) {
 
 define i32 @signum_i32_lshr_commuted(i32 %x) {
 ; CHECK-LABEL: @signum_i32_lshr_commuted(
-; CHECK-NEXT:    [[SIGN:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X]]
-; CHECK-NEXT:    [[LSHR:%.*]] = lshr i32 [[NEG]], 31
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[LSHR]], [[SIGN]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %sign = ashr i32 %x, 31


### PR DESCRIPTION
Removed Signum_match template and associated matching logic from PatternMatch.h.