### PR TITLE
[clang][DependencyScanning] Extracting a Driver-free CompilerInstaneWithContext Initializer

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -172,9 +172,8 @@ class CompilerInstanceWithContext {
   int32_t SrcLocOffset = 0;
 
   CompilerInstanceWithContext(dependencies::DependencyScanningWorker &Worker,
-                              StringRef CWD,
-                              const std::vector<std::string> &CMD)
-      : Worker(Worker), CWD(CWD), CommandLine(CMD) {};
+                              StringRef CWD, ArrayRef<std::string> CMD)
+      : Worker(Worker), CWD(CWD), CommandLine(CMD.begin(), CMD.end()) {}
 
   bool initialize(dependencies::DependencyActionController &Controller,
                   std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
@@ -197,6 +196,25 @@ public:
       ArrayRef<std::string> CommandLine,
       dependencies::DependencyActionController &Controller,
       DiagnosticConsumer &DC);
+
+  /// @brief Initialize the compiler instance from an already-lowered cc1
+  ///        commandline (driver-free).
+  /// @param Worker The dependency scanning worker to initialize the compiler
+  ///        instance.
+  /// @param CWD The current working directory.
+  /// @param CC1CommandLine A cc1 command.
+  /// @param DiagEngineWithDiagOpts The diagnostic engine used during scan.
+  /// @param OverlayFS An overlay FS containing the input file, which may be
+  ///        from an in-memory buffer.
+  /// @param Controller A dependency action controller to gather some results.
+  static std::optional<CompilerInstanceWithContext>
+  initializeFromCC1Commandline(
+      dependencies::DependencyScanningWorker &Worker, StringRef CWD,
+      ArrayRef<std::string> CC1CommandLine,
+      std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
+          DiagEngineWithDiagOpts,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
+      dependencies::DependencyActionController &Controller);
 
   /// @brief Initializing the context and the compiler instance.
   ///        This method must be called before calling

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -381,13 +381,9 @@ CompilerInstanceWithContext::initializeFromCommandline(
   if (ModifiedCommandLine.size() >= 2 && ModifiedCommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the
     // compiler instance directly from it.
-    CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD,
-                                              ModifiedCommandLine);
-    if (!CIWithContext.initialize(Controller,
-                                  std::move(DiagEngineWithCmdAndOpts),
-                                  std::move(OverlayFS)))
-      return std::nullopt;
-    return std::move(CIWithContext);
+    return initializeFromCC1Commandline(Tool.Worker, CWD, ModifiedCommandLine,
+                                        std::move(DiagEngineWithCmdAndOpts),
+                                        std::move(OverlayFS), Controller);
   }
 
   // The input command line is either a driver-style command line, or
@@ -400,12 +396,24 @@ CompilerInstanceWithContext::initializeFromCommandline(
 
   std::vector<std::string> CC1CommandLine(MaybeFirstCC1->begin(),
                                           MaybeFirstCC1->end());
-  CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD,
-                                            std::move(CC1CommandLine));
-  if (!CIWithContext.initialize(Controller, std::move(DiagEngineWithCmdAndOpts),
-                                std::move(OverlayFS)))
+  return initializeFromCC1Commandline(Tool.Worker, CWD, CC1CommandLine,
+                                      std::move(DiagEngineWithCmdAndOpts),
+                                      std::move(OverlayFS), Controller);
+}
+
+std::optional<CompilerInstanceWithContext>
+CompilerInstanceWithContext::initializeFromCC1Commandline(
+    DependencyScanningWorker &Worker, StringRef CWD,
+    ArrayRef<std::string> CC1CommandLine,
+    std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
+        DiagEngineWithDiagOpts,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
+    DependencyActionController &Controller) {
+  CompilerInstanceWithContext CIWC(Worker, CWD, CC1CommandLine);
+  if (!CIWC.initialize(Controller, std::move(DiagEngineWithDiagOpts),
+                       std::move(OverlayFS)))
     return std::nullopt;
-  return std::move(CIWithContext);
+  return std::move(CIWC);
 }
 
 llvm::Expected<CompilerInstanceWithContext>


### PR DESCRIPTION
This PR extracts out an initializer of `CompilerInstanceWithContext` that does not depend on any driver code in preperation of moving the `CompilerInstanceWithContext` into `DependencyScanningWorker.cpp` as an implementation detail that is not exposed by any APIs. 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>