### PR TITLE
[WebAssembly] Swap encoding bits for HAS_MEMORY_ORDER for relaxed atomics

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -88,7 +88,7 @@ enum : unsigned {
   // RMW/CMPXCHG operations have 2 orderings but they must currently match.
   WASM_MEM_ORDER_RMW_ACQ_REL = 0x11,
 };
-const unsigned WASM_MEMARG_HAS_MEM_ORDER = 0x20;
+const unsigned WASM_MEMARG_HAS_MEM_ORDER = 0x10;
 
 // Kinds of externals (for imports and exports).
 enum : unsigned {

--- a/llvm/test/MC/WebAssembly/atomics-orderings.s
+++ b/llvm/test/MC/WebAssembly/atomics-orderings.s
@@ -34,27 +34,27 @@ main:
   # DISASM: i32.atomic.load seqcst 0
   i32.atomic.load seqcst 0
 
-  # CHECK: i32.atomic.load acqrel 0 # encoding: [0xfe,0x10,0x22,0x01,0x00]
+  # CHECK: i32.atomic.load acqrel 0 # encoding: [0xfe,0x10,0x12,0x01,0x00]
   # DISASM: i32.atomic.load acqrel 0
   i32.atomic.load acqrel 0
 
-  # CHECK: i64.atomic.load acqrel 0 # encoding: [0xfe,0x11,0x23,0x01,0x00]
+  # CHECK: i64.atomic.load acqrel 0 # encoding: [0xfe,0x11,0x13,0x01,0x00]
   # DISASM: i64.atomic.load acqrel 0
   i64.atomic.load acqrel 0
 
-  # CHECK: i32.atomic.store acqrel 0 # encoding: [0xfe,0x17,0x22,0x01,0x00]
+  # CHECK: i32.atomic.store acqrel 0 # encoding: [0xfe,0x17,0x12,0x01,0x00]
   # DISASM: i32.atomic.store acqrel 0
   i32.atomic.store acqrel 0
 
-  # CHECK: i64.atomic.store acqrel 8 # encoding: [0xfe,0x18,0x23,0x01,0x08]
+  # CHECK: i64.atomic.store acqrel 8 # encoding: [0xfe,0x18,0x13,0x01,0x08]
   # DISASM: i64.atomic.store acqrel 8
   i64.atomic.store acqrel 8
 
-  # CHECK: i32.atomic.rmw.add acqrel 0 # encoding: [0xfe,0x1e,0x22,0x11,0x00]
+  # CHECK: i32.atomic.rmw.add acqrel 0 # encoding: [0xfe,0x1e,0x12,0x11,0x00]
   # DISASM: i32.atomic.rmw.add acqrel 0
   i32.atomic.rmw.add acqrel 0
 
-  # CHECK: i64.atomic.rmw.cmpxchg acqrel 0 # encoding: [0xfe,0x49,0x23,0x11,0x00]
+  # CHECK: i64.atomic.rmw.cmpxchg acqrel 0 # encoding: [0xfe,0x49,0x13,0x11,0x00]
   # DISASM: i64.atomic.rmw.cmpxchg acqrel 0
   i64.atomic.rmw.cmpxchg acqrel 0
 
@@ -62,7 +62,7 @@ main:
   # DISASM: i32.atomic.load8_u seqcst 0
   i32.atomic.load8_u seqcst 0:p2align=0
 
-  # CHECK: i64.atomic.rmw32.xchg_u acqrel 0 # encoding: [0xfe,0x47,0x22,0x11,0x00]
+  # CHECK: i64.atomic.rmw32.xchg_u acqrel 0 # encoding: [0xfe,0x47,0x12,0x11,0x00]
   # DISASM: i64.atomic.rmw32.xchg_u acqrel 0
   i64.atomic.rmw32.xchg_u acqrel 0
 


### PR DESCRIPTION

Following the decision in https://github.com/WebAssembly/relaxed-atomics/issues/3