### PR TITLE
[lldb/script] Only auto-open the generator template in an editor when interactive

### DIFF
--- a/lldb/source/Commands/CommandObjectScripting.cpp
+++ b/lldb/source/Commands/CommandObjectScripting.cpp
@@ -536,12 +536,31 @@ protected:
       return;
     }
 
-    if (m_options.m_open_editor != eLazyBoolNo) {
+    bool should_open_editor = false;
+    switch (m_options.m_open_editor) {
+    case eLazyBoolYes:
+      should_open_editor = true;
+      break;
+    case eLazyBoolNo:
+      should_open_editor = false;
+      break;
+    case eLazyBoolCalculate:
+      // Only auto-open when the command was invoked interactively.
+      // `result.GetInteractive()` is set to false by
+      // SBCommandInterpreter::HandleCommand and by batch command sourcing
+      // (test suite, scripts, headless drivers), so it's the accurate signal
+      // even when the process' stdin is a TTY inherited from the parent.
+      should_open_editor = result.GetInteractive();
+      break;
+    }
+
+    if (should_open_editor) {
       if (llvm::Error err = Host::OpenFileInExternalEditor(
               "", *generated_file_or_err, 1, true)) {
-        // The template is on disk; failing to launch an editor (e.g. no
-        // external editor available on this platform) shouldn't fail the
-        // whole command.
+        // Opening the file in an editor is a convenience, not a requirement:
+        // the template was already written to disk successfully, so don't
+        // fail the whole command over it (e.g. no external editor available
+        // on this platform).
         LLDB_LOG_ERROR(GetLog(LLDBLog::Host), std::move(err),
                        "OpenFileInExternalEditor failed: {0}");
       }


### PR DESCRIPTION
`scripting extension generate` always launched the external editor after writing the template to disk, which is fine when a user types the command at the prompt but is undesirable when the command runs from the test suite, a headless driver, or a script -- each invocation spawns an editor that nobody sees.

Extend `--open-editor` (`-e`) so that the default (`eLazyBoolCalculate`) now dispatches on `CommandReturnObject::GetInteractive()`, which `SBCommandInterpreter::HandleCommand` explicitly clears. That's the accurate signal even when the process' stdin is a TTY inherited from the parent (e.g. `lldb-dotest` invoked from a terminal). `--open-editor yes` and `--open-editor no` still force the behavior explicitly.