### PR TITLE
[clang] Remove stale TransformTypeTraits.def entry from module map

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -74,7 +74,6 @@ module Clang_Basic {
   textual header "clang/Basic/TargetCXXABI.def"
   textual header "clang/Basic/TargetOSMacros.def"
   textual header "clang/Basic/TokenKinds.def"
-  textual header "clang/Basic/TransformTypeTraits.def"
   textual header "clang/Basic/WebAssemblyReferenceTypes.def"
 
   module * { export * }


### PR DESCRIPTION
Commit 2a33792a2ec1 ("[clang][NFC] move traits to tablegen", #201491) deleted clang/include/clang/Basic/TransformTypeTraits.def in favor of a tablegen-generated clang/Basic/Traits.inc. The stale module map entry broke module builds. Renaming it to "clang/Basic/Traits.inc" doesn't seem to work, ('clang/Basic/Traits.inc' not found) but the build succeeds with the entry dropped entirely.

Assisted-by: Claude Sonnet 5

rdar://182772346