### PR TITLE
[rtsan] Clean up rtsan_opts default variable

### DIFF
--- a/compiler-rt/test/rtsan/lit.cfg.py
+++ b/compiler-rt/test/rtsan/lit.cfg.py
@@ -4,7 +4,9 @@ import os
 config.name = "RTSAN" + config.name_suffix
 
 
-default_rtsan_opts = ""
+# This is unimportant, just a "dummy" variable so we can append nicely
+# to it in the lines below
+default_rtsan_opts = "verbosity=1"
 
 if config.target_os == "Darwin":
     # On Darwin, we default to `abort_on_error=1`, which would make tests run


### PR DESCRIPTION
Follow on from https://github.com/llvm/llvm-project/pull/210395.

Some systems didn't like this empty variable when they appended to it later (and the original variable that we had as a dummy was unsupported by rtsan)

https://github.com/llvm/llvm-project/pull/210395/changes#diff-5f39176422b87f314a683584d1cabe670b4c1e3942d65bb2b5ce4d0623c40560L7

Change this to another inconsequential value so we can append `:other_options` to it easily later in the file 