### PR TITLE
cmake: Filter dangling symlinks from add_td_sources glob

### DIFF
--- a/llvm/cmake/modules/LLVMProcessSources.cmake
+++ b/llvm/cmake/modules/LLVMProcessSources.cmake
@@ -18,10 +18,19 @@ endfunction(llvm_replace_compiler_option)
 
 macro(add_td_sources srcs)
   file(GLOB tds *.td)
-  if( tds )
-    source_group("TableGen descriptions" FILES ${tds})
-    set_source_files_properties(${tds} PROPERTIES HEADER_FILE_ONLY ON)
-    list(APPEND ${srcs} ${tds})
+  # Explicit existence check is necessary to filter dangling symlinks out
+  # (e.g. editor lock files such as Emacs' `.#foo.td`), as also done in
+  # add_header_files_for_glob below.
+  set(existing_tds)
+  foreach(td ${tds})
+    if(EXISTS ${td})
+      list(APPEND existing_tds ${td})
+    endif()
+  endforeach()
+  if( existing_tds )
+    source_group("TableGen descriptions" FILES ${existing_tds})
+    set_source_files_properties(${existing_tds} PROPERTIES HEADER_FILE_ONLY ON)
+    list(APPEND ${srcs} ${existing_tds})
   endif()
 endmacro(add_td_sources)
 


### PR DESCRIPTION
Editor lock files (e.g. Emacs' `.#foo.td`) are dangling symlinks that
`file(GLOB *.td)` picks up and passes to add_library(), which then fails
with "Cannot find source file". Filter them out with an EXISTS check, as
already done for header files in add_header_files_for_glob.

Co-authored-by: Claude (Claude Opus 4.8)