### PR TITLE
[flang] Add warning when BOZ literal is too large for assignment

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -294,6 +294,7 @@ end
   not be known (e.g., `IAND(X'1',X'2')`, or as arguments of `DIM`, `MOD`,
   `MODULO`, and `SIGN`. Note that while other compilers may accept such usages,
   the type resolution of such BOZ literals usages is highly non portable).
+  A warning is emitted when the BOZ literal is too large for the target.
 * BOZ literals can also be used as REAL values in some contexts where the
   type is unambiguous, such as initializations of REAL parameters.
 * `TRANSFER(boz, MOLD=integer or real scalar)` is accepted as an alternate

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -87,7 +87,8 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
     MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure,
-    IgnoredNoReallocateLHS, ExperimentalOption, IoImpliedDoIndexConflict)
+    IgnoredNoReallocateLHS, ExperimentalOption, IoImpliedDoIndexConflict,
+    BOZLiteralTruncation)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -5875,6 +5875,17 @@ void ArgumentAnalyzer::ConvertBOZAssignmentRHS(const DynamicType &lhsType) {
       lhsType.category() == TypeCategory::Unsigned ||
       lhsType.category() == TypeCategory::Real) {
     Expr<SomeType> rhs{MoveExpr(1)};
+    if (lhsType.category() == TypeCategory::Integer ||
+        lhsType.category() == TypeCategory::Unsigned) {
+      if (const auto *boz{std::get_if<BOZLiteralConstant>(&rhs.u)};
+          boz && boz->bits - boz->LEADZ() > lhsType.kind() * 8) {
+        context_.Warn(common::UsageWarning::BOZLiteralTruncation,
+            "BOZ literal constant is too large for %s(KIND=%d) assignment target"_warn_en_US,
+            lhsType.category() == TypeCategory::Unsigned ? "UNSIGNED"
+                                                         : "INTEGER",
+            lhsType.kind());
+      }
+    }
     if (MaybeExpr converted{ConvertToType(lhsType, std::move(rhs))}) {
       actuals_[1] = std::move(*converted);
     }

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -5880,7 +5880,7 @@ void ArgumentAnalyzer::ConvertBOZAssignmentRHS(const DynamicType &lhsType) {
       if (const auto *boz{std::get_if<BOZLiteralConstant>(&rhs.u)};
           boz && boz->bits - boz->LEADZ() > lhsType.kind() * 8) {
         context_.Warn(common::UsageWarning::BOZLiteralTruncation,
-            "BOZ literal constant is too large for %s(KIND=%d) assignment target"_warn_en_US,
+            "BOZ literal constant is too large for %s(KIND=%d) assignment target; truncated"_warn_en_US,
             lhsType.category() == TypeCategory::Unsigned ? "UNSIGNED"
                                                          : "INTEGER",
             lhsType.kind());

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -222,6 +222,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnUsage_.set(UsageWarning::ImpureFinalInPure);
   warnUsage_.set(UsageWarning::IgnoredNoReallocateLHS);
   warnUsage_.set(UsageWarning::IoImpliedDoIndexConflict);
+  warnUsage_.set(UsageWarning::BOZLiteralTruncation);
   warnLanguage_.set(LanguageFeature::OpenMPThreadprivateEquivalence);
   warnLanguage_.set(LanguageFeature::OpenAccDefaultNoneScalarsStrict);
   warnLanguage_.set(LanguageFeature::OpenACCMultipleNamesInRoutine);

--- a/flang/test/Semantics/boz-truncation.f90
+++ b/flang/test/Semantics/boz-truncation.f90
@@ -1,0 +1,25 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -funsigned -Werror
+! Test the warning for a BOZ literal constant that is too large for the
+! INTEGER or UNSIGNED type of an assignment target.
+program boztest
+  integer(4) :: i4
+  integer(8) :: i8
+  unsigned(2) :: u2
+  unsigned(4) :: u4
+
+  ! INTEGER targets
+  i4 = z'FFFFFFFF' ! fits in 32 bits, no warning
+  !WARNING: BOZ literal constant is too large for INTEGER(KIND=4) assignment target [-Wboz-literal-truncation]
+  i4 = z'1FFFFFFFF' ! 33 bits, too large for INTEGER(4)
+  i8 = z'FFFFFFFFFFFFFFFF' ! fits in 64 bits, no warning
+  !WARNING: BOZ literal constant is too large for INTEGER(KIND=8) assignment target [-Wboz-literal-truncation]
+  i8 = z'1FFFFFFFFFFFFFFFF' ! 65 bits, too large for INTEGER(8)
+
+  ! UNSIGNED targets
+  u2 = z'FFFF' ! fits in 16 bits, no warning
+  !WARNING: BOZ literal constant is too large for UNSIGNED(KIND=2) assignment target [-Wboz-literal-truncation]
+  u2 = z'1FFFF' ! 17 bits, too large for UNSIGNED(2)
+  u4 = z'FFFFFFFF' ! fits in 32 bits, no warning
+  !WARNING: BOZ literal constant is too large for UNSIGNED(KIND=4) assignment target [-Wboz-literal-truncation]
+  u4 = z'1FFFFFFFF' ! 33 bits, too large for UNSIGNED(4)
+end program

--- a/flang/test/Semantics/boz-truncation.f90
+++ b/flang/test/Semantics/boz-truncation.f90
@@ -9,6 +9,7 @@ program boztest
 
   ! INTEGER targets
   i4 = z'FFFFFFFF' ! fits in 32 bits, no warning
+  i4 = z'0000000FFFFFFFF' ! long BOZ string with non-overflowing value
   !WARNING: BOZ literal constant is too large for INTEGER(KIND=4) assignment target [-Wboz-literal-truncation]
   i4 = z'1FFFFFFFF' ! 33 bits, too large for INTEGER(4)
   i8 = z'FFFFFFFFFFFFFFFF' ! fits in 64 bits, no warning

--- a/flang/test/Semantics/boz-truncation.f90
+++ b/flang/test/Semantics/boz-truncation.f90
@@ -10,17 +10,17 @@ program boztest
   ! INTEGER targets
   i4 = z'FFFFFFFF' ! fits in 32 bits, no warning
   i4 = z'0000000FFFFFFFF' ! long BOZ string with non-overflowing value
-  !WARNING: BOZ literal constant is too large for INTEGER(KIND=4) assignment target [-Wboz-literal-truncation]
+  !WARNING: BOZ literal constant is too large for INTEGER(KIND=4) assignment target; truncated [-Wboz-literal-truncation]
   i4 = z'1FFFFFFFF' ! 33 bits, too large for INTEGER(4)
   i8 = z'FFFFFFFFFFFFFFFF' ! fits in 64 bits, no warning
-  !WARNING: BOZ literal constant is too large for INTEGER(KIND=8) assignment target [-Wboz-literal-truncation]
+  !WARNING: BOZ literal constant is too large for INTEGER(KIND=8) assignment target; truncated [-Wboz-literal-truncation]
   i8 = z'1FFFFFFFFFFFFFFFF' ! 65 bits, too large for INTEGER(8)
 
   ! UNSIGNED targets
   u2 = z'FFFF' ! fits in 16 bits, no warning
-  !WARNING: BOZ literal constant is too large for UNSIGNED(KIND=2) assignment target [-Wboz-literal-truncation]
+  !WARNING: BOZ literal constant is too large for UNSIGNED(KIND=2) assignment target; truncated [-Wboz-literal-truncation]
   u2 = z'1FFFF' ! 17 bits, too large for UNSIGNED(2)
   u4 = z'FFFFFFFF' ! fits in 32 bits, no warning
-  !WARNING: BOZ literal constant is too large for UNSIGNED(KIND=4) assignment target [-Wboz-literal-truncation]
+  !WARNING: BOZ literal constant is too large for UNSIGNED(KIND=4) assignment target; truncated [-Wboz-literal-truncation]
   u4 = z'1FFFFFFFF' ! 33 bits, too large for UNSIGNED(4)
 end program


### PR DESCRIPTION
Generate a warning when a BOZ literal assignment does not fit into the left-hand side variable.

AI use disclaimer: Github CoPilot assisted with this PR. I manually reviewed and tested the code.

Co-authored-by: John Otken john.otken@hpe.com