### PR TITLE
[RISCV] Avoid forming Zilsd pairs with x0 for non-x0 register classes

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVZilsdOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVZilsdOptimizer.cpp
@@ -223,7 +223,8 @@ bool RISCVPreAllocZilsdOpt::canFormLdSdPair(MachineInstr *MI0,
   if (FirstReg == SecondReg) {
     const MachineInstr *FirstOpDefInst = MRI->getUniqueVRegDef(FirstReg);
     if (FirstOpDefInst->isCopy() &&
-        FirstOpDefInst->getOperand(1).getReg() == RISCV::X0)
+        FirstOpDefInst->getOperand(1).getReg() == RISCV::X0 &&
+        MRI->getRegClass(FirstReg)->contains(RISCV::X0))
       return true;
     return false;
   }

--- a/llvm/test/CodeGen/RISCV/zilsd-ldst-opt-prera.mir
+++ b/llvm/test/CodeGen/RISCV/zilsd-ldst-opt-prera.mir
@@ -397,7 +397,8 @@ body: |
     ; CHECK-4BYTE-NEXT: {{  $}}
     ; CHECK-4BYTE-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
     ; CHECK-4BYTE-NEXT: [[COPY1:%[0-9]+]]:gprnox0 = COPY $x0
-    ; CHECK-4BYTE-NEXT: PseudoSD_RV32_OPT [[COPY1]], [[COPY1]], [[COPY]], 0 :: (store (s32))
+    ; CHECK-4BYTE-NEXT: SW [[COPY1]], [[COPY]], 0 :: (store (s32))
+    ; CHECK-4BYTE-NEXT: SW [[COPY1]], [[COPY]], 4 :: (store (s32))
     ; CHECK-4BYTE-NEXT: PseudoRET
     %0:gpr = COPY $x10
     %1:gprnox0 = COPY $x0

--- a/llvm/test/CodeGen/RISCV/zilsd-ldst-opt-prera.mir
+++ b/llvm/test/CodeGen/RISCV/zilsd-ldst-opt-prera.mir
@@ -26,6 +26,13 @@
     ret void
   }
 
+  define void @basic_store_zero_no_combine(ptr %0, i32 %1, i32 %2) {
+    store i32 0, ptr %0, align 4
+    %4 = getelementptr inbounds i32, ptr %0, i32 1
+    store i32 0, ptr %4, align 4
+    ret void
+  }
+
   define i32 @basic_load_combine_8_byte_aligned(ptr %0) {
     %2 = load i32, ptr %0, align 8
     %3 = getelementptr inbounds i32, ptr %0, i32 1
@@ -360,6 +367,40 @@ body: |
     ; CHECK-4BYTE-NEXT: PseudoRET
     %0:gpr = COPY $x10
     %1:gpr = COPY $x0
+    SW %1, %0, 0 :: (store (s32))
+    SW %1, %0, 4 :: (store (s32))
+    PseudoRET
+
+...
+---
+# Basic case: two consecutive 32-bit store 0 that cannot be combined into SD
+name: basic_store_zero_no_combine
+alignment: 4
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x10', virtual-reg: '%0' }
+body: |
+  bb.0:
+    liveins: $x10
+
+    ; CHECK-LABEL: name: basic_store_zero_no_combine
+    ; CHECK: liveins: $x10
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gprnox0 = COPY $x0
+    ; CHECK-NEXT: SW [[COPY1]], [[COPY]], 0 :: (store (s32))
+    ; CHECK-NEXT: SW [[COPY1]], [[COPY]], 4 :: (store (s32))
+    ; CHECK-NEXT: PseudoRET
+    ;
+    ; CHECK-4BYTE-LABEL: name: basic_store_zero_no_combine
+    ; CHECK-4BYTE: liveins: $x10
+    ; CHECK-4BYTE-NEXT: {{  $}}
+    ; CHECK-4BYTE-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
+    ; CHECK-4BYTE-NEXT: [[COPY1:%[0-9]+]]:gprnox0 = COPY $x0
+    ; CHECK-4BYTE-NEXT: PseudoSD_RV32_OPT [[COPY1]], [[COPY1]], [[COPY]], 0 :: (store (s32))
+    ; CHECK-4BYTE-NEXT: PseudoRET
+    %0:gpr = COPY $x10
+    %1:gprnox0 = COPY $x0
     SW %1, %0, 0 :: (store (s32))
     SW %1, %0, 4 :: (store (s32))
     PseudoRET


### PR DESCRIPTION
The pre-RA Zilsd optimizer allowed a pair when both stored values came from the same virtual register if that virtual register was defined by a copy from X0. This is only valid when the virtual register class can actually contain X0.

Check the virtual register class before treating the value as `x0_pair`. This prevents forming an invalid paired store for register classes such as `GPRNoX0`.

Without this change we were hitting the following assertion in `RISCVLoadStoreOptimizer`:

```
assert(
    FirstReg != SecondReg &&
    "First register and second register is impossible to be same register");
```
