### PR TITLE
[libc] Fix atexit_test in hermetic mode

### DIFF
--- a/libc/src/__support/threads/thread.cpp
+++ b/libc/src/__support/threads/thread.cpp
@@ -131,6 +131,7 @@ public:
       atexit_unit.callback(atexit_unit.obj);
       mtx.lock();
     }
+    mtx.unlock();
   }
 };
 

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -531,8 +531,6 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     atexit_test
-    # TODO: Fix this test in hermetic mode.
-    UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS


### PR DESCRIPTION
We never unlocked the ThreadAtExit mutex, which meant the second call to exit deadlocked. This was detected in the unit tests as they were calling __cxa_thread_atexit from the system C library.