### PR TITLE
Revert "[lldb][Windows] Only embed Python home in Debug config (#209464)"

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -198,7 +198,7 @@ endif()
 option(LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS "Build the script interpreter plugins as shared libraries" ${default_enable_dynamic_scriptinterpreters})
 
 if (LLDB_ENABLE_PYTHON)
-  if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(default_embed_python_home ON)
   else()
     set(default_embed_python_home OFF)

--- a/lldb/docs/resources/build.md
+++ b/lldb/docs/resources/build.md
@@ -282,15 +282,15 @@ are commonly used on Windows.
   crash, rather than having to reproduce a failure or use a crash dump.
 - `PYTHON_HOME` (Required): Path to the folder where the Python distribution
   is installed. For example, `C:\Python35`.
-- `LLDB_EMBED_PYTHON_HOME` (Default=1 on Windows in the Debug configuration):
-  When this is 1, LLDB will bind statically to the location specified in the
-  `PYTHON_HOME` CMake variable, ignoring any value of `PYTHONHOME` set in the
-  environment. This is most useful for developers who simply want to run LLDB
-  after they build it. If you wish to move a build of LLDB to a different
-  machine where Python will be in a different location, setting 
-  `LLDB_EMBED_PYTHON_HOME` to 0 will cause Python to use its default mechanism
-  for finding the python installation at runtime (looking for installed 
-  Pythons, or using the `PYTHONHOME` environment variable if it is specified).
+- `LLDB_EMBED_PYTHON_HOME` (Default=1 on Windows): When this is 1, LLDB will bind
+  statically to the location specified in the `PYTHON_HOME` CMake variable,
+  ignoring any value of `PYTHONHOME` set in the environment. This is most
+  useful for developers who simply want to run LLDB after they build it. If you
+  wish to move a build of LLDB to a different machine where Python will be in a
+  different location, setting `LLDB_EMBED_PYTHON_HOME` to 0 will cause
+  Python to use its default mechanism for finding the python installation at
+  runtime (looking for installed Pythons, or using the `PYTHONHOME`
+  environment variable if it is specified).
 
 Sample command line:
 


### PR DESCRIPTION
This reverts commit 5a19a3a4b9915d19fff1b8298e723ee2b24ebc6a.

To fix a failure with MinGW (https://github.com/llvm/llvm-project/pull/209464#issuecomment-5034222807).