### PR TITLE
[Offload] Add olElfIsCompatibleWithDevice

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -142,3 +142,27 @@ def olGetDeviceInfoSize : Function {
     Return<"OL_ERRC_INVALID_DEVICE">
   ];
 }
+
+def olElfIsCompatibleWithDevice : Function {
+  let desc = "Checks if the given ELF binary is compatible with the specified device.";
+  let details = [
+    "This function determines whether an ELF image can be executed on the specified device."
+  ];
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device to check against", PARAM_IN>,
+    Param<"const void*", "ElfData", "pointer to the ELF image data in memory", PARAM_IN>,
+    Param<"size_t", "ElfSize", "size in bytes of the ELF image", PARAM_IN>,
+    Param<"bool*", "IsCompatible", "set to true if the ELF is compatible, false otherwise", PARAM_OUT>
+  ];
+  let returns = [
+    Return<"OL_ERRC_INVALID_DEVICE", [
+      "If the provided device handle is invalid."
+    ]>,
+    Return<"OL_ERRC_INVALID_ARGUMENT", [
+      "If `ElfData` is null or `ElfSize` is zero."
+    ]>,
+    Return<"OL_ERRC_NULL_POINTER", [
+      "If `IsCompatible` is null."
+    ]>
+  ];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -584,6 +584,23 @@ Error olIterateDevices_impl(ol_device_iterate_cb_t Callback, void *UserData) {
   return Error::success();
 }
 
+Error olElfIsCompatibleWithDevice_impl(ol_device_handle_t Device,
+                                       const void *ElfData, size_t ElfSize,
+                                       bool *IsCompatible) {
+  GenericDeviceTy *DeviceTy = Device->Device;
+  int32_t DeviceId = DeviceTy->getDeviceId();
+  GenericPluginTy &DevicePlugin = DeviceTy->Plugin;
+
+  StringRef Image(reinterpret_cast<const char *>(ElfData), ElfSize);
+
+  Expected<bool> ResultOrErr = DevicePlugin.isELFCompatible(DeviceId, Image);
+  if (!ResultOrErr)
+    return ResultOrErr.takeError();
+
+  *IsCompatible = *ResultOrErr;
+  return Error::success();
+}
+
 TargetAllocTy convertOlToPluginAllocTy(ol_alloc_type_t Type) {
   switch (Type) {
   case OL_ALLOC_TYPE_DEVICE:


### PR DESCRIPTION
The function checks whether an in-memory ELF image is compatible with a specific offload device by forwarding the query to the device’s owning plugin.