### PR TITLE
[LIT] Add RUN(<expr>): per-command gate on lit features

### DIFF
--- a/clang/test/utils/update_cc_test_checks/Inputs/gated-run-line.c
+++ b/clang/test/utils/update_cc_test_checks/Inputs/gated-run-line.c
@@ -1,0 +1,5 @@
+// RUN(some-feature): %clang_cc1 -triple x86_64-unknown-unknown %s -emit-llvm -o - | FileCheck %s --check-prefix=GATED
+
+int add(int a, int b) {
+  return a + b;
+}

--- a/clang/test/utils/update_cc_test_checks/gated-run-lines.test
+++ b/clang/test/utils/update_cc_test_checks/gated-run-lines.test
@@ -1,0 +1,8 @@
+## Feature-gated run lines in update_cc_test_checks.py.
+
+## Recognition: the gate is stripped and the command is run like an ordinary
+## run line, so its FileCheck prefix gets generated checks.
+# RUN: cp -f %S/Inputs/gated-run-line.c %t.c && %update_cc_test_checks --version 4 %t.c
+# RUN: FileCheck --input-file=%t.c %s --check-prefix=RECOGNIZE
+# RECOGNIZE: GATED-LABEL:
+

--- a/llvm/docs/TestingGuide.md
+++ b/llvm/docs/TestingGuide.md
@@ -667,6 +667,38 @@ Use, `XFAIL: *` if the test is expected to fail everywhere. Similarly, use
 ; XFAIL: target=powerpc{{.*}}, system-darwin
 ```
 
+### Gating individual RUN lines on a feature
+
+`REQUIRES`, `UNSUPPORTED` and `XFAIL` gate the *whole* test. To gate a
+single `RUN` line instead, write the `RUN` keyword immediately followed
+by a boolean expression in parentheses, `RUN(<expr>):`. The line is only
+added to the test script when `<expr>` is satisfied; otherwise it is
+silently skipped while the other `RUN` lines run as usual.
+
+`<expr>` is an ordinary lit boolean expression, parsed and evaluated by
+the same machinery as `REQUIRES`/`UNSUPPORTED`/`XFAIL` and against the
+same `config.available_features` set. It may therefore use feature
+names, the boolean operators `&&`, `||` and `!`, grouping parentheses,
+and `{{ }}` regular expressions (for example `RUN(linux && !asan):` or
+`RUN(target={{.*}}-windows{{.*}}):`). A malformed expression is a test
+error, exactly as it is for those keywords. Unlike them, `RUN(<expr>):`
+takes a single expression rather than a comma-separated list, and the
+gate is only supported on `RUN` lines (more precisely, on `COMMAND`
+directives); using it on any other keyword is an error.
+
+``` llvm
+; Always run this line.
+; RUN: <tool> < %s | FileCheck %s
+; Additionally run this line only when the tool under test understands
+; the 'lit-feature-A' feature and is not an asserts build.
+; RUN(lit-feature-A && !asserts): <tool> < %s  | FileCheck %s --check-prefix=FEATURE-A
+```
+
+A line continuation (trailing `\`) inherits the gate of the `RUN` line
+it continues. If *every* `RUN` line in a test is gated out, the test has
+nothing to execute and is reported as `UNSUPPORTED`, just like a test
+with no `RUN` line.
+
 ### Tips for writing constraints
 
 **`REQUIRES` and `UNSUPPORTED`**

--- a/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/Inputs/gated-run-line.ll
+++ b/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/Inputs/gated-run-line.ll
@@ -1,0 +1,9 @@
+; RUN(some-feature): opt < %s -passes='print<branch-prob>' -disable-output 2>&1 | FileCheck %s --check-prefix=GATED
+
+define void @test1() {
+entry:
+  br label %exit
+
+exit:
+  ret void
+}

--- a/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/gated-run-lines.test
+++ b/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/gated-run-lines.test
@@ -1,0 +1,8 @@
+## Feature-gated run lines in update_analyze_test_checks.py.
+
+## Recognition: the gate is stripped and the command is run like an ordinary
+## run line, so its FileCheck prefix gets generated checks.
+# RUN: cp -f %S/Inputs/gated-run-line.ll %t.ll && %update_analyze_test_checks %t.ll
+# RUN: FileCheck --input-file=%t.ll %s --check-prefix=RECOGNIZE
+# RECOGNIZE: GATED-LABEL:
+

--- a/llvm/test/tools/UpdateTestChecks/update_givaluetracking_test_checks/Inputs/gated-run-line.mir
+++ b/llvm/test/tools/UpdateTestChecks/update_givaluetracking_test_checks/Inputs/gated-run-line.mir
@@ -1,0 +1,9 @@
+# RUN(some-feature): llc -mtriple aarch64 -passes="print<gisel-value-tracking>" %s -filetype=null 2>&1 | FileCheck %s --check-prefix=GATED
+
+---
+name:            Cst
+body:             |
+  bb.1:
+    %0:_(s8) = G_CONSTANT i8 1
+    %1:_(s8) = COPY %0
+...

--- a/llvm/test/tools/UpdateTestChecks/update_givaluetracking_test_checks/gated-run-lines.test
+++ b/llvm/test/tools/UpdateTestChecks/update_givaluetracking_test_checks/gated-run-lines.test
@@ -1,0 +1,9 @@
+# REQUIRES: aarch64-registered-target
+## Feature-gated run lines in update_givaluetracking_test_checks.py.
+
+## Recognition: the gate is stripped and the command is run like an ordinary
+## run line, so its FileCheck prefix gets generated checks.
+# RUN: cp -f %S/Inputs/gated-run-line.mir %t.mir && %update_givaluetracking_test_checks %t.mir
+# RUN: FileCheck --input-file=%t.mir %s --check-prefix=RECOGNIZE
+# RECOGNIZE: GATED-LABEL:
+

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/gated-run-line.ll
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/gated-run-line.ll
@@ -1,0 +1,8 @@
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu | FileCheck %s --check-prefixes=PLAIN
+; RUN(some-feature): llc < %s -mtriple=i686-unknown-linux-gnu | FileCheck %s --check-prefixes=GATED
+
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %r = add i32 %a, %b
+  ret i32 %r
+}

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/gated-run-line.test
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/gated-run-line.test
@@ -1,0 +1,11 @@
+# REQUIRES: x86-registered-target
+## A feature-gated run line is treated like an ordinary run line: the gate is
+## stripped and the command is run, so its FileCheck prefix gets checks.
+
+# RUN: cp -f %S/Inputs/gated-run-line.ll %t.ll && %update_llc_test_checks %t.ll
+# RUN: FileCheck --input-file=%t.ll %s --check-prefix=OUTPUT
+
+## Both the plain and the gated run lines produced checks; the gate was stripped
+## from the gated command (otherwise llc would have rejected it).
+# OUTPUT-DAG: PLAIN-LABEL:
+# OUTPUT-DAG: GATED-LABEL:

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/gated-run-line.ll
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/gated-run-line.ll
@@ -1,0 +1,6 @@
+; RUN(some-feature): opt < %s -passes=instsimplify -S | FileCheck %s --check-prefix=GATED
+
+define i32 @add(i32 %a, i32 %b) {
+  %r = add i32 %a, %b
+  ret i32 %r
+}

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/gated-run-lines.test
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/gated-run-lines.test
@@ -1,0 +1,9 @@
+## Feature-gated run lines in update_test_checks.py.
+
+## Recognition: the gate is stripped and the command is run like an ordinary
+## run line, so its FileCheck prefix gets generated checks.  That any are
+## produced shows the gate was stripped (otherwise opt would have rejected it).
+# RUN: cp -f %S/Inputs/gated-run-line.ll %t.ll && %update_test_checks %t.ll
+# RUN: FileCheck --input-file=%t.ll %s --check-prefix=RECOGNIZE
+# RECOGNIZE: GATED-LABEL:
+

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -564,7 +564,13 @@ def invoke_tool(exe, cmd_args, ir, preprocess_cmd=None, verbose=False):
 
 
 ##### LLVM IR parser
-RUN_LINE_RE = re.compile(r"^\s*(?://|[;#])\s*RUN:\s*(.*)$")
+# A RUN line, which may carry a per-command feature gate written as
+# 'RUN(<expr>):' (see lit's TestRunner).  The gate is delimited but *not*
+# captured, so group(1) stays the command for every caller; the gate is simply
+# stripped so a gated line runs like an ordinary RUN line.  The inner '.*?' is
+# non-greedy so the gate ends at the first '):', while still allowing the
+# expression to contain its own (nested) parentheses, e.g. 'RUN((a || b)):'.
+RUN_LINE_RE = re.compile(r"^\s*(?://|[;#])\s*RUN(?:\(.*?\))?:\s*(.*)$")
 CHECK_PREFIX_RE = re.compile(r"--?check-prefix(?:es)?[= ](\S+)")
 PREFIX_RE = re.compile("^[a-zA-Z0-9_-]+$")
 CHECK_RE = re.compile(

--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -446,7 +446,8 @@ class Test:
         getUsedFeatures() -> list of strings
 
         Returns a list of all features appearing in XFAIL, UNSUPPORTED and
-        REQUIRES annotations for this test.
+        REQUIRES annotations, as well as in any 'RUN(<expr>):' command gate,
+        for this test.
         """
         import lit.TestRunner
 
@@ -454,9 +455,16 @@ class Test:
             self.getSourcePath(), require_script=False
         )
         feature_keywords = ("UNSUPPORTED:", "REQUIRES:", "XFAIL:")
-        boolean_expressions = itertools.chain.from_iterable(
-            parsed[k] or [] for k in feature_keywords
+        boolean_expressions = list(
+            itertools.chain.from_iterable(parsed[k] or [] for k in feature_keywords)
         )
+        # Command gates are boolean expressions too.
+        boolean_expressions += [
+            directive.gate
+            for directive in (parsed["RUN:"] or [])
+            if isinstance(directive, lit.TestRunner.CommandDirective)
+            and directive.gate is not None
+        ]
         tokens = itertools.chain.from_iterable(
             BooleanExpression.tokenize(expr)
             for expr in boolean_expressions

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -925,19 +925,53 @@ def executeScript(
         return (e.out, e.err, e.exitCode, e.msg, None)
 
 
+def _buildKeywordPattern(keyword):
+    """
+    Build the byte regex fragment matching a single keyword.
+
+    A ':'-terminated keyword may carry an optional gate, 'KEYWORD(<expr>):'
+    (see CommandDirective.gate), which _splitKeywordGate() separates back out.
+    The inner '.*?' is non-greedy so the gate ends at the first '):', while
+    backtracking against the trailing ':' still lets <expr> contain its own
+    (possibly nested) parentheses, e.g. 'RUN((a || b) && c):'.
+    """
+    kb = keyword.encode("utf-8")
+    if kb.endswith(b":"):
+        return re.escape(kb[:-1]) + rb"(?:\(.*?\))?" + re.escape(b":")
+    return re.escape(kb)
+
+
+# Matches a canonical ':'-keyword carrying a feature gate, e.g. 'RUN(expr):'.
+# Group 1 is the keyword base ('RUN'), group 2 is the gate expression ('expr').
+_keyword_gate_re = re.compile(r"([^(]+)\((.*)\):")
+
+
+def _splitKeywordGate(keyword):
+    """
+    Split a matched keyword into (canonical_keyword, gate).
+
+    'RUN(expr):' -> ('RUN:', 'expr'); 'RUN:' -> ('RUN:', None).
+    """
+    match = _keyword_gate_re.fullmatch(keyword)
+    if match:
+        return match.group(1) + ":", match.group(2).strip()
+    return keyword, None
+
+
 def parseIntegratedTestScriptCommands(source_path, keywords):
     """
     parseIntegratedTestScriptCommands(source_path) -> commands
 
     Parse the commands in an integrated test script file into a list of
-    (line_number, command_type, line).
+    (line_number, command_type, gate, line).  'gate' is the command's gate
+    expression (see CommandDirective.gate), or None.
     """
 
     # We use `bytes` for scanning input files to avoid requiring them to always
     # have valid codings.
 
     keywords_re = re.compile(
-        b"(%s)(.*)\n" % (b"|".join(re.escape(k.encode("utf-8")) for k in keywords),)
+        b"(%s)(.*)\n" % (b"|".join(_buildKeywordPattern(k) for k in keywords),)
     )
 
     f = open(source_path, "rb")
@@ -966,9 +1000,11 @@ def parseIntegratedTestScriptCommands(source_path, keywords):
             # characters from being converted to Unix \n newlines, so manually
             # strip those from the yielded lines.
             keyword, ln = match.groups()
+            command_type, gate = _splitKeywordGate(keyword.decode("utf-8"))
             yield (
                 line_number,
-                keyword.decode("utf-8"),
+                command_type,
+                gate,
                 ln.decode("utf-8").rstrip("\r"),
             )
     finally:
@@ -1152,11 +1188,23 @@ class CommandDirective(ExpandableScriptDirective):
 
     command: The content accumulated so far from the directive and its
         continuation lines.
+    gate: A feature gate written 'RUN(<expr>): ...', or None for an
+        unconditional command.  <expr> is an ordinary lit boolean expression
+        (same grammar and BooleanExpression machinery as
+        REQUIRES/UNSUPPORTED/XFAIL); the command is kept only when <expr> is
+        satisfied by the available features (see parseIntegratedTestScript).
     """
 
-    def __init__(self, start_line_number, end_line_number, keyword, line):
+    def __init__(self, start_line_number, end_line_number, keyword, line, gate):
         super().__init__(start_line_number, end_line_number, keyword)
         self.command = line.rstrip()
+        if gate is not None:
+            if not gate:
+                raise ValueError(f"'{keyword[:-1]}(...)' gate is empty")
+            # Evaluating against no features raises ValueError if <expr> is
+            # malformed; that syntax check is all we want here.
+            BooleanExpression.evaluate(gate, [])
+        self.gate = gate
 
     def add_continuation(self, line_number, keyword, line):
         if keyword != self.keyword or not self.needs_continuation():
@@ -1525,8 +1573,8 @@ class IntegratedTestKeywordParser:
         self.parser = parser
 
         if kind == ParserKind.COMMAND:
-            self.parser = lambda line_number, line, output: self._handleCommand(
-                line_number, line, output, self.keyword
+            self.parser = lambda line_number, line, output, gate: self._handleCommand(
+                line_number, line, output, self.keyword, gate
             )
         elif kind == ParserKind.LIST:
             self.parser = self._handleList
@@ -1553,10 +1601,13 @@ class IntegratedTestKeywordParser:
         else:
             raise ValueError("Unknown kind '%s'" % kind)
 
-    def parseLine(self, line_number, line):
+    def parseLine(self, line_number, line, gate):
         try:
             self.parsed_lines += [(line_number, line)]
-            self.value = self.parser(line_number, line, self.value)
+            if self.kind == ParserKind.COMMAND:
+                self.value = self.parser(line_number, line, self.value, gate)
+            else:
+                self.value = self.parser(line_number, line, self.value)
         except ValueError as e:
             raise ValueError(
                 str(e)
@@ -1584,18 +1635,19 @@ class IntegratedTestKeywordParser:
         return re.sub(r"%\(line *([\+-]) *(\d+)\)", replace_line_number, line)
 
     @classmethod
-    def _handleCommand(cls, line_number, line, output, keyword):
+    def _handleCommand(cls, line_number, line, output, keyword, gate):
         """A helper for parsing COMMAND type keywords"""
         # Substitute line number expressions.
         line = cls._substituteLineNumbers(line_number, line)
 
         # Collapse lines with trailing '\\', or add line with line number to
-        # start a new pipeline.
+        # start a new pipeline.  Only a new pipeline carries a gate; a
+        # continuation inherits it.
         if not output or not output[-1].add_continuation(line_number, keyword, line):
             if output is None:
                 output = []
             line = buildPdbgCommand(f"{keyword} at line {line_number}", line)
-            output.append(CommandDirective(line_number, line_number, keyword, line))
+            output.append(CommandDirective(line_number, line_number, keyword, line, gate))
         return output
 
     @staticmethod
@@ -1700,11 +1752,17 @@ def _parseKeywords(sourcepath, additional_parsers=[], require_script=True):
         keyword_parsers[parser.keyword] = parser
 
     # Collect the test lines from the script.
-    for line_number, command_type, ln in parseIntegratedTestScriptCommands(
+    for line_number, command_type, gate, ln in parseIntegratedTestScriptCommands(
         sourcepath, keyword_parsers.keys()
     ):
         parser = keyword_parsers[command_type]
-        parser.parseLine(line_number, ln)
+        if gate is not None and parser.kind != ParserKind.COMMAND:
+            raise ValueError(
+                "Feature gate '%s(%s):' is not supported; a '(<feature>)' gate "
+                "may only be used on COMMAND directives such as 'RUN:' "
+                "(test line %d)" % (command_type[:-1], gate, line_number)
+            )
+        parser.parseLine(line_number, ln, gate)
         if command_type == "END." and parser.getValue() is True:
             break
 
@@ -1802,6 +1860,28 @@ def parseIntegratedTestScript(test, additional_parsers=[], require_script=True):
             Test.UNSUPPORTED,
             "Test does not require any of the features "
             "specified in limit_to_features: %s" % msg,
+        )
+
+    # Drop gated commands whose expression is not satisfied by the available
+    # features; unconditional commands are kept as-is.
+    features = test.config.available_features
+    script = [
+        directive
+        for directive in script
+        if not isinstance(directive, CommandDirective)
+        or directive.gate is None
+        or BooleanExpression.evaluate(directive.gate, features)
+    ]
+
+    # If every 'RUN:' line was gated out, treat it like a missing script and
+    # mark the test unsupported -- but only when the test is expected to supply
+    # the script (require_script), not for a caller-provided preamble.
+    if require_script and not any(
+        isinstance(directive, CommandDirective) for directive in script
+    ):
+        return lit.Test.Result(
+            Test.UNSUPPORTED,
+            "Test has no 'RUN:' lines enabled for the available features",
         )
 
     return script

--- a/llvm/utils/lit/tests/Inputs/shtest-run-gate/all-gated.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-gate/all-gated.txt
@@ -1,0 +1,5 @@
+# When every run line is gated out by an unavailable feature there is nothing
+# to execute, so the test is reported UNSUPPORTED (like a test with no run
+# line).
+#
+# RUN(absent): echo NOPE

--- a/llvm/utils/lit/tests/Inputs/shtest-run-gate/bad-gate-expr.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-gate/bad-gate-expr.txt
@@ -1,0 +1,4 @@
+# A run-line gate must be a syntactically valid lit boolean expression;
+# a malformed one is a parse error (the same check REQUIRES/UNSUPPORTED use).
+#
+# RUN(present &&): echo NOPE

--- a/llvm/utils/lit/tests/Inputs/shtest-run-gate/gate-on-non-command.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-gate/gate-on-non-command.txt
@@ -1,0 +1,5 @@
+# A feature gate is only supported on COMMAND directives such as RUN:.  Using
+# it on any other keyword is a parse error.
+#
+# RUN: echo hi
+# REQUIRES(present): true

--- a/llvm/utils/lit/tests/Inputs/shtest-run-gate/gate.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-gate/gate.txt
@@ -1,0 +1,16 @@
+# An ungated run line always runs.  A gated run line runs only when its lit
+# boolean expression is satisfied by the available features; here 'present' is
+# available and 'absent' is not.  Every SKIP_* line must be gated out.
+#
+# RUN: echo RUNS_PLAIN
+# RUN(present): echo RUNS_PRESENT
+# RUN(present || absent): echo RUNS_OR
+# RUN(!absent): echo RUNS_NOTABSENT
+# RUN((present || absent) && !absent): echo RUNS_GROUPED
+# RUN(present): echo RUNS_CONT_A \
+# RUN:   && echo RUNS_CONT_B
+# RUN(absent): echo SKIP_CONT_A \
+# RUN:   && echo SKIP_CONT_B
+# RUN(absent): echo SKIP_ABSENT
+# RUN(present && absent): echo SKIP_AND
+# RUN(!present): echo SKIP_NOTPRESENT

--- a/llvm/utils/lit/tests/Inputs/shtest-run-gate/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-gate/lit.cfg
@@ -1,0 +1,9 @@
+import lit.formats
+
+config.name = "shtest-run-gate"
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+config.suffixes = [".txt"]
+# 'present' is an available feature; 'absent' is deliberately never added.
+config.available_features.add("present")

--- a/llvm/utils/lit/tests/shtest-run-gate.py
+++ b/llvm/utils/lit/tests/shtest-run-gate.py
@@ -1,0 +1,53 @@
+# Tests for the per-command feature gate on run lines, written as "RUN"
+# immediately followed by "(<expr>):", where <expr> is a lit boolean
+# expression (the same grammar as REQUIRES/UNSUPPORTED/XFAIL).
+#
+# The fixture suite (Inputs/shtest-run-gate/lit.cfg) makes the feature
+# 'present' available and deliberately never defines 'absent'.
+#
+# Note: directive keywords are escaped (e.g. written as {{RUN}} then a colon)
+# in the CHECK lines below so that lit does not mistake them for directives of
+# *this* test.
+
+# An ungated run line always runs; a gated run line runs only when its boolean
+# expression holds.  Here 'present' is available and 'absent' is not, so every
+# SKIP_* command must be gated out while every RUNS_* command executes.  A
+# continuation line (trailing '\') inherits the gate of the RUN line it
+# continues: RUNS_CONT_A/RUNS_CONT_B run as one gated-in command, while the
+# gated-out SKIP_CONT continuation is dropped whole.
+#
+# RUN: %{lit} -v --show-all %{inputs}/shtest-run-gate/gate.txt \
+# RUN:   | FileCheck %s --check-prefix=GATE --implicit-check-not=SKIP_
+#
+# GATE: PASS: shtest-run-gate :: gate.txt
+# GATE: echo RUNS_PLAIN
+# GATE: echo RUNS_PRESENT
+# GATE: echo RUNS_OR
+# GATE: echo RUNS_NOTABSENT
+# GATE: echo RUNS_GROUPED
+# GATE: echo RUNS_CONT_A && echo RUNS_CONT_B
+
+# When every run line is gated out, the test is unsupported (lit exits 0).
+#
+# RUN: %{lit} -v --show-all %{inputs}/shtest-run-gate/all-gated.txt \
+# RUN:   | FileCheck %s --check-prefix=ALLGATED
+#
+# ALLGATED: {{UNSUPPORTED}}: shtest-run-gate :: all-gated.txt
+# ALLGATED: no '{{RUN}}:' lines enabled for the available features
+
+# A gate must be a syntactically valid boolean expression; a malformed one is
+# reported by the same BooleanExpression check the other keywords use.
+#
+# RUN: not %{lit} -v --show-all %{inputs}/shtest-run-gate/bad-gate-expr.txt \
+# RUN:   | FileCheck %s --check-prefix=BADEXPR
+#
+# BADEXPR: UNRESOLVED: shtest-run-gate :: bad-gate-expr.txt
+# BADEXPR: expected: {{.*}}or identifier
+
+# A gate is only supported on COMMAND directives (i.e. run lines).
+#
+# RUN: not %{lit} -v --show-all %{inputs}/shtest-run-gate/gate-on-non-command.txt \
+# RUN:   | FileCheck %s --check-prefix=NONCMD
+#
+# NONCMD: UNRESOLVED: shtest-run-gate :: gate-on-non-command.txt
+# NONCMD: Feature gate {{.*}} may only be used on COMMAND directives

--- a/llvm/utils/lit/tests/unit/TestRunner.py
+++ b/llvm/utils/lit/tests/unit/TestRunner.py
@@ -134,6 +134,35 @@ class TestIntegratedTestKeywordParser(unittest.TestCase):
         self.assertEqual(value[0].command.strip(), "%dbg(MY_RUN: at line 4)  baz")
         self.assertEqual(value[1].command.strip(), "%dbg(MY_RUN: at line 12)  foo  bar")
 
+    def test_command_gate_split(self):
+        # A COMMAND-style keyword may carry a 'KEYWORD(<expr>):' gate; the
+        # canonical keyword and the boolean expression are separated by
+        # _splitKeywordGate.  Surrounding whitespace in the gate is stripped,
+        # and the expression may contain operators and (nested) parentheses.
+        split = lit.TestRunner._splitKeywordGate
+        self.assertEqual(split("RUN:"), ("RUN:", None))
+        self.assertEqual(split("RUN(lit-feature-A):"), ("RUN:", "lit-feature-A"))
+        self.assertEqual(split("RUN( foo ):"), ("RUN:", "foo"))
+        self.assertEqual(split("RUN(a && !b):"), ("RUN:", "a && !b"))
+        self.assertEqual(split("RUN((a || b) && c):"), ("RUN:", "(a || b) && c"))
+        # A keyword with no gate is returned unchanged (gate is None).
+        self.assertEqual(split("XFAIL:"), ("XFAIL:", None))
+
+    def test_command_gate_validation(self):
+        # A gated CommandDirective records the boolean expression it is gated
+        # on; any expression accepted by REQUIRES/UNSUPPORTED/XFAIL is valid.
+        for good in ("feat", "a && b", "!x", "(a || b) && !c", "he{{l+}}o"):
+            directive = lit.TestRunner.CommandDirective(1, 1, "RUN:", "echo hi", good)
+            self.assertEqual(directive.gate, good)
+        # An ungated command has gate None.
+        directive = lit.TestRunner.CommandDirective(1, 1, "RUN:", "echo hi", None)
+        self.assertIsNone(directive.gate)
+        # A malformed expression (or an empty gate) is rejected, using the same
+        # BooleanExpression syntax check as the BOOLEAN_EXPR keywords.
+        for bad in ("a &&", "&& b", "(a", ""):
+            with self.assertRaises(ValueError):
+                lit.TestRunner.CommandDirective(1, 1, "RUN:", "echo hi", bad)
+
     def test_boolean(self):
         parsers = self.make_parsers()
         self.parse_test(parsers)


### PR DESCRIPTION
Add a way to gate an individual RUN line on a lit feature. Writing the RUN keyword immediately followed by a parenthesized expression, "RUN(<expr>): <command>", includes that command in the test script only when <expr> is satisfied; the test's other RUN lines are unaffected. This complements REQUIRES/UNSUPPORTED/XFAIL, which can only gate a test as a whole.

<expr> is an ordinary lit boolean expression: it uses the same grammar and is parsed and evaluated by the same machinery as REQUIRES/UNSUPPORTED/XFAIL, against the same set of available features. It may therefore combine features with &&, || and !, use grouping parentheses, and match features with {{regex}}, for example "RUN(lit-feature-A && !lit-feature-B):". A malformed expression is reported the same way it is for those keywords.

The gate is only accepted on RUN (COMMAND) directives; using it on any other keyword is an error. A line continuation inherits the gate of the RUN line it continues, and if every RUN line in a test is gated out the test is reported UNSUPPORTED, just like a test with no RUN line.

Documentation is added to TestingGuide.rst, and the feature is covered by new unit tests and a lit integration test (shtest-run-gate).

Teach the update_*_test_checks (UTC) scripts about the new per-command lit feature gate, 'RUN(<expr>): <command>'.