### PR TITLE
[Flang][Semantics] Avoid crash in ALLOCATE SOURCE= check after resolution errors

### DIFF
--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -287,6 +287,7 @@ public:
 
   const Scope &FindScope(parser::CharBlock) const;
   Scope &FindScope(parser::CharBlock);
+  bool IsValidScope(parser::CharBlock);
   void UpdateScopeIndex(Scope &, parser::CharBlock);
   void DumpScopeIndex(llvm::raw_ostream &) const;
 

--- a/flang/lib/Semantics/check-allocate.cpp
+++ b/flang/lib/Semantics/check-allocate.cpp
@@ -267,10 +267,13 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
         }
       }
       if (info.gotSource) { // C1594(6) - SOURCE= restrictions when pure
-        const Scope &scope{context.FindScope(at)};
-        if (FindPureProcedureContaining(scope)) {
-          parser::ContextualMessages messages{at, &context.messages()};
-          CheckCopyabilityInPureScope(messages, *expr, scope);
+        parser::CharBlock scopeAt{parser::FindSourceLocation(allocateStmt)};
+        if (!context.AnyFatalError() || context.IsValidScope(scopeAt)) {
+          const Scope &scope{context.FindScope(scopeAt)};
+          if (FindPureProcedureContaining(scope)) {
+            parser::ContextualMessages messages{at, &context.messages()};
+            CheckCopyabilityInPureScope(messages, *expr, scope);
+          }
         }
       }
       auto maybeShape{evaluate::GetShape(context.foldingContext(), *expr)};

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -478,6 +478,13 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
   }
 }
 
+bool SemanticsContext::IsValidScope(parser::CharBlock source) {
+  if (auto iter{SearchScopeIndex(source)}; iter != scopeIndex_.end())
+    return true;
+
+  return false;
+}
+
 void SemanticsContext::UpdateScopeIndex(
     Scope &scope, parser::CharBlock newSource) {
   if (scope.sourceRange().empty()) {

--- a/flang/test/Semantics/allocate15.f90
+++ b/flang/test/Semantics/allocate15.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Do not crash when ALLOCATE has SOURCE= with a constant after module USE cycle errors.
+!ERROR: Some modules in this compilation unit form one or more cycles of dependence
+module m1
+  use m3
+end
+module m3
+  use m1
+end
+subroutine s()
+  allocate(x1, source = [1, 2, 3, 4, 5])
+end


### PR DESCRIPTION

When module USE cycles(or other fatal resolution failures), the scope index are partially set. AllocateChecker calls FindScope() on the SOURCE= expression source causing a fatal internal error instead of reporting the earlier semantic errors. This is fixed by skipping the SOURCE= check when AnyFatalError() is already set and the scope is invalid.

fixes issue #210369