### PR TITLE
[libc] Make getauxval test hermetic

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -793,6 +793,9 @@ function(add_libc_hermetic test_name)
       libc.src.unistd.fork
       libc.src.unistd.pipe
   )
+  if (LIBC_TARGET_ARCHITECTURE_IS_AARCH64 AND NOT(LIBC_TARGET_OS_IS_BAREMETAL))
+    list(APPEND fq_deps_list libc.src.sys.auxv.getauxval)
+  endif()
 
   if(libc.src.compiler.__stack_chk_fail IN_LIST TARGET_LLVMLIBC_ENTRYPOINTS)
     # __stack_chk_fail should always be included if supported to allow building
@@ -920,15 +923,6 @@ function(add_libc_hermetic test_name)
                    LibcTest.hermetic
                    libc.test.UnitTest.ErrnoSetterMatcher
                    ${fq_deps_list})
-  # TODO: currently the dependency chain is broken such that getauxval cannot properly
-  # propagate to hermetic tests. This is a temporary workaround.
-  if (LIBC_TARGET_ARCHITECTURE_IS_AARCH64 AND NOT(LIBC_TARGET_OS_IS_BAREMETAL))
-    target_link_libraries(
-      ${fq_build_target_name}
-      PRIVATE
-        libc.src.sys.auxv.getauxval
-    )
-  endif()
 
   if(NOT HERMETIC_TEST_NO_RUN_POSTBUILD)
     if (LIBC_TEST_CMD)

--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -25,14 +25,6 @@ void *memmove(void *dst, const void *src, size_t count);
 void *memset(void *ptr, int value, size_t count);
 int atexit(void (*func)(void));
 
-// TODO: It seems that some old test frameworks does not use
-// add_libc_hermetic_test properly. Such that they won't get correct linkage
-// against the object containing this function. We create a dummy function that
-// always returns 0 to indicate a failure.
-[[gnu::weak]] unsigned long getauxval([[maybe_unused]] unsigned long id) {
-  return 0;
-}
-
 } // namespace LIBC_NAMESPACE_DECL
 
 constexpr uint64_t ALIGNMENT = alignof(uintptr_t);

--- a/libc/test/src/sys/auxv/linux/CMakeLists.txt
+++ b/libc/test/src/sys/auxv/linux/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_custom_target(libc_sys_auxv_unittests)
-add_libc_unittest(
+add_libc_test(
   getauxval_test
   SUITE
     libc_sys_auxv_unittests


### PR DESCRIPTION
To make this work, I needed to remove the getauxval definition from HermeticTestUtils.cpp‎. Even though it was weak, it still prevented the real one from being used because the linker will not extract an archive member if the dependency has already been satisfied by a weak definition.

I *think* I've removed the need for it by changing how the getauxval dependency is declared in cmake (it fixes the errors on the presubmit aarch64 bot), but I don't know if that was the only issue.
