### PR TITLE
[AMDGPU] Add per-class register stress options

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -40,6 +40,18 @@ static cl::opt<bool> EnableSpillCFISavedRegs(
     cl::desc("Enable spilling the registers required for CFI emission"),
     cl::ReallyHidden, cl::init(false), cl::ZeroOrMore);
 
+static cl::opt<unsigned>
+    StressVGPRLimit("amdgpu-stress-vgpr", cl::Hidden, cl::init(0),
+                    cl::desc("Limit VGPRs to N registers by reserving the rest"));
+
+static cl::opt<unsigned>
+    StressAGPRLimit("amdgpu-stress-agpr", cl::Hidden, cl::init(0),
+                    cl::desc("Limit AGPRs to N registers by reserving the rest"));
+
+static cl::opt<unsigned>
+    StressSGPRLimit("amdgpu-stress-sgpr", cl::Hidden, cl::init(0),
+                    cl::desc("Limit SGPRs to N registers by reserving the rest"));
+
 std::array<std::vector<int16_t>, 32> SIRegisterInfo::RegSplitParts;
 std::array<std::array<uint16_t, 32>, 9> SIRegisterInfo::SubRegFromChannelTable;
 
@@ -644,6 +656,8 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   // Reserve SGPRs.
   //
   unsigned MaxNumSGPRs = ST.getMaxNumSGPRs(MF);
+  if (StressSGPRLimit.getNumOccurrences() && StressSGPRLimit < MaxNumSGPRs)
+    MaxNumSGPRs = StressSGPRLimit;
   unsigned TotalNumSGPRs = AMDGPU::SGPR_32RegClass.getNumRegs();
   for (const TargetRegisterClass &RC : regclasses()) {
     if (RC.isBaseClass() && isSGPRClass(&RC)) {
@@ -700,6 +714,12 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   // Reserve VGPRs/AGPRs.
   //
   auto [MaxNumVGPRs, MaxNumAGPRs] = ST.getMaxNumVectorRegs(MF.getFunction());
+
+  // Stress test: override VGPR/AGPR limits.
+  if (StressVGPRLimit.getNumOccurrences() && StressVGPRLimit < MaxNumVGPRs)
+    MaxNumVGPRs = StressVGPRLimit;
+  if (StressAGPRLimit.getNumOccurrences() && StressAGPRLimit < MaxNumAGPRs)
+    MaxNumAGPRs = StressAGPRLimit;
 
   for (const TargetRegisterClass &RC : regclasses()) {
     if (RC.isBaseClass() && isVGPRClass(&RC)) {

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -40,17 +40,17 @@ static cl::opt<bool> EnableSpillCFISavedRegs(
     cl::desc("Enable spilling the registers required for CFI emission"),
     cl::ReallyHidden, cl::init(false), cl::ZeroOrMore);
 
-static cl::opt<unsigned>
-    StressVGPRLimit("amdgpu-stress-vgpr", cl::Hidden, cl::init(0),
-                    cl::desc("Limit VGPRs to N registers by reserving the rest"));
+static cl::opt<unsigned> StressVGPRLimit(
+    "amdgpu-stress-vgpr", cl::Hidden, cl::init(0),
+    cl::desc("Limit VGPRs to N registers by reserving the rest"));
 
-static cl::opt<unsigned>
-    StressAGPRLimit("amdgpu-stress-agpr", cl::Hidden, cl::init(0),
-                    cl::desc("Limit AGPRs to N registers by reserving the rest"));
+static cl::opt<unsigned> StressAGPRLimit(
+    "amdgpu-stress-agpr", cl::Hidden, cl::init(0),
+    cl::desc("Limit AGPRs to N registers by reserving the rest"));
 
-static cl::opt<unsigned>
-    StressSGPRLimit("amdgpu-stress-sgpr", cl::Hidden, cl::init(0),
-                    cl::desc("Limit SGPRs to N registers by reserving the rest"));
+static cl::opt<unsigned> StressSGPRLimit(
+    "amdgpu-stress-sgpr", cl::Hidden, cl::init(0),
+    cl::desc("Limit SGPRs to N registers by reserving the rest"));
 
 std::array<std::vector<int16_t>, 32> SIRegisterInfo::RegSplitParts;
 std::array<std::array<uint16_t, 32>, 9> SIRegisterInfo::SubRegFromChannelTable;

--- a/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-regalloc.mir
+++ b/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-regalloc.mir
@@ -1,6 +1,6 @@
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 %s -o - | FileCheck -check-prefix=DEFAULT %s
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-stress-vgpr=2 %s -o - | FileCheck -check-prefix=VGPR2 %s
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-stress-vgpr=4 -amdgpu-stress-agpr=0 %s -o - | FileCheck -check-prefix=VGPR4-AGPR0 %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa %s -o - | FileCheck -check-prefix=DEFAULT %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -amdgpu-stress-vgpr=2 %s -o - | FileCheck -check-prefix=VGPR2 %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -amdgpu-stress-vgpr=4 -amdgpu-stress-agpr=0 %s -o - | FileCheck -check-prefix=VGPR4-AGPR0 %s
 
 # Test that -amdgpu-stress-vgpr and -amdgpu-stress-agpr limit register
 # availability during register allocation.

--- a/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-regalloc.mir
+++ b/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-regalloc.mir
@@ -1,0 +1,60 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 %s -o - | FileCheck -check-prefix=DEFAULT %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-stress-vgpr=2 %s -o - | FileCheck -check-prefix=VGPR2 %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-stress-vgpr=4 -amdgpu-stress-agpr=0 %s -o - | FileCheck -check-prefix=VGPR4-AGPR0 %s
+
+# Test that -amdgpu-stress-vgpr and -amdgpu-stress-agpr limit register
+# availability during register allocation.
+#
+# No limits - all values stay in VGPRs, no spills.
+# With -amdgpu-stress-vgpr=2 - overflow to AGPRs.
+# With -amdgpu-stress-vgpr=4 -amdgpu-stress-agpr=0 - forced to spill to scratch.
+
+--- |
+  define amdgpu_kernel void @stress_regalloc(ptr addrspace(1) %p) #0 { ret void }
+  attributes #0 = { "amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64" }
+...
+
+---
+# DEFAULT-LABEL: stress_regalloc:
+# DEFAULT:     global_load_dword v
+# DEFAULT-NOT: global_load_dword a
+# DEFAULT-NOT: scratch_store
+# DEFAULT:     s_endpgm
+
+# VGPR2-LABEL: stress_regalloc:
+# VGPR2:     global_load_dword a
+# VGPR2:     s_endpgm
+
+# VGPR4-AGPR0-LABEL: stress_regalloc:
+# VGPR4-AGPR0-NOT: global_load_dword a
+# VGPR4-AGPR0:     scratch_store
+# VGPR4-AGPR0:     s_endpgm
+
+name: stress_regalloc
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+body: |
+  bb.0:
+    liveins: $sgpr4_sgpr5
+
+    %0:sgpr_64 = COPY $sgpr4_sgpr5
+    %1:sreg_64_xexec = S_LOAD_DWORDX2_IMM %0, 0, 0 :: (load (s64), addrspace 4)
+    %addr:vreg_64_align2 = COPY %1
+
+    %v0:vgpr_32 = GLOBAL_LOAD_DWORD %addr, 0, 0, implicit $exec :: (volatile load (s32), addrspace 1)
+    %v1:vgpr_32 = GLOBAL_LOAD_DWORD %addr, 4, 0, implicit $exec :: (volatile load (s32), addrspace 1)
+    %v2:vgpr_32 = GLOBAL_LOAD_DWORD %addr, 8, 0, implicit $exec :: (volatile load (s32), addrspace 1)
+    %v3:vgpr_32 = GLOBAL_LOAD_DWORD %addr, 12, 0, implicit $exec :: (volatile load (s32), addrspace 1)
+    %v4:vgpr_32 = GLOBAL_LOAD_DWORD %addr, 16, 0, implicit $exec :: (volatile load (s32), addrspace 1)
+    %v5:vgpr_32 = GLOBAL_LOAD_DWORD %addr, 20, 0, implicit $exec :: (volatile load (s32), addrspace 1)
+
+    GLOBAL_STORE_DWORD %addr, %v0, 40, 0, implicit $exec :: (volatile store (s32), addrspace 1)
+    GLOBAL_STORE_DWORD %addr, %v1, 44, 0, implicit $exec :: (volatile store (s32), addrspace 1)
+    GLOBAL_STORE_DWORD %addr, %v2, 48, 0, implicit $exec :: (volatile store (s32), addrspace 1)
+    GLOBAL_STORE_DWORD %addr, %v3, 52, 0, implicit $exec :: (volatile store (s32), addrspace 1)
+    GLOBAL_STORE_DWORD %addr, %v4, 56, 0, implicit $exec :: (volatile store (s32), addrspace 1)
+    GLOBAL_STORE_DWORD %addr, %v5, 60, 0, implicit $exec :: (volatile store (s32), addrspace 1)
+
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-sched.mir
+++ b/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-sched.mir
@@ -1,0 +1,64 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -run-pass=machine-scheduler %s -o - | FileCheck -check-prefix=DEFAULT %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -run-pass=machine-scheduler -amdgpu-stress-vgpr=3 %s -o - | FileCheck -check-prefix=STRESS %s
+
+# Test that -amdgpu-stress-vgpr affects scheduler pressure tracking.
+# Without stress, the scheduler keeps all producers before consumers.
+# With stress, the scheduler interleaves producers and consumers to
+# reduce register pressure.
+
+--- |
+  define amdgpu_kernel void @sched_pressure() #0 { ret void }
+  attributes #0 = { "amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64" }
+...
+
+---
+# DEFAULT-LABEL: name: sched_pressure
+# DEFAULT:      %v0:vgpr_32 = V_ADD_U32_e32
+# DEFAULT-NEXT: %v1:vgpr_32 = V_MUL_LO_U32_e64
+# DEFAULT-NEXT: %v2:vgpr_32 = V_SUB_U32_e32
+# DEFAULT-NEXT: %v3:vgpr_32 = V_XOR_B32_e32
+# DEFAULT-NEXT: %v4:vgpr_32 = V_OR_B32_e32
+# DEFAULT-NEXT: %v5:vgpr_32 = V_AND_B32_e32
+# DEFAULT-NEXT: %r0:vgpr_32 = V_ADD_U32_e32 %v0, %v1
+# DEFAULT-NEXT: %r1:vgpr_32 = V_ADD_U32_e32 %v2, %v3
+# DEFAULT-NEXT: %r2:vgpr_32 = V_ADD_U32_e32 %v4, %v5
+
+# STRESS-LABEL: name: sched_pressure
+# STRESS:      %v0:vgpr_32 = V_ADD_U32_e32
+# STRESS-NEXT: %v1:vgpr_32 = V_MUL_LO_U32_e64
+# STRESS-NEXT: %r0:vgpr_32 = V_ADD_U32_e32 %v0, %v1
+# STRESS-NEXT: %v2:vgpr_32 = V_SUB_U32_e32
+# STRESS-NEXT: %v3:vgpr_32 = V_XOR_B32_e32
+# STRESS-NEXT: %r1:vgpr_32 = V_ADD_U32_e32 %v2, %v3
+# STRESS-NEXT: %v4:vgpr_32 = V_OR_B32_e32
+# STRESS-NEXT: %v5:vgpr_32 = V_AND_B32_e32
+# STRESS-NEXT: %r2:vgpr_32 = V_ADD_U32_e32 %v4, %v5
+
+name: sched_pressure
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+body: |
+  bb.0:
+    liveins: $vgpr0, $vgpr1
+
+    %a:vgpr_32 = COPY $vgpr0
+    %b:vgpr_32 = COPY $vgpr1
+
+    %v0:vgpr_32 = V_ADD_U32_e32 %a, %b, implicit $exec
+    %v1:vgpr_32 = V_MUL_LO_U32_e64 %a, %b, implicit $exec
+    %v2:vgpr_32 = V_SUB_U32_e32 %a, %b, implicit $exec
+    %v3:vgpr_32 = V_XOR_B32_e32 %a, %b, implicit $exec
+    %v4:vgpr_32 = V_OR_B32_e32 %a, %b, implicit $exec
+    %v5:vgpr_32 = V_AND_B32_e32 %a, %b, implicit $exec
+
+    %r0:vgpr_32 = V_ADD_U32_e32 %v0, %v1, implicit $exec
+    %r1:vgpr_32 = V_ADD_U32_e32 %v2, %v3, implicit $exec
+    %r2:vgpr_32 = V_ADD_U32_e32 %v4, %v5, implicit $exec
+    %r3:vgpr_32 = V_ADD_U32_e32 %r0, %r1, implicit $exec
+    %r4:vgpr_32 = V_ADD_U32_e32 %r3, %r2, implicit $exec
+
+    DS_WRITE_B32_gfx9 %a, %r4, 0, 0, implicit $exec :: (store (s32), addrspace 3)
+
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-sched.mir
+++ b/llvm/test/CodeGen/AMDGPU/stress-regalloc-limits-sched.mir
@@ -1,5 +1,5 @@
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -run-pass=machine-scheduler %s -o - | FileCheck -check-prefix=DEFAULT %s
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -run-pass=machine-scheduler -amdgpu-stress-vgpr=3 %s -o - | FileCheck -check-prefix=STRESS %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler %s -o - | FileCheck -check-prefix=DEFAULT %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler -amdgpu-stress-vgpr=3 %s -o - | FileCheck -check-prefix=STRESS %s
 
 # Test that -amdgpu-stress-vgpr affects scheduler pressure tracking.
 # Without stress, the scheduler keeps all producers before consumers.


### PR DESCRIPTION
Add options -amdgpu-stress-vgpr=N, -amdgpu-stress-agpr=N, and -amdgpu-stress-sgpr=N to limit each register class independently by reserving registers beyond N.