### PR TITLE
[bazel] Add os select for plugin process on Initialization target to add windows

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -353,9 +353,15 @@ cc_library(
         ":Utility",
         ":Version",
         "//lldb/source/Plugins:PluginProcessGDBRemote",
-        "//lldb/source/Plugins:PluginProcessPOSIX",
         "//llvm:Support",
-    ],
+    ] + select({
+        "@platforms//os:windows": [
+            "//lldb/source/Plugins:PluginProcessWindowsCommon",
+        ],
+        "//conditions:default": [
+            "//lldb/source/Plugins:PluginProcessPOSIX",
+        ],
+    }),
 )
 
 gentbl_cc_library(


### PR DESCRIPTION
Another small piece of windows build support for LLDB in bazel.    Internally at Meta, our buck2 rule for this has a split for mac/linux with PluginProcessPOSIX and windows with PluginProcessWindowsCommon.  So this should be a no-op for existing linux & mac builds while setting up a bit more for windows.  

I have no bazel build set up locally, so will wait on CI to confirm no regression.
bazel rule creation assisted with claude