### PR TITLE
[mlir][OpenACC] Preserve worker rows when combining reductions

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1270,15 +1270,35 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
   mlir::acc::GPUParallelDimAttr lowestParDim =
       mlir::acc::GPUParallelDimAttr::threadXDim(ctx);
   if (block) {
-    block->walk([&](Operation *op) {
+    std::optional<bool> combineThreadYActive;
+    auto applyCombineParDims =
+        [&](Operation *combineOp, Value src,
+            ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
+          bool isWorkerPrivate =
+              getPrivateScopeForMemref(src) == PrivateMemScope::Worker;
+          for (mlir::acc::GPUParallelDimAttr parDim : combineParDims) {
+            if (parDim.isThreadY()) {
+              if (combineThreadYActive &&
+                  *combineThreadYActive != isWorkerPrivate) {
+                combineOp->emitError()
+                    << "mixed worker-private and non-worker-private reduction "
+                       "combines require incompatible ThreadY predication";
+                hasFailed = true;
+                return failure();
+              }
+              combineThreadYActive = isWorkerPrivate;
+            } else {
+              mlir::acc::removeParDim(ancestorParDims, parDim);
+            }
+          }
+          return success();
+        };
+    block->walk([&](Operation *op) -> WalkResult {
       // Writes to acc.private_local must keep the privatization's par_dims
       // active so the write runs on all owning threads instead of being
       // predicated to a single lane.
       auto addPrivateStoreParDims = [&](Value target) {
         if (auto privateLocalOp = getPrivateLocalForMemref(target)) {
-          // The privatization par_dims may be recorded on the private_local
-          // itself (acc.par_dims attribute) or on its privatize; prefer the
-          // private_local's.
           mlir::acc::GPUParallelDimsAttr parDimsAttr =
               mlir::acc::getParDimsAttr(privateLocalOp);
           if (!parDimsAttr)
@@ -1314,17 +1334,17 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       // kernel and loop in combined constructs.
       if (acc::ReductionCombineOp reductionCombineOp =
               dyn_cast<acc::ReductionCombineOp>(op)) {
-        for (mlir::acc::GPUParallelDimAttr parDim :
-             getReductionCombineParDims(reductionCombineOp)) {
-          mlir::acc::removeParDim(ancestorParDims, parDim);
-        }
+        if (failed(applyCombineParDims(
+                reductionCombineOp, reductionCombineOp.getSrcMemref(),
+                getReductionCombineParDims(reductionCombineOp))))
+          return WalkResult::interrupt();
       }
       if (acc::ReductionCombineRegionOp combineRegionOp =
               dyn_cast<acc::ReductionCombineRegionOp>(op)) {
-        for (mlir::acc::GPUParallelDimAttr parDim :
-             getReductionCombineParDims(combineRegionOp)) {
-          mlir::acc::removeParDim(ancestorParDims, parDim);
-        }
+        if (failed(applyCombineParDims(
+                combineRegionOp, combineRegionOp.getSrcVar(),
+                getReductionCombineParDims(combineRegionOp))))
+          return WalkResult::interrupt();
       }
       // An array accumulate reduces across its par_dims via gpu.all_reduce, so
       // all those threads must execute it - treat them as active (unlike the
@@ -1338,6 +1358,14 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       }
       return WalkResult::advance();
     });
+    if (combineThreadYActive) {
+      mlir::acc::GPUParallelDimAttr threadY =
+          mlir::acc::GPUParallelDimAttr::threadYDim(ctx);
+      if (*combineThreadYActive)
+        mlir::acc::insertParDim(ancestorParDims, threadY);
+      else
+        mlir::acc::removeParDim(ancestorParDims, threadY);
+    }
   }
 
   // Obtain launch dimensions
@@ -1784,7 +1812,7 @@ ACCCGToGPULowering::getPrivateMemScope(acc::PrivatizeOp privatizeOp) {
   }
   if (hasThreadX)
     return PrivateMemScope::Thread;
-  if (hasBlock && hasThreadY)
+  if (hasThreadY)
     return PrivateMemScope::Worker;
   if (hasBlock)
     return PrivateMemScope::Gang;
@@ -1908,6 +1936,8 @@ void ACCCGToGPULowering::processPredicateRegion(
             SmallVector<mlir::acc::GPUParallelDimAttr>>
       parDimsPair = computeActiveAndInactiveParDims(
           interOp, &interOp.getRegion().front());
+  if (hasFailed)
+    return;
 
   // If ThreadY reduction exists, subgroup alignment is applied
   // (blockDim.x = subgroupSize), so ThreadX lanes exist even without explicit

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1292,15 +1292,22 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
         requirement.inactive |= !active;
         return success();
       };
+      auto hasThreadYPrivateStorage = [&](Value memref) {
+        acc::PrivatizeOp privatize = getPrivatizeForMemref(memref);
+        if (!privatize)
+          return false;
+        acc::GPUParallelDimsAttr parDims = privatize.getParDimsAttr();
+        return parDims && llvm::any_of(parDims.getArray(), [](auto parDim) {
+                 return parDim.isThreadY();
+               });
+      };
       auto applyCombineRequirement =
           [&](Operation *combineOp, Value src,
               ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
             if (llvm::none_of(combineParDims,
                               [](auto parDim) { return parDim.isThreadY(); }))
               return success();
-            bool isWorkerPrivate =
-                getPrivateScopeForMemref(src) == PrivateMemScope::Worker;
-            return requireThreadY(combineOp, isWorkerPrivate);
+            return requireThreadY(combineOp, hasThreadYPrivateStorage(src));
           };
 
       for (Operation &nestedOp : predicateBlock) {
@@ -1334,9 +1341,8 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
           continue;
         }
         if (memref::StoreOp storeOp = dyn_cast<memref::StoreOp>(nestedOp)) {
-          bool threadYActive = getPrivateScopeForMemref(storeOp.getMemref()) ==
-                               PrivateMemScope::Worker;
-          if (failed(requireThreadY(storeOp, threadYActive)))
+          if (failed(requireThreadY(
+                  storeOp, hasThreadYPrivateStorage(storeOp.getMemref()))))
             return failure();
           continue;
         }
@@ -1350,6 +1356,15 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
           continue;
         }
         if (nestedOp.getNumRegions() != 0) {
+          bool hasOwnEffects = true;
+          if (auto effectOp = dyn_cast<MemoryEffectOpInterface>(&nestedOp)) {
+            hasOwnEffects = !effectOp.hasNoEffect();
+          } else if (nestedOp.hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
+            hasOwnEffects = false;
+          }
+          if (hasOwnEffects &&
+              failed(requireThreadY(&nestedOp, /*active=*/false)))
+            return failure();
           for (Region &region : nestedOp.getRegions()) {
             for (Block &nestedBlock : region) {
               FailureOr<ThreadYRequirement> nestedRequirement =

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1253,14 +1253,9 @@ static void classifyThreadYCombine(ThreadYBroadeningInfo &info,
     info.diagnosticOp = combineOp;
 }
 
-/// Determines whether a predicate region can safely run on every ThreadY row.
-///
-/// A hierarchical block+ThreadY combine reads one partial value from each
-/// worker-private row, so ThreadY must remain active until that combine. Before
-/// broadening the predicate, recursively reject sibling combines that require
-/// ThreadY to be inactive and operations with side effects that would otherwise
-/// execute additional times. Nested predicate regions enforce their own
-/// compatibility; only their requirement for active ThreadY propagates out.
+/// ThreadY must remain active for hierarchical combines over worker rows.
+/// Broadening is rejected when siblings require inactive ThreadY or have side
+/// effects; nested predicates enforce their own safety.
 static ThreadYBroadeningInfo
 analyzeThreadYBroadening(Block &predicateBlock,
                          acc::ComputeRegionOp computeRegion) {

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1280,9 +1280,10 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
             if (parDim.isThreadY()) {
               if (combineThreadYActive &&
                   *combineThreadYActive != isWorkerPrivate) {
-                combineOp->emitError()
-                    << "mixed worker-private and non-worker-private reduction "
-                       "combines require incompatible ThreadY predication";
+                (void)accSupport.emitNYI(
+                    combineOp->getLoc(),
+                    "mixed worker-private and non-worker-private reduction "
+                    "combines require incompatible ThreadY predication");
                 hasFailed = true;
                 return failure();
               }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1187,23 +1187,19 @@ getPrivateParDims(acc::PrivateLocalOp privateLocal,
   return getPrivatizeOp(privateLocal, computeRegion).getParDimsAttr();
 }
 
-/// True when \p memref is backed by storage owned exclusively by ThreadY.
-static bool isExclusivelyThreadYPrivate(Value memref,
-                                        acc::ComputeRegionOp computeRegion) {
-  Value current = memref;
-  while (Operation *def = current.getDefiningOp()) {
-    if (acc::PrivateLocalOp privateLocal = dyn_cast<acc::PrivateLocalOp>(def)) {
-      GPUParallelDimsAttr parDims =
-          getPrivateParDims(privateLocal, computeRegion);
-      return parDims && parDims.hasOnlyThreadYLevel();
-    }
-    if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
-      current = viewLike.getViewSource();
-      continue;
-    }
-    break;
-  }
-  return false;
+/// True when \p privateLocal has one private slot per ThreadY row.
+static bool isThreadYPrivate(acc::PrivateLocalOp privateLocal, bool allowBlock,
+                             acc::ComputeRegionOp computeRegion) {
+  if (!privateLocal)
+    return false;
+  GPUParallelDimsAttr parDims = getPrivateParDims(privateLocal, computeRegion);
+  if (!parDims)
+    return false;
+  return llvm::any_of(parDims.getArray(),
+                      [](auto dim) { return dim.isThreadY(); }) &&
+         llvm::all_of(parDims.getArray(), [=](auto dim) {
+           return dim.isThreadY() || (allowBlock && dim.isAnyBlock());
+         });
 }
 
 struct ThreadYBroadeningInfo {
@@ -1235,15 +1231,23 @@ static bool hasUnsafeEffectsWhenBroadening(Operation *op) {
 
 /// Records whether \p combineOp requires ThreadY to remain active.
 static void classifyThreadYCombine(ThreadYBroadeningInfo &info,
-                                   Operation *combineOp, Value src,
+                                   Operation *combineOp, Value src, Value dest,
                                    ArrayRef<GPUParallelDimAttr> parDims,
                                    acc::ComputeRegionOp computeRegion) {
   bool hasThreadY = llvm::any_of(
       parDims, [](GPUParallelDimAttr parDim) { return parDim.isThreadY(); });
   bool hasBlock = llvm::any_of(
       parDims, [](GPUParallelDimAttr parDim) { return parDim.isAnyBlock(); });
+  acc::PrivateLocalOp srcPrivate =
+      unwrapMemRefConversion(src).getDefiningOp<acc::PrivateLocalOp>();
+  acc::PrivateLocalOp destPrivate =
+      unwrapMemRefConversion(dest).getDefiningOp<acc::PrivateLocalOp>();
+  bool hasPrivateDest = isa<acc::ReductionCombineOp>(combineOp) && srcPrivate &&
+                        destPrivate &&
+                        getPrivatizeOp(srcPrivate, computeRegion) !=
+                            getPrivatizeOp(destPrivate, computeRegion);
   if (hasThreadY && hasBlock &&
-      isExclusivelyThreadYPrivate(src, computeRegion)) {
+      isThreadYPrivate(srcPrivate, hasPrivateDest, computeRegion)) {
     info.hasActiveWorkerCombine = true;
     return;
   }
@@ -1270,14 +1274,15 @@ analyzeThreadYBroadening(Block &predicateBlock,
     }
     if (acc::ReductionCombineOp combineOp =
             dyn_cast<acc::ReductionCombineOp>(nestedOp)) {
-      classifyThreadYCombine(info, combineOp, combineOp.getSrcMemref(),
-                             getReductionCombineParDims(combineOp),
-                             computeRegion);
+      classifyThreadYCombine(
+          info, combineOp, combineOp.getSrcMemref(), combineOp.getDestMemref(),
+          getReductionCombineParDims(combineOp), computeRegion);
       continue;
     }
     if (acc::ReductionCombineRegionOp combineRegionOp =
             dyn_cast<acc::ReductionCombineRegionOp>(nestedOp)) {
       classifyThreadYCombine(info, combineRegionOp, combineRegionOp.getSrcVar(),
+                             combineRegionOp.getDestVar(),
                              getReductionCombineParDims(combineRegionOp),
                              computeRegion);
       continue;
@@ -1923,7 +1928,7 @@ ACCCGToGPULowering::getPrivateMemScope(acc::PrivatizeOp privatizeOp) {
   }
   if (hasThreadX)
     return PrivateMemScope::Thread;
-  if (hasThreadY)
+  if (hasBlock && hasThreadY)
     return PrivateMemScope::Worker;
   if (hasBlock)
     return PrivateMemScope::Gang;

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1270,130 +1270,112 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
   mlir::acc::GPUParallelDimAttr lowestParDim =
       mlir::acc::GPUParallelDimAttr::threadXDim(ctx);
   if (block) {
-    struct ThreadYRequirement {
-      bool active = false;
-      bool inactive = false;
+    struct ThreadYBroadeningInfo {
+      bool hasActiveWorkerCombine = false;
+      bool hasExplicitInactiveCombine = false;
+      bool hasBroadeningConflict = false;
+      Operation *diagnosticOp = nullptr;
     };
-    auto analyzeThreadYRequirements =
-        [&](auto &&self,
-            Block &predicateBlock) -> FailureOr<ThreadYRequirement> {
-      ThreadYRequirement requirement;
-      auto requireThreadY = [&](Operation *op, bool active) {
-        if ((active && requirement.inactive) ||
-            (!active && requirement.active)) {
-          (void)accSupport.emitNYI(
-              op->getLoc(),
-              "operations in the same predicate region require incompatible "
-              "ThreadY predication");
-          hasFailed = true;
-          return failure();
+    auto mergeBroadeningInfo = [](ThreadYBroadeningInfo &dst,
+                                  const ThreadYBroadeningInfo &src) {
+      dst.hasActiveWorkerCombine |= src.hasActiveWorkerCombine;
+      dst.hasExplicitInactiveCombine |= src.hasExplicitInactiveCombine;
+      dst.hasBroadeningConflict |= src.hasBroadeningConflict;
+      if (!dst.diagnosticOp)
+        dst.diagnosticOp = src.diagnosticOp;
+    };
+    auto isProvenWorkerPrivate = [&](Value memref) {
+      Value current = memref;
+      while (Operation *def = current.getDefiningOp()) {
+        if (acc::PrivateLocalOp privateLocal =
+                dyn_cast<acc::PrivateLocalOp>(def)) {
+          return getPrivateMemScope(getPrivatizeOp(
+                     privateLocal, computeRegion)) == PrivateMemScope::Worker;
         }
-        requirement.active |= active;
-        requirement.inactive |= !active;
-        return success();
-      };
-      auto hasThreadYPrivateStorage = [&](Value memref) {
-        acc::PrivatizeOp privatize = getPrivatizeForMemref(memref);
-        if (!privatize)
-          return false;
-        acc::GPUParallelDimsAttr parDims = privatize.getParDimsAttr();
-        return parDims && llvm::any_of(parDims.getArray(), [](auto parDim) {
-                 return parDim.isThreadY();
-               });
-      };
-      auto applyCombineRequirement = [&](Operation *combineOp, Value src) {
-        return requireThreadY(combineOp, hasThreadYPrivateStorage(src));
+        if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
+          current = viewLike.getViewSource();
+          continue;
+        }
+        break;
+      }
+      return false;
+    };
+    auto hasUnsafeOwnEffects = [](Operation *op) {
+      if (auto effectOp = dyn_cast<MemoryEffectOpInterface>(op)) {
+        SmallVector<MemoryEffects::EffectInstance> effects;
+        effectOp.getEffects(effects);
+        return llvm::any_of(effects, [](const auto &effect) {
+          return !isa<MemoryEffects::Read>(effect.getEffect());
+        });
+      }
+      return !op->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
+    };
+    auto analyzeThreadYBroadening =
+        [&](auto &&self, Block &predicateBlock) -> ThreadYBroadeningInfo {
+      ThreadYBroadeningInfo info;
+      auto classifyCombine = [&](Operation *combineOp, Value src,
+                                 ArrayRef<GPUParallelDimAttr> parDims) {
+        bool hasThreadY = llvm::any_of(
+            parDims, [](auto parDim) { return parDim.isThreadY(); });
+        if (hasThreadY && isProvenWorkerPrivate(src)) {
+          info.hasActiveWorkerCombine = true;
+        } else {
+          info.hasExplicitInactiveCombine = true;
+          if (!info.diagnosticOp)
+            info.diagnosticOp = combineOp;
+        }
       };
 
       for (Operation &nestedOp : predicateBlock) {
         if (acc::PredicateRegionOp nestedPredicate =
                 dyn_cast<acc::PredicateRegionOp>(nestedOp)) {
-          FailureOr<ThreadYRequirement> nestedRequirement =
+          ThreadYBroadeningInfo nestedInfo =
               self(self, nestedPredicate.getRegion().front());
-          if (failed(nestedRequirement))
-            return failure();
-          // An active descendant must not be excluded by this region's
-          // predicate. Inactive descendants apply their own predicate.
-          if (nestedRequirement->active &&
-              failed(requireThreadY(&nestedOp, /*active=*/true)))
-            return failure();
+          // A worker-active descendant must reach its own predicate. Other
+          // requirements are enforced within the nested predicate region.
+          info.hasActiveWorkerCombine |= nestedInfo.hasActiveWorkerCombine;
           continue;
         }
         if (acc::ReductionCombineOp combineOp =
                 dyn_cast<acc::ReductionCombineOp>(nestedOp)) {
-          if (failed(
-                  applyCombineRequirement(combineOp, combineOp.getSrcMemref())))
-            return failure();
+          classifyCombine(combineOp, combineOp.getSrcMemref(),
+                          getReductionCombineParDims(combineOp));
           continue;
         }
         if (acc::ReductionCombineRegionOp combineRegionOp =
                 dyn_cast<acc::ReductionCombineRegionOp>(nestedOp)) {
-          if (failed(applyCombineRequirement(combineRegionOp,
-                                             combineRegionOp.getSrcVar())))
-            return failure();
-          continue;
-        }
-        if (memref::StoreOp storeOp = dyn_cast<memref::StoreOp>(nestedOp)) {
-          if (failed(requireThreadY(
-                  storeOp, hasThreadYPrivateStorage(storeOp.getMemref()))))
-            return failure();
-          continue;
-        }
-        if (acc::ReductionAccumulateArrayOp accumulateArrayOp =
-                dyn_cast<acc::ReductionAccumulateArrayOp>(nestedOp)) {
-          bool threadYActive =
-              llvm::any_of(accumulateArrayOp.getParDims().getArray(),
-                           [](auto parDim) { return parDim.isThreadY(); });
-          if (failed(requireThreadY(accumulateArrayOp, threadYActive)))
-            return failure();
+          classifyCombine(combineRegionOp, combineRegionOp.getSrcVar(),
+                          getReductionCombineParDims(combineRegionOp));
           continue;
         }
         if (nestedOp.getNumRegions() != 0) {
-          bool hasOwnEffects = true;
-          if (auto effectOp = dyn_cast<MemoryEffectOpInterface>(&nestedOp)) {
-            hasOwnEffects = !effectOp.hasNoEffect();
-          } else if (nestedOp.hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
-            hasOwnEffects = false;
+          if (hasUnsafeOwnEffects(&nestedOp)) {
+            info.hasBroadeningConflict = true;
+            if (!info.diagnosticOp)
+              info.diagnosticOp = &nestedOp;
           }
-          if (hasOwnEffects &&
-              failed(requireThreadY(&nestedOp, /*active=*/false)))
-            return failure();
           for (Region &region : nestedOp.getRegions()) {
-            for (Block &nestedBlock : region) {
-              FailureOr<ThreadYRequirement> nestedRequirement =
-                  self(self, nestedBlock);
-              if (failed(nestedRequirement))
-                return failure();
-              // Other region-bearing operations do not introduce independent
-              // ACC predication, so both requirements apply to this region.
-              if (nestedRequirement->active &&
-                  failed(requireThreadY(&nestedOp, /*active=*/true)))
-                return failure();
-              if (nestedRequirement->inactive &&
-                  failed(requireThreadY(&nestedOp, /*active=*/false)))
-                return failure();
-            }
+            for (Block &nestedBlock : region)
+              mergeBroadeningInfo(info, self(self, nestedBlock));
           }
           continue;
         }
-        if (!isMemoryEffectFree(&nestedOp) &&
-            failed(requireThreadY(&nestedOp, /*active=*/false)))
-          return failure();
+        if (hasUnsafeOwnEffects(&nestedOp)) {
+          info.hasBroadeningConflict = true;
+          if (!info.diagnosticOp)
+            info.diagnosticOp = &nestedOp;
+        }
       }
-      return requirement;
+      return info;
     };
 
-    FailureOr<ThreadYRequirement> threadYRequirement =
-        analyzeThreadYRequirements(analyzeThreadYRequirements, *block);
-    if (failed(threadYRequirement))
-      return {};
+    ThreadYBroadeningInfo threadYInfo =
+        analyzeThreadYBroadening(analyzeThreadYBroadening, *block);
 
     auto applyCombineParDims =
         [&](ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
-          for (mlir::acc::GPUParallelDimAttr parDim : combineParDims) {
-            if (!parDim.isThreadY())
-              mlir::acc::removeParDim(ancestorParDims, parDim);
-          }
+          for (mlir::acc::GPUParallelDimAttr parDim : combineParDims)
+            mlir::acc::removeParDim(ancestorParDims, parDim);
           return success();
         };
     block->walk([&](Operation *op) -> WalkResult {
@@ -1459,13 +1441,22 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       }
       return WalkResult::advance();
     });
-    if (threadYRequirement->active || threadYRequirement->inactive) {
-      mlir::acc::GPUParallelDimAttr threadY =
-          mlir::acc::GPUParallelDimAttr::threadYDim(ctx);
-      if (threadYRequirement->active)
-        mlir::acc::insertParDim(ancestorParDims, threadY);
-      else
-        mlir::acc::removeParDim(ancestorParDims, threadY);
+    mlir::acc::GPUParallelDimAttr threadY =
+        mlir::acc::GPUParallelDimAttr::threadYDim(ctx);
+    bool baselineThreadYActive = llvm::is_contained(ancestorParDims, threadY);
+    if (threadYInfo.hasActiveWorkerCombine && !baselineThreadYActive) {
+      if (threadYInfo.hasExplicitInactiveCombine ||
+          threadYInfo.hasBroadeningConflict) {
+        Operation *diagnosticOp =
+            threadYInfo.diagnosticOp ? threadYInfo.diagnosticOp : op;
+        (void)accSupport.emitNYI(
+            diagnosticOp->getLoc(),
+            "operations in the same predicate region require incompatible "
+            "ThreadY predication");
+        hasFailed = true;
+        return {};
+      }
+      mlir::acc::insertParDim(ancestorParDims, threadY);
     }
   }
 
@@ -1922,22 +1913,18 @@ ACCCGToGPULowering::getPrivateMemScope(acc::PrivatizeOp privatizeOp) {
 
 /// Walks back from a memref use to its defining `acc.private_local`, if any.
 static acc::PrivateLocalOp getPrivateLocalForMemref(Value memref) {
-  Value current = memref;
-  while (Operation *def = current.getDefiningOp()) {
+  llvm::SmallVector<Value, 8> worklist{memref};
+  llvm::SmallPtrSet<Value, 8> seen;
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    if (!seen.insert(v).second)
+      continue;
+    Operation *def = v.getDefiningOp();
+    if (!def)
+      continue;
     if (acc::PrivateLocalOp privateLocal = dyn_cast<acc::PrivateLocalOp>(def))
       return privateLocal;
-    if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
-      current = viewLike.getViewSource();
-      continue;
-    }
-    if (acc::PartialEntityAccessOpInterface partialAccess =
-            dyn_cast<acc::PartialEntityAccessOpInterface>(def)) {
-      current = partialAccess.getBaseEntity();
-      continue;
-    }
-    // Do not follow arbitrary operands: multi-source operations such as
-    // arith.select do not prove that their result aliases private storage.
-    return nullptr;
+    worklist.append(def->getOperands().begin(), def->getOperands().end());
   }
   return nullptr;
 }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1289,8 +1289,11 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       while (Operation *def = current.getDefiningOp()) {
         if (acc::PrivateLocalOp privateLocal =
                 dyn_cast<acc::PrivateLocalOp>(def)) {
-          return getPrivateMemScope(getPrivatizeOp(
-                     privateLocal, computeRegion)) == PrivateMemScope::Worker;
+          GPUParallelDimsAttr parDims = mlir::acc::getParDimsAttr(privateLocal);
+          if (!parDims)
+            parDims =
+                getPrivatizeOp(privateLocal, computeRegion).getParDimsAttr();
+          return parDims && parDims.hasOnlyThreadYLevel();
         }
         if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
           current = viewLike.getViewSource();
@@ -1317,7 +1320,9 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
                                  ArrayRef<GPUParallelDimAttr> parDims) {
         bool hasThreadY = llvm::any_of(
             parDims, [](auto parDim) { return parDim.isThreadY(); });
-        if (hasThreadY && isProvenWorkerPrivate(src)) {
+        bool hasBlock = llvm::any_of(
+            parDims, [](auto parDim) { return parDim.isAnyBlock(); });
+        if (hasThreadY && hasBlock && isProvenWorkerPrivate(src)) {
           info.hasActiveWorkerCombine = true;
         } else {
           info.hasExplicitInactiveCombine = true;

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1270,27 +1270,111 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
   mlir::acc::GPUParallelDimAttr lowestParDim =
       mlir::acc::GPUParallelDimAttr::threadXDim(ctx);
   if (block) {
-    std::optional<bool> combineThreadYActive;
-    auto applyCombineParDims =
-        [&](Operation *combineOp, Value src,
-            ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
-          bool isWorkerPrivate =
-              getPrivateScopeForMemref(src) == PrivateMemScope::Worker;
-          for (mlir::acc::GPUParallelDimAttr parDim : combineParDims) {
-            if (parDim.isThreadY()) {
-              if (combineThreadYActive &&
-                  *combineThreadYActive != isWorkerPrivate) {
-                (void)accSupport.emitNYI(
-                    combineOp->getLoc(),
-                    "mixed worker-private and non-worker-private reduction "
-                    "combines require incompatible ThreadY predication");
-                hasFailed = true;
-                return failure();
-              }
-              combineThreadYActive = isWorkerPrivate;
-            } else {
-              mlir::acc::removeParDim(ancestorParDims, parDim);
+    struct ThreadYRequirement {
+      bool active = false;
+      bool inactive = false;
+    };
+    auto analyzeThreadYRequirements =
+        [&](auto &&self,
+            Block &predicateBlock) -> FailureOr<ThreadYRequirement> {
+      ThreadYRequirement requirement;
+      auto requireThreadY = [&](Operation *op, bool active) {
+        if ((active && requirement.inactive) ||
+            (!active && requirement.active)) {
+          (void)accSupport.emitNYI(
+              op->getLoc(),
+              "operations in the same predicate region require incompatible "
+              "ThreadY predication");
+          hasFailed = true;
+          return failure();
+        }
+        requirement.active |= active;
+        requirement.inactive |= !active;
+        return success();
+      };
+      auto applyCombineRequirement =
+          [&](Operation *combineOp, Value src,
+              ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
+            if (llvm::none_of(combineParDims,
+                              [](auto parDim) { return parDim.isThreadY(); }))
+              return success();
+            bool isWorkerPrivate =
+                getPrivateScopeForMemref(src) == PrivateMemScope::Worker;
+            return requireThreadY(combineOp, isWorkerPrivate);
+          };
+
+      for (Operation &nestedOp : predicateBlock) {
+        if (acc::PredicateRegionOp nestedPredicate =
+                dyn_cast<acc::PredicateRegionOp>(nestedOp)) {
+          FailureOr<ThreadYRequirement> nestedRequirement =
+              self(self, nestedPredicate.getRegion().front());
+          if (failed(nestedRequirement))
+            return failure();
+          // An active descendant must not be excluded by this region's
+          // predicate. Inactive descendants apply their own predicate.
+          if (nestedRequirement->active &&
+              failed(requireThreadY(&nestedOp, /*active=*/true)))
+            return failure();
+          continue;
+        }
+        if (acc::ReductionCombineOp combineOp =
+                dyn_cast<acc::ReductionCombineOp>(nestedOp)) {
+          if (failed(applyCombineRequirement(
+                  combineOp, combineOp.getSrcMemref(),
+                  getReductionCombineParDims(combineOp))))
+            return failure();
+          continue;
+        }
+        if (acc::ReductionCombineRegionOp combineRegionOp =
+                dyn_cast<acc::ReductionCombineRegionOp>(nestedOp)) {
+          if (failed(applyCombineRequirement(
+                  combineRegionOp, combineRegionOp.getSrcVar(),
+                  getReductionCombineParDims(combineRegionOp))))
+            return failure();
+          continue;
+        }
+        if (memref::StoreOp storeOp = dyn_cast<memref::StoreOp>(nestedOp)) {
+          bool threadYActive = false;
+          if (acc::PrivateLocalOp privateLocal =
+                  storeOp.getMemref().getDefiningOp<acc::PrivateLocalOp>()) {
+            if (acc::GPUParallelDimsAttr parDims =
+                    getPrivatizeOp(privateLocal, computeRegion)
+                        .getParDimsAttr()) {
+              threadYActive = llvm::any_of(parDims.getArray(), [](auto parDim) {
+                return parDim.isThreadY();
+              });
             }
+          }
+          if (failed(requireThreadY(storeOp, threadYActive)))
+            return failure();
+          continue;
+        }
+        if (acc::ReductionAccumulateArrayOp accumulateArrayOp =
+                dyn_cast<acc::ReductionAccumulateArrayOp>(nestedOp)) {
+          bool threadYActive =
+              llvm::any_of(accumulateArrayOp.getParDims().getArray(),
+                           [](auto parDim) { return parDim.isThreadY(); });
+          if (failed(requireThreadY(accumulateArrayOp, threadYActive)))
+            return failure();
+          continue;
+        }
+        if (!isMemoryEffectFree(&nestedOp) &&
+            failed(requireThreadY(&nestedOp, /*active=*/false)))
+          return failure();
+      }
+      return requirement;
+    };
+
+    FailureOr<ThreadYRequirement> threadYRequirement =
+        analyzeThreadYRequirements(analyzeThreadYRequirements, *block);
+    if (failed(threadYRequirement))
+      return {};
+
+    auto applyCombineParDims =
+        [&](ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
+          for (mlir::acc::GPUParallelDimAttr parDim : combineParDims) {
+            if (!parDim.isThreadY())
+              mlir::acc::removeParDim(ancestorParDims, parDim);
           }
           return success();
         };
@@ -1336,14 +1420,12 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       if (acc::ReductionCombineOp reductionCombineOp =
               dyn_cast<acc::ReductionCombineOp>(op)) {
         if (failed(applyCombineParDims(
-                reductionCombineOp, reductionCombineOp.getSrcMemref(),
                 getReductionCombineParDims(reductionCombineOp))))
           return WalkResult::interrupt();
       }
       if (acc::ReductionCombineRegionOp combineRegionOp =
               dyn_cast<acc::ReductionCombineRegionOp>(op)) {
         if (failed(applyCombineParDims(
-                combineRegionOp, combineRegionOp.getSrcVar(),
                 getReductionCombineParDims(combineRegionOp))))
           return WalkResult::interrupt();
       }
@@ -1359,10 +1441,10 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       }
       return WalkResult::advance();
     });
-    if (combineThreadYActive) {
+    if (threadYRequirement->active || threadYRequirement->inactive) {
       mlir::acc::GPUParallelDimAttr threadY =
           mlir::acc::GPUParallelDimAttr::threadYDim(ctx);
-      if (*combineThreadYActive)
+      if (threadYRequirement->active)
         mlir::acc::insertParDim(ancestorParDims, threadY);
       else
         mlir::acc::removeParDim(ancestorParDims, threadY);

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1301,14 +1301,9 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
                  return parDim.isThreadY();
                });
       };
-      auto applyCombineRequirement =
-          [&](Operation *combineOp, Value src,
-              ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
-            if (llvm::none_of(combineParDims,
-                              [](auto parDim) { return parDim.isThreadY(); }))
-              return success();
-            return requireThreadY(combineOp, hasThreadYPrivateStorage(src));
-          };
+      auto applyCombineRequirement = [&](Operation *combineOp, Value src) {
+        return requireThreadY(combineOp, hasThreadYPrivateStorage(src));
+      };
 
       for (Operation &nestedOp : predicateBlock) {
         if (acc::PredicateRegionOp nestedPredicate =
@@ -1326,17 +1321,15 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
         }
         if (acc::ReductionCombineOp combineOp =
                 dyn_cast<acc::ReductionCombineOp>(nestedOp)) {
-          if (failed(applyCombineRequirement(
-                  combineOp, combineOp.getSrcMemref(),
-                  getReductionCombineParDims(combineOp))))
+          if (failed(
+                  applyCombineRequirement(combineOp, combineOp.getSrcMemref())))
             return failure();
           continue;
         }
         if (acc::ReductionCombineRegionOp combineRegionOp =
                 dyn_cast<acc::ReductionCombineRegionOp>(nestedOp)) {
-          if (failed(applyCombineRequirement(
-                  combineRegionOp, combineRegionOp.getSrcVar(),
-                  getReductionCombineParDims(combineRegionOp))))
+          if (failed(applyCombineRequirement(combineRegionOp,
+                                             combineRegionOp.getSrcVar())))
             return failure();
           continue;
         }
@@ -1929,18 +1922,22 @@ ACCCGToGPULowering::getPrivateMemScope(acc::PrivatizeOp privatizeOp) {
 
 /// Walks back from a memref use to its defining `acc.private_local`, if any.
 static acc::PrivateLocalOp getPrivateLocalForMemref(Value memref) {
-  llvm::SmallVector<Value, 8> worklist{memref};
-  llvm::SmallPtrSet<Value, 8> seen;
-  while (!worklist.empty()) {
-    Value v = worklist.pop_back_val();
-    if (!seen.insert(v).second)
-      continue;
-    Operation *def = v.getDefiningOp();
-    if (!def)
-      continue;
+  Value current = memref;
+  while (Operation *def = current.getDefiningOp()) {
     if (acc::PrivateLocalOp privateLocal = dyn_cast<acc::PrivateLocalOp>(def))
       return privateLocal;
-    worklist.append(def->getOperands().begin(), def->getOperands().end());
+    if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
+      current = viewLike.getViewSource();
+      continue;
+    }
+    if (acc::PartialEntityAccessOpInterface partialAccess =
+            dyn_cast<acc::PartialEntityAccessOpInterface>(def)) {
+      current = partialAccess.getBaseEntity();
+      continue;
+    }
+    // Do not follow arbitrary operands: multi-source operations such as
+    // arith.select do not prove that their result aliases private storage.
+    return nullptr;
   }
   return nullptr;
 }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1178,6 +1178,135 @@ static bool isRedundantChainAccumulate(acc::ReductionAccumulateOp op) {
   return false;
 }
 
+/// Returns the dimensions that own \p privateLocal.
+static GPUParallelDimsAttr
+getPrivateParDims(acc::PrivateLocalOp privateLocal,
+                  acc::ComputeRegionOp computeRegion) {
+  if (GPUParallelDimsAttr parDims = acc::getParDimsAttr(privateLocal))
+    return parDims;
+  return getPrivatizeOp(privateLocal, computeRegion).getParDimsAttr();
+}
+
+/// True when \p memref is backed by storage owned exclusively by ThreadY.
+static bool isExclusivelyThreadYPrivate(Value memref,
+                                        acc::ComputeRegionOp computeRegion) {
+  Value current = memref;
+  while (Operation *def = current.getDefiningOp()) {
+    if (acc::PrivateLocalOp privateLocal = dyn_cast<acc::PrivateLocalOp>(def)) {
+      GPUParallelDimsAttr parDims =
+          getPrivateParDims(privateLocal, computeRegion);
+      return parDims && parDims.hasOnlyThreadYLevel();
+    }
+    if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
+      current = viewLike.getViewSource();
+      continue;
+    }
+    break;
+  }
+  return false;
+}
+
+struct ThreadYBroadeningInfo {
+  bool hasActiveWorkerCombine = false;
+  bool hasExplicitInactiveCombine = false;
+  bool hasBroadeningConflict = false;
+  Operation *diagnosticOp = nullptr;
+
+  void merge(const ThreadYBroadeningInfo &other) {
+    hasActiveWorkerCombine |= other.hasActiveWorkerCombine;
+    hasExplicitInactiveCombine |= other.hasExplicitInactiveCombine;
+    hasBroadeningConflict |= other.hasBroadeningConflict;
+    if (!diagnosticOp)
+      diagnosticOp = other.diagnosticOp;
+  }
+};
+
+/// True when executing \p op on additional ThreadY rows may change behavior.
+static bool hasUnsafeEffectsWhenBroadening(Operation *op) {
+  if (auto effectOp = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    effectOp.getEffects(effects);
+    return llvm::any_of(effects, [](const auto &effect) {
+      return !isa<MemoryEffects::Read>(effect.getEffect());
+    });
+  }
+  return !op->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
+}
+
+/// Records whether \p combineOp requires ThreadY to remain active.
+static void classifyThreadYCombine(ThreadYBroadeningInfo &info,
+                                   Operation *combineOp, Value src,
+                                   ArrayRef<GPUParallelDimAttr> parDims,
+                                   acc::ComputeRegionOp computeRegion) {
+  bool hasThreadY = llvm::any_of(
+      parDims, [](GPUParallelDimAttr parDim) { return parDim.isThreadY(); });
+  bool hasBlock = llvm::any_of(
+      parDims, [](GPUParallelDimAttr parDim) { return parDim.isAnyBlock(); });
+  if (hasThreadY && hasBlock &&
+      isExclusivelyThreadYPrivate(src, computeRegion)) {
+    info.hasActiveWorkerCombine = true;
+    return;
+  }
+
+  info.hasExplicitInactiveCombine = true;
+  if (!info.diagnosticOp)
+    info.diagnosticOp = combineOp;
+}
+
+/// Determines whether a predicate region can safely run on every ThreadY row.
+///
+/// A hierarchical block+ThreadY combine reads one partial value from each
+/// worker-private row, so ThreadY must remain active until that combine. Before
+/// broadening the predicate, recursively reject sibling combines that require
+/// ThreadY to be inactive and operations with side effects that would otherwise
+/// execute additional times. Nested predicate regions enforce their own
+/// compatibility; only their requirement for active ThreadY propagates out.
+static ThreadYBroadeningInfo
+analyzeThreadYBroadening(Block &predicateBlock,
+                         acc::ComputeRegionOp computeRegion) {
+  ThreadYBroadeningInfo info;
+  for (Operation &nestedOp : predicateBlock) {
+    if (acc::PredicateRegionOp nestedPredicate =
+            dyn_cast<acc::PredicateRegionOp>(nestedOp)) {
+      ThreadYBroadeningInfo nestedInfo = analyzeThreadYBroadening(
+          nestedPredicate.getRegion().front(), computeRegion);
+      info.hasActiveWorkerCombine |= nestedInfo.hasActiveWorkerCombine;
+      continue;
+    }
+    if (acc::ReductionCombineOp combineOp =
+            dyn_cast<acc::ReductionCombineOp>(nestedOp)) {
+      classifyThreadYCombine(info, combineOp, combineOp.getSrcMemref(),
+                             getReductionCombineParDims(combineOp),
+                             computeRegion);
+      continue;
+    }
+    if (acc::ReductionCombineRegionOp combineRegionOp =
+            dyn_cast<acc::ReductionCombineRegionOp>(nestedOp)) {
+      classifyThreadYCombine(info, combineRegionOp, combineRegionOp.getSrcVar(),
+                             getReductionCombineParDims(combineRegionOp),
+                             computeRegion);
+      continue;
+    }
+    if (nestedOp.getNumRegions() != 0) {
+      if (hasUnsafeEffectsWhenBroadening(&nestedOp)) {
+        info.hasBroadeningConflict = true;
+        if (!info.diagnosticOp)
+          info.diagnosticOp = &nestedOp;
+      }
+      for (Region &region : nestedOp.getRegions())
+        for (Block &nestedBlock : region)
+          info.merge(analyzeThreadYBroadening(nestedBlock, computeRegion));
+      continue;
+    }
+    if (hasUnsafeEffectsWhenBroadening(&nestedOp)) {
+      info.hasBroadeningConflict = true;
+      if (!info.diagnosticOp)
+        info.diagnosticOp = &nestedOp;
+    }
+  }
+  return info;
+}
+
 std::pair<SmallVector<mlir::acc::GPUParallelDimAttr>,
           SmallVector<mlir::acc::GPUParallelDimAttr>>
 ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
@@ -1251,13 +1380,10 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
     MemRefType baseTy = getPrivateBaseMemRefType(
         privTy.getBaseTy(), computeRegion->getParentOfType<ModuleOp>());
     if (!baseTy.hasStaticShape()) {
-      mlir::acc::GPUParallelDimsAttr ownParDims =
-          mlir::acc::getParDimsAttr(privateLocalOp);
-      if (!ownParDims)
-        ownParDims =
-            getPrivatizeOp(privateLocalOp, computeRegion).getParDimsAttr();
+      GPUParallelDimsAttr ownParDims =
+          getPrivateParDims(privateLocalOp, computeRegion);
       if (ownParDims)
-        for (mlir::acc::GPUParallelDimAttr parDim : ownParDims.getArray())
+        for (GPUParallelDimAttr parDim : ownParDims.getArray())
           mlir::acc::insertParDim(ancestorParDims, parDim);
     }
   }
@@ -1270,112 +1396,8 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
   mlir::acc::GPUParallelDimAttr lowestParDim =
       mlir::acc::GPUParallelDimAttr::threadXDim(ctx);
   if (block) {
-    struct ThreadYBroadeningInfo {
-      bool hasActiveWorkerCombine = false;
-      bool hasExplicitInactiveCombine = false;
-      bool hasBroadeningConflict = false;
-      Operation *diagnosticOp = nullptr;
-    };
-    auto mergeBroadeningInfo = [](ThreadYBroadeningInfo &dst,
-                                  const ThreadYBroadeningInfo &src) {
-      dst.hasActiveWorkerCombine |= src.hasActiveWorkerCombine;
-      dst.hasExplicitInactiveCombine |= src.hasExplicitInactiveCombine;
-      dst.hasBroadeningConflict |= src.hasBroadeningConflict;
-      if (!dst.diagnosticOp)
-        dst.diagnosticOp = src.diagnosticOp;
-    };
-    auto isProvenWorkerPrivate = [&](Value memref) {
-      Value current = memref;
-      while (Operation *def = current.getDefiningOp()) {
-        if (acc::PrivateLocalOp privateLocal =
-                dyn_cast<acc::PrivateLocalOp>(def)) {
-          GPUParallelDimsAttr parDims = mlir::acc::getParDimsAttr(privateLocal);
-          if (!parDims)
-            parDims =
-                getPrivatizeOp(privateLocal, computeRegion).getParDimsAttr();
-          return parDims && parDims.hasOnlyThreadYLevel();
-        }
-        if (ViewLikeOpInterface viewLike = dyn_cast<ViewLikeOpInterface>(def)) {
-          current = viewLike.getViewSource();
-          continue;
-        }
-        break;
-      }
-      return false;
-    };
-    auto hasUnsafeOwnEffects = [](Operation *op) {
-      if (auto effectOp = dyn_cast<MemoryEffectOpInterface>(op)) {
-        SmallVector<MemoryEffects::EffectInstance> effects;
-        effectOp.getEffects(effects);
-        return llvm::any_of(effects, [](const auto &effect) {
-          return !isa<MemoryEffects::Read>(effect.getEffect());
-        });
-      }
-      return !op->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
-    };
-    auto analyzeThreadYBroadening =
-        [&](auto &&self, Block &predicateBlock) -> ThreadYBroadeningInfo {
-      ThreadYBroadeningInfo info;
-      auto classifyCombine = [&](Operation *combineOp, Value src,
-                                 ArrayRef<GPUParallelDimAttr> parDims) {
-        bool hasThreadY = llvm::any_of(
-            parDims, [](auto parDim) { return parDim.isThreadY(); });
-        bool hasBlock = llvm::any_of(
-            parDims, [](auto parDim) { return parDim.isAnyBlock(); });
-        if (hasThreadY && hasBlock && isProvenWorkerPrivate(src)) {
-          info.hasActiveWorkerCombine = true;
-        } else {
-          info.hasExplicitInactiveCombine = true;
-          if (!info.diagnosticOp)
-            info.diagnosticOp = combineOp;
-        }
-      };
-
-      for (Operation &nestedOp : predicateBlock) {
-        if (acc::PredicateRegionOp nestedPredicate =
-                dyn_cast<acc::PredicateRegionOp>(nestedOp)) {
-          ThreadYBroadeningInfo nestedInfo =
-              self(self, nestedPredicate.getRegion().front());
-          // A worker-active descendant must reach its own predicate. Other
-          // requirements are enforced within the nested predicate region.
-          info.hasActiveWorkerCombine |= nestedInfo.hasActiveWorkerCombine;
-          continue;
-        }
-        if (acc::ReductionCombineOp combineOp =
-                dyn_cast<acc::ReductionCombineOp>(nestedOp)) {
-          classifyCombine(combineOp, combineOp.getSrcMemref(),
-                          getReductionCombineParDims(combineOp));
-          continue;
-        }
-        if (acc::ReductionCombineRegionOp combineRegionOp =
-                dyn_cast<acc::ReductionCombineRegionOp>(nestedOp)) {
-          classifyCombine(combineRegionOp, combineRegionOp.getSrcVar(),
-                          getReductionCombineParDims(combineRegionOp));
-          continue;
-        }
-        if (nestedOp.getNumRegions() != 0) {
-          if (hasUnsafeOwnEffects(&nestedOp)) {
-            info.hasBroadeningConflict = true;
-            if (!info.diagnosticOp)
-              info.diagnosticOp = &nestedOp;
-          }
-          for (Region &region : nestedOp.getRegions()) {
-            for (Block &nestedBlock : region)
-              mergeBroadeningInfo(info, self(self, nestedBlock));
-          }
-          continue;
-        }
-        if (hasUnsafeOwnEffects(&nestedOp)) {
-          info.hasBroadeningConflict = true;
-          if (!info.diagnosticOp)
-            info.diagnosticOp = &nestedOp;
-        }
-      }
-      return info;
-    };
-
     ThreadYBroadeningInfo threadYInfo =
-        analyzeThreadYBroadening(analyzeThreadYBroadening, *block);
+        analyzeThreadYBroadening(*block, computeRegion);
 
     auto applyCombineParDims =
         [&](ArrayRef<mlir::acc::GPUParallelDimAttr> combineParDims) {
@@ -1389,11 +1411,8 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
       // predicated to a single lane.
       auto addPrivateStoreParDims = [&](Value target) {
         if (auto privateLocalOp = getPrivateLocalForMemref(target)) {
-          mlir::acc::GPUParallelDimsAttr parDimsAttr =
-              mlir::acc::getParDimsAttr(privateLocalOp);
-          if (!parDimsAttr)
-            parDimsAttr =
-                getPrivatizeOp(privateLocalOp, computeRegion).getParDimsAttr();
+          GPUParallelDimsAttr parDimsAttr =
+              getPrivateParDims(privateLocalOp, computeRegion);
           if (parDimsAttr)
             for (auto parDim : parDimsAttr.getArray())
               mlir::acc::insertParDim(ancestorParDims, parDim);

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1334,17 +1334,8 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
           continue;
         }
         if (memref::StoreOp storeOp = dyn_cast<memref::StoreOp>(nestedOp)) {
-          bool threadYActive = false;
-          if (acc::PrivateLocalOp privateLocal =
-                  storeOp.getMemref().getDefiningOp<acc::PrivateLocalOp>()) {
-            if (acc::GPUParallelDimsAttr parDims =
-                    getPrivatizeOp(privateLocal, computeRegion)
-                        .getParDimsAttr()) {
-              threadYActive = llvm::any_of(parDims.getArray(), [](auto parDim) {
-                return parDim.isThreadY();
-              });
-            }
-          }
+          bool threadYActive = getPrivateScopeForMemref(storeOp.getMemref()) ==
+                               PrivateMemScope::Worker;
           if (failed(requireThreadY(storeOp, threadYActive)))
             return failure();
           continue;
@@ -1356,6 +1347,25 @@ ACCCGToGPULowering::computeActiveAndInactiveParDims(Operation *op,
                            [](auto parDim) { return parDim.isThreadY(); });
           if (failed(requireThreadY(accumulateArrayOp, threadYActive)))
             return failure();
+          continue;
+        }
+        if (nestedOp.getNumRegions() != 0) {
+          for (Region &region : nestedOp.getRegions()) {
+            for (Block &nestedBlock : region) {
+              FailureOr<ThreadYRequirement> nestedRequirement =
+                  self(self, nestedBlock);
+              if (failed(nestedRequirement))
+                return failure();
+              // Other region-bearing operations do not introduce independent
+              // ACC predication, so both requirements apply to this region.
+              if (nestedRequirement->active &&
+                  failed(requireThreadY(&nestedOp, /*active=*/true)))
+                return failure();
+              if (nestedRequirement->inactive &&
+                  failed(requireThreadY(&nestedOp, /*active=*/false)))
+                return failure();
+            }
+          }
           continue;
         }
         if (!isMemoryEffectFree(&nestedOp) &&

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -1,0 +1,43 @@
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" \
+// RUN:   -verify-diagnostics
+
+func.func @mixed_scope_worker_reduction_combine(
+    %other: memref<i32>, %result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    // expected-error@+1 {{failed to legalize operation 'acc.compute_region' that was explicitly marked illegal}}
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %other_arg = %other,
+            %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c0_i32 = arith.constant 0 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        scf.parallel (%worker_iv) = (%c0) to (%ty) step (%c1_inner) {
+          memref.store %c0_i32, %local[] : memref<i32>
+          scf.reduce
+        } {acc.par_dims = #acc<par_dims[thread_y]>}
+        acc.predicate_region {
+          acc.reduction_combine %local into %result_arg <add> : memref<i32>
+              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          // expected-error@+1 {{mixed worker-private and non-worker-private reduction combines require incompatible ThreadY predication}}
+          acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
+              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -79,3 +79,41 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
   }
   return
 }
+
+func.func @worker_combine_with_atomic_update(%result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    // expected-error@+1 {{failed to legalize operation 'acc.compute_region' that was explicitly marked illegal}}
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c1_i32 = arith.constant 1 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        acc.predicate_region {
+          acc.atomic.update %result_arg : memref<i32> {
+          ^bb0(%current: i32):
+            %next = arith.addi %current, %c1_i32 : i32
+            acc.yield %next : i32
+          }
+          // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
+          acc.reduction_combine %local into %result_arg <add> : memref<i32>
+              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -32,7 +32,7 @@ func.func @mixed_scope_worker_reduction_combine(
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
           // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
           acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+              {acc.par_dims = #acc<par_dims[block_y, thread_x]>}
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}
@@ -59,15 +59,17 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
       %c0 = arith.constant 0 : index
       %c1_inner = arith.constant 1 : index
       %c7_i32 = arith.constant 7 : i32
+      %false = arith.constant false
       scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
         %local = acc.private_local %private_arg
             : (!acc.private_type<memref<i32>>) -> memref<i32>
+        %selected = arith.select %false, %local, %result_arg : memref<i32>
         scf.parallel (%worker_iv) = (%c0) to (%ty) step (%c1_inner) {
           memref.store %c7_i32, %local[] : memref<i32>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         acc.predicate_region {
-          memref.store %c7_i32, %result_arg[] : memref<i32>
+          memref.store %c7_i32, %selected[] : memref<i32>
           // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
           acc.reduction_combine %local into %result_arg <add> : memref<i32>
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -30,8 +30,46 @@ func.func @mixed_scope_worker_reduction_combine(
         acc.predicate_region {
           acc.reduction_combine %local into %result_arg <add> : memref<i32>
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
-          // expected-error@+1 {{mixed worker-private and non-worker-private reduction combines require incompatible ThreadY predication}}
+          // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
           acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
+              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}
+
+func.func @worker_combine_with_single_store(%result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    // expected-error@+1 {{failed to legalize operation 'acc.compute_region' that was explicitly marked illegal}}
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c7_i32 = arith.constant 7 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        scf.parallel (%worker_iv) = (%c0) to (%ty) step (%c1_inner) {
+          memref.store %c7_i32, %local[] : memref<i32>
+          scf.reduce
+        } {acc.par_dims = #acc<par_dims[thread_y]>}
+        acc.predicate_region {
+          memref.store %c7_i32, %result_arg[] : memref<i32>
+          // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
+          acc.reduction_combine %local into %result_arg <add> : memref<i32>
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
         }
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -69,8 +69,8 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         acc.predicate_region {
-          memref.store %c7_i32, %selected[] : memref<i32>
           // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
+          memref.store %c7_i32, %selected[] : memref<i32>
           acc.reduction_combine %local into %result_arg <add> : memref<i32>
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
         }
@@ -103,12 +103,12 @@ func.func @worker_combine_with_atomic_update(%result: memref<i32>) {
         %local = acc.private_local %private_arg
             : (!acc.private_type<memref<i32>>) -> memref<i32>
         acc.predicate_region {
+          // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
           acc.atomic.update %result_arg : memref<i32> {
           ^bb0(%current: i32):
             %next = arith.addi %current, %c1_i32 : i32
             acc.yield %next : i32
           }
-          // expected-error@+1 {{operations in the same predicate region require incompatible ThreadY predication}}
           acc.reduction_combine %local into %result_arg <add> : memref<i32>
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
         }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -1,0 +1,95 @@
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
+
+// A worker-private reduction has one shared slot per ThreadY row. The combine
+// must keep ThreadY active and predicate only ThreadX.
+
+// CHECK-LABEL: func.func @worker_reduction_combine
+// CHECK: gpu.launch {{.*}} threads([[TID_X:%[^,]+]], [[TID_Y:%[^,]+]],
+// CHECK-NOT: arith.cmpi eq, [[TID_Y]]
+// CHECK: %[[IS_X_ZERO:.*]] = arith.cmpi eq, [[TID_X]],
+// CHECK-NOT: arith.andi
+// CHECK: scf.if %[[IS_X_ZERO]]
+// CHECK: acc.atomic.update
+
+func.func @worker_reduction_combine(%result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c0_i32 = arith.constant 0 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        scf.parallel (%worker_iv) = (%c0) to (%ty) step (%c1_inner) {
+          memref.store %c0_i32, %local[] : memref<i32>
+          scf.reduce
+        } {acc.par_dims = #acc<par_dims[thread_y]>}
+        acc.predicate_region {
+          acc.reduction_combine %local into %result_arg <add> : memref<i32>
+              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @worker_reduction_combine_region
+// CHECK: gpu.launch {{.*}} threads([[REGION_TID_X:%[^,]+]], [[REGION_TID_Y:%[^,]+]],
+// CHECK-NOT: arith.cmpi eq, [[REGION_TID_Y]]
+// CHECK: %[[REGION_IS_X_ZERO:.*]] = arith.cmpi eq, [[REGION_TID_X]],
+// CHECK-NOT: arith.andi
+// CHECK: scf.if %[[REGION_IS_X_ZERO]]
+// CHECK: arith.addi
+
+func.func @worker_reduction_combine_region(%result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c0_i32 = arith.constant 0 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        scf.parallel (%worker_iv) = (%c0) to (%ty) step (%c1_inner) {
+          memref.store %c0_i32, %local[] : memref<i32>
+          scf.reduce
+        } {acc.par_dims = #acc<par_dims[thread_y]>}
+        acc.predicate_region {
+          acc.reduction_combine_region %local into %result_arg : memref<i32> {
+            %lhs = memref.load %result_arg[] : memref<i32>
+            %rhs = memref.load %local[] : memref<i32>
+            %sum = arith.addi %lhs, %rhs : i32
+            memref.store %sum, %result_arg[] : memref<i32>
+            acc.yield
+          } {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -225,3 +225,39 @@ func.func @aliased_worker_store(%result: memref<i32>) {
   }
   return
 }
+
+// CHECK-LABEL: func.func @aliased_thread_store
+// CHECK: gpu.launch {{.*}} threads([[THREAD_TX:%[^,]+]], [[THREAD_TY:%[^,]+]],
+// CHECK-NOT: arith.cmpi eq, [[THREAD_TX]]
+// CHECK-NOT: arith.cmpi eq, [[THREAD_TY]]
+// CHECK: memref.store
+func.func @aliased_thread_store() {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y, thread_x]>]
+        : () -> !acc.private_type<memref<i32>>
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private)
+        : (!acc.private_type<memref<i32>>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c7_i32 = arith.constant 7 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        %cast = memref.cast %local : memref<i32> to memref<i32>
+        acc.predicate_region {
+          memref.store %c7_i32, %cast[] : memref<i32>
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -97,6 +97,12 @@ func.func @worker_reduction_combine_region(%result: memref<i32>) {
 // Nested predicate regions choose their ThreadY predicates independently. The
 // outer region must keep ThreadY active so it does not exclude worker rows
 // before the nested worker-private combine is reached.
+// CHECK-LABEL: func.func @nested_worker_reduction_combines
+// CHECK: gpu.launch {{.*}} threads([[NESTED_TX:%[^,]+]], [[NESTED_TY:%[^,]+]],
+// CHECK-NOT: arith.cmpi eq, [[NESTED_TY]]
+// CHECK: %[[NESTED_TX_ZERO:.*]] = arith.cmpi eq, [[NESTED_TX]],
+// CHECK-NOT: arith.andi
+// CHECK: scf.if %[[NESTED_TX_ZERO]]
 func.func @nested_worker_reduction_combines(
     %other: memref<i32>, %result: memref<i32>) {
   %c1 = arith.constant 1 : index
@@ -131,6 +137,86 @@ func.func @nested_worker_reduction_combines(
             acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
                 {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
           }
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @worker_combine_in_scf_if
+// CHECK: gpu.launch {{.*}} threads([[IF_TX:%[^,]+]], [[IF_TY:%[^,]+]],
+// CHECK-NOT: arith.cmpi eq, [[IF_TY]]
+// CHECK: %[[IF_TX_ZERO:.*]] = arith.cmpi eq, [[IF_TX]],
+// CHECK-NOT: arith.andi
+// CHECK: scf.if %[[IF_TX_ZERO]]
+func.func @worker_combine_in_scf_if(%result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %true = arith.constant true
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        acc.predicate_region {
+          scf.if %true {
+            acc.reduction_combine %local into %result_arg <add> : memref<i32>
+                {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          }
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @aliased_worker_store
+// CHECK: gpu.launch {{.*}} threads([[ALIAS_TX:%[^,]+]], [[ALIAS_TY:%[^,]+]],
+// CHECK-NOT: arith.cmpi eq, [[ALIAS_TY]]
+// CHECK: %[[ALIAS_TX_ZERO:.*]] = arith.cmpi eq, [[ALIAS_TX]],
+// CHECK-NOT: arith.andi
+// CHECK: scf.if %[[ALIAS_TX_ZERO]]
+// CHECK: memref.store
+// CHECK: acc.atomic.update
+func.func @aliased_worker_store(%result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c7_i32 = arith.constant 7 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        %cast = memref.cast %local : memref<i32> to memref<i32>
+        acc.predicate_region {
+          memref.store %c7_i32, %cast[] : memref<i32>
+          acc.reduction_combine %local into %result_arg <add> : memref<i32>
+              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -35,6 +35,7 @@ func.func @worker_reduction_combine(%result: memref<i32>) {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         acc.predicate_region {
+          %unused = memref.load %result_arg[] : memref<i32>
           acc.reduction_combine %local into %result_arg <add> : memref<i32>
               {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
         }
@@ -176,83 +177,6 @@ func.func @worker_combine_in_scf_if(%result: memref<i32>) {
             acc.reduction_combine %local into %result_arg <add> : memref<i32>
                 {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
           }
-        }
-        scf.reduce
-      } {acc.par_dims = #acc<par_dims[block_y]>}
-      acc.yield
-    } {origin = "acc.parallel"}
-  }
-  return
-}
-
-// CHECK-LABEL: func.func @aliased_worker_store
-// CHECK: gpu.launch {{.*}} threads([[ALIAS_TX:%[^,]+]], [[ALIAS_TY:%[^,]+]],
-// CHECK-NOT: arith.cmpi eq, [[ALIAS_TY]]
-// CHECK: %[[ALIAS_TX_ZERO:.*]] = arith.cmpi eq, [[ALIAS_TX]],
-// CHECK-NOT: arith.andi
-// CHECK: scf.if %[[ALIAS_TX_ZERO]]
-// CHECK: memref.store
-// CHECK: acc.atomic.update
-func.func @aliased_worker_store(%result: memref<i32>) {
-  %c1 = arith.constant 1 : index
-  %c4 = arith.constant 4 : index
-  %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
-  acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y]>]
-        : () -> !acc.private_type<memref<i32>>
-    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
-        ins(%private_arg = %private, %result_arg = %result)
-        : (!acc.private_type<memref<i32>>, memref<i32>) {
-      %c0 = arith.constant 0 : index
-      %c1_inner = arith.constant 1 : index
-      %c7_i32 = arith.constant 7 : i32
-      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
-        %local = acc.private_local %private_arg
-            : (!acc.private_type<memref<i32>>) -> memref<i32>
-        %cast = memref.cast %local : memref<i32> to memref<i32>
-        acc.predicate_region {
-          memref.store %c7_i32, %cast[] : memref<i32>
-          acc.reduction_combine %local into %result_arg <add> : memref<i32>
-              {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
-        }
-        scf.reduce
-      } {acc.par_dims = #acc<par_dims[block_y]>}
-      acc.yield
-    } {origin = "acc.parallel"}
-  }
-  return
-}
-
-// CHECK-LABEL: func.func @aliased_thread_store
-// CHECK: gpu.launch {{.*}} threads([[THREAD_TX:%[^,]+]], [[THREAD_TY:%[^,]+]],
-// CHECK-NOT: arith.cmpi eq, [[THREAD_TX]]
-// CHECK-NOT: arith.cmpi eq, [[THREAD_TY]]
-// CHECK: memref.store
-func.func @aliased_thread_store() {
-  %c1 = arith.constant 1 : index
-  %c4 = arith.constant 4 : index
-  %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
-  acc.kernel_environment {
-    %private = acc.privatize [#acc<par_dims[thread_y, thread_x]>]
-        : () -> !acc.private_type<memref<i32>>
-    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
-        ins(%private_arg = %private)
-        : (!acc.private_type<memref<i32>>) {
-      %c0 = arith.constant 0 : index
-      %c1_inner = arith.constant 1 : index
-      %c7_i32 = arith.constant 7 : i32
-      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
-        %local = acc.private_local %private_arg
-            : (!acc.private_type<memref<i32>>) -> memref<i32>
-        %cast = memref.cast %local : memref<i32> to memref<i32>
-        acc.predicate_region {
-          memref.store %c7_i32, %cast[] : memref<i32>
         }
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_y]>}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -93,3 +93,49 @@ func.func @worker_reduction_combine_region(%result: memref<i32>) {
   }
   return
 }
+
+// Nested predicate regions choose their ThreadY predicates independently. The
+// outer region must keep ThreadY active so it does not exclude worker rows
+// before the nested worker-private combine is reached.
+func.func @nested_worker_reduction_combines(
+    %other: memref<i32>, %result: memref<i32>) {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c32 = arith.constant 32 : index
+  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
+  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  acc.kernel_environment {
+    %private = acc.privatize [#acc<par_dims[thread_y]>]
+        : () -> !acc.private_type<memref<i32>>
+    acc.compute_region launch(%by = %block_y, %ty = %thread_y, %tx = %thread_x)
+        ins(%private_arg = %private, %other_arg = %other,
+            %result_arg = %result)
+        : (!acc.private_type<memref<i32>>, memref<i32>, memref<i32>) {
+      %c0 = arith.constant 0 : index
+      %c1_inner = arith.constant 1 : index
+      %c0_i32 = arith.constant 0 : i32
+      scf.parallel (%block_iv) = (%c0) to (%by) step (%c1_inner) {
+        %local = acc.private_local %private_arg
+            : (!acc.private_type<memref<i32>>) -> memref<i32>
+        scf.parallel (%worker_iv) = (%c0) to (%ty) step (%c1_inner) {
+          memref.store %c0_i32, %local[] : memref<i32>
+          scf.reduce
+        } {acc.par_dims = #acc<par_dims[thread_y]>}
+        acc.predicate_region {
+          acc.predicate_region {
+            acc.reduction_combine %local into %result_arg <add> : memref<i32>
+                {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          }
+          acc.predicate_region {
+            acc.reduction_combine %other_arg into %result_arg <add> : memref<i32>
+                {acc.par_dims = #acc<par_dims[block_y, thread_y]>}
+          }
+        }
+        scf.reduce
+      } {acc.par_dims = #acc<par_dims[block_y]>}
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}


### PR DESCRIPTION
Example:
```fortran
!$acc parallel loop gang worker reduction(+:sum)
do j = 1, n
  !$acc loop vector reduction(+:sum)
  do i = 1, n
    sum = sum + a(i, j)
  end do
end do
```

In this code, each worker has a private partial result, but combine predication previously allowed only ThreadY row zero to contribute.

Fix: keep ThreadY active only for proven atomic worker combines, while preserving legacy predication or reporting NYI for unsafe combinations.