### PR TITLE
[ELF] Fix --lto-obj-path with the ThinLTO cache

### DIFF
--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -383,12 +383,6 @@ SmallVector<std::unique_ptr<InputFile>, 0> BitcodeCompiler::compile() {
     check(
         pruneCache(ctx.arg.thinLTOCacheDir, ctx.arg.thinLTOCachePolicy, files));
 
-  if (!ctx.arg.ltoObjPath.empty()) {
-    saveBuffer(buf[0].second, ctx.arg.ltoObjPath);
-    for (unsigned i = 1; i != maxTasks; ++i)
-      saveBuffer(buf[i].second, ctx.arg.ltoObjPath + Twine(i));
-  }
-
   bool savePrelink = ctx.arg.saveTempsArgs.contains("prelink");
   SmallVector<std::unique_ptr<InputFile>, 0> ret;
   const char *ext = ctx.arg.ltoEmitAsm ? ".s" : ".o";
@@ -407,6 +401,8 @@ SmallVector<std::unique_ptr<InputFile>, 0> BitcodeCompiler::compile() {
       objBuf = buf[i].second;
       bitcodeFilePath = buf[i].first;
     }
+    if (!ctx.arg.ltoObjPath.empty())
+      saveBuffer(objBuf, ctx.arg.ltoObjPath + (i == 0 ? "" : Twine(i)));
     if (objBuf.empty())
       continue;
 

--- a/lld/test/ELF/lto/obj-path.ll
+++ b/lld/test/ELF/lto/obj-path.ll
@@ -52,6 +52,21 @@
 ; CHECK2-NEXT:    retq
 ; CHECK2-NOT:   {{.}}
 
+;; Test --lto-obj-path= with the ThinLTO cache, both when filling the cache and
+;; when reusing the cached native objects.
+; RUN: opt -module-hash -module-summary 1.ll -o cache1.bc
+; RUN: opt -module-hash -module-summary 2.ll -o d/cache2.bc
+; RUN: rm -rf cache objpath.o objpath.o1 objpath.o2
+; RUN: ld.lld --lto-obj-path=objpath.o --thinlto-cache-dir=cache -shared cache1.bc d/cache2.bc -o 3
+; RUN: ls cache/llvmcache-* | count 2
+; RUN: llvm-objdump -d objpath.o1 | FileCheck %s --check-prefix=CHECK1
+; RUN: llvm-objdump -d objpath.o2 | FileCheck %s --check-prefix=CHECK2
+; RUN: rm -f objpath.o objpath.o1 objpath.o2
+; RUN: ld.lld --lto-obj-path=objpath.o --thinlto-cache-dir=cache -shared cache1.bc d/cache2.bc -o 3
+; RUN: ls cache/llvmcache-* | count 2
+; RUN: llvm-objdump -d objpath.o1 | FileCheck %s --check-prefix=CHECK1
+; RUN: llvm-objdump -d objpath.o2 | FileCheck %s --check-prefix=CHECK2
+
 ;; With --thinlto-index-only, --lto-obj-path= creates just one file.
 ; RUN: rm -f objpath.o objpath.o1 objpath.o2
 ; RUN: ld.lld --thinlto-index-only --lto-obj-path=objpath.o -shared 1.bc d/2.bc

--- a/lld/test/ELF/lto/obj-path.ll
+++ b/lld/test/ELF/lto/obj-path.ll
@@ -1,11 +1,12 @@
 ; REQUIRES: x86
-;; Test --lto-obj-path= for regular LTO.
+;; Test --lto-obj-path.
 
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 ; RUN: mkdir d
 ; RUN: opt 1.ll -o 1.bc
 ; RUN: opt 2.ll -o d/2.bc
 
+;; Test --lto-obj-path= for regular LTO.
 ; RUN: rm -f objpath.o
 ; RUN: ld.lld --lto-obj-path=objpath.o -shared 1.bc d/2.bc -o 3
 ; RUN: llvm-nm 3 | FileCheck %s --check-prefix=NM


### PR DESCRIPTION
The --lto-obj-path option no longer writes empty files if the ThinLTO cache is enabled or DTLTO is used.

The implementation of --lto-obj-path derives the native ELF file contents from the buf[] array. When the ThinLTO cache or DTLTO is used the native ELF file contents may be in the files[] array instead. Delay the writing of the native ELF file till after the existing code that extracts the native ELF file contents from either files[] or buf[].

Assisted-by: codex
Signed-off-by: Longjun Luo <luolongjuna@gmail.com>
