### PR TITLE
[libc++] Use github-script instead of pygithub for benchmark jobs, and report failure

### DIFF
--- a/.github/workflows/libcxx-pr-benchmark.yml
+++ b/.github/workflows/libcxx-pr-benchmark.yml
@@ -48,43 +48,38 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.14'
-
-      - name: Setup virtual environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          python -m pip install pygithub==2.8.1
-
       - name: Extract information from the PR
         id: vars
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          source .venv/bin/activate
-          cat <<EOF | python >> ${GITHUB_OUTPUT}
-          import github
-          repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
-          pr = repo.get_pull(${{ github.event.issue.number }})
-          print(f"pr_base={pr.base.sha}")
-          print(f"pr_head={pr.head.sha}")
-          EOF
-          BENCHMARKS=$(echo "$COMMENT_BODY" | sed -nE 's/\/libcxx-bot benchmark (.+)/\1/p')
-          echo "benchmarks=${BENCHMARKS}" >> ${GITHUB_OUTPUT}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('pr_base', pr.data.base.sha);
+            core.setOutput('pr_head', pr.data.head.sha);
+            const match = context.payload.comment.body.match(/\/libcxx-bot benchmark (.+)/);
+            core.setOutput('benchmarks', match ? match[1] : '');
 
       - name: Update comment with link to the run
-        run: |
-          source .venv/bin/activate
-          cat <<EOF | python
-          import github
-          repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
-          pr = repo.get_pull(${{ github.event.issue.number }})
-          comment = pr.get_issue_comment(${{ github.event.comment.id }})
-          add_text = "> _Running benchmarks in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}_"
-          comment.edit('\n\n'.join([comment.body, add_text]))
-          EOF
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: comment } = await github.rest.issues.getComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+            });
+            const run_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const note = `> _Running benchmarks in ${run_url}_`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              body: [comment.body, note].join('\n\n'),
+            });
     outputs:
       pr_base: ${{ steps.vars.outputs.pr_base }}
       pr_head: ${{ steps.vars.outputs.pr_head }}
@@ -139,7 +134,6 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           python -m pip install -r libcxx/utils/requirements.txt
-          python -m pip install pygithub==2.8.1
 
       - name: Build the baseline and the candidate
         env:
@@ -178,30 +172,54 @@ jobs:
           ./libcxx/utils/compare-benchmarks baseline.lnt candidate.lnt | tee results.txt
 
       - name: Update comment with results
-        run: |
-          source .venv/bin/activate
-          cat <<EOF | python
-          import github
-          repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
-          pr = repo.get_pull(${{ github.event.issue.number }})
-          comment = pr.get_issue_comment(${{ github.event.comment.id }})
-          with open('results.txt', 'r') as f:
-            benchmark_results = f.read()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('results.txt', 'utf8');
+            const { data: comment } = await github.rest.issues.getComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+            });
+            const details = [
+              '<details>',
+              '<summary>',
+              `Benchmark results for ${process.env.PLATFORM}:`,
+              '</summary>',
+              '',
+              '```',
+              results,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              body: [comment.body, details].join('\n\n'),
+            });
 
-          new_comment_text = f"""
-          {comment.body}
-
-          <details>
-          <summary>
-          Benchmark results for ${{ matrix.platform }}:
-          </summary>
-
-          \`\`\`
-          {benchmark_results}
-          \`\`\`
-
-          </details>
-          """
-
-          comment.edit(new_comment_text)
-          EOF
+      - name: Report failure in the comment
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        with:
+          script: |
+            const { data: comment } = await github.rest.issues.getComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+            });
+            const run_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const note = `> _:x: Benchmarks for ${process.env.PLATFORM} failed. See ${run_url} for details._`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              body: [comment.body, note].join('\n\n'),
+            });


### PR DESCRIPTION
Switch GitHub API interactions to use actions/github-script instead of pygithub, as is done in other Github workflows in the repository. This is simpler and it also resolves the issue that if setting up the Python virtual environment fails, there's no way to communicate the issue back since doing so would require pygithub.

As a drive-by, also report the failure  when a step in the libc++ PR benchmark job fails, instead of leaving a "Running benchmarks in ..." comment indefinitely.

Assisted by Claude

Fixes #210985