### PR TITLE
[NFC][Clang] Remove dead code from LifetimeSafety/FactsGenerator.cpp

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -1042,8 +1042,6 @@ void FactsGenerator::handleLifetimeCaptureBy(const FunctionDecl *FD,
     OriginList *CapturedOriginList = getOriginsList(*Args[I]);
     if (!CapturedOriginList)
       continue;
-    if (!CapturedOriginList)
-      continue;
     for (int CapturingArgIdx : Attr->params()) {
       // FIXME: Add support for capturing to Global/unknown.
       if (CapturingArgIdx == LifetimeCaptureByAttr::Global ||


### PR DESCRIPTION
This PR removes dead code in `clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp`. This was discovered by a static analysis scan on clang.
