### PR TITLE
[Clang][RISCV] Add packed sign and zero extend intrinsics

### DIFF
--- a/clang/include/clang/Basic/BuiltinsRISCV.td
+++ b/clang/include/clang/Basic/BuiltinsRISCV.td
@@ -297,6 +297,18 @@ def pmulqr_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>, _Vector<4,
 def pmulq_i32x2  : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>)">;
 def pmulqr_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>, _Vector<2, int>)">;
 
+// Packed Sign and Zero Extend (32-bit)
+def psext_b_i16x2 : RISCVBuiltin<"_Vector<2, short>(_Vector<2, short>)">;
+def pzext_b_u16x2 : RISCVBuiltin<"_Vector<2, unsigned short>(_Vector<2, unsigned short>)">;
+
+// Packed Sign and Zero Extend (64-bit)
+def psext_b_i16x4 : RISCVBuiltin<"_Vector<4, short>(_Vector<4, short>)">;
+def psext_b_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>)">;
+def psext_h_i32x2 : RISCVBuiltin<"_Vector<2, int>(_Vector<2, int>)">;
+def pzext_b_u16x4 : RISCVBuiltin<"_Vector<4, unsigned short>(_Vector<4, unsigned short>)">;
+def pzext_h_u32x2 : RISCVBuiltin<"_Vector<2, unsigned int>(_Vector<2, unsigned int>)">;
+
+
 } // Features = "experimental-p"
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -1289,7 +1289,14 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__builtin_riscv_pmulq_i16x4:
   case RISCV::BI__builtin_riscv_pmulqr_i16x4:
   case RISCV::BI__builtin_riscv_pmulq_i32x2:
-  case RISCV::BI__builtin_riscv_pmulqr_i32x2: {
+  case RISCV::BI__builtin_riscv_pmulqr_i32x2:
+  case RISCV::BI__builtin_riscv_psext_b_i16x2:
+  case RISCV::BI__builtin_riscv_pzext_b_u16x2:
+  case RISCV::BI__builtin_riscv_psext_b_i16x4:
+  case RISCV::BI__builtin_riscv_psext_b_i32x2:
+  case RISCV::BI__builtin_riscv_psext_h_i32x2:
+  case RISCV::BI__builtin_riscv_pzext_b_u16x4:
+  case RISCV::BI__builtin_riscv_pzext_h_u32x2: {
     switch (BuiltinID) {
     default:
       llvm_unreachable("unexpected builtin ID");
@@ -1420,6 +1427,21 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
     case RISCV::BI__builtin_riscv_pmulqr_i16x4:
     case RISCV::BI__builtin_riscv_pmulqr_i32x2:
       ID = Intrinsic::riscv_pmulqr;
+      break;
+    case RISCV::BI__builtin_riscv_psext_b_i16x2:
+    case RISCV::BI__builtin_riscv_psext_b_i16x4:
+    case RISCV::BI__builtin_riscv_psext_b_i32x2:
+      ID = Intrinsic::riscv_psext_b;
+      break;
+    case RISCV::BI__builtin_riscv_psext_h_i32x2:
+      ID = Intrinsic::riscv_psext_h;
+      break;
+    case RISCV::BI__builtin_riscv_pzext_b_u16x2:
+    case RISCV::BI__builtin_riscv_pzext_b_u16x4:
+      ID = Intrinsic::riscv_pzext_b;
+      break;
+    case RISCV::BI__builtin_riscv_pzext_h_u32x2:
+      ID = Intrinsic::riscv_pzext_h;
       break;
     }
 

--- a/clang/lib/Headers/riscv_packed_simd.h
+++ b/clang/lib/Headers/riscv_packed_simd.h
@@ -121,7 +121,7 @@ typedef uint32_t uint32x2_t __attribute__((__vector_size__(8)));
     return (ty)builtin(__rs1, __rs2, __rd);                                    \
   }
 
-#define __packed_psabs(name, ty, builtin)                                      \
+#define __packed_unary_builtin(name, ty, builtin)                              \
   static __inline__ ty __DEFAULT_FN_ATTRS __riscv_##name(ty __rs1) {           \
     return builtin(__rs1);                                                     \
   }
@@ -753,12 +753,23 @@ __packed_abdsum_acc(pabdsumau_u8x8_u32, uint32_t, uint8x8_t, __builtin_riscv_pab
 __packed_abdsum_acc(pabdsumau_u8x8_u64, uint64_t, uint8x8_t, __builtin_riscv_pabdsumau_u8x8_u64)
 
 /* Packed Saturating Absolute Value (32-bit) */
-__packed_psabs(psabs_i8x4, int8x4_t, __builtin_riscv_psabs_i8x4)
-__packed_psabs(psabs_i16x2, int16x2_t, __builtin_riscv_psabs_i16x2)
+__packed_unary_builtin(psabs_i8x4, int8x4_t, __builtin_riscv_psabs_i8x4)
+__packed_unary_builtin(psabs_i16x2, int16x2_t, __builtin_riscv_psabs_i16x2)
 
 /* Packed Saturating Absolute Value (64-bit) */
-__packed_psabs(psabs_i8x8, int8x8_t, __builtin_riscv_psabs_i8x8)
-__packed_psabs(psabs_i16x4, int16x4_t, __builtin_riscv_psabs_i16x4)
+__packed_unary_builtin(psabs_i8x8, int8x8_t, __builtin_riscv_psabs_i8x8)
+__packed_unary_builtin(psabs_i16x4, int16x4_t, __builtin_riscv_psabs_i16x4)
+
+/* Packed Sign and Zero Extend (32-bit) */
+__packed_unary_builtin(psext_b_i16x2, int16x2_t, __builtin_riscv_psext_b_i16x2)
+__packed_unary_builtin(pzext_b_u16x2, uint16x2_t, __builtin_riscv_pzext_b_u16x2)
+
+/* Packed Sign and Zero Extend (64-bit) */
+__packed_unary_builtin(psext_b_i16x4, int16x4_t, __builtin_riscv_psext_b_i16x4)
+__packed_unary_builtin(psext_b_i32x2, int32x2_t, __builtin_riscv_psext_b_i32x2)
+__packed_unary_builtin(psext_h_i32x2, int32x2_t, __builtin_riscv_psext_h_i32x2)
+__packed_unary_builtin(pzext_b_u16x4, uint16x4_t, __builtin_riscv_pzext_b_u16x4)
+__packed_unary_builtin(pzext_h_u32x2, uint32x2_t, __builtin_riscv_pzext_h_u32x2)
 
 /* Packed "Q-format" Multiplication (32-bit) */
 __packed_binary_builtin(pmulq_i16x2, int16x2_t, __builtin_riscv_pmulq_i16x2)
@@ -882,7 +893,7 @@ __packed_reinterpret(u32x2_i32x2, int32x2_t, uint32x2_t)
 #undef __packed_binary_builtin_cast
 #undef __packed_reduction
 #undef __packed_merge_builtin
-#undef __packed_psabs
+#undef __packed_unary_builtin
 #undef __packed_widen_convert
 #undef __packed_widen_high2
 #undef __packed_widen_high4

--- a/clang/test/CodeGen/RISCV/rvp-intrinsics.c
+++ b/clang/test/CodeGen/RISCV/rvp-intrinsics.c
@@ -7562,6 +7562,150 @@ int16x4_t test_psabs_i16x4(int16x4_t rs1) {
   return __riscv_psabs_i16x4(rs1);
 }
 
+/* Packed Sign and Zero Extend (32-bit) */
+
+// RV32-LABEL: define dso_local i32 @test_psext_b_i16x2(
+// RV32-SAME: i32 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = call <2 x i16> @llvm.riscv.psext.b.v2i16(<2 x i16> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[TMP1]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_psext_b_i16x2(
+// RV64-SAME: i32 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = call <2 x i16> @llvm.riscv.psext.b.v2i16(<2 x i16> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[TMP1]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+int16x2_t test_psext_b_i16x2(int16x2_t rs1) {
+  return __riscv_psext_b_i16x2(rs1);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pzext_b_u16x2(
+// RV32-SAME: i32 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = call <2 x i16> @llvm.riscv.pzext.b.v2i16(<2 x i16> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[TMP1]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pzext_b_u16x2(
+// RV64-SAME: i32 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[RS1_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = call <2 x i16> @llvm.riscv.pzext.b.v2i16(<2 x i16> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[TMP1]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pzext_b_u16x2(uint16x2_t rs1) {
+  return __riscv_pzext_b_u16x2(rs1);
+}
+
+/* Packed Sign and Zero Extend (64-bit) */
+
+// RV32-LABEL: define dso_local i64 @test_psext_b_i16x4(
+// RV32-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = call <4 x i16> @llvm.riscv.psext.b.v4i16(<4 x i16> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[TMP1]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_psext_b_i16x4(
+// RV64-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = call <4 x i16> @llvm.riscv.psext.b.v4i16(<4 x i16> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[TMP1]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+int16x4_t test_psext_b_i16x4(int16x4_t rs1) {
+  return __riscv_psext_b_i16x4(rs1);
+}
+
+// RV32-LABEL: define dso_local i64 @test_psext_b_i32x2(
+// RV32-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.riscv.psext.b.v2i32(<2 x i32> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[TMP1]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_psext_b_i32x2(
+// RV64-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.riscv.psext.b.v2i32(<2 x i32> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[TMP1]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+int32x2_t test_psext_b_i32x2(int32x2_t rs1) {
+  return __riscv_psext_b_i32x2(rs1);
+}
+
+// RV32-LABEL: define dso_local i64 @test_psext_h_i32x2(
+// RV32-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.riscv.psext.h.v2i32(<2 x i32> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[TMP1]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_psext_h_i32x2(
+// RV64-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.riscv.psext.h.v2i32(<2 x i32> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[TMP1]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+int32x2_t test_psext_h_i32x2(int32x2_t rs1) {
+  return __riscv_psext_h_i32x2(rs1);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pzext_b_u16x4(
+// RV32-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = call <4 x i16> @llvm.riscv.pzext.b.v4i16(<4 x i16> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[TMP1]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pzext_b_u16x4(
+// RV64-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = call <4 x i16> @llvm.riscv.pzext.b.v4i16(<4 x i16> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[TMP1]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pzext_b_u16x4(uint16x4_t rs1) {
+  return __riscv_pzext_b_u16x4(rs1);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pzext_h_u32x2(
+// RV32-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.riscv.pzext.h.v2i32(<2 x i32> [[TMP0]])
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[TMP1]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pzext_h_u32x2(
+// RV64-SAME: i64 noundef [[RS1_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[RS1_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.riscv.pzext.h.v2i32(<2 x i32> [[TMP0]])
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[TMP1]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pzext_h_u32x2(uint32x2_t rs1) {
+  return __riscv_pzext_h_u32x2(rs1);
+}
+
 /* Packed Widening Convert */
 
 // RV32-LABEL: define dso_local i64 @test_pwcvt_i16x4(

--- a/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
+++ b/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
@@ -2820,6 +2820,39 @@ uint16x4_t test_ppairo_u16x4(uint16x4_t rs1, uint16x4_t rs2) {
   return __riscv_ppairo_u16x4(rs1, rs2);
 }
 
+// CHECK-LABEL: test_psext_b_i16x2:
+// CHECK:       psext.h.b
+int16x2_t test_psext_b_i16x2(int16x2_t a) { return __riscv_psext_b_i16x2(a); }
+
+// CHECK-LABEL: test_pzext_b_u16x2:
+// CHECK:       pzext.h.b
+uint16x2_t test_pzext_b_u16x2(uint16x2_t a) { return __riscv_pzext_b_u16x2(a); }
+
+// CHECK-LABEL: test_psext_b_i16x4:
+// RV32:        psext.dh.b
+// RV64:        psext.h.b
+int16x4_t test_psext_b_i16x4(int16x4_t a) { return __riscv_psext_b_i16x4(a); }
+
+// CHECK-LABEL: test_psext_b_i32x2:
+// RV32:        psext.dw.b
+// RV64:        psext.w.b
+int32x2_t test_psext_b_i32x2(int32x2_t a) { return __riscv_psext_b_i32x2(a); }
+
+// CHECK-LABEL: test_psext_h_i32x2:
+// RV32:        psext.dw.h
+// RV64:        psext.w.h
+int32x2_t test_psext_h_i32x2(int32x2_t a) { return __riscv_psext_h_i32x2(a); }
+
+// CHECK-LABEL: test_pzext_b_u16x4:
+// RV32:        pzext.dh.b
+// RV64:        pzext.h.b
+uint16x4_t test_pzext_b_u16x4(uint16x4_t a) { return __riscv_pzext_b_u16x4(a); }
+
+// CHECK-LABEL: test_pzext_h_u32x2:
+// RV32:        pzext.dw.h
+// RV64:        pzext.w.h
+uint32x2_t test_pzext_h_u32x2(uint32x2_t a) { return __riscv_pzext_h_u32x2(a); }
+
 // CHECK-LABEL: test_pnzip_i8x4:
 // CHECK:       ppaire.b
 int8x4_t test_pnzip_i8x4(int16x2_t rs1, int16x2_t rs2) {


### PR DESCRIPTION
Add clang builtins and header wrappers for the packed sign- and zero-extend intrinsics `__riscv_psext_b`/`_h` and `__riscv_pzext_b`/`_h`, lowering to the `llvm.riscv.psext`/`pzext` intrinsics from #208685.

The wrappers are unary, so the `__packed_psabs` header macro is renamed to `__packed_unary_builtin` and reused.