### PR TITLE
[MLIR][SPIRV] Lower static workgroup attributions as global instead of argument

### DIFF
--- a/mlir/include/mlir/Conversion/GPUToLLVMSPV/GPUToLLVMSPVPass.h
+++ b/mlir/include/mlir/Conversion/GPUToLLVMSPV/GPUToLLVMSPVPass.h
@@ -21,8 +21,9 @@ class TypeConverter;
 #define GEN_PASS_DECL_CONVERTGPUOPSTOLLVMSPVOPS
 #include "mlir/Conversion/Passes.h.inc"
 
-void populateGpuToLLVMSPVConversionPatterns(const LLVMTypeConverter &converter,
-                                            RewritePatternSet &patterns);
+void populateGpuToLLVMSPVConversionPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns,
+    bool encodeWorkgroupAttributionsAsArguments = true);
 
 /// Populates memory space attribute conversion rules for lowering
 /// gpu.address_space to integer values.

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -646,6 +646,11 @@ def ConvertGpuOpsToLLVMSPVOps : Pass<"convert-gpu-to-llvm-spv", "gpu::GPUModuleO
     Option<"use64bitIndex", "use-64bit-index",
            "bool", /*default=*/"false",
            "Use 64-bit integers to convert index types">,
+    Option<"encodeWorkgroupAttributionsAsArguments",
+           "encode-workgroup-attributions-as-arguments",
+           "bool", /*default=*/"true",
+           "Encode workgroup attributions as kernel arguments instead of "
+           "workgroup address-space globals">,
   ];
 }
 

--- a/mlir/lib/Conversion/GPUToLLVMSPV/GPUToLLVMSPV.cpp
+++ b/mlir/lib/Conversion/GPUToLLVMSPV/GPUToLLVMSPV.cpp
@@ -498,7 +498,8 @@ struct GPUToLLVMSPVConversionPass final
                         gpu::ShuffleOp, gpu::SubgroupIdOp, gpu::SubgroupSizeOp,
                         gpu::ThreadIdOp, gpu::PrintfOp>();
 
-    populateGpuToLLVMSPVConversionPatterns(converter, patterns);
+    populateGpuToLLVMSPVConversionPatterns(
+        converter, patterns, encodeWorkgroupAttributionsAsArguments);
     populateGpuMemorySpaceAttributeConversions(converter);
     patterns.add<GPUPrintfOpToLLVMCallLowering>(converter, /*addressSpace=*/2,
                                                 LLVM::cconv::CConv::SPIR_FUNC,
@@ -526,7 +527,8 @@ gpuAddressSpaceToOCLAddressSpace(gpu::AddressSpace addressSpace) {
 } // namespace
 
 void populateGpuToLLVMSPVConversionPatterns(
-    const LLVMTypeConverter &typeConverter, RewritePatternSet &patterns) {
+    const LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    bool encodeWorkgroupAttributionsAsArguments) {
   patterns.add<GPUBarrierConversion, GPUReturnOpLowering, GPUShuffleConversion,
                GPUSubgroupOpConversion<gpu::LaneIdOp>,
                GPUSubgroupOpConversion<gpu::NumSubgroupsOp>,
@@ -551,8 +553,7 @@ void populateGpuToLLVMSPVConversionPatterns(
           privateAddressSpace, localAddressSpace,
           /*kernelAttributeName=*/{}, kernelBlockSizeAttributeName,
           /*kernelClusterSizeAttributeName=*/{}, LLVM::CConv::SPIR_KERNEL,
-          LLVM::CConv::SPIR_FUNC,
-          /*encodeWorkgroupAttributionsAsArguments=*/true});
+          LLVM::CConv::SPIR_FUNC, encodeWorkgroupAttributionsAsArguments});
 }
 
 void populateGpuMemorySpaceAttributeConversions(TypeConverter &typeConverter) {

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -121,6 +121,10 @@ void buildGPUPassPipeline(OpPassManager &pm,
   {
     ConvertGpuOpsToLLVMSPVOpsOptions gpuToLLVMSPVOptions;
     gpuToLLVMSPVOptions.use64bitIndex = options.use64bitIndex;
+    // Static workgroup attributions are not launch operands. Lower them to
+    // workgroup address-space globals so that they do not become unset local
+    // pointer arguments in the Level Zero kernel ABI.
+    gpuToLLVMSPVOptions.encodeWorkgroupAttributionsAsArguments = false;
     pm.addNestedPass<gpu::GPUModuleOp>(
         createConvertGpuOpsToLLVMSPVOps(gpuToLLVMSPVOptions));
   }

--- a/mlir/test/Dialect/GPU/xevm-pipeline-workgroup-attributions.mlir
+++ b/mlir/test/Dialect/GPU/xevm-pipeline-workgroup-attributions.mlir
@@ -1,0 +1,40 @@
+// RUN: mlir-opt %s \
+// RUN:   --convert-gpu-to-llvm-spv="use-64bit-index=true \
+// RUN:     encode-workgroup-attributions-as-arguments=true" \
+// RUN:   | FileCheck %s --check-prefix=ARGS
+// RUN: mlir-opt %s \
+// RUN:   --gpu-lower-to-xevm-pipeline="xegpu-op-level=lane binary-format=llvm" \
+// RUN:   --mlir-print-ir-after=convert-gpu-to-llvm-spv -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=XEVM
+
+// Static workgroup attributions are not launch operands. Check that the XeVM
+// pipeline materializes them as workgroup address-space globals instead of
+// adding hidden kernel arguments that the host launch does not initialize.
+
+module attributes {gpu.container_module} {
+  gpu.module @kernels {
+    gpu.func @kernel()
+        workgroup(%scratch: memref<8xf32, 3>) kernel {
+      %c0 = arith.constant 0 : index
+      %one = arith.constant 1.0 : f32
+      memref.store %one, %scratch[%c0] : memref<8xf32, 3>
+      gpu.return
+    }
+  }
+}
+
+// With argument encoding enabled, the workgroup attribution becomes a hidden
+// local-pointer kernel argument.
+// ARGS-NOT: llvm.mlir.global internal @__wg_kernel_0
+// ARGS-LABEL: llvm.func spir_kernelcc @kernel(
+// ARGS-SAME: %[[SCRATCH:[a-zA-Z0-9_]+]]: !llvm.ptr<3>
+// ARGS-SAME: llvm.workgroup_attribution = #llvm.mlir.workgroup_attribution<8 : i64, f32>
+// ARGS: llvm.insertvalue %[[SCRATCH]],
+
+// The XeVM pipeline disables argument encoding and materializes the static
+// attribution as a workgroup address-space global instead.
+// XEVM: convert-gpu-to-llvm-spv{encode-workgroup-attributions-as-arguments=false
+// XEVM: llvm.mlir.global internal @__wg_kernel_0()
+// XEVM-SAME: {addr_space = 3 : i32} : !llvm.array<8 x f32>
+// XEVM-LABEL: llvm.func spir_kernelcc @kernel() attributes {gpu.kernel}
+// XEVM: llvm.mlir.addressof @__wg_kernel_0 : !llvm.ptr<3>


### PR DESCRIPTION
This PR resolves https://github.com/llvm/llvm-project/issues/210870. The GPU-to-LLVM-SPIR-V lowering set `encodeWorkgroupAttributionsAsArguments` as true, however, the XeVM host launch did not include this argument, so this PR just add a optional for `encodeWorkgroupAttributionsAsArguments` and set it as false in GPUToXeVMPipeline.

Assisted-by: OpenAI Codex