### PR TITLE
[analyzer] Detect dangling pointers passed to function calls

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -54,7 +54,7 @@ void DanglingPtrDeref::checkPostCall(const CallEvent &Call,
                                      CheckerContext &C) const {
   ProgramStateRef State = C.getState();
   // Only check calls arguments if it is not inlined by the engine. In case a
-  // function is inlined checkLocation handles any dereference in its body
+  // function is inlined checkLocation handles any dereference in its body.
   if (C.wasInlined)
     return;
 

--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -54,7 +54,7 @@ void DanglingPtrDeref::checkPostCall(const CallEvent &Call,
                                      CheckerContext &C) const {
   ProgramStateRef State = C.getState();
   // Only check calls arguments if it is not inlined by the engine. In case a
-  // function is inlined checkLocation handles any dereference in its body.
+  // function is inlined checkLocation handles any dereference in its body
   if (C.wasInlined)
     return;
 

--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -3,16 +3,18 @@
 #include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h"
 #include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
 
 using namespace clang;
 using namespace ento;
 
 namespace {
-class DanglingPtrDeref : public Checker<check::Location> {
+class DanglingPtrDeref : public Checker<check::Location, check::PreCall> {
 public:
   void checkLocation(SVal Loc, bool IsLoad, const Stmt *S,
                      CheckerContext &C) const;
+  void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
   void reportUseAfterScope(const MemRegion *Region, ExplodedNode *N,
                            CheckerContext &C) const;
   const BugType BugMsg{this, "ReportDanglingPtrDeref", "LifetimeBound"};
@@ -48,12 +50,24 @@ void DanglingPtrDeref::checkLocation(SVal Loc, bool IsLoad, const Stmt *S,
   }
 }
 
+void DanglingPtrDeref::checkPreCall(const CallEvent &Call,
+                                    CheckerContext &C) const {
+
+  ProgramStateRef State = C.getState();
+  for (unsigned I = 0; I < Call.getNumArgs(); I++) {
+    if (const MemRegion *ArgRegion = Call.getArgSVal(I).getAsRegion())
+      if (lifetime_modeling::isDeallocated(State, ArgRegion))
+        if (ExplodedNode *N = C.generateNonFatalErrorNode())
+          reportUseAfterScope(ArgRegion, N, C);
+  }
+}
+
 void DanglingPtrDeref::reportUseAfterScope(const MemRegion *Region,
                                            ExplodedNode *N,
                                            CheckerContext &C) const {
   auto BR = std::make_unique<PathSensitiveBugReport>(
       BugMsg,
-      (llvm::Twine("Use of '") + Region->getString() +
+      (llvm::Twine("Use of '") + Region->getBaseRegion()->getString() +
        "' after its lifetime ended."),
       N);
   BR->addVisitor<DanglingPtrDerefBRVisitor>(Region);
@@ -81,7 +95,8 @@ DanglingPtrDerefBRVisitor::VisitNode(const ExplodedNode *N,
       S, BRC.getSourceManager(), N->getStackFrame());
   return std::make_shared<PathDiagnosticEventPiece>(
       Pos,
-      (llvm::Twine("'") + SourceRegion->getString() + "' is destroyed here")
+      (llvm::Twine("'") + SourceRegion->getBaseRegion()->getString() +
+       "' is destroyed here")
           .str(),
       true);
 }

--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -10,11 +10,11 @@ using namespace clang;
 using namespace ento;
 
 namespace {
-class DanglingPtrDeref : public Checker<check::Location, check::PreCall> {
+class DanglingPtrDeref : public Checker<check::Location, check::PostCall> {
 public:
   void checkLocation(SVal Loc, bool IsLoad, const Stmt *S,
                      CheckerContext &C) const;
-  void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
+  void checkPostCall(const CallEvent &Call, CheckerContext &C) const;
   void reportUseAfterScope(const MemRegion *Region, ExplodedNode *N,
                            CheckerContext &C) const;
   const BugType BugMsg{this, "ReportDanglingPtrDeref", "LifetimeBound"};
@@ -50,12 +50,16 @@ void DanglingPtrDeref::checkLocation(SVal Loc, bool IsLoad, const Stmt *S,
   }
 }
 
-void DanglingPtrDeref::checkPreCall(const CallEvent &Call,
-                                    CheckerContext &C) const {
-
+void DanglingPtrDeref::checkPostCall(const CallEvent &Call,
+                                     CheckerContext &C) const {
   ProgramStateRef State = C.getState();
-  for (unsigned I = 0; I < Call.getNumArgs(); I++) {
-    if (const MemRegion *ArgRegion = Call.getArgSVal(I).getAsRegion())
+  // Only check calls arguments if it is not inlined by the engine. In case a
+  // function is inlined checkLocation handles any dereference in its body.
+  if (C.wasInlined)
+    return;
+
+  for (unsigned Idx = 0; Idx < Call.getNumArgs(); Idx++) {
+    if (const MemRegion *ArgRegion = Call.getArgSVal(Idx).getAsRegion())
       if (lifetime_modeling::isDeallocated(State, ArgRegion))
         if (ExplodedNode *N = C.generateNonFatalErrorNode())
           reportUseAfterScope(ArgRegion, N, C);
@@ -67,7 +71,7 @@ void DanglingPtrDeref::reportUseAfterScope(const MemRegion *Region,
                                            CheckerContext &C) const {
   auto BR = std::make_unique<PathSensitiveBugReport>(
       BugMsg,
-      (llvm::Twine("Use of '") + Region->getBaseRegion()->getString() +
+      (llvm::Twine("Use of '") + Region->getString() +
        "' after its lifetime ended."),
       N);
   BR->addVisitor<DanglingPtrDerefBRVisitor>(Region);
@@ -95,8 +99,7 @@ DanglingPtrDerefBRVisitor::VisitNode(const ExplodedNode *N,
       S, BRC.getSourceManager(), N->getStackFrame());
   return std::make_shared<PathDiagnosticEventPiece>(
       Pos,
-      (llvm::Twine("'") + SourceRegion->getBaseRegion()->getString() +
-       "' is destroyed here")
+      (llvm::Twine("'") + SourceRegion->getString() + "' is destroyed here")
           .str(),
       true);
 }

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -73,14 +73,7 @@ std::vector<const MemRegion *> lifetime_modeling::getDanglingRegionsAfterReturn(
 
 bool lifetime_modeling::isDeallocated(ProgramStateRef State,
                                       const MemRegion *Region) {
-  if (State->contains<DeallocatedSourceSet>(Region))
-    return true;
-
-  if (const MemRegion *Base = Region->getBaseRegion();
-      Base != Region && State->contains<DeallocatedSourceSet>(Base))
-    return true;
-
-  return false;
+  return State->contains<DeallocatedSourceSet>(Region);
 }
 
 static ProgramStateRef bindSource(ProgramStateRef State, SVal RetVal,

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -73,7 +73,14 @@ std::vector<const MemRegion *> lifetime_modeling::getDanglingRegionsAfterReturn(
 
 bool lifetime_modeling::isDeallocated(ProgramStateRef State,
                                       const MemRegion *Region) {
-  return State->contains<DeallocatedSourceSet>(Region);
+  if (State->contains<DeallocatedSourceSet>(Region))
+    return true;
+
+  if (const MemRegion *Base = Region->getBaseRegion();
+      Base != Region && State->contains<DeallocatedSourceSet>(Base))
+    return true;
+
+  return false;
 }
 
 static ProgramStateRef bindSource(ProgramStateRef State, SVal RetVal,

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -84,3 +84,44 @@ void test_case_seven() {
   // expected-warning@-1 {{Use of 'i' after its lifetime ended}}
   // expected-note@-2    {{Use of 'i' after its lifetime ended}}
 }
+
+struct MyBuffer {
+  char buffer[8];
+};
+
+void member_subregion_dangling_deref() {
+  const char *p = nullptr;
+  {
+    struct MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer;
+  }
+  // expected-note@-1 {{'tmp_buffer' is destroyed here}}
+  char c = *p;
+  // expected-warning@-1 {{Use of 'tmp_buffer' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer' after its lifetime ended}}
+  (void)c;
+}
+
+void opaque(const char *);
+
+void passing_dangling_to_call() {
+  const char *p = nullptr;
+  {
+    struct MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer;
+  }
+  // expected-note@-1 {{'tmp_buffer' is destroyed here}}
+  opaque(p);
+  // expected-warning@-1 {{Use of 'tmp_buffer' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer' after its lifetime ended}}
+}
+
+void member_subregion_alive_deref() {
+  {
+    struct MyBuffer tmp_buffer = {};
+    const char *p = tmp_buffer.buffer;
+    opaque(p); //   no-warning
+    char c = *p; // no-warning
+    (void)c;
+  }
+}

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -85,43 +85,30 @@ void test_case_seven() {
   // expected-note@-2    {{Use of 'i' after its lifetime ended}}
 }
 
-struct MyBuffer {
-  char buffer[8];
-};
-
-void member_subregion_dangling_deref() {
-  const char *p = nullptr;
+void passing_dangling_ptr_to_opaque_func() {
+  int *ptr = nullptr;
   {
-    struct MyBuffer tmp_buffer = {};
-    p = tmp_buffer.buffer;
+    int num = 5;
+    ptr = &num;
   }
-  // expected-note@-1 {{'tmp_buffer' is destroyed here}}
-  char c = *p;
-  // expected-warning@-1 {{Use of 'tmp_buffer' after its lifetime ended}}
-  // expected-note@-2    {{Use of 'tmp_buffer' after its lifetime ended}}
-  (void)c;
+  // expected-note@-1 {{'num' is destroyed here}}
+  escape(ptr);
+  // expected-warning@-1 {{Use of 'num' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'num' after its lifetime ended}}
 }
 
-void opaque(const char *);
+int deref_param(int *p) { return *p; }
+// expected-warning@-1 {{Use of 'num' after its lifetime ended}}
+// expected-note@-2    {{Use of 'num' after its lifetime ended}}
 
-void passing_dangling_to_call() {
-  const char *p = nullptr;
+void inlined_callee_single_report() {
+  int *ptr = nullptr;
   {
-    struct MyBuffer tmp_buffer = {};
-    p = tmp_buffer.buffer;
+    int num = 5;
+    ptr = &num;
   }
-  // expected-note@-1 {{'tmp_buffer' is destroyed here}}
-  opaque(p);
-  // expected-warning@-1 {{Use of 'tmp_buffer' after its lifetime ended}}
-  // expected-note@-2    {{Use of 'tmp_buffer' after its lifetime ended}}
-}
-
-void member_subregion_alive_deref() {
-  {
-    struct MyBuffer tmp_buffer = {};
-    const char *p = tmp_buffer.buffer;
-    opaque(p); //   no-warning
-    char c = *p; // no-warning
-    (void)c;
-  }
+  // expected-note@-1 {{'num' is destroyed here}}
+  int r = deref_param(ptr);
+  // expected-note@-1 {{Calling 'deref_param'}}
+  (void)r;
 }


### PR DESCRIPTION
In order to detect if a dangling pointer is passed to a function the analyzer has to inspect each call argument. For that reason I have implemented the `checkPostCall` for the `DanglingPtrDeref` checker to check if an argument passed to a function is dangling. Since `checkLocation` only catches dereferences and cannot reason about whether an argument passed to a function is dangling it cannot detect these type of bugs alone.