### PR TITLE
[lldb][lldb-server] Update the expected gdbserver's architecture

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3316,8 +3316,8 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
   response.Indent();
   const llvm::StringRef arch_name =
       m_current_process->GetArchitecture().GetTriple().getArchName();
-  // Match gdbserver's expected architecture name we aready do the same
-  // when decoding the architecture when receiving the target.xml
+  // Match gdbserver's expected architecture. We do the reverse when
+  // decoding the architecture when receiving the target.xml
   // in ProcessGDBRemote::GetGDBServerRegisterInfoXMLAndProcess.
   const llvm::StringRef new_arch_name = StringSwitch<llvm::StringRef>(arch_name)
                                             .Case("x86_64", "i386:x86-64")

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -43,6 +43,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/UnimplementedError.h"
 #include "lldb/Utility/UriParser.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/JSON.h"
@@ -3313,13 +3314,17 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
   response.IndentMore();
 
   response.Indent();
-  response.Printf("<architecture>%s</architecture>\n",
-                  m_current_process->GetArchitecture()
-                      .GetTriple()
-                      .getArchName()
-                      .str()
-                      .c_str());
-
+  const llvm::StringRef arch_name =
+      m_current_process->GetArchitecture().GetTriple().getArchName();
+  // Match gdbserver's expected architecture name we aready do the same
+  // when decoding the architecture when receiving the target.xml
+  // in ProcessGDBRemote::GetGDBServerRegisterInfoXMLAndProcess.
+  const llvm::StringRef new_arch_name = StringSwitch<llvm::StringRef>(arch_name)
+                                            .Case("x86_64", "i386:x86-64")
+                                            .Case("riscv64", "riscv:rv64")
+                                            .Case("riscv32", "riscv:rv32")
+                                            .Default(arch_name);
+  response.Format("<architecture>{}</architecture>\n", new_arch_name);
   response.Indent("<feature>\n");
 
   const int registers_count = reg_context.GetUserRegisterCount();

--- a/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
+++ b/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
@@ -40,7 +40,15 @@ class TestGdbRemoteTargetXmlPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         architecture = root.find("architecture")
         self.assertIsNotNone(architecture)
-        self.assertIn(self.getArchitecture(), architecture.text)
+        # Match the expected gdbserver's arch, see GDBRemoteCommunicationServerLLGS::BuildTargetXml.
+        replaced_arch = {
+            "x86_64": "i386:x86-64",
+            "riscv64": "riscv:rv64",
+            "riscv32": "riscv:rv32",
+        }
+        arch: str = self.getArchitecture()
+        expected_arch = replaced_arch.get(arch, arch)
+        self.assertIn(architecture.text, expected_arch)
 
         feature = root.find("feature")
         self.assertIsNotNone(feature)


### PR DESCRIPTION
gdbserver recognises 'x86_64' arch as 'i386:x86-64', this prevents gdb (binary) from connecting to lldb-server since lldb-server reports architecture  as 'x86_64'. we already do something similar when connecting a server to lldb.
This does not affect lldb -> lldb-server since we use qHostInfo to get that information.