### PR TITLE
[NFC][analyzer] Eliminate the NodeBuilder in VisitUnaryOperator

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -682,7 +682,7 @@ public:
                                       NodeBuilder &Bldr, ExplodedNode *Pred);
 
   void handleUOExtension(ExplodedNode *N, const UnaryOperator *U,
-                         NodeBuilder &Bldr);
+                         ExplodedNodeSet &Dst);
 
 public:
   SVal evalBinOp(ProgramStateRef ST, BinaryOperator::Opcode Op,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -681,9 +681,6 @@ public:
                                       QualType ExTy, const CastExpr *CastE,
                                       NodeBuilder &Bldr, ExplodedNode *Pred);
 
-  void handleUOExtension(ExplodedNode *N, const UnaryOperator *U,
-                         ExplodedNodeSet &Dst);
-
 public:
   SVal evalBinOp(ProgramStateRef ST, BinaryOperator::Opcode Op,
                  SVal LHS, SVal RHS, QualType T) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -891,7 +891,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
   ExplodedNodeSet EvalSet;
 
   // Lambda for handling the case when the operand is returned unchanged.
-  auto MakeNodeForIdentityOp = [U, &Engine=Engine](ExplodedNode *N) {
+  auto MakeNodeForIdentityOp = [U, &Engine = Engine](ExplodedNode *N) {
     const Expr *Ex = U->getSubExpr()->IgnoreParens();
     SVal SV = N->getState()->getSVal(Ex, N->getStackFrame());
     return Engine.makeNodeWithBinding(N, U, SV);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -882,22 +882,6 @@ VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *Ex,
   getCheckerManager().runCheckersForPostStmt(Dst, EvalSet, Ex, *this);
 }
 
-void ExprEngine::handleUOExtension(ExplodedNode *N, const UnaryOperator *U,
-                                   ExplodedNodeSet &Dst) {
-  // FIXME: We can probably just have some magic in Environment::getSVal()
-  // that propagates values, instead of creating a new node here.
-  //
-  // Unary "+" is a no-op, similar to a parentheses.  We still have places
-  // where it may be a block-level expression, so we need to
-  // generate an extra node that just propagates the value of the
-  // subexpression.
-  const Expr *Ex = U->getSubExpr()->IgnoreParens();
-  ProgramStateRef state = N->getState();
-  const StackFrame *SF = N->getStackFrame();
-
-  Dst.insert(Engine.makeNodeWithBinding(N, U, state->getSVal(Ex, SF)));
-}
-
 void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
                                     ExplodedNodeSet &Dst) {
   // FIXME: Prechecks eventually go in ::Visit().
@@ -905,6 +889,13 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
   getCheckerManager().runCheckersForPreStmt(CheckedSet, Pred, U, *this);
 
   ExplodedNodeSet EvalSet;
+
+  // Lambda for handling the case when the operand is returned unchanged.
+  auto MakeNodeForIdentityOp = [U, &Engine=Engine](ExplodedNode *N) {
+    const Expr *Ex = U->getSubExpr()->IgnoreParens();
+    SVal SV = N->getState()->getSVal(Ex, N->getStackFrame());
+    return Engine.makeNodeWithBinding(N, U, SV);
+  };
 
   for (ExplodedNode *N : CheckedSet) {
     switch (U->getOpcode()) {
@@ -926,9 +917,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
 
       // For all other types, UO_Real is an identity operation.
       assert (U->getType() == Ex->getType());
-      ProgramStateRef state = N->getState();
-      const StackFrame *SF = N->getStackFrame();
-      EvalSet.insert(Engine.makeNodeWithBinding(N, U, state->getSVal(Ex, SF)));
+      EvalSet.insert(MakeNodeForIdentityOp(N));
       break;
     }
 
@@ -959,7 +948,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
         }
       }
       // Explicitly proceed with default handler for this case cascade.
-      handleUOExtension(N, U, EvalSet);
+      EvalSet.insert(MakeNodeForIdentityOp(N));
       break;
     }
     case UO_Plus:
@@ -967,7 +956,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
       [[fallthrough]];
     case UO_Deref:
     case UO_Extension: {
-      handleUOExtension(N, U, EvalSet);
+      EvalSet.insert(MakeNodeForIdentityOp(N));
       break;
     }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -883,7 +883,7 @@ VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *Ex,
 }
 
 void ExprEngine::handleUOExtension(ExplodedNode *N, const UnaryOperator *U,
-                                   NodeBuilder &Bldr) {
+                                   ExplodedNodeSet &Dst) {
   // FIXME: We can probably just have some magic in Environment::getSVal()
   // that propagates values, instead of creating a new node here.
   //
@@ -894,7 +894,8 @@ void ExprEngine::handleUOExtension(ExplodedNode *N, const UnaryOperator *U,
   const Expr *Ex = U->getSubExpr()->IgnoreParens();
   ProgramStateRef state = N->getState();
   const StackFrame *SF = N->getStackFrame();
-  Bldr.generateNode(U, N, state->BindExpr(U, SF, state->getSVal(Ex, SF)));
+
+  Dst.insert(Engine.makeNodeWithBinding(N, U, state->getSVal(Ex, SF)));
 }
 
 void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
@@ -904,15 +905,13 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
   getCheckerManager().runCheckersForPreStmt(CheckedSet, Pred, U, *this);
 
   ExplodedNodeSet EvalSet;
-  NodeBuilder Bldr(CheckedSet, EvalSet, *currBldrCtx);
 
   for (ExplodedNode *N : CheckedSet) {
     switch (U->getOpcode()) {
     default: {
-      Bldr.takeNodes(N);
       ExplodedNodeSet Tmp;
       VisitIncrementDecrementOperator(U, N, Tmp);
-      Bldr.addNodes(Tmp);
+      EvalSet.insert(Tmp);
       break;
     }
     case UO_Real: {
@@ -921,6 +920,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
       // FIXME: We don't have complex SValues yet.
       if (Ex->getType()->isAnyComplexType()) {
         // Just report "Unknown."
+        EvalSet.insert(N);
         break;
       }
 
@@ -928,7 +928,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
       assert (U->getType() == Ex->getType());
       ProgramStateRef state = N->getState();
       const StackFrame *SF = N->getStackFrame();
-      Bldr.generateNode(U, N, state->BindExpr(U, SF, state->getSVal(Ex, SF)));
+      EvalSet.insert(Engine.makeNodeWithBinding(N, U, state->getSVal(Ex, SF)));
       break;
     }
 
@@ -937,13 +937,12 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
       // FIXME: We don't have complex SValues yet.
       if (Ex->getType()->isAnyComplexType()) {
         // Just report "Unknown."
+        EvalSet.insert(N);
         break;
       }
       // For all other types, UO_Imag returns 0.
-      ProgramStateRef state = N->getState();
-      const StackFrame *SF = N->getStackFrame();
       SVal X = svalBuilder.makeZeroVal(Ex->getType());
-      Bldr.generateNode(U, N, state->BindExpr(U, SF, X));
+      EvalSet.insert(Engine.makeNodeWithBinding(N, U, X));
       break;
     }
 
@@ -954,15 +953,13 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
         const ValueDecl *VD = DRE->getDecl();
 
         if (isa<CXXMethodDecl, FieldDecl, IndirectFieldDecl>(VD)) {
-          ProgramStateRef State = N->getState();
-          const StackFrame *SF = N->getStackFrame();
           SVal SV = svalBuilder.getMemberPointer(cast<NamedDecl>(VD));
-          Bldr.generateNode(U, N, State->BindExpr(U, SF, SV));
+          EvalSet.insert(Engine.makeNodeWithBinding(N, U, SV));
           break;
         }
       }
       // Explicitly proceed with default handler for this case cascade.
-      handleUOExtension(N, U, Bldr);
+      handleUOExtension(N, U, EvalSet);
       break;
     }
     case UO_Plus:
@@ -970,7 +967,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
       [[fallthrough]];
     case UO_Deref:
     case UO_Extension: {
-      handleUOExtension(N, U, Bldr);
+      handleUOExtension(N, U, EvalSet);
       break;
     }
 
@@ -986,7 +983,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
       SVal V = state->getSVal(Ex, SF);
 
       if (V.isUnknownOrUndef()) {
-        Bldr.generateNode(U, N, state->BindExpr(U, SF, V));
+        EvalSet.insert(Engine.makeNodeWithBinding(N, U, V));
         break;
       }
 
@@ -1023,7 +1020,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
           state = state->BindExpr(U, SF, Result);
           break;
       }
-      Bldr.generateNode(U, N, state);
+      EvalSet.insert(Engine.makePostStmtNode(U, state, N));
       break;
     }
     }


### PR DESCRIPTION
This is part of the commit series to gradually remove the class `NodeBuilder` from the analyzer codebase.

This was a relatively complex situation because there were many different `generateNode` calls and two situations where the the node from `CheckedSet` was left in `EvalSet` without changes (which is implicit with the `NodeBuilder` but now requires explicit `EvalSet.insert(N)` calls).