### PR TITLE
[Clang][LTO] Assign GUIDs after post-opt bitcode linking

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -91,6 +91,7 @@
 #include "llvm/Transforms/Scalar/EarlyCSE.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Scalar/JumpThreading.h"
+#include "llvm/Transforms/Utils/AssignGUID.h"
 #include "llvm/Transforms/Utils/Debugify.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <limits>
@@ -1139,8 +1140,10 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
   }
 
   // Link against bitcodes supplied via the -mlink-builtin-bitcode option
-  if (CodeGenOpts.LinkBitcodePostopt)
+  if (CodeGenOpts.LinkBitcodePostopt) {
     MPM.addPass(LinkInModulesPass(BC));
+    MPM.addPass(AssignGUIDPass());
+  }
 
   if (LangOpts.HIPStdPar && !LangOpts.CUDAIsDevice &&
       LangOpts.HIPStdParInterposeAlloc)

--- a/clang/test/CodeGen/linking-bitcode-postopt.cpp
+++ b/clang/test/CodeGen/linking-bitcode-postopt.cpp
@@ -13,7 +13,7 @@
 // RUN:   -mlink-builtin-bitcode-postopt \
 // RUN: %s 2>&1 | FileCheck --check-prefixes=OPTION-POSITIVE %s
 
-// OPTION-POSITIVE: LinkInModulesPass
+// OPTION-POSITIVE: LinkInModulesPass,assign-guid
 
 // RUN: %clang_cc1 -triple amdgcn-- -emit-llvm-bc -o /dev/null \
 // RUN:   -mllvm -print-pipeline-passes \


### PR DESCRIPTION
Run AssignGUIDPass after LinkInModulesPass so newly linked globals have GUIDs before LTO summary emission.

Fixes LCOMPILER-2475.