### PR TITLE
[libc++abi][NFC] Remove some XFAILs which never trigger

### DIFF
--- a/libcxxabi/test/cxa_vec_new_overflow_PR41395.pass.cpp
+++ b/libcxxabi/test/cxa_vec_new_overflow_PR41395.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 
-// This test requires the fix in http://llvm.org/PR41395 (c4225e124f9e).
-// XFAIL: using-built-library-before-llvm-9
-
 #include "cxxabi.h"
 #include <cassert>
 #include <cstddef>

--- a/libcxxabi/test/dynamic_cast.pass.cpp
+++ b/libcxxabi/test/dynamic_cast.pass.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This test requires PR33425, PR33487 and PR33439.
-// XFAIL: using-built-library-before-llvm-9
-
 #include <cassert>
 
 // This test explicitly tests dynamic cast with types that have inaccessible

--- a/libcxxabi/test/test_aux_runtime_op_array_new.pass.cpp
+++ b/libcxxabi/test/test_aux_runtime_op_array_new.pass.cpp
@@ -8,10 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 
-// ___cxa_throw_bad_array_new_length is re-exported from libc++ only starting
-// in LLVM 9.
-// XFAIL: using-built-library-before-llvm-9
-
 #include <cxxabi.h>
 #include <new>
 

--- a/libcxxabi/test/uncaught_exceptions.pass.cpp
+++ b/libcxxabi/test/uncaught_exceptions.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 
-// __cxa_uncaught_exceptions is not re-exported from libc++ until LLVM 9.
-// XFAIL: using-built-library-before-llvm-9
-
 #include <cxxabi.h>
 #include <cassert>
 


### PR DESCRIPTION
The oldest library we support is from LLVM 12, so we can remove any XFAILs for libraries built before that.
