### PR TITLE
[Clang][AMDGPU] Search both amdgcn and amdgpu libraries again

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1225,6 +1225,14 @@ ToolChain::path_list ToolChain::getArchSpecificLibPaths() const {
   };
 
   AddPath({getTriple().str()});
+
+  // Handle the legacy AMDGPU triple case as well.
+  if (getTriple().getArchName() == "amdgcn") {
+    llvm::Triple Canon(getTriple());
+    Canon.setArchName("amdgpu");
+    AddPath({Canon.str()});
+  }
+
   AddPath({getOSLibName(), llvm::Triple::getArchTypeName(getArch())});
   return Paths;
 }

--- a/clang/test/Driver/amdgpu-toolchain.c
+++ b/clang/test/Driver/amdgpu-toolchain.c
@@ -77,3 +77,9 @@
 // RUN:   -fprofile-generate %s 2>&1 | FileCheck -check-prefixes=PROFILE-AMDGPU %s
 //      PROFILE-AMDGPU: ld.lld
 // PROFILE-AMDGPU-SAME: "[[RESOURCE_DIR:.+]]{{/|\\\\}}lib{{/|\\\\}}amdgpu-amd-amdhsa{{/|\\\\}}libclang_rt.profile.a"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -nogpulib \
+// RUN:   -resource-dir=%S/Inputs/resource_dir_with_amdgpu_per_target_subdir \
+// RUN:   %s 2>&1 | FileCheck -check-prefixes=LIBPATH-AMDGPU %s
+//      LIBPATH-AMDGPU: ld.lld
+// LIBPATH-AMDGPU-SAME: "-L[[RESOURCE_DIR:.+]]{{/|\\\\}}lib{{/|\\\\}}amdgpu-amd-amdhsa"


### PR DESCRIPTION
Summary:
Extension to https://github.com/llvm/llvm-project/pull/209770/, the
previous one did not cover all cases we search paths, it only did the
relative paths for a few cases. This adds it to the other case, should
be the same logic and motivation.
