### PR TITLE
[rtsan] Loosen requirements of halt_on_error test

### DIFF
--- a/compiler-rt/test/rtsan/halt_on_error.cpp
+++ b/compiler-rt/test/rtsan/halt_on_error.cpp
@@ -22,5 +22,5 @@ int main() {
   // CHECK: ==ERROR: RealtimeSanitizer
   // CHECK-NEXT: {{.*`malloc`.*}}
   // CHECK-NO-HALT: ==ERROR: RealtimeSanitizer
-  // CHECK-NO-HALT-NEXT: {{.*`free`.*}}
+  // CHECK-NO-HALT: {{.*`free`.*}}
 }


### PR DESCRIPTION
Some systems may call other intercepted functions during the course of a `malloc`. This would result in some error stack such as:

```
 ERROR malloc
     ERROR pthread_mutex_lock
     ERROR pthread_mutex_unlock
     
 ERROR free
     ERROR pthread_mutex_lock
     ERROR pthread_mutex_unlock
```

We support this as RTSan, but this test would be overly specific on those platforms. As written, this requires "only malloc, then free immediately after". The change makes this "at least malloc is called, and then later at least free is called". This still keeps the spirit of the check the same but allows for more (valid) interpretation in between.



NOTE:
In the future, we may want to consider doing something similar here:
https://github.com/llvm/llvm-project/blob/40c4fea67f49b841bd064624219efceab91b65e0/compiler-rt/test/rtsan/stack_suppressions.cpp#L65

This specifies ONLY 7 suppressions should happen here which is extremely specific. However I did not change this because it's a little trickier. We don't really have a test for this stack suppressions method anywhere else. We could do something like "at least 7 things should be suppressed", but it's messier so I left that for a future exercise. 