### PR TITLE
[mlir][scf] Expose kPeeledLoopLabel as a public marker attribute

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
@@ -106,6 +106,9 @@ LogicalResult peelForLoopAndSimplifyBounds(RewriterBase &rewriter, ForOp forOp,
 LogicalResult peelForLoopFirstIteration(RewriterBase &rewriter, ForOp forOp,
                                         scf::ForOp &partialIteration);
 
+/// Marker attribute name for loops that have already been peeled.
+static constexpr StringLiteral kPeeledLoopLabel = "__peeled_loop__";
+
 /// Tile a parallel loop of the form
 ///   scf.parallel (%i0, %i1) = (%arg0, %arg1) to (%arg2, %arg3)
 ///                                             step (%arg4, %arg5)

--- a/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h
@@ -106,8 +106,8 @@ LogicalResult peelForLoopAndSimplifyBounds(RewriterBase &rewriter, ForOp forOp,
 LogicalResult peelForLoopFirstIteration(RewriterBase &rewriter, ForOp forOp,
                                         scf::ForOp &partialIteration);
 
-/// Marker attribute name for loops that have already been peeled.
-static constexpr StringLiteral kPeeledLoopLabel = "__peeled_loop__";
+/// Returns the attribute name used to mark loops that have already been peeled.
+StringRef getPeeledLoopAttrName();
 
 /// Tile a parallel loop of the form
 ///   scf.parallel (%i0, %i1) = (%arg0, %arg1) to (%arg2, %arg3)

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -256,7 +256,6 @@ LogicalResult mlir::scf::peelForLoopFirstIteration(RewriterBase &b, ForOp forOp,
   return success();
 }
 
-static constexpr char kPeeledLoopLabel[] = "__peeled_loop__";
 static constexpr char kPartialIterationLabel[] = "__partial_iteration__";
 
 namespace {
@@ -272,7 +271,7 @@ struct ForLoopPeelingPattern : public OpRewritePattern<ForOp> {
                                          "unsigned loops are not supported");
 
     // Do not peel already peeled loops.
-    if (forOp->hasAttr(kPeeledLoopLabel))
+    if (forOp->hasAttr(scf::kPeeledLoopLabel))
       return failure();
 
     scf::ForOp partialIteration;
@@ -300,11 +299,11 @@ struct ForLoopPeelingPattern : public OpRewritePattern<ForOp> {
 
     // Apply label, so that the same loop is not rewritten a second time.
     rewriter.modifyOpInPlace(partialIteration, [&]() {
-      partialIteration->setAttr(kPeeledLoopLabel, rewriter.getUnitAttr());
+      partialIteration->setAttr(scf::kPeeledLoopLabel, rewriter.getUnitAttr());
       partialIteration->setAttr(kPartialIterationLabel, rewriter.getUnitAttr());
     });
     rewriter.modifyOpInPlace(forOp, [&]() {
-      forOp->setAttr(kPeeledLoopLabel, rewriter.getUnitAttr());
+      forOp->setAttr(scf::kPeeledLoopLabel, rewriter.getUnitAttr());
     });
     return success();
   }
@@ -351,7 +350,7 @@ struct ForLoopPeeling : public impl::SCFForLoopPeelingBase<ForLoopPeeling> {
 
     // Drop the markers.
     parentOp->walk([](Operation *op) {
-      op->removeAttr(kPeeledLoopLabel);
+      op->removeAttr(scf::kPeeledLoopLabel);
       op->removeAttr(kPartialIterationLabel);
     });
   }

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -258,6 +258,8 @@ LogicalResult mlir::scf::peelForLoopFirstIteration(RewriterBase &b, ForOp forOp,
 
 static constexpr char kPartialIterationLabel[] = "__partial_iteration__";
 
+StringRef mlir::scf::getPeeledLoopAttrName() { return "__peeled_loop__"; }
+
 namespace {
 struct ForLoopPeelingPattern : public OpRewritePattern<ForOp> {
   ForLoopPeelingPattern(MLIRContext *ctx, bool peelFront, bool skipPartial)
@@ -271,7 +273,7 @@ struct ForLoopPeelingPattern : public OpRewritePattern<ForOp> {
                                          "unsigned loops are not supported");
 
     // Do not peel already peeled loops.
-    if (forOp->hasAttr(scf::kPeeledLoopLabel))
+    if (forOp->hasAttr(scf::getPeeledLoopAttrName()))
       return failure();
 
     scf::ForOp partialIteration;
@@ -299,11 +301,12 @@ struct ForLoopPeelingPattern : public OpRewritePattern<ForOp> {
 
     // Apply label, so that the same loop is not rewritten a second time.
     rewriter.modifyOpInPlace(partialIteration, [&]() {
-      partialIteration->setAttr(scf::kPeeledLoopLabel, rewriter.getUnitAttr());
+      partialIteration->setAttr(scf::getPeeledLoopAttrName(),
+                                rewriter.getUnitAttr());
       partialIteration->setAttr(kPartialIterationLabel, rewriter.getUnitAttr());
     });
     rewriter.modifyOpInPlace(forOp, [&]() {
-      forOp->setAttr(scf::kPeeledLoopLabel, rewriter.getUnitAttr());
+      forOp->setAttr(scf::getPeeledLoopAttrName(), rewriter.getUnitAttr());
     });
     return success();
   }
@@ -350,7 +353,7 @@ struct ForLoopPeeling : public impl::SCFForLoopPeelingBase<ForLoopPeeling> {
 
     // Drop the markers.
     parentOp->walk([](Operation *op) {
-      op->removeAttr(scf::kPeeledLoopLabel);
+      op->removeAttr(scf::getPeeledLoopAttrName());
       op->removeAttr(kPartialIterationLabel);
     });
   }


### PR DESCRIPTION
This should allow marking a for loop as peeled in downstream passes and have SCFForLoopPeeling skip it.