### PR TITLE
[M68k][CodeGen] pipeline failure fix

### DIFF
--- a/llvm/test/CodeGen/M68k/pipeline.ll
+++ b/llvm/test/CodeGen/M68k/pipeline.ll
@@ -76,6 +76,7 @@
 ; CHECK-NEXT:      Machine Common Subexpression Elimination
 ; CHECK-NEXT:      MachinePostDominator Tree Construction
 ; CHECK-NEXT:      Machine Cycle Info Analysis
+; CHECK-NEXT:      Machine Register Class Info Analysis
 ; CHECK-NEXT:      Machine code sinking
 ; CHECK-NEXT:      Peephole Optimizations
 ; CHECK-NEXT:      Remove dead machine instructions


### PR DESCRIPTION
Fixing pipeline mismatch on M68k (experimental target, failure shouldnt have been reported).
Triggered upon merge of this PR: https://github.com/llvm/llvm-project/pull/210826

Failure here: https://lab.llvm.org/buildbot/#/builders/27/builds/2162/steps/5/logs/FAIL__LLVM__pipeline_ll