### PR TITLE
[GlobalISel] Reject physicals in ConstantMatch::match.

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -91,6 +91,8 @@ template <typename ConstT> struct ConstantMatch {
   ConstT &CR;
   ConstantMatch(ConstT &C) : CR(C) {}
   bool match(const MachineRegisterInfo &MRI, Register Reg) {
+    if (Reg.isPhysical())
+      return false;
     if (auto MaybeCst = matchConstant<ConstT>(Reg, MRI)) {
       CR = *MaybeCst;
       return true;

--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -20,6 +20,7 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/IR/InstrTypes.h"
+#include <type_traits>
 
 namespace llvm {
 namespace MIPatternMatch {
@@ -91,8 +92,6 @@ template <typename ConstT> struct ConstantMatch {
   ConstT &CR;
   ConstantMatch(ConstT &C) : CR(C) {}
   bool match(const MachineRegisterInfo &MRI, Register Reg) {
-    if (Reg.isPhysical())
-      return false;
     if (auto MaybeCst = matchConstant<ConstT>(Reg, MRI)) {
       CR = *MaybeCst;
       return true;
@@ -876,7 +875,17 @@ template <typename SrcTy, unsigned Opcode> struct UnaryOp_match {
     MachineInstr *TmpMI;
     if (mi_match(Op, MRI, m_MInstr(TmpMI))) {
       if (TmpMI->getOpcode() == Opcode && TmpMI->getNumOperands() == 2) {
-        return L.match(MRI, TmpMI->getOperand(1).getReg());
+        Register SrcReg = TmpMI->getOperand(1).getReg();
+        // Unlike generic instructions, a COPY's source may be a physical
+        // register, which is not guaranteed to have a single definition.
+        // Reject looking through it (e.g. to match a constant or another
+        // instruction) unless we are just capturing the bare register.
+        if constexpr (Opcode == TargetOpcode::COPY) {
+          if (SrcReg.isPhysical() &&
+              !std::is_same_v<SrcTy, bind_ty<Register>>)
+            return false;
+        }
+        return L.match(MRI, SrcReg);
       }
     }
     return false;

--- a/llvm/unittests/CodeGen/GlobalISel/PatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/PatternMatchTest.cpp
@@ -990,6 +990,32 @@ TEST_F(AArch64GISelMITest, DeferredMatching) {
                        m_GAdd(m_Reg(X), m_GSub(m_Reg(), m_DeferredReg(X)))));
 }
 
+TEST_F(AArch64GISelMITest, MatchCopyWithIntConstantOrPhys) {
+  setUp();
+  if (!TM)
+    GTEST_SKIP();
+  LLT s64 = LLT::scalar(64);
+  auto Cst = B.buildConstant(s64, 42);
+  auto CopyCst = B.buildCopy(s64, Cst);
+  Register PhysReg = MCRegister::FirstPhysicalReg;
+  B.buildCopy(PhysReg, Cst);
+  B.buildCopy(PhysReg, Cst);
+  auto CopyPhys = B.buildCopy(s64, PhysReg);
+  int64_t CstVal;
+  bool match = mi_match(CopyCst.getReg(0), *MRI, m_Copy(m_ICst(CstVal)));
+  EXPECT_TRUE(match);
+  EXPECT_EQ(CstVal, 42);
+  // If the copy source happens to be a physical register, the match should
+  // fail (and we should not assert in getVRegDef).
+  Register X;
+  match = mi_match(CopyPhys.getReg(0), *MRI, m_Copy(m_Reg(X)));
+  EXPECT_TRUE(match);
+  EXPECT_TRUE(X.isPhysical());
+  EXPECT_EQ(X, PhysReg);
+  match = mi_match(CopyPhys.getReg(0), *MRI, m_Copy(m_ICst(CstVal)));
+  EXPECT_FALSE(match);
+}
+
 TEST_F(AArch64GISelMITest, AddLike) {
   setUp();
   if (!TM)


### PR DESCRIPTION
The `m_ICst` MI pattern matcher uses `ConstantMatch::match`, which itself defers to getIConstantVReg{Val,SExtVal}. Both of those assume a virtual register input and will eventually fail when calling `getVRegDef` if a physical is supplied instead. This can happen when the match input is a COPY with a physical source. We reject physicals in `UnaryOp_match` for `COPY` so that clients can obliviously match MIR.