### PR TITLE
[AMDGPU] Relax SGPR splat selection for PK_*64

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -3688,15 +3688,14 @@ bool AMDGPUDAGToDAGISel::SelectVOP3PMods(SDValue In, SDValue &Src,
         // bits of a scalar input into high 64 bits. Use VGPRs in this case.
         // TODO: This fact can be exploited but we need to set proper OPSEL for
         // codegen folding purposes. It will not affect a final instruction.
-        auto RC = (Lo->isDivergent() || !HasOpSel)
-                      ? TRI->getVGPRClassForBitWidth(VecSize)
-                      : TRI->getSGPRClassForBitWidth(VecSize);
+        auto RC = Lo->isDivergent() ? TRI->getVGPRClassForBitWidth(VecSize)
+                                    : TRI->getSGPRClassForBitWidth(VecSize);
         unsigned NumRegs = Lo.getValueSizeInBits() == 32 ? 1 : 2;
         const SDValue Ops[] = {
             CurDAG->getTargetConstant(RC->getID(), SL, MVT::i32), Lo,
             CurDAG->getTargetConstant(TRI->getSubRegFromChannel(0, NumRegs), SL,
                                       MVT::i32),
-            HasOpSel ? Undef : Hi,
+            (!HasOpSel && Lo->isDivergent()) ? Lo : Undef,
             CurDAG->getTargetConstant(
                 TRI->getSubRegFromChannel(NumRegs, NumRegs), SL, MVT::i32)};
 

--- a/llvm/test/CodeGen/AMDGPU/packed-fp64.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-fp64.ll
@@ -431,8 +431,8 @@ define amdgpu_kernel void @fadd_v2_v_imm(ptr addrspace(1) %a) {
   ret void
 }
 
-define amdgpu_kernel void @fadd_v2_v_v_splat(ptr addrspace(1) %a) {
-; GFX1251-LABEL: fadd_v2_v_v_splat:
+define amdgpu_kernel void @fadd_v2_v_v_vgpr_splat(ptr addrspace(1) %a) {
+; GFX1251-LABEL: fadd_v2_v_v_vgpr_splat:
 ; GFX1251:       ; %bb.0:
 ; GFX1251-NEXT:    global_wb
 ; GFX1251-NEXT:    v_nop
@@ -455,6 +455,50 @@ define amdgpu_kernel void @fadd_v2_v_v_splat(ptr addrspace(1) %a) {
   %fid = bitcast i64 %id.1 to double
   %tmp1 = insertelement <2 x double> poison, double %fid, i64 0
   %k = insertelement <2 x double> %tmp1, double %fid, i64 1
+  %add = fadd <2 x double> %load, %k
+  store <2 x double> %add, ptr addrspace(1) %gep, align 8
+  ret void
+}
+
+define amdgpu_kernel void @fadd_v2_v_v_sgpr_splat(ptr addrspace(1) %a, double %v) {
+; GFX1251-SDAG-LABEL: fadd_v2_v_v_sgpr_splat:
+; GFX1251-SDAG:       ; %bb.0:
+; GFX1251-SDAG-NEXT:    global_wb
+; GFX1251-SDAG-NEXT:    v_nop
+; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], s[4:7]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_endpgm
+;
+; GFX1251-GISEL-LABEL: fadd_v2_v_v_sgpr_splat:
+; GFX1251-GISEL:       ; %bb.0:
+; GFX1251-GISEL-NEXT:    global_wb
+; GFX1251-GISEL-NEXT:    v_nop
+; GFX1251-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1251-GISEL-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-GISEL-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
+; GFX1251-GISEL-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX1251-GISEL-NEXT:    s_mov_b64 s[6:7], s[2:3]
+; GFX1251-GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[4:5]
+; GFX1251-GISEL-NEXT:    v_mov_b64_e32 v[6:7], s[6:7]
+; GFX1251-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1251-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-GISEL-NEXT:    v_pk_add_f64 v[0:3], v[0:3], v[4:7]
+; GFX1251-GISEL-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-GISEL-NEXT:    s_endpgm
+  %id = tail call i32 @llvm.amdgcn.workitem.id.x()
+  %gep = getelementptr inbounds <2 x double>, ptr addrspace(1) %a, i32 %id
+  %load = load <2 x double>, ptr addrspace(1) %gep, align 8
+  %tmp1 = insertelement <2 x double> poison, double %v, i64 0
+  %k = insertelement <2 x double> %tmp1, double %v, i64 1
   %add = fadd <2 x double> %load, %k
   store <2 x double> %add, ptr addrspace(1) %gep, align 8
   ret void
@@ -615,15 +659,13 @@ define amdgpu_kernel void @fadd_v2_v_fneg(ptr addrspace(1) %a, double %x) {
 ; GFX1251-SDAG-NEXT:    v_nop
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[4:5], s[2:3]
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], v[4:7] neg_lo:[0,1] neg_hi:[0,1]
-; GFX1251-SDAG-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], s[4:7] neg_lo:[0,1] neg_hi:[0,1]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
 ; GFX1251-SDAG-NEXT:    s_endpgm
 ;
 ; GFX1251-GISEL-LABEL: fadd_v2_v_fneg:
@@ -665,15 +707,13 @@ define amdgpu_kernel void @fadd_v2_v_fneg_lo(ptr addrspace(1) %a, double %x) {
 ; GFX1251-SDAG-NEXT:    v_nop
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[4:5], s[2:3]
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], v[4:7] neg_lo:[0,1]
-; GFX1251-SDAG-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], s[4:7] neg_lo:[0,1]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
 ; GFX1251-SDAG-NEXT:    s_endpgm
 ;
 ; GFX1251-GISEL-LABEL: fadd_v2_v_fneg_lo:
@@ -715,15 +755,13 @@ define amdgpu_kernel void @fadd_v2_v_fneg_hi(ptr addrspace(1) %a, double %x) {
 ; GFX1251-SDAG-NEXT:    v_nop
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[4:5], s[2:3]
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], v[4:7] neg_hi:[0,1]
-; GFX1251-SDAG-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], s[4:7] neg_hi:[0,1]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
 ; GFX1251-SDAG-NEXT:    s_endpgm
 ;
 ; GFX1251-GISEL-LABEL: fadd_v2_v_fneg_hi:
@@ -1395,15 +1433,13 @@ define amdgpu_kernel void @fmul_v2_v_fneg(ptr addrspace(1) %a, double %x) {
 ; GFX1251-SDAG-NEXT:    v_nop
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[4:5], s[2:3]
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_pk_mul_f64 v[0:3], v[0:3], v[4:7] neg_lo:[0,1] neg_hi:[0,1]
-; GFX1251-SDAG-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    v_pk_mul_f64 v[0:3], v[0:3], s[4:7] neg_lo:[0,1] neg_hi:[0,1]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
 ; GFX1251-SDAG-NEXT:    s_endpgm
 ;
 ; GFX1251-GISEL-LABEL: fmul_v2_v_fneg:
@@ -1829,16 +1865,14 @@ define amdgpu_kernel void @fma_v2_v_imm(ptr addrspace(1) %a) {
 ; GFX1251-SDAG-NEXT:    global_wb
 ; GFX1251-SDAG-NEXT:    v_nop
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[4:5], 0x4059000000000000
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[6:7], v[4:5]
+; GFX1251-SDAG-NEXT:    s_load_b64 s[2:3], s[4:5], 0x24 nv
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[0:1], 0x4059000000000000
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[2:3] scale_offset
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX1251-SDAG-NEXT:    v_pk_fma_f64 v[0:3], v[0:3], v[4:7], 0x40690000
-; GFX1251-SDAG-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    v_pk_fma_f64 v[0:3], v[0:3], s[0:3], 0x40690000
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[2:3] scale_offset
 ; GFX1251-SDAG-NEXT:    s_endpgm
 ;
 ; GFX1251-GISEL-LABEL: fma_v2_v_imm:
@@ -1974,15 +2008,13 @@ define amdgpu_kernel void @fma_v2_v_fneg(ptr addrspace(1) %a, double %x) {
 ; GFX1251-SDAG-NEXT:    v_nop
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[4:5], s[2:3]
-; GFX1251-SDAG-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_pk_fma_f64 v[0:3], v[0:3], v[4:7], v[4:7] neg_lo:[0,1,1] neg_hi:[0,1,1]
-; GFX1251-SDAG-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    v_pk_fma_f64 v[0:3], v[0:3], s[4:7], s[4:7] neg_lo:[0,1,1] neg_hi:[0,1,1]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
 ; GFX1251-SDAG-NEXT:    s_endpgm
 ;
 ; GFX1251-GISEL-LABEL: fma_v2_v_fneg:

--- a/llvm/test/CodeGen/AMDGPU/packed-u64.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-u64.ll
@@ -431,8 +431,8 @@ define amdgpu_kernel void @add_v2_v_imm(ptr addrspace(1) %a) {
   ret void
 }
 
-define amdgpu_kernel void @add_v2_v_v_splat(ptr addrspace(1) %a) {
-; GFX1251-LABEL: add_v2_v_v_splat:
+define amdgpu_kernel void @add_v2_v_v_vgpr_splat(ptr addrspace(1) %a) {
+; GFX1251-LABEL: add_v2_v_v_vgpr_splat:
 ; GFX1251:       ; %bb.0:
 ; GFX1251-NEXT:    global_wb
 ; GFX1251-NEXT:    v_nop
@@ -455,6 +455,50 @@ define amdgpu_kernel void @add_v2_v_v_splat(ptr addrspace(1) %a) {
   %fid = bitcast i64 %id.1 to i64
   %tmp1 = insertelement <2 x i64> poison, i64 %fid, i64 0
   %k = insertelement <2 x i64> %tmp1, i64 %fid, i64 1
+  %add = add <2 x i64> %load, %k
+  store <2 x i64> %add, ptr addrspace(1) %gep, align 8
+  ret void
+}
+
+define amdgpu_kernel void @add_v2_v_v_sgpr_splat(ptr addrspace(1) %a, i64 %v) {
+; GFX1251-SDAG-LABEL: add_v2_v_v_sgpr_splat:
+; GFX1251-SDAG:       ; %bb.0:
+; GFX1251-SDAG-NEXT:    global_wb
+; GFX1251-SDAG-NEXT:    v_nop
+; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v4, 0x3ff, v0
+; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v4, s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1251-SDAG-NEXT:    v_pk_add_nc_u64 v[0:3], v[0:3], s[4:7]
+; GFX1251-SDAG-NEXT:    global_store_b128 v4, v[0:3], s[0:1] scale_offset
+; GFX1251-SDAG-NEXT:    s_endpgm
+;
+; GFX1251-GISEL-LABEL: add_v2_v_v_sgpr_splat:
+; GFX1251-GISEL:       ; %bb.0:
+; GFX1251-GISEL-NEXT:    global_wb
+; GFX1251-GISEL-NEXT:    v_nop
+; GFX1251-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
+; GFX1251-GISEL-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
+; GFX1251-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-GISEL-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
+; GFX1251-GISEL-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX1251-GISEL-NEXT:    s_mov_b64 s[6:7], s[2:3]
+; GFX1251-GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[4:5]
+; GFX1251-GISEL-NEXT:    v_mov_b64_e32 v[6:7], s[6:7]
+; GFX1251-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1251-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-GISEL-NEXT:    v_pk_add_nc_u64 v[0:3], v[0:3], v[4:7]
+; GFX1251-GISEL-NEXT:    global_store_b128 v8, v[0:3], s[0:1] scale_offset
+; GFX1251-GISEL-NEXT:    s_endpgm
+  %id = tail call i32 @llvm.amdgcn.workitem.id.x()
+  %gep = getelementptr inbounds <2 x i64>, ptr addrspace(1) %a, i32 %id
+  %load = load <2 x i64>, ptr addrspace(1) %gep, align 8
+  %tmp1 = insertelement <2 x i64> poison, i64 %v, i64 0
+  %k = insertelement <2 x i64> %tmp1, i64 %v, i64 1
   %add = add <2 x i64> %load, %k
   store <2 x i64> %add, ptr addrspace(1) %gep, align 8
   ret void


### PR DESCRIPTION
These instructions replicate SGPR operands into high 64-bit channel
w/o opsel.
