### PR TITLE
[flang][cuda] Break circular global init when copying them to the GPU module

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
@@ -12,10 +12,13 @@
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include <functional>
 
 namespace fir {
 #define GEN_PASS_DEF_CUFDEVICEGLOBAL
@@ -114,6 +117,101 @@ processPotentialTypeDescriptor(mlir::Type candidateType,
     processTypeDescriptor(recTy, symbolTable, candidates);
 }
 
+/// NVPTX cannot emit global initializers that form a reference cycle (see
+/// VisitGlobalVariableForEmission). Fortran type-info globals often do
+/// (mutually recursive derived types). Replace addr_of edges within each
+/// strongly connected component with zero so the GPU copies are acyclic.
+static void breakCircularGlobalAddrOfDeps(mlir::gpu::GPUModuleOp gpuMod) {
+  llvm::DenseMap<llvm::StringRef, fir::GlobalOp> byName;
+  llvm::SmallVector<fir::GlobalOp, 16> globals;
+  for (auto global : gpuMod.getOps<fir::GlobalOp>()) {
+    byName[global.getSymName()] = global;
+    globals.push_back(global);
+  }
+  if (globals.empty())
+    return;
+
+  // Adjacency: global -> targets referenced via fir.address_of in its body.
+  llvm::DenseMap<fir::GlobalOp, llvm::SmallVector<fir::GlobalOp, 4>> adj;
+  llvm::DenseMap<fir::GlobalOp,
+                 llvm::SmallVector<std::pair<fir::AddrOfOp, fir::GlobalOp>, 4>>
+      edgeOps;
+  for (fir::GlobalOp global : globals) {
+    global.walk([&](fir::AddrOfOp addrOf) {
+      fir::GlobalOp target =
+          byName.lookup(addrOf.getSymbol().getRootReference().getValue());
+      if (!target)
+        return;
+      adj[global].push_back(target);
+      edgeOps[global].push_back({addrOf, target});
+    });
+  }
+
+  // Tarjan SCC.
+  const int n = globals.size();
+  llvm::DenseMap<fir::GlobalOp, int> indexOf;
+  for (int i = 0; i < n; ++i)
+    indexOf[globals[i]] = i;
+
+  llvm::SmallVector<int, 16> index(n, -1), lowlink(n, -1), stack;
+  llvm::SmallVector<bool, 16> onStack(n, false);
+  llvm::SmallVector<llvm::SmallVector<fir::GlobalOp, 4>, 8> sccs;
+  int dfsNum = 0;
+
+  std::function<void(int)> strongConnect = [&](int v) {
+    index[v] = lowlink[v] = dfsNum++;
+    stack.push_back(v);
+    onStack[v] = true;
+    for (fir::GlobalOp wGlobal : adj.lookup(globals[v])) {
+      int w = indexOf[wGlobal];
+      if (index[w] < 0) {
+        strongConnect(w);
+        lowlink[v] = std::min(lowlink[v], lowlink[w]);
+      } else if (onStack[w]) {
+        lowlink[v] = std::min(lowlink[v], index[w]);
+      }
+    }
+    if (lowlink[v] == index[v]) {
+      llvm::SmallVector<fir::GlobalOp, 4> scc;
+      int w;
+      do {
+        w = stack.pop_back_val();
+        onStack[w] = false;
+        scc.push_back(globals[w]);
+      } while (w != v);
+      bool selfLoop = false;
+      if (scc.size() == 1)
+        for (fir::GlobalOp t : adj.lookup(scc[0]))
+          if (t == scc[0]) {
+            selfLoop = true;
+            break;
+          }
+      if (scc.size() > 1 || selfLoop)
+        sccs.push_back(std::move(scc));
+    }
+  };
+
+  for (int v = 0; v < n; ++v)
+    if (index[v] < 0)
+      strongConnect(v);
+
+  mlir::OpBuilder builder(gpuMod.getContext());
+  for (const auto &scc : sccs) {
+    llvm::DenseSet<fir::GlobalOp> inScc(scc.begin(), scc.end());
+    for (fir::GlobalOp global : scc) {
+      for (auto &[addrOf, target] : edgeOps.lookup(global)) {
+        if (!inScc.contains(target))
+          continue;
+        builder.setInsertionPoint(addrOf);
+        auto zero =
+            fir::ZeroOp::create(builder, addrOf.getLoc(), addrOf.getType());
+        addrOf.replaceAllUsesWith(zero.getResult());
+        addrOf.erase();
+      }
+    }
+  }
+}
+
 class CUFDeviceGlobal : public fir::impl::CUFDeviceGlobalBase<CUFDeviceGlobal> {
 public:
   using CUFDeviceGlobalBase::CUFDeviceGlobalBase;
@@ -190,6 +288,9 @@ public:
         clonedGlobal.removeLinkNameAttr();
       gpuSymTable.insert(cloned);
     }
+    // Type-info globals for mutually recursive derived types form initializer
+    // cycles; NVPTX rejects those. Break addr_of edges within each cycle.
+    breakCircularGlobalAddrOfDeps(gpuMod);
   }
 };
 } // namespace

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
@@ -12,7 +12,6 @@
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -119,9 +118,10 @@ processPotentialTypeDescriptor(mlir::Type candidateType,
 
 /// NVPTX cannot emit global initializers that form a reference cycle (see
 /// VisitGlobalVariableForEmission). Fortran type-info globals often do
-/// (mutually recursive derived types). Replace addr_of edges within each
-/// strongly connected component with zero so the GPU copies are acyclic.
-static void breakCircularGlobalAddrOfDeps(mlir::gpu::GPUModuleOp gpuMod) {
+/// (mutually recursive derived types). Make a subset of the GPU copies extern
+/// declarations so that the remaining initializer dependency graph is
+/// acyclic, while preserving as many complete initializers as possible.
+static void dropCyclicGlobalInitializers(mlir::gpu::GPUModuleOp gpuMod) {
   llvm::DenseMap<llvm::StringRef, fir::GlobalOp> byName;
   llvm::SmallVector<fir::GlobalOp, 16> globals;
   for (auto global : gpuMod.getOps<fir::GlobalOp>()) {
@@ -131,11 +131,12 @@ static void breakCircularGlobalAddrOfDeps(mlir::gpu::GPUModuleOp gpuMod) {
   if (globals.empty())
     return;
 
+  llvm::sort(globals, [](fir::GlobalOp lhs, fir::GlobalOp rhs) {
+    return lhs.getSymName() < rhs.getSymName();
+  });
+
   // Adjacency: global -> targets referenced via fir.address_of in its body.
   llvm::DenseMap<fir::GlobalOp, llvm::SmallVector<fir::GlobalOp, 4>> adj;
-  llvm::DenseMap<fir::GlobalOp,
-                 llvm::SmallVector<std::pair<fir::AddrOfOp, fir::GlobalOp>, 4>>
-      edgeOps;
   for (fir::GlobalOp global : globals) {
     global.walk([&](fir::AddrOfOp addrOf) {
       fir::GlobalOp target =
@@ -143,72 +144,50 @@ static void breakCircularGlobalAddrOfDeps(mlir::gpu::GPUModuleOp gpuMod) {
       if (!target)
         return;
       adj[global].push_back(target);
-      edgeOps[global].push_back({addrOf, target});
     });
   }
 
-  // Tarjan SCC.
-  const int n = globals.size();
-  llvm::DenseMap<fir::GlobalOp, int> indexOf;
-  for (int i = 0; i < n; ++i)
-    indexOf[globals[i]] = i;
-
-  llvm::SmallVector<int, 16> index(n, -1), lowlink(n, -1), stack;
-  llvm::SmallVector<bool, 16> onStack(n, false);
-  llvm::SmallVector<llvm::SmallVector<fir::GlobalOp, 4>, 8> sccs;
-  int dfsNum = 0;
-
-  std::function<void(int)> strongConnect = [&](int v) {
-    index[v] = lowlink[v] = dfsNum++;
-    stack.push_back(v);
-    onStack[v] = true;
-    for (fir::GlobalOp wGlobal : adj.lookup(globals[v])) {
-      int w = indexOf[wGlobal];
-      if (index[w] < 0) {
-        strongConnect(w);
-        lowlink[v] = std::min(lowlink[v], lowlink[w]);
-      } else if (onStack[w]) {
-        lowlink[v] = std::min(lowlink[v], index[w]);
-      }
-    }
-    if (lowlink[v] == index[v]) {
-      llvm::SmallVector<fir::GlobalOp, 4> scc;
-      int w;
-      do {
-        w = stack.pop_back_val();
-        onStack[w] = false;
-        scc.push_back(globals[w]);
-      } while (w != v);
-      bool selfLoop = false;
-      if (scc.size() == 1)
-        for (fir::GlobalOp t : adj.lookup(scc[0]))
-          if (t == scc[0]) {
-            selfLoop = true;
-            break;
-          }
-      if (scc.size() > 1 || selfLoop)
-        sccs.push_back(std::move(scc));
-    }
-  };
-
-  for (int v = 0; v < n; ++v)
-    if (index[v] < 0)
-      strongConnect(v);
-
-  mlir::OpBuilder builder(gpuMod.getContext());
-  for (const auto &scc : sccs) {
-    llvm::DenseSet<fir::GlobalOp> inScc(scc.begin(), scc.end());
-    for (fir::GlobalOp global : scc) {
-      for (auto &[addrOf, target] : edgeOps.lookup(global)) {
-        if (!inScc.contains(target))
+  // Greedily construct a feedback vertex set. Dropping one initializer
+  // removes all outgoing dependency edges from that global. Restart the DFS
+  // after each cut until no back edge remains.
+  llvm::DenseSet<fir::GlobalOp> declarationOnly;
+  while (true) {
+    // 0: unvisited, 1: active, 2: complete.
+    llvm::DenseMap<fir::GlobalOp, unsigned> state;
+    fir::GlobalOp cut;
+    std::function<bool(fir::GlobalOp)> findCycle =
+        [&](fir::GlobalOp global) -> bool {
+      if (declarationOnly.contains(global))
+        return false;
+      state[global] = 1;
+      for (fir::GlobalOp target : adj.lookup(global)) {
+        if (declarationOnly.contains(target))
           continue;
-        builder.setInsertionPoint(addrOf);
-        auto zero =
-            fir::ZeroOp::create(builder, addrOf.getLoc(), addrOf.getType());
-        addrOf.replaceAllUsesWith(zero.getResult());
-        addrOf.erase();
+        if (state.lookup(target) == 1) {
+          cut = global;
+          return true;
+        }
+        if (state.lookup(target) == 0 && findCycle(target))
+          return true;
       }
-    }
+      state[global] = 2;
+      return false;
+    };
+
+    for (fir::GlobalOp global : globals)
+      if (state.lookup(global) == 0 && findCycle(global))
+        break;
+    if (!cut)
+      break;
+    declarationOnly.insert(cut);
+  }
+
+  for (fir::GlobalOp global : declarationOnly) {
+    global.getRegion().getBlocks().clear();
+    global.removeInitValAttr();
+    // No initializer: use default external linkage so NVPTX emits
+    // `.extern .global` with no initializer dependency edges.
+    global.removeLinkNameAttr();
   }
 }
 
@@ -289,8 +268,8 @@ public:
       gpuSymTable.insert(cloned);
     }
     // Type-info globals for mutually recursive derived types form initializer
-    // cycles; NVPTX rejects those. Break addr_of edges within each cycle.
-    breakCircularGlobalAddrOfDeps(gpuMod);
+    // cycles; NVPTX rejects those. Drop initializers from cyclic GPU copies.
+    dropCyclicGlobalInitializers(gpuMod);
   }
 };
 } // namespace

--- a/flang/test/Fir/CUDA/cuda-device-global-cycle.fir
+++ b/flang/test/Fir/CUDA/cuda-device-global-cycle.fir
@@ -1,7 +1,8 @@
 // RUN: fir-opt --cuf-device-global %s | FileCheck %s
 
 // Mutually referencing type-descriptor globals must not cause infinite
-// recursion in processAddrOfOp when recurseInGlobal is true.
+// recursion, and GPU copies must not retain addr_of cycles (NVPTX rejects
+// circular global initializers).
 module attributes {gpu.container_module} {
   fir.global linkonce @_QMmE.dt.t1 constant : i64 {
     %0 = fir.address_of(@_QMmE.dt.t2) : !fir.ref<i64>
@@ -20,6 +21,16 @@ module attributes {gpu.container_module} {
   }
 }
 
+// Host copies keep the cycle.
+// CHECK: fir.global linkonce @_QMmE.dt.t1
+// CHECK: fir.address_of(@_QMmE.dt.t2)
+// CHECK: fir.global linkonce @_QMmE.dt.t2
+// CHECK: fir.address_of(@_QMmE.dt.t1)
+
 // CHECK-LABEL: gpu.module @cuda_device_mod
-// CHECK-DAG: fir.global linkonce @_QMmE.dt.t1
-// CHECK-DAG: fir.global linkonce @_QMmE.dt.t2
+// CHECK: fir.global linkonce @_QMmE.dt.t1
+// CHECK-NOT: fir.address_of
+// CHECK: fir.zero_bits !fir.ref<i64>
+// CHECK: fir.global linkonce @_QMmE.dt.t2
+// CHECK-NOT: fir.address_of
+// CHECK: fir.zero_bits !fir.ref<i64>

--- a/flang/test/Fir/CUDA/cuda-device-global-cycle.fir
+++ b/flang/test/Fir/CUDA/cuda-device-global-cycle.fir
@@ -29,7 +29,7 @@ module attributes {gpu.container_module} {
 
 // Cut the lexicographically last global in the cycle; the other keeps its init.
 // CHECK-LABEL: gpu.module @cuda_device_mod {
-// CHECK: fir.global @_QMmE.dt.t2 constant : i64{{$}}
-// CHECK: fir.global linkonce @_QMmE.dt.t1 constant : i64 {
-// CHECK: fir.address_of(@_QMmE.dt.t2)
-// CHECK: fir.has_value
+// CHECK-DAG: fir.global @_QMmE.dt.t2 constant : i64{{$}}
+// CHECK-DAG: fir.global linkonce @_QMmE.dt.t1 constant : i64 {
+// CHECK-DAG: fir.address_of(@_QMmE.dt.t2)
+// CHECK-DAG: fir.has_value

--- a/flang/test/Fir/CUDA/cuda-device-global-cycle.fir
+++ b/flang/test/Fir/CUDA/cuda-device-global-cycle.fir
@@ -1,8 +1,8 @@
 // RUN: fir-opt --cuf-device-global %s | FileCheck %s
 
 // Mutually referencing type-descriptor globals must not cause infinite
-// recursion, and GPU copies must not retain addr_of cycles (NVPTX rejects
-// circular global initializers).
+// recursion. One GPU copy must drop its initializer to break the cycle, while
+// the other keeps its complete initializer.
 module attributes {gpu.container_module} {
   fir.global linkonce @_QMmE.dt.t1 constant : i64 {
     %0 = fir.address_of(@_QMmE.dt.t2) : !fir.ref<i64>
@@ -27,10 +27,9 @@ module attributes {gpu.container_module} {
 // CHECK: fir.global linkonce @_QMmE.dt.t2
 // CHECK: fir.address_of(@_QMmE.dt.t1)
 
-// CHECK-LABEL: gpu.module @cuda_device_mod
-// CHECK: fir.global linkonce @_QMmE.dt.t1
-// CHECK-NOT: fir.address_of
-// CHECK: fir.zero_bits !fir.ref<i64>
-// CHECK: fir.global linkonce @_QMmE.dt.t2
-// CHECK-NOT: fir.address_of
-// CHECK: fir.zero_bits !fir.ref<i64>
+// Cut the lexicographically last global in the cycle; the other keeps its init.
+// CHECK-LABEL: gpu.module @cuda_device_mod {
+// CHECK: fir.global @_QMmE.dt.t2 constant : i64{{$}}
+// CHECK: fir.global linkonce @_QMmE.dt.t1 constant : i64 {
+// CHECK: fir.address_of(@_QMmE.dt.t2)
+// CHECK: fir.has_value


### PR DESCRIPTION
PTX does not support cycle in globals. 

```
error: Circular dependency found in global variable set
```

To avoid cycle in type descriptor, check if there is a cycle and break it.

The algorithm uses Tarjan’s strongly connected components algorithm for finding strongly connected components in a directed graph.
- Each fir.global is a graph node.
- Each fir.address_of in a global initializer is an edge to another global.
- An SCC containing multiple globals—or a self-edge—represents a circular initializer dependency.