### PR TITLE
[runtimes][cmake] Probe Fortran intrinsic modules for the target triple

### DIFF
--- a/runtimes/cmake/config-Fortran.cmake
+++ b/runtimes/cmake/config-Fortran.cmake
@@ -39,7 +39,8 @@
 # a compiler introspection environment, see
 # https://gitlab.kitware.com/cmake/cmake/-/issues/27419
 function (check_fortran_builtins_available)
-  if (CMAKE_Fortran_COMPILER_FORCED AND CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang" AND
+      (CMAKE_Fortran_COMPILER_FORCED OR CMAKE_VERSION VERSION_LESS "3.28"))
     # CMake's check_fortran_source_compiles/try_compile does not take a
     # user-defined CMAKE_Fortran_PREPROCESS_SOURCE into account. Instead of
     # test-compiling, ask Flang directly for the builtin module files.
@@ -47,10 +48,23 @@ function (check_fortran_builtins_available)
     # does not natively recognize Flang (see below). Once we bump the required
     # CMake version, and because setting CMAKE_Fortran_PREPROCESS_SOURCE has
     # been deprecated by CMake, this workaround can be removed.
+    #
+    # The same path is taken for CMake 3.24 to 3.27, which do recognize Flang
+    # but do not pass --target= to try_compile. Setting
+    # CMAKE_Fortran_COMPILE_OPTIONS_TARGET ourselves (see below) does not help:
+    # CMake sets it in CMakeFortranCompiler.cmake, whose scope try_compile
+    # inherits, while ours is only a directory-scope variable. The probe would
+    # therefore compile for the host and report the host's modules.
     if (NOT DEFINED FORTRAN_HAS_ISO_C_BINDING_MOD)
       message(STATUS "Performing Test ISO_C_BINDING_PATH")
+      # Flang's intrinsic modules are per-target; probe for the target we are
+      # compiling for. Empty for compilers without such an option (e.g. GNU).
+      set(_fortran_target_flag "")
+      if (CMAKE_Fortran_COMPILER_TARGET AND CMAKE_Fortran_COMPILE_OPTIONS_TARGET)
+        set(_fortran_target_flag "${CMAKE_Fortran_COMPILE_OPTIONS_TARGET}${CMAKE_Fortran_COMPILER_TARGET}")
+      endif ()
       execute_process(
-        COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_Fortran_FLAGS} "-print-file-name=iso_c_binding.mod"
+        COMMAND ${CMAKE_Fortran_COMPILER} ${_fortran_target_flag} ${CMAKE_Fortran_FLAGS} "-print-file-name=iso_c_binding.mod"
         OUTPUT_VARIABLE ISO_C_BINDING_PATH
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET
@@ -67,6 +81,8 @@ function (check_fortran_builtins_available)
   else ()
     cmake_push_check_state(RESET)
     set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+    # CMake 3.28 and later pass --target= to try_compile themselves, so nothing
+    # to add here. Do not pass it a second time.
     check_fortran_source_compiles("
       subroutine testroutine
         use iso_c_binding


### PR DESCRIPTION
Fixes #211134.

`check_fortran_builtins_available()` probes for Fortran intrinsic modules without passing the target triple, in both branches: the `-print-file-name=iso_c_binding.mod` query runs the driver with no `--target`, and the `check_fortran_source_compiles()` fallback uses `try_compile()`, which does not inherit `CMAKE_Fortran_COMPILER_TARGET`.

Flang's intrinsic modules are built per-target by flang-rt. When a runtime is configured for a GPU target without flang-rt in its runtime list, both probes test the host and succeed, so `RUNTIMES_FORTRAN_MODULES` is enabled for a target that cannot support it. `LIBOMP_FORTRAN_MODULES` inherits that and the failure is deferred to a cascade of BIND(C) diagnostics compiling `omp_lib.F90`, all stemming from one missing-module error.

Pass the triple to both probes so the existing graceful-degradation path is reached instead.

Uses `CMAKE_Fortran_COMPILE_OPTIONS_TARGET` rather than a hard-coded `--target=`. This file is also used with non-Flang compilers (`:229`, and `openmp/module/CMakeLists.txt:25` special-cases GNU), and the `check_fortran_source_compiles` branch is the live path for every compiler on CMake >= 3.24. gfortran rejects `--target=` outright, so hard-coding it would silently disable Fortran modules for gfortran users who get them today. `CMAKE_Fortran_COMPILE_OPTIONS_TARGET` is `--target=` for Flang and empty for GNU.

Tested:

| compiler | target | result |
|---|---|---|
| gfortran | `x86_64-unknown-linux-gnu` | modules ON, unchanged |
| flang | `x86_64-unknown-linux-gnu` | modules ON, unchanged |
| flang | `amdgcn-amd-amdhsa` | modules OFF, correctly disabled |
| flang | `amdgpu-amd-amdhsa` | modules OFF, correctly disabled |

Also built four full configurations: amdgcn with `openmp` unpatched fails as described; patched, it builds clean and produces `libompdevice.a` with no workaround; amdgcn with `openmp;flang-rt` (the `FlangOffload.cmake` recipe) still builds `omp_lib.mod` for the GPU triple, so the intentional GPU module support is preserved; and the x86_64 host build is unchanged.

No test: neither `runtimes/` nor `openmp/` has CMake-configuration test infrastructure, and this is configure-time logic with no lit surface.

This affects performance-critical applications on large AMD GPU supercomputers, including [MFC](https://github.com/MFlowCode/MFC).

All numbers above come from the validated reproducers included with this report and are independently reproducible; they stand on their own.

This was found and root-caused with the assistance of AI tools.
