### PR TITLE
[CoroElide] Remove restriction that the ramp function be inlined

### DIFF
--- a/llvm/docs/Coroutines.md
+++ b/llvm/docs/Coroutines.md
@@ -2087,7 +2087,7 @@ and replaces `coro.alloc` and `coro.free` intrinsics with `false` and `null`
 respectively to remove the deallocation code.
 
 ### CoroElide
-The pass CoroElide examines if the inlined coroutine is eligible for heap
+The pass CoroElide examines if the coroutine is eligible for heap
 allocation elision optimization. If so, it replaces
 `coro.begin` intrinsic with an address of a coroutine frame placed on its caller
 and replaces `coro.alloc` and `coro.free` intrinsics with `false` and `null`

--- a/llvm/lib/Transforms/Coroutines/CoroElide.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroElide.cpp
@@ -148,9 +148,7 @@ void FunctionElideInfo::collectPostSplitCoroIds() {
   for (auto &I : instructions(this->ContainingFunction)) {
     if (auto *CII = dyn_cast<CoroIdInst>(&I))
       if (CII->getInfo().isPostSplit())
-        // If it is the coroutine itself, don't touch it.
-        if (CII->getCoroutine() != CII->getFunction())
-          CoroIds.push_back(CII);
+        CoroIds.push_back(CII);
 
     // Consider case like:
     // %0 = call i8 @llvm.coro.suspend(...)

--- a/llvm/test/Transforms/Coroutines/coro-elide.ll
+++ b/llvm/test/Transforms/Coroutines/coro-elide.ll
@@ -149,6 +149,20 @@ entry:
   ret void
 }
 
+; Test that coroutines, when feasible, are elided without requiring inlining.
+define void @noinline_elision() {
+; CHECK-LABEL: define void @noinline_elision() {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    ret void
+;
+entry:
+  %id = call token @llvm.coro.id(i32 0, ptr null, ptr @noinline_elision, ptr @f.resumers)
+  %alloc = call i1 @llvm.coro.alloc(token %id)
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr null)
+  call void @llvm.coro.dead(ptr %hdl)
+  ret void
+}
+
 declare token @llvm.coro.id(i32, ptr, ptr, ptr)
 declare ptr @llvm.coro.begin(token, ptr)
 declare ptr @llvm.coro.frame()


### PR DESCRIPTION
This restriction dates back to the initial implementation of CoroElide support (https://github.com/llvm/llvm-project/commit/dce9b026773160769625a4809bf2dfbf4e636ef1), but the rationale for treating ramp functions specially seems unclear and lacks test coverage.

This patch proposes that we drop the restriction and enable more optimization opportunities. This also fixed the repro in #148380, but the root cause remains unresolved.