### PR TITLE
[MemCpyOpt] Ensure call slot optz does not lower destination alloca alignment

### DIFF
--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1075,7 +1075,8 @@ bool MemCpyOptPass::performCallSlotOptzn(Instruction *cpyLoad,
   // If the destination wasn't sufficiently aligned then increase its alignment.
   if (!isDestSufficientlyAligned) {
     assert(isa<AllocaInst>(cpyDest) && "Can only increase alloca alignment!");
-    cast<AllocaInst>(cpyDest)->setAlignment(srcAlign);
+    AllocaInst *DestAlloca = cast<AllocaInst>(cpyDest);
+    DestAlloca->setAlignment(std::max(DestAlloca->getAlign(), srcAlign));
   }
 
   if (NeedMoveGEP) {

--- a/llvm/test/Transforms/MemCpyOpt/callslot.ll
+++ b/llvm/test/Transforms/MemCpyOpt/callslot.ll
@@ -239,7 +239,7 @@ define void @dest_not_writable(ptr noalias dereferenceable(128) %dst) {
 define void @dest_alignment(ptr %src) {
 ; CHECK-LABEL: @dest_alignment(
 ; CHECK-NEXT:    [[SRC_2:%.*]] = alloca [24 x i8], align 4
-; CHECK-NEXT:    [[DST:%.*]] = alloca [24 x i8], align 4
+; CHECK-NEXT:    [[DST:%.*]] = alloca [24 x i8], align 16
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 16 [[DST]], ptr [[SRC:%.*]], i64 24, i1 false)
 ; CHECK-NEXT:    call void @accept_ptr(ptr [[DST]])
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
A destination alloca's alignment could have been unconditionally overwritten, letting a lower-aligned source incorrectly undo a previous alignment increase. This issue has been addressed by considering the maximum alignment between the new source target and current destination, adhering to what the existing comment already promises.

Fixes: https://github.com/llvm/llvm-project/issues/208092.