### PR TITLE
[Support][Unit] Fix ProgramTest.cpp build warning unused variable 'RetCode'

### DIFF
--- a/llvm/unittests/Support/ProgramTest.cpp
+++ b/llvm/unittests/Support/ProgramTest.cpp
@@ -692,8 +692,9 @@ TEST_F(ProgramEnvTest, TestExecuteEmptyEnvironment) {
 
   std::string Error;
   bool ExecutionFailed;
-  int RetCode = ExecuteAndWait(Executable, argv, ArrayRef<StringRef>{}, {}, 0,
-                               0, &Error, &ExecutionFailed);
+  [[maybe_unused]] int RetCode =
+      ExecuteAndWait(Executable, argv, ArrayRef<StringRef>{}, {}, 0, 0, &Error,
+                     &ExecutionFailed);
   EXPECT_FALSE(ExecutionFailed) << Error;
 #ifndef __MINGW32__
   // When running with an empty environment, the child process doesn't in herit


### PR DESCRIPTION
RetCode is unused if __MINGW32__ is defined.