### PR TITLE
[MemProf] Fix memprof metadata propagation issue

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -499,6 +499,11 @@ public:
   LLVM_ABI void copyMetadata(const Instruction &SrcInst,
                              ArrayRef<unsigned> WL = ArrayRef<unsigned>());
 
+  /// Copy debug, profile, and memprof metadata from \p SrcInst to this
+  /// instruction without copying alias-analysis or type-dependent metadata.
+  /// TODO: Include additional metadata in the future if appropriate.
+  LLVM_ABI void copyProfileAndDebugMetadata(const Instruction &SrcInst);
+
   /// Erase all metadata that matches the predicate.
   LLVM_ABI void eraseMetadataIf(function_ref<bool(unsigned, MDNode *)> Pred);
 

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -1503,6 +1503,14 @@ void Instruction::swapProfMetadata() {
               MDNode::get(ProfileData->getContext(), Ops));
 }
 
+void Instruction::copyProfileAndDebugMetadata(const Instruction &SrcInst) {
+  // TODO: Include additional metadata in the future if appropriate.
+  static const unsigned SafeIDs[] = {
+      LLVMContext::MD_dbg, LLVMContext::MD_prof, LLVMContext::MD_memprof,
+      LLVMContext::MD_callsite};
+  copyMetadata(SrcInst, SafeIDs);
+}
+
 void Instruction::copyMetadata(const Instruction &SrcInst,
                                ArrayRef<unsigned> WL) {
   if (WL.empty() || is_contained(WL, LLVMContext::MD_dbg))

--- a/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
+++ b/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
@@ -294,7 +294,7 @@ doPromotion(Function *F, FunctionAnalysisManager &FAM,
     NewCS->setAttributes(AttributeList::get(F->getContext(),
                                             CallPAL.getFnAttrs(),
                                             CallPAL.getRetAttrs(), ArgAttrVec));
-    NewCS->copyMetadata(CB, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+    NewCS->copyProfileAndDebugMetadata(CB);
     Args.clear();
     ArgAttrVec.clear();
 

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -3179,7 +3179,7 @@ ChangeStatus Attributor::rewriteFunctionSignatures(
       }
 
       // Copy over various properties and the new attributes.
-      NewCB->copyMetadata(*OldCB, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+      NewCB->copyProfileAndDebugMetadata(*OldCB);
       NewCB->setCallingConv(OldCB->getCallingConv());
       NewCB->takeName(OldCB);
       NewCB->setAttributes(AttributeList::get(

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -181,7 +181,7 @@ bool DeadArgumentEliminationPass::deleteDeadVarargs(Function &F) {
     }
     NewCB->setCallingConv(CB->getCallingConv());
     NewCB->setAttributes(PAL);
-    NewCB->copyMetadata(*CB, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+    NewCB->copyProfileAndDebugMetadata(*CB);
 
     Args.clear();
 
@@ -938,7 +938,7 @@ bool DeadArgumentEliminationPass::removeDeadStuffFromFunction(Function *F) {
     }
     NewCB->setCallingConv(CB.getCallingConv());
     NewCB->setAttributes(NewCallPAL);
-    NewCB->copyMetadata(CB, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+    NewCB->copyProfileAndDebugMetadata(CB);
     Args.clear();
     ArgAttrVec.clear();
 

--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -849,7 +849,7 @@ bool ExpandVariadics::expandCall(Module &M, IRBuilder<> &Builder, CallBase *CB,
   NewCB->setDebugLoc(DebugLoc());
 
   // DeadArgElim and ArgPromotion copy exactly this metadata
-  NewCB->copyMetadata(*CB, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+  NewCB->copyProfileAndDebugMetadata(*CB);
 
   CB->replaceAllUsesWith(NewCB);
   CB->eraseFromParent();

--- a/llvm/test/Transforms/ArgumentPromotion/call_memprof.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/call_memprof.ll
@@ -1,0 +1,21 @@
+; RUN: opt -passes=argpromotion -S < %s | FileCheck %s
+
+; Checks if !memprof and !callsite metadata are preserved in argpromotion.
+
+define internal i32 @test(ptr %p) {
+  %v = load i32, ptr %p
+  ret i32 %v
+}
+
+define void @caller(ptr %p) {
+; CHECK: call i32 @test(i32 %{{.*}}), !memprof ![[MEMPROF:[0-9]+]], !callsite ![[CALLSITE:[0-9]+]]
+  call i32 @test(ptr %p), !memprof !0, !callsite !2
+  ret void
+}
+
+; CHECK: ![[MEMPROF]] = !{![[MIB:[0-9]+]]}
+; CHECK: ![[MIB]] = !{![[CALLSITE]], !"cold"}
+; CHECK: ![[CALLSITE]] = !{i64 123}
+!0 = !{!1}
+!1 = !{!2, !"cold"}
+!2 = !{i64 123}

--- a/llvm/test/Transforms/Attributor/call_memprof.ll
+++ b/llvm/test/Transforms/Attributor/call_memprof.ll
@@ -1,0 +1,23 @@
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor -attributor-manifest-internal -attributor-annotate-decl-cs -S < %s | FileCheck %s
+
+; Checks if !memprof and !callsite metadata are preserved in attributor.
+
+declare void @external_sink()
+
+define void @caller() {
+; CHECK: call void @test(), !memprof ![[MEMPROF:[0-9]+]], !callsite ![[CALLSITE:[0-9]+]]
+  call void @test(i32 1), !memprof !0, !callsite !2
+  ret void
+}
+
+define internal void @test(i32 %dead_arg) {
+  call void @external_sink()
+  ret void
+}
+
+; CHECK: ![[MEMPROF]] = !{![[MIB:[0-9]+]]}
+; CHECK: ![[MIB]] = !{![[CALLSITE]], !"cold"}
+; CHECK: ![[CALLSITE]] = !{i64 123}
+!0 = !{!1}
+!1 = !{!2, !"cold"}
+!2 = !{i64 123}

--- a/llvm/test/Transforms/DeadArgElim/call_memprof.ll
+++ b/llvm/test/Transforms/DeadArgElim/call_memprof.ll
@@ -1,0 +1,20 @@
+; RUN: opt -passes=deadargelim -S < %s | FileCheck %s
+
+; Checks if !memprof and !callsite metadata are preserved in deadargelim.
+
+define void @caller() {
+; CHECK: call void @test(), !memprof ![[MEMPROF:[0-9]+]], !callsite ![[CALLSITE:[0-9]+]]
+  call void @test(i32 1), !memprof !0, !callsite !2
+  ret void
+}
+
+define internal void @test(i32 %dead_arg) {
+  ret void
+}
+
+; CHECK: ![[MEMPROF]] = !{![[MIB:[0-9]+]]}
+; CHECK: ![[MIB]] = !{![[CALLSITE]], !"cold"}
+; CHECK: ![[CALLSITE]] = !{i64 123}
+!0 = !{!1}
+!1 = !{!2, !"cold"}
+!2 = !{i64 123}

--- a/llvm/test/Transforms/ExpandVariadics/call_memprof.ll
+++ b/llvm/test/Transforms/ExpandVariadics/call_memprof.ll
@@ -1,0 +1,16 @@
+; RUN: opt -mtriple=wasm32-unknown-unknown -S --passes=expand-variadics --expand-variadics-override=lowering < %s | FileCheck %s
+
+declare void @sink(...)
+
+define void @caller() {
+; CHECK: call void @sink(ptr %{{.*}}), !memprof ![[MEMPROF:[0-9]+]], !callsite ![[CALLSITE:[0-9]+]]
+  call void (...) @sink(), !memprof !0, !callsite !2
+  ret void
+}
+
+; CHECK: ![[MEMPROF]] = !{![[MIB:[0-9]+]]}
+; CHECK: ![[MIB]] = !{![[CALLSITE]], !"cold"}
+; CHECK: ![[CALLSITE]] = !{i64 123}
+!0 = !{!1}
+!1 = !{!2, !"cold"}
+!2 = !{i64 123}


### PR DESCRIPTION
Fixes a few places where optimizations were dropping memprof related
metadata when creating new calls. Adds a new facility that can be used
to propagate profile and debug metadata, and employs that in the passes
that were manually specifying just MD_prof and MD_dbg.
