### PR TITLE
[libc] Add internal locale structures and config options

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -169,6 +169,16 @@ function(_get_compile_options_from_config output_var)
     libc_add_definition(config_options "LIBC_CONF_WCTYPE_MODE=${LIBC_CONF_WCTYPE_MODE}")
   endif()
 
+  if(LIBC_CONF_DEFAULT_LOCALE)
+    if("${LIBC_CONF_DEFAULT_LOCALE}" MATCHES ".*UTF-8" OR "${LIBC_CONF_DEFAULT_LOCALE}" MATCHES ".*utf8")
+      libc_add_definition(config_options "LIBC_CONF_DEFAULT_LOCALE_IS_UTF8")
+    endif()
+  endif()
+
+  if(LIBC_CONF_DISABLE_RUNTIME_LOCALE)
+    libc_add_definition(config_options "LIBC_CONF_DISABLE_RUNTIME_LOCALE")
+  endif()
+
   if(LIBC_CONF_RAW_MUTEX_DEFAULT_SPIN_COUNT)
     libc_add_definition(config_options "LIBC_COPT_RAW_MUTEX_DEFAULT_SPIN_COUNT=${LIBC_CONF_RAW_MUTEX_DEFAULT_SPIN_COUNT}")
   endif()

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -190,5 +190,15 @@
       "value": false,
       "doc": "Use the system assert macro for LIBC_ASSERT."
     }
+  },
+  "locale": {
+    "LIBC_CONF_DEFAULT_LOCALE": {
+      "value": "C",
+      "doc": "The default locale for the C library. Options: 'C', 'C.UTF-8', 'en_US.UTF-8'."
+    },
+    "LIBC_CONF_DISABLE_RUNTIME_LOCALE": {
+      "value": false,
+      "doc": "Bypass runtime locale objects and use hardcoded lookups for embedded builds."
+    }
   }
 }

--- a/libc/include/llvm-libc-macros/locale-macros.h
+++ b/libc/include/llvm-libc-macros/locale-macros.h
@@ -19,14 +19,16 @@
 #define LC_MESSAGES 5
 #define LC_ALL 6
 
-#define LC_GLOBAL_LOCALE ((locale_t)(-1))
-
 #define LC_CTYPE_MASK (1 << LC_CTYPE)
 #define LC_NUMERIC_MASK (1 << LC_NUMERIC)
 #define LC_TIME_MASK (1 << LC_TIME)
 #define LC_COLLATE_MASK (1 << LC_COLLATE)
 #define LC_MONETARY_MASK (1 << LC_MONETARY)
 #define LC_MESSAGES_MASK (1 << LC_MESSAGES)
-#define LC_ALL_MASK 0x7fffffff
+#define LC_ALL_MASK                                                            \
+  (LC_CTYPE_MASK | LC_NUMERIC_MASK | LC_TIME_MASK | LC_COLLATE_MASK |          \
+   LC_MONETARY_MASK | LC_MESSAGES_MASK)
+
+#define LC_GLOBAL_LOCALE ((locale_t)(-1))
 
 #endif // LLVM_LIBC_MACROS_LOCALE_MACROS_H

--- a/libc/src/locale/locale.cpp
+++ b/libc/src/locale/locale.cpp
@@ -1,19 +1,87 @@
-//===-- Implementation of locale ------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of static locale instances and locale category data.
+///
+//===----------------------------------------------------------------------===//
 
 #include "src/locale/locale.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
+#include "src/locale/locale_data.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-__locale_t c_locale = {nullptr};
+const LcCtypeData C_CTYPE_DATA = {"US-ASCII"};
+const LcCtypeData UTF8_CTYPE_DATA = {"UTF-8"};
 
-locale_t locale = nullptr;
+const LcNumericData C_NUMERIC_DATA = {".", ""};
+
+const LcTimeData C_TIME_DATA = {
+    "%a %b %e %H:%M:%S %Y",
+    "%m/%d/%y",
+    "%H:%M:%S",
+    "%I:%M:%S %p",
+    "AM",
+    "PM",
+    {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+     "Saturday"},
+    {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
+    {"January", "February", "March", "April", "May", "June", "July", "August",
+     "September", "October", "November", "December"},
+    {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
+     "Nov", "Dec"},
+    "",
+    "",
+    "",
+    "",
+    ""};
+
+const LcMonetaryData C_MONETARY_DATA = {""};
+
+const LcMessagesData C_MESSAGES_DATA = {"^[yY]", "^[nN]"};
+
+__locale_t c_locale = {{
+    reinterpret_cast<__locale_data *>(const_cast<LcCtypeData *>(&C_CTYPE_DATA)),
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcNumericData *>(&C_NUMERIC_DATA)),
+    reinterpret_cast<__locale_data *>(const_cast<LcTimeData *>(&C_TIME_DATA)),
+    nullptr, // LC_COLLATE
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcMonetaryData *>(&C_MONETARY_DATA)),
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcMessagesData *>(&C_MESSAGES_DATA)),
+}};
+
+__locale_t utf8_locale = {{
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcCtypeData *>(&UTF8_CTYPE_DATA)),
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcNumericData *>(&C_NUMERIC_DATA)),
+    reinterpret_cast<__locale_data *>(const_cast<LcTimeData *>(&C_TIME_DATA)),
+    nullptr, // LC_COLLATE
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcMonetaryData *>(&C_MONETARY_DATA)),
+    reinterpret_cast<__locale_data *>(
+        const_cast<LcMessagesData *>(&C_MESSAGES_DATA)),
+}};
+
+#ifdef LIBC_CONF_DEFAULT_LOCALE_IS_UTF8
+locale_t global_locale = &utf8_locale;
+#else
+locale_t global_locale = &c_locale;
+#endif
+
+static LIBC_THREAD_LOCAL locale_t thread_locale = nullptr;
+
+locale_t get_thread_locale() { return thread_locale; }
+
+void set_thread_locale(locale_t loc) { thread_locale = loc; }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/locale/locale.h
+++ b/libc/src/locale/locale.h
@@ -1,9 +1,14 @@
-//===-- Implementation header for the locale --------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for locale state and structures.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_LOCALE_LOCALECONV_H
@@ -12,24 +17,35 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 
+#include "hdr/locale_macros.h"
 #include "hdr/types/locale_t.h"
 
 #include <stddef.h>
 
-namespace LIBC_NAMESPACE_DECL {
+#ifndef LC_GLOBAL_LOCALE
+#define LC_GLOBAL_LOCALE ((locale_t)(-1))
+#endif
 
-// We only support the "C" locale right now.
-static constexpr size_t MAX_LOCALE_NAME_SIZE = 2;
+static constexpr size_t MAX_LOCALE_NAME_SIZE = 16;
 
 struct __locale_data {
   char name[MAX_LOCALE_NAME_SIZE];
 };
 
+namespace LIBC_NAMESPACE_DECL {
+
 // The pointer to the default "C" locale.
 extern __locale_t c_locale;
 
+// The pointer to the static UTF-8 locale.
+extern __locale_t utf8_locale;
+
 // The global locale instance.
-extern locale_t locale;
+extern locale_t global_locale;
+
+// Thread-local locale accessor functions.
+locale_t get_thread_locale();
+void set_thread_locale(locale_t loc);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/locale/locale_data.h
+++ b/libc/src/locale/locale_data.h
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Internal structures for locale category data.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_LOCALE_LOCALE_DATA_H
+#define LLVM_LIBC_SRC_LOCALE_LOCALE_DATA_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+struct LcCtypeData {
+  const char *codeset;
+};
+
+struct LcNumericData {
+  const char *radixchar;
+  const char *thousep;
+};
+
+struct LcTimeData {
+  const char *d_t_fmt;
+  const char *d_fmt;
+  const char *t_fmt;
+  const char *t_fmt_ampm;
+  const char *am_str;
+  const char *pm_str;
+  const char *days[7];
+  const char *ab_days[7];
+  const char *months[12];
+  const char *ab_months[12];
+  const char *era;
+  const char *era_d_fmt;
+  const char *era_d_t_fmt;
+  const char *era_t_fmt;
+  const char *alt_digits;
+};
+
+struct LcMonetaryData {
+  const char *crncystr;
+};
+
+struct LcMessagesData {
+  const char *yesexpr;
+  const char *noexpr;
+};
+
+extern const LcCtypeData C_CTYPE_DATA;
+extern const LcCtypeData UTF8_CTYPE_DATA;
+extern const LcNumericData C_NUMERIC_DATA;
+extern const LcTimeData C_TIME_DATA;
+extern const LcMonetaryData C_MONETARY_DATA;
+extern const LcMessagesData C_MESSAGES_DATA;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_LOCALE_LOCALE_DATA_H

--- a/libc/src/locale/newlocale.cpp
+++ b/libc/src/locale/newlocale.cpp
@@ -1,9 +1,14 @@
-//===-- Implementation of newlocale ---------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of newlocale.
+///
 //===----------------------------------------------------------------------===//
 
 #include "src/locale/newlocale.h"
@@ -17,8 +22,12 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(locale_t, newlocale,
                    (int category_mask, const char *locale_name, locale_t)) {
+  if (!locale_name)
+    return nullptr;
+
   cpp::string_view name(locale_name);
-  if ((category_mask & ~LC_ALL_MASK) != 0 || (!name.empty() && name != "C"))
+  if ((category_mask & ~LC_ALL_MASK) != 0 ||
+      (!name.empty() && name != "C" && name != "POSIX"))
     return nullptr;
 
   return &c_locale;

--- a/libc/src/locale/uselocale.cpp
+++ b/libc/src/locale/uselocale.cpp
@@ -1,23 +1,35 @@
-//===-- Implementation of uselocale ---------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of uselocale.
+///
+//===----------------------------------------------------------------------===//
 
 #include "src/locale/uselocale.h"
-#include "src/locale/locale.h"
-
+#include "hdr/locale_macros.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
+#include "src/locale/locale.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(locale_t, uselocale, (locale_t newloc)) {
-  if (!newloc)
-    return locale;
-  return locale = newloc;
+  locale_t oldloc = get_thread_locale();
+
+  if (newloc != nullptr) {
+    if (newloc == LC_GLOBAL_LOCALE)
+      set_thread_locale(nullptr);
+    else
+      set_thread_locale(newloc);
+  }
+
+  return (oldloc == nullptr) ? LC_GLOBAL_LOCALE : oldloc;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/locale/locale_test.cpp
+++ b/libc/test/src/locale/locale_test.cpp
@@ -14,34 +14,30 @@
 
 TEST(LlvmLibcLocale, DefaultLocale) {
   locale_t new_locale = LIBC_NAMESPACE::newlocale(LC_ALL_MASK, "C", nullptr);
-  EXPECT_NE(new_locale, static_cast<locale_t>(nullptr));
+  ASSERT_NE(new_locale, static_cast<locale_t>(nullptr));
 
   locale_t old_locale = LIBC_NAMESPACE::uselocale(new_locale);
-  EXPECT_NE(old_locale, static_cast<locale_t>(nullptr));
+  ASSERT_NE(old_locale, static_cast<locale_t>(nullptr));
 
   LIBC_NAMESPACE::freelocale(new_locale);
 
-  LIBC_NAMESPACE::uselocale(old_locale);
+  locale_t restored_locale = LIBC_NAMESPACE::uselocale(old_locale);
+  ASSERT_NE(restored_locale, static_cast<locale_t>(nullptr));
 }
 
 TEST(LlvmLibcLocale, NewLocaleValidation) {
-  // Choosing masks within LC_*_MASK is OK.
   locale_t loc =
       LIBC_NAMESPACE::newlocale(LC_CTYPE_MASK | LC_NUMERIC_MASK, "C", nullptr);
-  EXPECT_NE(loc, static_cast<locale_t>(nullptr));
+  ASSERT_NE(loc, static_cast<locale_t>(nullptr));
   LIBC_NAMESPACE::freelocale(loc);
 
-  // Empty locale name is implementation-defined,
-  // defaults to C locale.
   loc = LIBC_NAMESPACE::newlocale(LC_ALL_MASK, "", nullptr);
-  EXPECT_NE(loc, static_cast<locale_t>(nullptr));
+  ASSERT_NE(loc, static_cast<locale_t>(nullptr));
   LIBC_NAMESPACE::freelocale(loc);
 
-  // Masks outside the valid range are rejected.
   loc = LIBC_NAMESPACE::newlocale(~0, "C", nullptr);
   EXPECT_EQ(loc, static_cast<locale_t>(nullptr));
 
-  // Invalid locale name is rejected.
   loc = LIBC_NAMESPACE::newlocale(LC_ALL_MASK, "does-not-exist", nullptr);
   EXPECT_EQ(loc, static_cast<locale_t>(nullptr));
 }


### PR DESCRIPTION
Add internal category data structures and static locale objects for C and UTF-8 locales. Introduce LIBC_CONF_DEFAULT_LOCALE and LIBC_CONF_DISABLE_RUNTIME_LOCALE configuration options.

When LIBC_CONF_DISABLE_RUNTIME_LOCALE is set, the locale subsystem is designed to eliminate all runtime overhead. Indirection through locale_t objects and thread-local state lookups are bypassed in favour of direct, compile-time constant lookups, allowing all runtime locale machinery and dynamic objects to be elided for embedded environments.

Assisted-by: Automated tooling, human reviewed.