### PR TITLE
[clang] Clean up switch stack when transforming an invalid body

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -567,6 +567,9 @@ features cannot lower the translation-unit ABI level;
 - Fixed an assertion when instantiating the body of a C++26 expansion
   statement after a fatal error had occurred. (#GH214917)
 
+- Fixed an assertion when an invalid statement appeared in a ``switch``
+  statement nested inside a C++26 expansion statement. (#GH210575)
+
 - Fixed friend declarations sometimes making non-visible default arguments
   incorrectly visible to default argument redefinition checks across modules.
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -8461,8 +8461,10 @@ TreeTransform<Derived>::TransformSwitchStmt(SwitchStmt *S) {
 
   // Transform the body of the switch statement.
   StmtResult Body = getDerived().TransformStmt(S->getBody());
+  // Finish the switch even on error to pop it from Sema's switch stack.
   if (Body.isInvalid())
-    return StmtError();
+    return getDerived().RebuildSwitchStmtBody(S->getSwitchLoc(), Switch.get(),
+                                              nullptr);
 
   // Complete the switch statement.
   return getDerived().RebuildSwitchStmtBody(S->getSwitchLoc(), Switch.get(),

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -8619,8 +8619,10 @@ TreeTransform<Derived>::TransformSwitchStmt(SwitchStmt *S) {
 
   // Transform the body of the switch statement.
   StmtResult Body = getDerived().TransformStmt(S->getBody());
+  // Finish the switch even on error to pop it from Sema's switch stack.
   if (Body.isInvalid())
-    return StmtError();
+    return getDerived().RebuildSwitchStmtBody(S->getSwitchLoc(), Switch.get(),
+                                              nullptr);
 
   // Complete the switch statement.
   return getDerived().RebuildSwitchStmtBody(S->getSwitchLoc(), Switch.get(),

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -8619,10 +8619,6 @@ TreeTransform<Derived>::TransformSwitchStmt(SwitchStmt *S) {
 
   // Transform the body of the switch statement.
   StmtResult Body = getDerived().TransformStmt(S->getBody());
-  // Finish the switch even on error to pop it from Sema's switch stack.
-  if (Body.isInvalid())
-    return getDerived().RebuildSwitchStmtBody(S->getSwitchLoc(), Switch.get(),
-                                              nullptr);
 
   // Complete the switch statement.
   return getDerived().RebuildSwitchStmtBody(S->getSwitchLoc(), Switch.get(),

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts-control-flow.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts-control-flow.cpp
@@ -116,6 +116,16 @@ void case_default(int i) {
   }
 }
 
+void gh210575(int i) {
+  switch (i) {
+    template for (auto x : {1, 2}) {
+      switch (i) {
+        bar baz(); // expected-error {{unknown type name 'bar'}}
+      }
+    }
+  }
+}
+
 void case_constexpr(int i) {
   template for (constexpr auto x : {1, 2, 3}) { // expected-note {{in instantiation of expansion statement requested here}}
     switch (i) {

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts-control-flow.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts-control-flow.cpp
@@ -116,7 +116,7 @@ void case_default(int i) {
   }
 }
 
-void PR211162(int i) {
+void GH210575(int i) {
   switch (i) {
     template for (auto x : {1, 2}) {
       switch (i) {

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts-control-flow.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts-control-flow.cpp
@@ -116,7 +116,7 @@ void case_default(int i) {
   }
 }
 
-void gh210575(int i) {
+void PR211162(int i) {
   switch (i) {
     template for (auto x : {1, 2}) {
       switch (i) {


### PR DESCRIPTION
This PR resolves https://github.com/llvm/llvm-project/issues/210575. The codes just clear switch stack when Body.isInvalid() to avoid assert error in the following code.

Assisted-by: OpenAI Codex