### PR TITLE
 IR: Accept x86_fp80 and float as a long-double-type value

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -9419,11 +9419,17 @@ type, and must be one of:
 * - Value
   - Meaning
 
+* - `"float"`
+  - IEEE 754 single precision (32-bit).
+
 * - `"double"`
   - IEEE 754 double precision (64-bit).
 
 * - `"fp128"`
   - IEEE 754 quadruple precision (128-bit).
+
+* - `"x86_fp80"`
+  - x87 80-bit extended precision.
 
 * - `"ppc_fp128"`
   - IBM `double-double` (a pair of IEEE doubles).

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2007,7 +2007,9 @@ Verifier::visitModuleFlag(const MDNode *Op,
     Check(Value, "long-double-type metadata requires a string argument");
     if (Value)
       Check(Value->getString() == "ppc_fp128" ||
-                Value->getString() == "fp128" || Value->getString() == "double",
+                Value->getString() == "fp128" ||
+                Value->getString() == "x86_fp80" ||
+                Value->getString() == "double" || Value->getString() == "float",
             "invalid long-double-type metadata value", Op);
   }
 

--- a/llvm/test/Assembler/module-flags-long-double-type.ll
+++ b/llvm/test/Assembler/module-flags-long-double-type.ll
@@ -1,7 +1,9 @@
 ; RUN: split-file %s %t
 ; RUN: llvm-as < %t/ppc_fp128.ll | llvm-dis | FileCheck %s --check-prefix=PPCFP128
 ; RUN: llvm-as < %t/fp128.ll | llvm-dis | FileCheck %s --check-prefix=FP128
+; RUN: llvm-as < %t/x86_fp80.ll | llvm-dis | FileCheck %s --check-prefix=X86FP80
 ; RUN: llvm-as < %t/double.ll | llvm-dis | FileCheck %s --check-prefix=DOUBLE
+; RUN: llvm-as < %t/float.ll | llvm-dis | FileCheck %s --check-prefix=FLOAT
 
 ;--- ppc_fp128.ll
 !llvm.module.flags = !{!0}
@@ -13,7 +15,17 @@
 !0 = !{i32 1, !"long-double-type", !"fp128"}
 ; FP128: !0 = !{i32 1, !"long-double-type", !"fp128"}
 
+;--- x86_fp80.ll
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"long-double-type", !"x86_fp80"}
+; X86FP80: !0 = !{i32 1, !"long-double-type", !"x86_fp80"}
+
 ;--- double.ll
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"long-double-type", !"double"}
 ; DOUBLE: !0 = !{i32 1, !"long-double-type", !"double"}
+
+;--- float.ll
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"long-double-type", !"float"}
+; FLOAT: !0 = !{i32 1, !"long-double-type", !"float"}


### PR DESCRIPTION
Prepare to emit long-double-type for all targets. x86 obviously needs x87, and AVR uses float.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>