### PR TITLE
[IRCE] Discard speculative SCEV expansions when bailing out

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopConstrainer.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopConstrainer.h
@@ -24,6 +24,7 @@ class LoopInfo;
 class PHINode;
 class ScalarEvolution;
 class SCEV;
+class SCEVExpander;
 class Value;
 
 // Keeps track of the structure of a loop.  This is similar to llvm::Loop,
@@ -80,8 +81,12 @@ struct LoopStructure {
     return Result;
   }
 
+  /// Parse \p L and use \p Expander to materialize values needed by the parsed
+  /// structure. This allows the caller to discard speculative expansions with
+  /// a SCEVExpanderCleaner if the transformation is not committed.
   LLVM_ABI static std::optional<LoopStructure>
-  parseLoopStructure(ScalarEvolution &, Loop &, bool, const char *&);
+  parseLoopStructure(SCEVExpander &Expander, Loop &L,
+                     bool AllowUnsignedLatchCond, const char *&FailureReason);
 };
 
 /// This class is used to constrain loops to run within a given iteration space.

--- a/llvm/lib/Transforms/Scalar/InductiveRangeCheckElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/InductiveRangeCheckElimination.cpp
@@ -84,6 +84,7 @@
 #include "llvm/Transforms/Utils/LoopConstrainer.h"
 #include "llvm/Transforms/Utils/LoopSimplify.h"
 #include "llvm/Transforms/Utils/LoopUtils.h"
+#include "llvm/Transforms/Utils/ScalarEvolutionExpander.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
 #include <algorithm>
 #include <cassert>
@@ -1033,8 +1034,11 @@ bool InductiveRangeCheckElimination::run(
     PrintRecognizedRangeChecks(errs());
 
   const char *FailureReason = nullptr;
+  SCEVExpander LoopStructureExpander(SE, "loop-constrainer");
+  SCEVExpanderCleaner LoopStructureExpanderCleaner(LoopStructureExpander);
   std::optional<LoopStructure> MaybeLoopStructure =
-      LoopStructure::parseLoopStructure(SE, *L, AllowUnsignedLatchCondition,
+      LoopStructure::parseLoopStructure(LoopStructureExpander, *L,
+                                        AllowUnsignedLatchCondition,
                                         FailureReason);
   if (!MaybeLoopStructure) {
     LLVM_DEBUG(dbgs() << "irce: could not parse loop structure: "
@@ -1076,13 +1080,15 @@ bool InductiveRangeCheckElimination::run(
       calculateSubRanges(SE, *L, *SafeIterRange, LS);
   if (!MaybeSR) {
     LLVM_DEBUG(dbgs() << "irce: could not compute subranges\n");
-    return false;
+    return Changed;
   }
 
   LoopConstrainer LC(*L, LI, LPMAddNewLoop, LS, SE, DT,
                      SafeIterRange->getBegin()->getType(), *MaybeSR);
 
   if (LC.run()) {
+    LoopStructureExpanderCleaner.markResultUsed();
+    LS.IndVarStart->setName("indvar.start");
     Changed = true;
 
     auto PrintConstrainedLoopInfo = [L]() {

--- a/llvm/lib/Transforms/Utils/LoopConstrainer.cpp
+++ b/llvm/lib/Transforms/Utils/LoopConstrainer.cpp
@@ -128,9 +128,10 @@ static const SCEV *getNarrowestLatchMaxTakenCountEstimate(ScalarEvolution &SE,
 }
 
 std::optional<LoopStructure>
-LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
+LoopStructure::parseLoopStructure(SCEVExpander &Expander, Loop &L,
                                   bool AllowUnsignedLatchCond,
                                   const char *&FailureReason) {
+  ScalarEvolution &SE = *Expander.getSE();
   if (!L.isLoopSimplifyForm()) {
     FailureReason = "loop not in LoopSimplify form";
     return std::nullopt;
@@ -403,7 +404,6 @@ LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
   BasicBlock *LatchExit = LatchBr->getSuccessor(LatchBrExitIdx);
 
   assert(!L.contains(LatchExit) && "expected an exit block!");
-  SCEVExpander Expander(SE, "loop-constrainer");
   Instruction *Ins = Preheader->getTerminator();
 
   if (FixedRightSCEV)
@@ -411,7 +411,6 @@ LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
         Expander.expandCodeFor(FixedRightSCEV, FixedRightSCEV->getType(), Ins);
 
   Value *IndVarStartV = Expander.expandCodeFor(IndVarStart, IndVarTy, Ins);
-  IndVarStartV->setName("indvar.start");
 
   LoopStructure Result;
 
@@ -738,6 +737,7 @@ bool LoopConstrainer::run() {
   IntegerType *IVTy = cast<IntegerType>(RangeTy);
 
   SCEVExpander Expander(SE, "loop-constrainer");
+  SCEVExpanderCleaner ExpanderCleaner(Expander);
   Instruction *InsertPt = OriginalPreheader->getTerminator();
 
   // It would have been better to make `PreLoop' and `PostLoop'
@@ -778,7 +778,6 @@ bool LoopConstrainer::run() {
     }
 
     ExitPreLoopAt = Expander.expandCodeFor(ExitPreLoopAtSCEV, IVTy, InsertPt);
-    ExitPreLoopAt->setName("exit.preloop.at");
   }
 
   if (NeedsPostLoop) {
@@ -807,6 +806,12 @@ bool LoopConstrainer::run() {
     ExitMainLoopAt = Expander.expandCodeFor(ExitMainLoopAtSCEV, IVTy, InsertPt);
     ExitMainLoopAt->setName("exit.mainloop.at");
   }
+
+  // All checks which can fail after expanding SCEVs are complete. Keep the
+  // expansions now that the loop transformation is guaranteed to proceed.
+  ExpanderCleaner.markResultUsed();
+  if (ExitPreLoopAt)
+    ExitPreLoopAt->setName("exit.preloop.at");
 
   // We clone these ahead of time so that we don't have to deal with changing
   // and temporarily invalid IR as we transform the loops.

--- a/llvm/test/Transforms/IRCE/compound-loop-bound.ll
+++ b/llvm/test/Transforms/IRCE/compound-loop-bound.ll
@@ -126,7 +126,7 @@ define void @decrementing_loop(ptr %arr, ptr %len_ptr, i32 %K, i32 %M) {
 ; CHECK-NEXT:    [[IDX:%.*]] = phi i32 [ [[IDX_PRELOOP_COPY:%.*]], [[MAINLOOP:%.*]] ], [ [[IDX_DEC:%.*]], [[IN_BOUNDS:%.*]] ]
 ; CHECK-NEXT:    [[IDX_DEC]] = sub nsw i32 [[IDX]], 1
 ; CHECK-NEXT:    [[GUARD:%.*]] = icmp slt i32 [[IDX]], [[LEN]]
-; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label [[OUT_OF_BOUNDS_LOOPEXIT1:%.*]]
+; CHECK-NEXT:    br i1 true, label [[IN_BOUNDS]], label %[[OUT_OF_BOUNDS_LOOPEXIT:[^, ]+]]
 ; CHECK:       in.bounds:
 ; CHECK-NEXT:    [[ADDR:%.*]] = getelementptr i32, ptr [[ARR]], i32 [[IDX]]
 ; CHECK-NEXT:    store i32 0, ptr [[ADDR]], align 4
@@ -134,7 +134,7 @@ define void @decrementing_loop(ptr %arr, ptr %len_ptr, i32 %K, i32 %M) {
 ; CHECK-NEXT:    br i1 [[NEXT]], label [[LOOP]], label [[EXIT_LOOPEXIT_LOOPEXIT:%.*]]
 ; CHECK:       out.of.bounds.loopexit:
 ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS:%.*]]
-; CHECK:       out.of.bounds.loopexit1:
+; CHECK:       [[OUT_OF_BOUNDS_LOOPEXIT]]:
 ; CHECK-NEXT:    br label [[OUT_OF_BOUNDS]]
 ; CHECK:       out.of.bounds:
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/IRCE/expansion-cleanup-analysis-invalidation.ll
+++ b/llvm/test/Transforms/IRCE/expansion-cleanup-analysis-invalidation.ll
@@ -1,0 +1,84 @@
+; RUN: opt -passes=irce -irce-skip-profitability-checks \
+; RUN:   -verify-analysis-invalidation -S < %s | FileCheck %s
+; RUN: opt -passes=irce -irce-skip-profitability-checks \
+; RUN:   -irce-allow-narrow-latch=false -verify-analysis-invalidation -S \
+; RUN:   < %s | FileCheck %s --check-prefix=NARROW
+
+; Parsing the loop structure and computing the exit limits may materialize
+; SCEVs in the preheader before all bail-out points have been passed. If a
+; later check fails, those speculative instructions must be removed before
+; IRCE reports that it did not change the function.
+
+declare void @sideeffect()
+
+; The pre-loop limit can be expanded, but the post-loop limit contains a
+; conditionally executed division which cannot safely be expanded in the
+; preheader. Make sure the partially expanded pre-loop limit is removed and
+; the name of the reused induction start is left unchanged.
+
+define void @cleanup_after_partial_expansion(ptr %num.ptr, ptr %denom.ptr,
+                                             i64 range(i64 -100, -1) %offset,
+                                             i64 range(i64 0, 10) %start,
+                                             i1 %maybe.exit) {
+; CHECK-LABEL: define void @cleanup_after_partial_expansion(
+; CHECK-SAME: i64 range(i64 0, 10) %start,
+entry:
+; CHECK: entry:
+; CHECK-NEXT: %num = load i64, ptr %num.ptr, align 8, !range !0
+; CHECK-NEXT: %denom = load i64, ptr %denom.ptr, align 8, !range !0
+; CHECK-NEXT: br label %loop
+  %num = load i64, ptr %num.ptr, align 8, !range !0
+  %denom = load i64, ptr %denom.ptr, align 8, !range !0
+  br label %loop
+
+exit:
+  ret void
+
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %guarded ]
+  %checked = phi i64 [ %offset, %entry ], [ %checked.next, %guarded ]
+  %iv.next = add nuw nsw i64 %iv, 1
+  br i1 %maybe.exit, label %range.check, label %exit
+
+range.check:
+  %div.result = udiv i64 %num, %denom
+  %rc = icmp slt i64 %checked, %div.result
+  br i1 %rc, label %guarded, label %exit
+
+guarded:
+  %checked.next = add nsw i64 %checked, 1
+  call void @sideeffect()
+  %loop.cond = icmp slt i64 %iv.next, 1000
+  br i1 %loop.cond, label %loop, label %exit
+}
+
+; IRCE canonicalizes range-check branches before calculating the constrained
+; subranges. If mismatched types make that calculation fail, the branch
+; inversion must still be reported as a change.
+
+define void @inversion_before_subrange_failure() {
+; NARROW-LABEL: define void @inversion_before_subrange_failure(
+; NARROW: %range.check.failed = icmp slt i64 %iv, 100
+; NARROW-NEXT: br i1 %range.check.failed, label %backedge, label %check.failed
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %backedge ]
+  %range.check.failed = icmp sge i64 %iv, 100
+  br i1 %range.check.failed, label %check.failed, label %backedge
+
+backedge:
+  %iv.next = add i64 %iv, 1
+  %narrow.iv = trunc i64 %iv.next to i32
+  %latch.cond = icmp slt i32 %narrow.iv, 100
+  br i1 %latch.cond, label %loop, label %exit
+
+exit:
+  ret void
+
+check.failed:
+  ret void
+}
+
+!0 = !{i64 0, i64 100}


### PR DESCRIPTION
[Factored out of #151062 by review request; AI Disclosure: Done by Claude]

LoopStructure::parseLoopStructure materializes SCEVs in the preheader while merely analyzing the loop, and LoopConstrainer::run expands its exit limits before all of its bail-out points have been passed. When a later check failed, those expansions were left behind: the pass mutated the IR while reporting the function unchanged, which leaves stale analyses behind (observable with -verify-analysis-invalidation) and produces dead instructions that differ depending on how far the analysis got.

Fix this by having callers own the SCEVExpander passed to parseLoopStructure and wrapping both expanders (IRCE's and LoopConstrainer::run's) in a SCEVExpanderCleaner whose result is only marked used once the transformation is guaranteed to proceed. Value names ("indvar.start", "exit.preloop.at") are now applied only at that point, since the expander may have reused pre-existing values that must not be renamed when the transformation is abandoned.

Also return the correct Changed value from
InductiveRangeCheckElimination::run when subrange computation fails, since earlier steps may already have modified the function.