### PR TITLE
TargetParser: Add Triple::getDefaultFloatABI

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -10,6 +10,7 @@
 #define LLVM_TARGETPARSER_TRIPLE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/VersionTuple.h"
 
@@ -1249,13 +1250,12 @@ public:
            Env == Triple::GNUEABIHFT64;
   }
 
-  /// Tests if the target forces hardfloat.
-  bool isHardFloatABI() const {
-    EnvironmentType Env = getEnvironment();
-    return Env == llvm::Triple::GNUEABIHF ||
-           Env == llvm::Triple::GNUEABIHFT64 ||
-           Env == llvm::Triple::MuslEABIHF || Env == llvm::Triple::EABIHF;
-  }
+  /// Returns the default floating-point ABI for this target triple, i.e. the
+  /// ABI the code generator will resolve FloatABI::Default to
+  LLVM_ABI FloatABI::ABIType getDefaultFloatABI() const;
+
+  /// Tests if the target's default floating-point ABI is hard float.
+  bool isHardFloatABI() const { return getDefaultFloatABI() == FloatABI::Hard; }
 
   /// Tests whether the target supports comdat
   bool supportsCOMDAT() const {

--- a/llvm/lib/Target/ARM/ARMTargetMachine.h
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.h
@@ -79,13 +79,9 @@ public:
   }
 
   bool isTargetHardFloat() const {
-    return TargetTriple.getEnvironment() == Triple::GNUEABIHF ||
-           TargetTriple.getEnvironment() == Triple::GNUEABIHFT64 ||
-           TargetTriple.getEnvironment() == Triple::MuslEABIHF ||
-           TargetTriple.getEnvironment() == Triple::EABIHF ||
-           (TargetTriple.isOSBinFormatMachO() &&
-            TargetTriple.getSubArch() == Triple::ARMSubArch_v7em) ||
-           TargetTriple.isOSWindows() || TargetABI == ARM::ARM_ABI_AAPCS16;
+    // -target-abi=aapcs16 overrides the triple default.
+    return TargetABI == ARM::ARM_ABI_AAPCS16 ||
+           TargetTriple.getDefaultFloatABI() == FloatABI::Hard;
   }
 
   bool targetSchedulesPostRAScheduling() const override { return true; };

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -2556,6 +2556,31 @@ ExceptionHandling Triple::getDefaultExceptionHandling() const {
   return ExceptionHandling::None;
 }
 
+static FloatABI::ABIType getARMDefaultFloatABI(const Triple &T) {
+  Triple::EnvironmentType Env = T.getEnvironment();
+  bool IsHard =
+      Env == Triple::GNUEABIHF || Env == Triple::GNUEABIHFT64 ||
+      Env == Triple::MuslEABIHF || Env == Triple::EABIHF ||
+      (T.isOSBinFormatMachO() && T.getSubArch() == Triple::ARMSubArch_v7em) ||
+      T.isOSWindows() || ARM::computeTargetABI(T, "") == ARM::ARM_ABI_AAPCS16;
+  return IsHard ? FloatABI::Hard : FloatABI::Soft;
+}
+
+FloatABI::ABIType Triple::getDefaultFloatABI() const {
+  if (isARM() || isThumb())
+    return getARMDefaultFloatABI(*this);
+
+  // MIPS defaults to hard float, except on FreeBSD which uses soft float.
+  if (isMIPS())
+    return isOSFreeBSD() ? FloatABI::Soft : FloatABI::Hard;
+
+  if (isCSKY())
+    return FloatABI::Soft;
+
+  // Most targets use hard float unless soft float is explicitly requested.
+  return FloatABI::Hard;
+}
+
 // HLSL triple environment orders are relied on in the front end
 static_assert(Triple::Vertex - Triple::Pixel == 1,
               "incorrect HLSL stage order");

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -2574,7 +2574,7 @@ FloatABI::ABIType Triple::getDefaultFloatABI() const {
   if (isMIPS())
     return isOSFreeBSD() ? FloatABI::Soft : FloatABI::Hard;
 
-  if (isCSKY())
+  if (isCSKY() || isAVR() || getArch() == msp430)
     return FloatABI::Soft;
 
   // Most targets use hard float unless soft float is explicitly requested.

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1611,6 +1611,77 @@ static std::string Join(StringRef A, StringRef B, StringRef C, StringRef D) {
   return Str;
 }
 
+TEST(TripleTest, DefaultFloatABI) {
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("arm-none-none-eabihf").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("arm-none-linux-gnueabihf").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("arm-none-linux-gnueabihft64").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("arm-none-linux-musleabihf").getDefaultFloatABI());
+
+  // Non-hard EABI environments are soft, regardless of OS.
+  EXPECT_EQ(FloatABI::Soft, Triple("arm-none-none-eabi").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("arm-none-linux-gnueabi").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("arm-none-linux-musleabi").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("arm-none-linux-android").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft, Triple("armv7-apple-ios").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft, Triple("armv7-apple-macosx").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("armv7-unknown-fuchsia").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft, Triple("arm-unknown-openbsd").getDefaultFloatABI());
+
+  // MachO M-profile v7em is hard.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("thumbv7em-apple-darwin").getDefaultFloatABI());
+
+  // Windows is hard.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("thumbv7-unknown-windows-msvc").getDefaultFloatABI());
+
+  // The AAPCS16 (watchOS) ABI is hard.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("thumbv7k-apple-watchos").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard, Triple("thumbv7k-apple-ios").getDefaultFloatABI());
+
+  // The Thumb arch goes through the same ARM logic.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("thumbv7-none-linux-gnueabihf").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("thumbv7-none-linux-gnueabi").getDefaultFloatABI());
+
+  // PowerPC, SystemZ and SPARC default to hard float.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("powerpc64le-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("s390x-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("sparc-unknown-linux-gnu").getDefaultFloatABI());
+
+  // MIPS defaults to hard float, except on FreeBSD which uses soft float.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("mips-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("mips-unknown-freebsd").getDefaultFloatABI());
+
+  // CSKY defaults to soft float.
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("csky-unknown-linux-gnu").getDefaultFloatABI());
+
+  // Targets without a special case default to hard float.
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("x86_64-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("aarch64-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard,
+            Triple("riscv64-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Hard, Triple("amdgpu-amd-amdhsa").getDefaultFloatABI());
+}
+
 TEST(TripleTest, Normalization) {
 
   EXPECT_EQ("unknown", Triple::normalize(""));

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1668,9 +1668,12 @@ TEST(TripleTest, DefaultFloatABI) {
   EXPECT_EQ(FloatABI::Soft,
             Triple("mips-unknown-freebsd").getDefaultFloatABI());
 
-  // CSKY defaults to soft float.
+  // Defaults to soft float.
+  EXPECT_EQ(FloatABI::Soft, Triple("avr-unknown-unknown").getDefaultFloatABI());
   EXPECT_EQ(FloatABI::Soft,
             Triple("csky-unknown-linux-gnu").getDefaultFloatABI());
+  EXPECT_EQ(FloatABI::Soft,
+            Triple("msp430-unknown-unknown").getDefaultFloatABI());
 
   // Targets without a special case default to hard float.
   EXPECT_EQ(FloatABI::Hard,


### PR DESCRIPTION
In order to eliminate TargetOptions ABI fields the front and
middle end need to know what value the backend is going to choose
for the ABI properties. This is similar to how we have
getDefaultExceptionHandling and getDefaultWCharSize.

The clang driver seems to have a different notion of which targets
are default soft. This followed ARMTargetMachine as the authority.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>