### PR TITLE
[CMake] Added missing LLVM_PTHREAD_LIB dependency.

### DIFF
--- a/llvm/lib/DTLTO/CMakeLists.txt
+++ b/llvm/lib/DTLTO/CMakeLists.txt
@@ -3,6 +3,9 @@ add_llvm_component_library(LLVMDTLTO
   DTLTO.cpp
   DTLTODistributionDriver.cpp
 
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+
   LINK_COMPONENTS
   BinaryFormat
   Core


### PR DESCRIPTION
Required after #209423.
