### PR TITLE
[libc] Add stub implementation for strptime.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1333,6 +1333,9 @@ if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
       # sys/ptrace.h entrypoints
       libc.src.sys.ptrace.ptrace
 
+      # time.h entrypoints
+      libc.src.time.strptime
+
       # wchar.h entrypoints
       libc.src.wchar.swprintf
     )

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1570,6 +1570,9 @@ if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
       # sys/ptrace.h entrypoints
       libc.src.sys.ptrace.ptrace
 
+      # time.h entrypoints
+      libc.src.time.strptime
+
       # wchar.h entrypoints
       libc.src.wchar.swprintf
     )

--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -132,6 +132,14 @@ functions:
       - type: const char *__restrict
       - type: const struct tm *__restrict
       - type: locale_t
+  - name: strptime
+    standards:
+      - stdc
+    return_type: char *
+    arguments:
+      - type: const char *__restrict
+      - type: const char *__restrict
+      - type: struct tm *__restrict
   - name: time
     standards:
       - stdc

--- a/libc/src/time/CMakeLists.txt
+++ b/libc/src/time/CMakeLists.txt
@@ -215,6 +215,17 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  strptime
+  SRCS
+    strptime.cpp
+  HDRS
+    strptime.h
+  DEPENDS
+    libc.hdr.types.struct_tm
+    libc.src.__support.macros.config
+)
+
+add_entrypoint_object(
   time
   SRCS
     time.cpp

--- a/libc/src/time/CMakeLists.txt
+++ b/libc/src/time/CMakeLists.txt
@@ -222,6 +222,7 @@ add_entrypoint_object(
     strptime.h
   DEPENDS
     libc.hdr.types.struct_tm
+    libc.src.__support.common
     libc.src.__support.macros.config
 )
 

--- a/libc/src/time/strptime.cpp
+++ b/libc/src/time/strptime.cpp
@@ -21,7 +21,7 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(char *, strptime,
                    ([[maybe_unused]] const char *__restrict buf,
                     [[maybe_unused]] const char *__restrict format,
-                    [[maybe_unused]] const tm *__restrict tm)) {
+                    [[maybe_unused]] const struct tm *__restrict tm)) {
   return nullptr;
 }
 

--- a/libc/src/time/strptime.cpp
+++ b/libc/src/time/strptime.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of strptime function -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/time/strptime.h"
+#include "hdr/types/struct_tm.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strptime,
+                   ([[maybe_unused]] const char *__restrict buf,
+                    [[maybe_unused]] const char *__restrict format,
+                    [[maybe_unused]] const tm *__restrict tm)) {
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/time/strptime.cpp
+++ b/libc/src/time/strptime.cpp
@@ -1,9 +1,14 @@
-//===-- Implementation of strptime function -------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the definition of the strptime function.
+///
 //===----------------------------------------------------------------------===//
 
 #include "src/time/strptime.h"

--- a/libc/src/time/strptime.h
+++ b/libc/src/time/strptime.h
@@ -20,7 +20,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 char *strptime(const char *__restrict buf, const char *__restrict format,
-               const tm *__restrict tm);
+               const struct tm *__restrict tm);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/time/strptime.h
+++ b/libc/src/time/strptime.h
@@ -1,9 +1,14 @@
-//===-- Implementation header of strptime -----------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the strptime function.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_TIME_STRPTIME_H

--- a/libc/src/time/strptime.h
+++ b/libc/src/time/strptime.h
@@ -1,0 +1,22 @@
+//===-- Implementation header of strptime -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_TIME_STRPTIME_H
+#define LLVM_LIBC_SRC_TIME_STRPTIME_H
+
+#include "hdr/types/struct_tm.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strptime(const char *__restrict buf, const char *__restrict format,
+               const tm *__restrict tm);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_TIME_STRPTIME_H

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -226,6 +226,17 @@ add_libc_test(
     libc.src.time.strftime
 )
 
+add_libc_test(
+  strptime_test
+  SUITE
+    libc_time_unittests
+  SRCS
+    strptime_test.cpp
+  DEPENDS
+    libc.hdr.types.struct_tm
+    libc.src.time.strptime
+)
+
 add_libc_unittest(
   time_test
   SUITE

--- a/libc/test/src/time/strptime_test.cpp
+++ b/libc/test/src/time/strptime_test.cpp
@@ -1,9 +1,14 @@
-//===-- Unittests for strptime --------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains unit tests for strptime.
+///
 //===----------------------------------------------------------------------===//
 
 #include "hdr/types/struct_tm.h"

--- a/libc/test/src/time/strptime_test.cpp
+++ b/libc/test/src/time/strptime_test.cpp
@@ -1,0 +1,19 @@
+//===-- Unittests for strptime --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/types/struct_tm.h"
+#include "src/time/strptime.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcStrptimeTest, StubReturnsNull) {
+  struct tm time;
+  char *result;
+
+  result = LIBC_NAMESPACE::strptime("13:23:45", "%T", &time);
+  EXPECT_EQ(result, nullptr);
+}


### PR DESCRIPTION
This PR adds a stub for `strptime` under `LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS` for x86_64 and aarch64 as a first step in implementing the function.