### PR TITLE
workflows: Add missing checkouts when using validate-release-version (#210471)

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -68,6 +68,13 @@ jobs:
       release-version: ${{ steps.vars.outputs.release-version }}
       upload: ${{ steps.vars.outputs.upload }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/validate-release-version
+          sparse-checkout-cone-mode: false
+
       - name: Validate Input
         if: inputs.release-version != ''
         uses: ./.github/workflows/validate-release-version

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -72,16 +72,16 @@ jobs:
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
 
     steps:
+    - name: Checkout LLVM
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+          persist-credentials: false
+
     - name: Validate Release Version
       if: inputs.release-version != ''
       uses: ./.github/workflows/validate-release-version
       with:
         release-version: ${{ inputs.release-version }}
-
-    - name: Checkout LLVM
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-          persist-credentials: false
 
     - name: Check Permissions
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
We need to make sure all composite workflows we use are checked out manually from the git repo.

(cherry picked from commit 429c88d37f1f02e68ebc1fc7b0da4511ce6407e3)