### PR TITLE
[compiler-rt][test] Skip page-size feature detection under emulators.

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -972,7 +972,7 @@ def target_page_size():
         return None
     try:
         proc = subprocess.Popen(
-            f"{emulator or ''} {shlex.quote(config.python_executable)}",
+            shlex.quote(config.python_executable),
             shell=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -968,6 +968,8 @@ else:
 def target_page_size():
     if config.target_arch in ("amdgcn", "nvptx64"):
         return 4096
+    if emulator:
+        return None
     try:
         proc = subprocess.Popen(
             f"{emulator or ''} {shlex.quote(config.python_executable)}",
@@ -992,7 +994,9 @@ except ImportError:
         return 4096
 
 
-config.available_features.add(f"page-size-{target_page_size()}")
+page_size = target_page_size()
+if page_size is not None:
+    config.available_features.add(f"page-size-{page_size}")
 
 if config.expensive_checks:
     config.available_features.add("expensive_checks")

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -969,6 +969,9 @@ def target_page_size():
     if config.target_arch in ("amdgcn", "nvptx64"):
         return 4096
     if emulator:
+        # FIXME: Some emulators may support querying the target page size.
+        # For now, avoid advertising page-size features under emulation; only
+        # a few obscure tests depend on this.
         return None
     try:
         proc = subprocess.Popen(


### PR DESCRIPTION
This avoids adding a page-size-* lit feature when compiler-rt tests are configured to run through an emulator.

Perviously this used to work because failure to detect the page size would fall back to 4096. Now after this change https://github.com/llvm/llvm-project/pull/209175, the code tries to execute config.python_executable through the emulator. For emulator-based test configurations, this is inappropriate. The function now returns None when an emulator is configured, and the lit feature is only added when a concrete page size is available.