### PR TITLE
[SPIR-V] Avoid rescanning use lists to check for Block decoration

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -1416,7 +1416,7 @@ bool SPIRVGlobalRegistry::isResourceType(SPIRVTypeInst Type) const {
   case SPIRV::OpTypeSampledImage:
     return true;
   case SPIRV::OpTypeStruct:
-    return hasBlockDecoration(Type);
+    return BlockDecoratedTypes.contains(Type);
   default:
     return false;
   }
@@ -1545,6 +1545,7 @@ SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateVulkanBufferType(
 
   buildOpDecorate(BlockType->defs().begin()->getReg(), MIRBuilder,
                   SPIRV::Decoration::Block, {});
+  BlockDecoratedTypes.insert(BlockType);
 
   if (!IsWritable) {
     buildOpMemberDecorate(BlockType->defs().begin()->getReg(), MIRBuilder,
@@ -1585,6 +1586,7 @@ SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateVulkanPushConstantType(
 
   buildOpDecorate(BlockType->defs().begin()->getReg(), MIRBuilder,
                   SPIRV::Decoration::Block, {});
+  BlockDecoratedTypes.insert(BlockType);
   SPIRVTypeInst R = BlockType;
   add(Key, R);
   return R;
@@ -2297,17 +2299,4 @@ void SPIRVGlobalRegistry::addArrayStrideDecorations(
   uint32_t SizeInBytes = DL.getTypeAllocSize(ElementType);
   buildOpDecorate(Reg, MIRBuilder, SPIRV::Decoration::ArrayStride,
                   {SizeInBytes});
-}
-
-bool SPIRVGlobalRegistry::hasBlockDecoration(SPIRVTypeInst Type) const {
-  Register Def = getSPIRVTypeID(Type);
-  for (const MachineInstr &Use :
-       Type->getMF()->getRegInfo().use_instructions(Def)) {
-    if (Use.getOpcode() != SPIRV::OpDecorate)
-      continue;
-
-    if (Use.getOperand(1).getImm() == SPIRV::Decoration::Block)
-      return true;
-  }
-  return false;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -20,6 +20,7 @@
 #include "SPIRVIRMapping.h"
 #include "SPIRVInstrInfo.h"
 #include "SPIRVTypeInst.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/TypedPointerType.h"
@@ -59,6 +60,10 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
 
   SmallPtrSet<const Type *, 4> TypesInProcessing;
   DenseMap<const Type *, SPIRVTypeInst> ForwardPointerTypes;
+
+  // Struct types decorated with Block, recorded at the point the decoration
+  // is emitted.
+  DenseSet<SPIRVTypeInst> BlockDecoratedTypes;
 
   // Stores for each function the last inserted SPIR-V Type.
   // See: SPIRVGlobalRegistry::createOpType.
@@ -513,7 +518,6 @@ private:
                                   MachineIRBuilder &MIRBuilder);
   void addArrayStrideDecorations(Register Reg, Type *ElementType,
                                  MachineIRBuilder &MIRBuilder);
-  bool hasBlockDecoration(SPIRVTypeInst Type) const;
 
   SPIRVTypeInst
   getOrCreateOpTypeImage(MachineIRBuilder &MIRBuilder,


### PR DESCRIPTION
isResourceType previously re-walked the use list of every struct type to look for an OpDecorate Block, repeating the same scan whenever multiple types shared a struct element

Record Block-decorated types at the point the decoration is emitted instead