### PR TITLE
[Clang][LoongArch] Implement getConstraintRegister for LoongArch

### DIFF
--- a/clang/lib/Basic/Targets/LoongArch.h
+++ b/clang/lib/Basic/Targets/LoongArch.h
@@ -87,6 +87,11 @@ public:
 
   std::string_view getClobbers() const override { return ""; }
 
+  StringRef getConstraintRegister(StringRef Constraint,
+                                  StringRef Expression) const override {
+    return Expression;
+  }
+
   ArrayRef<const char *> getGCCRegNames() const override;
 
   int getEHDataRegisterNumber(unsigned RegNo) const override {

--- a/clang/test/Sema/inline-asm-validate-loongarch.c
+++ b/clang/test/Sema/inline-asm-validate-loongarch.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -triple loongarch32 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple loongarch64 -fsyntax-only -verify %s
+
+void test_clobber_conflict(void) {
+  register long r4 asm("r4");
+  asm volatile("" :: "r"(r4) : "$r4"); // expected-error {{conflicts with asm clobber list}}
+  asm volatile("" :: "r"(r4) : "$a0"); // expected-error {{conflicts with asm clobber list}}
+  asm volatile("" : "=r"(r4) :: "$r4"); // expected-error {{conflicts with asm clobber list}}
+  asm volatile("" : "=r"(r4) :: "$a0"); // expected-error {{conflicts with asm clobber list}}
+}


### PR DESCRIPTION
Implement `getConstraintRegister` so Clang can diagnose inline asm
register clobber conflicts for LoongArch, matching GCC.
