### PR TITLE
[MC][NFC] Share some code between MasmParser and AsmParser

### DIFF
--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -272,6 +272,11 @@ public:
   /// \param IncludeLoc The location of the include.
   /// \param OS the raw_ostream to print on.
   LLVM_ABI void PrintIncludeStack(SMLoc IncludeLoc, raw_ostream &OS) const;
+
+  /// Prints the include stack of a buffer unless it is a macro instantiation
+  /// buffer.
+  LLVM_ABI void printIncludeStackForDiagnostic(SMLoc Loc,
+                                               raw_ostream &OS) const;
 };
 
 /// Represents a single fixit, a replacement of one range of text with another.

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -2408,12 +2408,8 @@ void AsmParser::DiagHandler(const SMDiagnostic &Diag, void *Context) {
 
   // Like SourceMgr::printMessage() we need to print the include stack if any
   // before printing the message.
-  unsigned DiagCurBuffer = DiagSrcMgr.FindBufferContainingLoc(DiagLoc);
-  if (!Parser->SavedDiagHandler && DiagCurBuffer &&
-      DiagCurBuffer != DiagSrcMgr.getMainFileID()) {
-    SMLoc ParentIncludeLoc = DiagSrcMgr.getParentIncludeLoc(DiagCurBuffer);
-    DiagSrcMgr.PrintIncludeStack(ParentIncludeLoc, OS);
-  }
+  if (!Parser->SavedDiagHandler)
+    DiagSrcMgr.printIncludeStackForDiagnostic(DiagLoc, OS);
 
   // If we have not parsed a cpp hash line filename comment or the source
   // manager changed or buffer changed (like in a nested include) then just

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -2398,12 +2398,8 @@ void MasmParser::DiagHandler(const SMDiagnostic &Diag, void *Context) {
 
   // Like SourceMgr::printMessage() we need to print the include stack if any
   // before printing the message.
-  unsigned DiagCurBuffer = DiagSrcMgr.FindBufferContainingLoc(DiagLoc);
-  if (!Parser->SavedDiagHandler && DiagCurBuffer &&
-      DiagCurBuffer != DiagSrcMgr.getMainFileID()) {
-    SMLoc ParentIncludeLoc = DiagSrcMgr.getParentIncludeLoc(DiagCurBuffer);
-    DiagSrcMgr.PrintIncludeStack(ParentIncludeLoc, OS);
-  }
+  if (!Parser->SavedDiagHandler)
+    DiagSrcMgr.printIncludeStackForDiagnostic(DiagLoc, OS);
 
   // If we have not parsed a cpp hash line filename comment or the source
   // manager changed or buffer changed (like in a nested include) then just

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -298,6 +298,18 @@ void SourceMgr::PrintIncludeStack(SMLoc IncludeLoc, raw_ostream &OS) const {
      << ":" << FindLineNumber(IncludeLoc, CurBuf) << ":\n";
 }
 
+void SourceMgr::printIncludeStackForDiagnostic(SMLoc Loc,
+                                               raw_ostream &OS) const {
+  if (!Loc.isValid())
+    return;
+  unsigned DiagCurBuffer = FindBufferContainingLoc(Loc);
+  if (DiagCurBuffer && DiagCurBuffer != getMainFileID()) {
+    SMLoc ParentIncludeLoc = getParentIncludeLoc(DiagCurBuffer);
+    // Ignore macro instantiation buffers to avoid redundant include stacks.
+    PrintIncludeStack(ParentIncludeLoc, OS);
+  }
+}
+
 SMDiagnostic SourceMgr::GetMessage(SMLoc Loc, SourceMgr::DiagKind Kind,
                                    const Twine &Msg, ArrayRef<SMRange> Ranges,
                                    ArrayRef<SMFixIt> FixIts) const {

--- a/llvm/test/MC/AsmParser/macro-like-diagnostic.s
+++ b/llvm/test/MC/AsmParser/macro-like-diagnostic.s
@@ -1,0 +1,19 @@
+# RUN: not llvm-mc -triple x86_64 %s -o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: <instantiation>:1:1: error: unknown directive
+# CHECK: macro-like-diagnostic.s:5:1: note: while in macro instantiation
+.irp reg,%rax
+  .invalid_irp_directive_here \reg
+.endr
+
+# CHECK: <instantiation>:1:1: error: unknown directive
+# CHECK: macro-like-diagnostic.s:11:1: note: while in macro instantiation
+.irpc char,a
+  .invalid_irpc_directive_here \char
+.endr
+
+# CHECK: <instantiation>:1:1: error: unknown directive
+# CHECK: macro-like-diagnostic.s:17:1: note: while in macro instantiation
+.rept 1
+  .invalid_rept_directive_here
+.endr

--- a/llvm/test/tools/llvm-ml/macro_diagnostic.asm
+++ b/llvm/test/tools/llvm-ml/macro_diagnostic.asm
@@ -1,0 +1,12 @@
+; RUN: not llvm-ml -filetype=s %s /Fo - 2>&1 | FileCheck %s
+
+.code
+
+test_macro macro
+  invalid_instruction_here
+endm
+
+; CHECK: <instantiation>:1:1: error: invalid instruction mnemonic 'invalid_instruction_here'
+; CHECK: macro_diagnostic.asm:11:7: note: while in macro instantiation
+      test_macro
+end


### PR DESCRIPTION
Factor out printIncludeStackForDiagnostic() to SourceMgr in preparation
for a follow-up commit that changes the output here. This avoids needing
to update both of them. Also add two more tests for the current output.
