### PR TITLE
[asan] Add !dbg metadata to __asan_after/before_dynamic_init calls

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2097,12 +2097,22 @@ void ModuleAddressSanitizer::poisonOneInitializer(Function &GlobalInit) {
   // Add a call to poison all external globals before the given function starts.
   Value *ModuleNameAddr =
       ConstantExpr::getPointerCast(getOrCreateModuleName(), IntptrTy);
-  IRB.CreateCall(AsanPoisonGlobals, ModuleNameAddr);
+  CallInst *CallBefore = IRB.CreateCall(AsanPoisonGlobals, ModuleNameAddr);
+  if (DISubprogram *SP = GlobalInit.getSubprogram())
+    CallBefore->setDebugLoc(
+        DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP));
 
   // Add calls to unpoison all globals before each return instruction.
   for (auto &BB : GlobalInit)
-    if (ReturnInst *RI = dyn_cast<ReturnInst>(BB.getTerminator()))
-      CallInst::Create(AsanUnpoisonGlobals, "", RI->getIterator());
+    if (ReturnInst *RI = dyn_cast<ReturnInst>(BB.getTerminator())) {
+      CallInst *CallAfter =
+          CallInst::Create(AsanUnpoisonGlobals, "", RI->getIterator());
+      if (RI->getDebugLoc())
+        CallAfter->setDebugLoc(RI->getDebugLoc());
+      else if (DISubprogram *SP = GlobalInit.getSubprogram())
+        CallAfter->setDebugLoc(
+            DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP));
+    }
 }
 
 void ModuleAddressSanitizer::createInitializerPoisonCalls() {

--- a/llvm/test/Instrumentation/AddressSanitizer/instrument-initializer-dbgloc.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/instrument-initializer-dbgloc.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -passes=asan -S | FileCheck %s
+
+@glob = internal global i32 0, align 4, sanitize_address_dyninit
+
+define internal void @__late_ctor() sanitize_address section ".text.startup" !dbg !5 {
+entry:
+  ret void, !dbg !10
+}
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__late_ctor, ptr null }]
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cpp", directory: "/")
+!2 = !{i32 2, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DISubprogram(name: "__late_ctor", scope: !1, file: !1, line: 1, type: !6, isLocal: true, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !9)
+!6 = !DISubroutineType(types: !7)
+!7 = !{null}
+!9 = !{}
+!10 = !DILocation(line: 2, column: 1, scope: !5)
+
+; CHECK-LABEL: define internal void @__late_ctor
+; CHECK: call void @__asan_before_dynamic_init(i64 ptrtoint (ptr @___asan_gen_module to i64)), !dbg ![[DBG1:[0-9]+]]
+; CHECK: call void @__asan_after_dynamic_init(), !dbg ![[DBG2:[0-9]+]]
+; CHECK: ret void, !dbg ![[DBG2]]
+; CHECK: ![[DBG1]] = !DILocation(line: 1, scope: ![[SP:[0-9]+]])
+; CHECK: ![[DBG2]] = !DILocation(line: 2, column: 1, scope: ![[SP]])


### PR DESCRIPTION
We get this error when linking the kernel with a custom asan runtime

```
  = note: inlinable function call in a function with debug info must have a !dbg location
            call void @__asan_after_dynamic_init()
```

The verifier throws this because __asan_after_dynamic_init doesn't have !dbg but it is inlinable into the module ctor that invokes it which does have !dbg. Normally, these functions aren't inlinable because they're provided by some prebuilt library, but for Fuchsia's kernel, we provide a custom runtime defining these and it's built with LTO which does make it inlinable.

The fix in this patch is just adding the !dbg metadata to these calls which I think should be non-intrusive.

NOTE: Gemini was used to make the test.