### PR TITLE
[RuntimeDyld][COFF] Apply addend for IMAGE_REL_AMD64_SECREL

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
@@ -266,6 +266,12 @@ public:
       break;
     }
 
+    case COFF::IMAGE_REL_AMD64_SECREL: {
+      uint8_t *Displacement = (uint8_t *)ObjTarget;
+      Addend = readBytesUnaligned(Displacement, 4);
+      break;
+    }
+
     default:
       break;
     }

--- a/llvm/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64_SECREL.s
+++ b/llvm/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64_SECREL.s
@@ -1,0 +1,25 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=x86_64-pc-win32 -filetype=obj -o %t/COFF_x86_64_SECREL.o %s
+# RUN: llvm-rtdyld -triple=x86_64-pc-win32 -verify -check=%s %t/COFF_x86_64_SECREL.o
+
+	.section	.rdata,"dr"
+sec_base:                               # section-relative offset 0
+	.zero	0x10
+target:                                 # section-relative offset 0x10
+	.long	0
+
+	.data
+	.globl	relocations
+relocations:
+
+sr_symoff:
+	.secrel32	target
+# rtdyld-check: *{4}sr_symoff = 0x10
+
+sr_addend:
+	.secrel32	sec_base+0x2a
+# rtdyld-check: *{4}sr_addend = 0x2a
+
+sr_both:
+	.secrel32	target+0x2a
+# rtdyld-check: *{4}sr_both = 0x3a


### PR DESCRIPTION
`IMAGE_REL_AMD64_SECREL` currently falls through the default case. Its `Addend` is built using the target symbol's section offset. This is incorrect: for a SECREL against a section symbol (offset 0), the real value is stored as the addend in the relocated field. This results in the SECREL writer always writing 0, which is wrong.

This patch reads the 4-byte field addend for SECREL, as `REL32` and `ADDR64` already do. It also adds a test which fails without this.

Source: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format