### PR TITLE
[TLI] Make VecDesc statically initializable

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -50,6 +50,9 @@ class VecDesc {
   StringRef VABIPrefix;
   /// Encoded calling convention: 0 means absent (std::nullopt), otherwise
   /// stores CallingConv::ID + 1 so an explicit C (0) remains representable.
+  /// TODO: Since C++20 standard becomes default in LLVM we can return back to
+  /// use std::optional<CallingConv::ID> instead of unsigned and value_or()
+  /// in default constructor.
   unsigned CC;
 
 public:

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -48,23 +48,30 @@ class VecDesc {
   ElementCount VectorizationFactor;
   bool Masked;
   StringRef VABIPrefix;
-  std::optional<CallingConv::ID> CC;
+  /// Encoded calling convention: 0 means absent (std::nullopt), otherwise
+  /// stores CallingConv::ID + 1 so an explicit C (0) remains representable.
+  unsigned CC;
 
 public:
   VecDesc() = delete;
-  VecDesc(StringRef ScalarFnName, StringRef VectorFnName,
-          ElementCount VectorizationFactor, bool Masked, StringRef VABIPrefix,
-          std::optional<CallingConv::ID> Conv)
+  constexpr VecDesc(StringRef ScalarFnName, StringRef VectorFnName,
+                    ElementCount VectorizationFactor, bool Masked,
+                    StringRef VABIPrefix, std::optional<CallingConv::ID> Conv)
       : ScalarFnName(ScalarFnName), VectorFnName(VectorFnName),
         VectorizationFactor(VectorizationFactor), Masked(Masked),
-        VABIPrefix(VABIPrefix), CC(Conv) {}
+        VABIPrefix(VABIPrefix),
+        CC(Conv ? static_cast<unsigned>(*Conv) + 1u : 0u) {}
 
   StringRef getScalarFnName() const { return ScalarFnName; }
   StringRef getVectorFnName() const { return VectorFnName; }
   ElementCount getVectorizationFactor() const { return VectorizationFactor; }
   bool isMasked() const { return Masked; }
   StringRef getVABIPrefix() const { return VABIPrefix; }
-  std::optional<CallingConv::ID> getCallingConv() const { return CC; }
+  std::optional<CallingConv::ID> getCallingConv() const {
+    if (CC == 0)
+      return std::nullopt;
+    return static_cast<CallingConv::ID>(CC - 1);
+  }
 
   /// Returns a vector function ABI variant string on the form:
   ///    _ZGV<isa><mask><vlen><vparams>_<scalarname>(<vectorname>)

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1243,25 +1243,31 @@ void TargetLibraryInfoImpl::addVectorizableFunctions(ArrayRef<VecDesc> Fns) {
   llvm::sort(ScalarDescs, compareByVectorFnName);
 }
 
-static const VecDesc VecFuncs_Accelerate[] = {
+// The VecDesc tables should be constant-initialized to avoid compilation
+// regression. Now VecDesc (see class definition) intentionally keeps trivially
+// constructable/destructable, so the tables land in .rdata and do not run
+// through CRT dynamic init (which can overflow small stack on MSVC Debug
+// DLL loads). When LLVM requires C++20 mark them constinit to enforce this
+// at compile time.
+static constexpr VecDesc VecFuncs_Accelerate[] = {
 #define TLI_DEFINE_ACCELERATE_VECFUNCS
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_ACCELERATE_VECFUNCS
 };
 
-static const VecDesc VecFuncs_DarwinLibSystemM[] = {
+static constexpr VecDesc VecFuncs_DarwinLibSystemM[] = {
 #define TLI_DEFINE_DARWIN_LIBSYSTEM_M_VECFUNCS
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_DARWIN_LIBSYSTEM_M_VECFUNCS
 };
 
-static const VecDesc VecFuncs_LIBMVEC_X86[] = {
+static constexpr VecDesc VecFuncs_LIBMVEC_X86[] = {
 #define TLI_DEFINE_LIBMVEC_X86_VECFUNCS
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_LIBMVEC_X86_VECFUNCS
 };
 
-static const VecDesc VecFuncs_LIBMVEC_AARCH64[] = {
+static constexpr VecDesc VecFuncs_LIBMVEC_AARCH64[] = {
 #define TLI_DEFINE_LIBMVEC_AARCH64_VECFUNCS
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, MASK, VABI_PREFIX, CC)               \
   {SCAL, VEC, VF, MASK, VABI_PREFIX, CC},
@@ -1269,33 +1275,33 @@ static const VecDesc VecFuncs_LIBMVEC_AARCH64[] = {
 #undef TLI_DEFINE_LIBMVEC_AARCH64_VECFUNCS
 };
 
-static const VecDesc VecFuncs_MASSV[] = {
+static constexpr VecDesc VecFuncs_MASSV[] = {
 #define TLI_DEFINE_MASSV_VECFUNCS
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_MASSV_VECFUNCS
 };
 
-static const VecDesc VecFuncs_SVML[] = {
+static constexpr VecDesc VecFuncs_SVML[] = {
 #define TLI_DEFINE_SVML_VECFUNCS
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_SVML_VECFUNCS
 };
 
-static const VecDesc VecFuncs_SLEEFGNUABI_VF2[] = {
+static constexpr VecDesc VecFuncs_SLEEFGNUABI_VF2[] = {
 #define TLI_DEFINE_SLEEFGNUABI_VF2_VECFUNCS
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, VABI_PREFIX)                         \
   {SCAL, VEC, VF, /* MASK = */ false, VABI_PREFIX, /* CC = */ std::nullopt},
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_SLEEFGNUABI_VF2_VECFUNCS
 };
-static const VecDesc VecFuncs_SLEEFGNUABI_VF4[] = {
+static constexpr VecDesc VecFuncs_SLEEFGNUABI_VF4[] = {
 #define TLI_DEFINE_SLEEFGNUABI_VF4_VECFUNCS
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, VABI_PREFIX)                         \
   {SCAL, VEC, VF, /* MASK = */ false, VABI_PREFIX, /* CC = */ std::nullopt},
 #include "llvm/Analysis/VecFuncs.def"
 #undef TLI_DEFINE_SLEEFGNUABI_VF4_VECFUNCS
 };
-static const VecDesc VecFuncs_SLEEFGNUABI_VFScalable[] = {
+static constexpr VecDesc VecFuncs_SLEEFGNUABI_VFScalable[] = {
 #define TLI_DEFINE_SLEEFGNUABI_SCALABLE_VECFUNCS
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, MASK, VABI_PREFIX)                   \
   {SCAL, VEC, VF, MASK, VABI_PREFIX, /* CC = */ std::nullopt},
@@ -1303,7 +1309,7 @@ static const VecDesc VecFuncs_SLEEFGNUABI_VFScalable[] = {
 #undef TLI_DEFINE_SLEEFGNUABI_SCALABLE_VECFUNCS
 };
 
-static const VecDesc VecFuncs_SLEEFGNUABI_VFScalableRISCV[] = {
+static constexpr VecDesc VecFuncs_SLEEFGNUABI_VFScalableRISCV[] = {
 #define TLI_DEFINE_SLEEFGNUABI_SCALABLE_VECFUNCS_RISCV
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, MASK, VABI_PREFIX)                   \
   {SCAL, VEC, VF, MASK, VABI_PREFIX, /* CC = */ std::nullopt},
@@ -1311,7 +1317,7 @@ static const VecDesc VecFuncs_SLEEFGNUABI_VFScalableRISCV[] = {
 #undef TLI_DEFINE_SLEEFGNUABI_SCALABLE_VECFUNCS_RISCV
 };
 
-static const VecDesc VecFuncs_ArmPL[] = {
+static constexpr VecDesc VecFuncs_ArmPL[] = {
 #define TLI_DEFINE_ARMPL_VECFUNCS
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, MASK, VABI_PREFIX, CC)               \
   {SCAL, VEC, VF, MASK, VABI_PREFIX, CC},
@@ -1319,7 +1325,7 @@ static const VecDesc VecFuncs_ArmPL[] = {
 #undef TLI_DEFINE_ARMPL_VECFUNCS
 };
 
-const VecDesc VecFuncs_AMDLIBM[] = {
+constexpr VecDesc VecFuncs_AMDLIBM[] = {
 #define TLI_DEFINE_AMDLIBM_VECFUNCS
 #define TLI_DEFINE_VECFUNC(SCAL, VEC, VF, MASK, VABI_PREFIX)                   \
   {SCAL, VEC, VF, MASK, VABI_PREFIX, /* CC = */ std::nullopt},

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -8,11 +8,14 @@
 
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/SourceMgr.h"
 #include "gtest/gtest.h"
+
+#include <type_traits>
 
 using namespace llvm;
 
@@ -733,3 +736,48 @@ TEST_F(TLITestAarch64, TestFrem) {
   EXPECT_EQ(getScalarName(Instruction::FRem, Type::getDoubleTy(Ctx)), "fmod");
   EXPECT_EQ(getScalarName(Instruction::FRem, Type::getFloatTy(Ctx)), "fmodf");
 }
+
+namespace {
+
+TEST(VecDescTest, GetCallingConvAbsent) {
+  VecDesc VD("sin", "__svml_sin2", ElementCount::getFixed(2), false,
+             "_ZGV_LLVM_N2v", std::nullopt);
+  EXPECT_FALSE(VD.getCallingConv().has_value());
+}
+
+TEST(VecDescTest, GetCallingConvC) {
+  VecDesc VD("sin", "__svml_sin2", ElementCount::getFixed(2), false,
+             "_ZGV_LLVM_N2v", CallingConv::C);
+  ASSERT_TRUE(VD.getCallingConv().has_value());
+  EXPECT_EQ(VD.getCallingConv().value(), CallingConv::C);
+}
+
+TEST(VecDescTest, GetCallingConvAArch64VectorCall) {
+  VecDesc VD("acos", "armpl_vacosq_f64", ElementCount::getFixed(2), false,
+             "_ZGV_LLVM_N2v", CallingConv::AArch64_VectorCall);
+  ASSERT_TRUE(VD.getCallingConv().has_value());
+  EXPECT_EQ(VD.getCallingConv().value(), CallingConv::AArch64_VectorCall);
+}
+
+static_assert(std::is_trivially_destructible_v<VecDesc>,
+              "VecDesc must not require dynamic static initialization");
+static_assert(std::is_trivially_copyable_v<VecDesc>,
+              "VecDesc static tables must be constexpr-friendly");
+
+TEST(VecDescTest, ConstexprStaticTable) {
+  static constexpr VecDesc Table[] = {
+      {"ceilf", "vceilf", ElementCount::getFixed(4), false, "_ZGV_LLVM_N4v",
+       std::nullopt},
+      {"sin", "__svml_sin2", ElementCount::getFixed(2), false, "_ZGV_LLVM_N2v",
+       CallingConv::C},
+      {"acos", "armpl_vacosq_f64", ElementCount::getFixed(2), false,
+       "_ZGV_LLVM_N2v", CallingConv::AArch64_VectorCall},
+  };
+  EXPECT_FALSE(Table[0].getCallingConv().has_value());
+  ASSERT_TRUE(Table[1].getCallingConv().has_value());
+  EXPECT_EQ(Table[1].getCallingConv().value(), CallingConv::C);
+  ASSERT_TRUE(Table[2].getCallingConv().has_value());
+  EXPECT_EQ(Table[2].getCallingConv().value(), CallingConv::AArch64_VectorCall);
+}
+
+} // namespace


### PR DESCRIPTION
After commit 1cf9acdb ([TLI] Use AArch64 vector calling convention for ArmPL routines (#135790)), `VecDesc` gained a `std::optional<CallingConv::ID>` member. That made `VecDesc` non-trivial, so the large `static const VecDesc[]` tables (`VecFuncs_Accelerate`, `VecFuncs_SVML`, `VecFuncs_ArmPL`, and others) in `TargetLibraryInfo.cpp` (built from `VecFuncs.def`) required dynamic static initialization at DLL load time. In MSVC Debug builds with LLVM embedded in a DLL, CRT init can run on threads with limited stack (e.g. during `LoadLibrary` from a deep call stack), causing stack overflow and load failure.

This patch restores compile-time initialization without changing the public API or any `VecFuncs.def` / `TargetLibraryInfo.cpp` call sites. There are the following fixes:
1. Replace `std::optional<CallingConv::ID>` from `VecDesc` layout. `std::nullopt` is still in the constructor / `getCallingConv()` API. This is safe because no entry in `VecFuncs.def` uses `CallingConv::C` explicitly (entries either pass `NOCC` / `std::nullopt` or `CallingConv::AArch64_VectorCall`).
2. Mark the constructor `constexpr`. It allows the static `VecFuncs_*` tables to be constant-initialized at compile time and placed in `.rdata` instead of going through CRT dynamic initialization.
3. Keep the public API unchanged. Constructor still takes `std::optional<CallingConv::ID>`; `getCallingConv()` still returns `std::optional<CallingConv::ID>`. No changes to `VecFuncs.def`, `TargetLibraryInfo.cpp`, or vector-lib consumers.
4. Some unit tests were added into llvm/unittests/Analysis/TargetLibraryInfoTest.cpp:
- `VecDescTest.GetCallingConvAbsent` — `std::nullopt` → `getCallingConv()` is empty.
- `VecDescTest.GetCallingConvAArch64VectorCall` — `AArch64_VectorCall` is preserved (as in ArmPL / `LIBMVEC_AARCH64` in `VecFuncs.def`).
- `static_assert` — `VecDesc` is trivially destructible and trivially copyable (the main fix check).
- `VecDescTest.ConstexprStaticTable` — a `static constexpr VecDesc[]` table initializes at compile time and round-trips through `getCallingConv()`