### PR TITLE
Fix llvm-mlir-use-after-erase findings

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp
@@ -458,7 +458,7 @@ void NormalizeMemRefs::normalizeFuncOpMemRefs(func::FuncOp funcOp,
                                               /*replaceInDeallocOp=*/true))) {
             newOp->erase();
             replacingMemRefUsesFailed = true;
-            continue;
+            break;
           }
         }
         if (!replacingMemRefUsesFailed) {

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2696,8 +2696,7 @@ LogicalResult OperationLegalizer::legalizeWithFold(Operation *op) {
             "op '" + opName +
             "' folder rollback of IR modifications requested");
       }
-      rewriterImpl.resetState(
-          curState, std::string(op->getName().getStringRef()) + " folder");
+      rewriterImpl.resetState(curState, std::string(opName) + " folder");
       return failure();
     }
   }

--- a/mlir/test/Dialect/MemRef/normalize-memrefs-ops.mlir
+++ b/mlir/test/Dialect/MemRef/normalize-memrefs-ops.mlir
@@ -127,6 +127,20 @@ func.func @test_norm_ret(%arg0: memref<1x16x14x14xf32, #map_tile>) -> (memref<1x
     // CHECK-NEXT: return %[[v1]], %[[v2]] : memref<1x16x1x1x32x32xf32>, memref<1x16x14x14xf32>
 }
 
+// Test with op_norm_ret, where results are consumed by a non-normalizable op.
+
+// CHECK-LABEL: test_norm_ret_denorm
+// CHECK-SAME: (%[[ARG0:.*]]: memref<1x16x1x1x32x32xf32>)
+func.func @test_norm_ret_denorm(%arg0: memref<1x16x14x14xf32, #map_tile>) {
+    %0, %1 = "test.op_norm_ret"(%arg0) : (memref<1x16x14x14xf32, #map_tile>) -> (memref<1x16x14x14xf32, #map_tile>, memref<1x16x14x14xf32, #map_tile>)
+    // CHECK: %[[v0:.*]], %[[v1:.*]] = "test.op_norm_ret"(%[[ARG0]]) : (memref<1x16x1x1x32x32xf32>) -> (memref<1x16x14x14xf32, #[[MAP:.*]]>, memref<1x16x14x14xf32, #[[MAP]]>)
+    "test.op_nonnorm"(%0, %0) : (memref<1x16x14x14xf32, #map_tile>, memref<1x16x14x14xf32, #map_tile>) -> ()
+    // CHECK: "test.op_nonnorm"(%[[v0]], %[[v0]]) : (memref<1x16x14x14xf32, #[[MAP]]>, memref<1x16x14x14xf32, #[[MAP]]>) -> ()
+    memref.dealloc %1 : memref<1x16x14x14xf32, #map_tile>
+    // CHECK: memref.dealloc %[[v1]] : memref<1x16x14x14xf32, #[[MAP]]>
+    return
+}
+
 // Test with an arbitrary op that references the function symbol.
 
 "test.op_funcref"() {func = @test_norm_mix} : () -> ()


### PR DESCRIPTION
Fix the following warnings identified by the `llvm-mlir-use-after-erase` check from https://github.com/llvm/llvm-project/pull/210727:

```cpp
mlir/lib/Transforms/Utils/DialectConversion.cpp:2700:33: warning: operation 'op' is used after it was erased [llvm-mlir-use-after-erase]
 2700 |           curState, std::string(op->getName().getStringRef()) + " folder");
      |                                 ^
mlir/lib/Transforms/Utils/DialectConversion.cpp:2685:12: note: operation erased here
 2685 |   rewriter.replaceOp(op, replacementValues);
      |            ^
mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp:440:29: warning: operation 'newOp' is used after it was erased [llvm-mlir-use-after-erase]
  440 |           Value newMemRef = newOp->getResult(resIndex);
      |                             ^
mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp:459:20: note: operation erased here 
  459 |             newOp->erase();
      |                    ^
mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp:440:29: note: the use happens in a later loop iteration than the erase
  440 |           Value newMemRef = newOp->getResult(resIndex);
      |                             ^
```

The warning at `NormalizeMemRefs.cpp:440` is resolved by breaking the loop iteration after erasing the operation, similar to what is done at line 306.