### PR TITLE
[NVPTX] Fix illegal .ftz modifier for setp and neg PTX instructions for bf16

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
@@ -421,9 +421,9 @@ bool NVPTXDAGToDAGISel::SelectSETP_F16X2(SDNode *N) {
 bool NVPTXDAGToDAGISel::SelectSETP_BF16X2(SDNode *N) {
   SDValue PTXCmpMode = getPTXCmpMode(*cast<CondCodeSDNode>(N->getOperand(2)));
   SDLoc DL(N);
-  SDNode *SetP = CurDAG->getMachineNode(
-      NVPTX::SETP_bf16x2rr, DL, MVT::i1, MVT::i1,
-      {N->getOperand(0), N->getOperand(1), PTXCmpMode});
+  SDNode *SetP =
+      CurDAG->getMachineNode(NVPTX::SETP_bf16x2rr, DL, MVT::i1, MVT::i1,
+                             {N->getOperand(0), N->getOperand(1), PTXCmpMode});
   ReplaceNode(N, SetP);
   return true;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
@@ -423,8 +423,7 @@ bool NVPTXDAGToDAGISel::SelectSETP_BF16X2(SDNode *N) {
   SDLoc DL(N);
   SDNode *SetP = CurDAG->getMachineNode(
       NVPTX::SETP_bf16x2rr, DL, MVT::i1, MVT::i1,
-      {N->getOperand(0), N->getOperand(1), PTXCmpMode,
-       CurDAG->getTargetConstant(useF32FTZ() ? 1 : 0, DL, MVT::i1)});
+      {N->getOperand(0), N->getOperand(1), PTXCmpMode});
   ReplaceNode(N, SetP);
   return true;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -1134,10 +1134,6 @@ let Predicates = [useFP16Math, hasPTX<60>, hasSM<53>] in {
   def NEG_F16    : FNEG16<F16RT>;
   def NEG_F16x2  : FNEG16<F16X2RT>;
 }
-let Predicates = [hasBF16Math, hasPTX<70>, hasSM<80>] in {
-  def NEG_BF16   : FNEG16<BF16RT>;
-  def NEG_BF16x2 : FNEG16<BF16X2RT>;
-}
 
 //
 // EX2
@@ -1674,7 +1670,7 @@ defm SETP_f64 : FSETP<F64RT, allow_ftz = false>;
 let Predicates = [useFP16Math] in
   defm SETP_f16 : FSETP<F16RT>;
 let Predicates = [hasBF16Math, hasPTX<78>, hasSM<90>] in
-  defm SETP_bf16 : FSETP<BF16RT>;
+  defm SETP_bf16 : FSETP<BF16RT, allow_ftz = false>;
 
 def SETP_f16x2rr :
       BasicFlagsNVPTXInst<(outs B1:$p, B1:$q),
@@ -1684,8 +1680,8 @@ def SETP_f16x2rr :
 
 def SETP_bf16x2rr :
       BasicFlagsNVPTXInst<(outs B1:$p, B1:$q),
-                (ins B32:$a, B32:$b), (ins CmpMode:$cmp, FTZFlag:$ftz),
-                "setp.${cmp:FCmp}$ftz.bf16x2">,
+                (ins B32:$a, B32:$b), (ins CmpMode:$cmp),
+                "setp.${cmp:FCmp}.bf16x2">,
                 Requires<[hasBF16Math, hasPTX<78>, hasSM<90>]>;
 
 //-----------------------------------

--- a/llvm/test/CodeGen/NVPTX/bf16-neg-noftz.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16-neg-noftz.ll
@@ -1,0 +1,24 @@
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_80 -mattr=+ptx70 -denormal-fp-math-f32=preserve-sign | FileCheck %s
+; RUN: %if ptxas-sm_80 && ptxas-isa-7.0 %{ llc < %s -mtriple=nvptx64 -mcpu=sm_80 -mattr=+ptx70 -denormal-fp-math-f32=preserve-sign | %ptxas-verify -arch=sm_80 %}
+
+; Check for working ftz on f16 to be sure
+define half @neg_f16_ftz(half %a) {
+; CHECK-LABEL: neg_f16_ftz
+; CHECK: neg.ftz.f16
+  %r = fneg half %a
+  ret half %r
+}
+
+define bfloat @neg_bf16_no_ftz(bfloat %a) {
+; CHECK-LABEL: neg_bf16_no_ftz
+; CHECK: neg.bf16
+  %r = fneg bfloat %a
+  ret bfloat %r
+}
+
+define <2 x bfloat> @neg_bf16x2_no_ftz(<2 x bfloat> %a) {
+; CHECK-LABEL: neg_bf16x2_no_ftz
+; CHECK: neg.bf16x2
+  %r = fneg <2 x bfloat> %a
+  ret <2 x bfloat> %r
+}

--- a/llvm/test/CodeGen/NVPTX/bf16-setp-noftz.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16-setp-noftz.ll
@@ -1,0 +1,26 @@
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_90 -mattr=+ptx78 -denormal-fp-math-f32=preserve-sign | FileCheck %s
+; RUN: %if ptxas-sm_90 && ptxas-isa-7.8 %{ llc < %s -mtriple=nvptx64 -mcpu=sm_90 -mattr=+ptx78 -denormal-fp-math-f32=preserve-sign | %ptxas-verify -arch=sm_90 %}
+
+; Check for working ftz on f16 to be sure
+define i1 @setp_f16_ftz(half %a, half %b) {
+; CHECK-LABEL: setp_f16_ftz
+; CHECK: setp.neu.ftz.f16
+  %cmp = fcmp une half %a, %b
+  ret i1 %cmp
+}
+
+define i1 @setp_bf16_no_ftz(bfloat %a, bfloat %b) {
+; CHECK-LABEL: setp_bf16_no_ftz
+; CHECK: setp.neu.bf16
+  %cmp = fcmp une bfloat %a, %b
+  ret i1 %cmp
+}
+
+define <2 x bfloat> @setp_bf16x2_no_ftz(<2 x bfloat> %a, <2 x bfloat> %b,
+  <2 x bfloat> %x, <2 x bfloat> %y) {
+; CHECK-LABEL: setp_bf16x2_no_ftz
+; CHECK: setp.neu.bf16x2
+  %cmp = fcmp une <2 x bfloat> %a, %b
+  %sel = select <2 x i1> %cmp, <2 x bfloat> %x, <2 x bfloat> %y
+  ret <2 x bfloat> %sel
+}


### PR DESCRIPTION
This patch disables emitting .ftz modifier for bf16 and bf16x2 type setp and neg instructions, the PTX ISA does not specify this modifier for the same. FNEG_H already correctly handles fneg for bf16, so remove the redundant bf16 FNEG16 pattern.