### PR TITLE
[SSAF] Fix a stage2 test failure with ASan-instrumented clang

### DIFF
--- a/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
+++ b/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
@@ -94,7 +94,10 @@ namespace clang::ssaf {
 volatile int SSAFTestTransformationAnchorSource = 0;
 } // namespace clang::ssaf
 
+// This global causes issue (rdar://182623740) in stage2 with ASan-instrumented
+// clang.
 static TransformationRegistry::Add<TestTransformation>
+    __attribute__((no_sanitize("address")))
     RegisterTestTransformation("test-transformation",
                                "Test transformation for the SSAF "
                                "source-edit-generation lit suite");

--- a/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
+++ b/clang/test/Analysis/Scalable/source-edit-generation/Plugins/TestTransformationPlugin/TestTransformation.cpp
@@ -94,8 +94,8 @@ namespace clang::ssaf {
 volatile int SSAFTestTransformationAnchorSource = 0;
 } // namespace clang::ssaf
 
-// This global causes issue (rdar://182623740) in stage2 with ASan-instrumented
-// clang.
+// This global causes issue in stage2 with ASan-instrumented clang so
+// adding the no-ASan attribute.
 static TransformationRegistry::Add<TestTransformation>
     __attribute__((no_sanitize("address")))
     RegisterTestTransformation("test-transformation",


### PR DESCRIPTION
ASan emits a symbol for a static global in `TestTransformation.cpp` that causes link issues in green dragon.
Added `__attribute__((no_sanitize("address")))` to that static global to fix the test.

rdar://182623740