### PR TITLE
[SampleProfileMatcher] Move fuzzy base name matching to a later stage after more precise CG matching

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -37,8 +37,6 @@ class SampleProfileMatcher {
   // mapping from the source location of current build to the source location
   // in the profile.
   StringMap<LocToLocMap> FuncMappings;
-  // Hash mapping cache for matched anchor pairs in stale profile matching
-  DenseMap<FunctionId, const Function *> MatchedAnchorCache;
 
   // Match state for an anchor/callsite.
   enum class MatchState {
@@ -71,6 +69,11 @@ class SampleProfileMatcher {
   // the new(renamed) function pointer and the value is old(unused) profile
   // name.
   MapVector<Function *, FunctionId> FuncToProfileNameMap;
+  // Mapping from matched(renamed) profile name to IR function to during call
+  // graph matching. This is a reversed FuncToProfileNameMap to track duplicated
+  // profile matching and resolve multiple IR functions being mapped to a single
+  // profile.
+  DenseMap<FunctionId, const Function *> ProfileNameToFuncMap;
 
   // A map pointer to the FuncNameToProfNameMap in SampleProfileLoader,
   // which maps the function name to the matched profile name. This is used

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -69,6 +69,7 @@ class SampleProfileMatcher {
   // the new(renamed) function pointer and the value is old(unused) profile
   // name.
   MapVector<Function *, FunctionId> FuncToProfileNameMap;
+  MapVector<Function *, FunctionId> FuncToProfileNameMapByBase;
   // Mapping from matched(renamed) profile name to IR function to during call
   // graph matching. This is a reversed FuncToProfileNameMap to track duplicated
   // profile matching and resolve multiple IR functions being mapped to a single

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -69,7 +69,6 @@ class SampleProfileMatcher {
   // the new(renamed) function pointer and the value is old(unused) profile
   // name.
   MapVector<Function *, FunctionId> FuncToProfileNameMap;
-  MapVector<Function *, FunctionId> FuncToProfileNameMapByBase;
   // Mapping from matched(renamed) profile name to IR function to during call
   // graph matching. This is a reversed FuncToProfileNameMap to track duplicated
   // profile matching and resolve multiple IR functions being mapped to a single

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -386,6 +386,10 @@ void SampleProfileMatcher::runStaleProfileMatching(
       if (ProfAnchor == ProfileAnchors.end())
         continue;
       ProfId = ProfAnchor->second;
+      FuncProfileMatchCache[{IRFunc, ProfId}] = true;
+      FuncToProfileNameMap[Callee] = ProfId;
+      LLVM_DEBUG(dbgs() << "Function:" << IRFunc->getName()
+                        << " matches profile:" << ProfId << "\n");
     }
 
     // Conflicting profile previously matched
@@ -1032,12 +1036,8 @@ bool SampleProfileMatcher::functionMatchesProfile(Function &IRFunc,
     return false;
 
   bool Matched = functionMatchesProfileHelper(IRFunc, ProfFunc);
-  FuncProfileMatchCache[{&IRFunc, ProfFunc}] = Matched;
-  if (Matched) {
-    FuncToProfileNameMap.try_emplace(&IRFunc, ProfFunc);
-    LLVM_DEBUG(dbgs() << "Function:" << IRFunc.getName()
-                      << " matches profile:" << ProfFunc << "\n");
-  }
+  if (!Matched)
+    FuncProfileMatchCache[{&IRFunc, ProfFunc}] = Matched;
 
   return Matched;
 }

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -386,10 +386,12 @@ void SampleProfileMatcher::runStaleProfileMatching(
       if (ProfAnchor == ProfileAnchors.end())
         continue;
       ProfId = ProfAnchor->second;
-      FuncProfileMatchCache[{IRFunc, ProfId}] = true;
-      FuncToProfileNameMap[Callee] = ProfId;
-      LLVM_DEBUG(dbgs() << "Function:" << IRFunc->getName()
-                        << " matches profile:" << ProfId << "\n");
+      if (IRFunc->getName() != ProfId.stringRef()) {
+        FuncProfileMatchCache[{IRFunc, ProfId}] = true;
+        FuncToProfileNameMap[Callee] = ProfId;
+        LLVM_DEBUG(dbgs() << "Function:" << IRFunc->getName()
+                          << " matches profile:" << ProfId << "\n");
+      }
     }
 
     // Conflicting profile previously matched
@@ -416,7 +418,13 @@ void SampleProfileMatcher::runStaleProfileMatching(
       FunctionSamples &NewFS = FlattenedProfiles.create(NewProfId);
       NewFS.merge(*FSForMatching);
       FuncToProfileNameMap[IRFunc] = NewProfId;
+      FuncProfileMatchCache[{IRFunc, ProfId}] = false;
       FuncProfileMatchCache[{IRFunc, NewProfId}] = true;
+
+      LLVM_DEBUG(dbgs() << "Function:" << Callee->getName()
+                        << " encounters conflicting profile matchings, "
+                           "remapping to new profile:"
+                        << NewAnchor << "\n");
 
       // Update profile in the sample profile reader
       SampleProfileMap &Profiles = Reader.getProfiles();
@@ -685,7 +693,7 @@ void SampleProfileMatcher::computeAndReportProfileStaleness() {
   }
 
   // Count profile mismatches for profile staleness report.
-  for (const auto &F : M) {
+  for (auto &F : M) {
     if (skipProfileForFunction(F))
       continue;
     // As the stats will be merged by linker, skip reporting the metrics for

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -693,7 +693,7 @@ void SampleProfileMatcher::computeAndReportProfileStaleness() {
   }
 
   // Count profile mismatches for profile staleness report.
-  for (auto &F : M) {
+  for (const auto &F : M) {
     if (skipProfileForFunction(F))
       continue;
     // As the stats will be merged by linker, skip reporting the metrics for

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -1034,7 +1034,7 @@ bool SampleProfileMatcher::functionMatchesProfile(Function &IRFunc,
   bool Matched = functionMatchesProfileHelper(IRFunc, ProfFunc);
   FuncProfileMatchCache[{&IRFunc, ProfFunc}] = Matched;
   if (Matched) {
-    FuncToProfileNameMap[&IRFunc] = ProfFunc;
+    FuncToProfileNameMap.try_emplace(&IRFunc, ProfFunc);
     LLVM_DEBUG(dbgs() << "Function:" << IRFunc.getName()
                       << " matches profile:" << ProfFunc << "\n");
   }

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -364,59 +364,59 @@ void SampleProfileMatcher::runStaleProfileMatching(
 
   // Scan through the matched anchors to make sure functions and profiles are
   // 1:1 mapped. If the profile has already been mapped to another function
-  // during previous fuzzy matching, create a new profile with the same sample
-  // counts and assumed to be pre-inlined.
+  // during previous fuzzy matching, create a new profile the same as the
+  // flattened profile as a top-level function.
   for (const auto &IR : IRAnchors) {
     bool ProfileConflicted = false;
-    const auto &Loc = IR.first;
-    Function *Callee = M.getFunction(IR.second.stringRef());
-    if (!Callee)
+    const auto &IRLoc = IR.first;
+    Function *IRFunc = M.getFunction(IR.second.stringRef());
+    if (!IRFunc)
       continue;
-    FunctionId ProfAnchor;
-    auto AnchorLoc = MatchedAnchors.find(Loc);
-    if (AnchorLoc == MatchedAnchors.end()) {
+    FunctionId ProfId;
+    auto MatchedLoc = MatchedAnchors.find(IRLoc);
+    if (MatchedLoc == MatchedAnchors.end()) {
       // Search within the module and find if we have conflicts in pre-matched
       // profiles for this anchor
-      auto PreMatched = FuncToProfileNameMap.find(Callee);
+      auto PreMatched = FuncToProfileNameMap.find(IRFunc);
       if (PreMatched == FuncToProfileNameMap.end())
         continue;
-      ProfAnchor = PreMatched->second;
+      ProfId = PreMatched->second;
     } else {
-      const auto &Prof = ProfileAnchors.find(AnchorLoc->second);
-      if (Prof == ProfileAnchors.end())
+      const auto &ProfAnchor = ProfileAnchors.find(MatchedLoc->second);
+      if (ProfAnchor == ProfileAnchors.end())
         continue;
-      ProfAnchor = Prof->second;
+      ProfId = ProfAnchor->second;
     }
 
     // Conflicting profile previously matched
-    auto Cached = MatchedAnchorCache.find(ProfAnchor);
-    if (Cached == MatchedAnchorCache.end())
-      MatchedAnchorCache[ProfAnchor] = Callee;
-    else if (Cached->second != Callee)
+    auto PrevMatched = ProfileNameToFuncMap.find(ProfId);
+    if (PrevMatched == ProfileNameToFuncMap.end())
+      ProfileNameToFuncMap[ProfId] = IRFunc;
+    else if (PrevMatched->second != IRFunc)
       ProfileConflicted = true;
 
     if (ProfileConflicted) {
       // Create a flattened profile using the IR function name to avoid profile
       // name conflicts
-      const auto *FSForMatching = getFlattenedSamplesFor(ProfAnchor);
+      const auto *FSForMatching = getFlattenedSamplesFor(ProfId);
       if (!FSForMatching)
-        FSForMatching = Reader.getSamplesFor(ProfAnchor.stringRef());
+        FSForMatching = Reader.getSamplesFor(ProfId.stringRef());
       if (!FSForMatching)
         continue;
 
-      FunctionId NewAnchor(
+      FunctionId NewProfId(
           FunctionSamples::getCanonicalFnName(IR.second.stringRef()));
-      auto R = FuncProfileMatchCache.find({Callee, NewAnchor});
+      auto R = FuncProfileMatchCache.find({IRFunc, NewProfId});
       if (R != FuncProfileMatchCache.end() && R->second)
         continue;
-      FunctionSamples &NewFS = FlattenedProfiles.create(NewAnchor);
+      FunctionSamples &NewFS = FlattenedProfiles.create(NewProfId);
       NewFS.merge(*FSForMatching);
-      FuncToProfileNameMap[Callee] = NewAnchor;
-      FuncProfileMatchCache[{Callee, NewAnchor}] = true;
+      FuncToProfileNameMap[IRFunc] = NewProfId;
+      FuncProfileMatchCache[{IRFunc, NewProfId}] = true;
 
       // Update profile in the sample profile reader
       SampleProfileMap &Profiles = Reader.getProfiles();
-      SampleContext FContext(NewAnchor);
+      SampleContext FContext(NewProfId);
       auto Res = Profiles.try_emplace(FContext.getHashCode(), FContext, NewFS);
       FunctionSamples &FProfile = Res.first->second;
       FProfile.setContext(FContext);
@@ -897,7 +897,7 @@ void SampleProfileMatcher::matchFunctionsWithoutProfileByBasename() {
       continue;
 
     FuncToProfileNameMap[OrphanFunc] = ProfId;
-    MatchedAnchorCache[ProfId] = OrphanFunc;
+    ProfileNameToFuncMap[ProfId] = OrphanFunc;
     if (const auto *FS = Reader.getSamplesFor(ProfId.stringRef()))
       NewlyLoadedProfiles.create(FS->getFunction()).merge(*FS);
     MatchCount++;

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -388,7 +388,7 @@ void SampleProfileMatcher::runStaleProfileMatching(
       ProfId = ProfAnchor->second;
       if (IRFunc->getName() != ProfId.stringRef()) {
         FuncProfileMatchCache[{IRFunc, ProfId}] = true;
-        FuncToProfileNameMap[Callee] = ProfId;
+        FuncToProfileNameMap[IRFunc] = ProfId;
         LLVM_DEBUG(dbgs() << "Function:" << IRFunc->getName()
                           << " matches profile:" << ProfId << "\n");
       }
@@ -421,10 +421,10 @@ void SampleProfileMatcher::runStaleProfileMatching(
       FuncProfileMatchCache[{IRFunc, ProfId}] = false;
       FuncProfileMatchCache[{IRFunc, NewProfId}] = true;
 
-      LLVM_DEBUG(dbgs() << "Function:" << Callee->getName()
+      LLVM_DEBUG(dbgs() << "Function:" << IRFunc->getName()
                         << " encounters conflicting profile matchings, "
                            "remapping to new profile:"
-                        << NewAnchor << "\n");
+                        << NewProfId << "\n");
 
       // Update profile in the sample profile reader
       SampleProfileMap &Profiles = Reader.getProfiles();
@@ -910,6 +910,8 @@ void SampleProfileMatcher::matchFunctionsWithoutProfileByBasename() {
 
     FuncToProfileNameMap[OrphanFunc] = ProfId;
     ProfileNameToFuncMap[ProfId] = OrphanFunc;
+    FuncProfileMatchCache[{OrphanFunc, ProfId}] = true;
+
     if (const auto *FS = Reader.getSamplesFor(ProfId.stringRef()))
       NewlyLoadedProfiles.create(FS->getFunction()).merge(*FS);
     MatchCount++;
@@ -934,18 +936,6 @@ bool SampleProfileMatcher::functionMatchesProfileHelper(
   // The value is in the range [0, 1]. The bigger the value is, the more similar
   // two sequences are.
   float Similarity = 0.0;
-
-  // Match the functions if they have the same base name(after demangling) and
-  // skip the similarity check.
-  ItaniumPartialDemangler Demangler;
-  auto IRBaseName = getDemangledBaseName(Demangler, IRFunc.getName());
-  auto ProfBaseName = getDemangledBaseName(Demangler, ProfFunc.stringRef());
-  if (!IRBaseName.empty() && IRBaseName == ProfBaseName) {
-    LLVM_DEBUG(dbgs() << "The functions " << IRFunc.getName() << "(IR) and "
-                      << ProfFunc << "(Profile) share the same base name: "
-                      << IRBaseName << ".\n");
-    return true;
-  }
 
   const auto *FSForMatching = getFlattenedSamplesFor(ProfFunc);
   // With extbinary profile format, initial profile loading only reads profile
@@ -1044,8 +1034,21 @@ bool SampleProfileMatcher::functionMatchesProfile(Function &IRFunc,
     return false;
 
   bool Matched = functionMatchesProfileHelper(IRFunc, ProfFunc);
-  if (!Matched)
+  if (!Matched) {
+    // Match the functions if they have the same base name(after demangling) and
+    // skip the similarity check.
+    ItaniumPartialDemangler Demangler;
+    auto IRBaseName = getDemangledBaseName(Demangler, IRFunc.getName());
+    auto ProfBaseName = getDemangledBaseName(Demangler, ProfFunc.stringRef());
+    if (!IRBaseName.empty() && IRBaseName == ProfBaseName) {
+      LLVM_DEBUG(dbgs() << "The functions " << IRFunc.getName() << "(IR) and "
+                        << ProfFunc << "(Profile) share the same base name: "
+                        << IRBaseName << ".\n");
+      return true;
+    }
+    // Cache IR/Prof function pairs that don't match
     FuncProfileMatchCache[{&IRFunc, ProfFunc}] = Matched;
+  }
 
   return Matched;
 }
@@ -1088,11 +1091,11 @@ void SampleProfileMatcher::runOnModule() {
 
   if (SalvageUnusedProfile) {
     findFunctionsWithoutProfile();
-    matchFunctionsWithoutProfileByBasename();
   }
 
   // Process the matching in top-down order so that the caller matching result
   // can be used to the callee matching.
+  DenseSet<Function *> FunctionProcessedInStage1;
   std::vector<Function *> TopDownFunctionList;
   TopDownFunctionList.reserve(M.size());
   buildTopDownFuncOrder(CG, TopDownFunctionList);
@@ -1100,6 +1103,21 @@ void SampleProfileMatcher::runOnModule() {
     if (skipProfileForFunction(*F))
       continue;
     runOnFunction(*F);
+    if (getFlattenedSamplesFor(*F) || FuncToProfileNameMap.contains(F))
+      FunctionProcessedInStage1.insert(F);
+  }
+
+  // Stage 2 stale profile matching after rematching all the remaining functions
+  // without profile with fuzzy basename matching
+  if (SalvageUnusedProfile) {
+    matchFunctionsWithoutProfileByBasename();
+    for (auto *F : TopDownFunctionList) {
+      if (skipProfileForFunction(*F))
+        continue;
+      if (FunctionProcessedInStage1.contains(F))
+        continue;
+      runOnFunction(*F);
+    }
   }
 
   if (SalvageUnusedProfile)

--- a/llvm/test/Transforms/SampleProfile/Inputs/pseudo-probe-stale-profile-orphan-conflict.prof
+++ b/llvm/test/Transforms/SampleProfile/Inputs/pseudo-probe-stale-profile-orphan-conflict.prof
@@ -1,4 +1,5 @@
 _Z3fooi:1:0
+ 30: _Z3topi:1
  57: _Z3bari:1
  72: _Z3topi:1
   2: _Z3midi:1

--- a/llvm/test/Transforms/SampleProfile/Inputs/stale-profile-lcs-anchor-overwrite.prof
+++ b/llvm/test/Transforms/SampleProfile/Inputs/stale-profile-lcs-anchor-overwrite.prof
@@ -1,0 +1,7 @@
+_Z3fooi:29916:31
+ 349: 2 A:1 B:1
+ 350: 1 C:1
+ 6: _Z3bari:1843
+ 380: _Z3barl:323
+  3: _Z6calleei:306
+ !CFGChecksum: 1

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-orphan-conflict.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-orphan-conflict.ll
@@ -1,6 +1,6 @@
 ; Test direct basename matching for orphan functions where multiple callee anchors may be
 ; matched to one same profile during stale profile matching. In this test case, both of the
-; `mid` functions will be matched to the same `_Z3midi` function in the profile during stale
+; `top` functions will be matched to the same `_Z3topi` function in the profile during stale
 ; profile matching. This ends up causing an assertation error because only one profile
 ; function is supposed to be matched to an IR function.
 ;
@@ -10,21 +10,14 @@
 ;                          |_ sub
 ; 
 ; Profile Function:
-;   foo: bar ; top ; mid
-;                     |_ sub
+;   foo: top; bar ; top
+;                     |_ mid
+;                          |_ sub
 ; 
 ; Stale profile match order:
 ;   foo:  top<ir>   ; bar<ir>   ; top(2)<ir>
 ;            |           |           |
 ;         top<prof> ; bar<prof> ; top<prof>
-;
-;   top(2)<ir>:  mid(2)<ir>
-;                  |
-;                mid<prof>
-;
-;   top<ir>:  mid<ir>
-;               |
-;             mid<prof>    => (Assertation error)
 
 
 ; REQUIRES: x86_64-linux
@@ -32,23 +25,15 @@
 ; RUN: llvm-profdata merge --sample --extbinary %S/Inputs/pseudo-probe-stale-profile-orphan-conflict.prof -o %t.prof
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%t.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
 
-; CHECK: Function _Z3midl is not in profile or profile symbol list.
-; CHECK: Function _Z3midll is not in profile or profile symbol list.
-; CHECK: Function _Z3topl is not in profile or profile symbol list.
-; CHECK: Function _Z3barl is not in profile or profile symbol list.
-; CHECK: Function _Z3topll is not in profile or profile symbol list.
-; CHECK: Function _Z3fool is not in profile or profile symbol list.
-; CHECK: Direct basename match: _Z3barl (IR) -> _Z3bari (Profile) [basename: bar]
-; CHECK: Direct basename match: _Z3fool (IR) -> _Z3fooi (Profile) [basename: foo]
-; CHECK: Direct basename matching found 2 matches
 ; CHECK: Run stale profile matching for _Z3fool
 ; CHECK: The functions _Z3topl(IR) and _Z3topi(Profile) share the same base name: top.
-; CHECK: Function:_Z3topl matches profile:_Z3topi
 ; CHECK: The functions _Z3barl(IR) and _Z3bari(Profile) share the same base name: bar.
-; CHECK: Function:_Z3barl matches profile:_Z3bari
 ; CHECK: The functions _Z3topll(IR) and _Z3topi(Profile) share the same base name: top.
+; CHECK: Function:_Z3topl matches profile:_Z3topi
+; CHECK: Function:_Z3barl matches profile:_Z3bari
 ; CHECK: Function:_Z3topll matches profile:_Z3topi
-; CHECK: Location is matched from 2 to 2
+; CHECK: Function:_Z3topll encounters conflicting profile matchings, remapping to new profile:_Z3topll
+; CHECK: Callsite with callee:_Z3topl is matched from 2 to 30
 ; CHECK: Callsite with callee:_Z3barl is matched from 3 to 57
 ; CHECK: Callsite with callee:_Z3topll is matched from 4 to 72
 ; CHECK: Run stale profile matching for _Z3topll
@@ -59,6 +44,7 @@
 ; CHECK: Run stale profile matching for _Z3topl
 ; CHECK: The functions _Z3midl(IR) and _Z3midi(Profile) share the same base name: mid.
 ; CHECK: Function:_Z3midl matches profile:_Z3midi
+; CHECK: Function:_Z3midl encounters conflicting profile matchings, remapping to new profile:_Z3midl
 ; CHECK: Callsite with callee:_Z3midl is matched from 1 to 2
 ; CHECK: Run stale profile matching for _Z3midll
 ; CHECK: Callsite with callee:_Z3subi is matched from 1 to 11

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-orphan-conflict.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-orphan-conflict.ll
@@ -27,7 +27,6 @@
 
 ; CHECK: Run stale profile matching for _Z3fool
 ; CHECK: The functions _Z3topl(IR) and _Z3topi(Profile) share the same base name: top.
-; CHECK: The functions _Z3barl(IR) and _Z3bari(Profile) share the same base name: bar.
 ; CHECK: The functions _Z3topll(IR) and _Z3topi(Profile) share the same base name: top.
 ; CHECK: Function:_Z3topl matches profile:_Z3topi
 ; CHECK: Function:_Z3barl matches profile:_Z3bari

--- a/llvm/test/Transforms/SampleProfile/stale-profile-lcs-anchor-overwrite.ll
+++ b/llvm/test/Transforms/SampleProfile/stale-profile-lcs-anchor-overwrite.ll
@@ -1,0 +1,118 @@
+; REQUIRES: x86_64-linux
+; REQUIRES: asserts
+; RUN: llvm-profdata merge --sample --extbinary %S/Inputs/stale-profile-lcs-anchor-overwrite.prof -o %t.prof
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%t.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
+
+; CHECK: Function:_Z3barv matches profile:_Z3bari
+; CHECK: The functions _Z3barv(IR) and _Z3barl(Profile) share the same base name: bar.
+; CHECK: Function:_Z3barv matches profile:_Z3barl
+; CHECK: The functions _Z3barPv(IR) and _Z3barl(Profile) share the same base name: bar.
+; CHECK: Function:_Z3barPv matches profile:_Z3barl
+
+; CHECK: Run stale profile matching for _Z3barPv
+; CHECK: The functions _Z6calleePv(IR) and _Z6calleei(Profile) share the same base name: callee.
+; CHECK: Function:_Z6calleePv matches profile:_Z6calleei
+; CHECK: Location is matched from 1 to 1
+; CHECK: Callsite with callee:_Z6calleePv is matched from 2 to 3
+; CHECK: Run stale profile matching for _Z3barv
+; CHECK: Run stale profile matching for _Z6calleePv
+; CHECK: Function processing order:
+; CHECK: _Z3foov
+; CHECK: _Z3barPv
+; CHECK: _Z6calleePv
+; CHECK: _Z3barv
+
+
+target triple = "x86_64-linux-gnu"
+
+define dso_local noundef ptr @_Z6calleePv(ptr noundef %ptr) #0 !dbg !15 {
+entry:
+  %ptr.addr = alloca ptr, align 8
+  store ptr %ptr, ptr %ptr.addr, align 8
+    #dbg_declare(ptr %ptr.addr, !20, !DIExpression(), !21)
+  call void @llvm.pseudoprobe(i64 7108221232740920931, i64 1, i32 0, i64 -1), !dbg !22
+  ret ptr null, !dbg !22
+}
+
+define dso_local void @_Z3barv() #0 !dbg !23 {
+entry:
+  call void @llvm.pseudoprobe(i64 -1069303473483922844, i64 1, i32 0, i64 -1), !dbg !24
+  ret void, !dbg !24
+}
+
+define dso_local noundef ptr @_Z3barPv(ptr noundef %ptr) #0 !dbg !25 {
+entry:
+  %ptr.addr = alloca ptr, align 8
+  store ptr %ptr, ptr %ptr.addr, align 8
+    #dbg_declare(ptr %ptr.addr, !26, !DIExpression(), !27)
+  call void @llvm.pseudoprobe(i64 5678655469166311522, i64 1, i32 0, i64 -1), !dbg !28
+  %call = call noundef ptr @_Z6calleePv(ptr noundef null), !dbg !29
+  ret ptr %call, !dbg !31
+}
+
+define dso_local noundef ptr @_Z3foov() #0 !dbg !32 {
+entry:
+  call void @llvm.pseudoprobe(i64 9191153033785521275, i64 1, i32 0, i64 -1), !dbg !35
+  call void null(), !dbg !36
+  call void @_Z3barv(), !dbg !38
+  call void null(), !dbg !40
+  %call = call noundef ptr @_Z3barPv(ptr noundef null), !dbg !42
+  ret ptr %call, !dbg !44
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare void @llvm.pseudoprobe(i64, i64, i32, i64) #1
+
+attributes #0 = { "use-sample-profile" }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!6, !7, !8, !9}
+!llvm.ident = !{!10}
+!llvm.pseudo_probe_desc = !{!11, !12, !13, !14}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !2, splitDebugInlining: false, debugInfoForProfiling: true, nameTableKind: None)
+!1 = !DIFile(filename: "test.cc", directory: "/tmp", checksumkind: CSK_MD5, checksum: "e16862f6a655f30cd332532a91f867b6")
+!2 = !{!3}
+!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!4 = !DISubroutineType(types: !5)
+!5 = !{null}
+!6 = !{i32 7, !"Dwarf Version", i32 5}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+!8 = !{i32 7, !"uwtable", i32 2}
+!9 = !{i32 7, !"frame-pointer", i32 2}
+!10 = !{!"clang"}
+!11 = !{i64 7108221232740920931, i64 4294967295, !"_Z6calleePv"}
+!12 = !{i64 -1069303473483922844, i64 4294967295, !"_Z3barv"}
+!13 = !{i64 5678655469166311522, i64 281479271677951, !"_Z3barPv"}
+!14 = !{i64 9191153033785521275, i64 1125904201809919, !"_Z3foov"}
+!15 = distinct !DISubprogram(name: "callee", linkageName: "_Z6calleePv", scope: !1, file: !1, line: 1, type: !16, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !18}
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!19 = !{}
+!20 = !DILocalVariable(name: "ptr", arg: 1, scope: !15, file: !1, line: 1, type: !18)
+!21 = !DILocation(line: 1, column: 20, scope: !15)
+!22 = !DILocation(line: 2, column: 5, scope: !15)
+!23 = distinct !DISubprogram(name: "bar", linkageName: "_Z3barv", scope: !1, file: !1, line: 5, type: !4, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!24 = !DILocation(line: 5, column: 13, scope: !23)
+!25 = distinct !DISubprogram(name: "bar", linkageName: "_Z3barPv", scope: !1, file: !1, line: 7, type: !16, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!26 = !DILocalVariable(name: "ptr", arg: 1, scope: !25, file: !1, line: 7, type: !18)
+!27 = !DILocation(line: 7, column: 17, scope: !25)
+!28 = !DILocation(line: 8, column: 12, scope: !25)
+!29 = !DILocation(line: 8, column: 12, scope: !30)
+!30 = !DILexicalBlockFile(scope: !25, file: !1, discriminator: 455082007)
+!31 = !DILocation(line: 8, column: 5, scope: !25)
+!32 = distinct !DISubprogram(name: "foo", linkageName: "_Z3foov", scope: !1, file: !1, line: 11, type: !33, scopeLine: 11, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!33 = !DISubroutineType(types: !34)
+!34 = !{!18}
+!35 = !DILocation(line: 12, column: 5, scope: !32)
+!36 = !DILocation(line: 12, column: 5, scope: !37)
+!37 = !DILexicalBlockFile(scope: !32, file: !1, discriminator: 387973143)
+!38 = !DILocation(line: 13, column: 5, scope: !39)
+!39 = !DILexicalBlockFile(scope: !32, file: !1, discriminator: 455082015)
+!40 = !DILocation(line: 14, column: 5, scope: !41)
+!41 = !DILexicalBlockFile(scope: !32, file: !1, discriminator: 387973159)
+!42 = !DILocation(line: 15, column: 12, scope: !43)
+!43 = !DILexicalBlockFile(scope: !32, file: !1, discriminator: 455082031)
+!44 = !DILocation(line: 15, column: 5, scope: !32)

--- a/llvm/test/Transforms/SampleProfile/stale-profile-lcs-anchor-overwrite.ll
+++ b/llvm/test/Transforms/SampleProfile/stale-profile-lcs-anchor-overwrite.ll
@@ -3,12 +3,25 @@
 ; RUN: llvm-profdata merge --sample --extbinary %S/Inputs/stale-profile-lcs-anchor-overwrite.prof -o %t.prof
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%t.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
 
-; CHECK: Function:_Z3barv matches profile:_Z3bari
+; CHECK: Function _Z6calleePv is not in profile or profile symbol list.
+; CHECK: Function _Z3barv is not in profile or profile symbol list.
+; CHECK: Function _Z3barPv is not in profile or profile symbol list.
+; CHECK: Function _Z3foov is not in profile or profile symbol list.
+; CHECK: Direct basename match: _Z6calleePv (IR) -> _Z6calleei (Profile) [basename: callee]
+; CHECK: Direct basename match: _Z3foov (IR) -> _Z3fooi (Profile) [basename: foo]
+; CHECK: Direct basename matching found 2 matches
+; CHECK: Run stale profile matching for _Z3foov
+; CHECK: The functions _Z3barv(IR) and _Z3bari(Profile) share the same base name: bar.
 ; CHECK: The functions _Z3barv(IR) and _Z3barl(Profile) share the same base name: bar.
-; CHECK: Function:_Z3barv matches profile:_Z3barl
 ; CHECK: The functions _Z3barPv(IR) and _Z3barl(Profile) share the same base name: bar.
+; CHECK: Function:_Z3barv matches profile:_Z3bari
 ; CHECK: Function:_Z3barPv matches profile:_Z3barl
-
+; CHECK: Location is matched from 1 to 1
+; CHECK: Location is matched from 2 to 2
+; CHECK: Callsite with callee:_Z3barv is matched from 3 to 6
+; CHECK: Location is rematched backwards from 2 to 5
+; CHECK: Callsite with callee:unknown.indirect.callee is matched from 4 to 349
+; CHECK: Callsite with callee:_Z3barPv is matched from 5 to 380
 ; CHECK: Run stale profile matching for _Z3barPv
 ; CHECK: The functions _Z6calleePv(IR) and _Z6calleei(Profile) share the same base name: callee.
 ; CHECK: Function:_Z6calleePv matches profile:_Z6calleei

--- a/llvm/test/Transforms/SampleProfile/stale-profile-lcs-anchor-overwrite.ll
+++ b/llvm/test/Transforms/SampleProfile/stale-profile-lcs-anchor-overwrite.ll
@@ -23,7 +23,6 @@
 ; CHECK: Callsite with callee:unknown.indirect.callee is matched from 4 to 349
 ; CHECK: Callsite with callee:_Z3barPv is matched from 5 to 380
 ; CHECK: Run stale profile matching for _Z3barPv
-; CHECK: The functions _Z6calleePv(IR) and _Z6calleei(Profile) share the same base name: callee.
 ; CHECK: Function:_Z6calleePv matches profile:_Z6calleei
 ; CHECK: Location is matched from 1 to 1
 ; CHECK: Callsite with callee:_Z6calleePv is matched from 2 to 3


### PR DESCRIPTION
Currently stale profile matching runs base name matching before more precise LCS-based matching and CG-based similarity matching. An IR function is aggressively matched to a profile function based on its function base name instead of using the more accurate CG matching. This creates inaccuracy particularly when profiles of template functions or virtual functions are stale.

There are two places where base name matching takes place ahead of CG matching and short-circuiting the more precise CG-based matching steps:
1) before LCS matching: https://github.com/llvm/llvm-project/blob/95cabd6644eae6c1622750d78ebc90e68fe0e122/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp#L1083
2) before CG similarity match: https://github.com/llvm/llvm-project/blob/95cabd6644eae6c1622750d78ebc90e68fe0e122/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp#L926-L936

This patch moves the more generic base name matching to a later stage as a fallback of the CG matching. For 1), we shall perform LCS-based CG matching twice, where the first pass is based on the full function name match, and the second pass is based on function base name match. However, the second pass only runs stale profile matching over the unmatched functions from the first pass. For 2), we simply moves the base name matching out and make it a fallback only when CG similarity matching fails.