### PR TITLE
[RISCV][P-ext] Custom legalize v4i16->v4i8 and v2i32->v2i16 truncate.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -727,6 +727,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
       setOperationAction(ISD::SIGN_EXTEND_INREG,
                          {MVT::v2i16, MVT::v4i8, MVT::v2i32, MVT::v4i16},
                          Legal);
+      setOperationAction(ISD::TRUNCATE, {MVT::v4i8, MVT::v2i16}, Custom);
     }
   }
 
@@ -15724,6 +15725,36 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
            "Unexpected custom legalisation");
     Results.push_back(customLegalizeToWOpWithSExt(N, DAG));
     break;
+  case ISD::TRUNCATE: {
+    MVT VT = N->getSimpleValueType(0);
+    assert(VT.isFixedLengthVector() && Subtarget.hasStdExtP() &&
+           Subtarget.is64Bit() && (VT == MVT::v2i16 || VT == MVT::v4i8) &&
+           "Unexpected custom legalisation");
+
+    // v4i16->v4i8 and v2i32->v2i16 truncates aren't legal on their own, but
+    // the widened result type is. Bitcast the operand to the widened result
+    // type and use a shuffle to select the low half of each element, which
+    // gets matched to a P-extension packed narrowing convert
+    // (unzip8p/unzip16p).
+
+    SDValue Op0 = N->getOperand(0);
+
+    // Input should be a 64-bit vector.
+    if (!Op0.getValueType().is64BitVector())
+      break;
+
+    MVT WidenVT = getTypeToTransformTo(*DAG.getContext(), VT).getSimpleVT();
+
+    unsigned NumElts = VT.getVectorNumElements();
+    SmallVector<int, 8> ShuffleMask(WidenVT.getVectorNumElements(), -1);
+    for (unsigned i = 0; i != NumElts; ++i)
+      ShuffleMask[i] = i * 2;
+
+    SDValue Src = DAG.getBitcast(WidenVT, Op0);
+    Results.push_back(DAG.getVectorShuffle(WidenVT, DL, Src,
+                                           DAG.getUNDEF(WidenVT), ShuffleMask));
+    return;
+  }
   case ISD::SHL:
   case ISD::SRA:
   case ISD::SRL: {

--- a/llvm/test/CodeGen/RISCV/rvp-narrowing-shift-trunc.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-narrowing-shift-trunc.ll
@@ -18,8 +18,7 @@ define i32 @trunc_lshr_v2i32_to_v2i16(i64 %a.coerce) {
 ; CHECK-RV64-LABEL: trunc_lshr_v2i32_to_v2i16:
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    psrli.w a0, a0, 8
-; CHECK-RV64-NEXT:    srli a1, a0, 32
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
+; CHECK-RV64-NEXT:    pncvt.wh a0, a0
 ; CHECK-RV64-NEXT:    ret
   %v = bitcast i64 %a.coerce to <2 x i32>
   %shr = lshr <2 x i32> %v, splat (i32 8)
@@ -37,8 +36,7 @@ define i32 @trunc_ashr_v2i32_to_v2i16(i64 %a.coerce) {
 ; CHECK-RV64-LABEL: trunc_ashr_v2i32_to_v2i16:
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    psrli.w a0, a0, 8
-; CHECK-RV64-NEXT:    srli a1, a0, 32
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
+; CHECK-RV64-NEXT:    pncvt.wh a0, a0
 ; CHECK-RV64-NEXT:    ret
   %v = bitcast i64 %a.coerce to <2 x i32>
   %shr = ashr <2 x i32> %v, splat (i32 8)
@@ -56,12 +54,7 @@ define i32 @trunc_lshr_v4i16_to_v4i8(i64 %a.coerce) {
 ; CHECK-RV64-LABEL: trunc_lshr_v4i16_to_v4i8:
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    psrli.h a0, a0, 4
-; CHECK-RV64-NEXT:    srli a1, a0, 48
-; CHECK-RV64-NEXT:    srli a2, a0, 32
-; CHECK-RV64-NEXT:    srli a3, a0, 16
-; CHECK-RV64-NEXT:    ppaire.b a1, a2, a1
-; CHECK-RV64-NEXT:    ppaire.b a0, a0, a3
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
+; CHECK-RV64-NEXT:    pncvt.wb a0, a0
 ; CHECK-RV64-NEXT:    ret
   %v = bitcast i64 %a.coerce to <4 x i16>
   %shr = lshr <4 x i16> %v, splat (i16 4)

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -1360,18 +1360,13 @@ define <4 x i8> @test_pmulhsu_b(<4 x i8> %a, <4 x i8> %b) {
 ; RV64-LABEL: test_pmulhsu_b:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pwcvtu.wb a0, a0
-; RV64-NEXT:    pwcvtu.wb a1, a1
 ; RV64-NEXT:    psext.h.b a0, a0
+; RV64-NEXT:    pwcvtu.wb a1, a1
 ; RV64-NEXT:    pmul.w.h11 a2, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
 ; RV64-NEXT:    ppaire.h a0, a0, a2
 ; RV64-NEXT:    psrli.h a0, a0, 8
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %a_ext = sext <4 x i8> %a to <4 x i16>
   %b_ext = zext <4 x i8> %b to <4 x i16>
@@ -1402,12 +1397,7 @@ define <4 x i8> @test_pmulhsu_b_commuted(<4 x i8> %a, <4 x i8> %b) {
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
 ; RV64-NEXT:    ppaire.h a0, a0, a2
 ; RV64-NEXT:    psrli.h a0, a0, 8
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %a_ext = zext <4 x i8> %a to <4 x i16>
   %b_ext = sext <4 x i8> %b to <4 x i16>

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -2600,19 +2600,7 @@ define <8 x i8> @test_pmulhsu_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV64-NEXT:    ppaire.h a0, a0, a3
 ; RV64-NEXT:    psrli.h a1, a1, 8
 ; RV64-NEXT:    psrli.h a0, a0, 8
-; RV64-NEXT:    srli a2, a1, 48
-; RV64-NEXT:    srli a3, a1, 32
-; RV64-NEXT:    ppaire.b a2, a3, a2
-; RV64-NEXT:    srli a3, a1, 16
-; RV64-NEXT:    ppaire.b a1, a1, a3
-; RV64-NEXT:    srli a3, a0, 48
-; RV64-NEXT:    srli a4, a0, 32
-; RV64-NEXT:    srli a5, a0, 16
-; RV64-NEXT:    ppaire.b a3, a4, a3
-; RV64-NEXT:    ppaire.b a0, a0, a5
-; RV64-NEXT:    ppaire.h a1, a1, a2
-; RV64-NEXT:    ppaire.h a0, a0, a3
-; RV64-NEXT:    pack a0, a0, a1
+; RV64-NEXT:    unzip8p a0, a0, a1
 ; RV64-NEXT:    ret
   %a_ext = sext <8 x i8> %a to <8 x i16>
   %b_ext = zext <8 x i8> %b to <8 x i16>
@@ -2671,19 +2659,7 @@ define <8 x i8> @test_pmulhsu_b_commuted(<8 x i8> %a, <8 x i8> %b) {
 ; RV64-NEXT:    ppaire.h a0, a0, a3
 ; RV64-NEXT:    psrli.h a1, a1, 8
 ; RV64-NEXT:    psrli.h a0, a0, 8
-; RV64-NEXT:    srli a2, a1, 48
-; RV64-NEXT:    srli a3, a1, 32
-; RV64-NEXT:    ppaire.b a2, a3, a2
-; RV64-NEXT:    srli a3, a1, 16
-; RV64-NEXT:    ppaire.b a1, a1, a3
-; RV64-NEXT:    srli a3, a0, 48
-; RV64-NEXT:    srli a4, a0, 32
-; RV64-NEXT:    srli a5, a0, 16
-; RV64-NEXT:    ppaire.b a3, a4, a3
-; RV64-NEXT:    ppaire.b a0, a0, a5
-; RV64-NEXT:    ppaire.h a1, a1, a2
-; RV64-NEXT:    ppaire.h a0, a0, a3
-; RV64-NEXT:    pack a0, a0, a1
+; RV64-NEXT:    unzip8p a0, a0, a1
 ; RV64-NEXT:    ret
   %a_ext = zext <8 x i8> %a to <8 x i16>
   %b_ext = sext <8 x i8> %b to <8 x i16>
@@ -5033,8 +5009,7 @@ define <2 x i16> @test_pnsrai_h(<2 x i32> %a) {
 ; RV64-LABEL: test_pnsrai_h:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psrai.w a0, a0, 23
-; RV64-NEXT:    srli a1, a0, 32
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wh a0, a0
 ; RV64-NEXT:    ret
   %ashr = ashr <2 x i32> %a, splat(i32 23)
   %trunc = trunc <2 x i32> %ashr to <2 x i16>
@@ -5050,12 +5025,7 @@ define <4 x i8> @test_pnsrai_b(<4 x i16> %a) {
 ; RV64-LABEL: test_pnsrai_b:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psrai.h a0, a0, 9
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %ashr = ashr <4 x i16> %a, splat(i16 9)
   %trunc = trunc <4 x i16> %ashr to <4 x i8>
@@ -5071,12 +5041,7 @@ define <4 x i8> @test_pnsrl_bs(<4 x i16> %a, i16 %shamt) {
 ; RV64-LABEL: test_pnsrl_bs:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psrl.hs a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %insert = insertelement <4 x i16> poison, i16 %shamt, i32 0
   %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
@@ -5097,12 +5062,7 @@ define <4 x i8> @test_pnsrl_bs_mask(<4 x i16> %a, i16 %shamt) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    andi a1, a1, 15
 ; RV64-NEXT:    psrl.hs a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %masked = and i16 %shamt, 15
   %insert = insertelement <4 x i16> poison, i16 %masked, i32 0
@@ -5121,8 +5081,7 @@ define <2 x i16> @test_pnsrl_hs(<2 x i32> %a, i32 %shamt) {
 ; RV64-LABEL: test_pnsrl_hs:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psrl.ws a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 32
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wh a0, a0
 ; RV64-NEXT:    ret
   %insert = insertelement <2 x i32> poison, i32 %shamt, i32 0
   %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
@@ -5140,8 +5099,7 @@ define <2 x i16> @test_pnsrl_hs_mask(<2 x i32> %a, i32 %shamt) {
 ; RV64-LABEL: test_pnsrl_hs_mask:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psrl.ws a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 32
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wh a0, a0
 ; RV64-NEXT:    ret
   %masked = and i32 %shamt, 31
   %insert = insertelement <2 x i32> poison, i32 %masked, i32 0
@@ -5160,12 +5118,7 @@ define <4 x i8> @test_pnsra_bs(<4 x i16> %a, i16 %shamt) {
 ; RV64-LABEL: test_pnsra_bs:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psra.hs a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %insert = insertelement <4 x i16> poison, i16 %shamt, i32 0
   %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
@@ -5186,12 +5139,7 @@ define <4 x i8> @test_pnsra_bs_mask(<4 x i16> %a, i16 %shamt) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    andi a1, a1, 15
 ; RV64-NEXT:    psra.hs a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 48
-; RV64-NEXT:    srli a2, a0, 32
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.b a1, a2, a1
-; RV64-NEXT:    ppaire.b a0, a0, a3
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wb a0, a0
 ; RV64-NEXT:    ret
   %masked = and i16 %shamt, 15
   %insert = insertelement <4 x i16> poison, i16 %masked, i32 0
@@ -5210,8 +5158,7 @@ define <2 x i16> @test_pnsra_hs(<2 x i32> %a, i32 %shamt) {
 ; RV64-LABEL: test_pnsra_hs:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psra.ws a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 32
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wh a0, a0
 ; RV64-NEXT:    ret
   %insert = insertelement <2 x i32> poison, i32 %shamt, i32 0
   %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
@@ -5229,8 +5176,7 @@ define <2 x i16> @test_pnsra_hs_mask(<2 x i32> %a, i32 %shamt) {
 ; RV64-LABEL: test_pnsra_hs_mask:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    psra.ws a0, a0, a1
-; RV64-NEXT:    srli a1, a0, 32
-; RV64-NEXT:    ppaire.h a0, a0, a1
+; RV64-NEXT:    pncvt.wh a0, a0
 ; RV64-NEXT:    ret
   %masked = and i32 %shamt, 31
   %insert = insertelement <2 x i32> poison, i32 %masked, i32 0


### PR DESCRIPTION
Convert to a bitcast and a shufflevector.

Assisted-by: Claude