### PR TITLE
[Driver,FreeBSD] Fix -pie for -r and -no-pie links

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -134,9 +134,6 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   const Driver &D = ToolChain.getDriver();
   const llvm::Triple &Triple = ToolChain.getTriple();
   const llvm::Triple::ArchType Arch = ToolChain.getArch();
-  const bool IsPIE =
-      !Args.hasArg(options::OPT_shared) &&
-      (Args.hasArg(options::OPT_pie) || ToolChain.isPIEDefault(Args));
   ArgStringList CmdArgs;
 
   // Silence warning for "clang -g foo.o -o foo"
@@ -150,25 +147,7 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!D.SysRoot.empty())
     CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
 
-  if (IsPIE)
-    CmdArgs.push_back("-pie");
-
   CmdArgs.push_back("--eh-frame-hdr");
-  if (Args.hasArg(options::OPT_static)) {
-    CmdArgs.push_back("-Bstatic");
-  } else {
-    if (Args.hasArg(options::OPT_rdynamic))
-      CmdArgs.push_back("-export-dynamic");
-    if (Args.hasArg(options::OPT_shared)) {
-      CmdArgs.push_back("-shared");
-    } else if (!Args.hasArg(options::OPT_r)) {
-      CmdArgs.push_back("-dynamic-linker");
-      CmdArgs.push_back("/libexec/ld-elf.so.1");
-    }
-    if (Arch == llvm::Triple::arm || Triple.isX86())
-      CmdArgs.push_back("--hash-style=both");
-    CmdArgs.push_back("--enable-new-dtags");
-  }
 
   // Explicitly set the linker emulation for platforms that might not
   // be the default emulation for the linker.
@@ -224,6 +203,27 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-X");
     if (Args.hasArg(options::OPT_mno_relax))
       CmdArgs.push_back("--no-relax");
+  }
+
+  const bool IsShared = Args.hasArg(options::OPT_shared);
+  if (IsShared)
+    CmdArgs.push_back("-shared");
+  bool IsPIE = false;
+  if (Args.hasArg(options::OPT_static)) {
+    CmdArgs.push_back("-static");
+  } else if (!Args.hasArg(options::OPT_r)) {
+    if (Args.hasArg(options::OPT_rdynamic))
+      CmdArgs.push_back("-export-dynamic");
+    if (!IsShared) {
+      IsPIE = Args.hasFlag(options::OPT_pie, options::OPT_no_pie,
+                           ToolChain.isPIEDefault(Args));
+      if (IsPIE)
+        CmdArgs.push_back("-pie");
+      CmdArgs.push_back("-dynamic-linker");
+      CmdArgs.push_back("/libexec/ld-elf.so.1");
+    }
+    if (Arch == llvm::Triple::arm || Triple.isX86())
+      CmdArgs.push_back("--hash-style=both");
   }
 
   if (Arg *A = Args.getLastArg(options::OPT_G)) {

--- a/clang/lib/Driver/ToolChains/Serenity.cpp
+++ b/clang/lib/Driver/ToolChains/Serenity.cpp
@@ -53,8 +53,7 @@ void tools::serenity::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     if (Args.hasArg(options::OPT_rdynamic))
       CmdArgs.push_back("-export-dynamic");
     if (!IsShared) {
-      Arg *A = Args.getLastArg(options::OPT_pie, options::OPT_no_pie,
-                               options::OPT_nopie);
+      Arg *A = Args.getLastArg(options::OPT_pie, options::OPT_no_pie);
       bool IsPIE =
           A ? A->getOption().matches(options::OPT_pie) : TC.isPIEDefault(Args);
       if (IsPIE)

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -8,7 +8,7 @@
 // RUN:   FileCheck --check-prefix=CHECK-PPC %s
 // CHECK-PPC: "-cc1" "-triple" "powerpc-pc-freebsd12"
 // CHECK-PPC: ld{{.*}}" "--sysroot=[[SYSROOT:[^"]+]]"
-// CHECK-PPC: "--eh-frame-hdr" "-dynamic-linker" "{{.*}}ld-elf{{.*}}" "-o" "a.out" "{{.*}}crt1.o" "{{.*}}crti.o" "{{.*}}crtbegin.o" "-L[[SYSROOT]]/usr/lib" "{{.*}}.o" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "-lc" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "{{.*}}crtend.o" "{{.*}}crtn.o"
+// CHECK-PPC: "--eh-frame-hdr" "-m" "elf32ppc_fbsd" "-dynamic-linker" "{{.*}}ld-elf{{.*}}" "-o" "a.out" "{{.*}}crt1.o" "{{.*}}crti.o" "{{.*}}crtbegin.o" "-L[[SYSROOT]]/usr/lib" "{{.*}}.o" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "-lc" "-lgcc" "--as-needed" "-lgcc_s" "--no-as-needed" "{{.*}}crtend.o" "{{.*}}crtn.o"
 
 // RUN: %clang -### --target=powerpc64-pc-freebsd12 %s --sysroot=%S/Inputs/basic_freebsd64_tree 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-PPC64 %s
@@ -89,7 +89,6 @@
 // RUN:   --sysroot=%S/Inputs/multiarch_freebsd64_tree -### 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-LDFLAGS_HASH %s
 // CHECK-LDFLAGS_HASH: --hash-style=both
-// CHECK-LDFLAGS_HASH: --enable-new-dtags
 //
 // Check that we do not pass --hash-style=gnu and --hash-style=both to linker
 // and provide correct path to the dynamic linker for MIPS platforms.
@@ -122,7 +121,7 @@
 // RUN: %clang --target=x86_64-pc-freebsd -static %s \
 // RUN:   --sysroot=%S/Inputs/multiarch_freebsd64_tree -### 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-STATIC %s
-// CHECK-STATIC: ld{{.*}}" "--eh-frame-hdr" "-Bstatic"
+// CHECK-STATIC: ld{{.*}}" "--eh-frame-hdr" "-static"
 // CHECK-STATIC: crt1.o
 // CHECK-STATIC: crtbeginT.o
 
@@ -198,13 +197,18 @@
 // RUN: FileCheck -check-prefix=PPC64-MUNWIND %s
 // PPC64-MUNWIND: "-funwind-tables=2"
 
-/// -r suppresses -dynamic-linker, default -l and crt*.o like -nostdlib.
-// RUN: %clang -### %s --target=aarch64-pc-freebsd11 -r \
+/// -r suppresses -pie, -export-dynamic, -dynamic-linker, --hash-style,
+/// default -l and crt*.o like -nostdlib.
+// RUN: %clang -### %s --target=x86_64-pc-freebsd11 -r -pie -rdynamic \
 // RUN:   --sysroot=%S/Inputs/basic_freebsd64_tree 2>&1 | FileCheck %s --check-prefix=RELOCATABLE
-// RELOCATABLE:     "-r"
+// RELOCATABLE:     ld{{.*}}" "--sysroot=
+// RELOCATABLE-NOT: "-pie"
+// RELOCATABLE-NOT: "-export-dynamic"
 // RELOCATABLE-NOT: "-dynamic-linker"
+// RELOCATABLE-NOT: "--hash-style=
 // RELOCATABLE-NOT: "-l
 // RELOCATABLE-NOT: crt{{[^./\\]+}}.o
+// RELOCATABLE:     "-r"
 
 // Check that the -X and --no-relax flags are passed to the linker on riscv64
 // RUN: %clang --target=riscv64-unknown-freebsd -mno-relax -### %s 2>&1 \


### PR DESCRIPTION
Port Gnu.cpp changes ae623d16d50c and cac82e26c642 to FreeBSD and
Serenity: -r should suppress -pie. -nopie, OpenBSD specific, should not
be used by other OSes.

Group the options selecting the link mode and place them after -m, as
gnutools::Linker does, so that -r suppresses -export-dynamic and
--hash-style as well, and -no-pie overrides the -fsanitize PIE default.

Drop --enable-new-dtags: default in modern linkers.

Change -Bstatic to -static to follow Gnu.cpp (identical in lld and older
GNU ld).