### PR TITLE
[AMDGPU] Fix `GCNRegPressureTest`'s super-class to ensure proper target initialization

### DIFF
--- a/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
@@ -22,7 +22,7 @@
 
 using namespace llvm;
 
-class GCNRegPressureTest : public llvm::CodeGenTestBase {
+class GCNRegPressureTest : public AMDGPUCodeGenTestBase {
 public:
   void SetUp() override { setUpImpl("amdgpu9.08--", "", ""); }
 };


### PR DESCRIPTION
The typo made it so that all tests in the file would be skipped if no other testsuite explicitly initialized the AMDGPU target (for example when running `./unittests/Target/AMDGPU/AMDGPUTests --gtest_filter=GCNRegPressureTest.*`). `AMDGPUCodeGenTestBase` initializes the target so tests always run as long as LLVM is built with the AMDGPU target.