### PR TITLE
[MLIR][Python] Do not install ExecutionEngine wrapper when disabled

### DIFF
--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -41,15 +41,23 @@ declare_mlir_python_sources(MLIRPythonSources.Core.Python.Extras
     extras/meta.py
 )
 
+set(_execution_engine_python_sources)
+if(MLIR_ENABLE_EXECUTION_ENGINE)
+  list(APPEND _execution_engine_python_sources
+    execution_engine.py
+    _mlir_libs/_mlirExecutionEngine.pyi
+  )
+endif()
+
 declare_mlir_python_sources(MLIRPythonSources.ExecutionEngine
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
   ADD_TO_PARENT MLIRPythonSources
   SOURCES
-    execution_engine.py
-    _mlir_libs/_mlirExecutionEngine.pyi
+    ${_execution_engine_python_sources}
   SOURCES_GLOB
     runtime/*.py
 )
+unset(_execution_engine_python_sources)
 
 declare_mlir_python_sources(MLIRPythonCAPI.HeaderSources
   ROOT_DIR "${MLIR_SOURCE_DIR}/include"

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -41,9 +41,12 @@ declare_mlir_python_sources(MLIRPythonSources.Core.Python.Extras
     extras/meta.py
 )
 
+# Keep this source group unconditional because runtime/*.py contains generic
+# memref helpers that do not depend on the ExecutionEngine extension. Only the
+# wrapper and type stub require _mlirExecutionEngine.
 set(_execution_engine_python_sources)
 if(MLIR_ENABLE_EXECUTION_ENGINE)
-  list(APPEND _execution_engine_python_sources
+  set(_execution_engine_python_sources
     execution_engine.py
     _mlir_libs/_mlirExecutionEngine.pyi
   )


### PR DESCRIPTION
The `_mlirExecutionEngine` extension is declared only when `MLIR_ENABLE_EXECUTION_ENGINE` is enabled. However, `execution_engine.py` and its type stub are currently added to the Python package unconditionally.

This leaves an installed `mlir.execution_engine` module that fails immediately when imported because its native extension is absent. It also exposes a type stub for an unavailable API.

Making sure they're added only if `MLIR_ENABLE_EXECUTION_ENGINE` is enabled.