### PR TITLE
[libc++] Remove -Wpsabi workaround in locale

### DIFF
--- a/libcxx/include/__locale_dir/num.h
+++ b/libcxx/include/__locale_dir/num.h
@@ -92,16 +92,12 @@ struct __num_get : protected __num_get_base {
     // TODO: Remove the manual vectorization once https://llvm.org/PR168551 is resolved
 #  if _LIBCPP_HAS_ALGORITHM_VECTOR_UTILS
     if constexpr (is_same<_CharT, char>::value) {
-      // TODO(LLVM 24): This can be removed, since -Wpsabi doesn't warn on [[gnu::always_inline]] functions anymore.
-      _LIBCPP_DIAGNOSTIC_PUSH
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wpsabi")
       using __vec   = __simd_vector<char, 32>;
       __vec __cmp   = std::__partial_load<__vec, __int_chr_cnt>(__atoms);
       auto __res    = __vec(__val) == __cmp;
       if (std::__none_of(__res))
         return __int_chr_cnt;
       return std::min(__int_chr_cnt, std::__find_first_set(__res));
-      _LIBCPP_DIAGNOSTIC_POP
     }
 #  endif
     return std::find(__atoms, __atoms + __int_chr_cnt, __val) - __atoms;


### PR DESCRIPTION
The diagnostic suppression was needed to silence -Wpsabi on the manually vectorized code path. This suppression was slated for removal in LLVM 24, likely because Clang no longer warns about -Wpsabi on [[gnu::always_inline]] functions in all versions we support.