### PR TITLE
[compiler-rt][test] Use fallback page size with an emulator

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -968,9 +968,12 @@ else:
 def target_page_size():
     if config.target_arch in ("amdgcn", "nvptx64"):
         return 4096
+    if emulator:
+        # Emulators may not provide a target-side Python executable.
+        return 4096
     try:
         proc = subprocess.Popen(
-            f"{emulator or ''} {shlex.quote(config.python_executable)}",
+            shlex.quote(config.python_executable),
             shell=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Using the fallback page size avoids executing Python with an emulator, which can fail.

E.g. the failures could look like the ones in https://github.com/llvm/llvm-project/pull/209175#issuecomment-5021551711:

* `python3: No such file or directory`
* `subprocess.TimeoutExpired: Command '['/usr/local/bin/qemu-system-riscv32',  ... , '/usr/bin/python3']' timed out after 900 seconds`

In both cases, the pre-existing `4096` fallback was then picked.