### PR TITLE
[libc++][NFC] Fix synopsis comment for error_condition::message()

### DIFF
--- a/libcxx/include/system_error
+++ b/libcxx/include/system_error
@@ -98,7 +98,7 @@ public:
     // observers:
     int value() const noexcept;
     const error_category& category() const noexcept;
-    string message() const noexcept;
+    string message() const;
     explicit operator bool() const noexcept;
 };
 


### PR DESCRIPTION
The method was marked as noexcept in the synopsis, but it's neither marked noexcept in the spec nor in our implementation.