### PR TITLE
Exclude another coro test from profcheck

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -46,6 +46,7 @@ Transforms/Coroutines/coro-split-musttail7.ll
 Transforms/Coroutines/coro-split-musttail8.ll
 Transforms/Coroutines/coro-split-musttail9.ll
 Transforms/Coroutines/coro-split-noinline.ll
+Transforms/Coroutines/coro-split-resume-fallthrough-destroy-slot.ll
 Transforms/Coroutines/coro-split-tbaa-md-neg-2.ll
 Transforms/Coroutines/coro-split-tbaa-md-neg.ll
 Transforms/Coroutines/coro-split-tbaa-md.ll


### PR DESCRIPTION
Coro aren't yet fixed for profcheck.

(related: #207799)