### PR TITLE
[ProfileData] Split EagerSampleProfileNameTable by key type (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -416,13 +416,13 @@ public:
   }
 };
 
-class EagerStringSampleProfileNameTable final : public SampleProfileNameTable {
+class StringSampleProfileNameTable final : public SampleProfileNameTable {
   std::vector<FunctionId> Vec;
 
 public:
-  explicit EagerStringSampleProfileNameTable(std::vector<FunctionId> &&Vec)
+  explicit StringSampleProfileNameTable(std::vector<FunctionId> &&Vec)
       : Vec(std::move(Vec)) {}
-  explicit EagerStringSampleProfileNameTable(const std::vector<FunctionId> &Vec)
+  explicit StringSampleProfileNameTable(const std::vector<FunctionId> &Vec)
       : Vec(Vec) {}
 
   size_t size() const override { return Vec.size(); }
@@ -433,13 +433,13 @@ public:
   }
 };
 
-class EagerMD5SampleProfileNameTable final : public SampleProfileNameTable {
+class MD5SampleProfileNameTable final : public SampleProfileNameTable {
   std::vector<FunctionId> Vec;
 
 public:
-  explicit EagerMD5SampleProfileNameTable(std::vector<FunctionId> &&Vec)
+  explicit MD5SampleProfileNameTable(std::vector<FunctionId> &&Vec)
       : Vec(std::move(Vec)) {}
-  explicit EagerMD5SampleProfileNameTable(const std::vector<FunctionId> &Vec)
+  explicit MD5SampleProfileNameTable(const std::vector<FunctionId> &Vec)
       : Vec(Vec) {}
 
   size_t size() const override { return Vec.size(); }

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -416,13 +416,30 @@ public:
   }
 };
 
-class EagerSampleProfileNameTable final : public SampleProfileNameTable {
+class EagerStringSampleProfileNameTable final : public SampleProfileNameTable {
   std::vector<FunctionId> Vec;
 
 public:
-  explicit EagerSampleProfileNameTable(std::vector<FunctionId> &&Vec)
+  explicit EagerStringSampleProfileNameTable(std::vector<FunctionId> &&Vec)
       : Vec(std::move(Vec)) {}
-  explicit EagerSampleProfileNameTable(const std::vector<FunctionId> &Vec)
+  explicit EagerStringSampleProfileNameTable(const std::vector<FunctionId> &Vec)
+      : Vec(Vec) {}
+
+  size_t size() const override { return Vec.size(); }
+
+  FunctionId operator[](size_t Idx) const override {
+    assert(Idx < Vec.size() && "Index out of bounds");
+    return Vec[Idx];
+  }
+};
+
+class EagerMD5SampleProfileNameTable final : public SampleProfileNameTable {
+  std::vector<FunctionId> Vec;
+
+public:
+  explicit EagerMD5SampleProfileNameTable(std::vector<FunctionId> &&Vec)
+      : Vec(std::move(Vec)) {}
+  explicit EagerMD5SampleProfileNameTable(const std::vector<FunctionId> &Vec)
       : Vec(Vec) {}
 
   size_t size() const override { return Vec.size(); }

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -1295,10 +1295,10 @@ std::error_code SampleProfileReaderBinary::readNameTable() {
     MD5SampleContextStart = MD5SampleContextTable.data();
   if (UseMD5)
     NameTable =
-        std::make_unique<EagerMD5SampleProfileNameTable>(std::move(TableVec));
+        std::make_unique<MD5SampleProfileNameTable>(std::move(TableVec));
   else
-    NameTable = std::make_unique<EagerStringSampleProfileNameTable>(
-        std::move(TableVec));
+    NameTable =
+        std::make_unique<StringSampleProfileNameTable>(std::move(TableVec));
   return sampleprof_error::success;
 }
 
@@ -1330,7 +1330,7 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
         TableVec.emplace_back(FunctionId(FID));
       }
       NameTable =
-          std::make_unique<EagerMD5SampleProfileNameTable>(std::move(TableVec));
+          std::make_unique<MD5SampleProfileNameTable>(std::move(TableVec));
     }
     if (!ProfileIsCS)
       MD5SampleContextStart = reinterpret_cast<const uint64_t *>(Data);
@@ -1359,7 +1359,7 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
     if (!ProfileIsCS)
       MD5SampleContextStart = MD5SampleContextTable.data();
     NameTable =
-        std::make_unique<EagerMD5SampleProfileNameTable>(std::move(TableVec));
+        std::make_unique<MD5SampleProfileNameTable>(std::move(TableVec));
     return sampleprof_error::success;
   }
 

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -1293,8 +1293,12 @@ std::error_code SampleProfileReaderBinary::readNameTable() {
   }
   if (!ProfileIsCS)
     MD5SampleContextStart = MD5SampleContextTable.data();
-  NameTable =
-      std::make_unique<EagerSampleProfileNameTable>(std::move(TableVec));
+  if (UseMD5)
+    NameTable =
+        std::make_unique<EagerMD5SampleProfileNameTable>(std::move(TableVec));
+  else
+    NameTable = std::make_unique<EagerStringSampleProfileNameTable>(
+        std::move(TableVec));
   return sampleprof_error::success;
 }
 
@@ -1326,7 +1330,7 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
         TableVec.emplace_back(FunctionId(FID));
       }
       NameTable =
-          std::make_unique<EagerSampleProfileNameTable>(std::move(TableVec));
+          std::make_unique<EagerMD5SampleProfileNameTable>(std::move(TableVec));
     }
     if (!ProfileIsCS)
       MD5SampleContextStart = reinterpret_cast<const uint64_t *>(Data);
@@ -1355,7 +1359,7 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
     if (!ProfileIsCS)
       MD5SampleContextStart = MD5SampleContextTable.data();
     NameTable =
-        std::make_unique<EagerSampleProfileNameTable>(std::move(TableVec));
+        std::make_unique<EagerMD5SampleProfileNameTable>(std::move(TableVec));
     return sampleprof_error::success;
   }
 


### PR DESCRIPTION
This patch splits EagerSampleProfileNameTable into two separate
classes, EagerStringSampleProfileNameTable and
EagerMD5SampleProfileNameTable.  This patch is meant to be a
preparation patch for centralizing and speeding up symbol membership
queries like "is this symbol in the name table?".

Currently, we have two problems with these membership queries:

- Customers build their own data structures like DenseSet<uint64_t> of
  MD5 values and StringSet<> to serve those queries.  That is, the
  sample profile loader does not directly serve those queries.

- There are two places, namely SampleProfileLoader::doInitialization
  and SampleProfileNameSet, where we build identical StringSet<> of the
  name table entries, costing compilation time at both construction and
  destruction time.

Now, we could serve these membership queries from a central place using
DenseSet<uint64_t> of MD5 values, but that would be expensive if we
have a string-based name table because we need to compute MD5 values
for all name table entries.  In that case, we should construct
DenseSet<StringRef> using a cheaper hash function like
llvm::xxh3_64bits instead.

This patch helps us by separating the two cases -- MD5-based and
string-based name table.

In a subsequent patch, I'm planning to implement the "contains" method
so that users can easily ask us whether a given symbol is in the name
table.

RFC:
https://discourse.llvm.org/t/rfc-faster-sample-profile-loading/90957

Assisted-by: Antigravity
