### PR TITLE
[AMDGPU] Update assembler check to use global_prefetch_b8 for GFX1250

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1419,9 +1419,8 @@ class AMDGPUAsmParser : public MCTargetAsmParser {
   /// deferred to onEndOfFile(). We record an order-independent timeline of
   /// parsed labels and emitted instructions, plus the set of symbols
   /// named by .amdhsa_kernel directives, and match them up at end of file.
-  SmallVector<MCInst> InstStream;
-  SmallVector<std::tuple<const MCSymbol *, SMLoc, unsigned>>
-      InstStreamSymbols;
+  SmallVector<const MCInst *> InstStream;
+  SmallVector<std::tuple<const MCSymbol *, SMLoc, unsigned>> InstStreamSymbols;
   SmallPtrSet<const MCSymbol *, 8> AMDHSAKernelSymbols;
 
   /// Verify recorded kernel prologues.
@@ -5953,7 +5952,7 @@ bool AMDGPUAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     emitTargetDirective();
     Out.emitInstruction(Inst, getSTI());
     // Record for kernel prologue checking.
-    InstStream.push_back(Inst);
+    InstStream.push_back(&Inst);
     return false;
   }
 
@@ -7108,25 +7107,26 @@ void AMDGPUAsmParser::checkKernelPrologues() {
     for (auto [Sym, Loc, Offset] : InstStreamSymbols) {
       if (!AMDHSAKernelSymbols.contains(Sym))
         continue;
-      ArrayRef<MCInst> Prologue = ArrayRef(InstStream).drop_front(Offset);
+      ArrayRef<const MCInst *> Prologue =
+          ArrayRef(InstStream).drop_front(Offset);
       bool Valid = false;
       if (Prologue.size() >= 2) {
-        const MCInst &Prefetch = Prologue[0];
-        const MCInst &Nop = Prologue[1];
+        const MCInst *Prefetch = Prologue[0];
+        const MCInst *Nop = Prologue[1];
         // The required prologue sequence is:
         //   global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
         //   v_nop
-        if (Prefetch.getOpcode() == GLOBAL_PREFETCH_B8_SADDR_gfx1250 &&
-            Prefetch.getNumOperands() >= 4 &&
-            Prefetch.getOperand(0).isReg() &&
-            Prefetch.getOperand(0).getReg() == AMDGPU::SGPR0_SGPR1 &&
-            Prefetch.getOperand(1).isReg() &&
-            Prefetch.getOperand(1).getReg() == AMDGPU::VGPR0 &&
-            Prefetch.getOperand(2).isImm() &&
-            Prefetch.getOperand(2).getImm() == 0 &&
-            Prefetch.getOperand(3).isImm() &&
-            Prefetch.getOperand(3).getImm() == AMDGPU::CPol::SCOPE_SE &&
-            Nop.getOpcode() == V_NOP_e32_gfx12) {
+        if (Prefetch->getOpcode() == GLOBAL_PREFETCH_B8_SADDR_gfx1250 &&
+            Prefetch->getNumOperands() >= 4 &&
+            Prefetch->getOperand(0).isReg() &&
+            Prefetch->getOperand(0).getReg() == AMDGPU::SGPR0_SGPR1 &&
+            Prefetch->getOperand(1).isReg() &&
+            Prefetch->getOperand(1).getReg() == AMDGPU::VGPR0 &&
+            Prefetch->getOperand(2).isImm() &&
+            Prefetch->getOperand(2).getImm() == 0 &&
+            Prefetch->getOperand(3).isImm() &&
+            Prefetch->getOperand(3).getImm() == AMDGPU::CPol::SCOPE_SE &&
+            Nop->getOpcode() == V_NOP_e32_gfx12) {
           Valid = true;
         }
       }

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1417,11 +1417,11 @@ class AMDGPUAsmParser : public MCTargetAsmParser {
   /// directive may appear either before or after the kernel's label (it is
   /// normally emitted after the function body, in .rodata), validation is
   /// deferred to onEndOfFile(). We record an order-independent timeline of
-  /// parsed labels and emitted instruction opcodes, plus the set of symbols
+  /// parsed labels and emitted instructions, plus the set of symbols
   /// named by .amdhsa_kernel directives, and match them up at end of file.
-  SmallVector<unsigned> OpcodeStream;
+  SmallVector<MCInst> InstStream;
   SmallVector<std::tuple<const MCSymbol *, SMLoc, unsigned>>
-      OpcodeStreamSymbols;
+      InstStreamSymbols;
   SmallPtrSet<const MCSymbol *, 8> AMDHSAKernelSymbols;
 
   /// Verify recorded kernel prologues.
@@ -5953,7 +5953,7 @@ bool AMDGPUAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     emitTargetDirective();
     Out.emitInstruction(Inst, getSTI());
     // Record for kernel prologue checking.
-    OpcodeStream.push_back(Inst.getOpcode());
+    InstStream.push_back(Inst);
     return false;
   }
 
@@ -7100,25 +7100,47 @@ void AMDGPUAsmParser::doBeforeLabelEmit(MCSymbol *Symbol, SMLoc IDLoc) {
   // Record every parsed label in the timeline so that, at end of file, the
   // instructions following a kernel's label can be located regardless of
   // whether the .amdhsa_kernel directive came before or after the label.
-  OpcodeStreamSymbols.emplace_back(Symbol, IDLoc, OpcodeStream.size());
+  InstStreamSymbols.emplace_back(Symbol, IDLoc, InstStream.size());
 }
 
 void AMDGPUAsmParser::checkKernelPrologues() {
   if (getFeatureBits()[AMDGPU::FeatureRequiresInitialUnclausedVmem]) {
-    static const unsigned Required[] = {GLOBAL_WB_gfx12, V_NOP_e32_gfx12};
-    for (auto [Sym, Loc, Offset] : OpcodeStreamSymbols) {
+    for (auto [Sym, Loc, Offset] : InstStreamSymbols) {
       if (!AMDHSAKernelSymbols.contains(Sym))
         continue;
-      ArrayRef<unsigned> Prologue = ArrayRef(OpcodeStream).drop_front(Offset);
-      if (Prologue.take_front(std::size(Required)) != ArrayRef(Required)) {
-        Warning(Loc, "kernel '" + Sym->getName() +
-                         "' does not begin with the required prologue "
-                         "sequence: GLOBAL_WB followed by V_NOP");
+      ArrayRef<MCInst> Prologue = ArrayRef(InstStream).drop_front(Offset);
+      bool Valid = false;
+      if (Prologue.size() >= 2) {
+        const MCInst &Prefetch = Prologue[0];
+        const MCInst &Nop = Prologue[1];
+        // The required prologue sequence is:
+        //   global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+        //   v_nop
+        if (Prefetch.getOpcode() == GLOBAL_PREFETCH_B8_SADDR_gfx1250 &&
+            Prefetch.getNumOperands() >= 4 &&
+            Prefetch.getOperand(0).isReg() &&
+            Prefetch.getOperand(0).getReg() == AMDGPU::SGPR0_SGPR1 &&
+            Prefetch.getOperand(1).isReg() &&
+            Prefetch.getOperand(1).getReg() == AMDGPU::VGPR0 &&
+            Prefetch.getOperand(2).isImm() &&
+            Prefetch.getOperand(2).getImm() == 0 &&
+            Prefetch.getOperand(3).isImm() &&
+            Prefetch.getOperand(3).getImm() == AMDGPU::CPol::SCOPE_SE &&
+            Nop.getOpcode() == V_NOP_e32_gfx12) {
+          Valid = true;
+        }
+      }
+      if (!Valid) {
+        Warning(Loc,
+                "kernel '" + Sym->getName() +
+                    "' does not begin with the required prologue sequence: "
+                    "GLOBAL_PREFETCH_B8 v0, s[0:1] scope:SCOPE_SE followed by "
+                    "V_NOP");
       }
     }
   }
-  OpcodeStream.clear();
-  OpcodeStreamSymbols.clear();
+  InstStream.clear();
+  InstStreamSymbols.clear();
   AMDHSAKernelSymbols.clear();
 }
 

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -5956,10 +5956,12 @@ bool AMDGPUAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     }
     emitTargetDirective();
     Out.emitInstruction(Inst, getSTI());
-    // Record for kernel prologue checking (only first 2 instructions per
-    // label).
-    if (!LabelPrologues.empty() && LabelPrologues.back().Count < 2)
-      LabelPrologues.back().Insts[LabelPrologues.back().Count++] = Inst;
+    // Record first 2 instructions per label for kernel prologue checking.
+    if (!LabelPrologues.empty()) {
+      auto &LP = LabelPrologues.back();
+      if (LP.Count < 2)
+        LP.Insts[LP.Count++] = Inst;
+    }
     return false;
   }
 

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1416,11 +1416,16 @@ class AMDGPUAsmParser : public MCTargetAsmParser {
   /// begins with the required prologue instruction sequence. Because the
   /// directive may appear either before or after the kernel's label (it is
   /// normally emitted after the function body, in .rodata), validation is
-  /// deferred to onEndOfFile(). We record an order-independent timeline of
-  /// parsed labels and emitted instructions, plus the set of symbols
-  /// named by .amdhsa_kernel directives, and match them up at end of file.
-  SmallVector<const MCInst *> InstStream;
-  SmallVector<std::tuple<const MCSymbol *, SMLoc, unsigned>> InstStreamSymbols;
+  /// deferred to onEndOfFile(). We record only the first 2 instructions after
+  /// each label, plus the set of symbols named by .amdhsa_kernel directives,
+  /// and match them up at end of file.
+  struct LabelPrologue {
+    const MCSymbol *Sym;
+    SMLoc Loc;
+    MCInst Insts[2];
+    unsigned Count = 0;
+  };
+  std::vector<LabelPrologue> LabelPrologues;
   SmallPtrSet<const MCSymbol *, 8> AMDHSAKernelSymbols;
 
   /// Verify recorded kernel prologues.
@@ -5951,8 +5956,10 @@ bool AMDGPUAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     }
     emitTargetDirective();
     Out.emitInstruction(Inst, getSTI());
-    // Record for kernel prologue checking.
-    InstStream.push_back(&Inst);
+    // Record for kernel prologue checking (only first 2 instructions per
+    // label).
+    if (!LabelPrologues.empty() && LabelPrologues.back().Count < 2)
+      LabelPrologues.back().Insts[LabelPrologues.back().Count++] = Inst;
     return false;
   }
 
@@ -7096,51 +7103,47 @@ bool AMDGPUAsmParser::ParseDirectiveAMDGPUInfo() {
 }
 
 void AMDGPUAsmParser::doBeforeLabelEmit(MCSymbol *Symbol, SMLoc IDLoc) {
-  // Record every parsed label in the timeline so that, at end of file, the
-  // instructions following a kernel's label can be located regardless of
-  // whether the .amdhsa_kernel directive came before or after the label.
-  InstStreamSymbols.emplace_back(Symbol, IDLoc, InstStream.size());
+  // Record every parsed label so that, at end of file, the instructions
+  // following a kernel's label can be checked regardless of whether the
+  // .amdhsa_kernel directive came before or after the label.
+  LabelPrologues.push_back({Symbol, IDLoc, {}, 0});
 }
 
 void AMDGPUAsmParser::checkKernelPrologues() {
   if (getFeatureBits()[AMDGPU::FeatureRequiresInitialUnclausedVmem]) {
-    for (auto [Sym, Loc, Offset] : InstStreamSymbols) {
-      if (!AMDHSAKernelSymbols.contains(Sym))
+    for (const auto &LP : LabelPrologues) {
+      if (!AMDHSAKernelSymbols.contains(LP.Sym))
         continue;
-      ArrayRef<const MCInst *> Prologue =
-          ArrayRef(InstStream).drop_front(Offset);
       bool Valid = false;
-      if (Prologue.size() >= 2) {
-        const MCInst *Prefetch = Prologue[0];
-        const MCInst *Nop = Prologue[1];
+      if (LP.Count >= 2) {
+        const MCInst &Prefetch = LP.Insts[0];
+        const MCInst &Nop = LP.Insts[1];
         // The required prologue sequence is:
         //   global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
         //   v_nop
-        if (Prefetch->getOpcode() == GLOBAL_PREFETCH_B8_SADDR_gfx1250 &&
-            Prefetch->getNumOperands() >= 4 &&
-            Prefetch->getOperand(0).isReg() &&
-            Prefetch->getOperand(0).getReg() == AMDGPU::SGPR0_SGPR1 &&
-            Prefetch->getOperand(1).isReg() &&
-            Prefetch->getOperand(1).getReg() == AMDGPU::VGPR0 &&
-            Prefetch->getOperand(2).isImm() &&
-            Prefetch->getOperand(2).getImm() == 0 &&
-            Prefetch->getOperand(3).isImm() &&
-            Prefetch->getOperand(3).getImm() == AMDGPU::CPol::SCOPE_SE &&
-            Nop->getOpcode() == V_NOP_e32_gfx12) {
+        if (Prefetch.getOpcode() == GLOBAL_PREFETCH_B8_SADDR_gfx1250 &&
+            Prefetch.getNumOperands() >= 4 && Prefetch.getOperand(0).isReg() &&
+            Prefetch.getOperand(0).getReg() == AMDGPU::SGPR0_SGPR1 &&
+            Prefetch.getOperand(1).isReg() &&
+            Prefetch.getOperand(1).getReg() == AMDGPU::VGPR0 &&
+            Prefetch.getOperand(2).isImm() &&
+            Prefetch.getOperand(2).getImm() == 0 &&
+            Prefetch.getOperand(3).isImm() &&
+            Prefetch.getOperand(3).getImm() == AMDGPU::CPol::SCOPE_SE &&
+            Nop.getOpcode() == V_NOP_e32_gfx12) {
           Valid = true;
         }
       }
       if (!Valid) {
-        Warning(Loc,
-                "kernel '" + Sym->getName() +
+        Warning(LP.Loc,
+                "kernel '" + LP.Sym->getName() +
                     "' does not begin with the required prologue sequence: "
                     "GLOBAL_PREFETCH_B8 v0, s[0:1] scope:SCOPE_SE followed by "
                     "V_NOP");
       }
     }
   }
-  InstStream.clear();
-  InstStreamSymbols.clear();
+  LabelPrologues.clear();
   AMDHSAKernelSymbols.clear();
 }
 

--- a/llvm/test/MC/AMDGPU/amdhsa-kernel-prologue.s
+++ b/llvm/test/MC/AMDGPU/amdhsa-kernel-prologue.s
@@ -1,6 +1,6 @@
 // RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 %s -filetype=null 2>&1 | FileCheck %s -implicit-check-not=warning: -check-prefix=GFX1250
 
-// GFX1250: :[[@LINE+1]]:1: warning: kernel 'test_wrong_before' does not begin with the required prologue sequence: GLOBAL_WB followed by V_NOP
+// GFX1250: :[[@LINE+1]]:1: warning: kernel 'test_wrong_before' does not begin with the required prologue sequence: GLOBAL_PREFETCH_B8 v0, s[0:1] scope:SCOPE_SE followed by V_NOP
 test_wrong_before:
   s_nop 1
 
@@ -14,15 +14,38 @@ test_wrong_before:
   .amdhsa_next_free_vgpr 0
 .end_amdhsa_kernel
 
-// GFX1250: :[[@LINE+1]]:1: warning: kernel 'test_wrong_after' does not begin with the required prologue sequence: GLOBAL_WB followed by V_NOP
+// GFX1250: :[[@LINE+1]]:1: warning: kernel 'test_wrong_after' does not begin with the required prologue sequence: GLOBAL_PREFETCH_B8 v0, s[0:1] scope:SCOPE_SE followed by V_NOP
 test_wrong_after:
   s_nop 2
 
+// Test wrong registers - should warn
+.amdhsa_kernel test_wrong_regs
+  .amdhsa_next_free_sgpr 0
+  .amdhsa_next_free_vgpr 0
+.end_amdhsa_kernel
+
+// GFX1250: :[[@LINE+1]]:1: warning: kernel 'test_wrong_regs' does not begin with the required prologue sequence: GLOBAL_PREFETCH_B8 v0, s[0:1] scope:SCOPE_SE followed by V_NOP
+test_wrong_regs:
+  global_prefetch_b8 v1, s[2:3] scope:SCOPE_SE
+  v_nop
+
+// Test wrong scope - should warn
+.amdhsa_kernel test_wrong_scope
+  .amdhsa_next_free_sgpr 0
+  .amdhsa_next_free_vgpr 0
+.end_amdhsa_kernel
+
+// GFX1250: :[[@LINE+1]]:1: warning: kernel 'test_wrong_scope' does not begin with the required prologue sequence: GLOBAL_PREFETCH_B8 v0, s[0:1] scope:SCOPE_SE followed by V_NOP
+test_wrong_scope:
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_DEV
+  v_nop
+
+// Test correct sequence - no warning
 .amdhsa_kernel test_correct
   .amdhsa_next_free_sgpr 0
   .amdhsa_next_free_vgpr 0
 .end_amdhsa_kernel
 
 test_correct:
-  global_wb
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop

--- a/llvm/test/MC/AMDGPU/hsa-gfx1250-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx1250-v4.s
@@ -70,42 +70,42 @@
 .p2align 8
 .type minimal,@function
 minimal:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type complete,@function
 complete:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type special_sgpr,@function
 special_sgpr:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type disabled_user_sgpr,@function
 disabled_user_sgpr:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type max_lds_size,@function
 max_lds_size:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type max_vgprs,@function
 max_vgprs:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
@@ -276,9 +276,9 @@ max_vgprs:
 // ASM: .byte 0
 
 .byte .amdgcn.next_free_vgpr
-// ASM: .byte 0
+// ASM: .byte 1
 .byte .amdgcn.next_free_sgpr
-// ASM: .byte 0
+// ASM: .byte 2
 
 v_mov_b32_e32 v16, s3
 

--- a/llvm/test/MC/AMDGPU/hsa-gfx1251-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx1251-v4.s
@@ -70,42 +70,42 @@
 .p2align 8
 .type minimal,@function
 minimal:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type complete,@function
 complete:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type special_sgpr,@function
 special_sgpr:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type disabled_user_sgpr,@function
 disabled_user_sgpr:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type max_lds_size,@function
 max_lds_size:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
 .p2align 8
 .type max_vgprs,@function
 max_vgprs:
-  global_wb scope:SCOPE_CU
+  global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
   v_nop
   s_endpgm
 
@@ -276,9 +276,9 @@ max_vgprs:
 // ASM: .byte 1
 
 .byte .amdgcn.next_free_vgpr
-// ASM: .byte 0
+// ASM: .byte 1
 .byte .amdgcn.next_free_sgpr
-// ASM: .byte 0
+// ASM: .byte 2
 
 v_mov_b32_e32 v16, s3
 


### PR DESCRIPTION
Update the prologue check to require global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE instead of global_wb.