### PR TITLE
[Matrix] Use incoming terminator as insert point in visitPHI.

### DIFF
--- a/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
@@ -2400,9 +2400,9 @@ public:
     for (auto [IncomingV, IncomingB] :
          llvm::zip_equal(Inst->incoming_values(), Inst->blocks())) {
       // getMatrix() may insert some instructions to help with reshaping. The
-      // safest place for those is at the top of the block after the rest of the
-      // PHI's. Even better, if we can put it in the incoming block.
-      Builder.SetInsertPoint(BlockIP);
+      // safest place for those is just before the terminator of the incoming
+      // block. If there's a valid insert point before the def, even better.
+      Builder.SetInsertPoint(IncomingB->getTerminator());
       if (auto *IncomingInst = dyn_cast<Instruction>(IncomingV))
         if (auto MaybeIP = IncomingInst->getInsertionPointAfterDef())
           Builder.SetInsertPoint(*MaybeIP);

--- a/llvm/test/Transforms/LowerMatrixIntrinsics/phi.ll
+++ b/llvm/test/Transforms/LowerMatrixIntrinsics/phi.ll
@@ -787,3 +787,77 @@ if.end:                                        ; preds = %if.then, %if.else
   %res = tail call <9 x double> @llvm.matrix.multiply.v9f64.v9f64.v9f64(<9 x double> %C, <9 x double> %merge, i32 3, i32 3, i32 3)
   ret <9 x double> %res
 }
+
+define <4 x float> @matrix_phi_argument_incoming(<4 x float> %arg, i1 %cond) {
+; CHECK-LABEL: @matrix_phi_argument_incoming(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[SPLIT:%.*]] = shufflevector <4 x float> [[ARG:%.*]], <4 x float> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[SPLIT3:%.*]] = shufflevector <4 x float> [[ARG]], <4 x float> poison, <2 x i32> <i32 2, i32 3>
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[EXIT:%.*]], label [[BB:%.*]]
+; CHECK:       bb:
+; CHECK-NEXT:    br label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    [[PHI1:%.*]] = phi <2 x float> [ zeroinitializer, [[BB]] ], [ [[SPLIT]], [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[PHI2:%.*]] = phi <2 x float> [ zeroinitializer, [[BB]] ], [ [[SPLIT3]], [[ENTRY]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <2 x float> [[PHI1]], <2 x float> [[PHI2]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    ret <4 x float> [[TMP0]]
+;
+entry:
+  br i1 %cond, label %exit, label %bb
+
+bb:
+  %t = call <4 x float> @llvm.matrix.transpose.v4f32(<4 x float> zeroinitializer, i32 2, i32 2)
+  br label %exit
+
+exit:
+  %phi = phi <4 x float> [ %t, %bb ], [ %arg, %entry ]
+  ret <4 x float> %phi
+}
+
+declare <4 x float> @get_matrix()
+declare i32 @__gxx_personality_v0(...)
+
+define <4 x float> @matrix_phi_invoke_incoming(i1 %cond) personality ptr @__gxx_personality_v0 {
+; CHECK-LABEL: @matrix_phi_invoke_incoming(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[CALL:%.*]], label [[BB:%.*]]
+; CHECK:       call:
+; CHECK-NEXT:    [[INV:%.*]] = invoke <4 x float> @get_matrix()
+; CHECK-NEXT:            to label [[CONT:%.*]] unwind label [[LPAD:%.*]]
+; CHECK:       cont:
+; CHECK-NEXT:    [[SPLIT:%.*]] = shufflevector <4 x float> [[INV]], <4 x float> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[SPLIT3:%.*]] = shufflevector <4 x float> [[INV]], <4 x float> poison, <2 x i32> <i32 2, i32 3>
+; CHECK-NEXT:    br label [[EXIT:%.*]]
+; CHECK:       lpad:
+; CHECK-NEXT:    [[L:%.*]] = landingpad { ptr, i32 }
+; CHECK-NEXT:            cleanup
+; CHECK-NEXT:    ret <4 x float> zeroinitializer
+; CHECK:       bb:
+; CHECK-NEXT:    br label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    [[PHI1:%.*]] = phi <2 x float> [ [[SPLIT]], [[CONT]] ], [ zeroinitializer, [[BB]] ]
+; CHECK-NEXT:    [[PHI2:%.*]] = phi <2 x float> [ [[SPLIT3]], [[CONT]] ], [ zeroinitializer, [[BB]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <2 x float> [[PHI1]], <2 x float> [[PHI2]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    ret <4 x float> [[TMP0]]
+;
+entry:
+  br i1 %cond, label %call, label %bb
+
+call:
+  %inv = invoke <4 x float> @get_matrix() to label %cont unwind label %lpad
+
+cont:
+  br label %exit
+
+lpad:
+  %l = landingpad { ptr, i32 } cleanup
+  ret <4 x float> zeroinitializer
+
+bb:
+  %t = call <4 x float> @llvm.matrix.transpose.v4f32(<4 x float> zeroinitializer, i32 2, i32 2)
+  br label %exit
+
+exit:
+  %phi = phi <4 x float> [ %inv, %cont ], [ %t, %bb ]
+  ret <4 x float> %phi
+}


### PR DESCRIPTION
For some instructions, like invoke, getInsertionPointAfterDef may return an std::nullopt. Using the insert point after the phi is then incorrect. Use the incoming terminator as default insert point to fix a crash in the added test cases.