### PR TITLE
[Driver][test] Unwrap freebsd-mips-as.c RUN lines

### DIFF
--- a/clang/test/Driver/freebsd-mips-as.c
+++ b/clang/test/Driver/freebsd-mips-as.c
@@ -1,92 +1,75 @@
 // Check passing options to the assembler for MIPS targets.
 //
-// RUN: %clang --target=mips-unknown-freebsd -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EB-AS %s
+// RUN: %clang -### --target=mips-unknown-freebsd -fno-integrated-as -fno-pic -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EB-AS %s
 // MIPS32-EB-AS: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EB"
 // MIPS32-EB-AS-NOT: "-KPIC"
 //
-// RUN: %clang --target=mips-unknown-freebsd -### \
-// RUN:   -no-integrated-as -fPIC -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EB-PIC %s
+// RUN: %clang -### --target=mips-unknown-freebsd -fno-integrated-as -fPIC -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EB-PIC %s
 // MIPS32-EB-PIC: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EB"
 // MIPS32-EB-PIC: "-KPIC"
 //
-// RUN: %clang --target=mips-unknown-freebsd -### \
-// RUN:   -no-integrated-as -fpic -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EB-PIC-SMALL %s
+// RUN: %clang -### --target=mips-unknown-freebsd -fno-integrated-as -fpic -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EB-PIC-SMALL %s
 // MIPS32-EB-PIC-SMALL: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EB"
 // MIPS32-EB-PIC-SMALL: "-KPIC"
 //
-// RUN: %clang --target=mips-unknown-freebsd -### \
-// RUN:   -no-integrated-as -fPIE -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EB-PIE %s
+// RUN: %clang -### --target=mips-unknown-freebsd -fno-integrated-as -fPIE -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EB-PIE %s
 // MIPS32-EB-PIE: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EB"
 // MIPS32-EB-PIE: "-KPIC"
 //
-// RUN: %clang --target=mips-unknown-freebsd -### \
-// RUN:   -no-integrated-as -fpie -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EB-PIE-SMALL %s
+// RUN: %clang -### --target=mips-unknown-freebsd -fno-integrated-as -fpie -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EB-PIE-SMALL %s
 // MIPS32-EB-PIE-SMALL: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EB"
 // MIPS32-EB-PIE-SMALL: "-KPIC"
 //
-// RUN: %clang --target=mipsel-unknown-freebsd -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-DEF-EL-AS %s
+// RUN: %clang -### --target=mipsel-unknown-freebsd -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-DEF-EL-AS %s
 // MIPS32-DEF-EL-AS: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EL"
 //
-// RUN: %clang --target=mips64-unknown-freebsd -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS64-EB-AS %s
+// RUN: %clang -### --target=mips64-unknown-freebsd -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS64-EB-AS %s
 // MIPS64-EB-AS: as{{(.exe)?}}" "-march" "mips3" "-mabi" "64" "-EB"
 //
-// RUN: %clang --target=mips64el-unknown-freebsd -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS64-DEF-EL-AS %s
+// RUN: %clang -### --target=mips64el-unknown-freebsd -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS64-DEF-EL-AS %s
 // MIPS64-DEF-EL-AS: as{{(.exe)?}}" "-march" "mips3" "-mabi" "64" "-EL"
 //
-// RUN: %clang --target=mips64-unknown-freebsd -mabi=n32 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS-N32 %s
+// RUN: %clang -### --target=mips64-unknown-freebsd -mabi=n32 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS-N32 %s
 // MIPS-N32: as{{(.exe)?}}" "-march" "mips3" "-mabi" "n32" "-EB"
 //
-// RUN: %clang --target=mipsel-unknown-freebsd -mabi=32 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EL-AS %s
+// RUN: %clang -### --target=mipsel-unknown-freebsd -mabi=32 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EL-AS %s
 // MIPS32-EL-AS: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EL"
 //
-// RUN: %clang --target=mips64el-unknown-freebsd -mabi=64 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS64-EL-AS %s
+// RUN: %clang -### --target=mips64el-unknown-freebsd -mabi=64 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS64-EL-AS %s
 // MIPS64-EL-AS: as{{(.exe)?}}" "-march" "mips3" "-mabi" "64" "-EL"
 //
-// RUN: %clang --target=mips-linux-freebsd -march=mips32r2 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS-32R2 %s
+// RUN: %clang -### --target=mips-linux-freebsd -march=mips32r2 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS-32R2 %s
 // MIPS-32R2: as{{(.exe)?}}" "-march" "mips32r2" "-mabi" "32" "-EB"
 //
-// RUN: %clang --target=mips-unknown-freebsd -mips32 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS-ALIAS-32 %s
+// RUN: %clang -### --target=mips-unknown-freebsd -mips32 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS-ALIAS-32 %s
 // MIPS-ALIAS-32: as{{(.exe)?}}" "-march" "mips32" "-mabi" "32" "-EB"
 //
-// RUN: %clang --target=mips-unknown-freebsd -mips32r2 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS-ALIAS-32R2 %s
+// RUN: %clang -### --target=mips-unknown-freebsd -mips32r2 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS-ALIAS-32R2 %s
 // MIPS-ALIAS-32R2: as{{(.exe)?}}" "-march" "mips32r2" "-mabi" "32" "-EB"
 //
-// RUN: %clang --target=mips64-unknown-freebsd -mips64 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS-ALIAS-64 %s
+// RUN: %clang -### --target=mips64-unknown-freebsd -mips64 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS-ALIAS-64 %s
 // MIPS-ALIAS-64: as{{(.exe)?}}" "-march" "mips64" "-mabi" "64" "-EB"
 //
-// RUN: %clang --target=mips64-unknown-freebsd -mips64r2 -### \
-// RUN:   -no-integrated-as -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS-ALIAS-64R2 %s
+// RUN: %clang -### --target=mips64-unknown-freebsd -mips64r2 -fno-integrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS-ALIAS-64R2 %s
 // MIPS-ALIAS-64R2: as{{(.exe)?}}" "-march" "mips64r2" "-mabi" "64" "-EB"
 //
-// RUN: %clang --target=mips-unknown-freebsd -### \
-// RUN:   -no-integrated-as -G0 -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=MIPS32-EB-AS-G0 %s
+// RUN: %clang -### --target=mips-unknown-freebsd -fno-integrated-as -fno-pic -G0 -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=MIPS32-EB-AS-G0 %s
 // MIPS32-EB-AS-G0: as{{(.exe)?}}" "-march" "mips2" "-mabi" "32" "-EB" "-G0"
 // MIPS32-EB-AS-G0-NOT: "-KPIC"

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -1,31 +1,23 @@
-// RUN: %clang \
-// RUN:   --target=aarch64-pc-freebsd11 %s                              \
-// RUN:   --sysroot=%S/Inputs/basic_freebsd64_tree -### 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-ARM64 %s
+// RUN: %clang -### --target=aarch64-pc-freebsd11 %s --sysroot=%S/Inputs/basic_freebsd64_tree 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-ARM64 %s
 // CHECK-ARM64: "-cc1" "-triple" "aarch64-pc-freebsd11"
 // CHECK-ARM64: ld{{.*}}" "--sysroot=[[SYSROOT:[^"]+]]"
 // CHECK-ARM64: "--eh-frame-hdr" "-dynamic-linker" "{{.*}}ld-elf{{.*}}" "-o" "a.out" "{{.*}}crt1.o" "{{.*}}crti.o" "{{.*}}crtbegin.o" "-L[[SYSROOT]]/usr/lib" "{{.*}}.o" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "-lc" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "{{.*}}crtend.o" "{{.*}}crtn.o"
-//
-// RUN: %clang \
-// RUN:   --target=powerpc-pc-freebsd %s    \
-// RUN:   --sysroot=%S/Inputs/basic_freebsd_tree -### 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-PPC %s
-// CHECK-PPC: "-cc1" "-triple" "powerpc-pc-freebsd"
+
+// RUN: %clang -### --target=powerpc-pc-freebsd12 %s --sysroot=%S/Inputs/basic_freebsd_tree 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-PPC %s
+// CHECK-PPC: "-cc1" "-triple" "powerpc-pc-freebsd12"
 // CHECK-PPC: ld{{.*}}" "--sysroot=[[SYSROOT:[^"]+]]"
 // CHECK-PPC: "--eh-frame-hdr" "-dynamic-linker" "{{.*}}ld-elf{{.*}}" "-o" "a.out" "{{.*}}crt1.o" "{{.*}}crti.o" "{{.*}}crtbegin.o" "-L[[SYSROOT]]/usr/lib" "{{.*}}.o" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "-lc" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "{{.*}}crtend.o" "{{.*}}crtn.o"
-//
-// RUN: %clang \
-// RUN:   --target=powerpc64-pc-freebsd %s                              \
-// RUN:   --sysroot=%S/Inputs/basic_freebsd64_tree -### 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-PPC64 %s
-// CHECK-PPC64: "-cc1" "-triple" "powerpc64-pc-freebsd"
+
+// RUN: %clang -### --target=powerpc64-pc-freebsd12 %s --sysroot=%S/Inputs/basic_freebsd64_tree 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-PPC64 %s
+// CHECK-PPC64: "-cc1" "-triple" "powerpc64-pc-freebsd12"
 // CHECK-PPC64: ld{{.*}}" "--sysroot=[[SYSROOT:[^"]+]]"
 // CHECK-PPC64: "--eh-frame-hdr" "-dynamic-linker" "{{.*}}ld-elf{{.*}}" "-o" "a.out" "{{.*}}crt1.o" "{{.*}}crti.o" "{{.*}}crtbegin.o" "-L[[SYSROOT]]/usr/lib" "{{.*}}.o" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "-lc" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "{{.*}}crtend.o" "{{.*}}crtn.o"
 
-// RUN: %clang \
-// RUN:   --target=powerpc64le-unknown-freebsd13 %s \
-// RUN:   --sysroot=%S/Inputs/basic_freebsd64_tree -### 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-PPC64LE %s
+// RUN: %clang -### --target=powerpc64le-unknown-freebsd13 %s --sysroot=%S/Inputs/basic_freebsd64_tree 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-PPC64LE %s
 // CHECK-PPC64LE: "-cc1" "-triple" "powerpc64le-unknown-freebsd13"
 // CHECK-PPC64LE: ld{{.*}}" "--sysroot=[[SYSROOT:[^"]+]]"
 // CHECK-PPC64LE: "--eh-frame-hdr" "-dynamic-linker" "{{.*}}ld-elf{{.*}}" "-o" "a.out" "{{.*}}crt1.o" "{{.*}}crti.o" "{{.*}}crtbegin.o" "-L[[SYSROOT]]/usr/lib" "{{.*}}.o" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "-lc" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "{{.*}}crtend.o" "{{.*}}crtn.o"
@@ -148,9 +140,8 @@
 // CHECK-PIE: Scrt1.o
 // CHECK-PIE: crtbeginS.o
 
-// RUN: %clang --target=x86_64-pc-freebsd %s \
-// RUN:   --sysroot=%S/Inputs/multiarch_freebsd64_tree -### 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NORMAL %s
+// RUN: %clang -### --target=x86_64-pc-freebsd12 %s --sysroot=%S/Inputs/multiarch_freebsd64_tree 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-NORMAL %s
 // CHECK-NORMAL: crt1.o
 // CHECK-NORMAL: crtbegin.o
 


### PR DESCRIPTION
Collapse 3-line RUN blocks to 2 lines and move -### immediately after
%clang, matching the prevailing style for new tests.