### PR TITLE
[orc-rt] Rename CallVia* utils to reflect destination. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -381,8 +381,8 @@ public:
   /// Call a tagged handler in the Controller.
   ///
   /// This method can be called directly, but is expected to be more commonly
-  /// called via WrapperFunction::call using a CallViaSession object (returned
-  /// by the callViaSession method).
+  /// called via WrapperFunction::call using a ControllerCaller object (returned
+  /// by the controllerCaller method).
   void callController(OnControllerCallReturnFn OnComplete, HandlerTag T,
                       WrapperFunctionBuffer ArgBytes) {
     if (auto TmpCA = std::atomic_load(&CA))
@@ -396,9 +396,9 @@ public:
   /// controller handler with the given tag.
   ///
   /// Useable as a Caller implementation with WrapperFunction::call.
-  class CallViaSession {
+  class ControllerCaller {
   public:
-    CallViaSession(Session &S, HandlerTag T) : S(S), T(T) {}
+    ControllerCaller(Session &S, HandlerTag T) : S(S), T(T) {}
 
     void operator()(OnControllerCallReturnFn &&HandleResult,
                     WrapperFunctionBuffer ArgBytes) {
@@ -410,10 +410,10 @@ public:
     HandlerTag T;
   };
 
-  /// Get a WrapperFunction::call-compatible Caller that will call through to
-  /// the handler with the given tag.
-  CallViaSession callViaSession(HandlerTag T) noexcept {
-    return CallViaSession(*this, T);
+  /// Get a WrapperFunction::call-compatible Caller that will call the given
+  /// handler in the controller via Session::callController.
+  ControllerCaller controllerCaller(HandlerTag T) noexcept {
+    return ControllerCaller(*this, T);
   }
 
 private:

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -268,10 +268,9 @@ private:
   OnConnectFn OnConnect;
 };
 
-class CallViaMockControllerAccess {
+class CallFromController {
 public:
-  CallViaMockControllerAccess(MockControllerAccess &CA,
-                              orc_rt_WrapperFunction Fn)
+  CallFromController(MockControllerAccess &CA, orc_rt_WrapperFunction Fn)
       : CA(CA), Fn(Fn) {}
   void operator()(Session::OnControllerCallReturnFn OnComplete,
                   WrapperFunctionBuffer ArgBytes) {
@@ -612,7 +611,8 @@ TEST(ControllerAccessTest, ValidCallToController) {
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
-      S.callViaSession(reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+      S.controllerCaller(
+          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
   QueueingRunner<>::runFIFOUntilEmpty(Tasks);
@@ -627,7 +627,8 @@ TEST(ControllerAccessTest, CallToControllerBeforeAttach) {
 
   Error Err = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
-      S.callViaSession(reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+      S.controllerCaller(
+          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) {
         ErrorAsOutParameter _(Err);
         Err = R.takeError();
@@ -647,7 +648,8 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
 
   Error Err = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
-      S.callViaSession(reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+      S.controllerCaller(
+          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) {
         ErrorAsOutParameter _(Err);
         Err = R.takeError();
@@ -667,7 +669,7 @@ TEST(ControllerAccessTest, CallFromController) {
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
-      CallViaMockControllerAccess(*CA, add_sps_wrapper),
+      CallFromController(*CA, add_sps_wrapper),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
   QueueingRunner<>::runFIFOUntilEmpty(Tasks);
@@ -705,7 +707,7 @@ TEST(ControllerAccessTest, WrapperCallTokenReleasedWhenFnReturns) {
 
   bool GotResult = false;
   SPSWrapperFunction<void(SPSExecutorAddr)>::call(
-      CallViaMockControllerAccess(*CA, deferred_wrapper),
+      CallFromController(*CA, deferred_wrapper),
       [&](Error Err) {
         cantFail(std::move(Err));
         GotResult = true;
@@ -781,7 +783,8 @@ TEST(ControllerAccessTest, TryAttachSuccess) {
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
-      S.callViaSession(reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+      S.controllerCaller(
+          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
   QueueingRunner<>::runFIFOUntilEmpty(Tasks);
@@ -800,7 +803,8 @@ TEST(ControllerAccessTest, TryAttachFailure) {
   // would before any attach.
   Error CallErr = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
-      S.callViaSession(reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+      S.controllerCaller(
+          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) {
         ErrorAsOutParameter _(CallErr);
         CallErr = R.takeError();


### PR DESCRIPTION
Rename Session::CallViaSession to Session::ControllerCaller, and test utility CallViaMockControllerAccess to CallFromController.

The old names described who was routing the calls, but this is implicit at the call-site anyway (CallViaSession was a method on Session, and CallViaMockControllerAccess took a MockControllerAccess argument). The new names reflect the call destination, which is the thing clients care about.