### PR TITLE
[clang][Driver][SYCL] Fix SYCLInstallationDetector for compiler installs outside sysroot

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -21,7 +21,6 @@ SYCLInstallationDetector::SYCLInstallationDetector(
     : D(D) {
   // When -fsycl is active, locate the SYCL runtime library and record its
   // directory in SYCLRTLibPath for use by the linker.
-  StringRef SysRoot = D.SysRoot;
   SmallString<128> DriverDir(D.Dir);
 
   if (HostTriple.isWindowsMSVCEnvironment() ||
@@ -30,8 +29,7 @@ SYCLInstallationDetector::SYCLInstallationDetector(
     // NOTE: Only checks for LLVMSYCL.lib existence (release variant).
     // Debug vs release library selection happens at link time based on CRT
     // flags.
-    if (DriverDir.starts_with(SysRoot) &&
-        Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
+    if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
       SmallString<128> LibDir(DriverDir);
       llvm::sys::path::append(LibDir, "..", "lib");
 
@@ -52,8 +50,7 @@ SYCLInstallationDetector::SYCLInstallationDetector(
     SmallString<128> FlatLibPath(DriverDir);
     llvm::sys::path::append(FlatLibPath, "..", "lib", "libLLVMSYCL.so");
 
-    if (DriverDir.starts_with(SysRoot) &&
-        Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
+    if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
       // LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON: library is in lib/<triple>/
       if (D.getVFS().exists(LibPath))
         llvm::sys::path::append(DriverDir, "..", "lib", HostTriple.str());

--- a/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
+++ b/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
@@ -6,6 +6,13 @@
 // RUN: touch %t/lib/libLLVMSYCL.so
 // RUN: ln -s %clang %t/bin/clang
 // RUN: %t/bin/clang -### -no-canonical-prefixes --target=x86_64-unknown-linux-gnu -fsycl --sysroot=/nonexistent-prefix %s 2>&1 \
-// RUN:   | FileCheck %s
+// RUN:   | FileCheck -check-prefix=CHECK-FLAT %s
 
-// CHECK: "{{.*}}/bin/../lib/libLLVMSYCL.so"
+// RUN: rm -rf %t && mkdir -p %t/bin %t/lib/x86_64-unknown-linux-gnu
+// RUN: touch %t/lib/x86_64-unknown-linux-gnu/libLLVMSYCL.so
+// RUN: ln -s %clang %t/bin/clang
+// RUN: %t/bin/clang -### -no-canonical-prefixes --target=x86_64-unknown-linux-gnu -fsycl --sysroot=/nonexistent-prefix %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-PER-TARGET %s
+
+// CHECK-FLAT: "{{.*}}/bin/../lib/libLLVMSYCL.so"
+// CHECK-PER-TARGET: "{{.*}}/bin/../lib/x86_64-unknown-linux-gnu/libLLVMSYCL.so"

--- a/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
+++ b/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
@@ -1,0 +1,11 @@
+// REQUIRES: system-linux && symlinks
+
+// Verify we still generate a path to libLLVMSYCL.so even with sysroot set.
+
+// RUN: rm -rf %t && mkdir -p %t/bin %t/lib
+// RUN: touch %t/lib/libLLVMSYCL.so
+// RUN: ln -s %clang %t/bin/clang
+// RUN: %t/bin/clang -### -no-canonical-prefixes --target=x86_64-unknown-linux-gnu -fsycl --sysroot=/nonexistent-prefix %s 2>&1 \
+// RUN:   | FileCheck %s
+
+// CHECK: "{{.*}}/bin/../lib/libLLVMSYCL.so"


### PR DESCRIPTION
Currently if the compiler install is not under SYSROOT, we don't try to compute the relative path to `libLLVMSYCL.so` based on the compiler binary installation directory, resulting us never setting `SYCLRTLibPath` so when we try to geenerate a linker call we get a raw `libLLVMSYCL.so` which fails unless the user happens to be running the compiler from a directory with `libLLVMSYCL.so` inside it.

It seems we never use the result from SYCLInstallationDetector on Windows, so I can't add a test, however change the code to be consistent in case we start to use it in the future.