### PR TITLE
[OpenACC] add acc::FirstprivateSaveOp

### DIFF
--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-firstprivate.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-firstprivate.fir
@@ -39,18 +39,26 @@ module {
 // and an alloca (as per the recipe) inside the region.
 // Then ensure that all uses are of the private alloca.
 // CHECK-LABEL: func.func @firstpriv
-// CHECK: acc.parallel
-// CHECK: %[[ALLOCA:.*]] = fir.alloca i32 {{.*}}acc.var_name = #acc.var_name<"t">
-// CHECK: %[[FIRSTPRIVLOAD:.*]] = fir.load %{{.*}} : !fir.ref<i32>
-// CHECK: fir.store %[[FIRSTPRIVLOAD]] to %[[ALLOCA]] : !fir.ref<i32>
-// CHECK: %[[ALLOCALOAD:.*]] = fir.load %[[ALLOCA]] : !fir.ref<i32>
-// CHECK: %[[ADDI:.*]] = arith.addi %[[ALLOCALOAD]], %c1{{.*}} : i32
-// CHECK: fir.store %[[ADDI]] to %[[ALLOCA]] : !fir.ref<i32>
+// CHECK:       [[DECL:%.*]] = fir.declare
+// CHECK:       [[MAP:%.*]] = acc.firstprivate_map varPtr([[DECL]] : !fir.ref<i32>) -> !fir.ref<i32> {implicit = true, name = "t"}
+// CHECK:       acc.parallel {
+// CHECK:       [[FIRSTPRIV:%.*]] = fir.alloca i32 {{.*}}acc.var_name = #acc.var_name<"t">
+// CHECK:       [[FIRSTPRIVLOAD:%.*]] = fir.load [[MAP]] : !fir.ref<i32>
+// CHECK:       fir.store [[FIRSTPRIVLOAD]] to [[FIRSTPRIV]] : !fir.ref<i32>
+// CHECK:       [[FIRSTPRIVLOAD:%.*]] = fir.load [[FIRSTPRIV]] : !fir.ref<i32>
+// CHECK:       [[ADDI:%.*]] = arith.addi [[FIRSTPRIVLOAD]], %c1{{.*}} : i32
+// CHECK:       fir.store [[ADDI]] to [[FIRSTPRIV]] : !fir.ref<i32>
+// CHECK-NEXT:  [[VALUELOAD:%.*]] = fir.load
+// CHECK-NEXT:  acc.firstprivate_save [[VALUELOAD]] to [[MAP]] : i32 -> !fir.ref<i32>
 
+// With -acc-optimize-firstprivate-map, the map is retained because of the
+// firstprivate_save live-out.
 // CHECK-MAP-LABEL: func.func @firstpriv
-// CHECK-MAP: fir.load {{.*}} : !fir.ref<i32>
-// CHECK-MAP: acc.parallel {
-// CHECK-MAP-NOT: acc.firstprivate_map
-// CHECK-MAP: fir.alloca i32 {{.*}}acc.var_name = #acc.var_name<"t">
-// CHECK-MAP: fir.store {{.*}} to {{.*}} : !fir.ref<i32>
-// CHECK-MAP: arith.addi {{.*}} %c1
+// CHECK-MAP:       [[DECL:%.*]] = fir.declare
+// CHECK-MAP:       [[MAP:%.*]] = acc.firstprivate_map varPtr([[DECL]] : !fir.ref<i32>) -> !fir.ref<i32> {implicit = true, name = "t"}
+// CHECK-MAP:       acc.parallel {
+// CHECK-MAP:       [[FIRSTPRIV:%.*]] = fir.alloca i32 {{.*}}acc.var_name = #acc.var_name<"t">
+// CHECK-MAP:       fir.load [[MAP]] : !fir.ref<i32>
+// CHECK-MAP:       fir.store {{.*}} to [[FIRSTPRIV]] : !fir.ref<i32>
+// CHECK-MAP:       arith.addi {{.*}} %c1
+// CHECK-MAP:       acc.firstprivate_save {{.*}} to [[MAP]] : i32 -> !fir.ref<i32>

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -303,6 +303,28 @@ def OpenACC_FirstprivateMapInitialOp
 }
 
 //===----------------------------------------------------------------------===//
+// acc.firstprivate_save
+//===----------------------------------------------------------------------===//
+
+def OpenACC_FirstprivateSaveOp : OpenACC_Op<"firstprivate_save", []> {
+ let summary = "\"Saves\" a value to a firstprivate variable";
+ let description = [{
+    The `acc.firstprivate_save` operation is intended to provide a temporary
+    link from the compute region's private variable and the firstprivate map
+    init op. This facilitates analysis in cases where the compiler may
+    determine that a firstprivate should be converted to a copy and can be
+    safely erased when that analysis is complete.
+  }];
+  let arguments = (ins AnyType:$value,
+                       Arg<OpenACC_PointerLikeType,
+                           "FirstprivateMapInitOp",
+                           [MemWrite]>:$memref);
+  let assemblyFormat = [{
+    $value `to` $memref `:` type($value) `->` type($memref) attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // acc.privatize
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
@@ -305,6 +305,7 @@ LogicalResult ACCRecipeMaterialization::materialize(
     auto [results, ip] = acc::cloneACCRegionInto(
         &initRegion, block, block->begin(), mapping, {accPtr});
     assert(results.size() == 1 && "expected single result from init region");
+    Value alloca = results[0];
     saveVarName(op.getAccVar(), results[0]);
     resolveVarNamePlaceholders(block, ip, acc::getVariableName(op.getAccVar()));
     // We want the copy to store the origPtr to private
@@ -318,6 +319,17 @@ LogicalResult ACCRecipeMaterialization::materialize(
     Region &copyRegion = recipe.getCopyRegion();
     setLocation(copyRegion, loc);
     acc::cloneACCRegionInto(&copyRegion, block, std::next(ip), mapping, {});
+
+    // Create a temporary acc.firstprivate_save op to keep the value live-out
+    // until after other passes have determined it is truly firstprivate.
+    b.setInsertionPoint(accOp.getBody().getTerminator());
+    auto ptrLikeType = dyn_cast<acc::PointerLikeType>(alloca.getType());
+    assert(ptrLikeType && "alloca must be a pointer-like type");
+    auto xTyped = cast<TypedValue<acc::PointerLikeType>>(alloca);
+    assert(xTyped && "alloca must be a typed value");
+    auto loadOp = ptrLikeType.genLoad(b, op.getLoc(), xTyped, {});
+    acc::FirstprivateSaveOp::create(b, op.getLoc(), loadOp, origPtr);
+
     if (!recipe.getDestroyRegion().empty()) {
       // origPtr was already pushed.
       cloneDestroy(loc, recipe, block, std::prev(block->end()), results);

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate.mlir
@@ -24,14 +24,18 @@ acc.private.recipe @privatization_memref_i32 : memref<i32> init {
 // and an alloca (as per the recipe) inside the region.
 // Then ensure that all uses are of the private alloca.
 // CHECK-LABEL: func.func @firstpriv
-// CHECK: acc.parallel {
-// CHECK: %[[ALLOCA:.*]] = memref.alloca() {acc.var_name = #acc.var_name<"t">} : memref<i32>
-// CHECK: %[[FIRSTPRIVLOAD:.*]] = memref.load %{{.*}}[] : memref<i32>
-// CHECK: memref.store %[[FIRSTPRIVLOAD]], %[[ALLOCA]][] : memref<i32>
-// CHECK: %[[ALLOCALOAD:.*]] = memref.load %[[ALLOCA]][] : memref<i32>
-// CHECK: %[[ADDI:.*]] = arith.addi %[[ALLOCALOAD]], %c1{{.*}} : i32
-// CHECK: memref.store %[[ADDI]], %[[ALLOCA]][] : memref<i32>
-// CHECK: memref.dealloc %[[ALLOCA]] : memref<i32>
+// CHECK:       [[ALLOCA:%.*]] = memref.alloca() : memref<i32>
+// CHECK:       [[MAP:%.*]] = acc.firstprivate_map varPtr([[ALLOCA]] : memref<i32>) -> memref<i32> {implicit = true, name = "t"}
+// CHECK:       acc.parallel {
+// CHECK:       [[FIRSTPRIV:%.*]] = memref.alloca() {acc.var_name = #acc.var_name<"t">} : memref<i32>
+// CHECK:       [[FIRSTPRIVLOAD:%.*]] = memref.load [[MAP]][] : memref<i32>
+// CHECK:       memref.store [[FIRSTPRIVLOAD]], [[FIRSTPRIV]][] : memref<i32>
+// CHECK:       [[FIRSTPRIVLOAD:%.*]] = memref.load [[FIRSTPRIV]][] : memref<i32>
+// CHECK:       [[ADDI:%.*]] = arith.addi [[FIRSTPRIVLOAD]], %c1{{.*}} : i32
+// CHECK:       memref.store [[ADDI]], [[FIRSTPRIV]][] : memref<i32>
+// CHECK-NEXT:  [[VALUELOAD:%.*]] = memref.load
+// CHECK-NEXT:  acc.firstprivate_save [[VALUELOAD]] to [[MAP]] : i32 -> memref<i32>
+// CHECK-NEXT:  memref.dealloc [[FIRSTPRIV]] : memref<i32>
 
 func.func @firstpriv() {
   %c1336 = arith.constant 1336 : i32


### PR DESCRIPTION
The `acc.firstprivate_save` operation is intended to provide a temporary link from the compute region's private variable and the firstprivate map init op. This facilitates analysis in cases where the compiler may determine that a firstprivate should be converted to a copy and can be safely erased when that analysis is complete.