### PR TITLE
[MSan] Fix va_arg handling on 32-bit machines

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -153,6 +153,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -631,13 +632,17 @@ public:
 private:
   friend struct MemorySanitizerVisitor;
   friend struct VarArgHelperBase;
+  friend struct VarArgStackModelHelperBase;
+  friend struct VarArgNoByValHelper;
   friend struct VarArgAMD64Helper;
   friend struct VarArgAArch64Helper;
   friend struct VarArgPowerPC64Helper;
   friend struct VarArgPowerPC32Helper;
   friend struct VarArgSystemZHelper;
+  friend struct VarArgHexagonHelper;
   friend struct VarArgI386Helper;
-  friend struct VarArgGenericHelper;
+  friend struct VarArgRISCVHelper;
+  friend struct VarArgLoongArch64Helper;
 
   void initializeModule(Module &M);
   void initializeCallbacks(Module &M, const TargetLibraryInfo &TLI);
@@ -8227,6 +8232,61 @@ struct VarArgHelperBase : public VarArgHelper {
   }
 };
 
+struct VarArgStackModelHelperBase : public VarArgHelperBase {
+  AllocaInst *VAArgTLSCopy = nullptr;
+  Value *VAArgSize = nullptr;
+
+  VarArgStackModelHelperBase(Function &F, MemorySanitizer &MS,
+                             MemorySanitizerVisitor &MSV,
+                             unsigned VAListTagSize)
+      : VarArgHelperBase(F, MS, MSV, VAListTagSize) {}
+
+  void finalizeInstrumentation() override {
+    assert(!VAArgSize && !VAArgTLSCopy &&
+           "finalizeInstrumentation called twice");
+    IRBuilder<> IRB(MSV.FnPrologueEnd);
+    VAArgSize = IRB.CreateLoad(MS.IntptrTy, MS.VAArgOverflowSizeTLS);
+    Value *CopySize = VAArgSize;
+
+    if (!VAStartInstrumentationList.empty()) {
+      // If there is a va_start in this function, make a backup copy of
+      // va_arg_tls somewhere in the function entry block.
+      VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
+      VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+                       CopySize, kShadowTLSAlignment, false);
+
+      Value *SrcSize = IRB.CreateBinaryIntrinsic(
+          Intrinsic::umin, CopySize,
+          ConstantInt::get(MS.IntptrTy, kParamTLSSize));
+      IRB.CreateMemCpy(VAArgTLSCopy, kShadowTLSAlignment, MS.VAArgTLS,
+                       kShadowTLSAlignment, SrcSize);
+    }
+
+    // Instrument va_start.
+    // Copy va_list shadow from the backup copy of the TLS contents.
+    for (CallInst *OrigInst : VAStartInstrumentationList) {
+      NextNodeIRBuilder IRB(OrigInst);
+      Value *VAListTag = OrigInst->getArgOperand(0);
+      Type *RegSaveAreaPtrTy = PointerType::getUnqual(*MS.C);
+      Value *RegSaveAreaPtrPtr =
+          IRB.CreateIntToPtr(IRB.CreatePtrToInt(VAListTag, MS.IntptrTy),
+                             PointerType::get(*MS.C, 0));
+      Value *RegSaveAreaPtr =
+          IRB.CreateLoad(RegSaveAreaPtrTy, RegSaveAreaPtrPtr);
+      Value *RegSaveAreaShadowPtr, *RegSaveAreaOriginPtr;
+      const DataLayout &DL = F.getDataLayout();
+      unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+      const Align Alignment = Align(IntptrSize);
+      std::tie(RegSaveAreaShadowPtr, RegSaveAreaOriginPtr) =
+          MSV.getShadowOriginPtr(RegSaveAreaPtr, IRB, IRB.getInt8Ty(),
+                                 Alignment, /*isStore*/ true);
+      IRB.CreateMemCpy(RegSaveAreaShadowPtr, Alignment, VAArgTLSCopy, Alignment,
+                       CopySize);
+    }
+  }
+};
+
 /// AMD64-specific implementation of VarArgHelper.
 struct VarArgAMD64Helper : public VarArgHelperBase {
   // An unfortunate workaround for asymmetric lowering of va_arg stuff.
@@ -8830,104 +8890,239 @@ struct VarArgPowerPC64Helper : public VarArgHelperBase {
 
 /// PowerPC32-specific implementation of VarArgHelper.
 struct VarArgPowerPC32Helper : public VarArgHelperBase {
+  static const unsigned kPowerPC32GrArgSize = 32;
+  static const unsigned kPowerPC32FrArgSize = 64;
+  static const unsigned kPowerPC32GrArgBase = 0;
+  static const unsigned kPowerPC32FrArgBase =
+      kPowerPC32GrArgBase + kPowerPC32GrArgSize;
+  // Parameter save area is 8 bytes from frame pointer in PPC32
+  // So we add the 8-byte offset to the 16-byte aligned value
+  // FIXME: we need to support more than 16-byte alignment
+  static const unsigned kPowerPC32OverflowArgBase =
+      kPowerPC32FrArgBase + kPowerPC32FrArgSize;
+
+  enum class ArgKind {
+    GpReg,
+    ByVal,
+    FpReg,
+    Other,
+  };
+
+  struct ArgAttr {
+    ArgKind Kind;
+    Align ArgAlign;
+    uint64_t ArgSize;
+  };
+
+  bool IsSoftFloatABI = false;
+  bool HasSPE = false;
   AllocaInst *VAArgTLSCopy = nullptr;
-  Value *VAArgSize = nullptr;
+  Value *VAArgDesc = nullptr;
 
   VarArgPowerPC32Helper(Function &F, MemorySanitizer &MS,
                         MemorySanitizerVisitor &MSV)
-      : VarArgHelperBase(F, MS, MSV, /*VAListTagSize=*/12) {}
+      : VarArgHelperBase(F, MS, MSV, /*VAListTagSize=*/12),
+        IsSoftFloatABI(F.getFnAttribute("use-soft-float").getValueAsBool()) {
+    Attribute TFAttr = F.getFnAttribute("target-features");
+    if (TFAttr.isValid()) {
+      SmallVector<StringRef, 6> Features;
+      TFAttr.getValueAsString().split(Features, ',');
+      HasSPE = is_contained(Features, "+spe");
+    }
+  }
 
-  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
-    unsigned VAArgBase;
-    // Parameter save area is 8 bytes from frame pointer in PPC32
-    VAArgBase = 8;
-    unsigned VAArgOffset = VAArgBase;
+  ArgAttr classifyArgument(CallBase &CB, unsigned ArgNo, Use &A) {
     const DataLayout &DL = F.getDataLayout();
     unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+    unsigned DoubleSize = DL.getTypeStoreSize(Type::getDoubleTy(*MS.C));
+
+    Type *ArgType = A->getType();
+    uint64_t ArgSize = DL.getTypeAllocSize(ArgType);
+    Align ArgAlign = CB.getParamAlign(ArgNo).value_or(Align(IntptrSize));
+
+    bool IsByVal = CB.paramHasAttr(ArgNo, Attribute::ByVal);
+    bool IsSRet = CB.paramHasAttr(ArgNo, Attribute::StructRet);
+    if (IsByVal || IsSRet) {
+      assert(ArgType->isPointerTy());
+      assert(!IsSRet || ArgNo == 0U);
+      Type *RealTy = IsByVal ? CB.getParamByValType(ArgNo)
+                             : CB.getParamStructRetType(ArgNo);
+      ArgSize = DL.getTypeAllocSize(RealTy);
+      ArgAlign = DL.getABITypeAlign(RealTy);
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+
+      return ArgAttr{ArgKind::ByVal, ArgAlign, ArgSize};
+    }
+
+    if (ArgType->isIntOrPtrTy()) {
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+      if (ArgType->isIntegerTy(64))
+        ArgAlign = Align(ArgSize);
+
+      return ArgAttr{ArgKind::GpReg, ArgAlign, ArgSize};
+    }
+
+    if (ArgType->isFloatingPointTy()) {
+      if (IsSoftFloatABI) {
+        ArgAlign = Align(IntptrSize);
+        if (ArgType->isDoubleTy())
+          ArgAlign = Align(DoubleSize);
+
+        return ArgAttr{ArgKind::GpReg, ArgAlign, ArgSize};
+      }
+      if (HasSPE) {
+        ArgAlign = Align(DoubleSize);
+        return ArgAttr{ArgKind::GpReg, ArgAlign, ArgSize};
+      }
+      if (ArgAlign < DoubleSize)
+        ArgAlign = Align(DoubleSize);
+      if (ArgType->isFP128Ty() || ArgType->isPPC_FP128Ty())
+        ArgAlign = Align(ArgSize);
+
+      return ArgAttr{ArgKind::FpReg, ArgAlign, ArgSize};
+    }
+
+    return ArgAttr{ArgKind::Other, ArgAlign, ArgSize};
+  }
+
+  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
+    // GP integers fit in r3...r10 while qwords occupy (r3,r4)...(r9,r10)
+    unsigned GrArgBase = 0, GrArgOffset = GrArgBase;
+    // FP floats and doubles fit in f1...f8 while quads occupy (f2,f3)...(f6,f7)
+    unsigned FrArgBase = 8, FrArgOffset = FrArgBase;
+    // Parameter save area is 8 bytes from frame pointer in PPC32
+    unsigned OverflowArgBase = 8, OverflowArgOffset = OverflowArgBase;
+
+    unsigned GrFixedCount = 0, GrTotalCount = 0;
+    unsigned FrFixedCount = 0, FrTotalCount = 0;
+
+    const DataLayout &DL = F.getDataLayout();
+    unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+    unsigned DoubleSize = DL.getTypeStoreSize(Type::getDoubleTy(*MS.C));
     for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
       bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
-      bool IsByVal = CB.paramHasAttr(ArgNo, Attribute::ByVal);
-      if (IsByVal) {
-        assert(A->getType()->isPointerTy());
-        Type *RealTy = CB.getParamByValType(ArgNo);
-        uint64_t ArgSize = DL.getTypeAllocSize(RealTy);
-        Align ArgAlign = CB.getParamAlign(ArgNo).value_or(Align(IntptrSize));
-        if (ArgAlign < IntptrSize)
-          ArgAlign = Align(IntptrSize);
-        VAArgOffset = alignTo(VAArgOffset, ArgAlign);
-        if (!IsFixed) {
-          Value *Base =
-              getShadowPtrForVAArgument(IRB, VAArgOffset - VAArgBase, ArgSize);
-          if (Base) {
-            Value *AShadowPtr, *AOriginPtr;
-            std::tie(AShadowPtr, AOriginPtr) =
-                MSV.getShadowOriginPtr(A, IRB, IRB.getInt8Ty(),
-                                       kShadowTLSAlignment, /*isStore*/ false);
+      auto ArgAttr = classifyArgument(CB, ArgNo, A);
+      Value *Base = nullptr;
 
-            IRB.CreateMemCpy(Base, kShadowTLSAlignment, AShadowPtr,
-                             kShadowTLSAlignment, ArgSize);
-          }
-        }
-        VAArgOffset += alignTo(ArgSize, Align(IntptrSize));
-      } else {
-        Value *Base;
-        Type *ArgTy = A->getType();
+      if (ArgAttr.Kind == ArgKind::ByVal) {
+        if (GrArgOffset < GrArgBase + kPowerPC32GrArgSize)
+          GrArgOffset += IntptrSize;
+        else
+          OverflowArgOffset += IntptrSize;
+        continue;
+      }
 
-        // On PPC 32 floating point variable arguments are stored in separate
-        // area: fp_save_area = reg_save_area + 4*8. We do not copy shaodow for
-        // them as they will be found when checking call arguments.
-        if (!ArgTy->isFloatingPointTy()) {
-          uint64_t ArgSize = DL.getTypeAllocSize(ArgTy);
-          Align ArgAlign = Align(IntptrSize);
-          if (ArgTy->isArrayTy()) {
-            // Arrays are aligned to element size, except for long double
-            // arrays, which are aligned to 8 bytes.
-            Type *ElementTy = ArgTy->getArrayElementType();
-            if (!ElementTy->isPPC_FP128Ty())
-              ArgAlign = Align(DL.getTypeAllocSize(ElementTy));
-          } else if (ArgTy->isVectorTy()) {
-            // Vectors are naturally aligned.
-            ArgAlign = Align(ArgSize);
-          }
-          if (ArgAlign < IntptrSize)
-            ArgAlign = Align(IntptrSize);
-          VAArgOffset = alignTo(VAArgOffset, ArgAlign);
-          if (DL.isBigEndian()) {
-            // Adjusting the shadow for argument with size < IntptrSize to match
-            // the placement of bits in big endian system
-            if (ArgSize < IntptrSize)
-              VAArgOffset += (IntptrSize - ArgSize);
-          }
+      if (ArgAttr.Kind == ArgKind::GpReg) {
+        if (alignTo(GrArgOffset, ArgAttr.ArgAlign) + ArgAttr.ArgSize <=
+            GrArgBase + kPowerPC32GrArgSize) {
+          if (DL.isBigEndian() && ArgAttr.ArgSize < IntptrSize)
+            GrArgOffset += (IntptrSize - ArgAttr.ArgSize);
+          else
+            GrArgOffset = alignTo(GrArgOffset, ArgAttr.ArgAlign);
           if (!IsFixed) {
-            Base = getShadowPtrForVAArgument(IRB, VAArgOffset - VAArgBase,
-                                             ArgSize);
-            if (Base)
-              IRB.CreateAlignedStore(MSV.getShadow(A), Base,
-                                     kShadowTLSAlignment);
+            Base = getShadowPtrForVAArgument(
+                IRB, kPowerPC32GrArgBase + GrArgOffset - GrArgBase,
+                ArgAttr.ArgSize);
           }
-          VAArgOffset += ArgSize;
-          VAArgOffset = alignTo(VAArgOffset, Align(IntptrSize));
+        } else {
+          ArgAttr.Kind = ArgKind::Other;
         }
+      } else if (ArgAttr.Kind == ArgKind::FpReg) {
+        if (alignTo(FrArgOffset, ArgAttr.ArgAlign) + ArgAttr.ArgSize <=
+            FrArgBase + kPowerPC32FrArgSize) {
+          FrArgOffset = alignTo(FrArgOffset, ArgAttr.ArgAlign);
+          if (!IsFixed) {
+            Base = getShadowPtrForVAArgument(
+                IRB, kPowerPC32FrArgBase + FrArgOffset - FrArgBase,
+                ArgAttr.ArgSize);
+          }
+        } else {
+          ArgAttr.Kind = ArgKind::Other;
+        }
+      }
+
+      if (ArgAttr.Kind == ArgKind::Other) {
+        if (DL.isBigEndian() && ArgAttr.ArgSize < IntptrSize)
+          OverflowArgOffset += (IntptrSize - ArgAttr.ArgSize);
+        else
+          OverflowArgOffset = alignTo(OverflowArgOffset, ArgAttr.ArgAlign);
+        if (!IsFixed) {
+          Base = getShadowPtrForVAArgument(
+              IRB,
+              kPowerPC32OverflowArgBase + OverflowArgOffset - OverflowArgBase,
+              ArgAttr.ArgSize);
+        }
+      }
+
+      if (Base) {
+        IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
+      }
+
+      switch (ArgAttr.Kind) {
+      case ArgKind::GpReg:
+        GrArgOffset += ArgAttr.ArgSize;
+        GrArgOffset = alignTo(GrArgOffset, Align(IntptrSize));
+        [[fallthrough]];
+        // Shadow propagates since we effectively use by-ref semantic
+      case ArgKind::ByVal:
+        GrTotalCount = GrArgOffset / IntptrSize;
+        if (IsFixed)
+          GrFixedCount = GrTotalCount;
+        break;
+      case ArgKind::FpReg:
+        FrArgOffset += ArgAttr.ArgSize;
+        FrArgOffset = alignTo(FrArgOffset, Align(DoubleSize));
+        FrTotalCount = FrArgOffset / DoubleSize;
+        if (IsFixed)
+          FrFixedCount = FrTotalCount;
+        break;
+      case ArgKind::Other:
+        OverflowArgOffset += ArgAttr.ArgSize;
+        OverflowArgOffset = alignTo(OverflowArgOffset, Align(IntptrSize));
+        break;
       }
     }
 
-    Constant *TotalVAArgSize =
-        ConstantInt::get(MS.IntptrTy, VAArgOffset - VAArgBase);
-    // Here using VAArgOverflowSizeTLS as VAArgSizeTLS to avoid creation of
-    // a new class member i.e. it is the total size of all VarArgs.
-    IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
+    assert(GrTotalCount < 16);
+    assert(FrTotalCount < 16);
+    unsigned VAArgGrDescValue =
+        GrFixedCount | ((GrTotalCount - GrFixedCount) << 4);
+    unsigned VAArgFrDescValue =
+        FrFixedCount | ((FrTotalCount - FrFixedCount) << 4);
+    unsigned VAArgOverflowValue = OverflowArgOffset - OverflowArgBase;
+    unsigned VAArgDescValue =
+        VAArgGrDescValue | (VAArgFrDescValue << 8) | (VAArgOverflowValue << 16);
+    Constant *VAArgDesc = ConstantInt::get(MS.IntptrTy, VAArgDescValue);
+    // Here using VAArgOverflowSizeTLS as VAArgDescTLS to avoid creation of
+    // a new class member i.e. it is the descriptor of all VarArgs.
+    IRB.CreateStore(VAArgDesc, MS.VAArgOverflowSizeTLS);
   }
 
   void finalizeInstrumentation() override {
-    assert(!VAArgSize && !VAArgTLSCopy &&
+    assert(!VAArgDesc && !VAArgTLSCopy &&
            "finalizeInstrumentation called twice");
     IRBuilder<> IRB(MSV.FnPrologueEnd);
-    VAArgSize = IRB.CreateLoad(MS.IntptrTy, MS.VAArgOverflowSizeTLS);
-    Value *CopySize = VAArgSize;
+    VAArgDesc = IRB.CreateLoad(MS.IntptrTy, MS.VAArgOverflowSizeTLS);
+    Constant *Mask = ConstantInt::get(MS.IntptrTy, 0xF);
+    Value *GrFixedCount = IRB.CreateAnd(VAArgDesc, Mask);
+    Value *GrVAArgCount = IRB.CreateAnd(IRB.CreateLShr(VAArgDesc, 4), Mask);
+    Value *FrFixedCount = IRB.CreateAnd(IRB.CreateLShr(VAArgDesc, 8), Mask);
+    Value *FrVAArgCount = IRB.CreateAnd(IRB.CreateLShr(VAArgDesc, 12), Mask);
+    Value *OverflowSize = IRB.CreateLShr(VAArgDesc, 16);
+
+    OverflowSize = IRB.CreateBinaryIntrinsic(
+        Intrinsic::umin, OverflowSize,
+        ConstantInt::get(MS.IntptrTy,
+                         kParamTLSSize - kPowerPC32OverflowArgBase));
 
     if (!VAStartInstrumentationList.empty()) {
       // If there is a va_start in this function, make a backup copy of
       // va_arg_tls somewhere in the function entry block.
+      Value *CopySize = IRB.CreateAdd(
+          OverflowSize,
+          ConstantInt::get(MS.IntptrTy, kPowerPC32OverflowArgBase));
 
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
@@ -8947,46 +9142,60 @@ struct VarArgPowerPC32Helper : public VarArgHelperBase {
       NextNodeIRBuilder IRB(OrigInst);
       Value *VAListTag = OrigInst->getArgOperand(0);
       Value *RegSaveAreaPtrPtr = IRB.CreatePtrToInt(VAListTag, MS.IntptrTy);
-      Value *RegSaveAreaSize = CopySize;
 
       // In PPC32 va_list_tag is a struct
       RegSaveAreaPtrPtr =
           IRB.CreateAdd(RegSaveAreaPtrPtr, ConstantInt::get(MS.IntptrTy, 8));
 
-      // On PPC 32 reg_save_area can only hold 32 bytes of data
-      RegSaveAreaSize = IRB.CreateBinaryIntrinsic(
-          Intrinsic::umin, CopySize, ConstantInt::get(MS.IntptrTy, 32));
-
       RegSaveAreaPtrPtr = IRB.CreateIntToPtr(RegSaveAreaPtrPtr, MS.PtrTy);
-      Value *RegSaveAreaPtr = IRB.CreateLoad(MS.PtrTy, RegSaveAreaPtrPtr);
+      Value *GpSaveAreaPtr = IRB.CreateLoad(MS.PtrTy, RegSaveAreaPtrPtr);
+      Value *FpSaveAreaPtr =
+          IRB.CreateGEP(IRB.getInt8Ty(), GpSaveAreaPtr,
+                        {ConstantInt::get(MS.IntptrTy, kPowerPC32FrArgBase)});
+
+      Constant *NullPtr = ConstantPointerNull::get(PointerType::get(*MS.C, 0));
+
+      Value *GpVAPtr =
+          IRB.CreateGEP(MS.IntptrTy, GpSaveAreaPtr, {GrFixedCount});
+      Value *GpVASize = IRB.CreateGEP(MS.IntptrTy, NullPtr, {GrVAArgCount});
+      GpVASize = IRB.CreatePtrToInt(GpVASize, MS.IntptrTy);
+
+      Type *DoubleTy = Type::getDoubleTy(*MS.C);
+      Value *FpVAPtr = IRB.CreateGEP(DoubleTy, FpSaveAreaPtr, {FrFixedCount});
+      Value *FpVASize = IRB.CreateGEP(DoubleTy, NullPtr, {FrVAArgCount});
+      FpVASize = IRB.CreatePtrToInt(FpVASize, MS.IntptrTy);
 
       const DataLayout &DL = F.getDataLayout();
       unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
       const Align Alignment = Align(IntptrSize);
 
       { // Copy reg save area
-        Value *RegSaveAreaShadowPtr, *RegSaveAreaOriginPtr;
-        std::tie(RegSaveAreaShadowPtr, RegSaveAreaOriginPtr) =
-            MSV.getShadowOriginPtr(RegSaveAreaPtr, IRB, IRB.getInt8Ty(),
-                                   Alignment, /*isStore*/ true);
-        IRB.CreateMemCpy(RegSaveAreaShadowPtr, Alignment, VAArgTLSCopy,
-                         Alignment, RegSaveAreaSize);
+        Value *GpSaveAreaShadowPtr, *GpSaveAreaOriginPtr;
+        std::tie(GpSaveAreaShadowPtr, GpSaveAreaOriginPtr) =
+            MSV.getShadowOriginPtr(GpVAPtr, IRB, IRB.getInt8Ty(), Alignment,
+                                   /*isStore*/ true);
+        Value *GpVAArgTLSCopyPtr =
+            IRB.CreateGEP(MS.IntptrTy, VAArgTLSCopy, {GrFixedCount});
+        IRB.CreateMemCpy(GpSaveAreaShadowPtr, Alignment, GpVAArgTLSCopyPtr,
+                         Alignment, GpVASize);
 
-        RegSaveAreaShadowPtr =
-            IRB.CreatePtrToInt(RegSaveAreaShadowPtr, MS.IntptrTy);
-        Value *FPSaveArea = IRB.CreateAdd(RegSaveAreaShadowPtr,
-                                          ConstantInt::get(MS.IntptrTy, 32));
-        FPSaveArea = IRB.CreateIntToPtr(FPSaveArea, MS.PtrTy);
-        // We fill fp shadow with zeroes as uninitialized fp args should have
-        // been found during call base check
-        IRB.CreateMemSet(FPSaveArea, ConstantInt::getNullValue(IRB.getInt8Ty()),
-                         ConstantInt::get(MS.IntptrTy, 32), Alignment);
+        Value *FpSaveAreaShadowPtr, *FpSaveAreaOriginPtr;
+        std::tie(FpSaveAreaShadowPtr, FpSaveAreaOriginPtr) =
+            MSV.getShadowOriginPtr(FpVAPtr, IRB, IRB.getInt8Ty(), Alignment,
+                                   /*isStore*/ true);
+        Value *FpVAArgTLSCopyPtr =
+            IRB.CreatePtrToInt(VAArgTLSCopy, MS.IntptrTy);
+        FpVAArgTLSCopyPtr =
+            IRB.CreateAdd(FpVAArgTLSCopyPtr,
+                          ConstantInt::get(MS.IntptrTy, kPowerPC32FrArgBase));
+        FpVAArgTLSCopyPtr = IRB.CreateIntToPtr(FpVAArgTLSCopyPtr, MS.PtrTy);
+        FpVAArgTLSCopyPtr =
+            IRB.CreateGEP(DoubleTy, FpVAArgTLSCopyPtr, {FrFixedCount});
+        IRB.CreateMemCpy(FpSaveAreaShadowPtr, Alignment, FpVAArgTLSCopyPtr,
+                         Alignment, FpVASize);
       }
 
       { // Copy overflow area
-        // RegSaveAreaSize is min(CopySize, 32) -> no overflow can occur
-        Value *OverflowAreaSize = IRB.CreateSub(CopySize, RegSaveAreaSize);
-
         Value *OverflowAreaPtrPtr = IRB.CreatePtrToInt(VAListTag, MS.IntptrTy);
         OverflowAreaPtrPtr =
             IRB.CreateAdd(OverflowAreaPtrPtr, ConstantInt::get(MS.IntptrTy, 4));
@@ -9001,13 +9210,13 @@ struct VarArgPowerPC32Helper : public VarArgHelperBase {
 
         Value *OverflowVAArgTLSCopyPtr =
             IRB.CreatePtrToInt(VAArgTLSCopy, MS.IntptrTy);
-        OverflowVAArgTLSCopyPtr =
-            IRB.CreateAdd(OverflowVAArgTLSCopyPtr, RegSaveAreaSize);
-
+        OverflowVAArgTLSCopyPtr = IRB.CreateAdd(
+            OverflowVAArgTLSCopyPtr,
+            ConstantInt::get(MS.IntptrTy, kPowerPC32OverflowArgBase));
         OverflowVAArgTLSCopyPtr =
             IRB.CreateIntToPtr(OverflowVAArgTLSCopyPtr, MS.PtrTy);
         IRB.CreateMemCpy(OverflowAreaShadowPtr, Alignment,
-                         OverflowVAArgTLSCopyPtr, Alignment, OverflowAreaSize);
+                         OverflowVAArgTLSCopyPtr, Alignment, OverflowSize);
       }
     }
   }
@@ -9294,14 +9503,129 @@ struct VarArgSystemZHelper : public VarArgHelperBase {
   }
 };
 
-/// i386-specific implementation of VarArgHelper.
-struct VarArgI386Helper : public VarArgHelperBase {
+/// Implementation of VarArgHelper that is used for Hexagon.
+struct VarArgHexagonHelper : public VarArgHelperBase {
+  static const unsigned kHexagonGrArgSize = 24;
+
   AllocaInst *VAArgTLSCopy = nullptr;
   Value *VAArgSize = nullptr;
 
+  VarArgHexagonHelper(Function &F, MemorySanitizer &MS,
+                      MemorySanitizerVisitor &MSV, const unsigned VAListTagSize)
+      : VarArgHelperBase(F, MS, MSV, VAListTagSize) {}
+
+  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
+    unsigned VAArgBase = 0;
+    unsigned VAArgOffset = VAArgBase;
+    unsigned GpRegOffset = 0;
+    const DataLayout &DL = F.getDataLayout();
+    unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+    Align StackAlign = DL.getStackAlignment().value_or(Align(2 * IntptrSize));
+    for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
+      bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
+      uint64_t ArgSize = DL.getTypeAllocSize(A->getType());
+      Align ArgAlign = DL.getABITypeAlign(A->getType());
+      GpRegOffset = alignTo(GpRegOffset, Align(IntptrSize));
+      assert(!CB.paramHasAttr(ArgNo, Attribute::ByVal));
+      if (CB.paramHasAttr(ArgNo, Attribute::StructRet)) {
+        assert(A->getType()->isPointerTy());
+        assert(ArgNo == 0U);
+        GpRegOffset += IntptrSize;
+        continue;
+      }
+      if (IsFixed) {
+        if (ArgSize <= IntptrSize &&
+            GpRegOffset + ArgSize <= kHexagonGrArgSize) {
+          GpRegOffset += IntptrSize;
+          continue;
+        }
+        if (ArgSize <= 2 * IntptrSize &&
+            alignTo(GpRegOffset, Align(2 * IntptrSize)) + ArgSize <=
+                kHexagonGrArgSize) {
+          GpRegOffset =
+              alignTo(GpRegOffset, Align(2 * IntptrSize)) + 2 * IntptrSize;
+          continue;
+        }
+      }
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+      else if (ArgAlign > StackAlign)
+        ArgAlign = StackAlign;
+      VAArgOffset = alignTo(VAArgOffset, ArgAlign);
+      if (DL.isBigEndian() && ArgSize < IntptrSize) {
+        // Adjusting the shadow for argument with size < IntptrSize to match the
+        // placement of bits in big endian system
+        VAArgOffset += (IntptrSize - ArgSize);
+      }
+      Value *Base =
+          getShadowPtrForVAArgument(IRB, VAArgOffset - VAArgBase, ArgSize);
+      VAArgOffset += ArgSize;
+      if (IsFixed) {
+        VAArgBase = alignTo(VAArgOffset, IntptrSize);
+        continue;
+      }
+      if (!Base)
+        break;
+      IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
+    }
+
+    Constant *TotalVAArgSize =
+        ConstantInt::get(MS.IntptrTy, VAArgOffset - VAArgBase);
+    // Here using VAArgOverflowSizeTLS as VAArgSizeTLS to avoid creation of
+    // a new class member i.e. it is the total size of all VarArgs.
+    IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
+  }
+
+  void finalizeInstrumentation() override {
+    assert(!VAArgSize && !VAArgTLSCopy &&
+           "finalizeInstrumentation called twice");
+    IRBuilder<> IRB(MSV.FnPrologueEnd);
+    VAArgSize = IRB.CreateLoad(MS.IntptrTy, MS.VAArgOverflowSizeTLS);
+    Value *CopySize =
+        IRB.CreateBinaryIntrinsic(Intrinsic::umin, VAArgSize,
+                                  ConstantInt::get(MS.IntptrTy, kParamTLSSize));
+
+    if (!VAStartInstrumentationList.empty()) {
+      // If there is a va_start in this function, make a backup copy of
+      // va_arg_tls somewhere in the function entry block.
+      VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
+      VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
+      IRB.CreateMemCpy(VAArgTLSCopy, kShadowTLSAlignment, MS.VAArgTLS,
+                       kShadowTLSAlignment, CopySize);
+    }
+
+    // Instrument va_start.
+    // Copy va_list shadow from the backup copy of the TLS contents.
+    for (CallInst *OrigInst : VAStartInstrumentationList) {
+      NextNodeIRBuilder IRB(OrigInst);
+      Value *VAListTag = OrigInst->getArgOperand(0);
+      Value *OverflowAreaPtrPtr =
+          IRB.CreatePtrAdd(VAListTag, ConstantInt::get(MS.IntptrTy, 8));
+
+      const DataLayout &DL = F.getDataLayout();
+      unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+      const Align Alignment = Align(IntptrSize);
+
+      { // Copy overflow area
+        Value *OverflowAreaPtr = IRB.CreateLoad(MS.PtrTy, OverflowAreaPtrPtr);
+
+        Value *OverflowAreaShadowPtr, *OverflowAreaOriginPtr;
+        std::tie(OverflowAreaShadowPtr, OverflowAreaOriginPtr) =
+            MSV.getShadowOriginPtr(OverflowAreaPtr, IRB, IRB.getInt8Ty(),
+                                   Alignment, /*isStore*/ true);
+        IRB.CreateMemCpy(OverflowAreaShadowPtr, Alignment, VAArgTLSCopy,
+                         Alignment, CopySize);
+      }
+    }
+  }
+};
+
+/// i386-specific implementation of VarArgHelper.
+struct VarArgI386Helper : public VarArgStackModelHelperBase {
+
   VarArgI386Helper(Function &F, MemorySanitizer &MS,
                    MemorySanitizerVisitor &MSV)
-      : VarArgHelperBase(F, MS, MSV, /*VAListTagSize=*/4) {}
+      : VarArgStackModelHelperBase(F, MS, MSV, /*VAListTagSize=*/4) {}
 
   void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
     const DataLayout &DL = F.getDataLayout();
@@ -9310,131 +9634,31 @@ struct VarArgI386Helper : public VarArgHelperBase {
     for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
       bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
       bool IsByVal = CB.paramHasAttr(ArgNo, Attribute::ByVal);
-      if (IsByVal) {
-        assert(A->getType()->isPointerTy());
-        Type *RealTy = CB.getParamByValType(ArgNo);
-        uint64_t ArgSize = DL.getTypeAllocSize(RealTy);
-        Align ArgAlign = CB.getParamAlign(ArgNo).value_or(Align(IntptrSize));
-        if (ArgAlign < IntptrSize)
-          ArgAlign = Align(IntptrSize);
-        VAArgOffset = alignTo(VAArgOffset, ArgAlign);
-        if (!IsFixed) {
-          Value *Base = getShadowPtrForVAArgument(IRB, VAArgOffset, ArgSize);
-          if (Base) {
-            Value *AShadowPtr, *AOriginPtr;
-            std::tie(AShadowPtr, AOriginPtr) =
-                MSV.getShadowOriginPtr(A, IRB, IRB.getInt8Ty(),
-                                       kShadowTLSAlignment, /*isStore*/ false);
-
-            IRB.CreateMemCpy(Base, kShadowTLSAlignment, AShadowPtr,
-                             kShadowTLSAlignment, ArgSize);
-          }
-          VAArgOffset += alignTo(ArgSize, Align(IntptrSize));
-        }
-      } else {
-        Value *Base;
-        uint64_t ArgSize = DL.getTypeAllocSize(A->getType());
-        Align ArgAlign = Align(IntptrSize);
-        VAArgOffset = alignTo(VAArgOffset, ArgAlign);
-        if (DL.isBigEndian()) {
-          // Adjusting the shadow for argument with size < IntptrSize to match
-          // the placement of bits in big endian system
-          if (ArgSize < IntptrSize)
-            VAArgOffset += (IntptrSize - ArgSize);
-        }
-        if (!IsFixed) {
-          Base = getShadowPtrForVAArgument(IRB, VAArgOffset, ArgSize);
-          if (Base)
-            IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
-          VAArgOffset += ArgSize;
-          VAArgOffset = alignTo(VAArgOffset, Align(IntptrSize));
-        }
-      }
-    }
-
-    Constant *TotalVAArgSize = ConstantInt::get(MS.IntptrTy, VAArgOffset);
-    // Here using VAArgOverflowSizeTLS as VAArgSizeTLS to avoid creation of
-    // a new class member i.e. it is the total size of all VarArgs.
-    IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
-  }
-
-  void finalizeInstrumentation() override {
-    assert(!VAArgSize && !VAArgTLSCopy &&
-           "finalizeInstrumentation called twice");
-    IRBuilder<> IRB(MSV.FnPrologueEnd);
-    VAArgSize = IRB.CreateLoad(MS.IntptrTy, MS.VAArgOverflowSizeTLS);
-    Value *CopySize = VAArgSize;
-
-    if (!VAStartInstrumentationList.empty()) {
-      // If there is a va_start in this function, make a backup copy of
-      // va_arg_tls somewhere in the function entry block.
-      VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
-      VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
-                       CopySize, kShadowTLSAlignment, false);
-
-      Value *SrcSize = IRB.CreateBinaryIntrinsic(
-          Intrinsic::umin, CopySize,
-          ConstantInt::get(MS.IntptrTy, kParamTLSSize));
-      IRB.CreateMemCpy(VAArgTLSCopy, kShadowTLSAlignment, MS.VAArgTLS,
-                       kShadowTLSAlignment, SrcSize);
-    }
-
-    // Instrument va_start.
-    // Copy va_list shadow from the backup copy of the TLS contents.
-    for (CallInst *OrigInst : VAStartInstrumentationList) {
-      NextNodeIRBuilder IRB(OrigInst);
-      Value *VAListTag = OrigInst->getArgOperand(0);
-      Type *RegSaveAreaPtrTy = PointerType::getUnqual(*MS.C);
-      Value *RegSaveAreaPtrPtr =
-          IRB.CreateIntToPtr(IRB.CreatePtrToInt(VAListTag, MS.IntptrTy),
-                             PointerType::get(*MS.C, 0));
-      Value *RegSaveAreaPtr =
-          IRB.CreateLoad(RegSaveAreaPtrTy, RegSaveAreaPtrPtr);
-      Value *RegSaveAreaShadowPtr, *RegSaveAreaOriginPtr;
-      const DataLayout &DL = F.getDataLayout();
-      unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
-      const Align Alignment = Align(IntptrSize);
-      std::tie(RegSaveAreaShadowPtr, RegSaveAreaOriginPtr) =
-          MSV.getShadowOriginPtr(RegSaveAreaPtr, IRB, IRB.getInt8Ty(),
-                                 Alignment, /*isStore*/ true);
-      IRB.CreateMemCpy(RegSaveAreaShadowPtr, Alignment, VAArgTLSCopy, Alignment,
-                       CopySize);
-    }
-  }
-};
-
-/// Implementation of VarArgHelper that is used for ARM32, MIPS, RISCV,
-/// LoongArch64.
-struct VarArgGenericHelper : public VarArgHelperBase {
-  AllocaInst *VAArgTLSCopy = nullptr;
-  Value *VAArgSize = nullptr;
-
-  VarArgGenericHelper(Function &F, MemorySanitizer &MS,
-                      MemorySanitizerVisitor &MSV, const unsigned VAListTagSize)
-      : VarArgHelperBase(F, MS, MSV, VAListTagSize) {}
-
-  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
-    unsigned VAArgOffset = 0;
-    const DataLayout &DL = F.getDataLayout();
-    unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
-    for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
-      bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
-      if (IsFixed)
-        continue;
+      bool IsSRet = CB.paramHasAttr(ArgNo, Attribute::StructRet);
       uint64_t ArgSize = DL.getTypeAllocSize(A->getType());
+      Align ArgAlign = DL.getABITypeAlign(A->getType());
+      if (IsByVal || IsSRet) {
+        assert(A->getType()->isPointerTy());
+        assert(!IsSRet || ArgNo == 0U);
+        VAArgOffset += IntptrSize;
+        continue;
+      }
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+      VAArgOffset = alignTo(VAArgOffset, ArgAlign);
       if (DL.isBigEndian()) {
-        // Adjusting the shadow for argument with size < IntptrSize to match the
-        // placement of bits in big endian system
+        // Adjusting the shadow for argument with size < IntptrSize to match
+        // the placement of bits in big endian system
         if (ArgSize < IntptrSize)
           VAArgOffset += (IntptrSize - ArgSize);
       }
-      Value *Base = getShadowPtrForVAArgument(IRB, VAArgOffset, ArgSize);
-      VAArgOffset += ArgSize;
-      VAArgOffset = alignTo(VAArgOffset, IntptrSize);
-      if (!Base)
-        continue;
-      IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
+      if (!IsFixed) {
+        Value *Base = getShadowPtrForVAArgument(IRB, VAArgOffset, ArgSize);
+        if (Base)
+          IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
+        VAArgOffset += ArgSize;
+        VAArgOffset = alignTo(VAArgOffset, Align(IntptrSize));
+      }
     }
 
     Constant *TotalVAArgSize = ConstantInt::get(MS.IntptrTy, VAArgOffset);
@@ -9442,60 +9666,231 @@ struct VarArgGenericHelper : public VarArgHelperBase {
     // a new class member i.e. it is the total size of all VarArgs.
     IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
   }
+};
 
-  void finalizeInstrumentation() override {
-    assert(!VAArgSize && !VAArgTLSCopy &&
-           "finalizeInstrumentation called twice");
-    IRBuilder<> IRB(MSV.FnPrologueEnd);
-    VAArgSize = IRB.CreateLoad(MS.IntptrTy, MS.VAArgOverflowSizeTLS);
-    Value *CopySize = VAArgSize;
+/// Implementation of VarArgHelper that is used for RISCV.
+struct VarArgRISCVHelper : public VarArgStackModelHelperBase {
+  static const unsigned kGpRegAreaSize = 32;
 
-    if (!VAStartInstrumentationList.empty()) {
-      // If there is a va_start in this function, make a backup copy of
-      // va_arg_tls somewhere in the function entry block.
-      VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
-      VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
-                       CopySize, kShadowTLSAlignment, false);
+  VarArgRISCVHelper(Function &F, MemorySanitizer &MS,
+                    MemorySanitizerVisitor &MSV, const unsigned VAListTagSize)
+      : VarArgStackModelHelperBase(F, MS, MSV, VAListTagSize) {}
 
-      Value *SrcSize = IRB.CreateBinaryIntrinsic(
-          Intrinsic::umin, CopySize,
-          ConstantInt::get(MS.IntptrTy, kParamTLSSize));
-      IRB.CreateMemCpy(VAArgTLSCopy, kShadowTLSAlignment, MS.VAArgTLS,
-                       kShadowTLSAlignment, SrcSize);
+  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
+    unsigned VAArgBase = 0;
+    unsigned VAArgOffset = VAArgBase;
+    const DataLayout &DL = F.getDataLayout();
+    unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+    Align StackAlign = DL.getStackAlignment().value_or(Align(2 * IntptrSize));
+    for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
+      bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
+      bool IsByVal = CB.paramHasAttr(ArgNo, Attribute::ByVal);
+      bool IsSRet = CB.paramHasAttr(ArgNo, Attribute::StructRet);
+      uint64_t ArgSize = DL.getTypeAllocSize(A->getType());
+      Align ArgAlign = DL.getABITypeAlign(A->getType());
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+      VAArgOffset = alignTo(VAArgOffset, Align(IntptrSize));
+      if (IsByVal || IsSRet) {
+        assert(A->getType()->isPointerTy());
+        assert(!IsSRet || ArgNo == 0U);
+        VAArgOffset += IntptrSize;
+        continue;
+      }
+      if (ArgAlign > IntptrSize &&
+          (VAArgOffset >= VAArgBase + kGpRegAreaSize || !IsFixed)) {
+        if (ArgAlign > StackAlign)
+          ArgAlign = StackAlign;
+        VAArgOffset = alignTo(VAArgOffset, ArgAlign);
+      }
+      if (DL.isBigEndian() && ArgSize < IntptrSize) {
+        // Adjusting the shadow for argument with size < IntptrSize to match the
+        // placement of bits in big endian system
+        VAArgOffset += (IntptrSize - ArgSize);
+      }
+      Value *Base =
+          getShadowPtrForVAArgument(IRB, VAArgOffset - VAArgBase, ArgSize);
+      VAArgOffset += ArgSize;
+      if (IsFixed) {
+        VAArgBase = alignTo(VAArgOffset, IntptrSize);
+        continue;
+      }
+      if (!Base)
+        break;
+      IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
     }
 
-    // Instrument va_start.
-    // Copy va_list shadow from the backup copy of the TLS contents.
-    for (CallInst *OrigInst : VAStartInstrumentationList) {
-      NextNodeIRBuilder IRB(OrigInst);
-      Value *VAListTag = OrigInst->getArgOperand(0);
-      Type *RegSaveAreaPtrTy = PointerType::getUnqual(*MS.C);
-      Value *RegSaveAreaPtrPtr =
-          IRB.CreateIntToPtr(IRB.CreatePtrToInt(VAListTag, MS.IntptrTy),
-                             PointerType::get(*MS.C, 0));
-      Value *RegSaveAreaPtr =
-          IRB.CreateLoad(RegSaveAreaPtrTy, RegSaveAreaPtrPtr);
-      Value *RegSaveAreaShadowPtr, *RegSaveAreaOriginPtr;
-      const DataLayout &DL = F.getDataLayout();
-      unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
-      const Align Alignment = Align(IntptrSize);
-      std::tie(RegSaveAreaShadowPtr, RegSaveAreaOriginPtr) =
-          MSV.getShadowOriginPtr(RegSaveAreaPtr, IRB, IRB.getInt8Ty(),
-                                 Alignment, /*isStore*/ true);
-      IRB.CreateMemCpy(RegSaveAreaShadowPtr, Alignment, VAArgTLSCopy, Alignment,
-                       CopySize);
-    }
+    Constant *TotalVAArgSize =
+        ConstantInt::get(MS.IntptrTy, VAArgOffset - VAArgBase);
+    // Here using VAArgOverflowSizeTLS as VAArgSizeTLS to avoid creation of
+    // a new class member i.e. it is the total size of all VarArgs.
+    IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
   }
 };
 
-// ARM32, Loongarch64, MIPS and RISCV share the same calling conventions
-// regarding VAArgs.
-using VarArgARM32Helper = VarArgGenericHelper;
-using VarArgRISCVHelper = VarArgGenericHelper;
-using VarArgMIPSHelper = VarArgGenericHelper;
-using VarArgLoongArch64Helper = VarArgGenericHelper;
-using VarArgHexagonHelper = VarArgGenericHelper;
+/// Implementation of VarArgHelper that is used for LoongArch64.
+struct VarArgLoongArch64Helper : public VarArgStackModelHelperBase {
+  static const unsigned kGpRegAreaSize = 64;
+  static const unsigned kFpRegAreaSize = 64;
+
+  VarArgLoongArch64Helper(Function &F, MemorySanitizer &MS,
+                          MemorySanitizerVisitor &MSV,
+                          const unsigned VAListTagSize)
+      : VarArgStackModelHelperBase(F, MS, MSV, VAListTagSize) {}
+
+  void flattenAggregate(Type *Ty, SmallVector<Type *, 16> &Fields) {
+    if (auto *STy = dyn_cast<StructType>(Ty)) {
+      unsigned NElems = STy->getNumElements();
+      for (unsigned ElemNo = 0; ElemNo < NElems; ++ElemNo) {
+        flattenAggregate(STy->getElementType(ElemNo), Fields);
+      }
+    } else if (auto *ATy = dyn_cast<ArrayType>(Ty)) {
+      Type *ElemTy = ATy->getElementType();
+      unsigned NElems = ATy->getNumElements();
+      for (unsigned ElemNo = 0; ElemNo < NElems; ++ElemNo) {
+        flattenAggregate(ElemTy, Fields);
+      }
+    } else {
+      Fields.push_back(Ty);
+    }
+  }
+
+  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
+    unsigned VAArgBase = 0;
+    unsigned VAArgOffset = VAArgBase;
+    unsigned FPArgOffset = 0;
+    const DataLayout &DL = F.getDataLayout();
+    unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+    unsigned DoubleSize = DL.getTypeStoreSize(Type::getDoubleTy(*MS.C));
+    Align StackAlign = DL.getStackAlignment().value_or(Align(2 * IntptrSize));
+    for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
+      bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
+      bool IsByVal = CB.paramHasAttr(ArgNo, Attribute::ByVal);
+      bool IsSRet = CB.paramHasAttr(ArgNo, Attribute::StructRet);
+      uint64_t ArgSize = DL.getTypeAllocSize(A->getType());
+      Align ArgAlign = DL.getABITypeAlign(A->getType());
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+      VAArgOffset = alignTo(VAArgOffset, Align(IntptrSize));
+      if (IsByVal || IsSRet) {
+        assert(A->getType()->isPointerTy());
+        assert(!IsSRet || ArgNo == 0U);
+        VAArgOffset += IntptrSize;
+        continue;
+      }
+      if (IsFixed) {
+        if (auto *STy = dyn_cast<StructType>(A->getType())) {
+          SmallVector<Type *, 16> Fields;
+          assert(ArgSize <= 2 * IntptrSize);
+          flattenAggregate(STy, Fields);
+          if (Fields.size() <= 2) {
+            unsigned FPCount = count_if(Fields, [&DL, DoubleSize](Type *Ty) {
+              return Ty->isFloatingPointTy() &&
+                     DL.getTypeStoreSize(Ty) <= DoubleSize;
+            });
+            if (FPCount > 0 &&
+                FPArgOffset + FPCount * DoubleSize <= kFpRegAreaSize) {
+              FPArgOffset += FPCount * DoubleSize;
+              if (FPCount < Fields.size()) {
+                ArgSize = IntptrSize;
+                ArgAlign = Align(IntptrSize);
+              } else {
+                continue;
+              }
+            }
+          }
+        }
+      }
+      if (ArgAlign > IntptrSize &&
+          (VAArgOffset >= VAArgBase + kGpRegAreaSize || !IsFixed)) {
+        if (ArgAlign > StackAlign)
+          ArgAlign = StackAlign;
+        VAArgOffset = alignTo(VAArgOffset, ArgAlign);
+      }
+      if (DL.isBigEndian() && ArgSize < IntptrSize) {
+        // Adjusting the shadow for argument with size < IntptrSize to match the
+        // placement of bits in big endian system
+        VAArgOffset += (IntptrSize - ArgSize);
+      }
+      Value *Base =
+          getShadowPtrForVAArgument(IRB, VAArgOffset - VAArgBase, ArgSize);
+      VAArgOffset += ArgSize;
+      if (IsFixed) {
+        VAArgBase = alignTo(VAArgOffset, IntptrSize);
+        continue;
+      }
+      if (!Base)
+        break;
+      IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
+    }
+
+    Constant *TotalVAArgSize =
+        ConstantInt::get(MS.IntptrTy, VAArgOffset - VAArgBase);
+    // Here using VAArgOverflowSizeTLS as VAArgSizeTLS to avoid creation of
+    // a new class member i.e. it is the total size of all VarArgs.
+    IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
+  }
+};
+
+/// Implementation of VarArgHelper that is used for ARM32 and MIPS.
+struct VarArgNoByValHelper : public VarArgStackModelHelperBase {
+
+  VarArgNoByValHelper(Function &F, MemorySanitizer &MS,
+                      MemorySanitizerVisitor &MSV, const unsigned VAListTagSize)
+      : VarArgStackModelHelperBase(F, MS, MSV, VAListTagSize) {}
+
+  void visitCallBase(CallBase &CB, IRBuilder<> &IRB) override {
+    unsigned VAArgBase = 0;
+    unsigned VAArgOffset = VAArgBase;
+    const DataLayout &DL = F.getDataLayout();
+    unsigned IntptrSize = DL.getTypeStoreSize(MS.IntptrTy);
+    Align StackAlign = DL.getStackAlignment().value_or(Align(2 * IntptrSize));
+    for (const auto &[ArgNo, A] : llvm::enumerate(CB.args())) {
+      bool IsFixed = ArgNo < CB.getFunctionType()->getNumParams();
+      uint64_t ArgSize = DL.getTypeAllocSize(A->getType());
+      Align ArgAlign = DL.getABITypeAlign(A->getType());
+      VAArgOffset = alignTo(VAArgOffset, Align(IntptrSize));
+      assert(!CB.paramHasAttr(ArgNo, Attribute::ByVal));
+      if (CB.paramHasAttr(ArgNo, Attribute::StructRet)) {
+        assert(A->getType()->isPointerTy());
+        assert(ArgNo == 0U);
+        VAArgOffset += IntptrSize;
+        VAArgBase = VAArgOffset;
+        continue;
+      }
+      if (ArgAlign < IntptrSize)
+        ArgAlign = Align(IntptrSize);
+      else if (ArgAlign > StackAlign)
+        ArgAlign = StackAlign;
+      VAArgOffset = alignTo(VAArgOffset, ArgAlign);
+      if (DL.isBigEndian() && ArgSize < IntptrSize) {
+        // Adjusting the shadow for argument with size < IntptrSize to match the
+        // placement of bits in big endian system
+        VAArgOffset += (IntptrSize - ArgSize);
+      }
+      Value *Base =
+          getShadowPtrForVAArgument(IRB, VAArgOffset - VAArgBase, ArgSize);
+      VAArgOffset += ArgSize;
+      if (IsFixed) {
+        VAArgBase = alignTo(VAArgOffset, IntptrSize);
+        continue;
+      }
+      if (!Base)
+        break;
+      IRB.CreateAlignedStore(MSV.getShadow(A), Base, kShadowTLSAlignment);
+    }
+
+    Constant *TotalVAArgSize =
+        ConstantInt::get(MS.IntptrTy, VAArgOffset - VAArgBase);
+    // Here using VAArgOverflowSizeTLS as VAArgSizeTLS to avoid creation of
+    // a new class member i.e. it is the total size of all VarArgs.
+    IRB.CreateStore(TotalVAArgSize, MS.VAArgOverflowSizeTLS);
+  }
+};
+
+// ARM32 and MIPS share the same calling conventions regarding VAArgs.
+using VarArgARM32Helper = VarArgNoByValHelper;
+using VarArgMIPSHelper = VarArgNoByValHelper;
 
 /// A no-op implementation of VarArgHelper.
 struct VarArgNoOpHelper : public VarArgHelper {

--- a/llvm/test/Instrumentation/MemorySanitizer/ARM32/vararg-arm32.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/ARM32/vararg-arm32.ll
@@ -311,7 +311,7 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 776), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 784), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 792), align 8
-; CHECK-NEXT:    store i64 960, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 808, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    store i64 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[RET:%.*]] = call i64 (i64, ...) @sum(i64 120, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i64, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/Hexagon/hexagon.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/Hexagon/hexagon.ll
@@ -10,6 +10,7 @@ define void @Store(ptr nocapture %p, i32 %x) nounwind sanitize_memory {
 ; CHECK-SAME: ptr captures(none) [[P:%.*]], i32 [[X:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP5:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP0]], i32 800)
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[P]] to i32
@@ -23,6 +24,7 @@ define void @Store(ptr nocapture %p, i32 %x) nounwind sanitize_memory {
 ; ORIGIN-SAME: ptr captures(none) [[P:%.*]], i32 [[X:%.*]]) #[[ATTR0:[0-9]+]] {
 ; ORIGIN-NEXT:  [[ENTRY:.*:]]
 ; ORIGIN-NEXT:    [[TMP0:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; ORIGIN-NEXT:    [[TMP8:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP0]], i32 800)
 ; ORIGIN-NEXT:    [[TMP1:%.*]] = load i32, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
 ; ORIGIN-NEXT:    [[TMP2:%.*]] = load i32, ptr getelementptr (i8, ptr @__msan_param_origin_tls, i32 8), align 4
 ; ORIGIN-NEXT:    call void @llvm.donothing()
@@ -51,6 +53,7 @@ define i32 @Load(ptr nocapture %p) nounwind sanitize_memory {
 ; CHECK-SAME: ptr captures(none) [[P:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP5:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP0]], i32 800)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[P]], align 4
 ; CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[P]] to i32
@@ -64,6 +67,7 @@ define i32 @Load(ptr nocapture %p) nounwind sanitize_memory {
 ; ORIGIN-SAME: ptr captures(none) [[P:%.*]]) #[[ATTR0]] {
 ; ORIGIN-NEXT:  [[ENTRY:.*:]]
 ; ORIGIN-NEXT:    [[TMP0:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; ORIGIN-NEXT:    [[TMP8:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP0]], i32 800)
 ; ORIGIN-NEXT:    call void @llvm.donothing()
 ; ORIGIN-NEXT:    [[TMP1:%.*]] = load i32, ptr [[P]], align 4
 ; ORIGIN-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[P]] to i32

--- a/llvm/test/Instrumentation/MemorySanitizer/Hexagon/vararg-hexagon.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/Hexagon/vararg-hexagon.ll
@@ -9,9 +9,8 @@ define i32 @foo(i32 %guard, ...) {
 ; CHECK-LABEL: define i32 @foo(
 ; CHECK-SAME: i32 [[GUARD:%.*]], ...) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
-; CHECK-NEXT:    [[TMP2:%.*]] = alloca i8, i32 [[TMP1]], align 8
-; CHECK-NEXT:    call void @llvm.memset.p0.i32(ptr align 8 [[TMP2]], i8 0, i32 [[TMP1]], i1 false)
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP1]], i32 800)
+; CHECK-NEXT:    [[TMP2:%.*]] = alloca i8, i32 [[TMP3]], align 8
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i32 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[VL:%.*]] = alloca ptr, align 4
@@ -25,13 +24,12 @@ define i32 @foo(i32 %guard, ...) {
 ; CHECK-NEXT:    [[TMP9:%.*]] = inttoptr i32 [[TMP8]] to ptr
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 [[TMP9]], i8 0, i64 12, i1 false)
 ; CHECK-NEXT:    call void @llvm.va_start.p0(ptr [[VL]])
-; CHECK-NEXT:    [[TMP10:%.*]] = ptrtoint ptr [[VL]] to i32
-; CHECK-NEXT:    [[TMP11:%.*]] = inttoptr i32 [[TMP10]] to ptr
+; CHECK-NEXT:    [[TMP11:%.*]] = getelementptr i8, ptr [[VL]], i32 8
 ; CHECK-NEXT:    [[TMP12:%.*]] = load ptr, ptr [[TMP11]], align 4
 ; CHECK-NEXT:    [[TMP13:%.*]] = ptrtoint ptr [[TMP12]] to i32
 ; CHECK-NEXT:    [[TMP14:%.*]] = xor i32 [[TMP13]], 536870912
 ; CHECK-NEXT:    [[TMP15:%.*]] = inttoptr i32 [[TMP14]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP15]], ptr align 4 [[TMP2]], i32 [[TMP1]], i1 false)
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP15]], ptr align 4 [[TMP2]], i32 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.va_end.p0(ptr [[VL]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[VL]])
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
@@ -40,9 +38,8 @@ define i32 @foo(i32 %guard, ...) {
 ; ORIGIN-LABEL: define i32 @foo(
 ; ORIGIN-SAME: i32 [[GUARD:%.*]], ...) {
 ; ORIGIN-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
-; ORIGIN-NEXT:    [[TMP2:%.*]] = alloca i8, i32 [[TMP1]], align 8
-; ORIGIN-NEXT:    call void @llvm.memset.p0.i32(ptr align 8 [[TMP2]], i8 0, i32 [[TMP1]], i1 false)
 ; ORIGIN-NEXT:    [[TMP3:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP1]], i32 800)
+; ORIGIN-NEXT:    [[TMP2:%.*]] = alloca i8, i32 [[TMP3]], align 8
 ; ORIGIN-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i32 [[TMP3]], i1 false)
 ; ORIGIN-NEXT:    call void @llvm.donothing()
 ; ORIGIN-NEXT:    [[VL:%.*]] = alloca ptr, align 4
@@ -61,15 +58,14 @@ define i32 @foo(i32 %guard, ...) {
 ; ORIGIN-NEXT:    [[TMP14:%.*]] = inttoptr i32 [[TMP13]] to ptr
 ; ORIGIN-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 [[TMP12]], i8 0, i64 12, i1 false)
 ; ORIGIN-NEXT:    call void @llvm.va_start.p0(ptr [[VL]])
-; ORIGIN-NEXT:    [[TMP15:%.*]] = ptrtoint ptr [[VL]] to i32
-; ORIGIN-NEXT:    [[TMP16:%.*]] = inttoptr i32 [[TMP15]] to ptr
+; ORIGIN-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[VL]], i32 8
 ; ORIGIN-NEXT:    [[TMP17:%.*]] = load ptr, ptr [[TMP16]], align 4
 ; ORIGIN-NEXT:    [[TMP18:%.*]] = ptrtoint ptr [[TMP17]] to i32
 ; ORIGIN-NEXT:    [[TMP19:%.*]] = xor i32 [[TMP18]], 536870912
 ; ORIGIN-NEXT:    [[TMP20:%.*]] = inttoptr i32 [[TMP19]] to ptr
 ; ORIGIN-NEXT:    [[TMP21:%.*]] = add i32 [[TMP19]], 1342177280
 ; ORIGIN-NEXT:    [[TMP22:%.*]] = inttoptr i32 [[TMP21]] to ptr
-; ORIGIN-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP20]], ptr align 4 [[TMP2]], i32 [[TMP1]], i1 false)
+; ORIGIN-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP20]], ptr align 4 [[TMP2]], i32 [[TMP3]], i1 false)
 ; ORIGIN-NEXT:    call void @llvm.va_end.p0(ptr [[VL]])
 ; ORIGIN-NEXT:    call void @llvm.lifetime.end.p0(ptr [[VL]])
 ; ORIGIN-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/Mips32/vararg-mips.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/Mips32/vararg-mips.ll
@@ -311,7 +311,7 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 776), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 784), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 792), align 8
-; CHECK-NEXT:    store i64 960, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 808, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    store i64 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[RET:%.*]] = call i64 (i64, ...) @sum(i64 120, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i64, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/Mips32/vararg-mipsel.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/Mips32/vararg-mipsel.ll
@@ -310,7 +310,7 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 776), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 784), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 792), align 8
-; CHECK-NEXT:    store i64 960, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 808, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    store i64 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[RET:%.*]] = call i64 (i64, ...) @sum(i64 120, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i64, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/PowerPC32/kernel-ppcle.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/PowerPC32/kernel-ppcle.ll
@@ -21,6 +21,15 @@ define void @Store1(ptr %p, i8 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP13]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP10:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP11]], i32 704)
 ; CHECK-NEXT:    [[_MSARG1:%.*]] = getelementptr i8, ptr [[PARAM_SHADOW]], i32 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i8, ptr [[_MSARG1]], align 8
 ; CHECK-NEXT:    [[_MSARG_O2:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 8
@@ -29,7 +38,7 @@ define void @Store1(ptr %p, i8 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB6:.*]], label %[[BB7:.*]], !prof [[PROF1:![0-9]+]]
 ; CHECK:       [[BB6]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2:[0-9]+]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3:[0-9]+]]
 ; CHECK-NEXT:    br label %[[BB7]]
 ; CHECK:       [[BB7]]:
 ; CHECK-NEXT:    [[TMP15:%.*]] = call { ptr, ptr } @__msan_metadata_ptr_for_store_1(ptr [[P]])
@@ -69,6 +78,15 @@ define void @Store2(ptr %p, i16 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP13]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP10:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP11]], i32 704)
 ; CHECK-NEXT:    [[_MSARG1:%.*]] = getelementptr i8, ptr [[PARAM_SHADOW]], i32 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i16, ptr [[_MSARG1]], align 8
 ; CHECK-NEXT:    [[_MSARG_O2:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 8
@@ -77,7 +95,7 @@ define void @Store2(ptr %p, i16 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB6:.*]], label %[[BB7:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB6]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB7]]
 ; CHECK:       [[BB7]]:
 ; CHECK-NEXT:    [[TMP15:%.*]] = call { ptr, ptr } @__msan_metadata_ptr_for_store_2(ptr [[P]])
@@ -117,6 +135,15 @@ define void @Store4(ptr %p, i32 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP13]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP10:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP11]], i32 704)
 ; CHECK-NEXT:    [[_MSARG1:%.*]] = getelementptr i8, ptr [[PARAM_SHADOW]], i32 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i32, ptr [[_MSARG1]], align 8
 ; CHECK-NEXT:    [[_MSARG_O2:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 8
@@ -125,7 +152,7 @@ define void @Store4(ptr %p, i32 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB6:.*]], label %[[BB7:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB6]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB7]]
 ; CHECK:       [[BB7]]:
 ; CHECK-NEXT:    [[TMP15:%.*]] = call { ptr, ptr } @__msan_metadata_ptr_for_store_4(ptr [[P]])
@@ -165,6 +192,15 @@ define void @Store8(ptr %p, i64 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP13]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP10:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP11]], i32 704)
 ; CHECK-NEXT:    [[_MSARG1:%.*]] = getelementptr i8, ptr [[PARAM_SHADOW]], i32 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i64, ptr [[_MSARG1]], align 8
 ; CHECK-NEXT:    [[_MSARG_O2:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 8
@@ -173,7 +209,7 @@ define void @Store8(ptr %p, i64 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB6:.*]], label %[[BB7:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB6]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB7]]
 ; CHECK:       [[BB7]]:
 ; CHECK-NEXT:    [[TMP15:%.*]] = call { ptr, ptr } @__msan_metadata_ptr_for_store_8(ptr [[P]])
@@ -215,6 +251,15 @@ define void @Store16(ptr %p, i128 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP13]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP10:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP11]], i32 704)
 ; CHECK-NEXT:    [[_MSARG1:%.*]] = getelementptr i8, ptr [[PARAM_SHADOW]], i32 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i128, ptr [[_MSARG1]], align 8
 ; CHECK-NEXT:    [[_MSARG_O2:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 8
@@ -223,7 +268,7 @@ define void @Store16(ptr %p, i128 %x) sanitize_memory {
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB6:.*]], label %[[BB7:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB6]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB7]]
 ; CHECK:       [[BB7]]:
 ; CHECK-NEXT:    [[TMP15:%.*]] = call { ptr, ptr } @__msan_metadata_ptr_for_store_n(ptr [[P]], i32 16)
@@ -269,11 +314,20 @@ define i8 @Load1(ptr %p) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP15:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 15
+; CHECK-NEXT:    [[TMP17:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP17]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB4:.*]], label %[[BB5:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB4]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB5]]
 ; CHECK:       [[BB5]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i8, ptr [[P]], align 1
@@ -309,11 +363,20 @@ define i16 @Load2(ptr %p) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP15:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 15
+; CHECK-NEXT:    [[TMP17:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP17]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB4:.*]], label %[[BB5:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB4]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB5]]
 ; CHECK:       [[BB5]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i16, ptr [[P]], align 2
@@ -349,11 +412,20 @@ define i32 @Load4(ptr %p) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP15:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 15
+; CHECK-NEXT:    [[TMP17:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP17]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB4:.*]], label %[[BB5:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB4]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB5]]
 ; CHECK:       [[BB5]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i32, ptr [[P]], align 4
@@ -389,11 +461,20 @@ define i64 @Load8(ptr %p) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP15:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 15
+; CHECK-NEXT:    [[TMP17:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP17]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB4:.*]], label %[[BB5:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB4]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB5]]
 ; CHECK:       [[BB5]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i64, ptr [[P]], align 8
@@ -429,11 +510,20 @@ define i128 @Load16(ptr %p) sanitize_memory {
 ; CHECK-NEXT:    [[_MSARG_O:%.*]] = getelementptr i8, ptr [[PARAM_ORIGIN]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[_MSARG_O]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VA_ARG_OVERFLOW_SIZE]], align 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i32 [[TMP5]], 4
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP14]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP5]], 8
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP15:%.*]] = lshr i32 [[TMP5]], 12
+; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 15
+; CHECK-NEXT:    [[TMP17:%.*]] = lshr i32 [[TMP5]], 16
+; CHECK-NEXT:    [[TMP18:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP17]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    [[_MSCMP:%.*]] = icmp ne i32 [[TMP2]], 0
 ; CHECK-NEXT:    br i1 [[_MSCMP]], label %[[BB4:.*]], label %[[BB5:.*]], !prof [[PROF1]]
 ; CHECK:       [[BB4]]:
-; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR2]]
+; CHECK-NEXT:    call void @__msan_warning(i32 [[TMP3]]) #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[BB5]]
 ; CHECK:       [[BB5]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = load i128, ptr [[P]], align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/PowerPC32/vararg-ppc.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/PowerPC32/vararg-ppc.ll
@@ -7,7 +7,17 @@ target triple = "powerpc--linux"
 define i32 @foo(i32 %guard, ...) {
 ; CHECK-LABEL: define i32 @foo(
 ; CHECK-SAME: i32 [[GUARD:%.*]], ...) {
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP12:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP12]], 15
+; CHECK-NEXT:    [[TMP19:%.*]] = lshr i32 [[TMP12]], 4
+; CHECK-NEXT:    [[TMP38:%.*]] = and i32 [[TMP19]], 15
+; CHECK-NEXT:    [[TMP39:%.*]] = lshr i32 [[TMP12]], 8
+; CHECK-NEXT:    [[TMP40:%.*]] = and i32 [[TMP39]], 15
+; CHECK-NEXT:    [[TMP42:%.*]] = lshr i32 [[TMP12]], 12
+; CHECK-NEXT:    [[TMP43:%.*]] = and i32 [[TMP42]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP12]], 16
+; CHECK-NEXT:    [[TMP21:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[TMP21]], 96
 ; CHECK-NEXT:    [[TMP2:%.*]] = alloca i8, i32 [[TMP1]], align 8
 ; CHECK-NEXT:    call void @llvm.memset.p0.i32(ptr align 8 [[TMP2]], i8 0, i32 [[TMP1]], i1 false)
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP1]], i32 800)
@@ -26,18 +36,28 @@ define i32 @foo(i32 %guard, ...) {
 ; CHECK-NEXT:    call void @llvm.va_start.p0(ptr [[VL]])
 ; CHECK-NEXT:    [[TMP25:%.*]] = ptrtoint ptr [[VL]] to i32
 ; CHECK-NEXT:    [[TMP11:%.*]] = add i32 [[TMP25]], 8
-; CHECK-NEXT:    [[TMP26:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP1]], i32 32)
 ; CHECK-NEXT:    [[TMP27:%.*]] = inttoptr i32 [[TMP11]] to ptr
 ; CHECK-NEXT:    [[TMP14:%.*]] = load ptr, ptr [[TMP27]], align 4
-; CHECK-NEXT:    [[TMP15:%.*]] = ptrtoint ptr [[TMP14]] to i32
+; CHECK-NEXT:    [[TMP44:%.*]] = getelementptr i8, ptr [[TMP14]], i32 32
+; CHECK-NEXT:    [[TMP45:%.*]] = getelementptr i32, ptr [[TMP14]], i32 [[TMP18]]
+; CHECK-NEXT:    [[TMP26:%.*]] = getelementptr i32, ptr null, i32 [[TMP38]]
+; CHECK-NEXT:    [[TMP46:%.*]] = ptrtoint ptr [[TMP26]] to i32
+; CHECK-NEXT:    [[TMP47:%.*]] = getelementptr double, ptr [[TMP44]], i32 [[TMP40]]
+; CHECK-NEXT:    [[TMP48:%.*]] = getelementptr double, ptr null, i32 [[TMP43]]
+; CHECK-NEXT:    [[TMP49:%.*]] = ptrtoint ptr [[TMP48]] to i32
+; CHECK-NEXT:    [[TMP15:%.*]] = ptrtoint ptr [[TMP45]] to i32
 ; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 2147483647
 ; CHECK-NEXT:    [[TMP13:%.*]] = inttoptr i32 [[TMP16]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP13]], ptr align 4 [[TMP2]], i32 [[TMP26]], i1 false)
-; CHECK-NEXT:    [[TMP33:%.*]] = ptrtoint ptr [[TMP13]] to i32
+; CHECK-NEXT:    [[TMP50:%.*]] = getelementptr i32, ptr [[TMP2]], i32 [[TMP18]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP13]], ptr align 4 [[TMP50]], i32 [[TMP46]], i1 false)
+; CHECK-NEXT:    [[TMP51:%.*]] = ptrtoint ptr [[TMP47]] to i32
+; CHECK-NEXT:    [[TMP36:%.*]] = and i32 [[TMP51]], 2147483647
+; CHECK-NEXT:    [[TMP37:%.*]] = inttoptr i32 [[TMP36]] to ptr
+; CHECK-NEXT:    [[TMP33:%.*]] = ptrtoint ptr [[TMP2]] to i32
 ; CHECK-NEXT:    [[TMP34:%.*]] = add i32 [[TMP33]], 32
 ; CHECK-NEXT:    [[TMP20:%.*]] = inttoptr i32 [[TMP34]] to ptr
-; CHECK-NEXT:    call void @llvm.memset.p0.i32(ptr align 4 [[TMP20]], i8 0, i32 32, i1 false)
-; CHECK-NEXT:    [[TMP21:%.*]] = sub i32 [[TMP1]], [[TMP26]]
+; CHECK-NEXT:    [[TMP41:%.*]] = getelementptr double, ptr [[TMP20]], i32 [[TMP40]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP37]], ptr align 4 [[TMP41]], i32 [[TMP49]], i1 false)
 ; CHECK-NEXT:    [[TMP22:%.*]] = ptrtoint ptr [[VL]] to i32
 ; CHECK-NEXT:    [[TMP23:%.*]] = add i32 [[TMP22]], 4
 ; CHECK-NEXT:    [[TMP24:%.*]] = inttoptr i32 [[TMP23]] to ptr
@@ -46,7 +66,7 @@ define i32 @foo(i32 %guard, ...) {
 ; CHECK-NEXT:    [[TMP35:%.*]] = and i32 [[TMP32]], 2147483647
 ; CHECK-NEXT:    [[TMP17:%.*]] = inttoptr i32 [[TMP35]] to ptr
 ; CHECK-NEXT:    [[TMP29:%.*]] = ptrtoint ptr [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP30:%.*]] = add i32 [[TMP29]], [[TMP26]]
+; CHECK-NEXT:    [[TMP30:%.*]] = add i32 [[TMP29]], 96
 ; CHECK-NEXT:    [[TMP31:%.*]] = inttoptr i32 [[TMP30]] to ptr
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP17]], ptr align 4 [[TMP31]], i32 [[TMP21]], i1 false)
 ; CHECK-NEXT:    call void @llvm.va_end.p0(ptr [[VL]])
@@ -75,6 +95,15 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #1
 define i32 @bar() {
 ; CHECK-LABEL: define i32 @bar() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store i32 0, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
@@ -82,7 +111,8 @@ define i32 @bar() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_param_tls, i32 24), align 8
 ; CHECK-NEXT:    store i32 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 4), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 16, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 32), align 8
+; CHECK-NEXT:    store i32 8241, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, i32 1, i64 2, double 3.000000e+00)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -101,11 +131,20 @@ define i32 @bar() {
 define i32 @bar2() {
 ; CHECK-LABEL: define i32 @bar2() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
-; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 24, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
+; CHECK-NEXT:    store i32 1048577, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, <2 x i64> <i64 1, i64 2>)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -124,11 +163,20 @@ define i32 @bar2() {
 define i32 @bar4() {
 ; CHECK-LABEL: define i32 @bar4() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store [2 x i64] zeroinitializer, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
-; CHECK-NEXT:    store [2 x i64] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 24, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store [2 x i64] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
+; CHECK-NEXT:    store i32 1048577, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, [2 x i64] [i64 1, i64 2])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -144,11 +192,20 @@ define i32 @bar4() {
 define i32 @bar5() {
 ; CHECK-LABEL: define i32 @bar5() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store [2 x i128] zeroinitializer, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
-; CHECK-NEXT:    store [2 x i128] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 40, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store [2 x i128] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
+; CHECK-NEXT:    store i32 2097153, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, [2 x i128] [i128 1, i128 2])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -165,17 +222,22 @@ define i32 @bar6(ptr %arg) {
 ; CHECK-LABEL: define i32 @bar6(
 ; CHECK-SAME: ptr [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP11:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP12:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP14:%.*]] = and i32 [[TMP12]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[ARG]] to i32
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 2147483647
 ; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i32 [[TMP3]] to ptr
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i32 8), i8 0, i64 16, i1 false)
-; CHECK-NEXT:    [[TMP5:%.*]] = ptrtoint ptr [[ARG]] to i32
-; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 2147483647
-; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i32 [[TMP6]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), ptr align 8 [[TMP7]], i64 16, i1 false)
-; CHECK-NEXT:    store i32 24, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i32 1, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP13:%.*]] = call i32 (i32, ...) @foo(i32 0, ptr byval([2 x i64]) align 8 [[ARG]])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -192,17 +254,22 @@ define i32 @bar7(ptr %arg) {
 ; CHECK-LABEL: define i32 @bar7(
 ; CHECK-SAME: ptr [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP11:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP12:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP14:%.*]] = and i32 [[TMP12]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[ARG]] to i32
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 2147483647
 ; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i32 [[TMP3]] to ptr
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i32 8), i8 0, i64 32, i1 false)
-; CHECK-NEXT:    [[TMP5:%.*]] = ptrtoint ptr [[ARG]] to i32
-; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 2147483647
-; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i32 [[TMP6]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), ptr align 8 [[TMP7]], i64 32, i1 false)
-; CHECK-NEXT:    store i32 40, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i32 1, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP13:%.*]] = call i32 (i32, ...) @foo(i32 0, ptr byval([4 x i64]) align 16 [[ARG]])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -221,6 +288,15 @@ define dso_local i64 @many_args() {
 ; CHECK-LABEL: define dso_local i64 @many_args() {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[TMP0]], 15
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP0]], 4
+; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 15
+; CHECK-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP0]], 8
+; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP4]], 15
+; CHECK-NEXT:    [[TMP6:%.*]] = lshr i32 [[TMP0]], 12
+; CHECK-NEXT:    [[TMP7:%.*]] = and i32 [[TMP6]], 15
+; CHECK-NEXT:    [[TMP8:%.*]] = lshr i32 [[TMP0]], 16
+; CHECK-NEXT:    [[TMP9:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP8]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i64 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
@@ -325,14 +401,6 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 16), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 24), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 32), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 40), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 48), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 56), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 64), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 72), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 80), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 88), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 104), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 112), align 8
@@ -421,7 +489,7 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 776), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 784), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 792), align 8
-; CHECK-NEXT:    store i32 968, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i32 61341794, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i64 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[RET:%.*]] = call i64 (i64, ...) @sum(i64 120, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i64, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/PowerPC32/vararg-ppcle.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/PowerPC32/vararg-ppcle.ll
@@ -7,7 +7,17 @@ target triple = "powerpcle--linux"
 define i32 @foo(i32 %guard, ...) {
 ; CHECK-LABEL: define i32 @foo(
 ; CHECK-SAME: i32 [[GUARD:%.*]], ...) {
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP12:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP12]], 15
+; CHECK-NEXT:    [[TMP19:%.*]] = lshr i32 [[TMP12]], 4
+; CHECK-NEXT:    [[TMP38:%.*]] = and i32 [[TMP19]], 15
+; CHECK-NEXT:    [[TMP39:%.*]] = lshr i32 [[TMP12]], 8
+; CHECK-NEXT:    [[TMP40:%.*]] = and i32 [[TMP39]], 15
+; CHECK-NEXT:    [[TMP42:%.*]] = lshr i32 [[TMP12]], 12
+; CHECK-NEXT:    [[TMP43:%.*]] = and i32 [[TMP42]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP12]], 16
+; CHECK-NEXT:    [[TMP21:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[TMP21]], 96
 ; CHECK-NEXT:    [[TMP2:%.*]] = alloca i8, i32 [[TMP1]], align 8
 ; CHECK-NEXT:    call void @llvm.memset.p0.i32(ptr align 8 [[TMP2]], i8 0, i32 [[TMP1]], i1 false)
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP1]], i32 800)
@@ -26,18 +36,28 @@ define i32 @foo(i32 %guard, ...) {
 ; CHECK-NEXT:    call void @llvm.va_start.p0(ptr [[VL]])
 ; CHECK-NEXT:    [[TMP25:%.*]] = ptrtoint ptr [[VL]] to i32
 ; CHECK-NEXT:    [[TMP11:%.*]] = add i32 [[TMP25]], 8
-; CHECK-NEXT:    [[TMP26:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP1]], i32 32)
 ; CHECK-NEXT:    [[TMP27:%.*]] = inttoptr i32 [[TMP11]] to ptr
 ; CHECK-NEXT:    [[TMP14:%.*]] = load ptr, ptr [[TMP27]], align 4
-; CHECK-NEXT:    [[TMP15:%.*]] = ptrtoint ptr [[TMP14]] to i32
+; CHECK-NEXT:    [[TMP44:%.*]] = getelementptr i8, ptr [[TMP14]], i32 32
+; CHECK-NEXT:    [[TMP45:%.*]] = getelementptr i32, ptr [[TMP14]], i32 [[TMP18]]
+; CHECK-NEXT:    [[TMP26:%.*]] = getelementptr i32, ptr null, i32 [[TMP38]]
+; CHECK-NEXT:    [[TMP46:%.*]] = ptrtoint ptr [[TMP26]] to i32
+; CHECK-NEXT:    [[TMP47:%.*]] = getelementptr double, ptr [[TMP44]], i32 [[TMP40]]
+; CHECK-NEXT:    [[TMP48:%.*]] = getelementptr double, ptr null, i32 [[TMP43]]
+; CHECK-NEXT:    [[TMP49:%.*]] = ptrtoint ptr [[TMP48]] to i32
+; CHECK-NEXT:    [[TMP15:%.*]] = ptrtoint ptr [[TMP45]] to i32
 ; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 2147483647
 ; CHECK-NEXT:    [[TMP13:%.*]] = inttoptr i32 [[TMP16]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP13]], ptr align 4 [[TMP2]], i32 [[TMP26]], i1 false)
-; CHECK-NEXT:    [[TMP33:%.*]] = ptrtoint ptr [[TMP13]] to i32
+; CHECK-NEXT:    [[TMP50:%.*]] = getelementptr i32, ptr [[TMP2]], i32 [[TMP18]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP13]], ptr align 4 [[TMP50]], i32 [[TMP46]], i1 false)
+; CHECK-NEXT:    [[TMP51:%.*]] = ptrtoint ptr [[TMP47]] to i32
+; CHECK-NEXT:    [[TMP36:%.*]] = and i32 [[TMP51]], 2147483647
+; CHECK-NEXT:    [[TMP37:%.*]] = inttoptr i32 [[TMP36]] to ptr
+; CHECK-NEXT:    [[TMP33:%.*]] = ptrtoint ptr [[TMP2]] to i32
 ; CHECK-NEXT:    [[TMP34:%.*]] = add i32 [[TMP33]], 32
 ; CHECK-NEXT:    [[TMP20:%.*]] = inttoptr i32 [[TMP34]] to ptr
-; CHECK-NEXT:    call void @llvm.memset.p0.i32(ptr align 4 [[TMP20]], i8 0, i32 32, i1 false)
-; CHECK-NEXT:    [[TMP21:%.*]] = sub i32 [[TMP1]], [[TMP26]]
+; CHECK-NEXT:    [[TMP41:%.*]] = getelementptr double, ptr [[TMP20]], i32 [[TMP40]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP37]], ptr align 4 [[TMP41]], i32 [[TMP49]], i1 false)
 ; CHECK-NEXT:    [[TMP22:%.*]] = ptrtoint ptr [[VL]] to i32
 ; CHECK-NEXT:    [[TMP23:%.*]] = add i32 [[TMP22]], 4
 ; CHECK-NEXT:    [[TMP24:%.*]] = inttoptr i32 [[TMP23]] to ptr
@@ -46,7 +66,7 @@ define i32 @foo(i32 %guard, ...) {
 ; CHECK-NEXT:    [[TMP35:%.*]] = and i32 [[TMP32]], 2147483647
 ; CHECK-NEXT:    [[TMP17:%.*]] = inttoptr i32 [[TMP35]] to ptr
 ; CHECK-NEXT:    [[TMP29:%.*]] = ptrtoint ptr [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP30:%.*]] = add i32 [[TMP29]], [[TMP26]]
+; CHECK-NEXT:    [[TMP30:%.*]] = add i32 [[TMP29]], 96
 ; CHECK-NEXT:    [[TMP31:%.*]] = inttoptr i32 [[TMP30]] to ptr
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 4 [[TMP17]], ptr align 4 [[TMP31]], i32 [[TMP21]], i1 false)
 ; CHECK-NEXT:    call void @llvm.va_end.p0(ptr [[VL]])
@@ -75,6 +95,15 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #1
 define i32 @bar() {
 ; CHECK-LABEL: define i32 @bar() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store i32 0, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
@@ -82,7 +111,8 @@ define i32 @bar() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_param_tls, i32 24), align 8
 ; CHECK-NEXT:    store i32 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 4), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 16, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 32), align 8
+; CHECK-NEXT:    store i32 8241, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, i32 1, i64 2, double 3.000000e+00)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -100,11 +130,20 @@ define i32 @bar() {
 define i32 @bar2() {
 ; CHECK-LABEL: define i32 @bar2() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
-; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 24, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store <2 x i64> zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
+; CHECK-NEXT:    store i32 1048577, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, <2 x i64> <i64 1, i64 2>)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -123,11 +162,20 @@ define i32 @bar2() {
 define i32 @bar4() {
 ; CHECK-LABEL: define i32 @bar4() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store [2 x i64] zeroinitializer, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
-; CHECK-NEXT:    store [2 x i64] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 24, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store [2 x i64] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
+; CHECK-NEXT:    store i32 1048577, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, [2 x i64] [i64 1, i64 2])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -143,11 +191,20 @@ define i32 @bar4() {
 define i32 @bar5() {
 ; CHECK-LABEL: define i32 @bar5() {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP11]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store [2 x i128] zeroinitializer, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
-; CHECK-NEXT:    store [2 x i128] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
-; CHECK-NEXT:    store i32 40, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store [2 x i128] zeroinitializer, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
+; CHECK-NEXT:    store i32 2097153, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 (i32, ...) @foo(i32 0, [2 x i128] [i128 1, i128 2])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -164,17 +221,22 @@ define i32 @bar6(ptr %arg) {
 ; CHECK-LABEL: define i32 @bar6(
 ; CHECK-SAME: ptr [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP11:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP12:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP14:%.*]] = and i32 [[TMP12]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[ARG]] to i32
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 2147483647
 ; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i32 [[TMP3]] to ptr
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i32 8), i8 0, i64 16, i1 false)
-; CHECK-NEXT:    [[TMP5:%.*]] = ptrtoint ptr [[ARG]] to i32
-; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 2147483647
-; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i32 [[TMP6]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), ptr align 8 [[TMP7]], i64 16, i1 false)
-; CHECK-NEXT:    store i32 24, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i32 1, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP13:%.*]] = call i32 (i32, ...) @foo(i32 0, ptr byval([2 x i64]) align 8 [[ARG]])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -191,17 +253,22 @@ define i32 @bar7(ptr %arg) {
 ; CHECK-LABEL: define i32 @bar7(
 ; CHECK-SAME: ptr [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP11:%.*]] = and i32 [[TMP1]], 15
+; CHECK-NEXT:    [[TMP12:%.*]] = lshr i32 [[TMP1]], 4
+; CHECK-NEXT:    [[TMP14:%.*]] = and i32 [[TMP12]], 15
+; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP1]], 8
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 15
+; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP1]], 12
+; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[TMP7]], 15
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i32 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP9]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i32 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[ARG]] to i32
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 2147483647
 ; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i32 [[TMP3]] to ptr
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i32 8), i8 0, i64 32, i1 false)
-; CHECK-NEXT:    [[TMP5:%.*]] = ptrtoint ptr [[ARG]] to i32
-; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP5]], 2147483647
-; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i32 [[TMP6]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), ptr align 8 [[TMP7]], i64 32, i1 false)
-; CHECK-NEXT:    store i32 40, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i32 1, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i32 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[TMP13:%.*]] = call i32 (i32, ...) @foo(i32 0, ptr byval([4 x i64]) align 16 [[ARG]])
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i32, ptr @__msan_retval_tls, align 8
@@ -219,6 +286,15 @@ define dso_local i64 @many_args() {
 ; CHECK-LABEL: define dso_local i64 @many_args() {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[TMP0]], 15
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP0]], 4
+; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 15
+; CHECK-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP0]], 8
+; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP4]], 15
+; CHECK-NEXT:    [[TMP6:%.*]] = lshr i32 [[TMP0]], 12
+; CHECK-NEXT:    [[TMP7:%.*]] = and i32 [[TMP6]], 15
+; CHECK-NEXT:    [[TMP8:%.*]] = lshr i32 [[TMP0]], 16
+; CHECK-NEXT:    [[TMP9:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP8]], i32 704)
 ; CHECK-NEXT:    call void @llvm.donothing()
 ; CHECK-NEXT:    store i64 0, ptr @__msan_param_tls, align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_param_tls, i32 8), align 8
@@ -323,14 +399,6 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 8), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 16), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 24), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 32), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 40), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 48), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 56), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 64), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 72), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 80), align 8
-; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 88), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 96), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 104), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 112), align 8
@@ -419,7 +487,7 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 776), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 784), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i32 792), align 8
-; CHECK-NEXT:    store i32 968, ptr @__msan_va_arg_overflow_size_tls, align 4
+; CHECK-NEXT:    store i32 61341794, ptr @__msan_va_arg_overflow_size_tls, align 4
 ; CHECK-NEXT:    store i64 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[RET:%.*]] = call i64 (i64, ...) @sum(i64 120, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i64, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/RISCV32/vararg-riscv32.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/RISCV32/vararg-riscv32.ll
@@ -311,7 +311,7 @@ define dso_local i64 @many_args() {
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 776), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 784), align 8
 ; CHECK-NEXT:    store i64 0, ptr getelementptr (i8, ptr @__msan_va_arg_tls, i64 792), align 8
-; CHECK-NEXT:    store i64 960, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 808, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    store i64 0, ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    [[RET:%.*]] = call i64 (i64, ...) @sum(i64 120, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1, i64 1)
 ; CHECK-NEXT:    [[_MSRET:%.*]] = load i64, ptr @__msan_retval_tls, align 8

--- a/llvm/test/Instrumentation/MemorySanitizer/i386/vararg_shadow.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/i386/vararg_shadow.ll
@@ -404,11 +404,7 @@ define linkonce_odr dso_local void @_Z4testI7Double4EvT_(ptr noundef byval(%stru
 ; CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], -2147483649
 ; CHECK-NEXT:    [[TMP8:%.*]] = inttoptr i64 [[TMP7]] to ptr
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i64 40), ptr align 8 [[TMP8]], i64 32, i1 false)
-; CHECK-NEXT:    [[TMP11:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP12:%.*]] = and i64 [[TMP11]], -2147483649
-; CHECK-NEXT:    [[TMP13:%.*]] = inttoptr i64 [[TMP12]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 @__msan_va_arg_tls, ptr align 8 [[TMP13]], i64 32, i1 false)
-; CHECK-NEXT:    store i64 32, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 16, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    call void (ptr, i32, ...) @_Z5test2I7Double4EvT_iz(ptr noundef nonnull byval([[STRUCT_DOUBLE4]]) align 8 [[ARG]], i32 noundef 1, ptr noundef nonnull byval([[STRUCT_DOUBLE4]]) align 8 [[ARG]])
 ; CHECK-NEXT:    ret void
 ;
@@ -500,11 +496,7 @@ define linkonce_odr dso_local void @_Z4testI11LongDouble2EvT_(ptr noundef byval(
 ; CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], -2147483649
 ; CHECK-NEXT:    [[TMP8:%.*]] = inttoptr i64 [[TMP7]] to ptr
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i64 40), ptr align 8 [[TMP8]], i64 32, i1 false)
-; CHECK-NEXT:    [[TMP11:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP12:%.*]] = and i64 [[TMP11]], -2147483649
-; CHECK-NEXT:    [[TMP13:%.*]] = inttoptr i64 [[TMP12]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 @__msan_va_arg_tls, ptr align 8 [[TMP13]], i64 32, i1 false)
-; CHECK-NEXT:    store i64 32, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 16, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    call void (ptr, i32, ...) @_Z5test2I11LongDouble2EvT_iz(ptr noundef nonnull byval([[STRUCT_LONGDOUBLE2]]) align 16 [[ARG]], i32 noundef 1, ptr noundef nonnull byval([[STRUCT_LONGDOUBLE2]]) align 16 [[ARG]])
 ; CHECK-NEXT:    ret void
 ;
@@ -535,11 +527,7 @@ define linkonce_odr dso_local void @_Z4testI11LongDouble4EvT_(ptr noundef byval(
 ; CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], -2147483649
 ; CHECK-NEXT:    [[TMP8:%.*]] = inttoptr i64 [[TMP7]] to ptr
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i64 72), ptr align 8 [[TMP8]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP11:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP12:%.*]] = and i64 [[TMP11]], -2147483649
-; CHECK-NEXT:    [[TMP13:%.*]] = inttoptr i64 [[TMP12]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 @__msan_va_arg_tls, ptr align 8 [[TMP13]], i64 64, i1 false)
-; CHECK-NEXT:    store i64 64, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 16, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    call void (ptr, i32, ...) @_Z5test2I11LongDouble4EvT_iz(ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], i32 noundef 1, ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]])
 ; CHECK-NEXT:    ret void
 ;
@@ -561,7 +549,7 @@ define linkonce_odr dso_local void @_Z5test2IcEvT_iz(i8 noundef signext %t, i32 
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -613,7 +601,7 @@ define linkonce_odr dso_local void @_Z5test2IiEvT_iz(i32 noundef %t, i32 noundef
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -657,7 +645,7 @@ define linkonce_odr dso_local void @_Z5test2IfEvT_iz(float noundef %t, i32 nound
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -701,7 +689,7 @@ define linkonce_odr dso_local void @_Z5test2IdEvT_iz(double noundef %t, i32 noun
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -745,7 +733,7 @@ define linkonce_odr dso_local void @_Z5test2IeEvT_iz(x86_fp80 noundef %t, i32 no
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -789,7 +777,7 @@ define linkonce_odr dso_local void @_Z5test2I6IntIntEvT_iz(i64 %t.coerce, i32 no
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -833,7 +821,7 @@ define linkonce_odr dso_local void @_Z5test2I10Int64Int64EvT_iz(i64 %t.coerce0, 
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -877,7 +865,7 @@ define linkonce_odr dso_local void @_Z5test2I12DoubleDoubleEvT_iz(double %t.coer
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -921,7 +909,7 @@ define linkonce_odr dso_local void @_Z5test2I7Double4EvT_iz(ptr noundef byval(%s
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -965,7 +953,7 @@ define linkonce_odr dso_local void @_Z5test2I11DoubleFloatEvT_iz(double %t.coerc
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -1009,7 +997,7 @@ define linkonce_odr dso_local void @_Z5test2I11LongDouble2EvT_iz(ptr noundef byv
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -1053,7 +1041,7 @@ define linkonce_odr dso_local void @_Z5test2I11LongDouble4EvT_iz(ptr noundef byv
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP1]], i64 800)
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP2]], ptr align 8 @__msan_va_arg_tls, i64 [[TMP3]], i1 false)
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[ARGS:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[ARGS]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint ptr [[ARGS]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -2147483649
@@ -1148,55 +1136,7 @@ define linkonce_odr dso_local void @_Z4test3I11LongDouble4EvT_(ptr noundef byval
 ; CHECK-NEXT:    [[TMP37:%.*]] = and i64 [[TMP36]], -2147483649
 ; CHECK-NEXT:    [[TMP38:%.*]] = inttoptr i64 [[TMP37]] to ptr
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_param_tls, i64 712), ptr align 8 [[TMP38]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP41:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP42:%.*]] = and i64 [[TMP41]], -2147483649
-; CHECK-NEXT:    [[TMP43:%.*]] = inttoptr i64 [[TMP42]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 @__msan_va_arg_tls, ptr align 8 [[TMP43]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP44:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP45:%.*]] = and i64 [[TMP44]], -2147483649
-; CHECK-NEXT:    [[TMP46:%.*]] = inttoptr i64 [[TMP45]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 64), ptr align 8 [[TMP46]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP47:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP48:%.*]] = and i64 [[TMP47]], -2147483649
-; CHECK-NEXT:    [[TMP49:%.*]] = inttoptr i64 [[TMP48]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 128), ptr align 8 [[TMP49]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP50:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP51:%.*]] = and i64 [[TMP50]], -2147483649
-; CHECK-NEXT:    [[TMP52:%.*]] = inttoptr i64 [[TMP51]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 192), ptr align 8 [[TMP52]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP53:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP54:%.*]] = and i64 [[TMP53]], -2147483649
-; CHECK-NEXT:    [[TMP55:%.*]] = inttoptr i64 [[TMP54]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 256), ptr align 8 [[TMP55]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP56:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP57:%.*]] = and i64 [[TMP56]], -2147483649
-; CHECK-NEXT:    [[TMP58:%.*]] = inttoptr i64 [[TMP57]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 320), ptr align 8 [[TMP58]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP59:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP60:%.*]] = and i64 [[TMP59]], -2147483649
-; CHECK-NEXT:    [[TMP61:%.*]] = inttoptr i64 [[TMP60]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 384), ptr align 8 [[TMP61]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP62:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP63:%.*]] = and i64 [[TMP62]], -2147483649
-; CHECK-NEXT:    [[TMP64:%.*]] = inttoptr i64 [[TMP63]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 448), ptr align 8 [[TMP64]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP65:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP66:%.*]] = and i64 [[TMP65]], -2147483649
-; CHECK-NEXT:    [[TMP67:%.*]] = inttoptr i64 [[TMP66]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 512), ptr align 8 [[TMP67]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP68:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP69:%.*]] = and i64 [[TMP68]], -2147483649
-; CHECK-NEXT:    [[TMP70:%.*]] = inttoptr i64 [[TMP69]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 576), ptr align 8 [[TMP70]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP71:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP72:%.*]] = and i64 [[TMP71]], -2147483649
-; CHECK-NEXT:    [[TMP73:%.*]] = inttoptr i64 [[TMP72]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 640), ptr align 8 [[TMP73]], i64 64, i1 false)
-; CHECK-NEXT:    [[TMP74:%.*]] = ptrtoint ptr [[ARG]] to i64
-; CHECK-NEXT:    [[TMP75:%.*]] = and i64 [[TMP74]], -2147483649
-; CHECK-NEXT:    [[TMP76:%.*]] = inttoptr i64 [[TMP75]] to ptr
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 getelementptr (i8, ptr @__msan_va_arg_tls, i64 704), ptr align 8 [[TMP76]], i64 64, i1 false)
-; CHECK-NEXT:    store i64 1280, ptr @__msan_va_arg_overflow_size_tls, align 8
+; CHECK-NEXT:    store i64 168, ptr @__msan_va_arg_overflow_size_tls, align 8
 ; CHECK-NEXT:    call void (ptr, i32, ...) @_Z5test2I11LongDouble4EvT_iz(ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], i32 noundef 20, ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]], ptr noundef nonnull byval([[STRUCT_LONGDOUBLE4]]) align 16 [[ARG]])
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
Many ABIs including PowerPC32, ARM32, MIPS32, RISCV32 and others require special handling of byval parameters and proper alignment even for arguments passed in registers.
These requirements are not well-respected by current VarArgHelper impementations which leads to bugs in code passing nontrivial values in variable argument list.
Current patch fixes the problem by respecting ABI requirements.