### PR TITLE
[SampleProfile] Support Eytzinger layout in SecNameTable

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -207,8 +207,13 @@ enum class SecNameTableFlags : uint32_t {
   SecFlagFixedLengthMD5 = (1 << 1),
   // Profile contains ".__uniq." suffix name. Compiler shouldn't strip
   // the suffix when doing profile matching when seeing the flag.
-  SecFlagUniqSuffix = (1 << 2)
+  SecFlagUniqSuffix = (1 << 2),
+  // Name table is stored in 3-span Eytzinger layout (CS, Flat, Inlinees).
+  SecFlagEytzinger = (1 << 3)
 };
+
+enum class EytzingerSpan : size_t { CS, Flat, Inlinee, NumSpans };
+
 enum class SecProfileSymbolListFlags : uint32_t {
   SecFlagInValid = 0,
   SecFlagMD5 = (1 << 0)

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -225,6 +225,7 @@
 #ifndef LLVM_PROFILEDATA_SAMPLEPROFREADER_H
 #define LLVM_PROFILEDATA_SAMPLEPROFREADER_H
 
+#include "llvm/ADT/Eytzinger.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -240,6 +241,7 @@
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
+#include <array>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -430,6 +432,22 @@ public:
   FunctionId operator[](size_t Idx) const override {
     assert(Idx < Vec.size() && "Index out of bounds");
     return Vec[Idx];
+  }
+};
+
+class EytzingerSampleProfileNameTable final : public SampleProfileNameTable {
+  ArrayRef<support::ulittle64_t> Array;
+
+public:
+  EytzingerSampleProfileNameTable(const support::ulittle64_t *Data,
+                                  uint64_t NumCS, uint64_t NumFlat,
+                                  uint64_t NumInlinees)
+      : Array(Data, NumCS + NumFlat + NumInlinees) {}
+
+  size_t size() const override { return Array.size(); }
+
+  FunctionId operator[](size_t Idx) const override {
+    return FunctionId(Array[Idx]);
   }
 };
 
@@ -1017,7 +1035,10 @@ protected:
   std::error_code readFuncProfiles();
   std::error_code readFuncProfiles(const DenseSet<StringRef> &FuncsToUse,
                                    SampleProfileMap &Profiles);
-  std::error_code readNameTableSec(bool IsMD5, bool FixedLengthMD5);
+  std::error_code readNameTableSec(bool IsMD5, bool FixedLengthMD5,
+                                   bool IsEytzinger = false);
+  std::error_code readNameTableSecEytzinger(bool IsMD5, bool FixedLengthMD5);
+  std::error_code readNameTableSecLegacy(bool IsMD5, bool FixedLengthMD5);
   std::error_code readCSNameTableSec();
   std::error_code readProfileSymbolList(bool IsMD5);
   std::error_code readStringBasedProfileSymbolList();

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -415,6 +415,8 @@ protected:
 
   // Functions to write various kinds of sections.
   std::error_code writeNameTableSection(const SampleProfileMap &ProfileMap);
+  std::error_code
+  writeEytzingerNameTableSection(const SampleProfileMap &ProfileMap);
   std::error_code writeFuncOffsetTable();
   std::error_code writeProfileSymbolListSection();
   std::error_code writeStringBasedProfileSymbolListSection();

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -1307,8 +1307,14 @@ std::error_code SampleProfileReaderExtBinaryBase::readNameTableSec(
   return readNameTableSecLegacy(IsMD5, FixedLengthMD5);
 }
 
+// Read the Eytzinger layout for SecNameTable from an ExtBinary MD5 profile.
+//
+// The section consists of three sequential ULEB128 symbol counts (CS, Flat, and
+// Inlinees) followed by their corresponding arrays of 64-bit MD5 hash keys laid
+// out in Eytzinger order.
 std::error_code SampleProfileReaderExtBinaryBase::readNameTableSecEytzinger(
     bool IsMD5, bool FixedLengthMD5) {
+  assert(IsMD5 && "Eytzinger name tables require MD5 representation");
   if (!IsMD5)
     return sampleprof_error::malformed;
 

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -873,7 +873,9 @@ std::error_code SampleProfileReaderExtBinaryBase::readOneSection(
     ProfileIsMD5 = ProfileIsMD5 || UseMD5;
     FunctionSamples::HasUniqSuffix =
         hasSecFlag(Entry, SecNameTableFlags::SecFlagUniqSuffix);
-    if (std::error_code EC = readNameTableSec(UseMD5, FixedLengthMD5))
+    bool IsEytzinger = hasSecFlag(Entry, SecNameTableFlags::SecFlagEytzinger);
+    if (std::error_code EC =
+            readNameTableSec(UseMD5, FixedLengthMD5, IsEytzinger))
       return EC;
     break;
   }
@@ -1298,9 +1300,51 @@ std::error_code SampleProfileReaderBinary::readNameTable() {
   return sampleprof_error::success;
 }
 
+std::error_code SampleProfileReaderExtBinaryBase::readNameTableSec(
+    bool IsMD5, bool FixedLengthMD5, bool IsEytzinger) {
+  if (IsEytzinger)
+    return readNameTableSecEytzinger(IsMD5, FixedLengthMD5);
+  return readNameTableSecLegacy(IsMD5, FixedLengthMD5);
+}
+
+std::error_code SampleProfileReaderExtBinaryBase::readNameTableSecEytzinger(
+    bool IsMD5, bool FixedLengthMD5) {
+  if (!IsMD5)
+    return sampleprof_error::malformed;
+
+  // Read the table sizes for CS, flat, and inlinee symbols.
+  std::array<uint64_t, static_cast<size_t>(EytzingerSpan::NumSpans)> Counts;
+  for (uint64_t &Count : Counts) {
+    auto ValOrErr = readNumber<uint64_t>();
+    if (std::error_code EC = ValOrErr.getError())
+      return EC;
+    Count = *ValOrErr;
+  }
+  auto [NumCS, NumFlat, NumInlinees] = Counts;
+
+  // Guard against unsigned overflow in total entry computation.
+  if (NumCS > std::numeric_limits<uint32_t>::max() ||
+      NumFlat > std::numeric_limits<uint32_t>::max() ||
+      NumInlinees > std::numeric_limits<uint32_t>::max())
+    return sampleprof_error::malformed;
+
+  uint64_t TotalEntries = NumCS + NumFlat + NumInlinees;
+  if (static_cast<size_t>(End - Data) < TotalEntries * sizeof(uint64_t))
+    return sampleprof_error::truncated;
+
+  NameTable = std::make_unique<EytzingerSampleProfileNameTable>(
+      reinterpret_cast<const support::ulittle64_t *>(Data), NumCS, NumFlat,
+      NumInlinees);
+
+  if (!ProfileIsCS)
+    MD5SampleContextStart = reinterpret_cast<const uint64_t *>(Data);
+  Data = Data + TotalEntries * sizeof(uint64_t);
+  return sampleprof_error::success;
+}
+
 std::error_code
-SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
-                                                   bool FixedLengthMD5) {
+SampleProfileReaderExtBinaryBase::readNameTableSecLegacy(bool IsMD5,
+                                                         bool FixedLengthMD5) {
   if (FixedLengthMD5) {
     if (!IsMD5)
       errs() << "If FixedLengthMD5 is true, UseMD5 has to be true";
@@ -1593,6 +1637,8 @@ static std::string getSecFlagsStr(const SecHdrTableEntry &Entry) {
 
   switch (Entry.Type) {
   case SecNameTable:
+    if (hasSecFlag(Entry, SecNameTableFlags::SecFlagEytzinger))
+      Flags.append("eytzinger,");
     if (hasSecFlag(Entry, SecNameTableFlags::SecFlagFixedLengthMD5))
       Flags.append("fixlenmd5,");
     else if (hasSecFlag(Entry, SecNameTableFlags::SecFlagMD5Name))

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ProfileData/SampleProfWriter.h"
+#include "llvm/ADT/Eytzinger.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ProfileData/ProfileCommon.h"
 #include "llvm/ProfileData/SampleProf.h"
@@ -28,6 +29,7 @@
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/raw_ostream.h"
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -53,6 +55,10 @@ static cl::opt<bool>
     WriteMD5ProfSymList("md5-prof-sym-list", cl::init(false), cl::Hidden,
                         cl::desc("Write ProfileSymbolList (Cold Symbols) as "
                                  "64-bit MD5 hashes in Eytzinger layout"));
+
+static cl::opt<bool> WriteEytzingerNameTables(
+    "sample-profile-write-eytzinger-name-tables", cl::init(false), cl::Hidden,
+    cl::desc("Write Eytzinger 3-span layout for NameTable"));
 
 namespace llvm {
 namespace support {
@@ -402,8 +408,88 @@ std::error_code SampleProfileWriterExtBinaryBase::writeNameTableSection(
     }
   }
 
+  if (UseMD5 && WriteEytzingerNameTables) {
+    if (auto EC = writeEytzingerNameTableSection(ProfileMap))
+      return EC;
+    return sampleprof_error::success;
+  }
+
   if (auto EC = writeNameTable())
     return EC;
+  return sampleprof_error::success;
+}
+
+namespace {
+
+class EytzingerNameTable {
+  using TableT = llvm::EytzingerTable<support::ulittle64_t>;
+  std::array<TableT, static_cast<size_t>(EytzingerSpan::NumSpans)> Spans;
+
+public:
+  EytzingerNameTable(std::vector<support::ulittle64_t> CSKeys,
+                     std::vector<support::ulittle64_t> FlatKeys,
+                     std::vector<support::ulittle64_t> InlineeKeys)
+      : Spans{TableT::create(std::move(CSKeys)),
+              TableT::create(std::move(FlatKeys)),
+              TableT::create(std::move(InlineeKeys))} {}
+
+  // Find the global index of GUID across the three Eytzinger table spans.
+  uint64_t findGlobalIdx(uint64_t GUID) const {
+    uint64_t BaseIdx = 0;
+    for (const auto &Table : Spans) {
+      if (std::optional<size_t> LocalIdx = Table.findIndex(GUID))
+        return BaseIdx + *LocalIdx;
+      BaseIdx += Table.size();
+    }
+    llvm_unreachable("Symbol in NameTable missing from Eytzinger spans");
+  }
+
+  void write(raw_ostream &OS) const {
+    for (const auto &Table : Spans)
+      encodeULEB128(uint64_t(Table.size()), OS);
+    for (const auto &Table : Spans)
+      OS.write(reinterpret_cast<const char *>(Table.data()),
+               Table.size() * sizeof(support::ulittle64_t));
+  }
+};
+
+} // end anonymous namespace
+
+std::error_code
+SampleProfileWriterExtBinaryBase::writeEytzingerNameTableSection(
+    const SampleProfileMap &ProfileMap) {
+  DenseSet<uint64_t> TopLevelGUIDs;
+  std::vector<support::ulittle64_t> CSKeys, FlatKeys, InlineeKeys;
+
+  // Collect top-level CS and Flat keys directly from ProfileMap.
+  for (const auto &I : ProfileMap) {
+    const SampleContext &Ctx = I.second.getContext();
+    uint64_t GUID = Ctx.getFunction().getHashCode();
+    if (TopLevelGUIDs.insert(GUID).second) {
+      if (Ctx.hasContext())
+        CSKeys.emplace_back(GUID);
+      else
+        FlatKeys.emplace_back(GUID);
+    }
+  }
+
+  // Collect remaining non-top-level symbols (inlinees, targets, vtables) from
+  // NameTable.
+  for (const auto &Entry : NameTable) {
+    uint64_t GUID = Entry.first.getHashCode();
+    if (!TopLevelGUIDs.contains(GUID))
+      InlineeKeys.emplace_back(GUID);
+  }
+
+  EytzingerNameTable Tables(std::move(CSKeys), std::move(FlatKeys),
+                            std::move(InlineeKeys));
+
+  // Assign each symbol its corresponding index in the Eytzinger layout.
+  for (auto &[FId, Idx] : NameTable)
+    Idx = Tables.findGlobalIdx(FId.getHashCode());
+
+  Tables.write(*OutputStream);
+
   return sampleprof_error::success;
 }
 
@@ -484,6 +570,8 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
                    SecProfSummaryFlags::SecFlagHasVTableTypeProf);
   if (Type == SecProfileSymbolList && WriteMD5ProfSymList)
     addSectionFlag(SecProfileSymbolList, SecProfileSymbolListFlags::SecFlagMD5);
+  if (Type == SecNameTable && WriteEytzingerNameTables && UseMD5)
+    addSectionFlag(SecNameTable, SecNameTableFlags::SecFlagEytzinger);
 
   uint64_t SectionStart = markSectionStart(Type, LayoutIdx);
   switch (Type) {

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -429,8 +429,10 @@ namespace {
 // - ULEB128 count of Context-Sensitive (CS) top-level profile symbol keys
 // - ULEB128 count of Flat top-level profile symbol keys
 // - ULEB128 count of Inlinee and auxiliary profile symbol keys
-// - Array of 64-bit little-endian MD5 hash keys for CS profiles in Eytzinger order
-// - Array of 64-bit little-endian MD5 hash keys for Flat profiles in Eytzinger order
+// - Array of 64-bit little-endian MD5 hash keys for CS profiles in Eytzinger
+//   order
+// - Array of 64-bit little-endian MD5 hash keys for Flat profiles in Eytzinger
+//   order
 // - Array of 64-bit little-endian MD5 hash keys for Inlinees in Eytzinger order
 class EytzingerNameTable {
   using TableT = llvm::EytzingerTable<support::ulittle64_t>;

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -421,6 +421,17 @@ std::error_code SampleProfileWriterExtBinaryBase::writeNameTableSection(
 
 namespace {
 
+// Helper class to construct and write the SecNameTable section in Eytzinger
+// layout for ExtBinary MD5 profiles.
+//
+// The on-disk layout of the Eytzinger name table section consists of symbol
+// counts followed by three contiguous Eytzinger hash arrays:
+// - ULEB128 count of Context-Sensitive (CS) top-level profile symbol keys
+// - ULEB128 count of Flat top-level profile symbol keys
+// - ULEB128 count of Inlinee and auxiliary profile symbol keys
+// - Array of 64-bit little-endian MD5 hash keys for CS profiles in Eytzinger order
+// - Array of 64-bit little-endian MD5 hash keys for Flat profiles in Eytzinger order
+// - Array of 64-bit little-endian MD5 hash keys for Inlinees in Eytzinger order
 class EytzingerNameTable {
   using TableT = llvm::EytzingerTable<support::ulittle64_t>;
   std::array<TableT, static_cast<size_t>(EytzingerSpan::NumSpans)> Spans;

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -488,6 +488,20 @@ TEST_F(SampleProfTest, roundtrip_eytzinger_ext_binary_profile) {
   cl::ParseCommandLineOptions(2, ArgsFalse, StringRef(), &llvm::nulls());
 }
 
+TEST_F(SampleProfTest, roundtrip_eytzinger_name_table_ext_binary_profile) {
+  const char *Args[] = {"SampleProfTest",
+                        "--sample-profile-write-eytzinger-name-tables=true"};
+  cl::ResetAllOptionOccurrences();
+  cl::ParseCommandLineOptions(2, Args, StringRef(), &llvm::nulls());
+
+  testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, true);
+
+  const char *ArgsFalse[] = {
+      "SampleProfTest", "--sample-profile-write-eytzinger-name-tables=false"};
+  cl::ResetAllOptionOccurrences();
+  cl::ParseCommandLineOptions(2, ArgsFalse, StringRef(), &llvm::nulls());
+}
+
 TEST_F(SampleProfTest, remap_text_profile) {
   testRoundTrip(SampleProfileFormat::SPF_Text, true, false);
 }


### PR DESCRIPTION
This patch supports writing SecNameTable in Eytzinger layout for
ExtBinary MD5 sample profiles via a hidden command-line option,
-sample-profile-write-eytzinger-name-tables.

Specifically, this patch partitions function GUIDs in SecNameTable into
three mutually exclusive sets:

- CSKeys: Those GUIDs used as keys in context-sensitive SecLBRProfile.
- FlatKeys: Those GUIDs used as keys in flat SecLBRProfile.
- Inlinees: Those GUIDs mentioned in SecLBRProfile but not as keys.

Each set is constructed as an independent Eytzinger array using
llvm::EytzingerTable.  The section starts out with the three element
counts followed by the three successive spans.

A subsequent patch will add FuncOffsetTable as arrays parallel to
CSKeys and FlatKeys.  It will introduce binary search into the
Eytzinger name table, taking advantage of the cache-friendly layout.

RFC: https://discourse.llvm.org/t/rfc-faster-sample-profile-loading/90957/8

Assisted-by: Antigravity
