### PR TITLE
[github] Move BOLT reviewers to team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 # See https://llvm.org/docs/DeveloperPolicy.html#maintainers as well as the
 # Maintainers.md files in the the respective subproject directories.
 
+/bolt/ @llvm/reviewers-bolt
 /libc/ @llvm/reviewers-libc
 /libcxx/ @llvm/reviewers-libcxx
 /libcxxabi/ @llvm/reviewers-libcxxabi
@@ -173,9 +174,6 @@
 
 # MLIR IRDL-related
 /mlir/**/*IRDL* @moxinilian
-
-# BOLT
-/bolt/ @aaupov @maksfb @rafaelauler @ayermolo @yota9 @paschalis-mpeis @yozhu @yavtuk
 
 # Bazel build system.
 /utils/bazel/ @rupprecht @keith @aaronmondal @googlewalt


### PR DESCRIPTION
Use https://github.com/orgs/llvm/teams/reviewers-bolt in place of reviewers list, similar to runtimes