### PR TITLE
[SLP]Extend the instruction count check to wide in-loop store roots

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -19199,21 +19199,21 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
   };
   // Reject vectorization if the vector code would produce more instructions
   // than the scalar code. The cost model may underestimate overhead from
-  // shuffles, inserts, and extracts.
+  // shuffles, inserts, and extracts. The same guard also covers wider store
+  // roots inside a loop, where a greedily widened store repeats its
+  // underpriced shuffle overhead on every iteration.
   // FIXME: remove this as soon as correct fractional model is landed for all
   // targets.
+  const TreeEntry &Root = *VectorizableTree.front();
+  const Loop *RootLoop =
+      Root.hasState() ? LI->getLoopFor(Root.getMainOp()->getParent()) : nullptr;
+  bool IsWideStoreRoot = RootLoop && Root.getOpcode() == Instruction::Store &&
+                         Root.getVectorFactor() > 2;
   if (SLPInstCountCheck && TTI->preferSLPInstCountCheck() &&
-      VectorizableTree.front()->getVectorFactor() == 2 &&
+      (Root.getVectorFactor() == 2 || IsWideStoreRoot) &&
       SLPCostThreshold == 0 &&
-      (!SLPReVec ||
-       !isa<VectorType>(
-           VectorizableTree.front()->Scalars.front()->getType()))) {
-    // Loop containing the tree root; null for flat code or disabled
-    // loop-aware modeling. Shared by both calls below.
-    const Loop *TreeLoop = nullptr;
-    if (LoopAwareTripCount != 0 && VectorizableTree.front()->hasState())
-      TreeLoop =
-          LI->getLoopFor(VectorizableTree.front()->getMainOp()->getParent());
+      (!SLPReVec || !isa<VectorType>(Root.Scalars.front()->getType()))) {
+    const Loop *TreeLoop = LoopAwareTripCount != 0 ? RootLoop : nullptr;
     uint64_t NumScalar = getNumScalarInsts(TreeLoop);
     uint64_t NumVector = getNumVectorInsts(TreeLoop);
     LLVM_DEBUG(dbgs() << "SLP: Inst count check: vector=" << NumVector

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/wide-store.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/wide-store.ll
@@ -5,20 +5,25 @@ define void @test(ptr %p, float %conv, i64 %n) {
 ; CHECK-LABEL: define void @test(
 ; CHECK-SAME: ptr [[P:%.*]], float [[CONV:%.*]], i64 [[N:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x float> poison, float [[CONV]], i64 0
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <2 x float> [[TMP0]], <2 x float> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = fsub <2 x float> zeroinitializer, [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = fmul <2 x float> zeroinitializer, [[TMP1]]
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <2 x float> [[TMP2]], <2 x float> [[TMP3]], <2 x i32> <i32 0, i32 3>
 ; CHECK-NEXT:    br label %[[FOR_BODY:.*]]
 ; CHECK:       [[FOR_COND_CLEANUP:.*]]:
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[FOR_BODY]]:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[FOR_BODY]] ]
 ; CHECK-NEXT:    [[OUT:%.*]] = phi ptr [ [[P]], %[[ENTRY]] ], [ [[OUT_NEXT:%.*]], %[[FOR_BODY]] ]
-; CHECK-NEXT:    [[M2:%.*]] = fmul float [[CONV]], 0.000000e+00
+; CHECK-NEXT:    [[TMP5:%.*]] = fadd contract <2 x float> [[TMP4]], <float -0.000000e+00, float 0.000000e+00>
+; CHECK-NEXT:    store <2 x float> [[TMP5]], ptr [[OUT]], align 4
 ; CHECK-NEXT:    [[M3:%.*]] = fmul float [[CONV]], 0.000000e+00
-; CHECK-NEXT:    [[S0:%.*]] = fsub float 0.000000e+00, [[CONV]]
-; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <4 x float> <float poison, float poison, float poison, float -0.000000e+00>, float [[S0]], i64 0
-; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> [[TMP0]], float [[M2]], i64 1
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x float> [[TMP1]], float [[M3]], i64 2
-; CHECK-NEXT:    [[TMP3:%.*]] = fadd contract <4 x float> <float -0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00>, [[TMP2]]
-; CHECK-NEXT:    store <4 x float> [[TMP3]], ptr [[OUT]], align 4
+; CHECK-NEXT:    [[A2:%.*]] = fadd contract float [[M3]], 0.000000e+00
+; CHECK-NEXT:    [[O2:%.*]] = getelementptr inbounds i8, ptr [[OUT]], i64 8
+; CHECK-NEXT:    store float [[A2]], ptr [[O2]], align 4
+; CHECK-NEXT:    [[O3:%.*]] = getelementptr inbounds i8, ptr [[OUT]], i64 12
+; CHECK-NEXT:    store float 0.000000e+00, ptr [[O3]], align 4
 ; CHECK-NEXT:    [[OUT_NEXT]] = getelementptr inbounds i8, ptr [[OUT]], i64 16
 ; CHECK-NEXT:    [[IV_NEXT]] = add i64 [[IV]], 1
 ; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV_NEXT]], [[N]]


### PR DESCRIPTION
The vector-vs-scalar instruction count veto only guarded the two-element
root, letting a greedily widened, marginally profitable store be chosen
over a narrower and more profitable one, paying the extra shuffle overhead
on every loop iteration. Apply the same veto to wider store roots inside a
loop.
