### PR TITLE
[libunwind] XFAIL the za unwind test on Apple targets older than OS 27.0

### DIFF
--- a/libunwind/test/aarch64_za_unwind.pass.cpp
+++ b/libunwind/test/aarch64_za_unwind.pass.cpp
@@ -9,6 +9,10 @@
 // REQUIRES: target={{aarch64-.+}}
 // UNSUPPORTED: target={{.*-windows.*}}
 
+// Fails on targets that support SME but where the system libunwind is too old
+// to disable ZA before resuming from unwinding.
+// UNSUPPORTED: stdlib=system && target={{.+}}-apple-{{.*}}{{(11|12|13|14|15|26)(\.\d+)?}}
+
 #include <alloca.h>
 #include <libunwind.h>
 #include <stdint.h>


### PR DESCRIPTION
... when linking against the system unwinder.