### PR TITLE
[X86] Synchronise middle and backend test coverage for ADDSUBPS/PD patterns

### DIFF
--- a/llvm/test/CodeGen/X86/sse3-avx-addsub-2.ll
+++ b/llvm/test/CodeGen/X86/sse3-avx-addsub-2.ll
@@ -6,13 +6,13 @@
 ; Verify that we correctly generate 'addsub' instructions from
 ; a sequence of vector extracts + float add/sub + vector inserts.
 
-define <4 x float> @test1(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test1:
+define <4 x float> @test_addsub_v4f32(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test1:
+; AVX-LABEL: test_addsub_v4f32:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -35,13 +35,13 @@ define <4 x float> @test1(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert4
 }
 
-define <4 x float> @test2(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test2:
+define <4 x float> @test_addsub_v4f32_partial_23(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_23:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test2:
+; AVX-LABEL: test_addsub_v4f32_partial_23:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -56,13 +56,13 @@ define <4 x float> @test2(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert2
 }
 
-define <4 x float> @test3(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test3:
+define <4 x float> @test_addsub_v4f32_partial_03(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_03:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test3:
+; AVX-LABEL: test_addsub_v4f32_partial_03:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -77,13 +77,13 @@ define <4 x float> @test3(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert2
 }
 
-define <4 x float> @test4(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test4:
+define <4 x float> @test_addsub_v4f32_partial_12(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_12:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test4:
+; AVX-LABEL: test_addsub_v4f32_partial_12:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -98,13 +98,13 @@ define <4 x float> @test4(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert2
 }
 
-define <4 x float> @test5(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test5:
+define <4 x float> @test_addsub_v4f32_partial_01(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_01:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test5:
+; AVX-LABEL: test_addsub_v4f32_partial_01:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -119,13 +119,13 @@ define <4 x float> @test5(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert2
 }
 
-define <4 x float> @test6(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test6:
+define <4 x float> @test_addsub_v4f32_shuffle_1302(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_shuffle_1302:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test6:
+; AVX-LABEL: test_addsub_v4f32_shuffle_1302:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -148,14 +148,14 @@ define <4 x float> @test6(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert4
 }
 
-define <4 x double> @test7(<4 x double> %A, <4 x double> %B) {
-; SSE-LABEL: test7:
+define <4 x double> @test_addsub_v4f64(<4 x double> %A, <4 x double> %B) {
+; SSE-LABEL: test_addsub_v4f64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd %xmm2, %xmm0
 ; SSE-NEXT:    addsubpd %xmm3, %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test7:
+; AVX-LABEL: test_addsub_v4f64:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -178,13 +178,13 @@ define <4 x double> @test7(<4 x double> %A, <4 x double> %B) {
   ret <4 x double> %vecinsert4
 }
 
-define <2 x double> @test8(<2 x double> %A, <2 x double> %B) {
-; SSE-LABEL: test8:
+define <2 x double> @test_addsub_v2f64(<2 x double> %A, <2 x double> %B) {
+; SSE-LABEL: test_addsub_v2f64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test8:
+; AVX-LABEL: test_addsub_v2f64:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -199,14 +199,14 @@ define <2 x double> @test8(<2 x double> %A, <2 x double> %B) {
   ret <2 x double> %vecinsert2
 }
 
-define <8 x float> @test9(<8 x float> %A, <8 x float> %B) {
-; SSE-LABEL: test9:
+define <8 x float> @test_addsub_v8f32(<8 x float> %A, <8 x float> %B) {
+; SSE-LABEL: test_addsub_v8f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm2, %xmm0
 ; SSE-NEXT:    addsubps %xmm3, %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test9:
+; AVX-LABEL: test_addsub_v8f32:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -493,13 +493,13 @@ define <4 x float> @test16(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert4
 }
 
-define <2 x float> @test_v2f32(<2 x float> %v0, <2 x float> %v1) {
-; SSE-LABEL: test_v2f32:
+define <2 x float> @test_addsub_v2f32(<2 x float> %v0, <2 x float> %v1) {
+; SSE-LABEL: test_addsub_v2f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test_v2f32:
+; AVX-LABEL: test_addsub_v2f32:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -514,8 +514,8 @@ define <2 x float> @test_v2f32(<2 x float> %v0, <2 x float> %v1) {
   ret <2 x float> %res1
 }
 
-define <16 x float> @test17(<16 x float> %A, <16 x float> %B) {
-; SSE-LABEL: test17:
+define <16 x float> @test_addsub_v16f32(<16 x float> %A, <16 x float> %B) {
+; SSE-LABEL: test_addsub_v16f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm4, %xmm0
 ; SSE-NEXT:    addsubps %xmm5, %xmm1
@@ -523,13 +523,13 @@ define <16 x float> @test17(<16 x float> %A, <16 x float> %B) {
 ; SSE-NEXT:    addsubps %xmm7, %xmm3
 ; SSE-NEXT:    retq
 ;
-; AVX1-LABEL: test17:
+; AVX1-LABEL: test_addsub_v16f32:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vaddsubps %ymm2, %ymm0, %ymm0
 ; AVX1-NEXT:    vaddsubps %ymm3, %ymm1, %ymm1
 ; AVX1-NEXT:    retq
 ;
-; AVX512-LABEL: test17:
+; AVX512-LABEL: test_addsub_v16f32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vsubps %zmm1, %zmm0, %zmm2
 ; AVX512-NEXT:    movw $-21846, %ax # imm = 0xAAAA
@@ -604,8 +604,8 @@ define <16 x float> @test17(<16 x float> %A, <16 x float> %B) {
   ret <16 x float> %vecinsert16
 }
 
-define <8 x double> @test18(<8 x double> %A, <8 x double> %B) {
-; SSE-LABEL: test18:
+define <8 x double> @test_addsub_v8f64(<8 x double> %A, <8 x double> %B) {
+; SSE-LABEL: test_addsub_v8f64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd %xmm4, %xmm0
 ; SSE-NEXT:    addsubpd %xmm5, %xmm1
@@ -613,13 +613,13 @@ define <8 x double> @test18(<8 x double> %A, <8 x double> %B) {
 ; SSE-NEXT:    addsubpd %xmm7, %xmm3
 ; SSE-NEXT:    retq
 ;
-; AVX1-LABEL: test18:
+; AVX1-LABEL: test_addsub_v8f64:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vaddsubpd %ymm2, %ymm0, %ymm0
 ; AVX1-NEXT:    vaddsubpd %ymm3, %ymm1, %ymm1
 ; AVX1-NEXT:    retq
 ;
-; AVX512-LABEL: test18:
+; AVX512-LABEL: test_addsub_v8f64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vaddpd %zmm1, %zmm0, %zmm2
 ; AVX512-NEXT:    vsubpd %zmm1, %zmm0, %zmm0

--- a/llvm/test/CodeGen/X86/sse3-avx-addsub.ll
+++ b/llvm/test/CodeGen/X86/sse3-avx-addsub.ll
@@ -36,13 +36,29 @@
 ;   return (double2){X[0], Y[1]};
 ; }
 
-define <4 x float> @test1(<4 x float> %A, <4 x float> %B) {
-; SSE-LABEL: test1:
+define <2 x float> @test_addsub_v2f32(<2 x float> %A, <2 x float> %B) {
+; SSE-LABEL: test_addsub_v2f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test1:
+; AVX-LABEL: test_addsub_v2f32:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %sub = fsub <2 x float> %A, %B
+  %add = fadd <2 x float> %A, %B
+  %vecinit6 = shufflevector <2 x float> %sub, <2 x float> %add, <2 x i32> <i32 0, i32 3>
+  ret <2 x float> %vecinit6
+}
+
+define <4 x float> @test_addsub_v4f32(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32:
+; SSE:       # %bb.0:
+; SSE-NEXT:    addsubps %xmm1, %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_addsub_v4f32:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -52,14 +68,14 @@ define <4 x float> @test1(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinit6
 }
 
-define <8 x float> @test2(<8 x float> %A, <8 x float> %B) {
-; SSE-LABEL: test2:
+define <8 x float> @test_addsub_v8f32(<8 x float> %A, <8 x float> %B) {
+; SSE-LABEL: test_addsub_v8f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm2, %xmm0
 ; SSE-NEXT:    addsubps %xmm3, %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test2:
+; AVX-LABEL: test_addsub_v8f32:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -69,14 +85,33 @@ define <8 x float> @test2(<8 x float> %A, <8 x float> %B) {
   ret <8 x float> %vecinit14
 }
 
-define <4 x double> @test3(<4 x double> %A, <4 x double> %B) {
-; SSE-LABEL: test3:
+define <8 x float> @test_addsub_v8f32_sse(<8 x float> %A, <8 x float> %B) {
+; SSE-LABEL: test_addsub_v8f32_sse:
+; SSE:       # %bb.0:
+; SSE-NEXT:    addsubps %xmm2, %xmm0
+; SSE-NEXT:    addsubps %xmm3, %xmm1
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_addsub_v8f32_sse:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vaddsubps %ymm1, %ymm0, %ymm0
+; AVX-NEXT:    retq
+  %sub = fsub <8 x float> %A, %B
+  %add = fadd <8 x float> %A, %B
+  %vecinit0 = shufflevector <8 x float> %sub, <8 x float> poison, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
+  %vecinit1 = shufflevector <8 x float> %add, <8 x float> poison, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
+  %vecinit2 = shufflevector <4 x float> %vecinit0, <4 x float> %vecinit1, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
+  ret <8 x float> %vecinit2
+}
+
+define <4 x double> @test_addsub_v4f64(<4 x double> %A, <4 x double> %B) {
+; SSE-LABEL: test_addsub_v4f64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd %xmm2, %xmm0
 ; SSE-NEXT:    addsubpd %xmm3, %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test3:
+; AVX-LABEL: test_addsub_v4f64:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -86,13 +121,13 @@ define <4 x double> @test3(<4 x double> %A, <4 x double> %B) {
   ret <4 x double> %vecinit6
 }
 
-define <2 x double> @test4(<2 x double> %A, <2 x double> %B) #0 {
-; SSE-LABEL: test4:
+define <2 x double> @test_addsub_v2f64(<2 x double> %A, <2 x double> %B) #0 {
+; SSE-LABEL: test_addsub_v2f64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test4:
+; AVX-LABEL: test_addsub_v2f64:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -102,8 +137,8 @@ define <2 x double> @test4(<2 x double> %A, <2 x double> %B) #0 {
   ret <2 x double> %vecinit2
 }
 
-define <16 x float> @test5(<16 x float> %A, <16 x float> %B) {
-; SSE-LABEL: test5:
+define <16 x float> @test_addsub_v16f32(<16 x float> %A, <16 x float> %B) {
+; SSE-LABEL: test_addsub_v16f32:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps %xmm4, %xmm0
 ; SSE-NEXT:    addsubps %xmm5, %xmm1
@@ -111,13 +146,13 @@ define <16 x float> @test5(<16 x float> %A, <16 x float> %B) {
 ; SSE-NEXT:    addsubps %xmm7, %xmm3
 ; SSE-NEXT:    retq
 ;
-; AVX1-LABEL: test5:
+; AVX1-LABEL: test_addsub_v16f32:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vaddsubps %ymm2, %ymm0, %ymm0
 ; AVX1-NEXT:    vaddsubps %ymm3, %ymm1, %ymm1
 ; AVX1-NEXT:    retq
 ;
-; AVX512-LABEL: test5:
+; AVX512-LABEL: test_addsub_v16f32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vsubps %zmm1, %zmm0, %zmm2
 ; AVX512-NEXT:    movw $-21846, %ax # imm = 0xAAAA
@@ -131,8 +166,39 @@ define <16 x float> @test5(<16 x float> %A, <16 x float> %B) {
   ret <16 x float> %vecinit2
 }
 
-define <8 x double> @test6(<8 x double> %A, <8 x double> %B) {
-; SSE-LABEL: test6:
+define <16 x float> @test_addsub_v16f32_sse(<16 x float> %A, <16 x float> %B) {
+; SSE-LABEL: test_addsub_v16f32_sse:
+; SSE:       # %bb.0:
+; SSE-NEXT:    addsubps %xmm4, %xmm0
+; SSE-NEXT:    addsubps %xmm5, %xmm1
+; SSE-NEXT:    addsubps %xmm6, %xmm2
+; SSE-NEXT:    addsubps %xmm7, %xmm3
+; SSE-NEXT:    retq
+;
+; AVX1-LABEL: test_addsub_v16f32_sse:
+; AVX1:       # %bb.0:
+; AVX1-NEXT:    vaddsubps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vaddsubps %ymm3, %ymm1, %ymm1
+; AVX1-NEXT:    retq
+;
+; AVX512-LABEL: test_addsub_v16f32_sse:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vsubps %zmm1, %zmm0, %zmm2
+; AVX512-NEXT:    movw $-21846, %ax # imm = 0xAAAA
+; AVX512-NEXT:    kmovw %eax, %k1
+; AVX512-NEXT:    vaddps %zmm1, %zmm0, %zmm2 {%k1}
+; AVX512-NEXT:    vmovaps %zmm2, %zmm0
+; AVX512-NEXT:    retq
+  %sub = fsub <16 x float> %A, %B
+  %add = fadd <16 x float> %A, %B
+  %vecinit0 = shufflevector <16 x float> %sub, <16 x float> poison, <8 x i32> <i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12, i32 14>
+  %vecinit1 = shufflevector <16 x float> %add, <16 x float> poison, <8 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15>
+  %vecinit2 = shufflevector <8 x float> %vecinit0, <8 x float> %vecinit1, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
+  ret <16 x float> %vecinit2
+}
+
+define <8 x double> @test_addsub_v8f64(<8 x double> %A, <8 x double> %B) {
+; SSE-LABEL: test_addsub_v8f64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd %xmm4, %xmm0
 ; SSE-NEXT:    addsubpd %xmm5, %xmm1
@@ -140,13 +206,13 @@ define <8 x double> @test6(<8 x double> %A, <8 x double> %B) {
 ; SSE-NEXT:    addsubpd %xmm7, %xmm3
 ; SSE-NEXT:    retq
 ;
-; AVX1-LABEL: test6:
+; AVX1-LABEL: test_addsub_v8f64:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vaddsubpd %ymm2, %ymm0, %ymm0
 ; AVX1-NEXT:    vaddsubpd %ymm3, %ymm1, %ymm1
 ; AVX1-NEXT:    retq
 ;
-; AVX512-LABEL: test6:
+; AVX512-LABEL: test_addsub_v8f64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vaddpd %zmm1, %zmm0, %zmm2
 ; AVX512-NEXT:    vsubpd %zmm1, %zmm0, %zmm0
@@ -158,13 +224,42 @@ define <8 x double> @test6(<8 x double> %A, <8 x double> %B) {
   ret <8 x double> %vecinit2
 }
 
-define <4 x float> @test1b(<4 x float> %A, ptr %B) {
-; SSE-LABEL: test1b:
+define <8 x double> @test_addsub_v8f64_sse(<8 x double> %A, <8 x double> %B) {
+; SSE-LABEL: test_addsub_v8f64_sse:
+; SSE:       # %bb.0:
+; SSE-NEXT:    addsubpd %xmm4, %xmm0
+; SSE-NEXT:    addsubpd %xmm5, %xmm1
+; SSE-NEXT:    addsubpd %xmm6, %xmm2
+; SSE-NEXT:    addsubpd %xmm7, %xmm3
+; SSE-NEXT:    retq
+;
+; AVX1-LABEL: test_addsub_v8f64_sse:
+; AVX1:       # %bb.0:
+; AVX1-NEXT:    vaddsubpd %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vaddsubpd %ymm3, %ymm1, %ymm1
+; AVX1-NEXT:    retq
+;
+; AVX512-LABEL: test_addsub_v8f64_sse:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vaddpd %zmm1, %zmm0, %zmm2
+; AVX512-NEXT:    vsubpd %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vshufpd {{.*#+}} zmm0 = zmm0[0],zmm2[1],zmm0[2],zmm2[3],zmm0[4],zmm2[5],zmm0[6],zmm2[7]
+; AVX512-NEXT:    retq
+  %add = fadd <8 x double> %A, %B
+  %sub = fsub <8 x double> %A, %B
+  %vecinit0 = shufflevector <8 x double> %sub, <8 x double> poison, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
+  %vecinit1 = shufflevector <8 x double> %add, <8 x double> poison, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
+  %vecinit2 = shufflevector <4 x double> %vecinit0, <4 x double> %vecinit1, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
+  ret <8 x double> %vecinit2
+}
+
+define <4 x float> @test_addsub_v4f32_load(<4 x float> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v4f32_load:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps (%rdi), %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test1b:
+; AVX-LABEL: test_addsub_v4f32_load:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps (%rdi), %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -175,14 +270,14 @@ define <4 x float> @test1b(<4 x float> %A, ptr %B) {
   ret <4 x float> %vecinit6
 }
 
-define <8 x float> @test2b(<8 x float> %A, ptr %B) {
-; SSE-LABEL: test2b:
+define <8 x float> @test_addsub_v8f32_load(<8 x float> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v8f32_load:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps (%rdi), %xmm0
 ; SSE-NEXT:    addsubps 16(%rdi), %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test2b:
+; AVX-LABEL: test_addsub_v8f32_load:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps (%rdi), %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -193,14 +288,14 @@ define <8 x float> @test2b(<8 x float> %A, ptr %B) {
   ret <8 x float> %vecinit14
 }
 
-define <4 x double> @test3b(<4 x double> %A, ptr %B) {
-; SSE-LABEL: test3b:
+define <4 x double> @test_addsub_v4f64_load(<4 x double> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v4f64_load:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd (%rdi), %xmm0
 ; SSE-NEXT:    addsubpd 16(%rdi), %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test3b:
+; AVX-LABEL: test_addsub_v4f64_load:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd (%rdi), %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -211,13 +306,13 @@ define <4 x double> @test3b(<4 x double> %A, ptr %B) {
   ret <4 x double> %vecinit6
 }
 
-define <2 x double> @test4b(<2 x double> %A, ptr %B) {
-; SSE-LABEL: test4b:
+define <2 x double> @test_addsub_v2f64_load(<2 x double> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v2f64_load:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd (%rdi), %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test4b:
+; AVX-LABEL: test_addsub_v2f64_load:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd (%rdi), %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -228,13 +323,13 @@ define <2 x double> @test4b(<2 x double> %A, ptr %B) {
   ret <2 x double> %vecinit2
 }
 
-define <4 x float> @test1c(<4 x float> %A, ptr %B) {
-; SSE-LABEL: test1c:
+define <4 x float> @test_addsub_v4f32_load_commute(<4 x float> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v4f32_load_commute:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps (%rdi), %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test1c:
+; AVX-LABEL: test_addsub_v4f32_load_commute:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps (%rdi), %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -245,14 +340,14 @@ define <4 x float> @test1c(<4 x float> %A, ptr %B) {
   ret <4 x float> %vecinit6
 }
 
-define <8 x float> @test2c(<8 x float> %A, ptr %B) {
-; SSE-LABEL: test2c:
+define <8 x float> @test_addsub_v8f32_load_commute(<8 x float> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v8f32_load_commute:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubps (%rdi), %xmm0
 ; SSE-NEXT:    addsubps 16(%rdi), %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test2c:
+; AVX-LABEL: test_addsub_v8f32_load_commute:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubps (%rdi), %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -263,14 +358,14 @@ define <8 x float> @test2c(<8 x float> %A, ptr %B) {
   ret <8 x float> %vecinit14
 }
 
-define <4 x double> @test3c(<4 x double> %A, ptr %B) {
-; SSE-LABEL: test3c:
+define <4 x double> @test_addsub_v4f64_load_commute(<4 x double> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v4f64_load_commute:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd (%rdi), %xmm0
 ; SSE-NEXT:    addsubpd 16(%rdi), %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test3c:
+; AVX-LABEL: test_addsub_v4f64_load_commute:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd (%rdi), %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -281,13 +376,13 @@ define <4 x double> @test3c(<4 x double> %A, ptr %B) {
   ret <4 x double> %vecinit6
 }
 
-define <2 x double> @test4c(<2 x double> %A, ptr %B) {
-; SSE-LABEL: test4c:
+define <2 x double> @test_addsub_v2f64_load_commute(<2 x double> %A, ptr %B) {
+; SSE-LABEL: test_addsub_v2f64_load_commute:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    addsubpd (%rdi), %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: test4c:
+; AVX-LABEL: test_addsub_v2f64_load_commute:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vaddsubpd (%rdi), %xmm0, %xmm0
 ; AVX-NEXT:    retq
@@ -296,4 +391,95 @@ define <2 x double> @test4c(<2 x double> %A, ptr %B) {
   %add = fadd <2 x double> %A, %1
   %vecinit2 = shufflevector <2 x double> %add, <2 x double> %sub, <2 x i32> <i32 2, i32 1>
   ret <2 x double> %vecinit2
+}
+
+define <4 x float> @test_addsub_v4f32_partial_23(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_23:
+; SSE:       # %bb.0:
+; SSE-NEXT:    movhlps {{.*#+}} xmm0 = xmm0[1,1]
+; SSE-NEXT:    movhlps {{.*#+}} xmm1 = xmm1[1,1]
+; SSE-NEXT:    movaps %xmm0, %xmm2
+; SSE-NEXT:    subps %xmm1, %xmm2
+; SSE-NEXT:    addps %xmm0, %xmm1
+; SSE-NEXT:    shufps {{.*#+}} xmm1 = xmm1[1,0],xmm2[0,0]
+; SSE-NEXT:    shufps {{.*#+}} xmm2 = xmm2[0,1],xmm1[2,0]
+; SSE-NEXT:    movaps %xmm2, %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_addsub_v4f32_partial_23:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vshufpd {{.*#+}} xmm0 = xmm0[1,0]
+; AVX-NEXT:    vshufpd {{.*#+}} xmm1 = xmm1[1,0]
+; AVX-NEXT:    vsubps %xmm1, %xmm0, %xmm2
+; AVX-NEXT:    vaddps %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    vblendps {{.*#+}} xmm0 = xmm2[0],xmm0[1],xmm2[2,3]
+; AVX-NEXT:    vmovddup {{.*#+}} xmm0 = xmm0[0,0]
+; AVX-NEXT:    retq
+  %A.sub = shufflevector <4 x float> %A, <4 x float> poison, <2 x i32> <i32 2, i32 3>
+  %B.sub = shufflevector <4 x float> %B, <4 x float> poison, <2 x i32> <i32 2, i32 3>
+  %sub = fsub <2 x float> %A.sub, %B.sub
+  %add = fadd <2 x float> %A.sub, %B.sub
+  %vecinit = shufflevector <2 x float> %sub, <2 x float> %add, <4 x i32> <i32 poison, i32 poison, i32 0, i32 3>
+  ret <4 x float> %vecinit
+}
+
+define <4 x float> @test_addsub_v4f32_partial_03(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_03:
+; SSE:       # %bb.0:
+; SSE-NEXT:    addsubps %xmm1, %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_addsub_v4f32_partial_03:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %sub = fsub <4 x float> %A, %B
+  %add = fadd <4 x float> %A, %B
+  %vecinit = shufflevector <4 x float> %sub, <4 x float> %add, <4 x i32> <i32 0, i32 poison, i32 poison, i32 7>
+  ret <4 x float> %vecinit
+}
+
+define <4 x float> @test_addsub_v4f32_partial_12(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_12:
+; SSE:       # %bb.0:
+; SSE-NEXT:    shufps {{.*#+}} xmm0 = xmm0[1,2,2,3]
+; SSE-NEXT:    shufps {{.*#+}} xmm1 = xmm1[1,2,2,3]
+; SSE-NEXT:    movaps %xmm0, %xmm2
+; SSE-NEXT:    subps %xmm1, %xmm2
+; SSE-NEXT:    addps %xmm1, %xmm0
+; SSE-NEXT:    unpcklps {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_addsub_v4f32_partial_12:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vshufps {{.*#+}} xmm0 = xmm0[1,2,2,3]
+; AVX-NEXT:    vshufps {{.*#+}} xmm1 = xmm1[1,2,2,3]
+; AVX-NEXT:    vsubps %xmm1, %xmm0, %xmm2
+; AVX-NEXT:    vaddps %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    vunpcklps {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX-NEXT:    retq
+  %A.sub = shufflevector <4 x float> %A, <4 x float> poison, <2 x i32> <i32 1, i32 2>
+  %B.sub = shufflevector <4 x float> %B, <4 x float> poison, <2 x i32> <i32 1, i32 2>
+  %sub = fsub <2 x float> %A.sub, %B.sub
+  %add = fadd <2 x float> %A.sub, %B.sub
+  %vecinit = shufflevector <2 x float> %sub, <2 x float> %add, <4 x i32> <i32 poison, i32 0, i32 3, i32 poison>
+  ret <4 x float> %vecinit
+}
+
+define <4 x float> @test_addsub_v4f32_partial_01(<4 x float> %A, <4 x float> %B) {
+; SSE-LABEL: test_addsub_v4f32_partial_01:
+; SSE:       # %bb.0:
+; SSE-NEXT:    addsubps %xmm1, %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_addsub_v4f32_partial_01:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vaddsubps %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %A.sub = shufflevector <4 x float> %A, <4 x float> poison, <2 x i32> <i32 0, i32 1>
+  %B.sub = shufflevector <4 x float> %B, <4 x float> poison, <2 x i32> <i32 0, i32 1>
+  %sub = fsub <2 x float> %A.sub, %B.sub
+  %add = fadd <2 x float> %A.sub, %B.sub
+  %vecinit = shufflevector <2 x float> %sub, <2 x float> %add, <4 x i32> <i32 0, i32 3, i32 poison, i32 poison>
+  ret <4 x float> %vecinit
 }

--- a/llvm/test/Transforms/PhaseOrdering/X86/addsub-inseltpoison.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/addsub-inseltpoison.ll
@@ -156,8 +156,8 @@ define <4 x float> @test_addsub_v4f32(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert4
 }
 
-define <8 x float> @test_v8f32(<8 x float> %A, <8 x float> %B) {
-; SSE2-LABEL: @test_v8f32(
+define <8 x float> @test_addsub_v8f32(<8 x float> %A, <8 x float> %B) {
+; SSE2-LABEL: @test_addsub_v8f32(
 ; SSE2-NEXT:    [[TMP1:%.*]] = fsub <8 x float> [[A:%.*]], [[B:%.*]]
 ; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> poison, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
 ; SSE2-NEXT:    [[TMP3:%.*]] = fadd <8 x float> [[A]], [[B]]
@@ -165,13 +165,13 @@ define <8 x float> @test_v8f32(<8 x float> %A, <8 x float> %B) {
 ; SSE2-NEXT:    [[TMP5:%.*]] = shufflevector <4 x float> [[TMP2]], <4 x float> [[TMP4]], <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
 ; SSE2-NEXT:    ret <8 x float> [[TMP5]]
 ;
-; SSE4-LABEL: @test_v8f32(
+; SSE4-LABEL: @test_addsub_v8f32(
 ; SSE4-NEXT:    [[TMP1:%.*]] = fsub <8 x float> [[A:%.*]], [[B:%.*]]
 ; SSE4-NEXT:    [[TMP2:%.*]] = fadd <8 x float> [[A]], [[B]]
 ; SSE4-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[TMP2]], <8 x i32> <i32 0, i32 9, i32 2, i32 11, i32 4, i32 13, i32 6, i32 15>
 ; SSE4-NEXT:    ret <8 x float> [[TMP3]]
 ;
-; AVX-LABEL: @test_v8f32(
+; AVX-LABEL: @test_addsub_v8f32(
 ; AVX-NEXT:    [[TMP1:%.*]] = fsub <8 x float> [[A:%.*]], [[B:%.*]]
 ; AVX-NEXT:    [[TMP2:%.*]] = fadd <8 x float> [[A]], [[B]]
 ; AVX-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[TMP2]], <8 x i32> <i32 0, i32 9, i32 2, i32 11, i32 4, i32 13, i32 6, i32 15>

--- a/llvm/test/Transforms/PhaseOrdering/X86/addsub.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/addsub.ll
@@ -156,8 +156,8 @@ define <4 x float> @test_addsub_v4f32(<4 x float> %A, <4 x float> %B) {
   ret <4 x float> %vecinsert4
 }
 
-define <8 x float> @test_v8f32(<8 x float> %A, <8 x float> %B) {
-; SSE2-LABEL: @test_v8f32(
+define <8 x float> @test_addsub_v8f32(<8 x float> %A, <8 x float> %B) {
+; SSE2-LABEL: @test_addsub_v8f32(
 ; SSE2-NEXT:    [[TMP1:%.*]] = fsub <8 x float> [[A:%.*]], [[B:%.*]]
 ; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> poison, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
 ; SSE2-NEXT:    [[TMP3:%.*]] = fadd <8 x float> [[A]], [[B]]
@@ -165,13 +165,13 @@ define <8 x float> @test_v8f32(<8 x float> %A, <8 x float> %B) {
 ; SSE2-NEXT:    [[TMP5:%.*]] = shufflevector <4 x float> [[TMP2]], <4 x float> [[TMP4]], <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
 ; SSE2-NEXT:    ret <8 x float> [[TMP5]]
 ;
-; SSE4-LABEL: @test_v8f32(
+; SSE4-LABEL: @test_addsub_v8f32(
 ; SSE4-NEXT:    [[TMP1:%.*]] = fsub <8 x float> [[A:%.*]], [[B:%.*]]
 ; SSE4-NEXT:    [[TMP2:%.*]] = fadd <8 x float> [[A]], [[B]]
 ; SSE4-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[TMP2]], <8 x i32> <i32 0, i32 9, i32 2, i32 11, i32 4, i32 13, i32 6, i32 15>
 ; SSE4-NEXT:    ret <8 x float> [[TMP3]]
 ;
-; AVX-LABEL: @test_v8f32(
+; AVX-LABEL: @test_addsub_v8f32(
 ; AVX-NEXT:    [[TMP1:%.*]] = fsub <8 x float> [[A:%.*]], [[B:%.*]]
 ; AVX-NEXT:    [[TMP2:%.*]] = fadd <8 x float> [[A]], [[B]]
 ; AVX-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[TMP2]], <8 x i32> <i32 0, i32 9, i32 2, i32 11, i32 4, i32 13, i32 6, i32 15>


### PR DESCRIPTION
Use the same test names wherever possible and ensure sse3-avx-addsub.ll has test coverage for the IR emitted by the middle-end (no matter how poor it is)

Prep work for #144489 (sse3-avx-addsub-2.ll will be deleted along with lowerToAddSubOrFMAddSub)