### PR TITLE
workflows/release-documentation: Add missing checkout

### DIFF
--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -199,6 +199,13 @@ jobs:
       attestations: write # For artifact attestations
 
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/upload-release-artifact
+          sparse-checkout-cone-mode: false
+
      - name: Upload Man Page Artifacts
        id: man-page-artifact-upload
        uses: ./.github/workflows/upload-release-artifact


### PR DESCRIPTION
We need to checkout the upload-release-artifact composite action before using it.