### PR TITLE
[lldb][test] Skip stop-reason tests unsupported on WebAssembly

### DIFF
--- a/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
+++ b/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
@@ -11,6 +11,9 @@ from lldbsuite.test.lldbtest import *
 class BuiltinDebugTrapTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    # __builtin_debugtrap lowers to the WebAssembly `unreachable` instruction, a
+    # fatal trap that cannot be resumed as this test expects.
+    @skipIfWasm
     def test(self):
         platform_stop_reason = lldb.eStopReasonSignal
         platform = self.getPlatform()

--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -37,6 +37,7 @@ class ThreadStateTestCase(TestBase):
 
     @skipIfDarwin  # rdar://28557237
     @skipIfLinux  # llvm.org/pr15824 process interrupt stop reason is trace instead of signal sometimes
+    @skipIfWasm  # llvm.org/pr15824 the interrupting single-step's trap is reported as trace, not signal
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24668: Breakpoints not resolved correctly",


### PR DESCRIPTION
TestThreadStates::test_process_state expects a signal stop reason after "process interrupt", but the trap from the single step used to step off the breakpoint is reported as a trace stop. It is already skipped on Linux and Darwin for the same reason.

TestBuiltinDebugTrap expects to continue past __builtin_debugtrap, but on WebAssembly that lowers to the unreachable instruction, a fatal trap that cannot be resumed.