### PR TITLE
[llvm-profgen] Guard unwindReturn against zero call address

### DIFF
--- a/llvm/test/tools/llvm-profgen/X86/Inputs/cs-invalid-ret-unwind.perfscript
+++ b/llvm/test/tools/llvm-profgen/X86/Inputs/cs-invalid-ret-unwind.perfscript
@@ -1,9 +1,27 @@
 PERF_RECORD_MMAP2 2854748/2854748: [0x400000(0x1000) @ 0 00:1d 123291722 526021]: r-xp /home/noinline-cs-noprobe.perfbin
-// The 5th LBR entry 0x4005e9/0x400637 is a return (0x4005e9 is `retq` in bar)
-// whose target 0x400637 is NOT preceded by a call instruction (0x400634 is a
-// `mov`). getCallAddrFromFrameAddr(0x400637) returns 0, driving unwindReturn
+// Hand-crafted (synthetic) hybrid CS sample. It is intentionally NOT a
+// self-consistent physical trace: only the return anomaly below matters, and the
+// surrounding LBR entries are filler (e.g. the leaf 0x4005dc is unwound at the
+// `call bar` entry yet bar is re-entered later -- an artifact of the synthetic
+// stack, not something the unwinder relies on).
+//
+// Intended case: the LBR entry 0x4005e9/0x400637 is a return (0x4005e9 is `retq`
+// in bar) whose target 0x400637 is NOT preceded by a call instruction -- 0x400634
+// (the real return site of `call bar` at 0x40062f) is a `mov`; 0x400637 is a
+// `jmp`. So getCallAddrFromFrameAddr(0x400637) returns 0, driving unwindReturn
 // into the zero-address path. Without the guard, switchToFrame(0) trips the
 // "Address can't be zero!" assertion in getOrCreateChildFrame.
+//
+// Such call-less return targets are real, not just synthetic, so the unwinder
+// must tolerate them defensively:
+//   - the LBR is a fixed-depth hardware ring buffer, so a return's paired call
+//     can be truncated off the top of the sampling window;
+//   - perf's software branch synthesis (`perf script --itrace`, and the Arm
+//     CoreSight/CS-ETM decoder) can emit unpaired/standalone entries at
+//     trace-window seams, interrupts, or context switches;
+//   - tail calls, PLT stubs, and returns into prolog/epilog (before the
+//     frame-pointer chain is established) legitimately land on non-post-call
+//     addresses.
 
 	          4005dc
 	          400634

--- a/llvm/test/tools/llvm-profgen/X86/Inputs/cs-invalid-ret-unwind.perfscript
+++ b/llvm/test/tools/llvm-profgen/X86/Inputs/cs-invalid-ret-unwind.perfscript
@@ -1,0 +1,12 @@
+PERF_RECORD_MMAP2 2854748/2854748: [0x400000(0x1000) @ 0 00:1d 123291722 526021]: r-xp /home/noinline-cs-noprobe.perfbin
+// The 5th LBR entry 0x4005e9/0x400637 is a return (0x4005e9 is `retq` in bar)
+// whose target 0x400637 is NOT preceded by a call instruction (0x400634 is a
+// `mov`). getCallAddrFromFrameAddr(0x400637) returns 0, driving unwindReturn
+// into the zero-address path. Without the guard, switchToFrame(0) trips the
+// "Address can't be zero!" assertion in getOrCreateChildFrame.
+
+	          4005dc
+	          400634
+	          400684
+	    7f68c5788793
+ 0x4005c8/0x4005dc/P/-/-/0  0x40062f/0x4005b0/P/-/-/0  0x400645/0x4005ff/P/-/-/0  0x400637/0x400645/P/-/-/0  0x4005e9/0x400637/P/-/-/0  0x4005d7/0x4005e5/P/-/-/0  0x40062f/0x4005b0/P/-/-/0  0x400645/0x4005ff/P/-/-/0  0x400637/0x400645/P/-/-/0  0x4005e9/0x400634/P/-/-/0  0x4005d7/0x4005e5/P/-/-/0  0x40062f/0x4005b0/P/-/-/0

--- a/llvm/test/tools/llvm-profgen/X86/cs-invalid-ret-unwind.test
+++ b/llvm/test/tools/llvm-profgen/X86/cs-invalid-ret-unwind.test
@@ -1,0 +1,12 @@
+; REQUIRES: x86_64-linux
+; Ensure the virtual unwinder tolerates an LBR return whose target is not
+; preceded by a call instruction (getCallAddrFromFrameAddr == 0). Without the
+; guard in unwindReturn this asserts with "Address can't be zero!"; with it, the
+; trace is truncated and a valid profile is still produced.
+
+; RUN: llvm-profgen --format=text --perfscript=%S/Inputs/cs-invalid-ret-unwind.perfscript --binary=%S/Inputs/noinline-cs-noprobe.perfbin --output=%t
+; RUN: FileCheck %s --input-file %t
+
+; CHECK-DAG: main:{{.*}}
+; CHECK-DAG: foo:{{.*}}
+; CHECK-DAG: bar:{{.*}}

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -170,10 +170,22 @@ void VirtualUnwinder::unwindReturn(UnwindState &State) {
   const LBREntry &LBR = State.getCurrentLBR();
   uint64_t CallAddr = Binary->getCallAddrFromFrameAddr(LBR.Target);
   if (!CallAddr) {
-    // The return target is not preceded by a call instruction. This can happen
-    // with a broken LBR trace or a return into a function whose frame-pointer
-    // chain wasn't set up. Stop unwinding the rest of the trace rather than
-    // creating a zero-address frame (mirrors the guard in extractCallstack).
+    // The LBR target is not preceded by a call instruction, so there is no
+    // caller frame to materialize. isReturnState() classifies a branch as a
+    // return from its *source* alone (the source is a `ret`); it never
+    // validates the target, unlike isReturnFromExternal() which does check
+    // getCallAddrFromFrameAddr() != 0. So a `ret` whose recorded target is not
+    // a call-return site reaches here: e.g. a `ret` used as an indirect jump
+    // (retpoline or `push addr; ret` thunks), a non-local exit (longjmp,
+    // _Unwind_Resume, sigreturn), a stale binary whose disassembly no longer
+    // matches the one that was profiled, or synthesized branch records that
+    // pair imperfectly across trace-window seams.
+    //
+    // Truncate the trace rather than materializing a zero-address frame, the
+    // same way extractCallstack() already handles the identical
+    // getCallAddrFromFrameAddr() == 0 case. Note the assert in
+    // getOrCreateChildFrame() only fires with assertions enabled; otherwise a
+    // zero-address frame is silently folded into the profile instead.
     State.setInvalid();
     return;
   }

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -169,6 +169,14 @@ void VirtualUnwinder::unwindReturn(UnwindState &State) {
   // Add extra frame as we unwind through the return
   const LBREntry &LBR = State.getCurrentLBR();
   uint64_t CallAddr = Binary->getCallAddrFromFrameAddr(LBR.Target);
+  if (!CallAddr) {
+    // The return target is not preceded by a call instruction. This can happen
+    // with a broken LBR trace or a return into a function whose frame-pointer
+    // chain wasn't set up. Stop unwinding the rest of the trace rather than
+    // creating a zero-address frame (mirrors the guard in extractCallstack).
+    State.setInvalid();
+    return;
+  }
   State.switchToFrame(CallAddr);
   State.pushFrame(LBR.Source);
   State.InstPtr.update(LBR.Source);


### PR DESCRIPTION
`getCallAddrFromFrameAddr()` returns 0 when an LBR return target is not preceded by a call instruction (broken LBR trace, or a return into a function whose frame-pointer chain wasn't set up). unwindReturn passed that 0 straight to `switchToFrame()`, which asserts in `getOrCreateChildFrame ("Address can't be zero!")`.

Bail out of the trace on a null call address instead, mirroring the existing guard in `extractCallstack`.

Assisted-by: Claude