### PR TITLE
[OpenACC] Support dynamic worker-private shared memory

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
@@ -317,9 +317,10 @@ collectPrivateLocalParDims(PrivateLocalOp privateLocal,
   return parDims;
 }
 
-static FailureOr<std::optional<int64_t>> getWorkerPrivateSharedMemoryNumCopies(
-    PrivateLocalOp privateLocal, ComputeRegionOp computeRegion,
-    bool isWorkerPrivate, OpenACCSupport *support) {
+static FailureOr<std::optional<int64_t>>
+getWorkerPrivateSharedMemoryNumCopies(PrivateLocalOp privateLocal,
+                                      ComputeRegionOp computeRegion,
+                                      bool isWorkerPrivate, OpenACCSupport *) {
   if (!isWorkerPrivate)
     return std::optional<int64_t>(1);
 
@@ -330,15 +331,10 @@ static FailureOr<std::optional<int64_t>> getWorkerPrivateSharedMemoryNumCopies(
     return std::optional<int64_t>();
 
   auto workerArgConst = workerArg->getDefiningOp<arith::ConstantIndexOp>();
-  if (!workerArgConst) {
-    if (support) {
-      (void)support->emitNYI(privateLocal.getLoc(),
-                             "worker-private variables in shared memory "
-                             "require compile-time constant num_workers");
-      return failure();
-    }
-    return std::optional<int64_t>();
-  }
+  // ThreadY is bounded by 32 after subgroup alignment. Use that upper bound
+  // when the exact worker count is known only at runtime.
+  if (!workerArgConst)
+    return std::optional<int64_t>(32);
   return std::optional<int64_t>(workerArgConst.value());
 }
 

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -317,10 +318,9 @@ collectPrivateLocalParDims(PrivateLocalOp privateLocal,
   return parDims;
 }
 
-static FailureOr<std::optional<int64_t>>
-getWorkerPrivateSharedMemoryNumCopies(PrivateLocalOp privateLocal,
-                                      ComputeRegionOp computeRegion,
-                                      bool isWorkerPrivate, OpenACCSupport *) {
+static FailureOr<std::optional<int64_t>> getWorkerPrivateSharedMemoryNumCopies(
+    PrivateLocalOp privateLocal, ComputeRegionOp computeRegion,
+    bool isWorkerPrivate, OpenACCSupport *support) {
   if (!isWorkerPrivate)
     return std::optional<int64_t>(1);
 
@@ -331,11 +331,22 @@ getWorkerPrivateSharedMemoryNumCopies(PrivateLocalOp privateLocal,
     return std::optional<int64_t>();
 
   auto workerArgConst = workerArg->getDefiningOp<arith::ConstantIndexOp>();
-  // ThreadY is bounded by 32 after subgroup alignment. Use that upper bound
-  // when the exact worker count is known only at runtime.
-  if (!workerArgConst)
-    return std::optional<int64_t>(32);
-  return std::optional<int64_t>(workerArgConst.value());
+  if (workerArgConst)
+    return std::optional<int64_t>(workerArgConst.value());
+
+  FailureOr<int64_t> workerArgBound =
+      ValueBoundsConstraintSet::computeConstantBound(presburger::BoundType::EQ,
+                                                     *workerArg);
+  if (succeeded(workerArgBound))
+    return std::optional<int64_t>(*workerArgBound);
+
+  if (support) {
+    (void)support->emitNYI(privateLocal.getLoc(),
+                           "worker-private variables in shared memory "
+                           "require compile-time constant num_workers");
+    return failure();
+  }
+  return std::optional<int64_t>();
 }
 
 static bool isInsideACCSpecializedRoutine(Operation *op) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-dynamic-nw.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-dynamic-nw.mlir
@@ -1,7 +1,10 @@
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" --verify-diagnostics
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
 
-// Verify that worker-private shared memory with dynamic num_workers emits
-// a diagnostic instead of silently miscompiling.
+// Dynamic num_workers uses the maximum ThreadY width for shared memory.
+
+// CHECK-LABEL: func.func @test_worker_private_dynamic_nw
+// CHECK: acc.gpu_shared_memory
+// CHECK-SAME: num_copies = 32
 
 func.func @test_worker_private_dynamic_nw(%nw: index) {
   %c32 = arith.constant 32 : index
@@ -11,13 +14,11 @@ func.func @test_worker_private_dynamic_nw(%nw: index) {
   %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
   acc.kernel_environment {
     %priv = acc.privatize : () -> !acc.private_type<memref<2xi32>>
-    // expected-error @below {{failed to legalize operation 'acc.compute_region'}}
     acc.compute_region launch(%arg0 = %block_x, %arg1 = %thread_y, %arg2 = %thread_x) ins(%arg10 = %priv) : (!acc.private_type<memref<2xi32>>) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       %c0_i32 = arith.constant 0 : i32
       scf.parallel (%iv) = (%c0) to (%arg1) step (%c1) {
-        // expected-error @below {{worker-private variables in shared memory require compile-time constant num_workers}}
         %local = acc.private_local %arg10 : (!acc.private_type<memref<2xi32>>) -> memref<2xi32>
         memref.store %c0_i32, %local[%c0] : memref<2xi32>
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-foldable-nw.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-foldable-nw.mlir
@@ -1,23 +1,24 @@
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" --verify-diagnostics
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
 
-// Verify that worker-private shared memory with dynamic num_workers emits
-// a diagnostic instead of silently miscompiling.
+// CHECK-LABEL: func.func @test_worker_private_foldable_nw
+// CHECK: acc.gpu_shared_memory
+// CHECK-SAME: num_copies = 2
 
-func.func @test_worker_private_dynamic_nw(%nw: index) {
-  %c32 = arith.constant 32 : index
+func.func @test_worker_private_foldable_nw() {
+  %c1 = arith.constant 1 : index
   %c5 = arith.constant 5 : index
+  %c32 = arith.constant 32 : index
+  %nw = arith.addi %c1, %c1 : index
   %block_x = acc.par_width %c5 {par_dim = #acc.par_dim<block_x>}
   %thread_y = acc.par_width %nw {par_dim = #acc.par_dim<thread_y>}
   %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
   acc.kernel_environment {
     %priv = acc.privatize : () -> !acc.private_type<memref<2xi32>>
-    // expected-error @below {{failed to legalize operation 'acc.compute_region'}}
     acc.compute_region launch(%arg0 = %block_x, %arg1 = %thread_y, %arg2 = %thread_x) ins(%arg10 = %priv) : (!acc.private_type<memref<2xi32>>) {
       %c0 = arith.constant 0 : index
-      %c1 = arith.constant 1 : index
+      %c1_inner = arith.constant 1 : index
       %c0_i32 = arith.constant 0 : i32
-      scf.parallel (%iv) = (%c0) to (%arg1) step (%c1) {
-        // expected-error @below {{worker-private variables in shared memory require compile-time constant num_workers}}
+      scf.parallel (%iv) = (%c0) to (%arg1) step (%c1_inner) {
         %local = acc.private_local %arg10 : (!acc.private_type<memref<2xi32>>) -> memref<2xi32>
         memref.store %c0_i32, %local[%c0] : memref<2xi32>
         scf.reduce

--- a/mlir/unittests/Dialect/OpenACC/CMakeLists.txt
+++ b/mlir/unittests/Dialect/OpenACC/CMakeLists.txt
@@ -22,6 +22,7 @@ mlir_target_link_libraries(MLIROpenACCTests
   MLIRLLVMDialect
   MLIRMemRefDialect
   MLIRArithDialect
+  MLIRArithValueBoundsOpInterfaceImpl
   MLIROpenACCAnalysis
   MLIROpenACCDialect
   MLIROpenACCUtils

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
@@ -793,7 +793,7 @@ TEST_F(OpenACCUtilsCGTest, getSharedMemoryBytesGangWorkerReductionAccumulator) {
 }
 
 TEST_F(OpenACCUtilsCGTest,
-       isPrivateLocalSharedMemoryCandidateWorkerPrivateDynamicFails) {
+       isPrivateLocalSharedMemoryCandidateWorkerPrivateDynamicUsesUpperBound) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
   b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr workerDims = GPUParallelDimsAttr::get(
@@ -801,8 +801,7 @@ TEST_F(OpenACCUtilsCGTest,
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
   auto bx =
       ParWidthOp::create(b, loc, c1, GPUParallelDimAttr::blockXDim(&context));
-  // A non-constant num_workers: the launch operand exists but is not an
-  // arith.constant, which is what triggers the diagnostic / failure path.
+  // A non-constant num_workers uses the maximum ThreadY width.
   auto dynNumWorkers = arith::AddIOp::create(b, loc, c1, c1);
   auto ty = ParWidthOp::create(b, loc, dynNumWorkers,
                                GPUParallelDimAttr::threadYDim(&context));
@@ -818,11 +817,18 @@ TEST_F(OpenACCUtilsCGTest,
   FailureOr<bool> silent =
       isPrivateLocalSharedMemoryCandidate(privateLocal, cr, *module, policy);
   ASSERT_TRUE(succeeded(silent));
-  EXPECT_FALSE(*silent);
+  EXPECT_TRUE(*silent);
 
   FailureOr<bool> diagnosed = isPrivateLocalSharedMemoryCandidate(
       privateLocal, cr, *module, policy, &support);
-  EXPECT_TRUE(failed(diagnosed));
+  ASSERT_TRUE(succeeded(diagnosed));
+  EXPECT_TRUE(*diagnosed);
+
+  std::optional<int64_t> upperBound =
+      getPrivateLocalSharedMemoryUpperBoundBytes(privateLocal, cr, *module,
+                                                 policy);
+  ASSERT_TRUE(upperBound.has_value());
+  EXPECT_EQ(*upperBound, 512);
 }
 
 TEST_F(OpenACCUtilsCGTest, getPrivateLocalSharedMemoryUpperBoundBytes) {

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/OpenACC/OpenACCUtilsCG.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -34,6 +35,9 @@ using namespace mlir::acc;
 class OpenACCUtilsCGTest : public ::testing::Test {
 protected:
   OpenACCUtilsCGTest() : b(&context), loc(UnknownLoc::get(&context)) {
+    DialectRegistry registry;
+    arith::registerValueBoundsOpInterfaceExternalModels(registry);
+    context.appendDialectRegistry(registry);
     context.loadDialect<acc::OpenACCDialect, arith::ArithDialect,
                         func::FuncDialect, scf::SCFDialect, gpu::GPUDialect,
                         memref::MemRefDialect, DLTIDialect>();
@@ -793,7 +797,7 @@ TEST_F(OpenACCUtilsCGTest, getSharedMemoryBytesGangWorkerReductionAccumulator) {
 }
 
 TEST_F(OpenACCUtilsCGTest,
-       isPrivateLocalSharedMemoryCandidateWorkerPrivateDynamicUsesUpperBound) {
+       isPrivateLocalSharedMemoryCandidateWorkerPrivateFoldableExpression) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
   b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr workerDims = GPUParallelDimsAttr::get(
@@ -801,7 +805,7 @@ TEST_F(OpenACCUtilsCGTest,
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
   auto bx =
       ParWidthOp::create(b, loc, c1, GPUParallelDimAttr::blockXDim(&context));
-  // A non-constant num_workers uses the maximum ThreadY width.
+  // num_workers is not a constant op but has an exact constant bound.
   auto dynNumWorkers = arith::AddIOp::create(b, loc, c1, c1);
   auto ty = ParWidthOp::create(b, loc, dynNumWorkers,
                                GPUParallelDimAttr::threadYDim(&context));
@@ -828,7 +832,7 @@ TEST_F(OpenACCUtilsCGTest,
       getPrivateLocalSharedMemoryUpperBoundBytes(privateLocal, cr, *module,
                                                  policy);
   ASSERT_TRUE(upperBound.has_value());
-  EXPECT_EQ(*upperBound, 512);
+  EXPECT_EQ(*upperBound, 32);
 }
 
 TEST_F(OpenACCUtilsCGTest, getPrivateLocalSharedMemoryUpperBoundBytes) {


### PR DESCRIPTION
Use the maximum ThreadY width when the runtime worker count prevents exact static sizing.