### PR TITLE
[flang][OpenMP] Use llvm::omp::ClauseSet instead of common::EnumSet

### DIFF
--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -53,11 +53,8 @@ using MutableSymbolVector = std::vector<MutableSymbolRef>;
 // Mixin for details with OpenMP declarative constructs.
 class WithOmpDeclarative {
 public:
-  using OmpClauseSet =
-      common::EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
-
-  const OmpClauseSet &ompRequires() const { return ompRequires_; }
-  void set_ompRequires(OmpClauseSet clauses) { ompRequires_ = clauses; }
+  const llvm::omp::ClauseSet &ompRequires() const { return ompRequires_; }
+  void set_ompRequires(llvm::omp::ClauseSet clauses) { ompRequires_ = clauses; }
 
   const std::optional<common::OmpMemoryOrderType> &
   ompAtomicDefaultMemOrder() const {
@@ -67,8 +64,10 @@ public:
     ompAtomicDefaultMemOrder_ = flags;
   }
 
-  const OmpClauseSet &ompDeclTarget() const { return ompDeclTarget_; }
-  void set_ompDeclTarget(OmpClauseSet clauses) { ompDeclTarget_ = clauses; }
+  const llvm::omp::ClauseSet &ompDeclTarget() const { return ompDeclTarget_; }
+  void set_ompDeclTarget(llvm::omp::ClauseSet clauses) {
+    ompDeclTarget_ = clauses;
+  }
 
   const std::optional<common::OmpDeviceType> &ompDeclTargetDeviceType() const {
     return ompDeclTargetDeviceType_;
@@ -77,8 +76,12 @@ public:
     ompDeclTargetDeviceType_ = device;
   }
 
-  const OmpClauseSet &ompGroupprivate() const { return ompGroupprivate_; }
-  void set_ompGroupprivate(OmpClauseSet clauses) { ompGroupprivate_ = clauses; }
+  const llvm::omp::ClauseSet &ompGroupprivate() const {
+    return ompGroupprivate_;
+  }
+  void set_ompGroupprivate(llvm::omp::ClauseSet clauses) {
+    ompGroupprivate_ = clauses;
+  }
 
   const std::optional<common::OmpDeviceType> &
   ompGroupprivateDeviceType() const {
@@ -90,8 +93,8 @@ public:
 
   // \p dir indicates to which declarative directive the given clauses
   // belong to.
-  void printClauseSet(llvm::raw_ostream &os, const OmpClauseSet &clauses,
-      llvm::omp::Directive dir,
+  void printClauseSet(llvm::raw_ostream &os,
+      const llvm::omp::ClauseSet &clauses, llvm::omp::Directive dir,
       parser::CharBlock name = parser::CharBlock{}) const;
   friend llvm::raw_ostream &operator<<(
       llvm::raw_ostream &, const WithOmpDeclarative &);
@@ -104,18 +107,18 @@ private:
   // to program unit symbols (i.e. scopes of the REQUIRES directive).
   // The set of requirements for any program unit include requirements
   // from any module used in the program unit.
-  OmpClauseSet ompRequires_;
+  llvm::omp::ClauseSet ompRequires_;
   // The argument to ATOMIC_DEFAULT_MEM_ORDER. Only needed when the ADMO
   // clause is present in the ompRequires_ set.
   std::optional<common::OmpMemoryOrderType> ompAtomicDefaultMemOrder_;
   // The set of clauses on DECLARE_TARGET directive that apply to this
   // symbol.
-  OmpClauseSet ompDeclTarget_;
+  llvm::omp::ClauseSet ompDeclTarget_;
   // The argument to DEVICE_TYPE clause. Only needed when the clause is
   // present in the ompDeclTarget_ set.
   std::optional<common::OmpDeviceType> ompDeclTargetDeviceType_;
   // The set of clauses on a GROUPPRIVATE directive declaring this symbol.
-  OmpClauseSet ompGroupprivate_;
+  llvm::omp::ClauseSet ompGroupprivate_;
   // The argument to a DEVICE_TYPE clause on a GROUPPRIVATE directive declaring
   // this symbol. Only needed when the clause is present in ompGroupprivate_.
   std::optional<common::OmpDeviceType> ompGroupprivateDeviceType_;

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -58,6 +58,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Frontend/OpenMP/OMP.h"
 
 using namespace Fortran::lower::omp;
 using namespace Fortran::common::openmp;
@@ -6944,7 +6945,7 @@ void Fortran::lower::genOpenMPRequires(mlir::Operation *mod,
 
   if (auto offloadMod =
           llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(mod)) {
-    semantics::WithOmpDeclarative::OmpClauseSet reqs;
+    llvm::omp::ClauseSet reqs;
     if (symbol) {
       common::visit(
           [&](const auto &details) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3738,7 +3738,7 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &x) {
   };
 
   // [5.1] 2.21.2 Threadprivate Directive Restriction
-  OmpClauseSet threadprivateAllowedSet{llvm::omp::Clause::OMPC_copyin,
+  llvm::omp::ClauseSet threadprivateAllowedSet{llvm::omp::Clause::OMPC_copyin,
       llvm::omp::Clause::OMPC_copyprivate, llvm::omp::Clause::OMPC_schedule,
       llvm::omp::Clause::OMPC_num_threads, llvm::omp::Clause::OMPC_thread_limit,
       llvm::omp::Clause::OMPC_if};
@@ -4443,10 +4443,10 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Firstprivate &x) {
   // Check firstprivate variables in task and taskloop constructs
   dirClauseTriple.emplace(llvm::omp::Directive::OMPD_task,
       std::make_pair(llvm::omp::Directive::OMPD_parallel,
-          OmpClauseSet{llvm::omp::Clause::OMPC_reduction}));
+          llvm::omp::ClauseSet{llvm::omp::Clause::OMPC_reduction}));
   dirClauseTriple.emplace(llvm::omp::Directive::OMPD_taskloop,
       std::make_pair(llvm::omp::Directive::OMPD_parallel,
-          OmpClauseSet{llvm::omp::Clause::OMPC_reduction}));
+          llvm::omp::ClauseSet{llvm::omp::Clause::OMPC_reduction}));
 
   CheckPrivateSymbolsInOuterCxt(
       currSymbols, dirClauseTriple, llvm::omp::Clause::OMPC_firstprivate);

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -21,21 +21,22 @@
 #include "flang/Semantics/semantics.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Frontend/OpenMP/OMP.h"
 
+namespace Fortran::semantics {
 using OmpClauseSet =
-    Fortran::common::EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
+    common::EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
+}
 
 #define GEN_FLANG_DIRECTIVE_CLAUSE_SETS
 #include "llvm/Frontend/OpenMP/OMP.inc"
 
-namespace llvm {
-namespace omp {
-static OmpClauseSet privateSet{
+namespace llvm::omp {
+static ClauseSet privateSet{
     Clause::OMPC_private, Clause::OMPC_firstprivate, Clause::OMPC_lastprivate};
-static OmpClauseSet privateReductionSet{
-    OmpClauseSet{Clause::OMPC_reduction} | privateSet};
-} // namespace omp
-} // namespace llvm
+static ClauseSet privateReductionSet{
+    ClauseSet{Clause::OMPC_reduction} | privateSet};
+} // namespace llvm::omp
 
 namespace Fortran::semantics {
 struct AnalyzedCondStmt;
@@ -49,7 +50,7 @@ struct LoopSequence;
 using SymbolSourceMap = std::multimap<const Symbol *, parser::CharBlock>;
 // Multimap to check the triple <current_dir, enclosing_dir, enclosing_clause>
 using DirectivesClauseTriple = std::multimap<llvm::omp::Directive,
-    std::pair<llvm::omp::Directive, const OmpClauseSet>>;
+    std::pair<llvm::omp::Directive, const llvm::omp::ClauseSet>>;
 
 using OmpStructureCheckerBase = DirectiveStructureChecker<llvm::omp::Directive,
     llvm::omp::Clause, parser::OmpClause, llvm::omp::Clause_enumSize>;

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -380,11 +380,10 @@ static const WithOmpDeclarative *GetOmpDeclarative(const Symbol &symbol) {
 
 static void PutOpenMPRequirements(
     llvm::raw_ostream &os, const Symbol &symbol, SemanticsContext &semaCtx) {
-  using OmpClauseSet = WithOmpDeclarative::OmpClauseSet;
   unsigned version{semaCtx.langOptions().OpenMPVersion};
 
   if (const auto *decls{GetOmpDeclarative(symbol)}) {
-    if (const OmpClauseSet &reqs{decls->ompRequires()}; reqs.count()) {
+    if (const llvm::omp::ClauseSet &reqs{decls->ompRequires()}; reqs.count()) {
       os << "!$omp "
          << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(
                 llvm::omp::Directive::OMPD_requires, version));
@@ -396,12 +395,12 @@ static void PutOpenMPRequirements(
 
 static void PutOpenMPDeclarativeDirectives(llvm::raw_ostream &os,
     const SymbolVector &symbols, SemanticsContext &semaCtx) {
-  using OmpClauseSet = WithOmpDeclarative::OmpClauseSet;
   unsigned version{semaCtx.langOptions().OpenMPVersion};
 
   for (const Symbol &symbol : symbols) {
     if (const auto *decls{GetOmpDeclarative(symbol)}) {
-      if (const OmpClauseSet &dtgt{decls->ompDeclTarget()}; dtgt.count()) {
+      if (const llvm::omp::ClauseSet &dtgt{decls->ompDeclTarget()};
+          dtgt.count()) {
         os << "!$omp "
            << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(
                   llvm::omp::Directive::OMPD_declare_target, version))
@@ -413,7 +412,8 @@ static void PutOpenMPDeclarativeDirectives(llvm::raw_ostream &os,
       // Re-emit `!$omp groupprivate` (and its device_type) so a TU that `use`s
       // this module recovers the directive from the .mod file. Common-block
       // names must be wrapped in slashes when reparsed.
-      if (const OmpClauseSet &gp{decls->ompGroupprivate()}; gp.count()) {
+      if (const llvm::omp::ClauseSet &gp{decls->ompGroupprivate()};
+          gp.count()) {
         os << "!$omp "
            << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(
                   llvm::omp::Directive::OMPD_groupprivate, version))

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -641,11 +641,10 @@ public:
   void Post(const parser::OpenMPFlushConstruct &) { PopContext(); }
 
   bool Pre(const parser::OmpRequiresDirective &x) {
-    using OmpClauseSet = WithOmpDeclarative::OmpClauseSet;
     PushContext(x.source, llvm::omp::Directive::OMPD_requires);
 
     // Gather information from the clauses.
-    OmpClauseSet reqs;
+    llvm::omp::ClauseSet reqs;
     std::optional<common::OmpMemoryOrderType> memOrder;
     for (const parser::OmpClause &clause : x.v.Clauses().v) {
       using OmpClause = parser::OmpClause;
@@ -653,7 +652,7 @@ public:
           common::visitors{
               [&](const OmpClause::AtomicDefaultMemOrder &admo) {
                 memOrder = admo.v.v;
-                return OmpClauseSet{clause.Id()};
+                return llvm::omp::ClauseSet{clause.Id()};
               },
               [&](auto &&s) {
                 using TypeS = llvm::remove_cvref_t<decltype(s)>;
@@ -665,10 +664,10 @@ public:
                     std::is_same_v<TypeS, OmpClause::UnifiedAddress> ||
                     std::is_same_v<TypeS, OmpClause::UnifiedSharedMemory>) {
                   if (omp::GetLogicalArgument(s.v, context_).value_or(true)) {
-                    return OmpClauseSet{clause.Id()};
+                    return llvm::omp::ClauseSet{clause.Id()};
                   }
                 }
-                return OmpClauseSet{};
+                return llvm::omp::ClauseSet{};
               },
           },
           clause.u);
@@ -1041,7 +1040,7 @@ private:
   void CheckObjectIsPrivatizable(
       const parser::Name &, const Symbol &, Symbol::Flag);
 
-  void AddOmpRequiresToScope(Scope &, const WithOmpDeclarative::OmpClauseSet &,
+  void AddOmpRequiresToScope(Scope &, const llvm::omp::ClauseSet &,
       const std::optional<common::OmpMemoryOrderType> &);
 
   void CreateImplicitSymbols(const parser::Name &, const Symbol *symbol);
@@ -2267,8 +2266,7 @@ bool OmpAttributeVisitor::Pre(const parser::OmpGroupprivateDirective &x) {
   }
 
   unsigned version{context_.langOptions().OpenMPVersion};
-  WithOmpDeclarative::OmpClauseSet clauses;
-  clauses.set(llvm::omp::Clause::OMPC_device_type);
+  llvm::omp::ClauseSet clauses{llvm::omp::Clause::OMPC_device_type};
   for (const parser::OmpArgument &arg : x.v.Arguments().v) {
     if (const parser::OmpObject *object{parser::omp::GetArgumentObject(arg)}) {
       if (const Symbol *sym{omp::GetObjectSymbol(*object)}) {
@@ -2322,7 +2320,6 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
   PushContext(x.source, llvm::omp::Directive::OMPD_declare_target);
 
   unsigned version{context_.langOptions().OpenMPVersion};
-  using OmpClauseSet = WithOmpDeclarative::OmpClauseSet;
   std::map<const Symbol *, WithOmpDeclarative> details;
   std::optional<common::OmpDeviceType> device;
 
@@ -2331,13 +2328,14 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
     device = parser::UnwrapRef<common::OmpDeviceType>(*devClause);
   }
 
-  auto addClause{[&](const parser::OmpObject &object,
-                     llvm::omp::Clause clauseId) {
-    if (const Symbol *sym{omp::GetObjectSymbol(object)}) {
-      auto &clauseSet{const_cast<OmpClauseSet &>(details[sym].ompDeclTarget())};
-      clauseSet.set(clauseId);
-    }
-  }};
+  auto addClause{
+      [&](const parser::OmpObject &object, llvm::omp::Clause clauseId) {
+        if (const Symbol *sym{omp::GetObjectSymbol(object)}) {
+          auto &clauseSet{
+              const_cast<llvm::omp::ClauseSet &>(details[sym].ompDeclTarget())};
+          clauseSet.set(clauseId);
+        }
+      }};
 
   for (const parser::OmpArgument &arg : x.v.Arguments().v) {
     if (auto *object{parser::omp::GetArgumentObject(arg)}) {
@@ -2363,7 +2361,7 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
     if (auto *proc{const_cast<Symbol *>(scope.symbol())}) {
       proc->flags().set(Symbol::Flag::OmpDeclareTarget);
       auto &clauseSet{
-          const_cast<OmpClauseSet &>(details[proc].ompDeclTarget())};
+          const_cast<llvm::omp::ClauseSet &>(details[proc].ompDeclTarget())};
       clauseSet.set(llvm::omp::Clause::OMPC_enter);
     }
   }
@@ -2376,7 +2374,8 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
           using TypeD = llvm::remove_cvref_t<decltype(d)>;
           if constexpr (std::is_base_of_v<WithOmpDeclarative, TypeD>) {
             d.set_version(version);
-            auto &clauseSet{const_cast<OmpClauseSet &>(d.ompDeclTarget())};
+            auto &clauseSet{
+                const_cast<llvm::omp::ClauseSet &>(d.ompDeclTarget())};
             clauseSet |= decl.ompDeclTarget();
             if (device) {
               clauseSet.set(llvm::omp::Clause::OMPC_device_type);
@@ -3414,7 +3413,7 @@ void OmpAttributeVisitor::CheckObjectIsPrivatizable(
 }
 
 void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
-    const WithOmpDeclarative::OmpClauseSet &reqs,
+    const llvm::omp::ClauseSet &reqs,
     const std::optional<common::OmpMemoryOrderType> &memOrder) {
   unsigned version{context_.langOptions().OpenMPVersion};
   const Scope &programUnit{omp::GetProgramUnit(scope)};

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Semantics/symbol.h"
+
 #include "flang/Common/idioms.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Semantics/scope.h"
@@ -71,12 +72,12 @@ static void DumpList(llvm::raw_ostream &os, const char *label, const T &list) {
 }
 
 void WithOmpDeclarative::printClauseSet(llvm::raw_ostream &os,
-    const OmpClauseSet &clauses, llvm::omp::Directive dir,
+    const llvm::omp::ClauseSet &clauses, llvm::omp::Directive dir,
     parser::CharBlock name) const {
   auto toLower = parser::ToLowerCaseLetters;
-
   size_t idx{0}, size{clauses.count()};
-  clauses.IterateOverMembers([&](llvm::omp::Clause c) {
+
+  for (llvm::omp::Clause c : clauses) {
     os << toLower(llvm::omp::getOpenMPClauseName(c, version_));
     switch (c) {
     case llvm::omp::Clause::OMPC_atomic_default_mem_order:
@@ -107,24 +108,22 @@ void WithOmpDeclarative::printClauseSet(llvm::raw_ostream &os,
     if (++idx < size) {
       os << ' ';
     }
-  });
+  }
 }
 
 llvm::raw_ostream &operator<<(
     llvm::raw_ostream &os, const WithOmpDeclarative &x) {
-  using OmpClauseSet = WithOmpDeclarative::OmpClauseSet;
-
-  if (const OmpClauseSet &reqs{x.ompRequires()}; reqs.count()) {
+  if (const llvm::omp::ClauseSet &reqs{x.ompRequires()}; reqs.count()) {
     os << " OmpRequirements:(";
     x.printClauseSet(os, reqs, llvm::omp::Directive::OMPD_requires);
     os << ')';
   }
-  if (const OmpClauseSet &dtgt{x.ompDeclTarget()}; dtgt.count()) {
+  if (const llvm::omp::ClauseSet &dtgt{x.ompDeclTarget()}; dtgt.count()) {
     os << " OmpDeclareTargetFlags:(";
     x.printClauseSet(os, dtgt, llvm::omp::Directive::OMPD_declare_target);
     os << ')';
   }
-  if (const OmpClauseSet &gp{x.ompGroupprivate()}; gp.count()) {
+  if (const llvm::omp::ClauseSet &gp{x.ompGroupprivate()}; gp.count()) {
     os << " OmpGroupprivateFlags:(";
     x.printClauseSet(os, gp, llvm::omp::Directive::OMPD_groupprivate);
     os << ')';

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -146,6 +146,8 @@ constexpr auto &EnumSetIterator<Enum, Size>::operator++() {
 }
 } // namespace detail
 
+using ClauseSet = EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
+
 LLVM_ABI ArrayRef<Directive> getLeafConstructs(Directive D);
 LLVM_ABI ArrayRef<Directive> getLeafConstructsOrSelf(Directive D);
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -24,7 +24,7 @@ def OpenMP : DirectiveLanguage {
   let loopModifierPrefix = "OMPLM_";
   let makeEnumAvailableInNamespace = true;
   let enableBitmaskEnumInNamespace = true;
-  let clauseEnumSetClass = "OmpClauseSet";
+  let clauseEnumSetClass = "Fortran::semantics::OmpClauseSet";
   let flangClauseBaseClass = "OmpClause";
 }
 


### PR DESCRIPTION
Replace uses of OmpClauseSet (defined in terms of common::EnumSet)
with the common llvm::omp::ClauseSet (defined via llvm::EnumSet).