### PR TITLE
[AA] Respect atomic ordering in getModRefInfo(Instruction, CallBase)

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -201,6 +201,21 @@ ModRefInfo AAResults::getModRefInfo(const Instruction *I,
   return getModRefInfo(I, Call2, AAQIP);
 }
 
+/// Return true if \p I is an atomic operation whose ordering is stronger
+/// than monotonic, i.e. one that has synchronization effects on memory
+/// beyond its own location.
+static bool hasOrderingStrongerThanMonotonic(const Instruction *I) {
+  if (auto *LI = dyn_cast<LoadInst>(I))
+    return isStrongerThanMonotonic(LI->getOrdering());
+  if (auto *SI = dyn_cast<StoreInst>(I))
+    return isStrongerThanMonotonic(SI->getOrdering());
+  if (auto *RMW = dyn_cast<AtomicRMWInst>(I))
+    return isStrongerThanMonotonic(RMW->getOrdering());
+  if (auto *CX = dyn_cast<AtomicCmpXchgInst>(I))
+    return isStrongerThanMonotonic(CX->getMergedOrdering());
+  return false;
+}
+
 ModRefInfo AAResults::getModRefInfo(const Instruction *I, const CallBase *Call2,
                                     AAQueryInfo &AAQI) {
   // We may have two calls.
@@ -210,6 +225,15 @@ ModRefInfo AAResults::getModRefInfo(const Instruction *I, const CallBase *Call2,
   }
   // If this is a fence, just return ModRef.
   if (I->isFenceLike())
+    return ModRefInfo::ModRef;
+  // An atomic operation stronger than monotonic also synchronizes with other
+  // threads: like the location-based overloads (see getSyncEffects),
+  // conservatively treat it as ordering any memory the call may access, even
+  // memory disjoint from the atomic's own location. Without this, a client
+  // could e.g. sink a read-only call below a release store that publishes
+  // unrelated memory, breaking the publication guarantee.
+  if (hasOrderingStrongerThanMonotonic(I) &&
+      !getMemoryEffects(Call2, AAQI).doesNotAccessMemory())
     return ModRefInfo::ModRef;
   // Otherwise, check if the call modifies or references the
   // location this memory access defines.  The best we can say

--- a/llvm/test/Transforms/Sink/call-past-release-store.ll
+++ b/llvm/test/Transforms/Sink/call-past-release-store.ll
@@ -1,0 +1,89 @@
+; RUN: opt < %s -passes=sink -S | FileCheck %s
+;
+; A read-only call must not be sunk below an atomic store or RMW with release
+; (or stronger) ordering: moving a program-order-earlier read below a release
+; operation breaks the publication guarantee. Given a second thread executing
+;
+;   if (atomic_load_explicit(&flag, memory_order_acquire) == 1)
+;     data = 42;
+;
+; the pre-transform functions below are race-free: the call's read of @data
+; happens-before the release operation on @flag, which synchronizes-with the
+; acquire load, which happens-before the second thread's store to @data.
+; Sinking the call below the release operation would leave the read unordered
+; with that store, introducing a data race.
+;
+; Sinking past a monotonic store remains legal: monotonic ordering imposes no
+; constraint on other locations.
+
+@flag = global i32 0
+@data = global i32 0
+
+declare i32 @read_data(ptr) nounwind willreturn memory(argmem: read)
+
+define i32 @no_sink_call_past_release_store(i1 %c) {
+; CHECK-LABEL: @no_sink_call_past_release_store(
+; CHECK:         [[V:%.*]] = call i32 @read_data(ptr @data)
+; CHECK-NEXT:    store atomic i32 1, ptr @flag release
+entry:
+  %v = call i32 @read_data(ptr @data)
+  store atomic i32 1, ptr @flag release, align 4
+  br i1 %c, label %use, label %skip
+
+use:
+  ret i32 %v
+
+skip:
+  ret i32 0
+}
+
+define i32 @no_sink_call_past_seq_cst_store(i1 %c) {
+; CHECK-LABEL: @no_sink_call_past_seq_cst_store(
+; CHECK:         [[V:%.*]] = call i32 @read_data(ptr @data)
+; CHECK-NEXT:    store atomic i32 1, ptr @flag seq_cst
+entry:
+  %v = call i32 @read_data(ptr @data)
+  store atomic i32 1, ptr @flag seq_cst, align 4
+  br i1 %c, label %use, label %skip
+
+use:
+  ret i32 %v
+
+skip:
+  ret i32 0
+}
+
+define i32 @no_sink_call_past_release_rmw(i1 %c) {
+; CHECK-LABEL: @no_sink_call_past_release_rmw(
+; CHECK:         [[V:%.*]] = call i32 @read_data(ptr @data)
+; CHECK-NEXT:    {{%.*}} = atomicrmw add ptr @flag, i32 1 release
+entry:
+  %v = call i32 @read_data(ptr @data)
+  %old = atomicrmw add ptr @flag, i32 1 release, align 4
+  br i1 %c, label %use, label %skip
+
+use:
+  ret i32 %v
+
+skip:
+  ret i32 0
+}
+
+; Monotonic imposes no cross-location ordering; the call may be sunk.
+define i32 @sink_call_past_monotonic_store(i1 %c) {
+; CHECK-LABEL: @sink_call_past_monotonic_store(
+; CHECK:       entry:
+; CHECK-NEXT:    store atomic i32 1, ptr @flag monotonic
+; CHECK:       use:
+; CHECK-NEXT:    [[V:%.*]] = call i32 @read_data(ptr @data)
+entry:
+  %v = call i32 @read_data(ptr @data)
+  store atomic i32 1, ptr @flag monotonic, align 4
+  br i1 %c, label %use, label %skip
+
+use:
+  ret i32 %v
+
+skip:
+  ret i32 0
+}


### PR DESCRIPTION
[Split out of #210568 by request; AI Disclosure: Largely written by AI (Fable 5)]

AAResults::getModRefInfo(const Instruction *, const CallBase *) only asked whether the call accesses the instruction's own memory location. For atomic operations stronger than monotonic that is not sufficient: their synchronization effects order memory beyond their own location, and the location-based getModRefInfo overloads already account for this (see getSyncEffects). The instruction-vs-call overload predates that design and was never updated.

As a consequence, the Sink pass would sink a read-only call below a release store (or seq_cst store, or release RMW) that publishes unrelated memory:

```llvm
  %v = call i32 @read_data(ptr @data )          ; readonly, argmem only
  store atomic i32 1, ptr @flag release
  br i1 %c, label %use, label %skip            ; %v sunk into %use
```

With a second thread executing
```c
if (atomic_load_explicit(&flag, memory_order_acquire) == 1) *data = 42;
```
the original program is race-free (the call's read happens-before the release store, which synchronizes-with the acquire, which happens-before the store to data), while the transformed program has a data race. The equivalent load-sinking case is already handled correctly because isSafeToMove queries the location-based store overload.

Fix the overload to conservatively return ModRef when the non-call instruction is an atomic operation stronger than monotonic and the call may access memory. Monotonic and unordered atomics impose no cross-location ordering and keep the precise data-only answer.

Note: LICM's read-only call hoisting reaches this query through MemorySSA's instructionClobbersQuery and previously hoisted such calls past release and seq_cst stores only because ordering was ignored here. That hoisting is legal in the release case (moving a later read earlier), and will be addressed by #210568. No in-tree test relied on the hoisting.