### PR TITLE
[mlir-c] Fix pattern-set leak in rewrite.c materialization tests

### DIFF
--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -911,6 +911,7 @@ void testTypeConverterSourceMaterialization(MlirContext ctx) {
   mlirRewritePatternSetAdd(patterns,
                            mlirConversionPatternAsRewritePattern(pattern));
   MlirFrozenRewritePatternSet frozen = mlirFreezeRewritePattern(patterns);
+  mlirRewritePatternSetDestroy(patterns);
 
   MlirConversionTarget target = mlirConversionTargetCreate(ctx);
   mlirConversionTargetAddIllegalOp(
@@ -1002,6 +1003,7 @@ void testTypeConverterTargetMaterialization(MlirContext ctx) {
   mlirRewritePatternSetAdd(patterns,
                            mlirConversionPatternAsRewritePattern(pattern));
   MlirFrozenRewritePatternSet frozen = mlirFreezeRewritePattern(patterns);
+  mlirRewritePatternSetDestroy(patterns);
 
   MlirConversionTarget target = mlirConversionTargetCreate(ctx);
   mlirConversionTargetAddIllegalOp(


### PR DESCRIPTION
The `TypeConverter` materialization tests added in #208934 (`testTypeConverterSourceMaterialization` / `testTypeConverterTargetMaterialization`) freeze their `MlirRewritePatternSet` but never destroy it.

This was caught by LeakSanitizer on the aarch64 HWASan bootstrap bot ([builder 55, build 30763](https://lab.llvm.org/buildbot/#/builders/55/builds/30763)):

Fix: call `mlirRewritePatternSetDestroy(patterns)` after freezing in both tests, matching existing usage.

Assisted by: Claude