### PR TITLE
Add missing opcode for offset validity check

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -2833,6 +2833,7 @@ bool HexagonInstrInfo::isValidOffset(unsigned Opcode, int Offset,
   case Hexagon::V6_vL32b_nt_cur_npred_ai:
   case Hexagon::V6_vL32b_nt_tmp_pred_ai:
   case Hexagon::V6_vL32b_nt_tmp_npred_ai:
+  case Hexagon::V6_vS32Ub_pred_ai:
   case Hexagon::V6_vS32Ub_npred_ai:
   case Hexagon::V6_vgathermh_pseudo:
   case Hexagon::V6_vgather_vscatter_mh_pseudo:

--- a/llvm/test/CodeGen/Hexagon/amode-opt-vS32Ub-pred.mir
+++ b/llvm/test/CodeGen/Hexagon/amode-opt-vS32Ub-pred.mir
@@ -1,0 +1,30 @@
+# RUN: llc -mtriple=hexagon -mcpu=hexagonv65 -mhvx -run-pass=amode-opt %s -o /dev/null
+# REQUIRES: asserts
+
+# Tests that we don't hit the unreachable code with message
+# Failed Opcode is : V6_vS32Ub_pred_ai
+# No offset range is defined for this opcode
+#
+# The amode-opt pass folds an A2_addi into the base register of a load/store.
+# For V6_vS32Ub_pred_ai the opcode was missing from isValidOffset(), causing
+# an unreachable to be hit.
+
+--- |
+  target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
+  target triple = "hexagon"
+
+  define void @test(ptr %p) {
+    ret void
+  }
+...
+
+---
+name:            test
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r0, $p0, $v0
+
+    $r1 = A2_addi $r0, 64
+    V6_vS32Ub_pred_ai $p0, $r1, 0, $v0
+...


### PR DESCRIPTION
During offset validity check, the common API in HexagonInstrInfo does not handle the opcode. Adding it fixes wherever offset calculation is made for the instruction.