### PR TITLE
[CIR] Fix how we lower bitfield constants

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -231,13 +231,11 @@ mlir::Attribute updateBitfieldInit(CIRGenModule &cgm,
   // Extend to the full storage size so we can shift/mask.
   curValue = curValue.zext(bfInfo.storageSize);
 
-  unsigned offset = bfInfo.offset;
-  if (isBigEndian)
-    offset = bfInfo.storageSize - bfInfo.size - offset;
-
-  curValue = curValue.shl(offset);
+  // bfInfo.offset is already adjusted for endianness, so no endian-changes need
+  // to happen here.
+  curValue = curValue.shl(bfInfo.offset);
   llvm::APInt mask(bfInfo.storageSize, 0);
-  mask.setBits(offset, offset + bfInfo.size);
+  mask.setBits(bfInfo.offset, bfInfo.offset + bfInfo.size);
 
   result &= ~mask;
   result |= curValue;

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -156,12 +156,68 @@ public:
   }
 };
 
-mlir::Attribute updateBitfieldInit(CIRGenModule &cgm, cir::IntAttr existingVal,
+llvm::APInt bitfieldStorageToAPInt(mlir::Attribute attr, unsigned storageSize,
+                                   bool isBigEndian) {
+  // An empty attribute is just zero of the correct size.
+  if (!attr)
+    return llvm::APInt(storageSize, 0);
+  // An int type is just the value held in the attribute.
+  if (auto intAttr = mlir::dyn_cast<cir::IntAttr>(attr))
+    return intAttr.getValue();
+
+  // Else we are in the array case, we have to create the big APInt, and fill it
+  // up.
+  llvm::APInt result(storageSize, 0);
+  auto elts = mlir::cast<mlir::ArrayAttr>(
+      mlir::cast<cir::ConstArrayAttr>(attr).getElts());
+
+  unsigned numBytes = elts.size();
+  for (unsigned i = 0; i != numBytes; ++i) {
+    unsigned byteIdx = isBigEndian ? numBytes - 1 - i : i;
+    llvm::APInt byte =
+        mlir::cast<cir::IntAttr>(elts[i]).getValue().zextOrTrunc(8);
+    result.insertBits(byte, byteIdx * 8);
+  }
+  return result;
+}
+
+mlir::Attribute apIntToBitfieldStorage(CIRGenModule &cgm,
+                                       mlir::Type storageType,
+                                       const llvm::APInt &value,
+                                       bool isBigEndian) {
+  // If we'ere an int, just return the new value.
+  if (mlir::isa<cir::IntTypeInterface>(storageType))
+    return cir::IntAttr::get(storageType, value);
+
+  // Array of bytes case, fill up an array.
+  CIRGenBuilderTy &builder = cgm.getBuilder();
+  auto arrayTy = mlir::cast<cir::ArrayType>(storageType);
+
+  unsigned numBytes = arrayTy.getSize();
+  cir::IntType byteTy = builder.getUInt8Ty();
+  llvm::SmallVector<mlir::Attribute, 8> bytes(numBytes);
+
+  for (unsigned i = 0; i != numBytes; ++i) {
+    unsigned byteIdx = isBigEndian ? numBytes - 1 - i : i;
+    bytes[i] = cir::IntAttr::get(byteTy, value.extractBits(8, byteIdx * 8));
+  }
+  return cir::ConstArrayAttr::get(
+      arrayTy, mlir::ArrayAttr::get(builder.getContext(), bytes));
+}
+
+// Bitfields are lowered to either an integer type, or a series of bytes, see
+// getBitfieldStorageType. Because of this, we have to figure out how to store
+// this init value in those. Do this by converting the current value in the
+// 'storage' type to an APInt so we can do our masking correctly, then convert
+// back.  The int path is trivial (getValue/create a new one with the new
+// value).  The array type requires breaking it up into its constituent values.
+mlir::Attribute updateBitfieldInit(CIRGenModule &cgm,
+                                   mlir::Attribute existingVal,
                                    cir::IntAttr newVal, bool isSigned,
                                    const CIRGenBitFieldInfo &bfInfo) {
-  llvm::APInt result(bfInfo.storageSize, 0);
-  if (existingVal)
-    result = existingVal.getValue();
+  bool isBigEndian = cgm.getDataLayout().isBigEndian();
+  llvm::APInt result =
+      bitfieldStorageToAPInt(existingVal, bfInfo.storageSize, isBigEndian);
 
   llvm::APInt curValue = newVal.getValue();
   // Make sure we truncate (or properly extend) the existing value for the
@@ -176,7 +232,7 @@ mlir::Attribute updateBitfieldInit(CIRGenModule &cgm, cir::IntAttr existingVal,
   curValue = curValue.zext(bfInfo.storageSize);
 
   unsigned offset = bfInfo.offset;
-  if (cgm.getDataLayout().isBigEndian())
+  if (isBigEndian)
     offset = bfInfo.storageSize - bfInfo.size - offset;
 
   curValue = curValue.shl(offset);
@@ -186,7 +242,7 @@ mlir::Attribute updateBitfieldInit(CIRGenModule &cgm, cir::IntAttr existingVal,
   result &= ~mask;
   result |= curValue;
 
-  return cir::IntAttr::get(bfInfo.storageType, result);
+  return apIntToBitfieldStorage(cgm, bfInfo.storageType, result, isBigEndian);
 }
 
 mlir::Attribute
@@ -204,7 +260,7 @@ setBitfieldInit(CIRGenModule &cgm, const CIRGenRecordLayout &cirLayout,
   }
 
   return updateBitfieldInit(
-      cgm, dyn_cast_if_present<cir::IntAttr>(existingVal), intAttr,
+      cgm, existingVal, intAttr,
       field->getType()->isSignedIntegerOrEnumerationType(), info);
 }
 

--- a/clang/test/CIR/CodeGen/bitfield-init-values.c
+++ b/clang/test/CIR/CodeGen/bitfield-init-values.c
@@ -26,3 +26,9 @@ struct BS { int a : 4; int b : 4; };
 struct BS bs = { -1, 3 };
 // CIR: cir.global external @bs = #cir.const_record<{#cir.int<63> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_BS
 // LLVM: @bs = global %struct.BS { i8 63, [3 x i8] zeroinitializer }
+
+struct BA { int a : 24; char c; };
+struct BA ba = { 0x123456, 7 };
+// CIR: cir.global external @ba = #cir.const_record<{#cir.const_array<[#cir.int<86> : !u8i, #cir.int<52> : !u8i, #cir.int<18> : !u8i]> : !cir.array<!u8i x 3>, #cir.int<7> : !s8i}> : !rec_BA
+// LLVMCIR: @ba = global %struct.BA { [3 x i8] c"V4\12", i8 7 }
+// OGCG: @ba = global { i8, i8, i8, i8 } { i8 86, i8 52, i8 18, i8 7 }

--- a/clang/test/CIR/CodeGen/bitfield-init-values.c
+++ b/clang/test/CIR/CodeGen/bitfield-init-values.c
@@ -1,34 +1,58 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIRLE
+
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIRBE
+
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
-// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM,LLVMCIR
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVMLE,LLVMCIRLE
+//
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVMBE,LLVMCIRBE
+//
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM,OGCG
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVMLE,OGCGLE
+//
+// RUN: %clang_cc1 -triple aarch64_be-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVMBE,OGCGBE
 
 struct B1 { unsigned int a : 3; unsigned int b : 5; };
 struct B1 b1 = { 0b101, 0b01111 };
-// CIR: cir.global external @b1 = #cir.const_record<{#cir.int<125> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_B1
-// LLVM: @b1 = global %struct.B1 { i8 125, [3 x i8] zeroinitializer }
+// CIRLE: cir.global external @b1 = #cir.const_record<{#cir.int<125> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_B1
+// CIRBE: cir.global external @b1 = #cir.const_record<{#cir.int<175> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_B1
+// LLVMLE: @b1 = global %struct.B1 { i8 125, [3 x i8] zeroinitializer }
+// LLVMBE: @b1 = global %struct.B1 { i8 -81, [3 x i8] zeroinitializer }
 
 struct B2 { unsigned int a : 8; unsigned int b : 8; unsigned int c : 16; };
 struct B2 b2 = { 0xAA, 0xBB, 0xCCDD };
-// CIR: cir.global external @b2 = #cir.const_record<{#cir.int<3437083562> : !u32i}> : !rec_B2
-// LLVMCIR: @b2 = global %struct.B2 { i32 -857883734 }
-// OGCG: @b2 = global { i8, i8, i8, i8 } { i8 -86, i8 -69, i8 -35, i8 -52 }
+// CIRLE: cir.global external @b2 = #cir.const_record<{#cir.int<3437083562> : !u32i}> : !rec_B2
+// CIRBE: cir.global external @b2 = #cir.const_record<{#cir.int<2864434397> : !u32i}> : !rec_B2
+// LLVMCIRLE: @b2 = global %struct.B2 { i32 -857883734 }
+// LLVMCIRBE: @b2 = global %struct.B2 { i32 -1430532899 }
+// OGCGLE: @b2 = global { i8, i8, i8, i8 } { i8 -86, i8 -69, i8 -35, i8 -52 }
+// OGCGBE: @b2 = global { i8, i8, i8, i8 } { i8 -86, i8 -69, i8 -52, i8 -35 }
 
 struct BP { unsigned int a : 3; unsigned int b : 5; int c; };
 struct BP bp = { 1, 2, 99 };
-// CIR: cir.global external @bp = #cir.const_record<{#cir.int<17> : !u8i, #cir.int<99> : !s32i}> : !rec_BP
-// LLVMCIR: @bp = global %struct.BP { i8 17, i32 99 }
-// OGCG: @bp = global { i8, [3 x i8], i32 } { i8 17, [3 x i8] zeroinitializer, i32 99 }
+// CIRLE: cir.global external @bp = #cir.const_record<{#cir.int<17> : !u8i, #cir.int<99> : !s32i}> : !rec_BP
+// CIRBE: cir.global external @bp = #cir.const_record<{#cir.int<34> : !u8i, #cir.int<99> : !s32i}> : !rec_BP
+// LLVMCIRLE: @bp = global %struct.BP { i8 17, i32 99 }
+// LLVMCIRBE: @bp = global %struct.BP { i8 34, i32 99 }
+// OGCGLE: @bp = global { i8, [3 x i8], i32 } { i8 17, [3 x i8] zeroinitializer, i32 99 }
+// OGCGBE: @bp = global { i8, [3 x i8], i32 } { i8 34, [3 x i8] zeroinitializer, i32 99 }
 
 struct BS { int a : 4; int b : 4; };
 struct BS bs = { -1, 3 };
-// CIR: cir.global external @bs = #cir.const_record<{#cir.int<63> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_BS
-// LLVM: @bs = global %struct.BS { i8 63, [3 x i8] zeroinitializer }
+// CIRLE: cir.global external @bs = #cir.const_record<{#cir.int<63> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_BS
+// CIRBE: cir.global external @bs = #cir.const_record<{#cir.int<243> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_BS
+// LLVMLE: @bs = global %struct.BS { i8 63, [3 x i8] zeroinitializer }
+// LLVMBE: @bs = global %struct.BS { i8 -13, [3 x i8] zeroinitializer }
 
 struct BA { int a : 24; char c; };
 struct BA ba = { 0x123456, 7 };
-// CIR: cir.global external @ba = #cir.const_record<{#cir.const_array<[#cir.int<86> : !u8i, #cir.int<52> : !u8i, #cir.int<18> : !u8i]> : !cir.array<!u8i x 3>, #cir.int<7> : !s8i}> : !rec_BA
-// LLVMCIR: @ba = global %struct.BA { [3 x i8] c"V4\12", i8 7 }
-// OGCG: @ba = global { i8, i8, i8, i8 } { i8 86, i8 52, i8 18, i8 7 }
+// CIRLE:  cir.global external @ba = #cir.const_record<{#cir.const_array<[#cir.int<86> : !u8i, #cir.int<52> : !u8i, #cir.int<18> : !u8i]> : !cir.array<!u8i x 3>, #cir.int<7> : !s8i}> : !rec_BA
+// CIRBE:  cir.global external @ba = #cir.const_record<{#cir.const_array<[#cir.int<18> : !u8i, #cir.int<52> : !u8i, #cir.int<86> : !u8i]> : !cir.array<!u8i x 3>, #cir.int<7> : !s8i}> : !rec_BA
+// LLVMCIRLE: @ba = global %struct.BA { [3 x i8] c"V4\12", i8 7 }
+// LLVMCIRBE: @ba = global %struct.BA { [3 x i8] c"\124V", i8 7 }
+// OGCGLE: @ba = global { i8, i8, i8, i8 } { i8 86, i8 52, i8 18, i8 7 }
+// OGCGBE: @ba = global { i8, i8, i8, i8 } { i8 18, i8 52, i8 86, i8 7 }


### PR DESCRIPTION
My patch to change the type of a const missed that there is a difference between how we were representing a bitfield (always as an int) in the constant, and in the struct(as a byte array).

This patch makes sure we correctly match the storage type, and just requires packing/unpacking arrays when we store it.