### PR TITLE
[Flang][OpenMP] Allow `parallel loop` inside of `teams`

### DIFF
--- a/flang/include/flang/Semantics/openmp-directive-sets.h
+++ b/flang/include/flang/Semantics/openmp-directive-sets.h
@@ -402,6 +402,7 @@ static const OmpDirectiveSet nestedTeamsAllowedSet{
     Directive::OMPD_parallel,
     Directive::OMPD_parallel_do,
     Directive::OMPD_parallel_do_simd,
+    Directive::OMPD_parallel_loop,
     Directive::OMPD_parallel_master,
     Directive::OMPD_parallel_master_taskloop,
     Directive::OMPD_parallel_master_taskloop_simd,

--- a/flang/test/Semantics/OpenMP/teams_loop.f90
+++ b/flang/test/Semantics/OpenMP/teams_loop.f90
@@ -1,0 +1,37 @@
+! RUN: %flang_fc1 -fopenmp -fsyntax-only %s
+
+! Test that various ways of nesting combined and standalone `loop` constructs
+! inside of `teams` are accepted.
+
+subroutine test()
+  implicit none
+  integer :: i
+
+  !$omp teams
+  !$omp parallel loop
+  do i=1, 10
+    call foo()
+  end do
+  !$omp end teams
+
+  !$omp target teams
+  !$omp parallel loop
+  do i=1, 10
+    call foo()
+  end do
+  !$omp end target teams
+
+  !$omp target teams
+  !$omp loop
+  do i=1, 10
+    call foo()
+  end do
+  !$omp end target teams
+
+  !$omp teams
+  !$omp loop
+  do i=1, 10
+    call foo()
+  end do
+  !$omp end teams
+end subroutine


### PR DESCRIPTION
A missing `parallel_loop` directive in the `nestedTeamsAllowedSet` currently causes code like the following to report a semantics issue:
```f90
!$omp teams
  !$omp parallel loop
  do i=1, 10
  end do
!$omp end teams
```
This patch makes sure to accept it, since `parallel` is an allowed construct to be immediately nested inside of `teams`, even when combined with another construct.