### PR TITLE
[AArch64] Lower Darwin stack probes through __chkstk_darwin

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -732,6 +732,16 @@ def CSR_AArch64_StackProbe_Windows
                            (sequence "X%u", 18, 28), FP, SP,
                            (sequence "Q%u", 0, 31))>;
 
+// ___chkstk_darwin takes the prospective stack allocation size in X9. The
+// compatibility implementation used by older Darwin versions also uses X10,
+// and its dispatch veneer uses X16.
+def CSR_AArch64_StackProbe_Darwin
+    : CalleeSavedRegs<(add (sequence "X%u", 0, 8),
+                           (sequence "X%u", 11, 15),
+                           (sequence "X%u", 17, 28), FP, SP,
+                           (sequence "Z%u", 0, 31),
+                           (sequence "P%u", 0, 15))>;
+
 // Darwin variants of AAPCS.
 // Darwin puts the frame-record at the top of the callee-save area.
 def CSR_Darwin_AArch64_AAPCS : CalleeSavedRegs<(add LR, FP, X19, X20, X21, X22,

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -904,6 +904,13 @@ bool AArch64FrameLowering::windowsRequiresStackProbe(
          StackSizeInBytes >= uint64_t(MFI.getStackProbeSize());
 }
 
+bool AArch64FrameLowering::darwinRequiresStackProbe(
+    const MachineFunction &MF, uint64_t StackSizeInBytes) const {
+  const AArch64FunctionInfo &MFI = *MF.getInfo<AArch64FunctionInfo>();
+  return MFI.hasDarwinStackProbe() &&
+         StackSizeInBytes >= uint64_t(MFI.getStackProbeSize());
+}
+
 static void getLiveRegsForEntryMBB(LivePhysRegs &LiveRegs,
                                    const MachineBasicBlock &MBB) {
   const MachineFunction *MF = MBB.getParent();
@@ -978,6 +985,16 @@ bool AArch64FrameLowering::canUseAsPrologue(
   if (RegInfo->hasStackRealignment(*MF) || TLI->hasInlineStackProbe(*MF))
     if (findScratchNonCalleeSaveRegister(TmpMBB) == AArch64::NoRegister)
       return false;
+
+  if (darwinRequiresStackProbe(*MF, std::numeric_limits<uint64_t>::max())) {
+    const AArch64RegisterInfo &TRI = *Subtarget.getRegisterInfo();
+    const MachineRegisterInfo &MRI = MF->getRegInfo();
+    LivePhysRegs LiveRegs(TRI);
+    getLiveRegsForEntryMBB(LiveRegs, MBB);
+    if (!LiveRegs.available(MRI, AArch64::X9) ||
+        !LiveRegs.available(MRI, AArch64::X16))
+      return false;
+  }
 
   // May need a scratch register (for return value) if require making a special
   // call

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.h
@@ -233,6 +233,8 @@ private:
 
   bool windowsRequiresStackProbe(const MachineFunction &MF,
                                  uint64_t StackSizeInBytes) const;
+  bool darwinRequiresStackProbe(const MachineFunction &MF,
+                                uint64_t StackSizeInBytes) const;
 
   bool shouldSignReturnAddressEverywhere(const MachineFunction &MF) const;
 

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -18272,12 +18272,58 @@ AArch64TargetLowering::LowerInlineDYNAMIC_STACKALLOC(SDValue Op,
 }
 
 SDValue
+AArch64TargetLowering::LowerDarwinDYNAMIC_STACKALLOC(SDValue Op,
+                                                     SelectionDAG &DAG) const {
+  SDNode *Node = Op.getNode();
+  SDValue Chain = Op.getOperand(0);
+  SDValue Size = Op.getOperand(1);
+  MaybeAlign Align =
+      cast<ConstantSDNode>(Op.getOperand(2))->getMaybeAlignValue();
+  SDLoc DL(Op);
+  EVT VT = Node->getValueType(0);
+
+  SDValue SP = DAG.getCopyFromReg(Chain, DL, AArch64::SP, MVT::i64);
+  Chain = SP.getValue(1);
+  SDValue TargetSP = DAG.getNode(ISD::SUB, DL, MVT::i64, SP, Size);
+  if (Align)
+    TargetSP = DAG.getNode(ISD::AND, DL, VT, TargetSP,
+                           DAG.getSignedConstant(-Align->value(), DL, VT));
+  SDValue ProbeSize = DAG.getNode(ISD::SUB, DL, MVT::i64, SP, TargetSP);
+
+  Chain = DAG.getCALLSEQ_START(Chain, 0, 0, DL);
+
+  EVT PtrVT = getPointerTy(DAG.getDataLayout());
+  SDValue Callee =
+      DAG.getTargetExternalSymbol("__chkstk_darwin", PtrVT, AArch64II::MO_GOT);
+  Callee = DAG.getNode(AArch64ISD::LOADgot, DL, PtrVT, Callee);
+
+  const AArch64RegisterInfo *TRI = Subtarget->getRegisterInfo();
+  const uint32_t *Mask = TRI->getDarwinStackProbePreservedMask();
+  if (Subtarget->hasCustomCallingConv())
+    TRI->UpdateCustomCallPreservedMask(DAG.getMachineFunction(), &Mask);
+
+  Chain = DAG.getCopyToReg(Chain, DL, AArch64::X9, ProbeSize, SDValue());
+  Chain =
+      DAG.getNode(AArch64ISD::CALL, DL, DAG.getVTList(MVT::Other, MVT::Glue),
+                  Chain, Callee, DAG.getRegister(AArch64::X9, MVT::i64),
+                  DAG.getRegisterMask(Mask), Chain.getValue(1));
+
+  Chain = DAG.getCopyToReg(Chain, DL, AArch64::SP, TargetSP);
+  Chain = DAG.getCALLSEQ_END(Chain, 0, 0, SDValue(), DL);
+
+  SDValue Ops[2] = {TargetSP, Chain};
+  return DAG.getMergeValues(Ops, DL);
+}
+
+SDValue
 AArch64TargetLowering::LowerDYNAMIC_STACKALLOC(SDValue Op,
                                                SelectionDAG &DAG) const {
   MachineFunction &MF = DAG.getMachineFunction();
 
   if (Subtarget->isTargetWindows())
     return LowerWindowsDYNAMIC_STACKALLOC(Op, DAG);
+  else if (MF.getInfo<AArch64FunctionInfo>()->hasDarwinStackProbe())
+    return LowerDarwinDYNAMIC_STACKALLOC(Op, DAG);
   else if (hasInlineStackProbe(MF))
     return LowerInlineDYNAMIC_STACKALLOC(Op, DAG);
   else
@@ -35574,8 +35620,7 @@ unsigned AArch64TargetLowering::getVectorTypeBreakdownForCallingConv(
 
 bool AArch64TargetLowering::hasInlineStackProbe(
     const MachineFunction &MF) const {
-  return !Subtarget->isTargetWindows() &&
-         MF.getInfo<AArch64FunctionInfo>()->hasStackProbing();
+  return MF.getInfo<AArch64FunctionInfo>()->hasInlineStackProbe();
 }
 
 bool AArch64TargetLowering::isTypeDesirableForOp(unsigned Opc, EVT VT) const {

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -805,6 +805,7 @@ private:
   SDValue LowerVECREDUCE_MUL(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerATOMIC_LOAD_AND(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerWindowsDYNAMIC_STACKALLOC(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerDarwinDYNAMIC_STACKALLOC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerInlineDYNAMIC_STACKALLOC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerDYNAMIC_STACKALLOC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerMSTORE(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
@@ -146,8 +146,10 @@ AArch64FunctionInfo::AArch64FunctionInfo(const Function &F,
   assert(int64_t(ProbeSize) > 0 && "Invalid stack probe size");
 
   if (STI->isTargetWindows()) {
-    if (!F.hasFnAttribute("no-stack-arg-probe"))
+    if (!F.hasFnAttribute("no-stack-arg-probe")) {
+      StackProbe = StackProbeKind::Windows;
       StackProbeSize = ProbeSize;
+    }
   } else {
     // Round down to the stack alignment.
     uint64_t StackAlign =
@@ -160,11 +162,11 @@ AArch64FunctionInfo::AArch64FunctionInfo(const Function &F,
                  F.getParent()->getModuleFlag("probe-stack")))
       ProbeKind = PS->getString();
     if (ProbeKind.size()) {
-      // Apple Swift emits __chkstk_darwin for Darwin bitcode. Treat it as a
-      // request for the existing inline probe sequence; this backend does not
-      // provide Apple's out-of-tree helper-based implementation.
-      if (ProbeKind != "inline-asm" &&
-          !(STI->isTargetDarwin() && ProbeKind == "__chkstk_darwin"))
+      if (ProbeKind == "inline-asm")
+        StackProbe = StackProbeKind::Inline;
+      else if (STI->isTargetDarwin() && ProbeKind == "__chkstk_darwin")
+        StackProbe = StackProbeKind::Darwin;
+      else
         report_fatal_error("Unsupported stack probing method");
       StackProbeSize = ProbeSize;
     }

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
@@ -160,7 +160,11 @@ AArch64FunctionInfo::AArch64FunctionInfo(const Function &F,
                  F.getParent()->getModuleFlag("probe-stack")))
       ProbeKind = PS->getString();
     if (ProbeKind.size()) {
-      if (ProbeKind != "inline-asm")
+      // Apple Swift emits __chkstk_darwin for Darwin bitcode. Treat it as a
+      // request for the existing inline probe sequence; this backend does not
+      // provide Apple's out-of-tree helper-based implementation.
+      if (ProbeKind != "inline-asm" &&
+          !(STI->isTargetDarwin() && ProbeKind == "__chkstk_darwin"))
         report_fatal_error("Unsupported stack probing method");
       StackProbeSize = ProbeSize;
     }

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -46,6 +46,13 @@ enum class SignReturnAddress {
   All,
 };
 
+enum class StackProbeKind {
+  None,
+  Inline,
+  Darwin,
+  Windows,
+};
+
 /// AArch64FunctionInfo - This class is derived from MachineFunctionInfo and
 /// contains private AArch64-specific information for each MachineFunction.
 class AArch64FunctionInfo final : public MachineFunctionInfo {
@@ -223,6 +230,7 @@ class AArch64FunctionInfo final : public MachineFunctionInfo {
   /// True if the function need asynchronous unwind information.
   mutable std::optional<bool> NeedsAsyncDwarfUnwindInfo;
 
+  StackProbeKind StackProbe = StackProbeKind::None;
   int64_t StackProbeSize = 0;
 
   // Holds a register containing pstate.sm. This is set
@@ -603,7 +611,15 @@ public:
     HasStreamingModeChanges = HasChanges;
   }
 
-  bool hasStackProbing() const { return StackProbeSize != 0; }
+  bool hasStackProbing() const { return StackProbe != StackProbeKind::None; }
+
+  bool hasInlineStackProbe() const {
+    return StackProbe == StackProbeKind::Inline;
+  }
+
+  bool hasDarwinStackProbe() const {
+    return StackProbe == StackProbeKind::Darwin;
+  }
 
   int64_t getStackProbeSize() const { return StackProbeSize; }
 

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
@@ -702,7 +702,8 @@ void AArch64PrologueEmitter::emitPrologue() {
   // function, including the funclet.
   int64_t NumBytes =
       IsFunclet ? AFL.getWinEHFuncletFrameSize(MF) : MFI.getStackSize();
-  if (!AFI->hasStackFrame() && !AFL.windowsRequiresStackProbe(MF, NumBytes))
+  if (!AFI->hasStackFrame() && !AFL.windowsRequiresStackProbe(MF, NumBytes) &&
+      !AFL.darwinRequiresStackProbe(MF, NumBytes))
     return emitEmptyStackFramePrologue(NumBytes, PrologueBeginI, DL);
 
   bool IsWin64 = Subtarget.isCallingConvWin64(F.getCallingConv(), F.isVarArg());
@@ -791,6 +792,8 @@ void AArch64PrologueEmitter::emitPrologue() {
 
   if (AFL.windowsRequiresStackProbe(MF, NumBytes + RealignmentPadding))
     emitWindowsStackProbe(AfterGPRSavesI, DL, NumBytes, RealignmentPadding);
+  else if (AFL.darwinRequiresStackProbe(MF, NumBytes + RealignmentPadding))
+    emitDarwinStackProbe(AfterGPRSavesI, DL, NumBytes + RealignmentPadding);
 
   StackOffset NonSVELocalsSize = StackOffset::getFixed(NumBytes);
   SVEAllocs.AfterZPRs += NonSVELocalsSize;
@@ -1790,6 +1793,40 @@ void AArch64EpilogueEmitter::finalizeEpilogue() const {
     if (!HasWinCFI)
       MBB.erase(SEHEpilogueStartI);
   }
+}
+
+void AArch64PrologueEmitter::emitDarwinStackProbe(
+    MachineBasicBlock::iterator MBBI, const DebugLoc &DL,
+    uint64_t NumBytes) const {
+  constexpr StringLiteral ChkStk = "__chkstk_darwin";
+
+  BuildMI(MBB, MBBI, DL, TII->get(AArch64::STRXpre))
+      .addReg(AArch64::SP, RegState::Define)
+      .addReg(AArch64::LR)
+      .addReg(AArch64::SP)
+      .addImm(-16)
+      .setMIFlag(MachineInstr::FrameSetup);
+
+  BuildMI(MBB, MBBI, DL, TII->get(AArch64::MOVi64imm), AArch64::X9)
+      .addImm(NumBytes)
+      .setMIFlag(MachineInstr::FrameSetup);
+
+  BuildMI(MBB, MBBI, DL, TII->get(AArch64::LOADgot), AArch64::X16)
+      .addExternalSymbol(ChkStk.data(), AArch64II::MO_GOT)
+      .setMIFlag(MachineInstr::FrameSetup);
+
+  BuildMI(MBB, MBBI, DL, TII->get(getBLRCallOpcode(MF)))
+      .addReg(AArch64::X16, RegState::Kill)
+      .addReg(AArch64::X9, RegState::Implicit)
+      .addRegMask(RegInfo.getDarwinStackProbePreservedMask())
+      .setMIFlag(MachineInstr::FrameSetup);
+
+  BuildMI(MBB, MBBI, DL, TII->get(AArch64::LDRXpost))
+      .addReg(AArch64::SP, RegState::Define)
+      .addReg(AArch64::LR, RegState::Define)
+      .addReg(AArch64::SP)
+      .addImm(16)
+      .setMIFlag(MachineInstr::FrameSetup);
 }
 
 } // namespace llvm

--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.h
@@ -142,6 +142,8 @@ private:
   void emitWindowsStackProbe(MachineBasicBlock::iterator MBBI,
                              const DebugLoc &DL, int64_t &NumBytes,
                              int64_t RealignmentPadding) const;
+  void emitDarwinStackProbe(MachineBasicBlock::iterator MBBI,
+                            const DebugLoc &DL, uint64_t NumBytes) const;
 
   void emitCalleeSavedGPRLocations(MachineBasicBlock::iterator MBBI) const;
   void emitCalleeSavedSVELocations(MachineBasicBlock::iterator MBBI) const;

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -388,6 +388,10 @@ const uint32_t *AArch64RegisterInfo::getWindowsStackProbePreservedMask() const {
   return CSR_AArch64_StackProbe_Windows_RegMask;
 }
 
+const uint32_t *AArch64RegisterInfo::getDarwinStackProbePreservedMask() const {
+  return CSR_AArch64_StackProbe_Darwin_RegMask;
+}
+
 std::optional<std::string>
 AArch64RegisterInfo::explainReservedReg(const MachineFunction &MF,
                                         MCRegister PhysReg) const {

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
@@ -96,6 +96,7 @@ public:
 
   /// Stack probing calls preserve different CSRs to the normal CC.
   const uint32_t *getWindowsStackProbePreservedMask() const;
+  const uint32_t *getDarwinStackProbePreservedMask() const;
 
   BitVector getStrictlyReservedRegs(const MachineFunction &MF) const;
   BitVector getUserReservedRegs(const MachineFunction &MF) const;

--- a/llvm/test/CodeGen/AArch64/swift-darwin-stack-probing.ll
+++ b/llvm/test/CodeGen/AArch64/swift-darwin-stack-probing.ll
@@ -1,14 +1,81 @@
 ; RUN: llc -mtriple=arm64-apple-macosx -verify-machineinstrs < %s | FileCheck %s
+; RUN: not --crash llc -mtriple=aarch64-unknown-linux < %s 2>&1 | FileCheck %s --check-prefix=ERROR
 
 ; Verify that the stack-probing attribute emitted by Apple Swift is accepted
-; on Darwin and lowered to the existing inline stack-probing sequence.
+; on Darwin and lowered through the Darwin stack-check helper ABI.
 
-define void @swift_darwin_stack_probe(ptr %out) #0 {
-; CHECK-LABEL: swift_darwin_stack_probe:
-; CHECK:       sub sp, sp, #1, lsl #12
-; CHECK:       ldr xzr, [sp]
+define void @below_probe_threshold(ptr %out) #0 {
+; CHECK-LABEL: below_probe_threshold:
+; CHECK-NOT:   ___chkstk_darwin
+; CHECK:       sub sp, sp, #1040
+; CHECK-NOT:   ___chkstk_darwin
+; CHECK:       ret
+entry:
+  %frame = alloca i8, i64 1040, align 1
+  store ptr %frame, ptr %out, align 8
+  ret void
+}
+
+define void @just_below_probe_threshold(ptr %out) #0 {
+; CHECK-LABEL: just_below_probe_threshold:
+; CHECK-NOT:   ___chkstk_darwin
+; CHECK:       sub sp, sp, #4080
+; CHECK-NOT:   ___chkstk_darwin
+; CHECK:       ret
+entry:
+  %frame = alloca i8, i64 4080, align 1
+  store ptr %frame, ptr %out, align 8
+  ret void
+}
+
+define void @fixed_probe(ptr %out) #0 {
+; CHECK-LABEL: fixed_probe:
+; CHECK:       str x30, [sp, #-16]!
+; CHECK-DAG:   mov x9, #4096
+; CHECK-DAG:   adrp x16, ___chkstk_darwin@GOTPAGE
+; CHECK:       ldr x16, [x16, ___chkstk_darwin@GOTPAGEOFF]
+; CHECK-NEXT:  blr x16
+; CHECK-NEXT:  ldr x30, [sp], #16
+; CHECK-NEXT:  sub sp, sp, #1, lsl #12
+; CHECK-NOT:   ldr xzr, [sp]
+; CHECK:       ret
 entry:
   %frame = alloca i8, i64 4096, align 1
+  store ptr %frame, ptr %out, align 8
+  ret void
+}
+
+define void @large_fixed_probe(ptr %out) #0 {
+; CHECK-LABEL: large_fixed_probe:
+; CHECK:       str x30, [sp, #-16]!
+; CHECK-DAG:   mov x9, #20480
+; CHECK-DAG:   adrp x16, ___chkstk_darwin@GOTPAGE
+; CHECK:       ldr x16, [x16, ___chkstk_darwin@GOTPAGEOFF]
+; CHECK-NEXT:  blr x16
+; CHECK-NEXT:  ldr x30, [sp], #16
+; CHECK-NEXT:  sub sp, sp, #5, lsl #12
+; CHECK-NOT:   ldr xzr, [sp]
+; CHECK:       ret
+entry:
+  %frame = alloca i8, i64 20480, align 1
+  store ptr %frame, ptr %out, align 8
+  ret void
+}
+
+define void @dynamic_probe(ptr %out, i64 %size) #0 {
+; CHECK-LABEL: dynamic_probe:
+; CHECK-DAG:   mov x9, [[SIZE:x[0-9]+]]
+; Keep the old SP in a register preserved by both the current helper and the
+; compatibility implementation, which clobbers x9, x10, and x16.
+; CHECK-DAG:   mov [[OLDSP:x([0-8]|1[1-5]|1[7-9]|2[0-8])]], sp
+; CHECK-DAG:   adrp [[CALLEE:x[0-9]+]], ___chkstk_darwin@GOTPAGE
+; CHECK-DAG:   ldr [[CALLEE]], {{\[}}[[CALLEE]], ___chkstk_darwin@GOTPAGEOFF]
+; CHECK:       blr [[CALLEE]]
+; CHECK:       sub [[TARGETSP:x[0-9]+]], [[OLDSP]], [[SIZE]]
+; CHECK-NEXT:  mov sp, [[TARGETSP]]
+; CHECK:       ret
+entry:
+  %frame = alloca i8, i64 %size, align 16
   store ptr %frame, ptr %out, align 8
   ret void
 }
@@ -20,3 +87,5 @@ attributes #0 = {
   "stack-probe-size"="4096"
   uwtable(async)
 }
+
+; ERROR: LLVM ERROR: Unsupported stack probing method

--- a/llvm/test/CodeGen/AArch64/swift-darwin-stack-probing.ll
+++ b/llvm/test/CodeGen/AArch64/swift-darwin-stack-probing.ll
@@ -6,7 +6,7 @@
 define void @swift_darwin_stack_probe(ptr %out) #0 {
 ; CHECK-LABEL: swift_darwin_stack_probe:
 ; CHECK:       sub sp, sp, #1, lsl #12
-; CHECK-NEXT:  ldr xzr, [sp]
+; CHECK:       ldr xzr, [sp]
 entry:
   %frame = alloca i8, i64 4096, align 1
   store ptr %frame, ptr %out, align 8

--- a/llvm/test/CodeGen/AArch64/swift-darwin-stack-probing.ll
+++ b/llvm/test/CodeGen/AArch64/swift-darwin-stack-probing.ll
@@ -1,0 +1,22 @@
+; RUN: llc -mtriple=arm64-apple-macosx -verify-machineinstrs < %s | FileCheck %s
+
+; Verify that the stack-probing attribute emitted by Apple Swift is accepted
+; on Darwin and lowered to the existing inline stack-probing sequence.
+
+define void @swift_darwin_stack_probe(ptr %out) #0 {
+; CHECK-LABEL: swift_darwin_stack_probe:
+; CHECK:       sub sp, sp, #1, lsl #12
+; CHECK-NEXT:  ldr xzr, [sp]
+entry:
+  %frame = alloca i8, i64 4096, align 1
+  store ptr %frame, ptr %out, align 8
+  ret void
+}
+
+attributes #0 = {
+  noinline
+  "frame-pointer"="none"
+  "probe-stack"="__chkstk_darwin"
+  "stack-probe-size"="4096"
+  uwtable(async)
+}


### PR DESCRIPTION
Apple Swift 6.3 Darwin bitcode can carry the
`"probe-stack"="__chkstk_darwin"` function attribute. AArch64 currently
rejects that method with `LLVM ERROR: Unsupported stack probing method` when
code generation consumes the bitcode, including when code generation runs as
an LTO backend.

Lower Darwin probes through the `__chkstk_darwin` helper ABI instead of
translating the spelling to AArch64's generic inline page-probe sequence. This
matches the helper-based lowering emitted by the Apple toolchain and avoids
replicating an inline page-touch sequence at every large-frame site.

## Lowering

- Represent inline, Darwin-helper, and Windows probes as distinct stack-probe
  kinds. Unknown methods and `__chkstk_darwin` on non-Darwin targets remain
  rejected.
- For a fixed frame at or above the probe threshold, save LR transiently, pass
  the prospective allocation size in X9, load `___chkstk_darwin` through the
  GOT, call it indirectly, restore LR, and only then adjust SP. Frames below
  the threshold retain the existing prologue.
- For SelectionDAG dynamic allocas, calculate the aligned target SP, pass the
  exact delta in X9, call the helper while the old SP is still active, and
  install the target SP after the call.
- Model X9, X10, X16, LR, and condition flags as clobbered by the public
  compatibility contract. Other preserved registers remain available to hold
  the old SP across a dynamic probe.

The helper call must precede the SP adjustment because its job is to touch the
pages between the current stack pointer and the prospective stack pointer.
Fixed-frame lowering saves LR separately because the call is emitted before
the normal frame allocation has established its final spill locations.

## Validation

- Built exact PR head `5c53f122582d` with AppleClang 21 in Release mode,
  assertions enabled, and only AArch64 enabled.
- Passed 16 focused AArch64 CodeGen tests covering the new Darwin test and the
  existing fixed, dynamic, inline, SVE, shrink-wrap, no-scratch-register, and
  GlobalISel dynamic-alloca regression coverage.
- The dedicated test verifies that 1040- and 4080-byte frames do not call the
  helper, while 4096- and 20480-byte frames do. It also verifies X9 input,
  GOT-indirect loading, transient LR preservation, call-before-SP-adjustment,
  dynamic allocation, absence of the inline `ldr xzr, [sp]` sequence, and
  rejection on a non-Darwin target.
- An optimized `arm64-apple-ios16.0` object records iOS 16.0 deployment
  metadata, has an undefined `___chkstk_darwin` import, and its corresponding
  assembly contains no inline `ldr xzr, [sp]` probes.

Forced GlobalISel lowering of Darwin dynamic allocas is not implemented by
this patch. The validated dynamic path is SelectionDAG; configurations that
explicitly force GlobalISel for those allocas remain a known limitation.
