### PR TITLE
[clang][NFC] Refactor flag enum caching

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4780,9 +4780,6 @@ public:
                             const IdentifierInfo *FieldName, QualType FieldTy,
                             bool IsMsStruct, Expr *BitWidth);
 
-  /// CacheFlagEnum - Insert flag enum into cache and compute its flag bit mask.
-  void CacheFlagEnum(const EnumDecl *ED);
-
   /// IsValueInFlagEnum - Determine if a value is allowed as part of a flag
   /// enum. If AllowMask is true, then we also allow the complement of a valid
   /// value, to be used as a mask.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3580,7 +3580,7 @@ public:
 
   /// A cache of the flags available in enumerations with the flag_enum
   /// attribute.
-  mutable llvm::DenseMap<const EnumDecl *, llvm::APInt> FlagBitsCache;
+  llvm::DenseMap<const EnumDecl *, llvm::APInt> FlagBitsCache;
 
   /// A cache of enumerator values for enums checked by -Wassign-enum.
   llvm::DenseMap<const EnumDecl *, llvm::SmallVector<llvm::APSInt>>
@@ -4779,6 +4779,9 @@ public:
   ExprResult VerifyBitField(SourceLocation FieldLoc,
                             const IdentifierInfo *FieldName, QualType FieldTy,
                             bool IsMsStruct, Expr *BitWidth);
+
+  /// CacheFlagEnum - Insert flag enum into cache and compute its flag bit mask.
+  void CacheFlagEnum(const EnumDecl *ED);
 
   /// IsValueInFlagEnum - Determine if a value is allowed as part of a flag
   /// enum. If AllowMask is true, then we also allow the complement of a valid

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20959,22 +20959,6 @@ static void CheckForDuplicateEnumValues(Sema &S, ArrayRef<Decl *> Elements,
   }
 }
 
-void Sema::CacheFlagEnum(const EnumDecl *ED) {
-  assert(ED->hasAttr<FlagEnumAttr>() && "expected flag enum");
-
-  auto R = FlagBitsCache.try_emplace(ED);
-  llvm::APInt &FlagBits = R.first->second;
-
-  if (R.second) {
-    for (auto *E : ED->enumerators()) {
-      const auto &EVal = E->getInitVal();
-      // Only single-bit enumerators introduce new flag values.
-      if (EVal.isPowerOf2())
-        FlagBits = FlagBits.zext(EVal.getBitWidth()) | EVal;
-    }
-  }
-}
-
 bool Sema::IsValueInFlagEnum(const EnumDecl *ED, const llvm::APInt &Val,
                              bool AllowMask) const {
   assert(ED->isClosedFlag() && "looking for value in non-flag or open enum");
@@ -21191,8 +21175,19 @@ void Sema::ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
   CheckForDuplicateEnumValues(*this, Elements, Enum, EnumType);
   CheckForComparisonInEnumInitializer(*this, Enum);
 
-  if (Enum->hasAttr<FlagEnumAttr>())
-    CacheFlagEnum(Enum);
+  if (Enum->hasAttr<FlagEnumAttr>()) {
+    auto R = FlagBitsCache.try_emplace(Enum);
+    llvm::APInt &FlagBits = R.first->second;
+
+    if (R.second) {
+      for (auto *E : Enum->enumerators()) {
+        const auto &EVal = E->getInitVal();
+        // Only single-bit enumerators introduce new flag values.
+        if (EVal.isPowerOf2())
+          FlagBits = FlagBits.zext(EVal.getBitWidth()) | EVal;
+      }
+    }
+  }
 
   if (Enum->isClosedFlag()) {
     for (Decl *D : Elements) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20959,10 +20959,8 @@ static void CheckForDuplicateEnumValues(Sema &S, ArrayRef<Decl *> Elements,
   }
 }
 
-bool Sema::IsValueInFlagEnum(const EnumDecl *ED, const llvm::APInt &Val,
-                             bool AllowMask) const {
-  assert(ED->isClosedFlag() && "looking for value in non-flag or open enum");
-  assert(ED->isCompleteDefinition() && "expected enum definition");
+void Sema::CacheFlagEnum(const EnumDecl *ED) {
+  assert(ED->hasAttr<FlagEnumAttr>() && "expected flag enum");
 
   auto R = FlagBitsCache.try_emplace(ED);
   llvm::APInt &FlagBits = R.first->second;
@@ -20975,6 +20973,14 @@ bool Sema::IsValueInFlagEnum(const EnumDecl *ED, const llvm::APInt &Val,
         FlagBits = FlagBits.zext(EVal.getBitWidth()) | EVal;
     }
   }
+}
+
+bool Sema::IsValueInFlagEnum(const EnumDecl *ED, const llvm::APInt &Val,
+                             bool AllowMask) const {
+  assert(ED->isClosedFlag() && "looking for value in non-flag or open enum");
+  assert(ED->isCompleteDefinition() && "expected enum definition");
+
+  llvm::APInt FlagBits = FlagBitsCache.at(ED);
 
   // A value is in a flag enum if either its bits are a subset of the enum's
   // flag bits (the first condition) or we are allowing masks and the same is
@@ -21184,6 +21190,9 @@ void Sema::ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
 
   CheckForDuplicateEnumValues(*this, Elements, Enum, EnumType);
   CheckForComparisonInEnumInitializer(*this, Enum);
+
+  if (Enum->hasAttr<FlagEnumAttr>())
+    CacheFlagEnum(Enum);
 
   if (Enum->isClosedFlag()) {
     for (Decl *D : Elements) {


### PR DESCRIPTION
Extracts cache insertion logic from `IsValueInFlagEnum`. This allows us to drop `mutable` on `FlagBitsCache` while making it reusable as work list for additional flag_enum diagnostics. 