### PR TITLE
[PAC][libc++] Fix build with `ptrauth_calls` feature

### DIFF
--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -114,6 +114,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  else // __has_feature(ptrauth_calls)
 
+#    include <cstdint>
 #    include <ptrauth.h>
 
 #    if defined(_LIBCPP_OBJECT_FORMAT_MACHO)


### PR DESCRIPTION
After partial revert of #208330 in #209928, the libcxx build started failing because of missing `<cstdint>` include required for `uintptr_t` declaration used only by code behind `ptrauth_calls` feature check. See https://lab.llvm.org/buildbot/#/builders/227/builds/3358

This patch adds the missing include.