### PR TITLE
[clang-format] Respect JavaScriptWrapImports with ColumnLimit: 0

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -484,6 +484,14 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
          Style.ColumnLimit > 0)))) {
     return true;
   }
+  // JavaScript import/export statements must not be wrapped when
+  // JavaScriptWrapImports is disabled. Existing line breaks are still kept
+  // (they are preserved outside of mustBreak), so this only prevents new,
+  // forced wrapping, e.g. with ColumnLimit set to 0.
+  if (Style.isJavaScript() && !Style.JavaScriptWrapImports &&
+      State.Line->Type == LT_ImportStatement) {
+    return false;
+  }
   if (CurrentState.BreakBeforeClosingBrace &&
       (Current.closesBlockOrBlockTypeList(Style) ||
        (Current.is(tok::r_brace) && Current.MatchingParen &&

--- a/clang/unittests/Format/FormatTestJS.cpp
+++ b/clang/unittests/Format/FormatTestJS.cpp
@@ -2035,6 +2035,22 @@ TEST_F(FormatTestJS, ImportWrapping) {
                "  }    from\n"
                "      'some/path/longer/than/column/limit/module.js'  ; ",
                Style);
+
+  // https://github.com/llvm/llvm-project/issues/52935
+  // With ColumnLimit = 0 and JavaScriptWrapImports disabled, imports must not
+  // be force-wrapped, while existing line breaks are left as they are.
+  Style = getGoogleJSStyleWithColumns(0);
+  Style.JavaScriptWrapImports = false;
+  verifyFormat("import {aaa, bbb, ccc} from 'abc';", Style);
+  verifyFormat("export {aaa, bbb, ccc} from 'abc';", Style);
+  // Existing line breaks are preserved rather than re-added, so check that the
+  // already-wrapped form is left unchanged (without messing it up first).
+  const char *Wrapped = "import {\n"
+                        "  aaa,\n"
+                        "  bbb,\n"
+                        "  ccc\n"
+                        "} from 'abc';";
+  verifyFormat(Wrapped, Wrapped, Style);
 }
 
 TEST_F(FormatTestJS, TemplateStrings) {


### PR DESCRIPTION
When ColumnLimit is set to 0, clang-format was still wrapping JavaScript import statements even when JavaScriptWrapImports was set to false. This happened because mustBreak() always breaks braced comma lists, and the
ColumnLimit 0 code path never looked at the JavaScriptWrapImports option.

This change skips those forced breaks for import statements when JavaScriptWrapImports is false. The result is:
* A single line import stays on one line.
* An import that was already written across multiple lines keeps its existing line breaks (it is not collapsed or re-wrapped).

Behavior is unchanged in the other cases:
* JavaScriptWrapImports set to true still wraps as before.
* ColumnLimit greater than 0 is unaffected.
* Non-import code such as object literals is unaffected.

A test covering the ColumnLimit 0 case was added to clang/unittests/Format/FormatTestJS.cpp. The full Format unit test suite passes locally.

Fixes #52935
