### PR TITLE
[clang-tidy] Add bugprone-macro-condition check

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp
@@ -46,6 +46,7 @@
 #include "IntegerDivisionCheck.h"
 #include "InvalidEnumDefaultInitializationCheck.h"
 #include "LambdaFunctionNameCheck.h"
+#include "MacroConditionCheck.h"
 #include "MacroParenthesesCheck.h"
 #include "MacroRepeatedSideEffectsCheck.h"
 #include "MisleadingSetterOfReferenceCheck.h"
@@ -203,6 +204,8 @@ public:
         "bugprone-invalid-enum-default-initialization");
     CheckFactories.registerCheck<LambdaFunctionNameCheck>(
         "bugprone-lambda-function-name");
+    CheckFactories.registerCheck<MacroConditionCheck>(
+        "bugprone-macro-condition");
     CheckFactories.registerCheck<MacroParenthesesCheck>(
         "bugprone-macro-parentheses");
     CheckFactories.registerCheck<MacroRepeatedSideEffectsCheck>(

--- a/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
@@ -50,6 +50,7 @@ add_clang_library(clangTidyBugproneModule STATIC
   InfiniteLoopCheck.cpp
   IntegerDivisionCheck.cpp
   LambdaFunctionNameCheck.cpp
+  MacroConditionCheck.cpp
   MacroParenthesesCheck.cpp
   MacroRepeatedSideEffectsCheck.cpp
   MisleadingSetterOfReferenceCheck.cpp

--- a/clang-tools-extra/clang-tidy/bugprone/MacroConditionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MacroConditionCheck.cpp
@@ -1,0 +1,357 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MacroConditionCheck.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Lex/MacroInfo.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSet.h"
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace clang::tidy::bugprone {
+
+namespace {
+class MacroConditionCallbacks : public PPCallbacks {
+public:
+  MacroConditionCallbacks(MacroConditionCheck *Check, const SourceManager &SM,
+                          Preprocessor &PP)
+      : Check(Check), SM(SM), PP(PP) {}
+
+  void If(SourceLocation Loc, SourceRange ConditionRange,
+          ConditionValueKind ConditionValue) override;
+  void Ifdef(SourceLocation Loc, const Token &MacroNameTok,
+             const MacroDefinition &MD) override;
+  void Ifndef(SourceLocation Loc, const Token &MacroNameTok,
+              const MacroDefinition &MD) override;
+  void Elif(SourceLocation Loc, SourceRange ConditionRange,
+            ConditionValueKind ConditionValue, SourceLocation IfLoc) override;
+  void Elifdef(SourceLocation Loc, const Token &MacroNameTok,
+               const MacroDefinition &MD) override;
+  void Elifdef(SourceLocation Loc, SourceRange ConditionRange,
+               SourceLocation IfLoc) override;
+  void Elifndef(SourceLocation Loc, const Token &MacroNameTok,
+                const MacroDefinition &MD) override;
+  void Elifndef(SourceLocation Loc, SourceRange ConditionRange,
+                SourceLocation IfLoc) override;
+  void Else(SourceLocation Loc, SourceLocation IfLoc) override;
+  void Endif(SourceLocation Loc, SourceLocation IfLoc) override;
+
+private:
+  struct MacroReference {
+    std::string Name;
+    SourceLocation Loc;
+  };
+
+  struct ConditionReferences {
+    SmallVector<MacroReference, 2> Definition;
+    SmallVector<MacroReference, 2> Value;
+  };
+
+  struct DefinitionCheck {
+    std::string Name;
+    SourceLocation DefinitionLoc;
+    SourceLocation CheckLoc;
+    bool ValueTested = false;
+  };
+
+  struct ConditionalBranch {
+    SmallVector<DefinitionCheck, 2> Checks;
+    llvm::StringSet<> DefinitionTests;
+  };
+
+  ConditionReferences referencesInCondition(SourceRange ConditionRange) const;
+  MacroReference referenceFromRange(SourceRange Range,
+                                    SourceLocation Loc) const;
+  bool isIgnoredIdentifier(StringRef Name) const;
+  void startCondition(const ConditionReferences &References);
+  void startDefinitionCondition(StringRef Name, SourceLocation Loc);
+  void nextBranch(const ConditionReferences &References = {});
+  void processReferences(const ConditionReferences &References);
+  void finishBranch(ConditionalBranch &Branch);
+  void checkDefinitionReference(const MacroReference &Reference,
+                                ConditionalBranch &Branch);
+  void checkValueReference(const MacroReference &Reference);
+  bool isDefinitionTestActive(StringRef Name) const;
+
+  SmallVector<ConditionalBranch, 8> Conditions;
+  llvm::DenseSet<unsigned> DiagnosedDefinitions;
+  MacroConditionCheck *Check;
+  const SourceManager &SM;
+  Preprocessor &PP;
+};
+
+} // namespace
+
+static StringRef getTokenName(const Token &Tok) {
+  if (Tok.is(tok::raw_identifier))
+    return Tok.getRawIdentifier();
+  if (const IdentifierInfo *Info = Tok.getIdentifierInfo())
+    return Info->getName();
+  return {};
+}
+
+MacroConditionCallbacks::ConditionReferences
+MacroConditionCallbacks::referencesInCondition(
+    SourceRange ConditionRange) const {
+  ConditionReferences References;
+  const SourceLocation BeginLoc = SM.getExpansionLoc(ConditionRange.getBegin());
+  if (BeginLoc.isInvalid())
+    return References;
+
+  const std::pair<FileID, unsigned> Decomposed = SM.getDecomposedLoc(BeginLoc);
+  bool Invalid = false;
+  StringRef Buffer = SM.getBufferData(Decomposed.first, &Invalid);
+  if (Invalid || Decomposed.second >= Buffer.size())
+    return References;
+
+  size_t End = Decomposed.second;
+  while (End < Buffer.size()) {
+    if (Buffer[End] != '\r' && Buffer[End] != '\n') {
+      ++End;
+      continue;
+    }
+
+    const size_t Newline = End;
+    if (Newline > Decomposed.second && Buffer[Newline - 1] == '\\') {
+      if (Buffer[End] == '\r' && End + 1 < Buffer.size() &&
+          Buffer[End + 1] == '\n')
+        ++End;
+      ++End;
+      continue;
+    }
+    break;
+  }
+
+  std::string Text = Buffer.slice(Decomposed.second, End).str();
+  Lexer Lex(BeginLoc, PP.getLangOpts(), Text.data(), Text.data(),
+            Text.data() + Text.size());
+  SmallVector<Token, 16> Tokens;
+  Token Tok;
+  bool AtEnd = false;
+  do {
+    AtEnd = Lex.LexFromRawLexer(Tok);
+    if (Tok.isNot(tok::eof))
+      Tokens.push_back(Tok);
+  } while (!AtEnd);
+
+  for (size_t Index = 0; Index < Tokens.size(); ++Index) {
+    const Token &Current = Tokens[Index];
+    if (!Current.is(tok::raw_identifier))
+      continue;
+
+    StringRef Name = Current.getRawIdentifier();
+    if (Name != "defined") {
+      if (!isIgnoredIdentifier(Name))
+        References.Value.push_back({Name.str(), Current.getLocation()});
+      continue;
+    }
+
+    const SourceLocation DefinedLoc = Current.getLocation();
+    ++Index;
+    if (Index < Tokens.size() && Tokens[Index].is(tok::l_paren))
+      ++Index;
+    if (Index < Tokens.size() && Tokens[Index].is(tok::raw_identifier))
+      References.Definition.push_back(
+          {Tokens[Index].getRawIdentifier().str(), DefinedLoc});
+  }
+  return References;
+}
+
+MacroConditionCallbacks::MacroReference
+MacroConditionCallbacks::referenceFromRange(SourceRange Range,
+                                            SourceLocation Loc) const {
+  ConditionReferences References = referencesInCondition(Range);
+  if (!References.Value.empty()) {
+    References.Value.front().Loc = Loc;
+    return std::move(References.Value.front());
+  }
+  return {{}, Loc};
+}
+
+bool MacroConditionCallbacks::isIgnoredIdentifier(StringRef Name) const {
+  const IdentifierInfo *Info = PP.getIdentifierInfo(Name);
+  return Name == "true" || Name == "false" ||
+         Info->isCPlusPlusOperatorKeyword();
+}
+
+void MacroConditionCallbacks::startCondition(
+    const ConditionReferences &References) {
+  Conditions.emplace_back();
+  processReferences(References);
+}
+
+void MacroConditionCallbacks::startDefinitionCondition(StringRef Name,
+                                                       SourceLocation Loc) {
+  ConditionReferences References;
+  if (!Name.empty())
+    References.Definition.push_back({Name.str(), Loc});
+  startCondition(References);
+}
+
+void MacroConditionCallbacks::nextBranch(
+    const ConditionReferences &References) {
+  if (Conditions.empty())
+    return;
+  finishBranch(Conditions.back());
+  Conditions.back().Checks.clear();
+  Conditions.back().DefinitionTests.clear();
+  processReferences(References);
+}
+
+void MacroConditionCallbacks::processReferences(
+    const ConditionReferences &References) {
+  if (Conditions.empty())
+    return;
+
+  ConditionalBranch &Branch = Conditions.back();
+  for (const MacroReference &Reference : References.Definition)
+    checkDefinitionReference(Reference, Branch);
+  for (const MacroReference &Reference : References.Value)
+    checkValueReference(Reference);
+}
+
+void MacroConditionCallbacks::checkDefinitionReference(
+    const MacroReference &Reference, ConditionalBranch &Branch) {
+  Branch.DefinitionTests.insert(Reference.Name);
+
+  const IdentifierInfo *Info = PP.getIdentifierInfo(Reference.Name);
+  const MacroDefinition Definition = PP.getMacroDefinition(Info);
+  const MacroInfo *Macro = Definition.getMacroInfo();
+  if (!Macro || Macro->isBuiltinMacro() || Macro->isFunctionLike() ||
+      Macro->tokens().empty())
+    return;
+
+  const SourceLocation DefinitionLoc = Macro->getDefinitionLoc();
+  if (DefinitionLoc.isInvalid() || SM.getFilename(DefinitionLoc).empty())
+    return;
+
+  Branch.Checks.push_back(
+      {Reference.Name, DefinitionLoc, Reference.Loc, false});
+}
+
+void MacroConditionCallbacks::checkValueReference(
+    const MacroReference &Reference) {
+  const IdentifierInfo *Info = PP.getIdentifierInfo(Reference.Name);
+  if (!PP.getMacroDefinition(Info) && !isDefinitionTestActive(Reference.Name))
+    Check->diag(Reference.Loc, "Undefined macro '%0' checked here for value")
+        << Reference.Name;
+
+  for (ConditionalBranch &Branch : Conditions)
+    for (DefinitionCheck &Definition : Branch.Checks)
+      if (Definition.Name == Reference.Name)
+        Definition.ValueTested = true;
+}
+
+bool MacroConditionCallbacks::isDefinitionTestActive(StringRef Name) const {
+  return llvm::any_of(Conditions, [Name](const ConditionalBranch &Branch) {
+    return Branch.DefinitionTests.contains(Name);
+  });
+}
+
+void MacroConditionCallbacks::finishBranch(ConditionalBranch &Branch) {
+  for (const DefinitionCheck &Definition : Branch.Checks) {
+    if (Definition.ValueTested)
+      continue;
+
+    if (DiagnosedDefinitions.insert(Definition.DefinitionLoc.getRawEncoding())
+            .second)
+      Check->diag(Definition.DefinitionLoc,
+                  "Macro '%0' defined here with a value and checked for "
+                  "definition")
+          << Definition.Name;
+    Check->diag(Definition.CheckLoc,
+                "Macro '%0' defined with a value and checked here for "
+                "definition")
+        << Definition.Name;
+  }
+}
+
+void MacroConditionCallbacks::If(SourceLocation Loc, SourceRange ConditionRange,
+                                 ConditionValueKind ConditionValue) {
+  startCondition(referencesInCondition(ConditionRange));
+}
+
+void MacroConditionCallbacks::Ifdef(SourceLocation Loc,
+                                    const Token &MacroNameTok,
+                                    const MacroDefinition &MD) {
+  startDefinitionCondition(getTokenName(MacroNameTok), Loc);
+}
+
+void MacroConditionCallbacks::Ifndef(SourceLocation Loc,
+                                     const Token &MacroNameTok,
+                                     const MacroDefinition &MD) {
+  startDefinitionCondition(getTokenName(MacroNameTok), Loc);
+}
+
+void MacroConditionCallbacks::Elif(SourceLocation Loc,
+                                   SourceRange ConditionRange,
+                                   ConditionValueKind ConditionValue,
+                                   SourceLocation IfLoc) {
+  nextBranch(referencesInCondition(ConditionRange));
+}
+
+void MacroConditionCallbacks::Elifdef(SourceLocation Loc,
+                                      const Token &MacroNameTok,
+                                      const MacroDefinition &MD) {
+  ConditionReferences References;
+  References.Definition.push_back({getTokenName(MacroNameTok).str(), Loc});
+  nextBranch(References);
+}
+
+void MacroConditionCallbacks::Elifdef(SourceLocation Loc,
+                                      SourceRange ConditionRange,
+                                      SourceLocation IfLoc) {
+  MacroReference Reference = referenceFromRange(ConditionRange, Loc);
+  ConditionReferences References;
+  if (!Reference.Name.empty())
+    References.Definition.push_back(std::move(Reference));
+  nextBranch(References);
+}
+
+void MacroConditionCallbacks::Elifndef(SourceLocation Loc,
+                                       const Token &MacroNameTok,
+                                       const MacroDefinition &MD) {
+  ConditionReferences References;
+  References.Definition.push_back({getTokenName(MacroNameTok).str(), Loc});
+  nextBranch(References);
+}
+
+void MacroConditionCallbacks::Elifndef(SourceLocation Loc,
+                                       SourceRange ConditionRange,
+                                       SourceLocation IfLoc) {
+  MacroReference Reference = referenceFromRange(ConditionRange, Loc);
+  ConditionReferences References;
+  if (!Reference.Name.empty())
+    References.Definition.push_back(std::move(Reference));
+  nextBranch(References);
+}
+
+void MacroConditionCallbacks::Else(SourceLocation Loc, SourceLocation IfLoc) {
+  nextBranch();
+}
+
+void MacroConditionCallbacks::Endif(SourceLocation Loc, SourceLocation IfLoc) {
+  if (Conditions.empty())
+    return;
+  finishBranch(Conditions.back());
+  Conditions.pop_back();
+}
+
+void MacroConditionCheck::registerPPCallbacks(const SourceManager &SM,
+                                              Preprocessor *PP,
+                                              Preprocessor *ModuleExpanderPP) {
+  PP->addPPCallbacks(std::make_unique<MacroConditionCallbacks>(this, SM, *PP));
+}
+
+} // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/MacroConditionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/MacroConditionCheck.h
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_MACROCONDITIONCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_MACROCONDITIONCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::bugprone {
+
+/// Warns about inconsistent macro usage in preprocessor conditions.
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/bugprone-macro-condition.html
+class MacroConditionCheck : public ClangTidyCheck {
+public:
+  using ClangTidyCheck::ClangTidyCheck;
+
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+};
+
+} // namespace clang::tidy::bugprone
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_MACROCONDITIONCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -97,6 +97,11 @@ Improvements to clang-tidy
 New checks
 ^^^^^^^^^^
 
+- New :doc:`bugprone-macro-condition
+  <clang-tidy/checks/bugprone/macro-condition>` check.
+
+  Warns about inconsistent macro usage in preprocessor conditions.
+
 New check aliases
 ^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-condition.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-condition.rst
@@ -1,0 +1,39 @@
+.. title:: clang-tidy - bugprone-macro-condition
+
+bugprone-macro-condition
+========================
+
+Warns about inconsistent macro usage in preprocessor conditions.
+
+Given the following code:
+
+.. code-block:: c++
+
+  #define USE_FOO 0
+  // ...
+  #if defined(USE_FOO)
+    // ...
+  #endif
+
+Here `USE_FOO` is defined to a value that would evaluate to false in a
+preprocessor condition, but checked for definition and not for its value.
+Was the intention to evaluate `USE_FOO` for a `true` expression, or was
+the intention to merely check whether or not the macro was defined?
+
+If the code later contains:
+
+.. code-block:: c++
+
+  #if USE_FOO
+    // ...
+  #endif
+
+Then the suspicions are raised further.
+
+The following scenarios result in warnings; no fixes
+are offered as the scenarios are all ambiguous.
+
+- A macro is defined to a value,
+  but it is checked for definition in a condition.
+- A macro in a condition is checked for definition in one location
+  and for value in another location.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -1,3 +1,4 @@
+
 .. title:: clang-tidy - Clang-Tidy Checks
 
 Clang-Tidy Checks
@@ -115,6 +116,7 @@ Clang-Tidy Checks
    :doc:`bugprone-integer-division <bugprone/integer-division>`,
    :doc:`bugprone-invalid-enum-default-initialization <bugprone/invalid-enum-default-initialization>`,
    :doc:`bugprone-lambda-function-name <bugprone/lambda-function-name>`,
+   :doc:`bugprone-macro-condition <bugprone/macro-condition>`,
    :doc:`bugprone-macro-parentheses <bugprone/macro-parentheses>`, "Yes"
    :doc:`bugprone-macro-repeated-side-effects <bugprone/macro-repeated-side-effects>`,
    :doc:`bugprone-misleading-setter-of-reference <bugprone/misleading-setter-of-reference>`,

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/macro-condition.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/macro-condition.cpp
@@ -1,0 +1,87 @@
+// RUN: %check_clang_tidy %s bugprone-macro-condition %t
+
+#define USE_FOO 0
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: Macro 'USE_FOO' defined here with a value and checked for definition
+
+#if defined(USE_FOO)
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: Macro 'USE_FOO' defined with a value and checked here for definition
+void f()
+{
+  extern void foo();
+  foo();
+}
+#endif
+
+#if 0
+#elif OTHER_MACRO
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Undefined macro 'OTHER_MACRO' checked here for value
+#elifdef OTHER_MACRO2
+#else
+#endif
+
+#if !defined(USE_FOO)
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: Macro 'USE_FOO' defined with a value and checked here for definition
+void f2()
+{
+  extern void notFoo();
+  notFoo();
+}
+#endif
+
+#ifdef USE_FOO
+// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: Macro 'USE_FOO' defined with a value and checked here for definition
+void f3()
+{
+  extern void foo();
+  foo();
+}
+#endif
+
+#ifndef USE_FOO
+// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: Macro 'USE_FOO' defined with a value and checked here for definition
+void f4()
+{
+  extern void notFoo();
+  notFoo();
+}
+#endif
+
+#if 0
+#elif defined(USE_FOO)
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: Macro 'USE_FOO' defined with a value and checked here for definition
+void f5()
+{
+  extern void foo();
+  foo();
+}
+#endif
+
+#define USE_GRONK 0
+#ifdef USE_GRONK
+#if USE_GRONK
+void f6()
+{
+  extern void foo();
+  foo();
+}
+#endif
+#endif
+
+#if 0
+#elif defined(USE_GRONK)
+#if USE_GRONK
+void f7()
+{
+  extern void foo();
+  foo();
+}
+#endif
+#endif
+
+#if defined(USE_GRONK) && USE_GRONK
+void f8()
+{
+  extern void foo();
+  foo();
+}
+#endif


### PR DESCRIPTION
Warns about inconsistent macro usage in preprocessor conditions.

  #define USE_FOO 0
  #ifdef USE_FOO
  // ...no preprocessor directives testing the value of USE_FOO
  #endif

Here USE_FOO is defined to a value (and furthermore defined to evaluate to false) but the preprocessor condition only checks for the macro being defined.

Fixes #27438