### PR TITLE
[OpenMPIRBuilder] Clear the debug location when emitting reduction helpers

### DIFF
--- a/flang/test/Integration/OpenMP/target-reduction-debug-loc.f90
+++ b/flang/test/Integration/OpenMP/target-reduction-debug-loc.f90
@@ -1,0 +1,43 @@
+!===----------------------------------------------------------------------===!
+! This directory can be used to add Integration tests involving multiple
+! stages of the compiler (for eg. from Fortran to LLVM IR). It should not
+! contain executable tests. We should only add tests here sparingly and only
+! if there is no other way to test. Repeat this message in each test that is
+! added to this directory and sub-directories.
+!===----------------------------------------------------------------------===!
+
+! The device reduction helpers emitted by OpenMPIRBuilder have no debug info of
+! their own. If the builder's current debug location is left set while they are
+! emitted, their instructions carry locations scoped to the enclosing kernel's
+! subprogram. That is latent until the inliner folds a helper into a function
+! that does have a subprogram, at which point the module fails verification with
+! "!dbg attachment points at wrong subprogram for function".
+
+! REQUIRES: amdgpu-registered-target
+
+! RUN: %flang_fc1 -emit-llvm -fopenmp -fopenmp-is-target-device \
+! RUN:   -triple amdgcn-amd-amdhsa -debug-info-kind=standalone -O0 \
+! RUN:   -o - %s | FileCheck %s
+
+subroutine k(a, n, s)
+  real(8), intent(in)  :: a(*)
+  integer, intent(in)  :: n
+  real(8), intent(out) :: s
+  integer :: i
+  s = 0
+  !$omp target teams distribute parallel do reduction(+:s)
+  do i = 1, n
+     s = s + a(i)
+  end do
+end subroutine
+
+! The helpers must be emitted without debug locations, so no !dbg appears
+! between their definition and the closing brace.
+
+! CHECK-LABEL: define internal void @_omp_reduction_shuffle_and_reduce_func
+! CHECK-NOT:     !dbg
+! CHECK:       }
+
+! CHECK-LABEL: define internal void @_omp_reduction_inter_warp_copy_func
+! CHECK-NOT:     !dbg
+! CHECK:       }

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -3526,7 +3526,8 @@ Error OpenMPIRBuilder::emitReductionListCopy(
 Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
     const LocationDescription &Loc, ArrayRef<ReductionInfo> ReductionInfos,
     AttributeList FuncAttrs, ArrayRef<bool> IsByRef) {
-  InsertPointTy SavedIP = Builder.saveIP();
+  // Restores the insertion point and the debug location on the way out.
+  IRBuilder<>::InsertPointGuard IPG(Builder);
   LLVMContext &Ctx = M.getContext();
   FunctionType *FuncTy = FunctionType::get(
       Builder.getVoidTy(), {Builder.getPtrTy(), Builder.getInt32Ty()},
@@ -3540,6 +3541,9 @@ Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
   WcFunc->addParamAttr(1, Attribute::NoUndef);
   BasicBlock *EntryBB = BasicBlock::Create(M.getContext(), "entry", WcFunc);
   Builder.SetInsertPoint(EntryBB);
+  // The helper has no debug info of its own; a location left over from the
+  // caller would be scoped to the caller's subprogram.
+  Builder.SetCurrentDebugLocation(DebugLoc());
 
   // ReduceList: thread local Reduce list.
   // At the stage of the computation when this function is called, partially
@@ -3646,7 +3650,7 @@ Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
 
       // kmpc_barrier.
       InsertPointOrErrorTy BarrierIP1 =
-          createBarrier(LocationDescription(Builder.saveIP(), Loc.DL),
+          createBarrier(LocationDescription(Builder.saveIP(), DebugLoc()),
                         omp::Directive::OMPD_unknown,
                         /* ForceSimpleCall */ false,
                         /* CheckCancelFlag */ true);
@@ -3705,7 +3709,7 @@ Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
       // endif
       emitBlock(MergeBB, Builder.GetInsertBlock()->getParent());
       InsertPointOrErrorTy BarrierIP2 =
-          createBarrier(LocationDescription(Builder.saveIP(), Loc.DL),
+          createBarrier(LocationDescription(Builder.saveIP(), DebugLoc()),
                         omp::Directive::OMPD_unknown,
                         /* ForceSimpleCall */ false,
                         /* CheckCancelFlag */ true);
@@ -3778,7 +3782,6 @@ Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
   }
 
   Builder.CreateRetVoid();
-  Builder.restoreIP(SavedIP);
 
   return WcFunc;
 }
@@ -3786,6 +3789,8 @@ Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
 Expected<Function *> OpenMPIRBuilder::emitShuffleAndReduceFunction(
     ArrayRef<ReductionInfo> ReductionInfos, Function *ReduceFn,
     AttributeList FuncAttrs, ArrayRef<bool> IsByRef) {
+  // Restores the insertion point and the debug location on the way out.
+  IRBuilder<>::InsertPointGuard IPG(Builder);
   LLVMContext &Ctx = M.getContext();
   FunctionType *FuncTy =
       FunctionType::get(Builder.getVoidTy(),
@@ -3806,6 +3811,9 @@ Expected<Function *> OpenMPIRBuilder::emitShuffleAndReduceFunction(
   SarFunc->addParamAttr(3, Attribute::SExt);
   BasicBlock *EntryBB = BasicBlock::Create(M.getContext(), "entry", SarFunc);
   Builder.SetInsertPoint(EntryBB);
+  // The helper has no debug info of its own; a location left over from the
+  // caller would be scoped to the caller's subprogram.
+  Builder.SetCurrentDebugLocation(DebugLoc());
 
   // Thread local Reduce list used to host the values of data to be reduced.
   Argument *ReduceListArg = SarFunc->getArg(0);


### PR DESCRIPTION
Fixes #211385.

The device reduction helpers (`_omp_reduction_shuffle_and_reduce_func`, `_omp_reduction_inter_warp_copy_func` and the four global/list copy and reduce helpers) are created with no debug info of their own, but `Builder`'s current debug location is left set while their bodies are emitted. Their instructions therefore carry `DILocation`s scoped to the enclosing kernel's subprogram.

`Verifier`'s subprogram check only applies to a function that has a `DISubprogram`, so this is latent: the helpers themselves are never flagged. It becomes visible when the inliner folds a helper into a function that does have one.

For a Fortran `target` region with a scalar reduction that happens during the device LTO link:

```
!dbg attachment points at wrong subprogram for function
!99 = distinct !DISubprogram(name: "..._k__l7..omp_par.5", ...)
ptr @..._k__l7..omp_par.5
  %132 = bitcast double %79 to i64, !dbg !148
!148 = !DILocation(line: 7, column: 9, scope: !29)
!29 = distinct !DISubprogram(name: "..._k__l7", ...)     <- the kernel
LLVM ERROR: Broken module found, compilation aborted!
```

How it was narrowed, in case it helps review: the pre-link IR verifies clean at every `-O` level and after `openmp-opt` alone. Reduced to `opt -passes='lto<O3>' <internalize.bc>`, `-opt-bisect-limit` points at `inline` on the outlined region, and dumping that module with `-disable-verify` shows 167 instructions in the outlined function scoped to the kernel's subprogram. Walking the pre-inline module for functions with no `!dbg` attachment that nevertheless carry `DebugLoc`s finds exactly the two helpers used by this reduction, 54 and 5 locations, all scoped to the kernel.

Fix: clear the debug location after switching the insert point into each helper. Applied to all six helpers that follow this pattern, not just the two this reproducer exercises.

Testing:

- new `flang/test/Integration/OpenMP/target-reduction-debug-loc.f90`, which fails without the change
- `llvm/test/Transforms/OpenMP`, 51 pass
- `LLVMFrontendTests --gtest_filter='*OpenMPIRBuilder*'`, 115 pass
- `llvm/test/Transforms`, `flang/test/Lower/OpenMP`, `flang/test/Integration`: 12254 tests, 4 failures, all pre-existing and identical with the patch stashed (`Lower/OpenMP/cfg-conversion-omp.private.f90`, `wsloop-computed-goto.f90`, `wsloop-select-case.f90`, `Transforms/ThinLTOBitcodeWriter/no-type-md.ll`)
- end to end on gfx90a: `-O2 -g`, `-O3 -g` and `-O3 -Rpass-analysis=kernel-resource-usage` all build and the reduction returns the correct value

Note the premerge failure on this PR will be #211393, an unrelated breakage on `main`.

This affects performance-critical applications on large AMD GPU supercomputers, including [MFC](https://github.com/MFlowCode/MFC).

All results above come from validated reproducers and are independently reproducible; they stand on their own.

This was found and root-caused with the assistance of AI tools.
