### PR TITLE
[GVN] Propagate constant equalities into expressions defined outside...

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -59,6 +59,7 @@ class MemorySSAUpdater;
 class NonLocalDepResult;
 class OptimizationRemarkEmitter;
 class PHINode;
+class PostDominatorTree;
 class TargetLibraryInfo;
 class Value;
 class IntrinsicInst;
@@ -247,6 +248,7 @@ private:
 
   MemoryDependenceResults *MD = nullptr;
   DominatorTree *DT = nullptr;
+  PostDominatorTree *PDT = nullptr;
   const TargetLibraryInfo *TLI = nullptr;
   AssumptionCache *AC = nullptr;
   SetVector<BasicBlock *> DeadBlocks;
@@ -352,8 +354,8 @@ private:
   using UnavailBlkVect = SmallVector<BasicBlock *, 64>;
 
   bool runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
-               const TargetLibraryInfo &RunTLI, AAResults &RunAA,
-               MemoryDependenceResults *RunMD, LoopInfo &LI,
+               PostDominatorTree &RunPDT, const TargetLibraryInfo &RunTLI,
+               AAResults &RunAA, MemoryDependenceResults *RunMD, LoopInfo &LI,
                OptimizationRemarkEmitter *ORE, MemorySSA *MSSA = nullptr);
 
   // List of critical edges to be split between iterations.
@@ -506,6 +508,14 @@ private:
   bool
   propagateEquality(Value *LHS, Value *RHS,
                     const std::variant<BasicBlockEdge, Instruction *> &Root);
+  /// Given that LHS and RHS are known to be equal along the \p Root edge (one
+  /// of them being a constant), clone expressions that are solely built from
+  /// the non-constant value and are used outside the block(s) dominated by
+  /// \p Root into that dominated region with the constant substituted in.
+  /// This exposes further constant folding for uses that propagateEquality
+  /// cannot handle because they are not a direct use of LHS.
+  bool propagateConstExpressions(Value *LHS, Value *RHS,
+                                 const BasicBlockEdge &Root);
   bool processFoldableCondBr(CondBrInst *BI);
   void addDeadBlock(BasicBlock *BB);
   void assignValNumForDeadCode();

--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -59,7 +59,6 @@ class MemorySSAUpdater;
 class NonLocalDepResult;
 class OptimizationRemarkEmitter;
 class PHINode;
-class PostDominatorTree;
 class TargetLibraryInfo;
 class Value;
 class IntrinsicInst;
@@ -248,7 +247,6 @@ private:
 
   MemoryDependenceResults *MD = nullptr;
   DominatorTree *DT = nullptr;
-  PostDominatorTree *PDT = nullptr;
   const TargetLibraryInfo *TLI = nullptr;
   AssumptionCache *AC = nullptr;
   SetVector<BasicBlock *> DeadBlocks;
@@ -354,8 +352,8 @@ private:
   using UnavailBlkVect = SmallVector<BasicBlock *, 64>;
 
   bool runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
-               PostDominatorTree &RunPDT, const TargetLibraryInfo &RunTLI,
-               AAResults &RunAA, MemoryDependenceResults *RunMD, LoopInfo &LI,
+               const TargetLibraryInfo &RunTLI, AAResults &RunAA,
+               MemoryDependenceResults *RunMD, LoopInfo &LI,
                OptimizationRemarkEmitter *ORE, MemorySSA *MSSA = nullptr);
 
   // List of critical edges to be split between iterations.

--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -506,12 +506,8 @@ private:
   bool
   propagateEquality(Value *LHS, Value *RHS,
                     const std::variant<BasicBlockEdge, Instruction *> &Root);
-  /// Given that LHS and RHS are known to be equal along the \p Root edge (one
-  /// of them being a constant), clone expressions that are solely built from
-  /// the non-constant value and are used outside the block(s) dominated by
-  /// \p Root into that dominated region with the constant substituted in.
-  /// This exposes further constant folding for uses that propagateEquality
-  /// cannot handle because they are not a direct use of LHS.
+  /// Clone expressions built from a non-constant value into the dominated
+  /// region with the constant substituted, enabling further constant folding.
   bool propagateConstExpressions(Value *LHS, Value *RHS,
                                  const BasicBlockEdge &Root);
   bool processFoldableCondBr(CondBrInst *BI);

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Analysis/MemorySSAUpdater.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/PHITransAddr.h"
+#include "llvm/Analysis/PostDominators.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Attributes.h"
@@ -144,6 +145,11 @@ static cl::opt<uint32_t> MaxNumInsnsPerBlock(
     "gvn-max-num-insns", cl::Hidden, cl::init(100),
     cl::desc("Max number of instructions to scan in each basic block in GVN "
              "(default = 100)"));
+
+static cl::opt<bool> GVNPropagateConstExp(
+    "gvn-const-expr-prop", cl::ReallyHidden, cl::init(true),
+    cl::desc("Propagate expressions defined outside the dominating blocks "
+             "for equality checks"));
 
 struct llvm::GVNPass::Expression {
   uint32_t Opcode;
@@ -883,6 +889,7 @@ PreservedAnalyses GVNPass::run(Function &F, FunctionAnalysisManager &AM) {
   // behavior, but until then don't change the order here.
   auto &AC = AM.getResult<AssumptionAnalysis>(F);
   auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
+  auto &PDT = AM.getResult<PostDominatorTreeAnalysis>(F);
   auto &TLI = AM.getResult<TargetLibraryAnalysis>(F);
   auto &AA = AM.getResult<AAManager>(F);
   auto *MemDep =
@@ -895,7 +902,7 @@ PreservedAnalyses GVNPass::run(Function &F, FunctionAnalysisManager &AM) {
     MSSA = &AM.getResult<MemorySSAAnalysis>(F);
   }
   auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
-  bool Changed = runImpl(F, AC, DT, TLI, AA, MemDep, LI, &ORE,
+  bool Changed = runImpl(F, AC, DT, PDT, TLI, AA, MemDep, LI, &ORE,
                          MSSA ? &MSSA->getMSSA() : nullptr);
   if (!Changed)
     return PreservedAnalyses::all();
@@ -3083,6 +3090,151 @@ void GVNPass::assignBlockRPONumber(Function &F) {
   InvalidBlockRPONumbers = false;
 }
 
+namespace {
+
+/// Check if \p Expr is an expression involving only \p Base and/or constants.
+bool isExprBuiltFromOnly(Value *Expr, Value *Base) {
+  if (isa<Constant>(Expr))
+    return false;
+  if (Expr == Base)
+    return true;
+  if (!isa<Instruction>(Expr))
+    return false;
+  if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
+    return false;
+  if (auto *II = dyn_cast<IntrinsicInst>(Expr))
+    if (II->getIntrinsicID() == Intrinsic::fake_use)
+      return false;
+  auto *ExprInst = cast<Instruction>(Expr);
+  bool UsedAtleastOnce = false;
+  for (unsigned i = 0, e = ExprInst->getNumOperands(); i != e; ++i) {
+    auto *Op = ExprInst->getOperand(i);
+    if (isa<Constant>(Op))
+      continue;
+    if (!isExprBuiltFromOnly(Op, Base))
+      return false;
+    UsedAtleastOnce = true;
+  }
+  return UsedAtleastOnce;
+}
+
+/// Clone the valid-use expression \p Expr, replacing any use of \p OldVal
+/// with \p NewVal, inserting the cloned instructions right before
+/// \p InsertPt. This avoids creating a new expression for the same value
+/// more than once and keeps the clone as close as possible to its first use.
+Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
+                                 Value *NewVal, Instruction *InsertPt) {
+  if (isa<Constant>(Expr))
+    return Expr;
+  if (Expr == OldVal)
+    return NewVal;
+  if (!isa<Instruction>(Expr))
+    return nullptr;
+  // Only handle Cast, BinOp, UnaryOp for now.
+  if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
+    return nullptr;
+  auto *ExprInst = cast<Instruction>(Expr);
+  SmallVector<Value *, 4> NewOps;
+  for (unsigned i = 0, e = ExprInst->getNumOperands(); i != e; ++i) {
+    auto *Op = ExprInst->getOperand(i);
+    auto *NewOp = cloneExprReplacingOperand(Op, OldVal, NewVal, InsertPt);
+    if (!NewOp)
+      return nullptr;
+    NewOps.push_back(NewOp);
+  }
+  auto *NewInst = ExprInst->clone();
+  for (unsigned i = 0, e = NewOps.size(); i != e; ++i)
+    NewInst->setOperand(i, NewOps[i]);
+
+  NewInst->insertBefore(InsertPt->getIterator());
+  LLVM_DEBUG(dbgs() << "ConstPropExpr: Cloning Inst " << *NewInst << "\n");
+  return NewInst;
+}
+
+} // end anonymous namespace
+
+/// LHS and RHS are known to be equal along the \p Root edge, with one of
+/// them being a constant. Look for instructions dominated by \p Root that
+/// use an expression built solely from the non-constant value but whose
+/// operand is defined outside the region dominated by \p Root (so
+/// propagateEquality's direct-use replacement cannot reach it). Clone such
+/// expressions into the dominated region with the constant substituted in,
+/// exposing further constant folding. Returns whether a change was made.
+bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
+                                        const BasicBlockEdge &Root) {
+  if (!GVNPropagateConstExp || !LHS->getType()->isIntegerTy() ||
+      !(isa<Constant>(LHS) || isa<Constant>(RHS)))
+    return false;
+  if (!isa<Constant>(RHS))
+    std::swap(LHS, RHS);
+  if (!DT || !PDT)
+    return false;
+  if (!isOnlyReachableViaThisEdge(Root, DT))
+    return false;
+
+  BasicBlock *RootBB = const_cast<BasicBlock *>(Root.getEnd());
+
+  if (PDT->dominates(Root.getEnd(), Root.getStart()))
+    return false;
+
+  for (const BasicBlock *BB : successors(Root.getStart())) {
+    if (BB != Root.getEnd() &&
+        (PDT->dominates(Root.getEnd(), BB) ||
+         isPotentiallyReachable(BB, Root.getEnd())))
+      return false;
+  }
+
+  bool ChangedIR = false;
+  for (BasicBlock *BB : depth_first(RootBB)) {
+    if (!DT->dominates(Root.getEnd(), BB))
+      continue;
+    if (PDT->dominates(BB, Root.getStart()))
+      break;
+    for (Instruction &I : *BB) {
+      if (isa<PHINode>(&I))
+        continue;
+      if (auto *II = dyn_cast<IntrinsicInst>(&I))
+        if (II->getIntrinsicID() == Intrinsic::fake_use)
+          continue;
+
+      for (unsigned OpNum = 0; OpNum < I.getNumOperands(); ++OpNum) {
+        Value *Op = I.getOperand(OpNum);
+        if (!isa<Instruction>(Op) || !isExprBuiltFromOnly(Op, LHS))
+          continue;
+
+        Instruction *OpInst = cast<Instruction>(Op);
+        if (DT->dominates(Root.getEnd(), OpInst->getParent()))
+          continue;
+
+        Value *ClonedExpr = cloneExprReplacingOperand(OpInst, LHS, RHS, &I);
+        if (!ClonedExpr || ClonedExpr == OpInst)
+          continue;
+
+        LLVM_DEBUG(dbgs() << "ConstPropExpr: From: " << I);
+        I.setOperand(OpNum, ClonedExpr);
+        LLVM_DEBUG(dbgs() << "\nConstPropExpr: To: " << I << "\n");
+
+        if (isa<Instruction>(ClonedExpr) && ClonedExpr->hasOneUse()) {
+          auto *CI = cast<Instruction>(ClonedExpr);
+          const DataLayout &DL = I.getDataLayout();
+          if (Value *V = simplifyInstruction(CI, {DL, TLI, DT, AC})) {
+            I.setOperand(OpNum, V);
+            LLVM_DEBUG(dbgs() << "ConstPropExpr: Optimized instruction: " << I
+                              << "\n");
+          }
+          ++NumGVNEqProp;
+        }
+        ChangedIR = true;
+      }
+    }
+  }
+
+  if (ChangedIR)
+    LLVM_DEBUG(dbgs() << "ConstPropExpr: With " << *LHS << " == " << *RHS
+                      << "\n");
+  return ChangedIR;
+}
+
 /// The given values are known to be equal in every use
 /// dominated by 'Root'.  Exploit this, for example by replacing 'LHS' with
 /// 'RHS' everywhere in the scope.  Returns whether a change was made.
@@ -3354,10 +3506,25 @@ bool GVNPass::processInstruction(Instruction *I) {
     Value *TrueVal = ConstantInt::getTrue(TrueSucc->getContext());
     BasicBlockEdge TrueE(Parent, TrueSucc);
     Changed |= propagateEquality(BranchCond, TrueVal, TrueE);
+    Changed |= propagateConstExpressions(BranchCond, TrueVal, TrueE);
 
     Value *FalseVal = ConstantInt::getFalse(FalseSucc->getContext());
     BasicBlockEdge FalseE(Parent, FalseSucc);
     Changed |= propagateEquality(BranchCond, FalseVal, FalseE);
+    Changed |= propagateConstExpressions(BranchCond, FalseVal, FalseE);
+
+    // If the condition is a comparison, also propagate the equality (or
+    // disequality) between its operands into whichever edge it is known to
+    // hold along, e.g. for "if (x == 5) ... " propagate x == 5 into the
+    // true edge. This mirrors the equality propagateEquality() itself
+    // derives from CmpInst equivalences.
+    if (CmpInst *Cmp = dyn_cast<CmpInst>(BranchCond)) {
+      Value *Op0 = Cmp->getOperand(0), *Op1 = Cmp->getOperand(1);
+      if (Cmp->isEquivalence(/*Invert=*/false))
+        Changed |= propagateConstExpressions(Op0, Op1, TrueE);
+      if (Cmp->isEquivalence(/*Invert=*/true))
+        Changed |= propagateConstExpressions(Op0, Op1, FalseE);
+    }
 
     return Changed;
   }
@@ -3379,6 +3546,7 @@ bool GVNPass::processInstruction(Instruction *I) {
       if (SwitchEdges.lookup(Dst) == 1) {
         BasicBlockEdge E(Parent, Dst);
         Changed |= propagateEquality(SwitchCond, Case.getCaseValue(), E);
+        Changed |= propagateConstExpressions(SwitchCond, Case.getCaseValue(), E);
       }
     }
     return Changed;
@@ -3449,11 +3617,13 @@ bool GVNPass::processInstruction(Instruction *I) {
 
 /// runOnFunction - This is the main transformation entry point for a function.
 bool GVNPass::runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
-                      const TargetLibraryInfo &RunTLI, AAResults &RunAA,
-                      MemoryDependenceResults *RunMD, LoopInfo &LI,
-                      OptimizationRemarkEmitter *RunORE, MemorySSA *MSSA) {
+                      PostDominatorTree &RunPDT, const TargetLibraryInfo &RunTLI,
+                      AAResults &RunAA, MemoryDependenceResults *RunMD,
+                      LoopInfo &LI, OptimizationRemarkEmitter *RunORE,
+                      MemorySSA *MSSA) {
   AC = &RunAC;
   DT = &RunDT;
+  PDT = &RunPDT;
   VN.setDomTree(DT);
   TLI = &RunTLI;
   AA = &RunAA;
@@ -4012,6 +4182,7 @@ public:
     return Impl.runImpl(
         F, getAnalysis<AssumptionCacheTracker>().getAssumptionCache(F),
         getAnalysis<DominatorTreeWrapperPass>().getDomTree(),
+        getAnalysis<PostDominatorTreeWrapperPass>().getPostDomTree(),
         getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F),
         getAnalysis<AAResultsWrapperPass>().getAAResults(),
         Impl.isMemDepEnabled()
@@ -4025,6 +4196,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<AssumptionCacheTracker>();
     AU.addRequired<DominatorTreeWrapperPass>();
+    AU.addRequired<PostDominatorTreeWrapperPass>();
     AU.addRequired<TargetLibraryInfoWrapperPass>();
     AU.addRequired<LoopInfoWrapperPass>();
     if (Impl.isMemDepEnabled())
@@ -4051,6 +4223,7 @@ INITIALIZE_PASS_DEPENDENCY(AssumptionCacheTracker)
 INITIALIZE_PASS_DEPENDENCY(MemoryDependenceWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MemorySSAWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(PostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetLibraryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(AAResultsWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(GlobalsAAWrapperPass)

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -41,7 +41,6 @@
 #include "llvm/Analysis/MemorySSAUpdater.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/PHITransAddr.h"
-#include "llvm/Analysis/PostDominators.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Attributes.h"
@@ -889,7 +888,6 @@ PreservedAnalyses GVNPass::run(Function &F, FunctionAnalysisManager &AM) {
   // behavior, but until then don't change the order here.
   auto &AC = AM.getResult<AssumptionAnalysis>(F);
   auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
-  auto &PDT = AM.getResult<PostDominatorTreeAnalysis>(F);
   auto &TLI = AM.getResult<TargetLibraryAnalysis>(F);
   auto &AA = AM.getResult<AAManager>(F);
   auto *MemDep =
@@ -902,7 +900,7 @@ PreservedAnalyses GVNPass::run(Function &F, FunctionAnalysisManager &AM) {
     MSSA = &AM.getResult<MemorySSAAnalysis>(F);
   }
   auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
-  bool Changed = runImpl(F, AC, DT, PDT, TLI, AA, MemDep, LI, &ORE,
+  bool Changed = runImpl(F, AC, DT, TLI, AA, MemDep, LI, &ORE,
                          MSSA ? &MSSA->getMSSA() : nullptr);
   if (!Changed)
     return PreservedAnalyses::all();
@@ -3162,52 +3160,53 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
 /// exposing further constant folding. Returns whether a change was made.
 bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
                                         const BasicBlockEdge &Root) {
-  if (!GVNPropagateConstExp || !LHS->getType()->isIntegerTy() ||
-      !(isa<Constant>(LHS) || isa<Constant>(RHS)))
+  if (!GVNPropagateConstExp)
     return false;
+
+  // Restrict to integer type for now.
+  if (!LHS->getType()->isIntegerTy())
+    return false;
+
+  // Exactly one of the two should be a constant.
+  if (isa<Constant>(LHS) == isa<Constant>(RHS))
+    return false;
+
+  // Prefer RHS to be the constant.
   if (!isa<Constant>(RHS))
     std::swap(LHS, RHS);
-  if (!DT || !PDT)
-    return false;
+
   if (!isOnlyReachableViaThisEdge(Root, DT))
     return false;
 
   BasicBlock *RootBB = const_cast<BasicBlock *>(Root.getEnd());
-
-  if (PDT->dominates(Root.getEnd(), Root.getStart()))
-    return false;
-
-  for (const BasicBlock *BB : successors(Root.getStart())) {
-    if (BB != Root.getEnd() &&
-        (PDT->dominates(Root.getEnd(), BB) ||
-         isPotentiallyReachable(BB, Root.getEnd())))
-      return false;
-  }
-
   bool ChangedIR = false;
   for (BasicBlock *BB : depth_first(RootBB)) {
     if (!DT->dominates(Root.getEnd(), BB))
       continue;
-    if (PDT->dominates(BB, Root.getStart()))
-      break;
+
     for (Instruction &I : *BB) {
       if (isa<PHINode>(&I))
         continue;
+
       if (auto *II = dyn_cast<IntrinsicInst>(&I))
         if (II->getIntrinsicID() == Intrinsic::fake_use)
           continue;
 
       for (unsigned OpNum = 0; OpNum < I.getNumOperands(); ++OpNum) {
-        Value *Op = I.getOperand(OpNum);
-        if (!isa<Instruction>(Op) || !isExprBuiltFromOnly(Op, LHS))
+        Instruction *OpExpr = dyn_cast<Instruction>(I.getOperand(OpNum));
+        if (!OpExpr)
           continue;
 
-        Instruction *OpInst = cast<Instruction>(Op);
-        if (DT->dominates(Root.getEnd(), OpInst->getParent()))
+        // Skip if OpExpr is not defined outside the dominated region.
+        if (DT->dominates(Root.getEnd(), OpExpr->getParent()))
           continue;
 
-        Value *ClonedExpr = cloneExprReplacingOperand(OpInst, LHS, RHS, &I);
-        if (!ClonedExpr || ClonedExpr == OpInst)
+        // Make sure the expression is built only from LHS.
+        if (!isExprBuiltFromOnly(OpExpr, LHS))
+          continue;
+
+        Value *ClonedExpr = cloneExprReplacingOperand(OpExpr, LHS, RHS, &I);
+        if (!ClonedExpr || ClonedExpr == OpExpr)
           continue;
 
         LLVM_DEBUG(dbgs() << "ConstPropExpr: From: " << I);
@@ -3617,13 +3616,11 @@ bool GVNPass::processInstruction(Instruction *I) {
 
 /// runOnFunction - This is the main transformation entry point for a function.
 bool GVNPass::runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
-                      PostDominatorTree &RunPDT, const TargetLibraryInfo &RunTLI,
-                      AAResults &RunAA, MemoryDependenceResults *RunMD,
-                      LoopInfo &LI, OptimizationRemarkEmitter *RunORE,
-                      MemorySSA *MSSA) {
+                      const TargetLibraryInfo &RunTLI, AAResults &RunAA,
+                      MemoryDependenceResults *RunMD, LoopInfo &LI,
+                      OptimizationRemarkEmitter *RunORE, MemorySSA *MSSA) {
   AC = &RunAC;
   DT = &RunDT;
-  PDT = &RunPDT;
   VN.setDomTree(DT);
   TLI = &RunTLI;
   AA = &RunAA;
@@ -4182,7 +4179,6 @@ public:
     return Impl.runImpl(
         F, getAnalysis<AssumptionCacheTracker>().getAssumptionCache(F),
         getAnalysis<DominatorTreeWrapperPass>().getDomTree(),
-        getAnalysis<PostDominatorTreeWrapperPass>().getPostDomTree(),
         getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F),
         getAnalysis<AAResultsWrapperPass>().getAAResults(),
         Impl.isMemDepEnabled()
@@ -4196,7 +4192,6 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<AssumptionCacheTracker>();
     AU.addRequired<DominatorTreeWrapperPass>();
-    AU.addRequired<PostDominatorTreeWrapperPass>();
     AU.addRequired<TargetLibraryInfoWrapperPass>();
     AU.addRequired<LoopInfoWrapperPass>();
     if (Impl.isMemDepEnabled())
@@ -4223,7 +4218,6 @@ INITIALIZE_PASS_DEPENDENCY(AssumptionCacheTracker)
 INITIALIZE_PASS_DEPENDENCY(MemoryDependenceWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MemorySSAWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(PostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetLibraryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(AAResultsWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(GlobalsAAWrapperPass)

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3545,7 +3545,8 @@ bool GVNPass::processInstruction(Instruction *I) {
       if (SwitchEdges.lookup(Dst) == 1) {
         BasicBlockEdge E(Parent, Dst);
         Changed |= propagateEquality(SwitchCond, Case.getCaseValue(), E);
-        Changed |= propagateConstExpressions(SwitchCond, Case.getCaseValue(), E);
+        Changed |=
+            propagateConstExpressions(SwitchCond, Case.getCaseValue(), E);
       }
     }
     return Changed;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -146,7 +146,7 @@ static cl::opt<uint32_t> MaxNumInsnsPerBlock(
              "(default = 100)"));
 
 static cl::opt<bool> GVNPropagateConstExp(
-    "gvn-const-expr-prop", cl::ReallyHidden, cl::init(true),
+    "gvn-const-expr-prop", cl::Hidden, cl::init(true),
     cl::desc("Propagate expressions defined outside the dominating blocks "
              "for equality checks"));
 
@@ -3091,50 +3091,44 @@ void GVNPass::assignBlockRPONumber(Function &F) {
 namespace {
 
 /// Check if \p Expr is an expression involving only \p Base and/or constants.
-bool isExprBuiltFromOnly(Value *Expr, Value *Base) {
-  if (isa<Constant>(Expr))
+bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
+  if (!Expr || !Base) 
     return false;
   if (Expr == Base)
     return true;
-  if (!isa<Instruction>(Expr))
-    return false;
+  // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
-    return false;
-  if (auto *II = dyn_cast<IntrinsicInst>(Expr))
-    if (II->getIntrinsicID() == Intrinsic::fake_use)
       return false;
   auto *ExprInst = cast<Instruction>(Expr);
-  bool UsedAtleastOnce = false;
-  for (unsigned i = 0, e = ExprInst->getNumOperands(); i != e; ++i) {
-    auto *Op = ExprInst->getOperand(i);
+  bool isUsedAtLeastOnce = false;
+  for (Value *Op : ExprInst->operands()) {
     if (isa<Constant>(Op))
       continue;
-    if (!isExprBuiltFromOnly(Op, Base))
+    if (!isExprBuiltFromBaseOnly(Op, Base))
       return false;
-    UsedAtleastOnce = true;
+    isUsedAtLeastOnce = true;
   }
-  return UsedAtleastOnce;
+  return isUsedAtLeastOnce;
 }
 
-/// Clone the valid-use expression \p Expr, replacing any use of \p OldVal
-/// with \p NewVal, inserting the cloned instructions right before
-/// \p InsertPt. This avoids creating a new expression for the same value
-/// more than once and keeps the clone as close as possible to its first use.
+/// Clone the expression \p Expr, replacing any use of \p OldVal with \p NewVal,
+/// inserting the cloned instructions right before \p InsertPt. This avoids 
+// creating a new expression for the same value more than once and keeps the 
+// clone as close as possible to its first use.
 Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
                                  Value *NewVal, Instruction *InsertPt) {
+  if (!Expr || !OldVal || !NewVal || !InsertPt)
+     return nullptr;
   if (isa<Constant>(Expr))
     return Expr;
   if (Expr == OldVal)
     return NewVal;
-  if (!isa<Instruction>(Expr))
-    return nullptr;
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
     return nullptr;
   auto *ExprInst = cast<Instruction>(Expr);
   SmallVector<Value *, 4> NewOps;
-  for (unsigned i = 0, e = ExprInst->getNumOperands(); i != e; ++i) {
-    auto *Op = ExprInst->getOperand(i);
+  for (Value *Op : ExprInst->operands()) {
     auto *NewOp = cloneExprReplacingOperand(Op, OldVal, NewVal, InsertPt);
     if (!NewOp)
       return nullptr;
@@ -3151,13 +3145,6 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
 
 } // end anonymous namespace
 
-/// LHS and RHS are known to be equal along the \p Root edge, with one of
-/// them being a constant. Look for instructions dominated by \p Root that
-/// use an expression built solely from the non-constant value but whose
-/// operand is defined outside the region dominated by \p Root (so
-/// propagateEquality's direct-use replacement cannot reach it). Clone such
-/// expressions into the dominated region with the constant substituted in,
-/// exposing further constant folding. Returns whether a change was made.
 bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
                                         const BasicBlockEdge &Root) {
   if (!GVNPropagateConstExp)
@@ -3202,7 +3189,7 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
           continue;
 
         // Make sure the expression is built only from LHS.
-        if (!isExprBuiltFromOnly(OpExpr, LHS))
+        if (!isExprBuiltFromBaseOnly(OpExpr, LHS))
           continue;
 
         Value *ClonedExpr = cloneExprReplacingOperand(OpExpr, LHS, RHS, &I);
@@ -3223,15 +3210,15 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
           }
           ++NumGVNEqProp;
         }
-        ChangedIR = true;
+        Changed = true;
       }
     }
   }
 
-  if (ChangedIR)
+  if (Changed)
     LLVM_DEBUG(dbgs() << "ConstPropExpr: With " << *LHS << " == " << *RHS
                       << "\n");
-  return ChangedIR;
+  return Changed;
 }
 
 /// The given values are known to be equal in every use

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3092,7 +3092,7 @@ namespace {
 
 /// Check if \p Expr is an expression involving only \p Base and/or constants.
 bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
-  if (!Expr || !Base) 
+  if (!Expr || !Base)
     return false;
 
   if (Expr == Base)
@@ -3116,13 +3116,13 @@ bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
 }
 
 /// Clone the expression \p Expr, replacing any use of \p OldVal with \p NewVal,
-/// inserting the cloned instructions right before \p InsertPt. This avoids 
-// creating a new expression for the same value more than once and keeps the 
+/// inserting the cloned instructions right before \p InsertPt. This avoids
+// creating a new expression for the same value more than once and keeps the
 // clone as close as possible to its first use.
 Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
                                  Value *NewVal, Instruction *InsertPt) {
   if (!Expr || !OldVal || !NewVal || !InsertPt)
-     return nullptr;
+    return nullptr;
 
   if (isa<Constant>(Expr))
     return Expr;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3120,7 +3120,8 @@ bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
 // creating a new expression for the same value more than once and keeps the
 // clone as close as possible to its first use.
 Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
-                                 Value *NewVal, Instruction *InsertPt) {
+                                 Value *NewVal, Instruction *InsertPt,
+                                 DenseMap<Value *, Value *> &ClonedExprs) {
   if (!Expr || !OldVal || !NewVal || !InsertPt)
     return nullptr;
 
@@ -3130,6 +3131,11 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
   if (Expr == OldVal)
     return NewVal;
 
+  // Check if we already have a clone for this expression.
+  auto It = ClonedExprs.find(Expr);
+  if (It != ClonedExprs.end())
+    return It->second;
+
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
     return nullptr;
@@ -3137,7 +3143,8 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
   auto *ExprInst = cast<Instruction>(Expr);
   SmallVector<Value *, 4> NewOps;
   for (Value *Op : ExprInst->operands()) {
-    auto *NewOp = cloneExprReplacingOperand(Op, OldVal, NewVal, InsertPt);
+    auto *NewOp =
+        cloneExprReplacingOperand(Op, OldVal, NewVal, InsertPt, ClonedExprs);
     if (!NewOp)
       return nullptr;
     NewOps.push_back(NewOp);
@@ -3148,6 +3155,9 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
 
   NewInst->insertBefore(InsertPt->getIterator());
   LLVM_DEBUG(dbgs() << "ConstPropExpr: Cloning Inst " << *NewInst << "\n");
+
+  // Store the clone in the map for future reuse.
+  ClonedExprs[Expr] = NewInst;
   return NewInst;
 }
 
@@ -3200,7 +3210,9 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
         if (!isExprBuiltFromBaseOnly(OpExpr, LHS))
           continue;
 
-        Value *ClonedExpr = cloneExprReplacingOperand(OpExpr, LHS, RHS, &I);
+        DenseMap<Value *, Value *> ClonedExprs;
+        Value *ClonedExpr =
+            cloneExprReplacingOperand(OpExpr, LHS, RHS, &I, ClonedExprs);
         if (!ClonedExpr || ClonedExpr == OpExpr)
           continue;
 

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3094,11 +3094,14 @@ namespace {
 bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
   if (!Expr || !Base) 
     return false;
+  
   if (Expr == Base)
     return true;
+  
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
       return false;
+    
   auto *ExprInst = cast<Instruction>(Expr);
   bool isUsedAtLeastOnce = false;
   for (Value *Op : ExprInst->operands()) {
@@ -3108,6 +3111,7 @@ bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
       return false;
     isUsedAtLeastOnce = true;
   }
+  
   return isUsedAtLeastOnce;
 }
 
@@ -3119,13 +3123,17 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
                                  Value *NewVal, Instruction *InsertPt) {
   if (!Expr || !OldVal || !NewVal || !InsertPt)
      return nullptr;
+    
   if (isa<Constant>(Expr))
     return Expr;
+  
   if (Expr == OldVal)
     return NewVal;
+  
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
     return nullptr;
+  
   auto *ExprInst = cast<Instruction>(Expr);
   SmallVector<Value *, 4> NewOps;
   for (Value *Op : ExprInst->operands()) {
@@ -3149,6 +3157,9 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
                                         const BasicBlockEdge &Root) {
   if (!GVNPropagateConstExp)
     return false;
+  
+  if (!LHS || !RHS || !DT)
+    return false;
 
   // Restrict to integer type for now.
   if (!LHS->getType()->isIntegerTy())
@@ -3164,14 +3175,11 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
 
   if (!isOnlyReachableViaThisEdge(Root, DT))
     return false;
-
-  BasicBlock *RootBB = const_cast<BasicBlock *>(Root.getEnd());
-  bool ChangedIR = false;
-  for (BasicBlock *BB : depth_first(RootBB)) {
-    if (!DT->dominates(Root.getEnd(), BB))
-      continue;
-
-    for (Instruction &I : *BB) {
+  
+  auto processBlock = [&](BasicBlock *Block) {
+    bool Changed = false;
+    for (auto &I : *Block) {
+      
       if (isa<PHINode>(&I))
         continue;
 
@@ -3200,7 +3208,7 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
         I.setOperand(OpNum, ClonedExpr);
         LLVM_DEBUG(dbgs() << "\nConstPropExpr: To: " << I << "\n");
 
-        if (isa<Instruction>(ClonedExpr) && ClonedExpr->hasOneUse()) {
+        if (isa<Instruction>(ClonedExpr)) {
           auto *CI = cast<Instruction>(ClonedExpr);
           const DataLayout &DL = I.getDataLayout();
           if (Value *V = simplifyInstruction(CI, {DL, TLI, DT, AC})) {
@@ -3213,6 +3221,15 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
         Changed = true;
       }
     }
+    
+    return Changed;
+  };
+  
+  bool Changed = false;
+  auto *RootNode = DT->getNode(Root.getEnd());
+  Changed |= processBlock(const_cast<BasicBlock *>(Root.getEnd()));
+  for (auto *DominatedNode : *RootNode) {
+    Changed |= processBlock(DominatedNode->getBlock());
   }
 
   if (Changed)

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3100,7 +3100,7 @@ bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
 
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
-      return false;
+    return false;
 
   auto *ExprInst = cast<Instruction>(Expr);
   bool isUsedAtLeastOnce = false;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3246,10 +3246,8 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
 bool GVNPass::propagateEquality(
     Value *LHS, Value *RHS,
     const std::variant<BasicBlockEdge, Instruction *> &Root) {
-      
   SmallVector<std::pair<Value*, Value*>, 4> Worklist;
   Worklist.push_back(std::make_pair(LHS, RHS));
-  
   bool Changed = false;
   SmallVector<const BasicBlock *> DominatedBlocks;
   if (const BasicBlockEdge *Edge = std::get_if<BasicBlockEdge>(&Root)) {

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3094,14 +3094,14 @@ namespace {
 bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
   if (!Expr || !Base) 
     return false;
-  
+
   if (Expr == Base)
     return true;
-  
+
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
       return false;
-    
+
   auto *ExprInst = cast<Instruction>(Expr);
   bool isUsedAtLeastOnce = false;
   for (Value *Op : ExprInst->operands()) {
@@ -3111,7 +3111,7 @@ bool isExprBuiltFromBaseOnly(Value *Expr, Value *Base) {
       return false;
     isUsedAtLeastOnce = true;
   }
-  
+
   return isUsedAtLeastOnce;
 }
 
@@ -3123,17 +3123,17 @@ Value *cloneExprReplacingOperand(Value *Expr, const Value *OldVal,
                                  Value *NewVal, Instruction *InsertPt) {
   if (!Expr || !OldVal || !NewVal || !InsertPt)
      return nullptr;
-    
+
   if (isa<Constant>(Expr))
     return Expr;
-  
+
   if (Expr == OldVal)
     return NewVal;
-  
+
   // Only handle Cast, BinOp, UnaryOp for now.
   if (!isa<CastInst, BinaryOperator, UnaryOperator>(Expr))
     return nullptr;
-  
+
   auto *ExprInst = cast<Instruction>(Expr);
   SmallVector<Value *, 4> NewOps;
   for (Value *Op : ExprInst->operands()) {
@@ -3157,7 +3157,7 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
                                         const BasicBlockEdge &Root) {
   if (!GVNPropagateConstExp)
     return false;
-  
+
   if (!LHS || !RHS || !DT)
     return false;
 
@@ -3175,11 +3175,11 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
 
   if (!isOnlyReachableViaThisEdge(Root, DT))
     return false;
-  
+
   auto processBlock = [&](BasicBlock *Block) {
     bool Changed = false;
     for (auto &I : *Block) {
-      
+
       if (isa<PHINode>(&I))
         continue;
 
@@ -3221,10 +3221,10 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
         Changed = true;
       }
     }
-    
+
     return Changed;
   };
-  
+
   bool Changed = false;
   auto *RootNode = DT->getNode(Root.getEnd());
   Changed |= processBlock(const_cast<BasicBlock *>(Root.getEnd()));

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3246,8 +3246,10 @@ bool GVNPass::propagateConstExpressions(Value *LHS, Value *RHS,
 bool GVNPass::propagateEquality(
     Value *LHS, Value *RHS,
     const std::variant<BasicBlockEdge, Instruction *> &Root) {
+      
   SmallVector<std::pair<Value*, Value*>, 4> Worklist;
   Worklist.push_back(std::make_pair(LHS, RHS));
+  
   bool Changed = false;
   SmallVector<const BasicBlock *> DominatedBlocks;
   if (const BasicBlockEdge *Edge = std::get_if<BasicBlockEdge>(&Root)) {
@@ -3272,6 +3274,10 @@ bool GVNPass::propagateEquality(
     // Don't try to propagate equalities between constants.
     if (isa<Constant>(LHS) && isa<Constant>(RHS))
       continue;
+
+    // Clone constant expressions into dominated region for further folding.
+    if (auto *Edge = std::get_if<BasicBlockEdge>(&Root))
+      Changed |= propagateConstExpressions(LHS, RHS, *Edge);
 
     // Prefer a constant on the right-hand side, or an Argument if no constants.
     if (isa<Constant>(LHS) || (isa<Argument>(LHS) && !isa<Constant>(RHS)))
@@ -3509,25 +3515,10 @@ bool GVNPass::processInstruction(Instruction *I) {
     Value *TrueVal = ConstantInt::getTrue(TrueSucc->getContext());
     BasicBlockEdge TrueE(Parent, TrueSucc);
     Changed |= propagateEquality(BranchCond, TrueVal, TrueE);
-    Changed |= propagateConstExpressions(BranchCond, TrueVal, TrueE);
 
     Value *FalseVal = ConstantInt::getFalse(FalseSucc->getContext());
     BasicBlockEdge FalseE(Parent, FalseSucc);
     Changed |= propagateEquality(BranchCond, FalseVal, FalseE);
-    Changed |= propagateConstExpressions(BranchCond, FalseVal, FalseE);
-
-    // If the condition is a comparison, also propagate the equality (or
-    // disequality) between its operands into whichever edge it is known to
-    // hold along, e.g. for "if (x == 5) ... " propagate x == 5 into the
-    // true edge. This mirrors the equality propagateEquality() itself
-    // derives from CmpInst equivalences.
-    if (CmpInst *Cmp = dyn_cast<CmpInst>(BranchCond)) {
-      Value *Op0 = Cmp->getOperand(0), *Op1 = Cmp->getOperand(1);
-      if (Cmp->isEquivalence(/*Invert=*/false))
-        Changed |= propagateConstExpressions(Op0, Op1, TrueE);
-      if (Cmp->isEquivalence(/*Invert=*/true))
-        Changed |= propagateConstExpressions(Op0, Op1, FalseE);
-    }
 
     return Changed;
   }
@@ -3549,8 +3540,6 @@ bool GVNPass::processInstruction(Instruction *I) {
       if (SwitchEdges.lookup(Dst) == 1) {
         BasicBlockEdge E(Parent, Dst);
         Changed |= propagateEquality(SwitchCond, Case.getCaseValue(), E);
-        Changed |=
-            propagateConstExpressions(SwitchCond, Case.getCaseValue(), E);
       }
     }
     return Changed;

--- a/llvm/test/Transforms/GVN/PRE/rle.ll
+++ b/llvm/test/Transforms/GVN/PRE/rle.ll
@@ -980,33 +980,16 @@ entry:
 
 ; Cross block partial alias case.
 define i32 @load_load_partial_alias_cross_block(ptr %P) nounwind ssp {
-; LE-LABEL: define i32 @load_load_partial_alias_cross_block(
-; LE-SAME: ptr [[P:%.*]]) #[[ATTR0]] {
-; LE-NEXT:  [[ENTRY:.*:]]
-; LE-NEXT:    [[X1:%.*]] = load i32, ptr [[P]], align 4
-; LE-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X1]], 127
-; LE-NEXT:    [[TMP0:%.*]] = lshr i32 [[X1]], 8
-; LE-NEXT:    [[TMP1:%.*]] = trunc i32 [[TMP0]] to i8
-; LE-NEXT:    br i1 [[CMP]], label %[[LAND_LHS_TRUE:.*]], label %[[IF_END:.*]]
-; LE:       [[LAND_LHS_TRUE]]:
-; LE-NEXT:    [[CONV6:%.*]] = zext i8 [[TMP1]] to i32
-; LE-NEXT:    ret i32 [[CONV6]]
-; LE:       [[IF_END]]:
-; LE-NEXT:    ret i32 52
-;
-; BE-LABEL: define i32 @load_load_partial_alias_cross_block(
-; BE-SAME: ptr [[P:%.*]]) #[[ATTR0]] {
-; BE-NEXT:  [[ENTRY:.*:]]
-; BE-NEXT:    [[X1:%.*]] = load i32, ptr [[P]], align 4
-; BE-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X1]], 127
-; BE-NEXT:    [[TMP0:%.*]] = lshr i32 [[X1]], 16
-; BE-NEXT:    [[TMP1:%.*]] = trunc i32 [[TMP0]] to i8
-; BE-NEXT:    br i1 [[CMP]], label %[[LAND_LHS_TRUE:.*]], label %[[IF_END:.*]]
-; BE:       [[LAND_LHS_TRUE]]:
-; BE-NEXT:    [[CONV6:%.*]] = zext i8 [[TMP1]] to i32
-; BE-NEXT:    ret i32 [[CONV6]]
-; BE:       [[IF_END]]:
-; BE-NEXT:    ret i32 52
+; CHECK-LABEL: define i32 @load_load_partial_alias_cross_block(
+; CHECK-SAME: ptr [[P:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[X1:%.*]] = load i32, ptr [[P]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X1]], 127
+; CHECK-NEXT:    br i1 [[CMP]], label %[[LAND_LHS_TRUE:.*]], label %[[IF_END:.*]]
+; CHECK:       [[LAND_LHS_TRUE]]:
+; CHECK-NEXT:    ret i32 0
+; CHECK:       [[IF_END]]:
+; CHECK-NEXT:    ret i32 52
 ;
 entry:
   %x1 = load i32, ptr %P, align 4

--- a/llvm/test/Transforms/GVN/const-expr-prop.ll
+++ b/llvm/test/Transforms/GVN/const-expr-prop.ll
@@ -1,0 +1,172 @@
+; RUN: opt -S -passes=gvn -gvn-const-expr-prop=true < %s | FileCheck %s
+
+declare void @llvm.fake.use(...)
+
+; %a is built solely from %x but is defined *outside* the region dominated by
+; the true edge of %c, so propagateEquality's direct-use replacement cannot
+; reach it. propagateConstExpressions should clone %a into if.true with %x
+; replaced by the known constant 5, and constant-fold the clone.
+define i32 @add_outside_dominated_region(i32 %x) {
+; CHECK-LABEL: @add_outside_dominated_region(
+; CHECK: if.true:
+; CHECK-NEXT: ret i32 6
+  %a = add i32 %x, 1
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  ret i32 %a
+if.false:
+  ret i32 0
+}
+
+; Same as above, but with the constant on the left-hand side of the compare.
+define i32 @add_outside_dominated_region_constant_lhs(i32 %x) {
+; CHECK-LABEL: @add_outside_dominated_region_constant_lhs(
+; CHECK: if.true:
+; CHECK-NEXT: ret i32 6
+  %a = add i32 %x, 1
+  %c = icmp eq i32 5, %x
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  ret i32 %a
+if.false:
+  ret i32 0
+}
+
+; Cast expressions should also be cloned and folded.
+define i64 @zext_outside_dominated_region(i32 %x) {
+; CHECK-LABEL: @zext_outside_dominated_region(
+; CHECK: if.true:
+; CHECK-NEXT: ret i64 5
+  %z = zext i32 %x to i64
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  ret i64 %z
+if.false:
+  ret i64 0
+}
+
+; Chains of expressions built solely from %x should be cloned recursively.
+define i32 @chained_expr_outside_dominated_region(i32 %x) {
+; CHECK-LABEL: @chained_expr_outside_dominated_region(
+; CHECK: if.true:
+; CHECK-NEXT: ret i32 12
+  %a = add i32 %x, 1
+  %m = mul i32 %a, 2
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  ret i32 %m
+if.false:
+  ret i32 0
+}
+
+; Switch case edges are also handled, not just conditional branches.
+define i32 @switch_case_outside_dominated_region(i32 %x) {
+; CHECK-LABEL: @switch_case_outside_dominated_region(
+; CHECK: case3:
+; CHECK-NEXT: ret i32 13
+  %a = add i32 %x, 10
+  switch i32 %x, label %default [
+  i32 3, label %case3
+  ]
+case3:
+  ret i32 %a
+default:
+  ret i32 0
+}
+
+; The dominated region is intentionally widened beyond Root.getEnd(): an
+; expression only reachable through a whole diamond nested inside if.true
+; should still be folded.
+define i32 @nested_diamond_inside_dominated_region(i32 %x, i1 %arg) {
+; CHECK-LABEL: @nested_diamond_inside_dominated_region(
+; CHECK: inner.merge:
+; CHECK-NEXT: ret i32 6
+  %a = add i32 %x, 1
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  br i1 %arg, label %inner.a, label %inner.b
+inner.a:
+  br label %inner.merge
+inner.b:
+  br label %inner.merge
+inner.merge:
+  ret i32 %a
+if.false:
+  ret i32 0
+}
+
+; PHI operands are deliberately left untouched even inside the dominated
+; region: rewriting them would need to account for which predecessor the
+; value flows from. Use different incoming values so the PHI cannot be
+; trivially simplified away before we get a chance to (not) rewrite it.
+define i32 @phi_operand_not_touched(i32 %x, i1 %arg) {
+; CHECK-LABEL: @phi_operand_not_touched(
+; CHECK: inner.merge:
+; CHECK-NEXT: %p = phi i32 [ %a, %inner.a ], [ 0, %inner.b ]
+; CHECK-NEXT: ret i32 %p
+  %a = add i32 %x, 1
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  br i1 %arg, label %inner.a, label %inner.b
+inner.a:
+  br label %inner.merge
+inner.b:
+  br label %inner.merge
+inner.merge:
+  %p = phi i32 [ %a, %inner.a ], [ 0, %inner.b ]
+  ret i32 %p
+if.false:
+  ret i32 0
+}
+
+; llvm.fake.use operands are deliberately left untouched, but other uses in
+; the same block are still folded normally.
+define i32 @fake_use_operand_not_touched(i32 %x) {
+; CHECK-LABEL: @fake_use_operand_not_touched(
+; CHECK: if.true:
+; CHECK-NEXT: call void (...) @llvm.fake.use(i32 %a)
+; CHECK-NEXT: ret i32 6
+  %a = add i32 %x, 1
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  call void (...) @llvm.fake.use(i32 %a)
+  ret i32 %a
+if.false:
+  ret i32 0
+}
+
+; if.true is reachable from more than one predecessor, so the edge equality
+; does not hold throughout it and no propagation should happen.
+define i32 @not_only_reachable_via_edge(i32 %x, i1 %arg) {
+; CHECK-LABEL: @not_only_reachable_via_edge(
+; CHECK: if.true:
+; CHECK-NEXT: ret i32 %a
+  %a = add i32 %x, 1
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %other
+other:
+  br label %if.true
+if.true:
+  ret i32 %a
+}
+
+; Only integer equalities are supported: an expression built from a pointer
+; known-equal to null should not be folded.
+define i64 @pointer_type_not_propagated(ptr %x) {
+; CHECK-LABEL: @pointer_type_not_propagated(
+; CHECK: if.true:
+; CHECK-NEXT: ret i64 %a
+  %a = ptrtoint ptr %x to i64
+  %c = icmp eq ptr %x, null
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  ret i64 %a
+if.false:
+  ret i64 0
+}

--- a/llvm/test/Transforms/GVN/const-expr-prop.ll
+++ b/llvm/test/Transforms/GVN/const-expr-prop.ll
@@ -170,3 +170,29 @@ if.true:
 if.false:
   ret i64 0
 }
+
+; The dominated region (if.true) is nested inside a loop, and the other
+; successor of the branch (if.false) can loop back around and reach if.true
+; again on a later iteration. This should not prevent folding: whenever
+; if.true executes, %x == 5 was just established by the icmp on that same
+; iteration, regardless of how it was reached on prior iterations.
+define i32 @loop_other_successor_can_reach_root(i32 %x, i32 %n) {
+; CHECK-LABEL: @loop_other_successor_can_reach_root(
+; CHECK: if.true:
+; CHECK-NEXT: ret i32 6
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %if.false ]
+  %a = add i32 %x, 1
+  %c = icmp eq i32 %x, 5
+  br i1 %c, label %if.true, label %if.false
+if.true:
+  ret i32 %a
+if.false:
+  %i.next = add i32 %i, 1
+  %cmp = icmp slt i32 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+exit:
+  ret i32 0
+}

--- a/llvm/test/Transforms/GVN/rle-coerced-noalias.ll
+++ b/llvm/test/Transforms/GVN/rle-coerced-noalias.ll
@@ -67,8 +67,7 @@ define i32 @noalias_dropped_nonlocal(ptr %p) {
 ; CHECK-NEXT:    br i1 [[CMP]], label %[[T:.*]], label %[[F:.*]]
 ; CHECK:       [[T]]:
 ; CHECK-NEXT:    [[P1:%.*]] = getelementptr inbounds i8, ptr [[P]], i64 1
-; CHECK-NEXT:    [[CONV:%.*]] = zext i8 [[TMP1]] to i32
-; CHECK-NEXT:    ret i32 [[CONV]]
+; CHECK-NEXT:    ret i32 0
 ; CHECK:       [[F]]:
 ; CHECK-NEXT:    ret i32 52
 ;


### PR DESCRIPTION
…the dominated region

GVN's existing equality propagation replaces direct uses of a value with a known-equal constant within the region dominated by a branch or switch edge: after `if (x == 5)`, uses of `x` in the "then" block become `5`. It does not, however, handle values computed from `x` prior to the branch, for example:

    a = x + 1
    if (x == 5) {
      use(a)   // a is known to be 6 here, but was not folded
    }

This change clones such expressions into the dominated region with the constant substituted for the compared value, allowing them to be folded in the same way direct uses of `x` are.

The implementation is intentionally conservative and has a few limitations: it only follows simple chains of casts, unary operators, and binary operators built solely from the compared value; it leaves PHI operands and llvm.fake.use operands unmodified; and it requires a PostDominatorTree, which GVN now computes unconditionally, to bound the region into which expressions may be cloned. It also does not share a clone across multiple uses of the same expression, so the same computation may be duplicated if it does not fully constant-fold, relying on later DCE/CSE passes for cleanup.