### PR TITLE
[CIR] Recognize loop interchange candidates

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -46,6 +46,7 @@ std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createLoopInterchangePass();
 
 void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -195,6 +195,21 @@ def IdiomRecognizer : Pass<"cir-idiom-recognizer", "mlir::ModuleOp"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def LoopInterchange : Pass<"cir-loop-interchange", "mlir::ModuleOp"> {
+  let summary = "Interchange a strided loop nest to make its inner access "
+                "contiguous";
+  let description = [{
+    Interchange a counted loop nest whose inner loop reads a matrix down a
+    column, so the strided access becomes contiguous while the loop body order
+    is preserved. This first patch recognizes and reports candidates and does
+    not yet modify the IR.
+  }];
+  let constructor = "mlir::createLoopInterchangePass()";
+  let dependentDialects = ["cir::CIRDialect"];
+  let statistics = [Statistic<"numCandidates", "num-candidates",
+                              "Number of loop interchange candidates">];
+}
+
 def LibOpt : Pass<"cir-lib-opt"> {
   let summary = "Optimize C/C++ library calls";
   let description = [{

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_library(MLIRCIRTransforms
   GotoSolver.cpp
   IdiomRecognizer.cpp
   LibOpt.cpp
+  LoopInterchange.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/LoopInterchange.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoopInterchange.cpp
@@ -1,0 +1,201 @@
+//===- LoopInterchange.cpp - recognize loop interchange candidates --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Recognizes loop interchange candidates. See the pass description in
+// Passes.td.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+using namespace mlir;
+using namespace cir;
+
+namespace mlir {
+#define GEN_PASS_DEF_LOOPINTERCHANGE
+#include "clang/CIR/Dialect/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+struct CountedLoop {
+  mlir::Value ivSlot;
+  mlir::Value bound;
+};
+
+static bool storesToSlot(mlir::Region &region, mlir::Value slot) {
+  bool found = false;
+  region.walk([&](cir::StoreOp store) {
+    if (store.getAddr() != slot)
+      return mlir::WalkResult::advance();
+    found = true;
+    return mlir::WalkResult::interrupt();
+  });
+  return found;
+}
+
+static std::optional<CountedLoop> recognizeCountedLoop(cir::ForOp forOp) {
+  mlir::Region &cond = forOp.getCond();
+  if (!cond.hasOneBlock())
+    return std::nullopt;
+  auto condOp =
+      mlir::dyn_cast_or_null<cir::ConditionOp>(cond.front().getTerminator());
+  if (!condOp)
+    return std::nullopt;
+  auto cmp = condOp.getCondition().getDefiningOp<cir::CmpOp>();
+  // Only the iv < bound form is matched. le and ne are left for a later patch.
+  if (!cmp || cmp.getKind() != cir::CmpOpKind::lt)
+    return std::nullopt;
+  auto ivLoad = cmp.getLhs().getDefiningOp<cir::LoadOp>();
+  if (!ivLoad)
+    return std::nullopt;
+  mlir::Value ivSlot = ivLoad.getAddr();
+  if (!ivSlot.getDefiningOp<cir::AllocaOp>())
+    return std::nullopt;
+  // The step must write the iv. A later patch checks it is a unit increment.
+  if (!storesToSlot(forOp.getStep(), ivSlot) ||
+      storesToSlot(forOp.getBody(), ivSlot))
+    return std::nullopt;
+  return CountedLoop{ivSlot, cmp.getRhs()};
+}
+
+static void peelAddress(mlir::Value addr,
+                        llvm::SmallVectorImpl<mlir::Value> &indices) {
+  while (true) {
+    if (auto ge = addr.getDefiningOp<cir::GetElementOp>()) {
+      indices.push_back(ge.getIndex());
+      addr = ge.getBase();
+      continue;
+    }
+    if (auto ps = addr.getDefiningOp<cir::PtrStrideOp>()) {
+      indices.push_back(ps.getStride());
+      addr = ps.getBase();
+      continue;
+    }
+    break;
+  }
+}
+
+static bool loadsFromSlot(mlir::Value v, mlir::Value slot) {
+  while (auto cast = v.getDefiningOp<cir::CastOp>())
+    v = cast.getSrc();
+  auto load = v.getDefiningOp<cir::LoadOp>();
+  return load && load.getAddr() == slot;
+}
+
+static bool dependsOnSlot(mlir::Value v, mlir::Value slot) {
+  llvm::SmallVector<mlir::Value> work{v};
+  llvm::SmallPtrSet<mlir::Value, 8> seen;
+  while (!work.empty()) {
+    mlir::Value cur = work.pop_back_val();
+    if (!seen.insert(cur).second)
+      continue;
+    if (auto load = cur.getDefiningOp<cir::LoadOp>()) {
+      if (load.getAddr() == slot)
+        return true;
+      continue;
+    }
+    if (mlir::Operation *def = cur.getDefiningOp())
+      work.append(def->operand_begin(), def->operand_end());
+  }
+  return false;
+}
+
+static cir::ForOp singleInnerFor(cir::ForOp outer) {
+  llvm::SmallVector<cir::ForOp> inner;
+  outer.getBody().walk([&](cir::ForOp f) {
+    if (f != outer && f->getParentOfType<cir::ForOp>() == outer)
+      inner.push_back(f);
+  });
+  return inner.size() == 1 ? inner.front() : cir::ForOp{};
+}
+
+// A perfect nest holds nothing but the inner loop and its iv setup in the
+// outer body. A stray load, store, or call there makes it imperfect.
+static bool isPerfectNest(cir::ForOp outer, cir::ForOp inner,
+                          mlir::Value innerSlot) {
+  bool perfect = true;
+  outer.getBody().walk([&](mlir::Operation *op) {
+    if (inner->isAncestor(op))
+      return;
+    if (auto store = mlir::dyn_cast<cir::StoreOp>(op))
+      perfect &= store.getAddr() == innerSlot;
+    else if (mlir::isa<cir::LoadOp, cir::CallOp>(op))
+      perfect = false;
+  });
+  return perfect;
+}
+
+// True when an access uses the outer iv for the contiguous dimension and the
+// inner iv for the next one out, so the inner loop strides down a column.
+static bool hasColumnStridedAccess(cir::ForOp inner, mlir::Value outerSlot,
+                                   mlir::Value innerSlot) {
+  bool found = false;
+  inner.getBody().walk([&](mlir::Operation *op) {
+    mlir::Value addr;
+    if (auto load = mlir::dyn_cast<cir::LoadOp>(op))
+      addr = load.getAddr();
+    else if (auto store = mlir::dyn_cast<cir::StoreOp>(op))
+      addr = store.getAddr();
+    else
+      return mlir::WalkResult::advance();
+    llvm::SmallVector<mlir::Value> idx;
+    peelAddress(addr, idx);
+    if (idx.size() != 2 || !loadsFromSlot(idx[0], outerSlot) ||
+        !loadsFromSlot(idx[1], innerSlot))
+      return mlir::WalkResult::advance();
+    found = true;
+    return mlir::WalkResult::interrupt();
+  });
+  return found;
+}
+
+// The one recognition entry point. Future shapes are added here, or by
+// relaxing one of the predicates it calls.
+static bool isInterchangeCandidate(cir::ForOp outer) {
+  std::optional<CountedLoop> o = recognizeCountedLoop(outer);
+  if (!o)
+    return false;
+  cir::ForOp inner = singleInnerFor(outer);
+  if (!inner)
+    return false;
+  std::optional<CountedLoop> i = recognizeCountedLoop(inner);
+  // Skip a triangular nest whose inner bound varies with the outer iv.
+  return i && isPerfectNest(outer, inner, i->ivSlot) &&
+         !dependsOnSlot(i->bound, o->ivSlot) &&
+         hasColumnStridedAccess(inner, o->ivSlot, i->ivSlot);
+}
+
+struct LoopInterchangePass
+    : public impl::LoopInterchangeBase<LoopInterchangePass> {
+  using impl::LoopInterchangeBase<LoopInterchangePass>::LoopInterchangeBase;
+
+  void runOnOperation() override {
+    getOperation()->walk([&](cir::ForOp outer) {
+      if (!isInterchangeCandidate(outer))
+        return;
+      ++numCandidates;
+      auto func = outer->getParentOfType<cir::FuncOp>();
+      assert(func && "candidate loop outside a function");
+      outer.emitRemark() << "loop interchange candidate in function '"
+                         << func.getSymName() << "'";
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createLoopInterchangePass() {
+  return std::make_unique<LoopInterchangePass>();
+}

--- a/clang/test/CIR/Transforms/loop-interchange-candidates.c
+++ b/clang/test/CIR/Transforms/loop-interchange-candidates.c
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -fclangir -emit-cir %s -o - | cir-opt -cir-loop-interchange -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=remark:
+
+double A[256][256], x[256], y[256];
+
+void column_strided(void) {
+  for (int i = 0; i < 256; i++)
+    for (int j = 0; j < 256; j++)
+      x[i] += A[j][i] * y[j];
+}
+// CHECK: remark: loop interchange candidate in function 'column_strided'
+
+void row_contiguous(void) {
+  for (int i = 0; i < 256; i++)
+    for (int j = 0; j < 256; j++)
+      x[i] += A[i][j] * y[j];
+}
+
+void not_perfect(void) {
+  for (int i = 0; i < 256; i++) {
+    x[i] = 0;
+    for (int j = 0; j < 256; j++)
+      x[i] += A[j][i] * y[j];
+  }
+}
+
+void triangular(void) {
+  for (int i = 0; i < 256; i++)
+    for (int j = 0; j < i; j++)
+      x[i] += A[j][i] * y[j];
+}
+
+void not_less_than(void) {
+  for (int i = 0; i < 256; i++)
+    for (int j = 0; j <= 255; j++)
+      x[i] += A[j][i] * y[j];
+}

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -72,6 +72,10 @@ int main(int argc, char **argv) {
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createLoopInterchangePass();
+  });
+
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createCallConvLoweringPass();
   });
 


### PR DESCRIPTION
This patch adds a cir-loop-interchange pass that recognizes and reports a loop interchange candidate. The candidate is a perfect rectangular counted nest whose inner loop reads a matrix down a column, the shape where swapping the two loops turns a strided access into a contiguous one. This patch only reports candidates and does not modify the IR.

The PolyBench mvt kernel has this shape. Its second nest reads A down a column, with the arrays passed as pointer parameters.

```c
for (i = 0; i < _PB_N; i++)
  for (j = 0; j < _PB_N; j++)
    x2[i] = x2[i] + A[j][i] * y_2[j];
```

At O3 LLVM keeps the inner loop scalar and declines its own loop interchange, because it cannot prove the pointer parameters do not alias.

```
$ clang -O3 -march=native -floop-interchange -Rpass-missed=loop-interchange mvt.c
mvt.c:91:3: remark: All loops have dependencies in all directions.
```

Every load is scalar and nothing vectorizes. At the LARGE size a row is a flat 16000 byte stride.

```llvm
%255 = getelementptr inbounds nuw [16000 x i8], ptr %196, i64 %254
%256 = load double, ptr %255, align 8, !tbaa !9
%257 = getelementptr inbounds nuw [8 x i8], ptr %7, i64 %254
%258 = load double, ptr %257, align 8, !tbaa !9
%259 = tail call double @llvm.fmuladd.f64(double %256, double %258, double %253)
```

CIR still has the shape. A is a pointer to a row of known width, so `A[j][i]` is a `cir.ptr_stride` to row `j` then a `cir.get_element` for column `i`, the access the recognizer matches.

```cir
%73 = cir.load align(8) %5 : !cir.ptr<!cir.ptr<!cir.array<!cir.double x 2000>>>, !cir.ptr<!cir.array<!cir.double x 2000>>
%74 = cir.ptr_stride %73, %72 : (!cir.ptr<!cir.array<!cir.double x 2000>>, !s64i) -> !cir.ptr<!cir.array<!cir.double x 2000>>
%75 = cir.get_element %74[%70 : !s64i] : !cir.ptr<!cir.array<!cir.double x 2000>> -> !cir.ptr<!cir.double>
```

Running the pass reports the candidate on the same nest.

```
$ cir-opt -cir-loop-interchange mvt.cir
mvt.c:91:3: remark: loop interchange candidate in function 'kernel_mvt'
```

The pass is registered only for cir-opt. The Clang driver flag and the transform come in later patches, so no flag ships without an effect.

The recognizer reads the counted nest, checks it is perfect and rectangular, and matches the two dimensional column access where the outer iv indexes the contiguous dimension and the inner iv the next one out. Tests cover the candidate remark and negative cases for a row major access, an imperfect nest, a triangular bound, and a non lt comparison.