### PR TITLE
[mlir][vector] Verify non-unit strides on `masked/expand/compress` ops 

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6299,8 +6299,8 @@ LogicalResult MaskedLoadOp::verify() {
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (!memType.isLastDimUnitStride())
-    return emitOpError("most minor memref dim must have unit stride");
+  if (failed(verifyLoadStoreMemRefLayout(*this, resVType, memType)))
+    return failure();
 
   // Negative strides are not supported on vector.maskedload. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6368,8 +6368,8 @@ LogicalResult MaskedStoreOp::verify() {
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (!memType.isLastDimUnitStride())
-    return emitOpError("most minor memref dim must have unit stride");
+  if (failed(verifyLoadStoreMemRefLayout(*this, valueVType, memType)))
+    return failure();
 
   // Negative strides are not supported on vector.maskedstore. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6654,8 +6654,8 @@ LogicalResult ExpandLoadOp::verify() {
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (!memType.isLastDimUnitStride())
-    return emitOpError("most minor memref dim must have unit stride");
+  if (failed(verifyLoadStoreMemRefLayout(*this, resVType, memType)))
+    return failure();
 
   // Negative strides are not supported on vector.expandload. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6720,8 +6720,8 @@ LogicalResult CompressStoreOp::verify() {
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (!memType.isLastDimUnitStride())
-    return emitOpError("most minor memref dim must have unit stride");
+  if (failed(verifyLoadStoreMemRefLayout(*this, valueVType, memType)))
+    return failure();
 
   // Negative strides are not supported on vector.compressstore. The lowering
   // to LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6190,6 +6190,33 @@ static LogicalResult verifyLoadStoreMemRefLayout(Operation *op,
   return success();
 }
 
+/// Verifies that `memRefTy`'s most minor dimension does not have a
+/// statically known non-unit stride; a dynamic (not provably unit) stride
+/// is accepted.
+///
+/// This is more permissive than vector.load/store's stride check: ops such
+/// as vector.maskedload/maskedstore and vector.expandload/compressstore are
+/// also used on memrefs whose most minor dimension is contiguous at runtime
+/// but not provable as such at the type level (e.g., buffers produced by
+/// the sparsifier).
+static LogicalResult verifyNonStaticNonUnitStrideRejected(Operation *op,
+                                                          VectorType vecTy,
+                                                          MemRefType memRefTy) {
+  if (!vecTy.isScalable() &&
+      (vecTy.getRank() == 0 || vecTy.getNumElements() == 1))
+    return success();
+
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (failed(memRefTy.getStridesAndOffset(strides, offset)))
+    return success();
+
+  if (!strides.empty() && !ShapedType::isDynamic(strides.back()) &&
+      strides.back() != 1)
+    return op->emitOpError("most minor memref dim must have unit stride");
+  return success();
+}
+
 LogicalResult vector::LoadOp::verify() {
   VectorType resVecTy = getVectorType();
   MemRefType memRefTy = getMemRefType();
@@ -6299,6 +6326,9 @@ LogicalResult MaskedLoadOp::verify() {
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
 
+  if (failed(verifyNonStaticNonUnitStrideRejected(*this, resVType, memType)))
+    return failure();
+
   // Negative strides are not supported on vector.maskedload. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
   // assume non-negative strides to avoid undefined behavior.
@@ -6364,6 +6394,9 @@ LogicalResult MaskedStoreOp::verify() {
   VectorType maskVType = getMaskVectorType();
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
+
+  if (failed(verifyNonStaticNonUnitStrideRejected(*this, valueVType, memType)))
+    return failure();
 
   // Negative strides are not supported on vector.maskedstore. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6648,6 +6681,15 @@ LogicalResult ExpandLoadOp::verify() {
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
 
+  if (failed(verifyNonStaticNonUnitStrideRejected(*this, resVType, memType)))
+    return failure();
+
+  // Negative strides are not supported on vector.expandload. The lowering to
+  // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
+  // assume non-negative strides to avoid undefined behavior.
+  if (memref::hasNegativeStaticStride(memType))
+    return emitOpError("memref strides must be non-negative");
+
   if (failed(
           verifyElementTypesMatch(*this, memType, resVType, "base", "result")))
     return failure();
@@ -6704,6 +6746,15 @@ LogicalResult CompressStoreOp::verify() {
   VectorType maskVType = getMaskVectorType();
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
+
+  if (failed(verifyNonStaticNonUnitStrideRejected(*this, valueVType, memType)))
+    return failure();
+
+  // Negative strides are not supported on vector.compressstore. The lowering
+  // to LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
+  // assume non-negative strides to avoid undefined behavior.
+  if (memref::hasNegativeStaticStride(memType))
+    return emitOpError("memref strides must be non-negative");
 
   if (failed(verifyElementTypesMatch(*this, memType, valueVType, "base",
                                      "valueToStore")))

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6190,33 +6190,6 @@ static LogicalResult verifyLoadStoreMemRefLayout(Operation *op,
   return success();
 }
 
-/// Verifies that `memRefTy`'s most minor dimension does not have a
-/// statically known non-unit stride; a dynamic (not provably unit) stride
-/// is accepted.
-///
-/// This is more permissive than vector.load/store's stride check: ops such
-/// as vector.maskedload/maskedstore and vector.expandload/compressstore are
-/// also used on memrefs whose most minor dimension is contiguous at runtime
-/// but not provable as such at the type level (e.g., buffers produced by
-/// the sparsifier).
-static LogicalResult verifyNonStaticNonUnitStrideRejected(Operation *op,
-                                                          VectorType vecTy,
-                                                          MemRefType memRefTy) {
-  if (!vecTy.isScalable() &&
-      (vecTy.getRank() == 0 || vecTy.getNumElements() == 1))
-    return success();
-
-  SmallVector<int64_t> strides;
-  int64_t offset;
-  if (failed(memRefTy.getStridesAndOffset(strides, offset)))
-    return success();
-
-  if (!strides.empty() && !ShapedType::isDynamic(strides.back()) &&
-      strides.back() != 1)
-    return op->emitOpError("most minor memref dim must have unit stride");
-  return success();
-}
-
 LogicalResult vector::LoadOp::verify() {
   VectorType resVecTy = getVectorType();
   MemRefType memRefTy = getMemRefType();
@@ -6326,8 +6299,8 @@ LogicalResult MaskedLoadOp::verify() {
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (failed(verifyNonStaticNonUnitStrideRejected(*this, resVType, memType)))
-    return failure();
+  if (!memType.isLastDimUnitStride())
+    return emitOpError("most minor memref dim must have unit stride");
 
   // Negative strides are not supported on vector.maskedload. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6395,8 +6368,8 @@ LogicalResult MaskedStoreOp::verify() {
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (failed(verifyNonStaticNonUnitStrideRejected(*this, valueVType, memType)))
-    return failure();
+  if (!memType.isLastDimUnitStride())
+    return emitOpError("most minor memref dim must have unit stride");
 
   // Negative strides are not supported on vector.maskedstore. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6681,8 +6654,8 @@ LogicalResult ExpandLoadOp::verify() {
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (failed(verifyNonStaticNonUnitStrideRejected(*this, resVType, memType)))
-    return failure();
+  if (!memType.isLastDimUnitStride())
+    return emitOpError("most minor memref dim must have unit stride");
 
   // Negative strides are not supported on vector.expandload. The lowering to
   // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
@@ -6747,8 +6720,8 @@ LogicalResult CompressStoreOp::verify() {
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (failed(verifyNonStaticNonUnitStrideRejected(*this, valueVType, memType)))
-    return failure();
+  if (!memType.isLastDimUnitStride())
+    return emitOpError("most minor memref dim must have unit stride");
 
   // Negative strides are not supported on vector.compressstore. The lowering
   // to LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -1431,6 +1431,15 @@ func.func @maskedload_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?>
 
 // -----
 
+func.func @maskedload_dynamic_stride(%src: memref<?xi8, strided<[?], offset: ?>>, %mask: vector<8xi1>, %pass: vector<8xi8>) -> vector<8xi8> {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.maskedload' op most minor memref dim must have unit stride}}
+  %0 = vector.maskedload %src[%c0], %mask, %pass : memref<?xi8, strided<[?], offset: ?>>, vector<8xi1>, vector<8xi8> into vector<8xi8>
+  return %0 : vector<8xi8>
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // vector.maskedstore
 //===----------------------------------------------------------------------===//
@@ -1488,6 +1497,15 @@ func.func @maskedstore_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?
   %c0 = arith.constant 0 : index
   // expected-error @+1 {{'vector.maskedstore' op most minor memref dim must have unit stride}}
   vector.maskedstore %src[%c0], %mask, %value : memref<?xi8, strided<[2], offset: ?>>, vector<8xi1>, vector<8xi8>
+  return
+}
+
+// -----
+
+func.func @maskedstore_dynamic_stride(%src: memref<?xi8, strided<[?], offset: ?>>, %mask: vector<8xi1>, %value: vector<8xi8>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.maskedstore' op most minor memref dim must have unit stride}}
+  vector.maskedstore %src[%c0], %mask, %value : memref<?xi8, strided<[?], offset: ?>>, vector<8xi1>, vector<8xi8>
   return
 }
 
@@ -1768,6 +1786,15 @@ func.func @expandload_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?>
 
 // -----
 
+func.func @expandload_dynamic_stride(%src: memref<?xi8, strided<[?], offset: ?>>, %mask: vector<8xi1>, %pass_thru: vector<8xi8>) -> vector<8xi8> {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.expandload' op most minor memref dim must have unit stride}}
+  %0 = vector.expandload %src[%c0], %mask, %pass_thru : memref<?xi8, strided<[?], offset: ?>>, vector<8xi1>, vector<8xi8> into vector<8xi8>
+  return %0 : vector<8xi8>
+}
+
+// -----
+
 func.func @expandload_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %mask: vector<8xi1>, %pass_thru: vector<8xf32>) -> vector<8xf32> {
   %c0 = arith.constant 0 : index
   // expected-error @+1 {{'vector.expandload' op memref strides must be non-negative}}
@@ -1835,6 +1862,15 @@ func.func @compressstore_non_unit_stride(%src: memref<?xi8, strided<[2], offset:
   %c0 = arith.constant 0 : index
   // expected-error @+1 {{'vector.compressstore' op most minor memref dim must have unit stride}}
   vector.compressstore %src[%c0], %mask, %value : memref<?xi8, strided<[2], offset: ?>>, vector<8xi1>, vector<8xi8>
+  return
+}
+
+// -----
+
+func.func @compressstore_dynamic_stride(%src: memref<?xi8, strided<[?], offset: ?>>, %mask: vector<8xi1>, %value: vector<8xi8>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.compressstore' op most minor memref dim must have unit stride}}
+  vector.compressstore %src[%c0], %mask, %value : memref<?xi8, strided<[?], offset: ?>>, vector<8xi1>, vector<8xi8>
   return
 }
 

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -2268,10 +2268,6 @@ func.func @load_non_unit_stride(%src : memref<?xi8, strided<[2], offset: ?>>) {
 
 // -----
 
-// Unlike vector.maskedload/maskedstore/expandload/compressstore, a dynamic
-// (unprovable) stride is rejected here too: vector.load/store require a
-// statically known unit stride, with no exception for strides that merely
-// aren't provably non-unit.
 func.func @load_dynamic_stride(%src : memref<?xi8, strided<[?], offset: ?>>) {
   %c0 = arith.constant 0 : index
   // expected-error @+1 {{'vector.load' op most minor memref dim must have unit stride}}
@@ -2317,8 +2313,6 @@ func.func @store_non_unit_stride(%src : memref<?xi8, strided<[2], offset:?>>,%va
 
 // -----
 
-// See load_dynamic_stride above: vector.store also rejects a dynamic stride,
-// unlike vector.maskedstore.
 func.func @store_dynamic_stride(%src : memref<?xi8, strided<[?], offset: ?>>, %val : vector<16xi8>, %c0: index) {
   // expected-error @below {{'vector.store' op most minor memref dim must have unit stride}}
   vector.store %val, %src[%c0] : memref<?xi8, strided<[?], offset: ?>>, vector<16xi8>

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -1422,6 +1422,15 @@ func.func @maskedload_negative_stride(%src: memref<100x100xf32, strided<[-100, 1
 
 // -----
 
+func.func @maskedload_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?>>, %mask: vector<8xi1>, %pass: vector<8xi8>) -> vector<8xi8> {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.maskedload' op most minor memref dim must have unit stride}}
+  %0 = vector.maskedload %src[%c0], %mask, %pass : memref<?xi8, strided<[2], offset: ?>>, vector<8xi1>, vector<8xi8> into vector<8xi8>
+  return %0 : vector<8xi8>
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // vector.maskedstore
 //===----------------------------------------------------------------------===//
@@ -1470,6 +1479,15 @@ func.func @maskedstore_negative_stride(%src: memref<100x100xf32, strided<[-100, 
   %c0 = arith.constant 0 : index
   // expected-error @+1 {{'vector.maskedstore' op memref strides must be non-negative}}
   vector.maskedstore %src[%c0, %c0], %mask, %value : memref<100x100xf32, strided<[-100, 1]>>, vector<8xi1>, vector<8xf32>
+  return
+}
+
+// -----
+
+func.func @maskedstore_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?>>, %mask: vector<8xi1>, %value: vector<8xi8>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.maskedstore' op most minor memref dim must have unit stride}}
+  vector.maskedstore %src[%c0], %mask, %value : memref<?xi8, strided<[2], offset: ?>>, vector<8xi1>, vector<8xi8>
   return
 }
 
@@ -1741,6 +1759,24 @@ func.func @expand_scalable_dims_mismatch(%base: memref<?xf32>, %mask: vector<16x
 
 // -----
 
+func.func @expandload_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?>>, %mask: vector<8xi1>, %pass_thru: vector<8xi8>) -> vector<8xi8> {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.expandload' op most minor memref dim must have unit stride}}
+  %0 = vector.expandload %src[%c0], %mask, %pass_thru : memref<?xi8, strided<[2], offset: ?>>, vector<8xi1>, vector<8xi8> into vector<8xi8>
+  return %0 : vector<8xi8>
+}
+
+// -----
+
+func.func @expandload_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %mask: vector<8xi1>, %pass_thru: vector<8xf32>) -> vector<8xf32> {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.expandload' op memref strides must be non-negative}}
+  %0 = vector.expandload %src[%c0, %c0], %mask, %pass_thru : memref<100x100xf32, strided<[-100, 1]>>, vector<8xi1>, vector<8xf32> into vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+// -----
+
 func.func @compress_base_type_mismatch(%base: memref<?xf64>, %mask: vector<16xi1>, %value: vector<16xf32>) {
   %c0 = arith.constant 0 : index
   // expected-error@+1 {{'vector.compressstore' op base element type ('f64') does not match valueToStore element type ('f32')}}
@@ -1791,6 +1827,24 @@ func.func @compress_scalable_dims_mismatch(%base: memref<?xf32>, %mask: vector<1
   %c0 = arith.constant 0 : index
   // expected-error@+1 {{expected valueToStore scalable dims to match mask scalable dims}}
   vector.compressstore %base[%c0], %mask, %value : memref<?xf32>, vector<16xi1>, vector<[16]xf32>
+}
+
+// -----
+
+func.func @compressstore_non_unit_stride(%src: memref<?xi8, strided<[2], offset: ?>>, %mask: vector<8xi1>, %value: vector<8xi8>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.compressstore' op most minor memref dim must have unit stride}}
+  vector.compressstore %src[%c0], %mask, %value : memref<?xi8, strided<[2], offset: ?>>, vector<8xi1>, vector<8xi8>
+  return
+}
+
+// -----
+
+func.func @compressstore_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %mask: vector<8xi1>, %value: vector<8xf32>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.compressstore' op memref strides must be non-negative}}
+  vector.compressstore %src[%c0, %c0], %mask, %value : memref<100x100xf32, strided<[-100, 1]>>, vector<8xi1>, vector<8xf32>
+  return
 }
 
 // -----
@@ -2178,6 +2232,19 @@ func.func @load_non_unit_stride(%src : memref<?xi8, strided<[2], offset: ?>>) {
 
 // -----
 
+// Unlike vector.maskedload/maskedstore/expandload/compressstore, a dynamic
+// (unprovable) stride is rejected here too: vector.load/store require a
+// statically known unit stride, with no exception for strides that merely
+// aren't provably non-unit.
+func.func @load_dynamic_stride(%src : memref<?xi8, strided<[?], offset: ?>>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{'vector.load' op most minor memref dim must have unit stride}}
+  %0 = vector.load %src[%c0] : memref<?xi8, strided<[?], offset: ?>>, vector<16xi8>
+  return
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // vector.store
 //===----------------------------------------------------------------------===//
@@ -2209,6 +2276,16 @@ func.func @store_non_pow_of_2_alignment(%memref: memref<4xi32>, %val: vector<4xi
 func.func @store_non_unit_stride(%src : memref<?xi8, strided<[2], offset:?>>,%val : vector<16xi8>, %c0: index) {
   // expected-error @below {{'vector.store' op most minor memref dim must have unit stride}}
   vector.store %val, %src[%c0] : memref<?xi8, strided<[2], offset: ?>>, vector<16xi8>
+  return
+}
+
+// -----
+
+// See load_dynamic_stride above: vector.store also rejects a dynamic stride,
+// unlike vector.maskedstore.
+func.func @store_dynamic_stride(%src : memref<?xi8, strided<[?], offset: ?>>, %val : vector<16xi8>, %c0: index) {
+  // expected-error @below {{'vector.store' op most minor memref dim must have unit stride}}
+  vector.store %val, %src[%c0] : memref<?xi8, strided<[?], offset: ?>>, vector<16xi8>
   return
 }
 


### PR DESCRIPTION
Closes the stride-verification gap left open by #204611 and #205869.

`vector.maskedload`/`maskedstore`/`expandload`/`compressstore` lower to LLVM masked intrinsics that read/write N *consecutive* elements from a single pointer (see [LangRef](https://llvm.org/docs/LangRef.htm)), but none of them verified the memref's minor-dim stride, so `strided<[2]>` verified successfully and silently miscompiled.

This PR rejects statically-known non-unit and dynamic strides.

**Stacked on #211004**