### PR TITLE
[libclang/python] Remove CompletionChunk.isKind methods

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3184,57 +3184,6 @@ class CompletionChunk:
             return None
         return CompletionString(res)
 
-    __deprecation_message = (
-        "'CompletionChunk.{}' will be removed in a future release. "
-        "All uses of 'CompletionChunk.{}' should be replaced by checking "
-        "if 'CompletionChunk.kind` is equal to 'CompletionChunkKind.{}'."
-    )
-
-    def isKindOptional(self) -> bool:
-        deprecation_message = self.__deprecation_message.format(
-            "isKindOptional",
-            "isKindOptional",
-            "OPTIONAL",
-        )
-        warnings.warn(deprecation_message, DeprecationWarning)
-        return self.kind == CompletionChunkKind.OPTIONAL
-
-    def isKindTypedText(self) -> bool:
-        deprecation_message = self.__deprecation_message.format(
-            "isKindTypedText",
-            "isKindTypedText",
-            "TYPED_TEXT",
-        )
-        warnings.warn(deprecation_message, DeprecationWarning)
-        return self.kind == CompletionChunkKind.TYPED_TEXT
-
-    def isKindPlaceHolder(self) -> bool:
-        deprecation_message = self.__deprecation_message.format(
-            "isKindPlaceHolder",
-            "isKindPlaceHolder",
-            "PLACEHOLDER",
-        )
-        warnings.warn(deprecation_message, DeprecationWarning)
-        return self.kind == CompletionChunkKind.PLACEHOLDER
-
-    def isKindInformative(self) -> bool:
-        deprecation_message = self.__deprecation_message.format(
-            "isKindInformative",
-            "isKindInformative",
-            "INFORMATIVE",
-        )
-        warnings.warn(deprecation_message, DeprecationWarning)
-        return self.kind == CompletionChunkKind.INFORMATIVE
-
-    def isKindResultType(self) -> bool:
-        deprecation_message = self.__deprecation_message.format(
-            "isKindResultType",
-            "isKindResultType",
-            "RESULT_TYPE",
-        )
-        warnings.warn(deprecation_message, DeprecationWarning)
-        return self.kind == CompletionChunkKind.RESULT_TYPE
-
 
 SPELLING_CACHE = CompletionChunk.SpellingCacheAlias()
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -58,6 +58,12 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 ### Clang Python Bindings Potentially Breaking Changes
 
+- Remove the deprecated `CompletionChunk.isKind...` methods.
+  Existing uses should be adapted to directly compare equality of the `CompletionChunk` kind with the corresponding `CompletionChunkKind` variant.
+
+  Affected methods: `isKindOptional`, `isKindTypedText`, `isKindPlaceHolder`,
+  `isKindInformative` and `isKindResultType`.
+
 ### OpenCL Potentially Breaking Changes
 
 ## What's New in Clang {{env.config.release}}?


### PR DESCRIPTION
This completes the third step of https://github.com/llvm/llvm-project/issues/156680
This change is a follow-up to https://github.com/llvm/llvm-project/pull/177854, following the release branching, to ensure a one release-cycle deprecation period.