### PR TITLE
[mlir][xegpu] Lower lane_data repack convert_layout to lane_shuffle

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSgToLaneDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSgToLaneDistribute.cpp
@@ -1672,9 +1672,10 @@ shuffleDataAsLaneLayoutChange(ConversionPatternRewriter &rewriter, Location loc,
 /// `inputData`/`targetData` are the `repackDim` `lane_data` of the input and
 /// target layouts; exactly one must be 1 (round-robin) and the other `k`
 /// (contiguous). Returns failure if that does not hold.
-static FailureOr<Value>
-repackLaneData(ConversionPatternRewriter &rewriter, Location loc, Value src,
-               int64_t repackDim, int64_t inputData, int64_t targetData) {
+static FailureOr<Value> repackLaneData(ConversionPatternRewriter &rewriter,
+                                       Location loc, Value src,
+                                       int64_t repackDim, int64_t inputData,
+                                       int64_t targetData) {
   auto srcTy = dyn_cast<VectorType>(src.getType());
   if (!srcTy)
     return failure();
@@ -1698,8 +1699,8 @@ repackLaneData(ConversionPatternRewriter &rewriter, Location loc, Value src,
   // `repackDim` is unit), so collapse it to 1D, shuffle once, and restore it.
   if (srcTy.getNumElements() == k) {
     if (rank == 1)
-      return Value(xegpu::LaneShuffleOp::create(rewriter, loc, runTy, src,
-                                                mode));
+      return Value(
+          xegpu::LaneShuffleOp::create(rewriter, loc, runTy, src, mode));
     Value flat = vector::ShapeCastOp::create(rewriter, loc, runTy, src);
     Value shuffled =
         xegpu::LaneShuffleOp::create(rewriter, loc, runTy, flat, mode);
@@ -1844,18 +1845,16 @@ struct SgToLaneConvertLayout
       // `repackDim` must be the distributed dim (lane_layout != 1) and the
       // other innermost dim non-distributed (lane_layout == 1).
       int64_t otherDim = repackDim == rank - 1 ? rank - 2 : rank - 1;
-      bool laneLayoutOk =
-          repackDim != -1 && laneLayout[repackDim] != 1 &&
-          (rank < 2 || laneLayout[otherDim] == 1);
+      bool laneLayoutOk = repackDim != -1 && laneLayout[repackDim] != 1 &&
+                          (rank < 2 || laneLayout[otherDim] == 1);
 
       // Exactly one dimension must change, and it must be one of the two
       // innermost (>= rank - 2).
       if (repackDim != -1 && repackDim >= rank - 2 && !multipleChanged &&
           laneLayoutOk) {
-        FailureOr<Value> res =
-            repackLaneData(rewriter, op.getLoc(), adaptor.getSource(),
-                           repackDim, laneData[repackDim],
-                           targetLaneData[repackDim]);
+        FailureOr<Value> res = repackLaneData(
+            rewriter, op.getLoc(), adaptor.getSource(), repackDim,
+            laneData[repackDim], targetLaneData[repackDim]);
         if (succeeded(res)) {
           rewriter.replaceOp(op, *res);
           return success();

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSgToLaneDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSgToLaneDistribute.cpp
@@ -1665,6 +1665,101 @@ shuffleDataAsLaneLayoutChange(ConversionPatternRewriter &rewriter, Location loc,
   return res;
 }
 
+/// Repacks `src`'s `lane_data` along `repackDim` between round-robin and
+/// contiguous form with an `xegpu.lane_shuffle`, which moves each lane's run of
+/// `k` elements across lanes while preserving the element type.
+///
+/// `inputData`/`targetData` are the `repackDim` `lane_data` of the input and
+/// target layouts; exactly one must be 1 (round-robin) and the other `k`
+/// (contiguous). Returns failure if that does not hold.
+static FailureOr<Value>
+repackLaneData(ConversionPatternRewriter &rewriter, Location loc, Value src,
+               int64_t repackDim, int64_t inputData, int64_t targetData) {
+  auto srcTy = dyn_cast<VectorType>(src.getType());
+  if (!srcTy)
+    return failure();
+  int64_t rank = srcTy.getRank();
+  Type elemTy = srcTy.getElementType();
+  int64_t k = srcTy.getShape()[repackDim];
+
+  bool roundRobinToContig = inputData == 1 && targetData == k;
+  bool contigToRoundRobin = inputData == k && targetData == 1;
+  if (!roundRobinToContig && !contigToRoundRobin)
+    return failure();
+
+  // Round-robin -> contiguous gathers a lane's strided elements into
+  // consecutive positions (pack); the reverse scatters them back (unpack).
+  xegpu::LaneShuffleMode mode = roundRobinToContig
+                                    ? xegpu::LaneShuffleMode::Pack
+                                    : xegpu::LaneShuffleMode::Unpack;
+  VectorType runTy = VectorType::get({k}, elemTy);
+
+  // Common case: the lane fragment is a single run (every dimension other than
+  // `repackDim` is unit), so collapse it to 1D, shuffle once, and restore it.
+  if (srcTy.getNumElements() == k) {
+    if (rank == 1)
+      return Value(xegpu::LaneShuffleOp::create(rewriter, loc, runTy, src,
+                                                mode));
+    Value flat = vector::ShapeCastOp::create(rewriter, loc, runTy, src);
+    Value shuffled =
+        xegpu::LaneShuffleOp::create(rewriter, loc, runTy, flat, mode);
+    return Value(vector::ShapeCastOp::create(rewriter, loc, srcTy, shuffled));
+  }
+
+  // When `repackDim` is innermost each run is a contiguous sub-vector, so it is
+  // extracted and re-inserted as a whole.
+  if (repackDim == rank - 1) {
+    SmallVector<int64_t> outerShape(srcTy.getShape().drop_back());
+    int64_t numRuns = computeProduct(outerShape);
+    SmallVector<int64_t> outerStrides = computeStrides(outerShape);
+    Value result = arith::ConstantOp::create(rewriter, loc, srcTy,
+                                             rewriter.getZeroAttr(srcTy));
+    for (int64_t i = 0; i < numRuns; ++i) {
+      SmallVector<int64_t> pos = delinearize(i, outerStrides);
+      Value run = vector::ExtractOp::create(rewriter, loc, src, pos);
+      Value shuffled =
+          xegpu::LaneShuffleOp::create(rewriter, loc, runTy, run, mode);
+      result = vector::InsertOp::create(rewriter, loc, shuffled, result, pos);
+    }
+    return result;
+  }
+
+  // Otherwise each run is strided along `repackDim`: extract the `k`-long slice
+  // (a sub-vector that is unit along every other dim), flatten it to 1D,
+  // shuffle, and insert it back.
+  SmallVector<int64_t> keptShape;
+  SmallVector<int64_t> keptDims;
+  for (int64_t d = 0; d < rank; ++d)
+    if (d != repackDim) {
+      keptShape.push_back(srcTy.getShape()[d]);
+      keptDims.push_back(d);
+    }
+  int64_t numRuns = computeProduct(keptShape);
+  SmallVector<int64_t> keptStrides = computeStrides(keptShape);
+  SmallVector<int64_t> sliceSizes(rank, 1);
+  sliceSizes[repackDim] = k;
+  SmallVector<int64_t> sliceStrides(rank, 1);
+  VectorType sliceTy = VectorType::get(sliceSizes, elemTy);
+  Value result = arith::ConstantOp::create(rewriter, loc, srcTy,
+                                           rewriter.getZeroAttr(srcTy));
+  for (int64_t i = 0; i < numRuns; ++i) {
+    SmallVector<int64_t> keptPos = delinearize(i, keptStrides);
+    SmallVector<int64_t> offsets(rank, 0);
+    for (auto [dim, coord] : llvm::zip_equal(keptDims, keptPos))
+      offsets[dim] = coord;
+    Value slice = vector::ExtractStridedSliceOp::create(
+        rewriter, loc, src, offsets, sliceSizes, sliceStrides);
+    Value run = vector::ShapeCastOp::create(rewriter, loc, runTy, slice);
+    Value repacked =
+        xegpu::LaneShuffleOp::create(rewriter, loc, runTy, run, mode);
+    Value repackedSlice =
+        vector::ShapeCastOp::create(rewriter, loc, sliceTy, repacked);
+    result = vector::InsertStridedSliceOp::create(
+        rewriter, loc, repackedSlice, result, offsets, sliceStrides);
+  }
+  return result;
+}
+
 /// Folds a subgroup-level ConvertLayout op with compatible lane layouts.
 struct SgToLaneConvertLayout
     : public OpConversionPattern<xegpu::ConvertLayoutOp> {
@@ -1714,6 +1809,53 @@ struct SgToLaneConvertLayout
         FailureOr<Value> res = shuffleDataAsLaneLayoutChange(
             rewriter, op.getLoc(), adaptor.getSource(), laneLayout[0],
             targetLaneLayout[0]);
+        if (succeeded(res)) {
+          rewriter.replaceOp(op, *res);
+          return success();
+        }
+      }
+    }
+
+    // Handle a pure `lane_data` repack: `lane_layout` and `order` are unchanged
+    // and exactly one dimension's `lane_data` switches between round-robin
+    // (lane_data 1) and contiguous (lane_data == run length). The elements per
+    // lane are unchanged, but their assignment to lanes is not, so the data is
+    // moved across lanes with `xegpu.lane_shuffle`. The changed dimension must
+    // be one of the two innermost ones, since sg-to-lane distribution is 2D.
+    if (inputLayout.getEffectiveOrderAsInt() ==
+            targetLayout.getEffectiveOrderAsInt() &&
+        inputLayout.getEffectiveLaneLayoutAsInt() ==
+            targetLayout.getEffectiveLaneLayoutAsInt()) {
+      auto laneLayout = inputLayout.getEffectiveLaneLayoutAsInt();
+      auto laneData = inputLayout.getEffectiveLaneDataAsInt();
+      auto targetLaneData = targetLayout.getEffectiveLaneDataAsInt();
+      // Find the single dimension whose lane_data changed; bail out if more
+      // than one differs.
+      int64_t rank = laneData.size();
+      int64_t repackDim = -1;
+      bool multipleChanged = false;
+      for (int64_t d = 0; d < rank; ++d)
+        if (laneData[d] != targetLaneData[d]) {
+          if (repackDim != -1)
+            multipleChanged = true;
+          repackDim = d;
+        }
+
+      // `repackDim` must be the distributed dim (lane_layout != 1) and the
+      // other innermost dim non-distributed (lane_layout == 1).
+      int64_t otherDim = repackDim == rank - 1 ? rank - 2 : rank - 1;
+      bool laneLayoutOk =
+          repackDim != -1 && laneLayout[repackDim] != 1 &&
+          (rank < 2 || laneLayout[otherDim] == 1);
+
+      // Exactly one dimension must change, and it must be one of the two
+      // innermost (>= rank - 2).
+      if (repackDim != -1 && repackDim >= rank - 2 && !multipleChanged &&
+          laneLayoutOk) {
+        FailureOr<Value> res =
+            repackLaneData(rewriter, op.getLoc(), adaptor.getSource(),
+                           repackDim, laneData[repackDim],
+                           targetLaneData[repackDim]);
         if (succeeded(res)) {
           rewriter.replaceOp(op, *res);
           return success();

--- a/mlir/test/Dialect/XeGPU/sg-to-lane-distribute-unit.mlir
+++ b/mlir/test/Dialect/XeGPU/sg-to-lane-distribute-unit.mlir
@@ -1046,6 +1046,87 @@ gpu.func @convert_layout_scalar() {
 }
 
 // -----
+gpu.module @xevm_module {
+// CHECK-LABEL: gpu.func @convert_layout_repack_innermost_lane_data
+// CHECK-NOT:     xegpu.convert_layout
+// CHECK:         %[[SRC:.*]] = builtin.unrealized_conversion_cast %{{.*}} : vector<1x64xbf16> to vector<1x4xbf16>
+// CHECK:         %[[F:.*]] = vector.shape_cast %[[SRC]] : vector<1x4xbf16> to vector<4xbf16>
+// CHECK:         %[[S0:.*]] = xegpu.lane_shuffle %[[F]] pack : vector<4xbf16>
+// CHECK:         vector.shape_cast %[[S0]] : vector<4xbf16> to vector<1x4xbf16>
+gpu.func @convert_layout_repack_innermost_lane_data() {
+  %src = "some_op"() : () -> vector<1x64xbf16>
+  %cvt = xegpu.convert_layout %src
+    <{
+      input_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 1]>,
+      target_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 4]>
+    }> : vector<1x64xbf16>
+  "some_use"(%cvt) : (vector<1x64xbf16>) -> ()
+  gpu.return
+}
+}
+
+// -----
+gpu.module @xevm_module {
+// CHECK-LABEL: gpu.func @convert_layout_repack_innermost_lane_data_1d
+// CHECK-NOT:     xegpu.convert_layout
+// CHECK:         %[[SRC:.*]] = builtin.unrealized_conversion_cast %{{.*}} : vector<64xbf16> to vector<4xbf16>
+// CHECK:         xegpu.lane_shuffle %[[SRC]] pack : vector<4xbf16>
+gpu.func @convert_layout_repack_innermost_lane_data_1d() {
+  %src = "some_op"() : () -> vector<64xbf16>
+  %cvt = xegpu.convert_layout %src
+    <{
+      input_layout = #xegpu.layout<lane_layout = [16], lane_data = [1]>,
+      target_layout = #xegpu.layout<lane_layout = [16], lane_data = [4]>
+    }> : vector<64xbf16>
+  "some_use"(%cvt) : (vector<64xbf16>) -> ()
+  gpu.return
+}
+}
+
+// -----
+gpu.module @xevm_module {
+// CHECK-LABEL: gpu.func @convert_layout_repack_second_innermost_lane_data
+// CHECK-NOT:     xegpu.convert_layout
+// CHECK:         %[[SRC:.*]] = builtin.unrealized_conversion_cast %{{.*}} : vector<64x4xbf16> to vector<4x4xbf16>
+// CHECK:         %[[SL0:.*]] = vector.extract_strided_slice %[[SRC]] {offsets = [0, 0], sizes = [4, 1], strides = [1, 1]} : vector<4x4xbf16> to vector<4x1xbf16>
+// CHECK:         %[[F0:.*]] = vector.shape_cast %[[SL0]] : vector<4x1xbf16> to vector<4xbf16>
+// CHECK:         %[[S0:.*]] = xegpu.lane_shuffle %[[F0]] unpack : vector<4xbf16>
+// CHECK:         %[[C0:.*]] = vector.shape_cast %[[S0]] : vector<4xbf16> to vector<4x1xbf16>
+// CHECK:         vector.insert_strided_slice %[[C0]], %{{.*}} {offsets = [0, 0], strides = [1, 1]} : vector<4x1xbf16> into vector<4x4xbf16>
+// CHECK-COUNT-3: xegpu.lane_shuffle %{{.*}} unpack : vector<4xbf16>
+gpu.func @convert_layout_repack_second_innermost_lane_data() {
+  %src = "some_op"() : () -> vector<64x4xbf16>
+  %cvt = xegpu.convert_layout %src
+    <{
+      input_layout = #xegpu.layout<lane_layout = [16, 1], lane_data = [4, 1]>,
+      target_layout = #xegpu.layout<lane_layout = [16, 1], lane_data = [1, 1]>
+    }> : vector<64x4xbf16>
+  "some_use"(%cvt) : (vector<64x4xbf16>) -> ()
+  gpu.return
+}
+}
+
+// -----
+gpu.module @xevm_module {
+// CHECK-LABEL: gpu.func @convert_layout_repack_innermost_lane_data_3d
+// CHECK-NOT:     xegpu.convert_layout
+// CHECK:         %[[SRC:.*]] = builtin.unrealized_conversion_cast %{{.*}} : vector<1x1x64xbf16> to vector<1x1x4xbf16>
+// CHECK:         %[[F:.*]] = vector.shape_cast %[[SRC]] : vector<1x1x4xbf16> to vector<4xbf16>
+// CHECK:         %[[S0:.*]] = xegpu.lane_shuffle %[[F]] pack : vector<4xbf16>
+// CHECK:         vector.shape_cast %[[S0]] : vector<4xbf16> to vector<1x1x4xbf16>
+gpu.func @convert_layout_repack_innermost_lane_data_3d() {
+  %src = "some_op"() : () -> vector<1x1x64xbf16>
+  %cvt = xegpu.convert_layout %src
+    <{
+      input_layout = #xegpu.layout<lane_layout = [1, 1, 16], lane_data = [1, 1, 1]>,
+      target_layout = #xegpu.layout<lane_layout = [1, 1, 16], lane_data = [1, 1, 4]>
+    }> : vector<1x1x64xbf16>
+  "some_use"(%cvt) : (vector<1x1x64xbf16>) -> ()
+  gpu.return
+}
+}
+
+// -----
 // load_matrix and store_matrix with coordinate computation (offsets [0,0])
 gpu.module @xevm_module {
 // CHECK-LABEL: gpu.func @load_store_matrix_1


### PR DESCRIPTION
Extend the SgToLaneConvertLayout pattern to lower a convert_layout that only repacks lane_data between round-robin and contiguous form (keeping lane_layout and order unchanged) into xegpu.lane_shuffle. Each lane keeps the same elements and total bits along the repacked dimension, but their assignment to lanes changes, so the data is moved across lanes with a bit-preserving bitcast_shuffle.

assisted-by-claude
