### PR TITLE
[SCEV] Distribute zext across (C + Rest) in LoopGuards rewriter

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -16424,6 +16424,30 @@ const SCEV *ScalarEvolution::LoopGuards::rewrite(const SCEV *Expr) const {
         Bitwidth = Bitwidth / 2;
       }
 
+      // Pull a leading constant out of the zext:
+      //   zext(C + X) -> zext(X) - zext(-C), if X >=u -C.
+      const SCEVAddExpr *Add;
+      const APInt *C;
+      if (match(Op, m_scev_Add(Add)) &&
+          match(Add->getOperand(0), m_scev_APInt(C))) {
+        SmallVector<SCEVUse, 4> XOps(llvm::drop_begin(Add->operands()));
+        const SCEV *X = SE.getAddExpr(XOps);
+        // Rewrite X first so guard clamps (e.g. umax(X, K)) can
+        // supply the lower bound for the range check below.
+        const SCEV *GuardedX = visit(X);
+        // Let NegC = -C modulo the narrow bit width. If X >=u NegC:
+        //   zext(C + X) == zext(X) - zext(NegC)
+        //
+        // For C < 0, the addition acts as subtraction without underflow.
+        // For C > 0, the guard guarantees narrow-width wrap. In both cases,
+        // it prevents the widened subtraction from underflowing.
+        APInt NegC = -*C;
+        if (SE.getUnsignedRangeMin(GuardedX).uge(NegC))
+          return SE.getMinusSCEV(
+              SE.getZeroExtendExpr(GuardedX, Ty),
+              SE.getConstant(NegC.zext(Ty->getScalarSizeInBits())));
+      }
+
       return SCEVRewriteVisitor<SCEVLoopGuardRewriter>::visitZeroExtendExpr(
           Expr);
     }

--- a/llvm/test/Transforms/LoopVectorize/single_early_exit_zext_trip_count.ll
+++ b/llvm/test/Transforms/LoopVectorize/single_early_exit_zext_trip_count.ll
@@ -11,9 +11,9 @@
 ;   AccessSize = (9 + (zext i32 (-1 + %len)<nsw> to i64))<nuw><nsw>
 ;   KnownSize = (8 + (zext i32 %len to i64))<nuw><nsw>
 ;
-; TODO: when applying loop guards SCEV should move -1 outside the zext and fold
-; it with the outer 9. Then AccessSize and KnownSize would have equal
-; loop-guarded forms, so ULE would be trivially true.
+; When applying loop guards SCEV moves -1 outside the zext and folds it with
+; the outer 9. Then AccessSize and KnownSize have equal loop-guarded forms, so
+; ULE is trivially true.
 define void @test1(ptr %p) {
 ; CHECK-LABEL: define void @test1(
 ; CHECK-SAME: ptr [[P:%.*]]) {
@@ -28,17 +28,43 @@ define void @test1(ptr %p) {
 ; CHECK:       [[PREHEADER]]:
 ; CHECK-NEXT:    [[EXIT_32:%.*]] = add nsw i32 [[LEN]], -1
 ; CHECK-NEXT:    [[EXIT:%.*]] = zext i32 [[EXIT_32]] to i64
+; CHECK-NEXT:    [[TMP0:%.*]] = add nuw nsw i64 [[EXIT]], 1
+; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP0]], 4
+; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
+; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[TMP0]], 4
+; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[TMP0]], [[N_MOD_VF]]
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
-; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ], [ 0, %[[PREHEADER]] ]
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY_INTERIM:.*]] ]
 ; CHECK-NEXT:    [[ELEM_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[BASE]], i64 [[IV]]
-; CHECK-NEXT:    [[ELEM:%.*]] = load i8, ptr [[ELEM_PTR]], align 1
+; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x i8>, ptr [[ELEM_PTR]], align 1
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <4 x i8> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[TMP3:%.*]] = freeze <4 x i1> [[TMP2]]
+; CHECK-NEXT:    [[TMP4:%.*]] = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> [[TMP3]])
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[IV]], 4
+; CHECK-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[TMP4]], label %[[VECTOR_EARLY_EXIT:.*]], label %[[VECTOR_BODY_INTERIM]]
+; CHECK:       [[VECTOR_BODY_INTERIM]]:
+; CHECK-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[LOOP]], !llvm.loop [[LOOP1:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[CMP_N]], label %[[RET_LOOPEXIT:.*]], label %[[SCALAR_PH]]
+; CHECK:       [[VECTOR_EARLY_EXIT]]:
+; CHECK-NEXT:    br label %[[RET_LOOPEXIT]]
+; CHECK:       [[SCALAR_PH]]:
+; CHECK-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i64 [ [[N_VEC]], %[[MIDDLE_BLOCK]] ], [ 0, %[[PREHEADER]] ]
+; CHECK-NEXT:    br label %[[LOOP2:.*]]
+; CHECK:       [[LOOP2]]:
+; CHECK-NEXT:    [[IV1:%.*]] = phi i64 [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ], [ [[BC_RESUME_VAL]], %[[SCALAR_PH]] ]
+; CHECK-NEXT:    [[ELEM_PTR1:%.*]] = getelementptr inbounds nuw i8, ptr [[BASE]], i64 [[IV1]]
+; CHECK-NEXT:    [[ELEM:%.*]] = load i8, ptr [[ELEM_PTR1]], align 1
 ; CHECK-NEXT:    [[IS_TARGET:%.*]] = icmp eq i8 [[ELEM]], 0
-; CHECK-NEXT:    br i1 [[IS_TARGET]], label %[[RET_LOOPEXIT:.*]], label %[[LATCH]]
+; CHECK-NEXT:    br i1 [[IS_TARGET]], label %[[RET_LOOPEXIT]], label %[[LATCH]]
 ; CHECK:       [[LATCH]]:
-; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i64 [[IV]], 1
-; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i64 [[IV]], [[EXIT]]
-; CHECK-NEXT:    br i1 [[LOOP_COND]], label %[[LOOP]], label %[[RET_LOOPEXIT]]
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i64 [[IV1]], 1
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i64 [[IV1]], [[EXIT]]
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label %[[LOOP2]], label %[[RET_LOOPEXIT]], !llvm.loop [[LOOP4:![0-9]+]]
 ; CHECK:       [[RET_LOOPEXIT]]:
 ; CHECK-NEXT:    br label %[[RET]]
 ; CHECK:       [[RET]]:

--- a/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
+++ b/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
@@ -1673,6 +1673,70 @@ TEST_F(ScalarEvolutionsTest, ApplyLoopGuards) {
   });
 }
 
+// Cover the LoopGuards rule zext(C + X) -> zext(X) - zext(-C), when X >=u -C.
+TEST_F(ScalarEvolutionsTest, ApplyLoopGuardsZextAddConst) {
+  LLVMContext C;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(
+      // Guard %n uge 1 clamps %n to umax(1, %n) in the LoopGuards map.
+      "define void @neg_const(i32 %n) { "
+      "entry: "
+      "  %g = icmp uge i32 %n, 1 "
+      "  br i1 %g, label %ph, label %exit "
+      "ph: "
+      "  br label %loop "
+      "loop: "
+      "  %iv = phi i32 [ 0, %ph ], [ %iv.next, %loop ] "
+      "  %iv.next = add nuw nsw i32 %iv, 1 "
+      "  %ec = icmp ult i32 %iv, %n "
+      "  br i1 %ec, label %loop, label %exit "
+      "exit: "
+      "  ret void "
+      "} "
+      // Negative: no guard, no clamp. Transform must NOT fire.
+      "define void @no_guard(i32 %n) { "
+      "entry: "
+      "  br label %loop "
+      "loop: "
+      "  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ] "
+      "  %iv.next = add nuw nsw i32 %iv, 1 "
+      "  %ec = icmp ult i32 %iv, %n "
+      "  br i1 %ec, label %loop, label %exit "
+      "exit: "
+      "  ret void "
+      "} ",
+      Err, C);
+
+  ASSERT_TRUE(M && "Could not parse module?");
+  ASSERT_TRUE(!verifyModule(*M) && "Must have been well formed!");
+
+  Type *I32 = Type::getInt32Ty(C);
+  Type *I64 = Type::getInt64Ty(C);
+
+  auto Rewrite = [&](ScalarEvolution &SE, LoopInfo &LI, const SCEV *Inner) {
+    return SE.applyLoopGuards(SE.getZeroExtendExpr(Inner, I64), *LI.begin());
+  };
+
+  // Guard %n uge 1: zext(-1 + %n) -> -1 + zext(umax(1, %n)).
+  runWithSE(*M, "neg_const",
+            [&](Function &F, LoopInfo &LI, ScalarEvolution &SE) {
+              const SCEV *N = SE.getSCEV(getArgByName(F, "n"));
+              const SCEV *Inner = SE.getAddExpr(SE.getMinusOne(I32), N);
+              const SCEV *Clamped = SE.getUMaxExpr(SE.getConstant(I32, 1), N);
+              const SCEV *Expected = SE.getAddExpr(
+                  SE.getMinusOne(I64), SE.getZeroExtendExpr(Clamped, I64));
+              EXPECT_EQ(Rewrite(SE, LI, Inner), Expected);
+            });
+
+  // No guard, plain %n: transform must not fire, zext stays fused.
+  runWithSE(
+      *M, "no_guard", [&](Function &F, LoopInfo &LI, ScalarEvolution &SE) {
+        const SCEV *N = SE.getSCEV(getArgByName(F, "n"));
+        const SCEV *Inner = SE.getAddExpr(SE.getMinusOne(I32), N);
+        EXPECT_EQ(Rewrite(SE, LI, Inner), SE.getZeroExtendExpr(Inner, I64));
+      });
+}
+
 TEST_F(ScalarEvolutionsTest, ForgetValueWithOverflowInst) {
   LLVMContext C;
   SMDiagnostic Err;


### PR DESCRIPTION
When visiting zext(-C + Rest) in the loop-guard rewriter and the Rest is known >=u to C, distribute the zext as zext(Rest) - C_ext.

The narrow add cannot unsigned-wrap under that precondition, so the transform is safe and exposes trip-count-like expressions to further simplification.

Related to: https://github.com/llvm/llvm-project/issues/208778

Alive2 proof: https://alive2.llvm.org/ce/z/H7g3Rb