### PR TITLE
[CodeGen] Avoid stale LocalMIs entries after compare optimization

### DIFF
--- a/llvm/lib/CodeGen/PeepholeOptimizer.cpp
+++ b/llvm/lib/CodeGen/PeepholeOptimizer.cpp
@@ -957,8 +957,15 @@ bool PeepholeOptimizer::optimizeCmpInstr(
 
   // Attempt to optimize the comparison instruction.
   LLVM_DEBUG(dbgs() << "Attempting to optimize compare: " << MI);
-  if (!TII->optimizeCompareInstr(MI, SrcReg, SrcReg2, CmpMask, CmpValue, MRI))
+  // Stop tracking MI before optimizeCompareInstr may erase it. Any instruction
+  // created below could otherwise reuse MI's address and be confused with the
+  // erased instruction in LocalMIs.
+  LocalMIs.erase(&MI);
+  if (!TII->optimizeCompareInstr(MI, SrcReg, SrcReg2, CmpMask, CmpValue, MRI)) {
+    // MI was not erased, and is still part of the already visited region.
+    LocalMIs.insert(&MI);
     return false;
+  }
 
   LLVM_DEBUG(dbgs() << "  -> Successfully optimized compare!\n");
   ++NumCmps;
@@ -1843,7 +1850,6 @@ bool PeepholeOptimizer::run(MachineFunction &MF) {
       }
 
       if (MI->isCompare() && optimizeCmpInstr(*MI, MF, LocalMIs)) {
-        LocalMIs.erase(MI);
         Changed = true;
         continue;
       }

--- a/llvm/test/CodeGen/X86/peephole-compare-load-fold-ext.mir
+++ b/llvm/test/CodeGen/X86/peephole-compare-load-fold-ext.mir
@@ -1,0 +1,40 @@
+# RUN: llc -mtriple=x86_64-- -run-pass=peephole-opt -verify-machineinstrs %s -o - | FileCheck %s
+
+# When removing the second compare makes a load foldable into the first one,
+# make sure the folded compare remains marked as already visited. Otherwise,
+# the extension optimization may incorrectly replace its source with a subreg
+# of a result defined later in the block.
+
+---
+name: compare_load_fold_before_ext
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $edi, $rsi
+
+    ; CHECK-LABEL: name: compare_load_fold_before_ext
+    ; CHECK: [[SRC:%[0-9]+]]:gr32 = COPY $edi
+    ; CHECK-NEXT: [[PTR:%[0-9]+]]:gr64 = COPY $rsi
+    ; CHECK-NEXT: CMP32mr [[PTR]], 1, $noreg, 0, $noreg, [[SRC]], implicit-def $eflags
+    ; CHECK-NEXT: [[SETCC:%[0-9]+]]:gr8 = SETCCr 14, implicit $eflags
+    ; CHECK-NEXT: [[EXT:%[0-9]+]]:gr64 = MOVSX64rr32 [[SRC]]
+    ; CHECK-NEXT: NOOP implicit [[EXT]]
+    ; CHECK-NEXT: JCC_1 %bb.1, 14, implicit $eflags
+
+    %0:gr32 = COPY $edi
+    %1:gr64 = COPY $rsi
+    %2:gr32 = MOV32rm %1, 1, $noreg, 0, $noreg :: (load (s32))
+    %3:gr32 = SUB32rr %2, %0, implicit-def $eflags
+    %4:gr8 = SETCCr 14, implicit $eflags
+    %5:gr32 = SUB32rr %2, %0, implicit-def $eflags
+    %6:gr64 = MOVSX64rr32 %0
+    NOOP implicit %6
+    JCC_1 %bb.1, 14, implicit $eflags
+    JMP_1 %bb.2
+
+  bb.1:
+    RET 0
+
+  bb.2:
+    RET 0
+...


### PR DESCRIPTION
This PR fixes https://github.com/llvm/llvm-project/issues/208746. OptimizeCompareInstr function may erase the current compare and enable load folding to creates a new instruction which will reuse the erased compare's address. So LocalMIs will remove the new instruction and caused a series of chain reactions. Currently, just remove it before entring optimizeCompareInstr and restore it when the optimization fails. 

Assisted-by: OpenAI Codex