### PR TITLE
[SSAF] Fix Expected return type in TypeConstrainedPointers deserialization (gcc 7.5.0)

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Analyses/TypeConstrainedPointers/TypeConstrainedPointers.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/TypeConstrainedPointers/TypeConstrainedPointers.cpp
@@ -212,7 +212,7 @@ deserializeSummary(const llvm::json::Object &Data, EntityIdTable &,
       std::make_unique<TypeConstrainedPointersEntitySummary>();
 
   Sum->Entities = std::move(*EntityIDSet);
-  return Sum;
+  return std::unique_ptr<EntitySummary>(std::move(Sum));
 }
 
 struct TypeConstrainedPointersJSONFormatInfo final : JSONFormat::FormatInfo {
@@ -246,7 +246,7 @@ deserializeAnalysisResult(const llvm::json::Object &Data,
       std::make_unique<TypeConstrainedPointersAnalysisResult>();
 
   AR->Entities = std::move(*EntityIDSet);
-  return AR;
+  return std::unique_ptr<AnalysisResult>(std::move(AR));
 }
 
 JSONFormat::AnalysisResultRegistry::Add<TypeConstrainedPointersAnalysisResult>


### PR DESCRIPTION
GCC 7.5.0 fails to compile this code. Use explicit upcasts from std::unique_ptr<Derived> to std::unique_ptr<Base> in deserializeSummary and deserializeAnalysisResult. This resolves a compilation error where llvm::Expected<std::unique_ptr<Base>> could not be constructed from unique_ptr of derived summary/result types.