### PR TITLE
[ilbc] Revert recent changes to the hermetic tests

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -782,23 +782,6 @@ function(add_libc_hermetic test_name)
       libc.src.strings.bzero
   )
 
-  # Syscalls used by death tests. See also libc/test/UnitTest/CMakeLists.txt.
-  if(${LIBC_TARGET_OS} STREQUAL "linux" OR ${LIBC_TARGET_OS} STREQUAL "darwin")
-    list(APPEND fq_deps_list
-        libc.src.poll.poll
-        libc.src.signal.kill
-        libc.src.stdio.fflush
-        libc.src.stdio.stderr
-        libc.src.stdio.stdout
-        libc.src.stdlib.exit
-        libc.src.string.strsignal
-        libc.src.sys.wait.waitpid
-        libc.src.unistd.close
-        libc.src.unistd.fork
-        libc.src.unistd.pipe
-    )
-  endif()
-
   if(libc.src.compiler.__stack_chk_fail IN_LIST TARGET_LLVMLIBC_ENTRYPOINTS)
     # __stack_chk_fail should always be included if supported to allow building
     # libc with the stack protector enabled.
@@ -1026,7 +1009,6 @@ function(add_libc_test test_name)
       ${test_name}.__hermetic__
       LINK_LIBRARIES
         LibcTest.hermetic
-        LibcDeathTestExecutors.hermetic
       ${LIBC_TEST_UNPARSED_ARGUMENTS}
     )
     get_fq_target_name(${test_name} fq_test_name)

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -40,7 +40,7 @@ function(add_unittest_framework_library name)
   endif()
   target_compile_options(${name}.unit PRIVATE ${compile_options})
 
-  _get_hermetic_test_compile_options(compile_options "")
+    _get_hermetic_test_compile_options(compile_options "")
   target_include_directories(${name}.hermetic PRIVATE ${LIBC_INCLUDE_DIR})
   target_compile_options(${name}.hermetic PRIVATE ${compile_options} -nostdinc++)
 
@@ -100,17 +100,6 @@ set(libc_death_test_srcs LibcDeathTestExecutors.cpp)
 if(${LIBC_TARGET_OS} STREQUAL "linux" OR ${LIBC_TARGET_OS} STREQUAL "darwin")
   list(APPEND libc_death_test_srcs ExecuteFunctionUnix.cpp)
 endif()
-set(libc_death_tess_deps libc.hdr.stdint_proxy)
-if (LLVM_LIBC_FULL_BUILD)
-  list(APPEND libc_death_tess_deps
-    libc.include.llvm-libc-macros.poll-macros
-    libc.include.llvm-libc-macros.signal_macros
-    libc.include.llvm-libc-macros.sys_wait_macros
-    libc.include.llvm-libc-types.pid_t
-    libc.include.llvm-libc-types.struct_pollfd
-    libc.src.__support.libc_assert
-  )
-endif()
 
 add_unittest_framework_library(
   LibcDeathTestExecutors
@@ -119,7 +108,7 @@ add_unittest_framework_library(
   HDRS
     ExecuteFunction.h
   DEPENDS
-    ${libc_death_tess_deps}
+    libc.hdr.stdint_proxy
 )
 
 add_unittest_framework_library(

--- a/libc/test/UnitTest/ExecuteFunctionUnix.cpp
+++ b/libc/test/UnitTest/ExecuteFunctionUnix.cpp
@@ -7,32 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "ExecuteFunction.h"
-#include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
 #include "test/UnitTest/ExecuteFunction.h" // FunctionCaller
-
-#ifdef LIBC_FULL_BUILD
-#include "include/llvm-libc-macros/poll-macros.h"
-#include "include/llvm-libc-macros/signal-macros.h"
-#include "include/llvm-libc-macros/sys-wait-macros.h"
-#include "include/llvm-libc-types/pid_t.h"
-#include "include/llvm-libc-types/struct_pollfd.h"
-#include "src/__support/libc_assert.h"
-#include "src/poll/poll.h"
-#include "src/signal/kill.h"
-#include "src/stdio/fflush.h"
-#include "src/stdio/stderr.h"
-#include "src/stdio/stdout.h"
-#include "src/stdlib/exit.h"
-#include "src/string/strsignal.h"
-#include "src/sys/wait/waitpid.h"
-#include "src/unistd/close.h"
-#include "src/unistd/fork.h"
-#include "src/unistd/pipe.h"
-
-#define LIBC_IMPL LIBC_NAMESPACE
-
-#else // Overlay mode
+#include <assert.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdio.h>
@@ -41,16 +18,13 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define LIBC_IMPL
-#endif
-
 namespace LIBC_NAMESPACE_DECL {
 namespace testutils {
 
 bool ProcessStatus::exited_normally() { return WIFEXITED(platform_defined); }
 
 int ProcessStatus::get_exit_code() {
-  LIBC_ASSERT(exited_normally() && "Abnormal termination, no exit code");
+  assert(exited_normally() && "Abnormal termination, no exit code");
   return WEXITSTATUS(platform_defined);
 }
 
@@ -62,15 +36,15 @@ int ProcessStatus::get_fatal_signal() {
 
 ProcessStatus invoke_in_subprocess(FunctionCaller *func, int timeout_ms) {
   int pipe_fds[2];
-  if (LIBC_IMPL::pipe(pipe_fds) == -1) {
+  if (::pipe(pipe_fds) == -1) {
     delete func;
     return ProcessStatus::error("pipe(2) failed");
   }
 
   // Don't copy the buffers into the child process and print twice.
-  LIBC_IMPL::fflush(stderr);
-  LIBC_IMPL::fflush(stdout);
-  pid_t pid = LIBC_IMPL::fork();
+  ::fflush(stderr);
+  ::fflush(stdout);
+  pid_t pid = ::fork();
   if (pid == -1) {
     delete func;
     return ProcessStatus::error("fork(2) failed");
@@ -79,20 +53,20 @@ ProcessStatus invoke_in_subprocess(FunctionCaller *func, int timeout_ms) {
   if (!pid) {
     (*func)();
     delete func;
-    LIBC_IMPL::exit(0);
+    ::exit(0);
   }
-  LIBC_IMPL::close(pipe_fds[1]);
+  ::close(pipe_fds[1]);
 
   pollfd poll_fd{pipe_fds[0], POLLIN, 0};
   // No events requested so this call will only return after the timeout or if
   // the pipes peer was closed, signaling the process exited.
-  if (LIBC_IMPL::poll(&poll_fd, 1, timeout_ms) == -1) {
+  if (::poll(&poll_fd, 1, timeout_ms) == -1) {
     delete func;
     return ProcessStatus::error("poll(2) failed");
   }
   // If the pipe wasn't closed by the child yet then timeout has expired.
   if (!(poll_fd.revents & POLLHUP)) {
-    LIBC_IMPL::kill(pid, SIGKILL);
+    ::kill(pid, SIGKILL);
     delete func;
     return ProcessStatus::timed_out_ps();
   }
@@ -100,19 +74,17 @@ ProcessStatus invoke_in_subprocess(FunctionCaller *func, int timeout_ms) {
   int wstatus = 0;
   // Wait on the pid of the subprocess here so it gets collected by the system
   // and doesn't turn into a zombie.
-  pid_t status = LIBC_IMPL::waitpid(pid, &wstatus, 0);
+  pid_t status = ::waitpid(pid, &wstatus, 0);
   if (status == -1) {
     delete func;
     return ProcessStatus::error("waitpid(2) failed");
   }
-  LIBC_ASSERT(status == pid);
+  assert(status == pid);
   delete func;
   return {wstatus};
 }
 
-const char *signal_as_string(int signum) {
-  return LIBC_IMPL::strsignal(signum);
-}
+const char *signal_as_string(int signum) { return ::strsignal(signum); }
 
 } // namespace testutils
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -132,9 +132,15 @@ void *operator new(size_t size) { return malloc(size); }
 
 void *operator new[](size_t size) { return malloc(size); }
 
-void operator delete(void *ptr) { free(ptr); }
+void operator delete(void *) {
+  // The libc runtime should not use the global delete operator. Hence,
+  // we just trap here to catch any such accidental usages.
+  __builtin_trap();
+}
 
-void operator delete(void *ptr, [[maybe_unused]] size_t size) { free(ptr); }
+void operator delete([[maybe_unused]] void *ptr, [[maybe_unused]] size_t size) {
+  __builtin_trap();
+}
 
 // Defining members in the std namespace is not preferred. But, we do it here
 // so that we can use it to define the operator new which takes std::align_val_t
@@ -143,8 +149,11 @@ namespace std {
 enum class align_val_t : size_t {};
 } // namespace std
 
-void operator delete(void *ptr, std::align_val_t) noexcept { free(ptr); }
+void operator delete([[maybe_unused]] void *mem, std::align_val_t) noexcept {
+  __builtin_trap();
+}
 
-void operator delete(void *ptr, unsigned int, std::align_val_t) noexcept {
-  free(ptr);
+void operator delete([[maybe_unused]] void *mem, unsigned int,
+                     std::align_val_t) noexcept {
+  __builtin_trap();
 }

--- a/libc/test/UnitTest/LibcDeathTestExecutors.cpp
+++ b/libc/test/UnitTest/LibcDeathTestExecutors.cpp
@@ -8,10 +8,11 @@
 
 #include "LibcTest.h"
 
-#include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
 #include "test/UnitTest/ExecuteFunction.h"
 #include "test/UnitTest/TestLogger.h"
+
+#include <assert.h>
 
 namespace {
 constexpr unsigned TIMEOUT_MS = 10000;
@@ -50,7 +51,7 @@ bool Test::testProcessKilled(testutils::FunctionCaller *Func, int Signal,
   }
 
   int KilledBy = Result.get_fatal_signal();
-  LIBC_ASSERT(KilledBy != 0 && "Not killed by any signal");
+  assert(KilledBy != 0 && "Not killed by any signal");
   if (Signal == -1 || KilledBy == Signal)
     return true;
 

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -509,6 +509,8 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     _Exit_test
+    # The EXPECT_EXITS test is only availible for unit tests.
+    UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS
@@ -520,6 +522,8 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     exit_test
+    # The EXPECT_EXITS test is only availible for unit tests.
+    UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS
@@ -531,7 +535,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     atexit_test
-    # TODO: Fix this test in hermetic mode.
+    # The EXPECT_EXITS test is only availible for unit tests.
     UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
@@ -546,6 +550,8 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     at_quick_exit_test
+    # The EXPECT_EXITS test is only availible for unit tests.
+    UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS
@@ -559,6 +565,8 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     abort_test
+    # The EXPECT_DEATH test is only availible for unit tests.
+    UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS
@@ -572,6 +580,8 @@ if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(
     quick_exit_test
+    # The EXPECT_EXITS test is only availible for unit tests.
+    UNIT_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS

--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -61,7 +61,6 @@ libc_test_library(
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_fputil_fpbits_str",
         "//libc:__support_fputil_rounding_mode",
-        "//libc:__support_libc_assert",
         "//libc:__support_libc_errno",
         "//libc:__support_macros_config",
         "//libc:__support_macros_properties_architectures",


### PR DESCRIPTION
PR #209999 (9e2e9b33e14808541c0470b92ade34bee6608bf6) "broke" the GPU build by causing many/most tests to not run.

The follow-up in #210715 (4bd1a447e136e60ea441370ac5d7b898aa4efab0) broke it for real
(https://lab.llvm.org/buildbot/#/builders/10/builds/32254) by causing too many tests to run.

I think we just need to disable the extra tests, but I want to start out by reverting both patches so that it's easier to compare the before/after state in the next attempt.