### PR TITLE
[OpenMPIRBuilder] Always inline device-outlined target regions

### DIFF
--- a/flang/test/Integration/OpenMP/target-outlined-alwaysinline.f90
+++ b/flang/test/Integration/OpenMP/target-outlined-alwaysinline.f90
@@ -1,0 +1,45 @@
+!===----------------------------------------------------------------------===!
+! This directory can be used to add Integration tests involving multiple
+! stages of the compiler (for eg. from Fortran to LLVM IR). It should not
+! contain executable tests. We should only add tests here sparingly and only
+! if there is no other way to test. Repeat this message in each test that is
+! added to this directory and sub-directories.
+!===----------------------------------------------------------------------===!
+
+! On target devices the OpenMP outlined region holds the whole compute body of
+! the construct. Leaving it as a separate function means it is register
+! allocated without the enclosing kernel's occupancy context, which costs a
+! large number of VGPRs on AMDGPU. Check that outlined regions are marked
+! alwaysinline on the device so they get folded back into the kernel, and that
+! the attribute is not added when the option is disabled.
+
+! REQUIRES: amdgpu-registered-target
+
+! RUN: %flang_fc1 -emit-llvm -fopenmp -fopenmp-is-target-device \
+! RUN:   -triple amdgcn-amd-amdhsa -o - %s | FileCheck %s
+
+! RUN: %flang_fc1 -emit-llvm -fopenmp -fopenmp-is-target-device \
+! RUN:   -triple amdgcn-amd-amdhsa \
+! RUN:   -mllvm -openmp-ir-builder-device-always-inline-outlined=false \
+! RUN:   -o - %s | FileCheck %s --check-prefix=DISABLED
+
+subroutine kern(a, b, n)
+  implicit none
+  real(8), intent(in)    :: a(*)
+  real(8), intent(inout) :: b(*)
+  integer, intent(in)    :: n
+  integer :: i
+
+  !$omp target teams distribute parallel do
+  do i = 1, n
+     b(i) = 2.0d0 * a(i)
+  end do
+end subroutine kern
+
+! The outlined loop body must carry alwaysinline on the device.
+! CHECK: define internal void @{{.*}}..omp_par(i32 {{.*}}) #[[ATTR:[0-9]+]]
+! CHECK: attributes #[[ATTR]] = { alwaysinline
+
+! With the option disabled the outlined body keeps its original attributes.
+! DISABLED: define internal void @{{.*}}..omp_par(i32 {{.*}}) #[[ATTR:[0-9]+]]
+! DISABLED: attributes #[[ATTR]] = { "amdgpu-flat-work-group-size"

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -88,6 +88,11 @@ static cl::opt<bool> UseDefaultMaxThreads(
     "openmp-ir-builder-use-default-max-threads", cl::Hidden,
     cl::desc("Use a default max threads if none is provided."), cl::init(true));
 
+static cl::opt<bool> DeviceAlwaysInlineOutlined(
+    "openmp-ir-builder-device-always-inline-outlined", cl::Hidden,
+    cl::desc("Mark OpenMP outlined regions alwaysinline on target devices."),
+    cl::init(true));
+
 #ifndef NDEBUG
 /// Return whether IP1 and IP2 are ambiguous, i.e. that inserting instructions
 /// at position IP1 may change the meaning of IP2 or vice-versa. This is because
@@ -949,6 +954,13 @@ void OpenMPIRBuilder::finalize(Function *Fn) {
     auto TargetFeaturesAttr = OuterFn->getFnAttribute("target-features");
     if (TargetFeaturesAttr.isStringAttribute())
       OutlinedFn->addFnAttr(TargetFeaturesAttr);
+
+    // On device, keep the outlined region in the kernel: left standalone it is
+    // register allocated without the kernel's occupancy target. The function is
+    // still emitted for entry points that take its address (generic mode).
+    if (DeviceAlwaysInlineOutlined && Config.isTargetDevice() &&
+        !OutlinedFn->hasFnAttribute(Attribute::NoInline))
+      OutlinedFn->addFnAttr(Attribute::AlwaysInline);
 
     LLVM_DEBUG(dbgs() << "After      outlining: " << *OuterFn << "\n");
     LLVM_DEBUG(dbgs() << "   Outlined function: " << *OutlinedFn << "\n");


### PR DESCRIPTION
Fixes #211132.

The driver splits an OpenMP target region into an outlined device function. The inliner then rejects it as too costly (cost=1280 vs threshold=495), so it is register-allocated and scheduled without the enclosing kernel's occupancy target.

gfx90a, full driver, `-Rpass-analysis=kernel-resource-usage`:

| | VGPRs | scratch | occupancy |
|---|---|---|---|
| before | 212 | 48 B | 2 |
| after | 94 | 0 | 5 |
| clang, C equivalent | 80 | 0 | 6 |

Mark OpenMP outlined regions `alwaysinline` on target devices in `OpenMPIRBuilder::finalize()`, behind hidden `-openmp-ir-builder-device-always-inline-outlined` (default on). The function is still emitted, so generic-execution-mode runtime entry points that take its address keep working.

Throughput, WENO5 + HLLC finite-volume kernel, 1M cells, best of 50, MI250X (Mcell/s):

| NEQ | before | after | gain |
|---|---|---|---|
| 8 | 2507.4 | 2520.4 | 1.01x |
| 16 | 1045.4 | 1381.7 | 1.32x |
| 24 | 720.6 | 793.3 | 1.10x |

Monotone at all three sizes. Output numerically identical. Both toolchains are Release builds
from the same commit differing only by this patch.

Testing, baseline measured first without the patch:

| suite | baseline | patched |
|---|---|---|
| `check-flang` | 4557 pass / 68 fail | 4558 pass / 68 fail |
| `clang/test/OpenMP` | | 1572/1572 |
| `mlir/test/Target/LLVMIR` | | 405/405 |
| `LLVMFrontendTests` | | 1281/1281 |

The +1 is the added test. The 68 failures are pre-existing at this HEAD.

`alwaysinline` is blunt: it inlines outlined regions unconditionally on device, including generic mode and nested parallelism, which could bloat code for very large constructs. The structural alternative is to stop passing `private()` by pointer through a struct in `applyWorkshareLoopTarget`, which is what inflates the inline cost in the first place. Happy to pursue that instead if preferred.

This affects performance-critical applications on large AMD GPU supercomputers, including [MFC](https://github.com/MFlowCode/MFC).

All numbers above come from the validated reproducers included with this report and are independently reproducible; they stand on their own.

This was found and root-caused with the assistance of AI tools.
