### PR TITLE
[SandboxVec][Scheduler] Fix false negatives

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -66,12 +66,7 @@ public:
   void insert(DGNode *N) {
 #ifndef NDEBUG
     assert(!N->scheduled() && "Don't insert a scheduled node!");
-    auto ListCopy = List;
-    while (!ListCopy.empty()) {
-      DGNode *Top = ListCopy.top();
-      ListCopy.pop();
-      assert(Top != N && "Node already exists in ready list!");
-    }
+    assert(!contains(N) && "Node already exists in ready list!");
 #endif
     List.push(N);
   }
@@ -82,6 +77,17 @@ public:
   }
   bool empty() const { return List.empty(); }
   void clear() { List = {}; }
+  bool contains(DGNode *N) const {
+    // TODO: We should update the data structure to make this O(1).
+    auto ListCopy = List;
+    while (!ListCopy.empty()) {
+      DGNode *Top = ListCopy.top();
+      if (Top == N)
+        return true;
+      ListCopy.pop();
+    }
+    return false;
+  }
   /// \Removes \p N if found in the ready list.
   void remove(DGNode *N) {
     // TODO: Use a more efficient data-structure for the ready list because the

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -418,9 +418,9 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
       auto *N = DAG.getNode(&I);
       if (N->scheduled())
         continue;
-      ReadyList.remove(N);
-      if (Dir == SchedDirection::BottomUp ? N->readyBottomUp()
-                                          : N->readyTopDown())
+      bool IsReady = Dir == SchedDirection::BottomUp ? N->readyBottomUp()
+                                                     : N->readyTopDown();
+      if (IsReady && !ReadyList.contains(N))
         ReadyList.insert(N);
     }
     // Try schedule all nodes until we can schedule Instrs back-to-back.

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -411,8 +411,14 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     // Extend the DAG to include Instrs.
     Interval<Instruction> Extension = DAG.extend(Instrs);
     // Add nodes from the new interval to ready list if they are ready.
-    for (auto &I : Extension) {
+    Interval<Instruction> InstrsInterval(Instrs);
+    Interval<Instruction> ScanForReady =
+        InstrsInterval.getUnionInterval(Extension);
+    for (auto &I : ScanForReady) {
       auto *N = DAG.getNode(&I);
+      if (N->scheduled())
+        continue;
+      ReadyList.remove(N);
       if (Dir == SchedDirection::BottomUp ? N->readyBottomUp()
                                           : N->readyTopDown())
         ReadyList.insert(N);

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -282,7 +282,6 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   auto *L1 = cast<sandboxir::LoadInst>(&*It++);
   auto *S0 = cast<sandboxir::StoreInst>(&*It++);
   auto *S1 = cast<sandboxir::StoreInst>(&*It++);
-  auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
 
   sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx,
                              sandboxir::SchedDirection::BottomUp);
@@ -924,10 +923,13 @@ define void @foo(ptr %ptr) {
   sandboxir::ReadyListContainer ReadyList;
   // Check empty().
   EXPECT_TRUE(ReadyList.empty());
-  // Check insert(), pop().
+  EXPECT_FALSE(ReadyList.contains(L0N));
+  // Check insert(), pop(), contains().
   ReadyList.insert(L0N);
   EXPECT_FALSE(ReadyList.empty());
+  EXPECT_TRUE(ReadyList.contains(L0N));
   EXPECT_EQ(ReadyList.pop(), L0N);
+  EXPECT_FALSE(ReadyList.contains(L0N));
   // Check clear().
   ReadyList.insert(L0N);
   EXPECT_FALSE(ReadyList.empty());
@@ -939,7 +941,11 @@ define void @foo(ptr %ptr) {
   ReadyList.insert(L0N);
   ReadyList.insert(S0N);
   ReadyList.insert(RetN);
+  EXPECT_TRUE(ReadyList.contains(L0N));
+  EXPECT_TRUE(ReadyList.contains(S0N));
+  EXPECT_TRUE(ReadyList.contains(RetN));
   ReadyList.remove(S0N);
+  EXPECT_FALSE(ReadyList.contains(S0N));
   DenseSet<sandboxir::DGNode *> Nodes;
   Nodes.insert(ReadyList.pop());
   Nodes.insert(ReadyList.pop());

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -263,6 +263,33 @@ define void @foo(ptr %ptr, i8 %v0, i8 %v1) {
   }
 }
 
+TEST_F(SchedulerTest, FalseNegatives) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
+  %ld0 = load i8, ptr %ptr0
+  %ld1 = load i8, ptr %ptr1
+  store i8 %ld0, ptr %ptr0
+  store i8 %ld1, ptr %ptr1
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx,
+                             sandboxir::SchedDirection::BottomUp);
+  EXPECT_FALSE(Sched.trySchedule({S0, S1, L0, L1}));
+  EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+}
+
 TEST_F(SchedulerTest, Basic_TopDown) {
   parseIR(C, R"IR(
 define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {


### PR DESCRIPTION
This patch fixes an issue where trySchedule() could return false even though scheduling was legal. This would happen after a failed trySchedule(Bndl1) attempt for a bundle that would span a large number of instructions. Any subsequent trySchedule(Bndl2) for a bundle that would span fewer instrs than Bndl1 would return false because the scheduler would not scan the required instructions to add them to the ready list.