### PR TITLE
workflows/release-sources: Add missing checkout for composite action

### DIFF
--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -53,6 +53,12 @@ jobs:
       export-args: ${{ steps.inputs.outputs.export-args }}
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/validate-release-version
+          sparse-checkout-cone-mode: false
       - name: Validate Input
         if: inputs.release-version != ''
         uses: ./.github/workflows/validate-release-version


### PR DESCRIPTION
We need to explicitly checkout .github/workflows/validate-release-version if we are going to use it.