### PR TITLE
[IR] Reject token overload types in intrinsic signature matching

### DIFF
--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -1097,6 +1097,12 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
            "Table consistency error");
     OverloadTys.push_back(Ty);
 
+    // Token has no mangling (see getMangledTypeStr), so it cannot be an
+    // overload type; reject it with a signature error. Label is already
+    // excluded from function signatures, so it never reaches here.
+    if (Ty->isTokenTy())
+      return PrintMsg(false, "any manglable type", OIdx);
+
     IITDescriptor::AnyKindVectorConstraint VC;
     IITDescriptor::AnyKindElementConstraint EC;
     std::tie(VC, EC) = D.getOverloadConstraints();

--- a/llvm/test/Assembler/intrinsic-token-overload-invalid.ll
+++ b/llvm/test/Assembler/intrinsic-token-overload-invalid.ll
@@ -1,0 +1,13 @@
+; RUN: not opt -disable-output %s 2>&1 | FileCheck %s
+
+; Token overloads of llvm_any_ty intrinsics used to crash parse-time intrinsic
+; remangling with "Unhandled type" in the name mangler (#210641). They must be
+; rejected with a normal signature error, like constrained overloads are.
+
+; CHECK: intrinsic return type (overload type 0) expected any manglable type, but got token
+declare token @llvm.ssa.copy.token(token)
+
+; CHECK: intrinsic argument 0 type (overload type 0) expected any manglable type, but got token
+declare i1 @llvm.is.constant.token(token)
+
+; CHECK: error: input module is broken!


### PR DESCRIPTION
Parsing a declaration of an llvm_any_ty intrinsic with a token overload type crashes opt at parse time:

```
declare token @llvm.ssa.copy.token(token)
Unhandled type
UNREACHABLE executed at llvm/lib/IR/Intrinsics.cpp:133!
```
The unconstrained Any matcher accepts a token, and Intrinsic::remangleIntrinsicFunction (run from `LLParser::validateEndOfModule`, before the Verifier) then fails to mangle it into the intrinsic name.

Token has no name mangling, so no overloaded intrinsic can be instantiated on it. Reject it in matchIntrinsicType's Overloaded case, turning the crash into the same clean "expected ..., but got token" broken-module error that constrained overloads already produce.

Label needs no such check: it is excluded from function signatures by `FunctionType::isValidReturnType`/`isValidArgumentType` and the LLParser, so it never reaches matchIntrinsicType.

Fixed llvm_token_ty operands (gc.result, coro.*, ...) are unaffected.

Fixes #210641.