### PR TITLE
[X86] Fix getStackProbeSymbolName returning non-callable values on Windows

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -64599,9 +64599,19 @@ X86TargetLowering::getStackProbeSymbolName(const MachineFunction &MF) const {
   if (hasInlineStackProbe(MF))
     return "";
 
-  // If the function specifically requests stack probes, emit them.
-  if (MF.getFunction().hasFnAttribute("probe-stack"))
-    return MF.getFunction().getFnAttribute("probe-stack").getValueAsString();
+  // If the function specifically requests a named stack probe function, use it.
+  if (MF.getFunction().hasFnAttribute("probe-stack")) {
+    StringRef Value =
+        MF.getFunction().getFnAttribute("probe-stack").getValueAsString();
+    // "inline-asm" is a sentinel value requesting inline stack probes rather
+    // than a function call. hasInlineStackProbe() already handles this and
+    // returned false (e.g. because Windows targets use their own mechanism).
+    // Don't return the sentinel as a literal symbol name; fall through to
+    // the platform default. Also skip empty values, which would crash
+    // downstream in the mangler.
+    if (Value != "inline-asm" && !Value.empty())
+      return Value;
+  }
 
   // Generally, if we aren't on Windows, the platform ABI does not include
   // support for stack probes, so don't emit them.

--- a/llvm/test/CodeGen/X86/probe-stack-dynalloca-windows.ll
+++ b/llvm/test/CodeGen/X86/probe-stack-dynalloca-windows.ll
@@ -1,0 +1,49 @@
+; RUN: llc -O2 < %s -o /dev/null
+; RUN: llc -O2 < %s | FileCheck %s
+;
+; Test that dynamic allocas on Windows with probe-stack attributes that are
+; not callable symbol names correctly fall back to the platform stack probe.
+;
+; probe-stack=inline-asm is a sentinel requesting inline probing, but
+; hasInlineStackProbe() returns false on Windows (Windows uses __chkstk).
+; Previously, getStackProbeSymbolName() returned the sentinel as a literal
+; symbol name, emitting callq "inline-asm".
+;
+; probe-stack="" (empty) flowed through unchecked and crashed in
+; Mangler::getNameWithPrefix via X86MCInstLower::GetSymbolFromOperand.
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+; The "inline-asm" sentinel must resolve to __chkstk, not "inline-asm".
+; CHECK-LABEL: test_inline_asm_sentinel:
+; CHECK-NOT:   inline-asm
+; CHECK:       callq __chkstk
+define ptr @test_inline_asm_sentinel(i64 %n) #0 {
+entry:
+  %cmp = icmp ugt i64 %n, 0
+  br i1 %cmp, label %alloc, label %exit
+alloc:
+  %buf = alloca i8, i64 %n, align 16
+  ret ptr %buf
+exit:
+  ret ptr null
+}
+
+; An empty probe-stack value must not crash; should also resolve to __chkstk.
+; CHECK-LABEL: test_empty_probe_stack:
+; CHECK-NOT:   inline-asm
+; CHECK:       callq __chkstk
+define ptr @test_empty_probe_stack(i64 %n) #1 {
+entry:
+  %cmp = icmp ugt i64 %n, 0
+  br i1 %cmp, label %alloc, label %exit
+alloc:
+  %buf = alloca i8, i64 %n, align 16
+  ret ptr %buf
+exit:
+  ret ptr null
+}
+
+attributes #0 = { "probe-stack"="inline-asm" }
+attributes #1 = { "probe-stack"="" }


### PR DESCRIPTION
`getStackProbeSymbolName()` returns the raw `probe-stack` attribute value as a
call target without checking it's a function name. On Windows
`hasInlineStackProbe()` returns false (Windows probes via `__chkstk`), so the
value flows straight through. Two values break this: `probe-stack="inline-asm"`,
a sentinel rather than a symbol, is emitted as `callq "inline-asm"` (undefined
at link time) — rustc sets it on every `x86_64-pc-windows-msvc` function; and
`probe-stack=""` reaches the mangler, tripping `assert(!Name.empty())` in
`Mangler::getNameWithPrefix` with assertions or SIGSEGV in
`GetSymbolFromOperand` without (seen on 21.1.8 release).

Both need a dynamic alloca to reach `emitStackProbeCall()`, a non-entry-block
or variable-sized alloca routed through `DYN_ALLOCA` -> `X86DynAllocaExpander`.
In the wild this appears when CodeGenPrepare splits the entry block at `-O2`
and a static alloca lands in a successor.

The fix skips both values and falls through to the RTLIB lookup already at the
tail of `getStackProbeSymbolName()`, resolving the correct per-target symbol
(`__chkstk` on Win64 MSVC, `_chkstk` on Win32, `___chkstk_ms` on MinGW), the
same path a Windows function with no `probe-stack` attribute takes. For
`probe-stack=""` this flips `hasStackProbeSymbol()` from false to true, so large
static frames also get a prologue probe; that matches the Windows ABI and the
no-attribute case.

Test: `llvm/test/CodeGen/X86/probe-stack-dynalloca-windows.ll`, covering both
values with per-function `CHECK-LABEL`. Existing `probe-stack-*` /
`stack-clash-*` tests are Linux or static-alloca and unaffected.

---
Discovered during Rust cross-compilation targeting `x86_64-pc-windows-msvc`
at `-O2`.