### PR TITLE
[lldb][NFC] Don't use LLDB.h in multiple-targets/debuggers tests

### DIFF
--- a/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
+++ b/lldb/test/API/api/multiple-debuggers/multi-process-driver.cpp
@@ -19,10 +19,18 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "lldb/API/LLDB.h"
+#include "lldb/API/SBBreakpoint.h"
+#include "lldb/API/SBBroadcaster.h"
 #include "lldb/API/SBCommandInterpreter.h"
-#include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBError.h"
+#include "lldb/API/SBEvent.h"
+#include "lldb/API/SBFrame.h"
+#include "lldb/API/SBLaunchInfo.h"
+#include "lldb/API/SBListener.h"
+#include "lldb/API/SBProcess.h"
+#include "lldb/API/SBTarget.h"
+#include "lldb/API/SBThread.h"
 
 #include <chrono>
 #include <csignal>

--- a/lldb/test/API/api/multiple-targets/main.cpp
+++ b/lldb/test/API/api/multiple-targets/main.cpp
@@ -1,7 +1,7 @@
 #include <thread>
 
-#include "lldb/API/LLDB.h"
 #include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBError.h"
 #include "lldb/API/SBTarget.h"
 
 using namespace lldb;


### PR DESCRIPTION
LLDB.h is a header that includes (nearly) every SB API header indirectly. This patch replaces the use of this header in some .cpp tests by instead directly including the needed headers. This is mainly to reduce compilation times of these files as they are recompiled on each test run.