### PR TITLE
RuntimeLibcalls: Add sqrtf to the Hexagon runtime libcall set

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -2640,7 +2640,7 @@ def HexagonSystemLibrary
     : SystemRuntimeLibrary<isHexagon,
     (add (sub DefaultLibcallImpls32,
     __adddf3, __divsf3, __udivsi3, __udivdi3,
-    __umoddi3, __divdf3, __muldf3, __divsi3, __subdf3, sqrtf,
+    __umoddi3, __divdf3, __muldf3, __divsi3, __subdf3,
     __divdi3, __umodsi3, __moddi3, __modsi3), HexagonLibcalls,
     LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
     exp10f, exp10, exp10l_f128, __stack_chk_fail, __stack_chk_guard,


### PR DESCRIPTION
The library definitions go out of the way to avoid adding sqrtf, in favor
of __hexagon_sqrtf. I'm assuming that libm does provide sqrtf, it just
happens that there is a more-preferred function to use. RuntimeLibcallsInfo
should express the full set of functions that do exist, and LibcallLoweringInfo
should express the preference for which calls should be used.

By the current ordering rules, it just so happens __hexagon_sqrtf will win out
for SQRT_F32. Add this to avoid a special case to faciliate future libcall
improvements.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>