### PR TITLE
[ARM] Fix chkstk definition

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -6041,7 +6041,7 @@ def MSRbanked : ABI<0b0001, (outs), (ins banked_reg:$banked, GPRnopc:$Rn),
 def win__chkstk : SDNode<"ARMISD::WIN__CHKSTK", SDTNone,
                       [SDNPHasChain, SDNPSideEffect]>;
 
-let usesCustomInserter = 1, Uses = [R4], Defs = [R4, SP], hasNoSchedulingInfo = 1 in
+let usesCustomInserter = 1, Uses = [R4], Defs = [R4, R12, LR, SP, CPSR], hasNoSchedulingInfo = 1 in
   def WIN__CHKSTK : PseudoInst<(outs), (ins), NoItinerary, [(win__chkstk)]>;
 
 // Windows' divide by zero check

--- a/llvm/test/CodeGen/ARM/Windows/chkstk-cpsr-clobber.ll
+++ b/llvm/test/CodeGen/ARM/Windows/chkstk-cpsr-clobber.ll
@@ -1,0 +1,25 @@
+; RUN: llc -O2 -mtriple=thumbv7-windows %s -o - | FileCheck %s
+
+; Ensure that __chkstk correctly marks CPSR as clobbered so that conditional
+; operations after dynamic stack allocation re-evaluate condition flags.
+
+define arm_aapcs_vfpcc void @chkstk_cpsr_clobber(i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  %max = select i1 %cmp, i32 %n, i32 1
+  %vla = alloca i8, i32 %max
+  br i1 %cmp, label %then, label %exit
+
+then:
+  store volatile i8 1, ptr %vla
+  ret void
+
+exit:
+  ret void
+}
+
+; CHECK-LABEL: chkstk_cpsr_clobber:
+; CHECK:         bl __chkstk
+; CHECK:         sub.w sp, sp, r4
+; CHECK:         cmp r0, #0
+; CHECK:         it gt


### PR DESCRIPTION
The `chkstk` pseudo-instruction involves a function call, which clobbers R12 and LR.

Additionally, the code inside `chkstk` clobbers CPSR.

Fixes #210939.