### PR TITLE
[AMDGPU] Fix register pressure estimates for use-and-redefs

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -844,6 +844,8 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
   RegOpers.collect(*MI, *TRI, *MRI, true, /*IgnoreDead=*/false);
   RegOpers.adjustLaneLiveness(LIS, *MRI, SlotIdx);
   GCNRegPressure TempPressure = CurPressure;
+  // Tracks the live mask reported by the use loop for redefined registers.
+  SmallDenseMap<Register, LaneBitmask, 8> PostUseMask;
 
   for (const VRegMaskOrUnit &Use : RegOpers.Uses) {
     if (!Use.VRegOrUnit.isVirtualReg())
@@ -865,6 +867,7 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
     auto It = LiveRegs.find(Reg);
     LaneBitmask LiveMask = It != LiveRegs.end() ? It->second : LaneBitmask(0);
     LaneBitmask NewMask = LiveMask & ~LastUseMask;
+    PostUseMask[Reg] = NewMask;
     TempPressure.inc(Reg, LiveMask, NewMask, *MRI);
   }
 
@@ -873,8 +876,15 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
     if (!Def.VRegOrUnit.isVirtualReg())
       continue;
     Register Reg = Def.VRegOrUnit.asVirtualReg();
-    auto It = LiveRegs.find(Reg);
-    LaneBitmask LiveMask = It != LiveRegs.end() ? It->second : LaneBitmask(0);
+    auto PostIt = PostUseMask.find(Reg);
+    LaneBitmask LiveMask;
+    if (PostIt != PostUseMask.end()) {
+      LiveMask = PostIt->second;
+    } else {
+      auto It = LiveRegs.find(Reg);
+      LiveMask = It != LiveRegs.end() ? It->second : LaneBitmask(0);
+    }
+
     LaneBitmask NewMask = LiveMask | Def.LaneMask;
     TempPressure.inc(Reg, LiveMask, NewMask, *MRI);
   }

--- a/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
@@ -200,3 +200,49 @@ body:             |
   GCNRegPressure P = RPTracker.bumpDownwardPressure(U2, TRI);
   EXPECT_EQ(P.getArchVGPRNum(), 1U);
 }
+
+// Tests bumpDownwardPressure for an instruction that uses and redefines
+// the same register.
+TEST_F(GCNRegPressureTest, BumpDownwardPressureUseAndRedef) {
+  StringRef MIR = R"(
+name:            BumpDownwardPressureUseAndRedef
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    %0:sgpr_32 = IMPLICIT_DEF
+    %0:sgpr_32 = S_OR_B32 %0:sgpr_32, 1, implicit-def dead $scc
+    S_NOP 0, implicit %0
+    S_ENDPGM 0
+...
+)";
+  ASSERT_TRUE(parseMIR(MIR));
+  MachineFunction &MF = getMF("BumpDownwardPressureUseAndRedef");
+  const LiveIntervals &LIS = MFAM.getResult<LiveIntervalsAnalysis>(MF);
+  const MachineRegisterInfo &MRI = MF.getRegInfo();
+  const SIRegisterInfo *TRI = MF.getSubtarget<GCNSubtarget>().getRegisterInfo();
+
+  MachineBasicBlock &MBB = *MF.getBlockNumbered(0);
+
+  SmallVector<MachineInstr *, 8> Instrs;
+  for (MachineInstr &MI : MBB)
+    Instrs.push_back(&MI);
+  // 0: def %0 (sgpr_32 = 1 SGPR)
+  // 1: use+redef of %0
+  // 2: use %0
+  // 3: S_ENDPGM
+  MachineInstr *DefS0 = Instrs[0];
+  MachineInstr *UseRedef = Instrs[1];
+
+  GCNDownwardRPTracker RPTracker(LIS);
+  GCNRPTracker::LiveRegSet Empty;
+  RPTracker.reset(MRI, Empty);
+
+  // Commit the def; %0 occupies 1 SGPR and stays live.
+  RPTracker.advance(DefS0, /*UseInternalIterator=*/false);
+  EXPECT_EQ(RPTracker.getPressure().getSGPRNum(), 1U);
+
+  // Speculate the instruction. It uses and redefines %0, which stays live, so
+  // pressure must be unchanged.
+  GCNRegPressure P = RPTracker.bumpDownwardPressure(UseRedef, TRI);
+  EXPECT_EQ(P.getSGPRNum(), 1U);
+}


### PR DESCRIPTION
Current register pressure estimate (bumpDownwardPressure) has a bug triggered by an instruction that reads and writes the same register:
1) first we go over the uses and determine that this is the last use (before redef), pressure decrease is reported;
2) then we go over the (re)defs and compare the previous mask (before the use) with a new mask, see no difference and report nothing; instead we should compare the new mask with the mask we get after processing the uses.

Test plan:
```
ninja AMDGPUTests llc
./unittests/Target/AMDGPU/AMDGPUTests  --gtest_filter='*AMDGPU*:*BumpDownward*'
```
