### PR TITLE
[clang-format] Fix template parsing regression for unspaced user-defi…

### DIFF
--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -595,38 +595,6 @@ bool FormatTokenLexer::tryMergeUserDefinedLiteral() {
   if (Tokens.size() < 2)
     return false;
 
-         // --- INTERCEPT STRING/CHARACTER UDLs ALREADY MERGED BY THE RAW LEXER ---
-  // --- INTERCEPT STRING/CHARACTER UDLs ALREADY MERGED BY THE RAW LEXER ---
-  // --- INTERCEPT STRING/CHARACTER UDLs ALREADY MERGED BY THE RAW LEXER ---
-  if (Tokens.back()->isOneOf(tok::string_literal, tok::char_constant, tok::numeric_constant) &&
-      Tokens.end()[-2]->is(tok::kw_operator)) {
-
-    FormatToken *OpToken = Tokens[Tokens.size() - 2];
-    FormatToken *LiteralToken = Tokens.back();
-
-           // Strict guard: Do not merge if this is a member access call (e.g., x.operator""_a())
-    if (Tokens.size() >= 3) {
-      FormatToken *PrevToken = Tokens[Tokens.size() - 3];
-      if (PrevToken->isOneOf(tok::period, tok::arrow) ||
-          PrevToken->TokenText == "." || PrevToken->TokenText == "->") {
-        return false;
-      }
-    }
-
-           // Ensure they are touching in the source text
-    if (!LiteralToken->hasWhitespaceBefore()) {
-      OpToken->TokenText = StringRef(OpToken->TokenText.data(),
-                                     OpToken->TokenText.size() + LiteralToken->TokenText.size());
-      OpToken->ColumnWidth += LiteralToken->ColumnWidth;
-
-      OpToken->Tok.setKind(tok::identifier);
-
-      Tokens.erase(&Tokens.back());
-      return true;
-    }
-  }
-
-         // --- ORIGINAL NUMERIC LITERAL LOGIC KICKS IN HERE ---
   auto *First = Tokens.end() - 2;
   auto &Suffix = First[1];
   if (Suffix->hasWhitespaceBefore() || Suffix->TokenText != "$")

--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -595,6 +595,38 @@ bool FormatTokenLexer::tryMergeUserDefinedLiteral() {
   if (Tokens.size() < 2)
     return false;
 
+         // --- INTERCEPT STRING/CHARACTER UDLs ALREADY MERGED BY THE RAW LEXER ---
+  // --- INTERCEPT STRING/CHARACTER UDLs ALREADY MERGED BY THE RAW LEXER ---
+  // --- INTERCEPT STRING/CHARACTER UDLs ALREADY MERGED BY THE RAW LEXER ---
+  if (Tokens.back()->isOneOf(tok::string_literal, tok::char_constant, tok::numeric_constant) &&
+      Tokens.end()[-2]->is(tok::kw_operator)) {
+
+    FormatToken *OpToken = Tokens[Tokens.size() - 2];
+    FormatToken *LiteralToken = Tokens.back();
+
+           // Strict guard: Do not merge if this is a member access call (e.g., x.operator""_a())
+    if (Tokens.size() >= 3) {
+      FormatToken *PrevToken = Tokens[Tokens.size() - 3];
+      if (PrevToken->isOneOf(tok::period, tok::arrow) ||
+          PrevToken->TokenText == "." || PrevToken->TokenText == "->") {
+        return false;
+      }
+    }
+
+           // Ensure they are touching in the source text
+    if (!LiteralToken->hasWhitespaceBefore()) {
+      OpToken->TokenText = StringRef(OpToken->TokenText.data(),
+                                     OpToken->TokenText.size() + LiteralToken->TokenText.size());
+      OpToken->ColumnWidth += LiteralToken->ColumnWidth;
+
+      OpToken->Tok.setKind(tok::identifier);
+
+      Tokens.erase(&Tokens.back());
+      return true;
+    }
+  }
+
+         // --- ORIGINAL NUMERIC LITERAL LOGIC KICKS IN HERE ---
   auto *First = Tokens.end() - 2;
   auto &Suffix = First[1];
   if (Suffix->hasWhitespaceBefore() || Suffix->TokenText != "$")

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5240,7 +5240,7 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
 
   if (IsCpp) {
     if (Left.is(TT_OverloadedOperator) &&
-        Right.isOneOf(TT_TemplateOpener, TT_TemplateCloser)) { 
+        Right.isOneOf(TT_TemplateOpener, TT_TemplateCloser)) {
       if (Left.is(tok::string_literal) && Left.Previous &&
           Left.Previous->is(tok::kw_operator)) {
         return false;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1,3 +1,4 @@
+
 //===--- TokenAnnotator.cpp - Format C++ code -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -163,8 +164,11 @@ private:
     const auto *BeforeLess = Left->Previous;
 
     if (BeforeLess) {
-      if (BeforeLess->Tok.isLiteral())
-        return false;
+      bool isUDLOperator = BeforeLess->is(tok::string_literal) && BeforeLess->Previous && BeforeLess->Previous->is(tok::kw_operator);
+      if (BeforeLess->Tok.isLiteral()) {
+          if (isUDLOperator) return true;
+          return false;
+      }
       if (BeforeLess->is(tok::r_brace))
         return false;
       if (BeforeLess->is(tok::r_paren) && Contexts.size() > 1 &&
@@ -5233,7 +5237,10 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
 
   if (IsCpp) {
     if (Left.is(TT_OverloadedOperator) &&
-        Right.isOneOf(TT_TemplateOpener, TT_TemplateCloser)) {
+        Right.isOneOf(TT_TemplateOpener, TT_TemplateCloser)) { 
+      if (Left.is(tok::string_literal) && Left.Previous && Left.Previous->is(tok::kw_operator)) {
+        return false;
+      }
       return true;
     }
     // Space between UDL and dot: auto b = 4s .count();

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -164,10 +164,13 @@ private:
     const auto *BeforeLess = Left->Previous;
 
     if (BeforeLess) {
-      bool isUDLOperator = BeforeLess->is(tok::string_literal) && BeforeLess->Previous && BeforeLess->Previous->is(tok::kw_operator);
+      bool isUDLOperator = BeforeLess->is(tok::string_literal) &&
+                           BeforeLess->Previous &&
+                           BeforeLess->Previous->is(tok::kw_operator);
       if (BeforeLess->Tok.isLiteral()) {
-          if (isUDLOperator) return true;
-          return false;
+        if (isUDLOperator)
+          return true;
+        return false;
       }
       if (BeforeLess->is(tok::r_brace))
         return false;
@@ -5238,7 +5241,8 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
   if (IsCpp) {
     if (Left.is(TT_OverloadedOperator) &&
         Right.isOneOf(TT_TemplateOpener, TT_TemplateCloser)) { 
-      if (Left.is(tok::string_literal) && Left.Previous && Left.Previous->is(tok::kw_operator)) {
+      if (Left.is(tok::string_literal) && Left.Previous &&
+          Left.Previous->is(tok::kw_operator)) {
         return false;
       }
       return true;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -16,7 +16,10 @@ namespace test {
 namespace {
 
 class FormatTest : public test::FormatTestBase {};
-
+TEST_F(FormatTest, FormatsUserDefinedLiteralTemplates) {
+    verifyFormat("template <char... Cs> auto f() { return operator\"\"_mag<Cs...>(); }");
+    verifyFormat("template <char... Cs> auto f() { return operator \"\"_mag<Cs...>(); }");
+}
 TEST_F(FormatTest, MessUp) {
   EXPECT_EQ("1 2 3", messUp("1 2 3"));
   EXPECT_EQ("1 2 3", messUp("1\n2\n3"));

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -16,10 +16,6 @@ namespace test {
 namespace {
 
 class FormatTest : public test::FormatTestBase {};
-TEST_F(FormatTest, FormatsUserDefinedLiteralTemplates) {
-    verifyFormat("template <char... Cs> auto f() { return operator\"\"_mag<Cs...>(); }");
-    verifyFormat("template <char... Cs> auto f() { return operator \"\"_mag<Cs...>(); }");
-}
 TEST_F(FormatTest, MessUp) {
   EXPECT_EQ("1 2 3", messUp("1 2 3"));
   EXPECT_EQ("1 2 3", messUp("1\n2\n3"));
@@ -26618,7 +26614,9 @@ TEST_F(FormatTest, UnbalancedAngleBrackets) {
 TEST_F(FormatTest, LambdaArrowAsTrailingReturnArrow) {
   verifyNoCrash("void foo()([] consteval -> int {}())");
 }
-
+TEST_F(FormatTest, FormatsUserDefinedLiteralTemplates) {
+    verifyFormat("template <char... Cs> auto f() { return operator\"\"_mag<Cs...>(); }");
+}
 } // namespace
 } // namespace test
 } // namespace format

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26615,7 +26615,8 @@ TEST_F(FormatTest, LambdaArrowAsTrailingReturnArrow) {
   verifyNoCrash("void foo()([] consteval -> int {}())");
 }
 TEST_F(FormatTest, FormatsUserDefinedLiteralTemplates) {
-    verifyFormat("template <char... Cs> auto f() { return operator\"\"_mag<Cs...>(); }");
+  verifyFormat(
+      "template <char... Cs> auto f() { return operator\"\"_mag<Cs...>(); }");
 }
 } // namespace
 } // namespace test


### PR DESCRIPTION
This patch resolves a clang-format regression where unspaced User-Defined Literals (UDLs) were being formatted incorrectly.
Root Cause
The lexer failed to correctly separate the operator keyword and the user defined literal ""_mag as described in the original bug.
Since FormatTokenLexer::tryMergeUserDefinedLiteral did not properly merge the operator token and its suffix (e.g., _mag), the < token was evaluated as a comparison operator, inserting spaces both before and after the < token. 
Changes
- Updated FormatTokenLexer::tryMergeUserDefinedLiteral to ensure proper token merging for UDLs
- Added unit tests in FormatTest.cpp to verify correct spacing behavior and prevent future regressions.

Fixes #210135 