### PR TITLE
Fix LLVM_VERSION_SUFFIX handling for release branches

### DIFF
--- a/llvm/docs/HowToReleaseLLVM.rst
+++ b/llvm/docs/HowToReleaseLLVM.rst
@@ -152,10 +152,25 @@ Branch the Git trunk using the following procedure:
 Tagging the LLVM Release Candidates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Tag release candidates:
+Before tagging each release candidate, bump the version suffix on the release
+branch to match the release candidate number.  This ensures that builds from the
+release branch produce the correct version string (e.g. ``libLLVM-X.Y-rcN.so``
+instead of ``libLLVM-X.Y-git.so``).
+
+For RC1:
 
 ::
 
+  $ llvm/utils/release/bump-version.py --rc 1 X.Y.Z
+  $ git commit -am "Bump version to X.Y.Z-rc1"
+  $ git tag -sa llvmorg-X.Y.Z-rcN
+
+For RC2 and subsequent release candidates, use the corresponding RC number:
+
+::
+
+  $ llvm/utils/release/bump-version.py --rc N X.Y.Z
+  $ git commit -am "Bump version to X.Y.Z-rcN"
   $ git tag -sa llvmorg-X.Y.Z-rcN
 
 The pre-packaged source tarballs will be automatically generated via the
@@ -383,7 +398,16 @@ version number tag and changes in basic system requirements.
 Tag the LLVM Final Release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Tag the final release sources:
+Before tagging the final release, clear the version suffix so that builds
+produce the correct un-suffixed version string (e.g. ``libLLVM-X.Y.so``
+instead of ``libLLVM-X.Y-rcN.so``):
+
+::
+
+  $ llvm/utils/release/bump-version.py X.Y.Z
+  $ git commit -am "Bump version to X.Y.Z"
+
+Then tag the final release sources:
 
 ::
 

--- a/llvm/utils/release/bump-version.py
+++ b/llvm/utils/release/bump-version.py
@@ -20,12 +20,19 @@ class Processor:
 
     def process_file(self, fpath: Path, version: packaging.version.Version) -> None:
         self.version = version
-        self.major, self.minor, self.patch, self.suffix = (
+        self.major, self.minor, self.patch, pre = (
             version.major,
             version.minor,
             version.micro,
             version.pre,
         )
+
+        # Convert version.pre tuple (e.g. ('rc', 1)) to a proper string (e.g. '-rc1').
+        # version.pre is None for final releases.
+        if pre is not None:
+            self.suffix = f"-{pre[0]}{pre[1]}"
+        else:
+            self.suffix = None
 
         if self.args.rc:
             self.suffix = f"-rc{self.args.rc}"


### PR DESCRIPTION
When bumping a version string like '23.1.0-rc1', packaging.version.parse() returns version.pre as a tuple ('rc', 1), which was being written directly into LLVMVersion.cmake as-is, producing invalid CMake:

  set(LLVM_VERSION_SUFFIX ('rc', 1))

instead of the expected:

  set(LLVM_VERSION_SUFFIX -rc1)

Fix the bump-version.py script to properly convert the version.pre tuple to a properly formatted suffix string.

Also update the release documentation (HowToReleaseLLVM.rst) to include bumping LLVM_VERSION_SUFFIX as an explicit step when tagging release candidates and the final release.  This prevents the suffix from staying as 'git' on release branches, which otherwise causes builds to produce incorrectly-named libraries like libLLVM-23git.so.

AI assistance was used for code review analysis

Fixes: https://github.com/llvm/llvm-project/issues/210691