### PR TITLE
[flang] Add policy-driven allocation-placement pass - memory passes unification [2/5]

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/AllocationPlacementPolicy.h
+++ b/flang/include/flang/Optimizer/Transforms/AllocationPlacementPolicy.h
@@ -1,0 +1,90 @@
+//===-- Optimizer/Transforms/AllocationPlacementPolicy.h --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header defines the policy used by the allocation-placement pass to
+// decide whether an array allocation should live on the stack (fir.alloca) or
+// on the heap (fir.allocmem). The policy is expressed with tunable thresholds
+// and a per-function stack budget, and can be customized through a hook (e.g.
+// with different thresholds inside device routines or parallel regions).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_TRANSFORMS_ALLOCATIONPLACEMENTPOLICY_H
+#define FORTRAN_OPTIMIZER_TRANSFORMS_ALLOCATIONPLACEMENTPOLICY_H
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+namespace mlir {
+class Operation;
+} // namespace mlir
+
+namespace fir {
+
+/// Desired placement for an array allocation.
+enum class AllocationPlacement {
+  /// The allocation should live on the stack (fir.alloca).
+  Stack,
+  /// The allocation should live on the heap (fir.allocmem).
+  Heap,
+  /// The allocation should be left where it currently is.
+  Leave,
+};
+
+/// Tunable thresholds controlling where array allocations are placed.
+struct AllocationPlacementThresholds {
+  /// Place all array allocations on the stack when possible (-fstack-arrays).
+  /// When false, use the size/kind-based placement policy.
+  bool stackArrays = false;
+  /// Constant-size arrays up to this many bytes are considered "small".
+  std::size_t smallArrayThresholdBytes = 64;
+  /// Per-function budget (in bytes) for small arrays placed on the stack.
+  std::size_t totalStackLimitBytes = 4ull * 1024 * 1024;
+};
+
+/// Facts about a single array allocation used to decide its placement.
+struct AllocationInfo {
+  /// The allocation operation (fir.alloca or fir.allocmem).
+  mlir::Operation *op = nullptr;
+  /// True if the allocation currently lives on the stack (fir.alloca).
+  bool isCurrentlyOnStack = false;
+  /// True if the allocation is a compiler temporary (as opposed to a user
+  /// variable).
+  bool isTemporary = false;
+  /// True if the allocation has a runtime-determined size. Note this is not the
+  /// same as !byteSize: a constant-size array may have no computable byteSize
+  /// (e.g. when no data layout is available), in which case it is not dynamic
+  /// but its size is still unknown.
+  bool isDynamic = false;
+  /// The constant size of the allocation in bytes, if it can be determined.
+  std::optional<std::int64_t> byteSize;
+};
+
+/// Default placement policy. Decides where \p info should live given \p
+/// thresholds and the per-function stack bytes already committed to the stack
+/// (\p stackBytesUsed). The caller is responsible for updating \p
+/// stackBytesUsed based on the returned decision.
+AllocationPlacement
+decideAllocationPlacement(const AllocationInfo &info,
+                          const AllocationPlacementThresholds &thresholds,
+                          std::size_t stackBytesUsed);
+
+/// Placement decision hook. Has the same signature as decideAllocationPlacement
+/// so the policy can be fully overridden (e.g. different thresholds inside
+/// device routines or parallel regions); a hook may adjust the thresholds and
+/// delegate to decideAllocationPlacement.
+using AllocationPlacementHook = std::function<AllocationPlacement(
+    const AllocationInfo & /*info*/,
+    const AllocationPlacementThresholds & /*thresholds*/,
+    std::size_t /*stackBytesUsed*/)>;
+
+} // namespace fir
+
+#endif // FORTRAN_OPTIMIZER_TRANSFORMS_ALLOCATIONPLACEMENTPOLICY_H

--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -9,6 +9,7 @@
 #ifndef FORTRAN_OPTIMIZER_TRANSFORMS_PASSES_H
 #define FORTRAN_OPTIMIZER_TRANSFORMS_PASSES_H
 
+#include "flang/Optimizer/Transforms/AllocationPlacementPolicy.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -40,6 +41,13 @@ enum class LICMNestedHoistingMode {
 #define GEN_PASS_DECL
 
 #include "flang/Optimizer/Transforms/Passes.h.inc"
+
+/// Create the allocation-placement pass with the given options and a hook that
+/// can override the thresholds per allocation (e.g. for device routines or
+/// parallel regions). This complements the tablegen-generated overloads.
+std::unique_ptr<mlir::Pass>
+createAllocationPlacement(const AllocationPlacementOptions &options,
+                          AllocationPlacementHook placementHook);
 
 std::unique_ptr<mlir::Pass> createAffineDemotionPass();
 std::unique_ptr<mlir::Pass>

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -312,6 +312,32 @@ def MemoryAllocationOpt : Pass<"memory-allocation-opt", "mlir::func::FuncOp"> {
   ];
 }
 
+def AllocationPlacement : Pass<"allocation-placement", "mlir::func::FuncOp"> {
+  let summary = "Place array allocations on the stack or the heap by policy.";
+  let description = [{
+    Unified array allocation placement. Converts fir.alloca to fir.allocmem and
+    fir.allocmem to fir.alloca based on tunable byte-size thresholds, a
+    per-function stack budget, and whether the allocation is a user variable or
+    a compiler temporary. Heap-to-stack conversions are only performed where the
+    allocation is provably freed on all paths through the function.
+  }];
+  let dependentDialects = [
+    "fir::FIROpsDialect", "mlir::DLTIDialect", "mlir::LLVM::LLVMDialect",
+    "mlir::arith::ArithDialect"
+  ];
+  let options = [
+    Option<"stackArrays", "stack-arrays", "bool", /*default=*/"false",
+           "Place all array allocations on the stack (-fstack-arrays); "
+           "otherwise use the size/kind-based placement policy.">,
+    Option<"smallArrayThresholdBytes", "small-array-threshold", "std::size_t",
+           /*default=*/"64",
+           "Constant-size arrays up to this many bytes are considered small.">,
+    Option<"totalStackLimitBytes", "total-stack-limit", "std::size_t",
+           /*default=*/"4194304",
+           "Per-function budget (bytes) for small arrays placed on the stack.">
+  ];
+}
+
 // This needs to be a "mlir::ModuleOp" pass, because it inserts global constants
 def ConstantArgumentGlobalisationOpt : Pass<"constant-argument-globalisation-opt", "mlir::ModuleOp"> {
   let summary = "Convert constant function arguments to global constants.";

--- a/flang/lib/Optimizer/Transforms/AllocationPlacement.cpp
+++ b/flang/lib/Optimizer/Transforms/AllocationPlacement.cpp
@@ -1,0 +1,324 @@
+//===- AllocationPlacement.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass decides, for each array allocation in a function, whether it should
+// live on the stack (fir.alloca) or on the heap (fir.allocmem), and rewrites it
+// accordingly. The decision is delegated to the policy in
+// AllocationPlacementPolicy.h. Two rewrite engines are reused:
+//   - stack-to-heap uses fir::replaceAllocas (MemoryUtils);
+//   - heap-to-stack reuses the StackArrays analysis and rewrite, which only
+//     stackifies fir.allocmem that are provably freed on all paths.
+//
+//===----------------------------------------------------------------------===//
+
+#include "StackArrays.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIROpsSupport.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Dialect/Support/FIRContext.h"
+#include "flang/Optimizer/Support/DataLayout.h"
+#include "flang/Optimizer/Transforms/AllocationPlacementPolicy.h"
+#include "flang/Optimizer/Transforms/MemoryUtils.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+namespace fir {
+#define GEN_PASS_DEF_ALLOCATIONPLACEMENT
+#include "flang/Optimizer/Transforms/Passes.h.inc"
+} // namespace fir
+
+#define DEBUG_TYPE "allocation-placement"
+
+//===----------------------------------------------------------------------===//
+// Default placement policy
+//===----------------------------------------------------------------------===//
+
+fir::AllocationPlacement
+fir::decideAllocationPlacement(const AllocationInfo &info,
+                               const AllocationPlacementThresholds &thresholds,
+                               std::size_t stackBytesUsed) {
+  using P = fir::AllocationPlacement;
+
+  // Translate a "should this be on the stack" decision into a placement,
+  // accounting for where the allocation currently lives.
+  auto place = [&](bool wantStack) -> P {
+    if (wantStack)
+      return info.isCurrentlyOnStack ? P::Leave : P::Stack;
+    return info.isCurrentlyOnStack ? P::Heap : P::Leave;
+  };
+
+  // -fstack-arrays: put everything on the stack (best effort). The
+  // heap-to-stack conversion still only happens where it is provably safe.
+  if (thresholds.stackArrays)
+    return place(/*wantStack=*/true);
+
+  // Runtime-sized arrays (automatic arrays, dynamic temporaries) go on the
+  // heap.
+  if (info.isDynamic)
+    return place(/*wantStack=*/false);
+
+  // Without a known constant size we cannot reason about thresholds.
+  if (!info.byteSize)
+    return P::Leave;
+
+  // Constant-size user variables always go on the stack.
+  if (!info.isTemporary)
+    return place(/*wantStack=*/true);
+
+  auto size = static_cast<std::size_t>(*info.byteSize);
+  if (size <= thresholds.smallArrayThresholdBytes)
+    // Small arrays go on the stack while the per-function budget allows it.
+    return place(/*wantStack=*/stackBytesUsed + size <=
+                 thresholds.totalStackLimitBytes);
+
+  // Big array temporaries go on the heap.
+  return place(/*wantStack=*/false);
+}
+
+namespace {
+
+/// Return true if the allocation is a compiler temporary, i.e. it has no
+/// uniqued name (user variables always carry one).
+static bool isTemporaryAllocation(mlir::Operation *op) {
+  std::optional<llvm::StringRef> uniqName;
+  if (auto alloca = mlir::dyn_cast<fir::AllocaOp>(op))
+    uniqName = alloca.getUniqName();
+  else if (auto allocmem = mlir::dyn_cast<fir::AllocMemOp>(op))
+    uniqName = allocmem.getUniqName();
+  return !uniqName || uniqName->empty();
+}
+
+/// Return the constant byte size of an array allocation, or std::nullopt if it
+/// is dynamic or cannot be determined.
+static std::optional<std::int64_t>
+getConstantByteSize(mlir::Operation *op,
+                    const std::optional<mlir::DataLayout> &dl,
+                    const std::optional<fir::KindMapping> &kindMap) {
+  if (!dl || !kindMap)
+    return std::nullopt;
+  if (auto alloca = mlir::dyn_cast<fir::AllocaOp>(op))
+    return fir::getAllocaByteSize(alloca, *dl, *kindMap);
+  if (auto allocmem = mlir::dyn_cast<fir::AllocMemOp>(op)) {
+    if (allocmem.hasLenParams() || allocmem.hasShapeOperands())
+      return std::nullopt;
+    if (auto sizeAndAlignment = fir::getTypeSizeAndAlignment(
+            op->getLoc(), allocmem.getAllocatedType(), *dl, *kindMap))
+      return static_cast<std::int64_t>(sizeAndAlignment->first);
+  }
+  return std::nullopt;
+}
+
+/// Replacement generator used for stack-to-heap conversions (fir.alloca ->
+/// fir.allocmem). Mirrors the MemoryAllocation pass.
+static mlir::Value genAllocmem(mlir::OpBuilder &builder, fir::AllocaOp alloca,
+                               bool /*deallocPointsDominateAlloc*/) {
+  mlir::Type varTy = alloca.getInType();
+  auto unpackName = [](std::optional<llvm::StringRef> opt) -> llvm::StringRef {
+    if (opt)
+      return *opt;
+    return {};
+  };
+  llvm::StringRef uniqName = unpackName(alloca.getUniqName());
+  llvm::StringRef bindcName = unpackName(alloca.getBindcName());
+  auto heap = fir::AllocMemOp::create(builder, alloca.getLoc(), varTy, uniqName,
+                                      bindcName, alloca.getTypeparams(),
+                                      alloca.getShape());
+  LLVM_DEBUG(llvm::dbgs() << "allocation placement: replaced " << alloca
+                          << " with " << heap << '\n');
+  return heap;
+}
+
+static void genFreemem(mlir::Location loc, mlir::OpBuilder &builder,
+                       mlir::Value allocmem) {
+  [[maybe_unused]] auto free = fir::FreeMemOp::create(builder, loc, allocmem);
+  LLVM_DEBUG(llvm::dbgs() << "allocation placement: add free " << free
+                          << " for " << allocmem << '\n');
+}
+
+[[maybe_unused]] static llvm::StringRef
+placementName(fir::AllocationPlacement placement) {
+  switch (placement) {
+  case fir::AllocationPlacement::Stack:
+    return "stack";
+  case fir::AllocationPlacement::Heap:
+    return "heap";
+  case fir::AllocationPlacement::Leave:
+    return "leave";
+  }
+  return "?";
+}
+
+/// Return true if \p placement leaves the allocation on the stack.
+static bool endsUpOnStack(fir::AllocationPlacement placement,
+                          bool isCurrentlyOnStack) {
+  return placement == fir::AllocationPlacement::Stack ||
+         (placement == fir::AllocationPlacement::Leave && isCurrentlyOnStack);
+}
+
+class AllocationPlacementPass
+    : public fir::impl::AllocationPlacementBase<AllocationPlacementPass> {
+public:
+  AllocationPlacementPass() = default;
+  AllocationPlacementPass(const AllocationPlacementPass &pass)
+      : fir::impl::AllocationPlacementBase<AllocationPlacementPass>(pass),
+        placementHook(pass.placementHook) {}
+  AllocationPlacementPass(fir::AllocationPlacementOptions options)
+      : fir::impl::AllocationPlacementBase<AllocationPlacementPass>(
+            std::move(options)) {}
+  AllocationPlacementPass(fir::AllocationPlacementOptions options,
+                          fir::AllocationPlacementHook hook)
+      : fir::impl::AllocationPlacementBase<AllocationPlacementPass>(
+            std::move(options)),
+        placementHook(std::move(hook)) {}
+
+  void runOnOperation() override;
+
+private:
+  fir::AllocationPlacementHook placementHook;
+};
+
+void AllocationPlacementPass::runOnOperation() {
+  mlir::func::FuncOp func = getOperation();
+  if (func.empty())
+    return;
+
+  fir::AllocationPlacementThresholds baseThresholds;
+  baseThresholds.stackArrays = stackArrays;
+  baseThresholds.smallArrayThresholdBytes = smallArrayThresholdBytes;
+  baseThresholds.totalStackLimitBytes = totalStackLimitBytes;
+
+  auto module = func->getParentOfType<mlir::ModuleOp>();
+  std::optional<mlir::DataLayout> dl =
+      module ? fir::support::getOrSetMLIRDataLayout(
+                   module, /*allowDefaultLayout=*/false)
+             : std::nullopt;
+  std::optional<fir::KindMapping> kindMap;
+  if (module)
+    kindMap = fir::getKindMapping(module);
+
+  // Analysis of which fir.allocmem can be safely moved to the stack, and where.
+  auto &analysis = getAnalysis<fir::StackArraysAnalysisWrapper>();
+  const fir::StackArraysAnalysisWrapper::AllocMemMap *candidateOps =
+      analysis.getCandidateOps(func);
+  if (!candidateOps) {
+    signalPassFailure();
+    return;
+  }
+
+  // Walk allocations in deterministic program order, maintaining the running
+  // per-function stack budget while collecting the conversions to perform.
+  std::size_t stackBytesUsed = 0;
+  llvm::DenseSet<mlir::Operation *> allocasToHeap;
+  llvm::SmallVector<mlir::Operation *> allocmemsToStack;
+
+  func.walk([&](mlir::Operation *op) {
+    auto alloca = mlir::dyn_cast<fir::AllocaOp>(op);
+    auto allocmem = mlir::dyn_cast<fir::AllocMemOp>(op);
+    if (!alloca && !allocmem)
+      return;
+
+    // Only array allocations are considered.
+    mlir::Type inTy = alloca ? alloca.getInType() : allocmem.getAllocatedType();
+    if (!mlir::isa<fir::SequenceType>(inTy))
+      return;
+
+    fir::AllocationInfo info;
+    info.op = op;
+    info.isCurrentlyOnStack = static_cast<bool>(alloca);
+    info.isTemporary = isTemporaryAllocation(op);
+    info.isDynamic =
+        alloca ? alloca.isDynamic()
+               : (allocmem.hasLenParams() || allocmem.hasShapeOperands());
+    info.byteSize = getConstantByteSize(op, dl, kindMap);
+
+    // A hook, if provided, fully overrides the default policy; it may delegate
+    // back to decideAllocationPlacement after adjusting the thresholds.
+    fir::AllocationPlacement placement =
+        placementHook ? placementHook(info, baseThresholds, stackBytesUsed)
+                      : fir::decideAllocationPlacement(info, baseThresholds,
+                                                       stackBytesUsed);
+
+    // Account for the decision in the running stack budget.
+    if (endsUpOnStack(placement, info.isCurrentlyOnStack) && info.byteSize)
+      stackBytesUsed += static_cast<std::size_t>(*info.byteSize);
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "allocation-placement: "
+                   << (info.isCurrentlyOnStack ? "alloca" : "allocmem") << " "
+                   << (info.isTemporary ? "temp" : "user") << " ";
+      if (info.isDynamic)
+        llvm::dbgs() << "dynamic";
+      else if (info.byteSize)
+        llvm::dbgs() << *info.byteSize << "B";
+      else
+        llvm::dbgs() << "unknown-size";
+      llvm::dbgs() << " -> " << placementName(placement) << "\n";
+    });
+
+    if (alloca && placement == fir::AllocationPlacement::Heap)
+      allocasToHeap.insert(op);
+    else if (allocmem && placement == fir::AllocationPlacement::Stack &&
+             candidateOps->contains(op))
+      allocmemsToStack.push_back(op);
+  });
+
+  LLVM_DEBUG(llvm::dbgs() << "allocation-placement: " << func.getSymName()
+                          << ": " << allocasToHeap.size() << " stack->heap, "
+                          << allocmemsToStack.size() << " heap->stack, "
+                          << stackBytesUsed << " stack bytes used\n");
+
+  // Heap-to-stack: only provably-safe candidates are converted.
+  if (!allocmemsToStack.empty()) {
+    mlir::MLIRContext &context = getContext();
+    mlir::RewritePatternSet patterns(&context);
+    mlir::GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(
+        mlir::GreedySimplifyRegionLevel::Disabled);
+    config.setStrictness(mlir::GreedyRewriteStrictness::ExistingAndNewOps);
+    config.enableFolding(false);
+    patterns.insert<fir::AllocMemConversion>(&context, *candidateOps, dl,
+                                             kindMap);
+    if (mlir::failed(mlir::applyOpPatternsGreedily(
+            allocmemsToStack, std::move(patterns), config))) {
+      mlir::emitError(func->getLoc(),
+                      "error in allocation placement (heap to stack)\n");
+      signalPassFailure();
+      return;
+    }
+  }
+
+  // Stack-to-heap.
+  if (!allocasToHeap.empty()) {
+    mlir::IRRewriter rewriter(&getContext());
+    auto mustReplace = [&](fir::AllocaOp alloca) {
+      return allocasToHeap.contains(alloca.getOperation());
+    };
+    fir::replaceAllocas(rewriter, func.getOperation(), mustReplace, genAllocmem,
+                        genFreemem);
+  }
+}
+
+} // namespace
+
+std::unique_ptr<mlir::Pass>
+fir::createAllocationPlacement(const fir::AllocationPlacementOptions &options,
+                               fir::AllocationPlacementHook placementHook) {
+  return std::make_unique<AllocationPlacementPass>(options,
+                                                   std::move(placementHook));
+}

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_flang_library(FIRTransforms
   AffineDemotion.cpp
   AffinePromotion.cpp
   AlgebraicSimplification.cpp
+  AllocationPlacement.cpp
   AnnotateConstant.cpp
   ArrayValueCopy.cpp
   ArrayValueCopy.cpp

--- a/flang/lib/Optimizer/Transforms/StackArrays.cpp
+++ b/flang/lib/Optimizer/Transforms/StackArrays.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "StackArrays.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/LowLevelIntrinsics.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
@@ -74,52 +75,6 @@ enum class AllocationState {
   Allocated,
 };
 
-/// Stores where an alloca should be inserted. If the PointerUnion is an
-/// Operation the alloca should be inserted /after/ the operation. If it is a
-/// block, the alloca can be placed anywhere in that block.
-class InsertionPoint {
-  llvm::PointerUnion<mlir::Operation *, mlir::Block *> location;
-  bool saveRestoreStack;
-
-  /// Get contained pointer type or nullptr
-  template <class T>
-  T *tryGetPtr() const {
-    // Use llvm::dyn_cast_if_present because location may be null here.
-    if (T *ptr = llvm::dyn_cast_if_present<T *>(location))
-      return ptr;
-    return nullptr;
-  }
-
-public:
-  template <class T>
-  InsertionPoint(T *ptr, bool saveRestoreStack = false)
-      : location(ptr), saveRestoreStack{saveRestoreStack} {}
-  InsertionPoint(std::nullptr_t null)
-      : location(null), saveRestoreStack{false} {}
-
-  /// Get contained operation, or nullptr
-  mlir::Operation *tryGetOperation() const {
-    return tryGetPtr<mlir::Operation>();
-  }
-
-  /// Get contained block, or nullptr
-  mlir::Block *tryGetBlock() const { return tryGetPtr<mlir::Block>(); }
-
-  /// Get whether the stack should be saved/restored. If yes, an llvm.stacksave
-  /// intrinsic should be added before the alloca, and an llvm.stackrestore
-  /// intrinsic should be added where the freemem is
-  bool shouldSaveRestoreStack() const { return saveRestoreStack; }
-
-  operator bool() const { return tryGetOperation() || tryGetBlock(); }
-
-  bool operator==(const InsertionPoint &rhs) const {
-    return (location == rhs.location) &&
-           (saveRestoreStack == rhs.saveRestoreStack);
-  }
-
-  bool operator!=(const InsertionPoint &rhs) const { return !(*this == rhs); }
-};
-
 /// Maps SSA values to their AllocationState at a particular program point.
 /// Also caches the insertion points for the new alloca operations
 class LatticePoint : public mlir::dataflow::AbstractDenseLattice {
@@ -172,74 +127,6 @@ protected:
   /// Visit control flow operations and decide whether to call visitOperation
   /// to apply the transfer function
   mlir::LogicalResult processOperation(mlir::Operation *op) override;
-};
-
-/// Drives analysis to find candidate fir.allocmem operations which could be
-/// moved to the stack. Intended to be used with mlir::Pass::getAnalysis
-class StackArraysAnalysisWrapper {
-public:
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(StackArraysAnalysisWrapper)
-
-  // Maps fir.allocmem -> place to insert alloca
-  using AllocMemMap = llvm::DenseMap<mlir::Operation *, InsertionPoint>;
-
-  StackArraysAnalysisWrapper(mlir::Operation *op) {}
-
-  // returns nullptr if analysis failed
-  const AllocMemMap *getCandidateOps(mlir::Operation *func);
-
-private:
-  llvm::DenseMap<mlir::Operation *, AllocMemMap> funcMaps;
-
-  llvm::LogicalResult analyseFunction(mlir::Operation *func);
-};
-
-/// Converts a fir.allocmem to a fir.alloca
-class AllocMemConversion : public mlir::OpRewritePattern<fir::AllocMemOp> {
-public:
-  explicit AllocMemConversion(
-      mlir::MLIRContext *ctx,
-      const StackArraysAnalysisWrapper::AllocMemMap &candidateOps,
-      std::optional<mlir::DataLayout> &dl,
-      std::optional<fir::KindMapping> &kindMap)
-      : OpRewritePattern(ctx), candidateOps{candidateOps}, dl{dl},
-        kindMap{kindMap} {}
-
-  llvm::LogicalResult
-  matchAndRewrite(fir::AllocMemOp allocmem,
-                  mlir::PatternRewriter &rewriter) const override;
-
-  /// Determine where to insert the alloca operation. The returned value should
-  /// be checked to see if it is inside a loop
-  static InsertionPoint
-  findAllocaInsertionPoint(fir::AllocMemOp &oldAlloc,
-                           const llvm::SmallVector<mlir::Operation *> &freeOps);
-
-private:
-  /// Handle to the DFA (already run)
-  const StackArraysAnalysisWrapper::AllocMemMap &candidateOps;
-
-  const std::optional<mlir::DataLayout> &dl;
-  const std::optional<fir::KindMapping> &kindMap;
-
-  /// If we failed to find an insertion point not inside a loop, see if it would
-  /// be safe to use an llvm.stacksave/llvm.stackrestore inside the loop
-  static InsertionPoint findAllocaLoopInsertionPoint(
-      fir::AllocMemOp &oldAlloc,
-      const llvm::SmallVector<mlir::Operation *> &freeOps);
-
-  /// Returns the alloca if it was successfully inserted, otherwise {}
-  std::optional<fir::AllocaOp>
-  insertAlloca(fir::AllocMemOp &oldAlloc,
-               mlir::PatternRewriter &rewriter) const;
-
-  /// Inserts a stacksave before oldAlloc and a stackrestore after each freemem
-  void insertStackSaveRestore(fir::AllocMemOp oldAlloc,
-                              mlir::PatternRewriter &rewriter) const;
-  /// Emit lifetime markers for newAlloc between oldAlloc and each freemem.
-  /// If the allocation is dynamic, no life markers are emitted.
-  void insertLifetimeMarkers(fir::AllocMemOp oldAlloc, fir::AllocaOp newAlloc,
-                             mlir::PatternRewriter &rewriter) const;
 };
 
 class StackArraysPass : public fir::impl::StackArraysBase<StackArraysPass> {
@@ -462,7 +349,7 @@ mlir::LogicalResult AllocationAnalysis::processOperation(mlir::Operation *op) {
 }
 
 llvm::LogicalResult
-StackArraysAnalysisWrapper::analyseFunction(mlir::Operation *func) {
+fir::StackArraysAnalysisWrapper::analyseFunction(mlir::Operation *func) {
   assert(mlir::isa<mlir::func::FuncOp>(func));
   size_t nAllocs = 0;
   func->walk([&nAllocs](fir::AllocMemOp) { nAllocs++; });
@@ -543,8 +430,8 @@ StackArraysAnalysisWrapper::analyseFunction(mlir::Operation *func) {
   return mlir::success();
 }
 
-const StackArraysAnalysisWrapper::AllocMemMap *
-StackArraysAnalysisWrapper::getCandidateOps(mlir::Operation *func) {
+const fir::StackArraysAnalysisWrapper::AllocMemMap *
+fir::StackArraysAnalysisWrapper::getCandidateOps(mlir::Operation *func) {
   if (!funcMaps.contains(func))
     if (mlir::failed(analyseFunction(func)))
       return nullptr;
@@ -575,9 +462,8 @@ static mlir::Value convertAllocationType(mlir::PatternRewriter &rewriter,
   return conv;
 }
 
-llvm::LogicalResult
-AllocMemConversion::matchAndRewrite(fir::AllocMemOp allocmem,
-                                    mlir::PatternRewriter &rewriter) const {
+llvm::LogicalResult fir::AllocMemConversion::matchAndRewrite(
+    fir::AllocMemOp allocmem, mlir::PatternRewriter &rewriter) const {
   auto oldInsertionPt = rewriter.saveInsertionPoint();
   // add alloca operation
   std::optional<fir::AllocaOp> alloca = insertAlloca(allocmem, rewriter);
@@ -615,7 +501,7 @@ static bool isInLoop(mlir::Operation *op) {
          op->getParentOfType<mlir::LoopLikeOpInterface>();
 }
 
-InsertionPoint AllocMemConversion::findAllocaInsertionPoint(
+fir::InsertionPoint fir::AllocMemConversion::findAllocaInsertionPoint(
     fir::AllocMemOp &oldAlloc,
     const llvm::SmallVector<mlir::Operation *> &freeOps) {
   // Ideally the alloca should be inserted at the end of the function entry
@@ -731,7 +617,7 @@ InsertionPoint AllocMemConversion::findAllocaInsertionPoint(
   return checkReturn(&entryBlock);
 }
 
-InsertionPoint AllocMemConversion::findAllocaLoopInsertionPoint(
+fir::InsertionPoint fir::AllocMemConversion::findAllocaLoopInsertionPoint(
     fir::AllocMemOp &oldAlloc,
     const llvm::SmallVector<mlir::Operation *> &freeOps) {
   mlir::Operation *oldAllocOp = oldAlloc;
@@ -762,8 +648,8 @@ InsertionPoint AllocMemConversion::findAllocaLoopInsertionPoint(
 }
 
 std::optional<fir::AllocaOp>
-AllocMemConversion::insertAlloca(fir::AllocMemOp &oldAlloc,
-                                 mlir::PatternRewriter &rewriter) const {
+fir::AllocMemConversion::insertAlloca(fir::AllocMemOp &oldAlloc,
+                                      mlir::PatternRewriter &rewriter) const {
   auto it = candidateOps.find(oldAlloc.getOperation());
   if (it == candidateOps.end())
     return {};
@@ -811,7 +697,7 @@ visitFreeMemOp(fir::AllocMemOp oldAlloc,
   });
 }
 
-void AllocMemConversion::insertStackSaveRestore(
+void fir::AllocMemConversion::insertStackSaveRestore(
     fir::AllocMemOp oldAlloc, mlir::PatternRewriter &rewriter) const {
   mlir::OpBuilder::InsertionGuard insertGuard(rewriter);
   auto mod = oldAlloc->getParentOfType<mlir::ModuleOp>();
@@ -827,7 +713,7 @@ void AllocMemConversion::insertStackSaveRestore(
   visitFreeMemOp(oldAlloc, createStackRestoreCall);
 }
 
-void AllocMemConversion::insertLifetimeMarkers(
+void fir::AllocMemConversion::insertLifetimeMarkers(
     fir::AllocMemOp oldAlloc, fir::AllocaOp newAlloc,
     mlir::PatternRewriter &rewriter) const {
   if (!dl || !kindMap)
@@ -860,8 +746,8 @@ llvm::StringRef StackArraysPass::getDescription() const {
 void StackArraysPass::runOnOperation() {
   mlir::func::FuncOp func = getOperation();
 
-  auto &analysis = getAnalysis<StackArraysAnalysisWrapper>();
-  const StackArraysAnalysisWrapper::AllocMemMap *candidateOps =
+  auto &analysis = getAnalysis<fir::StackArraysAnalysisWrapper>();
+  const fir::StackArraysAnalysisWrapper::AllocMemMap *candidateOps =
       analysis.getCandidateOps(func);
   if (!candidateOps) {
     signalPassFailure();
@@ -893,7 +779,8 @@ void StackArraysPass::runOnOperation() {
   if (module)
     kindMap = fir::getKindMapping(module);
 
-  patterns.insert<AllocMemConversion>(&context, *candidateOps, dl, kindMap);
+  patterns.insert<fir::AllocMemConversion>(&context, *candidateOps, dl,
+                                           kindMap);
   if (mlir::failed(mlir::applyOpPatternsGreedily(
           opsToConvert, std::move(patterns), config))) {
     mlir::emitError(func->getLoc(), "error in stack arrays optimization\n");

--- a/flang/lib/Optimizer/Transforms/StackArrays.h
+++ b/flang/lib/Optimizer/Transforms/StackArrays.h
@@ -1,0 +1,154 @@
+//===- StackArrays.h ------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+//
+// This header exposes the reusable pieces of the StackArrays pass: the
+// analysis that determines which fir.allocmem operations can safely be moved
+// to the stack (and where the replacement fir.alloca should be inserted), and
+// the pattern that performs the heap-to-stack rewrite. They are shared so that
+// other passes can reuse the same "is this heap allocation safely stackifiable,
+// and where" logic.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_TRANSFORMS_STACKARRAYS_H
+#define FORTRAN_OPTIMIZER_TRANSFORMS_STACKARRAYS_H
+
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/Support/KindMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "mlir/Support/TypeID.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
+#include <optional>
+
+namespace fir {
+
+/// Stores where an alloca should be inserted. If the PointerUnion is an
+/// Operation the alloca should be inserted /after/ the operation. If it is a
+/// block, the alloca can be placed anywhere in that block.
+class InsertionPoint {
+  llvm::PointerUnion<mlir::Operation *, mlir::Block *> location;
+  bool saveRestoreStack;
+
+  /// Get contained pointer type or nullptr
+  template <class T>
+  T *tryGetPtr() const {
+    // Use llvm::dyn_cast_if_present because location may be null here.
+    if (T *ptr = llvm::dyn_cast_if_present<T *>(location))
+      return ptr;
+    return nullptr;
+  }
+
+public:
+  template <class T>
+  InsertionPoint(T *ptr, bool saveRestoreStack = false)
+      : location(ptr), saveRestoreStack{saveRestoreStack} {}
+  InsertionPoint(std::nullptr_t null)
+      : location(null), saveRestoreStack{false} {}
+
+  /// Get contained operation, or nullptr
+  mlir::Operation *tryGetOperation() const {
+    return tryGetPtr<mlir::Operation>();
+  }
+
+  /// Get contained block, or nullptr
+  mlir::Block *tryGetBlock() const { return tryGetPtr<mlir::Block>(); }
+
+  /// Get whether the stack should be saved/restored. If yes, an llvm.stacksave
+  /// intrinsic should be added before the alloca, and an llvm.stackrestore
+  /// intrinsic should be added where the freemem is
+  bool shouldSaveRestoreStack() const { return saveRestoreStack; }
+
+  operator bool() const { return tryGetOperation() || tryGetBlock(); }
+
+  bool operator==(const InsertionPoint &rhs) const {
+    return (location == rhs.location) &&
+           (saveRestoreStack == rhs.saveRestoreStack);
+  }
+
+  bool operator!=(const InsertionPoint &rhs) const { return !(*this == rhs); }
+};
+
+/// Drives analysis to find candidate fir.allocmem operations which could be
+/// moved to the stack. Intended to be used with mlir::Pass::getAnalysis
+class StackArraysAnalysisWrapper {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(StackArraysAnalysisWrapper)
+
+  // Maps fir.allocmem -> place to insert alloca
+  using AllocMemMap = llvm::DenseMap<mlir::Operation *, InsertionPoint>;
+
+  StackArraysAnalysisWrapper(mlir::Operation *op) {}
+
+  // returns nullptr if analysis failed
+  const AllocMemMap *getCandidateOps(mlir::Operation *func);
+
+private:
+  llvm::DenseMap<mlir::Operation *, AllocMemMap> funcMaps;
+
+  llvm::LogicalResult analyseFunction(mlir::Operation *func);
+};
+
+/// Converts a fir.allocmem to a fir.alloca
+class AllocMemConversion : public mlir::OpRewritePattern<fir::AllocMemOp> {
+public:
+  explicit AllocMemConversion(
+      mlir::MLIRContext *ctx,
+      const StackArraysAnalysisWrapper::AllocMemMap &candidateOps,
+      std::optional<mlir::DataLayout> &dl,
+      std::optional<fir::KindMapping> &kindMap)
+      : OpRewritePattern(ctx), candidateOps{candidateOps}, dl{dl},
+        kindMap{kindMap} {}
+
+  llvm::LogicalResult
+  matchAndRewrite(fir::AllocMemOp allocmem,
+                  mlir::PatternRewriter &rewriter) const override;
+
+  /// Determine where to insert the alloca operation. The returned value should
+  /// be checked to see if it is inside a loop
+  static InsertionPoint
+  findAllocaInsertionPoint(fir::AllocMemOp &oldAlloc,
+                           const llvm::SmallVector<mlir::Operation *> &freeOps);
+
+private:
+  /// Handle to the DFA (already run)
+  const StackArraysAnalysisWrapper::AllocMemMap &candidateOps;
+
+  const std::optional<mlir::DataLayout> &dl;
+  const std::optional<fir::KindMapping> &kindMap;
+
+  /// If we failed to find an insertion point not inside a loop, see if it would
+  /// be safe to use an llvm.stacksave/llvm.stackrestore inside the loop
+  static InsertionPoint findAllocaLoopInsertionPoint(
+      fir::AllocMemOp &oldAlloc,
+      const llvm::SmallVector<mlir::Operation *> &freeOps);
+
+  /// Returns the alloca if it was successfully inserted, otherwise {}
+  std::optional<fir::AllocaOp>
+  insertAlloca(fir::AllocMemOp &oldAlloc,
+               mlir::PatternRewriter &rewriter) const;
+
+  /// Inserts a stacksave before oldAlloc and a stackrestore after each freemem
+  void insertStackSaveRestore(fir::AllocMemOp oldAlloc,
+                              mlir::PatternRewriter &rewriter) const;
+  /// Emit lifetime markers for newAlloc between oldAlloc and each freemem.
+  /// If the allocation is dynamic, no life markers are emitted.
+  void insertLifetimeMarkers(fir::AllocMemOp oldAlloc, fir::AllocaOp newAlloc,
+                             mlir::PatternRewriter &rewriter) const;
+};
+
+} // namespace fir
+
+#endif // FORTRAN_OPTIMIZER_TRANSFORMS_STACKARRAYS_H

--- a/flang/lib/Optimizer/Transforms/StackArrays.h
+++ b/flang/lib/Optimizer/Transforms/StackArrays.h
@@ -92,7 +92,11 @@ public:
 
   StackArraysAnalysisWrapper(mlir::Operation *op) {}
 
-  // returns nullptr if analysis failed
+  // Returns nullptr if analysis failed.
+  // Note: the returned pointer points into funcMaps and is invalidated if
+  // funcMaps grows (i.e. when a not-yet-analysed function is queried). This
+  // does not happen currently because each StackArraysAnalysisWrapper instance
+  // is only used to analyse a single function.
   const AllocMemMap *getCandidateOps(mlir::Operation *func);
 
 private:

--- a/flang/test/Transforms/allocation-placement-budget.fir
+++ b/flang/test/Transforms/allocation-placement-budget.fir
@@ -1,0 +1,29 @@
+// Test the per-function stack budget: small arrays are placed on the stack
+// until the total stack limit is reached, after which further small arrays are
+// left on the heap. With a 64-byte limit, the first 40-byte array fits on the
+// stack but the following 48-byte array does not (40 + 48 = 88 > 64).
+
+// RUN: fir-opt --allocation-placement="small-array-threshold=64 total-stack-limit=64" %s | FileCheck %s
+
+module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
+
+// CHECK-LABEL: func.func @budget
+// CHECK-DAG: fir.alloca !fir.array<10xi32>
+// CHECK-DAG: fir.allocmem !fir.array<12xi32>
+func.func @budget() {
+  %0 = fir.allocmem !fir.array<10xi32>
+  %1 = fir.allocmem !fir.array<12xi32>
+  %c0 = arith.constant 0 : index
+  %v = arith.constant 0 : i32
+  %r0 = fir.convert %0 : (!fir.heap<!fir.array<10xi32>>) -> !fir.ref<!fir.array<10xi32>>
+  %e0 = fir.coordinate_of %r0, %c0 : (!fir.ref<!fir.array<10xi32>>, index) -> !fir.ref<i32>
+  fir.store %v to %e0 : !fir.ref<i32>
+  %r1 = fir.convert %1 : (!fir.heap<!fir.array<12xi32>>) -> !fir.ref<!fir.array<12xi32>>
+  %e1 = fir.coordinate_of %r1, %c0 : (!fir.ref<!fir.array<12xi32>>, index) -> !fir.ref<i32>
+  fir.store %v to %e1 : !fir.ref<i32>
+  fir.freemem %0 : !fir.heap<!fir.array<10xi32>>
+  fir.freemem %1 : !fir.heap<!fir.array<12xi32>>
+  return
+}
+
+}

--- a/flang/test/Transforms/allocation-placement-stack-arrays-mode.fir
+++ b/flang/test/Transforms/allocation-placement-stack-arrays-mode.fir
@@ -1,0 +1,24 @@
+// Test the aggressive (-fstack-arrays) allocation-placement mode: all array
+// temporaries are moved to the stack regardless of size, as long as the
+// heap-to-stack conversion is provably safe.
+
+// RUN: fir-opt --allocation-placement="stack-arrays=true" %s | FileCheck %s
+
+module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
+
+// Big temporary heap allocation -> stack under -fstack-arrays.
+// CHECK-LABEL: func.func @big_temp_to_stack
+// CHECK: fir.alloca !fir.array<100xi32>
+// CHECK-NOT: fir.allocmem
+func.func @big_temp_to_stack() {
+  %0 = fir.allocmem !fir.array<100xi32>
+  %c0 = arith.constant 0 : index
+  %v = arith.constant 0 : i32
+  %r = fir.convert %0 : (!fir.heap<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>>
+  %e = fir.coordinate_of %r, %c0 : (!fir.ref<!fir.array<100xi32>>, index) -> !fir.ref<i32>
+  fir.store %v to %e : !fir.ref<i32>
+  fir.freemem %0 : !fir.heap<!fir.array<100xi32>>
+  return
+}
+
+}

--- a/flang/test/Transforms/allocation-placement.fir
+++ b/flang/test/Transforms/allocation-placement.fir
@@ -1,0 +1,84 @@
+// Test the default (-fno-stack-arrays) allocation-placement policy:
+//  - small constant-size arrays go on the stack (within the budget),
+//  - big constant-size arrays: user variables stay on the stack, temporaries
+//    go on the heap,
+//  - runtime-sized arrays go on the heap.
+// A user variable is identified by a non-empty uniq_name; a temporary has none.
+// i32 is 4 bytes, so <10xi32> = 40 bytes (small) and <100xi32> = 400 bytes (big)
+// with the default 64-byte small threshold.
+
+// RUN: fir-opt --allocation-placement %s | FileCheck %s
+
+module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
+
+// Small temporary heap allocation -> stack.
+// CHECK-LABEL: func.func @small_temp
+// CHECK: fir.alloca !fir.array<10xi32>
+// CHECK-NOT: fir.allocmem
+func.func @small_temp() {
+  %0 = fir.allocmem !fir.array<10xi32>
+  %c0 = arith.constant 0 : index
+  %v = arith.constant 0 : i32
+  %r = fir.convert %0 : (!fir.heap<!fir.array<10xi32>>) -> !fir.ref<!fir.array<10xi32>>
+  %e = fir.coordinate_of %r, %c0 : (!fir.ref<!fir.array<10xi32>>, index) -> !fir.ref<i32>
+  fir.store %v to %e : !fir.ref<i32>
+  fir.freemem %0 : !fir.heap<!fir.array<10xi32>>
+  return
+}
+
+// Small temporary stack allocation -> stays on the stack.
+// CHECK-LABEL: func.func @small_temp_alloca
+// CHECK: fir.alloca !fir.array<10xi32>
+// CHECK-NOT: fir.allocmem
+func.func @small_temp_alloca() {
+  %0 = fir.alloca !fir.array<10xi32>
+  return
+}
+
+// Big temporary heap allocation -> stays on the heap.
+// CHECK-LABEL: func.func @big_temp
+// CHECK: fir.allocmem !fir.array<100xi32>
+// CHECK: fir.freemem
+func.func @big_temp() {
+  %0 = fir.allocmem !fir.array<100xi32>
+  fir.freemem %0 : !fir.heap<!fir.array<100xi32>>
+  return
+}
+
+// Big user-variable stack allocation -> stays on the stack.
+// CHECK-LABEL: func.func @big_user
+// CHECK: fir.alloca !fir.array<100xi32>
+// CHECK-NOT: fir.allocmem
+func.func @big_user() {
+  %0 = fir.alloca !fir.array<100xi32> {bindc_name = "arr", uniq_name = "_QFbig_userEarr"}
+  return
+}
+
+// Big temporary stack allocation -> heap.
+// CHECK-LABEL: func.func @big_temp_alloca
+// CHECK: fir.allocmem !fir.array<100xi32>
+// CHECK: fir.freemem
+func.func @big_temp_alloca() {
+  %0 = fir.alloca !fir.array<100xi32>
+  return
+}
+
+// Runtime-sized user variable (automatic array) -> heap.
+// CHECK-LABEL: func.func @dyn_user
+// CHECK: fir.allocmem !fir.array<?xi32>
+// CHECK: fir.freemem
+func.func @dyn_user(%n: index) {
+  %0 = fir.alloca !fir.array<?xi32>, %n {bindc_name = "arr", uniq_name = "_QFdyn_userEarr"}
+  return
+}
+
+// Runtime-sized temporary -> stays on the heap.
+// CHECK-LABEL: func.func @dyn_temp
+// CHECK: fir.allocmem !fir.array<?xi32>
+func.func @dyn_temp(%n: index) {
+  %0 = fir.allocmem !fir.array<?xi32>, %n
+  fir.freemem %0 : !fir.heap<!fir.array<?xi32>>
+  return
+}
+
+}


### PR DESCRIPTION
Introduce a new function-level pass, allocation-placement, that unifies the stack/heap placement decisions currently split between the stack-arrays and memory-allocation-opt passes. For each array allocation it consults a policy to decide whether it should live on the stack (fir.alloca) or the heap (fir.allocmem) and rewrites it accordingly, reusing fir::replaceAllocas for stack-to-heap and the StackArrays analysis/rewrite for heap-to-stack (so heap-to-stack only happens where it is provably safe).

The default policy (AllocationPlacementPolicy.h) is threshold-driven:
  - small constant-size arrays go on the stack within a per-function stack budget, otherwise on the heap;
  - big constant-size arrays: user variables stay on the stack, temporaries go on the heap;
  - runtime-sized arrays go on the heap;
  - an aggressive mode places all arrays on the stack (best effort). User variables are distinguished from compiler temporaries via the presence of a uniqued name. A hook lets downstream users override the thresholds per allocation (e.g. for device routines or parallel regions).

The pass is not wired into any pipeline yet; it is reachable through fir-opt and covered by isolated tests.

Assisted-by: AI