### PR TITLE
[LLVM] Auto-upgrade legacy coro.end results

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1447,10 +1447,18 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
       }
     }
 
-    if (F->arg_size() == 2 && Name == "coro.end") {
+    Intrinsic::ID CoroEndID = Intrinsic::not_intrinsic;
+    if (Name == "coro.end" &&
+        (F->arg_size() == 2 || F->getReturnType()->isIntegerTy(1)))
+      CoroEndID = Intrinsic::coro_end;
+    else if (Name == "coro.end.async" &&
+             F->getReturnType()->isIntegerTy(1))
+      CoroEndID = Intrinsic::coro_end_async;
+
+    if (CoroEndID != Intrinsic::not_intrinsic) {
       rename(F);
       NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(),
-                                                Intrinsic::coro_end);
+                                                CoroEndID);
       return true;
     }
 
@@ -5338,10 +5346,24 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     break;
   }
 
+  case Intrinsic::coro_end_async:
   case Intrinsic::coro_end: {
     SmallVector<Value *, 3> Args(CI->args());
-    Args.push_back(ConstantTokenNone::get(CI->getContext()));
+    if (NewFn->getIntrinsicID() == Intrinsic::coro_end && Args.size() == 2)
+      Args.push_back(ConstantTokenNone::get(CI->getContext()));
     NewCall = Builder.CreateCall(NewFn, Args);
+
+    if (!CI->getType()->isVoidTy()) {
+      if (!CI->use_empty()) {
+        Function *IsInRamp = Intrinsic::getOrInsertDeclaration(
+            CI->getModule(), Intrinsic::coro_is_in_ramp);
+        Value *InRamp = Builder.CreateCall(IsInRamp);
+        CI->replaceAllUsesWith(Builder.CreateNot(InRamp));
+      }
+      CI->eraseFromParent();
+      return;
+    }
+
     break;
   }
 

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1451,14 +1451,12 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
     if (Name == "coro.end" &&
         (F->arg_size() == 2 || F->getReturnType()->isIntegerTy(1)))
       CoroEndID = Intrinsic::coro_end;
-    else if (Name == "coro.end.async" &&
-             F->getReturnType()->isIntegerTy(1))
+    else if (Name == "coro.end.async" && F->getReturnType()->isIntegerTy(1))
       CoroEndID = Intrinsic::coro_end_async;
 
     if (CoroEndID != Intrinsic::not_intrinsic) {
       rename(F);
-      NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(),
-                                                CoroEndID);
+      NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), CoroEndID);
       return true;
     }
 

--- a/llvm/test/Assembler/auto_upgrade_coro_end_result.ll
+++ b/llvm/test/Assembler/auto_upgrade_coro_end_result.ll
@@ -1,0 +1,49 @@
+; RUN: opt -S %s | FileCheck %s
+
+declare i1 @llvm.coro.end(ptr, i1, token)
+
+define i1 @used_result(ptr %frame) presplitcoroutine {
+; CHECK-LABEL: @used_result(
+; CHECK: call void @llvm.coro.end(ptr %frame, i1 false, token none)
+; CHECK-NEXT: [[IN_RAMP:%.*]] = call i1 @llvm.coro.is_in_ramp()
+; CHECK-NEXT: [[IN_RESUME:%.*]] = xor i1 [[IN_RAMP]], true
+; CHECK-NEXT: ret i1 [[IN_RESUME]]
+entry:
+  %in.resume = call i1 @llvm.coro.end(ptr %frame, i1 false, token none)
+  ret i1 %in.resume
+}
+
+define void @unused_result(ptr %frame) presplitcoroutine {
+; CHECK-LABEL: @unused_result(
+; CHECK: call void @llvm.coro.end(ptr %frame, i1 false, token none)
+; CHECK-NEXT: ret void
+entry:
+  %unused = call i1 @llvm.coro.end(ptr %frame, i1 false, token none)
+  ret void
+}
+
+declare i1 @llvm.coro.end.async(ptr, i1, ...)
+
+define i1 @used_async_result(ptr %frame) presplitcoroutine {
+; CHECK-LABEL: @used_async_result(
+; CHECK: call void (ptr, i1, ...) @llvm.coro.end.async(ptr %frame, i1 false)
+; CHECK-NEXT: [[ASYNC_IN_RAMP:%.*]] = call i1 @llvm.coro.is_in_ramp()
+; CHECK-NEXT: [[ASYNC_IN_RESUME:%.*]] = xor i1 [[ASYNC_IN_RAMP]], true
+; CHECK-NEXT: ret i1 [[ASYNC_IN_RESUME]]
+entry:
+  %in.resume = call i1 (ptr, i1, ...) @llvm.coro.end.async(ptr %frame, i1 false)
+  ret i1 %in.resume
+}
+
+define void @unused_async_result(ptr %frame) presplitcoroutine {
+; CHECK-LABEL: @unused_async_result(
+; CHECK: call void (ptr, i1, ...) @llvm.coro.end.async(ptr %frame, i1 false)
+; CHECK-NEXT: ret void
+entry:
+  %unused = call i1 (ptr, i1, ...) @llvm.coro.end.async(ptr %frame, i1 false)
+  ret void
+}
+
+; CHECK-DAG: declare void @llvm.coro.end(ptr, i1, token)
+; CHECK-DAG: declare void @llvm.coro.end.async(ptr, i1, ...)
+; CHECK-DAG: declare i1 @llvm.coro.is_in_ramp()


### PR DESCRIPTION
When `llvm.coro.end` and `llvm.coro.end.async` changed from returning `i1`
to returning `void` in #159278, the bitcode auto-upgrader continued to handle
only the older two-argument `llvm.coro.end` form.

As a result, valid bitcode produced before that transition fails verification
when a current LLVM ThinLTO backend materializes a module containing either:

* the three-argument, `i1`-returning `llvm.coro.end`; or
* the `i1`-returning `llvm.coro.end.async`.

Teach `AutoUpgrade` to recognize both legacy declarations and rebuild their
calls with the current `void`-returning intrinsics. If the legacy result is
used, replace it with `!llvm.coro.is_in_ramp()`, which preserves the old
`true in a resume function, false in the ramp function` behavior. Unused
results require no replacement.

The new assembler test covers used and unused results for both synchronous
and async coroutine ends.

Tested with:

```console
$ cmake --build build --target opt FileCheck -j8
$ build/bin/opt -S llvm/test/Assembler/auto_upgrade_coro_end_result.ll | \
    build/bin/FileCheck llvm/test/Assembler/auto_upgrade_coro_end_result.ll
```
