### PR TITLE
Revert "[clang] Update diagnostics to include matrices as accepted types"

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13393,8 +13393,7 @@ def err_builtin_is_within_lifetime_invalid_arg : Error<
 def err_builtin_invalid_arg_type: Error<
   "%ordinal0 argument must be a "
   // First component: scalar or container types
-  "%select{|scalar|vector|matrix|vector of|scalar or vector of|"
-  "scalar, vector, or matrix of}1"
+  "%select{|scalar|vector|matrix|vector of|scalar or vector of}1"
   // A comma after generic vector/matrix types if there are non-empty second
   // and third components, to initiate a list.
   "%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1"

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2360,22 +2360,23 @@ checkMathBuiltinElementType(Sema &S, SourceLocation Loc, QualType ArgTy,
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::FloatTy:
     if (!EltTy->isRealFloatingType()) {
+      // FIXME: make diagnostic's wording correct for matrices
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* scalar, vector, or matrix */ 6
-             << /* no int */ 0 << /* floating-point */ 1 << ArgTy;
+             << ArgOrdinal << /* scalar or vector */ 5 << /* no int */ 0
+             << /* floating-point */ 1 << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::IntegerTy:
     if (!EltTy->isIntegerType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* scalar, vector, or matrix */ 6
-             << /* integer */ 1 << /* no fp */ 0 << ArgTy;
+             << ArgOrdinal << /* scalar or vector */ 5 << /* integer */ 1
+             << /* no fp */ 0 << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::SignedIntOrFloatTy:
     if (!EltTy->isSignedIntegerType() && !EltTy->isRealFloatingType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << 1 << /* scalar, vector, or matrix */ 6 << /* signed int */ 2
+             << 1 << /* scalar or vector */ 5 << /* signed int */ 2
              << /* or fp */ 1 << ArgTy;
     }
     break;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -3402,7 +3402,7 @@ static bool CheckFloatOrHalfRepresentation(Sema *S, SourceLocation Loc,
 
   if (!BaseType->isHalfType() && !BaseType->isFloat32Type())
     return S->Diag(Loc, diag::err_builtin_invalid_arg_type)
-           << ArgOrdinal << /* scalar, vector, or matrix */ 6 << /* no int */ 0
+           << ArgOrdinal << /* scalar or vector of */ 5 << /* no int */ 0
            << /* half or float */ 2 << PassedType;
   return false;
 }
@@ -3493,8 +3493,8 @@ static bool CheckUnsignedIntRepresentation(Sema *S, SourceLocation Loc,
                                            clang::QualType PassedType) {
   if (!PassedType->hasUnsignedIntegerRepresentation())
     return S->Diag(Loc, diag::err_builtin_invalid_arg_type)
-           << ArgOrdinal << /* scalar, vector, or matrix */ 6
-           << /* unsigned int */ 3 << /* no fp */ 0 << PassedType;
+           << ArgOrdinal << /* scalar or vector of */ 5 << /* unsigned int */ 3
+           << /* no fp */ 0 << PassedType;
   return false;
 }
 
@@ -4325,8 +4325,8 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
              ->hasFloatingRepresentation()) // half or float or double
       return SemaRef.Diag(TheCall->getArg(0)->getBeginLoc(),
                           diag::err_builtin_invalid_arg_type)
-             << /* ordinal */ 1 << /* scalar, vector, or matrix */ 6
-             << /* no int */ 0 << /* fp */ 1 << TheCall->getArg(0)->getType();
+             << /* ordinal */ 1 << /* scalar or vector */ 5 << /* no int */ 0
+             << /* fp */ 1 << TheCall->getArg(0)->getType();
     if (SemaRef.PrepareBuiltinElementwiseMathOneArgCall(TheCall))
       return true;
     break;

--- a/clang/lib/Sema/SemaSPIRV.cpp
+++ b/clang/lib/Sema/SemaSPIRV.cpp
@@ -324,8 +324,8 @@ bool SemaSPIRV::CheckSPIRVBuiltinFunctionCall(const TargetInfo &TI,
     QualType ArgTyA = A.get()->getType();
     if (!ArgTyA->hasFloatingRepresentation()) {
       SemaRef.Diag(A.get()->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << /* ordinal */ 1 << /* scalar, vector, or matrix */ 6
-          << /* no int */ 0 << /* fp */ 1 << ArgTyA;
+          << /* ordinal */ 1 << /* scalar or vector */ 5 << /* no int */ 0
+          << /* fp */ 1 << ArgTyA;
       return true;
     }
 
@@ -345,8 +345,8 @@ bool SemaSPIRV::CheckSPIRVBuiltinFunctionCall(const TargetInfo &TI,
     QualType ArgTyA = A.get()->getType();
     if (!ArgTyA->hasFloatingRepresentation()) {
       SemaRef.Diag(A.get()->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << /* ordinal */ 1 << /* scalar, vector, or matrix */ 6
-          << /* no int */ 0 << /* fp */ 1 << ArgTyA;
+          << /* ordinal */ 1 << /* scalar or vector */ 5 << /* no int */ 0
+          << /* fp */ 1 << ArgTyA;
       return true;
     }
 
@@ -371,8 +371,8 @@ bool SemaSPIRV::CheckSPIRVBuiltinFunctionCall(const TargetInfo &TI,
     QualType ArgTyA = A.get()->getType();
     if (!ArgTyA->hasFloatingRepresentation()) {
       SemaRef.Diag(A.get()->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << /* ordinal */ 1 << /* scalar, vector, or matrix */ 6
-          << /* no int */ 0 << /* fp */ 1 << ArgTyA;
+          << /* ordinal */ 1 << /* scalar or vector */ 5 << /* no int */ 0
+          << /* fp */ 1 << ArgTyA;
       return true;
     }
 

--- a/clang/test/Sema/aarch64-sve-vector-exp-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-exp-ops.c
@@ -7,11 +7,11 @@
 svfloat32_t test_exp_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_exp(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_exp2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_exp2(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-log-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-log-ops.c
@@ -7,17 +7,17 @@
 svfloat32_t test_log_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_log10_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log10(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_log2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log2(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-pow-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-pow-ops.c
@@ -7,5 +7,5 @@
 svfloat32_t test_pow_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_pow(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-trig-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-trig-ops.c
@@ -7,59 +7,59 @@
 svfloat32_t test_asin_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_asin(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_acos_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_acos(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_atan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_atan(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_atan2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_atan2(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_sin_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_sin(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_cos_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_cos(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_tan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tan(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_sinh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_sinh(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_cosh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_cosh(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_tanh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tanh(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -39,18 +39,18 @@ void test_builtin_elementwise_abs(int i, double d, float4 v, int3 iv, unsigned u
   // expected-error@-1 {{assigning to 'int' from incompatible type 'float4' (vector of 4 'float' values)}}
 
   u = __builtin_elementwise_abs(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of signed integer or floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_abs(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of signed integer or floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   i = __builtin_elementwise_abs(&i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of signed integer or floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'int *')}}
 }
 
 void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_add_sat(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_add_sat(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -65,7 +65,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_add_sat(v, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_add_sat(iv, v);
   // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'float4' (vector of 4 'float' values))}}
@@ -74,7 +74,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
 
   v = __builtin_elementwise_add_sat(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   s = __builtin_elementwise_add_sat(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -103,7 +103,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   int A[10];
   A = __builtin_elementwise_add_sat(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   int(ii);
   int j;
@@ -111,12 +111,12 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_add_sat(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_sub_sat(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_sub_sat(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -131,7 +131,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_sub_sat(v, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_sub_sat(iv, v);
   // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'float4' (vector of 4 'float' values))}}
@@ -140,7 +140,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
 
   v = __builtin_elementwise_sub_sat(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   s = __builtin_elementwise_sub_sat(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -169,7 +169,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   int A[10];
   A = __builtin_elementwise_sub_sat(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   int(ii);
   int j;
@@ -177,14 +177,14 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_sub_sat(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_clmul(int i, short s, double d, float4 v,
                                     int3 iv, unsigned3 uv, unsigned u,
                                     unsigned4 vu, int *p) {
   i = __builtin_elementwise_clmul(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_clmul(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -199,7 +199,7 @@ void test_builtin_elementwise_clmul(int i, short s, double d, float4 v,
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_clmul(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_clmul(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -420,7 +420,7 @@ void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, u
 
 void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_maximum(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_maximum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -438,7 +438,7 @@ void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximum(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_maximum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -449,23 +449,23 @@ void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 
   fv = __builtin_elementwise_maximum(fv, fv);
 
   i = __builtin_elementwise_maximum(iv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximum(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   int A[10];
   A = __builtin_elementwise_maximum(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_maximum(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_minimum(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_minimum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -483,7 +483,7 @@ void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimum(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_minimum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -494,23 +494,23 @@ void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 
   fv = __builtin_elementwise_minimum(fv, fv);
 
   i = __builtin_elementwise_minimum(iv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimum(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   int A[10];
   A = __builtin_elementwise_minimum(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_minimum(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_maximumnum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_maximumnum(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_maximumnum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -528,7 +528,7 @@ void test_builtin_elementwise_maximumnum(int i, short s, float f, double d, floa
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximumnum(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_maximumnum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -539,23 +539,23 @@ void test_builtin_elementwise_maximumnum(int i, short s, float f, double d, floa
   fv = __builtin_elementwise_maximumnum(fv, fv);
 
   i = __builtin_elementwise_maximumnum(iv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximumnum(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   int A[10];
   A = __builtin_elementwise_maximumnum(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_maximumnum(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_minimumnum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_minimumnum(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_minimumnum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -573,7 +573,7 @@ void test_builtin_elementwise_minimumnum(int i, short s, float f, double d, floa
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimumnum(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_minimumnum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -584,18 +584,18 @@ void test_builtin_elementwise_minimumnum(int i, short s, float f, double d, floa
   fv = __builtin_elementwise_minimumnum(fv, fv);
 
   i = __builtin_elementwise_minimumnum(iv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimumnum(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   int A[10];
   A = __builtin_elementwise_minimumnum(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_minimumnum(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_bitreverse(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -607,16 +607,16 @@ void test_builtin_elementwise_bitreverse(int i, float f, double d, float4 v, int
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_bitreverse(f);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float')}}
   
   i = __builtin_elementwise_bitreverse(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_bitreverse(d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 
   v = __builtin_elementwise_bitreverse(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_elementwise_ceil(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -628,16 +628,16 @@ void test_builtin_elementwise_ceil(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_ceil(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_ceil(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_ceil(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_ceil(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_acos(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -649,16 +649,16 @@ void test_builtin_elementwise_acos(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_acos(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_acos(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_acos(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_acos(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_cos(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -670,16 +670,16 @@ void test_builtin_elementwise_cos(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_cos(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_cos(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_cos(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_cos(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_cosh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -691,16 +691,16 @@ void test_builtin_elementwise_cosh(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_cosh(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_cosh(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_cosh(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_cosh(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_exp(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -712,16 +712,16 @@ void test_builtin_elementwise_exp(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_exp(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_exp(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_exp(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_exp(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_exp2(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -733,16 +733,16 @@ void test_builtin_elementwise_exp2(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_exp2(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_exp2(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_exp2(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_exp2(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_exp10(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -754,16 +754,16 @@ void test_builtin_elementwise_exp10(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_exp10(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_exp10(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_exp10(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_exp10(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_ldexp(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -781,10 +781,10 @@ void test_builtin_elementwise_ldexp(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   f = __builtin_elementwise_ldexp(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f = __builtin_elementwise_ldexp(f, f);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of integer types (was 'float')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of integer types (was 'float')}}
 
   f = __builtin_elementwise_ldexp(v, iv);
   // expected-error@-1 {{vector operands do not have the same number of elements ('float4' (vector of 4 'float' values) and 'int3' (vector of 3 'int' values))}}
@@ -796,10 +796,10 @@ void test_builtin_elementwise_ldexp(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{vector operands do not have the same number of elements ('float' and 'int3' (vector of 3 'int' values))}}
 
   f = __builtin_elementwise_ldexp(u, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   f = __builtin_elementwise_ldexp(uv, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_floor(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -811,16 +811,16 @@ void test_builtin_elementwise_floor(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_floor(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_floor(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_floor(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_floor(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_log(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -832,16 +832,16 @@ void test_builtin_elementwise_log(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_log(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_log(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_log(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_log(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_log10(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -853,16 +853,16 @@ void test_builtin_elementwise_log10(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_log10(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_log10(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_log10(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_log10(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_log2(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -874,16 +874,16 @@ void test_builtin_elementwise_log2(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_log2(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_log2(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_log2(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_log2(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -895,16 +895,16 @@ void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_popcount(f);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float')}}
 
   i = __builtin_elementwise_popcount(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_popcount(d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 
   v = __builtin_elementwise_popcount(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   int2 i2 = __builtin_elementwise_popcount(iv);
   // expected-error@-1 {{initializing 'int2' (vector of 2 'int' values) with an expression of incompatible type 'int3' (vector of 3 'int' values)}}
@@ -921,10 +921,10 @@ void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 
 
 void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_fmod(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_fmod(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_fmod(i);
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
@@ -939,7 +939,7 @@ void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_fmod(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   i = __builtin_elementwise_fmod(d, v);
   // expected-error@-1 {{arguments are of different types ('double' vs 'float4' (vector of 4 'float' values))}}
@@ -947,10 +947,10 @@ void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, 
 
 void test_builtin_elementwise_pow(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_pow(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_pow(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_pow(i);
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
@@ -965,7 +965,7 @@ void test_builtin_elementwise_pow(int i, short s, double d, float4 v, int3 iv, u
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_pow(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
   
 }
 
@@ -978,16 +978,16 @@ void test_builtin_elementwise_roundeven(int i, float f, double d, float4 v, int3
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_roundeven(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_roundeven(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_roundeven(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_roundeven(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_round(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -998,20 +998,20 @@ void test_builtin_elementwise_round(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_round(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_round(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_round(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_round(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_round(c1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_rint(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1022,20 +1022,20 @@ void test_builtin_elementwise_rint(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_rint(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_rint(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_rint(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_rint(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_rint(c1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1046,20 +1046,20 @@ void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_nearbyint(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_nearbyint(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_nearbyint(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_nearbyint(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_nearbyint(c1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_asin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1071,16 +1071,16 @@ void test_builtin_elementwise_asin(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_asin(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_asin(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_asin(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_asin(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_sin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1092,16 +1092,16 @@ void test_builtin_elementwise_sin(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_sin(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_sin(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_sin(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sin(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_sinh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1113,16 +1113,16 @@ void test_builtin_elementwise_sinh(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_sinh(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_sinh(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_sinh(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sinh(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_sqrt(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1134,16 +1134,16 @@ void test_builtin_elementwise_sqrt(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_sqrt(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_sqrt(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_sqrt(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sqrt(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_atan(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1155,16 +1155,16 @@ void test_builtin_elementwise_atan(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_atan(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_atan(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_atan(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_atan(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_atan2(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1179,16 +1179,16 @@ void test_builtin_elementwise_atan2(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
 
   i = __builtin_elementwise_atan2(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_atan2(f, f, f);
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   u = __builtin_elementwise_atan2(u, u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_atan2(uv, uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_tan(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1200,16 +1200,16 @@ void test_builtin_elementwise_tan(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_tan(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_tan(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_tan(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_tan(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_tanh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1221,16 +1221,16 @@ void test_builtin_elementwise_tanh(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_tanh(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_tanh(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_tanh(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_tanh(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_trunc(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1242,16 +1242,16 @@ void test_builtin_elementwise_trunc(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_trunc(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_trunc(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_trunc(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_trunc(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_canonicalize(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1263,24 +1263,24 @@ void test_builtin_elementwise_canonicalize(int i, float f, double d, float4 v, i
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_canonicalize(i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_canonicalize(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_canonicalize(u);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_canonicalize(uv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_copysign(p, d);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   i = __builtin_elementwise_copysign(i, i);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_copysign(i);
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
@@ -1292,32 +1292,32 @@ void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_copysign(v, iv);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of floating-point types (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_copysign(uv, iv);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   s = __builtin_elementwise_copysign(i, s);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f = __builtin_elementwise_copysign(f, i);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f = __builtin_elementwise_copysign(i, f);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   enum e { one,
            two };
   i = __builtin_elementwise_copysign(one, two);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   enum f { three };
   enum f x = __builtin_elementwise_copysign(one, three);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   _BitInt(32) ext; // expected-warning {{'_BitInt' in C17 and earlier is a Clang extension}}
   ext = __builtin_elementwise_copysign(ext, ext);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_BitInt(32)')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_BitInt(32)')}}
 
   const float cf32 = 0.0f;
   f = __builtin_elementwise_copysign(cf32, f);
@@ -1329,7 +1329,7 @@ void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4
 
   float A[10];
   A = __builtin_elementwise_copysign(A, A);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'float *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'float *')}}
 
   float(ii);
   float j;
@@ -1337,7 +1337,7 @@ void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_copysign(c1, c2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 
   double f64 = 0.0;
   double tmp0 = __builtin_elementwise_copysign(f64, f);
@@ -1426,30 +1426,30 @@ void test_builtin_elementwise_fma(int i32, int2 v2i32, short i16,
   // expected-error@-1 {{arguments are of different types ('double' vs 'double2' (vector of 2 'double' values)}}
 
   i32 = __builtin_elementwise_fma(i32, i32, i32);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   v2i32 = __builtin_elementwise_fma(v2i32, v2i32, v2i32);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (vector of 2 'int' values))}}
 
   f32 = __builtin_elementwise_fma(f32, f32, i32);
-  // expected-error@-1 {{3rd argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f32 = __builtin_elementwise_fma(f32, i32, f32);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f32 = __builtin_elementwise_fma(f32, f32, i32);
-  // expected-error@-1 {{3rd argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'int')}}
 
 
   _Complex float c1, c2, c3;
   c1 = __builtin_elementwise_fma(c1, f32, f32);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 
   c2 = __builtin_elementwise_fma(f32, c2, f32);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 
   c3 = __builtin_elementwise_fma(f32, f32, c3);
-  // expected-error@-1 {{3rd argument must be a scalar, vector, or matrix of floating-point types (was '_Complex float')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_fsh(int i32, int2 v2i32, short i16, int3 v3i32,
@@ -1473,13 +1473,13 @@ void test_builtin_elementwise_fsh(int i32, int2 v2i32, short i16, int3 v3i32,
     // expected-error@-1 {{arguments are of different types ('short' vs 'int')}}
 
     f32 = __builtin_elementwise_fshl(f32, f32, f32);
-    // expected-error@-1 {{argument must be a scalar, vector, or matrix of integer types (was 'float')}}
+    // expected-error@-1 {{argument must be a scalar or vector of integer types (was 'float')}}
 
     f64 = __builtin_elementwise_fshr(f64, f64, f64);
-    // expected-error@-1 {{argument must be a scalar, vector, or matrix of integer types (was 'double')}}
+    // expected-error@-1 {{argument must be a scalar or vector of integer types (was 'double')}}
 
     v2i32 = __builtin_elementwise_fshl(v2i32, v2i32, v2f32);
-    // expected-error@-1 {{argument must be a scalar, vector, or matrix of integer types (was 'float2' (vector of 2 'float' values))}}
+    // expected-error@-1 {{argument must be a scalar or vector of integer types (was 'float2' (vector of 2 'float' values))}}
 
     v2i32 = __builtin_elementwise_fshr(v2i32, v2i32, v3i32);
     // expected-error@-1 {{arguments are of different types ('int2' (vector of 2 'int' values) vs 'int3' (vector of 3 'int' values))}}
@@ -1518,11 +1518,11 @@ cfloat4 quux(cfloat4 x, float4 y) {
 void test_builtin_elementwise_clzg(int i32, int2 v2i32, short i16,
                                    double f64, double2 v2f64) {
   f64 = __builtin_elementwise_clzg(f64);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 
   _Complex float c1;
   c1 = __builtin_elementwise_clzg(c1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was '_Complex float')}}
 
   v2i32 = __builtin_elementwise_clzg(v2i32, i32);
   // expected-error@-1 {{arguments are of different types ('int2' (vector of 2 'int' values) vs 'int')}}
@@ -1540,11 +1540,11 @@ void test_builtin_elementwise_clzg(int i32, int2 v2i32, short i16,
 void test_builtin_elementwise_ctzg(int i32, int2 v2i32, short i16,
                                    double f64, double2 v2f64) {
   f64 = __builtin_elementwise_ctzg(f64);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 
   _Complex float c1;
   c1 = __builtin_elementwise_ctzg(c1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was '_Complex float')}}
 
   v2i32 = __builtin_elementwise_ctzg(v2i32, i32);
   // expected-error@-1 {{arguments are of different types ('int2' (vector of 2 'int' values) vs 'int')}}

--- a/clang/test/Sema/riscv-rvv-vector-exp-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-exp-ops.c
@@ -9,11 +9,11 @@
 vfloat32mf2_t test_exp_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_exp(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_exp2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_exp2(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-log-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-log-ops.c
@@ -9,17 +9,17 @@
 vfloat32mf2_t test_log_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_log10_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log10(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_log2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log2(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-trig-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-trig-ops.c
@@ -8,60 +8,60 @@
 vfloat32mf2_t test_asin_vv_i8mf8(vfloat32mf2_t v) {
 
     return __builtin_elementwise_asin(v);
-    // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_acos_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_acos(v);
-    // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_atan_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_atan(v);
-    // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
 
 vfloat32mf2_t test_atan2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_atan2(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_sin_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_sin(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_cos_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_cos(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_tan_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_tan(v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_sinh_vv_i8mf8(vfloat32mf2_t v) {
 
     return __builtin_elementwise_sinh(v);
-    // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_cosh_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_cosh(v);
-    // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_tanh_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_tanh(v);
-    // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   

--- a/clang/test/Sema/riscv-sve-vector-pow-ops.c
+++ b/clang/test/Sema/riscv-sve-vector-pow-ops.c
@@ -9,5 +9,5 @@
 vfloat32mf2_t test_pow_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_pow(v, v);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point type}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/atan2-errors_mat.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/atan2-errors_mat.hlsl
@@ -3,5 +3,5 @@
 
 double2x2 test_vec_double_builtin(double2x2 p0, double2x2 p1) {
     return __builtin_elementwise_atan2(p0, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double2x2' (aka 'matrix<double, 2, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double2x2' (aka 'matrix<double, 2, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/ddx-coarse-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ddx-coarse-errors.hlsl
@@ -13,10 +13,10 @@ float too_many_args(float val) {
 
 float test_integer_scalar_input(int val) {
   return __builtin_hlsl_elementwise_ddx_coarse(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 double test_double_scalar_input(double val) {
   return __builtin_hlsl_elementwise_ddx_coarse(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/ddx-fine-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ddx-fine-errors.hlsl
@@ -13,10 +13,10 @@ float too_many_args(float val) {
 
 float test_integer_scalar_input(int val) {
   return __builtin_hlsl_elementwise_ddx_fine(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 double test_double_scalar_input(double val) {
   return __builtin_hlsl_elementwise_ddx_fine(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/ddy-coarse-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ddy-coarse-errors.hlsl
@@ -13,10 +13,10 @@ float too_many_args(float val) {
 
 float test_integer_scalar_input(int val) {
   return __builtin_hlsl_elementwise_ddy_coarse(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 double test_double_scalar_input(double val) {
   return __builtin_hlsl_elementwise_ddy_coarse(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/ddy-fine-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ddy-fine-errors.hlsl
@@ -13,10 +13,10 @@ float too_many_args(float val) {
 
 float test_integer_scalar_input(int val) {
   return __builtin_hlsl_elementwise_ddy_fine(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 double test_double_scalar_input(double val) {
   return __builtin_hlsl_elementwise_ddy_fine(val);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/degrees-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/degrees-errors.hlsl
@@ -12,15 +12,15 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_degrees(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_degrees_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_degrees(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float2 builtin_degrees_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_degrees(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/exp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/exp-errors.hlsl
@@ -14,15 +14,15 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_exp_int_to_float_promotion(int p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float2 builtin_exp_int2_to_float2_promotion(int2 p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/f16tof32-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/f16tof32-errors.hlsl
@@ -24,7 +24,7 @@ float builtin_f16tof32_bool4(bool4 p0) {
 
 float builtin_f16tof32_short(short p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'short')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'short')}}
 }
 
 float builtin_f16tof32_unsigned_short(unsigned short p0) {
@@ -34,37 +34,37 @@ float builtin_f16tof32_unsigned_short(unsigned short p0) {
 
 float builtin_f16tof32_int(int p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'int')}}
 }
 
 float builtin_f16tof32_int64_t(long p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'long')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'long')}}
 }
 
 float2 builtin_f16tof32_int2_to_float2_promotion(int2 p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 
 float builtin_f16tof32_half(half p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'half')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'half')}}
 }
 
 float builtin_f16tof32_half4(half4 p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'half4' (aka 'vector<half, 4>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'half4' (aka 'vector<half, 4>'))}}
 }
 
 float builtin_f16tof32_float(float p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'float')}}
 }
 
 float builtin_f16tof32_double(double p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'double')}}
 }
 
 float f16tof32_too_few_arg() {

--- a/clang/test/SemaHLSL/BuiltIns/frac-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/frac-errors.hlsl
@@ -13,16 +13,16 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_frac(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_frac_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_frac(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float2 builtin_frac_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_frac(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 

--- a/clang/test/SemaHLSL/BuiltIns/half-float-only-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/half-float-only-errors.hlsl
@@ -23,10 +23,10 @@
 
 double test_double_builtin(double p0) {
     return TEST_FUNC(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }
 
 double2 test_vec_double_builtin(double2 p0) {
     return TEST_FUNC(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/half-float-only-errors2.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/half-float-only-errors2.hlsl
@@ -4,10 +4,10 @@
 
 double test_double_builtin(double p0, double p1) {
     return TEST_FUNC(p0, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }
 
 double2 test_vec_double_builtin(double2 p0, double2 p1) {
     return TEST_FUNC(p0, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/isinf-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/isinf-errors.hlsl
@@ -13,26 +13,26 @@ bool2 test_too_many_arg(float2 p0) {
 
 bool builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_isinf(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 bool builtin_isinf_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_isinf(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 bool2 builtin_isinf_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_isinf(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 
 // builtins are variadic functions and so are subject to DefaultVariadicArgumentPromotion
 half builtin_isinf_half_scalar (half p0) {
   return __builtin_hlsl_elementwise_isinf (p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }
 
 float builtin_isinf_float_scalar ( float p0) {
   return __builtin_hlsl_elementwise_isinf (p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/isnan-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/isnan-errors.hlsl
@@ -13,26 +13,26 @@ bool2 test_too_many_arg(float2 p0) {
 
 bool builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_isnan(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 bool builtin_isnan_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_isnan(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 bool2 builtin_isnan_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_isnan(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 
 // builtins are variadic functions and so are subject to DefaultVariadicArgumentPromotion
 half builtin_isnan_half_scalar (half p0) {
   return __builtin_hlsl_elementwise_isnan (p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }
 
 float builtin_isnan_float_scalar ( float p0) {
   return __builtin_hlsl_elementwise_isnan (p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
@@ -71,12 +71,12 @@ float2 test_builtin_lerp_float2_splat(float p0, float2 p1) {
 
 float2 test_builtin_lerp_float2_splat2(double p0, double2 p1) {
   return __builtin_hlsl_lerp(p1, p0, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 float2 test_builtin_lerp_float2_splat3(double p0, double2 p1) {
   return __builtin_hlsl_lerp(p1, p1, p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 float3 test_builtin_lerp_float3_splat(float p0, float3 p1) {
@@ -91,40 +91,40 @@ float4 test_builtin_lerp_float4_splat(float p0, float4 p1) {
 
 float2 test_lerp_float2_int_splat(float2 p0, int p1) {
   return __builtin_hlsl_lerp(p0, p1, p1);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float3 test_lerp_float3_int_splat(float3 p0, int p1) {
   return __builtin_hlsl_lerp(p0, p1, p1);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float2 test_builtin_lerp_int_vect_to_float_vec_promotion(int2 p0, float p1) {
   return __builtin_hlsl_lerp(p0, p1, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 
 float test_builtin_lerp_bool_type_promotion(bool p0) {
   return __builtin_hlsl_lerp(p0, p0, p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_bool_to_float_type_promotion(float p0, bool p1) {
   return __builtin_hlsl_lerp(p0, p0, p1);
-  // expected-error@-1 {{3rd argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_bool_to_float_type_promotion2(bool p0, float p1) {
   return __builtin_hlsl_lerp(p1, p0, p1);
-  // expected-error@-1 {{2nd argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_lerp_int_to_float_promotion(float p0, int p1) {
   return __builtin_hlsl_lerp(p0, p0, p1);
-  // expected-error@-1 {{3rd argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float4 test_lerp_int4(int4 p0, int4 p1, int4 p2) {
   return __builtin_hlsl_lerp(p0, p1, p2);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int4' (aka 'vector<int, 4>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int4' (aka 'vector<int, 4>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/normalize-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/normalize-errors.hlsl
@@ -15,17 +15,17 @@ void test_too_many_arg(float2 p0)
 bool builtin_bool_to_float_type_promotion(bool p1)
 {
   return __builtin_hlsl_normalize(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 bool builtin_normalize_int_to_float_promotion(int p1)
 {
   return __builtin_hlsl_normalize(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 bool2 builtin_normalize_int2_to_float2_promotion(int2 p1)
 {
   return __builtin_hlsl_normalize(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/radians-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/radians-errors.hlsl
@@ -12,16 +12,16 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_radians(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_radians_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_radians(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float2 builtin_radians_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_radians(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 

--- a/clang/test/SemaHLSL/BuiltIns/rcp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/rcp-errors.hlsl
@@ -12,15 +12,15 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_rcp(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_rcp_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_rcp(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float2 builtin_rcp_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_rcp(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/reversebits-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/reversebits-errors.hlsl
@@ -3,10 +3,10 @@
 
 double2 test_int_builtin(double2 p0) {
     return __builtin_elementwise_bitreverse(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of integer types (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 int2 test_int_builtin(int2 p0) {
     return __builtin_elementwise_bitreverse(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of unsigned integer types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of unsigned integer types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/round-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/round-errors.hlsl
@@ -13,15 +13,15 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_round_int_to_float_promotion(int p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float2 builtin_round_int2_to_float2_promotion(int2 p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/rsqrt-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/rsqrt-errors.hlsl
@@ -12,20 +12,20 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_hlsl_elementwise_rsqrt(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 float builtin_rsqrt_int_to_float_promotion(int p1) {
   return __builtin_hlsl_elementwise_rsqrt(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 float2 builtin_rsqrt_int2_to_float2_promotion(int2 p1) {
   return __builtin_hlsl_elementwise_rsqrt(p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }
 
 double builtin_rsqrt_double(double p0) {
   return __builtin_hlsl_elementwise_rsqrt(p0);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/step-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/step-errors.hlsl
@@ -15,17 +15,17 @@ void test_too_many_arg(float2 p0)
 bool builtin_bool_to_float_type_promotion(bool p1)
 {
   return __builtin_hlsl_step(p1, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'bool')}}
 }
 
 bool builtin_step_int_to_float_promotion(int p1)
 {
   return __builtin_hlsl_step(p1, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int')}}
 }
 
 bool2 builtin_step_int2_to_float2_promotion(int2 p1)
 {
   return __builtin_hlsl_step(p1, p1);
-  // expected-error@-1 {{1st argument must be a scalar, vector, or matrix of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of 16 or 32 bit floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaSPIRV/BuiltIns/ddx-errors.c
+++ b/clang/test/SemaSPIRV/BuiltIns/ddx-errors.c
@@ -15,7 +15,7 @@ float test_too_many_arg(float p0) {
 
 float test_int_scalar_inputs(int p0) {
   return __builtin_spirv_ddx(p0);
-  //  expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  //  expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float test_mismatched_return(float2 p0) {

--- a/clang/test/SemaSPIRV/BuiltIns/ddy-errors.c
+++ b/clang/test/SemaSPIRV/BuiltIns/ddy-errors.c
@@ -15,7 +15,7 @@ float test_too_many_arg(float p0) {
 
 float test_int_scalar_inputs(int p0) {
   return __builtin_spirv_ddy(p0);
-  //  expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  //  expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float test_mismatched_return(float2 p0) {

--- a/clang/test/SemaSPIRV/BuiltIns/faceforward-errors.c
+++ b/clang/test/SemaSPIRV/BuiltIns/faceforward-errors.c
@@ -20,7 +20,7 @@ float2 test_too_many_arg(float2 p0) {
 
 int test_int_scalar_inputs(int p0) {
   return __builtin_spirv_faceforward(p0, p0, p0);
-  //  expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  //  expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float test_int_scalar_inputs2(float p0, int p1) {

--- a/clang/test/SemaSPIRV/BuiltIns/fwidth-errors.c
+++ b/clang/test/SemaSPIRV/BuiltIns/fwidth-errors.c
@@ -15,7 +15,7 @@ float test_too_many_arg(float p0) {
 
 float test_int_scalar_inputs(int p0) {
   return __builtin_spirv_fwidth(p0);
-  //  expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  //  expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float test_mismatched_return(float2 p0) {

--- a/clang/test/SemaSPIRV/BuiltIns/smoothstep-errors.c
+++ b/clang/test/SemaSPIRV/BuiltIns/smoothstep-errors.c
@@ -20,7 +20,7 @@ float2 test_too_many_arg(float2 p0) {
 
 int test_int_scalar_inputs(int p0) {
   return __builtin_spirv_smoothstep(p0, p0, p0);
-  //  expected-error@-1 {{1st argument must be a scalar, vector, or matrix of floating-point types (was 'int')}}
+  //  expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float test_int_scalar_inputs2(float p0, int p1) {


### PR DESCRIPTION
Reverts llvm/llvm-project#201237. The PR did not update the test assertions for `Sema/builtins-elementwise-math.c`

https://github.com/llvm/llvm-project/pull/201237#issuecomment-5037239584