### PR TITLE
[LoopInfo][LCSSA] Handle token-like values

### DIFF
--- a/llvm/include/llvm/Analysis/LoopInfo.h
+++ b/llvm/include/llvm/Analysis/LoopInfo.h
@@ -311,12 +311,13 @@ public:
   bool isCanonical(ScalarEvolution &SE) const;
 
   /// Return true if the Loop is in LCSSA form. If \p IgnoreTokens is set to
-  /// true, token values defined inside loop are allowed to violate LCSSA form.
+  /// true, token-like values defined inside loop are allowed to violate LCSSA
+  /// form.
   bool isLCSSAForm(const DominatorTree &DT, bool IgnoreTokens = true) const;
 
   /// Return true if this Loop and all inner subloops are in LCSSA form. If \p
-  /// IgnoreTokens is set to true, token values defined inside loop are allowed
-  /// to violate LCSSA form.
+  /// IgnoreTokens is set to true, token-like values defined inside loop are
+  /// allowed to violate LCSSA form.
   bool isRecursivelyLCSSAForm(const DominatorTree &DT, const LoopInfo &LI,
                               bool IgnoreTokens = true) const;
 

--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -453,10 +453,10 @@ bool Loop::isCanonical(ScalarEvolution &SE) const {
 static bool isBlockInLCSSAForm(const Loop &L, const BasicBlock &BB,
                                const DominatorTree &DT, bool IgnoreTokens) {
   for (const Instruction &I : BB) {
-    // Tokens can't be used in PHI nodes and live-out tokens prevent loop
-    // optimizations, so for the purposes of considered LCSSA form, we
-    // can ignore them.
-    if (IgnoreTokens && I.getType()->isTokenTy())
+    // Token-like values can't be used in PHI nodes and live-out token-like
+    // values prevent loop optimizations, so for the purposes of considered
+    // LCSSA form, we can ignore them.
+    if (IgnoreTokens && I.getType()->isTokenLikeTy())
       continue;
 
     for (const Use &U : I.uses()) {
@@ -969,9 +969,9 @@ void LoopInfo::erase(Loop *Unloop) {
 
 bool LoopInfo::wouldBeOutOfLoopUseRequiringLCSSA(
     const Value *V, const BasicBlock *ExitBB) const {
-  if (V->getType()->isTokenTy())
-    // We can't form PHIs of token type, so the definition of LCSSA excludes
-    // values of that type.
+  if (V->getType()->isTokenLikeTy())
+    // We can't form PHIs of token-like type, so the definition of LCSSA
+    // excludes values of that type.
     return false;
 
   const Instruction *I = dyn_cast<Instruction>(V);

--- a/llvm/lib/Transforms/Utils/LCSSA.cpp
+++ b/llvm/lib/Transforms/Utils/LCSSA.cpp
@@ -94,7 +94,8 @@ formLCSSAForInstructionsImpl(SmallVectorImpl<Instruction *> &Worklist,
     UsesToRewrite.clear();
 
     Instruction *I = Worklist.pop_back_val();
-    assert(!I->getType()->isTokenTy() && "Tokens shouldn't be in the worklist");
+    assert(!I->getType()->isTokenLikeTy() &&
+           "Token-like values shouldn't be in the worklist");
     BasicBlock *InstBB = I->getParent();
     Loop *L = LI.getLoopFor(InstBB);
     assert(L && "Instruction belongs to a BB that's not part of a loop");
@@ -405,11 +406,11 @@ static bool formLCSSAImpl(Loop &L, const DominatorTree &DT, const LoopInfo *LI,
            !isa<PHINode>(I.user_back())))
         continue;
 
-      // Tokens cannot be used in PHI nodes, so we skip over them.
+      // Token-like values cannot be used in PHI nodes, so we skip over them.
       // We can run into tokens which are live out of a loop with catchswitch
       // instructions in Windows EH if the catchswitch has one catchpad which
       // is inside the loop and another which is not.
-      if (I.getType()->isTokenTy())
+      if (I.getType()->isTokenLikeTy())
         continue;
 
       Worklist.push_back(&I);

--- a/llvm/test/Transforms/LCSSA/token-like-live-out.ll
+++ b/llvm/test/Transforms/LCSSA/token-like-live-out.ll
@@ -1,0 +1,24 @@
+; RUN: opt -passes='lcssa,verify' -verify-loop-info -S < %s | FileCheck %s
+
+; Token-like target extension values cannot be used in PHI nodes. Make sure
+; LCSSA formation leaves a live-out resource handle unchanged.
+
+define void @target_type_live_out(ptr %resource.ptr) {
+; CHECK-LABEL: define void @target_type_live_out(
+entry:
+  br label %loop
+
+loop:
+  %idx = phi i32 [ 0, %entry ], [ %idx.next, %loop ]
+  %resource = load target("dx.RawBuffer", i32, 1, 0), ptr %resource.ptr
+  %idx.next = add i32 %idx, 1
+  %continue = icmp slt i32 %idx.next, 100
+  br i1 %continue, label %loop, label %exit
+
+exit:
+; CHECK: exit:
+; CHECK-NEXT: store target("dx.RawBuffer", i32, 1, 0) %resource, ptr %resource.ptr
+; CHECK-NEXT: ret void
+  store target("dx.RawBuffer", i32, 1, 0) %resource, ptr %resource.ptr
+  ret void
+}


### PR DESCRIPTION
Token-like values have many (but not all) of the same restrictions as regular token values.
They do however inherit the restriction on being placed in PHI and thus they need to be
treated like regular tokens in LCSSA.

AI Disclosure: Written by GPT 5.6 - flagged during GPT 5.6 review of #151062 rebase.