### PR TITLE
[LLD][COFF] Only merge funclets with mergeable parents

### DIFF
--- a/lld/COFF/ICF.cpp
+++ b/lld/COFF/ICF.cpp
@@ -22,6 +22,7 @@
 #include "Chunks.h"
 #include "Symbols.h"
 #include "lld/Common/Timer.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Parallel.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/xxhash.h"
@@ -42,6 +43,7 @@ private:
   void segregate(size_t begin, size_t end, bool constant);
 
   bool assocEquals(const SectionChunk *a, const SectionChunk *b);
+  bool funcletParentEqual(const SectionChunk *a, const SectionChunk *b);
 
   bool equalsConstant(const SectionChunk *a, const SectionChunk *b);
   bool equalsVariable(const SectionChunk *a, const SectionChunk *b);
@@ -56,6 +58,8 @@ private:
   void forEachClass(std::function<void(size_t, size_t)> fn);
 
   std::vector<SectionChunk *> chunks;
+  llvm::DenseMap<const SectionChunk *, const SectionChunk *> funcletParent;
+
   int cnt = 0;
   std::atomic<bool> repeat = {false};
 
@@ -143,6 +147,52 @@ bool ICF::assocEquals(const SectionChunk *a, const SectionChunk *b) {
                     });
 }
 
+namespace {
+
+bool isFunclet(const SectionChunk *c) {
+  return c->selection == llvm::COFF::IMAGE_COMDAT_SELECT_ASSOCIATIVE &&
+         (c->getOutputCharacteristics() & llvm::COFF::IMAGE_SCN_MEM_EXECUTE);
+}
+
+} // namespace
+
+// Returns true if it is safe to fold the two sections with respect to their
+// parent (leader) sections.
+//
+// A C++ exception-handling funclet (a catch/cleanup block) is emitted as an
+// associative, executable comdat section (typically ".text$x"). Unlike a normal
+// function, a funclet's own unwind info (its .pdata/.xdata) is emitted in
+// sections that are associative to the funclet's *parent* function, not to the
+// funclet itself. Those unwind sections chain back to the parent's
+// exception-handling data, so a given funclet is only correct for one specific
+// parent.
+//
+// ICF folds each associative section independently, and a funclet's own body
+// carries no reference to its unwind info, so two funclets with identical code
+// look mergeable even when their parents (and thus their unwind info) differ.
+// Folding them would leave the single surviving funclet described by two
+// different .pdata entries with the same address range but conflicting unwind
+// info, which corrupts exception dispatch (llvm/llvm-project#41566).
+//
+// To keep folding safe, a funclet may only be folded with another funclet when
+// their parents are themselves in the same equivalence class (i.e. are being
+// folded too); in that case the parents' exception-handling data is identical
+// and the funclet's unwind info is consistent for both.
+bool ICF::funcletParentEqual(const SectionChunk *a, const SectionChunk *b) {
+  bool aFunclet = isFunclet(a);
+  if (aFunclet != isFunclet(b))
+    return false;
+  if (!aFunclet)
+    return true;
+
+  const SectionChunk *pa = funcletParent.lookup(a);
+  const SectionChunk *pb = funcletParent.lookup(b);
+  // Be conservative and refuse to fold if we can't identify both parents.
+  if (!pa || !pb)
+    return false;
+  return pa->eqClass[cnt % 2] == pb->eqClass[cnt % 2];
+}
+
 // Compare "non-moving" part of two sections, namely everything
 // except relocation targets.
 bool ICF::equalsConstant(const SectionChunk *a, const SectionChunk *b) {
@@ -174,7 +224,8 @@ bool ICF::equalsConstant(const SectionChunk *a, const SectionChunk *b) {
          a->getSectionName() == b->getSectionName() &&
          a->header->SizeOfRawData == b->header->SizeOfRawData &&
          a->checksum == b->checksum && a->getContents() == b->getContents() &&
-         a->getMachine() == b->getMachine() && assocEquals(a, b);
+         a->getMachine() == b->getMachine() && funcletParentEqual(a, b) &&
+         assocEquals(a, b);
 }
 
 // Compare "moving" part of two sections, namely relocation targets.
@@ -201,7 +252,7 @@ bool ICF::equalsVariable(const SectionChunk *a, const SectionChunk *b) {
 
   return std::equal(a->getRelocs().begin(), a->getRelocs().end(),
                     b->getRelocs().begin(), eq) &&
-         assocEquals(a, b);
+         funcletParentEqual(a, b) && assocEquals(a, b);
 }
 
 // Find the first Chunk after Begin that has a different class from Begin.
@@ -262,10 +313,15 @@ void ICF::run() {
   uint32_t nextId = 1;
   for (Chunk *c : ctx.driver.getChunks()) {
     if (auto *sc = dyn_cast<SectionChunk>(c)) {
-      if (isEligible(sc))
+      if (isEligible(sc)) {
         chunks.push_back(sc);
-      else
+        // see funcletParentEqual.
+        for (const SectionChunk &child : sc->children())
+          if (isFunclet(&child))
+            funcletParent[&child] = sc;
+      } else {
         sc->eqClass[0] = nextId++;
+      }
     }
   }
 

--- a/lld/test/COFF/Inputs/icf-eh-funclet.cpp
+++ b/lld/test/COFF/Inputs/icf-eh-funclet.cpp
@@ -1,0 +1,64 @@
+// Reduced reproducer for llvm/llvm-project#41566.
+//
+// Compile with MSVC to produce the C++ exception-handling funclet layout that
+// lld's ICF must handle correctly:
+//
+//   cl.exe /c /EHsc /O2 /GS- /d2FH4- icf-eh-funclet.cpp
+//
+// (/d2FH4- selects the classic __CxxFrameHandler3 model, matching the original
+// bug report; the same issue also affects __CxxFrameHandler4.)
+//
+// foo() and bar() each contain a catch block whose body is byte-for-byte
+// identical -- catch Thrown and rethrow it as Wrapped -- so MSVC emits two
+// identical catch funclets, each in its own associative ".text$x" comdat. A
+// funclet's own unwind info (.pdata/.xdata) is emitted in comdats associative
+// to the funclet's *parent* function and chains to that parent's
+// exception-handling data (FuncInfo).
+//
+// The two parent bodies differ, so the parents (and their FuncInfo) are not
+// folded. The funclet bodies are identical, so ICF would fold them -- but that
+// is unsafe: the single surviving funclet would then be described by two .pdata
+// entries covering the same address range but pointing at different unwind
+// info, and Windows' RtlLookupFunctionEntry would pick one arbitrarily. A
+// thrown exception then unwinds using the wrong parent's FuncInfo and is
+// dispatched to the wrong catch handler (or terminate()).
+//
+// The hand-written object in ../icf-eh-funclet.s models the sections this file
+// produces.
+
+struct Thrown {
+  int code;
+};
+
+struct Wrapped {
+  int code;
+};
+
+// Defined elsewhere; throws Thrown when it fails.
+void mayThrow(int x);
+
+// Parent #1: a single call site before the try.
+int foo(int a) {
+  int acc = a;
+  try {
+    mayThrow(a);
+    acc += 1;
+  } catch (const Thrown &e) {
+    throw Wrapped{e.code};
+  }
+  return acc;
+}
+
+// Parent #2: a different body so the two parent functions are not themselves
+// folded -- only the catch funclets match.
+int bar(int a, int b) {
+  int acc = a * 3 + b;
+  try {
+    mayThrow(a);
+    mayThrow(b);
+    acc += 7;
+  } catch (const Thrown &e) {
+    throw Wrapped{e.code};
+  }
+  return acc;
+}

--- a/lld/test/COFF/icf-eh-funclet.s
+++ b/lld/test/COFF/icf-eh-funclet.s
@@ -1,0 +1,135 @@
+# REQUIRES: x86
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc %s -o %t.obj
+# RUN: lld-link %t.obj /dll /noentry /out:%t.dll /opt:noref,icf
+# RUN: llvm-readobj --coff-exports %t.dll | FileCheck %s
+
+## This test models the object produced by Inputs/icf-eh-funclet.cpp, built with:
+##   cl.exe /c /EHsc /O2 /GS- /d2FH4- icf-eh-funclet.cpp
+## which is a reduced reproducer for llvm/llvm-project#41566.
+##
+## A C++ EH catch/cleanup funclet is emitted as an associative, executable comdat
+## (".text$x"). A funclet's own unwind info (.pdata/.xdata) is emitted in comdats
+## that are associative to the funclet's *parent* function (not to the funclet)
+## and that chain to the parent's exception-handling data (FuncInfo). The funclet
+## body carries no reference to that unwind info, so two funclets with identical
+## code look mergeable to ICF even when their parents differ. Folding them would
+## leave the single surviving funclet described by two .pdata entries covering
+## the same address range but with conflicting unwind info, so a thrown exception
+## unwinds with the wrong parent's FuncInfo and is dispatched to the wrong catch
+## handler (or terminate()).
+##
+## f1c and f2c are identical funclets whose parents (f1, f2) differ, and whose
+## unwind info (f1c_xdata, f2c_xdata) chains to those different parents. They must
+## NOT be folded and must keep distinct addresses.
+# CHECK:      Name: f1c
+# CHECK-NEXT: RVA: 0x1012
+# CHECK:      Name: f2c
+# CHECK-NEXT: RVA: 0x1015
+
+## g1c and g2c are identical funclets whose parents (g1, g2) are themselves
+## identical and fold, so folding the funclets is safe and must still happen.
+# CHECK:      Name: g1c
+# CHECK-NEXT: RVA: [[G:0x[0-9A-Fa-f]+]]
+# CHECK:      Name: g2c
+# CHECK-NEXT: RVA: [[G]]
+
+## --- Parents f1/f2: different bodies, so they do not fold. ---
+	.section	.text,"xr",one_only,f1
+	.globl	f1
+f1:
+	movl	$1, %eax
+	retq
+
+	.section	.text,"xr",one_only,f2
+	.globl	f2
+f2:
+	movl	$2, %eax
+	retq
+
+## Catch funclets for f1/f2: identical bodies in associative .text$x comdats.
+	.section	.text$x,"xr",associative,f1
+	.globl	f1c
+f1c:
+	nop
+	nop
+	retq
+.Lf1c_end:
+
+	.section	.text$x,"xr",associative,f2
+	.globl	f2c
+f2c:
+	nop
+	nop
+	retq
+.Lf2c_end:
+
+## Funclet unwind info (.xdata), associative to the *parent*, chaining to it.
+## Because they reference different parents, f1c_xdata and f2c_xdata differ.
+	.section	.xdata,"dr",associative,f1
+f1c_xdata:
+	.long	1
+	.long	f1@IMGREL
+	.section	.xdata,"dr",associative,f2
+f2c_xdata:
+	.long	1
+	.long	f2@IMGREL
+
+## Funclet .pdata (RUNTIME_FUNCTION), associative to the *parent*.
+	.section	.pdata,"dr",associative,f1
+	.long	f1c@IMGREL
+	.long	.Lf1c_end@IMGREL
+	.long	f1c_xdata@IMGREL
+	.section	.pdata,"dr",associative,f2
+	.long	f2c@IMGREL
+	.long	.Lf2c_end@IMGREL
+	.long	f2c_xdata@IMGREL
+
+## --- Parents g1/g2: identical bodies, so they fold. ---
+	.section	.text,"xr",one_only,g1
+	.globl	g1
+g1:
+	movl	$7, %eax
+	retq
+
+	.section	.text,"xr",one_only,g2
+	.globl	g2
+g2:
+	movl	$7, %eax
+	retq
+
+	.section	.text$x,"xr",associative,g1
+	.globl	g1c
+g1c:
+	int3
+	int3
+	retq
+.Lg1c_end:
+
+	.section	.text$x,"xr",associative,g2
+	.globl	g2c
+g2c:
+	int3
+	int3
+	retq
+.Lg2c_end:
+
+	.section	.xdata,"dr",associative,g1
+g1c_xdata:
+	.long	1
+	.long	g1@IMGREL
+	.section	.xdata,"dr",associative,g2
+g2c_xdata:
+	.long	1
+	.long	g2@IMGREL
+
+	.section	.pdata,"dr",associative,g1
+	.long	g1c@IMGREL
+	.long	.Lg1c_end@IMGREL
+	.long	g1c_xdata@IMGREL
+	.section	.pdata,"dr",associative,g2
+	.long	g2c@IMGREL
+	.long	.Lg2c_end@IMGREL
+	.long	g2c_xdata@IMGREL
+
+	.section	.drectve,"yn"
+	.ascii	" -export:f1c -export:f2c -export:g1c -export:g2c"


### PR DESCRIPTION
COFF ICF decides to merge sections if they are equal and their associated sections are also equal. EH funclets are emitted as independent sections from their parent sections, but the funclet associated sections are associated with the parent section. This means identical catch funclets can appear to be mergeable to ICF when they should not be merged.

Adjust ICF to check parent section equality when comparing funclets.

Fixes #41566.