### PR TITLE
[flang][OpenACC] Don't rebind construct entities to enclosing variables

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1833,6 +1833,18 @@ void AccAttributeVisitor::Post(const parser::Name &name) {
         !symbol.has<AssocEntityDetails>() && !symbol.has<MiscDetails>()) {
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         if (&symbol != found) {
+          // Don't "adjust" a name that resolution already bound to a construct
+          // entity declared within this region: a DO CONCURRENT or FORALL
+          // index-name (Forall scope) or an entity declared in a nested BLOCK
+          // construct (BlockConstruct scope). currScope() here does not descend
+          // into those construct scopes, so FindSymbol instead resolves to a
+          // like-named variable in an enclosing scope. Rebinding to it would
+          // make the construct entity alias the enclosing variable and, e.g.,
+          // trip the DO-variable redefinition check when that enclosing
+          // variable is an active DO index.
+          if (DoesScopeContain(&currScope(), symbol)) {
+            return;
+          }
           // adjust the symbol within the region
           // TODO: why didn't name resolution set the right name originally?
           name.symbol = found;

--- a/flang/test/Lower/OpenACC/acc-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-loop.f90
@@ -388,15 +388,15 @@ subroutine sub1(i, j, k)
 end subroutine
 
 ! CHECK: func.func @_QPsub1
-! CHECK-SAME: %[[ARG_I:.*]]: !fir.ref<i32> {fir.bindc_name = "i"}
-! CHECK-SAME: %[[ARG_J:.*]]: !fir.ref<i32> {fir.bindc_name = "j"}
-! CHECK-SAME: %[[ARG_K:.*]]: !fir.ref<i32> {fir.bindc_name = "k"}
-! CHECK: %[[DC_I:.*]]:2 = hlfir.declare %[[ARG_I]] dummy_scope %0
-! CHECK: %[[DC_J:.*]]:2 = hlfir.declare %[[ARG_J]] dummy_scope %0
-! CHECK: %[[DC_K:.*]]:2 = hlfir.declare %[[ARG_K]] dummy_scope %0
 ! CHECK: acc.parallel combined(loop)
-! CHECK: %[[P_I:.*]] = acc.private varPtr(%[[DC_I]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
-! CHECK: %[[P_J:.*]] = acc.private varPtr(%[[DC_J]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
-! CHECK: %[[P_K:.*]] = acc.private varPtr(%[[DC_K]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "k"}
+! A DO CONCURRENT index-name is a construct entity distinct from a like-named
+! dummy argument, so the induction variables are fresh construct-local
+! allocations that get privatized (not the dummy arguments).
+! CHECK-DAG: %[[ALLOCA_I:.*]] = fir.alloca i32 {bindc_name = "i"}
+! CHECK-DAG: %[[ALLOCA_J:.*]] = fir.alloca i32 {bindc_name = "j"}
+! CHECK-DAG: %[[ALLOCA_K:.*]] = fir.alloca i32 {bindc_name = "k"}
+! CHECK: %[[P_I:.*]] = acc.private varPtr(%[[ALLOCA_I]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[P_J:.*]] = acc.private varPtr(%[[ALLOCA_J]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
+! CHECK: %[[P_K:.*]] = acc.private varPtr(%[[ALLOCA_K]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "k"}
 ! CHECK: acc.loop combined(parallel) private(%[[P_I]], %[[P_J]], %[[P_K]] : !fir.ref<i32>, !fir.ref<i32>, !fir.ref<i32>) control(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32) = (%c1{{.*}}, %c1{{.*}}, %c1{{.*}} : i32, i32, i32) to (%c10{{.*}}, %c100{{.*}}, %c200{{.*}} : i32, i32, i32)  step (%c1{{.*}}, %c1{{.*}}, %c1{{.*}} : i32, i32, i32)
 ! CHECK: } attributes {inclusiveUpperbound = array<i1: true, true, true>, independent = [#acc.device_type<none>]}

--- a/flang/test/Semantics/OpenACC/acc-construct-entity-shadow.f90
+++ b/flang/test/Semantics/OpenACC/acc-construct-entity-shadow.f90
@@ -1,0 +1,66 @@
+! RUN: %flang_fc1 -fopenacc -fsyntax-only %s 2>&1 | FileCheck %s --allow-empty --implicit-check-not=error:
+
+! A construct entity -- a DO CONCURRENT/FORALL index-name, or a variable
+! declared in a BLOCK construct -- lives in its own scope, distinct from a
+! like-named variable in an enclosing scope. Referencing or defining such an
+! entity inside an OpenACC region must not be treated as redefining an
+! enclosing DO variable. Enabling OpenACC must not turn this legal code into
+! a "Cannot redefine DO variable" error.
+
+! DO CONCURRENT index-name shadowing an enclosing DO variable.
+subroutine dc_index_shadow(a, b, n, m)
+  integer, intent(in) :: n, m
+  real, intent(inout) :: a(n,m), b(n,m)
+  integer :: i, j
+
+  do i = 1, m
+    !$acc parallel loop gang vector collapse(2) independent
+    do concurrent (j = 1:n, i = 1:m)
+      a(i,j) = b(i,j)
+    end do
+  end do
+
+  ! Also with a plain associated loop (no collapse).
+  do i = 1, m
+    !$acc loop
+    do concurrent (i = 1:m)
+      a(i,1) = b(i,1)
+    end do
+  end do
+end subroutine
+
+! BLOCK-local variable, inside a DO CONCURRENT, shadowing an enclosing DO
+! variable and defined within the block.
+subroutine block_in_do_concurrent(a, b, n, m)
+  integer, intent(in) :: n, m
+  real, intent(inout) :: a(n,m), b(n,m)
+  integer :: i, ii, j
+
+  do i = 1, m
+    !$acc parallel loop gang vector collapse(2) independent
+    do concurrent (j = 1:n, ii = 1:m)
+      block
+        integer :: i
+        i = ii
+        a(i,j) = b(i,j)
+      end block
+    end do
+  end do
+end subroutine
+
+! BLOCK-local variable, inside a plain loop nest, shadowing an enclosing DO
+! variable and defined within the block.
+subroutine block_in_do_loop(array)
+  integer :: i, j, array(1000)
+
+  !$acc parallel loop gang vector
+  do i = 1, 1000
+    do j = 1, 1000
+      block
+        integer :: i
+        i = j
+        array(i) = 42
+      end block
+    end do
+  end do
+end subroutine


### PR DESCRIPTION
`AccAttributeVisitor::Post(Name)` "adjusts" every name referenced inside an OpenACC region to the symbol found in the current scope. A construct entity -- a `DO CONCURRENT`/`FORALL` index-name, or a variable declared in a `BLOCK` construct -- lives in its own scope nested within the region, but the visitor's current scope does not descend into that construct scope. `FindSymbol` therefore resolves the name to a like-named variable in an enclosing scope and rebinds the reference to it.

When such an entity shadows an enclosing DO variable and the loop is associated with an OpenACC construct, this makes the entity alias that active DO variable, so referencing or defining it wrongly triggers "Cannot redefine DO variable" -- even though the code is legal and compiles without error when OpenACC is disabled. This affected a `DO CONCURRENT` index-name as well as a variable declared in a `BLOCK` construct nested in the loop, e.g.:

```fortran
do i = 1, m
  !$acc parallel loop gang vector collapse(2) independent
  do concurrent (j = 1:n, ii = 1:m)
    block
      integer :: i     ! shadows the enclosing `do i`
      i = ii
      a(i,j) = b(i,j)
    end block
  end do
end do
```

Skip the adjustment when the resolved symbol is owned by a scope contained in the current scope, i.e. it was declared within the region; name resolution already bound it correctly. The `DO CONCURRENT` induction variables are then privatized as their own construct-local entities rather than the shadowed enclosing variable, as reflected in the updated `acc-loop.f90` lowering test.

Add a Semantics regression test covering the `DO CONCURRENT` and `BLOCK` cases.
