### PR TITLE
[libc] Add err.h to Linux public header target lists

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -10,6 +10,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.dlfcn
     libc.include.elf
     libc.include.endian
+    libc.include.err
     libc.include.errno
     libc.include.fcntl
     libc.include.features

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -3,6 +3,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.complex
     libc.include.cpio
     libc.include.ctype
+    libc.include.err
     libc.include.errno
     libc.include.fenv
     libc.include.float

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -10,6 +10,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.dlfcn
     libc.include.elf
     libc.include.endian
+    libc.include.err
     libc.include.errno
     libc.include.fcntl
     libc.include.features

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -10,6 +10,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.dlfcn
     libc.include.elf
     libc.include.endian
+    libc.include.err
     libc.include.errno
     libc.include.fcntl
     libc.include.features


### PR DESCRIPTION
Add libc.include.err to TARGET_PUBLIC_HEADERS for Linux targets (aarch64, arm, riscv, x86_64) so that err.h gets generated and installed.

Assisted-by: Automated tooling, human reviewed.