### PR TITLE
[clang][SemaCXX] Fixed a crash when returning an initialization to a top-level deleted function

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -339,6 +339,8 @@ in a future version of Clang.
   `[](Types... = args...) {}`). Clang now diagnoses the illegal default
   argument instead of asserting. (#GH210714)
 
+- Fixed a crash when returning an initialization to a top-level deleted function. (#GH208488)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3545,6 +3545,13 @@ Sema::NamedReturnInfo Sema::getNamedReturnInfo(const VarDecl *VD) {
     return NamedReturnInfo();
   }
 
+  const Type *T = VDType.getTypePtr();
+  if (T->getTypeClass() == Type::Auto) {
+    const auto *A = cast<DeducedType>(T);
+    if (A->isUndeducedAutoType())
+      return NamedReturnInfo();
+  }
+
   // Variables with higher required alignment than their type's ABI
   // alignment cannot use NRVO.
   if (!VD->hasDependentAlignment() && !VDType->isIncompleteType() &&

--- a/clang/test/SemaCXX/deleted-function-return.cpp
+++ b/clang/test/SemaCXX/deleted-function-return.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -verify -std=c++2a -fsyntax-only %s
+
+auto f() = delete; // expected-note 2 {{candidate function has been explicitly deleted}}
+
+auto g1() {
+  auto x = f(); // expected-error {{call to deleted function 'f'}}
+  return x;
+}
+
+auto g2() {
+  decltype(auto) x = f(); // expected-error {{call to deleted function 'f'}}
+  return x;
+}


### PR DESCRIPTION
Resolves #208488

This crash is caused due to requesting declaration alignment for undeduced types like `auto` for explicitly deleted functions.