### PR TITLE
[libc] Fix standard streams variable name typos in overlay mode.

### DIFF
--- a/libc/src/stdio/linux/stdin.cpp
+++ b/libc/src/stdio/linux/stdin.cpp
@@ -29,6 +29,6 @@ LLVM_LIBC_VARIABLE(FILE *, stdin) = reinterpret_cast<FILE *>(&StdIn);
 
 #else // overlay mode
 
-extern "C" FILE *stderr;
+extern "C" FILE *stdin;
 
 #endif // LIBC_FULL_BUILD

--- a/libc/src/stdio/linux/stdout.cpp
+++ b/libc/src/stdio/linux/stdout.cpp
@@ -29,6 +29,6 @@ LLVM_LIBC_VARIABLE(FILE *, stdout) = reinterpret_cast<FILE *>(&StdOut);
 
 #else // overlay mode
 
-extern "C" FILE *stderr;
+extern "C" FILE *stdout;
 
 #endif // LIBC_FULL_BUILD


### PR DESCRIPTION
These appear to be a couple of copy/paste misses from #187522.