### PR TITLE
[lldb][test] Skip more WebAssembly-unsupported API tests

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/TestWasHit.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/TestWasHit.py
@@ -13,6 +13,7 @@ class TestWasHit(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    @skipIfWasm  # no expression evaluation (was_hit evaluates change_him())
     def test_was_hit_resolver(self):
         """Use facade breakpoints to emulate hitting some locations"""
         self.build()

--- a/lldb/test/API/functionalities/memory/find/TestMemoryFind.py
+++ b/lldb/test/API/functionalities/memory/find/TestMemoryFind.py
@@ -16,6 +16,7 @@ class MemoryFindTestCase(TestBase):
         # Find the line number to break inside main().
         self.line = line_number("main.cpp", "// break here")
 
+    @skipIfWasm  # no expression evaluation (memory find calls strlen())
     def test_memory_find(self):
         """Test the 'memory find' command."""
         self.build()

--- a/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
+++ b/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCppGlobalOperators(TestBase):
     def prepare_executable_and_get_frame(self):
         self.build()

--- a/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
+++ b/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
@@ -48,6 +48,7 @@ class TestCase(TestBase):
 
     # We fail to lookup static members on Windows.
     @expectedFailureAll(oslist=["windows"])
+    @skipIfWasm  # no expression evaluation
     def test_no_crash_in_IR_arithmetic(self):
         """
         Test that LLDB doesn't crash on evaluating specific expression involving

--- a/lldb/test/API/python_api/exprpath_register/TestExprPathRegisters.py
+++ b/lldb/test/API/python_api/exprpath_register/TestExprPathRegisters.py
@@ -4,6 +4,7 @@ Test Getting the expression path for registers works correctly
 
 import lldb
 from lldbsuite.test import lldbutil
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import TestBase, VALID_BREAKPOINT, VALID_TARGET
 
 
@@ -49,6 +50,7 @@ class TestExprPathRegisters(TestBase):
             if reg_value:
                 self.verify_register_path(reg_value)
 
+    @skipIfWasm  # wasm exposes no registers
     def test_all_registers(self):
         """Test all the registers that is avaiable on the machine"""
         self.build()

--- a/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
+++ b/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no ABI plugin, so address masks are never applied
 class AddressMasksTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
+++ b/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestReadMemCString(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfWasm  # linear memory has no unmapped pages, so a bad in-range pointer still reads
     def test_read_memory_c_string(self):
         """Test corner case behavior of SBProcess::ReadCStringFromMemory"""
         self.build()


### PR DESCRIPTION
Skip tests that exercise features WebAssembly does not provide: expression evaluation, registers, an ABI plugin, and unmapped memory pages.