### PR TITLE
[flang][acc] Reject generic interface name in acc routine

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1425,7 +1425,16 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCRoutineConstruct &x) {
     for (const auto &name : names) {
       if (Symbol * sym{ResolveFctName(name)}) {
         Symbol &ultimate{sym->GetUltimate()};
-        AddRoutineInfoToSymbol(ultimate, x);
+        // OpenACC ties the named argument of a ROUTINE directive to a
+        // subroutine or function. A generic interface name is therefore not a
+        // valid target.
+        if (ultimate.has<GenericDetails>()) {
+          context_.Say(name.source,
+              "A generic interface name may not appear in an ACC ROUTINE clause: %s"_err_en_US,
+              name.source);
+        } else {
+          AddRoutineInfoToSymbol(ultimate, x);
+        }
       } else {
         context_.Say(name.source,
             "No function or subroutine declared for '%s'"_err_en_US,

--- a/flang/test/Semantics/OpenACC/acc-routine-generic.f90
+++ b/flang/test/Semantics/OpenACC/acc-routine-generic.f90
@@ -1,0 +1,33 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenacc
+
+! A generic interface name is not a valid target of an OpenACC ROUTINE
+! directive. The name argument denotes a subroutine or function; the same
+! restriction appears in OpenMP for declare target procedure list items.
+
+module m1
+  interface foo
+    module procedure sbar, dbar
+  end interface
+  !ERROR: A generic interface name may not appear in an ACC ROUTINE clause: foo
+  !$acc routine(foo) seq
+contains
+  real function sbar(x)
+    real, intent(in) :: x
+    sbar = x
+  end function
+  double precision function dbar(x)
+    double precision, intent(in) :: x
+    dbar = x
+  end function
+end module
+
+program gen
+  use m1
+  real :: y = 1.0, z
+  !ERROR: A generic interface name may not appear in an ACC ROUTINE clause: foo
+  !$acc routine(foo) seq
+  !$acc parallel
+  z = foo(y)
+  !$acc end parallel
+  print *, z
+end program


### PR DESCRIPTION
OpenACC ties the named argument of a ROUTINE directive to a subroutine or function. A generic interface name is therefore not a valid target. Thus adding an explicit check for this plus informational error message.