### PR TITLE
[SandboxVec][Scheduler] Refill ready list during topdown scheduling

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -344,12 +344,18 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
     }
   }
 
-  // Refill the ready list by visiting all nodes from the top of DAG to LowestI.
+  // Refill the ready list by visiting all the nodes in the unscheduled part of
+  // the DAG. In bottom-up that is from the top of the DAG down to LowestI; in
+  // top-down it is the mirror image, from TopI down to the bottom of the DAG.
   ReadyList.clear();
-  Interval<Instruction> RefillIntvl(DAG.getInterval().top(), LowestI);
+  Interval<Instruction> RefillIntvl =
+      Dir == SchedDirection::BottomUp
+          ? Interval<Instruction>(DAG.getInterval().top(), LowestI)
+          : Interval<Instruction>(TopI, DAG.getInterval().bottom());
   for (Instruction &I : RefillIntvl) {
     auto *N = DAG.getNode(&I);
-    if (N->readyBottomUp())
+    if (Dir == SchedDirection::BottomUp ? N->readyBottomUp()
+                                        : N->readyTopDown())
       ReadyList.insert(N);
   }
 }

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -427,6 +427,34 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, i8 %arg) {
   EXPECT_TRUE(Sched.trySchedule({L0, L1}));
 }
 
+// Top-down mirror of the TrimSchedule test. This exercises the top-down path of
+// Scheduler::trimSchedule(), where the ready list must be refilled by visiting
+// the nodes from the top of schedule down to the bottom of the DAG.
+TEST_F(SchedulerTest, TrimSchedule_TopDown) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, i8 %arg) {
+  %ld = load i8, ptr %ptr0
+  %add = add i8 %ld, 0
+  store i8 %add, ptr %ptr0
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *Load = cast<sandboxir::LoadInst>(&*It++);
+  auto *Add = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Store = cast<sandboxir::StoreInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx,
+                             sandboxir::SchedDirection::TopDown);
+  EXPECT_TRUE(Sched.trySchedule({Load}));
+  EXPECT_TRUE(Sched.trySchedule({Store}));
+  EXPECT_TRUE(Sched.trySchedule({Add}));
+}
+
 // Make sure that instructions in  SchedBundles are always scheduled
 // back-to-back
 TEST_F(SchedulerTest, SchedBundleBackToBack) {


### PR DESCRIPTION
Visit nodes which are ready according to the direction of scheduling.
