### PR TITLE
[libc] Add aligned_alloc and delete[] to hermetic tests

### DIFF
--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -78,13 +78,16 @@ void *memset(void *ptr, int value, size_t count) {
 // This is needed if the test was compiled with '-fno-use-cxa-atexit'.
 int atexit(void (*func)(void)) { return LIBC_NAMESPACE::atexit(func); }
 
-void *malloc(size_t s) {
-  // Keep the bump pointer aligned on an eight byte boundary.
-  s = ((s + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+void *aligned_alloc(size_t align, size_t s) {
+  if (align & (align - 1)) // Must be power of 2
+    return nullptr;
+  s = ((s + align - 1) / align) * align;
   void *mem = ptr;
   ptr += s;
   return static_cast<uint64_t>(ptr - memory) >= MEMORY_SIZE ? nullptr : mem;
 }
+
+void *malloc(size_t s) { return aligned_alloc(ALIGNMENT, s); }
 
 void free(void *) {}
 
@@ -133,6 +136,8 @@ void *operator new(size_t size) { return malloc(size); }
 void *operator new[](size_t size) { return malloc(size); }
 
 void operator delete(void *ptr) { free(ptr); }
+
+void operator delete[](void *ptr) { free(ptr); }
 
 void operator delete(void *ptr, size_t) { free(ptr); }
 

--- a/libc/test/src/search/CMakeLists.txt
+++ b/libc/test/src/search/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_custom_target(libc_search_unittests)
-add_libc_unittest(
+add_libc_test(
   hsearch_test
   SUITE
     libc_search_unittests
@@ -15,7 +15,7 @@ add_libc_unittest(
     libc.src.errno.errno
 )
 
-add_libc_unittest(
+add_libc_test(
   insque_test
   SUITE
     libc_search_unittests
@@ -26,7 +26,7 @@ add_libc_unittest(
     libc.src.search.remque
 )
 
-add_libc_unittest(
+add_libc_test(
   lfind_test
   SUITE
     libc_search_unittests
@@ -36,7 +36,7 @@ add_libc_unittest(
     libc.src.search.lfind
 )
 
-add_libc_unittest(
+add_libc_test(
   lsearch_test
   SUITE
     libc_search_unittests
@@ -46,7 +46,7 @@ add_libc_unittest(
     libc.src.search.lsearch
 )
 
-add_libc_unittest(
+add_libc_test(
   tsearch_test
   SUITE
     libc_search_unittests


### PR DESCRIPTION
This lets us run (at least) <search.h> tests in hermetic mode.