### PR TITLE
[SPIRV] SPIRVTools custom targets should not have executable suffix

### DIFF
--- a/llvm/tools/spirv-tools/CMakeLists.txt
+++ b/llvm/tools/spirv-tools/CMakeLists.txt
@@ -44,7 +44,7 @@ if (SPIRV_DIS)
   add_custom_target(spirv-dis
     COMMAND ${CMAKE_COMMAND} -E ${LLVM_LINK_OR_COPY} "${SPIRV_DIS}" "${LLVM_RUNTIME_OUTPUT_INTDIR}/spirv-dis${CMAKE_EXECUTABLE_SUFFIX}")
 else ()
-  add_custom_target(spirv-dis${CMAKE_EXECUTABLE_SUFFIX}
+  add_custom_target(spirv-dis
     COMMAND ${CMAKE_COMMAND} -E ${LLVM_LINK_OR_COPY} "${BINARY_DIR}/tools/spirv-dis${CMAKE_EXECUTABLE_SUFFIX}" "${LLVM_RUNTIME_OUTPUT_INTDIR}/spirv-dis${CMAKE_EXECUTABLE_SUFFIX}"
     DEPENDS SPIRVTools
     )


### PR DESCRIPTION
This looks like it was likely a copy paste mistake. When we invoke the binary via the cmake command yes we need the executable suffix. but the custom target name is the same across all OSes.

This bug manifests itself on Windows when you add -DLLVM_INCLUDE_SPIRV_TOOLS_TESTS=ON to the cmake.