### PR TITLE
[clang-tidy] reword the diag messages of `TemplateVirtualMemberFunctionCheck`

### DIFF
--- a/clang-tools-extra/clang-tidy/portability/TemplateVirtualMemberFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/portability/TemplateVirtualMemberFunctionCheck.cpp
@@ -35,11 +35,12 @@ void TemplateVirtualMemberFunctionCheck::check(
   const auto *MethodDecl = Result.Nodes.getNodeAs<CXXMethodDecl>("method");
 
   diag(MethodDecl->getLocation(),
-       "unspecified virtual member function instantiation; the virtual "
-       "member function is not instantiated but it might be with a "
-       "different compiler");
+       "it is unspecified whether or not an implementation implicitly "
+       "instantiates a virtual member function of a class template if the "
+       "virtual member function would not otherwise be instantiated; consider "
+       "using or removing the virtual member function for better portability");
   diag(ImplicitSpecialization->getPointOfInstantiation(),
-       "template instantiated here", DiagnosticIDs::Note);
+       "class template instantiated here", DiagnosticIDs::Note);
 }
 
 } // namespace clang::tidy::portability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -94,6 +94,10 @@ Improvements to clang-query
 Improvements to clang-tidy
 --------------------------
 
+- Improved :doc:`portability-template-virtual-member-function
+  <clang-tidy/checks/portability/template-virtual-member-function>` check to
+  make it easier to understand what the issue is and how to fix it.
+
 New checks
 ^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/checkers/portability/template-virtual-member-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/portability/template-virtual-member-function.cpp
@@ -6,14 +6,14 @@ struct CrossPlatformError {
 
     static void used() {}
 
-    // CHECK-MESSAGES: [[#@LINE+1]]:18: warning: unspecified virtual member function instantiation
+    // CHECK-MESSAGES: [[#@LINE+1]]:18: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
     virtual void unused() {
         T MSVCError = this;
     };
 };
 
 int main() {
-    // CHECK-MESSAGES: [[#@LINE+1]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+1]]:5: note: class template instantiated here
     CrossPlatformError<int>::used();
     return 0;
 }
@@ -26,14 +26,14 @@ struct CrossPlatformError {
 
     static void used() {}
 
-    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: unspecified virtual member function instantiation
-    // CHECK-MESSAGES: [[#@LINE+13]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
+    // CHECK-MESSAGES: [[#@LINE+13]]:5: note: class template instantiated here
     virtual void unused() {
         T MSVCError = this;
     };
 
-    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: unspecified virtual member function instantiation
-    // CHECK-MESSAGES: [[#@LINE+7]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
+    // CHECK-MESSAGES: [[#@LINE+7]]:5: note: class template instantiated here
     virtual void unused2() {
         T MSVCError = this;
     };
@@ -48,8 +48,8 @@ int main() {
 namespace UninstantiatedVirtualDestructor {
 template<typename T>
 struct CrossPlatformError {
-    // CHECK-MESSAGES: [[#@LINE+2]]:13: warning: unspecified virtual member function instantiation
-    // CHECK-MESSAGES: [[#@LINE+9]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+2]]:13: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
+    // CHECK-MESSAGES: [[#@LINE+9]]:5: note: class template instantiated here
     virtual ~CrossPlatformError() {
         T MSVCError = this;
     };
@@ -70,8 +70,8 @@ struct CrossPlatformError {
 
     static void used() {}
 
-    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: unspecified virtual member function instantiation
-    // CHECK-MESSAGES: [[#@LINE+7]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
+    // CHECK-MESSAGES: [[#@LINE+7]]:5: note: class template instantiated here
     virtual void unused() {
         T MSVCError = this;
     };
@@ -91,8 +91,8 @@ template <typename T> struct CrossPlatformError {
 
     static void used() {}
 
-    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: unspecified virtual member function instantiation
-    // CHECK-MESSAGES: [[#@LINE+5]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
+    // CHECK-MESSAGES: [[#@LINE+5]]:5: note: class template instantiated here
     virtual void unused(){};
 };
 
@@ -143,8 +143,8 @@ struct CrossPlatformError<int, U>{
 
     static void used() {}
 
-    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: unspecified virtual member function instantiation
-    // CHECK-MESSAGES: [[#@LINE+7]]:5: note: template instantiated here
+    // CHECK-MESSAGES: [[#@LINE+2]]:18: warning: it is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated; consider using or removing the virtual member function for better portability
+    // CHECK-MESSAGES: [[#@LINE+7]]:5: note: class template instantiated here
     virtual void unused() {
         U MSVCError = this;
     };


### PR DESCRIPTION
The previous diag message caused a lot of confusion for users, as the wording made it unclear what the problem is, and how to fix it. This change ensures that the diag message explicitly states the issue and recommends a fix for it.

Fixes #153155
Fixes #206767