### PR TITLE
[RISCV] Preserve call-preserved reg mask for LPAD-aligned calls

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -3244,12 +3244,22 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
       LpadLabel = PreferredLandingPadLabel;
     }
 
-    SmallVector<SDValue, 4> Ops;
+    // Preserve the argument-register and register-mask operands, between
+    // Callee and the optional glue, so the pseudo call still reports its
+    // call-preserved mask to the register allocator.
+    SmallVector<SDValue, 8> Ops;
     Ops.push_back(Node->getOperand(1));
     Ops.push_back(CurDAG->getTargetConstant(LpadLabel, DL, XLenVT));
+
+    unsigned NumOps = Node->getNumOperands();
+    bool HasGlue = Node->getGluedNode() != nullptr;
+    unsigned RegOperandsEnd = HasGlue ? NumOps - 1 : NumOps;
+    for (unsigned I = 2; I != RegOperandsEnd; ++I)
+      Ops.push_back(Node->getOperand(I));
+
     Ops.push_back(Node->getOperand(0));
-    if (Node->getGluedNode())
-      Ops.push_back(Node->getOperand(Node->getNumOperands() - 1));
+    if (HasGlue)
+      Ops.push_back(Node->getOperand(NumOps - 1));
 
     ReplaceNode(Node,
                 CurDAG->getMachineNode(PseudoOpc, DL, Node->getVTList(), Ops));

--- a/llvm/test/CodeGen/RISCV/lpad-setjmp-regmask.ll
+++ b/llvm/test/CodeGen/RISCV/lpad-setjmp-regmask.ll
@@ -1,0 +1,35 @@
+; RUN: llc -mtriple=riscv32 -target-abi=ilp32 -stop-after=finalize-isel < %s | FileCheck %s --check-prefix=RV32
+; RUN: llc -mtriple=riscv64 -target-abi=lp64 -stop-after=finalize-isel < %s | FileCheck %s --check-prefix=RV64
+
+; PseudoCALLLpadAlign/PseudoCALLIndirectLpadAlign must carry the same
+; call-preserved register mask as PseudoCALL/PseudoCALLIndirect, otherwise
+; values live across a returns_twice call are not spilled/reloaded and get
+; corrupted when the callee clobbers them.
+
+declare i32 @setjmp(ptr) returns_twice
+declare void @use(ptr, ptr)
+
+define void @test_direct_call_preserved_mask(ptr %buf) {
+  ; RV32-LABEL: name: test_direct_call_preserved_mask
+  ; RV32: PseudoCALLLpadAlign target-flags(riscv-call) @setjmp, 0, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit-def $x2, implicit-def $x10
+  ; RV64-LABEL: name: test_direct_call_preserved_mask
+  ; RV64: PseudoCALLLpadAlign target-flags(riscv-call) @setjmp, 0, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit-def $x2, implicit-def $x10
+  %call = call i32 @setjmp(ptr %buf)
+  call void @use(ptr %buf, ptr %buf)
+  ret void
+}
+
+define void @test_indirect_call_preserved_mask(ptr %fptr, ptr %buf) {
+  ; RV32-LABEL: name: test_indirect_call_preserved_mask
+  ; RV32: PseudoCALLIndirectLpadAlign %{{[0-9]+}}, 0, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit-def $x2, implicit-def $x10
+  ; RV64-LABEL: name: test_indirect_call_preserved_mask
+  ; RV64: PseudoCALLIndirectLpadAlign %{{[0-9]+}}, 0, csr_ilp32_lp64, implicit-def dead $x1, implicit $x10, implicit-def $x2, implicit-def $x10
+  %call = call i32 %fptr(ptr %buf) #0
+  call void @use(ptr %buf, ptr %buf)
+  ret void
+}
+
+attributes #0 = { returns_twice }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 8, !"cf-protection-branch", i32 1}


### PR DESCRIPTION
RISCVISelDAGToDAG's lowering of RISCVISD::LPAD_CALL / LPAD_CALL_INDIRECT to PseudoCALLLpadAlign / PseudoCALLIndirectLpadAlign (introduced in #177515) only copied the callee, lpad label, chain, and glue operands, dropping the argument-register and register-mask operands in between.

Without the register-mask operand, the register allocator treats these calls as clobbering nothing but ra, so values live across the call are not spilled/reloaded even though the callee is free to clobber caller-saved registers. This caused a miscompile where a pointer held live across a call to getcontext() (a returns_twice function) was corrupted after the call returned, leading to a SIGSEGV in llvm-test-suite's siod test.

Fix the operand copy to include the argument-register and register-mask operands, matching the pseudo-instruction operands of a regular PseudoCALL/PseudoCALLIndirect.