### PR TITLE
[NVPTX][Rubin] Add Rubin baseline support

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTX.td
+++ b/llvm/lib/Target/NVPTX/NVPTX.td
@@ -86,7 +86,7 @@ class Proc<FeatureSM SM>
 
 foreach sm = [20, 21, 30, 32, 35, 37, 50, 52, 53, 60,
               61, 62, 70, 72, 75, 80, 86, 87, 88, 89,
-              90, 100, 101, 103, 110, 120, 121] in {
+              90, 100, 101, 103, 107, 110, 120, 121] in {
   // Base SM version (e.g. FullSMVersion for sm_100 is 1000)
   def SM#sm : FeatureSM<""#sm, !mul(sm, 10)>;
   def : Proc<!cast<FeatureSM>("SM"#sm)>;
@@ -106,7 +106,7 @@ foreach sm = [20, 21, 30, 32, 35, 37, 50, 52, 53, 60,
 
 foreach version = [32, 40, 41, 42, 43, 50, 60, 61, 62, 63, 64, 65, 70, 71, 72,
                    73, 74, 75, 76, 77, 78, 80, 81, 82, 83, 84, 85, 86, 87, 88,
-                   90, 91, 92, 93] in
+                   90, 91, 92, 93, 94] in
   def PTX#version : FeaturePTX<version>;
 
 def Is64Bit : Predicate<"Subtarget->getTargetTriple().getArch() == Triple::nvptx64">;

--- a/llvm/lib/Target/NVPTX/NVPTXSubtarget.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXSubtarget.cpp
@@ -111,6 +111,10 @@ static unsigned getMinPTXVersionForSM(unsigned FullSmVersion) {
   case SMF(110):
   case SMA(110):
     return 90;
+  case SM(107):
+  case SMF(107):
+  case SMA(107):
+    return 94;
   default:
     llvm_unreachable("Unknown SM version");
   }

--- a/llvm/test/CodeGen/NVPTX/sm-version.ll
+++ b/llvm/test/CodeGen/NVPTX/sm-version.ll
@@ -26,6 +26,9 @@
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_103 | FileCheck %s --check-prefix=SM103
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_103a | FileCheck %s --check-prefix=SM103a
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_103f | FileCheck %s --check-prefix=SM103f
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_107 | FileCheck %s --check-prefix=SM107
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_107a | FileCheck %s --check-prefix=SM107a
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_107f | FileCheck %s --check-prefix=SM107f
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_110 | FileCheck %s --check-prefix=SM110
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_110a | FileCheck %s --check-prefix=SM110a
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_110f | FileCheck %s --check-prefix=SM110f
@@ -64,6 +67,9 @@
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_103 | FileCheck %s --check-prefix=SM103
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_103a | FileCheck %s --check-prefix=SM103a
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_103f | FileCheck %s --check-prefix=SM103f
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_107 | FileCheck %s --check-prefix=SM107
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_107a | FileCheck %s --check-prefix=SM107a
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_107f | FileCheck %s --check-prefix=SM107f
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_110 | FileCheck %s --check-prefix=SM110
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_110a | FileCheck %s --check-prefix=SM110a
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_110f | FileCheck %s --check-prefix=SM110f
@@ -102,6 +108,9 @@
 ; SM103: .version 8.8
 ; SM103a: .version 8.8
 ; SM103f: .version 8.8
+; SM107: .version 9.4
+; SM107a: .version 9.4
+; SM107f: .version 9.4
 ; SM110: .version 9.0
 ; SM110a: .version 9.0
 ; SM110f: .version 9.0
@@ -140,6 +149,9 @@
 ; SM103: .target sm_103
 ; SM103a: .target sm_103a
 ; SM103f: .target sm_103f
+; SM107: .target sm_107
+; SM107a: .target sm_107a
+; SM107f: .target sm_107f
 ; SM110: .target sm_110
 ; SM110a: .target sm_110a
 ; SM110f: .target sm_110f


### PR DESCRIPTION
This change adds Rubin (sm_107) baseline support in NVPTX backend.