### PR TITLE
[MLIR][Python] Remove stale Python module naming status message

### DIFF
--- a/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
+++ b/mlir/cmake/modules/MLIRDetectPythonEnv.cmake
@@ -84,8 +84,5 @@ macro(mlir_configure_python_dev_packages)
     endif()
     find_package(nanobind 2.9 CONFIG REQUIRED)
     message(STATUS "Found nanobind v${nanobind_VERSION}: ${nanobind_INCLUDE_DIR}")
-    message(STATUS "Python prefix = '${PYTHON_MODULE_PREFIX}', "
-            "suffix = '${PYTHON_MODULE_SUFFIX}', "
-            "extension = '${PYTHON_MODULE_EXTENSION}")
   endif()
 endmacro()


### PR DESCRIPTION
`PYTHON_MODULE_PREFIX`, `PYTHON_MODULE_SUFFIX`, and `PYTHON_MODULE_EXTENSION` are remnants of the previous pybind11-based Python discovery path and are no longer populated or used by the nanobind build.

The relevant Python SOABI is already reported through `Python3_SOABI`, so we can remove the redundant status message, which currently prints only empty values.