### PR TITLE
[OpenACC] Make sure our 'init' recipe handles nullptr_t

### DIFF
--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -2734,6 +2734,9 @@ Expr *GenerateReductionInitRecipeExpr(ASTContext &Context,
                                                   IK == InitKind::AllOnes ||
                                                   IK == InitKind::Largest),
                                                  Ty, ExprRange.getBegin()));
+    } else if (Ty->isNullPtrType()) {
+      Exprs.push_back(new (Context)
+                          CXXNullPtrLiteralExpr(Ty, ExprRange.getBegin()));
     } else {
       Exprs.push_back(IntegerLiteral::Create(
           Context, getInitIntValue(Context, IK, Ty), Ty, ExprRange.getBegin()));

--- a/clang/test/SemaOpenACC/compute-construct-reduction-clause.cpp
+++ b/clang/test/SemaOpenACC/compute-construct-reduction-clause.cpp
@@ -320,3 +320,24 @@ void incomplete_use(Incomplete &i) {
 #pragma acc parallel reduction(+:i)
   while (1);
 }
+
+namespace GH210877 {
+struct S {
+  decltype(nullptr) x;
+  S &operator*=(S &s);
+};
+
+void foo() {
+  S t;
+#pragma acc parallel reduction(* : t)
+  ;
+}
+
+template <typename T> void fooTempl() {
+  T t;
+#pragma acc parallel reduction(* : t)
+  ;
+}
+
+void bar() { fooTempl<S>(); }
+}


### PR DESCRIPTION
The bug report shows that we missed one scalar type in our initialization code, nullptr_t!  This patch adds the initializer to make sure it works correctly, and adds the test (plus a non-template
    version).

Fixes: #210877