### PR TITLE
[lldb] Add opt-in `target.process.fork-debug-mode` setting

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -116,6 +116,7 @@ public:
   bool GetSteppingRunsAllThreads() const;
   Args GetAlwaysRunThreadNames() const;
   FollowForkMode GetFollowForkMode() const;
+  ForkDebugMode GetForkDebugMode() const;
   bool TrackMemoryCacheChanges() const;
   bool GetUseDelayedBreakpoints() const;
 

--- a/lldb/include/lldb/lldb-private-enumerations.h
+++ b/lldb/include/lldb/lldb-private-enumerations.h
@@ -189,6 +189,13 @@ enum FollowForkMode {
   eFollowChild,  // Follow child process
 };
 
+// What happens to the process that follow-fork-mode does not continue
+// tracing.
+enum ForkDebugMode {
+  eForkDebugDetach,       // Detach it, as lldb has always done
+  eForkDebugCreateTarget, // Create a new Target/Process for it
+};
+
 // Result enums for when reading multiple lines from IOHandlers
 enum class LineStatus {
   Success, // The line that was just edited if good and should be added to the

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -132,6 +132,21 @@ static constexpr OptionEnumValueElement g_follow_fork_mode_values[] = {
     },
 };
 
+static constexpr OptionEnumValueElement g_fork_debug_mode_values[] = {
+    {
+        eForkDebugDetach,
+        "detach",
+        "Detach the process that follow-fork-mode does not continue "
+        "tracing.",
+    },
+    {
+        eForkDebugCreateTarget,
+        "create-target",
+        "Create a new target for the process that follow-fork-mode does "
+        "not continue tracing, instead of detaching it.",
+    },
+};
+
 static constexpr unsigned g_string_read_width = 256;
 
 #define LLDB_PROPERTIES_process
@@ -398,6 +413,13 @@ FollowForkMode ProcessProperties::GetFollowForkMode() const {
   const uint32_t idx = ePropertyFollowForkMode;
   return GetPropertyAtIndexAs<FollowForkMode>(
       idx, static_cast<FollowForkMode>(
+               g_process_properties[idx].default_uint_value));
+}
+
+ForkDebugMode ProcessProperties::GetForkDebugMode() const {
+  const uint32_t idx = ePropertyForkDebugMode;
+  return GetPropertyAtIndexAs<ForkDebugMode>(
+      idx, static_cast<ForkDebugMode>(
                g_process_properties[idx].default_uint_value));
 }
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -309,6 +309,15 @@ let Definition = "process", Path = "target.process" in {
     DefaultEnumValue<"eFollowParent">,
     EnumValues<"OptionEnumValues(g_follow_fork_mode_values)">,
     Desc<"Debugger's behavior upon fork or vfork.">;
+  def ForkDebugMode: Property<"fork-debug-mode", "Enum">,
+    DefaultEnumValue<"eForkDebugDetach">,
+    EnumValues<"OptionEnumValues(g_fork_debug_mode_values)">,
+    Desc<"Controls what happens to the process that follow-fork-mode does "
+         "not continue tracing. 'detach' (the default) simply detaches it, "
+         "as lldb has always done. 'create-target' instead creates a new "
+         "Target for it and broadcasts a Target::eBroadcastBitNewTargetCreated "
+         "event, which front ends such as lldb-dap can use to open a new "
+         "debug session for it automatically.">;
   def TrackMemoryCacheChanges: Property<"track-memory-cache-changes", "Boolean">,
     DefaultTrue,
     Desc<"If true, memory cache modifications (which happen often during expressions evaluation) will bump process state ID (and invalidate all synthetic children). Disabling this option helps to avoid synthetic children reevaluation when pretty printers heavily use expressions. The downside of disabled setting is that convenience variables won't reevaluate synthetic children automatically.">;

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -39,6 +39,32 @@ class SettingsCommandTestCase(TestBase):
             ],
         )
 
+    def test_fork_debug_mode_setting(self):
+        """Test the `target.process.fork-debug-mode` setting."""
+        # Defaults to 'detach', preserving lldb's traditional fork behavior.
+        self.expect(
+            "settings show target.process.fork-debug-mode",
+            substrs=["target.process.fork-debug-mode (enum) = detach"],
+        )
+
+        self.runCmd("settings set target.process.fork-debug-mode create-target")
+        self.expect(
+            "settings show target.process.fork-debug-mode",
+            substrs=["target.process.fork-debug-mode (enum) = create-target"],
+        )
+
+        self.expect(
+            "settings set target.process.fork-debug-mode bogus-value",
+            error=True,
+            substrs=["invalid enumeration value"],
+        )
+
+        self.runCmd("settings clear target.process.fork-debug-mode")
+        self.expect(
+            "settings show target.process.fork-debug-mode",
+            substrs=["target.process.fork-debug-mode (enum) = detach"],
+        )
+
     def test_set_interpreter_repeat_prev_command(self):
         """Test the `interpreter.repeat-previous-command` setting."""
         self.build()


### PR DESCRIPTION
## Commit 1:
Add a new`target.process.fork-debug-mode` process property with two values, `detach` (default) and `create-target`. It defaults to `detach`, which preserves lldb's current behavior exactly, so this change has no behavior impact on its own.

This is groundwork for [#139025:](https://github.com/llvm/llvm-project/issues/139025) when set to `create-target`, a future change to `ProcessGDBRemote::DidFork/DidVFork` will create a new Target for the process that follow-fork-mode does not continue tracing,  instead of just detaching it, and broadcast `Target::eBroadcastBitNewTargetCreated`. Front ends like lldb-dap already listen for that event (added in [#163653](https://github.com/llvm/llvm-project/pull/163653)) and can use it to open a new debug session automatically -- useful for multi-process applications like Chromium where a renderer subprocess forks and today has to be attached to by hand via `process attach -p <pid>`.

An enum was chosen over a plain boolean so a later phase (keeping the child on the same gdb-remote connection instead of a fresh one) can add a third value without a second setting.

Fixes https://github.com/llvm/llvm-project/issues/139025