### PR TITLE
[mlir][OpenACC] Carry array reduction storage scope

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -195,15 +195,18 @@ def OpenACC_ReductionAccumulateArrayOp
     : OpenACC_Op<"reduction_accumulate_array", []> {
   let summary = "Accumulates elements of an array";
   let description = [{
-    Accumulates elements of an array across the specified parallel dimension 
-    given an acc.bounds op.
+    Accumulates elements of an array across the specified parallel dimensions
+    given an acc.bounds op. `storage_par_dims` records the parallel dimensions
+    across which the accumulator storage is replicated. This is decided before
+    target lowering and may differ from the reduction's `par_dims`.
   }];
   let arguments = (ins Arg<OpenACC_PointerLikeTypeInterface,
                            "Reduction variable to update",
                            [MemRead, MemWrite]>:$memref,
                        OpenACC_DataBoundsType:$bounds,
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
-                       OpenACC_GPUParallelDimsAttr:$par_dims);
+                       OpenACC_GPUParallelDimsAttr:$par_dims,
+                       OpenACC_GPUParallelDimsAttr:$storage_par_dims);
   let assemblyFormat = [{
     $memref `bounds` `(` $bounds `)` $reductionOperator `:` type($memref) attr-dict
   }];
@@ -362,7 +365,8 @@ def OpenACC_UnwrapPrivateOp
 //===----------------------------------------------------------------------===//
 
 def OpenACC_PrivateLocalOp
-    : OpenACC_Op<"private_local", [NoMemoryEffect, AlwaysSpeculatable]> {
+    : OpenACC_Op<"private_local",
+          [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Materialize privatized storage for the current parallelism context";
   let description = [{
     Given a value of type `acc.private_type<T>`, materializes the underlying
@@ -375,8 +379,13 @@ def OpenACC_PrivateLocalOp
     still aliases the same underlying storage as `T`; in that case passes that
     consume this operation must treat the handle type and the result type as
     describing the same storage layout.
+
+    `reduction_operator`, when present, requests that a newly materialized
+    private array be initialized to the operator's identity.
   }];
-  let arguments = (ins OpenACC_PrivateType:$privatized);
+  let arguments = (ins OpenACC_PrivateType:$privatized,
+                       OptionalAttr<OpenACC_ReductionOperatorAttr>:
+                           $reduction_operator);
   let results = (outs AnyType:$output);
   let assemblyFormat = [{
     $privatized attr-dict `:` functional-type(operands, results)
@@ -387,6 +396,7 @@ def OpenACC_PrivateLocalOp
       $_state.addTypes(resultType);
     }]>
   ];
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -206,7 +206,8 @@ def OpenACC_ReductionAccumulateArrayOp
                        OpenACC_DataBoundsType:$bounds,
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
                        OpenACC_GPUParallelDimsAttr:$par_dims,
-                       OpenACC_GPUParallelDimsAttr:$storage_par_dims);
+                       OptionalAttr<OpenACC_GPUParallelDimsAttr>:
+                           $storage_par_dims);
   let assemblyFormat = [{
     $memref `bounds` `(` $bounds `)` $reductionOperator `:` type($memref) attr-dict
   }];

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -16,6 +16,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -502,9 +503,14 @@ LogicalResult PrivateLocalOp::verify() {
     return success();
   auto privateTy = cast<PrivateType>(getPrivatized().getType());
   auto memrefTy = dyn_cast<MemRefType>(privateTy.getBaseTy());
-  if (!memrefTy || memrefTy.getRank() != 1 || !memrefTy.hasStaticShape())
+  if (!memrefTy || memrefTy.getRank() != 1)
     return emitOpError(
-        "reduction_operator requires static rank-1 memref private storage");
+        "reduction_operator requires rank-1 memref private storage");
+  if (auto outputMemrefTy = dyn_cast<MemRefType>(getOutput().getType());
+      outputMemrefTy && !memref::CastOp::areCastCompatible(
+                            TypeRange{memrefTy}, TypeRange{outputMemrefTy}))
+    return emitOpError(
+        "reduction_operator requires compatible private and output storage");
   return success();
 }
 
@@ -515,17 +521,17 @@ LogicalResult PrivateLocalOp::verify() {
 LogicalResult ReductionAccumulateArrayOp::verify() {
   if (getParDims().getArray().empty())
     return emitOpError("par_dims must specify at least one parallel dimension");
-  if (getStorageParDims().getArray().empty())
-    return emitOpError(
-        "storage_par_dims must specify at least one parallel dimension");
+  GPUParallelDimsAttr storageParDims = getStorageParDimsAttr();
+  if (!storageParDims)
+    return success();
   bool hasThreadXStorage =
-      llvm::any_of(getStorageParDims().getArray(),
+      llvm::any_of(storageParDims.getArray(),
                    [](GPUParallelDimAttr dim) { return dim.isThreadX(); });
   bool hasThreadYReduction =
       llvm::any_of(getParDims().getArray(),
                    [](GPUParallelDimAttr dim) { return dim.isThreadY(); });
   bool hasThreadYStorage =
-      llvm::any_of(getStorageParDims().getArray(),
+      llvm::any_of(storageParDims.getArray(),
                    [](GPUParallelDimAttr dim) { return dim.isThreadY(); });
   if (hasThreadXStorage && hasThreadYReduction && !hasThreadYStorage)
     return emitOpError(

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -487,12 +487,50 @@ LogicalResult ReductionAccumulateOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// PrivateLocalOp
+//===----------------------------------------------------------------------===//
+
+void PrivateLocalOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (getReductionOperatorAttr())
+    addOperandEffect<MemoryEffects::Write>(effects, getPrivatizedMutable());
+}
+
+LogicalResult PrivateLocalOp::verify() {
+  if (!getReductionOperatorAttr())
+    return success();
+  auto privateTy = cast<PrivateType>(getPrivatized().getType());
+  auto memrefTy = dyn_cast<MemRefType>(privateTy.getBaseTy());
+  if (!memrefTy || memrefTy.getRank() != 1 || !memrefTy.hasStaticShape())
+    return emitOpError(
+        "reduction_operator requires static rank-1 memref private storage");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReductionAccumulateArrayOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReductionAccumulateArrayOp::verify() {
   if (getParDims().getArray().empty())
     return emitOpError("par_dims must specify at least one parallel dimension");
+  if (getStorageParDims().getArray().empty())
+    return emitOpError(
+        "storage_par_dims must specify at least one parallel dimension");
+  bool hasThreadXStorage =
+      llvm::any_of(getStorageParDims().getArray(),
+                   [](GPUParallelDimAttr dim) { return dim.isThreadX(); });
+  bool hasThreadYReduction =
+      llvm::any_of(getParDims().getArray(),
+                   [](GPUParallelDimAttr dim) { return dim.isThreadY(); });
+  bool hasThreadYStorage =
+      llvm::any_of(getStorageParDims().getArray(),
+                   [](GPUParallelDimAttr dim) { return dim.isThreadY(); });
+  if (hasThreadXStorage && hasThreadYReduction && !hasThreadYStorage)
+    return emitOpError(
+        "thread_x-replicated storage_par_dims must include thread_y when "
+        "par_dims includes thread_y");
   return success();
 }
 

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -661,12 +661,16 @@ static void initPrivateArrayAccum(OpBuilder &b, Location loc, Value storage,
                                   MemRefType baseTy, arith::AtomicRMWKind kind,
                                   bool hasThreadXStorage,
                                   llvm::function_ref<void()> emitRowBarrier) {
-  assert(baseTy.getRank() == 1 && baseTy.hasStaticShape() &&
-         "private array reduction accumulator must be static rank-1");
+  assert(baseTy.getRank() == 1 &&
+         "private array reduction accumulator must be rank-1");
   Value ident = createIdentityValue(b, loc, baseTy.getElementType(), kind,
                                     /*useOnlyFiniteValue=*/true);
   Value lb = arith::ConstantIndexOp::create(b, loc, 0);
-  Value ub = arith::ConstantIndexOp::create(b, loc, baseTy.getShape()[0]);
+  Value ub;
+  if (baseTy.isDynamicDim(0))
+    ub = memref::DimOp::create(b, loc, storage, 0);
+  else
+    ub = arith::ConstantIndexOp::create(b, loc, baseTy.getShape()[0]);
   Value step = arith::ConstantIndexOp::create(b, loc, 1);
   auto emitInitLoop = [&]() {
     auto forOp = scf::ForOp::create(b, loc, lb, ub, step);
@@ -3240,7 +3244,10 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
   bool hasThreadStorage = false;
   bool hasThreadXStorage = false;
   bool hasBlockStorage = false;
-  for (mlir::acc::GPUParallelDimAttr dim : op.getStorageParDims().getArray()) {
+  mlir::acc::GPUParallelDimsAttr storageParDims =
+      op.getStorageParDimsAttr() ? op.getStorageParDimsAttr()
+                                 : op.getParDimsAttr();
+  for (mlir::acc::GPUParallelDimAttr dim : storageParDims.getArray()) {
     hasThreadStorage |= dim.isAnyThread();
     hasThreadXStorage |= dim.isThreadX();
     hasBlockStorage |= dim.isAnyBlock();

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -306,31 +306,6 @@ static bool sameEffectiveValue(Value x, int64_t y) {
   return *conX == y;
 }
 
-/// Continues tracking a memref through view-like and partial-access ops.
-static bool getPassThroughResults(Operation *userOp, Value trackedOperand,
-                                  SmallVectorImpl<Value> &passThroughResults) {
-  if (ViewLikeOpInterface viewLikeOp = dyn_cast<ViewLikeOpInterface>(userOp)) {
-    if (viewLikeOp.getViewSource() == trackedOperand) {
-      passThroughResults.push_back(viewLikeOp.getViewDest());
-      return true;
-    }
-    return false;
-  }
-
-  // Partial-entity accesses (e.g. array element or field access) forward the
-  // base entity through to their results, so treat them as pass-through when
-  // the base entity is the value being tracked.
-  if (acc::PartialEntityAccessOpInterface partialAccess =
-          dyn_cast<acc::PartialEntityAccessOpInterface>(userOp)) {
-    if (partialAccess.getBaseEntity() == trackedOperand) {
-      passThroughResults.append(userOp->result_begin(), userOp->result_end());
-      return true;
-    }
-    return false;
-  }
-  return false;
-}
-
 /// Skips memref view/cast chains to reach the underlying buffer.
 static Value unwrapMemRefConversion(Value v) {
   while (Operation *op = v.getDefiningOp()) {
@@ -680,81 +655,55 @@ bool ACCCGToGPULowering::canUseStackAlloca(
   return elementSize * numElements < maxThreadPrivateStack;
 }
 
-/// True if the accumulate spans a block dim or is nested in a block-mapped
-/// loop, i.e. each block owns the elements it reduces across threads. A
-/// thread-only accumulate with no block context grid-strides its element loop
-/// onto blocks, so per-thread partials would be dropped; such reductions must
-/// stay shared.
-static bool reductionHasBlockContext(acc::ReductionAccumulateArrayOp accArr) {
-  auto hasBlock = [](mlir::acc::GPUParallelDimsAttr parDims) {
-    return parDims && llvm::any_of(parDims.getArray(),
-                                   [](auto pd) { return pd.isAnyBlock(); });
-  };
-  if (hasBlock(accArr.getParDimsAttr()))
-    return true;
-  for (scf::ParallelOp loop = accArr->getParentOfType<scf::ParallelOp>(); loop;
-       loop = loop->getParentOfType<scf::ParallelOp>()) {
-    if (hasBlock(mlir::acc::getParDimsAttr(loop)))
-      return true;
-  }
-  return false;
-}
-
-/// Returns the array reduction accumulate (through cast/view ops) that \p v
-/// feeds if it needs per-thread storage: its par_dims include a thread dim
-/// and it has block context so the cross-thread all_reduce is well defined.
-static acc::ReductionAccumulateArrayOp perThreadArrayReductionAccum(Value v) {
-  SmallVector<Value> worklist{v};
-  DenseSet<Value> seen;
-  while (!worklist.empty()) {
-    Value cur = worklist.pop_back_val();
-    if (!seen.insert(cur).second)
-      continue;
-    for (Operation *user : cur.getUsers()) {
-      if (acc::ReductionAccumulateArrayOp accArr =
-              dyn_cast<acc::ReductionAccumulateArrayOp>(user)) {
-        bool hasThread = false;
-        for (auto pd : accArr.getParDims().getArray())
-          hasThread |= pd.isAnyThread();
-        if (hasThread && reductionHasBlockContext(accArr))
-          return accArr;
-        continue;
-      }
-      SmallVector<Value> through;
-      if (getPassThroughResults(user, cur, through))
-        worklist.append(through.begin(), through.end());
-      else if (isa<ViewLikeOpInterface>(user))
-        worklist.append(user->result_begin(), user->result_end());
-    }
-  }
-  return nullptr;
-}
-
-/// Store the reduction identity to every element of a freshly allocated
-/// per-thread array accumulator so all lanes start from identity (the original
-/// init loop may only run on one lane).
-static void initPerThreadArrayAccum(OpBuilder &b, Location loc, Value alloca,
-                                    MemRefType baseTy,
-                                    arith::AtomicRMWKind kind) {
+/// Initialize a newly materialized array accumulator. Worker-private storage
+/// is initialized by one vector lane before the workgroup proceeds.
+static void initPrivateArrayAccum(OpBuilder &b, Location loc, Value storage,
+                                  MemRefType baseTy, arith::AtomicRMWKind kind,
+                                  bool hasThreadXStorage,
+                                  llvm::function_ref<void()> emitRowBarrier) {
   assert(baseTy.getRank() == 1 && baseTy.hasStaticShape() &&
-         "per-thread array reduction accumulator must be static rank-1");
+         "private array reduction accumulator must be static rank-1");
   Value ident = createIdentityValue(b, loc, baseTy.getElementType(), kind,
                                     /*useOnlyFiniteValue=*/true);
   Value lb = arith::ConstantIndexOp::create(b, loc, 0);
   Value ub = arith::ConstantIndexOp::create(b, loc, baseTy.getShape()[0]);
   Value step = arith::ConstantIndexOp::create(b, loc, 1);
-  auto forOp = scf::ForOp::create(b, loc, lb, ub, step);
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPoint(forOp.getBody()->getTerminator());
-  memref::StoreOp::create(b, loc, ident, alloca, forOp.getInductionVar());
+  auto emitInitLoop = [&]() {
+    auto forOp = scf::ForOp::create(b, loc, lb, ub, step);
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(forOp.getBody()->getTerminator());
+    memref::StoreOp::create(b, loc, ident, storage, forOp.getInductionVar());
+  };
+  if (hasThreadXStorage) {
+    emitInitLoop();
+    return;
+  }
+  Value threadX = gpu::ThreadIdOp::create(b, loc, gpu::Dimension::x);
+  Value isLeader =
+      arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq, threadX, lb);
+  auto ifOp = scf::IfOp::create(b, loc, isLeader, /*withElseRegion=*/false);
+  {
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(ifOp.thenYield());
+    emitInitLoop();
+  }
+  emitRowBarrier();
 }
 
 std::optional<int64_t>
 ACCCGToGPULowering::isEligibleForSharedMemory(acc::PrivateLocalOp privateLocal,
                                               MemRefType baseTy) {
-  // Cross-thread array reduction accumulators must stay per-thread.
-  if (perThreadArrayReductionAccum(privateLocal.getResult()))
-    return std::nullopt;
+  if (privateLocal.getReductionOperatorAttr()) {
+    GPUParallelDimsAttr parDimsAttr = getParDimsAttr(privateLocal);
+    bool hasThreadXStorage =
+        parDimsAttr
+            ? llvm::any_of(
+                  parDimsAttr.getArray(),
+                  [](GPUParallelDimAttr dim) { return dim.isThreadX(); })
+            : isThreadXPrivatize(getPrivatizeOp(privateLocal, computeRegion));
+    if (hasThreadXStorage)
+      return std::nullopt;
+  }
   ModuleOp module = computeRegion->getParentOfType<ModuleOp>();
   FailureOr<bool> isCandidate = isPrivateLocalSharedMemoryCandidate(
       privateLocal, computeRegion, module, defaultPolicy, &accSupport);
@@ -2466,33 +2415,51 @@ void ACCCGToGPULowering::processPrivateLocal(
   MemRefType baseTy = getPrivateBaseMemRefType(privTy.getBaseTy(), module);
   MemRefType byteMemrefTy =
       MemRefType::get({ShapedType::kDynamic}, rewriter.getI8Type());
-
   acc::PrivatizeOp privatizeOp = getPrivatizeOp(privateLocal, computeRegion);
+  auto initializeReductionStorage = [&](Value storage) -> LogicalResult {
+    auto reductionOperator = privateLocal.getReductionOperatorAttr();
+    if (!reductionOperator)
+      return success();
+    GPUParallelDimsAttr parDimsAttr = getParDimsAttr(privateLocal);
+    bool hasThreadXStorage = parDimsAttr
+                                 ? llvm::any_of(parDimsAttr.getArray(),
+                                                [](GPUParallelDimAttr dim) {
+                                                  return dim.isThreadX();
+                                                })
+                                 : isThreadXPrivatize(privatizeOp);
+    FailureOr<arith::AtomicRMWKind> kind = getReductionKind(
+        reductionOperator.getValue(), baseTy.getElementType(), loc);
+    if (failed(kind))
+      return failure();
+    initPrivateArrayAccum(
+        rewriter, loc, storage, baseTy, *kind, hasThreadXStorage, [&]() {
+          GPUParallelDimsAttr vectorDimsAttr = GPUParallelDimsAttr::get(
+              rewriter.getContext(),
+              {GPUParallelDimAttr::threadXDim(rewriter.getContext())});
+          createBarrier(loc, vectorDimsAttr);
+        });
+    return success();
+  };
+
   Value inputMem;
   if (privatizeOp->getParentOfType<acc::ComputeRegionOp>() == computeRegion) {
     inputMem = mapping.lookupOrNull(privatizeOp);
     if (inputMem) {
       Value result = castPointerLikeTypeIfNeeded(rewriter, loc, inputMem,
                                                  privateLocal.getType());
+      if (failed(initializeReductionStorage(result)))
+        return;
       mapping.map(privateLocal.getResult(), result);
       return;
     }
   } else {
-    // Hoisted acc.privatize: allocate per-thread stack storage in the launch
-    // body. Cross-thread array reduction accumulators are per-thread too, so
-    // the accumulate can reduce each element across threads.
-    acc::ReductionAccumulateArrayOp arrayAccum =
-        perThreadArrayReductionAccum(privateLocal.getResult());
-    if ((isThreadXPrivatize(privatizeOp) || arrayAccum) &&
+    // Hoisted vector-private storage is allocated on the thread stack when it
+    // fits the configured budget.
+    if (isThreadXPrivatize(privatizeOp) &&
         canUseStackAlloca(baseTy, loc, options.maxThreadPrivateStack)) {
       Value alloca = memref::AllocaOp::create(rewriter, loc, baseTy);
-      if (arrayAccum) {
-        FailureOr<arith::AtomicRMWKind> kind = getReductionKind(
-            arrayAccum.getReductionOperator(), baseTy.getElementType(), loc);
-        if (failed(kind))
-          return;
-        initPerThreadArrayAccum(rewriter, loc, alloca, baseTy, *kind);
-      }
+      if (failed(initializeReductionStorage(alloca)))
+        return;
       Value mem = castPointerLikeTypeIfNeeded(rewriter, loc, alloca,
                                               privateLocal.getType());
       mapping.map(privateLocal.getResult(), mem);
@@ -2530,6 +2497,8 @@ void ACCCGToGPULowering::processPrivateLocal(
 
         Value mem =
             castPointerLikeTypeIfNeeded(rewriter, loc, sharedMem, baseTy);
+        if (failed(initializeReductionStorage(mem)))
+          return;
         Value result = castPointerLikeTypeIfNeeded(rewriter, loc, mem,
                                                    privateLocal.getType());
 
@@ -2547,6 +2516,8 @@ void ACCCGToGPULowering::processPrivateLocal(
     assert(inputMem && "expected input mem to be mapped");
     Value result = castPointerLikeTypeIfNeeded(rewriter, loc, inputMem,
                                                privateLocal.getType());
+    if (failed(initializeReductionStorage(result)))
+      return;
     mapping.map(privateLocal.getResult(), result);
     return;
   }
@@ -2569,19 +2540,12 @@ void ACCCGToGPULowering::processPrivateLocal(
   std::pair<SmallVector<mlir::acc::GPUParallelDimAttr>,
             SmallVector<mlir::acc::GPUParallelDimAttr>>
       parDimsPair = computeActiveAndInactiveParDims(privateLocal, nullptr);
-  acc::ReductionAccumulateArrayOp arrayAccum =
-      perThreadArrayReductionAccum(privateLocal.getResult());
   for (mlir::acc::GPUParallelDimAttr parDim : parDimsPair.first) {
-    if ((parDim.isThreadX() || arrayAccum) &&
+    if (parDim.isThreadX() &&
         canUseStackAlloca(baseTy, loc, options.maxThreadPrivateStack)) {
       Value alloca = memref::AllocaOp::create(rewriter, loc, baseTy);
-      if (arrayAccum) {
-        FailureOr<arith::AtomicRMWKind> kind = getReductionKind(
-            arrayAccum.getReductionOperator(), baseTy.getElementType(), loc);
-        if (failed(kind))
-          return;
-        initPerThreadArrayAccum(rewriter, loc, alloca, baseTy, *kind);
-      }
+      if (failed(initializeReductionStorage(alloca)))
+        return;
       Value mem = castPointerLikeTypeIfNeeded(rewriter, loc, alloca,
                                               privateLocal.getType());
       mapping.map(privateLocal.getResult(), mem);
@@ -2649,6 +2613,8 @@ void ACCCGToGPULowering::processPrivateLocal(
   SmallVector<OpFoldResult> ones(viewType.getRank(), rewriter.getIndexAttr(1));
   Value subview = memref::SubViewOp::create(rewriter, loc, subviewType, view,
                                             subviewOffset, subviewSizes, ones);
+  if (failed(initializeReductionStorage(subview)))
+    return;
 
   // Cast subview to the target type, preserving the dynamic offset.
   // Do NOT cast to a plain memref (offset: 0) - the LLVM optimizer
@@ -3271,6 +3237,14 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
     hasThreadDim |= pd.isAnyThread();
     hasBlockDim |= pd.isAnyBlock();
   }
+  bool hasThreadStorage = false;
+  bool hasThreadXStorage = false;
+  bool hasBlockStorage = false;
+  for (mlir::acc::GPUParallelDimAttr dim : op.getStorageParDims().getArray()) {
+    hasThreadStorage |= dim.isAnyThread();
+    hasThreadXStorage |= dim.isThreadX();
+    hasBlockStorage |= dim.isAnyBlock();
+  }
 
   // Block-only (gang) reduction: each element is produced by one gang, so the
   // per-gang copy already holds the result and the combine does the rest.
@@ -3281,32 +3255,16 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
 
   // A thread-level reduction with no block owner for its elements cannot merge
   // the cross-thread partials, so report NYI.
-  if (!reductionHasBlockContext(op)) {
+  if (!hasBlockDim && !hasBlockStorage) {
     (void)accSupport.emitNYI(
         loc, "reduction: thread-only array reduction accumulate");
     return;
   }
 
-  // Per-element gpu.all_reduce is only correct when each thread owns its own
-  // accumulator copy. For a statically-shaped accumulator, classify from the
-  // operand: an explicit shared allocation is block-shared regardless of size,
-  // and anything else (a per-thread stack alloca, or a view over one) is
-  // per-thread when it fits the per-thread stack budget and block-shared when
-  // it is too large. For a dynamically-shaped accumulator the type conveys no
-  // size, so classify from par_dims (which the producer sets to the reduction's
-  // actual parallel scope): a thread dimension means per-thread storage.
-  bool isPerThreadPrivate;
-  if (memrefTy.hasStaticShape()) {
-    Operation *rootOp = unwrapMemRefConversion(memref).getDefiningOp();
-    isPerThreadPrivate =
-        !isa_and_nonnull<memref::AllocOp>(rootOp) &&
-        canUseStackAlloca(memrefTy, loc, options.maxThreadPrivateStack);
-  } else {
-    isPerThreadPrivate = llvm::any_of(
-        op.getParDims().getArray(),
-        [](mlir::acc::GPUParallelDimAttr d) { return d.isThreadX(); });
-  }
-  if (!isPerThreadPrivate) {
+  // Storage replication is decided before target lowering. A thread dimension
+  // means that each thread or worker owns an accumulator copy; block-only
+  // storage is shared by the workgroup.
+  if (!hasThreadStorage) {
     // Block-shared accumulator: no-op only when the accumulate spans a block
     // dim (threads distribute distinct elements, so the block partial is in
     // place and the atomic combine finishes it). A thread-only shared
@@ -3356,9 +3314,18 @@ void ACCCGToGPULowering::processAccumulateArrayOp(
     rewriter.setInsertionPoint(forOp.getBody()->getTerminator());
     Value iv = forOp.getInductionVar();
     Value elem = memref::LoadOp::create(rewriter, loc, memref, ValueRange{iv});
+    if (!hasThreadXStorage) {
+      Value threadX = getThreadId(loc, gpu::Dimension::x);
+      Value isLeader = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::eq, threadX, zero);
+      Value identity =
+          createIdentityValue(rewriter, loc, memrefTy.getElementType(), kind,
+                              /*useOnlyFiniteValue=*/true);
+      elem = arith::SelectOp::create(rewriter, loc, isLeader, elem, identity);
+    }
     createGPUAllReduceOp(loc, elem, memref, kind, op.getParDims(),
                          ValueRange{iv},
-                         /*isPerThreadPrivateTarget=*/true);
+                         /*isPerThreadPrivateTarget=*/hasThreadXStorage);
   }
 
   eraseDeadBounds();

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -51,6 +51,26 @@ func.func @threadprivate_array_reduction() {
   return
 }
 
+// CHECK-LABEL: func.func @dynamic_threadprivate_array_reduction
+// CHECK:       gpu.launch
+// CHECK:         %[[PRIVATE:.*]] = memref.subview
+// CHECK:         %[[EXTENT:.*]] = memref.dim %[[PRIVATE]]
+// CHECK:         scf.for %[[IV:.*]] = %{{.*}} to %[[EXTENT]] step %{{.*}} {
+// CHECK:           memref.store {{.*}}, %[[PRIVATE]][%[[IV]]]
+
+func.func @dynamic_threadprivate_array_reduction(%n: index) {
+  %priv = acc.privatize(%n) [#acc<par_dims[thread_x]>]
+      : (index) -> !acc.private_type<memref<?xi32>>
+  acc.compute_region ins(%priv_in = %priv) :
+      (!acc.private_type<memref<?xi32>>) {
+    %local = acc.private_local %priv_in
+        {reduction_operator = #acc.reduction_operator<add>}
+        : (!acc.private_type<memref<?xi32>>) -> memref<?xi32>
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
 // CHECK-LABEL: func.func @workerprivate_array_reduction
 // CHECK:       gpu.launch
 // CHECK:         %[[TX:.*]] = gpu.thread_id x

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu{max-thread-private-stack=1}))" | FileCheck %s --check-prefix=FALLBACK
 
 // CHECK-LABEL: func.func @threadprivate
 // CHECK:       acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<i32>>
@@ -19,6 +20,53 @@ func.func @threadprivate(%host: memref<i32>) {
     %v = memref.load %local[] : memref<i32>
     %next = arith.addi %v, %v : i32
     memref.store %next, %local[] : memref<i32>
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// CHECK-LABEL: func.func @threadprivate_array_reduction
+// CHECK:       gpu.launch
+// CHECK:         %[[PRIVATE:.*]] = memref.alloca() : memref<2xi32>
+// CHECK:         %[[ZERO:.*]] = arith.constant 0 : i32
+// CHECK:         scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:           memref.store %[[ZERO]], %[[PRIVATE]][%[[IV]]]
+// FALLBACK-LABEL: func.func @threadprivate_array_reduction
+// FALLBACK:       gpu.launch
+// FALLBACK-NOT:     memref.alloca() : memref<2xi32>
+// FALLBACK:         %[[PRIVATE:.*]] = memref.subview
+// FALLBACK:         %[[ZERO:.*]] = arith.constant 0 : i32
+// FALLBACK:         scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+// FALLBACK:           memref.store %[[ZERO]], %[[PRIVATE]][%[[IV]]]
+
+func.func @threadprivate_array_reduction() {
+  %priv = acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<2xi32>>
+  acc.compute_region ins(%priv_in = %priv) :
+      (!acc.private_type<memref<2xi32>>) {
+    %local = acc.private_local %priv_in
+        {reduction_operator = #acc.reduction_operator<add>}
+        : (!acc.private_type<memref<2xi32>>) -> memref<2xi32>
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// CHECK-LABEL: func.func @workerprivate_array_reduction
+// CHECK:       gpu.launch
+// CHECK:         %[[TX:.*]] = gpu.thread_id x
+// CHECK:         %[[LEADER:.*]] = arith.cmpi eq, %[[TX]], %{{.*}} : index
+// CHECK:         scf.if %[[LEADER]]
+// CHECK:           memref.store
+// CHECK:         gpu.barrier scope <subgroup>
+// CHECK-NOT:     gpu.barrier
+
+func.func @workerprivate_array_reduction() {
+  %priv = acc.privatize [#acc<par_dims[thread_y]>] : () -> !acc.private_type<memref<2xi32>>
+  acc.compute_region ins(%priv_in = %priv) :
+      (!acc.private_type<memref<2xi32>>) {
+    %local = acc.private_local %priv_in
+        {reduction_operator = #acc.reduction_operator<add>}
+        : (!acc.private_type<memref<2xi32>>) -> memref<2xi32>
     acc.yield
   } {origin = "acc.parallel"}
   return

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
@@ -43,7 +43,7 @@ func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c8192 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x]>}
       acc.reduction_combine_region %2 into %arg2 : memref<8192xi32> {
         scf.for %i = %c0 to %c8192 step %c1 {
           %3 = memref.load %2[%i] : memref<8192xi32>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -47,7 +47,7 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c2 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_x]>}
       acc.reduction_combine_region %2 into %arg2 : memref<2xi32> {
         scf.for %i = %c0 to %c2 step %c1 {
           %3 = memref.load %2[%i] : memref<2xi32>
@@ -77,7 +77,7 @@ func.func @array_reduction_small_shared() {
     %shared = memref.alloc() : memref<2xi32>
     %bounds = acc.bounds extent(%c2 : index)
     acc.reduction_accumulate_array %shared bounds(%bounds) <add>
-        : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+        : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x]>}
     memref.dealloc %shared : memref<2xi32>
     acc.yield
   } {origin = "acc.parallel"}
@@ -105,15 +105,14 @@ func.func @array_reduction_strided_extent() {
     %bounds = acc.bounds lowerbound(%c1_b : index) extent(%c3 : index)
         stride(%c2 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<8xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+        : memref<8xi32> {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_x]>}
     acc.yield
   } {origin = "acc.parallel"}
   return
 }
 
-// A dynamically-shaped accumulator (a strided view whose type conveys no size)
-// is classified per-thread from par_dims: a thread dimension means per-thread
-// storage, so lowering emits the per-element gpu.all_reduce.
+// A dynamically-shaped accumulator carries explicit per-thread
+// storage_par_dims, so lowering emits the per-element gpu.all_reduce.
 //
 // CHECK-LABEL: func.func @array_reduction_dynamic_par_dims
 // CHECK: scf.for
@@ -129,7 +128,7 @@ func.func @array_reduction_dynamic_par_dims(%buf: memref<?xi32>, %n: index) {
     %bounds = acc.bounds extent(%ext : index)
     acc.reduction_accumulate_array %view bounds(%bounds) <add>
         : memref<?xi32, strided<[1]>>
-        {par_dims = #acc<par_dims[block_x, thread_x]>}
+        {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_x]>}
     acc.yield
   } {origin = "acc.parallel"}
   return

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -94,8 +94,7 @@ func.func @reduction_accumulate_array_empty_par_dims(%private: memref<4xi32>, %b
 
 // -----
 
-func.func @reduction_accumulate_array_empty_storage_par_dims(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
-  // expected-error@+1 {{storage_par_dims must specify at least one parallel dimension}}
+func.func @reduction_accumulate_array_unreplicated_storage(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   acc.reduction_accumulate_array %private bounds(%bounds) <add>
       : memref<4xi32> {par_dims = #acc<par_dims[thread_x]>, storage_par_dims = #acc<par_dims[]>}
   return
@@ -114,10 +113,21 @@ func.func @reduction_accumulate_array_partial_thread_storage(%private: memref<4x
 
 func.func @private_local_invalid_reduction_operator_shape() {
   %private = acc.privatize : () -> !acc.private_type<memref<2x2xi32>>
-  // expected-error@+1 {{reduction_operator requires static rank-1 memref private storage}}
+  // expected-error@+1 {{reduction_operator requires rank-1 memref private storage}}
   %local = acc.private_local %private {
     reduction_operator = #acc.reduction_operator<add>
   } : (!acc.private_type<memref<2x2xi32>>) -> memref<4xi32>
+  return
+}
+
+// -----
+
+func.func @private_local_incompatible_reduction_storage() {
+  %private = acc.privatize : () -> !acc.private_type<memref<4xi32>>
+  // expected-error@+1 {{reduction_operator requires compatible private and output storage}}
+  %local = acc.private_local %private {
+    reduction_operator = #acc.reduction_operator<add>
+  } : (!acc.private_type<memref<4xi32>>) -> memref<4xf32>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -77,7 +77,7 @@ func.func @reduction_accumulate_empty_par_dims() {
 
 func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   acc.reduction_accumulate_array %private bounds(%bounds) <addi>
-      : memref<4xi32> {par_dims = #acc<par_dims[thread_x]>}
+      : memref<4xi32> {par_dims = #acc<par_dims[thread_x]>, storage_par_dims = #acc<par_dims[thread_x]>}
   // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
   // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
   return
@@ -88,7 +88,36 @@ func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, 
 func.func @reduction_accumulate_array_empty_par_dims(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
   acc.reduction_accumulate_array %private bounds(%bounds) <add>
-      : memref<4xi32> {par_dims = #acc<par_dims[]>}
+      : memref<4xi32> {par_dims = #acc<par_dims[]>, storage_par_dims = #acc<par_dims[thread_x]>}
+  return
+}
+
+// -----
+
+func.func @reduction_accumulate_array_empty_storage_par_dims(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
+  // expected-error@+1 {{storage_par_dims must specify at least one parallel dimension}}
+  acc.reduction_accumulate_array %private bounds(%bounds) <add>
+      : memref<4xi32> {par_dims = #acc<par_dims[thread_x]>, storage_par_dims = #acc<par_dims[]>}
+  return
+}
+
+// -----
+
+func.func @reduction_accumulate_array_partial_thread_storage(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
+  // expected-error@+1 {{thread_x-replicated storage_par_dims must include thread_y when par_dims includes thread_y}}
+  acc.reduction_accumulate_array %private bounds(%bounds) <add>
+      : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x, thread_y]>, storage_par_dims = #acc<par_dims[block_x, thread_x]>}
+  return
+}
+
+// -----
+
+func.func @private_local_invalid_reduction_operator_shape() {
+  %private = acc.privatize : () -> !acc.private_type<memref<2x2xi32>>
+  // expected-error@+1 {{reduction_operator requires static rank-1 memref private storage}}
+  %local = acc.private_local %private {
+    reduction_operator = #acc.reduction_operator<add>
+  } : (!acc.private_type<memref<2x2xi32>>) -> memref<4xi32>
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -336,10 +336,19 @@ func.func @reduction_accumulate_block_thread(%partial: i32, %private: memref<i32
 
 // CHECK-LABEL: func @reduction_accumulate_array
 func.func @reduction_accumulate_array(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
-  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_x]>}
   return
 }
-// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_x]>}
+
+// -----
+
+// CHECK-LABEL: func @reduction_accumulate_array_worker_storage
+func.func @reduction_accumulate_array_worker_storage(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
+  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_y, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_y]>}
+  return
+}
+// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_y, thread_x]>, storage_par_dims = #acc<par_dims[block_x, thread_y]>}
 
 // -----
 


### PR DESCRIPTION
Example:
```fortran
integer :: a(8192)

a = 0
!$acc parallel num_gangs(8) vector_length(128)
!$acc loop reduction(+:a)
do j = 1, 8
  !$acc loop
  do k = 1, 8192
    a(k) = a(k) + 1
  enddo
enddo
!$acc end parallel
```

Each element should be `8`. Because this reduction array is too large for per-thread storage, its accumulator is block-shared. Treating it as per-thread and applying `gpu.all_reduce` scales the result by the thread count, producing `1024`.

The reduction parallelism alone does not describe whether accumulator storage is per-thread or block-shared. That information can also be obscured by dynamic memref views, so ACCCGToGPU cannot reliably reconstruct it.

Fix: decide the storage scope before ACCCGToGPU, carry it explicitly in `storage_par_dims`, and make ACCCGToGPU mechanically lower and initialize that storage.