### PR TITLE
[orc-rt] Fix wrapper-call managed-code token lifetime

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -463,7 +463,8 @@ private:
 
   void handleWrapperCall(uint64_t CallId, orc_rt_WrapperFunction Fn,
                          WrapperFunctionBuffer ArgBytes) {
-    if (!ManagedCodeTaskGroup->acquireToken()) {
+    TaskGroup::Token T(ManagedCodeTaskGroup);
+    if (!T) {
       // The ManagedCodeTaskGroup is only closed after detach, so if token
       // acquisition fails we don't try to return an error: the controller
       // should already have signalled error to the caller, and we have no
@@ -471,7 +472,8 @@ private:
       return;
     }
 
-    Dispatch([this, CallId, Fn, ArgBytes = std::move(ArgBytes)]() mutable {
+    Dispatch([this, CallId, Fn, ArgBytes = std::move(ArgBytes),
+              T = std::move(T)]() mutable {
       Fn(wrap(this), CallId, &wrapperReturn, ArgBytes.release());
     });
   }

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -362,7 +362,6 @@ void Session::sendWrapperResult(uint64_t CallId,
                                 WrapperFunctionBuffer ResultBytes) {
   if (auto TmpCA = std::atomic_load(&CA))
     TmpCA->sendWrapperResult(CallId, std::move(ResultBytes));
-  ManagedCodeTaskGroup->releaseToken();
 }
 
 void Session::wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -675,6 +675,59 @@ TEST(ControllerAccessTest, CallFromController) {
   EXPECT_EQ(Result, 42);
 }
 
+// Stashes Return, via the address passed as the wrapper call's argument,
+// instead of calling it -- simulating a wrapper function that defers
+// completion past its own return.
+static void deferred_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+                             orc_rt_WrapperFunctionReturn Return,
+                             orc_rt_WrapperFunctionBuffer ArgBytes) {
+  SPSWrapperFunction<void(SPSExecutorAddr)>::handle(
+      S, CallId, Return, ArgBytes,
+      [](move_only_function<void()> Return, ExecutorAddr P) {
+        *P.toPtr<move_only_function<void()> *>() = std::move(Return);
+      });
+}
+
+TEST(ControllerAccessTest, WrapperCallTokenReleasedWhenFnReturns) {
+  // A managed-code token acquired for an incoming wrapper call must bracket
+  // only the (synchronous) span of Fn's execution -- not the whole
+  // call/response chain -- per the "Managed code execution and shutdown"
+  // policy in docs/Design.md. Check this by having Fn defer its Return call
+  // past its own return, then confirming that Session shutdown's drain phase
+  // does not wait on that deferred call.
+  QueueingRunner<>::WorkQueue Tasks;
+  Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
+  MockControllerAccess *CA = nullptr;
+  S.attach<MockControllerAccess>(BootstrapInfo(S), postOnto(Tasks),
+                                 MockControllerAccess::OnConnectFn{}, &CA);
+
+  move_only_function<void()> DeferredReturn;
+
+  bool GotResult = false;
+  SPSWrapperFunction<void(SPSExecutorAddr)>::call(
+      CallViaMockControllerAccess(*CA, deferred_wrapper),
+      [&](Error Err) {
+        cantFail(std::move(Err));
+        GotResult = true;
+      },
+      &DeferredReturn);
+
+  QueueingRunner<>::runFIFOUntilEmpty(Tasks);
+
+  // Fn ran and deferred its Return call, so no result should have been sent
+  // back yet.
+  ASSERT_TRUE(DeferredReturn);
+  EXPECT_FALSE(GotResult);
+
+  // Fn has already returned, so its managed-code token should have been
+  // released even though the call is still logically outstanding. Shutdown's
+  // drain phase should therefore complete without waiting on the deferred
+  // Return call.
+  bool ShutdownComplete = false;
+  S.shutdown([&] { ShutdownComplete = true; });
+  EXPECT_TRUE(ShutdownComplete);
+}
+
 TEST(ControllerAccessTest, FailConnect) {
   // Simulate failure to connect.
   bool GotError = false;


### PR DESCRIPTION
d199b284c7d established that ManagedCodeTaskGroup tokens must bracket a single span of execution on a stack, not a chain of asynchronous operations (see orc-rt/docs/Design.md's "Managed code execution and shutdown" section). Session::handleWrapperCall and sendWrapperResult predated that policy and didn't conform to it: the token was acquired in handleWrapperCall but only released in sendWrapperResult, holding it for the whole call/response chain. If Fn deferred sending its result asynchronously, Session shutdown would incorrectly wait on that deferred completion instead of proceeding as soon as Fn's stack unwound.

Acquire the token as a TaskGroup::Token scoped to the dispatched call, and let it release when Fn returns rather than when its result is sent.