### PR TITLE
[openmp][cmake] Match GPU triples consistently in openmp/module

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -168,13 +168,22 @@ add_custom_target(install-openmp-stripped
 add_dependencies(install-openmp openmp)
 add_dependencies(install-openmp-stripped openmp)
 
+# Whether this build targets a GPU. "amdgcn" is the legacy spelling of "amdgpu";
+# both reach here, and the offload cache files use "amdgpu-amd-amdhsa".
+set(LIBOMP_GPU_TRIPLE_REGEX "^amdgpu|^amdgcn|^nvptx|^spirv64")
+if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "${LIBOMP_GPU_TRIPLE_REGEX}" OR
+   "${CMAKE_CXX_COMPILER_TARGET}" MATCHES "${LIBOMP_GPU_TRIPLE_REGEX}" OR
+   "${CMAKE_Fortran_COMPILER_TARGET}" MATCHES "${LIBOMP_GPU_TRIPLE_REGEX}")
+  set(LIBOMP_TARGET_IS_GPU TRUE)
+else()
+  set(LIBOMP_TARGET_IS_GPU FALSE)
+endif()
+
 if(LIBOMP_FORTRAN_MODULES)
   add_subdirectory(module)
 endif()
 
-# Use the current compiler target to determine the appropriate runtime to build.
-if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgpu|^amdgcn|^nvptx|^spirv64" OR
-   "${CMAKE_CXX_COMPILER_TARGET}" MATCHES "^amdgpu|^amdgcn|^nvptx|^spirv64")
+if(LIBOMP_TARGET_IS_GPU)
   add_subdirectory(device)
 else()
   # Build host runtime library, after LIBOMPTARGET variables are set since they

--- a/openmp/module/CMakeLists.txt
+++ b/openmp/module/CMakeLists.txt
@@ -26,7 +26,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   target_compile_options(libomp-mod PRIVATE -fno-range-check)
 endif ()
 
-if ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx")
+if (LIBOMP_TARGET_IS_GPU)
   target_compile_options(libomp-mod PRIVATE
     $<$<COMPILE_LANGUAGE:Fortran>:-nogpulib -flto>
   )


### PR DESCRIPTION
Fixes #211135.

`openmp/module/CMakeLists.txt:29` gates the GPU-only Fortran compile options on `"^amdgcn|^nvptx"`, while `openmp/CMakeLists.txt:176-177` selects host-vs-device layout for the same build using `"^amdgpu|^amdgcn|^nvptx|^spirv64"` against both `LLVM_DEFAULT_TARGET_TRIPLE` and `CMAKE_CXX_COMPILER_TARGET`.

All four offload cache files use the triple `amdgpu-amd-amdhsa`, which `^amdgcn` does not match, so `-nogpulib -flto` are silently not applied to `libomp-mod` in the recommended AMDGPU offload configurations.

Compute the test once as `LIBOMP_TARGET_IS_GPU` in `openmp/CMakeLists.txt` and use it at both sites, rather than duplicating a widened regex. The conditions differ, not just the patterns: copying the regex alone would leave a build that sets `CMAKE_CXX_COMPILER_TARGET` without `LLVM_DEFAULT_TARGET_TRIPLE` still taking the device path in `openmp/` while `libomp-mod` misses the flags. `libomp-mod` compiles Fortran, so `CMAKE_Fortran_COMPILER_TARGET` is also consulted; neither site did before.

Evaluated with CMake's regex engine:

| triple | before | after |
|---|---|---|
| `amdgpu-amd-amdhsa` | 0 | 1 |
| `amdgcn-amd-amdhsa` | 1 | 1 |
| `nvptx64-nvidia-cuda` | 1 | 1 |
| `spirv64-amd-amdhsa` | 0 | 1 |
| `x86_64-unknown-linux-gnu` | 0 | 0 |

`^spirv64` only brings `module/` in line with `openmp/CMakeLists.txt:176`, which already routes spirv64 to `device/`. Host builds are unaffected.

Roughly five other sites carry the same `amdgcn`-only pattern (`offload/CMakeLists.txt:30`, `flang-rt/CMakeLists.txt:126`, `flang-rt/lib/runtime/CMakeLists.txt:317`, `flang-rt/cmake/modules/AddFlangRT.cmake:298`, `cmake/Modules/GetToolchainDirs.cmake:118`) and are left for a follow-up.

No test: configure-time logic, no test mechanism exists in `openmp/`.

This affects performance-critical applications on large AMD GPU supercomputers, including [MFC](https://github.com/MFlowCode/MFC).

All numbers above come from the validated reproducers included with this report and are independently reproducible; they stand on their own.

This was found and root-caused with the assistance of AI tools.
