### PR TITLE
[lld][docs] Document /DRIVER support

### DIFF
--- a/lld/docs/windows_support.md
+++ b/lld/docs/windows_support.md
@@ -26,8 +26,8 @@ real-world binaries such as Firefox and Chromium.
 ## Development status
 
 Driver
-: {good}`Mostly done`. Some exotic command line options that are not usually
-  used for application development, such as `/DRIVER`, are not supported.
+: {good}`Mostly done`. LLD supports `/DRIVER`, `/DRIVER:WDM`, and
+  `/DRIVER:UPONLY` for linking Windows NT kernel-mode drivers.
 
 Linking against DLL
 : {good}`Done`. LLD can read import libraries needed to link against DLL. Both


### PR DESCRIPTION
The Windows support page still lists `/DRIVER` as unsupported, even
though LLD implements `/DRIVER`, `/DRIVER:WDM`, and `/DRIVER:UPONLY`
and covers them in `lld/test/COFF/driver-opt.s`.

Document the supported forms.

Fixes #174163

AI assistance: OpenAI Codex helped investigate, draft, and validate this
change. I reviewed and understand the final patch.
