### PR TITLE
RuntimeLibcalls: Rename RuntimeLibcallPredicate to RuntimeLibcallAvailability

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -16,63 +16,63 @@ class DuplicateLibcallImplWithPrefix<RuntimeLibcallImpl Impl, string prefix>
     : RuntimeLibcallImpl<Impl.Provides, prefix#Impl.LibCallFuncName>;
 
 /// Libcall Predicates
-def isOSDarwin : RuntimeLibcallPredicate<"TT.isOSDarwin()">;
-def isOSOpenBSD : RuntimeLibcallPredicate<"TT.isOSOpenBSD()">;
-def isNotOSOpenBSD : RuntimeLibcallPredicate<"!TT.isOSOpenBSD()">;
-def isOSWindows : RuntimeLibcallPredicate<"TT.isOSWindows()">;
-def isNotOSWindows : RuntimeLibcallPredicate<"!TT.isOSWindows()">;
-def isNotOSLinux : RuntimeLibcallPredicate<[{!TT.isOSLinux()}]>;
-def isNotOSMSVCRT : RuntimeLibcallPredicate<"!TT.isOSMSVCRT()">;
-def isPS : RuntimeLibcallPredicate<"TT.isPS()">;
-def isMacOSX : RuntimeLibcallPredicate<[{TT.isMacOSX()}]>;
+def isOSDarwin : RuntimeLibcallAvailability<"TT.isOSDarwin()">;
+def isOSOpenBSD : RuntimeLibcallAvailability<"TT.isOSOpenBSD()">;
+def isNotOSOpenBSD : RuntimeLibcallAvailability<"!TT.isOSOpenBSD()">;
+def isOSWindows : RuntimeLibcallAvailability<"TT.isOSWindows()">;
+def isNotOSWindows : RuntimeLibcallAvailability<"!TT.isOSWindows()">;
+def isNotOSLinux : RuntimeLibcallAvailability<[{!TT.isOSLinux()}]>;
+def isNotOSMSVCRT : RuntimeLibcallAvailability<"!TT.isOSMSVCRT()">;
+def isPS : RuntimeLibcallAvailability<"TT.isPS()">;
+def isMacOSX : RuntimeLibcallAvailability<[{TT.isMacOSX()}]>;
 def isNotOSWindowsOrIsCygwinMinGW
-  : RuntimeLibcallPredicate<"!TT.isOSWindows() || TT.isOSCygMing()">;
+  : RuntimeLibcallAvailability<"!TT.isOSWindows() || TT.isOSCygMing()">;
 
-def isWindowsMSVCEnvironment : RuntimeLibcallPredicate<
+def isWindowsMSVCEnvironment : RuntimeLibcallAvailability<
   [{TT.isWindowsMSVCEnvironment()}]>;
 
-def isNotOSLinuxAndNotOSOpenBSD : RuntimeLibcallPredicate<
+def isNotOSLinuxAndNotOSOpenBSD : RuntimeLibcallAvailability<
   [{!TT.isOSLinux() && !TT.isOSOpenBSD()}]>;
 
-def isNotOSAIXAndNotOSOpenBSD : RuntimeLibcallPredicate<
+def isNotOSAIXAndNotOSOpenBSD : RuntimeLibcallAvailability<
   [{!TT.isOSAIX() && !TT.isOSOpenBSD()}]>;
 
-def isNotPS : RuntimeLibcallPredicate<
+def isNotPS : RuntimeLibcallAvailability<
   [{!TT.isPS()}]>;
 
 // OpenBSD uses __guard_local. AIX uses __ssp_canary_word, MSVC/Windows
 // Itanium uses __security_cookie
-def hasStackChkFail : RuntimeLibcallPredicate<
+def hasStackChkFail : RuntimeLibcallAvailability<
   [{ !TT.isOSOpenBSD() && !TT.isWindowsMSVCEnvironment() &&
      !TT.isWindowsItaniumEnvironment()}]>;
 
-def isWindowsMSVCOrItaniumEnvironment : RuntimeLibcallPredicate<
+def isWindowsMSVCOrItaniumEnvironment : RuntimeLibcallAvailability<
   [{TT.isWindowsMSVCEnvironment() || TT.isWindowsItaniumEnvironment()}]>;
 
-def isAndroid : RuntimeLibcallPredicate<"TT.isAndroid()">;
+def isAndroid : RuntimeLibcallAvailability<"TT.isAndroid()">;
 
-def isGNUEnvironment : RuntimeLibcallPredicate<"TT.isGNUEnvironment()">;
-def darwinHasSinCosStret : RuntimeLibcallPredicate<"darwinHasSinCosStret(TT)">;
-def darwinHasExp10 : RuntimeLibcallPredicate<"darwinHasExp10(TT)">;
-def darwinHasMemsetPattern : RuntimeLibcallPredicate<[{darwinHasMemsetPattern(TT)}]>;
+def isGNUEnvironment : RuntimeLibcallAvailability<"TT.isGNUEnvironment()">;
+def darwinHasSinCosStret : RuntimeLibcallAvailability<"darwinHasSinCosStret(TT)">;
+def darwinHasExp10 : RuntimeLibcallAvailability<"darwinHasExp10(TT)">;
+def darwinHasMemsetPattern : RuntimeLibcallAvailability<[{darwinHasMemsetPattern(TT)}]>;
 
-def hasExp10 : RuntimeLibcallPredicate<[{!TT.isOSDarwin()}]>;
+def hasExp10 : RuntimeLibcallAvailability<[{!TT.isOSDarwin()}]>;
 
-def hasSinCos : RuntimeLibcallPredicate<"hasSinCos(TT)">;
+def hasSinCos : RuntimeLibcallAvailability<"hasSinCos(TT)">;
 
 // FIXME: Way to combine predicates
-def hasSinCos_f32_f64 : RuntimeLibcallPredicate<"hasSinCos_f32_f64(TT)">;
+def hasSinCos_f32_f64 : RuntimeLibcallAvailability<"hasSinCos_f32_f64(TT)">;
 
-def ExceptionModelIsNotNone : RuntimeLibcallPredicate<
+def ExceptionModelIsNotNone : RuntimeLibcallAvailability<
   [{ExceptionModel != ExceptionHandling::None}]
 >;
 
-def ExceptionModelHasUnwindResume : RuntimeLibcallPredicate<
+def ExceptionModelHasUnwindResume : RuntimeLibcallAvailability<
   [{ExceptionModel != ExceptionHandling::None &&
     ExceptionModel != ExceptionHandling::SjLj}]
 >;
 
-def ExceptionModelIsSjLj : RuntimeLibcallPredicate<
+def ExceptionModelIsSjLj : RuntimeLibcallAvailability<
   [{ExceptionModel == ExceptionHandling::SjLj}]
 >;
 
@@ -1998,9 +1998,9 @@ def SMEABI_LibCalls_PreserveMost_From_X2 : LibcallsWithCC<(add
   SMEABI_PreserveMost_From_X2>;
 
 def isAArch64_ExceptArm64EC
-    : RuntimeLibcallPredicate<"(TT.isAArch64() && !TT.isWindowsArm64EC())">;
-def isWindowsArm64EC : RuntimeLibcallPredicate<"TT.isWindowsArm64EC()">;
-def isAArch64_ILP64  : RuntimeLibcallPredicate<"TT.isAArch64(64)">;
+    : RuntimeLibcallAvailability<"(TT.isAArch64() && !TT.isWindowsArm64EC())">;
+def isWindowsArm64EC : RuntimeLibcallAvailability<"TT.isWindowsArm64EC()">;
+def isAArch64_ILP64  : RuntimeLibcallAvailability<"TT.isAArch64(64)">;
 
 
 def AArch64SystemLibrary : SystemRuntimeLibrary<
@@ -2075,7 +2075,7 @@ def WindowsARM64ECSystemLibrary
 // AMDGPU Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isAMDGPU : RuntimeLibcallPredicate<"TT.isAMDGPU()">;
+def isAMDGPU : RuntimeLibcallAvailability<"TT.isAMDGPU()">;
 
 def __llvm_profile_instrument_gpu : RuntimeLibcallImpl<PROFILE_INSTRUMENT_GPU>;
 def __llvm_profile_sampling_gpu : RuntimeLibcallImpl<PROFILE_SAMPLING_GPU>;
@@ -2088,7 +2088,7 @@ def AMDGPUSystemLibrary
 // ARM Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isTargetAEABIAndAAPCS_ABI : RuntimeLibcallPredicate<
+def isTargetAEABIAndAAPCS_ABI : RuntimeLibcallAvailability<
   [{TT.isTargetAEABI() && isAAPCS_ABI(TT, ABIName)}]>;
 
 // if (isTargetMachO()) {
@@ -2342,7 +2342,7 @@ def ARMHalfConvertLibcallCallingConv : LibcallCallingConv<
 
 def ARMLibgccHalfConvertCalls :
   LibcallImpls<(add __truncsfhf2, __extendhfsf2),
-    RuntimeLibcallPredicate<[{!TT.isTargetAEABI() && TT.isOSBinFormatMachO()}]>> {
+    RuntimeLibcallAvailability<[{!TT.isTargetAEABI() && TT.isOSBinFormatMachO()}]>> {
   let CallingConv = ARMHalfConvertLibcallCallingConv;
 }
 
@@ -2350,7 +2350,7 @@ def ARMLibgccHalfConvertCalls :
 // default libgcc call when the other cases are replaced.
 def ARMDoubleToHalfCalls :
   LibcallImpls<(add __truncdfhf2),
-    RuntimeLibcallPredicate<[{!TT.isTargetAEABI()}]>> {
+    RuntimeLibcallAvailability<[{!TT.isTargetAEABI()}]>> {
   let CallingConv = ARMHalfConvertLibcallCallingConv;
 }
 
@@ -2363,7 +2363,7 @@ def EABIHalfConvertCalls : LibcallImpls<(add __aeabi_f2h, __aeabi_h2f),
 
 def GNUEABIHalfConvertCalls :
   LibcallImpls<(add __gnu_f2h_ieee, __gnu_h2f_ieee),
-    RuntimeLibcallPredicate<[{!TT.isOSBinFormatMachO() &&
+    RuntimeLibcallAvailability<[{!TT.isOSBinFormatMachO() &&
                               !TT.isTargetAEABI()}]>> {
   let CallingConv = ARMHalfConvertLibcallCallingConv;
 }
@@ -2385,7 +2385,7 @@ def WindowARMFPIntCasts : LibcallImpls<
 def AEABIDivRemCalls : LibcallImpls<
   (add __aeabi_idivmod, __aeabi_ldivmod,
        __aeabi_uidivmod, __aeabi_uldivmod),
-  RuntimeLibcallPredicate<[{hasAEABILibcalls(TT)}]>> {
+  RuntimeLibcallAvailability<[{hasAEABILibcalls(TT)}]>> {
   let CallingConv = ARM_AAPCS;
 }
 
@@ -2466,7 +2466,7 @@ def AEABICalls : LibcallImpls<
       // RTABI chapter 4.3.1
       __aeabi_idiv,
       __aeabi_uidiv),
-  RuntimeLibcallPredicate<[{hasAEABILibcalls(TT) && isAAPCS_ABI(TT, ABIName)}]>> {
+  RuntimeLibcallAvailability<[{hasAEABILibcalls(TT) && isAAPCS_ABI(TT, ABIName)}]>> {
   let CallingConv = ARM_AAPCS;
 }
 
@@ -2477,7 +2477,7 @@ def AEABI45MemCalls : LibcallImpls<
        __aeabi_memmove, __aeabi_memmove4, __aeabi_memmove8,
        __aeabi_memset, __aeabi_memset4, __aeabi_memset8,
        __aeabi_memclr, __aeabi_memclr4, __aeabi_memclr8),
-  RuntimeLibcallPredicate<[{(EABIVersion == EABI::EABI4 ||
+  RuntimeLibcallAvailability<[{(EABIVersion == EABI::EABI4 ||
                              EABIVersion == EABI::EABI5) &&
                              hasAEABILibcalls(TT) && isAAPCS_ABI(TT, ABIName)}]>> {
   let CallingConv = ARM_AAPCS;
@@ -2488,11 +2488,11 @@ def AEABI45MemCalls : LibcallImpls<
 def AEABIUnalignedMemCalls : LibcallImpls<
   (add __aeabi_uread4,  __aeabi_uread8,
        __aeabi_uwrite4, __aeabi_uwrite8),
-  RuntimeLibcallPredicate<[{hasAEABILibcalls(TT) && isAAPCS_ABI(TT, ABIName)}]>> {
+  RuntimeLibcallAvailability<[{hasAEABILibcalls(TT) && isAAPCS_ABI(TT, ABIName)}]>> {
   let CallingConv = ARM_AAPCS;
 }
 
-def isARMOrThumb : RuntimeLibcallPredicate<"TT.isARM() || TT.isThumb()">;
+def isARMOrThumb : RuntimeLibcallAvailability<"TT.isARM() || TT.isThumb()">;
 
 def ARMSystemLibrary
     : SystemRuntimeLibrary<isARMOrThumb,
@@ -2522,13 +2522,13 @@ def ARMSystemLibrary
            ARMDoubleToHalfCalls,
 
            LibcallImpls<(add AEABIOverrides),
-             RuntimeLibcallPredicate<[{
+             RuntimeLibcallAvailability<[{
                (!hasAEABILibcalls(TT) || !isAAPCS_ABI(TT, ABIName)) &&
                !TT.isOSWindows()
             }]>>,
            // Use divmod compiler-rt calls for iOS 5.0 and later.
            LibcallImpls<(add __divmodsi4, __udivmodsi4),
-                        RuntimeLibcallPredicate<[{TT.isOSBinFormatMachO() &&
+                        RuntimeLibcallAvailability<[{TT.isOSBinFormatMachO() &&
                                                   (!TT.isiOS() || !TT.isOSVersionLT(5, 0))}]>>,
            DefaultStackProtector,
            DefaultSafeStackGlobals)> {
@@ -2557,7 +2557,7 @@ def __udivmodhi4 : RuntimeLibcallImpl<UDIVREM_I16>;
 def avr_sin : RuntimeLibcallImpl<SIN_F32, "sin">;
 def avr_cos : RuntimeLibcallImpl<COS_F32, "cos">;
 
-def isAVR : RuntimeLibcallPredicate<"TT.getArch() == Triple::avr">;
+def isAVR : RuntimeLibcallAvailability<"TT.getArch() == Triple::avr">;
 
 def AVRSystemLibrary
     : SystemRuntimeLibrary<
@@ -2588,7 +2588,7 @@ def AVRSystemLibrary
 // DXIL Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isDXIL : RuntimeLibcallPredicate<"TT.isDXIL()">;
+def isDXIL : RuntimeLibcallAvailability<"TT.isDXIL()">;
 
 // No calls
 def DXILSystemLibrary : SystemRuntimeLibrary<isDXIL, (add)>;
@@ -2634,7 +2634,7 @@ def __hexagon_memcpy_likely_aligned_min32bytes_mult8bytes
 def hexagon_memcpy_forward_vp4cp4n2 : RuntimeLibcallImpl<HEXAGON_VOLATILE_MEMCPY>;
 }
 
-def isHexagon : RuntimeLibcallPredicate<"TT.getArch() == Triple::hexagon">;
+def isHexagon : RuntimeLibcallAvailability<"TT.getArch() == Triple::hexagon">;
 
 def HexagonSystemLibrary
     : SystemRuntimeLibrary<isHexagon,
@@ -2650,7 +2650,7 @@ def HexagonSystemLibrary
 // Lanai Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isLanai : RuntimeLibcallPredicate<"TT.getArch() == Triple::lanai">;
+def isLanai : RuntimeLibcallAvailability<"TT.getArch() == Triple::lanai">;
 
 // Use fast calling convention for library functions.
 def LanaiSystemLibrary
@@ -2840,7 +2840,7 @@ def __mspabi_mpyll : RuntimeLibcallImpl<MUL_I64>;
 
 // setLibcallCallingConv(MUL_I64, CallingConv::MSP430_BUILTIN);
 
-def isMSP430 : RuntimeLibcallPredicate<"TT.getArch() == Triple::msp430">;
+def isMSP430 : RuntimeLibcallAvailability<"TT.getArch() == Triple::msp430">;
 
 defvar MSP430DefaultOptOut = [
   __addsf3, __divsf3, __extendsfdf2, __truncdfsf2, __fixsfsi,
@@ -2964,7 +2964,7 @@ def MSP430SystemLibrary
 // NVPTX Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isNVPTX : RuntimeLibcallPredicate<"TT.isNVPTX()">;
+def isNVPTX : RuntimeLibcallAvailability<"TT.isNVPTX()">;
 
 // No calls.
 def NVPTXSystemLibrary : SystemRuntimeLibrary<isNVPTX, (add)>;
@@ -3032,13 +3032,13 @@ defset list<RuntimeLibcallImpl> PPC32AIXCallList = {
 
 defvar PPCOverrides = !foreach(entry, PPCRuntimeLibcalls, entry.Provides);
 
-def isPPC : RuntimeLibcallPredicate<"TT.isPPC()">;
-def isPPC32 : RuntimeLibcallPredicate<"TT.isPPC32()">;
-def isPPC64 : RuntimeLibcallPredicate<"TT.isPPC64()">;
-def isAIX : RuntimeLibcallPredicate<"TT.isOSAIX()">;
-def isNotAIX : RuntimeLibcallPredicate<"!TT.isOSAIX()">;
-def isPPC32_AIX : RuntimeLibcallPredicate<"(TT.isPPC32() && TT.isOSAIX())">;
-def isPPC64_AIX : RuntimeLibcallPredicate<"(TT.isPPC64() && TT.isOSAIX())">;
+def isPPC : RuntimeLibcallAvailability<"TT.isPPC()">;
+def isPPC32 : RuntimeLibcallAvailability<"TT.isPPC32()">;
+def isPPC64 : RuntimeLibcallAvailability<"TT.isPPC64()">;
+def isAIX : RuntimeLibcallAvailability<"TT.isOSAIX()">;
+def isNotAIX : RuntimeLibcallAvailability<"!TT.isOSAIX()">;
+def isPPC32_AIX : RuntimeLibcallAvailability<"(TT.isPPC32() && TT.isOSAIX())">;
+def isPPC64_AIX : RuntimeLibcallAvailability<"(TT.isPPC64() && TT.isOSAIX())">;
 
 def AIX32Calls : LibcallImpls<(add PPC32AIXCallList), isPPC32_AIX>;
 def AIX64Calls : LibcallImpls<(add PPC64AIXCallList), isPPC64_AIX>;
@@ -3074,8 +3074,8 @@ def PPCSystemLibrary
 // RISCV Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isRISCV : RuntimeLibcallPredicate<"TT.isRISCV()">;
-def isRISCV64 : RuntimeLibcallPredicate<"TT.isRISCV64()">;
+def isRISCV : RuntimeLibcallAvailability<"TT.isRISCV()">;
+def isRISCV64 : RuntimeLibcallAvailability<"TT.isRISCV64()">;
 
 def RISCVSystemLibrary
     : SystemRuntimeLibrary<isRISCV,
@@ -3137,9 +3137,9 @@ def _Q_qtoull : RuntimeLibcallImpl<FPTOUINT_F128_I64>;
 def _Q_lltoq : RuntimeLibcallImpl<SINTTOFP_I64_F128>;
 def _Q_ulltoq : RuntimeLibcallImpl<UINTTOFP_I64_F128>;
 
-def isSPARC : RuntimeLibcallPredicate<"TT.isSPARC()">;
-def isSPARC32 : RuntimeLibcallPredicate<"TT.isSPARC32()">;
-def isSPARC64 : RuntimeLibcallPredicate<"TT.isSPARC64()">;
+def isSPARC : RuntimeLibcallAvailability<"TT.isSPARC()">;
+def isSPARC32 : RuntimeLibcallAvailability<"TT.isSPARC32()">;
+def isSPARC64 : RuntimeLibcallAvailability<"TT.isSPARC64()">;
 
 defvar SPARC64_MulDivCalls = [
   __mulsi3, __divsi3, __modsi3, __udivsi3, __umodsi3
@@ -3163,7 +3163,7 @@ def SPARCSystemLibrary
 // SPIRV Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isSPIRV : RuntimeLibcallPredicate<"TT.isSPIRV()">;
+def isSPIRV : RuntimeLibcallAvailability<"TT.isSPIRV()">;
 
 // No calls FIXME: Add memcpy/memset is a hack to skip
 // PreISelIntrinsicLowering in favor of SPIRVPrepareFunctions;
@@ -3191,29 +3191,29 @@ defvar WindowsDivRemMulLibcallOverrides = [
 // X86 Runtime Libcalls
 //===----------------------------------------------------------------------===//
 
-def isX86_32 : RuntimeLibcallPredicate<"TT.getArch() == Triple::x86">;
-def isX86_64 : RuntimeLibcallPredicate<"TT.getArch() == Triple::x86_64">;
-def isX86 : RuntimeLibcallPredicate<"TT.isX86()">;
+def isX86_32 : RuntimeLibcallAvailability<"TT.getArch() == Triple::x86">;
+def isX86_64 : RuntimeLibcallAvailability<"TT.getArch() == Triple::x86_64">;
+def isX86 : RuntimeLibcallAvailability<"TT.isX86()">;
 
-def isCygwinMinGW64 : RuntimeLibcallPredicate<
+def isCygwinMinGW64 : RuntimeLibcallAvailability<
   [{TT.isOSCygMing() && TT.getArch() == Triple::x86_64}]>;
-def isCygwinMinGW32 : RuntimeLibcallPredicate<
+def isCygwinMinGW32 : RuntimeLibcallAvailability<
   [{TT.isOSCygMing() && TT.getArch() == Triple::x86}]>;
 
-def isWin32NotCygMing : RuntimeLibcallPredicate<
+def isWin32NotCygMing : RuntimeLibcallAvailability<
   [{TT.getArch() == Triple::x86 &&
      TT.isOSWindowsOrUEFI() && !TT.isOSCygMing()}]>;
-def isWin64NotCygMing : RuntimeLibcallPredicate<
+def isWin64NotCygMing : RuntimeLibcallAvailability<
   [{TT.getArch() == Triple::x86_64 &&
     TT.isOSWindowsOrUEFI() && !TT.isOSCygMing()}]>;
 
 
 // Some darwins have an optimized __bzero/bzero function.
-def darwinHas__bzero : RuntimeLibcallPredicate<"TT.isMacOSX() && !TT.isMacOSXVersionLT(10, 6)">;
+def darwinHas__bzero : RuntimeLibcallAvailability<"TT.isMacOSX() && !TT.isMacOSXVersionLT(10, 6)">;
 
 // FIXME: This is has ldexpl/frexpl plus use f128 for long double.
 def hasExpFrexplLdexplF128
-  : RuntimeLibcallPredicate<[{(!TT.isOSWindows() || TT.isOSCygMing()) && !TT.isGNUEnvironment()}]>;
+  : RuntimeLibcallAvailability<[{(!TT.isOSWindows() || TT.isOSCygMing()) && !TT.isGNUEnvironment()}]>;
 
 // Use the f128 variants of math functions on x86
 defvar X86_F128_Libcalls = LibcallImpls<(add LibmF128Libcalls, LibmF128FiniteLibcalls), isGNUEnvironment>;
@@ -3251,11 +3251,11 @@ defvar X86CommonLibcalls =
 
 defvar Windows32DivRemMulCalls =
   LibcallsWithCC<(add WindowsDivRemMulLibcalls), X86_STDCALL,
-  RuntimeLibcallPredicate<"TT.isWindowsMSVCEnvironment() || TT.isWindowsItaniumEnvironment()">>;
+  RuntimeLibcallAvailability<"TT.isWindowsMSVCEnvironment() || TT.isWindowsItaniumEnvironment()">>;
 
 defvar NotWindows32DivRemMulCalls =
   LibcallImpls<(add WindowsDivRemMulLibcallOverrides),
-    RuntimeLibcallPredicate<"!TT.isWindowsMSVCEnvironment() && !TT.isWindowsItaniumEnvironment()">>;
+    RuntimeLibcallAvailability<"!TT.isWindowsMSVCEnvironment() && !TT.isWindowsItaniumEnvironment()">>;
 
 def X86_32SystemLibrary
     : SystemRuntimeLibrary<isX86_32,
@@ -3273,7 +3273,7 @@ def X86_64SystemLibrary
 
 def __memcpy_4 : RuntimeLibcallImpl<MEMCPY_ALIGN_4>;
 
-def isXCore : RuntimeLibcallPredicate<"TT.getArch() == Triple::xcore">;
+def isXCore : RuntimeLibcallAvailability<"TT.getArch() == Triple::xcore">;
 def XCoreSystemLibrary
     : SystemRuntimeLibrary<isXCore,
     (add DefaultRuntimeLibcallImpls,
@@ -3371,8 +3371,8 @@ defset list<RuntimeLibcallImpl> ZOSRuntimeLibcalls = {
   def zos___LCBT_B : RuntimeLibcallImpl<CBRT_F128, "@@LCBT@B">;
 }
 
-def isSystemZZOS : RuntimeLibcallPredicate<"(TT.isSystemZ() && TT.isOSzOS())">;
-def isZOS : RuntimeLibcallPredicate<"TT.isOSzOS()">;
+def isSystemZZOS : RuntimeLibcallAvailability<"(TT.isSystemZ() && TT.isOSzOS())">;
+def isZOS : RuntimeLibcallAvailability<"TT.isOSzOS()">;
 def SystemZZOSSystemLibrary
     : SystemRuntimeLibrary<
           isSystemZZOS, (add DefaultLibcallImpls64,
@@ -3388,8 +3388,8 @@ def SystemZZOSSystemLibrary
 // this on emscripten depending on what they end up doing.
 def emscripten_return_address : RuntimeLibcallImpl<RETURN_ADDRESS>;
 
-def isWasm : RuntimeLibcallPredicate<"TT.isWasm()">;
-def isOSEmscripten : RuntimeLibcallPredicate<[{TT.isOSEmscripten()}]>;
+def isWasm : RuntimeLibcallAvailability<"TT.isWasm()">;
+def isOSEmscripten : RuntimeLibcallAvailability<[{TT.isOSEmscripten()}]>;
 
 // Define the emscripten name for return address helper.
 // TODO: when implementing other Wasm backends, make this generic or only do
@@ -3411,7 +3411,7 @@ def WasmSystemLibrary
 //===----------------------------------------------------------------------===//
 
 // TODO: Should make every target explicit.
-def isDefaultLibcallArch : RuntimeLibcallPredicate<[{
+def isDefaultLibcallArch : RuntimeLibcallAvailability<[{
   TT.isMIPS() || TT.isLoongArch() || TT.isVE() || TT.isBPF() ||
   TT.getArch() == Triple::csky || TT.getArch() == Triple::arc ||
   TT.getArch() == Triple::m68k ||  TT.getArch() == Triple::xtensa ||
@@ -3419,7 +3419,7 @@ def isDefaultLibcallArch : RuntimeLibcallPredicate<[{
 }]>;
 
 
-def isArch64Bit : RuntimeLibcallPredicate<[{TT.isArch64Bit()}]>;
+def isArch64Bit : RuntimeLibcallAvailability<[{TT.isArch64Bit()}]>;
 def LegacyDefaultSystemLibrary
     : SystemRuntimeLibrary<isDefaultLibcallArch,
       (add DefaultRuntimeLibcallImpls,

--- a/llvm/include/llvm/IR/RuntimeLibcallsImpl.td
+++ b/llvm/include/llvm/IR/RuntimeLibcallsImpl.td
@@ -11,7 +11,7 @@ include "llvm/TableGen/SetTheory.td"
 // Predicate for whether a libcall exists for the target ABI. This is
 // a module level property that should only be computed based on the
 // triple.
-class RuntimeLibcallPredicate<code cond> {
+class RuntimeLibcallAvailability<code cond> {
   // Expression of an llvm::Triple named TT for whether a libcall
   // should exist.
   code Cond = cond;
@@ -21,7 +21,7 @@ class RuntimeLibcallPredicate<code cond> {
 // function/subtarget.
 class LibcallLoweringPredicate<code cond> { code Cond = cond; }
 
-def AlwaysAvailable : RuntimeLibcallPredicate<[{}]>;
+def AlwaysAvailable : RuntimeLibcallAvailability<[{}]>;
 
 class LibcallCallingConv<code CC = [{}]> {
   // Enum value for the calling convention. Empty string defaults to
@@ -65,9 +65,9 @@ class RuntimeLibcallImpl<RuntimeLibcall P, string Name = NAME> {
 }
 
 class LibcallImpls<dag funcList,
-                   RuntimeLibcallPredicate Pred = AlwaysAvailable> {
+                   RuntimeLibcallAvailability Pred = AlwaysAvailable> {
   // Function of the triple where this applies
-  RuntimeLibcallPredicate AvailabilityPredicate = Pred;
+  RuntimeLibcallAvailability AvailabilityPredicate = Pred;
   dag MemberList = funcList;
 
   // If set, applies calling convention to every entry instead of
@@ -77,19 +77,19 @@ class LibcallImpls<dag funcList,
 
 /// Convenience wrapper around LibcallImplSet to make a single libcall
 /// implementation conditionally conditionally available.
-class AvailableIf<RuntimeLibcallImpl Impl, RuntimeLibcallPredicate Pred>
+class AvailableIf<RuntimeLibcallImpl Impl, RuntimeLibcallAvailability Pred>
     : LibcallImpls<(add Impl), Pred>;
 
 class LibcallsWithCC<dag funcList, LibcallCallingConv CC,
-                     RuntimeLibcallPredicate Pred = AlwaysAvailable>
+                     RuntimeLibcallAvailability Pred = AlwaysAvailable>
     : LibcallImpls<funcList, Pred> {
   LibcallCallingConv CallingConv = CC;
 }
 
 /// Define a complete top level set of runtime libcalls for a target.
-class SystemRuntimeLibrary<RuntimeLibcallPredicate Pred, dag funcList> {
+class SystemRuntimeLibrary<RuntimeLibcallAvailability Pred, dag funcList> {
   /// Set the default calling convention assumed for RuntimeLibcallImpl members.
   LibcallCallingConv DefaultLibcallCallingConv = DefaultCC;
-  RuntimeLibcallPredicate TriplePred = Pred;
+  RuntimeLibcallAvailability TriplePred = Pred;
   LibcallImpls MemberList = LibcallImpls<funcList>;
 }

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-bad-system-library-entry-error.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-bad-system-library-entry-error.td
@@ -5,7 +5,7 @@ include "llvm/IR/RuntimeLibcallsImpl.td"
 def SOME_FUNC : RuntimeLibcall;
 def func_a : RuntimeLibcallImpl<SOME_FUNC>;
 
-def isTargetArchA : RuntimeLibcallPredicate<[{isTargetArchA()}]>;
+def isTargetArchA : RuntimeLibcallAvailability<[{isTargetArchA()}]>;
 
 // CHECK: [[@LINE+4]]:5: error: entry for SystemLibrary is not a RuntimeLibcallImpl
 // CHECK-NEXT: def TheSystemLibraryA : SystemRuntimeLibrary<isTargetArchA,

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-calling-conv.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-calling-conv.td
@@ -16,9 +16,9 @@ def __target_override_cc : RuntimeLibcallImpl<TARGET_OVERRIDE_CC>;
 
 def malloc : RuntimeLibcallImpl<MALLOC>;
 
-def isAVR : RuntimeLibcallPredicate<[{TT.getArch() == Triple::avr}]>;
+def isAVR : RuntimeLibcallAvailability<[{TT.getArch() == Triple::avr}]>;
 
-def isAVRHurd : RuntimeLibcallPredicate<
+def isAVRHurd : RuntimeLibcallAvailability<
   [{TT.getArch() == Triple::avr && TT.isOSHurd()}]>;
 
 def AVRLibrary : SystemRuntimeLibrary<isAVR,
@@ -32,12 +32,12 @@ def AVRHurdLibrary : SystemRuntimeLibrary<isAVRHurd,
     = LibcallCallingConv<[{isFoo() ? CallingConv::Fast : CallingConv::GHC}]>;
 }
 
-def isMSP430 : RuntimeLibcallPredicate<[{TT.getArch() == Triple::msp430}]>;
+def isMSP430 : RuntimeLibcallAvailability<[{TT.getArch() == Triple::msp430}]>;
 
 def MSP430LibraryWithCondCC : SystemRuntimeLibrary<isMSP430,
   (add malloc,
-       LibcallsWithCC<(add __divmodqi4), AVR_BUILTIN, RuntimeLibcallPredicate<[{ isFoo() }]>>,
-       LibcallsWithCC<(add __udivmodhi4), MSP430_BUILTIN, RuntimeLibcallPredicate<[{ isBar() }]>>)
+       LibcallsWithCC<(add __divmodqi4), AVR_BUILTIN, RuntimeLibcallAvailability<[{ isFoo() }]>>,
+       LibcallsWithCC<(add __udivmodhi4), MSP430_BUILTIN, RuntimeLibcallAvailability<[{ isBar() }]>>)
 >;
 
 

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-conflict-warning.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-conflict-warning.td
@@ -10,9 +10,9 @@ def SOME_FUNC : RuntimeLibcall;
 def OTHER_FUNC : RuntimeLibcall;
 def ANOTHER_DUP : RuntimeLibcall;
 
-def isTargetArchA : RuntimeLibcallPredicate<[{isTargetArchA()}]>;
-def isTargetArchB : RuntimeLibcallPredicate<[{isTargetArchB()}]>;
-def isTargetArchC : RuntimeLibcallPredicate<[{isTargetArchC()}]>;
+def isTargetArchA : RuntimeLibcallAvailability<[{isTargetArchA()}]>;
+def isTargetArchB : RuntimeLibcallAvailability<[{isTargetArchB()}]>;
+def isTargetArchC : RuntimeLibcallAvailability<[{isTargetArchC()}]>;
 
 def func_a : RuntimeLibcallImpl<SOME_FUNC>;
 def func_b : RuntimeLibcallImpl<SOME_FUNC>;

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-nested-predicates-error.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-nested-predicates-error.td
@@ -5,9 +5,9 @@ include "llvm/IR/RuntimeLibcallsImpl.td"
 def FUNC0 : RuntimeLibcall;
 def FUNC1 : RuntimeLibcall;
 
-def isFoo : RuntimeLibcallPredicate<[{isFoo()}]>;
-def isBar : RuntimeLibcallPredicate<[{isBar()}]>;
-def isTargetArch : RuntimeLibcallPredicate<[{isTargetArch()}]>;
+def isFoo : RuntimeLibcallAvailability<[{isFoo()}]>;
+def isBar : RuntimeLibcallAvailability<[{isBar()}]>;
+def isTargetArch : RuntimeLibcallAvailability<[{isTargetArch()}]>;
 
 def func0 : RuntimeLibcallImpl<FUNC0>;
 def func1 : RuntimeLibcallImpl<FUNC1>;

--- a/llvm/test/TableGen/RuntimeLibcallEmitter-predicate-cc-sort.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter-predicate-cc-sort.td
@@ -12,7 +12,7 @@ def FUNC_DEFAULT : RuntimeLibcall;
 def impl_aapcs : RuntimeLibcallImpl<FUNC_AAPCS>;
 def impl_default : RuntimeLibcallImpl<FUNC_DEFAULT>;
 
-def isWin : RuntimeLibcallPredicate<[{TT.isOSWindows()}]>;
+def isWin : RuntimeLibcallAvailability<[{TT.isOSWindows()}]>;
 
 def WinLibrary : SystemRuntimeLibrary<isWin,
   (add LibcallsWithCC<(add impl_aapcs), ARM_AAPCS, isWin>,

--- a/llvm/test/TableGen/RuntimeLibcallEmitter.td
+++ b/llvm/test/TableGen/RuntimeLibcallEmitter.td
@@ -33,21 +33,21 @@ def calloc  : RuntimeLibcallImpl<CALLOC, "calloc">;
 def CompilerRTLibcalls : LibcallImpls<(add __ashlsi3, __lshrdi3)>;
 def LibmLibcalls : LibcallImpls<(add sqrtl_f80)>;
 
-def isSimpleArch : RuntimeLibcallPredicate<[{TT.getArch() == Triple::simple}]>;
-def isFooArch : RuntimeLibcallPredicate<[{TT.getArch() == Triple::foo}]>;
+def isSimpleArch : RuntimeLibcallAvailability<[{TT.getArch() == Triple::simple}]>;
+def isFooArch : RuntimeLibcallAvailability<[{TT.getArch() == Triple::foo}]>;
 
 
-def isZOS : RuntimeLibcallPredicate<[{TT.getOS() == Triple::zos}]>;
-def isPPC : RuntimeLibcallPredicate<[{TT.getArch().isPPC()}]>;
-def isPPC64 : RuntimeLibcallPredicate<[{TT.getArch().isPPC64()}]>;
+def isZOS : RuntimeLibcallAvailability<[{TT.getOS() == Triple::zos}]>;
+def isPPC : RuntimeLibcallAvailability<[{TT.getArch().isPPC()}]>;
+def isPPC64 : RuntimeLibcallAvailability<[{TT.getArch().isPPC64()}]>;
 
 
-def isFoo : RuntimeLibcallPredicate<[{isFOO()}]>;
-def isBarOS : RuntimeLibcallPredicate<[{TT.getOS() == Triple::bar}]>;
-def isBuzzArch : RuntimeLibcallPredicate<[{TT.getArch() == Triple::buzz}]>;
-def isBlahArch : RuntimeLibcallPredicate<[{TT.getArch() == Triple::blah}]>;
+def isFoo : RuntimeLibcallAvailability<[{isFOO()}]>;
+def isBarOS : RuntimeLibcallAvailability<[{TT.getOS() == Triple::bar}]>;
+def isBuzzArch : RuntimeLibcallAvailability<[{TT.getArch() == Triple::buzz}]>;
+def isBlahArch : RuntimeLibcallAvailability<[{TT.getArch() == Triple::blah}]>;
 
-def hasCompilerRT : RuntimeLibcallPredicate<[{TT.hasCompilerRT()}]>;
+def hasCompilerRT : RuntimeLibcallAvailability<[{TT.hasCompilerRT()}]>;
 
 
 def SimpleLibrary : SystemRuntimeLibrary<isSimpleArch,

--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -27,28 +27,30 @@
 using namespace llvm;
 
 namespace {
-// Pair of a RuntimeLibcallPredicate and LibcallCallingConv to use as a map key.
+// Pair of a RuntimeLibcallAvailability and LibcallCallingConv to use as a map
+// key.
 struct PredicateWithCC {
-  const Record *Predicate = nullptr;
+  const Record *Availability = nullptr;
   const Record *CallingConv = nullptr;
 
   PredicateWithCC() = default;
   PredicateWithCC(std::pair<const Record *, const Record *> P)
-      : Predicate(P.first), CallingConv(P.second) {}
+      : Availability(P.first), CallingConv(P.second) {}
 
   PredicateWithCC(const Record *P, const Record *C)
-      : Predicate(P), CallingConv(C) {}
+      : Availability(P), CallingConv(C) {}
 };
 
 inline bool operator==(PredicateWithCC LHS, PredicateWithCC RHS) {
-  return LHS.Predicate == RHS.Predicate && LHS.CallingConv == RHS.CallingConv;
+  return LHS.Availability == RHS.Availability &&
+         LHS.CallingConv == RHS.CallingConv;
 }
 } // namespace
 
 namespace llvm {
 template <> struct DenseMapInfo<PredicateWithCC, void> {
   static unsigned getHashValue(const PredicateWithCC Val) {
-    auto Pair = std::make_pair(Val.Predicate, Val.CallingConv);
+    auto Pair = std::make_pair(Val.Availability, Val.CallingConv);
     return DenseMapInfo<
         std::pair<const Record *, const Record *>>::getHashValue(Pair);
   }
@@ -444,8 +446,8 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
         PredicateSorter.takeVector();
 
     llvm::sort(SortedPredicates, [](PredicateWithCC A, PredicateWithCC B) {
-      StringRef AName = A.Predicate ? A.Predicate->getName() : "";
-      StringRef BName = B.Predicate ? B.Predicate->getName() : "";
+      StringRef AName = A.Availability ? A.Availability->getName() : "";
+      StringRef BName = B.Availability ? B.Availability->getName() : "";
       if (AName != BName)
         return AName < BName;
       // Break ties on the calling convention so predicates that share a name
@@ -456,7 +458,7 @@ void RuntimeLibcallEmitter::emitSystemRuntimeLibrarySetCalls(
     });
 
     for (PredicateWithCC Entry : SortedPredicates) {
-      AvailabilityPredicate SubsetPredicate(Entry.Predicate);
+      AvailabilityPredicate SubsetPredicate(Entry.Availability);
       unsigned IndentDepth = 2;
 
       auto It = Pred2Funcs.find(Entry);


### PR DESCRIPTION
Rename to avoid confusing partial name collisions in future changes.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>