### PR TITLE
[dsymutil] Drop icf-ed DIE if size mismatch

### DIFF
--- a/llvm/docs/CommandGuide/dsymutil.rst
+++ b/llvm/docs/CommandGuide/dsymutil.rst
@@ -57,6 +57,17 @@ OPTIONS
  N_OSO entries. If `--oso-prepend-path` is specified, the path prefix applies,
  i.e. paths in the file should exact match that of N_OSO entries.
 
+.. option:: --drop-icf-shrunk-subprograms
+
+ Drop ``DW_TAG_subprogram`` DIEs whose debug-map size is strictly smaller
+ than the DIE's compile-time ``high_pc - low_pc``. Intended for use with
+ linkers that perform aggressive ICF that folds a function body into a
+ smaller branch-only stub (for example lld's ``--icf=fbsafe_thunks``), where
+ keeping the DIE at its original size would trigger the DWARF verifier's
+ "DIEs have overlapping address ranges" check. The dropped DIE's aranges /
+ ``.debug_frame`` entries are still emitted at the smaller (actual) size.
+ Currently supported only with ``--linker classic``.
+
 .. option:: --dump-debug-map
 
  Dump the *executable*'s debug-map (the list of the object files containing the

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -104,6 +104,14 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the LLVM tools
 
+* `dsymutil` gained a `--drop-icf-shrunk-subprograms` flag that drops
+  `DW_TAG_subprogram` DIEs whose debug-map size is strictly smaller than the
+  DIE's compile-time `high_pc - low_pc`. This is intended for linkers that
+  perform aggressive ICF that folds a function body into a smaller
+  branch-only stub, where keeping the DIE at its original size would trigger
+  the DWARF verifier's "DIEs have overlapping address ranges" check.
+  Currently supported only with `--linker classic`.
+
 ### Changes to LLDB
 
 #### Windows

--- a/llvm/include/llvm/DWARFLinker/AddressesMap.h
+++ b/llvm/include/llvm/DWARFLinker/AddressesMap.h
@@ -55,6 +55,31 @@ public:
   virtual std::optional<int64_t>
   getSubprogramRelocAdjustment(const DWARFDie &DIE, bool Verbose) = 0;
 
+  /// Returns the size of the subprogram \p DIE's symbol in the final linked
+  /// binary as reported by the debug map / symbol table, or std::nullopt if
+  /// no such information is available.
+  ///
+  /// Used by DWARFLinker to detect post-link symbol shrinkage: when a linker
+  /// pass (for example, an aggressive ICF mode that replaces the body of an
+  /// identical function with a small branch-only stub) makes the final
+  /// symbol strictly smaller than what the DIE's compile-time
+  /// `high_pc - low_pc` says, keeping the DIE would produce two failures:
+  ///
+  ///   1. "DIEs have overlapping address ranges" -- dsymutil's additive PC
+  ///      shift preserves the original compile-time size, so the emitted DIE
+  ///      claims a range that overlaps the next symbol's stub in the binary.
+  ///   2. "DIE address ranges are not contained in its parent's ranges" --
+  ///      if we tried to clamp the parent's high_pc, its inlined-subroutine
+  ///      children (which still describe instructions in the pre-fold body)
+  ///      would fall outside the clamped range.
+  ///
+  /// Default returns std::nullopt for AddressesMap implementations that do
+  /// not carry per-symbol size information; in that case DWARFLinker keeps
+  /// its pre-existing behavior of trusting the DIE's compile-time size.
+  virtual std::optional<uint64_t> getSubprogramBinarySize(const DWARFDie &DIE) {
+    return std::nullopt;
+  }
+
   // Returns the library install name associated to the AddessesMap.
   virtual std::optional<StringRef> getLibraryInstallName() = 0;
 

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinker.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinker.h
@@ -272,6 +272,12 @@ public:
     Options.KeepFunctionForStatic = KeepFunctionForStatic;
   }
 
+  /// Set whether to drop DW_TAG_subprogram DIEs whose debug-map size is
+  /// strictly smaller than the DIE's compile-time high_pc - low_pc.
+  void setDropIcfShrunkSubprograms(bool DropIcfShrunkSubprograms) override {
+    Options.DropIcfShrunkSubprograms = DropIcfShrunkSubprograms;
+  }
+
   /// Use specified number of threads for parallel files linking.
   void setNumThreads(unsigned NumThreads) override {
     Options.Threads = NumThreads;
@@ -818,6 +824,11 @@ private:
     /// Whether we want a static variable to force us to keep its enclosing
     /// function.
     bool KeepFunctionForStatic = false;
+
+    /// Drop DW_TAG_subprogram DIEs whose debug-map size is strictly
+    /// smaller than the DIE's compile-time high_pc - low_pc. Guards the
+    /// ICF-shrunk-subprogram drop in shouldKeepSubprogramDIE.
+    bool DropIcfShrunkSubprograms = false;
 
     /// Number of threads.
     unsigned Threads = 1;

--- a/llvm/include/llvm/DWARFLinker/DWARFLinkerBase.h
+++ b/llvm/include/llvm/DWARFLinker/DWARFLinkerBase.h
@@ -122,6 +122,10 @@ public:
   virtual void setUpdateIndexTablesOnly(bool Update) = 0;
   /// Set whether to keep the enclosing function for a static variable.
   virtual void setKeepFunctionForStatic(bool KeepFunctionForStatic) = 0;
+  /// Set whether to drop DW_TAG_subprogram DIEs whose debug-map size is
+  /// strictly smaller than the DIE's compile-time high_pc - low_pc.
+  /// Default is a no-op; override on linkers that support the check.
+  virtual void setDropIcfShrunkSubprograms(bool DropIcfShrunkSubprograms) {}
   /// Use specified number of threads for parallel files linking.
   virtual void setNumThreads(unsigned NumThreads) = 0;
   /// Add kind of accelerator tables to be generated.

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -644,6 +644,62 @@ unsigned DWARFLinker::shouldKeepSubprogramDIE(
   if (!RelocAdjustment)
     return Flags;
 
+  // If a linker pass shrunk this subprogram post-link (e.g. an aggressive
+  // ICF mode that replaced its body with a small branch-only stub), the
+  // debug-map size will be strictly smaller than the DIE's compile-time
+  // size. Keeping the DIE would produce:
+  //   (a) "DIEs have overlapping address ranges" -- the additive PC shift
+  //       preserves the original size, so the emitted DIE claims a range
+  //       that overlaps the next symbol's stub, and
+  //   (b) "DIE address ranges are not contained in its parent's ranges"
+  //       for inlined_subroutine children (which still describe
+  //       instructions in the pre-fold body).
+  // Drop the entire subprogram DIE tree in that case: treat it as though
+  // the symbol were absent from the debug map. The debug map / symbol
+  // table still records the name->address mapping for stack symbolication;
+  // we drop only the compile-time debug tree that no longer describes
+  // real code. We still register the clamped range with
+  // `Unit.addFunctionRange` so aranges and .debug_frame FDEs cover the
+  // actual bytes present in the linked binary.
+  //
+  // Opt-in via `--drop-icf-shrunk-subprograms`. Off by default: several
+  // existing tests intentionally hand-author debug-map YAMLs with sizes
+  // smaller than the DIE's compile-time size and expect the DIE to still
+  // be emitted, so unconditionally dropping would be a behavior change.
+  if (Options.DropIcfShrunkSubprograms &&
+      DIE.getTag() == dwarf::DW_TAG_subprogram) {
+    if (std::optional<uint64_t> HighPc = DIE.getHighPC(*LowPc)) {
+      if (std::optional<uint64_t> BinSize =
+              RelocMgr.getSubprogramBinarySize(DIE)) {
+        if (*BinSize > 0 && *HighPc >= *LowPc &&
+            *BinSize < (*HighPc - *LowPc)) {
+          if (Options.Verbose) {
+            outs() << "Dropping ICF-shrunk subprogram DIE (compile-time size 0x"
+                   << Twine::utohexstr(*HighPc - *LowPc)
+                   << ", debug-map size 0x" << Twine::utohexstr(*BinSize)
+                   << "):";
+            DIDumpOptions DumpOpts;
+            DumpOpts.ChildRecurseDepth = 0;
+            DumpOpts.Verbose = true;
+            DIE.dump(outs(), 8 /* Indent */, DumpOpts);
+          }
+          Unit.addFunctionRange(*LowPc, *LowPc + *BinSize, *RelocAdjustment);
+          // Return without TF_Keep. This drops the subprogram DIE from *this*
+          // walk, but a subsequent lookForChildDIEsToKeep pass still visits
+          // the children -- an individually-kept child (for example a static
+          // local under --keep-function-for-static) will force Info.Keep=true
+          // on this subprogram through lookForParentDIEsToKeep. In that
+          // follow-up path we never set MyInfo.InDebugMap, so cloning takes
+          // the `!Info.InDebugMap` branch further down (which OR-s in
+          // TF_SkipPC) and strips low_pc/high_pc/ranges. The emitted DIE
+          // therefore carries no PC info and cannot overlap the next symbol,
+          // but it is not literally pruned.
+          return Flags;
+        }
+      }
+    }
+  }
+
   MyInfo.AddrAdjust = *RelocAdjustment;
   MyInfo.InDebugMap = true;
 

--- a/llvm/test/tools/dsymutil/AArch64/subprogram-die-icf-shrunk.test
+++ b/llvm/test/tools/dsymutil/AArch64/subprogram-die-icf-shrunk.test
@@ -1,0 +1,109 @@
+# Behavior WITHOUT --drop-icf-shrunk-subprograms (default): DIE is kept, even
+# when the debug-map size (0x0c) is smaller than the DIE's compile-time size
+# (0x10). Preserves pre-existing dsymutil behavior.
+# RUN: dsymutil --linker classic -no-output -verbose \
+# RUN:     -oso-prepend-path=%p/../Inputs -y %s \
+# RUN:   | FileCheck %s --check-prefix=DEFAULT
+#
+# Behavior WITH --drop-icf-shrunk-subprograms: DIE is dropped.
+# RUN: dsymutil --linker classic --drop-icf-shrunk-subprograms -no-output \
+# RUN:     -verbose -oso-prepend-path=%p/../Inputs -y %s \
+# RUN:   | FileCheck %s --check-prefix=DROP \
+# RUN:       --implicit-check-not="Keeping subprogram DIE:"
+#
+# Boundary: debug-map size == compile-time DIE size. Not shrunk -> must NOT drop.
+# RUN: sed 's/size: 0x0000000C/size: 0x00000010/' %s > %t-equal.yaml
+# RUN: dsymutil --linker classic --drop-icf-shrunk-subprograms -no-output \
+# RUN:     -verbose -oso-prepend-path=%p/../Inputs -y %t-equal.yaml \
+# RUN:   | FileCheck %s --check-prefix=NOSHRUNK \
+# RUN:       --implicit-check-not="Dropping ICF-shrunk subprogram DIE"
+#
+# Boundary: debug-map size > compile-time DIE size (grown symbol; shouldn't
+# happen in practice but must NOT drop).
+# RUN: sed 's/size: 0x0000000C/size: 0x00000020/' %s > %t-grown.yaml
+# RUN: dsymutil --linker classic --drop-icf-shrunk-subprograms -no-output \
+# RUN:     -verbose -oso-prepend-path=%p/../Inputs -y %t-grown.yaml \
+# RUN:   | FileCheck %s --check-prefix=NOSHRUNK \
+# RUN:       --implicit-check-not="Dropping ICF-shrunk subprogram DIE"
+#
+# Boundary: debug-map size == 0 (no meaningful size info; guarded by
+# `*BinSize > 0` in shouldKeepSubprogramDIE). Must NOT drop.
+# RUN: sed 's/size: 0x0000000C/size: 0x00000000/' %s > %t-zero.yaml
+# RUN: dsymutil --linker classic --drop-icf-shrunk-subprograms -no-output \
+# RUN:     -verbose -oso-prepend-path=%p/../Inputs -y %t-zero.yaml \
+# RUN:   | FileCheck %s --check-prefix=NOSHRUNK \
+# RUN:       --implicit-check-not="Dropping ICF-shrunk subprogram DIE"
+#
+# End-to-end: with the flag, dsymutil produces a real dSYM file, its
+# built-in DWARF verifier passes, and the standalone llvm-dwarfdump --verify
+# on the resulting dSYM also passes. Dumping the dSYM confirms the shrunk
+# subprogram DIE is absent while other DIEs (the compile unit, base types)
+# are preserved.
+# RUN: rm -rf %t.dSYM
+# RUN: dsymutil --linker classic --drop-icf-shrunk-subprograms -verify \
+# RUN:     -oso-prepend-path=%p/../Inputs -y %s -o %t.dSYM 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=VERIFY --allow-empty
+# RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=DWARFDUMP-VERIFY
+# RUN: llvm-dwarfdump -a %t.dSYM \
+# RUN:   | FileCheck %s --check-prefix=DUMP
+#
+# Regression test: when a subprogram's final-binary size (from the debug map)
+# is strictly smaller than the DIE's compile-time `high_pc - low_pc` (as
+# happens when an aggressive linker ICF mode folds an arm64 function body
+# into a 12-byte adrp+add+br stub), keeping the subprogram DIE would produce
+# "DIEs have overlapping address ranges" from the DWARF verifier because
+# dsymutil's additive PC shift preserves the original compile-time size,
+# causing the emitted DIE to overlap the next symbol's stub.
+#
+# With --drop-icf-shrunk-subprograms, DWARFLinker drops the whole subprogram
+# DIE tree in this situation. The debug-map lookup itself still succeeds --
+# the symbol table entry is preserved for stack symbolication. Only the
+# compile-time debug tree is dropped, since it no longer describes real code.
+#
+# The `_foo` symbol in Inputs/discriminator.arm64.o has a compile-time DIE
+# size of 0x10 (high_pc - low_pc) and its low_pc uses DW_FORM_addrx (DWARF 5),
+# exercising the addrx branch of `getSubprogramBinarySize`. The YAML debug
+# map below claims a post-link size of 0x0c to simulate ICF shrinkage.
+#
+# DEFAULT: Found valid debug map entry: _foo
+# DEFAULT: Keeping subprogram DIE:
+# DEFAULT-NEXT: DW_TAG_subprogram
+# DEFAULT-NEXT: DW_AT_low_pc
+# DEFAULT-NEXT: DW_AT_high_pc
+# DEFAULT-NOT: Dropping ICF-shrunk subprogram DIE
+#
+# DROP: Found valid debug map entry: _foo
+# DROP: Dropping ICF-shrunk subprogram DIE (compile-time size 0x10, debug-map size 0xc):
+# DROP-NEXT: DW_TAG_subprogram
+# DROP-NEXT: DW_AT_low_pc
+# DROP-NEXT: DW_AT_high_pc
+#
+# NOSHRUNK: Found valid debug map entry: _foo
+# NOSHRUNK: Keeping subprogram DIE:
+# NOSHRUNK-NEXT: DW_TAG_subprogram
+#
+# The dsymutil -verify pass must not report any output-verification failure,
+# and dsymutil must exit 0 (the RUN would fail otherwise -- it isn't wrapped
+# in `not`).
+# VERIFY-NOT: error: output verification failed
+#
+# The independent llvm-dwarfdump --verify pass on the resulting dSYM must
+# also succeed (no verification errors).
+# DWARFDUMP-VERIFY: Verifying {{.*}}subprogram-die-icf-shrunk
+# DWARFDUMP-VERIFY: No errors.
+#
+# The resulting dSYM contains the compile unit but not the dropped _foo
+# subprogram DIE.
+# DUMP: file format Mach-O arm64
+# DUMP: DW_TAG_compile_unit
+# DUMP-NOT: DW_TAG_subprogram
+# DUMP-NOT: DW_AT_name{{.*}}"foo"
+
+---
+triple:          'arm64-apple-darwin'
+objects:
+  - filename: discriminator.arm64.o
+    symbols:
+      - { sym: _foo, objAddr: 0x0, binAddr: 0x0000000100000EA0, size: 0x0000000C }
+...

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -743,8 +743,7 @@ bool DwarfLinkerForBinary::linkImpl(
   GeneralLinker->setNumThreads(Options.Threads);
   GeneralLinker->setPrependPath(Options.PrependPath);
   GeneralLinker->setKeepFunctionForStatic(Options.KeepFunctionForStatic);
-  GeneralLinker->setDropIcfShrunkSubprograms(
-      Options.DropIcfShrunkSubprograms);
+  GeneralLinker->setDropIcfShrunkSubprograms(Options.DropIcfShrunkSubprograms);
   GeneralLinker->setThreadPool(ThreadPool);
   GeneralLinker->setInputVerificationHandler(
       [&](const DWARFFile &File, llvm::StringRef Output) {
@@ -1324,9 +1323,9 @@ DwarfLinkerForBinary::AddressManager::getSubprogramBinarySize(
     if (std::optional<uint64_t> AddressOffset =
             DIE.getDwarfUnit()->getIndexedAddressOffset(
                 AddrValue->getRawUValue()))
-      return SizeFromRelocs(
-          ValidDebugAddrRelocs, *AddressOffset,
-          *AddressOffset + DIE.getDwarfUnit()->getAddressByteSize());
+      return SizeFromRelocs(ValidDebugAddrRelocs, *AddressOffset,
+                            *AddressOffset +
+                                DIE.getDwarfUnit()->getAddressByteSize());
     return std::nullopt;
   }
   default:

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -743,6 +743,8 @@ bool DwarfLinkerForBinary::linkImpl(
   GeneralLinker->setNumThreads(Options.Threads);
   GeneralLinker->setPrependPath(Options.PrependPath);
   GeneralLinker->setKeepFunctionForStatic(Options.KeepFunctionForStatic);
+  GeneralLinker->setDropIcfShrunkSubprograms(
+      Options.DropIcfShrunkSubprograms);
   GeneralLinker->setThreadPool(ThreadPool);
   GeneralLinker->setInputVerificationHandler(
       [&](const DWARFFile &File, llvm::StringRef Output) {
@@ -1258,6 +1260,8 @@ DwarfLinkerForBinary::AddressManager::getSubprogramRelocAdjustment(
   case dwarf::DW_FORM_addrx3:
   case dwarf::DW_FORM_addrx4: {
     std::optional<DWARFFormValue> AddrValue = DIE.find(dwarf::DW_AT_low_pc);
+    if (!AddrValue)
+      return std::nullopt;
     if (std::optional<uint64_t> AddressOffset =
             DIE.getDwarfUnit()->getIndexedAddressOffset(
                 AddrValue->getRawUValue()))
@@ -1266,6 +1270,63 @@ DwarfLinkerForBinary::AddressManager::getSubprogramRelocAdjustment(
           *AddressOffset + DIE.getDwarfUnit()->getAddressByteSize(), Verbose);
 
     Linker.reportWarning("no base offset for address table", SrcFileName);
+    return std::nullopt;
+  }
+  default:
+    return std::nullopt;
+  }
+}
+
+std::optional<uint64_t>
+DwarfLinkerForBinary::AddressManager::getSubprogramBinarySize(
+    const DWARFDie &DIE) {
+  const auto *Abbrev = DIE.getAbbreviationDeclarationPtr();
+  std::optional<uint32_t> LowPcIdx =
+      Abbrev->findAttributeIndex(dwarf::DW_AT_low_pc);
+  if (!LowPcIdx)
+    return std::nullopt;
+
+  // Locate the ValidReloc that anchors this DIE's low_pc (same lookup as in
+  // getSubprogramRelocAdjustment above), then read the debug-map's Size for
+  // the associated symbol.
+  auto SizeFromRelocs = [&](const std::vector<ValidReloc> &Relocs,
+                            uint64_t StartOffset,
+                            uint64_t EndOffset) -> std::optional<uint64_t> {
+    std::vector<ValidReloc> Found =
+        getRelocations(Relocs, StartOffset, EndOffset);
+    if (Found.empty())
+      return std::nullopt;
+    return Found[0].SymbolMapping.Size;
+  };
+
+  dwarf::Form Form = Abbrev->getFormByIndex(*LowPcIdx);
+  switch (Form) {
+  case dwarf::DW_FORM_addr: {
+    uint64_t Offset = DIE.getOffset() + getULEB128Size(Abbrev->getCode());
+    uint64_t LowPcOffset, LowPcEndOffset;
+    std::tie(LowPcOffset, LowPcEndOffset) =
+        getAttributeOffsets(Abbrev, *LowPcIdx, Offset, *DIE.getDwarfUnit());
+    // Note: for DW_TAG_subprogram, the low_pc relocation's addend is 0 in
+    // practice (subprogram symbols are always addressed at their start), so
+    // SymbolMapping.Size -- which is the whole-symbol size from the debug
+    // map -- is what we want without any addend adjustment. Do NOT rewrite
+    // this to `Size - Addend` without also handling non-subprogram callers.
+    return SizeFromRelocs(ValidDebugInfoRelocs, LowPcOffset, LowPcEndOffset);
+  }
+  case dwarf::DW_FORM_addrx:
+  case dwarf::DW_FORM_addrx1:
+  case dwarf::DW_FORM_addrx2:
+  case dwarf::DW_FORM_addrx3:
+  case dwarf::DW_FORM_addrx4: {
+    std::optional<DWARFFormValue> AddrValue = DIE.find(dwarf::DW_AT_low_pc);
+    if (!AddrValue)
+      return std::nullopt;
+    if (std::optional<uint64_t> AddressOffset =
+            DIE.getDwarfUnit()->getIndexedAddressOffset(
+                AddrValue->getRawUValue()))
+      return SizeFromRelocs(
+          ValidDebugAddrRelocs, *AddressOffset,
+          *AddressOffset + DIE.getDwarfUnit()->getAddressByteSize());
     return std::nullopt;
   }
   default:

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -221,6 +221,9 @@ private:
     std::optional<int64_t> getSubprogramRelocAdjustment(const DWARFDie &DIE,
                                                         bool Verbose) override;
 
+    std::optional<uint64_t>
+    getSubprogramBinarySize(const DWARFDie &DIE) override;
+
     std::optional<StringRef> getLibraryInstallName() override;
 
     bool applyValidRelocs(MutableArrayRef<char> Data, uint64_t BaseOffset,

--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -64,6 +64,10 @@ struct LinkOptions {
   /// function.
   bool KeepFunctionForStatic = false;
 
+  /// Drop DW_TAG_subprogram DIEs whose debug-map size is strictly smaller
+  /// than the DIE's compile-time `high_pc - low_pc`.
+  bool DropIcfShrunkSubprograms = false;
+
   /// Type of DWARFLinker to use.
   DsymutilDWARFLinkerType DWARFLinkerType = DsymutilDWARFLinkerType::Parallel;
 

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -36,6 +36,19 @@ def keep_func_for_static: F<"keep-function-for-static">,
   HelpText<"Make a static variable keep the enclosing function even if it would have been omitted otherwise.">,
   Group<grp_general>;
 
+def drop_icf_shrunk_subprograms: F<"drop-icf-shrunk-subprograms">,
+  HelpText<"Drop DW_TAG_subprogram DIEs whose debug-map size is strictly "
+           "smaller than the DIE's compile-time high_pc - low_pc. Intended "
+           "for use with linkers that perform aggressive ICF that folds a "
+           "function body into a smaller branch-only stub (e.g. lld's "
+           "--icf=fbsafe_thunks), where keeping the DIE at its original size "
+           "would trigger the DWARF verifier's 'DIEs have overlapping address "
+           "ranges' check. The dropped DIE's aranges / .debug_frame entries "
+           "are still emitted at the smaller (actual) size."
+           " Currently supported only with --linker classic; combining with "
+           "--linker parallel is a hard error.">,
+  Group<grp_general>;
+
 def statistics: F<"statistics">,
   HelpText<"Print statistics about the contribution of each object file to "
            "the linked debug info. This prints a table after linking with the "

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -348,6 +348,8 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   Options.LinkOpts.Fat64 = Args.hasArg(OPT_fat64);
   Options.LinkOpts.KeepFunctionForStatic =
       Args.hasArg(OPT_keep_func_for_static);
+  Options.LinkOpts.DropIcfShrunkSubprograms =
+      Args.hasArg(OPT_drop_icf_shrunk_subprograms);
   Options.LinkOpts.AllowSectionHeaderOffsetOverflow =
       Args.hasArg(OPT_allow_section_header_offset_overflow);
 
@@ -374,6 +376,13 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   } else {
     return DWARFLinkerType.takeError();
   }
+
+  if (Options.LinkOpts.DropIcfShrunkSubprograms &&
+      Options.LinkOpts.DWARFLinkerType != DsymutilDWARFLinkerType::Classic)
+    return make_error<StringError>(
+        "--drop-icf-shrunk-subprograms is currently supported only with "
+        "--linker classic.",
+        inconvertibleErrorCode());
 
   if (Expected<std::vector<std::string>> InputFiles =
           getInputs(Args, Options.LinkOpts.Update)) {


### PR DESCRIPTION
## Problem

When a linker post-processing steps like ICF shrink a function's on-disk footprint below the DIE-recorded compile-time size, dsymutil emits a DWARF subprogram DIE that overlaps adjacent symbols. The DWARF verifier then rejects the resulting dSYM with `error: DIEs have overlapping address ranges`.

Some Mach-O ICF modes fold duplicate function bodies into a small tail-branch stub while preserving the folded symbol at its original address. For example, lld's `--icf=safe_thunks` (+ `--keep-icf-stabs`) replaces a folded function's body with a 12-byte `adrp+add+br` stub. The `LC_SYMTAB` entry (`n_desc`/size field) correctly reports the shrunk size, but the corresponding `.o`'s `DW_TAG_subprogram` DIE still carries `high_pc - low_pc` equal to the pre-fold function size — the `.o` was compiled independently, before any linker knew about the fold.

`dsymutil` relocates the DIE's `low_pc` to the linked address but keeps the DIE's compile-time size. For a shrunk symbol at linked address `L`, the emitted DIE covers `[L, L + compile_time_size)`, which extends past the actual bytes present (`[L, L + shrunk_size)`) and overlaps whatever symbol was placed next. When many symbols in a compile unit are shrunk this way, verifier failures cascade — Instagram and Stella iOS builds produced thousands of "DIEs have overlapping address ranges" errors and could not ship.

## Solution

Add an opt-in `--drop-icf-shrunk-subprograms` flag to dsymutil (Classic linker). When enabled, `DWARFLinker::shouldKeepSubprogramDIE` compares the debug-map symbol size (post-link, from the STAB) against the DIE's compile-time `high_pc - low_pc`. If the debug-map size is strictly smaller and non-zero, the subprogram DIE is dropped from the emitted dSYM instead of relocated.

The dropped DIE's *actual* byte range is still registered via `Unit.addFunctionRange(low_pc, low_pc + bin_size, reloc_adjustment)` so:

- `.debug_aranges` and `.debug_frame` FDEs cover the shrunk stub bytes correctly
- `.debug_line` rows falling within the shrunk range are preserved (line-table filtering keys off `Unit.getFunctionRanges()`)
- Symbolication tools (llvm-symbolizer, atos, GSYM via `llvm-gsymutil`'s `ObjectFileTransformer` SYMTAB path) still return the shrunk function's name at the stub's address — the `LC_SYMTAB` entry is untouched

Trade-off: for a crash PC landing inside the stub itself (rare — 3 non-faulting instructions), source-level info beyond the function name is unavailable. That info would have described pre-fold instructions that no longer exist at that address, and keeping the DIE would actively mislead file:line resolution. Callers reaching the canonical body via the tail branch already lose their identity at the ICF layer (no LR save), independent of any DWARF choice.

New method `AddressesMap::getSubprogramBinarySize` returns the debug-map size for a subprogram DIE; implemented in `DwarfLinkerForBinary` using the same relocation lookup as the existing `getSubprogramRelocAdjustment`.

Flag is off by default. Combining `--drop-icf-shrunk-subprograms` with `--linker parallel` is a hard error (for now until @royitaqi  made parallel linker work for ICF).

Also adds a `getSubprogramRelocAdjustment` `AddrValue` null guard in the DWARF-5 `DW_FORM_addrx` branch (pre-existing latent null-deref; the sibling `getSubprogramBinarySize` guards it correctly and this brings the two paths into agreement).

## Testing

New LIT test `llvm/test/tools/dsymutil/AArch64/subprogram-die-icf-shrunk.test` covers:

- **Default (no flag):** DIE kept — matches pre-existing dsymutil behavior
- **`--drop-icf-shrunk-subprograms`:** DIE dropped, verbose log emits `Dropping ICF-shrunk subprogram DIE (compile-time size 0x10, debug-map size 0xc):`
- **End-to-end:** With the flag, `dsymutil -verify` exits 0, `llvm-dwarfdump --verify` on the produced dSYM reports "No errors.", and dumping the dSYM confirms the compile unit is preserved while the dropped subprogram DIE is absent
- **Boundary cases** (via `sed` YAML rewrites): `debug_map_size == DIE_size` (no drop — guards `<` vs `<=`), `debug_map_size > DIE_size` (grown; no drop), `debug_map_size == 0` (no drop — guards `*BinSize > 0`)
- **`--implicit-check-not`** on DROP and NOSHRUNK runs catches any drop/keep reordering regression

The AArch64 input `Inputs/discriminator.arm64.o` uses `DW_FORM_addrx` for `low_pc`, exercising the DWARF-5 addrx path of the new `getSubprogramBinarySize`.

Manually validated end-to-end on a 6.24 GB dSYM produced from a real large iOS binary (thousands of ICF-shrunk symbols): all DIE overlap errors eliminated, verifier passes, subsequent GSYM conversion via `llvm-gsymutil convert` also succeeds.
