### PR TITLE
[NewPM] Port LegacyPM regalloc Refactoring

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -516,8 +516,8 @@ protected:
 
   /// Add core register allocator passes which do the actual register assignment
   /// and rewriting.
-  Error addRegAssignmentFast(PassManagerWrapper &PMW) const;
-  Error addRegAssignmentOptimized(PassManagerWrapper &PMW) const;
+  Error addRegAssignAndRewriteFast(PassManagerWrapper &PMW) const;
+  Error addRegAssignAndRewriteOptimized(PassManagerWrapper &PMW) const;
 
   /// Allow the target to disable a specific pass by default.
   /// Backend can declare unwanted passes in constructor.
@@ -1183,7 +1183,7 @@ void CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPass(
 }
 
 template <typename Derived, typename TargetMachineT>
-Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAssignmentFast(
+Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAssignAndRewriteFast(
     PassManagerWrapper &PMW) const {
   // TODO: Ensure allocator is default or fast.
   addRegAllocPass(PMW, false);
@@ -1191,8 +1191,8 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAssignmentFast(
 }
 
 template <typename Derived, typename TargetMachineT>
-Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAssignmentOptimized(
-    PassManagerWrapper &PMW) const {
+Error CodeGenPassBuilder<Derived, TargetMachineT>::
+    addRegAssignAndRewriteOptimized(PassManagerWrapper &PMW) const {
   // Add the selected register allocation pass.
   addRegAllocPass(PMW, true);
 
@@ -1201,11 +1201,6 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAssignmentOptimized(
 
   // Finally rewrite virtual registers.
   addMachineFunctionPass(VirtRegRewriterPass(), PMW);
-  // Perform stack slot coloring and post-ra machine LICM.
-  //
-  // FIXME: Re-enable coloring with register when it's capable of adding
-  // kill markers.
-  addMachineFunctionPass(StackSlotColoringPass(), PMW);
 
   return Error::success();
 }
@@ -1217,7 +1212,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addFastRegAlloc(
     PassManagerWrapper &PMW) const {
   addMachineFunctionPass(PHIEliminationPass(), PMW);
   addMachineFunctionPass(TwoAddressInstructionPass(), PMW);
-  return derived().addRegAssignmentFast(PMW);
+  return derived().addRegAssignAndRewriteFast(PMW);
 }
 
 /// Add standard target-independent passes that are tightly coupled with
@@ -1267,7 +1262,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addOptimizedRegAlloc(
   // PreRA instruction scheduling.
   addMachineFunctionPass(MachineSchedulerPass(&TM), PMW);
 
-  if (auto E = derived().addRegAssignmentOptimized(PMW))
+  if (auto E = derived().addRegAssignAndRewriteOptimized(PMW))
     return std::move(E);
 
   addMachineFunctionPass(StackSlotColoringPass(), PMW);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -162,8 +162,8 @@ public:
   void addPostRegAlloc(PassManagerWrapper &PMW) const;
   void addPreEmitPass(PassManagerWrapper &PMWM) const;
   void addPreEmitRegAlloc(PassManagerWrapper &PMW) const;
-  Error addRegAssignmentFast(PassManagerWrapper &PMW) const;
-  Error addRegAssignmentOptimized(PassManagerWrapper &PMW) const;
+  Error addRegAssignAndRewriteFast(PassManagerWrapper &PMW) const;
+  Error addRegAssignAndRewriteOptimized(PassManagerWrapper &PMW) const;
   void addPreRegAlloc(PassManagerWrapper &PMW) const;
   Error addFastRegAlloc(PassManagerWrapper &PMW) const;
   Error addOptimizedRegAlloc(PassManagerWrapper &PMW) const;
@@ -2523,7 +2523,7 @@ Error AMDGPUCodeGenPassBuilder::addFastRegAlloc(PassManagerWrapper &PMW) const {
   return Base::addFastRegAlloc(PMW);
 }
 
-Error AMDGPUCodeGenPassBuilder::addRegAssignmentFast(
+Error AMDGPUCodeGenPassBuilder::addRegAssignAndRewriteFast(
     PassManagerWrapper &PMW) const {
   if (auto Err = validateRegAllocOptions())
     return Err;
@@ -2606,7 +2606,7 @@ void AMDGPUCodeGenPassBuilder::addPreRegAlloc(PassManagerWrapper &PMW) const {
     addMachineFunctionPass(AMDGPUPrepareAGPRAllocPass(), PMW);
 }
 
-Error AMDGPUCodeGenPassBuilder::addRegAssignmentOptimized(
+Error AMDGPUCodeGenPassBuilder::addRegAssignAndRewriteOptimized(
     PassManagerWrapper &PMW) const {
   if (auto Err = validateRegAllocOptions())
     return Err;

--- a/llvm/test/CodeGen/Lanai/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/Lanai/llc-pipeline-npm.ll
@@ -61,7 +61,6 @@
 ; CHECK:     greedy<all>
 ; CHECK:     virt-reg-rewriter
 ; CHECK:     stack-slot-coloring
-; CHECK:     stack-slot-coloring
 ; CHECK:     machine-cp
 ; CHECK:     machinelicm
 ; CHECK:     remove-redundant-debug-values

--- a/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
@@ -160,7 +160,6 @@
 ; O2-NEXT:     greedy<all>
 ; O2-NEXT:     virt-reg-rewriter
 ; O2-NEXT:     stack-slot-coloring
-; O2-NEXT:     stack-slot-coloring
 ; O2-NEXT:     machine-cp
 ; O2-NEXT:     machinelicm
 ; O2-NEXT:     x86-lower-tile-copy
@@ -360,7 +359,6 @@
 ; O3-WINDOWS-NEXT:     machine-scheduler
 ; O3-WINDOWS-NEXT:     greedy<all>
 ; O3-WINDOWS-NEXT:     virt-reg-rewriter
-; O3-WINDOWS-NEXT:     stack-slot-coloring
 ; O3-WINDOWS-NEXT:     stack-slot-coloring
 ; O3-WINDOWS-NEXT:     machine-cp
 ; O3-WINDOWS-NEXT:     machinelicm


### PR DESCRIPTION
This didn't seem to make it into the original CodeGen NewPM patches, so
add it now to keep things consistent. This also removes duplicate
StackSlotColoring passes.

Originally done for the LegacyPM in
c9122ddef5213fbdd2d82c473a74e1742010f62f.