### PR TITLE
[flang][OpenMP] Use llvm::omp::DirectiveSet instead of common::EnumSet

### DIFF
--- a/flang/include/flang/Semantics/openmp-directive-sets.h
+++ b/flang/include/flang/Semantics/openmp-directive-sets.h
@@ -9,11 +9,7 @@
 #ifndef FORTRAN_SEMANTICS_OPENMP_DIRECTIVE_SETS_H_
 #define FORTRAN_SEMANTICS_OPENMP_DIRECTIVE_SETS_H_
 
-#include "flang/Common/enum-set.h"
-#include "llvm/Frontend/OpenMP/OMPConstants.h"
-
-using OmpDirectiveSet = Fortran::common::EnumSet<llvm::omp::Directive,
-    llvm::omp::Directive_enumSize>;
+#include "llvm/Frontend/OpenMP/OMP.h"
 
 namespace llvm::omp {
 //===----------------------------------------------------------------------===//
@@ -25,15 +21,15 @@ namespace llvm::omp {
 //   compound construct.
 // - all<Directive>Set: All standalone or compound uses of the directive.
 
-static const OmpDirectiveSet topDistributeSet{
+static const llvm::omp::DirectiveSet topDistributeSet{
     Directive::OMPD_distribute,
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_distribute_parallel_do_simd,
     Directive::OMPD_distribute_simd,
 };
 
-static const OmpDirectiveSet allDistributeSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allDistributeSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_target_teams_distribute,
         Directive::OMPD_target_teams_distribute_parallel_do,
         Directive::OMPD_target_teams_distribute_parallel_do_simd,
@@ -45,13 +41,13 @@ static const OmpDirectiveSet allDistributeSet{
     } | topDistributeSet,
 };
 
-static const OmpDirectiveSet topDoSet{
+static const llvm::omp::DirectiveSet topDoSet{
     Directive::OMPD_do,
     Directive::OMPD_do_simd,
 };
 
-static const OmpDirectiveSet allDoSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allDoSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_distribute_parallel_do,
         Directive::OMPD_distribute_parallel_do_simd,
         Directive::OMPD_parallel_do,
@@ -65,12 +61,12 @@ static const OmpDirectiveSet allDoSet{
     } | topDoSet,
 };
 
-static const OmpDirectiveSet topLoopSet{
+static const llvm::omp::DirectiveSet topLoopSet{
     Directive::OMPD_loop,
 };
 
-static const OmpDirectiveSet allLoopSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allLoopSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_parallel_loop,
         Directive::OMPD_target_parallel_loop,
         Directive::OMPD_target_teams_loop,
@@ -78,7 +74,7 @@ static const OmpDirectiveSet allLoopSet{
     } | topLoopSet,
 };
 
-static const OmpDirectiveSet topParallelSet{
+static const llvm::omp::DirectiveSet topParallelSet{
     Directive::OMPD_parallel,
     Directive::OMPD_parallel_do,
     Directive::OMPD_parallel_do_simd,
@@ -93,8 +89,8 @@ static const OmpDirectiveSet topParallelSet{
     Directive::OMPD_parallel_workshare,
 };
 
-static const OmpDirectiveSet allParallelSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allParallelSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_distribute_parallel_do,
         Directive::OMPD_distribute_parallel_do_simd,
         Directive::OMPD_target_parallel,
@@ -108,12 +104,12 @@ static const OmpDirectiveSet allParallelSet{
     } | topParallelSet,
 };
 
-static const OmpDirectiveSet topSimdSet{
+static const llvm::omp::DirectiveSet topSimdSet{
     Directive::OMPD_simd,
 };
 
-static const OmpDirectiveSet allSimdSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allSimdSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_distribute_parallel_do_simd,
         Directive::OMPD_distribute_simd,
         Directive::OMPD_do_simd,
@@ -132,7 +128,7 @@ static const OmpDirectiveSet allSimdSet{
     } | topSimdSet,
 };
 
-static const OmpDirectiveSet topTargetSet{
+static const llvm::omp::DirectiveSet topTargetSet{
     Directive::OMPD_target,
     Directive::OMPD_target_parallel,
     Directive::OMPD_target_parallel_do,
@@ -148,15 +144,15 @@ static const OmpDirectiveSet topTargetSet{
     Directive::OMPD_target_teams_workdistribute,
 };
 
-static const OmpDirectiveSet allTargetSet{topTargetSet};
+static const llvm::omp::DirectiveSet allTargetSet{topTargetSet};
 
-static const OmpDirectiveSet topTaskloopSet{
+static const llvm::omp::DirectiveSet topTaskloopSet{
     Directive::OMPD_taskloop,
     Directive::OMPD_taskloop_simd,
 };
 
-static const OmpDirectiveSet allTaskloopSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allTaskloopSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_masked_taskloop,
         Directive::OMPD_masked_taskloop_simd,
         Directive::OMPD_master_taskloop,
@@ -168,7 +164,7 @@ static const OmpDirectiveSet allTaskloopSet{
     } | topTaskloopSet,
 };
 
-static const OmpDirectiveSet topTeamsSet{
+static const llvm::omp::DirectiveSet topTeamsSet{
     Directive::OMPD_teams,
     Directive::OMPD_teams_distribute,
     Directive::OMPD_teams_distribute_parallel_do,
@@ -178,13 +174,13 @@ static const OmpDirectiveSet topTeamsSet{
     Directive::OMPD_teams_workdistribute,
 };
 
-static const OmpDirectiveSet bottomTeamsSet{
+static const llvm::omp::DirectiveSet bottomTeamsSet{
     Directive::OMPD_target_teams,
     Directive::OMPD_teams,
 };
 
-static const OmpDirectiveSet allTeamsSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet allTeamsSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_target_teams,
         Directive::OMPD_target_teams_distribute,
         Directive::OMPD_target_teams_distribute_parallel_do,
@@ -200,16 +196,17 @@ static const OmpDirectiveSet allTeamsSet{
 //===----------------------------------------------------------------------===//
 
 // Composite constructs
-static const OmpDirectiveSet allDistributeParallelDoSet{
+static const llvm::omp::DirectiveSet allDistributeParallelDoSet{
     allDistributeSet & allParallelSet & allDoSet};
-static const OmpDirectiveSet allDistributeParallelDoSimdSet{
+static const llvm::omp::DirectiveSet allDistributeParallelDoSimdSet{
     allDistributeSet & allParallelSet & allDoSet & allSimdSet};
-static const OmpDirectiveSet allDistributeSimdSet{
+static const llvm::omp::DirectiveSet allDistributeSimdSet{
     allDistributeSet & allSimdSet};
-static const OmpDirectiveSet allDoSimdSet{allDoSet & allSimdSet};
-static const OmpDirectiveSet allTaskloopSimdSet{allTaskloopSet & allSimdSet};
+static const llvm::omp::DirectiveSet allDoSimdSet{allDoSet & allSimdSet};
+static const llvm::omp::DirectiveSet allTaskloopSimdSet{
+    allTaskloopSet & allSimdSet};
 
-static const OmpDirectiveSet compositeConstructSet{
+static const llvm::omp::DirectiveSet compositeConstructSet{
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_distribute_parallel_do_simd,
     Directive::OMPD_distribute_simd,
@@ -217,7 +214,7 @@ static const OmpDirectiveSet compositeConstructSet{
     Directive::OMPD_taskloop_simd,
 };
 
-static const OmpDirectiveSet blockConstructSet{
+static const llvm::omp::DirectiveSet blockConstructSet{
     Directive::OMPD_masked,
     Directive::OMPD_master,
     Directive::OMPD_ordered,
@@ -240,7 +237,7 @@ static const OmpDirectiveSet blockConstructSet{
     Directive::OMPD_workdistribute,
 };
 
-static const OmpDirectiveSet loopConstructSet{
+static const llvm::omp::DirectiveSet loopConstructSet{
     Directive::OMPD_distribute,
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_distribute_parallel_do_simd,
@@ -283,28 +280,28 @@ static const OmpDirectiveSet loopConstructSet{
     Directive::OMPD_interchange,
 };
 
-static const OmpDirectiveSet loopTransformationSet{
+static const llvm::omp::DirectiveSet loopTransformationSet{
     Directive::OMPD_tile,
     Directive::OMPD_unroll,
     Directive::OMPD_fuse,
     Directive::OMPD_interchange,
 };
 
-static const OmpDirectiveSet nonPartialVarSet{
+static const llvm::omp::DirectiveSet nonPartialVarSet{
     Directive::OMPD_allocate,
     Directive::OMPD_allocators,
     Directive::OMPD_threadprivate,
     Directive::OMPD_declare_target,
 };
 
-static const OmpDirectiveSet taskGeneratingSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet taskGeneratingSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_task,
     } | allTaskloopSet,
 };
 
-static const OmpDirectiveSet workShareSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet workShareSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_workshare,
         Directive::OMPD_parallel_workshare,
         Directive::OMPD_parallel_sections,
@@ -318,14 +315,15 @@ static const OmpDirectiveSet workShareSet{
 // Directive sets for parent directives that do allow/not allow a construct
 //===----------------------------------------------------------------------===//
 
-static const OmpDirectiveSet scanParentAllowedSet{allDoSet | allSimdSet};
+static const llvm::omp::DirectiveSet scanParentAllowedSet{
+    allDoSet | allSimdSet};
 
 //===----------------------------------------------------------------------===//
 // Directive sets for allowed/not allowed nested directives
 //===----------------------------------------------------------------------===//
 
-static const OmpDirectiveSet nestedBarrierErrSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet nestedBarrierErrSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_atomic,
         Directive::OMPD_critical,
         Directive::OMPD_master,
@@ -334,7 +332,7 @@ static const OmpDirectiveSet nestedBarrierErrSet{
         workShareSet,
 };
 
-static const OmpDirectiveSet nestedCancelDoAllowedSet{
+static const llvm::omp::DirectiveSet nestedCancelDoAllowedSet{
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_do,
     Directive::OMPD_parallel_do,
@@ -343,35 +341,35 @@ static const OmpDirectiveSet nestedCancelDoAllowedSet{
     Directive::OMPD_teams_distribute_parallel_do,
 };
 
-static const OmpDirectiveSet nestedCancelParallelAllowedSet{
+static const llvm::omp::DirectiveSet nestedCancelParallelAllowedSet{
     Directive::OMPD_parallel,
     Directive::OMPD_target_parallel,
 };
 
-static const OmpDirectiveSet nestedCancelSectionsAllowedSet{
+static const llvm::omp::DirectiveSet nestedCancelSectionsAllowedSet{
     Directive::OMPD_parallel_sections,
     Directive::OMPD_sections,
 };
 
-static const OmpDirectiveSet nestedCancelTaskgroupAllowedSet{
+static const llvm::omp::DirectiveSet nestedCancelTaskgroupAllowedSet{
     Directive::OMPD_task,
     Directive::OMPD_taskloop,
 };
 
-static const OmpDirectiveSet nestedMasterErrSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet nestedMasterErrSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_atomic,
     } | taskGeneratingSet |
         workShareSet,
 };
 
-static const OmpDirectiveSet nestedOrderedDoAllowedSet{
+static const llvm::omp::DirectiveSet nestedOrderedDoAllowedSet{
     Directive::OMPD_do,
     Directive::OMPD_parallel_do,
     Directive::OMPD_target_parallel_do,
 };
 
-static const OmpDirectiveSet nestedOrderedErrSet{
+static const llvm::omp::DirectiveSet nestedOrderedErrSet{
     Directive::OMPD_atomic,
     Directive::OMPD_critical,
     Directive::OMPD_ordered,
@@ -379,20 +377,20 @@ static const OmpDirectiveSet nestedOrderedErrSet{
     Directive::OMPD_taskloop,
 };
 
-static const OmpDirectiveSet nestedOrderedParallelErrSet{
+static const llvm::omp::DirectiveSet nestedOrderedParallelErrSet{
     Directive::OMPD_parallel,
     Directive::OMPD_parallel_sections,
     Directive::OMPD_parallel_workshare,
     Directive::OMPD_target_parallel,
 };
 
-static const OmpDirectiveSet nestedReduceWorkshareAllowedSet{
+static const llvm::omp::DirectiveSet nestedReduceWorkshareAllowedSet{
     Directive::OMPD_do,
     Directive::OMPD_do_simd,
     Directive::OMPD_sections,
 };
 
-static const OmpDirectiveSet nestedTeamsAllowedSet{
+static const llvm::omp::DirectiveSet nestedTeamsAllowedSet{
     Directive::OMPD_workdistribute,
     Directive::OMPD_distribute,
     Directive::OMPD_distribute_parallel_do,
@@ -410,8 +408,8 @@ static const OmpDirectiveSet nestedTeamsAllowedSet{
     Directive::OMPD_parallel_workshare,
 };
 
-static const OmpDirectiveSet nestedWorkshareErrSet{
-    OmpDirectiveSet{
+static const llvm::omp::DirectiveSet nestedWorkshareErrSet{
+    llvm::omp::DirectiveSet{
         Directive::OMPD_atomic,
         Directive::OMPD_critical,
         Directive::OMPD_master,
@@ -426,7 +424,7 @@ static const OmpDirectiveSet nestedWorkshareErrSet{
 //===----------------------------------------------------------------------===//
 
 // Simple standalone directives than can be erased by -fopenmp-simd.
-static const OmpDirectiveSet simpleStandaloneNonSimdOnlySet{
+static const llvm::omp::DirectiveSet simpleStandaloneNonSimdOnlySet{
     Directive::OMPD_taskyield,
     Directive::OMPD_barrier,
     Directive::OMPD_ordered,

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -334,12 +334,12 @@ public:
 protected:
   /// Initializes the visitor and returns the set of initial directives of
   /// interest to be matched the beginning of the pattern.
-  virtual OmpDirectiveSet initialize() = 0;
+  virtual llvm::omp::DirectiveSet initialize() = 0;
 
   /// Visits a single directive and, based on it, returns the set of other
   /// directives of interest that would be part of the pattern if nested inside.
-  virtual OmpDirectiveSet visitDirective(lower::pft::Evaluation &eval,
-                                         llvm::omp::Directive dir) = 0;
+  virtual llvm::omp::DirectiveSet visitDirective(lower::pft::Evaluation &eval,
+                                                 llvm::omp::Directive dir) = 0;
 
   /// Obtain the list of clauses of the given OpenMP block or loop construct
   /// evaluation. If it's not an OpenMP construct, no modifications are made to
@@ -396,14 +396,14 @@ private:
       return;
 
     const auto &ompEval{eval.get<parser::OpenMPConstruct>()};
-    OmpDirectiveSet visitNested{
+    llvm::omp::DirectiveSet visitNested{
         visitDirective(eval, parser::omp::GetOmpDirectiveName(ompEval).v)};
 
-    if (visitNested.empty())
+    if (visitNested.none())
       return;
 
     if (lower::pft::Evaluation *nestedEval = extractOnlyOmpNestedEval(eval)) {
-      OmpDirectiveSet prevDirs{directivesOfInterest};
+      llvm::omp::DirectiveSet prevDirs{directivesOfInterest};
       directivesOfInterest = visitNested;
       visitEval(*nestedEval);
       directivesOfInterest = prevDirs;
@@ -414,7 +414,7 @@ protected:
   semantics::SemanticsContext &semaCtx;
 
 private:
-  OmpDirectiveSet directivesOfInterest;
+  llvm::omp::DirectiveSet directivesOfInterest;
 };
 
 /// Helper pattern to navigate target SPMD.
@@ -424,13 +424,14 @@ public:
   virtual ~TargetSPMDVisitor() = default;
 
 protected:
-  virtual OmpDirectiveSet initialize() override {
+  virtual llvm::omp::DirectiveSet initialize() override {
     teamsVisited = false;
     return llvm::omp::allTargetSet;
   }
 
-  virtual OmpDirectiveSet visitDirective(lower::pft::Evaluation &eval,
-                                         llvm::omp::Directive dir) override {
+  virtual llvm::omp::DirectiveSet
+  visitDirective(lower::pft::Evaluation &eval,
+                 llvm::omp::Directive dir) override {
     using namespace llvm::omp;
 
     // The default implementation does nothing, except it returns the allowed
@@ -502,8 +503,9 @@ public:
   virtual ~HostEvalVisitor() = default;
 
 protected:
-  virtual OmpDirectiveSet visitDirective(lower::pft::Evaluation &eval,
-                                         llvm::omp::Directive dir) override {
+  virtual llvm::omp::DirectiveSet
+  visitDirective(lower::pft::Evaluation &eval,
+                 llvm::omp::Directive dir) override {
     using namespace llvm::omp;
 
     List<lower::omp::Clause> clauses;
@@ -627,8 +629,9 @@ public:
   }
 
 protected:
-  virtual OmpDirectiveSet visitDirective(lower::pft::Evaluation &eval,
-                                         llvm::omp::Directive dir) override {
+  virtual llvm::omp::DirectiveSet
+  visitDirective(lower::pft::Evaluation &eval,
+                 llvm::omp::Directive dir) override {
     using namespace llvm::omp;
 
     // We know this to be the case because any changes to the exec mode are made
@@ -3741,12 +3744,8 @@ struct DynamicSubstringVisitor {
   explicit DynamicSubstringVisitor(semantics::SemanticsContext &ctx)
       : semaCtx(ctx) {}
 
-  template <typename T>
-  bool Pre(const T &) {
-    return true;
-  }
-  template <typename T>
-  void Post(const T &) {}
+  template <typename T> bool Pre(const T &) { return true; }
+  template <typename T> void Post(const T &) {}
 
   // Check each expression for substring access
   void Post(const parser::Expr &expr) {
@@ -5032,11 +5031,11 @@ static void genOMPDispatch(lower::AbstractConverter &converter,
       // statements or directives preventing them from being combined need the
       // attribute as well. Disallow block constructs that can only be outermost
       // leafs and loop transformation constructs.
-      OmpDirectiveSet combinableDirs =
+      llvm::omp::DirectiveSet combinableDirs =
           (llvm::omp::blockConstructSet &
-           ~OmpDirectiveSet{llvm::omp::Directive::OMPD_ordered,
-                            llvm::omp::Directive::OMPD_scope,
-                            llvm::omp::Directive::OMPD_taskgroup}) |
+           ~llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_ordered,
+                                    llvm::omp::Directive::OMPD_scope,
+                                    llvm::omp::Directive::OMPD_taskgroup}) |
           (llvm::omp::loopConstructSet & ~llvm::omp::loopTransformationSet);
       const auto &ompEval = nestedEval->get<parser::OpenMPConstruct>();
       llvm::omp::Directive nestedDir =

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3744,8 +3744,12 @@ struct DynamicSubstringVisitor {
   explicit DynamicSubstringVisitor(semantics::SemanticsContext &ctx)
       : semaCtx(ctx) {}
 
-  template <typename T> bool Pre(const T &) { return true; }
-  template <typename T> void Post(const T &) {}
+  template <typename T>
+  bool Pre(const T &) {
+    return true;
+  }
+  template <typename T>
+  void Post(const T &) {}
 
   // Check each expression for substring access
   void Post(const parser::Expr &expr) {

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -43,9 +43,6 @@
 namespace Fortran::parser {
 using namespace Fortran::parser::omp;
 
-using DirectiveSet =
-    llvm::Bitset<llvm::NextPowerOf2(llvm::omp::Directive_enumSize)>;
-
 // Helper function to print the buffer contents starting at the current point.
 [[maybe_unused]] static std::string ahead(const ParseState &state) {
   return std::string(
@@ -1750,9 +1747,9 @@ static inline constexpr auto IsDirective(llvm::omp::Directive dir) {
   return [dir](const OmpDirectiveName &name) -> bool { return dir == name.v; };
 }
 
-static inline constexpr auto IsMemberOf(const DirectiveSet &dirs) {
+static inline constexpr auto IsMemberOf(const llvm::omp::DirectiveSet &dirs) {
   return [&dirs](const OmpDirectiveName &name) -> bool {
-    return dirs.test(llvm::to_underlying(name.v));
+    return dirs.test(name.v);
   };
 }
 
@@ -1974,9 +1971,8 @@ TYPE_PARSER(construct<OmpMetadirectiveDirective>(
 struct OmpDirectiveParser {
   using resultType = OmpDirectiveSpecification;
 
-  constexpr OmpDirectiveParser(DirectiveSet dirs) : dirs_(dirs) {}
-  constexpr OmpDirectiveParser(llvm::omp::Directive dir)
-      : dirs_({static_cast<unsigned>(llvm::to_underlying(dir))}) {}
+  constexpr OmpDirectiveParser(llvm::omp::DirectiveSet dirs) : dirs_(dirs) {}
+  constexpr OmpDirectiveParser(llvm::omp::Directive dir) : dirs_({dir}) {}
 
   std::optional<resultType> Parse(ParseState &state) const {
     auto p{predicated(Parser<OmpDirectiveName>{}, IsMemberOf(dirs_)) >=
@@ -1985,7 +1981,7 @@ struct OmpDirectiveParser {
   }
 
 private:
-  DirectiveSet dirs_;
+  llvm::omp::DirectiveSet dirs_;
 };
 
 // Parse the directive that begins a construct. In some cases the directive
@@ -1997,7 +1993,8 @@ private:
 struct OmpBeginDirectiveParser {
   using resultType = OmpDirectiveSpecification;
 
-  constexpr OmpBeginDirectiveParser(DirectiveSet dirs, bool implicit = true)
+  constexpr OmpBeginDirectiveParser(
+      llvm::omp::DirectiveSet dirs, bool implicit = true)
       : dparser_(dirs), implicit_(implicit) {}
   constexpr OmpBeginDirectiveParser(
       llvm::omp::Directive dir, bool implicit = true)
@@ -2036,7 +2033,8 @@ private:
 struct OmpEndDirectiveParser {
   using resultType = OmpDirectiveSpecification;
 
-  constexpr OmpEndDirectiveParser(DirectiveSet dirs) : dparser_(dirs) {}
+  constexpr OmpEndDirectiveParser(llvm::omp::DirectiveSet dirs)
+      : dparser_(dirs) {}
   constexpr OmpEndDirectiveParser(llvm::omp::Directive dir) : dparser_(dir) {}
 
   std::optional<resultType> Parse(ParseState &state) const {
@@ -2130,7 +2128,8 @@ private:
 struct OmpLoopConstructParser {
   using resultType = OpenMPLoopConstruct;
 
-  constexpr OmpLoopConstructParser(DirectiveSet dirs, bool implicit = true)
+  constexpr OmpLoopConstructParser(
+      llvm::omp::DirectiveSet dirs, bool implicit = true)
       : dirs_(dirs), implicit_(implicit) {}
 
   std::optional<resultType> Parse(ParseState &state) const {
@@ -2173,7 +2172,7 @@ struct OmpLoopConstructParser {
   }
 
 private:
-  DirectiveSet dirs_;
+  llvm::omp::DirectiveSet dirs_;
   bool implicit_;
 };
 
@@ -2559,11 +2558,10 @@ TYPE_PARSER(sourced(
         llvm::omp::Directive::OMPD_metadirective, /*implicit=*/false})))
 
 // OMP SECTIONS Directive
-static constexpr DirectiveSet GetSectionsDirectives() {
-  using Directive = llvm::omp::Directive;
-  constexpr DirectiveSet sectionsDirectives{
-      unsigned(Directive::OMPD_sections),
-      unsigned(Directive::OMPD_parallel_sections),
+static constexpr llvm::omp::DirectiveSet GetSectionsDirectives() {
+  constexpr llvm::omp::DirectiveSet sectionsDirectives{
+      llvm::omp::Directive::OMPD_sections,
+      llvm::omp::Directive::OMPD_parallel_sections,
   };
   return sectionsDirectives;
 }
@@ -2621,9 +2619,9 @@ TYPE_CONTEXT_PARSER("OpenMP construct"_en_US,
                 construct<OpenMPConstruct>(
                     Parser<OmpDelimitedMetadirectiveDirective>{}))))
 
-static constexpr DirectiveSet GetLoopDirectives() {
+static constexpr llvm::omp::DirectiveSet GetLoopDirectives() {
   using SourceLanguage = llvm::omp::SourceLanguage;
-  DirectiveSet loopDirectives;
+  llvm::omp::DirectiveSet loopDirectives;
 
   for (auto dirId : llvm::omp::directives()) {
     auto assoc{getDirectiveAssociation(dirId)};
@@ -2631,7 +2629,7 @@ static constexpr DirectiveSet GetLoopDirectives() {
         assoc == llvm::omp::Association::LoopSeq) {
       auto langs{getDirectiveLanguages(dirId)};
       if (llvm::to_underlying(langs & SourceLanguage::Fortran) != 0) {
-        loopDirectives.set(llvm::to_underlying(dirId));
+        loopDirectives.set(dirId);
       }
     }
   }
@@ -2641,8 +2639,8 @@ static constexpr DirectiveSet GetLoopDirectives() {
 TYPE_PARSER(sourced(construct<OpenMPLoopConstruct>(
     OmpLoopConstructParser(GetLoopDirectives()))))
 
-static constexpr DirectiveSet GetAllDirectives() { //
-  return ~DirectiveSet{};
+static constexpr llvm::omp::DirectiveSet GetAllDirectives() {
+  return ~llvm::omp::DirectiveSet();
 }
 
 TYPE_PARSER(construct<OpenMPMisplacedEndDirective>(

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -160,7 +160,7 @@ void OmpStructureChecker::HasInvalidLoopBinding(
         "strictly nested inside a `TEAMS` region."_err_en_US);
   }
 
-  if (OmpDirectiveSet{
+  if (llvm::omp::DirectiveSet{
           llvm::omp::OMPD_teams_loop, llvm::omp::OMPD_target_teams_loop}
           .test(beginName.v)) {
     teamsBindingChecker(

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -633,7 +633,8 @@ void OmpStructureChecker::ClearLabels() {
   targetLabels_.clear();
 }
 
-bool OmpStructureChecker::IsCloselyNestedRegion(const OmpDirectiveSet &set) {
+bool OmpStructureChecker::IsCloselyNestedRegion(
+    const llvm::omp::DirectiveSet &set) {
   // Definition of close nesting:
   //
   // `A region nested inside another region with no parallel region nested
@@ -1168,7 +1169,7 @@ bool OmpStructureChecker::IsCombinedParallelWorksharing(
 }
 
 bool OmpStructureChecker::HasInvalidWorksharingNesting(
-    const parser::OmpDirectiveName &name, const OmpDirectiveSet &set) {
+    const parser::OmpDirectiveName &name, const llvm::omp::DirectiveSet &set) {
   // set contains all the invalid closely nested directives
   // for the given directive (`source` here)
   if (IsCombinedParallelWorksharing(name.v)) {
@@ -4579,7 +4580,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::If &x) {
           "%s is not a constituent of the %s directive"_err_en_US, subName,
           dirName);
     } else {
-      static OmpDirectiveSet valid45{
+      static llvm::omp::DirectiveSet valid45{
           llvm::omp::Directive::OMPD_cancel, //
           llvm::omp::Directive::OMPD_parallel, //
           llvm::omp::Directive::OMPD_target, //
@@ -4590,13 +4591,13 @@ void OmpStructureChecker::Enter(const parser::OmpClause::If &x) {
           llvm::omp::Directive::OMPD_task, //
           llvm::omp::Directive::OMPD_taskloop, //
       };
-      static OmpDirectiveSet valid50{
-          valid45 | OmpDirectiveSet{llvm::omp::Directive::OMPD_simd}};
+      static llvm::omp::DirectiveSet valid50{
+          valid45 | llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_simd}};
       // 5.1 is the same as 5.0.
-      static OmpDirectiveSet valid52{
-          valid50 | OmpDirectiveSet{llvm::omp::Directive::OMPD_teams}};
-      static OmpDirectiveSet valid60{valid52 |
-          OmpDirectiveSet{llvm::omp::Directive::OMPD_taskgraph,
+      static llvm::omp::DirectiveSet valid52{
+          valid50 | llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_teams}};
+      static llvm::omp::DirectiveSet valid60{valid52 |
+          llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_taskgraph,
               /*TODO llvm::omp::Directive::OMPD_task_iteration*/}};
 
       static auto minVersion{[&](llvm::omp::Directive d) {

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -354,9 +354,9 @@ private:
   void CheckStructureComponent(
       const parser::OmpObjectList &objects, llvm::omp::Clause clauseId);
   bool HasInvalidWorksharingNesting(
-      const parser::OmpDirectiveName &name, const OmpDirectiveSet &);
+      const parser::OmpDirectiveName &name, const llvm::omp::DirectiveSet &);
 
-  bool IsCloselyNestedRegion(const OmpDirectiveSet &set);
+  bool IsCloselyNestedRegion(const llvm::omp::DirectiveSet &set);
   bool IsNestedInDirective(llvm::omp::Directive directive);
   bool IsCombinedParallelWorksharing(llvm::omp::Directive directive) const;
   bool InTargetRegion();

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -147,6 +147,8 @@ constexpr auto &EnumSetIterator<Enum, Size>::operator++() {
 } // namespace detail
 
 using ClauseSet = EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
+using DirectiveSet =
+    EnumSet<llvm::omp::Directive, llvm::omp::Directive_enumSize>;
 
 LLVM_ABI ArrayRef<Directive> getLeafConstructs(Directive D);
 LLVM_ABI ArrayRef<Directive> getLeafConstructsOrSelf(Directive D);


### PR DESCRIPTION
Replace uses of OmpDirectiveSet (defined in terms of common::EnumSet)
with the common llvm::omp::DirectiveSet (defined via llvm::EnumSet).

The llvm::omp::DirectiveSet class will also be used in openmp-parsers,
where OmpDirectiveSet was an instance of llvm::Bitset.