### PR TITLE
[libc] Fix missed errno deps for integration tests

### DIFF
--- a/libc/test/integration/src/stdlib/CMakeLists.txt
+++ b/libc/test/integration/src/stdlib/CMakeLists.txt
@@ -25,6 +25,7 @@ if(${LIBC_TARGET_OS} STREQUAL "linux")
     SRCS
       setenv_test.cpp
     DEPENDS
+      libc.src.errno.errno
       libc.src.stdlib.getenv
       libc.src.stdlib.setenv
       libc.src.string.strcmp
@@ -38,6 +39,7 @@ if(${LIBC_TARGET_OS} STREQUAL "linux")
       unsetenv_test.cpp
     DEPENDS
       libc.src.__support.alloc_checker
+      libc.src.errno.errno
       libc.src.stdlib.getenv
       libc.src.stdlib.setenv
       libc.src.stdlib.unsetenv

--- a/libc/test/integration/src/sys/sem/CMakeLists.txt
+++ b/libc/test/integration/src/sys/sem/CMakeLists.txt
@@ -13,6 +13,7 @@ add_integration_test(
     libc.hdr.sys_sem_macros
     libc.hdr.types.struct_sembuf
     libc.src.__support.threads.sleep
+    libc.src.errno.errno
     libc.src.fcntl.open
     libc.src.signal.kill
     libc.src.stdlib.exit


### PR DESCRIPTION
Fullbuild testing pulls in LLVM-libc's errno, which needs to be linked
explicitly.
