### PR TITLE
[lldb-dap][VSCode][Windows] check that --check-python is available before using it

### DIFF
--- a/lldb/tools/lldb-dap/extension/src/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/extension/src/debug-configuration-provider.ts
@@ -237,19 +237,25 @@ export class LLDBDapConfigurationProvider
         }
 
         if (os.platform() === "win32") {
-          const pythonCheckProcess = child_process.spawnSync(
+          const lldbDapProcess = child_process.spawnSync(
             executable.command,
-            ["--check-python"],
+            ["--help"],
           );
-          if (pythonCheckProcess.status !== 0) {
-            await vscode.window.showErrorMessage(
-              "Python is not installed correctly. Please install it to use lldb-dap.",
-              {
-                modal: true,
-                detail: pythonCheckProcess.stderr?.toString() ?? "",
-              },
+          if (lldbDapProcess.stdout?.toString().includes("--check-python")) {
+            const pythonCheckProcess = child_process.spawnSync(
+              executable.command,
+              ["--check-python"],
             );
-            return undefined;
+            if (pythonCheckProcess.status !== 0) {
+              await vscode.window.showErrorMessage(
+                "Python is not installed correctly. Please install it to use lldb-dap.",
+                {
+                  modal: true,
+                  detail: pythonCheckProcess.stderr?.toString() ?? "",
+                },
+              );
+              return undefined;
+            }
           }
         }
 


### PR DESCRIPTION
`--check-python` is only available as of lldb-dap 23. Running that check regardless of it's availability causes the extension to fail to start if it's not available.

Check that the flag is available first by searching for it in the `--help`. Checking for a version number would be a cleaner approach but I reckon it would fail for local builds.

Fixes https://github.com/llvm/llvm-project/issues/210879