### PR TITLE
Revert "[GVN] Remove the "private" `llvm::gvn` namespace (NFC)"

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -61,6 +61,15 @@ class PHINode;
 class TargetLibraryInfo;
 class Value;
 class IntrinsicInst;
+/// A private "module" namespace for types and utilities used by GVN. These
+/// are implementation details and should not be used by clients.
+namespace LLVM_LIBRARY_VISIBILITY_NAMESPACE gvn {
+
+struct AvailableValue;
+struct AvailableValueInBlock;
+class GVNLegacyPass;
+
+} // end namespace gvn
 
 /// A set of parameters to control various transforms performed by GVN pass.
 //  Each of the optional boolean parameters can be set to:
@@ -124,8 +133,6 @@ class GVNPass : public OptionalPassInfoMixin<GVNPass> {
 
 public:
   struct Expression;
-  struct AvailableValue;
-  struct AvailableValueInBlock;
 
   GVNPass(GVNOptions Options = {}) : Options(Options) {}
 
@@ -241,7 +248,7 @@ public:
   };
 
 private:
-  friend class GVNLegacyPass;
+  friend class gvn::GVNLegacyPass;
   friend struct DenseMapInfo<Expression>;
 
   MemoryDependenceResults *MD = nullptr;
@@ -347,7 +354,7 @@ private:
   bool InvalidBlockRPONumbers = true;
 
   using LoadDepVect = SmallVector<NonLocalDepResult, 64>;
-  using AvailValInBlkVect = SmallVector<AvailableValueInBlock, 64>;
+  using AvailValInBlkVect = SmallVector<gvn::AvailableValueInBlock, 64>;
   using UnavailBlkVect = SmallVector<BasicBlock *, 64>;
 
   bool runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
@@ -447,7 +454,7 @@ private:
 
   /// Given a local dependency (Def or Clobber) determine if a value is
   /// available for the load.
-  std::optional<AvailableValue>
+  std::optional<gvn::AvailableValue>
   AnalyzeLoadAvailability(LoadInst *Load, const ReachingMemVal &Dep,
                           Value *Address);
 
@@ -455,7 +462,7 @@ private:
   /// \p TrueAddr and \p FalseAddr guarded by \p Cond), determine whether a
   /// value is available by finding dominating values for both addresses.  If
   /// so, the load can be rematerialized as a select of those two values.
-  std::optional<AvailableValue>
+  std::optional<gvn::AvailableValue>
   AnalyzeSelectAvailability(LoadInst *Load, Value *Cond, Value *TrueAddr,
                             Value *FalseAddr, Instruction *From);
 

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -81,11 +81,9 @@
 #include <utility>
 
 using namespace llvm;
+using namespace llvm::gvn;
 using namespace llvm::VNCoercion;
 using namespace PatternMatch;
-
-using AvailableValue = GVNPass::AvailableValue;
-using AvailableValueInBlock = GVNPass::AvailableValueInBlock;
 
 #define DEBUG_TYPE "gvn"
 
@@ -195,7 +193,7 @@ template <> struct llvm::DenseMapInfo<GVNPass::Expression> {
 /// Materialization of an AvailableValue never fails.  An AvailableValue is
 /// implicitly associated with a rematerialization point which is the
 /// location of the instruction from which it was formed.
-struct llvm::GVNPass::AvailableValue {
+struct llvm::gvn::AvailableValue {
   enum class ValType {
     SimpleVal, // A simple offsetted value that is accessed.
     LoadVal,   // A value produced by a load.
@@ -291,7 +289,7 @@ struct llvm::GVNPass::AvailableValue {
 
 /// Represents an AvailableValue which can be rematerialized at the end of
 /// the associated BasicBlock.
-struct llvm::GVNPass::AvailableValueInBlock {
+struct llvm::gvn::AvailableValueInBlock {
   /// BB - The basic block in question.
   BasicBlock *BB = nullptr;
 
@@ -3998,7 +3996,7 @@ void GVNPass::assignValNumForDeadCode() {
   }
 }
 
-class llvm::GVNLegacyPass : public FunctionPass {
+class llvm::gvn::GVNLegacyPass : public FunctionPass {
 public:
   static char ID; // Pass identification, replacement for typeid.
 


### PR DESCRIPTION
Reverts llvm/llvm-project#210323

FAILED: lib/Transforms/Scalar/CMakeFiles/LLVMScalarOpts.dir/GVN.cpp.o 

/var/llvm-compile-time-tracker/llvm-project/llvm/lib/Transforms/Scalar/GVN.cpp:4001:27: error: qualified name does not name a class before ‘:’ token
 4001 | class llvm::GVNLegacyPass : public FunctionPass {
