### PR TITLE
Fix crash on defaulted comparison recovery in Sema and AST

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -3138,6 +3138,11 @@ FunctionDecl::DefaultedOrDeletedFunctionInfo::Create(
 void FunctionDecl::setDefaultedOrDeletedInfo(
     DefaultedOrDeletedFunctionInfo *Info) {
   assert(!FunctionDeclBits.HasDefaultedOrDeletedInfo && "already have this");
+
+  // Guard against assertions tripping during error-recovery states
+  if (isInvalidDecl() || Body)
+    return;
+  
   assert(!Body && "can't replace function body with defaulted function info");
 
   FunctionDeclBits.HasDefaultedOrDeletedInfo = true;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9042,7 +9042,7 @@ bool Sema::CheckExplicitlyDefaultedComparison(Scope *S, FunctionDecl *FD,
 
   // Perform any unqualified lookups we're going to need to default this
   // function.
-  if (S) {
+  if (S && !FD->isInvalidDecl()) {
     UnresolvedSet<32> Operators;
     lookupOperatorsForDefaultedComparison(*this, S, Operators,
                                           FD->getOverloadedOperator());
@@ -18806,7 +18806,7 @@ void Sema::SetDeclDefaulted(Decl *Dcl, SourceLocation DefaultLoc) {
   // Only allocate DefaultedOrDeletedFunctionInfo if we actually have
   // non-default FP features to stash. This avoids memory overhead for
   // the vast majority of defaulted functions.
-  if (!FD->getDefaultedOrDeletedInfo() &&
+  if (!FD->isInvalidDecl() && !FD->getDefaultedOrDeletedInfo() &&
       CurFPFeatureOverrides().requiresTrailingStorage()) {
     FD->setDefaultedOrDeletedInfo(
         FunctionDecl::DefaultedOrDeletedFunctionInfo::Create(

--- a/clang/test/SemaCXX/defaulted-compare-recovery-crash.cpp
+++ b/clang/test/SemaCXX/defaulted-compare-recovery-crash.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+namespace std {
+  struct strong_ordering {
+    int n;
+    static const strong_ordering less, equal, greater;
+  };
+  constexpr strong_ordering strong_ordering::less{-1}, strong_ordering::equal{0}, strong_ordering::greater{1};
+  struct reverse_compare {
+    constexpr explicit reverse_compare(std::strong_ordering o) : n(-o.n) {} // expected-error {{member initializer 'n' does not name a non-static data member or base class}}
+  } // expected-error {{expected ';' after struct}}
+  struct B { // expected-note 2{{definition of 'std::B' is not complete until the closing '}'}}
+    friend reverse_compare operator<=>(const B&, const B&) = default; // expected-note {{while rewriting comparison as call to 'operator<=>' declared here}}
+    static_assert(B{1, 2, 3, 4, 5} >= B{1, 2, 0, 40, 5}); // expected-error 2{{invalid use of incomplete type 'B'}} expected-error {{invalid operands to binary expression ('reverse_compare' and 'int')}}
+  } // expected-error {{expected ';' after struct}}
+}


### PR DESCRIPTION

This PR addresses a compiler crash encountered when handling defaulted comparison operators (`operator<=>`) inside a struct.

- Explored the Clang AST and Sema codebase (`clang/lib/AST/Decl.cpp` and `clang/lib/Sema/SemaDeclCXX.cpp`) to trace and resolve the underlying recovery state handling, added some code too in these files. 
- Added a new regression test (`clang/test/SemaCXX/defaulted-compare-recovery-crash.cpp`) to ensure the compiler recovers cleanly and emits proper diagnostics instead of crashing.
- issue #210286 