### PR TITLE
[lldb][NFC] Replace prefix/suffix variables with ColorSetting

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -31,6 +31,7 @@
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/TargetList.h"
 #include "lldb/Utility/Broadcaster.h"
+#include "lldb/Utility/ColorSetting.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Status.h"
@@ -310,9 +311,7 @@ public:
 
   llvm::StringRef GetPrompt() const;
 
-  llvm::StringRef GetPromptAnsiPrefix() const;
-
-  llvm::StringRef GetPromptAnsiSuffix() const;
+  ColorSetting GetPromptColor() const;
 
   void SetPrompt(llvm::StringRef p);
   void SetPrompt(const char *) = delete;
@@ -340,23 +339,15 @@ public:
   llvm::StringRef GetSeparator() const;
   bool SetSeparator(llvm::StringRef s);
 
-  llvm::StringRef GetShowProgressAnsiPrefix() const;
+  ColorSetting GetShowProgressColor() const;
 
-  llvm::StringRef GetShowProgressAnsiSuffix() const;
-
-  llvm::StringRef GetDisabledAnsiPrefix() const;
-
-  llvm::StringRef GetDisabledAnsiSuffix() const;
+  ColorSetting GetDisabledColor() const;
 
   AutosuggestionMode GetAutosuggestionMode() const;
 
-  llvm::StringRef GetAutosuggestionAnsiPrefix() const;
+  ColorSetting GetAutosuggestionColor() const;
 
-  llvm::StringRef GetAutosuggestionAnsiSuffix() const;
-
-  llvm::StringRef GetRegexMatchAnsiPrefix() const;
-
-  llvm::StringRef GetRegexMatchAnsiSuffix() const;
+  ColorSetting GetRegexMatchColor() const;
 
   bool GetShowDontUsePoHint() const;
 
@@ -370,9 +361,7 @@ public:
 
   lldb::StopShowColumn GetStopShowColumn() const;
 
-  llvm::StringRef GetStopShowColumnAnsiPrefix() const;
-
-  llvm::StringRef GetStopShowColumnAnsiSuffix() const;
+  ColorSetting GetStopShowColumnColor() const;
 
   uint64_t GetStopSourceLineCount(bool before) const;
 
@@ -380,9 +369,7 @@ public:
 
   uint64_t GetDisassemblyLineCount() const;
 
-  llvm::StringRef GetStopShowLineMarkerAnsiPrefix() const;
-
-  llvm::StringRef GetStopShowLineMarkerAnsiSuffix() const;
+  ColorSetting GetStopShowLineMarkerColor() const;
 
   bool GetAutoOneLineSummaries() const;
 
@@ -668,6 +655,10 @@ protected:
   friend class Progress;
   friend class ProgressManager;
   friend class Statusline;
+
+  /// Read the pair of ANSI color-code settings at the given property indices
+  /// and return them as a single ColorSetting.
+  ColorSetting GetColorProperty(uint32_t prefix_idx, uint32_t suffix_idx) const;
 
   /// Report progress events.
   ///

--- a/lldb/include/lldb/Utility/ColorSetting.h
+++ b/lldb/include/lldb/Utility/ColorSetting.h
@@ -1,0 +1,42 @@
+//===-- ColorSetting.h ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UTILITY_COLORSETTING_H
+#define LLDB_UTILITY_COLORSETTING_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace lldb_private {
+
+class Stream;
+
+/// A pair of ANSI terminal escape sequences used to colorize a piece of text.
+///
+/// The \c prefix is emitted immediately before the text and the \c suffix
+/// immediately after it (typically a reset code) to restore the previous
+/// terminal appearance.
+class ColorSetting {
+public:
+  ColorSetting() = default;
+  ColorSetting(llvm::StringRef prefix, llvm::StringRef suffix)
+      : m_prefix(prefix), m_suffix(suffix) {}
+
+  llvm::StringRef GetPrefix() const { return m_prefix; }
+  llvm::StringRef GetSuffix() const { return m_suffix; }
+
+  /// Write \a str to \a s wrapped in this setting's ANSI color codes.
+  void render(Stream &s, llvm::StringRef str) const;
+
+private:
+  llvm::StringRef m_prefix;
+  llvm::StringRef m_suffix;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_UTILITY_COLORSETTING_H

--- a/lldb/include/lldb/Utility/Stream.h
+++ b/lldb/include/lldb/Utility/Stream.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_UTILITY_STREAM_H
 #define LLDB_UTILITY_STREAM_H
 
+#include "lldb/Utility/ColorSetting.h"
 #include "lldb/Utility/Flags.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
@@ -36,13 +37,11 @@ public:
   /// Struct to store information for color highlighting in the stream.
   struct HighlightSettings {
     llvm::StringRef pattern; ///< Regex pattern for highlighting.
-    llvm::StringRef prefix;  ///< ANSI color code to start colorization.
-    llvm::StringRef suffix;  ///< ANSI color code to end colorization.
+    ColorSetting color;      ///< ANSI color codes wrapping each match.
     bool ignore_case = false; ///< Whether to match case-insensitively.
 
-    HighlightSettings(llvm::StringRef p, llvm::StringRef pre,
-                      llvm::StringRef suf, bool ic = false)
-        : pattern(p), prefix(pre), suffix(suf), ignore_case(ic) {}
+    HighlightSettings(llvm::StringRef p, ColorSetting color, bool ic = false)
+        : pattern(p), color(color), ignore_case(ic) {}
   };
 
   /// Utility class for counting the bytes that were written to a stream in a

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -928,9 +928,8 @@ void Breakpoint::GetDescription(Stream *s, lldb::DescriptionLevel level,
   const bool dim_breakpoint_description =
       !IsEnabled() && s->AsRawOstream().colors_enabled();
   if (dim_breakpoint_description)
-    s->Printf("%s", ansi::FormatAnsiTerminalCodes(
-                        GetTarget().GetDebugger().GetDisabledAnsiPrefix())
-                        .c_str());
+    s->PutCString(ansi::FormatAnsiTerminalCodes(
+        GetTarget().GetDebugger().GetDisabledColor().GetPrefix()));
 
   if (!m_kind_description.empty()) {
     if (level == eDescriptionLevelBrief) {
@@ -954,9 +953,8 @@ void Breakpoint::GetDescription(Stream *s, lldb::DescriptionLevel level,
   }
   // Reset the colors back to normal if they were previously greyed out.
   if (dim_breakpoint_description)
-    s->Printf("%s", ansi::FormatAnsiTerminalCodes(
-                        GetTarget().GetDebugger().GetDisabledAnsiSuffix())
-                        .c_str());
+    s->PutCString(ansi::FormatAnsiTerminalCodes(
+        GetTarget().GetDebugger().GetDisabledColor().GetSuffix()));
 }
 
 void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,

--- a/lldb/source/Commands/CommandObjectApropos.cpp
+++ b/lldb/source/Commands/CommandObjectApropos.cpp
@@ -43,8 +43,7 @@ void CommandObjectApropos::DoExecute(Args &args, CommandReturnObject &result) {
       Debugger &dbg = GetDebugger();
       if (dbg.GetUseColor()) {
         escaped_search_word = llvm::Regex::escape(search_word);
-        highlight.emplace(escaped_search_word, dbg.GetRegexMatchAnsiPrefix(),
-                          dbg.GetRegexMatchAnsiSuffix(), true);
+        highlight.emplace(escaped_search_word, dbg.GetRegexMatchColor(), true);
       }
 
       // Find all commands matching the search word.

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1595,9 +1595,8 @@ static uint32_t LookupSymbolInModule(CommandInterpreter &interpreter,
     DumpFullpath(strm, &module->GetFileSpec(), 0);
     strm.PutCString(":\n");
     strm.IndentMore();
-    Stream::HighlightSettings settings(
-        name, interpreter.GetDebugger().GetRegexMatchAnsiPrefix(),
-        interpreter.GetDebugger().GetRegexMatchAnsiSuffix());
+    ColorSetting regex_color = interpreter.GetDebugger().GetRegexMatchColor();
+    Stream::HighlightSettings settings(name, regex_color);
     for (uint32_t i = 0; i < num_matches; ++i) {
       const Symbol *symbol = symtab->SymbolAtIndex(match_indexes[i]);
       if (symbol) {

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -422,16 +422,17 @@ llvm::StringRef Debugger::GetPrompt() const {
       idx, g_debugger_properties[idx].default_cstr_value);
 }
 
-llvm::StringRef Debugger::GetPromptAnsiPrefix() const {
-  const uint32_t idx = ePropertyPromptAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetColorProperty(uint32_t prefix_idx,
+                                        uint32_t suffix_idx) const {
+  return {
+      GetPropertyAtIndexAs<llvm::StringRef>(
+          prefix_idx, g_debugger_properties[prefix_idx].default_cstr_value),
+      GetPropertyAtIndexAs<llvm::StringRef>(
+          suffix_idx, g_debugger_properties[suffix_idx].default_cstr_value)};
 }
 
-llvm::StringRef Debugger::GetPromptAnsiSuffix() const {
-  const uint32_t idx = ePropertyPromptAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetPromptColor() const {
+  return GetColorProperty(ePropertyPromptAnsiPrefix, ePropertyPromptAnsiSuffix);
 }
 
 void Debugger::SetPrompt(llvm::StringRef p) {
@@ -566,16 +567,9 @@ bool Debugger::SetShowProgress(bool show_progress) {
   return SetPropertyAtIndex(idx, show_progress);
 }
 
-llvm::StringRef Debugger::GetShowProgressAnsiPrefix() const {
-  const uint32_t idx = ePropertyShowProgressAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
-}
-
-llvm::StringRef Debugger::GetShowProgressAnsiSuffix() const {
-  const uint32_t idx = ePropertyShowProgressAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetShowProgressColor() const {
+  return GetColorProperty(ePropertyShowProgressAnsiPrefix,
+                          ePropertyShowProgressAnsiSuffix);
 }
 
 bool Debugger::GetShowStatusline() const {
@@ -602,16 +596,9 @@ llvm::StringRef Debugger::GetSeparator() const {
       idx, g_debugger_properties[idx].default_cstr_value);
 }
 
-llvm::StringRef Debugger::GetDisabledAnsiPrefix() const {
-  const uint32_t idx = ePropertyShowDisabledAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
-}
-
-llvm::StringRef Debugger::GetDisabledAnsiSuffix() const {
-  const uint32_t idx = ePropertyShowDisabledAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetDisabledColor() const {
+  return GetColorProperty(ePropertyShowDisabledAnsiPrefix,
+                          ePropertyShowDisabledAnsiSuffix);
 }
 
 bool Debugger::SetSeparator(llvm::StringRef s) {
@@ -628,28 +615,14 @@ AutosuggestionMode Debugger::GetAutosuggestionMode() const {
                g_debugger_properties[idx].default_uint_value));
 }
 
-llvm::StringRef Debugger::GetAutosuggestionAnsiPrefix() const {
-  const uint32_t idx = ePropertyShowAutosuggestionAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetAutosuggestionColor() const {
+  return GetColorProperty(ePropertyShowAutosuggestionAnsiPrefix,
+                          ePropertyShowAutosuggestionAnsiSuffix);
 }
 
-llvm::StringRef Debugger::GetAutosuggestionAnsiSuffix() const {
-  const uint32_t idx = ePropertyShowAutosuggestionAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
-}
-
-llvm::StringRef Debugger::GetRegexMatchAnsiPrefix() const {
-  const uint32_t idx = ePropertyShowRegexMatchAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
-}
-
-llvm::StringRef Debugger::GetRegexMatchAnsiSuffix() const {
-  const uint32_t idx = ePropertyShowRegexMatchAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetRegexMatchColor() const {
+  return GetColorProperty(ePropertyShowRegexMatchAnsiPrefix,
+                          ePropertyShowRegexMatchAnsiSuffix);
 }
 
 bool Debugger::GetShowDontUsePoHint() const {
@@ -692,28 +665,14 @@ StopShowColumn Debugger::GetStopShowColumn() const {
                g_debugger_properties[idx].default_uint_value));
 }
 
-llvm::StringRef Debugger::GetStopShowColumnAnsiPrefix() const {
-  const uint32_t idx = ePropertyStopShowColumnAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetStopShowColumnColor() const {
+  return GetColorProperty(ePropertyStopShowColumnAnsiPrefix,
+                          ePropertyStopShowColumnAnsiSuffix);
 }
 
-llvm::StringRef Debugger::GetStopShowColumnAnsiSuffix() const {
-  const uint32_t idx = ePropertyStopShowColumnAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
-}
-
-llvm::StringRef Debugger::GetStopShowLineMarkerAnsiPrefix() const {
-  const uint32_t idx = ePropertyStopShowLineMarkerAnsiPrefix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
-}
-
-llvm::StringRef Debugger::GetStopShowLineMarkerAnsiSuffix() const {
-  const uint32_t idx = ePropertyStopShowLineMarkerAnsiSuffix;
-  return GetPropertyAtIndexAs<llvm::StringRef>(
-      idx, g_debugger_properties[idx].default_cstr_value);
+ColorSetting Debugger::GetStopShowLineMarkerColor() const {
+  return GetColorProperty(ePropertyStopShowLineMarkerAnsiPrefix,
+                          ePropertyStopShowLineMarkerAnsiSuffix);
 }
 
 uint64_t Debugger::GetStopSourceLineCount(bool before) const {

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -270,10 +270,11 @@ IOHandlerEditline::IOHandlerEditline(
       m_editline_up->SetSuggestionCallback([this](llvm::StringRef line) {
         return this->SuggestionCallback(line);
       });
-      m_editline_up->SetSuggestionAnsiPrefix(ansi::FormatAnsiTerminalCodes(
-          debugger.GetAutosuggestionAnsiPrefix()));
-      m_editline_up->SetSuggestionAnsiSuffix(ansi::FormatAnsiTerminalCodes(
-          debugger.GetAutosuggestionAnsiSuffix()));
+      ColorSetting color = debugger.GetAutosuggestionColor();
+      m_editline_up->SetSuggestionAnsiPrefix(
+          ansi::FormatAnsiTerminalCodes(color.GetPrefix()));
+      m_editline_up->SetSuggestionAnsiSuffix(
+          ansi::FormatAnsiTerminalCodes(color.GetSuffix()));
     }
     // See if the delegate supports fixing indentation
     const char *indent_chars = delegate.IOHandlerGetFixIndentationCharacters();
@@ -487,10 +488,11 @@ bool IOHandlerEditline::SetPrompt(llvm::StringRef prompt) {
 #if LLDB_ENABLE_LIBEDIT
   if (m_editline_up) {
     m_editline_up->SetPrompt(m_prompt.empty() ? nullptr : m_prompt.c_str());
+    ColorSetting color = m_debugger.GetPromptColor();
     m_editline_up->SetPromptAnsiPrefix(
-        ansi::FormatAnsiTerminalCodes(m_debugger.GetPromptAnsiPrefix()));
+        ansi::FormatAnsiTerminalCodes(color.GetPrefix()));
     m_editline_up->SetPromptAnsiSuffix(
-        ansi::FormatAnsiTerminalCodes(m_debugger.GetPromptAnsiSuffix()));
+        ansi::FormatAnsiTerminalCodes(color.GetSuffix()));
   }
 #endif
   return true;
@@ -502,10 +504,11 @@ bool IOHandlerEditline::SetUseColor(bool use_color) {
 #if LLDB_ENABLE_LIBEDIT
   if (m_editline_up) {
     m_editline_up->UseColor(use_color);
-    m_editline_up->SetSuggestionAnsiPrefix(ansi::FormatAnsiTerminalCodes(
-        m_debugger.GetAutosuggestionAnsiPrefix()));
-    m_editline_up->SetSuggestionAnsiSuffix(ansi::FormatAnsiTerminalCodes(
-        m_debugger.GetAutosuggestionAnsiSuffix()));
+    ColorSetting color = m_debugger.GetAutosuggestionColor();
+    m_editline_up->SetSuggestionAnsiPrefix(
+        ansi::FormatAnsiTerminalCodes(color.GetPrefix()));
+    m_editline_up->SetSuggestionAnsiSuffix(
+        ansi::FormatAnsiTerminalCodes(color.GetSuffix()));
   }
 #endif
   return true;

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -30,6 +30,7 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/Utility/Stream.h"
+#include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/SupportFile.h"
 #include "lldb/lldb-enumerations.h"
 
@@ -272,11 +273,10 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
 
       auto debugger_sp = m_debugger_wp.lock();
       if (should_show_stop_line_with_ansi(debugger_sp)) {
-        current_line_highlight = ansi::FormatAnsiTerminalCodes(
-            (debugger_sp->GetStopShowLineMarkerAnsiPrefix() +
-             current_line_highlight +
-             debugger_sp->GetStopShowLineMarkerAnsiSuffix())
-                .str());
+        StreamString highlight_stream;
+        debugger_sp->GetStopShowLineMarkerColor().render(
+            highlight_stream, current_line_highlight);
+        current_line_highlight = highlight_stream.GetString().str();
       }
 
       s->Printf("%s%s %-4u\t", prefix.c_str(), current_line_highlight.c_str(),
@@ -712,9 +712,10 @@ size_t SourceManager::File::DisplaySourceLines(
 
   // If we should mark the stop column with color codes, then copy the prefix
   // and suffix to our color style.
-  if (should_show_stop_column_with_ansi(debugger_sp))
-    style.selected.Set(debugger_sp->GetStopShowColumnAnsiPrefix(),
-                       debugger_sp->GetStopShowColumnAnsiSuffix());
+  if (should_show_stop_column_with_ansi(debugger_sp)) {
+    ColorSetting color = debugger_sp->GetStopShowColumnColor();
+    style.selected.Set(color.GetPrefix(), color.GetSuffix());
+  }
 
   HighlighterManager mgr;
   std::string path =

--- a/lldb/source/Utility/CMakeLists.txt
+++ b/lldb/source/Utility/CMakeLists.txt
@@ -30,6 +30,7 @@ add_lldb_library(lldbUtility NO_INTERNAL_DEPENDENCIES
   Baton.cpp
   Broadcaster.cpp
   Checksum.cpp
+  ColorSetting.cpp
   CompletionRequest.cpp
   Connection.cpp
   ConstString.cpp

--- a/lldb/source/Utility/ColorSetting.cpp
+++ b/lldb/source/Utility/ColorSetting.cpp
@@ -1,0 +1,22 @@
+//===-- ColorSetting.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Utility/ColorSetting.h"
+
+#include "lldb/Utility/AnsiTerminal.h"
+#include "lldb/Utility/Stream.h"
+
+using namespace lldb_private;
+
+void ColorSetting::render(Stream &s, llvm::StringRef str) const {
+  if (!m_prefix.empty())
+    s.PutCString(ansi::FormatAnsiTerminalCodes(m_prefix));
+  s.PutCString(str);
+  if (!m_suffix.empty())
+    s.PutCString(ansi::FormatAnsiTerminalCodes(m_suffix));
+}

--- a/lldb/source/Utility/Stream.cpp
+++ b/lldb/source/Utility/Stream.cpp
@@ -84,13 +84,11 @@ void Stream::PutCStringColorHighlighted(
                                                      : llvm::Regex::NoFlags);
   llvm::SmallVector<llvm::StringRef, 1> matches;
   llvm::StringRef remaining = text;
-  std::string format_str = lldb_private::ansi::FormatAnsiTerminalCodes(
-      pattern_info->prefix.str() + "%.*s" + pattern_info->suffix.str());
   while (reg_pattern.match(remaining, &matches)) {
     llvm::StringRef match = matches[0];
     size_t match_start_pos = match.data() - remaining.data();
     PutCString(remaining.take_front(match_start_pos));
-    Printf(format_str.c_str(), match.size(), match.data());
+    pattern_info->color.render(*this, match);
     remaining = remaining.drop_front(match_start_pos + match.size());
   }
   if (remaining.size())

--- a/lldb/unittests/Utility/StreamTest.cpp
+++ b/lldb/unittests/Utility/StreamTest.cpp
@@ -729,19 +729,19 @@ TEST_F(StreamTest, PutSLEB128) {
 }
 
 TEST_F(StreamTest, PutCStringColorHighlightedCaseInsensitive) {
-  Stream::HighlightSettings settings("hello", "[", "]", true);
+  Stream::HighlightSettings settings("hello", {"[", "]"}, true);
   s.PutCStringColorHighlighted("Say Hello World", settings);
   EXPECT_EQ("Say [Hello] World", TakeValue());
 }
 
 TEST_F(StreamTest, PutCStringColorHighlightedCaseSensitive) {
-  Stream::HighlightSettings settings("hello", "[", "]", false);
+  Stream::HighlightSettings settings("hello", {"[", "]"}, false);
   s.PutCStringColorHighlighted("Say Hello World", settings);
   EXPECT_EQ("Say Hello World", TakeValue());
 }
 
 TEST_F(StreamTest, PutCStringColorHighlightedMultipleMatches) {
-  Stream::HighlightSettings settings("o", "[", "]", false);
+  Stream::HighlightSettings settings("o", {"[", "]"}, false);
   s.PutCStringColorHighlighted("foo bar boo", settings);
   EXPECT_EQ("f[o][o] bar b[o][o]", TakeValue());
 }


### PR DESCRIPTION
We use pairs of prefix/suffix strings across our code base to represent the ANSI color codes emitted before/after a highlighted word.

This patch replaces these pairs with a single ColorSettings class. The motivation is just to get rid of all the duplicated prefix/suffix variables and functions everywhere.