### PR TITLE
libclc: Use fma and simplify inf handling in half hypot

### DIFF
--- a/libclc/clc/lib/generic/math/clc_hypot.cl
+++ b/libclc/clc/lib/generic/math/clc_hypot.cl
@@ -10,6 +10,7 @@
 #include "clc/float/definitions.h"
 #include "clc/internal/clc.h"
 #include "clc/math/clc_fabs.h"
+#include "clc/math/clc_fma.h"
 #include "clc/math/clc_fmax.h"
 #include "clc/math/clc_frexp_exp.h"
 #include "clc/math/clc_ldexp.h"

--- a/libclc/clc/lib/generic/math/clc_hypot.inc
+++ b/libclc/clc/lib/generic/math/clc_hypot.inc
@@ -47,11 +47,9 @@ _CLC_OVERLOAD _CLC_DEF _CLC_CONST __CLC_GENTYPE __clc_hypot(__CLC_GENTYPE x,
                                                             __CLC_GENTYPE y) {
   __CLC_FLOATN fx = __CLC_CONVERT_FLOATN(x);
   __CLC_FLOATN fy = __CLC_CONVERT_FLOATN(y);
-  __CLC_FLOATN d2 = __clc_mad(fx, fx, fy * fy);
+  __CLC_FLOATN d2 = __clc_fma(fx, fx, fy * fy);
 
-  __CLC_GENTYPE ret = __CLC_CONVERT_HALFN(__clc_sqrt_fast(d2));
-
-  return __clc_isinf(x) || __clc_isinf(y) ? __CLC_GENTYPE_INF : ret;
+  return __CLC_CONVERT_HALFN(__clc_sqrt_fast(d2));
 }
 
 #endif


### PR DESCRIPTION
The inf handling should naturally fall through this sequence without
the explicit check.