### PR TITLE
[OpenACC] Accept funcs with `acc.specialized_routine` in `acc::isValidSymbolUse`

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
@@ -220,9 +220,10 @@ bool mlir::acc::isValidSymbolUse(mlir::Operation *user,
   // Check if the defining op is a function
   if (auto func =
           mlir::dyn_cast_if_present<mlir::FunctionOpInterface>(definingOp)) {
-    // If this symbol is actually an acc routine - then it is expected for it
-    // to be offloaded - therefore it is valid.
-    if (func->hasAttr(mlir::acc::getRoutineInfoAttrName()))
+    // If this symbol is actually an acc routine or a specialized acc routine -
+    // then it is expected for it to be offloaded - therefore it is valid.
+    if (func->hasAttr(mlir::acc::getRoutineInfoAttrName()) ||
+        func->hasAttr(mlir::acc::getSpecializedRoutineAttrName()))
       return true;
 
     // If this symbol is a call to an LLVM intrinsic, then it is likely valid.

--- a/mlir/test/Dialect/OpenACC/offload-target-verifier.mlir
+++ b/mlir/test/Dialect/OpenACC/offload-target-verifier.mlir
@@ -245,3 +245,37 @@ func.func @test_f64_scalar() {
   }
   return
 }
+
+// -----
+
+// Test call to a function marked as an acc routine - should pass
+acc.routine @acc_routine_0 func(@routine_callee) gang
+func.func @routine_callee() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>} {
+  return
+}
+
+func.func @test_acc_routine() {
+  // expected-remark @below {{passed validity check}}
+  acc.parallel {
+    func.call @routine_callee() : () -> ()
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// Test call to a function marked as a specialized acc routine - should pass
+acc.routine @acc_routine_1 func(@specialized_callee) gang
+func.func @specialized_callee() attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_1, <gang_dim1>, "specialized_callee">} {
+  return
+}
+
+func.func @test_acc_specialized_routine() {
+  // expected-remark @below {{passed validity check}}
+  acc.parallel {
+    func.call @specialized_callee() : () -> ()
+    acc.yield
+  }
+  return
+}


### PR DESCRIPTION
`ACCRoutineLowering` generates device side specialized version of routines that have the `acc.specialized_routine` attribute. Those are expected to be offloaded and therefore are valid symbol uses.