### PR TITLE
[clang-format] Prevent re-assigning type on finalized tokens

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2308,7 +2308,8 @@ private:
           }
           if (Previous->opensScope())
             break;
-          if (!Previous->isTypeFinalized() && Previous->isOneOf(TT_BinaryOperator, TT_UnaryOperator) &&
+          if (!Previous->isTypeFinalized() &&
+              Previous->isOneOf(TT_BinaryOperator, TT_UnaryOperator) &&
               Previous->isPointerOrReference() && Previous->Previous &&
               Previous->Previous->isNot(tok::equal)) {
             Previous->setType(TT_PointerOrReference);

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2308,9 +2308,9 @@ private:
           }
           if (Previous->opensScope())
             break;
-          if (Previous->isOneOf(TT_BinaryOperator, TT_UnaryOperator) &&
+          if (!Previous->isTypeFinalized() && Previous->isOneOf(TT_BinaryOperator, TT_UnaryOperator) &&
               Previous->isPointerOrReference() && Previous->Previous &&
-              Previous->Previous->isNot(tok::equal) && !Previous->isTypeFinalized()) {
+              Previous->Previous->isNot(tok::equal)) {
             Previous->setType(TT_PointerOrReference);
           }
         }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2310,7 +2310,7 @@ private:
             break;
           if (Previous->isOneOf(TT_BinaryOperator, TT_UnaryOperator) &&
               Previous->isPointerOrReference() && Previous->Previous &&
-              Previous->Previous->isNot(tok::equal)) {
+              Previous->Previous->isNot(tok::equal) && !Previous->isTypeFinalized()) {
             Previous->setType(TT_PointerOrReference);
           }
         }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22562,6 +22562,7 @@ TEST_F(FormatTest, DoNotCrashOnInvalidInput) {
   verifyNoCrash("[[ [a] ]]");
   verifyNoCrash(
       "#xxxx??x<xxxxxxx||??x<xxxxxxx and xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+  verifyNoCrash("a &alias & =");
 }
 
 TEST_F(FormatTest, FormatsTableGenCode) {


### PR DESCRIPTION
Prevents a finalized token inside modifyContext from being reassigned through the setType member function by checking if the token is finalized.

This ensures ill-defined code like does not trigger an assertion failure during reformatting.
Fixes #210509 