### PR TITLE
Improving the diagnostic for the orphan header case

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12553,6 +12553,10 @@ def note_unreachable_entity : Note<
   "%select{declaration|definition|default argument declared|"
   "explicit specialization declared|partial specialization declared}0 here "
   "is not %select{visible|reachable|reachable|reachable|reachable|reachable}0">;
+def note_entity_declared_via_orphan_header : Note<
+  "the header declaring this entity is not listed in any module map; it was "
+  "pulled into module '%0' only because another header in that module "
+  "'#include's it non-modularly">;
 def ext_module_import_in_extern_c : ExtWarn<
   "import of C++ module '%0' appears within extern \"C\" language linkage "
   "specification">, DefaultError,

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -5705,6 +5705,22 @@ void Sema::diagnoseMissingImport(SourceLocation UseLoc, const NamedDecl *Decl,
     // -fdiagnostics-show-note-include-stack. We don't care how this
     // declaration was previously reached.
     Diag(DeclLoc, diag::note_unreachable_entity) << (int)MIK;
+
+    // If the declaring header isn't itself listed in any module map,
+    // but some other header in Modules[0] textually includes it, it
+    // should be reported. The owning module is an accident of include
+    // order, header is not explicitly listed in any modulemap.
+    if (OptionalFileEntryRef DeclFile =
+            SourceMgr.getFileEntryRefForID(SourceMgr.getFileID(DeclLoc))) {
+      ModuleMap &Map = PP.getHeaderSearchInfo().getModuleMap();
+      if (!Map.findModuleForHeader(*DeclFile, /*AllowTextual=*/false)) {
+        ModuleMap::KnownHeader Textual =
+            Map.findModuleForHeader(*DeclFile, /*AllowTextual=*/true);
+        if (Textual && Textual.getModule() == Modules[0])
+          Diag(DeclLoc, diag::note_entity_declared_via_orphan_header)
+              << Modules[0]->getFullModuleName();
+      }
+    }
   };
 
   // Weed out duplicates from module list.


### PR DESCRIPTION
Sema::diagnoseMissingImport is being emitted in a special case, when a header is not listed in any modulemap (orphan header). The "missing import" in this case is a bit confusing and requires clarification.