### PR TITLE
[libc] Make hermetic test syscall deps linux-only

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -780,19 +780,24 @@ function(add_libc_hermetic test_name)
       libc.src.string.memset
       libc.src.strings.bcmp
       libc.src.strings.bzero
-      # Syscalls used by death tests.
-      libc.src.poll.poll
-      libc.src.signal.kill
-      libc.src.stdio.fflush
-      libc.src.stdio.stderr
-      libc.src.stdio.stdout
-      libc.src.stdlib.exit
-      libc.src.string.strsignal
-      libc.src.sys.wait.waitpid
-      libc.src.unistd.close
-      libc.src.unistd.fork
-      libc.src.unistd.pipe
   )
+
+  # Syscalls used by death tests. See also libc/test/UnitTest/CMakeLists.txt.
+  if(${LIBC_TARGET_OS} STREQUAL "linux" OR ${LIBC_TARGET_OS} STREQUAL "darwin")
+    list(APPEND fq_deps_list
+        libc.src.poll.poll
+        libc.src.signal.kill
+        libc.src.stdio.fflush
+        libc.src.stdio.stderr
+        libc.src.stdio.stdout
+        libc.src.stdlib.exit
+        libc.src.string.strsignal
+        libc.src.sys.wait.waitpid
+        libc.src.unistd.close
+        libc.src.unistd.fork
+        libc.src.unistd.pipe
+    )
+  endif()
 
   if(libc.src.compiler.__stack_chk_fail IN_LIST TARGET_LLVMLIBC_ENTRYPOINTS)
     # __stack_chk_fail should always be included if supported to allow building


### PR DESCRIPTION
They are only used on linux, so this matches that.

They are also only used in full build mode, but hermetic tests only work in full build mode, so we don't need to check that here. The darwin check is a noop as (AAIU) we don't support full_build on darwin, but I've kept it for symmetry.