### PR TITLE
[mlir][OpenACC] Forward dynamic boxed reduction extents

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -2650,10 +2650,17 @@ void ACCCGToGPULowering::processPrivateLocal(
   Value subview = memref::SubViewOp::create(rewriter, loc, subviewType, view,
                                             subviewOffset, subviewSizes, ones);
 
-  // Cast subview to the target type, preserving the dynamic offset.
-  // Do NOT cast to a plain memref (offset: 0) - the LLVM optimizer
-  // would fold the gang offset to zero, making all gangs share memory.
-  Value result = castPointerLikeTypeIfNeeded(rewriter, loc, subview,
+  // Pointer-like casts cannot carry memref offsets. Shift the aligned pointer
+  // so downstream zero-offset views retain this thread's private slice.
+  auto metadata =
+      memref::ExtractStridedMetadataOp::create(rewriter, loc, subview);
+  Value elementBytes = arith::ConstantIndexOp::create(
+      rewriter, loc, getElementSizeInBytes(loc, baseTy.getElementType()));
+  Value byteOffset =
+      arith::MulIOp::create(rewriter, loc, metadata.getOffset(), elementBytes);
+  Value privateView = memref::ViewOp::create(rewriter, loc, baseTy, memBuffer,
+                                             byteOffset, innerDynSizes);
+  Value result = castPointerLikeTypeIfNeeded(rewriter, loc, privateView,
                                              privateLocal.getType());
   mapping.map(privateLocal.getResult(), result);
 }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -2651,7 +2651,7 @@ void ACCCGToGPULowering::processPrivateLocal(
                                             subviewOffset, subviewSizes, ones);
 
   // Pointer-like casts cannot carry memref offsets. Shift the aligned pointer
-  // so downstream zero-offset views retain this thread's private slice.
+  // so later zero-offset views retain this thread's private slice.
   auto metadata =
       memref::ExtractStridedMetadataOp::create(rewriter, loc, subview);
   Value elementBytes = arith::ConstantIndexOp::create(

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -23,3 +23,34 @@ func.func @threadprivate(%host: memref<i32>) {
   } {origin = "acc.parallel"}
   return
 }
+
+// CHECK-LABEL: func.func @dynamic_threadprivate
+// CHECK:       gpu.launch
+// CHECK:         %[[STORAGE:.*]] = memref.view %{{.*}}[%{{.*}}]{{.*}} : memref<?xi8> to memref<?x?xi32>
+// CHECK:         %[[SLICE:.*]] = memref.subview %[[STORAGE]]
+// CHECK:         %[[META:.*]]:4 = memref.extract_strided_metadata %[[SLICE]]
+// CHECK:         %[[ELEMENT_BYTES:.*]] = arith.constant 4 : index
+// CHECK:         %[[BYTE_OFFSET:.*]] = arith.muli %[[META]]#1, %[[ELEMENT_BYTES]]
+// CHECK:         %[[PRIVATE:.*]] = memref.view %{{.*}}[%[[BYTE_OFFSET]]]
+// CHECK:         memref.store %{{.*}}, %[[PRIVATE]][%{{.*}}] : memref<?xi32>
+
+func.func @dynamic_threadprivate(%n: index) {
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  %bx = acc.par_width %c4 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %private = acc.privatize(%n) [#acc<par_dims[block_x, thread_x]>]
+      : (index) -> !acc.private_type<memref<?xi32>>
+
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx)
+      ins(%arg = %private) : (!acc.private_type<memref<?xi32>>) {
+    %c0 = arith.constant 0 : index
+    %one = arith.constant 1 : i32
+    %local = acc.private_local %arg
+        {acc.par_dims = #acc<par_dims[block_x, thread_x]>}
+        : (!acc.private_type<memref<?xi32>>) -> memref<?xi32>
+    memref.store %one, %local[%c0] : memref<?xi32>
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -26,11 +26,11 @@ func.func @threadprivate(%host: memref<i32>) {
 
 // CHECK-LABEL: func.func @dynamic_threadprivate
 // CHECK:       gpu.launch
-// CHECK:         %[[STORAGE:.*]] = memref.view %{{.*}}[%{{.*}}]{{.*}} : memref<?xi8> to memref<?x?xi32>
+// CHECK:         %[[STORAGE:.*]] = memref.view %{{.*}}[%{{.*}}][%{{.*}}, %{{.*}}, %{{.*}}]
 // CHECK:         %[[SLICE:.*]] = memref.subview %[[STORAGE]]
-// CHECK:         %[[META:.*]]:4 = memref.extract_strided_metadata %[[SLICE]]
+// CHECK:         %{{.*}}, %[[OFFSET:.*]], %{{.*}}, %{{.*}} = memref.extract_strided_metadata %[[SLICE]]
 // CHECK:         %[[ELEMENT_BYTES:.*]] = arith.constant 4 : index
-// CHECK:         %[[BYTE_OFFSET:.*]] = arith.muli %[[META]]#1, %[[ELEMENT_BYTES]]
+// CHECK:         %[[BYTE_OFFSET:.*]] = arith.muli %[[OFFSET]], %[[ELEMENT_BYTES]]
 // CHECK:         %[[PRIVATE:.*]] = memref.view %{{.*}}[%[[BYTE_OFFSET]]]
 // CHECK:         memref.store %{{.*}}, %[[PRIVATE]][%{{.*}}] : memref<?xi32>
 


### PR DESCRIPTION
Example:
```fortran
subroutine reduce(a, x, n)
  integer :: n, i
  real :: a(:), x(:)

  !$acc parallel loop reduction(+:a)
  do i = 1, n
    a(:) = a(:) + x(i)
  end do
end subroutine
```

`ACCCGToGPU` represents each gang/thread-private array as a dynamically offset `memref.subview`. Converting this subview directly to a FIR pointer-like type loses the memref offset, causing different private copies to alias the same storage.

Fix: extract the selected subview’s element offset, convert it to bytes, and create a zero-offset view at that address before converting to the FIR pointer-like type. This preserves the selected gang/thread-private slice.

Before:
```mlir
%subview = memref.subview %view[%block_id, 0] [1, %extent] [1, 1]
    : memref<?x?xf64> to memref<?xf64, strided<[1], offset: ?>>

%result = fir.convert %subview
    : (memref<?xf64, strided<[1], offset: ?>>) ->
      !fir.heap<!fir.array<?xf64>>
```

After:
```mlir
%subview = memref.subview %view[%block_id, 0] [1, %extent] [1, 1]
    : memref<?x?xf64> to memref<?xf64, strided<[1], offset: ?>>

%base, %offset, %sizes, %strides =
    memref.extract_strided_metadata %subview
    : memref<?xf64, strided<[1], offset: ?>> ->
      memref<f64>, index, index, index

%c8 = arith.constant 8 : index
%byte_offset = arith.muli %offset, %c8 : index

%private_view = memref.view %buffer[%byte_offset][%extent]
    : memref<?xi8> to memref<?xf64>

%result = fir.convert %private_view
    : (memref<?xf64>) -> !fir.heap<!fir.array<?xf64>>
```
