### PR TITLE
[llubi][NFC] Use context-aware value printer

### DIFF
--- a/llvm/tools/llubi/lib/ExecutorBase.h
+++ b/llvm/tools/llubi/lib/ExecutorBase.h
@@ -130,11 +130,12 @@ class DiagnosticReporter {
   ExecutorBase &Executor;
   std::string Buf;
   raw_string_ostream OS;
+  AnyValuePrinter Printer;
   DiagnosticKind Kind;
 
 public:
   DiagnosticReporter(ExecutorBase &E, DiagnosticKind K)
-      : Executor(E), OS(Buf), Kind(K) {}
+      : Executor(E), OS(Buf), Printer(E.Ctx, OS), Kind(K) {}
 
   DiagnosticReporter(const DiagnosticReporter &) = delete;
   DiagnosticReporter(DiagnosticReporter &&) noexcept = delete;
@@ -154,7 +155,7 @@ public:
   }
 
   template <typename T> DiagnosticReporter &operator<<(const T &Val) {
-    OS << Val;
+    Printer << Val;
     return *this;
   }
 };

--- a/llvm/tools/llubi/lib/Value.cpp
+++ b/llvm/tools/llubi/lib/Value.cpp
@@ -59,7 +59,7 @@ bool Pointer::isNullPtr(unsigned AS, const DataLayout &DL) const {
   return Address == DL.getNullPtrValue(AS);
 }
 
-void AnyValue::print(raw_ostream &OS) const {
+void AnyValue::print(Context &Ctx, raw_ostream &OS) const {
   switch (Kind) {
   case StorageKind::Integer:
     if (IntVal.getBitWidth() == 1) {
@@ -129,7 +129,7 @@ void AnyValue::print(raw_ostream &OS) const {
     for (size_t I = 0, E = AggVal.size(); I != E; ++I) {
       if (I != 0)
         OS << ", ";
-      AggVal[I].print(OS);
+      AggVal[I].print(Ctx, OS);
     }
     OS << " }";
     break;

--- a/llvm/tools/llubi/lib/Value.h
+++ b/llvm/tools/llubi/lib/Value.h
@@ -248,7 +248,7 @@ public:
   AnyValue &operator=(AnyValue &&);
   ~AnyValue() { destroy(); }
 
-  void print(raw_ostream &OS) const;
+  void print(Context &Ctx, raw_ostream &OS) const;
 
   static AnyValue poison() { return AnyValue(PoisonTag{}); }
   static AnyValue boolean(bool Val) { return AnyValue(APInt(1, Val)); }
@@ -324,10 +324,22 @@ public:
   }
 };
 
-inline raw_ostream &operator<<(raw_ostream &OS, const AnyValue &V) {
-  V.print(OS);
-  return OS;
-}
+class AnyValuePrinter {
+  Context &Ctx;
+  raw_ostream &OS;
+
+public:
+  AnyValuePrinter(Context &Ctx, raw_ostream &OS) : Ctx(Ctx), OS(OS) {}
+  AnyValuePrinter &operator<<(const AnyValue &V) {
+    V.print(Ctx, OS);
+    return *this;
+  }
+  template <typename T> AnyValuePrinter &operator<<(const T &Val) {
+    OS << Val;
+    return *this;
+  }
+  operator raw_ostream &() { return OS; }
+};
 
 inline raw_ostream &operator<<(raw_ostream &OS, const Pointer &P) {
   P.print(OS);

--- a/llvm/tools/llubi/llubi.cpp
+++ b/llvm/tools/llubi/llubi.cpp
@@ -136,40 +136,44 @@ class NoopEventHandler : public ubi::EventHandler {
 };
 
 class VerboseEventHandler : public NoopEventHandler {
+  ubi::AnyValuePrinter OS;
+
 public:
+  VerboseEventHandler(ubi::Context &Ctx) : OS(Ctx, errs()) {}
+
   bool onInstructionExecuted(Instruction &I,
                              const ubi::AnyValue &Result) override {
     if (Result.isNone()) {
-      errs() << I << '\n';
+      OS << I << '\n';
     } else {
-      errs() << I << " => " << Result << '\n';
+      OS << I << " => " << Result << '\n';
     }
 
     return true;
   }
 
   bool onBBJump(Instruction &I, BasicBlock &To) override {
-    errs() << I << " jump to ";
-    To.printAsOperand(errs(), /*PrintType=*/false);
-    errs() << '\n';
+    OS << I << " jump to ";
+    To.printAsOperand(OS, /*PrintType=*/false);
+    OS << '\n';
     return true;
   }
 
   bool onFunctionEntry(Function &F, ArrayRef<ubi::AnyValue> Args,
                        CallBase *CallSite) override {
-    errs() << "Entering function: " << F.getName() << '\n';
+    OS << "Entering function: " << F.getName() << '\n';
     size_t ArgSize = F.arg_size();
     for (auto &&[Idx, Arg] : enumerate(Args)) {
       if (Idx >= ArgSize)
-        errs() << "  vaarg[" << (Idx - ArgSize) << "] = " << Arg << '\n';
+        OS << "  vaarg[" << (Idx - ArgSize) << "] = " << Arg << '\n';
       else
-        errs() << "  " << *F.getArg(Idx) << " = " << Arg << '\n';
+        OS << "  " << *F.getArg(Idx) << " = " << Arg << '\n';
     }
     return true;
   }
 
   bool onFunctionExit(Function &F, const ubi::AnyValue &RetVal) override {
-    errs() << "Exiting function: " << F.getName() << '\n';
+    OS << "Exiting function: " << F.getName() << '\n';
     return true;
   }
 
@@ -180,13 +184,13 @@ public:
     case ubi::ProgramExitInfo::ProgramExitKind::Failed:
       return;
     case ubi::ProgramExitInfo::ProgramExitKind::Exited:
-      errs() << "Program exited with code " << Info.ExitCode << '\n';
+      OS << "Program exited with code " << Info.ExitCode << '\n';
       return;
     case ubi::ProgramExitInfo::ProgramExitKind::Aborted:
-      errs() << "Program aborted.\n";
+      OS << "Program aborted.\n";
       return;
     case ubi::ProgramExitInfo::ProgramExitKind::Terminated:
-      errs() << "Program terminated.\n";
+      OS << "Program terminated.\n";
       return;
     }
 
@@ -320,7 +324,7 @@ int main(int argc, char **argv) {
   }
 
   NoopEventHandler NoopHandler;
-  VerboseEventHandler VerboseHandler;
+  VerboseEventHandler VerboseHandler(Ctx);
   ubi::AnyValue RetVal;
   ubi::ProgramExitInfo ExitInfo = Ctx.runFunction(
       *EntryFn, Args, RetVal, Verbose ? VerboseHandler : NoopHandler);


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/pull/200672#discussion_r3624927046, we need information from the global state to provide a better debugging representation of byte SSA values.

This patch adds a wrapper to pass `Context&` into the actual printer.
