### PR TITLE
[SCEV][NFC] Precommit tests for MatchRangeCheckIdiom through zext

### DIFF
--- a/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
+++ b/llvm/test/Analysis/ScalarEvolution/max-backedge-taken-count-guard-info.ll
@@ -1699,3 +1699,152 @@ loop:
 exit:
   ret void
 }
+
+; TODO: The guard `zext i32 (-1 + %len) to i64 ult 4` implies that
+; `%len` is in [1, 5).
+define void @range_check_idiom_through_zext(i32 %len) {
+; CHECK-LABEL: 'range_check_idiom_through_zext'
+; CHECK-NEXT:  Classifying expressions for: @range_check_idiom_through_zext
+; CHECK-NEXT:    %len.off = add i32 %len, -1
+; CHECK-NEXT:    --> (-1 + %len) U: full-set S: full-set
+; CHECK-NEXT:    %len.wide = zext i32 %len.off to i64
+; CHECK-NEXT:    --> (zext i32 (-1 + %len) to i64) U: [0,4294967296) S: [0,4294967296)
+; CHECK-NEXT:    %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,-2147483648) S: [0,-2147483648) Exits: (-1 + %len) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw nsw i32 %iv, 1
+; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,-2147483648) S: [1,-2147483648) Exits: %len LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @range_check_idiom_through_zext
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 -2
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %len.off = add i32 %len, -1
+  %len.wide = zext i32 %len.off to i64
+  %chk = icmp ult i64 %len.wide, 4
+  br i1 %chk, label %loop, label %exit
+
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  %ec = icmp eq i32 %iv.next, %len
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; TODO: The guard `zext i32 (-1 + %len) to i64 ugt 2` implies that
+; `%len` is in [4, 1) (wrapping: {4,...,UINT_MAX} U {0};
+; note that %len == 0 satisfies the guard via 0 - 1 = UINT_MAX).
+define void @range_check_idiom_through_zext_ugt(i32 %len) {
+; CHECK-LABEL: 'range_check_idiom_through_zext_ugt'
+; CHECK-NEXT:  Classifying expressions for: @range_check_idiom_through_zext_ugt
+; CHECK-NEXT:    %len.off = add i32 %len, -1
+; CHECK-NEXT:    --> (-1 + %len) U: full-set S: full-set
+; CHECK-NEXT:    %len.wide = zext i32 %len.off to i64
+; CHECK-NEXT:    --> (zext i32 (-1 + %len) to i64) U: [0,4294967296) S: [0,4294967296)
+; CHECK-NEXT:    %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,-2147483648) S: [0,-2147483648) Exits: (-1 + %len) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw nsw i32 %iv, 1
+; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,-2147483648) S: [1,-2147483648) Exits: %len LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @range_check_idiom_through_zext_ugt
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 -1
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %len.off = add i32 %len, -1
+  %len.wide = zext i32 %len.off to i64
+  %chk = icmp ugt i64 %len.wide, 2
+  br i1 %chk, label %loop, label %exit
+
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  %ec = icmp eq i32 %iv.next, %len
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; Do not peel when the RHS does not fit in the narrow type:
+;   (zext X) ult 300  !=  X ult trunc(300)
+;
+; Since trunc i64 300 to i8 is 44, X = 44 is a counterexample: the wide
+; comparison is true, while the narrow comparison would be false.
+define void @range_check_idiom_through_zext_rhs_too_wide(i8 %len) {
+; CHECK-LABEL: 'range_check_idiom_through_zext_rhs_too_wide'
+; CHECK-NEXT:  Classifying expressions for: @range_check_idiom_through_zext_rhs_too_wide
+; CHECK-NEXT:    %len.off = add i8 %len, -1
+; CHECK-NEXT:    --> (-1 + %len) U: full-set S: full-set
+; CHECK-NEXT:    %len.wide = zext i8 %len.off to i64
+; CHECK-NEXT:    --> (zext i8 (-1 + %len) to i64) U: [0,256) S: [0,256)
+; CHECK-NEXT:    %iv = phi i8 [ 0, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,-128) S: [0,-128) Exits: (-1 + %len) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw nsw i8 %iv, 1
+; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,-128) S: [1,-128) Exits: %len LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @range_check_idiom_through_zext_rhs_too_wide
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i8 -1
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %len.off = add i8 %len, -1
+  %len.wide = zext i8 %len.off to i64
+  %chk = icmp ult i64 %len.wide, 300
+  br i1 %chk, label %loop, label %exit
+
+loop:
+  %iv = phi i8 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add nuw nsw i8 %iv, 1
+  %ec = icmp eq i8 %iv.next, %len
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+
+; Do not peel signed predicates through zext:
+;   (zext X) slt 4  !=  X slt 4
+;
+; For example, when %len = 0, %len.off is i32 -1. After zext it becomes
+; 4294967295, so the wide signed comparison is false, while the narrow
+; signed comparison would be true.
+define void @range_check_idiom_through_zext_signed(i32 %len) {
+; CHECK-LABEL: 'range_check_idiom_through_zext_signed'
+; CHECK-NEXT:  Classifying expressions for: @range_check_idiom_through_zext_signed
+; CHECK-NEXT:    %len.off = add i32 %len, -1
+; CHECK-NEXT:    --> (-1 + %len) U: full-set S: full-set
+; CHECK-NEXT:    %len.wide = zext i32 %len.off to i64
+; CHECK-NEXT:    --> (zext i32 (-1 + %len) to i64) U: [0,4294967296) S: [0,4294967296)
+; CHECK-NEXT:    %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,-2147483648) S: [0,-2147483648) Exits: (-1 + %len) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %iv.next = add nuw nsw i32 %iv, 1
+; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,-2147483648) S: [1,-2147483648) Exits: %len LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @range_check_idiom_through_zext_signed
+; CHECK-NEXT:  Loop %loop: backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 -1
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is (-1 + %len)
+; CHECK-NEXT:  Loop %loop: Trip multiple is 1
+;
+entry:
+  %len.off = add i32 %len, -1
+  %len.wide = zext i32 %len.off to i64
+  %chk = icmp slt i64 %len.wide, 4
+  br i1 %chk, label %loop, label %exit
+
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  %ec = icmp eq i32 %iv.next, %len
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}


### PR DESCRIPTION
'zext(X - 1) ult C'  =>  'X in [1, C+1)'; 
also ugt case (wrapping range)

Alive2 proof: https://alive2.llvm.org/ce/z/zcdv_2