### PR TITLE
[OpenMP] Implement EnumSet container

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -17,11 +17,115 @@
 #include "llvm/Support/Compiler.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Bitset.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm::omp {
+template <typename Enum, size_t Size> struct EnumSet;
+
+namespace detail {
+template <size_t Size>
+static constexpr inline size_t findFirstSet(size_t Begin, size_t End,
+                                            const llvm::Bitset<Size> &Set) {
+  unsigned FirstWord = Begin / 64;
+  unsigned LastWord = End / 64;
+
+  for (unsigned I = FirstWord; I <= LastWord; ++I) {
+    uint64_t Word = Set.getWord64(I);
+    if (I == FirstWord && Begin % 64 != 0) {
+      Word &= ~uint64_t() << (Begin % 64);
+    }
+    auto Count = static_cast<unsigned>(llvm::countr_zero_constexpr(Word));
+    if (Count < 64) {
+      unsigned Idx = I * 64 + Count;
+      if (Idx >= Begin && Idx < End)
+        return Idx;
+    }
+  }
+  return Size;
+}
+
+template <typename Enum, size_t Size> struct EnumSetIterator {
+  constexpr EnumSetIterator(const EnumSet<Enum, Size> &Set, size_t At)
+      : Set(Set), At(At) {}
+
+  constexpr Enum operator*() const;
+  constexpr auto &operator++();
+
+  constexpr bool operator==(const EnumSetIterator<Enum, Size> &Other) const {
+    return &Set == &Other.Set && At == Other.At;
+  }
+  constexpr bool operator!=(const EnumSetIterator<Enum, Size> &Other) const {
+    return !operator==(Other);
+  }
+
+private:
+  const EnumSet<Enum, Size> &Set;
+  size_t At;
+};
+} // namespace detail
+
+template <typename Enum, size_t Size>
+struct EnumSet : public llvm::Bitset<Size> {
+  using value_type = Enum;
+  using Base = llvm::Bitset<Size>;
+  using Base::Base;
+  using iterator = detail::EnumSetIterator<Enum, Size>;
+
+  constexpr EnumSet(Base &&B) : Base(std::move(B)) {}
+  constexpr EnumSet(std::initializer_list<value_type> Init) {
+    for (value_type E : Init) {
+      auto Value = static_cast<unsigned>(E);
+      assert(Value < Base::size() && "Invalid enumeration value");
+      Base::set(Value);
+    }
+  }
+
+  constexpr bool empty() const { return Base::none(); }
+  constexpr size_t size() const { return Base::count(); }
+  constexpr size_t max_size() const { return Size; }
+
+  constexpr bool test(Enum E) const {
+    return Base::test(static_cast<unsigned>(E));
+  }
+  constexpr bool operator[](Enum E) const {
+    return Base::operator[](static_cast<unsigned>(E));
+  }
+  constexpr EnumSet &flip(Enum E) {
+    Base::flip(static_cast<unsigned>(E));
+    return *this;
+  }
+  constexpr EnumSet &reset(Enum E) {
+    Base::reset(static_cast<unsigned>(E));
+    return *this;
+  }
+  constexpr EnumSet &set(Enum E) {
+    Base::set(static_cast<unsigned>(E));
+    return *this;
+  }
+
+  constexpr iterator begin() const {
+    return iterator(*this, detail::findFirstSet<Size>(0, Size, *this));
+  }
+  constexpr iterator end() const { return iterator(*this, Size); }
+};
+
+namespace detail {
+template <typename Enum, size_t Size>
+constexpr Enum EnumSetIterator<Enum, Size>::operator*() const {
+  assert(Set.Base::test(At));
+  return static_cast<Enum>(At);
+}
+
+template <typename Enum, size_t Size>
+constexpr auto &EnumSetIterator<Enum, Size>::operator++() {
+  At = findFirstSet<Size>(At + 1, Size, Set);
+  return *this;
+}
+} // namespace detail
+
 LLVM_ABI ArrayRef<Directive> getLeafConstructs(Directive D);
 LLVM_ABI ArrayRef<Directive> getLeafConstructsOrSelf(Directive D);
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -29,12 +29,12 @@ namespace detail {
 template <size_t Size>
 static constexpr inline size_t findFirstSet(size_t Begin, size_t End,
                                             const llvm::Bitset<Size> &Set) {
-  unsigned FirstWord = Begin / 64;
-  unsigned LastWord = End / 64;
+  unsigned BeginWord = Begin / 64;
+  unsigned EndWord = (End + 63) / 64;
 
-  for (unsigned I = FirstWord; I <= LastWord; ++I) {
+  for (unsigned I = BeginWord; I < EndWord; ++I) {
     uint64_t Word = Set.getWord64(I);
-    if (I == FirstWord && Begin % 64 != 0) {
+    if (I == BeginWord && Begin % 64 != 0) {
       Word &= ~uint64_t() << (Begin % 64);
     }
     auto Count = static_cast<unsigned>(llvm::countr_zero_constexpr(Word));

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -109,6 +109,23 @@ struct EnumSet : public llvm::Bitset<Size> {
     return *this;
   }
 
+  constexpr EnumSet &operator|=(const EnumSet &S) {
+    Base::operator|=(S);
+    return *this;
+  }
+  constexpr EnumSet &operator&=(const EnumSet &S) {
+    Base::operator&=(S);
+    return *this;
+  }
+  constexpr EnumSet operator|(const EnumSet &S) const {
+    EnumSet T{*this};
+    return T |= S;
+  }
+  constexpr EnumSet operator&(const EnumSet &S) const {
+    EnumSet T{*this};
+    return T &= S;
+  }
+
   constexpr iterator begin() const {
     return iterator(*this, detail::findFirstSet<Size>(0, Size, *this));
   }

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -48,6 +48,9 @@ static constexpr inline size_t findFirstSet(size_t Begin, size_t End,
 }
 
 template <typename Enum, size_t Size> struct EnumSetIterator {
+  using value_type = Enum;
+  static constexpr size_t enum_size = Size;
+
   constexpr EnumSetIterator(const EnumSet<Enum, Size> &Set, size_t At)
       : Set(Set), At(At) {}
 

--- a/llvm/unittests/Frontend/CMakeLists.txt
+++ b/llvm/unittests/Frontend/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(LLVMFrontendTests
+  EnumSetTest.cpp
   HLSLBindingTest.cpp
   HLSLRootSignatureDumpTest.cpp
   OpenACCTest.cpp

--- a/llvm/unittests/Frontend/EnumSetTest.cpp
+++ b/llvm/unittests/Frontend/EnumSetTest.cpp
@@ -1,0 +1,134 @@
+#include "llvm/Frontend/OpenMP/OMP.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::omp;
+
+namespace {
+namespace detail {
+template <typename Elem, Elem...> struct is_one_of {
+  constexpr bool operator()(Elem) const { return false; }
+};
+
+template <typename Elem, Elem Value, Elem... Values>
+struct is_one_of<Elem, Value, Values...> {
+  constexpr bool operator()(Elem V) const {
+    return V == Value || is_one_of<Elem, Values...>{}(V);
+  }
+};
+
+template <typename Elem, Elem... Values, typename Range>
+constexpr bool ElementsAre(Range &&R) {
+  size_t Count = 0;
+  // This also serves as an EnumSetIterator test.
+  for (auto It = R.begin(), End = R.end(); It != End; ++It) {
+    if (!is_one_of<Elem, Values...>{}(*It))
+      return false;
+    ++Count;
+  }
+  if (Count != sizeof...(Values))
+    return false;
+  return true;
+}
+} // namespace detail
+
+using ClauseSet = EnumSet<Clause, Clause_enumSize>;
+
+TEST(EnumSetTest, DefaultInitialization) {
+  constexpr ClauseSet S;
+  EXPECT_THAT(S, testing::IsEmpty());
+  EXPECT_EQ(S.size(), static_cast<size_t>(0));
+
+  static_assert(S.empty());
+  static_assert(S.size() == 0);
+}
+
+TEST(EnumSetTest, ListInitialization) {
+  constexpr ClauseSet S{Clause::OMPC_private, Clause::OMPC_shared};
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_private, OMPC_shared));
+
+  static_assert(
+      detail::ElementsAre<Clause, Clause::OMPC_private, Clause::OMPC_shared>(
+          S));
+}
+
+TEST(EnumSetTest, CopyInitialization) {
+  constexpr ClauseSet S(ClauseSet{Clause::OMPC_private, Clause::OMPC_shared});
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_private, OMPC_shared));
+
+  static_assert(
+      detail::ElementsAre<Clause, Clause::OMPC_private, Clause::OMPC_shared>(
+          S));
+}
+
+TEST(EnumSetTest, Set) {
+  ClauseSet S;
+  S.set(Clause::OMPC_private);
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_private));
+
+  static_assert(detail::ElementsAre<Clause, Clause::OMPC_private>(
+      ClauseSet{}.set(Clause::OMPC_private)));
+}
+
+TEST(EnumSetTest, Reset) {
+  ClauseSet S{Clause::OMPC_private, Clause::OMPC_shared};
+  S.reset(Clause::OMPC_private);
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
+
+  static_assert(detail::ElementsAre<Clause, Clause::OMPC_shared>(
+      ClauseSet{Clause::OMPC_private, Clause::OMPC_shared}.reset(
+          Clause::OMPC_private)));
+}
+
+TEST(EnumSetTest, Flip) {
+  ClauseSet S{Clause::OMPC_private};
+  S.flip(Clause::OMPC_private);
+  S.flip(Clause::OMPC_shared);
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
+
+  static_assert(detail::ElementsAre<Clause, Clause::OMPC_shared>(
+      ClauseSet{Clause::OMPC_private}
+          .flip(Clause::OMPC_private)
+          .flip(Clause::OMPC_shared)));
+}
+
+TEST(EnumSetTest, Test) {
+  constexpr ClauseSet S{Clause::OMPC_private};
+  ASSERT_TRUE(S.test(Clause::OMPC_private));
+  ASSERT_FALSE(S.test(Clause::OMPC_shared));
+
+  static_assert(S.test(Clause::OMPC_private));
+  static_assert(!S.test(Clause::OMPC_shared));
+}
+
+TEST(EnumSetTest, SquareBracket) {
+  constexpr ClauseSet S{Clause::OMPC_private};
+  ASSERT_TRUE(S[Clause::OMPC_private]);
+  ASSERT_FALSE(S[Clause::OMPC_shared]);
+
+  static_assert(S[Clause::OMPC_private]);
+  static_assert(!S[Clause::OMPC_shared]);
+}
+
+TEST(EnumSetTest, Union) {
+  constexpr ClauseSet A{Clause::OMPC_private, OMPC_shared};
+  constexpr ClauseSet B{Clause::OMPC_nowait};
+  constexpr ClauseSet S = A | B;
+  EXPECT_THAT(S, testing::ElementsAre(Clause::OMPC_nowait, Clause::OMPC_private,
+                                      OMPC_shared));
+
+  static_assert(detail::ElementsAre<Clause, Clause::OMPC_nowait,
+                                    Clause::OMPC_private, OMPC_shared>(S));
+}
+
+TEST(EnumSetTest, Intersection) {
+  constexpr ClauseSet A{Clause::OMPC_private, OMPC_shared};
+  constexpr ClauseSet B{Clause::OMPC_nowait, OMPC_shared};
+  constexpr ClauseSet S = A & B;
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
+
+  static_assert(detail::ElementsAre<Clause, OMPC_shared>(S));
+}
+} // namespace

--- a/llvm/unittests/Frontend/EnumSetTest.cpp
+++ b/llvm/unittests/Frontend/EnumSetTest.cpp
@@ -6,10 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Frontend/OpenMP/OMP.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+#include <type_traits>
 
 using namespace llvm;
 using namespace llvm::omp;
@@ -120,10 +123,19 @@ TEST(EnumSetTest, SquareBracket) {
   static_assert(!S[Clause::OMPC_shared]);
 }
 
+TEST(EnumSetTest, UnionUpdate) {
+  ClauseSet S{Clause::OMPC_private, OMPC_shared};
+  ClauseSet A{Clause::OMPC_nowait};
+  S |= A;
+  EXPECT_THAT(S, testing::ElementsAre(Clause::OMPC_nowait, Clause::OMPC_private,
+                                      OMPC_shared));
+}
+
 TEST(EnumSetTest, Union) {
   constexpr ClauseSet A{Clause::OMPC_private, OMPC_shared};
   constexpr ClauseSet B{Clause::OMPC_nowait};
-  constexpr ClauseSet S = A | B;
+  constexpr auto S = A | B;
+  static_assert(std::is_same_v<llvm::remove_cvref_t<decltype(S)>, ClauseSet>);
   EXPECT_THAT(S, testing::ElementsAre(Clause::OMPC_nowait, Clause::OMPC_private,
                                       OMPC_shared));
 
@@ -131,10 +143,18 @@ TEST(EnumSetTest, Union) {
                                     Clause::OMPC_private, OMPC_shared>(S));
 }
 
+TEST(EnumSetTest, IntersectionUpdate) {
+  ClauseSet S{Clause::OMPC_private, OMPC_shared};
+  ClauseSet A{Clause::OMPC_nowait, OMPC_shared};
+  S &= A;
+  EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
+}
+
 TEST(EnumSetTest, Intersection) {
   constexpr ClauseSet A{Clause::OMPC_private, OMPC_shared};
   constexpr ClauseSet B{Clause::OMPC_nowait, OMPC_shared};
-  constexpr ClauseSet S = A & B;
+  constexpr auto S = A & B;
+  static_assert(std::is_same_v<llvm::remove_cvref_t<decltype(S)>, ClauseSet>);
   EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
 
   static_assert(detail::ElementsAre<Clause, OMPC_shared>(S));

--- a/llvm/unittests/Frontend/EnumSetTest.cpp
+++ b/llvm/unittests/Frontend/EnumSetTest.cpp
@@ -1,3 +1,11 @@
+//===- llvm/unittests/Frontend/EnumSetTest.cpp - EnumSet unit tests -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "llvm/Frontend/OpenMP/OMP.h"
 
 #include "gmock/gmock.h"

--- a/llvm/unittests/Frontend/EnumSetTest.cpp
+++ b/llvm/unittests/Frontend/EnumSetTest.cpp
@@ -139,4 +139,81 @@ TEST(EnumSetTest, Intersection) {
 
   static_assert(detail::ElementsAre<Clause, OMPC_shared>(S));
 }
+
+TEST(EnumSetTest, WordCount) {
+  // Check that for an enum that is exactly 64 in size, the iterator will not
+  // try to access an out-of-bounds word of the underlying bitset.
+  enum class E {
+    V0,
+    V1,
+    V2,
+    V3,
+    V4,
+    V5,
+    V6,
+    V7,
+    V8,
+    V9,
+    V10,
+    V11,
+    V12,
+    V13,
+    V14,
+    V15,
+    V16,
+    V17,
+    V18,
+    V19,
+    V20,
+    V21,
+    V22,
+    V23,
+    V24,
+    V25,
+    V26,
+    V27,
+    V28,
+    V29,
+    V30,
+    V31,
+    V32,
+    V33,
+    V34,
+    V35,
+    V36,
+    V37,
+    V38,
+    V39,
+    V40,
+    V41,
+    V42,
+    V43,
+    V44,
+    V45,
+    V46,
+    V47,
+    V48,
+    V49,
+    V50,
+    V51,
+    V52,
+    V53,
+    V54,
+    V55,
+    V56,
+    V57,
+    V58,
+    V59,
+    V60,
+    V61,
+    V62,
+    V63
+  };
+  using ESet = EnumSet<E, 64>;
+
+  constexpr ESet S{E::V0, E::V63};
+  EXPECT_THAT(S, testing::ElementsAre(E::V0, E::V63));
+
+  static_assert(detail::ElementsAre<E, E::V0, E::V63>(S));
+}
 } // namespace


### PR DESCRIPTION
This is close to flang's common::EnumSet with the difference being that
it provides forward iterators.

The reason for having an implementation that is separate from
common::EnumSet is that this is intended to be shared for all consumers
of llvm/lib/Frontend/OpenMP. This class is also planned to be one of the
core containers for representing auto-generated OpenMP data in the future.