### PR TITLE
[clang] Fix crash caused by undeduced auto return variable

### DIFF
--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3527,6 +3527,12 @@ Sema::NamedReturnInfo Sema::getNamedReturnInfo(const VarDecl *VD) {
     return NamedReturnInfo();
 
   QualType VDType = VD->getType();
+
+  if (const AutoType *AT =
+        VDType.getCanonicalType()->getContainedAutoType())
+  if (!AT->isDeduced())
+    return NamedReturnInfo();
+
   if (VDType->isObjectType()) {
     // C++17 [class.copy.elision]p3:
     // ...non-volatile automatic object...

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3528,10 +3528,9 @@ Sema::NamedReturnInfo Sema::getNamedReturnInfo(const VarDecl *VD) {
 
   QualType VDType = VD->getType();
 
-  if (const AutoType *AT =
-        VDType.getCanonicalType()->getContainedAutoType())
-  if (!AT->isDeduced())
-    return NamedReturnInfo();
+  if (const AutoType *AT = VDType.getCanonicalType()->getContainedAutoType())
+    if (!AT->isDeduced())
+      return NamedReturnInfo();
 
   if (VDType->isObjectType()) {
     // C++17 [class.copy.elision]p3:

--- a/clang/test/SemaCXX/deleted-function-undeduced-auto.cpp
+++ b/clang/test/SemaCXX/deleted-function-undeduced-auto.cpp
@@ -1,8 +1,13 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 
-auto f() = delete; // expected-note {{candidate function has been explicitly deleted}}
+auto f() = delete; // expected-note 2 {{candidate function has been explicitly deleted}}
 
 auto g() {
   auto x = f(); // expected-error {{call to deleted function 'f'}}
+  return x;
+}
+
+auto g2() {
+  decltype(auto) x = f(); // expected-error {{call to deleted function 'f'}}
   return x;
 }

--- a/clang/test/SemaCXX/deleted-function-undeduced-auto.cpp
+++ b/clang/test/SemaCXX/deleted-function-undeduced-auto.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+auto f() = delete; // expected-note {{candidate function has been explicitly deleted}}
+
+auto g() {
+  auto x = f(); // expected-error {{call to deleted function 'f'}}
+  return x;
+}


### PR DESCRIPTION
Resolves #208488

The fix checks whether the variable's type contains an undeduced AutoType. If the auto type has not been deduced, getNamedReturnInfo() returns an empty NamedReturnInfo instead of continuing to query type information for the undeduced type, preventing the crash.