### PR TITLE
[flang] Preserve DO variable updates through aliases

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -32,6 +32,7 @@
 #include "flang/Lower/StatementContext.h"
 #include "flang/Lower/Support/ReductionProcessor.h"
 #include "flang/Lower/Support/Utils.h"
+#include "flang/Optimizer/Analysis/AliasAnalysis.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/CUFCommon.h"
 #include "flang/Optimizer/Builder/Character.h"
@@ -132,6 +133,7 @@ struct IncrementLoopInfo {
 
   // Data members for structured loops.
   mlir::Operation *loopOp = nullptr;
+  mlir::Operation *loopVariableStore = nullptr;
 
   // Data members for unstructured loops.
   bool hasRealControl = false;
@@ -3062,18 +3064,16 @@ private:
         if (genDoConcurrent)
           continue;
 
-        // Lower the loop without the secondary-induction iter_arg so memory
-        // recurrences (e.g. reductions) stay visible to later analyses. The DO
-        // variable is recomputed from the induction variable in the body; its
-        // post-loop value is materialized in genFIRIncrementLoopEnd.
+        // Start with SSA-controlled induction. After lowering the body, switch
+        // to memory-controlled induction if another reference may modify it.
         auto loopOp = fir::DoLoopOp::create(
             *builder, loc, lowerValue, upperValue, stepValue,
             /*unordered=*/false, /*finalCountValue=*/false,
             /*iterArgs=*/mlir::ValueRange{});
         info.loopOp = loopOp;
         builder->setInsertionPointToStart(loopOp.getBody());
-        fir::StoreOp::create(*builder, loc, loopOp.getInductionVar(),
-                             info.loopVariable);
+        info.loopVariableStore = fir::StoreOp::create(
+            *builder, loc, loopOp.getInductionVar(), info.loopVariable);
         addLoopAnnotationAttr(info, dirs);
         continue;
       }
@@ -3214,13 +3214,39 @@ private:
           continue;
         }
 
-        // End fir.do_loop. The loop carries no secondary-induction iter_arg, so
-        // materialize the Fortran post-loop value lb + tripCount*step after the
-        // loop for later uses of the DO variable. Compute it in the loop's
-        // index type (matching how the loop counts iterations) so the trip
-        // arithmetic does not overflow the DO variable's type for empty
-        // range-extreme loops.
+        // Detect writes that may update the DO variable through another
+        // reference.
         auto doLoopOp = mlir::cast<fir::DoLoopOp>(info.loopOp);
+        fir::AliasAnalysis aliasAnalysis;
+        bool loopVariableMayBeModified = false;
+        for (mlir::Operation &op : doLoopOp.getBody()->without_terminator()) {
+          if (&op != info.loopVariableStore &&
+              aliasAnalysis.getModRef(&op, info.loopVariable).isMod()) {
+            loopVariableMayBeModified = true;
+            break;
+          }
+        }
+        if (loopVariableMayBeModified) {
+          builder->setInsertionPoint(doLoopOp);
+          fir::StoreOp::create(*builder, loc, doLoopOp.getLowerBound(),
+                               info.loopVariable);
+          info.loopVariableStore->erase();
+          info.loopVariableStore = nullptr;
+
+          builder->setInsertionPoint(doLoopOp.getBody()->getTerminator());
+          mlir::Value value =
+              fir::LoadOp::create(*builder, loc, info.loopVariable);
+          mlir::Value step = builder->createConvert(
+              loc, info.getLoopVariableType(), doLoopOp.getStep());
+          value =
+              mlir::arith::AddIOp::create(*builder, loc, value, step, iofAttr);
+          fir::StoreOp::create(*builder, loc, value, info.loopVariable);
+          builder->setInsertionPointAfter(doLoopOp);
+          continue;
+        }
+
+        // Compute the SSA-controlled post-loop value in index type to avoid
+        // narrow integer overflow for empty range-extreme loops.
         builder->setInsertionPointAfter(doLoopOp);
         mlir::Type idxTy = builder->getIndexType();
         mlir::Value lb =

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -53,6 +53,7 @@ add_flang_library(FortranLower
   DEPENDS
   CUFAttrs
   CUFDialect
+  FIRAnalysis
   FIRDialect
   FIRTransforms
   HLFIRDialect
@@ -61,6 +62,7 @@ add_flang_library(FortranLower
   LINK_LIBS
   CUFAttrs
   CUFDialect
+  FIRAnalysis
   FIRDialect
   FIRDialectSupport
   FIRBuilder

--- a/flang/test/Lower/do_loop_alias_update.f90
+++ b/flang/test/Lower/do_loop_alias_update.f90
@@ -1,0 +1,53 @@
+! RUN: %flang_fc1 -emit-hlfir -mmlir --unsafe-cray-pointers -o - %s | FileCheck %s
+
+! CHECK-LABEL: func.func @_QPcray_pointer_loop()
+subroutine cray_pointer_loop
+  integer :: g, g5
+  integer(8) :: lm
+  pointer(lm, gpl6l)
+
+  ! CHECK: %[[G_REF:.*]] = fir.alloca i32 {bindc_name = "g"
+  ! CHECK: %[[G:.*]]:2 = hlfir.declare %[[G_REF]]
+  lm = loc(g)
+  g5 = 0
+
+  ! CHECK: %[[LB:.*]] = arith.constant -2 : i32
+  ! CHECK: %[[UB:.*]] = arith.constant -7 : i32
+  ! CHECK: %[[STEP:.*]] = arith.constant -2 : i32
+  ! CHECK: fir.store %[[LB]] to %[[G]]#0 : !fir.ref<i32>
+  ! CHECK: fir.do_loop %[[IV:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] : i32 {
+  ! CHECK-NOT: fir.store %[[IV]] to %[[G]]#0
+  do g = -2, -7, -2
+    g5 = g5 + 5
+    gpl6l = g - 3
+  ! CHECK: %[[UPDATED:.*]] = fir.load %[[G]]#0 : !fir.ref<i32>
+  ! CHECK: %[[NEXT:.*]] = arith.addi %[[UPDATED]], %[[STEP]] overflow<nsw> : i32
+  ! CHECK: fir.store %[[NEXT]] to %[[G]]#0 : !fir.ref<i32>
+  ! CHECK: fir.result
+  ! CHECK: }
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPpointer_alias_loop()
+subroutine pointer_alias_loop
+  integer, target :: i
+  integer, pointer :: p
+
+  p => i
+  ! CHECK: %[[I_REF:.*]] = fir.alloca i32 {bindc_name = "i"
+  ! CHECK: %[[I:.*]]:2 = hlfir.declare %[[I_REF]]
+  ! CHECK: %[[LB:.*]] = arith.constant 1 : i32
+  ! CHECK: %[[UB:.*]] = arith.constant 3 : i32
+  ! CHECK: %[[STEP:.*]] = arith.constant 1 : i32
+  ! CHECK: fir.store %[[LB]] to %[[I]]#0 : !fir.ref<i32>
+  ! CHECK: fir.do_loop %[[IV:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] : i32 {
+  ! CHECK-NOT: fir.store %[[IV]] to %[[I]]#0
+  do i = 1, 3
+    p = i + 1
+  ! CHECK: %[[UPDATED:.*]] = fir.load %[[I]]#0 : !fir.ref<i32>
+  ! CHECK: %[[NEXT:.*]] = arith.addi %[[UPDATED]], %[[STEP]] overflow<nsw> : i32
+  ! CHECK: fir.store %[[NEXT]] to %[[I]]#0 : !fir.ref<i32>
+  ! CHECK: fir.result
+  ! CHECK: }
+  end do
+end subroutine

--- a/flang/test/Lower/do_loop_alias_update.f90
+++ b/flang/test/Lower/do_loop_alias_update.f90
@@ -20,10 +20,10 @@ subroutine cray_pointer_loop
   do g = -2, -7, -2
     g5 = g5 + 5
     gpl6l = g - 3
+  ! CHECK: hlfir.assign {{.*}} to {{.*}} : f32, !fir.ptr<f32>
   ! CHECK: %[[UPDATED:.*]] = fir.load %[[G]]#0 : !fir.ref<i32>
   ! CHECK: %[[NEXT:.*]] = arith.addi %[[UPDATED]], %[[STEP]] overflow<nsw> : i32
   ! CHECK: fir.store %[[NEXT]] to %[[G]]#0 : !fir.ref<i32>
-  ! CHECK: fir.result
   ! CHECK: }
   end do
 end subroutine
@@ -44,10 +44,10 @@ subroutine pointer_alias_loop
   ! CHECK-NOT: fir.store %[[IV]] to %[[I]]#0
   do i = 1, 3
     p = i + 1
+  ! CHECK: hlfir.assign {{.*}} to {{.*}} : i32, !fir.ptr<i32>
   ! CHECK: %[[UPDATED:.*]] = fir.load %[[I]]#0 : !fir.ref<i32>
   ! CHECK: %[[NEXT:.*]] = arith.addi %[[UPDATED]], %[[STEP]] overflow<nsw> : i32
   ! CHECK: fir.store %[[NEXT]] to %[[I]]#0 : !fir.ref<i32>
-  ! CHECK: fir.result
   ! CHECK: }
   end do
 end subroutine

--- a/flang/test/Transforms/DoConcurrent/skip_all_nested_loops.f90
+++ b/flang/test/Transforms/DoConcurrent/skip_all_nested_loops.f90
@@ -48,9 +48,12 @@ end
 
 ! COMMON: omp.wsloop {
 ! COMMON: omp.loop_nest ({{[^[:space:]]+}}) {{.*}} {
-! COMMON:   fir.do_loop %[[J_IV:.*]] = {{.*}} to {{.*}} step {{.*}} : i32 {
-! HOST:       fir.store %[[J_IV]] to %[[ORIG_J_DECL]]#0
-! DEVICE:     fir.store %[[J_IV]] to %[[TARGET_J_DECL]]#0
+! HOST:     fir.store %[[HOST_J_LB:.*]] to %[[ORIG_J_DECL]]#0
+! HOST:     fir.do_loop %[[J_IV:.*]] = %[[HOST_J_LB]] to {{.*}} step %[[HOST_J_STEP:.*]] : i32 {
+! HOST-NOT:   fir.store %[[J_IV]] to %[[ORIG_J_DECL]]#0
+! DEVICE:   fir.store %[[DEVICE_J_LB:.*]] to %[[TARGET_J_DECL]]#0
+! DEVICE:   fir.do_loop %[[J_IV:.*]] = %[[DEVICE_J_LB]] to {{.*}} step %[[DEVICE_J_STEP:.*]] : i32 {
+! DEVICE-NOT: fir.store %[[J_IV]] to %[[TARGET_J_DECL]]#0
 
 ! COMMON:     fir.do_concurrent {
 ! COMMON:         %[[ORIG_K_ALLOC:.*]] = fir.alloca i32 {bindc_name = "k"}
@@ -60,6 +63,12 @@ end
 ! COMMON:           fir.store %[[K_IV_CONV]] to %[[ORIG_K_DECL]]#0
 ! COMMON:       }
 ! COMMON:     }
+! HOST:       %[[UPDATED_J:.*]] = fir.load %[[ORIG_J_DECL]]#0
+! HOST:       %[[NEXT_J:.*]] = arith.addi %[[UPDATED_J]], %[[HOST_J_STEP]] overflow<nsw> : i32
+! HOST:       fir.store %[[NEXT_J]] to %[[ORIG_J_DECL]]#0
+! DEVICE:     %[[UPDATED_J:.*]] = fir.load %[[TARGET_J_DECL]]#0
+! DEVICE:     %[[NEXT_J:.*]] = arith.addi %[[UPDATED_J]], %[[DEVICE_J_STEP]] overflow<nsw> : i32
+! DEVICE:     fir.store %[[NEXT_J]] to %[[TARGET_J_DECL]]#0
 ! COMMON:   }
 ! COMMON: omp.yield
 ! COMMON: }


### PR DESCRIPTION
Use FIR ModRef analysis to retain memory-driven induction when a loop body may update the DO variable through another reference.