### PR TITLE
[clang-tidy][docs] Generate static analyzer check docs as Markdown

### DIFF
--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -368,8 +368,8 @@ def get_actual_filename(dirname: str, filename: str) -> str:
 # Recreates the list of checks in the docs/clang-tidy/checks directory.
 def update_checks_list(clang_tidy_path: str) -> None:
     docs_dir = os.path.join(clang_tidy_path, "../docs/clang-tidy/checks")
-    filename = os.path.normpath(os.path.join(docs_dir, "list.rst"))
-    # Read the content of the current list.rst file
+    filename = os.path.normpath(os.path.join(docs_dir, "list.md"))
+    # Read the content of the current list.md file.
     with open(filename, "r", encoding="utf8") as f:
         lines = f.readlines()
     # Get all existing docs
@@ -377,12 +377,23 @@ def update_checks_list(clang_tidy_path: str) -> None:
     for subdir in filter(
         lambda s: os.path.isdir(os.path.join(docs_dir, s)), os.listdir(docs_dir)
     ):
+        if subdir == "clang-analyzer":
+            continue
         for file in os.listdir(os.path.join(docs_dir, subdir)):
             # TODO: Stop discovering reST files once all clang-tidy check
             # documentation has been migrated to MyST.
             if os.path.splitext(file)[1] in (".md", ".rst"):
                 doc_files.append((subdir, file))
     doc_files.sort()
+
+    # Filter the file for the rows in the table corresponding to CSA check
+    # aliases.
+    check_alias_lines = lines[lines.index("## Check aliases\n") :]
+    clang_analyzer_alias_rows = [
+        row
+        for row in check_alias_lines
+        if re.match(r"^\| \{doc\}`.*clang-analyzer", row)
+    ]
 
     # We couldn't find the source file from the check name, so try to find the
     # class name that corresponds to the check in the module file.
@@ -528,9 +539,11 @@ def update_checks_list(clang_tidy_path: str) -> None:
                     return match.group(1)
         return None
 
+    def doc_file_stem(doc_file: Tuple[str, str]) -> str:
+        return os.path.splitext(doc_file[1])[0]
+
     def process_doc(doc_file: Tuple[str, str]) -> Tuple[str, Optional[str]]:
-        check_file = os.path.splitext(doc_file[1])[0]
-        check_name = f"{doc_file[0]}-{check_file}"
+        check_name = f"{doc_file[0]}-{doc_file_stem(doc_file)}"
 
         with open(os.path.join(docs_dir, *doc_file), "r", encoding="utf8") as doc:
             content = doc.read()
@@ -544,13 +557,18 @@ def update_checks_list(clang_tidy_path: str) -> None:
 
             return check_name, detect_alias_target(check_name, content)
 
+    def format_doc_ref(label: str, module: str, check_file: str) -> str:
+        return f"{{doc}}`{label} <{module}/{check_file}>`"
+
+    def has_auto_fix_cell(check_name: str) -> str:
+        return has_auto_fix(check_name).strip().strip('"')
+
     def format_link(doc_file: Tuple[str, str]) -> str:
         check_name, match = process_doc(doc_file)
         if not match and check_name and not check_name.startswith("clang-analyzer-"):
-            check_file = os.path.splitext(doc_file[1])[0]
             return (
-                f"   :doc:`{check_name} <{doc_file[0]}/{check_file}>`,"
-                f"{has_auto_fix(check_name)}\n"
+                f"| {format_doc_ref(check_name, doc_file[0], doc_file_stem(doc_file))} | "
+                f"{has_auto_fix_cell(check_name)} |\n"
             )
         else:
             return ""
@@ -558,57 +576,40 @@ def update_checks_list(clang_tidy_path: str) -> None:
     def format_link_alias(doc_file: Tuple[str, str]) -> str:
         check_name, match = process_doc(doc_file)
         is_clang_analyzer = check_name.startswith("clang-analyzer-")
-        if not check_name or (not match and not is_clang_analyzer):
+        if not check_name or is_clang_analyzer or not match:
             return ""
 
         module = doc_file[0]
-        check_file = os.path.splitext(doc_file[1])[0]
-        if is_clang_analyzer:
-            title = f"Clang Static Analyzer {check_file}"
-            # Clang Static Analyzer aliases still need the external redirect
-            # target so list.rst can link to the upstream analyzer docs.
-            with open(os.path.join(docs_dir, *doc_file), "r", encoding="utf8") as doc:
-                content = doc.read()
-            redirect = re.search(r"http-equiv=refresh.*?URL=([^\"'\s]+)", content)
-            # Preserve any anchor in checkers.html as part of the redirect target.
-            target = "" if not redirect else redirect.group(1)
-            autofix = ""
-            ref_begin = ""
-            ref_end = "_"
-        else:
-            # Match neighbour or current-directory doc targets.
-            redirect_parts = re.search(r"^(?:\.\./([^/]+)/)?([^/]+)$", match)
-            assert redirect_parts
-            redirect_module = redirect_parts[1] or module
-            title = f"{redirect_module}-{redirect_parts[2]}"
-            target = f"{redirect_module}/{redirect_parts[2]}"
-            autofix = has_auto_fix(title)
-            ref_begin = ":doc:"
-            ref_end = ""
+        check_file = doc_file_stem(doc_file)
+        # Match neighbour or current-directory doc targets.
+        redirect_parts = re.search(r"^(?:\.\./([^/]+)/)?([^/]+)$", match)
+        assert redirect_parts
+        redirect_module = redirect_parts[1] or module
+        redirect_check = redirect_parts[2]
+        title = f"{redirect_module}-{redirect_check}"
+        redirect = format_doc_ref(title, redirect_module, redirect_check)
+        autofix = has_auto_fix_cell(title)
 
-        if target:
-            # The checker is just a redirect.
-            return (
-                f"   :doc:`{check_name} <{module}/{check_file}>`, "
-                f"{ref_begin}`{title} <{target}>`{ref_end},{autofix}\n"
-            )
-
-        # The checker is just a alias without redirect.
-        return f"   :doc:`{check_name} <{module}/{check_file}>`, {title},{autofix}\n"
+        return (
+            f"| {format_doc_ref(check_name, module, check_file)} | "
+            f"{redirect} | {autofix} |\n"
+        )
 
     print(f"Updating {filename}...")
     with open(filename, "w", encoding="utf8", newline="\n") as f:
         for line in lines:
             f.write(line)
-            if line.strip() == ".. csv-table::":
+            if line == "| Name | Offers fixes |\n":
                 # We dump the checkers
-                f.write('   :header: "Name", "Offers fixes"\n\n')
-                f.writelines(map(format_link, doc_files))
+                f.write("| --- | --- |\n")
+                f.writelines(sorted(filter(None, map(format_link, doc_files))))
                 # and the aliases
-                f.write("\nCheck aliases\n-------------\n\n")
-                f.write(".. csv-table::\n")
-                f.write('   :header: "Name", "Redirect", "Offers fixes"\n\n')
-                f.writelines(map(format_link_alias, doc_files))
+                f.write("\n## Check aliases\n\n")
+                f.write("| Name | Redirect | Offers fixes |\n")
+                f.write("| --- | --- | --- |\n")
+                alias_rows = list(map(format_link_alias, doc_files))
+                alias_rows.extend(clang_analyzer_alias_rows)
+                f.writelines(sorted(filter(None, alias_rows)))
                 break
 
 
@@ -622,16 +623,13 @@ def write_docs(module_path: str, module: str, check_name: str) -> None:
     )
     print(f"Creating {filename}...")
     with open(filename, "w", encoding="utf8", newline="\n") as f:
-        f.write(
-            """```{title} clang-tidy - %(check_name_dashes)s
+        f.write("""```{title} clang-tidy - %(check_name_dashes)s
 ```
 
 # %(check_name_dashes)s
 
 FIXME: Describe what patterns does the check detect and why. Give examples.
-"""
-            % {"check_name_dashes": check_name_dashes}
-        )
+""" % {"check_name_dashes": check_name_dashes})
 
 
 def get_camel_name(check_name: str) -> str:

--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -624,13 +624,16 @@ def write_docs(module_path: str, module: str, check_name: str) -> None:
     )
     print(f"Creating {filename}...")
     with open(filename, "w", encoding="utf8", newline="\n") as f:
-        f.write("""```{title} clang-tidy - %(check_name_dashes)s
+        f.write(
+            """```{title} clang-tidy - %(check_name_dashes)s
 ```
 
 # %(check_name_dashes)s
 
 FIXME: Describe what patterns does the check detect and why. Give examples.
-""" % {"check_name_dashes": check_name_dashes})
+"""
+            % {"check_name_dashes": check_name_dashes}
+        )
 
 
 def get_camel_name(check_name: str) -> str:

--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -377,6 +377,7 @@ def update_checks_list(clang_tidy_path: str) -> None:
     for subdir in filter(
         lambda s: os.path.isdir(os.path.join(docs_dir, s)), os.listdir(docs_dir)
     ):
+        # Static analyzer checks are maintained by gen-static-analyzer-docs.py.
         if subdir == "clang-analyzer":
             continue
         for file in os.listdir(os.path.join(docs_dir, subdir)):

--- a/clang-tools-extra/clang-tidy/performance/NoexceptDestructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptDestructorCheck.cpp
@@ -11,7 +11,7 @@
 
 using namespace clang::ast_matchers;
 
-// FixItHint - comment added to fix list.rst generation in add_new_check.py.
+// FixItHint - comment added to fix list.md generation in add_new_check.py.
 // Do not remove. Fixes are generated in base class.
 
 namespace clang::tidy::performance {

--- a/clang-tools-extra/clang-tidy/performance/NoexceptMoveConstructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptMoveConstructorCheck.cpp
@@ -11,7 +11,7 @@
 
 using namespace clang::ast_matchers;
 
-// FixItHint - comment added to fix list.rst generation in add_new_check.py.
+// FixItHint - comment added to fix list.md generation in add_new_check.py.
 // Do not remove. Fixes are generated in base class.
 
 namespace clang::tidy::performance {

--- a/clang-tools-extra/clang-tidy/performance/NoexceptSwapCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptSwapCheck.cpp
@@ -11,7 +11,7 @@
 
 using namespace clang::ast_matchers;
 
-// FixItHint - comment added to fix list.rst generation in add_new_check.py.
+// FixItHint - comment added to fix list.md generation in add_new_check.py.
 // Do not remove. Fixes are generated in base class.
 
 namespace clang::tidy::performance {

--- a/clang-tools-extra/clang-tidy/tool/check_alphabetical_order.py
+++ b/clang-tools-extra/clang-tidy/tool/check_alphabetical_order.py
@@ -16,7 +16,7 @@ Clang-Tidy Alphabetical Order Checker
 Normalize Clang-Tidy documentation with deterministic sorting for linting/tests.
 
 Behavior:
-- Sort entries in docs/clang-tidy/checks/list.rst csv-table.
+- Sort entries in docs/clang-tidy/checks/list.md Markdown tables.
 - Sort key sections in docs/ReleaseNotes.rst.
 - Detect duplicated entries in 'Changes in existing checks'.
 
@@ -47,16 +47,16 @@ from typing import (
 # items by their label.
 DOC_LABEL_RN_RE: Final = re.compile(r":doc:`(?P<label>[^`<]+)\s*(?:<[^>]+>)?`")
 
-# Matches a single csv-table row line in list.rst that begins with a :doc:
-# reference, capturing the label. Used to extract the sort key per row.
-DOC_LINE_RE: Final = re.compile(r"^\s*:doc:`(?P<label>[^`<]+?)\s*<[^>]+>`.*$")
+# Matches a single Markdown table row line in list.md that begins with a
+# {doc} reference, capturing the label. Used to extract the sort key per row.
+DOC_LINE_RE: Final = re.compile(r"^\|\s*\{doc\}`(?P<label>[^`<]+?)\s*<[^>]+>`.*$")
 
 
 EXTRA_DIR: Final = os.path.join(os.path.dirname(__file__), "../..")
 DOCS_DIR: Final = os.path.join(EXTRA_DIR, "docs")
 CLANG_TIDY_DOCS_DIR: Final = os.path.join(DOCS_DIR, "clang-tidy")
 CHECKS_DOCS_DIR: Final = os.path.join(CLANG_TIDY_DOCS_DIR, "checks")
-LIST_DOC: Final = os.path.join(CHECKS_DOCS_DIR, "list.rst")
+LIST_DOC: Final = os.path.join(CHECKS_DOCS_DIR, "list.md")
 RELEASE_NOTES_DOC: Final = os.path.join(DOCS_DIR, "ReleaseNotes.rst")
 
 
@@ -136,8 +136,16 @@ def write_text(path: str, content: str) -> None:
         f.write(content)
 
 
-def _normalize_list_rst_lines(lines: Sequence[str]) -> List[str]:
-    """Return normalized content of checks list.rst as a list of lines."""
+def _is_markdown_table_header(lines: Sequence[str], index: int) -> bool:
+    return (
+        index + 1 < len(lines)
+        and lines[index].startswith("| Name |")
+        and lines[index + 1].startswith("| ---")
+    )
+
+
+def _normalize_list_md_lines(lines: Sequence[str]) -> List[str]:
+    """Return normalized content of checks list.md as a list of lines."""
     out: List[str] = []
     i = 0
     n = len(lines)
@@ -148,19 +156,13 @@ def _normalize_list_rst_lines(lines: Sequence[str]) -> List[str]:
         return (1, "")
 
     while i < n:
-        line = lines[i]
-        if line.lstrip().startswith(".. csv-table::"):
-            out.append(line)
-            i += 1
-
-            while i < n and (lines[i].startswith(" ") or lines[i].strip() == ""):
-                if DOC_LINE_RE.match(lines[i]):
-                    break
-                out.append(lines[i])
-                i += 1
+        if _is_markdown_table_header(lines, i):
+            out.append(lines[i])
+            out.append(lines[i + 1])
+            i += 2
 
             entries: List[str] = []
-            while i < n and lines[i].startswith(" "):
+            while i < n and lines[i].startswith("| "):
                 entries.append(lines[i])
                 i += 1
 
@@ -168,16 +170,16 @@ def _normalize_list_rst_lines(lines: Sequence[str]) -> List[str]:
             out.extend(entries_sorted)
             continue
 
-        out.append(line)
+        out.append(lines[i])
         i += 1
 
     return out
 
 
-def normalize_list_rst(data: str) -> str:
-    """Normalize list.rst content and return a string."""
+def normalize_list_md(data: str) -> str:
+    """Normalize list.md content and return a string."""
     lines = data.splitlines(True)
-    return "".join(_normalize_list_rst_lines(lines))
+    return "".join(_normalize_list_md_lines(lines))
 
 
 def find_heading(lines: Sequence[str], title: str) -> Optional[int]:
@@ -395,11 +397,11 @@ def process_release_notes(out_path: str, rn_doc: str) -> int:
 
 def process_checks_list(out_path: str, list_doc: str) -> int:
     text = read_text(list_doc)
-    normalized = normalize_list_rst(text)
+    normalized = normalize_list_md(text)
 
     if text != normalized:
         sys.stderr.write(
-            "\nChecks in 'clang-tools-extra/docs/clang-tidy/checks/list.rst' csv-table are not alphabetically sorted.\n"
+            "\nChecks in 'clang-tools-extra/docs/clang-tidy/checks/list.md' tables are not alphabetically sorted.\n"
             "Fix the ordering by applying diff printed below.\n\n"
         )
 

--- a/clang-tools-extra/clang-tidy/tool/check_alphabetical_order_test.py
+++ b/clang-tools-extra/clang-tidy/tool/check_alphabetical_order_test.py
@@ -16,32 +16,26 @@ import unittest
 
 
 class TestAlphabeticalOrderCheck(unittest.TestCase):
-    def test_normalize_list_rst_sorts_rows(self) -> None:
-        input_text = textwrap.dedent(
-            """\
-            .. csv-table:: Clang-Tidy checks
-               :header: "Name", "Offers fixes"
+    def test_normalize_list_md_sorts_rows(self) -> None:
+        input_text = textwrap.dedent("""\
+            | Name | Offers fixes |
+            | --- | --- |
+            | {doc}`bugprone-virtual-near-miss <bugprone/virtual-near-miss>` | Yes |
+            | {doc}`cert-flp30-c <cert/flp30-c>` |  |
+            | {doc}`abseil-cleanup-ctad <abseil/cleanup-ctad>` | Yes |
+            | A non-doc row that should stay after docs |  |
+            """)
 
-               :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes"
-               :doc:`cert-flp30-c <cert/flp30-c>`,
-               :doc:`abseil-cleanup-ctad <abseil/cleanup-ctad>`, "Yes"
-               A non-doc row that should stay after docs
-            """
-        )
+        expected_text = textwrap.dedent("""\
+            | Name | Offers fixes |
+            | --- | --- |
+            | {doc}`abseil-cleanup-ctad <abseil/cleanup-ctad>` | Yes |
+            | {doc}`bugprone-virtual-near-miss <bugprone/virtual-near-miss>` | Yes |
+            | {doc}`cert-flp30-c <cert/flp30-c>` |  |
+            | A non-doc row that should stay after docs |  |
+            """)
 
-        expected_text = textwrap.dedent(
-            """\
-            .. csv-table:: Clang-Tidy checks
-               :header: "Name", "Offers fixes"
-
-               :doc:`abseil-cleanup-ctad <abseil/cleanup-ctad>`, "Yes"
-               :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes"
-               :doc:`cert-flp30-c <cert/flp30-c>`,
-               A non-doc row that should stay after docs
-            """
-        )
-
-        out_str = _mod.normalize_list_rst(input_text)
+        out_str = _mod.normalize_list_md(input_text)
         self.assertEqual(out_str, expected_text)
 
     def test_find_heading(self) -> None:
@@ -403,20 +397,17 @@ class TestAlphabeticalOrderCheck(unittest.TestCase):
         self.assertEqual(out, expected_out)
 
     def test_process_checks_list_normalizes_output(self) -> None:
-        list_text = textwrap.dedent(
-            """\
-            .. csv-table:: List
-               :header: "Name", "Redirect", "Offers fixes"
-
-               :doc:`cert-dcl16-c <cert/dcl16-c>`, :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes"
-               :doc:`cert-con36-c <cert/con36-c>`, :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,
-               :doc:`cert-dcl37-c <cert/dcl37-c>`, :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
-               :doc:`cert-arr39-c <cert/arr39-c>`, :doc:`bugprone-sizeof-expression <bugprone/sizeof-expression>`,
-            """
-        )
+        list_text = textwrap.dedent("""\
+            | Name | Redirect | Offers fixes |
+            | --- | --- | --- |
+            | {doc}`cert-dcl16-c <cert/dcl16-c>` | {doc}`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>` | Yes |
+            | {doc}`cert-con36-c <cert/con36-c>` | {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
+            | {doc}`cert-dcl37-c <cert/dcl37-c>` | {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
+            | {doc}`cert-arr39-c <cert/arr39-c>` | {doc}`bugprone-sizeof-expression <bugprone/sizeof-expression>` |  |
+            """)
         with tempfile.TemporaryDirectory() as td:
-            in_doc = os.path.join(td, "list.rst")
-            out_doc = os.path.join(td, "out.rst")
+            in_doc = os.path.join(td, "list.md")
+            out_doc = os.path.join(td, "out.md")
             with open(in_doc, "w", encoding="utf-8") as f:
                 f.write(list_text)
             buf = io.StringIO()
@@ -424,24 +415,21 @@ class TestAlphabeticalOrderCheck(unittest.TestCase):
                 rc = _mod.process_checks_list(out_doc, in_doc)
             self.assertEqual(rc, 0)
             self.assertIn(
-                "Checks in 'clang-tools-extra/docs/clang-tidy/checks/list.rst' csv-table are not alphabetically sorted.",
+                "Checks in 'clang-tools-extra/docs/clang-tidy/checks/list.md' tables are not alphabetically sorted.",
                 buf.getvalue(),
             )
             self.assertEqual(rc, 0)
             with open(out_doc, "r", encoding="utf-8") as f:
                 out = f.read()
 
-            expected_out = textwrap.dedent(
-                """\
-                .. csv-table:: List
-                   :header: "Name", "Redirect", "Offers fixes"
-
-                   :doc:`cert-arr39-c <cert/arr39-c>`, :doc:`bugprone-sizeof-expression <bugprone/sizeof-expression>`,
-                   :doc:`cert-con36-c <cert/con36-c>`, :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,
-                   :doc:`cert-dcl16-c <cert/dcl16-c>`, :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes"
-                   :doc:`cert-dcl37-c <cert/dcl37-c>`, :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
-                """
-            )
+            expected_out = textwrap.dedent("""\
+                | Name | Redirect | Offers fixes |
+                | --- | --- | --- |
+                | {doc}`cert-arr39-c <cert/arr39-c>` | {doc}`bugprone-sizeof-expression <bugprone/sizeof-expression>` |  |
+                | {doc}`cert-con36-c <cert/con36-c>` | {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
+                | {doc}`cert-dcl16-c <cert/dcl16-c>` | {doc}`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>` | Yes |
+                | {doc}`cert-dcl37-c <cert/dcl37-c>` | {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
+                """)
             self.assertEqual(out, expected_out)
 
 

--- a/clang-tools-extra/clang-tidy/tool/check_alphabetical_order_test.py
+++ b/clang-tools-extra/clang-tidy/tool/check_alphabetical_order_test.py
@@ -17,23 +17,27 @@ import unittest
 
 class TestAlphabeticalOrderCheck(unittest.TestCase):
     def test_normalize_list_md_sorts_rows(self) -> None:
-        input_text = textwrap.dedent("""\
+        input_text = textwrap.dedent(
+            """\
             | Name | Offers fixes |
             | --- | --- |
             | {doc}`bugprone-virtual-near-miss <bugprone/virtual-near-miss>` | Yes |
             | {doc}`cert-flp30-c <cert/flp30-c>` |  |
             | {doc}`abseil-cleanup-ctad <abseil/cleanup-ctad>` | Yes |
             | A non-doc row that should stay after docs |  |
-            """)
+            """
+        )
 
-        expected_text = textwrap.dedent("""\
+        expected_text = textwrap.dedent(
+            """\
             | Name | Offers fixes |
             | --- | --- |
             | {doc}`abseil-cleanup-ctad <abseil/cleanup-ctad>` | Yes |
             | {doc}`bugprone-virtual-near-miss <bugprone/virtual-near-miss>` | Yes |
             | {doc}`cert-flp30-c <cert/flp30-c>` |  |
             | A non-doc row that should stay after docs |  |
-            """)
+            """
+        )
 
         out_str = _mod.normalize_list_md(input_text)
         self.assertEqual(out_str, expected_text)
@@ -397,14 +401,16 @@ class TestAlphabeticalOrderCheck(unittest.TestCase):
         self.assertEqual(out, expected_out)
 
     def test_process_checks_list_normalizes_output(self) -> None:
-        list_text = textwrap.dedent("""\
+        list_text = textwrap.dedent(
+            """\
             | Name | Redirect | Offers fixes |
             | --- | --- | --- |
             | {doc}`cert-dcl16-c <cert/dcl16-c>` | {doc}`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>` | Yes |
             | {doc}`cert-con36-c <cert/con36-c>` | {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
             | {doc}`cert-dcl37-c <cert/dcl37-c>` | {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
             | {doc}`cert-arr39-c <cert/arr39-c>` | {doc}`bugprone-sizeof-expression <bugprone/sizeof-expression>` |  |
-            """)
+            """
+        )
         with tempfile.TemporaryDirectory() as td:
             in_doc = os.path.join(td, "list.md")
             out_doc = os.path.join(td, "out.md")
@@ -422,14 +428,16 @@ class TestAlphabeticalOrderCheck(unittest.TestCase):
             with open(out_doc, "r", encoding="utf-8") as f:
                 out = f.read()
 
-            expected_out = textwrap.dedent("""\
+            expected_out = textwrap.dedent(
+                """\
                 | Name | Redirect | Offers fixes |
                 | --- | --- | --- |
                 | {doc}`cert-arr39-c <cert/arr39-c>` | {doc}`bugprone-sizeof-expression <bugprone/sizeof-expression>` |  |
                 | {doc}`cert-con36-c <cert/con36-c>` | {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
                 | {doc}`cert-dcl16-c <cert/dcl16-c>` | {doc}`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>` | Yes |
                 | {doc}`cert-dcl37-c <cert/dcl37-c>` | {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
-                """)
+                """
+            )
             self.assertEqual(out, expected_out)
 
 

--- a/clang-tools-extra/clang-tidy/tool/check_update_docs.py
+++ b/clang-tools-extra/clang-tidy/tool/check_update_docs.py
@@ -15,7 +15,7 @@ Clang-Tidy Check List Checker
 
 This wrapper script runs `add_new_check.py --update-docs` on
 a temporary copy of clang-tools-extra/{clang-tidy,docs} and
-writes the generated docs/clang-tidy/checks/list.rst to the
+writes the generated docs/clang-tidy/checks/list.md to the
 requested output path.
 """
 
@@ -32,7 +32,7 @@ from typing import Final, Sequence
 EXTRA_DIR: Final = os.path.join(os.path.dirname(__file__), "../..")
 CLANG_TIDY_DIR: Final = os.path.join(EXTRA_DIR, "clang-tidy")
 DOCS_DIR: Final = os.path.join(EXTRA_DIR, "docs")
-LIST_DOC: Final = os.path.join(DOCS_DIR, "clang-tidy", "checks", "list.rst")
+LIST_DOC: Final = os.path.join(DOCS_DIR, "clang-tidy", "checks", "list.md")
 
 
 def read_text(path: str) -> str:
@@ -67,9 +67,7 @@ def generate_updated_list() -> str:
             text=True,
         )
 
-        return read_text(
-            os.path.join(temp_docs_dir, "clang-tidy", "checks", "list.rst")
-        )
+        return read_text(os.path.join(temp_docs_dir, "clang-tidy", "checks", "list.md"))
 
 
 def main(argv: Sequence[str]) -> int:
@@ -82,7 +80,7 @@ def main(argv: Sequence[str]) -> int:
 
     if read_text(LIST_DOC) != generated:
         sys.stderr.write(
-            "\n'clang-tools-extra/docs/clang-tidy/checks/list.rst' is out of date.\n"
+            "\n'clang-tools-extra/docs/clang-tidy/checks/list.md' is out of date.\n"
             "Fix it by running 'clang-tools-extra/clang-tidy/add_new_check.py --update-docs'.\n\n"
         )
 

--- a/clang-tools-extra/docs/clang-tidy/Contributing.rst
+++ b/clang-tools-extra/docs/clang-tidy/Contributing.rst
@@ -166,7 +166,7 @@ The ``add_new_check.py`` script will:
     register it in the module and in the build system;
   * create a lit test file in the ``test/clang-tidy/`` directory;
   * create a documentation file and include it into the
-    ``docs/clang-tidy/checks/list.rst``.
+    ``docs/clang-tidy/checks/list.md``.
 
 Let's look at the check class definition in more detail:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.BitwiseShift.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.BitwiseShift.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.BitwiseShift
+```{title} clang-tidy - clang-analyzer-core.BitwiseShift
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift
+```
 
-clang-analyzer-core.BitwiseShift
-================================
+# clang-analyzer-core.BitwiseShift
 
 Finds cases where bitwise shift operation causes undefined behaviour.
 
 The `clang-analyzer-core.BitwiseShift` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.CallAndMessage.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.CallAndMessage.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-core.CallAndMessage
+```{title} clang-tidy - clang-analyzer-core.CallAndMessage
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage
+```
 
-clang-analyzer-core.CallAndMessage
-==================================
+# clang-analyzer-core.CallAndMessage
 
 Check for logical errors for function calls and Objective-C message expressions
 (e.g., uninitialized arguments, null function pointers).
 
 The `clang-analyzer-core.CallAndMessage` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.DivideZero.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.DivideZero.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.DivideZero
+```{title} clang-tidy - clang-analyzer-core.DivideZero
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero
+```
 
-clang-analyzer-core.DivideZero
-==============================
+# clang-analyzer-core.DivideZero
 
 Check for division by zero.
 
 The `clang-analyzer-core.DivideZero` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-core.NonNullParamChecker
+```{title} clang-tidy - clang-analyzer-core.NonNullParamChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker
+```
 
-clang-analyzer-core.NonNullParamChecker
-=======================================
+# clang-analyzer-core.NonNullParamChecker
 
 Check for null pointers passed as arguments to a function whose arguments are
 references or marked with the 'nonnull' attribute.
 
 The `clang-analyzer-core.NonNullParamChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NullDereference.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NullDereference.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.NullDereference
+```{title} clang-tidy - clang-analyzer-core.NullDereference
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference
+```
 
-clang-analyzer-core.NullDereference
-===================================
+# clang-analyzer-core.NullDereference
 
 Check for dereferences of null pointers.
 
 The `clang-analyzer-core.NullDereference` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NullPointerArithm.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NullPointerArithm.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-core.NullPointerArithm
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-nullpointerarithm
+```
+
+# clang-analyzer-core.NullPointerArithm
+
+Check for undefined arithmetic operations on null pointers.
+
+The `clang-analyzer-core.NullPointerArithm` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-nullpointerarithm)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.StackAddressEscape
+```{title} clang-tidy - clang-analyzer-core.StackAddressEscape
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape
+```
 
-clang-analyzer-core.StackAddressEscape
-======================================
+# clang-analyzer-core.StackAddressEscape
 
 Check that addresses to stack memory do not escape the function.
 
 The `clang-analyzer-core.StackAddressEscape` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.UndefinedBinaryOperatorResult
+```{title} clang-tidy - clang-analyzer-core.UndefinedBinaryOperatorResult
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult
+```
 
-clang-analyzer-core.UndefinedBinaryOperatorResult
-=================================================
+# clang-analyzer-core.UndefinedBinaryOperatorResult
 
 Check for undefined results of binary operators.
 
 The `clang-analyzer-core.UndefinedBinaryOperatorResult` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.VLASize.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.VLASize.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.VLASize
+```{title} clang-tidy - clang-analyzer-core.VLASize
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize
+```
 
-clang-analyzer-core.VLASize
-===========================
+# clang-analyzer-core.VLASize
 
 Check for declarations of VLA of undefined or zero size.
 
 The `clang-analyzer-core.VLASize` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.uninitialized.ArraySubscript
+```{title} clang-tidy - clang-analyzer-core.uninitialized.ArraySubscript
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript
+```
 
-clang-analyzer-core.uninitialized.ArraySubscript
-================================================
+# clang-analyzer-core.uninitialized.ArraySubscript
 
 Check for uninitialized values used as array subscripts.
 
 The `clang-analyzer-core.uninitialized.ArraySubscript` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.uninitialized.Assign
+```{title} clang-tidy - clang-analyzer-core.uninitialized.Assign
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign
+```
 
-clang-analyzer-core.uninitialized.Assign
-========================================
+# clang-analyzer-core.uninitialized.Assign
 
 Check for assigning uninitialized values.
 
 The `clang-analyzer-core.uninitialized.Assign` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.uninitialized.Branch
+```{title} clang-tidy - clang-analyzer-core.uninitialized.Branch
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch
+```
 
-clang-analyzer-core.uninitialized.Branch
-========================================
+# clang-analyzer-core.uninitialized.Branch
 
 Check for uninitialized values used as branch conditions.
 
 The `clang-analyzer-core.uninitialized.Branch` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.uninitialized.CapturedBlockVariable
+```{title} clang-tidy - clang-analyzer-core.uninitialized.CapturedBlockVariable
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable
+```
 
-clang-analyzer-core.uninitialized.CapturedBlockVariable
-=======================================================
+# clang-analyzer-core.uninitialized.CapturedBlockVariable
 
 Check for blocks that capture uninitialized values.
 
 The `clang-analyzer-core.uninitialized.CapturedBlockVariable` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.NewArraySize.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.NewArraySize.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.uninitialized.NewArraySize
+```{title} clang-tidy - clang-analyzer-core.uninitialized.NewArraySize
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize
+```
 
-clang-analyzer-core.uninitialized.NewArraySize
-==============================================
+# clang-analyzer-core.uninitialized.NewArraySize
 
 Check if the size of the array in a new[] expression is undefined.
 
 The `clang-analyzer-core.uninitialized.NewArraySize` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-core.uninitialized.UndefReturn
+```{title} clang-tidy - clang-analyzer-core.uninitialized.UndefReturn
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn
+```
 
-clang-analyzer-core.uninitialized.UndefReturn
-=============================================
+# clang-analyzer-core.uninitialized.UndefReturn
 
 Check for uninitialized values being returned to the caller.
 
 The `clang-analyzer-core.uninitialized.UndefReturn` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.ArrayDelete
+```{title} clang-tidy - clang-analyzer-cplusplus.ArrayDelete
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete
+```
 
-clang-analyzer-cplusplus.ArrayDelete
-====================================
+# clang-analyzer-cplusplus.ArrayDelete
 
 Reports destructions of arrays of polymorphic objects that are destructed as
 their base class.
 
 The `clang-analyzer-cplusplus.ArrayDelete` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.InnerPointer
+```{title} clang-tidy - clang-analyzer-cplusplus.InnerPointer
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer
+```
 
-clang-analyzer-cplusplus.InnerPointer
-=====================================
+# clang-analyzer-cplusplus.InnerPointer
 
 Check for inner pointers of C++ containers used after re/deallocation.
 
 The `clang-analyzer-cplusplus.InnerPointer` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.Move.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.Move.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.Move
+```{title} clang-tidy - clang-analyzer-cplusplus.Move
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move
+```
 
-clang-analyzer-cplusplus.Move
-=============================
+# clang-analyzer-cplusplus.Move
 
 Find use-after-move bugs in C++.
 
 The `clang-analyzer-cplusplus.Move` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.NewDelete
+```{title} clang-tidy - clang-analyzer-cplusplus.NewDelete
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete
+```
 
-clang-analyzer-cplusplus.NewDelete
-==================================
+# clang-analyzer-cplusplus.NewDelete
 
 Check for double-free and use-after-free problems. Traces memory managed by
 new/delete.
 
 The `clang-analyzer-cplusplus.NewDelete` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.NewDeleteLeaks
+```{title} clang-tidy - clang-analyzer-cplusplus.NewDeleteLeaks
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks
+```
 
-clang-analyzer-cplusplus.NewDeleteLeaks
-=======================================
+# clang-analyzer-cplusplus.NewDeleteLeaks
 
 Check for memory leaks. Traces memory managed by new/delete.
 
 The `clang-analyzer-cplusplus.NewDeleteLeaks` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.PlacementNew.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.PlacementNew.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.PlacementNew
+```{title} clang-tidy - clang-analyzer-cplusplus.PlacementNew
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew
+```
 
-clang-analyzer-cplusplus.PlacementNew
-=====================================
+# clang-analyzer-cplusplus.PlacementNew
 
 Check if default placement new is provided with pointers to sufficient storage
 capacity.
 
 The `clang-analyzer-cplusplus.PlacementNew` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.PureVirtualCall.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.PureVirtualCall.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-cplusplus.PureVirtualCall
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-purevirtualcall
+```
+
+# clang-analyzer-cplusplus.PureVirtualCall
+
+Check pure virtual function calls during construction/destruction.
+
+The `clang-analyzer-cplusplus.PureVirtualCall` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-purevirtualcall)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.SelfAssignment.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.SelfAssignment.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.SelfAssignment
+```{title} clang-tidy - clang-analyzer-cplusplus.SelfAssignment
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-selfassignment
+```
 
-clang-analyzer-cplusplus.SelfAssignment
-=======================================
+# clang-analyzer-cplusplus.SelfAssignment
 
 Checks C++ copy and move assignment operators for self assignment.
 
 The `clang-analyzer-cplusplus.SelfAssignment` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-selfassignment)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.StringChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.StringChecker.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-cplusplus.StringChecker
+```{title} clang-tidy - clang-analyzer-cplusplus.StringChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker
+```
 
-clang-analyzer-cplusplus.StringChecker
-======================================
+# clang-analyzer-cplusplus.StringChecker
 
 Checks C++ std::string bugs.
 
 The `clang-analyzer-cplusplus.StringChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-deadcode.DeadStores
+```{title} clang-tidy - clang-analyzer-deadcode.DeadStores
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores
+```
 
-clang-analyzer-deadcode.DeadStores
-==================================
+# clang-analyzer-deadcode.DeadStores
 
 Check for values stored to variables that are never read afterwards.
 
 The `clang-analyzer-deadcode.DeadStores` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/fuchsia.HandleChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/fuchsia.HandleChecker.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-fuchsia.HandleChecker
+```{title} clang-tidy - clang-analyzer-fuchsia.HandleChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker
+```
 
-clang-analyzer-fuchsia.HandleChecker
-====================================
+# clang-analyzer-fuchsia.HandleChecker
 
 A Checker that detect leaks related to Fuchsia handles.
 
 The `clang-analyzer-fuchsia.HandleChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-nullability.NullPassedToNonnull
+```{title} clang-tidy - clang-analyzer-nullability.NullPassedToNonnull
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull
+```
 
-clang-analyzer-nullability.NullPassedToNonnull
-==============================================
+# clang-analyzer-nullability.NullPassedToNonnull
 
 Warns when a null pointer is passed to a pointer which has a _Nonnull type.
 
 The `clang-analyzer-nullability.NullPassedToNonnull` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-nullability.NullReturnedFromNonnull
+```{title} clang-tidy - clang-analyzer-nullability.NullReturnedFromNonnull
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull
+```
 
-clang-analyzer-nullability.NullReturnedFromNonnull
-==================================================
+# clang-analyzer-nullability.NullReturnedFromNonnull
 
 Warns when a null pointer is returned from a function that has _Nonnull return
 type.
 
 The `clang-analyzer-nullability.NullReturnedFromNonnull` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-nullability.NullableDereferenced
+```{title} clang-tidy - clang-analyzer-nullability.NullableDereferenced
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced
+```
 
-clang-analyzer-nullability.NullableDereferenced
-===============================================
+# clang-analyzer-nullability.NullableDereferenced
 
 Warns when a nullable pointer is dereferenced.
 
 The `clang-analyzer-nullability.NullableDereferenced` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-nullability.NullablePassedToNonnull
+```{title} clang-tidy - clang-analyzer-nullability.NullablePassedToNonnull
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull
+```
 
-clang-analyzer-nullability.NullablePassedToNonnull
-==================================================
+# clang-analyzer-nullability.NullablePassedToNonnull
 
 Warns when a nullable pointer is passed to a pointer which has a _Nonnull type.
 
 The `clang-analyzer-nullability.NullablePassedToNonnull` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-nullability.NullableReturnedFromNonnull
+```{title} clang-tidy - clang-analyzer-nullability.NullableReturnedFromNonnull
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull
+```
 
-clang-analyzer-nullability.NullableReturnedFromNonnull
-======================================================
+# clang-analyzer-nullability.NullableReturnedFromNonnull
 
 Warns when a nullable pointer is returned from a function that has _Nonnull
 return type.
 
 The `clang-analyzer-nullability.NullableReturnedFromNonnull` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.EnumCastOutOfRange.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.EnumCastOutOfRange.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.core.EnumCastOutOfRange
+```{title} clang-tidy - clang-analyzer-optin.core.EnumCastOutOfRange
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange
+```
 
-clang-analyzer-optin.core.EnumCastOutOfRange
-============================================
+# clang-analyzer-optin.core.EnumCastOutOfRange
 
 Check integer to enumeration casts for out of range values.
 
 The `clang-analyzer-optin.core.EnumCastOutOfRange` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.FixedAddressDereference.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.FixedAddressDereference.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-optin.core.FixedAddressDereference
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-fixedaddressdereference
+```
+
+# clang-analyzer-optin.core.FixedAddressDereference
+
+Check for dereferences of fixed addresses.
+
+The `clang-analyzer-optin.core.FixedAddressDereference` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-fixedaddressdereference)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.UnconditionalVAArg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.UnconditionalVAArg.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-optin.core.UnconditionalVAArg
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-unconditionalvaarg
+```
+
+# clang-analyzer-optin.core.UnconditionalVAArg
+
+Check variadic functions unconditionally using va_arg.
+
+The `clang-analyzer-optin.core.UnconditionalVAArg` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-unconditionalvaarg)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.cplusplus.UninitializedObject
+```{title} clang-tidy - clang-analyzer-optin.cplusplus.UninitializedObject
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject
+```
 
-clang-analyzer-optin.cplusplus.UninitializedObject
-==================================================
+# clang-analyzer-optin.cplusplus.UninitializedObject
 
 Reports uninitialized fields after object construction.
 
 The `clang-analyzer-optin.cplusplus.UninitializedObject` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.cplusplus.VirtualCall
+```{title} clang-tidy - clang-analyzer-optin.cplusplus.VirtualCall
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall
+```
 
-clang-analyzer-optin.cplusplus.VirtualCall
-==========================================
+# clang-analyzer-optin.cplusplus.VirtualCall
 
 Check virtual function calls during construction/destruction.
 
 The `clang-analyzer-optin.cplusplus.VirtualCall` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.mpi.MPI-Checker
+```{title} clang-tidy - clang-analyzer-optin.mpi.MPI-Checker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker
+```
 
-clang-analyzer-optin.mpi.MPI-Checker
-====================================
+# clang-analyzer-optin.mpi.MPI-Checker
 
 Checks MPI code.
 
 The `clang-analyzer-optin.mpi.MPI-Checker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.OSObjectCStyleCast.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.OSObjectCStyleCast.md
@@ -1,0 +1,9 @@
+```{title} clang-tidy - clang-analyzer-optin.osx.OSObjectCStyleCast
+```
+
+# clang-analyzer-optin.osx.OSObjectCStyleCast
+
+Checker for C-style casts of OSObjects.
+
+The clang-analyzer-optin.osx.OSObjectCStyleCast check is an alias of
+Clang Static Analyzer optin.osx.OSObjectCStyleCast.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker
+```{title} clang-tidy - clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker
+```
 
-clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker
-=============================================================================
+# clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker
 
 Check that NSLocalizedString macros include a comment for context.
 
 The `clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker
+```{title} clang-tidy - clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker
+```
 
-clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker
-=======================================================================
+# clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker
 
 Warns about uses of non-localized NSStrings passed to UI methods expecting
 localized NSStrings.
 
 The `clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.performance.GCDAntipattern
+```{title} clang-tidy - clang-analyzer-optin.performance.GCDAntipattern
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern
+```
 
-clang-analyzer-optin.performance.GCDAntipattern
-===============================================
+# clang-analyzer-optin.performance.GCDAntipattern
 
 Check for performance anti-patterns when using Grand Central Dispatch.
 
 The `clang-analyzer-optin.performance.GCDAntipattern` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.Padding.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.Padding.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.performance.Padding
+```{title} clang-tidy - clang-analyzer-optin.performance.Padding
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding
+```
 
-clang-analyzer-optin.performance.Padding
-========================================
+# clang-analyzer-optin.performance.Padding
 
 Check for excessively padded structs.
 
 The `clang-analyzer-optin.performance.Padding` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-optin.portability.UnixAPI
+```{title} clang-tidy - clang-analyzer-optin.portability.UnixAPI
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi
+```
 
-clang-analyzer-optin.portability.UnixAPI
-========================================
+# clang-analyzer-optin.portability.UnixAPI
 
-Finds implementation-defined behavior in UNIX/Posix functions.
+Finds dynamic memory allocation with size zero.
 
 The `clang-analyzer-optin.portability.UnixAPI` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.GenericTaint.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.GenericTaint.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-optin.taint.GenericTaint
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint
+```
+
+# clang-analyzer-optin.taint.GenericTaint
+
+Reports potential injection vulnerabilities.
+
+The `clang-analyzer-optin.taint.GenericTaint` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-optin.taint.TaintedAlloc
+```{title} clang-tidy - clang-analyzer-optin.taint.TaintedAlloc
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc
+```
 
-clang-analyzer-optin.taint.TaintedAlloc
-=======================================
+# clang-analyzer-optin.taint.TaintedAlloc
 
 Check for memory allocations, where the size parameter might be a tainted
 (attacker controlled) value.
 
 The `clang-analyzer-optin.taint.TaintedAlloc` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedDiv.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedDiv.md
@@ -1,0 +1,16 @@
+```{title} clang-tidy - clang-analyzer-optin.taint.TaintedDiv
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-tainteddiv
+```
+
+# clang-analyzer-optin.taint.TaintedDiv
+
+Check for divisions where the denominator is tainted (attacker controlled) and
+might be 0.
+
+The `clang-analyzer-optin.taint.TaintedDiv` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-tainteddiv)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.API.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.API.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.API
+```{title} clang-tidy - clang-analyzer-osx.API
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-api
+```
 
-clang-analyzer-osx.API
-======================
+# clang-analyzer-osx.API
 
 Check for proper uses of various Apple APIs.
 
 The `clang-analyzer-osx.API` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-api>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-api)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.MIG.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.MIG.md
@@ -1,0 +1,9 @@
+```{title} clang-tidy - clang-analyzer-osx.MIG
+```
+
+# clang-analyzer-osx.MIG
+
+Find violations of the Mach Interface Generator calling convention.
+
+The clang-analyzer-osx.MIG check is an alias of
+Clang Static Analyzer osx.MIG.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.NumberObjectConversion
+```{title} clang-tidy - clang-analyzer-osx.NumberObjectConversion
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion
+```
 
-clang-analyzer-osx.NumberObjectConversion
-=========================================
+# clang-analyzer-osx.NumberObjectConversion
 
 Check for erroneous conversions of objects representing numbers into numbers.
 
 The `clang-analyzer-osx.NumberObjectConversion` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.OSObjectRetainCount.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.OSObjectRetainCount.md
@@ -1,0 +1,9 @@
+```{title} clang-tidy - clang-analyzer-osx.OSObjectRetainCount
+```
+
+# clang-analyzer-osx.OSObjectRetainCount
+
+Check for leaks and improper reference count management for OSObject.
+
+The clang-analyzer-osx.OSObjectRetainCount check is an alias of
+Clang Static Analyzer osx.OSObjectRetainCount.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.ObjCProperty
+```{title} clang-tidy - clang-analyzer-osx.ObjCProperty
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty
+```
 
-clang-analyzer-osx.ObjCProperty
-===============================
+# clang-analyzer-osx.ObjCProperty
 
 Check for proper uses of Objective-C properties.
 
 The `clang-analyzer-osx.ObjCProperty` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.SecKeychainAPI
+```{title} clang-tidy - clang-analyzer-osx.SecKeychainAPI
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi
+```
 
-clang-analyzer-osx.SecKeychainAPI
-=================================
+# clang-analyzer-osx.SecKeychainAPI
 
 Check for proper uses of Secure Keychain APIs.
 
 The `clang-analyzer-osx.SecKeychainAPI` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.AtSync
+```{title} clang-tidy - clang-analyzer-osx.cocoa.AtSync
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync
+```
 
-clang-analyzer-osx.cocoa.AtSync
-===============================
+# clang-analyzer-osx.cocoa.AtSync
 
 Check for nil pointers used as mutexes for @synchronized.
 
 The `clang-analyzer-osx.cocoa.AtSync` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.AutoreleaseWrite
+```{title} clang-tidy - clang-analyzer-osx.cocoa.AutoreleaseWrite
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite
+```
 
-clang-analyzer-osx.cocoa.AutoreleaseWrite
-=========================================
+# clang-analyzer-osx.cocoa.AutoreleaseWrite
 
 Warn about potentially crashing writes to autoreleasing objects from different
 autoreleasing pools in Objective-C.
 
 The `clang-analyzer-osx.cocoa.AutoreleaseWrite` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.ClassRelease
+```{title} clang-tidy - clang-analyzer-osx.cocoa.ClassRelease
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease
+```
 
-clang-analyzer-osx.cocoa.ClassRelease
-=====================================
+# clang-analyzer-osx.cocoa.ClassRelease
 
 Check for sending 'retain', 'release', or 'autorelease' directly to a Class.
 
 The `clang-analyzer-osx.cocoa.ClassRelease` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.Dealloc
+```{title} clang-tidy - clang-analyzer-osx.cocoa.Dealloc
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc
+```
 
-clang-analyzer-osx.cocoa.Dealloc
-================================
+# clang-analyzer-osx.cocoa.Dealloc
 
 Warn about Objective-C classes that lack a correct implementation of -dealloc.
 
 The `clang-analyzer-osx.cocoa.Dealloc` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.IncompatibleMethodTypes
+```{title} clang-tidy - clang-analyzer-osx.cocoa.IncompatibleMethodTypes
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes
+```
 
-clang-analyzer-osx.cocoa.IncompatibleMethodTypes
-================================================
+# clang-analyzer-osx.cocoa.IncompatibleMethodTypes
 
 Warn about Objective-C method signatures with type incompatibilities.
 
 The `clang-analyzer-osx.cocoa.IncompatibleMethodTypes` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.Loops
+```{title} clang-tidy - clang-analyzer-osx.cocoa.Loops
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops
+```
 
-clang-analyzer-osx.cocoa.Loops
-==============================
+# clang-analyzer-osx.cocoa.Loops
 
 Improved modeling of loops using Cocoa collection types.
 
 The `clang-analyzer-osx.cocoa.Loops` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.MissingSuperCall
+```{title} clang-tidy - clang-analyzer-osx.cocoa.MissingSuperCall
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall
+```
 
-clang-analyzer-osx.cocoa.MissingSuperCall
-=========================================
+# clang-analyzer-osx.cocoa.MissingSuperCall
 
 Warn about Objective-C methods that lack a necessary call to super.
 
 The `clang-analyzer-osx.cocoa.MissingSuperCall` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.NSAutoreleasePool
+```{title} clang-tidy - clang-analyzer-osx.cocoa.NSAutoreleasePool
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool
+```
 
-clang-analyzer-osx.cocoa.NSAutoreleasePool
-==========================================
+# clang-analyzer-osx.cocoa.NSAutoreleasePool
 
 Warn for suboptimal uses of NSAutoreleasePool in Objective-C GC mode.
 
 The `clang-analyzer-osx.cocoa.NSAutoreleasePool` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.NSError
+```{title} clang-tidy - clang-analyzer-osx.cocoa.NSError
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror
+```
 
-clang-analyzer-osx.cocoa.NSError
-================================
+# clang-analyzer-osx.cocoa.NSError
 
 Check usage of NSError** parameters.
 
 The `clang-analyzer-osx.cocoa.NSError` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.NilArg
+```{title} clang-tidy - clang-analyzer-osx.cocoa.NilArg
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg
+```
 
-clang-analyzer-osx.cocoa.NilArg
-===============================
+# clang-analyzer-osx.cocoa.NilArg
 
 Check for prohibited nil arguments to ObjC method calls.
 
 The `clang-analyzer-osx.cocoa.NilArg` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.NonNilReturnValue
+```{title} clang-tidy - clang-analyzer-osx.cocoa.NonNilReturnValue
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue
+```
 
-clang-analyzer-osx.cocoa.NonNilReturnValue
-==========================================
+# clang-analyzer-osx.cocoa.NonNilReturnValue
 
 Model the APIs that are guaranteed to return a non-nil value.
 
 The `clang-analyzer-osx.cocoa.NonNilReturnValue` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.ObjCGenerics
+```{title} clang-tidy - clang-analyzer-osx.cocoa.ObjCGenerics
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics
+```
 
-clang-analyzer-osx.cocoa.ObjCGenerics
-=====================================
+# clang-analyzer-osx.cocoa.ObjCGenerics
 
 Check for type errors when using Objective-C generics.
 
 The `clang-analyzer-osx.cocoa.ObjCGenerics` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.RetainCount
+```{title} clang-tidy - clang-analyzer-osx.cocoa.RetainCount
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount
+```
 
-clang-analyzer-osx.cocoa.RetainCount
-====================================
+# clang-analyzer-osx.cocoa.RetainCount
 
 Check for leaks and improper reference count management.
 
 The `clang-analyzer-osx.cocoa.RetainCount` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak
+```{title} clang-tidy - clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak
+```
 
-clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak
-===============================================
+# clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak
 
 Check for leaked memory in autorelease pools that will never be drained.
 
 The `clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.SelfInit
+```{title} clang-tidy - clang-analyzer-osx.cocoa.SelfInit
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit
+```
 
-clang-analyzer-osx.cocoa.SelfInit
-=================================
+# clang-analyzer-osx.cocoa.SelfInit
 
 Check that 'self' is properly initialized inside an initializer method.
 
 The `clang-analyzer-osx.cocoa.SelfInit` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.SuperDealloc
+```{title} clang-tidy - clang-analyzer-osx.cocoa.SuperDealloc
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc
+```
 
-clang-analyzer-osx.cocoa.SuperDealloc
-=====================================
+# clang-analyzer-osx.cocoa.SuperDealloc
 
 Warn about improper use of '[super dealloc]' in Objective-C.
 
 The `clang-analyzer-osx.cocoa.SuperDealloc` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.UnusedIvars
+```{title} clang-tidy - clang-analyzer-osx.cocoa.UnusedIvars
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars
+```
 
-clang-analyzer-osx.cocoa.UnusedIvars
-====================================
+# clang-analyzer-osx.cocoa.UnusedIvars
 
 Warn about private ivars that are never used.
 
 The `clang-analyzer-osx.cocoa.UnusedIvars` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-osx.cocoa.VariadicMethodTypes
+```{title} clang-tidy - clang-analyzer-osx.cocoa.VariadicMethodTypes
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes
+```
 
-clang-analyzer-osx.cocoa.VariadicMethodTypes
-============================================
+# clang-analyzer-osx.cocoa.VariadicMethodTypes
 
 Check for passing non-Objective-C types to variadic collection initialization
 methods that expect only Objective-C types.
 
 The `clang-analyzer-osx.cocoa.VariadicMethodTypes` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.coreFoundation.CFError
+```{title} clang-tidy - clang-analyzer-osx.coreFoundation.CFError
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror
+```
 
-clang-analyzer-osx.coreFoundation.CFError
-=========================================
+# clang-analyzer-osx.coreFoundation.CFError
 
 Check usage of CFErrorRef* parameters.
 
 The `clang-analyzer-osx.coreFoundation.CFError` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.coreFoundation.CFNumber
+```{title} clang-tidy - clang-analyzer-osx.coreFoundation.CFNumber
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber
+```
 
-clang-analyzer-osx.coreFoundation.CFNumber
-==========================================
+# clang-analyzer-osx.coreFoundation.CFNumber
 
 Check for proper uses of CFNumber APIs.
 
 The `clang-analyzer-osx.coreFoundation.CFNumber` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.coreFoundation.CFRetainRelease
+```{title} clang-tidy - clang-analyzer-osx.coreFoundation.CFRetainRelease
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease
+```
 
-clang-analyzer-osx.coreFoundation.CFRetainRelease
-=================================================
+# clang-analyzer-osx.coreFoundation.CFRetainRelease
 
 Check for null arguments to CFRetain/CFRelease/CFMakeCollectable.
 
 The `clang-analyzer-osx.coreFoundation.CFRetainRelease` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-osx.coreFoundation.containers.OutOfBounds
+```{title} clang-tidy - clang-analyzer-osx.coreFoundation.containers.OutOfBounds
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds
+```
 
-clang-analyzer-osx.coreFoundation.containers.OutOfBounds
-========================================================
+# clang-analyzer-osx.coreFoundation.containers.OutOfBounds
 
 Checks for index out-of-bounds when using 'CFArray' API.
 
 The `clang-analyzer-osx.coreFoundation.containers.OutOfBounds` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
+```{title} clang-tidy - clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues
+```
 
-clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
-===============================================================
+# clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
 
 Warns if 'CFArray', 'CFDictionary', 'CFSet' are created with non-pointer-size
 values.
 
 The `clang-analyzer-osx.coreFoundation.containers.PointerSizedValues` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.ArrayBound.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.ArrayBound.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-security.ArrayBound
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-arraybound
+```
+
+# clang-analyzer-security.ArrayBound
+
+Warn about out of bounds access to memory.
+
+The `clang-analyzer-security.ArrayBound` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-arraybound)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-security.FloatLoopCounter
+```{title} clang-tidy - clang-analyzer-security.FloatLoopCounter
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter
+```
 
-clang-analyzer-security.FloatLoopCounter
-========================================
+# clang-analyzer-security.FloatLoopCounter
 
 Warn on using a floating point value as a loop counter (CERT: FLP30-C,
 FLP30-CPP).
 
 The `clang-analyzer-security.FloatLoopCounter` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.MmapWriteExec.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.MmapWriteExec.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-security.MmapWriteExec
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-mmapwriteexec
+```
+
+# clang-analyzer-security.MmapWriteExec
+
+Warn on mmap() calls with both writable and executable access.
+
+The `clang-analyzer-security.MmapWriteExec` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-mmapwriteexec)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PointerSub.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PointerSub.md
@@ -1,0 +1,16 @@
+```{title} clang-tidy - clang-analyzer-security.PointerSub
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-pointersub
+```
+
+# clang-analyzer-security.PointerSub
+
+Check for pointer subtractions on two pointers pointing to different memory
+chunks.
+
+The `clang-analyzer-security.PointerSub` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-pointersub)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.md
@@ -1,17 +1,10 @@
-.. title:: clang-tidy - clang-analyzer-security.PutenvStackArray
-.. meta::
-   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-putenvstackarray-c
+```{title} clang-tidy - clang-analyzer-security.PutenvStackArray
+```
 
-clang-analyzer-security.PutenvStackArray
-========================================
+# clang-analyzer-security.PutenvStackArray
 
-Finds calls to the putenv function which pass a pointer to a stack-allocated
-(automatic) array as the argument. Function putenv does not copy the passed
-string, only a pointer to the data is stored and this data can be read even by
-other threads. Content of a stack-allocated array is likely to be overwritten
-after exiting from the function.
+Finds calls to the function 'putenv' which pass a pointer to an automatic
+(stack-allocated) array as the argument.
 
-The `clang-analyzer-security.PutenvStackArray` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-putenvstackarray-c>`_
-for more information.
+The clang-analyzer-security.PutenvStackArray check is an alias of
+Clang Static Analyzer security.PutenvStackArray.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.md
@@ -1,19 +1,10 @@
-.. title:: clang-tidy - clang-analyzer-security.SetgidSetuidOrder
-.. meta::
-   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-setgidsetuidorder-c
+```{title} clang-tidy - clang-analyzer-security.SetgidSetuidOrder
+```
 
-clang-analyzer-security.SetgidSetuidOrder
-=========================================
+# clang-analyzer-security.SetgidSetuidOrder
 
-The checker checks for sequences of ``setuid(getuid())`` and
-``setgid(getgid())`` calls (in this order). If such a sequence is found and
-there is no other privilege-changing function call (``seteuid``, ``setreuid``,
-``setresuid`` and the GID versions of these) in between, a warning is
-generated. The checker finds only exactly ``setuid(getuid())`` calls (and the
-GID versions), not for example if the result of ``getuid()`` is stored in
-a variable.
+Warn on possible reversed order of 'setgid(getgid()))' and 'setuid(getuid())'
+(CERT: POS36-C).
 
-The `clang-analyzer-security.SetgidSetuidOrder` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-setgidsetuidorder-c>`_
-for more information.
+The clang-analyzer-security.SetgidSetuidOrder check is an alias of
+Clang Static Analyzer security.SetgidSetuidOrder.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.VAList.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.VAList.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-security.VAList
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-valist
+```
+
+# clang-analyzer-security.VAList
+
+Warn on misuse of va_list objects.
+
+The `clang-analyzer-security.VAList` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-valist)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.cert.env.InvalidPtr.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.cert.env.InvalidPtr.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.cert.env.InvalidPtr
+```{title} clang-tidy - clang-analyzer-security.cert.env.InvalidPtr
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr
+```
 
-clang-analyzer-security.cert.env.InvalidPtr
-===========================================
+# clang-analyzer-security.cert.env.InvalidPtr
 
 Finds usages of possibly invalidated pointers.
 
 The `clang-analyzer-security.cert.env.InvalidPtr` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling
+```
 
-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
-====================================================================
+# clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
 
 Warn on uses of unsecure or deprecated buffer manipulating functions.
 
 The `clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.UncheckedReturn
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.UncheckedReturn
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn
+```
 
-clang-analyzer-security.insecureAPI.UncheckedReturn
-===================================================
+# clang-analyzer-security.insecureAPI.UncheckedReturn
 
 Warn on uses of functions whose return values must be always checked.
 
 The `clang-analyzer-security.insecureAPI.UncheckedReturn` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.bcmp
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.bcmp
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp
+```
 
-clang-analyzer-security.insecureAPI.bcmp
-========================================
+# clang-analyzer-security.insecureAPI.bcmp
 
 Warn on uses of the 'bcmp' function.
 
 The `clang-analyzer-security.insecureAPI.bcmp` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.bcopy
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.bcopy
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy
+```
 
-clang-analyzer-security.insecureAPI.bcopy
-=========================================
+# clang-analyzer-security.insecureAPI.bcopy
 
 Warn on uses of the 'bcopy' function.
 
 The `clang-analyzer-security.insecureAPI.bcopy` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.bzero
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.bzero
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero
+```
 
-clang-analyzer-security.insecureAPI.bzero
-=========================================
+# clang-analyzer-security.insecureAPI.bzero
 
 Warn on uses of the 'bzero' function.
 
 The `clang-analyzer-security.insecureAPI.bzero` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.decodeValueOfObjCType.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.decodeValueOfObjCType.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.decodeValueOfObjCType
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.decodeValueOfObjCType
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-decodevalueofobjctype
+```
 
-clang-analyzer-security.insecureAPI.decodeValueOfObjCType
-=========================================================
+# clang-analyzer-security.insecureAPI.decodeValueOfObjCType
 
 Warn on uses of the '-decodeValueOfObjCType:at:' method.
 
 The `clang-analyzer-security.insecureAPI.decodeValueOfObjCType` check is an alias, please see
-`Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-decodevalueofobjctype>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-decodevalueofobjctype)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.getpw
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.getpw
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw
+```
 
-clang-analyzer-security.insecureAPI.getpw
-=========================================
+# clang-analyzer-security.insecureAPI.getpw
 
 Warn on uses of the 'getpw' function.
 
 The `clang-analyzer-security.insecureAPI.getpw` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.gets
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.gets
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets
+```
 
-clang-analyzer-security.insecureAPI.gets
-========================================
+# clang-analyzer-security.insecureAPI.gets
 
 Warn on uses of the 'gets' function.
 
 The `clang-analyzer-security.insecureAPI.gets` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.mkstemp
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.mkstemp
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp
+```
 
-clang-analyzer-security.insecureAPI.mkstemp
-===========================================
+# clang-analyzer-security.insecureAPI.mkstemp
 
 Warn when 'mkstemp' is passed fewer than 6 X's in the format string.
 
 The `clang-analyzer-security.insecureAPI.mkstemp` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.mktemp
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.mktemp
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp
+```
 
-clang-analyzer-security.insecureAPI.mktemp
-==========================================
+# clang-analyzer-security.insecureAPI.mktemp
 
 Warn on uses of the 'mktemp' function.
 
 The `clang-analyzer-security.insecureAPI.mktemp` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.rand
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.rand
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand
+```
 
-clang-analyzer-security.insecureAPI.rand
-========================================
+# clang-analyzer-security.insecureAPI.rand
 
 Warn on uses of the 'rand', 'random', and related functions.
 
 The `clang-analyzer-security.insecureAPI.rand` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.strcpy
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.strcpy
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy
+```
 
-clang-analyzer-security.insecureAPI.strcpy
-==========================================
+# clang-analyzer-security.insecureAPI.strcpy
 
 Warn on uses of the 'strcpy' and 'strcat' functions.
 
 The `clang-analyzer-security.insecureAPI.strcpy` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-security.insecureAPI.vfork
+```{title} clang-tidy - clang-analyzer-security.insecureAPI.vfork
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork
+```
 
-clang-analyzer-security.insecureAPI.vfork
-=========================================
+# clang-analyzer-security.insecureAPI.vfork
 
 Warn on uses of the 'vfork' function.
 
 The `clang-analyzer-security.insecureAPI.vfork` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.API.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.API.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.API
+```{title} clang-tidy - clang-analyzer-unix.API
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-api
+```
 
-clang-analyzer-unix.API
-=======================
+# clang-analyzer-unix.API
 
 Check calls to various UNIX/Posix functions.
 
 The `clang-analyzer-unix.API` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-api>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-api)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.BlockInCriticalSection
+```{title} clang-tidy - clang-analyzer-unix.BlockInCriticalSection
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection
+```
 
-clang-analyzer-unix.BlockInCriticalSection
-==========================================
+# clang-analyzer-unix.BlockInCriticalSection
 
 Check for calls to blocking functions inside a critical section.
 
 The `clang-analyzer-unix.BlockInCriticalSection` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Chroot.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Chroot.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-unix.Chroot
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-chroot
+```
+
+# clang-analyzer-unix.Chroot
+
+Check improper use of chroot.
+
+The `clang-analyzer-unix.Chroot` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-chroot)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Errno.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Errno.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.Errno
+```{title} clang-tidy - clang-analyzer-unix.Errno
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno
+```
 
-clang-analyzer-unix.Errno
-=========================
+# clang-analyzer-unix.Errno
 
 Check for improper use of 'errno'.
 
 The `clang-analyzer-unix.Errno` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Malloc.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Malloc.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-unix.Malloc
+```{title} clang-tidy - clang-analyzer-unix.Malloc
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc
+```
 
-clang-analyzer-unix.Malloc
-==========================
+# clang-analyzer-unix.Malloc
 
 Check for memory leaks, double free, and use-after-free problems. Traces memory
 managed by malloc()/free().
 
 The `clang-analyzer-unix.Malloc` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.MallocSizeof
+```{title} clang-tidy - clang-analyzer-unix.MallocSizeof
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof
+```
 
-clang-analyzer-unix.MallocSizeof
-================================
+# clang-analyzer-unix.MallocSizeof
 
 Check for dubious malloc arguments involving sizeof.
 
 The `clang-analyzer-unix.MallocSizeof` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.MismatchedDeallocator
+```{title} clang-tidy - clang-analyzer-unix.MismatchedDeallocator
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator
+```
 
-clang-analyzer-unix.MismatchedDeallocator
-=========================================
+# clang-analyzer-unix.MismatchedDeallocator
 
 Check for mismatched deallocators.
 
 The `clang-analyzer-unix.MismatchedDeallocator` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-unix.StdCLibraryFunctions
+```{title} clang-tidy - clang-analyzer-unix.StdCLibraryFunctions
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions
+```
 
-clang-analyzer-unix.StdCLibraryFunctions
-========================================
+# clang-analyzer-unix.StdCLibraryFunctions
 
-Check for invalid arguments of C standard library functions, and apply
-relations between arguments and return value.
+Check for invalid arguments of C standard library functions, and apply relations
+between arguments and return value.
 
 The `clang-analyzer-unix.StdCLibraryFunctions` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Stream.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Stream.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.Stream
+```{title} clang-tidy - clang-analyzer-unix.Stream
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream
+```
 
-clang-analyzer-unix.Stream
-==========================
+# clang-analyzer-unix.Stream
 
 Check stream handling functions.
 
 The `clang-analyzer-unix.Stream` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Vfork.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Vfork.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.Vfork
+```{title} clang-tidy - clang-analyzer-unix.Vfork
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork
+```
 
-clang-analyzer-unix.Vfork
-=========================
+# clang-analyzer-unix.Vfork
 
 Check for proper usage of vfork.
 
 The `clang-analyzer-unix.Vfork` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.md
@@ -1,14 +1,16 @@
-.. title:: clang-tidy - clang-analyzer-unix.cstring.BadSizeArg
+```{title} clang-tidy - clang-analyzer-unix.cstring.BadSizeArg
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg
+```
 
-clang-analyzer-unix.cstring.BadSizeArg
-======================================
+# clang-analyzer-unix.cstring.BadSizeArg
 
 Check the size argument passed into C string functions for common erroneous
 patterns.
 
 The `clang-analyzer-unix.cstring.BadSizeArg` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NotNullTerminated.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NotNullTerminated.md
@@ -1,0 +1,16 @@
+```{title} clang-tidy - clang-analyzer-unix.cstring.NotNullTerminated
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-notnullterminated
+```
+
+# clang-analyzer-unix.cstring.NotNullTerminated
+
+Check for arguments passed to C string functions which are not null-terminated
+strings.
+
+The `clang-analyzer-unix.cstring.NotNullTerminated` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-notnullterminated)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-unix.cstring.NullArg
+```{title} clang-tidy - clang-analyzer-unix.cstring.NullArg
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg
+```
 
-clang-analyzer-unix.cstring.NullArg
-===================================
+# clang-analyzer-unix.cstring.NullArg
 
 Check for null pointers being passed as arguments to C string functions.
 
 The `clang-analyzer-unix.cstring.NullArg` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.UninitializedRead.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.UninitializedRead.md
@@ -1,0 +1,15 @@
+```{title} clang-tidy - clang-analyzer-unix.cstring.UninitializedRead
+```
+
+```{eval-rst}
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-uninitializedread
+```
+
+# clang-analyzer-unix.cstring.UninitializedRead
+
+Checks if the string manipulation function would read uninitialized bytes.
+
+The `clang-analyzer-unix.cstring.UninitializedRead` check is an alias, please see
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-uninitializedread)
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.NoUncountedMemberChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.NoUncountedMemberChecker.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-webkit.NoUncountedMemberChecker
+```{title} clang-tidy - clang-analyzer-webkit.NoUncountedMemberChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker
+```
 
-clang-analyzer-webkit.NoUncountedMemberChecker
-==============================================
+# clang-analyzer-webkit.NoUncountedMemberChecker
 
 Check for no uncounted member variables.
 
 The `clang-analyzer-webkit.NoUncountedMemberChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.RefCntblBaseVirtualDtor.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.RefCntblBaseVirtualDtor.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-webkit.RefCntblBaseVirtualDtor
+```{title} clang-tidy - clang-analyzer-webkit.RefCntblBaseVirtualDtor
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor
+```
 
-clang-analyzer-webkit.RefCntblBaseVirtualDtor
-=============================================
+# clang-analyzer-webkit.RefCntblBaseVirtualDtor
 
 Check for any ref-countable base class having virtual destructor.
 
 The `clang-analyzer-webkit.RefCntblBaseVirtualDtor` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.UncountedLambdaCapturesChecker.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.UncountedLambdaCapturesChecker.md
@@ -1,13 +1,15 @@
-.. title:: clang-tidy - clang-analyzer-webkit.UncountedLambdaCapturesChecker
+```{title} clang-tidy - clang-analyzer-webkit.UncountedLambdaCapturesChecker
+```
+
+```{eval-rst}
 .. meta::
    :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker
+```
 
-clang-analyzer-webkit.UncountedLambdaCapturesChecker
-====================================================
+# clang-analyzer-webkit.UncountedLambdaCapturesChecker
 
 Check uncounted lambda captures.
 
 The `clang-analyzer-webkit.UncountedLambdaCapturesChecker` check is an alias, please see
-`Clang Static Analyzer Available Checkers
-<https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker>`_
+[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker)
 for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
+++ b/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
@@ -7,6 +7,7 @@ import subprocess
 import json
 import os
 import re
+import textwrap
 
 """Get path of script so files are always in correct directory"""
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -82,38 +83,35 @@ Args:
 def generate_documentation(checker, has_documentation):
 
     with open(
-        os.path.join(__location__, "clang-analyzer", checker["ShortName"] + ".rst"), "w"
+        os.path.join(__location__, "clang-analyzer", checker["ShortName"] + ".md"), "w"
     ) as f:
-        f.write(".. title:: clang-tidy - %s\n" % checker["FullPackageName"])
+        f.write("```{title} clang-tidy - %s\n" % checker["FullPackageName"])
+        f.write("```\n")
         if has_documentation:
+            f.write("\n")
+            # {meta} is not a supported MyST directive in the LLVM docs build,
+            # and we are not yet aware of a MyST-native way to implement these
+            # documentation redirects.
+            f.write("```{eval-rst}\n")
             f.write(".. meta::\n")
             f.write(
                 "   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#%s\n"
                 % checker["AnchorUrl"]
             )
+            f.write("```\n")
         f.write("\n")
-        f.write("%s\n" % checker["FullPackageName"])
-        f.write("=" * len(checker["FullPackageName"]) + "\n")
+        f.write("# %s\n\n" % checker["FullPackageName"])
         help_text = checker["HelpText"].strip()
         if not help_text.endswith("."):
             help_text += "."
-        characters = 80
-        for word in help_text.split(" "):
-            if characters+len(word)+1 > 80:
-                characters = len(word)
-                f.write("\n")
-                f.write(word)
-            else:
-                f.write(" ")
-                f.write(word)
-                characters += len(word) + 1
+        f.write(textwrap.fill(help_text, 80))
         f.write("\n\n")
         if has_documentation:
             f.write(
                 "The `%s` check is an alias, please see\n" % checker["FullPackageName"]
             )
             f.write(
-                "`Clang Static Analyzer Available Checkers\n<https://clang.llvm.org/docs/analyzer/checkers.html#%s>`_\n"
+                "[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#%s)\n"
                 % checker["AnchorUrl"]
             )
             f.write("for more information.\n")
@@ -122,24 +120,41 @@ def generate_documentation(checker, has_documentation):
         f.close()
 
 
-"""Update list.rst to include the new checks
+"""Update list.md to include the new checks
 
 Args:
   checkers: dict acquired from get_checkers()
 """
 def update_documentation_list(checkers):
-    with open(os.path.join(__location__, "list.rst"), "r+") as f:
+    with open(os.path.join(__location__, "list.md"), "r+") as f:
         f_text = f.read()
-        check_text = f_text.split(':header: "Name", "Redirect", "Offers fixes"\n')[1]
-        checks = [x for x in check_text.split("\n") if ":header:" not in x and x]
+        table_header = "| Name | Redirect | Offers fixes |\n| --- | --- | --- |\n"
+        check_text = f_text.split(table_header)[1]
+        checks = [x for x in check_text.splitlines() if x.startswith("| ")]
         old_check_text = "\n".join(checks)
         checks = [x for x in checks if "clang-analyzer-" not in x]
         for checker in checkers:
             if checker["Documentation"]:
-                checks.append("   :doc:`%s <clang-analyzer/%s>`, `Clang Static Analyzer %s <https://clang.llvm.org/docs/analyzer/checkers.html#%s>`_," % (checker["FullPackageName"],
-                                                        checker["ShortName"],  checker["ShortName"], checker["AnchorUrl"]))
+                checks.append(
+                    "| {doc}`%s <clang-analyzer/%s>` | "
+                    "[Clang Static Analyzer %s](https://clang.llvm.org/docs/analyzer/checkers.html#%s) |  |"
+                    % (
+                        checker["FullPackageName"],
+                        checker["ShortName"],
+                        checker["ShortName"],
+                        checker["AnchorUrl"],
+                    )
+                )
             else:
-                checks.append("   :doc:`%s <clang-analyzer/%s>`, Clang Static Analyzer %s," % (checker["FullPackageName"], checker["ShortName"],  checker["ShortName"]))
+                checks.append(
+                    "| {doc}`%s <clang-analyzer/%s>` | "
+                    "Clang Static Analyzer %s |  |"
+                    % (
+                        checker["FullPackageName"],
+                        checker["ShortName"],
+                        checker["ShortName"],
+                    )
+                )
 
         checks.sort()
 
@@ -147,6 +162,7 @@ def update_documentation_list(checkers):
         f.seek(0)
         f_text = f_text.replace(old_check_text, "\n".join(checks))
         f.write(f_text)
+        f.truncate()
         f.close()
 
 

--- a/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
+++ b/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
@@ -110,9 +110,7 @@ def generate_documentation(checker, has_documentation):
         f.write(textwrap.fill(help_text, 80))
         f.write("\n\n")
         if has_documentation:
-            f.write(
-                f"The `{full_package_name}` check is an alias, please see\n"
-            )
+            f.write(f"The `{full_package_name}` check is an alias, please see\n")
             f.write(
                 "[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#"
                 f"{anchor_url})\n"
@@ -149,13 +147,9 @@ def update_documentation_list(checkers):
                     "(https://clang.llvm.org/docs/analyzer/checkers.html#"
                     f"{checker['AnchorUrl']})"
                 )
-                checks.append(
-                    f"| {doc_link} | {analyzer_link} |  |"
-                )
+                checks.append(f"| {doc_link} | {analyzer_link} |  |")
             else:
-                checks.append(
-                    f"| {doc_link} | Clang Static Analyzer {short_name} |  |"
-                )
+                checks.append(f"| {doc_link} | Clang Static Analyzer {short_name} |  |")
 
         checks.sort()
 

--- a/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
+++ b/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
@@ -81,11 +81,14 @@ Args:
   has_documentation: Specify that there is other documentation to link to.
 """
 def generate_documentation(checker, has_documentation):
+    full_package_name = checker["FullPackageName"]
+    short_name = checker["ShortName"]
+    anchor_url = checker["AnchorUrl"]
 
     with open(
-        os.path.join(__location__, "clang-analyzer", checker["ShortName"] + ".md"), "w"
+        os.path.join(__location__, "clang-analyzer", short_name + ".md"), "w"
     ) as f:
-        f.write("```{title} clang-tidy - %s\n" % checker["FullPackageName"])
+        f.write(f"```{{title}} clang-tidy - {full_package_name}\n")
         f.write("```\n")
         if has_documentation:
             f.write("\n")
@@ -95,12 +98,12 @@ def generate_documentation(checker, has_documentation):
             f.write("```{eval-rst}\n")
             f.write(".. meta::\n")
             f.write(
-                "   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#%s\n"
-                % checker["AnchorUrl"]
+                "   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#"
+                f"{anchor_url}\n"
             )
             f.write("```\n")
         f.write("\n")
-        f.write("# %s\n\n" % checker["FullPackageName"])
+        f.write(f"# {full_package_name}\n\n")
         help_text = checker["HelpText"].strip()
         if not help_text.endswith("."):
             help_text += "."
@@ -108,15 +111,18 @@ def generate_documentation(checker, has_documentation):
         f.write("\n\n")
         if has_documentation:
             f.write(
-                "The `%s` check is an alias, please see\n" % checker["FullPackageName"]
+                f"The `{full_package_name}` check is an alias, please see\n"
             )
             f.write(
-                "[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#%s)\n"
-                % checker["AnchorUrl"]
+                "[Clang Static Analyzer Available Checkers](https://clang.llvm.org/docs/analyzer/checkers.html#"
+                f"{anchor_url})\n"
             )
             f.write("for more information.\n")
         else:
-            f.write("The %s check is an alias of\nClang Static Analyzer %s.\n" % (checker["FullPackageName"], checker["ShortName"]));
+            f.write(
+                f"The {full_package_name} check is an alias of\n"
+                f"Clang Static Analyzer {short_name}.\n"
+            )
         f.close()
 
 
@@ -134,26 +140,21 @@ def update_documentation_list(checkers):
         old_check_text = "\n".join(checks)
         checks = [x for x in checks if "clang-analyzer-" not in x]
         for checker in checkers:
+            full_package_name = checker["FullPackageName"]
+            short_name = checker["ShortName"]
+            doc_link = f"{{doc}}`{full_package_name} <clang-analyzer/{short_name}>`"
             if checker["Documentation"]:
+                analyzer_link = (
+                    f"[Clang Static Analyzer {short_name}]"
+                    "(https://clang.llvm.org/docs/analyzer/checkers.html#"
+                    f"{checker['AnchorUrl']})"
+                )
                 checks.append(
-                    "| {doc}`%s <clang-analyzer/%s>` | "
-                    "[Clang Static Analyzer %s](https://clang.llvm.org/docs/analyzer/checkers.html#%s) |  |"
-                    % (
-                        checker["FullPackageName"],
-                        checker["ShortName"],
-                        checker["ShortName"],
-                        checker["AnchorUrl"],
-                    )
+                    f"| {doc_link} | {analyzer_link} |  |"
                 )
             else:
                 checks.append(
-                    "| {doc}`%s <clang-analyzer/%s>` | "
-                    "Clang Static Analyzer %s |  |"
-                    % (
-                        checker["FullPackageName"],
-                        checker["ShortName"],
-                        checker["ShortName"],
-                    )
+                    f"| {doc_link} | Clang Static Analyzer {short_name} |  |"
                 )
 
         checks.sort()

--- a/clang-tools-extra/docs/clang-tidy/checks/list.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.md
@@ -1,613 +1,626 @@
-.. title:: clang-tidy - Clang-Tidy Checks
+```{title} clang-tidy - Clang-Tidy Checks
+```
 
-Clang-Tidy Checks
-=================
+# Clang-Tidy Checks
 
-.. toctree::
-   :glob:
-   :hidden:
+```{toctree}
+:glob: true
+:hidden: true
 
-   abseil/*
-   altera/*
-   android/*
-   boost/*
-   bugprone/*
-   cert/*
-   clang-analyzer/*
-   concurrency/*
-   cppcoreguidelines/*
-   darwin/*
-   fuchsia/*
-   google/*
-   linuxkernel/*
-   llvm/*
-   llvmlibc/*
-   misc/*
-   modernize/*
-   mpi/*
-   objc/*
-   openmp/*
-   performance/*
-   portability/*
-   readability/*
-   zircon/*
+abseil/*
+altera/*
+android/*
+boost/*
+bugprone/*
+cert/*
+clang-analyzer/*
+concurrency/*
+cppcoreguidelines/*
+darwin/*
+fuchsia/*
+google/*
+linuxkernel/*
+llvm/*
+llvmlibc/*
+misc/*
+modernize/*
+mpi/*
+objc/*
+openmp/*
+performance/*
+portability/*
+readability/*
+zircon/*
+```
 
-.. csv-table::
-   :header: "Name", "Offers fixes"
+| Name | Offers fixes |
+| --- | --- |
+| {doc}`abseil-cleanup-ctad <abseil/cleanup-ctad>` | Yes |
+| {doc}`abseil-duration-addition <abseil/duration-addition>` | Yes |
+| {doc}`abseil-duration-comparison <abseil/duration-comparison>` | Yes |
+| {doc}`abseil-duration-conversion-cast <abseil/duration-conversion-cast>` | Yes |
+| {doc}`abseil-duration-division <abseil/duration-division>` | Yes |
+| {doc}`abseil-duration-factory-float <abseil/duration-factory-float>` | Yes |
+| {doc}`abseil-duration-factory-scale <abseil/duration-factory-scale>` | Yes |
+| {doc}`abseil-duration-subtraction <abseil/duration-subtraction>` | Yes |
+| {doc}`abseil-duration-unnecessary-conversion <abseil/duration-unnecessary-conversion>` | Yes |
+| {doc}`abseil-faster-strsplit-delimiter <abseil/faster-strsplit-delimiter>` | Yes |
+| {doc}`abseil-no-internal-dependencies <abseil/no-internal-dependencies>` |  |
+| {doc}`abseil-no-namespace <abseil/no-namespace>` |  |
+| {doc}`abseil-redundant-strcat-calls <abseil/redundant-strcat-calls>` | Yes |
+| {doc}`abseil-str-cat-append <abseil/str-cat-append>` | Yes |
+| {doc}`abseil-string-find-startswith <abseil/string-find-startswith>` | Yes |
+| {doc}`abseil-string-find-str-contains <abseil/string-find-str-contains>` | Yes |
+| {doc}`abseil-time-comparison <abseil/time-comparison>` | Yes |
+| {doc}`abseil-time-subtraction <abseil/time-subtraction>` | Yes |
+| {doc}`abseil-unchecked-statusor-access <abseil/unchecked-statusor-access>` |  |
+| {doc}`abseil-upgrade-duration-conversions <abseil/upgrade-duration-conversions>` | Yes |
+| {doc}`altera-id-dependent-backward-branch <altera/id-dependent-backward-branch>` |  |
+| {doc}`altera-kernel-name-restriction <altera/kernel-name-restriction>` |  |
+| {doc}`altera-single-work-item-barrier <altera/single-work-item-barrier>` |  |
+| {doc}`altera-struct-pack-align <altera/struct-pack-align>` | Yes |
+| {doc}`altera-unroll-loops <altera/unroll-loops>` |  |
+| {doc}`android-cloexec-accept <android/cloexec-accept>` | Yes |
+| {doc}`android-cloexec-accept4 <android/cloexec-accept4>` | Yes |
+| {doc}`android-cloexec-creat <android/cloexec-creat>` | Yes |
+| {doc}`android-cloexec-dup <android/cloexec-dup>` | Yes |
+| {doc}`android-cloexec-epoll-create <android/cloexec-epoll-create>` | Yes |
+| {doc}`android-cloexec-epoll-create1 <android/cloexec-epoll-create1>` | Yes |
+| {doc}`android-cloexec-fopen <android/cloexec-fopen>` | Yes |
+| {doc}`android-cloexec-inotify-init <android/cloexec-inotify-init>` | Yes |
+| {doc}`android-cloexec-inotify-init1 <android/cloexec-inotify-init1>` | Yes |
+| {doc}`android-cloexec-memfd-create <android/cloexec-memfd-create>` | Yes |
+| {doc}`android-cloexec-open <android/cloexec-open>` | Yes |
+| {doc}`android-cloexec-pipe <android/cloexec-pipe>` | Yes |
+| {doc}`android-cloexec-pipe2 <android/cloexec-pipe2>` | Yes |
+| {doc}`android-cloexec-socket <android/cloexec-socket>` | Yes |
+| {doc}`android-comparison-in-temp-failure-retry <android/comparison-in-temp-failure-retry>` |  |
+| {doc}`boost-use-ranges <boost/use-ranges>` | Yes |
+| {doc}`boost-use-to-string <boost/use-to-string>` | Yes |
+| {doc}`bugprone-argument-comment <bugprone/argument-comment>` | Yes |
+| {doc}`bugprone-assert-side-effect <bugprone/assert-side-effect>` |  |
+| {doc}`bugprone-assignment-in-if-condition <bugprone/assignment-in-if-condition>` |  |
+| {doc}`bugprone-assignment-in-selection-statement <bugprone/assignment-in-selection-statement>` |  |
+| {doc}`bugprone-bad-signal-to-kill-thread <bugprone/bad-signal-to-kill-thread>` |  |
+| {doc}`bugprone-bitwise-pointer-cast <bugprone/bitwise-pointer-cast>` |  |
+| {doc}`bugprone-bool-pointer-implicit-conversion <bugprone/bool-pointer-implicit-conversion>` | Yes |
+| {doc}`bugprone-branch-clone <bugprone/branch-clone>` |  |
+| {doc}`bugprone-capturing-this-in-member-variable <bugprone/capturing-this-in-member-variable>` |  |
+| {doc}`bugprone-casting-through-void <bugprone/casting-through-void>` |  |
+| {doc}`bugprone-chained-comparison <bugprone/chained-comparison>` |  |
+| {doc}`bugprone-command-processor <bugprone/command-processor>` |  |
+| {doc}`bugprone-compare-pointer-to-member-virtual-function <bugprone/compare-pointer-to-member-virtual-function>` |  |
+| {doc}`bugprone-copy-constructor-init <bugprone/copy-constructor-init>` | Yes |
+| {doc}`bugprone-copy-constructor-mutates-argument <bugprone/copy-constructor-mutates-argument>` |  |
+| {doc}`bugprone-crtp-constructor-accessibility <bugprone/crtp-constructor-accessibility>` | Yes |
+| {doc}`bugprone-dangling-handle <bugprone/dangling-handle>` |  |
+| {doc}`bugprone-default-operator-new-on-overaligned-type <bugprone/default-operator-new-on-overaligned-type>` |  |
+| {doc}`bugprone-derived-method-shadowing-base-method <bugprone/derived-method-shadowing-base-method>` |  |
+| {doc}`bugprone-dynamic-static-initializers <bugprone/dynamic-static-initializers>` |  |
+| {doc}`bugprone-easily-swappable-parameters <bugprone/easily-swappable-parameters>` |  |
+| {doc}`bugprone-empty-catch <bugprone/empty-catch>` |  |
+| {doc}`bugprone-exception-copy-constructor-throws <bugprone/exception-copy-constructor-throws>` |  |
+| {doc}`bugprone-exception-escape <bugprone/exception-escape>` |  |
+| {doc}`bugprone-float-loop-counter <bugprone/float-loop-counter>` |  |
+| {doc}`bugprone-fold-init-type <bugprone/fold-init-type>` |  |
+| {doc}`bugprone-forward-declaration-namespace <bugprone/forward-declaration-namespace>` |  |
+| {doc}`bugprone-forwarding-reference-overload <bugprone/forwarding-reference-overload>` |  |
+| {doc}`bugprone-implicit-widening-of-multiplication-result <bugprone/implicit-widening-of-multiplication-result>` | Yes |
+| {doc}`bugprone-inaccurate-erase <bugprone/inaccurate-erase>` | Yes |
+| {doc}`bugprone-inc-dec-in-conditions <bugprone/inc-dec-in-conditions>` |  |
+| {doc}`bugprone-incorrect-enable-if <bugprone/incorrect-enable-if>` | Yes |
+| {doc}`bugprone-incorrect-enable-shared-from-this <bugprone/incorrect-enable-shared-from-this>` | Yes |
+| {doc}`bugprone-incorrect-roundings <bugprone/incorrect-roundings>` |  |
+| {doc}`bugprone-infinite-loop <bugprone/infinite-loop>` |  |
+| {doc}`bugprone-integer-division <bugprone/integer-division>` |  |
+| {doc}`bugprone-invalid-enum-default-initialization <bugprone/invalid-enum-default-initialization>` |  |
+| {doc}`bugprone-lambda-function-name <bugprone/lambda-function-name>` |  |
+| {doc}`bugprone-macro-parentheses <bugprone/macro-parentheses>` | Yes |
+| {doc}`bugprone-macro-repeated-side-effects <bugprone/macro-repeated-side-effects>` |  |
+| {doc}`bugprone-misleading-setter-of-reference <bugprone/misleading-setter-of-reference>` |  |
+| {doc}`bugprone-misplaced-operator-in-strlen-in-alloc <bugprone/misplaced-operator-in-strlen-in-alloc>` | Yes |
+| {doc}`bugprone-misplaced-pointer-arithmetic-in-alloc <bugprone/misplaced-pointer-arithmetic-in-alloc>` | Yes |
+| {doc}`bugprone-misplaced-widening-cast <bugprone/misplaced-widening-cast>` |  |
+| {doc}`bugprone-missing-end-comparison <bugprone/missing-end-comparison>` | Yes |
+| {doc}`bugprone-move-forwarding-reference <bugprone/move-forwarding-reference>` | Yes |
+| {doc}`bugprone-multi-level-implicit-pointer-conversion <bugprone/multi-level-implicit-pointer-conversion>` |  |
+| {doc}`bugprone-multiple-new-in-one-expression <bugprone/multiple-new-in-one-expression>` |  |
+| {doc}`bugprone-multiple-statement-macro <bugprone/multiple-statement-macro>` |  |
+| {doc}`bugprone-narrowing-conversions <bugprone/narrowing-conversions>` |  |
+| {doc}`bugprone-no-escape <bugprone/no-escape>` |  |
+| {doc}`bugprone-non-zero-enum-to-bool-conversion <bugprone/non-zero-enum-to-bool-conversion>` |  |
+| {doc}`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>` |  |
+| {doc}`bugprone-not-null-terminated-result <bugprone/not-null-terminated-result>` | Yes |
+| {doc}`bugprone-optional-value-conversion <bugprone/optional-value-conversion>` | Yes |
+| {doc}`bugprone-parent-virtual-call <bugprone/parent-virtual-call>` | Yes |
+| {doc}`bugprone-pointer-arithmetic-on-polymorphic-object <bugprone/pointer-arithmetic-on-polymorphic-object>` |  |
+| {doc}`bugprone-posix-return <bugprone/posix-return>` | Yes |
+| {doc}`bugprone-random-generator-seed <bugprone/random-generator-seed>` |  |
+| {doc}`bugprone-raw-memory-call-on-non-trivial-type <bugprone/raw-memory-call-on-non-trivial-type>` |  |
+| {doc}`bugprone-redundant-branch-condition <bugprone/redundant-branch-condition>` | Yes |
+| {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
+| {doc}`bugprone-return-const-ref-from-parameter <bugprone/return-const-ref-from-parameter>` |  |
+| {doc}`bugprone-shared-ptr-array-mismatch <bugprone/shared-ptr-array-mismatch>` | Yes |
+| {doc}`bugprone-signal-handler <bugprone/signal-handler>` |  |
+| {doc}`bugprone-signed-bitwise <bugprone/signed-bitwise>` |  |
+| {doc}`bugprone-signed-char-misuse <bugprone/signed-char-misuse>` |  |
+| {doc}`bugprone-sizeof-container <bugprone/sizeof-container>` |  |
+| {doc}`bugprone-sizeof-expression <bugprone/sizeof-expression>` |  |
+| {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
+| {doc}`bugprone-standalone-empty <bugprone/standalone-empty>` | Yes |
+| {doc}`bugprone-std-exception-baseclass <bugprone/std-exception-baseclass>` |  |
+| {doc}`bugprone-std-namespace-modification <bugprone/std-namespace-modification>` |  |
+| {doc}`bugprone-string-constructor <bugprone/string-constructor>` | Yes |
+| {doc}`bugprone-string-integer-assignment <bugprone/string-integer-assignment>` | Yes |
+| {doc}`bugprone-string-literal-with-embedded-nul <bugprone/string-literal-with-embedded-nul>` |  |
+| {doc}`bugprone-stringview-nullptr <bugprone/stringview-nullptr>` | Yes |
+| {doc}`bugprone-suspicious-enum-usage <bugprone/suspicious-enum-usage>` |  |
+| {doc}`bugprone-suspicious-include <bugprone/suspicious-include>` |  |
+| {doc}`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>` |  |
+| {doc}`bugprone-suspicious-memset-usage <bugprone/suspicious-memset-usage>` | Yes |
+| {doc}`bugprone-suspicious-missing-comma <bugprone/suspicious-missing-comma>` |  |
+| {doc}`bugprone-suspicious-realloc-usage <bugprone/suspicious-realloc-usage>` |  |
+| {doc}`bugprone-suspicious-semicolon <bugprone/suspicious-semicolon>` | Yes |
+| {doc}`bugprone-suspicious-string-compare <bugprone/suspicious-string-compare>` | Yes |
+| {doc}`bugprone-suspicious-stringview-data-usage <bugprone/suspicious-stringview-data-usage>` |  |
+| {doc}`bugprone-swapped-arguments <bugprone/swapped-arguments>` | Yes |
+| {doc}`bugprone-switch-missing-default-case <bugprone/switch-missing-default-case>` |  |
+| {doc}`bugprone-tagged-union-member-count <bugprone/tagged-union-member-count>` |  |
+| {doc}`bugprone-terminating-continue <bugprone/terminating-continue>` | Yes |
+| {doc}`bugprone-throw-keyword-missing <bugprone/throw-keyword-missing>` |  |
+| {doc}`bugprone-throwing-static-initialization <bugprone/throwing-static-initialization>` |  |
+| {doc}`bugprone-too-small-loop-variable <bugprone/too-small-loop-variable>` |  |
+| {doc}`bugprone-unchecked-optional-access <bugprone/unchecked-optional-access>` |  |
+| {doc}`bugprone-unchecked-string-to-number-conversion <bugprone/unchecked-string-to-number-conversion>` |  |
+| {doc}`bugprone-undefined-memory-manipulation <bugprone/undefined-memory-manipulation>` |  |
+| {doc}`bugprone-undelegated-constructor <bugprone/undelegated-constructor>` |  |
+| {doc}`bugprone-unhandled-code-paths <bugprone/unhandled-code-paths>` |  |
+| {doc}`bugprone-unhandled-exception-at-new <bugprone/unhandled-exception-at-new>` |  |
+| {doc}`bugprone-unhandled-self-assignment <bugprone/unhandled-self-assignment>` |  |
+| {doc}`bugprone-unintended-char-ostream-output <bugprone/unintended-char-ostream-output>` | Yes |
+| {doc}`bugprone-unique-ptr-array-mismatch <bugprone/unique-ptr-array-mismatch>` | Yes |
+| {doc}`bugprone-unsafe-functions <bugprone/unsafe-functions>` |  |
+| {doc}`bugprone-unsafe-to-allow-exceptions <bugprone/unsafe-to-allow-exceptions>` |  |
+| {doc}`bugprone-unused-local-non-trivial-variable <bugprone/unused-local-non-trivial-variable>` |  |
+| {doc}`bugprone-unused-raii <bugprone/unused-raii>` | Yes |
+| {doc}`bugprone-unused-return-value <bugprone/unused-return-value>` |  |
+| {doc}`bugprone-use-after-move <bugprone/use-after-move>` |  |
+| {doc}`bugprone-virtual-near-miss <bugprone/virtual-near-miss>` | Yes |
+| {doc}`concurrency-mt-unsafe <concurrency/mt-unsafe>` |  |
+| {doc}`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>` |  |
+| {doc}`cppcoreguidelines-avoid-capturing-lambda-coroutines <cppcoreguidelines/avoid-capturing-lambda-coroutines>` |  |
+| {doc}`cppcoreguidelines-avoid-const-or-ref-data-members <cppcoreguidelines/avoid-const-or-ref-data-members>` |  |
+| {doc}`cppcoreguidelines-avoid-do-while <cppcoreguidelines/avoid-do-while>` |  |
+| {doc}`cppcoreguidelines-avoid-goto <cppcoreguidelines/avoid-goto>` |  |
+| {doc}`cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines/avoid-non-const-global-variables>` |  |
+| {doc}`cppcoreguidelines-avoid-reference-coroutine-parameters <cppcoreguidelines/avoid-reference-coroutine-parameters>` |  |
+| {doc}`cppcoreguidelines-init-variables <cppcoreguidelines/init-variables>` | Yes |
+| {doc}`cppcoreguidelines-interfaces-global-init <cppcoreguidelines/interfaces-global-init>` |  |
+| {doc}`cppcoreguidelines-macro-usage <cppcoreguidelines/macro-usage>` |  |
+| {doc}`cppcoreguidelines-misleading-capture-default-by-value <cppcoreguidelines/misleading-capture-default-by-value>` | Yes |
+| {doc}`cppcoreguidelines-missing-std-forward <cppcoreguidelines/missing-std-forward>` |  |
+| {doc}`cppcoreguidelines-no-malloc <cppcoreguidelines/no-malloc>` |  |
+| {doc}`cppcoreguidelines-no-suspend-with-lock <cppcoreguidelines/no-suspend-with-lock>` |  |
+| {doc}`cppcoreguidelines-owning-memory <cppcoreguidelines/owning-memory>` |  |
+| {doc}`cppcoreguidelines-prefer-member-initializer <cppcoreguidelines/prefer-member-initializer>` | Yes |
+| {doc}`cppcoreguidelines-pro-bounds-array-to-pointer-decay <cppcoreguidelines/pro-bounds-array-to-pointer-decay>` |  |
+| {doc}`cppcoreguidelines-pro-bounds-avoid-unchecked-container-access <cppcoreguidelines/pro-bounds-avoid-unchecked-container-access>` | Yes |
+| {doc}`cppcoreguidelines-pro-bounds-constant-array-index <cppcoreguidelines/pro-bounds-constant-array-index>` | Yes |
+| {doc}`cppcoreguidelines-pro-bounds-pointer-arithmetic <cppcoreguidelines/pro-bounds-pointer-arithmetic>` |  |
+| {doc}`cppcoreguidelines-pro-type-const-cast <cppcoreguidelines/pro-type-const-cast>` |  |
+| {doc}`cppcoreguidelines-pro-type-cstyle-cast <cppcoreguidelines/pro-type-cstyle-cast>` | Yes |
+| {doc}`cppcoreguidelines-pro-type-member-init <cppcoreguidelines/pro-type-member-init>` | Yes |
+| {doc}`cppcoreguidelines-pro-type-reinterpret-cast <cppcoreguidelines/pro-type-reinterpret-cast>` |  |
+| {doc}`cppcoreguidelines-pro-type-static-cast-downcast <cppcoreguidelines/pro-type-static-cast-downcast>` | Yes |
+| {doc}`cppcoreguidelines-pro-type-union-access <cppcoreguidelines/pro-type-union-access>` |  |
+| {doc}`cppcoreguidelines-pro-type-vararg <cppcoreguidelines/pro-type-vararg>` |  |
+| {doc}`cppcoreguidelines-rvalue-reference-param-not-moved <cppcoreguidelines/rvalue-reference-param-not-moved>` |  |
+| {doc}`cppcoreguidelines-slicing <cppcoreguidelines/slicing>` |  |
+| {doc}`cppcoreguidelines-special-member-functions <cppcoreguidelines/special-member-functions>` |  |
+| {doc}`cppcoreguidelines-use-enum-class <cppcoreguidelines/use-enum-class>` |  |
+| {doc}`cppcoreguidelines-virtual-class-destructor <cppcoreguidelines/virtual-class-destructor>` | Yes |
+| {doc}`darwin-avoid-spinlock <darwin/avoid-spinlock>` |  |
+| {doc}`darwin-dispatch-once-nonstatic <darwin/dispatch-once-nonstatic>` | Yes |
+| {doc}`fuchsia-default-arguments-calls <fuchsia/default-arguments-calls>` |  |
+| {doc}`fuchsia-default-arguments-declarations <fuchsia/default-arguments-declarations>` | Yes |
+| {doc}`fuchsia-overloaded-operator <fuchsia/overloaded-operator>` |  |
+| {doc}`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>` |  |
+| {doc}`fuchsia-temporary-objects <fuchsia/temporary-objects>` |  |
+| {doc}`fuchsia-trailing-return <fuchsia/trailing-return>` |  |
+| {doc}`fuchsia-virtual-inheritance <fuchsia/virtual-inheritance>` |  |
+| {doc}`google-build-explicit-make-pair <google/build-explicit-make-pair>` |  |
+| {doc}`google-build-using-namespace <google/build-using-namespace>` |  |
+| {doc}`google-default-arguments <google/default-arguments>` |  |
+| {doc}`google-global-names-in-headers <google/global-names-in-headers>` |  |
+| {doc}`google-objc-avoid-nsobject-new <google/objc-avoid-nsobject-new>` |  |
+| {doc}`google-objc-avoid-throwing-exception <google/objc-avoid-throwing-exception>` |  |
+| {doc}`google-objc-function-naming <google/objc-function-naming>` |  |
+| {doc}`google-objc-global-variable-declaration <google/objc-global-variable-declaration>` |  |
+| {doc}`google-readability-avoid-underscore-in-googletest-name <google/readability-avoid-underscore-in-googletest-name>` |  |
+| {doc}`google-readability-todo <google/readability-todo>` |  |
+| {doc}`google-runtime-float <google/runtime-float>` |  |
+| {doc}`google-runtime-int <google/runtime-int>` |  |
+| {doc}`google-runtime-operator <google/runtime-operator>` |  |
+| {doc}`google-upgrade-googletest-case <google/upgrade-googletest-case>` | Yes |
+| {doc}`linuxkernel-must-check-errs <linuxkernel/must-check-errs>` |  |
+| {doc}`llvm-formatv-string <llvm/formatv-string>` |  |
+| {doc}`llvm-header-guard <llvm/header-guard>` |  |
+| {doc}`llvm-include-order <llvm/include-order>` | Yes |
+| {doc}`llvm-namespace-comment <llvm/namespace-comment>` |  |
+| {doc}`llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm/prefer-isa-or-dyn-cast-in-conditionals>` | Yes |
+| {doc}`llvm-prefer-register-over-unsigned <llvm/prefer-register-over-unsigned>` | Yes |
+| {doc}`llvm-prefer-static-over-anonymous-namespace <llvm/prefer-static-over-anonymous-namespace>` |  |
+| {doc}`llvm-redundant-casting <llvm/redundant-casting>` | Yes |
+| {doc}`llvm-twine-local <llvm/twine-local>` | Yes |
+| {doc}`llvm-type-switch-case-types <llvm/type-switch-case-types>` | Yes |
+| {doc}`llvm-use-new-mlir-op-builder <llvm/use-new-mlir-op-builder>` | Yes |
+| {doc}`llvm-use-ranges <llvm/use-ranges>` | Yes |
+| {doc}`llvm-use-vector-utils <llvm/use-vector-utils>` | Yes |
+| {doc}`llvmlibc-callee-namespace <llvmlibc/callee-namespace>` |  |
+| {doc}`llvmlibc-implementation-in-namespace <llvmlibc/implementation-in-namespace>` |  |
+| {doc}`llvmlibc-inline-function-decl <llvmlibc/inline-function-decl>` | Yes |
+| {doc}`llvmlibc-restrict-system-libc-headers <llvmlibc/restrict-system-libc-headers>` | Yes |
+| {doc}`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>` |  |
+| {doc}`misc-confusable-identifiers <misc/confusable-identifiers>` |  |
+| {doc}`misc-const-correctness <misc/const-correctness>` | Yes |
+| {doc}`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>` |  |
+| {doc}`misc-definitions-in-headers <misc/definitions-in-headers>` | Yes |
+| {doc}`misc-explicit-constructor <misc/explicit-constructor>` | Yes |
+| {doc}`misc-header-include-cycle <misc/header-include-cycle>` |  |
+| {doc}`misc-include-cleaner <misc/include-cleaner>` | Yes |
+| {doc}`misc-misleading-bidirectional <misc/misleading-bidirectional>` |  |
+| {doc}`misc-misleading-identifier <misc/misleading-identifier>` |  |
+| {doc}`misc-misplaced-const <misc/misplaced-const>` |  |
+| {doc}`misc-multiple-inheritance <misc/multiple-inheritance>` |  |
+| {doc}`misc-new-delete-overloads <misc/new-delete-overloads>` |  |
+| {doc}`misc-no-recursion <misc/no-recursion>` |  |
+| {doc}`misc-non-copyable-objects <misc/non-copyable-objects>` |  |
+| {doc}`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>` |  |
+| {doc}`misc-override-with-different-visibility <misc/override-with-different-visibility>` |  |
+| {doc}`misc-predictable-rand <misc/predictable-rand>` |  |
+| {doc}`misc-redundant-expression <misc/redundant-expression>` | Yes |
+| {doc}`misc-static-assert <misc/static-assert>` | Yes |
+| {doc}`misc-static-initialization-cycle <misc/static-initialization-cycle>` |  |
+| {doc}`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>` |  |
+| {doc}`misc-unconventional-assign-operator <misc/unconventional-assign-operator>` |  |
+| {doc}`misc-uniqueptr-reset-release <misc/uniqueptr-reset-release>` | Yes |
+| {doc}`misc-unused-alias-decls <misc/unused-alias-decls>` | Yes |
+| {doc}`misc-unused-parameters <misc/unused-parameters>` | Yes |
+| {doc}`misc-unused-using-decls <misc/unused-using-decls>` | Yes |
+| {doc}`misc-use-anonymous-namespace <misc/use-anonymous-namespace>` |  |
+| {doc}`misc-use-internal-linkage <misc/use-internal-linkage>` | Yes |
+| {doc}`modernize-avoid-bind <modernize/avoid-bind>` | Yes |
+| {doc}`modernize-avoid-c-arrays <modernize/avoid-c-arrays>` |  |
+| {doc}`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>` | Yes |
+| {doc}`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>` |  |
+| {doc}`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>` |  |
+| {doc}`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>` | Yes |
+| {doc}`modernize-deprecated-headers <modernize/deprecated-headers>` | Yes |
+| {doc}`modernize-deprecated-ios-base-aliases <modernize/deprecated-ios-base-aliases>` | Yes |
+| {doc}`modernize-loop-convert <modernize/loop-convert>` | Yes |
+| {doc}`modernize-macro-to-enum <modernize/macro-to-enum>` | Yes |
+| {doc}`modernize-make-shared <modernize/make-shared>` | Yes |
+| {doc}`modernize-make-unique <modernize/make-unique>` | Yes |
+| {doc}`modernize-min-max-use-initializer-list <modernize/min-max-use-initializer-list>` | Yes |
+| {doc}`modernize-pass-by-value <modernize/pass-by-value>` | Yes |
+| {doc}`modernize-raw-string-literal <modernize/raw-string-literal>` | Yes |
+| {doc}`modernize-redundant-void-arg <modernize/redundant-void-arg>` | Yes |
+| {doc}`modernize-replace-auto-ptr <modernize/replace-auto-ptr>` | Yes |
+| {doc}`modernize-replace-disallow-copy-and-assign-macro <modernize/replace-disallow-copy-and-assign-macro>` | Yes |
+| {doc}`modernize-replace-random-shuffle <modernize/replace-random-shuffle>` | Yes |
+| {doc}`modernize-return-braced-init-list <modernize/return-braced-init-list>` | Yes |
+| {doc}`modernize-shrink-to-fit <modernize/shrink-to-fit>` | Yes |
+| {doc}`modernize-type-traits <modernize/type-traits>` | Yes |
+| {doc}`modernize-unary-static-assert <modernize/unary-static-assert>` | Yes |
+| {doc}`modernize-use-auto <modernize/use-auto>` | Yes |
+| {doc}`modernize-use-bool-literals <modernize/use-bool-literals>` | Yes |
+| {doc}`modernize-use-constraints <modernize/use-constraints>` | Yes |
+| {doc}`modernize-use-default-member-init <modernize/use-default-member-init>` | Yes |
+| {doc}`modernize-use-designated-initializers <modernize/use-designated-initializers>` | Yes |
+| {doc}`modernize-use-emplace <modernize/use-emplace>` | Yes |
+| {doc}`modernize-use-equals-default <modernize/use-equals-default>` | Yes |
+| {doc}`modernize-use-equals-delete <modernize/use-equals-delete>` | Yes |
+| {doc}`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>` | Yes |
+| {doc}`modernize-use-nodiscard <modernize/use-nodiscard>` | Yes |
+| {doc}`modernize-use-noexcept <modernize/use-noexcept>` | Yes |
+| {doc}`modernize-use-nullptr <modernize/use-nullptr>` | Yes |
+| {doc}`modernize-use-override <modernize/use-override>` | Yes |
+| {doc}`modernize-use-ranges <modernize/use-ranges>` | Yes |
+| {doc}`modernize-use-scoped-lock <modernize/use-scoped-lock>` | Yes |
+| {doc}`modernize-use-starts-ends-with <modernize/use-starts-ends-with>` | Yes |
+| {doc}`modernize-use-std-bit <modernize/use-std-bit>` | Yes |
+| {doc}`modernize-use-std-format <modernize/use-std-format>` | Yes |
+| {doc}`modernize-use-std-numbers <modernize/use-std-numbers>` | Yes |
+| {doc}`modernize-use-std-print <modernize/use-std-print>` | Yes |
+| {doc}`modernize-use-string-view <modernize/use-string-view>` | Yes |
+| {doc}`modernize-use-structured-binding <modernize/use-structured-binding>` | Yes |
+| {doc}`modernize-use-trailing-return-type <modernize/use-trailing-return-type>` | Yes |
+| {doc}`modernize-use-transparent-functors <modernize/use-transparent-functors>` | Yes |
+| {doc}`modernize-use-uncaught-exceptions <modernize/use-uncaught-exceptions>` | Yes |
+| {doc}`modernize-use-using <modernize/use-using>` | Yes |
+| {doc}`mpi-buffer-deref <mpi/buffer-deref>` | Yes |
+| {doc}`mpi-type-mismatch <mpi/type-mismatch>` | Yes |
+| {doc}`objc-assert-equals <objc/assert-equals>` | Yes |
+| {doc}`objc-avoid-nserror-init <objc/avoid-nserror-init>` |  |
+| {doc}`objc-dealloc-in-category <objc/dealloc-in-category>` |  |
+| {doc}`objc-forbidden-subclassing <objc/forbidden-subclassing>` |  |
+| {doc}`objc-missing-hash <objc/missing-hash>` |  |
+| {doc}`objc-nsdate-formatter <objc/nsdate-formatter>` |  |
+| {doc}`objc-nsinvocation-argument-lifetime <objc/nsinvocation-argument-lifetime>` | Yes |
+| {doc}`objc-property-declaration <objc/property-declaration>` | Yes |
+| {doc}`objc-super-self <objc/super-self>` | Yes |
+| {doc}`openmp-exception-escape <openmp/exception-escape>` |  |
+| {doc}`openmp-use-default-none <openmp/use-default-none>` |  |
+| {doc}`performance-avoid-endl <performance/avoid-endl>` | Yes |
+| {doc}`performance-enum-size <performance/enum-size>` |  |
+| {doc}`performance-expensive-value-or <performance/expensive-value-or>` | Yes |
+| {doc}`performance-for-range-copy <performance/for-range-copy>` | Yes |
+| {doc}`performance-implicit-conversion-in-loop <performance/implicit-conversion-in-loop>` |  |
+| {doc}`performance-inefficient-algorithm <performance/inefficient-algorithm>` | Yes |
+| {doc}`performance-inefficient-string-concatenation <performance/inefficient-string-concatenation>` |  |
+| {doc}`performance-inefficient-vector-operation <performance/inefficient-vector-operation>` | Yes |
+| {doc}`performance-move-const-arg <performance/move-const-arg>` | Yes |
+| {doc}`performance-move-constructor-init <performance/move-constructor-init>` |  |
+| {doc}`performance-no-automatic-move <performance/no-automatic-move>` |  |
+| {doc}`performance-no-int-to-ptr <performance/no-int-to-ptr>` |  |
+| {doc}`performance-noexcept-destructor <performance/noexcept-destructor>` | Yes |
+| {doc}`performance-noexcept-move-constructor <performance/noexcept-move-constructor>` | Yes |
+| {doc}`performance-noexcept-swap <performance/noexcept-swap>` | Yes |
+| {doc}`performance-prefer-single-char-overloads <performance/prefer-single-char-overloads>` | Yes |
+| {doc}`performance-string-view-conversions <performance/string-view-conversions>` | Yes |
+| {doc}`performance-trivially-destructible <performance/trivially-destructible>` | Yes |
+| {doc}`performance-type-promotion-in-math-fn <performance/type-promotion-in-math-fn>` | Yes |
+| {doc}`performance-unnecessary-copy-initialization <performance/unnecessary-copy-initialization>` | Yes |
+| {doc}`performance-unnecessary-value-param <performance/unnecessary-value-param>` | Yes |
+| {doc}`performance-use-std-move <performance/use-std-move>` | Yes |
+| {doc}`portability-avoid-pragma-once <portability/avoid-pragma-once>` |  |
+| {doc}`portability-no-assembler <portability/no-assembler>` |  |
+| {doc}`portability-restrict-system-includes <portability/restrict-system-includes>` | Yes |
+| {doc}`portability-simd-intrinsics <portability/simd-intrinsics>` |  |
+| {doc}`portability-std-allocator-const <portability/std-allocator-const>` |  |
+| {doc}`portability-template-virtual-member-function <portability/template-virtual-member-function>` |  |
+| {doc}`readability-ambiguous-smartptr-reset-call <readability/ambiguous-smartptr-reset-call>` | Yes |
+| {doc}`readability-avoid-const-params-in-decls <readability/avoid-const-params-in-decls>` | Yes |
+| {doc}`readability-avoid-nested-conditional-operator <readability/avoid-nested-conditional-operator>` |  |
+| {doc}`readability-avoid-return-with-void-value <readability/avoid-return-with-void-value>` | Yes |
+| {doc}`readability-avoid-unconditional-preprocessor-if <readability/avoid-unconditional-preprocessor-if>` |  |
+| {doc}`readability-braces-around-statements <readability/braces-around-statements>` | Yes |
+| {doc}`readability-const-return-type <readability/const-return-type>` | Yes |
+| {doc}`readability-container-contains <readability/container-contains>` | Yes |
+| {doc}`readability-container-data-pointer <readability/container-data-pointer>` | Yes |
+| {doc}`readability-container-size-empty <readability/container-size-empty>` | Yes |
+| {doc}`readability-convert-member-functions-to-static <readability/convert-member-functions-to-static>` | Yes |
+| {doc}`readability-delete-null-pointer <readability/delete-null-pointer>` | Yes |
+| {doc}`readability-duplicate-include <readability/duplicate-include>` | Yes |
+| {doc}`readability-else-after-return <readability/else-after-return>` | Yes |
+| {doc}`readability-enum-initial-value <readability/enum-initial-value>` | Yes |
+| {doc}`readability-function-cognitive-complexity <readability/function-cognitive-complexity>` |  |
+| {doc}`readability-function-size <readability/function-size>` |  |
+| {doc}`readability-identifier-length <readability/identifier-length>` |  |
+| {doc}`readability-identifier-naming <readability/identifier-naming>` | Yes |
+| {doc}`readability-implicit-bool-conversion <readability/implicit-bool-conversion>` | Yes |
+| {doc}`readability-inconsistent-declaration-parameter-name <readability/inconsistent-declaration-parameter-name>` | Yes |
+| {doc}`readability-inconsistent-ifelse-braces <readability/inconsistent-ifelse-braces>` | Yes |
+| {doc}`readability-isolate-declaration <readability/isolate-declaration>` | Yes |
+| {doc}`readability-magic-numbers <readability/magic-numbers>` |  |
+| {doc}`readability-make-member-function-const <readability/make-member-function-const>` | Yes |
+| {doc}`readability-math-missing-parentheses <readability/math-missing-parentheses>` | Yes |
+| {doc}`readability-misleading-indentation <readability/misleading-indentation>` |  |
+| {doc}`readability-misplaced-array-index <readability/misplaced-array-index>` | Yes |
+| {doc}`readability-named-parameter <readability/named-parameter>` | Yes |
+| {doc}`readability-non-const-parameter <readability/non-const-parameter>` | Yes |
+| {doc}`readability-operators-representation <readability/operators-representation>` | Yes |
+| {doc}`readability-qualified-auto <readability/qualified-auto>` | Yes |
+| {doc}`readability-redundant-access-specifiers <readability/redundant-access-specifiers>` | Yes |
+| {doc}`readability-redundant-casting <readability/redundant-casting>` | Yes |
+| {doc}`readability-redundant-control-flow <readability/redundant-control-flow>` | Yes |
+| {doc}`readability-redundant-declaration <readability/redundant-declaration>` | Yes |
+| {doc}`readability-redundant-function-ptr-dereference <readability/redundant-function-ptr-dereference>` | Yes |
+| {doc}`readability-redundant-inline-specifier <readability/redundant-inline-specifier>` | Yes |
+| {doc}`readability-redundant-lambda-parameter-list <readability/redundant-lambda-parameter-list>` | Yes |
+| {doc}`readability-redundant-member-init <readability/redundant-member-init>` | Yes |
+| {doc}`readability-redundant-nested-if <readability/redundant-nested-if>` | Yes |
+| {doc}`readability-redundant-parentheses <readability/redundant-parentheses>` | Yes |
+| {doc}`readability-redundant-preprocessor <readability/redundant-preprocessor>` |  |
+| {doc}`readability-redundant-qualified-alias <readability/redundant-qualified-alias>` | Yes |
+| {doc}`readability-redundant-smartptr-get <readability/redundant-smartptr-get>` | Yes |
+| {doc}`readability-redundant-string-cstr <readability/redundant-string-cstr>` | Yes |
+| {doc}`readability-redundant-string-init <readability/redundant-string-init>` | Yes |
+| {doc}`readability-redundant-typename <readability/redundant-typename>` | Yes |
+| {doc}`readability-reference-to-constructed-temporary <readability/reference-to-constructed-temporary>` |  |
+| {doc}`readability-simplify-boolean-expr <readability/simplify-boolean-expr>` | Yes |
+| {doc}`readability-simplify-subscript-expr <readability/simplify-subscript-expr>` | Yes |
+| {doc}`readability-static-accessed-through-instance <readability/static-accessed-through-instance>` | Yes |
+| {doc}`readability-static-definition-in-anonymous-namespace <readability/static-definition-in-anonymous-namespace>` | Yes |
+| {doc}`readability-string-compare <readability/string-compare>` | Yes |
+| {doc}`readability-suspicious-call-argument <readability/suspicious-call-argument>` |  |
+| {doc}`readability-trailing-comma <readability/trailing-comma>` | Yes |
+| {doc}`readability-trivial-switch <readability/trivial-switch>` |  |
+| {doc}`readability-uniqueptr-delete-release <readability/uniqueptr-delete-release>` | Yes |
+| {doc}`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>` | Yes |
+| {doc}`readability-use-anyofallof <readability/use-anyofallof>` |  |
+| {doc}`readability-use-concise-preprocessor-directives <readability/use-concise-preprocessor-directives>` | Yes |
+| {doc}`readability-use-std-min-max <readability/use-std-min-max>` | Yes |
+| {doc}`zircon-temporary-objects <zircon/temporary-objects>` |  |
 
-   :doc:`abseil-cleanup-ctad <abseil/cleanup-ctad>`, "Yes"
-   :doc:`abseil-duration-addition <abseil/duration-addition>`, "Yes"
-   :doc:`abseil-duration-comparison <abseil/duration-comparison>`, "Yes"
-   :doc:`abseil-duration-conversion-cast <abseil/duration-conversion-cast>`, "Yes"
-   :doc:`abseil-duration-division <abseil/duration-division>`, "Yes"
-   :doc:`abseil-duration-factory-float <abseil/duration-factory-float>`, "Yes"
-   :doc:`abseil-duration-factory-scale <abseil/duration-factory-scale>`, "Yes"
-   :doc:`abseil-duration-subtraction <abseil/duration-subtraction>`, "Yes"
-   :doc:`abseil-duration-unnecessary-conversion <abseil/duration-unnecessary-conversion>`, "Yes"
-   :doc:`abseil-faster-strsplit-delimiter <abseil/faster-strsplit-delimiter>`, "Yes"
-   :doc:`abseil-no-internal-dependencies <abseil/no-internal-dependencies>`,
-   :doc:`abseil-no-namespace <abseil/no-namespace>`,
-   :doc:`abseil-redundant-strcat-calls <abseil/redundant-strcat-calls>`, "Yes"
-   :doc:`abseil-str-cat-append <abseil/str-cat-append>`, "Yes"
-   :doc:`abseil-string-find-startswith <abseil/string-find-startswith>`, "Yes"
-   :doc:`abseil-string-find-str-contains <abseil/string-find-str-contains>`, "Yes"
-   :doc:`abseil-time-comparison <abseil/time-comparison>`, "Yes"
-   :doc:`abseil-time-subtraction <abseil/time-subtraction>`, "Yes"
-   :doc:`abseil-unchecked-statusor-access <abseil/unchecked-statusor-access>`,
-   :doc:`abseil-upgrade-duration-conversions <abseil/upgrade-duration-conversions>`, "Yes"
-   :doc:`altera-id-dependent-backward-branch <altera/id-dependent-backward-branch>`,
-   :doc:`altera-kernel-name-restriction <altera/kernel-name-restriction>`,
-   :doc:`altera-single-work-item-barrier <altera/single-work-item-barrier>`,
-   :doc:`altera-struct-pack-align <altera/struct-pack-align>`, "Yes"
-   :doc:`altera-unroll-loops <altera/unroll-loops>`,
-   :doc:`android-cloexec-accept <android/cloexec-accept>`, "Yes"
-   :doc:`android-cloexec-accept4 <android/cloexec-accept4>`, "Yes"
-   :doc:`android-cloexec-creat <android/cloexec-creat>`, "Yes"
-   :doc:`android-cloexec-dup <android/cloexec-dup>`, "Yes"
-   :doc:`android-cloexec-epoll-create <android/cloexec-epoll-create>`, "Yes"
-   :doc:`android-cloexec-epoll-create1 <android/cloexec-epoll-create1>`, "Yes"
-   :doc:`android-cloexec-fopen <android/cloexec-fopen>`, "Yes"
-   :doc:`android-cloexec-inotify-init <android/cloexec-inotify-init>`, "Yes"
-   :doc:`android-cloexec-inotify-init1 <android/cloexec-inotify-init1>`, "Yes"
-   :doc:`android-cloexec-memfd-create <android/cloexec-memfd-create>`, "Yes"
-   :doc:`android-cloexec-open <android/cloexec-open>`, "Yes"
-   :doc:`android-cloexec-pipe <android/cloexec-pipe>`, "Yes"
-   :doc:`android-cloexec-pipe2 <android/cloexec-pipe2>`, "Yes"
-   :doc:`android-cloexec-socket <android/cloexec-socket>`, "Yes"
-   :doc:`android-comparison-in-temp-failure-retry <android/comparison-in-temp-failure-retry>`,
-   :doc:`boost-use-ranges <boost/use-ranges>`, "Yes"
-   :doc:`boost-use-to-string <boost/use-to-string>`, "Yes"
-   :doc:`bugprone-argument-comment <bugprone/argument-comment>`, "Yes"
-   :doc:`bugprone-assert-side-effect <bugprone/assert-side-effect>`,
-   :doc:`bugprone-assignment-in-if-condition <bugprone/assignment-in-if-condition>`,
-   :doc:`bugprone-assignment-in-selection-statement <bugprone/assignment-in-selection-statement>`,
-   :doc:`bugprone-bad-signal-to-kill-thread <bugprone/bad-signal-to-kill-thread>`,
-   :doc:`bugprone-bitwise-pointer-cast <bugprone/bitwise-pointer-cast>`,
-   :doc:`bugprone-bool-pointer-implicit-conversion <bugprone/bool-pointer-implicit-conversion>`, "Yes"
-   :doc:`bugprone-branch-clone <bugprone/branch-clone>`,
-   :doc:`bugprone-capturing-this-in-member-variable <bugprone/capturing-this-in-member-variable>`,
-   :doc:`bugprone-casting-through-void <bugprone/casting-through-void>`,
-   :doc:`bugprone-chained-comparison <bugprone/chained-comparison>`,
-   :doc:`bugprone-command-processor <bugprone/command-processor>`,
-   :doc:`bugprone-compare-pointer-to-member-virtual-function <bugprone/compare-pointer-to-member-virtual-function>`,
-   :doc:`bugprone-copy-constructor-init <bugprone/copy-constructor-init>`, "Yes"
-   :doc:`bugprone-copy-constructor-mutates-argument <bugprone/copy-constructor-mutates-argument>`,
-   :doc:`bugprone-crtp-constructor-accessibility <bugprone/crtp-constructor-accessibility>`, "Yes"
-   :doc:`bugprone-dangling-handle <bugprone/dangling-handle>`,
-   :doc:`bugprone-default-operator-new-on-overaligned-type <bugprone/default-operator-new-on-overaligned-type>`,
-   :doc:`bugprone-derived-method-shadowing-base-method <bugprone/derived-method-shadowing-base-method>`,
-   :doc:`bugprone-dynamic-static-initializers <bugprone/dynamic-static-initializers>`,
-   :doc:`bugprone-easily-swappable-parameters <bugprone/easily-swappable-parameters>`,
-   :doc:`bugprone-empty-catch <bugprone/empty-catch>`,
-   :doc:`bugprone-exception-copy-constructor-throws <bugprone/exception-copy-constructor-throws>`,
-   :doc:`bugprone-exception-escape <bugprone/exception-escape>`,
-   :doc:`bugprone-float-loop-counter <bugprone/float-loop-counter>`,
-   :doc:`bugprone-fold-init-type <bugprone/fold-init-type>`,
-   :doc:`bugprone-forward-declaration-namespace <bugprone/forward-declaration-namespace>`,
-   :doc:`bugprone-forwarding-reference-overload <bugprone/forwarding-reference-overload>`,
-   :doc:`bugprone-implicit-widening-of-multiplication-result <bugprone/implicit-widening-of-multiplication-result>`, "Yes"
-   :doc:`bugprone-inaccurate-erase <bugprone/inaccurate-erase>`, "Yes"
-   :doc:`bugprone-inc-dec-in-conditions <bugprone/inc-dec-in-conditions>`,
-   :doc:`bugprone-incorrect-enable-if <bugprone/incorrect-enable-if>`, "Yes"
-   :doc:`bugprone-incorrect-enable-shared-from-this <bugprone/incorrect-enable-shared-from-this>`, "Yes"
-   :doc:`bugprone-incorrect-roundings <bugprone/incorrect-roundings>`,
-   :doc:`bugprone-infinite-loop <bugprone/infinite-loop>`,
-   :doc:`bugprone-integer-division <bugprone/integer-division>`,
-   :doc:`bugprone-invalid-enum-default-initialization <bugprone/invalid-enum-default-initialization>`,
-   :doc:`bugprone-lambda-function-name <bugprone/lambda-function-name>`,
-   :doc:`bugprone-macro-parentheses <bugprone/macro-parentheses>`, "Yes"
-   :doc:`bugprone-macro-repeated-side-effects <bugprone/macro-repeated-side-effects>`,
-   :doc:`bugprone-misleading-setter-of-reference <bugprone/misleading-setter-of-reference>`,
-   :doc:`bugprone-misplaced-operator-in-strlen-in-alloc <bugprone/misplaced-operator-in-strlen-in-alloc>`, "Yes"
-   :doc:`bugprone-misplaced-pointer-arithmetic-in-alloc <bugprone/misplaced-pointer-arithmetic-in-alloc>`, "Yes"
-   :doc:`bugprone-misplaced-widening-cast <bugprone/misplaced-widening-cast>`,
-   :doc:`bugprone-missing-end-comparison <bugprone/missing-end-comparison>`, "Yes"
-   :doc:`bugprone-move-forwarding-reference <bugprone/move-forwarding-reference>`, "Yes"
-   :doc:`bugprone-multi-level-implicit-pointer-conversion <bugprone/multi-level-implicit-pointer-conversion>`,
-   :doc:`bugprone-multiple-new-in-one-expression <bugprone/multiple-new-in-one-expression>`,
-   :doc:`bugprone-multiple-statement-macro <bugprone/multiple-statement-macro>`,
-   :doc:`bugprone-narrowing-conversions <bugprone/narrowing-conversions>`,
-   :doc:`bugprone-no-escape <bugprone/no-escape>`,
-   :doc:`bugprone-non-zero-enum-to-bool-conversion <bugprone/non-zero-enum-to-bool-conversion>`,
-   :doc:`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>`,
-   :doc:`bugprone-not-null-terminated-result <bugprone/not-null-terminated-result>`, "Yes"
-   :doc:`bugprone-optional-value-conversion <bugprone/optional-value-conversion>`, "Yes"
-   :doc:`bugprone-parent-virtual-call <bugprone/parent-virtual-call>`, "Yes"
-   :doc:`bugprone-pointer-arithmetic-on-polymorphic-object <bugprone/pointer-arithmetic-on-polymorphic-object>`,
-   :doc:`bugprone-posix-return <bugprone/posix-return>`, "Yes"
-   :doc:`bugprone-random-generator-seed <bugprone/random-generator-seed>`,
-   :doc:`bugprone-raw-memory-call-on-non-trivial-type <bugprone/raw-memory-call-on-non-trivial-type>`,
-   :doc:`bugprone-redundant-branch-condition <bugprone/redundant-branch-condition>`, "Yes"
-   :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
-   :doc:`bugprone-return-const-ref-from-parameter <bugprone/return-const-ref-from-parameter>`,
-   :doc:`bugprone-shared-ptr-array-mismatch <bugprone/shared-ptr-array-mismatch>`, "Yes"
-   :doc:`bugprone-signal-handler <bugprone/signal-handler>`,
-   :doc:`bugprone-signed-bitwise <bugprone/signed-bitwise>`,
-   :doc:`bugprone-signed-char-misuse <bugprone/signed-char-misuse>`,
-   :doc:`bugprone-sizeof-container <bugprone/sizeof-container>`,
-   :doc:`bugprone-sizeof-expression <bugprone/sizeof-expression>`,
-   :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,
-   :doc:`bugprone-standalone-empty <bugprone/standalone-empty>`, "Yes"
-   :doc:`bugprone-std-exception-baseclass <bugprone/std-exception-baseclass>`,
-   :doc:`bugprone-std-namespace-modification <bugprone/std-namespace-modification>`,
-   :doc:`bugprone-string-constructor <bugprone/string-constructor>`, "Yes"
-   :doc:`bugprone-string-integer-assignment <bugprone/string-integer-assignment>`, "Yes"
-   :doc:`bugprone-string-literal-with-embedded-nul <bugprone/string-literal-with-embedded-nul>`,
-   :doc:`bugprone-stringview-nullptr <bugprone/stringview-nullptr>`, "Yes"
-   :doc:`bugprone-suspicious-enum-usage <bugprone/suspicious-enum-usage>`,
-   :doc:`bugprone-suspicious-include <bugprone/suspicious-include>`,
-   :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,
-   :doc:`bugprone-suspicious-memset-usage <bugprone/suspicious-memset-usage>`, "Yes"
-   :doc:`bugprone-suspicious-missing-comma <bugprone/suspicious-missing-comma>`,
-   :doc:`bugprone-suspicious-realloc-usage <bugprone/suspicious-realloc-usage>`,
-   :doc:`bugprone-suspicious-semicolon <bugprone/suspicious-semicolon>`, "Yes"
-   :doc:`bugprone-suspicious-string-compare <bugprone/suspicious-string-compare>`, "Yes"
-   :doc:`bugprone-suspicious-stringview-data-usage <bugprone/suspicious-stringview-data-usage>`,
-   :doc:`bugprone-swapped-arguments <bugprone/swapped-arguments>`, "Yes"
-   :doc:`bugprone-switch-missing-default-case <bugprone/switch-missing-default-case>`,
-   :doc:`bugprone-tagged-union-member-count <bugprone/tagged-union-member-count>`,
-   :doc:`bugprone-terminating-continue <bugprone/terminating-continue>`, "Yes"
-   :doc:`bugprone-throw-keyword-missing <bugprone/throw-keyword-missing>`,
-   :doc:`bugprone-throwing-static-initialization <bugprone/throwing-static-initialization>`,
-   :doc:`bugprone-too-small-loop-variable <bugprone/too-small-loop-variable>`,
-   :doc:`bugprone-unchecked-optional-access <bugprone/unchecked-optional-access>`,
-   :doc:`bugprone-unchecked-string-to-number-conversion <bugprone/unchecked-string-to-number-conversion>`,
-   :doc:`bugprone-undefined-memory-manipulation <bugprone/undefined-memory-manipulation>`,
-   :doc:`bugprone-undelegated-constructor <bugprone/undelegated-constructor>`,
-   :doc:`bugprone-unhandled-code-paths <bugprone/unhandled-code-paths>`,
-   :doc:`bugprone-unhandled-exception-at-new <bugprone/unhandled-exception-at-new>`,
-   :doc:`bugprone-unhandled-self-assignment <bugprone/unhandled-self-assignment>`,
-   :doc:`bugprone-unintended-char-ostream-output <bugprone/unintended-char-ostream-output>`, "Yes"
-   :doc:`bugprone-unique-ptr-array-mismatch <bugprone/unique-ptr-array-mismatch>`, "Yes"
-   :doc:`bugprone-unsafe-functions <bugprone/unsafe-functions>`,
-   :doc:`bugprone-unsafe-to-allow-exceptions <bugprone/unsafe-to-allow-exceptions>`,
-   :doc:`bugprone-unused-local-non-trivial-variable <bugprone/unused-local-non-trivial-variable>`,
-   :doc:`bugprone-unused-raii <bugprone/unused-raii>`, "Yes"
-   :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,
-   :doc:`bugprone-use-after-move <bugprone/use-after-move>`,
-   :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes"
-   :doc:`concurrency-mt-unsafe <concurrency/mt-unsafe>`,
-   :doc:`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>`,
-   :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines <cppcoreguidelines/avoid-capturing-lambda-coroutines>`,
-   :doc:`cppcoreguidelines-avoid-const-or-ref-data-members <cppcoreguidelines/avoid-const-or-ref-data-members>`,
-   :doc:`cppcoreguidelines-avoid-do-while <cppcoreguidelines/avoid-do-while>`,
-   :doc:`cppcoreguidelines-avoid-goto <cppcoreguidelines/avoid-goto>`,
-   :doc:`cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines/avoid-non-const-global-variables>`,
-   :doc:`cppcoreguidelines-avoid-reference-coroutine-parameters <cppcoreguidelines/avoid-reference-coroutine-parameters>`,
-   :doc:`cppcoreguidelines-init-variables <cppcoreguidelines/init-variables>`, "Yes"
-   :doc:`cppcoreguidelines-interfaces-global-init <cppcoreguidelines/interfaces-global-init>`,
-   :doc:`cppcoreguidelines-macro-usage <cppcoreguidelines/macro-usage>`,
-   :doc:`cppcoreguidelines-misleading-capture-default-by-value <cppcoreguidelines/misleading-capture-default-by-value>`, "Yes"
-   :doc:`cppcoreguidelines-missing-std-forward <cppcoreguidelines/missing-std-forward>`,
-   :doc:`cppcoreguidelines-no-malloc <cppcoreguidelines/no-malloc>`,
-   :doc:`cppcoreguidelines-no-suspend-with-lock <cppcoreguidelines/no-suspend-with-lock>`,
-   :doc:`cppcoreguidelines-owning-memory <cppcoreguidelines/owning-memory>`,
-   :doc:`cppcoreguidelines-prefer-member-initializer <cppcoreguidelines/prefer-member-initializer>`, "Yes"
-   :doc:`cppcoreguidelines-pro-bounds-array-to-pointer-decay <cppcoreguidelines/pro-bounds-array-to-pointer-decay>`,
-   :doc:`cppcoreguidelines-pro-bounds-avoid-unchecked-container-access <cppcoreguidelines/pro-bounds-avoid-unchecked-container-access>`, "Yes"
-   :doc:`cppcoreguidelines-pro-bounds-constant-array-index <cppcoreguidelines/pro-bounds-constant-array-index>`, "Yes"
-   :doc:`cppcoreguidelines-pro-bounds-pointer-arithmetic <cppcoreguidelines/pro-bounds-pointer-arithmetic>`,
-   :doc:`cppcoreguidelines-pro-type-const-cast <cppcoreguidelines/pro-type-const-cast>`,
-   :doc:`cppcoreguidelines-pro-type-cstyle-cast <cppcoreguidelines/pro-type-cstyle-cast>`, "Yes"
-   :doc:`cppcoreguidelines-pro-type-member-init <cppcoreguidelines/pro-type-member-init>`, "Yes"
-   :doc:`cppcoreguidelines-pro-type-reinterpret-cast <cppcoreguidelines/pro-type-reinterpret-cast>`,
-   :doc:`cppcoreguidelines-pro-type-static-cast-downcast <cppcoreguidelines/pro-type-static-cast-downcast>`, "Yes"
-   :doc:`cppcoreguidelines-pro-type-union-access <cppcoreguidelines/pro-type-union-access>`,
-   :doc:`cppcoreguidelines-pro-type-vararg <cppcoreguidelines/pro-type-vararg>`,
-   :doc:`cppcoreguidelines-rvalue-reference-param-not-moved <cppcoreguidelines/rvalue-reference-param-not-moved>`,
-   :doc:`cppcoreguidelines-slicing <cppcoreguidelines/slicing>`,
-   :doc:`cppcoreguidelines-special-member-functions <cppcoreguidelines/special-member-functions>`,
-   :doc:`cppcoreguidelines-use-enum-class <cppcoreguidelines/use-enum-class>`,
-   :doc:`cppcoreguidelines-virtual-class-destructor <cppcoreguidelines/virtual-class-destructor>`, "Yes"
-   :doc:`darwin-avoid-spinlock <darwin/avoid-spinlock>`,
-   :doc:`darwin-dispatch-once-nonstatic <darwin/dispatch-once-nonstatic>`, "Yes"
-   :doc:`fuchsia-default-arguments-calls <fuchsia/default-arguments-calls>`,
-   :doc:`fuchsia-default-arguments-declarations <fuchsia/default-arguments-declarations>`, "Yes"
-   :doc:`fuchsia-overloaded-operator <fuchsia/overloaded-operator>`,
-   :doc:`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>`,
-   :doc:`fuchsia-temporary-objects <fuchsia/temporary-objects>`,
-   :doc:`fuchsia-trailing-return <fuchsia/trailing-return>`,
-   :doc:`fuchsia-virtual-inheritance <fuchsia/virtual-inheritance>`,
-   :doc:`google-build-explicit-make-pair <google/build-explicit-make-pair>`,
-   :doc:`google-build-using-namespace <google/build-using-namespace>`,
-   :doc:`google-default-arguments <google/default-arguments>`,
-   :doc:`google-global-names-in-headers <google/global-names-in-headers>`,
-   :doc:`google-objc-avoid-nsobject-new <google/objc-avoid-nsobject-new>`,
-   :doc:`google-objc-avoid-throwing-exception <google/objc-avoid-throwing-exception>`,
-   :doc:`google-objc-function-naming <google/objc-function-naming>`,
-   :doc:`google-objc-global-variable-declaration <google/objc-global-variable-declaration>`,
-   :doc:`google-readability-avoid-underscore-in-googletest-name <google/readability-avoid-underscore-in-googletest-name>`,
-   :doc:`google-readability-todo <google/readability-todo>`,
-   :doc:`google-runtime-float <google/runtime-float>`,
-   :doc:`google-runtime-int <google/runtime-int>`,
-   :doc:`google-runtime-operator <google/runtime-operator>`,
-   :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes"
-   :doc:`linuxkernel-must-check-errs <linuxkernel/must-check-errs>`,
-   :doc:`llvm-formatv-string <llvm/formatv-string>`,
-   :doc:`llvm-header-guard <llvm/header-guard>`,
-   :doc:`llvm-include-order <llvm/include-order>`, "Yes"
-   :doc:`llvm-namespace-comment <llvm/namespace-comment>`,
-   :doc:`llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm/prefer-isa-or-dyn-cast-in-conditionals>`, "Yes"
-   :doc:`llvm-prefer-register-over-unsigned <llvm/prefer-register-over-unsigned>`, "Yes"
-   :doc:`llvm-prefer-static-over-anonymous-namespace <llvm/prefer-static-over-anonymous-namespace>`,
-   :doc:`llvm-redundant-casting <llvm/redundant-casting>`, "Yes"
-   :doc:`llvm-twine-local <llvm/twine-local>`, "Yes"
-   :doc:`llvm-type-switch-case-types <llvm/type-switch-case-types>`, "Yes"
-   :doc:`llvm-use-new-mlir-op-builder <llvm/use-new-mlir-op-builder>`, "Yes"
-   :doc:`llvm-use-ranges <llvm/use-ranges>`, "Yes"
-   :doc:`llvm-use-vector-utils <llvm/use-vector-utils>`, "Yes"
-   :doc:`llvmlibc-callee-namespace <llvmlibc/callee-namespace>`,
-   :doc:`llvmlibc-implementation-in-namespace <llvmlibc/implementation-in-namespace>`,
-   :doc:`llvmlibc-inline-function-decl <llvmlibc/inline-function-decl>`, "Yes"
-   :doc:`llvmlibc-restrict-system-libc-headers <llvmlibc/restrict-system-libc-headers>`, "Yes"
-   :doc:`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>`,
-   :doc:`misc-confusable-identifiers <misc/confusable-identifiers>`,
-   :doc:`misc-const-correctness <misc/const-correctness>`, "Yes"
-   :doc:`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>`,
-   :doc:`misc-definitions-in-headers <misc/definitions-in-headers>`, "Yes"
-   :doc:`misc-explicit-constructor <misc/explicit-constructor>`, "Yes"
-   :doc:`misc-header-include-cycle <misc/header-include-cycle>`,
-   :doc:`misc-include-cleaner <misc/include-cleaner>`, "Yes"
-   :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,
-   :doc:`misc-misleading-identifier <misc/misleading-identifier>`,
-   :doc:`misc-misplaced-const <misc/misplaced-const>`,
-   :doc:`misc-multiple-inheritance <misc/multiple-inheritance>`,
-   :doc:`misc-new-delete-overloads <misc/new-delete-overloads>`,
-   :doc:`misc-no-recursion <misc/no-recursion>`,
-   :doc:`misc-non-copyable-objects <misc/non-copyable-objects>`,
-   :doc:`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>`,
-   :doc:`misc-override-with-different-visibility <misc/override-with-different-visibility>`,
-   :doc:`misc-predictable-rand <misc/predictable-rand>`,
-   :doc:`misc-redundant-expression <misc/redundant-expression>`, "Yes"
-   :doc:`misc-static-assert <misc/static-assert>`, "Yes"
-   :doc:`misc-static-initialization-cycle <misc/static-initialization-cycle>`,
-   :doc:`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>`,
-   :doc:`misc-unconventional-assign-operator <misc/unconventional-assign-operator>`,
-   :doc:`misc-uniqueptr-reset-release <misc/uniqueptr-reset-release>`, "Yes"
-   :doc:`misc-unused-alias-decls <misc/unused-alias-decls>`, "Yes"
-   :doc:`misc-unused-parameters <misc/unused-parameters>`, "Yes"
-   :doc:`misc-unused-using-decls <misc/unused-using-decls>`, "Yes"
-   :doc:`misc-use-anonymous-namespace <misc/use-anonymous-namespace>`,
-   :doc:`misc-use-internal-linkage <misc/use-internal-linkage>`, "Yes"
-   :doc:`modernize-avoid-bind <modernize/avoid-bind>`, "Yes"
-   :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,
-   :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`, "Yes"
-   :doc:`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>`,
-   :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,
-   :doc:`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>`, "Yes"
-   :doc:`modernize-deprecated-headers <modernize/deprecated-headers>`, "Yes"
-   :doc:`modernize-deprecated-ios-base-aliases <modernize/deprecated-ios-base-aliases>`, "Yes"
-   :doc:`modernize-loop-convert <modernize/loop-convert>`, "Yes"
-   :doc:`modernize-macro-to-enum <modernize/macro-to-enum>`, "Yes"
-   :doc:`modernize-make-shared <modernize/make-shared>`, "Yes"
-   :doc:`modernize-make-unique <modernize/make-unique>`, "Yes"
-   :doc:`modernize-min-max-use-initializer-list <modernize/min-max-use-initializer-list>`, "Yes"
-   :doc:`modernize-pass-by-value <modernize/pass-by-value>`, "Yes"
-   :doc:`modernize-raw-string-literal <modernize/raw-string-literal>`, "Yes"
-   :doc:`modernize-redundant-void-arg <modernize/redundant-void-arg>`, "Yes"
-   :doc:`modernize-replace-auto-ptr <modernize/replace-auto-ptr>`, "Yes"
-   :doc:`modernize-replace-disallow-copy-and-assign-macro <modernize/replace-disallow-copy-and-assign-macro>`, "Yes"
-   :doc:`modernize-replace-random-shuffle <modernize/replace-random-shuffle>`, "Yes"
-   :doc:`modernize-return-braced-init-list <modernize/return-braced-init-list>`, "Yes"
-   :doc:`modernize-shrink-to-fit <modernize/shrink-to-fit>`, "Yes"
-   :doc:`modernize-type-traits <modernize/type-traits>`, "Yes"
-   :doc:`modernize-unary-static-assert <modernize/unary-static-assert>`, "Yes"
-   :doc:`modernize-use-auto <modernize/use-auto>`, "Yes"
-   :doc:`modernize-use-bool-literals <modernize/use-bool-literals>`, "Yes"
-   :doc:`modernize-use-constraints <modernize/use-constraints>`, "Yes"
-   :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes"
-   :doc:`modernize-use-designated-initializers <modernize/use-designated-initializers>`, "Yes"
-   :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes"
-   :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes"
-   :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes"
-   :doc:`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>`, "Yes"
-   :doc:`modernize-use-nodiscard <modernize/use-nodiscard>`, "Yes"
-   :doc:`modernize-use-noexcept <modernize/use-noexcept>`, "Yes"
-   :doc:`modernize-use-nullptr <modernize/use-nullptr>`, "Yes"
-   :doc:`modernize-use-override <modernize/use-override>`, "Yes"
-   :doc:`modernize-use-ranges <modernize/use-ranges>`, "Yes"
-   :doc:`modernize-use-scoped-lock <modernize/use-scoped-lock>`, "Yes"
-   :doc:`modernize-use-starts-ends-with <modernize/use-starts-ends-with>`, "Yes"
-   :doc:`modernize-use-std-bit <modernize/use-std-bit>`, "Yes"
-   :doc:`modernize-use-std-format <modernize/use-std-format>`, "Yes"
-   :doc:`modernize-use-std-numbers <modernize/use-std-numbers>`, "Yes"
-   :doc:`modernize-use-std-print <modernize/use-std-print>`, "Yes"
-   :doc:`modernize-use-string-view <modernize/use-string-view>`, "Yes"
-   :doc:`modernize-use-structured-binding <modernize/use-structured-binding>`, "Yes"
-   :doc:`modernize-use-trailing-return-type <modernize/use-trailing-return-type>`, "Yes"
-   :doc:`modernize-use-transparent-functors <modernize/use-transparent-functors>`, "Yes"
-   :doc:`modernize-use-uncaught-exceptions <modernize/use-uncaught-exceptions>`, "Yes"
-   :doc:`modernize-use-using <modernize/use-using>`, "Yes"
-   :doc:`mpi-buffer-deref <mpi/buffer-deref>`, "Yes"
-   :doc:`mpi-type-mismatch <mpi/type-mismatch>`, "Yes"
-   :doc:`objc-assert-equals <objc/assert-equals>`, "Yes"
-   :doc:`objc-avoid-nserror-init <objc/avoid-nserror-init>`,
-   :doc:`objc-dealloc-in-category <objc/dealloc-in-category>`,
-   :doc:`objc-forbidden-subclassing <objc/forbidden-subclassing>`,
-   :doc:`objc-missing-hash <objc/missing-hash>`,
-   :doc:`objc-nsdate-formatter <objc/nsdate-formatter>`,
-   :doc:`objc-nsinvocation-argument-lifetime <objc/nsinvocation-argument-lifetime>`, "Yes"
-   :doc:`objc-property-declaration <objc/property-declaration>`, "Yes"
-   :doc:`objc-super-self <objc/super-self>`, "Yes"
-   :doc:`openmp-exception-escape <openmp/exception-escape>`,
-   :doc:`openmp-use-default-none <openmp/use-default-none>`,
-   :doc:`performance-avoid-endl <performance/avoid-endl>`, "Yes"
-   :doc:`performance-enum-size <performance/enum-size>`,
-   :doc:`performance-expensive-value-or <performance/expensive-value-or>`, "Yes"
-   :doc:`performance-for-range-copy <performance/for-range-copy>`, "Yes"
-   :doc:`performance-implicit-conversion-in-loop <performance/implicit-conversion-in-loop>`,
-   :doc:`performance-inefficient-algorithm <performance/inefficient-algorithm>`, "Yes"
-   :doc:`performance-inefficient-string-concatenation <performance/inefficient-string-concatenation>`,
-   :doc:`performance-inefficient-vector-operation <performance/inefficient-vector-operation>`, "Yes"
-   :doc:`performance-move-const-arg <performance/move-const-arg>`, "Yes"
-   :doc:`performance-move-constructor-init <performance/move-constructor-init>`,
-   :doc:`performance-no-automatic-move <performance/no-automatic-move>`,
-   :doc:`performance-no-int-to-ptr <performance/no-int-to-ptr>`,
-   :doc:`performance-noexcept-destructor <performance/noexcept-destructor>`, "Yes"
-   :doc:`performance-noexcept-move-constructor <performance/noexcept-move-constructor>`, "Yes"
-   :doc:`performance-noexcept-swap <performance/noexcept-swap>`, "Yes"
-   :doc:`performance-prefer-single-char-overloads <performance/prefer-single-char-overloads>`, "Yes"
-   :doc:`performance-string-view-conversions <performance/string-view-conversions>`, "Yes"
-   :doc:`performance-trivially-destructible <performance/trivially-destructible>`, "Yes"
-   :doc:`performance-type-promotion-in-math-fn <performance/type-promotion-in-math-fn>`, "Yes"
-   :doc:`performance-unnecessary-copy-initialization <performance/unnecessary-copy-initialization>`, "Yes"
-   :doc:`performance-unnecessary-value-param <performance/unnecessary-value-param>`, "Yes"
-   :doc:`performance-use-std-move <performance/use-std-move>`, "Yes"
-   :doc:`portability-avoid-pragma-once <portability/avoid-pragma-once>`,
-   :doc:`portability-no-assembler <portability/no-assembler>`,
-   :doc:`portability-restrict-system-includes <portability/restrict-system-includes>`, "Yes"
-   :doc:`portability-simd-intrinsics <portability/simd-intrinsics>`,
-   :doc:`portability-std-allocator-const <portability/std-allocator-const>`,
-   :doc:`portability-template-virtual-member-function <portability/template-virtual-member-function>`,
-   :doc:`readability-ambiguous-smartptr-reset-call <readability/ambiguous-smartptr-reset-call>`, "Yes"
-   :doc:`readability-avoid-const-params-in-decls <readability/avoid-const-params-in-decls>`, "Yes"
-   :doc:`readability-avoid-nested-conditional-operator <readability/avoid-nested-conditional-operator>`,
-   :doc:`readability-avoid-return-with-void-value <readability/avoid-return-with-void-value>`, "Yes"
-   :doc:`readability-avoid-unconditional-preprocessor-if <readability/avoid-unconditional-preprocessor-if>`,
-   :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes"
-   :doc:`readability-const-return-type <readability/const-return-type>`, "Yes"
-   :doc:`readability-container-contains <readability/container-contains>`, "Yes"
-   :doc:`readability-container-data-pointer <readability/container-data-pointer>`, "Yes"
-   :doc:`readability-container-size-empty <readability/container-size-empty>`, "Yes"
-   :doc:`readability-convert-member-functions-to-static <readability/convert-member-functions-to-static>`, "Yes"
-   :doc:`readability-delete-null-pointer <readability/delete-null-pointer>`, "Yes"
-   :doc:`readability-duplicate-include <readability/duplicate-include>`, "Yes"
-   :doc:`readability-else-after-return <readability/else-after-return>`, "Yes"
-   :doc:`readability-enum-initial-value <readability/enum-initial-value>`, "Yes"
-   :doc:`readability-function-cognitive-complexity <readability/function-cognitive-complexity>`,
-   :doc:`readability-function-size <readability/function-size>`,
-   :doc:`readability-identifier-length <readability/identifier-length>`,
-   :doc:`readability-identifier-naming <readability/identifier-naming>`, "Yes"
-   :doc:`readability-implicit-bool-conversion <readability/implicit-bool-conversion>`, "Yes"
-   :doc:`readability-inconsistent-declaration-parameter-name <readability/inconsistent-declaration-parameter-name>`, "Yes"
-   :doc:`readability-inconsistent-ifelse-braces <readability/inconsistent-ifelse-braces>`, "Yes"
-   :doc:`readability-isolate-declaration <readability/isolate-declaration>`, "Yes"
-   :doc:`readability-magic-numbers <readability/magic-numbers>`,
-   :doc:`readability-make-member-function-const <readability/make-member-function-const>`, "Yes"
-   :doc:`readability-math-missing-parentheses <readability/math-missing-parentheses>`, "Yes"
-   :doc:`readability-misleading-indentation <readability/misleading-indentation>`,
-   :doc:`readability-misplaced-array-index <readability/misplaced-array-index>`, "Yes"
-   :doc:`readability-named-parameter <readability/named-parameter>`, "Yes"
-   :doc:`readability-non-const-parameter <readability/non-const-parameter>`, "Yes"
-   :doc:`readability-operators-representation <readability/operators-representation>`, "Yes"
-   :doc:`readability-qualified-auto <readability/qualified-auto>`, "Yes"
-   :doc:`readability-redundant-access-specifiers <readability/redundant-access-specifiers>`, "Yes"
-   :doc:`readability-redundant-casting <readability/redundant-casting>`, "Yes"
-   :doc:`readability-redundant-control-flow <readability/redundant-control-flow>`, "Yes"
-   :doc:`readability-redundant-declaration <readability/redundant-declaration>`, "Yes"
-   :doc:`readability-redundant-function-ptr-dereference <readability/redundant-function-ptr-dereference>`, "Yes"
-   :doc:`readability-redundant-inline-specifier <readability/redundant-inline-specifier>`, "Yes"
-   :doc:`readability-redundant-lambda-parameter-list <readability/redundant-lambda-parameter-list>`, "Yes"
-   :doc:`readability-redundant-member-init <readability/redundant-member-init>`, "Yes"
-   :doc:`readability-redundant-nested-if <readability/redundant-nested-if>`, "Yes"
-   :doc:`readability-redundant-parentheses <readability/redundant-parentheses>`, "Yes"
-   :doc:`readability-redundant-preprocessor <readability/redundant-preprocessor>`,
-   :doc:`readability-redundant-qualified-alias <readability/redundant-qualified-alias>`, "Yes"
-   :doc:`readability-redundant-smartptr-get <readability/redundant-smartptr-get>`, "Yes"
-   :doc:`readability-redundant-string-cstr <readability/redundant-string-cstr>`, "Yes"
-   :doc:`readability-redundant-string-init <readability/redundant-string-init>`, "Yes"
-   :doc:`readability-redundant-typename <readability/redundant-typename>`, "Yes"
-   :doc:`readability-reference-to-constructed-temporary <readability/reference-to-constructed-temporary>`,
-   :doc:`readability-simplify-boolean-expr <readability/simplify-boolean-expr>`, "Yes"
-   :doc:`readability-simplify-subscript-expr <readability/simplify-subscript-expr>`, "Yes"
-   :doc:`readability-static-accessed-through-instance <readability/static-accessed-through-instance>`, "Yes"
-   :doc:`readability-static-definition-in-anonymous-namespace <readability/static-definition-in-anonymous-namespace>`, "Yes"
-   :doc:`readability-string-compare <readability/string-compare>`, "Yes"
-   :doc:`readability-suspicious-call-argument <readability/suspicious-call-argument>`,
-   :doc:`readability-trailing-comma <readability/trailing-comma>`, "Yes"
-   :doc:`readability-trivial-switch <readability/trivial-switch>`,
-   :doc:`readability-uniqueptr-delete-release <readability/uniqueptr-delete-release>`, "Yes"
-   :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes"
-   :doc:`readability-use-anyofallof <readability/use-anyofallof>`,
-   :doc:`readability-use-concise-preprocessor-directives <readability/use-concise-preprocessor-directives>`, "Yes"
-   :doc:`readability-use-std-min-max <readability/use-std-min-max>`, "Yes"
-   :doc:`zircon-temporary-objects <zircon/temporary-objects>`,
+## Check aliases
 
-Check aliases
--------------
-
-.. csv-table::
-   :header: "Name", "Redirect", "Offers fixes"
-
-   :doc:`cert-arr39-c <cert/arr39-c>`, :doc:`bugprone-sizeof-expression <bugprone/sizeof-expression>`,
-   :doc:`cert-con36-c <cert/con36-c>`, :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,
-   :doc:`cert-con54-cpp <cert/con54-cpp>`, :doc:`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>`,
-   :doc:`cert-ctr56-cpp <cert/ctr56-cpp>`, :doc:`bugprone-pointer-arithmetic-on-polymorphic-object <bugprone/pointer-arithmetic-on-polymorphic-object>`,
-   :doc:`cert-dcl03-c <cert/dcl03-c>`, :doc:`misc-static-assert <misc/static-assert>`, "Yes"
-   :doc:`cert-dcl16-c <cert/dcl16-c>`, :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes"
-   :doc:`cert-dcl37-c <cert/dcl37-c>`, :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
-   :doc:`cert-dcl50-cpp <cert/dcl50-cpp>`, :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,
-   :doc:`cert-dcl51-cpp <cert/dcl51-cpp>`, :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
-   :doc:`cert-dcl54-cpp <cert/dcl54-cpp>`, :doc:`misc-new-delete-overloads <misc/new-delete-overloads>`,
-   :doc:`cert-dcl58-cpp <cert/dcl58-cpp>`, :doc:`bugprone-std-namespace-modification <bugprone/std-namespace-modification>`,
-   :doc:`cert-dcl59-cpp <cert/dcl59-cpp>`, :doc:`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>`,
-   :doc:`cert-env33-c <cert/env33-c>`, :doc:`bugprone-command-processor <bugprone/command-processor>`,
-   :doc:`cert-err09-cpp <cert/err09-cpp>`, :doc:`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>`,
-   :doc:`cert-err33-c <cert/err33-c>`, :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,
-   :doc:`cert-err34-c <cert/err34-c>`, :doc:`bugprone-unchecked-string-to-number-conversion <bugprone/unchecked-string-to-number-conversion>`,
-   :doc:`cert-err52-cpp <cert/err52-cpp>`, :doc:`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>`,
-   :doc:`cert-err58-cpp <cert/err58-cpp>`, :doc:`bugprone-throwing-static-initialization <bugprone/throwing-static-initialization>`,
-   :doc:`cert-err60-cpp <cert/err60-cpp>`, :doc:`bugprone-exception-copy-constructor-throws <bugprone/exception-copy-constructor-throws>`,
-   :doc:`cert-err61-cpp <cert/err61-cpp>`, :doc:`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>`,
-   :doc:`cert-exp42-c <cert/exp42-c>`, :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,
-   :doc:`cert-exp45-c <cert/exp45-c>`, :doc:`bugprone-assignment-in-selection-statement <bugprone/assignment-in-selection-statement>`,
-   :doc:`cert-fio38-c <cert/fio38-c>`, :doc:`misc-non-copyable-objects <misc/non-copyable-objects>`,
-   :doc:`cert-flp30-c <cert/flp30-c>`, :doc:`bugprone-float-loop-counter <bugprone/float-loop-counter>`,
-   :doc:`cert-flp37-c <cert/flp37-c>`, :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,
-   :doc:`cert-int09-c <cert/int09-c>`, :doc:`readability-enum-initial-value <readability/enum-initial-value>`, "Yes"
-   :doc:`cert-mem57-cpp <cert/mem57-cpp>`, :doc:`bugprone-default-operator-new-on-overaligned-type <bugprone/default-operator-new-on-overaligned-type>`,
-   :doc:`cert-msc24-c <cert/msc24-c>`, :doc:`bugprone-unsafe-functions <bugprone/unsafe-functions>`,
-   :doc:`cert-msc30-c <cert/msc30-c>`, :doc:`misc-predictable-rand <misc/predictable-rand>`,
-   :doc:`cert-msc32-c <cert/msc32-c>`, :doc:`bugprone-random-generator-seed <bugprone/random-generator-seed>`,
-   :doc:`cert-msc33-c <cert/msc33-c>`, :doc:`bugprone-unsafe-functions <bugprone/unsafe-functions>`,
-   :doc:`cert-msc50-cpp <cert/msc50-cpp>`, :doc:`misc-predictable-rand <misc/predictable-rand>`,
-   :doc:`cert-msc51-cpp <cert/msc51-cpp>`, :doc:`bugprone-random-generator-seed <bugprone/random-generator-seed>`,
-   :doc:`cert-msc54-cpp <cert/msc54-cpp>`, :doc:`bugprone-signal-handler <bugprone/signal-handler>`,
-   :doc:`cert-oop11-cpp <cert/oop11-cpp>`, :doc:`performance-move-constructor-init <performance/move-constructor-init>`,
-   :doc:`cert-oop54-cpp <cert/oop54-cpp>`, :doc:`bugprone-unhandled-self-assignment <bugprone/unhandled-self-assignment>`,
-   :doc:`cert-oop57-cpp <cert/oop57-cpp>`, :doc:`bugprone-raw-memory-call-on-non-trivial-type <bugprone/raw-memory-call-on-non-trivial-type>`,
-   :doc:`cert-oop58-cpp <cert/oop58-cpp>`, :doc:`bugprone-copy-constructor-mutates-argument <bugprone/copy-constructor-mutates-argument>`,
-   :doc:`cert-pos44-c <cert/pos44-c>`, :doc:`bugprone-bad-signal-to-kill-thread <bugprone/bad-signal-to-kill-thread>`,
-   :doc:`cert-pos47-c <cert/pos47-c>`, :doc:`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>`,
-   :doc:`cert-sig30-c <cert/sig30-c>`, :doc:`bugprone-signal-handler <bugprone/signal-handler>`,
-   :doc:`cert-str34-c <cert/str34-c>`, :doc:`bugprone-signed-char-misuse <bugprone/signed-char-misuse>`,
-   :doc:`clang-analyzer-core.BitwiseShift <clang-analyzer/core.BitwiseShift>`, `Clang Static Analyzer core.BitwiseShift <https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift>`_,
-   :doc:`clang-analyzer-core.CallAndMessage <clang-analyzer/core.CallAndMessage>`, `Clang Static Analyzer core.CallAndMessage <https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage>`_,
-   :doc:`clang-analyzer-core.DivideZero <clang-analyzer/core.DivideZero>`, `Clang Static Analyzer core.DivideZero <https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero>`_,
-   :doc:`clang-analyzer-core.NonNullParamChecker <clang-analyzer/core.NonNullParamChecker>`, `Clang Static Analyzer core.NonNullParamChecker <https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker>`_,
-   :doc:`clang-analyzer-core.NullDereference <clang-analyzer/core.NullDereference>`, `Clang Static Analyzer core.NullDereference <https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference>`_,
-   :doc:`clang-analyzer-core.StackAddressEscape <clang-analyzer/core.StackAddressEscape>`, `Clang Static Analyzer core.StackAddressEscape <https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape>`_,
-   :doc:`clang-analyzer-core.UndefinedBinaryOperatorResult <clang-analyzer/core.UndefinedBinaryOperatorResult>`, `Clang Static Analyzer core.UndefinedBinaryOperatorResult <https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult>`_,
-   :doc:`clang-analyzer-core.VLASize <clang-analyzer/core.VLASize>`, `Clang Static Analyzer core.VLASize <https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize>`_,
-   :doc:`clang-analyzer-core.uninitialized.ArraySubscript <clang-analyzer/core.uninitialized.ArraySubscript>`, `Clang Static Analyzer core.uninitialized.ArraySubscript <https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript>`_,
-   :doc:`clang-analyzer-core.uninitialized.Assign <clang-analyzer/core.uninitialized.Assign>`, `Clang Static Analyzer core.uninitialized.Assign <https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign>`_,
-   :doc:`clang-analyzer-core.uninitialized.Branch <clang-analyzer/core.uninitialized.Branch>`, `Clang Static Analyzer core.uninitialized.Branch <https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch>`_,
-   :doc:`clang-analyzer-core.uninitialized.CapturedBlockVariable <clang-analyzer/core.uninitialized.CapturedBlockVariable>`, `Clang Static Analyzer core.uninitialized.CapturedBlockVariable <https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable>`_,
-   :doc:`clang-analyzer-core.uninitialized.NewArraySize <clang-analyzer/core.uninitialized.NewArraySize>`, `Clang Static Analyzer core.uninitialized.NewArraySize <https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize>`_,
-   :doc:`clang-analyzer-core.uninitialized.UndefReturn <clang-analyzer/core.uninitialized.UndefReturn>`, `Clang Static Analyzer core.uninitialized.UndefReturn <https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn>`_,
-   :doc:`clang-analyzer-cplusplus.ArrayDelete <clang-analyzer/cplusplus.ArrayDelete>`, `Clang Static Analyzer cplusplus.ArrayDelete <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete>`_,
-   :doc:`clang-analyzer-cplusplus.InnerPointer <clang-analyzer/cplusplus.InnerPointer>`, `Clang Static Analyzer cplusplus.InnerPointer <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer>`_,
-   :doc:`clang-analyzer-cplusplus.Move <clang-analyzer/cplusplus.Move>`, `Clang Static Analyzer cplusplus.Move <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move>`_,
-   :doc:`clang-analyzer-cplusplus.NewDelete <clang-analyzer/cplusplus.NewDelete>`, `Clang Static Analyzer cplusplus.NewDelete <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete>`_,
-   :doc:`clang-analyzer-cplusplus.NewDeleteLeaks <clang-analyzer/cplusplus.NewDeleteLeaks>`, `Clang Static Analyzer cplusplus.NewDeleteLeaks <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks>`_,
-   :doc:`clang-analyzer-cplusplus.PlacementNew <clang-analyzer/cplusplus.PlacementNew>`, `Clang Static Analyzer cplusplus.PlacementNew <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew>`_,
-   :doc:`clang-analyzer-cplusplus.SelfAssignment <clang-analyzer/cplusplus.SelfAssignment>`, `Clang Static Analyzer cplusplus.SelfAssignment <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-selfassignment>`_,
-   :doc:`clang-analyzer-cplusplus.StringChecker <clang-analyzer/cplusplus.StringChecker>`, `Clang Static Analyzer cplusplus.StringChecker <https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker>`_,
-   :doc:`clang-analyzer-deadcode.DeadStores <clang-analyzer/deadcode.DeadStores>`, `Clang Static Analyzer deadcode.DeadStores <https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores>`_,
-   :doc:`clang-analyzer-fuchsia.HandleChecker <clang-analyzer/fuchsia.HandleChecker>`, `Clang Static Analyzer fuchsia.HandleChecker <https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker>`_,
-   :doc:`clang-analyzer-nullability.NullPassedToNonnull <clang-analyzer/nullability.NullPassedToNonnull>`, `Clang Static Analyzer nullability.NullPassedToNonnull <https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull>`_,
-   :doc:`clang-analyzer-nullability.NullReturnedFromNonnull <clang-analyzer/nullability.NullReturnedFromNonnull>`, `Clang Static Analyzer nullability.NullReturnedFromNonnull <https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull>`_,
-   :doc:`clang-analyzer-nullability.NullableDereferenced <clang-analyzer/nullability.NullableDereferenced>`, `Clang Static Analyzer nullability.NullableDereferenced <https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced>`_,
-   :doc:`clang-analyzer-nullability.NullablePassedToNonnull <clang-analyzer/nullability.NullablePassedToNonnull>`, `Clang Static Analyzer nullability.NullablePassedToNonnull <https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull>`_,
-   :doc:`clang-analyzer-nullability.NullableReturnedFromNonnull <clang-analyzer/nullability.NullableReturnedFromNonnull>`, `Clang Static Analyzer nullability.NullableReturnedFromNonnull <https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull>`_,
-   :doc:`clang-analyzer-optin.core.EnumCastOutOfRange <clang-analyzer/optin.core.EnumCastOutOfRange>`, `Clang Static Analyzer optin.core.EnumCastOutOfRange <https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange>`_,
-   :doc:`clang-analyzer-optin.cplusplus.UninitializedObject <clang-analyzer/optin.cplusplus.UninitializedObject>`, `Clang Static Analyzer optin.cplusplus.UninitializedObject <https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject>`_,
-   :doc:`clang-analyzer-optin.cplusplus.VirtualCall <clang-analyzer/optin.cplusplus.VirtualCall>`, `Clang Static Analyzer optin.cplusplus.VirtualCall <https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall>`_,
-   :doc:`clang-analyzer-optin.mpi.MPI-Checker <clang-analyzer/optin.mpi.MPI-Checker>`, `Clang Static Analyzer optin.mpi.MPI-Checker <https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker>`_,
-   :doc:`clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker <clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker>`, `Clang Static Analyzer optin.osx.cocoa.localizability.EmptyLocalizationContextChecker <https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker>`_,
-   :doc:`clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker <clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker>`, `Clang Static Analyzer optin.osx.cocoa.localizability.NonLocalizedStringChecker <https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker>`_,
-   :doc:`clang-analyzer-optin.performance.GCDAntipattern <clang-analyzer/optin.performance.GCDAntipattern>`, `Clang Static Analyzer optin.performance.GCDAntipattern <https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern>`_,
-   :doc:`clang-analyzer-optin.performance.Padding <clang-analyzer/optin.performance.Padding>`, `Clang Static Analyzer optin.performance.Padding <https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding>`_,
-   :doc:`clang-analyzer-optin.portability.UnixAPI <clang-analyzer/optin.portability.UnixAPI>`, `Clang Static Analyzer optin.portability.UnixAPI <https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi>`_,
-   :doc:`clang-analyzer-optin.taint.TaintedAlloc <clang-analyzer/optin.taint.TaintedAlloc>`, `Clang Static Analyzer optin.taint.TaintedAlloc <https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc>`_,
-   :doc:`clang-analyzer-osx.API <clang-analyzer/osx.API>`, `Clang Static Analyzer osx.API <https://clang.llvm.org/docs/analyzer/checkers.html#osx-api>`_,
-   :doc:`clang-analyzer-osx.NumberObjectConversion <clang-analyzer/osx.NumberObjectConversion>`, `Clang Static Analyzer osx.NumberObjectConversion <https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion>`_,
-   :doc:`clang-analyzer-osx.ObjCProperty <clang-analyzer/osx.ObjCProperty>`, `Clang Static Analyzer osx.ObjCProperty <https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty>`_,
-   :doc:`clang-analyzer-osx.SecKeychainAPI <clang-analyzer/osx.SecKeychainAPI>`, `Clang Static Analyzer osx.SecKeychainAPI <https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi>`_,
-   :doc:`clang-analyzer-osx.cocoa.AtSync <clang-analyzer/osx.cocoa.AtSync>`, `Clang Static Analyzer osx.cocoa.AtSync <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync>`_,
-   :doc:`clang-analyzer-osx.cocoa.AutoreleaseWrite <clang-analyzer/osx.cocoa.AutoreleaseWrite>`, `Clang Static Analyzer osx.cocoa.AutoreleaseWrite <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite>`_,
-   :doc:`clang-analyzer-osx.cocoa.ClassRelease <clang-analyzer/osx.cocoa.ClassRelease>`, `Clang Static Analyzer osx.cocoa.ClassRelease <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease>`_,
-   :doc:`clang-analyzer-osx.cocoa.Dealloc <clang-analyzer/osx.cocoa.Dealloc>`, `Clang Static Analyzer osx.cocoa.Dealloc <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc>`_,
-   :doc:`clang-analyzer-osx.cocoa.IncompatibleMethodTypes <clang-analyzer/osx.cocoa.IncompatibleMethodTypes>`, `Clang Static Analyzer osx.cocoa.IncompatibleMethodTypes <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes>`_,
-   :doc:`clang-analyzer-osx.cocoa.Loops <clang-analyzer/osx.cocoa.Loops>`, `Clang Static Analyzer osx.cocoa.Loops <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops>`_,
-   :doc:`clang-analyzer-osx.cocoa.MissingSuperCall <clang-analyzer/osx.cocoa.MissingSuperCall>`, `Clang Static Analyzer osx.cocoa.MissingSuperCall <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall>`_,
-   :doc:`clang-analyzer-osx.cocoa.NSAutoreleasePool <clang-analyzer/osx.cocoa.NSAutoreleasePool>`, `Clang Static Analyzer osx.cocoa.NSAutoreleasePool <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool>`_,
-   :doc:`clang-analyzer-osx.cocoa.NSError <clang-analyzer/osx.cocoa.NSError>`, `Clang Static Analyzer osx.cocoa.NSError <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror>`_,
-   :doc:`clang-analyzer-osx.cocoa.NilArg <clang-analyzer/osx.cocoa.NilArg>`, `Clang Static Analyzer osx.cocoa.NilArg <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg>`_,
-   :doc:`clang-analyzer-osx.cocoa.NonNilReturnValue <clang-analyzer/osx.cocoa.NonNilReturnValue>`, `Clang Static Analyzer osx.cocoa.NonNilReturnValue <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue>`_,
-   :doc:`clang-analyzer-osx.cocoa.ObjCGenerics <clang-analyzer/osx.cocoa.ObjCGenerics>`, `Clang Static Analyzer osx.cocoa.ObjCGenerics <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics>`_,
-   :doc:`clang-analyzer-osx.cocoa.RetainCount <clang-analyzer/osx.cocoa.RetainCount>`, `Clang Static Analyzer osx.cocoa.RetainCount <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount>`_,
-   :doc:`clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak <clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak>`, `Clang Static Analyzer osx.cocoa.RunLoopAutoreleaseLeak <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak>`_,
-   :doc:`clang-analyzer-osx.cocoa.SelfInit <clang-analyzer/osx.cocoa.SelfInit>`, `Clang Static Analyzer osx.cocoa.SelfInit <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit>`_,
-   :doc:`clang-analyzer-osx.cocoa.SuperDealloc <clang-analyzer/osx.cocoa.SuperDealloc>`, `Clang Static Analyzer osx.cocoa.SuperDealloc <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc>`_,
-   :doc:`clang-analyzer-osx.cocoa.UnusedIvars <clang-analyzer/osx.cocoa.UnusedIvars>`, `Clang Static Analyzer osx.cocoa.UnusedIvars <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars>`_,
-   :doc:`clang-analyzer-osx.cocoa.VariadicMethodTypes <clang-analyzer/osx.cocoa.VariadicMethodTypes>`, `Clang Static Analyzer osx.cocoa.VariadicMethodTypes <https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes>`_,
-   :doc:`clang-analyzer-osx.coreFoundation.CFError <clang-analyzer/osx.coreFoundation.CFError>`, `Clang Static Analyzer osx.coreFoundation.CFError <https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror>`_,
-   :doc:`clang-analyzer-osx.coreFoundation.CFNumber <clang-analyzer/osx.coreFoundation.CFNumber>`, `Clang Static Analyzer osx.coreFoundation.CFNumber <https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber>`_,
-   :doc:`clang-analyzer-osx.coreFoundation.CFRetainRelease <clang-analyzer/osx.coreFoundation.CFRetainRelease>`, `Clang Static Analyzer osx.coreFoundation.CFRetainRelease <https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease>`_,
-   :doc:`clang-analyzer-osx.coreFoundation.containers.OutOfBounds <clang-analyzer/osx.coreFoundation.containers.OutOfBounds>`, `Clang Static Analyzer osx.coreFoundation.containers.OutOfBounds <https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds>`_,
-   :doc:`clang-analyzer-osx.coreFoundation.containers.PointerSizedValues <clang-analyzer/osx.coreFoundation.containers.PointerSizedValues>`, `Clang Static Analyzer osx.coreFoundation.containers.PointerSizedValues <https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues>`_,
-   :doc:`clang-analyzer-security.FloatLoopCounter <clang-analyzer/security.FloatLoopCounter>`, `Clang Static Analyzer security.FloatLoopCounter <https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter>`_,
-   :doc:`clang-analyzer-security.PutenvStackArray <clang-analyzer/security.PutenvStackArray>`, `Clang Static Analyzer security.PutenvStackArray <https://clang.llvm.org/docs/analyzer/checkers.html#security-putenvstackarray-c>`_,
-   :doc:`clang-analyzer-security.SetgidSetuidOrder <clang-analyzer/security.SetgidSetuidOrder>`, `Clang Static Analyzer security.SetgidSetuidOrder <https://clang.llvm.org/docs/analyzer/checkers.html#security-setgidsetuidorder-c>`_,
-   :doc:`clang-analyzer-security.cert.env.InvalidPtr <clang-analyzer/security.cert.env.InvalidPtr>`, `Clang Static Analyzer security.cert.env.InvalidPtr <https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr>`_,
-   :doc:`clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling <clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling>`, `Clang Static Analyzer security.insecureAPI.DeprecatedOrUnsafeBufferHandling <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling>`_,
-   :doc:`clang-analyzer-security.insecureAPI.UncheckedReturn <clang-analyzer/security.insecureAPI.UncheckedReturn>`, `Clang Static Analyzer security.insecureAPI.UncheckedReturn <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn>`_,
-   :doc:`clang-analyzer-security.insecureAPI.bcmp <clang-analyzer/security.insecureAPI.bcmp>`, `Clang Static Analyzer security.insecureAPI.bcmp <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp>`_,
-   :doc:`clang-analyzer-security.insecureAPI.bcopy <clang-analyzer/security.insecureAPI.bcopy>`, `Clang Static Analyzer security.insecureAPI.bcopy <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy>`_,
-   :doc:`clang-analyzer-security.insecureAPI.bzero <clang-analyzer/security.insecureAPI.bzero>`, `Clang Static Analyzer security.insecureAPI.bzero <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero>`_,
-   :doc:`clang-analyzer-security.insecureAPI.decodeValueOfObjCType <clang-analyzer/security.insecureAPI.decodeValueOfObjCType>`, `Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-decodevalueofobjctype>`_,
-   :doc:`clang-analyzer-security.insecureAPI.getpw <clang-analyzer/security.insecureAPI.getpw>`, `Clang Static Analyzer security.insecureAPI.getpw <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw>`_,
-   :doc:`clang-analyzer-security.insecureAPI.gets <clang-analyzer/security.insecureAPI.gets>`, `Clang Static Analyzer security.insecureAPI.gets <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets>`_,
-   :doc:`clang-analyzer-security.insecureAPI.mkstemp <clang-analyzer/security.insecureAPI.mkstemp>`, `Clang Static Analyzer security.insecureAPI.mkstemp <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp>`_,
-   :doc:`clang-analyzer-security.insecureAPI.mktemp <clang-analyzer/security.insecureAPI.mktemp>`, `Clang Static Analyzer security.insecureAPI.mktemp <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp>`_,
-   :doc:`clang-analyzer-security.insecureAPI.rand <clang-analyzer/security.insecureAPI.rand>`, `Clang Static Analyzer security.insecureAPI.rand <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand>`_,
-   :doc:`clang-analyzer-security.insecureAPI.strcpy <clang-analyzer/security.insecureAPI.strcpy>`, `Clang Static Analyzer security.insecureAPI.strcpy <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy>`_,
-   :doc:`clang-analyzer-security.insecureAPI.vfork <clang-analyzer/security.insecureAPI.vfork>`, `Clang Static Analyzer security.insecureAPI.vfork <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork>`_,
-   :doc:`clang-analyzer-unix.API <clang-analyzer/unix.API>`, `Clang Static Analyzer unix.API <https://clang.llvm.org/docs/analyzer/checkers.html#unix-api>`_,
-   :doc:`clang-analyzer-unix.BlockInCriticalSection <clang-analyzer/unix.BlockInCriticalSection>`, `Clang Static Analyzer unix.BlockInCriticalSection <https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection>`_,
-   :doc:`clang-analyzer-unix.Errno <clang-analyzer/unix.Errno>`, `Clang Static Analyzer unix.Errno <https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno>`_,
-   :doc:`clang-analyzer-unix.Malloc <clang-analyzer/unix.Malloc>`, `Clang Static Analyzer unix.Malloc <https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc>`_,
-   :doc:`clang-analyzer-unix.MallocSizeof <clang-analyzer/unix.MallocSizeof>`, `Clang Static Analyzer unix.MallocSizeof <https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof>`_,
-   :doc:`clang-analyzer-unix.MismatchedDeallocator <clang-analyzer/unix.MismatchedDeallocator>`, `Clang Static Analyzer unix.MismatchedDeallocator <https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator>`_,
-   :doc:`clang-analyzer-unix.StdCLibraryFunctions <clang-analyzer/unix.StdCLibraryFunctions>`, `Clang Static Analyzer unix.StdCLibraryFunctions <https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions>`_,
-   :doc:`clang-analyzer-unix.Stream <clang-analyzer/unix.Stream>`, `Clang Static Analyzer unix.Stream <https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream>`_,
-   :doc:`clang-analyzer-unix.Vfork <clang-analyzer/unix.Vfork>`, `Clang Static Analyzer unix.Vfork <https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork>`_,
-   :doc:`clang-analyzer-unix.cstring.BadSizeArg <clang-analyzer/unix.cstring.BadSizeArg>`, `Clang Static Analyzer unix.cstring.BadSizeArg <https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg>`_,
-   :doc:`clang-analyzer-unix.cstring.NullArg <clang-analyzer/unix.cstring.NullArg>`, `Clang Static Analyzer unix.cstring.NullArg <https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg>`_,
-   :doc:`clang-analyzer-webkit.NoUncountedMemberChecker <clang-analyzer/webkit.NoUncountedMemberChecker>`, `Clang Static Analyzer webkit.NoUncountedMemberChecker <https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker>`_,
-   :doc:`clang-analyzer-webkit.RefCntblBaseVirtualDtor <clang-analyzer/webkit.RefCntblBaseVirtualDtor>`, `Clang Static Analyzer webkit.RefCntblBaseVirtualDtor <https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor>`_,
-   :doc:`clang-analyzer-webkit.UncountedLambdaCapturesChecker <clang-analyzer/webkit.UncountedLambdaCapturesChecker>`, `Clang Static Analyzer webkit.UncountedLambdaCapturesChecker <https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker>`_,
-   :doc:`cppcoreguidelines-avoid-c-arrays <cppcoreguidelines/avoid-c-arrays>`, :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,
-   :doc:`cppcoreguidelines-avoid-magic-numbers <cppcoreguidelines/avoid-magic-numbers>`, :doc:`readability-magic-numbers <readability/magic-numbers>`,
-   :doc:`cppcoreguidelines-c-copy-assignment-signature <cppcoreguidelines/c-copy-assignment-signature>`, :doc:`misc-unconventional-assign-operator <misc/unconventional-assign-operator>`,
-   :doc:`cppcoreguidelines-explicit-constructor <cppcoreguidelines/explicit-constructor>`, :doc:`misc-explicit-constructor <misc/explicit-constructor>`, "Yes"
-   :doc:`cppcoreguidelines-explicit-virtual-functions <cppcoreguidelines/explicit-virtual-functions>`, :doc:`modernize-use-override <modernize/use-override>`, "Yes"
-   :doc:`cppcoreguidelines-macro-to-enum <cppcoreguidelines/macro-to-enum>`, :doc:`modernize-macro-to-enum <modernize/macro-to-enum>`, "Yes"
-   :doc:`cppcoreguidelines-narrowing-conversions <cppcoreguidelines/narrowing-conversions>`, :doc:`bugprone-narrowing-conversions <bugprone/narrowing-conversions>`,
-   :doc:`cppcoreguidelines-noexcept-destructor <cppcoreguidelines/noexcept-destructor>`, :doc:`performance-noexcept-destructor <performance/noexcept-destructor>`, "Yes"
-   :doc:`cppcoreguidelines-noexcept-move-operations <cppcoreguidelines/noexcept-move-operations>`, :doc:`performance-noexcept-move-constructor <performance/noexcept-move-constructor>`, "Yes"
-   :doc:`cppcoreguidelines-noexcept-swap <cppcoreguidelines/noexcept-swap>`, :doc:`performance-noexcept-swap <performance/noexcept-swap>`, "Yes"
-   :doc:`cppcoreguidelines-non-private-member-variables-in-classes <cppcoreguidelines/non-private-member-variables-in-classes>`, :doc:`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>`,
-   :doc:`cppcoreguidelines-use-default-member-init <cppcoreguidelines/use-default-member-init>`, :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes"
-   :doc:`fuchsia-header-anon-namespaces <fuchsia/header-anon-namespaces>`, :doc:`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>`,
-   :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`, :doc:`misc-multiple-inheritance <misc/multiple-inheritance>`,
-   :doc:`google-build-namespaces <google/build-namespaces>`, :doc:`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>`,
-   :doc:`google-explicit-constructor <google/explicit-constructor>`, :doc:`misc-explicit-constructor <misc/explicit-constructor>`, "Yes"
-   :doc:`google-readability-braces-around-statements <google/readability-braces-around-statements>`, :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes"
-   :doc:`google-readability-casting <google/readability-casting>`, :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`, "Yes"
-   :doc:`google-readability-function-size <google/readability-function-size>`, :doc:`readability-function-size <readability/function-size>`,
-   :doc:`google-readability-namespace-comments <google/readability-namespace-comments>`, :doc:`llvm-namespace-comment <llvm/namespace-comment>`,
-   :doc:`llvm-else-after-return <llvm/else-after-return>`, :doc:`readability-else-after-return <readability/else-after-return>`, "Yes"
-   :doc:`llvm-qualified-auto <llvm/qualified-auto>`, :doc:`readability-qualified-auto <readability/qualified-auto>`, "Yes"
-   :doc:`performance-faster-string-find <performance/faster-string-find>`, :doc:`performance-prefer-single-char-overloads <performance/prefer-single-char-overloads>`, "Yes"
+| Name | Redirect | Offers fixes |
+| --- | --- | --- |
+| {doc}`cert-arr39-c <cert/arr39-c>` | {doc}`bugprone-sizeof-expression <bugprone/sizeof-expression>` |  |
+| {doc}`cert-con36-c <cert/con36-c>` | {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
+| {doc}`cert-con54-cpp <cert/con54-cpp>` | {doc}`bugprone-spuriously-wake-up-functions <bugprone/spuriously-wake-up-functions>` |  |
+| {doc}`cert-ctr56-cpp <cert/ctr56-cpp>` | {doc}`bugprone-pointer-arithmetic-on-polymorphic-object <bugprone/pointer-arithmetic-on-polymorphic-object>` |  |
+| {doc}`cert-dcl03-c <cert/dcl03-c>` | {doc}`misc-static-assert <misc/static-assert>` | Yes |
+| {doc}`cert-dcl16-c <cert/dcl16-c>` | {doc}`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>` | Yes |
+| {doc}`cert-dcl37-c <cert/dcl37-c>` | {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
+| {doc}`cert-dcl50-cpp <cert/dcl50-cpp>` | {doc}`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>` |  |
+| {doc}`cert-dcl51-cpp <cert/dcl51-cpp>` | {doc}`bugprone-reserved-identifier <bugprone/reserved-identifier>` | Yes |
+| {doc}`cert-dcl54-cpp <cert/dcl54-cpp>` | {doc}`misc-new-delete-overloads <misc/new-delete-overloads>` |  |
+| {doc}`cert-dcl58-cpp <cert/dcl58-cpp>` | {doc}`bugprone-std-namespace-modification <bugprone/std-namespace-modification>` |  |
+| {doc}`cert-dcl59-cpp <cert/dcl59-cpp>` | {doc}`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>` |  |
+| {doc}`cert-env33-c <cert/env33-c>` | {doc}`bugprone-command-processor <bugprone/command-processor>` |  |
+| {doc}`cert-err09-cpp <cert/err09-cpp>` | {doc}`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>` |  |
+| {doc}`cert-err33-c <cert/err33-c>` | {doc}`bugprone-unused-return-value <bugprone/unused-return-value>` |  |
+| {doc}`cert-err34-c <cert/err34-c>` | {doc}`bugprone-unchecked-string-to-number-conversion <bugprone/unchecked-string-to-number-conversion>` |  |
+| {doc}`cert-err52-cpp <cert/err52-cpp>` | {doc}`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>` |  |
+| {doc}`cert-err58-cpp <cert/err58-cpp>` | {doc}`bugprone-throwing-static-initialization <bugprone/throwing-static-initialization>` |  |
+| {doc}`cert-err60-cpp <cert/err60-cpp>` | {doc}`bugprone-exception-copy-constructor-throws <bugprone/exception-copy-constructor-throws>` |  |
+| {doc}`cert-err61-cpp <cert/err61-cpp>` | {doc}`misc-throw-by-value-catch-by-reference <misc/throw-by-value-catch-by-reference>` |  |
+| {doc}`cert-exp42-c <cert/exp42-c>` | {doc}`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>` |  |
+| {doc}`cert-exp45-c <cert/exp45-c>` | {doc}`bugprone-assignment-in-selection-statement <bugprone/assignment-in-selection-statement>` |  |
+| {doc}`cert-fio38-c <cert/fio38-c>` | {doc}`misc-non-copyable-objects <misc/non-copyable-objects>` |  |
+| {doc}`cert-flp30-c <cert/flp30-c>` | {doc}`bugprone-float-loop-counter <bugprone/float-loop-counter>` |  |
+| {doc}`cert-flp37-c <cert/flp37-c>` | {doc}`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>` |  |
+| {doc}`cert-int09-c <cert/int09-c>` | {doc}`readability-enum-initial-value <readability/enum-initial-value>` | Yes |
+| {doc}`cert-mem57-cpp <cert/mem57-cpp>` | {doc}`bugprone-default-operator-new-on-overaligned-type <bugprone/default-operator-new-on-overaligned-type>` |  |
+| {doc}`cert-msc24-c <cert/msc24-c>` | {doc}`bugprone-unsafe-functions <bugprone/unsafe-functions>` |  |
+| {doc}`cert-msc30-c <cert/msc30-c>` | {doc}`misc-predictable-rand <misc/predictable-rand>` |  |
+| {doc}`cert-msc32-c <cert/msc32-c>` | {doc}`bugprone-random-generator-seed <bugprone/random-generator-seed>` |  |
+| {doc}`cert-msc33-c <cert/msc33-c>` | {doc}`bugprone-unsafe-functions <bugprone/unsafe-functions>` |  |
+| {doc}`cert-msc50-cpp <cert/msc50-cpp>` | {doc}`misc-predictable-rand <misc/predictable-rand>` |  |
+| {doc}`cert-msc51-cpp <cert/msc51-cpp>` | {doc}`bugprone-random-generator-seed <bugprone/random-generator-seed>` |  |
+| {doc}`cert-msc54-cpp <cert/msc54-cpp>` | {doc}`bugprone-signal-handler <bugprone/signal-handler>` |  |
+| {doc}`cert-oop11-cpp <cert/oop11-cpp>` | {doc}`performance-move-constructor-init <performance/move-constructor-init>` |  |
+| {doc}`cert-oop54-cpp <cert/oop54-cpp>` | {doc}`bugprone-unhandled-self-assignment <bugprone/unhandled-self-assignment>` |  |
+| {doc}`cert-oop57-cpp <cert/oop57-cpp>` | {doc}`bugprone-raw-memory-call-on-non-trivial-type <bugprone/raw-memory-call-on-non-trivial-type>` |  |
+| {doc}`cert-oop58-cpp <cert/oop58-cpp>` | {doc}`bugprone-copy-constructor-mutates-argument <bugprone/copy-constructor-mutates-argument>` |  |
+| {doc}`cert-pos44-c <cert/pos44-c>` | {doc}`bugprone-bad-signal-to-kill-thread <bugprone/bad-signal-to-kill-thread>` |  |
+| {doc}`cert-pos47-c <cert/pos47-c>` | {doc}`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>` |  |
+| {doc}`cert-sig30-c <cert/sig30-c>` | {doc}`bugprone-signal-handler <bugprone/signal-handler>` |  |
+| {doc}`cert-str34-c <cert/str34-c>` | {doc}`bugprone-signed-char-misuse <bugprone/signed-char-misuse>` |  |
+| {doc}`clang-analyzer-core.BitwiseShift <clang-analyzer/core.BitwiseShift>` | [Clang Static Analyzer core.BitwiseShift](https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift) |  |
+| {doc}`clang-analyzer-core.CallAndMessage <clang-analyzer/core.CallAndMessage>` | [Clang Static Analyzer core.CallAndMessage](https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage) |  |
+| {doc}`clang-analyzer-core.DivideZero <clang-analyzer/core.DivideZero>` | [Clang Static Analyzer core.DivideZero](https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero) |  |
+| {doc}`clang-analyzer-core.NonNullParamChecker <clang-analyzer/core.NonNullParamChecker>` | [Clang Static Analyzer core.NonNullParamChecker](https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker) |  |
+| {doc}`clang-analyzer-core.NullDereference <clang-analyzer/core.NullDereference>` | [Clang Static Analyzer core.NullDereference](https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference) |  |
+| {doc}`clang-analyzer-core.NullPointerArithm <clang-analyzer/core.NullPointerArithm>` | [Clang Static Analyzer core.NullPointerArithm](https://clang.llvm.org/docs/analyzer/checkers.html#core-nullpointerarithm) |  |
+| {doc}`clang-analyzer-core.StackAddressEscape <clang-analyzer/core.StackAddressEscape>` | [Clang Static Analyzer core.StackAddressEscape](https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape) |  |
+| {doc}`clang-analyzer-core.UndefinedBinaryOperatorResult <clang-analyzer/core.UndefinedBinaryOperatorResult>` | [Clang Static Analyzer core.UndefinedBinaryOperatorResult](https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult) |  |
+| {doc}`clang-analyzer-core.VLASize <clang-analyzer/core.VLASize>` | [Clang Static Analyzer core.VLASize](https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize) |  |
+| {doc}`clang-analyzer-core.uninitialized.ArraySubscript <clang-analyzer/core.uninitialized.ArraySubscript>` | [Clang Static Analyzer core.uninitialized.ArraySubscript](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript) |  |
+| {doc}`clang-analyzer-core.uninitialized.Assign <clang-analyzer/core.uninitialized.Assign>` | [Clang Static Analyzer core.uninitialized.Assign](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign) |  |
+| {doc}`clang-analyzer-core.uninitialized.Branch <clang-analyzer/core.uninitialized.Branch>` | [Clang Static Analyzer core.uninitialized.Branch](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch) |  |
+| {doc}`clang-analyzer-core.uninitialized.CapturedBlockVariable <clang-analyzer/core.uninitialized.CapturedBlockVariable>` | [Clang Static Analyzer core.uninitialized.CapturedBlockVariable](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable) |  |
+| {doc}`clang-analyzer-core.uninitialized.NewArraySize <clang-analyzer/core.uninitialized.NewArraySize>` | [Clang Static Analyzer core.uninitialized.NewArraySize](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize) |  |
+| {doc}`clang-analyzer-core.uninitialized.UndefReturn <clang-analyzer/core.uninitialized.UndefReturn>` | [Clang Static Analyzer core.uninitialized.UndefReturn](https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn) |  |
+| {doc}`clang-analyzer-cplusplus.ArrayDelete <clang-analyzer/cplusplus.ArrayDelete>` | [Clang Static Analyzer cplusplus.ArrayDelete](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete) |  |
+| {doc}`clang-analyzer-cplusplus.InnerPointer <clang-analyzer/cplusplus.InnerPointer>` | [Clang Static Analyzer cplusplus.InnerPointer](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer) |  |
+| {doc}`clang-analyzer-cplusplus.Move <clang-analyzer/cplusplus.Move>` | [Clang Static Analyzer cplusplus.Move](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move) |  |
+| {doc}`clang-analyzer-cplusplus.NewDelete <clang-analyzer/cplusplus.NewDelete>` | [Clang Static Analyzer cplusplus.NewDelete](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete) |  |
+| {doc}`clang-analyzer-cplusplus.NewDeleteLeaks <clang-analyzer/cplusplus.NewDeleteLeaks>` | [Clang Static Analyzer cplusplus.NewDeleteLeaks](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks) |  |
+| {doc}`clang-analyzer-cplusplus.PlacementNew <clang-analyzer/cplusplus.PlacementNew>` | [Clang Static Analyzer cplusplus.PlacementNew](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew) |  |
+| {doc}`clang-analyzer-cplusplus.PureVirtualCall <clang-analyzer/cplusplus.PureVirtualCall>` | [Clang Static Analyzer cplusplus.PureVirtualCall](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-purevirtualcall) |  |
+| {doc}`clang-analyzer-cplusplus.StringChecker <clang-analyzer/cplusplus.StringChecker>` | [Clang Static Analyzer cplusplus.StringChecker](https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker) |  |
+| {doc}`clang-analyzer-deadcode.DeadStores <clang-analyzer/deadcode.DeadStores>` | [Clang Static Analyzer deadcode.DeadStores](https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores) |  |
+| {doc}`clang-analyzer-fuchsia.HandleChecker <clang-analyzer/fuchsia.HandleChecker>` | [Clang Static Analyzer fuchsia.HandleChecker](https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker) |  |
+| {doc}`clang-analyzer-nullability.NullPassedToNonnull <clang-analyzer/nullability.NullPassedToNonnull>` | [Clang Static Analyzer nullability.NullPassedToNonnull](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull) |  |
+| {doc}`clang-analyzer-nullability.NullReturnedFromNonnull <clang-analyzer/nullability.NullReturnedFromNonnull>` | [Clang Static Analyzer nullability.NullReturnedFromNonnull](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull) |  |
+| {doc}`clang-analyzer-nullability.NullableDereferenced <clang-analyzer/nullability.NullableDereferenced>` | [Clang Static Analyzer nullability.NullableDereferenced](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced) |  |
+| {doc}`clang-analyzer-nullability.NullablePassedToNonnull <clang-analyzer/nullability.NullablePassedToNonnull>` | [Clang Static Analyzer nullability.NullablePassedToNonnull](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull) |  |
+| {doc}`clang-analyzer-nullability.NullableReturnedFromNonnull <clang-analyzer/nullability.NullableReturnedFromNonnull>` | [Clang Static Analyzer nullability.NullableReturnedFromNonnull](https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull) |  |
+| {doc}`clang-analyzer-optin.core.EnumCastOutOfRange <clang-analyzer/optin.core.EnumCastOutOfRange>` | [Clang Static Analyzer optin.core.EnumCastOutOfRange](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange) |  |
+| {doc}`clang-analyzer-optin.core.FixedAddressDereference <clang-analyzer/optin.core.FixedAddressDereference>` | [Clang Static Analyzer optin.core.FixedAddressDereference](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-fixedaddressdereference) |  |
+| {doc}`clang-analyzer-optin.core.UnconditionalVAArg <clang-analyzer/optin.core.UnconditionalVAArg>` | [Clang Static Analyzer optin.core.UnconditionalVAArg](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-unconditionalvaarg) |  |
+| {doc}`clang-analyzer-optin.cplusplus.UninitializedObject <clang-analyzer/optin.cplusplus.UninitializedObject>` | [Clang Static Analyzer optin.cplusplus.UninitializedObject](https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject) |  |
+| {doc}`clang-analyzer-optin.cplusplus.VirtualCall <clang-analyzer/optin.cplusplus.VirtualCall>` | [Clang Static Analyzer optin.cplusplus.VirtualCall](https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall) |  |
+| {doc}`clang-analyzer-optin.mpi.MPI-Checker <clang-analyzer/optin.mpi.MPI-Checker>` | [Clang Static Analyzer optin.mpi.MPI-Checker](https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker) |  |
+| {doc}`clang-analyzer-optin.osx.OSObjectCStyleCast <clang-analyzer/optin.osx.OSObjectCStyleCast>` | Clang Static Analyzer optin.osx.OSObjectCStyleCast |  |
+| {doc}`clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker <clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker>` | [Clang Static Analyzer optin.osx.cocoa.localizability.EmptyLocalizationContextChecker](https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker) |  |
+| {doc}`clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker <clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker>` | [Clang Static Analyzer optin.osx.cocoa.localizability.NonLocalizedStringChecker](https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker) |  |
+| {doc}`clang-analyzer-optin.performance.GCDAntipattern <clang-analyzer/optin.performance.GCDAntipattern>` | [Clang Static Analyzer optin.performance.GCDAntipattern](https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern) |  |
+| {doc}`clang-analyzer-optin.performance.Padding <clang-analyzer/optin.performance.Padding>` | [Clang Static Analyzer optin.performance.Padding](https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding) |  |
+| {doc}`clang-analyzer-optin.portability.UnixAPI <clang-analyzer/optin.portability.UnixAPI>` | [Clang Static Analyzer optin.portability.UnixAPI](https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi) |  |
+| {doc}`clang-analyzer-optin.taint.GenericTaint <clang-analyzer/optin.taint.GenericTaint>` | [Clang Static Analyzer optin.taint.GenericTaint](https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-generictaint) |  |
+| {doc}`clang-analyzer-optin.taint.TaintedAlloc <clang-analyzer/optin.taint.TaintedAlloc>` | [Clang Static Analyzer optin.taint.TaintedAlloc](https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc) |  |
+| {doc}`clang-analyzer-optin.taint.TaintedDiv <clang-analyzer/optin.taint.TaintedDiv>` | [Clang Static Analyzer optin.taint.TaintedDiv](https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-tainteddiv) |  |
+| {doc}`clang-analyzer-osx.API <clang-analyzer/osx.API>` | [Clang Static Analyzer osx.API](https://clang.llvm.org/docs/analyzer/checkers.html#osx-api) |  |
+| {doc}`clang-analyzer-osx.MIG <clang-analyzer/osx.MIG>` | Clang Static Analyzer osx.MIG |  |
+| {doc}`clang-analyzer-osx.NumberObjectConversion <clang-analyzer/osx.NumberObjectConversion>` | [Clang Static Analyzer osx.NumberObjectConversion](https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion) |  |
+| {doc}`clang-analyzer-osx.OSObjectRetainCount <clang-analyzer/osx.OSObjectRetainCount>` | Clang Static Analyzer osx.OSObjectRetainCount |  |
+| {doc}`clang-analyzer-osx.ObjCProperty <clang-analyzer/osx.ObjCProperty>` | [Clang Static Analyzer osx.ObjCProperty](https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty) |  |
+| {doc}`clang-analyzer-osx.SecKeychainAPI <clang-analyzer/osx.SecKeychainAPI>` | [Clang Static Analyzer osx.SecKeychainAPI](https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi) |  |
+| {doc}`clang-analyzer-osx.cocoa.AtSync <clang-analyzer/osx.cocoa.AtSync>` | [Clang Static Analyzer osx.cocoa.AtSync](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync) |  |
+| {doc}`clang-analyzer-osx.cocoa.AutoreleaseWrite <clang-analyzer/osx.cocoa.AutoreleaseWrite>` | [Clang Static Analyzer osx.cocoa.AutoreleaseWrite](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite) |  |
+| {doc}`clang-analyzer-osx.cocoa.ClassRelease <clang-analyzer/osx.cocoa.ClassRelease>` | [Clang Static Analyzer osx.cocoa.ClassRelease](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease) |  |
+| {doc}`clang-analyzer-osx.cocoa.Dealloc <clang-analyzer/osx.cocoa.Dealloc>` | [Clang Static Analyzer osx.cocoa.Dealloc](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc) |  |
+| {doc}`clang-analyzer-osx.cocoa.IncompatibleMethodTypes <clang-analyzer/osx.cocoa.IncompatibleMethodTypes>` | [Clang Static Analyzer osx.cocoa.IncompatibleMethodTypes](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes) |  |
+| {doc}`clang-analyzer-osx.cocoa.Loops <clang-analyzer/osx.cocoa.Loops>` | [Clang Static Analyzer osx.cocoa.Loops](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops) |  |
+| {doc}`clang-analyzer-osx.cocoa.MissingSuperCall <clang-analyzer/osx.cocoa.MissingSuperCall>` | [Clang Static Analyzer osx.cocoa.MissingSuperCall](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall) |  |
+| {doc}`clang-analyzer-osx.cocoa.NSAutoreleasePool <clang-analyzer/osx.cocoa.NSAutoreleasePool>` | [Clang Static Analyzer osx.cocoa.NSAutoreleasePool](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool) |  |
+| {doc}`clang-analyzer-osx.cocoa.NSError <clang-analyzer/osx.cocoa.NSError>` | [Clang Static Analyzer osx.cocoa.NSError](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror) |  |
+| {doc}`clang-analyzer-osx.cocoa.NilArg <clang-analyzer/osx.cocoa.NilArg>` | [Clang Static Analyzer osx.cocoa.NilArg](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg) |  |
+| {doc}`clang-analyzer-osx.cocoa.NonNilReturnValue <clang-analyzer/osx.cocoa.NonNilReturnValue>` | [Clang Static Analyzer osx.cocoa.NonNilReturnValue](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue) |  |
+| {doc}`clang-analyzer-osx.cocoa.ObjCGenerics <clang-analyzer/osx.cocoa.ObjCGenerics>` | [Clang Static Analyzer osx.cocoa.ObjCGenerics](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics) |  |
+| {doc}`clang-analyzer-osx.cocoa.RetainCount <clang-analyzer/osx.cocoa.RetainCount>` | [Clang Static Analyzer osx.cocoa.RetainCount](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount) |  |
+| {doc}`clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak <clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak>` | [Clang Static Analyzer osx.cocoa.RunLoopAutoreleaseLeak](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak) |  |
+| {doc}`clang-analyzer-osx.cocoa.SelfInit <clang-analyzer/osx.cocoa.SelfInit>` | [Clang Static Analyzer osx.cocoa.SelfInit](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit) |  |
+| {doc}`clang-analyzer-osx.cocoa.SuperDealloc <clang-analyzer/osx.cocoa.SuperDealloc>` | [Clang Static Analyzer osx.cocoa.SuperDealloc](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc) |  |
+| {doc}`clang-analyzer-osx.cocoa.UnusedIvars <clang-analyzer/osx.cocoa.UnusedIvars>` | [Clang Static Analyzer osx.cocoa.UnusedIvars](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars) |  |
+| {doc}`clang-analyzer-osx.cocoa.VariadicMethodTypes <clang-analyzer/osx.cocoa.VariadicMethodTypes>` | [Clang Static Analyzer osx.cocoa.VariadicMethodTypes](https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes) |  |
+| {doc}`clang-analyzer-osx.coreFoundation.CFError <clang-analyzer/osx.coreFoundation.CFError>` | [Clang Static Analyzer osx.coreFoundation.CFError](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror) |  |
+| {doc}`clang-analyzer-osx.coreFoundation.CFNumber <clang-analyzer/osx.coreFoundation.CFNumber>` | [Clang Static Analyzer osx.coreFoundation.CFNumber](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber) |  |
+| {doc}`clang-analyzer-osx.coreFoundation.CFRetainRelease <clang-analyzer/osx.coreFoundation.CFRetainRelease>` | [Clang Static Analyzer osx.coreFoundation.CFRetainRelease](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease) |  |
+| {doc}`clang-analyzer-osx.coreFoundation.containers.OutOfBounds <clang-analyzer/osx.coreFoundation.containers.OutOfBounds>` | [Clang Static Analyzer osx.coreFoundation.containers.OutOfBounds](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds) |  |
+| {doc}`clang-analyzer-osx.coreFoundation.containers.PointerSizedValues <clang-analyzer/osx.coreFoundation.containers.PointerSizedValues>` | [Clang Static Analyzer osx.coreFoundation.containers.PointerSizedValues](https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues) |  |
+| {doc}`clang-analyzer-security.ArrayBound <clang-analyzer/security.ArrayBound>` | [Clang Static Analyzer security.ArrayBound](https://clang.llvm.org/docs/analyzer/checkers.html#security-arraybound) |  |
+| {doc}`clang-analyzer-security.FloatLoopCounter <clang-analyzer/security.FloatLoopCounter>` | [Clang Static Analyzer security.FloatLoopCounter](https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter) |  |
+| {doc}`clang-analyzer-security.MmapWriteExec <clang-analyzer/security.MmapWriteExec>` | [Clang Static Analyzer security.MmapWriteExec](https://clang.llvm.org/docs/analyzer/checkers.html#security-mmapwriteexec) |  |
+| {doc}`clang-analyzer-security.PointerSub <clang-analyzer/security.PointerSub>` | [Clang Static Analyzer security.PointerSub](https://clang.llvm.org/docs/analyzer/checkers.html#security-pointersub) |  |
+| {doc}`clang-analyzer-security.PutenvStackArray <clang-analyzer/security.PutenvStackArray>` | Clang Static Analyzer security.PutenvStackArray |  |
+| {doc}`clang-analyzer-security.SetgidSetuidOrder <clang-analyzer/security.SetgidSetuidOrder>` | Clang Static Analyzer security.SetgidSetuidOrder |  |
+| {doc}`clang-analyzer-security.VAList <clang-analyzer/security.VAList>` | [Clang Static Analyzer security.VAList](https://clang.llvm.org/docs/analyzer/checkers.html#security-valist) |  |
+| {doc}`clang-analyzer-security.cert.env.InvalidPtr <clang-analyzer/security.cert.env.InvalidPtr>` | [Clang Static Analyzer security.cert.env.InvalidPtr](https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr) |  |
+| {doc}`clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling <clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling>` | [Clang Static Analyzer security.insecureAPI.DeprecatedOrUnsafeBufferHandling](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling) |  |
+| {doc}`clang-analyzer-security.insecureAPI.UncheckedReturn <clang-analyzer/security.insecureAPI.UncheckedReturn>` | [Clang Static Analyzer security.insecureAPI.UncheckedReturn](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn) |  |
+| {doc}`clang-analyzer-security.insecureAPI.bcmp <clang-analyzer/security.insecureAPI.bcmp>` | [Clang Static Analyzer security.insecureAPI.bcmp](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp) |  |
+| {doc}`clang-analyzer-security.insecureAPI.bcopy <clang-analyzer/security.insecureAPI.bcopy>` | [Clang Static Analyzer security.insecureAPI.bcopy](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy) |  |
+| {doc}`clang-analyzer-security.insecureAPI.bzero <clang-analyzer/security.insecureAPI.bzero>` | [Clang Static Analyzer security.insecureAPI.bzero](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero) |  |
+| {doc}`clang-analyzer-security.insecureAPI.decodeValueOfObjCType <clang-analyzer/security.insecureAPI.decodeValueOfObjCType>` | [Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-decodevalueofobjctype) |  |
+| {doc}`clang-analyzer-security.insecureAPI.getpw <clang-analyzer/security.insecureAPI.getpw>` | [Clang Static Analyzer security.insecureAPI.getpw](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw) |  |
+| {doc}`clang-analyzer-security.insecureAPI.gets <clang-analyzer/security.insecureAPI.gets>` | [Clang Static Analyzer security.insecureAPI.gets](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets) |  |
+| {doc}`clang-analyzer-security.insecureAPI.mkstemp <clang-analyzer/security.insecureAPI.mkstemp>` | [Clang Static Analyzer security.insecureAPI.mkstemp](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp) |  |
+| {doc}`clang-analyzer-security.insecureAPI.mktemp <clang-analyzer/security.insecureAPI.mktemp>` | [Clang Static Analyzer security.insecureAPI.mktemp](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp) |  |
+| {doc}`clang-analyzer-security.insecureAPI.rand <clang-analyzer/security.insecureAPI.rand>` | [Clang Static Analyzer security.insecureAPI.rand](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand) |  |
+| {doc}`clang-analyzer-security.insecureAPI.strcpy <clang-analyzer/security.insecureAPI.strcpy>` | [Clang Static Analyzer security.insecureAPI.strcpy](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy) |  |
+| {doc}`clang-analyzer-security.insecureAPI.vfork <clang-analyzer/security.insecureAPI.vfork>` | [Clang Static Analyzer security.insecureAPI.vfork](https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork) |  |
+| {doc}`clang-analyzer-unix.API <clang-analyzer/unix.API>` | [Clang Static Analyzer unix.API](https://clang.llvm.org/docs/analyzer/checkers.html#unix-api) |  |
+| {doc}`clang-analyzer-unix.BlockInCriticalSection <clang-analyzer/unix.BlockInCriticalSection>` | [Clang Static Analyzer unix.BlockInCriticalSection](https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection) |  |
+| {doc}`clang-analyzer-unix.Chroot <clang-analyzer/unix.Chroot>` | [Clang Static Analyzer unix.Chroot](https://clang.llvm.org/docs/analyzer/checkers.html#unix-chroot) |  |
+| {doc}`clang-analyzer-unix.Errno <clang-analyzer/unix.Errno>` | [Clang Static Analyzer unix.Errno](https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno) |  |
+| {doc}`clang-analyzer-unix.Malloc <clang-analyzer/unix.Malloc>` | [Clang Static Analyzer unix.Malloc](https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc) |  |
+| {doc}`clang-analyzer-unix.MallocSizeof <clang-analyzer/unix.MallocSizeof>` | [Clang Static Analyzer unix.MallocSizeof](https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof) |  |
+| {doc}`clang-analyzer-unix.MismatchedDeallocator <clang-analyzer/unix.MismatchedDeallocator>` | [Clang Static Analyzer unix.MismatchedDeallocator](https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator) |  |
+| {doc}`clang-analyzer-unix.StdCLibraryFunctions <clang-analyzer/unix.StdCLibraryFunctions>` | [Clang Static Analyzer unix.StdCLibraryFunctions](https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions) |  |
+| {doc}`clang-analyzer-unix.Stream <clang-analyzer/unix.Stream>` | [Clang Static Analyzer unix.Stream](https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream) |  |
+| {doc}`clang-analyzer-unix.Vfork <clang-analyzer/unix.Vfork>` | [Clang Static Analyzer unix.Vfork](https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork) |  |
+| {doc}`clang-analyzer-unix.cstring.BadSizeArg <clang-analyzer/unix.cstring.BadSizeArg>` | [Clang Static Analyzer unix.cstring.BadSizeArg](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg) |  |
+| {doc}`clang-analyzer-unix.cstring.NotNullTerminated <clang-analyzer/unix.cstring.NotNullTerminated>` | [Clang Static Analyzer unix.cstring.NotNullTerminated](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-notnullterminated) |  |
+| {doc}`clang-analyzer-unix.cstring.NullArg <clang-analyzer/unix.cstring.NullArg>` | [Clang Static Analyzer unix.cstring.NullArg](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg) |  |
+| {doc}`clang-analyzer-unix.cstring.UninitializedRead <clang-analyzer/unix.cstring.UninitializedRead>` | [Clang Static Analyzer unix.cstring.UninitializedRead](https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-uninitializedread) |  |
+| {doc}`clang-analyzer-webkit.NoUncountedMemberChecker <clang-analyzer/webkit.NoUncountedMemberChecker>` | [Clang Static Analyzer webkit.NoUncountedMemberChecker](https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker) |  |
+| {doc}`clang-analyzer-webkit.RefCntblBaseVirtualDtor <clang-analyzer/webkit.RefCntblBaseVirtualDtor>` | [Clang Static Analyzer webkit.RefCntblBaseVirtualDtor](https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor) |  |
+| {doc}`clang-analyzer-webkit.UncountedLambdaCapturesChecker <clang-analyzer/webkit.UncountedLambdaCapturesChecker>` | [Clang Static Analyzer webkit.UncountedLambdaCapturesChecker](https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker) |  |
+| {doc}`cppcoreguidelines-avoid-c-arrays <cppcoreguidelines/avoid-c-arrays>` | {doc}`modernize-avoid-c-arrays <modernize/avoid-c-arrays>` |  |
+| {doc}`cppcoreguidelines-avoid-magic-numbers <cppcoreguidelines/avoid-magic-numbers>` | {doc}`readability-magic-numbers <readability/magic-numbers>` |  |
+| {doc}`cppcoreguidelines-c-copy-assignment-signature <cppcoreguidelines/c-copy-assignment-signature>` | {doc}`misc-unconventional-assign-operator <misc/unconventional-assign-operator>` |  |
+| {doc}`cppcoreguidelines-explicit-constructor <cppcoreguidelines/explicit-constructor>` | {doc}`misc-explicit-constructor <misc/explicit-constructor>` | Yes |
+| {doc}`cppcoreguidelines-explicit-virtual-functions <cppcoreguidelines/explicit-virtual-functions>` | {doc}`modernize-use-override <modernize/use-override>` | Yes |
+| {doc}`cppcoreguidelines-macro-to-enum <cppcoreguidelines/macro-to-enum>` | {doc}`modernize-macro-to-enum <modernize/macro-to-enum>` | Yes |
+| {doc}`cppcoreguidelines-narrowing-conversions <cppcoreguidelines/narrowing-conversions>` | {doc}`bugprone-narrowing-conversions <bugprone/narrowing-conversions>` |  |
+| {doc}`cppcoreguidelines-noexcept-destructor <cppcoreguidelines/noexcept-destructor>` | {doc}`performance-noexcept-destructor <performance/noexcept-destructor>` | Yes |
+| {doc}`cppcoreguidelines-noexcept-move-operations <cppcoreguidelines/noexcept-move-operations>` | {doc}`performance-noexcept-move-constructor <performance/noexcept-move-constructor>` | Yes |
+| {doc}`cppcoreguidelines-noexcept-swap <cppcoreguidelines/noexcept-swap>` | {doc}`performance-noexcept-swap <performance/noexcept-swap>` | Yes |
+| {doc}`cppcoreguidelines-non-private-member-variables-in-classes <cppcoreguidelines/non-private-member-variables-in-classes>` | {doc}`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>` |  |
+| {doc}`cppcoreguidelines-use-default-member-init <cppcoreguidelines/use-default-member-init>` | {doc}`modernize-use-default-member-init <modernize/use-default-member-init>` | Yes |
+| {doc}`fuchsia-header-anon-namespaces <fuchsia/header-anon-namespaces>` | {doc}`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>` |  |
+| {doc}`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>` | {doc}`misc-multiple-inheritance <misc/multiple-inheritance>` |  |
+| {doc}`google-build-namespaces <google/build-namespaces>` | {doc}`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>` |  |
+| {doc}`google-explicit-constructor <google/explicit-constructor>` | {doc}`misc-explicit-constructor <misc/explicit-constructor>` | Yes |
+| {doc}`google-readability-braces-around-statements <google/readability-braces-around-statements>` | {doc}`readability-braces-around-statements <readability/braces-around-statements>` | Yes |
+| {doc}`google-readability-casting <google/readability-casting>` | {doc}`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>` | Yes |
+| {doc}`google-readability-function-size <google/readability-function-size>` | {doc}`readability-function-size <readability/function-size>` |  |
+| {doc}`google-readability-namespace-comments <google/readability-namespace-comments>` | {doc}`llvm-namespace-comment <llvm/namespace-comment>` |  |
+| {doc}`llvm-else-after-return <llvm/else-after-return>` | {doc}`readability-else-after-return <readability/else-after-return>` | Yes |
+| {doc}`llvm-qualified-auto <llvm/qualified-auto>` | {doc}`readability-qualified-auto <readability/qualified-auto>` | Yes |
+| {doc}`performance-faster-string-find <performance/faster-string-find>` | {doc}`performance-prefer-single-char-overloads <performance/prefer-single-char-overloads>` | Yes |

--- a/clang-tools-extra/test/clang-tidy/infrastructure/alphabetical-order.test
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/alphabetical-order.test
@@ -1,5 +1,5 @@
-// RUN: %python %S/../../../clang-tidy/tool/check_alphabetical_order.py -o %t.clang-tidy-checks-list.rst
-// RUN: diff --strip-trailing-cr %S/../../../docs/clang-tidy/checks/list.rst %t.clang-tidy-checks-list.rst
+// RUN: %python %S/../../../clang-tidy/tool/check_alphabetical_order.py -o %t.clang-tidy-checks-list.md
+// RUN: diff --strip-trailing-cr %S/../../../docs/clang-tidy/checks/list.md %t.clang-tidy-checks-list.md
 
 // RUN: %python %S/../../../clang-tidy/tool/check_alphabetical_order.py -o %t.ReleaseNotes.rst
 // RUN: diff --strip-trailing-cr %S/../../../docs/ReleaseNotes.rst %t.ReleaseNotes.rst

--- a/clang-tools-extra/test/clang-tidy/infrastructure/update-checks-list.test
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/update-checks-list.test
@@ -1,2 +1,2 @@
-// RUN: %python %S/../../../clang-tidy/tool/check_update_docs.py -o %t.clang-tidy-checks-list.rst
-// RUN: diff --strip-trailing-cr %S/../../../docs/clang-tidy/checks/list.rst %t.clang-tidy-checks-list.rst
+// RUN: %python %S/../../../clang-tidy/tool/check_update_docs.py -o %t.clang-tidy-checks-list.md
+// RUN: diff --strip-trailing-cr %S/../../../docs/clang-tidy/checks/list.md %t.clang-tidy-checks-list.md


### PR DESCRIPTION
Tracking issue: #201242
See the [migration guide] for more information. 

[migration guide]: https://llvm.org/docs/SphinxQuickstartTemplate.html#markdown-migration-guidelines
This is a stacked PR based on #211448 , which will be a standalone commit that
renames *.rst -> *.md before this PR lands for history preservation purposes.

Unlike the other changes in this series, most of these changes are from the generator script. Ignore all files under checks/ except `list.md`, that is hand-modified. I confirmed that running the generator script produces no changes.

Notably, the generator script *added new files*, since it seems there are new checks since the script was run.

-----

HTML tearoff links below for review convenience:
| Source file | Before HTML | After HTML |
| --- | --- | --- |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.BitwiseShift.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.BitwiseShift.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.BitwiseShift.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.CallAndMessage.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.DivideZero.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.DivideZero.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.DivideZero.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NullDereference.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.NullDereference.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.NullDereference.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.VLASize.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.VLASize.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.VLASize.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.NewArraySize.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.NewArraySize.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.NewArraySize.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.Move.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.Move.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.Move.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.PlacementNew.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.PlacementNew.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.PlacementNew.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.SelfAssignment.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.SelfAssignment.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.SelfAssignment.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.StringChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/cplusplus.StringChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/cplusplus.StringChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/fuchsia.HandleChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/fuchsia.HandleChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/fuchsia.HandleChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.EnumCastOutOfRange.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.core.EnumCastOutOfRange.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.core.EnumCastOutOfRange.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.Padding.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.performance.Padding.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.performance.Padding.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.API.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.API.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.API.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.cert.env.InvalidPtr.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.cert.env.InvalidPtr.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.cert.env.InvalidPtr.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.decodeValueOfObjCType.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.decodeValueOfObjCType.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.decodeValueOfObjCType.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.API.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.API.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.API.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Errno.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.Errno.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Errno.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Malloc.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.Malloc.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Malloc.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Stream.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.Stream.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Stream.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Vfork.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.Vfork.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.Vfork.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.NoUncountedMemberChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/webkit.NoUncountedMemberChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.NoUncountedMemberChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.RefCntblBaseVirtualDtor.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/webkit.RefCntblBaseVirtualDtor.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.RefCntblBaseVirtualDtor.html) |
| `clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.UncountedLambdaCapturesChecker.md` | [before](https://llvm.org/docs/clang-tidy/checks/clang-analyzer/webkit.UncountedLambdaCapturesChecker.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/webkit.UncountedLambdaCapturesChecker.html) |
| `clang-tools-extra/docs/clang-tidy/checks/list.md` | [before](https://llvm.org/docs/clang-tidy/checks/list.html) | [after](https://llvmdocs.staging.reidkleckner.dev/clang-tools-extra/docs/clang-tidy/checks/list.html) |
