### PR TITLE
[libc] Make assert_test hermetic

### DIFF
--- a/libc/test/src/assert/CMakeLists.txt
+++ b/libc/test/src/assert/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_assert_unittests)
 
-add_libc_unittest(
+add_libc_test(
   assert_test
   SUITE
     libc_assert_unittests
@@ -8,6 +8,7 @@ add_libc_unittest(
     assert_test.cpp
   DEPENDS
     libc.src.assert.__assert_fail
+    libc.src.unistd.close
     # These are necessary for now because dependencies are not properly added.
     libc.src.signal.raise
     libc.src.stdlib._Exit

--- a/libc/test/src/assert/assert_test.cpp
+++ b/libc/test/src/assert/assert_test.cpp
@@ -9,16 +9,15 @@
 #undef NDEBUG
 #include "hdr/signal_macros.h"
 #include "src/assert/assert.h"
+#include "src/unistd/close.h"
 #include "test/UnitTest/Test.h"
-
-extern "C" int close(int);
 
 TEST(LlvmLibcAssert, Enabled) {
   // Close standard error for the child process so we don't print the assertion
   // failure message.
   EXPECT_DEATH(
       [] {
-        close(2);
+        LIBC_NAMESPACE::close(2);
         assert(0);
       },
       WITH_SIGNAL(SIGABRT));


### PR DESCRIPTION
Call our own close() instead of the system one.