### PR TITLE
[PseudoProbe] Avoid inserting probes between musttail/deoptimize calls and returns

### DIFF
--- a/llvm/lib/Transforms/IPO/SampleProfileProbe.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileProbe.cpp
@@ -393,6 +393,18 @@ void SampleProfileProber::instrumentOneFunc(Function &F, TargetMachine *TM) {
       J = J->getNextNode();
     }
 
+    // A pseudo probe must not be inserted between a `musttail` or
+    // `llvm.experimental.deoptimize` call and its following `ret`, as this
+    // produces invalid IR. Such a call is required to immediately precede the
+    // block's `ret`, so only that position needs to be checked. Insert the
+    // probe before the call instead.
+    if (auto *Ret = dyn_cast<ReturnInst>(BB->getTerminator()))
+      if (auto *CI = dyn_cast_or_null<CallInst>(Ret->getPrevNode()))
+        if ((CI->isMustTailCall() ||
+             CI->getIntrinsicID() == Intrinsic::experimental_deoptimize) &&
+            !J->comesBefore(CI))
+          J = CI;
+
     IRBuilder<> Builder(J);
     assert(Builder.GetInsertPoint() != BB->end() &&
            "Cannot get the probing point");

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-musttail-deopt.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-musttail-deopt.ll
@@ -1,0 +1,26 @@
+; A pseudo-probe must not be inserted between a musttail or
+; llvm.experimental.deoptimize call and its following return, as this produces
+; invalid IR. Verify that probes are inserted before these calls instead.
+;
+; RUN: opt < %s -passes=pseudo-probe -S | FileCheck %s
+
+; CHECK-LABEL: define i32 @mt(ptr %p)
+; CHECK:      call void @llvm.pseudoprobe
+; CHECK-NEXT: %v = musttail call i32 @callee(ptr %p)
+; CHECK-NEXT: ret i32 %v
+define i32 @mt(ptr %p) {
+  %v = musttail call i32 @callee(ptr %p)
+  ret i32 %v
+}
+
+; CHECK-LABEL: define i32 @deopt()
+; CHECK:      call void @llvm.pseudoprobe
+; CHECK-NEXT: %v = call i32 (...) @llvm.experimental.deoptimize.i32() [ "deopt"() ]
+; CHECK-NEXT: ret i32 %v
+define i32 @deopt() {
+  %v = call i32 (...) @llvm.experimental.deoptimize.i32() [ "deopt"() ]
+  ret i32 %v
+}
+
+declare i32 @callee(ptr)
+declare i32 @llvm.experimental.deoptimize.i32(...)


### PR DESCRIPTION
PseudoProbe insertion can generate invalid IR by inserting a probe between a musttail/llvm.experimental.deoptimize call and its following ret. Insert the probe before these calls to preserve the required instruction ordering.