### PR TITLE
[flang][OpenMP] Fix new metadirective-loop-nest.f90 test expectation with collapse changes in #208528

### DIFF
--- a/flang/test/Semantics/OpenMP/metadirective-loop-nest.f90
+++ b/flang/test/Semantics/OpenMP/metadirective-loop-nest.f90
@@ -199,7 +199,7 @@ end subroutine
 ! subprogram for its execution part.
 subroutine no_loop_in_interface_body_preserves_outer(n, a)
   integer :: n, a(n), i
-  !ERROR: This construct requires a perfect nest of depth 2, but the associated nest is a perfect nest of depth 1
+  !ERROR: This construct requires a nest of depth 2, but the associated nest is a nest of depth 1
   !BECAUSE: COLLAPSE clause was specified with argument 2
   !$omp metadirective when(implementation={vendor(llvm)}: do collapse(2)) default(nothing)
   interface


### PR DESCRIPTION
Fixes a lit test failure affecting buildbots from #208528. I'm attempting to land this quickly rather than revert COLLAPSE (again). I missed an additional test change in the main branch before merging the reland for COLLAPSE.