### PR TITLE
[Offload][OpenMP] Skip RPC callback registration when plugin has no devices

### DIFF
--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -650,6 +650,6 @@ EXTERN void __tgt_register_rpc_callback(unsigned (*Callback)(void *,
     return;
 
   for (auto &Plugin : PM->plugins())
-    if (Plugin.is_initialized())
+    if (Plugin.is_initialized() && Plugin.getNumDevices() > 0)
       Plugin.getRPCServer().registerCallback(Callback);
 }


### PR DESCRIPTION

`__tgt_register_rpc_callback` unconditionally called `Plugin::getRPCServer()` which asserts if the RPC server pointer is null. When a plugin is initialized but its RPC server has not been created (e.g., `NumDevices == 0` in `GenericPluginTy::init()`), this triggers a crash.

Rather than introducing a nullable accessor, guard the call by also checking that the plugin has at least one device. A zero-device plugin has no RPC server to register callbacks with, so the extra check is both correct and sufficient.

Suggested by @jhuber6 in the review of the previous attempt (#210215).