### PR TITLE
[GlobalISel] Add immediates to `LegalizerQuery`

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -205,11 +205,12 @@ public:
     Register TruncSrc;
     if (mi_match(SrcReg, MRI, m_GTrunc(m_Reg(TruncSrc)))) {
       LLT DstTy = MRI.getType(DstReg);
-      if (isInstUnsupported({TargetOpcode::G_SEXT_INREG, {DstTy}}))
-        return false;
-      LLVM_DEBUG(dbgs() << ".. Combine MI: " << MI);
       LLT SrcTy = MRI.getType(SrcReg);
       uint64_t SizeInBits = SrcTy.getScalarSizeInBits();
+      if (isInstUnsupported(
+              {TargetOpcode::G_SEXT_INREG, {DstTy}, {}, {(int64_t)SizeInBits}}))
+        return false;
+      LLVM_DEBUG(dbgs() << ".. Combine MI: " << MI);
       if (DstTy != MRI.getType(TruncSrc))
         TruncSrc = Builder.buildAnyExtOrTrunc(DstTy, TruncSrc).getReg(0);
       // Elide G_SEXT_INREG if possible. This is similar to eliding G_AND in

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -207,8 +207,10 @@ public:
       LLT DstTy = MRI.getType(DstReg);
       LLT SrcTy = MRI.getType(SrcReg);
       uint64_t SizeInBits = SrcTy.getScalarSizeInBits();
-      if (isInstUnsupported(
-              {TargetOpcode::G_SEXT_INREG, {DstTy}, {}, {(int64_t)SizeInBits}}))
+      if (isInstUnsupported({TargetOpcode::G_SEXT_INREG,
+                             {DstTy},
+                             {},
+                             {static_cast<int64_t>(SizeInBits)}}))
         return false;
       LLVM_DEBUG(dbgs() << ".. Combine MI: " << MI);
       if (DstTy != MRI.getType(TruncSrc))

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -127,9 +127,13 @@ struct LegalityQuery {
   /// memory type for each MMO.
   ArrayRef<MemDesc> MMODescrs;
 
+  ArrayRef<int64_t> Immediates;
+
   constexpr LegalityQuery(unsigned Opcode, ArrayRef<LLT> Types,
-                          ArrayRef<MemDesc> MMODescrs = {})
-      : Opcode(Opcode), Types(Types), MMODescrs(MMODescrs) {}
+                          ArrayRef<MemDesc> MMODescrs = {},
+                          ArrayRef<int64_t> Immediates = {})
+      : Opcode(Opcode), Types(Types), MMODescrs(MMODescrs),
+        Immediates(Immediates) {}
 
   LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 };
@@ -326,6 +330,14 @@ LLVM_ABI LegalityPredicate numElementsNotPow2(unsigned TypeIdx);
 /// stronger.
 LLVM_ABI LegalityPredicate
 atomicOrderingAtLeastOrStrongerThan(unsigned MMOIdx, AtomicOrdering Ordering);
+
+/// True iff the immediate at the given index has the specified value.
+LLVM_ABI LegalityPredicate immIs(unsigned ImmIdx, int64_t Imm);
+/// True iff the immediate at the given index has one of the specified values.
+LLVM_ABI LegalityPredicate immInSet(unsigned ImmIdx,
+                                    std::initializer_list<int64_t> ImmsInit);
+/// True iff the immediate at the given index does not have the specified value.
+LLVM_ABI LegalityPredicate immIsNot(unsigned ImmIdx, int64_t Imm);
 } // end namespace LegalityPredicates
 
 namespace LegalizeMutations {

--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -903,8 +903,13 @@ def neg_and_one_to_sext_inreg : GICombineRule<
   (match (G_AND $and, $x, 1),
          (G_SUB $dst, 0, $and),
          [{ return MRI.hasOneNonDBGUse(${and}.getReg()) &&
-            Helper.isLegalOrBeforeLegalizer(
-              {TargetOpcode::G_SEXT_INREG, {MRI.getType(${x}.getReg())}}); }]),
+            Helper.isLegalOrBeforeLegalizer({
+              TargetOpcode::G_SEXT_INREG,
+              {MRI.getType(${x}.getReg())},
+              {},
+              {1}
+            });
+         }]),
   (apply (G_SEXT_INREG $dst, $x, 1))
 >;
 

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -3476,7 +3476,10 @@ bool CombinerHelper::matchAshrShlToSextInreg(
   if (ShlCst != AshrCst)
     return false;
   if (!isLegalOrBeforeLegalizer(
-          {TargetOpcode::G_SEXT_INREG, {MRI.getType(Src)}}))
+          {TargetOpcode::G_SEXT_INREG,
+           {MRI.getType(Src)},
+           {},
+           {MRI.getType(Src).getScalarSizeInBits() - ShlCst}}))
     return false;
   MatchInfo = std::make_tuple(Src, ShlCst);
   return true;

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelperCasts.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelperCasts.cpp
@@ -38,14 +38,15 @@ bool CombinerHelper::matchSextOfTrunc(const MachineOperand &MO,
 
   // Combines without nsw trunc.
   if (!Trunc->getFlag(MachineInstr::NoSWrap)) {
-    if (DstTy != SrcTy ||
-        !isLegalOrBeforeLegalizer({TargetOpcode::G_SEXT_INREG, {DstTy, SrcTy}}))
-      return false;
-
     // Do this for 8 bit values and up. We don't want to do it for e.g. G_TRUNC
     // to i1.
     unsigned TruncWidth = MRI.getType(Trunc->getReg(0)).getScalarSizeInBits();
     if (TruncWidth < 8)
+      return false;
+
+    if (DstTy != SrcTy ||
+        !isLegalOrBeforeLegalizer(
+            {TargetOpcode::G_SEXT_INREG, {DstTy, SrcTy}, {}, {TruncWidth}}))
       return false;
 
     MatchInfo = [=](MachineIRBuilder &B) {

--- a/llvm/lib/CodeGen/GlobalISel/LegalityPredicates.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalityPredicates.cpp
@@ -249,3 +249,24 @@ LegalityPredicate LegalityPredicates::atomicOrderingAtLeastOrStrongerThan(
     return isAtLeastOrStrongerThan(Query.MMODescrs[MMOIdx].Ordering, Ordering);
   };
 }
+
+LegalityPredicate LegalityPredicates::immIs(unsigned ImmIdx, int64_t Imm) {
+  return [=](const LegalityQuery &Query) {
+    return Query.Immediates[ImmIdx] == Imm;
+  };
+}
+
+LegalityPredicate
+LegalityPredicates::immInSet(unsigned ImmIdx,
+                             std::initializer_list<int64_t> ImmsInit) {
+  SmallVector<int64_t, 4> Imms = ImmsInit;
+  return [=](const LegalityQuery &Query) {
+    return llvm::is_contained(Imms, Query.Immediates[ImmIdx]);
+  };
+}
+
+LegalityPredicate LegalityPredicates::immIsNot(unsigned ImmIdx, int64_t Imm) {
+  return [=](const LegalityQuery &Query) {
+    return Query.Immediates[ImmIdx] != Imm;
+  };
+}

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerInfo.cpp
@@ -88,6 +88,10 @@ raw_ostream &LegalityQuery::print(raw_ostream &OS) const {
   for (const auto &MMODescr : MMODescrs) {
     OS << MMODescr.MemoryTy << ", ";
   }
+  OS << "}, Imms={";
+  for (const auto Imm : Immediates) {
+    OS << Imm << ", ";
+  }
   OS << "}";
 
   return OS;
@@ -343,30 +347,32 @@ LegalizeActionStep
 LegalizerInfo::getAction(const MachineInstr &MI,
                          const MachineRegisterInfo &MRI) const {
   SmallVector<LLT, 8> Types;
+  SmallVector<int64_t, 8> Immediates;
   SmallBitVector SeenTypes(8);
   ArrayRef<MCOperandInfo> OpInfo = MI.getDesc().operands();
   // FIXME: probably we'll need to cache the results here somehow?
   for (unsigned i = 0; i < MI.getDesc().getNumOperands(); ++i) {
-    if (!OpInfo[i].isGenericType())
-      continue;
+    if (OpInfo[i].isGenericType()) {
+      // We must only record actions once for each TypeIdx; otherwise we'd
+      // try to legalize operands multiple times down the line.
+      unsigned TypeIdx = OpInfo[i].getGenericTypeIndex();
+      if (SeenTypes[TypeIdx])
+        continue;
 
-    // We must only record actions once for each TypeIdx; otherwise we'd
-    // try to legalize operands multiple times down the line.
-    unsigned TypeIdx = OpInfo[i].getGenericTypeIndex();
-    if (SeenTypes[TypeIdx])
-      continue;
+      SeenTypes.set(TypeIdx);
 
-    SeenTypes.set(TypeIdx);
-
-    LLT Ty = getTypeFromTypeIdx(MI, MRI, i, TypeIdx);
-    Types.push_back(Ty);
+      LLT Ty = getTypeFromTypeIdx(MI, MRI, i, TypeIdx);
+      Types.push_back(Ty);
+    } else if (OpInfo[i].isGenericImm()) {
+      Immediates.push_back(MI.getOperand(i).getImm());
+    }
   }
 
   SmallVector<LegalityQuery::MemDesc, 2> MemDescrs;
   for (const auto &MMO : MI.memoperands())
     MemDescrs.push_back({*MMO});
 
-  return getAction({MI.getOpcode(), Types, MemDescrs});
+  return getAction({MI.getOpcode(), Types, MemDescrs, Immediates});
 }
 
 bool LegalizerInfo::isLegal(const MachineInstr &MI,

--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
@@ -178,10 +178,18 @@ RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST)
 
   getActionDefinitionsBuilder(G_TRUNC).alwaysLegal();
 
-  getActionDefinitionsBuilder(G_SEXT_INREG)
-      .customFor({sXLen})
-      .clampScalar(0, sXLen, sXLen)
-      .lower();
+  {
+    LegalityPredicate ValidSextInRegWidth = all(sizeIs(0, 64), immIs(0, 32));
+
+    if (STI.hasStdExtZbb())
+      ValidSextInRegWidth =
+          LegalityPredicates::any(ValidSextInRegWidth, immInSet(0, {8, 16}));
+
+    getActionDefinitionsBuilder(G_SEXT_INREG)
+        .legalIf(all(typeIs(0, sXLen), ValidSextInRegWidth))
+        .clampScalar(0, sXLen, sXLen)
+        .lower();
+  }
 
   // Merge/Unmerge
   for (unsigned Op : {G_MERGE_VALUES, G_UNMERGE_VALUES}) {
@@ -1495,19 +1503,6 @@ bool RISCVLegalizerInfo::legalizeCustom(
 
     Helper.Observer.changedInstr(MI);
     return true;
-  }
-  case TargetOpcode::G_SEXT_INREG: {
-    LLT DstTy = MRI.getType(MI.getOperand(0).getReg());
-    int64_t SizeInBits = MI.getOperand(2).getImm();
-    // Source size of 32 is sext.w.
-    if (DstTy.getSizeInBits() == 64 && SizeInBits == 32)
-      return true;
-
-    if (STI.hasStdExtZbb() && (SizeInBits == 8 || SizeInBits == 16))
-      return true;
-
-    return Helper.lower(MI, 0, /* Unused hint type */ LLT()) ==
-           LegalizerHelper::Legalized;
   }
   case TargetOpcode::G_ASHR:
   case TargetOpcode::G_LSHR:

--- a/llvm/lib/Target/WebAssembly/GISel/WebAssemblyLegalizerInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/GISel/WebAssemblyLegalizerInfo.cpp
@@ -20,6 +20,7 @@
 
 using namespace llvm;
 using namespace LegalizeActions;
+using namespace LegalityPredicates;
 
 WebAssemblyLegalizerInfo::WebAssemblyLegalizerInfo(
     const WebAssemblySubtarget &ST) {
@@ -86,10 +87,17 @@ WebAssemblyLegalizerInfo::WebAssemblyLegalizerInfo(
       .clampScalar(0, s32, s32)
       .clampScalar(1, s64, s64);
 
-  getActionDefinitionsBuilder(G_SEXT_INREG)
-      .customFor(ST.hasSignExt(), {i32, i64})
-      .clampScalar(0, s32, s64)
-      .lower();
+  {
+    LegalizeRuleSet &Builder = getActionDefinitionsBuilder(G_SEXT_INREG);
+
+    if (ST.hasSignExt())
+      Builder.legalIf(
+          all(typeInSet(0, {i32, i64}),
+              LegalityPredicates::any(immInSet(0, {8, 16}),
+                                      all(typeIs(0, i64), immIs(0, 32)))));
+
+    Builder.clampScalar(0, s32, s64).lower();
+  }
 
   getActionDefinitionsBuilder({G_FCONSTANT, G_FABS, G_FNEG, G_FCEIL, G_FFLOOR,
                                G_INTRINSIC_TRUNC, G_FNEARBYINT, G_FRINT,
@@ -152,20 +160,6 @@ bool WebAssemblyLegalizerInfo::legalizeCustom(
     LegalizerHelper &Helper, MachineInstr &MI,
     LostDebugLocObserver &LocObserver) const {
   switch (MI.getOpcode()) {
-  case TargetOpcode::G_SEXT_INREG: {
-    assert(MI.getOperand(2).isImm() && "Expected immediate");
-
-    // Mark only 8/16/32-bit SEXT_INREG as legal
-    auto [DstType, SrcType] = MI.getFirst2LLTs();
-    auto ExtFromWidth = MI.getOperand(2).getImm();
-
-    if (ExtFromWidth == 8 || ExtFromWidth == 16 ||
-        (DstType.getScalarSizeInBits() == 64 && ExtFromWidth == 32)) {
-      return true;
-    }
-
-    return Helper.lower(MI, 0, DstType) != LegalizerHelper::UnableToLegalize;
-  }
   default:
     break;
   }

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
@@ -376,7 +376,9 @@ TEST(LegalizerInfoTest, MSVCDebugMiscompile) {
   (void)Builder.legalForCartesianProduct({S1}, {P0});
 }
 
-// We need a target machine for MRI
+// AArch64GISemMITest instead of LegalizerInfoTest
+// as we need a target machine for MRI.
+//
 // Check that immediates for the query are populated from the MI
 TEST_F(AArch64GISelMITest, ImmediatesFromMI) {
   setUp();

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
@@ -272,6 +272,45 @@ TEST(LegalizerInfoTest, RuleSets) {
     EXPECT_ACTION(WidenScalar, 1, v2s32, LegalityQuery(G_SELECT, {v2p0, v2s1}));
     EXPECT_ACTION(WidenScalar, 1, v2s32, LegalityQuery(G_SELECT, {v2p1, v2s1}));
   }
+
+  // Test immIs
+  {
+    LegalizerInfo LI;
+
+    LI.getActionDefinitionsBuilder(G_SEXT_INREG)
+        .legalIf(all(typeIs(0, s32), immIs(0, 8)));
+
+    EXPECT_ACTION(Legal, 0, LLT(), LegalityQuery(G_SEXT_INREG, {s32}, {}, {8}));
+    EXPECT_ACTION(Unsupported, 0, LLT(),
+                  LegalityQuery(G_SEXT_INREG, {s32}, {}, {16}));
+  }
+
+  // Test immIsNot
+  {
+    LegalizerInfo LI;
+
+    LI.getActionDefinitionsBuilder(G_SEXT_INREG)
+        .legalIf(all(typeIs(0, s32), immIsNot(0, 8)));
+
+    EXPECT_ACTION(Unsupported, 0, LLT(),
+                  LegalityQuery(G_SEXT_INREG, {s32}, {}, {8}));
+    EXPECT_ACTION(Legal, 0, LLT(),
+                  LegalityQuery(G_SEXT_INREG, {s32}, {}, {16}));
+  }
+
+  // Test immIsSet
+  {
+    LegalizerInfo LI;
+
+    LI.getActionDefinitionsBuilder(G_SEXT_INREG)
+        .legalIf(all(typeIs(0, s32), immInSet(0, {8, 16})));
+
+    EXPECT_ACTION(Legal, 0, LLT(), LegalityQuery(G_SEXT_INREG, {s32}, {}, {8}));
+    EXPECT_ACTION(Legal, 0, LLT(),
+                  LegalityQuery(G_SEXT_INREG, {s32}, {}, {16}));
+    EXPECT_ACTION(Unsupported, 0, LLT(),
+                  LegalityQuery(G_SEXT_INREG, {s32}, {}, {5}));
+  }
 }
 
 TEST(LegalizerInfoTest, MMOAlignment) {
@@ -335,4 +374,35 @@ TEST(LegalizerInfoTest, MSVCDebugMiscompile) {
   LegalizerInfo LI;
   auto Builder = LI.getActionDefinitionsBuilder(TargetOpcode::G_PTRTOINT);
   (void)Builder.legalForCartesianProduct({S1}, {P0});
+}
+
+// We need a target machine for MRI
+// Check that immediates for the query are populated from the MI
+TEST_F(AArch64GISelMITest, ImmediatesFromMI) {
+  setUp();
+  if (!TM)
+    GTEST_SKIP();
+
+  DefineLegalizerInfo(A, {
+    getActionDefinitionsBuilder(G_SEXT_INREG)
+        .legalIf(all(typeIs(0, s32), immIs(0, 8)));
+  });
+
+  AInfo LI(MF->getSubtarget());
+
+  {
+    auto MI =
+        B.buildSExtInReg(LLT::scalar(32), B.buildUndef(LLT::scalar(32)), 8);
+
+    auto Action = LI.getAction(*MI, MF->getRegInfo());
+    EXPECT_EQ(LegalizeActionStep(Legal, 0, LLT()), Action) << Action;
+  }
+
+  {
+    auto MI =
+        B.buildSExtInReg(LLT::scalar(32), B.buildUndef(LLT::scalar(32)), 16);
+
+    auto Action = LI.getAction(*MI, MF->getRegInfo());
+    EXPECT_EQ(LegalizeActionStep(Unsupported, 0, LLT()), Action) << Action;
+  }
 }


### PR DESCRIPTION
Expands `LegalityQuery` to include instruction immediates in the query.

This allows instructions with immediates to be handled more fully with legalization rules/predicates (e.g. `G_SEXT_INREG` based on its sext width) rather than having to resort to custom legalizer logic.

Split from #198979