### PR TITLE
[Coroutines] Support typed retcon allocators

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1955,11 +1955,11 @@ def int_coro_id : DefaultAttrsIntrinsic<[llvm_token_ty],
      NoCapture<ArgIndex<2>>]>;
 def int_coro_id_retcon : Intrinsic<[llvm_token_ty],
     [llvm_i32_ty, llvm_i32_ty, llvm_ptr_ty,
-     llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
+     llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty, llvm_vararg_ty],
     []>;
 def int_coro_id_retcon_once : Intrinsic<[llvm_token_ty],
     [llvm_i32_ty, llvm_i32_ty, llvm_ptr_ty,
-     llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
+     llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty, llvm_vararg_ty],
     []>;
 def int_coro_alloc : Intrinsic<[llvm_i1_ty], [llvm_token_ty], []>;
 def int_coro_id_async : Intrinsic<[llvm_token_ty],

--- a/llvm/include/llvm/Transforms/Coroutines/CoroInstr.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroInstr.h
@@ -236,7 +236,15 @@ public:
 /// This represents either the llvm.coro.id.retcon or
 /// llvm.coro.id.retcon.once instruction.
 class AnyCoroIdRetconInst : public AnyCoroIdInst {
-  enum { SizeArg, AlignArg, StorageArg, PrototypeArg, AllocArg, DeallocArg };
+  enum {
+    SizeArg,
+    AlignArg,
+    StorageArg,
+    PrototypeArg,
+    AllocArg,
+    DeallocArg,
+    TypeIdArg
+  };
 
 public:
   LLVM_ABI void checkWellFormed() const;
@@ -270,6 +278,17 @@ public:
     return cast<Function>(
         getArgOperand(DeallocArg)->stripPointerCastsAndAliases());
   }
+
+  /// Return the type ID to use when allocating typed memory.
+  ConstantInt *getTypeId() const {
+    if (arg_size() <= TypeIdArg)
+      return nullptr;
+    assert(hasTypeId() && "Invalid number of arguments");
+    return cast<ConstantInt>(getArgOperand(TypeIdArg));
+  }
+
+  /// Return whether a type ID is present in the argument list.
+  bool hasTypeId() const { return arg_size() == TypeIdArg + 1; }
 
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -120,6 +120,7 @@ struct Shape {
     Function *Dealloc;
     BasicBlock *ReturnBlock;
     bool IsFrameInlineInStorage;
+    ConstantInt *TypeId;
   };
 
   struct AsyncLoweringStorage {

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1454,6 +1454,19 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
       return true;
     }
 
+    if (F->arg_size() == 6 && !F->isVarArg()) {
+      Intrinsic::ID ID =
+          StringSwitch<Intrinsic::ID>(Name)
+              .Case("coro.id.retcon", Intrinsic::coro_id_retcon)
+              .Case("coro.id.retcon.once", Intrinsic::coro_id_retcon_once)
+              .Default(Intrinsic::not_intrinsic);
+      if (ID != Intrinsic::not_intrinsic) {
+        rename(F);
+        NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), ID);
+        return true;
+      }
+    }
+
     break;
   }
   case 'd':
@@ -5341,6 +5354,13 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
   case Intrinsic::coro_end: {
     SmallVector<Value *, 3> Args(CI->args());
     Args.push_back(ConstantTokenNone::get(CI->getContext()));
+    NewCall = Builder.CreateCall(NewFn, Args);
+    break;
+  }
+
+  case Intrinsic::coro_id_retcon:
+  case Intrinsic::coro_id_retcon_once: {
+    SmallVector<Value *, 6> Args(CI->args());
     NewCall = Builder.CreateCall(NewFn, Args);
     break;
   }

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -330,6 +330,7 @@ void coro::Shape::analyze(Function &F,
     RetconLowering.Dealloc = ContinuationId->getDeallocFunction();
     RetconLowering.ReturnBlock = nullptr;
     RetconLowering.IsFrameInlineInStorage = false;
+    RetconLowering.TypeId = ContinuationId->getTypeId();
     break;
   }
   default:
@@ -506,7 +507,12 @@ Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
     Size = Builder.CreateIntCast(Size,
                                  Alloc->getFunctionType()->getParamType(0),
                                  /*is signed*/ false);
-    auto *Call = Builder.CreateCall(Alloc, Size);
+    ConstantInt *TypeId = RetconLowering.TypeId;
+    CallInst *Call;
+    if (TypeId)
+      Call = Builder.CreateCall(Alloc, {Size, TypeId});
+    else
+      Call = Builder.CreateCall(Alloc, Size);
     propagateCallAttrsFromCallee(Call, Alloc);
     addCallToCallGraph(CG, Call, Alloc);
     return Call;
@@ -599,9 +605,16 @@ static void checkWFAlloc(const Instruction *I, Value *V) {
   if (!FT->getReturnType()->isPointerTy())
     fail(I, "llvm.coro.* allocator must return a pointer", F);
 
-  if (FT->getNumParams() != 1 ||
-      !FT->getParamType(0)->isIntegerTy())
-    fail(I, "llvm.coro.* allocator must take integer as only param", F);
+  if (FT->getNumParams() == 0 || FT->getNumParams() > 2)
+    fail(I, "llvm.coro.* allocator must take one or two parameters", F);
+
+  if (!FT->getParamType(0)->isIntegerTy())
+    fail(I, "llvm.coro.* allocator must take integer as its first parameter",
+         F);
+
+  if (FT->getNumParams() == 2 && !FT->getParamType(1)->isIntegerTy())
+    fail(I, "llvm.coro.* allocator must take integer as its second parameter",
+         F);
 }
 
 /// Check that the given value is a well-formed deallocator.
@@ -634,6 +647,9 @@ void AnyCoroIdRetconInst::checkWellFormed() const {
   checkWFRetconPrototype(this, getArgOperand(PrototypeArg));
   checkWFAlloc(this, getArgOperand(AllocArg));
   checkWFDealloc(this, getArgOperand(DeallocArg));
+  if (hasTypeId())
+    checkConstantInt(this, getArgOperand(TypeIdArg),
+                     "type ID argument to coro.id.retcon.* must be constant");
 }
 
 static void checkAsyncFuncPointer(const Instruction *I, Value *V) {

--- a/llvm/test/Transforms/Coroutines/coro-retcon-typed-allocator.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-typed-allocator.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -passes='cgscc(coro-split),simplifycfg,early-cse' -S | FileCheck %s
+
+define ptr @typed_allocator(ptr noalias dereferenceable(32) %buffer) presplitcoroutine {
+; CHECK-LABEL: @typed_allocator(
+; CHECK: call ptr @swift_coroFrameAlloc(i64 40, i64 123)
+entry:
+  %value = alloca [5 x i64], align 8
+  %id = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 32, i32 8, ptr %buffer, ptr @prototype, ptr @swift_coroFrameAlloc, ptr @free, i64 123)
+  %handle = call ptr @llvm.coro.begin(token %id, ptr null)
+  call void @use(ptr %value)
+  %suspend = call i1 (...) @llvm.coro.suspend.retcon.i1()
+  br i1 %suspend, label %cleanup, label %resume
+
+resume:
+  call void @use(ptr %value)
+  br label %cleanup
+
+cleanup:
+  call void @llvm.coro.end(ptr %handle, i1 false, token none)
+  unreachable
+}
+
+declare void @prototype(ptr, i1 zeroext)
+declare ptr @swift_coroFrameAlloc(i64, i64)
+declare void @free(ptr)
+declare void @use(ptr)
+declare token @llvm.coro.id.retcon.once(i32, i32, ptr, ptr, ptr, ptr, ...)
+declare ptr @llvm.coro.begin(token, ptr)
+declare i1 @llvm.coro.suspend.retcon.i1(...)
+declare void @llvm.coro.end(ptr, i1, token)

--- a/llvm/test/Transforms/Coroutines/coro-retcon-unreachable.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-unreachable.ll
@@ -10,7 +10,7 @@ target datalayout = "E-p:64:64"
 define hidden swiftcc { ptr, ptr } @no_suspends(ptr %buffer, i64 %arg) #1 {
 ; CHECK-LABEL: @no_suspends(
 ; CHECK-NEXT:  AllocaSpillBB:
-; CHECK-NEXT:    [[ID:%.*]] = call token @llvm.coro.id.retcon.once(i32 32, i32 8, ptr [[BUFFER:%.*]], ptr @prototype, ptr @malloc, ptr @free)
+; CHECK-NEXT:    [[ID:%.*]] = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 32, i32 8, ptr [[BUFFER:%.*]], ptr @prototype, ptr @malloc, ptr @free)
 ; CHECK-NEXT:    call void @print(i64 [[ARG:%.*]])
 ; CHECK-NEXT:    call void @llvm.trap()
 ; CHECK-NEXT:    unreachable


### PR DESCRIPTION
Continuation-based coroutine lowering currently assumes that the retcon
allocator has the shape `ptr (size)`. Swift's typed allocation entry point
uses `ptr (size, type-id)` so Swift-generated LLVM IR carries an optional
constant type identifier on `llvm.coro.id.retcon{.once}`.

Teach the retcon intrinsics to accept that optional identifier, validate the
one- and two-argument allocator forms, and forward the identifier when
emitting the frame allocation call. Auto-upgrade legacy fixed-six-argument
declarations and calls to the new variadic declaration so existing LLVM IR
and one-argument allocators keep their current behavior.

This is the upstream form of the compatibility change shipped by the Swift
LLVM fork in
[swiftlang/llvm-project@fe25ae6](https://github.com/swiftlang/llvm-project/commit/fe25ae6b55bd07f489faf24ebee66073d96eb126).

The new coroutine transform test covers the typed allocator form.

Local validation:

```
cmake --build build --target opt FileCheck -j8
build/bin/opt < llvm/test/Transforms/Coroutines/coro-retcon-typed-allocator.ll \
  -passes='cgscc(coro-split),simplifycfg,early-cse' -S | \
  build/bin/FileCheck llvm/test/Transforms/Coroutines/coro-retcon-typed-allocator.ll
cmake --build build --target check-llvm-transforms -j8
```
