### PR TITLE
[X86][AVX10.2] Add missing _mm_cvtts_ss/sd* intrinsics

### DIFF
--- a/clang/lib/Headers/avx10_2satcvtdsintrin.h
+++ b/clang/lib/Headers/avx10_2satcvtdsintrin.h
@@ -44,6 +44,38 @@
   ((unsigned int)__builtin_ia32_vcvttss2usis32((__v4sf)(__m128)(__A),          \
                                                (const int)(__R)))
 
+static __inline__ int __DEFAULT_FN_ATTRS128 _mm_cvtts_sd_i32(__m128d __A) {
+  return (int)__builtin_ia32_vcvttsd2sis32((__v2df)__A,
+                                           _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ int __DEFAULT_FN_ATTRS128 _mm_cvtts_sd_si32(__m128d __A) {
+  return (int)__builtin_ia32_vcvttsd2sis32((__v2df)__A,
+                                           _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ unsigned int __DEFAULT_FN_ATTRS128
+_mm_cvtts_sd_u32(__m128d __A) {
+  return (unsigned int)__builtin_ia32_vcvttsd2usis32((__v2df)__A,
+                                                     _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ int __DEFAULT_FN_ATTRS128 _mm_cvtts_ss_i32(__m128 __A) {
+  return (int)__builtin_ia32_vcvttss2sis32((__v4sf)__A,
+                                           _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ int __DEFAULT_FN_ATTRS128 _mm_cvtts_ss_si32(__m128 __A) {
+  return (int)__builtin_ia32_vcvttss2sis32((__v4sf)__A,
+                                           _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ unsigned int __DEFAULT_FN_ATTRS128
+_mm_cvtts_ss_u32(__m128 __A) {
+  return (unsigned int)__builtin_ia32_vcvttss2usis32((__v4sf)__A,
+                                                     _MM_FROUND_CUR_DIRECTION);
+}
+
 #ifdef __x86_64__
 #define _mm_cvtts_roundss_u64(__A, __R)                                        \
   ((unsigned long long)__builtin_ia32_vcvttss2usis64((__v4sf)(__m128)(__A),    \
@@ -68,6 +100,41 @@
 #define _mm_cvtts_roundsd_i64(__A, __R)                                        \
   ((long long)__builtin_ia32_vcvttsd2sis64((__v2df)(__m128d)(__A),             \
                                            (const int)(__R)))
+
+static __inline__ unsigned long long
+    __DEFAULT_FN_ATTRS128 _mm_cvtts_ss_u64(__m128 __A) {
+  return (unsigned long long)__builtin_ia32_vcvttss2usis64(
+      (__v4sf)__A, _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ unsigned long long __DEFAULT_FN_ATTRS128
+_mm_cvtts_sd_u64(__m128d __A) {
+  return (unsigned long long)__builtin_ia32_vcvttsd2usis64(
+      (__v2df)__A, _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ long long __DEFAULT_FN_ATTRS128 _mm_cvtts_ss_i64(__m128 __A) {
+  return (long long)__builtin_ia32_vcvttss2sis64((__v4sf)__A,
+                                                 _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ long long __DEFAULT_FN_ATTRS128
+_mm_cvtts_ss_si64(__m128 __A) {
+  return (long long)__builtin_ia32_vcvttss2sis64((__v4sf)__A,
+                                                 _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ long long __DEFAULT_FN_ATTRS128
+_mm_cvtts_sd_si64(__m128d __A) {
+  return (long long)__builtin_ia32_vcvttsd2sis64((__v2df)__A,
+                                                 _MM_FROUND_CUR_DIRECTION);
+}
+
+static __inline__ long long __DEFAULT_FN_ATTRS128
+_mm_cvtts_sd_i64(__m128d __A) {
+  return (long long)__builtin_ia32_vcvttsd2sis64((__v2df)__A,
+                                                 _MM_FROUND_CUR_DIRECTION);
+}
 #endif /* __x86_64__ */
 
 // 128 Bit : Double -> int

--- a/clang/test/CodeGen/X86/avx10_2satcvtds-builtins-x64.c
+++ b/clang/test/CodeGen/X86/avx10_2satcvtds-builtins-x64.c
@@ -41,6 +41,42 @@ unsigned test_mm_cvtts_ss_u32(__m128 __A) {
   return _mm_cvtts_roundss_u32(__A, _MM_FROUND_NO_EXC);
 }
 
+unsigned long long test_mm_cvtts_ss_u64(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_u64(
+  // CHECK: @llvm.x86.avx10.vcvttss2usis64(<4 x float>
+  return _mm_cvtts_ss_u64(__A);
+}
+
+unsigned long long test_mm_cvtts_sd_u64(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_u64(
+  // CHECK: @llvm.x86.avx10.vcvttsd2usis64(<2 x double>
+  return _mm_cvtts_sd_u64(__A);
+}
+
+long long test_mm_cvtts_ss_i64(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_i64(
+  // CHECK: @llvm.x86.avx10.vcvttss2sis64(<4 x float>
+  return _mm_cvtts_ss_i64(__A);
+}
+
+long long test_mm_cvtts_ss_si64(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_si64(
+  // CHECK: @llvm.x86.avx10.vcvttss2sis64(<4 x float>
+  return _mm_cvtts_ss_si64(__A);
+}
+
+long long test_mm_cvtts_sd_si64(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_si64(
+  // CHECK: @llvm.x86.avx10.vcvttsd2sis64(<2 x double>
+  return _mm_cvtts_sd_si64(__A);
+}
+
+long long test_mm_cvtts_sd_i64(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_i64(
+  // CHECK: @llvm.x86.avx10.vcvttsd2sis64(<2 x double>
+  return _mm_cvtts_sd_i64(__A);
+}
+
 // vector
 // 128 bit
 __m128i test_mm_cvtts_pd_epi64(__m128d A){

--- a/clang/test/CodeGen/X86/avx10_2satcvtds-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2satcvtds-builtins.c
@@ -4,6 +4,42 @@
 #include <immintrin.h>
 #include <stddef.h>
 
+int test_mm_cvtts_sd_i32(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_i32(
+  // CHECK: @llvm.x86.avx10.vcvttsd2sis(<2 x double>
+  return _mm_cvtts_sd_i32(__A);
+}
+
+int test_mm_cvtts_sd_si32(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_si32(
+  // CHECK: @llvm.x86.avx10.vcvttsd2sis(<2 x double>
+  return _mm_cvtts_sd_si32(__A);
+}
+
+unsigned int test_mm_cvtts_sd_u32(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_u32(
+  // CHECK: @llvm.x86.avx10.vcvttsd2usis(<2 x double>
+  return _mm_cvtts_sd_u32(__A);
+}
+
+int test_mm_cvtts_ss_i32(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_i32(
+  // CHECK: @llvm.x86.avx10.vcvttss2sis(<4 x float>
+  return _mm_cvtts_ss_i32(__A);
+}
+
+int test_mm_cvtts_ss_si32(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_si32(
+  // CHECK: @llvm.x86.avx10.vcvttss2sis(<4 x float>
+  return _mm_cvtts_ss_si32(__A);
+}
+
+unsigned int test_mm_cvtts_ss_u32(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_u32(
+  // CHECK: @llvm.x86.avx10.vcvttss2usis(<4 x float>
+  return _mm_cvtts_ss_u32(__A);
+}
+
 __m128i test_mm_cvtts_pd_epi32(__m128d A){
 // CHECK-LABEL: @test_mm_cvtts_pd_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.128(<2 x double>


### PR DESCRIPTION
Fixes part of #210947

Assisted-by: Claude Opus 4.8