### PR TITLE
Revert "[libc++][test] XFAIL `text/text_encoding/environment.pass.cpp` test on Armv7/Linux Ubuntu targets."

### DIFF
--- a/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
@@ -16,10 +16,6 @@
 // UNSUPPORTED: availability-te-environment-missing
 // UNSUPPORTED: LLVM-LIBC-FIXME
 
-// FIXME: gets failed on Armv7/Linux Ubuntu 18.04 LTS board (remote exec) with
-//        "Environment mismatch: Expected ID 3, received: {106,UTF-8}"
-// XFAIL: buildhost=windows && target=armv7-unknown-linux-gnueabihf
-
 // std::text_encoding::environment()
 
 #include <algorithm>


### PR DESCRIPTION
Reverts llvm/llvm-project#206188

XFAIL'ed wrong test