### PR TITLE
[Darwin][TSan] Fix race in mach_vm_deallocate interceptor

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_mach_vm.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_mach_vm.cpp
@@ -44,10 +44,9 @@ TSAN_INTERCEPTOR(kern_return_t, mach_vm_deallocate, vm_map_t target,
   SCOPED_TSAN_INTERCEPTOR(mach_vm_deallocate, target, address, size);
   if (target != mach_task_self())
     return REAL(mach_vm_deallocate)(target, address, size);
-  kern_return_t kr = REAL(mach_vm_deallocate)(target, address, size);
-  if (kr == KERN_SUCCESS && address)
+  if (address)
     UnmapShadow(thr, address, size);
-  return kr;
+  return REAL(mach_vm_deallocate)(target, address, size);
 }
 
 }  // namespace __tsan

--- a/compiler-rt/test/tsan/Darwin/mach_vm_deallocate_race.c
+++ b/compiler-rt/test/tsan/Darwin/mach_vm_deallocate_race.c
@@ -1,0 +1,57 @@
+// Test that concurrent mach_vm_deallocate / mach_vm_allocate on the same
+// virtual address range do not race in the TSan runtime's shadow/meta reset.
+//
+// Several threads free a region while others reuse the same VA (via an address
+// hint) and touch it. If mach_vm_deallocate resets the shadow/meta *after* the
+// real deallocation, the freed VA can be handed to a reusing thread mid reset
+// -> SEGV at a meta address (or clobbered metadata). Resetting before the real
+// deallocation (while we still own the mapping) avoids this.
+//
+// RUN: %clang_tsan %s -o %t
+// RUN: %env_tsan_opts=abort_on_error=0 %run %t 2>&1 | FileCheck %s
+
+// UNSUPPORTED: iossim
+
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <pthread.h>
+#include <stdio.h>
+
+static const mach_vm_size_t kSize =
+    16 << 20; // >128KB forces ResetRange unmap path
+static const int kThreads = 4;
+static const long kIters = 1000;
+static mach_vm_address_t g_hint; // shared placement hint (the contended VA)
+
+static void *worker(void *arg) {
+  for (long i = 0; i < kIters; i++) {
+    mach_vm_address_t a = g_hint; // prefer the just-freed VA
+    if (mach_vm_allocate(mach_task_self(), &a, kSize, VM_FLAGS_ANYWHERE) !=
+        KERN_SUCCESS)
+      continue;
+    *(volatile char *)a = 1; // touch to check for faults
+    mach_vm_deallocate(mach_task_self(), a, kSize);
+  }
+  return NULL;
+}
+
+int main(void) {
+  mach_vm_address_t a = 0;
+  if (mach_vm_allocate(mach_task_self(), &a, kSize, VM_FLAGS_ANYWHERE) !=
+      KERN_SUCCESS)
+    return 1;
+  g_hint = a;
+  mach_vm_deallocate(mach_task_self(), a, kSize);
+
+  pthread_t t[kThreads];
+  for (int i = 0; i < kThreads; i++)
+    pthread_create(&t[i], NULL, worker, NULL);
+  for (int i = 0; i < kThreads; i++)
+    pthread_join(t[i], NULL);
+
+  fprintf(stderr, "Done.\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer
+// CHECK: Done.


### PR DESCRIPTION
I have seen an issue whereby the meta store in MetaMap::AllocBlock lands in the unmapped gap left during the tsan::MetaMap::ResetRange call; where the range is first unmapped, and then remapped with MAP_FIXED. This occurred under the mach_vm_deallocate interceptor, because it first does the deallocate call, and only then does it call UnmapShadow - leaving a gap where a fresh slab for malloc can land, only to have the meta region for that range mapped out from under it, resulting in a bad access fault.

It is worth noting that there is a comment above the IsValidMmapRange function (which gets called during UnmapShadow), that describes this exact issue in the context of munmap.

rdar://179172055

Assisted by: Claude