### PR TITLE
[lldb] Fix qSpeedTest radix mistake, make number parsings explicit

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
@@ -30,6 +30,11 @@ enum GDBStoppointType {
   eWatchpointReadWrite
 };
 
+// StringRef::getAsInteger()'s first argument specifies the
+// radix of the number it is parsing.  Define enums for easiser
+// searching/reading.
+enum { BASE_AUTOSENSE = 0, BASE_10 = 10, BASE_16 = 16 };
+
 enum class CompressionType {
   None = 0,    // no compression
   ZlibDeflate, // zlib's deflate compression scheme, requires zlib or Apple's

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1179,7 +1179,7 @@ bool GDBRemoteCommunicationClient::GetGDBServerVersion() {
           } else if (name == "version") {
             llvm::StringRef major, minor;
             std::tie(major, minor) = value.split('.');
-            if (!major.getAsInteger(10, m_gdb_server_version))
+            if (!major.getAsInteger(BASE_10, m_gdb_server_version))
               success = true;
           }
         }
@@ -1347,11 +1347,11 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
         while (response.GetNameColonValue(name, value)) {
           if (name == "cputype") {
             // exception type in big endian hex
-            if (!value.getAsInteger(10, cpu))
+            if (!value.getAsInteger(BASE_10, cpu))
               ++num_keys_decoded;
           } else if (name == "cpusubtype") {
             // exception count in big endian hex
-            if (!value.getAsInteger(10, sub))
+            if (!value.getAsInteger(BASE_10, sub))
               ++num_keys_decoded;
           } else if (name == "arch") {
             arch_name = std::string(value);
@@ -1391,17 +1391,17 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
             if (byte_order != eByteOrderInvalid)
               ++num_keys_decoded;
           } else if (name == "ptrsize") {
-            if (!value.getAsInteger(10, pointer_byte_size))
+            if (!value.getAsInteger(BASE_10, pointer_byte_size))
               ++num_keys_decoded;
           } else if (name == "addressing_bits") {
-            if (!value.getAsInteger(10, m_low_mem_addressing_bits)) {
+            if (!value.getAsInteger(BASE_10, m_low_mem_addressing_bits)) {
               ++num_keys_decoded;
             }
           } else if (name == "high_mem_addressing_bits") {
-            if (!value.getAsInteger(10, m_high_mem_addressing_bits))
+            if (!value.getAsInteger(BASE_10, m_high_mem_addressing_bits))
               ++num_keys_decoded;
           } else if (name == "low_mem_addressing_bits") {
-            if (!value.getAsInteger(10, m_low_mem_addressing_bits))
+            if (!value.getAsInteger(BASE_10, m_low_mem_addressing_bits))
               ++num_keys_decoded;
           } else if (name == "os_version" ||
                      name == "version") // Older debugserver binaries used
@@ -1423,14 +1423,14 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
               ++num_keys_decoded;
           } else if (name == "default_packet_timeout") {
             uint32_t timeout_seconds;
-            if (!value.getAsInteger(10, timeout_seconds)) {
+            if (!value.getAsInteger(BASE_10, timeout_seconds)) {
               m_default_packet_timeout = seconds(timeout_seconds);
               SetPacketTimeout(m_default_packet_timeout);
               ++num_keys_decoded;
             }
           } else if (name == "vm-page-size") {
             int page_size;
-            if (!value.getAsInteger(10, page_size)) {
+            if (!value.getAsInteger(BASE_10, page_size)) {
               m_target_vm_page_size = page_size;
               ++num_keys_decoded;
             }
@@ -1687,10 +1687,10 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
       bool saw_permissions = false;
       while (success && response.GetNameColonValue(name, value)) {
         if (name == "start") {
-          if (!value.getAsInteger(16, addr_value))
+          if (!value.getAsInteger(BASE_16, addr_value))
             region_info.GetRange().SetRangeBase(addr_value);
         } else if (name == "size") {
-          if (!value.getAsInteger(16, addr_value)) {
+          if (!value.getAsInteger(BASE_16, addr_value)) {
             region_info.GetRange().SetByteSize(addr_value);
             if (region_info.GetRange().GetRangeEnd() <
                 region_info.GetRange().GetRangeBase()) {
@@ -1771,7 +1771,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
           region_info.SetDirtyPageList(dirty_page_list);
         } else if (name == "protection-key") {
           unsigned protection_key = 0;
-          if (!value.getAsInteger(10, protection_key))
+          if (!value.getAsInteger(BASE_10, protection_key))
             region_info.SetProtectionKey(protection_key);
         }
       }
@@ -1942,7 +1942,7 @@ std::optional<uint32_t> GDBRemoteCommunicationClient::GetWatchpointSlotCount() {
       llvm::StringRef value;
       while (response.GetNameColonValue(name, value)) {
         if (name == "num") {
-          value.getAsInteger(0, m_num_supported_hardware_watchpoints);
+          value.getAsInteger(BASE_10, m_num_supported_hardware_watchpoints);
           num = m_num_supported_hardware_watchpoints;
         }
       }
@@ -2144,27 +2144,27 @@ bool GDBRemoteCommunicationClient::DecodeProcessInfoResponse(
     while (response.GetNameColonValue(name, value)) {
       if (name == "pid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        value.getAsInteger(10, pid);
+        value.getAsInteger(BASE_10, pid);
         process_info.SetProcessID(pid);
       } else if (name == "ppid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        value.getAsInteger(10, pid);
+        value.getAsInteger(BASE_10, pid);
         process_info.SetParentProcessID(pid);
       } else if (name == "uid") {
         uint32_t uid = UINT32_MAX;
-        value.getAsInteger(10, uid);
+        value.getAsInteger(BASE_10, uid);
         process_info.SetUserID(uid);
       } else if (name == "euid") {
         uint32_t uid = UINT32_MAX;
-        value.getAsInteger(10, uid);
+        value.getAsInteger(BASE_10, uid);
         process_info.SetEffectiveUserID(uid);
       } else if (name == "gid") {
         uint32_t gid = UINT32_MAX;
-        value.getAsInteger(10, gid);
+        value.getAsInteger(BASE_10, gid);
         process_info.SetGroupID(gid);
       } else if (name == "egid") {
         uint32_t gid = UINT32_MAX;
-        value.getAsInteger(10, gid);
+        value.getAsInteger(BASE_10, gid);
         process_info.SetEffectiveGroupID(gid);
       } else if (name == "triple") {
         StringExtractor extractor(value);
@@ -2199,9 +2199,9 @@ bool GDBRemoteCommunicationClient::DecodeProcessInfoResponse(
           is_arg0 = false;
         }
       } else if (name == "cputype") {
-        value.getAsInteger(10, cpu);
+        value.getAsInteger(BASE_10, cpu);
       } else if (name == "cpusubtype") {
-        value.getAsInteger(10, sub);
+        value.getAsInteger(BASE_10, sub);
       } else if (name == "vendor") {
         vendor = std::string(value);
       } else if (name == "ostype") {
@@ -2280,10 +2280,10 @@ bool GDBRemoteCommunicationClient::GetCurrentProcessInfo(bool allow_lazy) {
       lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
       while (response.GetNameColonValue(name, value)) {
         if (name == "cputype") {
-          if (!value.getAsInteger(16, cpu))
+          if (!value.getAsInteger(BASE_16, cpu))
             ++num_keys_decoded;
         } else if (name == "cpusubtype") {
-          if (!value.getAsInteger(16, sub)) {
+          if (!value.getAsInteger(BASE_16, sub)) {
             ++num_keys_decoded;
             // Workaround for pre-2024 Apple debugserver, which always
             // returns arm64e on arm64e-capable hardware regardless of
@@ -2316,10 +2316,10 @@ bool GDBRemoteCommunicationClient::GetCurrentProcessInfo(bool allow_lazy) {
           if (byte_order != eByteOrderInvalid)
             ++num_keys_decoded;
         } else if (name == "ptrsize") {
-          if (!value.getAsInteger(16, pointer_byte_size))
+          if (!value.getAsInteger(BASE_16, pointer_byte_size))
             ++num_keys_decoded;
         } else if (name == "pid") {
-          if (!value.getAsInteger(16, pid))
+          if (!value.getAsInteger(BASE_16, pid))
             ++num_keys_decoded;
         } else if (name == "elf_abi") {
           elf_abi = std::string(value);
@@ -2772,9 +2772,9 @@ bool GDBRemoteCommunicationClient::LaunchGDBServer(
     llvm::StringRef value;
     while (response.GetNameColonValue(name, value)) {
       if (name == "port")
-        value.getAsInteger(10, port);
+        value.getAsInteger(BASE_10, port);
       else if (name == "pid")
-        value.getAsInteger(10, pid);
+        value.getAsInteger(BASE_10, pid);
       else if (name.compare("socket_name") == 0) {
         StringExtractor extractor(value);
         extractor.GetHexByteString(socket_name);
@@ -3589,7 +3589,7 @@ llvm::ErrorOr<llvm::MD5::MD5Result> GDBRemoteCommunicationClient::CalculateMD5(
     response.SetFilePos(response.GetFilePos() + part.size());
 
     uint64_t low;
-    if (part.getAsInteger(/*radix=*/16, low))
+    if (part.getAsInteger(BASE_16, low))
       return std::make_error_code(std::errc::illegal_byte_sequence);
 
     // Get high part
@@ -3600,7 +3600,7 @@ llvm::ErrorOr<llvm::MD5::MD5Result> GDBRemoteCommunicationClient::CalculateMD5(
     response.SetFilePos(response.GetFilePos() + part.size());
 
     uint64_t high;
-    if (part.getAsInteger(/*radix=*/16, high))
+    if (part.getAsInteger(BASE_16, high))
       return std::make_error_code(std::errc::illegal_byte_sequence);
 
     llvm::MD5::MD5Result result;
@@ -4004,11 +4004,11 @@ bool GDBRemoteCommunicationClient::GetModuleInfo(
       module_spec.GetArchitecture().SetTriple(triple.c_str());
     } else if (name == "file_offset") {
       uint64_t ival = 0;
-      if (!value.getAsInteger(16, ival))
+      if (!value.getAsInteger(BASE_16, ival))
         module_spec.SetObjectOffset(ival);
     } else if (name == "file_size") {
       uint64_t ival = 0;
-      if (!value.getAsInteger(16, ival))
+      if (!value.getAsInteger(BASE_16, ival))
         module_spec.SetObjectSize(ival);
     } else if (name == "file_path") {
       StringExtractor extractor(value);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1179,7 +1179,7 @@ bool GDBRemoteCommunicationClient::GetGDBServerVersion() {
           } else if (name == "version") {
             llvm::StringRef major, minor;
             std::tie(major, minor) = value.split('.');
-            if (!major.getAsInteger(0, m_gdb_server_version))
+            if (!major.getAsInteger(10, m_gdb_server_version))
               success = true;
           }
         }
@@ -1347,11 +1347,11 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
         while (response.GetNameColonValue(name, value)) {
           if (name == "cputype") {
             // exception type in big endian hex
-            if (!value.getAsInteger(0, cpu))
+            if (!value.getAsInteger(10, cpu))
               ++num_keys_decoded;
           } else if (name == "cpusubtype") {
             // exception count in big endian hex
-            if (!value.getAsInteger(0, sub))
+            if (!value.getAsInteger(10, sub))
               ++num_keys_decoded;
           } else if (name == "arch") {
             arch_name = std::string(value);
@@ -1391,17 +1391,17 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
             if (byte_order != eByteOrderInvalid)
               ++num_keys_decoded;
           } else if (name == "ptrsize") {
-            if (!value.getAsInteger(0, pointer_byte_size))
+            if (!value.getAsInteger(10, pointer_byte_size))
               ++num_keys_decoded;
           } else if (name == "addressing_bits") {
-            if (!value.getAsInteger(0, m_low_mem_addressing_bits)) {
+            if (!value.getAsInteger(10, m_low_mem_addressing_bits)) {
               ++num_keys_decoded;
             }
           } else if (name == "high_mem_addressing_bits") {
-            if (!value.getAsInteger(0, m_high_mem_addressing_bits))
+            if (!value.getAsInteger(10, m_high_mem_addressing_bits))
               ++num_keys_decoded;
           } else if (name == "low_mem_addressing_bits") {
-            if (!value.getAsInteger(0, m_low_mem_addressing_bits))
+            if (!value.getAsInteger(10, m_low_mem_addressing_bits))
               ++num_keys_decoded;
           } else if (name == "os_version" ||
                      name == "version") // Older debugserver binaries used
@@ -1423,14 +1423,14 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
               ++num_keys_decoded;
           } else if (name == "default_packet_timeout") {
             uint32_t timeout_seconds;
-            if (!value.getAsInteger(0, timeout_seconds)) {
+            if (!value.getAsInteger(10, timeout_seconds)) {
               m_default_packet_timeout = seconds(timeout_seconds);
               SetPacketTimeout(m_default_packet_timeout);
               ++num_keys_decoded;
             }
           } else if (name == "vm-page-size") {
             int page_size;
-            if (!value.getAsInteger(0, page_size)) {
+            if (!value.getAsInteger(10, page_size)) {
               m_target_vm_page_size = page_size;
               ++num_keys_decoded;
             }
@@ -2144,27 +2144,27 @@ bool GDBRemoteCommunicationClient::DecodeProcessInfoResponse(
     while (response.GetNameColonValue(name, value)) {
       if (name == "pid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        value.getAsInteger(0, pid);
+        value.getAsInteger(10, pid);
         process_info.SetProcessID(pid);
       } else if (name == "ppid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        value.getAsInteger(0, pid);
+        value.getAsInteger(10, pid);
         process_info.SetParentProcessID(pid);
       } else if (name == "uid") {
         uint32_t uid = UINT32_MAX;
-        value.getAsInteger(0, uid);
+        value.getAsInteger(10, uid);
         process_info.SetUserID(uid);
       } else if (name == "euid") {
         uint32_t uid = UINT32_MAX;
-        value.getAsInteger(0, uid);
+        value.getAsInteger(10, uid);
         process_info.SetEffectiveUserID(uid);
       } else if (name == "gid") {
         uint32_t gid = UINT32_MAX;
-        value.getAsInteger(0, gid);
+        value.getAsInteger(10, gid);
         process_info.SetGroupID(gid);
       } else if (name == "egid") {
         uint32_t gid = UINT32_MAX;
-        value.getAsInteger(0, gid);
+        value.getAsInteger(10, gid);
         process_info.SetEffectiveGroupID(gid);
       } else if (name == "triple") {
         StringExtractor extractor(value);
@@ -2199,9 +2199,9 @@ bool GDBRemoteCommunicationClient::DecodeProcessInfoResponse(
           is_arg0 = false;
         }
       } else if (name == "cputype") {
-        value.getAsInteger(0, cpu);
+        value.getAsInteger(10, cpu);
       } else if (name == "cpusubtype") {
-        value.getAsInteger(0, sub);
+        value.getAsInteger(10, sub);
       } else if (name == "vendor") {
         vendor = std::string(value);
       } else if (name == "ostype") {
@@ -2570,7 +2570,7 @@ bool GDBRemoteCommunicationClient::GetGroupName(uint32_t gid,
 static void MakeSpeedTestPacket(StreamString &packet, uint32_t send_size,
                                 uint32_t recv_size) {
   packet.Clear();
-  packet.Printf("qSpeedTest:response_size:%i;data:", recv_size);
+  packet.Printf("qSpeedTest:response_size:%x;data:", recv_size);
   uint32_t bytes_left = send_size;
   while (bytes_left > 0) {
     if (bytes_left >= 26) {
@@ -2772,9 +2772,9 @@ bool GDBRemoteCommunicationClient::LaunchGDBServer(
     llvm::StringRef value;
     while (response.GetNameColonValue(name, value)) {
       if (name == "port")
-        value.getAsInteger(0, port);
+        value.getAsInteger(10, port);
       else if (name == "pid")
-        value.getAsInteger(0, pid);
+        value.getAsInteger(10, pid);
       else if (name.compare("socket_name") == 0) {
         StringExtractor extractor(value);
         extractor.GetHexByteString(socket_name);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
@@ -365,32 +365,32 @@ GDBRemoteCommunicationServerCommon::Handle_qfProcessInfo(
           return SendErrorResponse(2);
       } else if (key == "pid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        if (value.getAsInteger(0, pid))
+        if (value.getAsInteger(10, pid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetProcessID(pid);
       } else if (key == "parent_pid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        if (value.getAsInteger(0, pid))
+        if (value.getAsInteger(10, pid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetParentProcessID(pid);
       } else if (key == "uid") {
         uint32_t uid = UINT32_MAX;
-        if (value.getAsInteger(0, uid))
+        if (value.getAsInteger(10, uid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetUserID(uid);
       } else if (key == "gid") {
         uint32_t gid = UINT32_MAX;
-        if (value.getAsInteger(0, gid))
+        if (value.getAsInteger(10, gid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetGroupID(gid);
       } else if (key == "euid") {
         uint32_t uid = UINT32_MAX;
-        if (value.getAsInteger(0, uid))
+        if (value.getAsInteger(10, uid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetEffectiveUserID(uid);
       } else if (key == "egid") {
         uint32_t gid = UINT32_MAX;
-        if (value.getAsInteger(0, gid))
+        if (value.getAsInteger(10, gid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetEffectiveGroupID(gid);
       } else if (key == "all_users") {
@@ -480,7 +480,7 @@ GDBRemoteCommunicationServerCommon::Handle_qSpeedTest(
   bool success = packet.GetNameColonValue(key, value);
   if (success && key == "response_size") {
     uint32_t response_size = 0;
-    if (!value.getAsInteger(0, response_size)) {
+    if (!value.getAsInteger(16, response_size)) {
       if (response_size == 0)
         return SendOKResponse();
       StreamString response;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
@@ -365,32 +365,32 @@ GDBRemoteCommunicationServerCommon::Handle_qfProcessInfo(
           return SendErrorResponse(2);
       } else if (key == "pid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        if (value.getAsInteger(10, pid))
+        if (value.getAsInteger(BASE_10, pid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetProcessID(pid);
       } else if (key == "parent_pid") {
         lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-        if (value.getAsInteger(10, pid))
+        if (value.getAsInteger(BASE_10, pid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetParentProcessID(pid);
       } else if (key == "uid") {
         uint32_t uid = UINT32_MAX;
-        if (value.getAsInteger(10, uid))
+        if (value.getAsInteger(BASE_10, uid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetUserID(uid);
       } else if (key == "gid") {
         uint32_t gid = UINT32_MAX;
-        if (value.getAsInteger(10, gid))
+        if (value.getAsInteger(BASE_10, gid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetGroupID(gid);
       } else if (key == "euid") {
         uint32_t uid = UINT32_MAX;
-        if (value.getAsInteger(10, uid))
+        if (value.getAsInteger(BASE_10, uid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetEffectiveUserID(uid);
       } else if (key == "egid") {
         uint32_t gid = UINT32_MAX;
-        if (value.getAsInteger(10, gid))
+        if (value.getAsInteger(BASE_10, gid))
           return SendErrorResponse(2);
         match_info.GetProcessInfo().SetEffectiveGroupID(gid);
       } else if (key == "all_users") {
@@ -480,7 +480,7 @@ GDBRemoteCommunicationServerCommon::Handle_qSpeedTest(
   bool success = packet.GetNameColonValue(key, value);
   if (success && key == "response_size") {
     uint32_t response_size = 0;
-    if (!value.getAsInteger(16, response_size)) {
+    if (!value.getAsInteger(BASE_16, response_size)) {
       if (response_size == 0)
         return SendOKResponse();
       StreamString response;
@@ -987,7 +987,8 @@ GDBRemoteCommunicationServerCommon::Handle_QSetSTDIOWindowSize(
     else
       continue;
     unsigned parsed = 0;
-    if (value.empty() || value.getAsInteger(10, parsed) || parsed > UINT16_MAX)
+    if (value.empty() || value.getAsInteger(BASE_10, parsed) ||
+        parsed > UINT16_MAX)
       continue;
     *dest = static_cast<uint16_t>(parsed);
   }

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -164,7 +164,7 @@ GDBRemoteCommunicationServerPlatform::Handle_qLaunchGDBServer(
     if (name == "port") {
       // Make the Optional valid so we can use its value
       port = 0;
-      value.getAsInteger(10, *port);
+      value.getAsInteger(BASE_10, *port);
     }
   }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -164,7 +164,7 @@ GDBRemoteCommunicationServerPlatform::Handle_qLaunchGDBServer(
     if (name == "port") {
       // Make the Optional valid so we can use its value
       port = 0;
-      value.getAsInteger(0, *port);
+      value.getAsInteger(10, *port);
     }
   }
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -540,10 +540,10 @@ void ProcessGDBRemote::BuildDynamicRegisterInfo(bool force) {
           } else if (name == "alt-name") {
             reg_info.alt_name.SetString(value);
           } else if (name == "bitsize") {
-            if (!value.getAsInteger(0, reg_info.byte_size))
+            if (!value.getAsInteger(10, reg_info.byte_size))
               reg_info.byte_size /= CHAR_BIT;
           } else if (name == "offset") {
-            value.getAsInteger(0, reg_info.byte_offset);
+            value.getAsInteger(10, reg_info.byte_offset);
           } else if (name == "encoding") {
             const Encoding encoding = Args::StringToEncoding(value);
             if (encoding != eEncodingInvalid)
@@ -2515,7 +2515,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
                          .Default(eQueueKindUnknown);
         queue_vars_valid = queue_kind != eQueueKindUnknown;
       } else if (key.compare("qserialnum") == 0) {
-        if (!value.getAsInteger(0, queue_serial_number))
+        if (!value.getAsInteger(10, queue_serial_number))
           queue_vars_valid = true;
       } else if (key.compare("reason") == 0) {
         reason = std::string(value);
@@ -2541,7 +2541,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         std::tie(addr_str, bytes_str) = value.split('=');
         if (!addr_str.empty() && !bytes_str.empty()) {
           lldb::addr_t mem_cache_addr = LLDB_INVALID_ADDRESS;
-          if (!addr_str.getAsInteger(0, mem_cache_addr)) {
+          if (!addr_str.getAsInteger(16, mem_cache_addr)) {
             StringExtractor bytes(bytes_str);
             const size_t byte_size = bytes.GetBytesLeft() / 2;
             WritableDataBufferSP data_buffer_sp(
@@ -2594,17 +2594,17 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         description = std::string(ostr.GetString());
       } else if (key.compare("addressing_bits") == 0) {
         uint64_t addressing_bits;
-        if (!value.getAsInteger(0, addressing_bits)) {
+        if (!value.getAsInteger(10, addressing_bits)) {
           addressable_bits.SetAddressableBits(addressing_bits);
         }
       } else if (key.compare("low_mem_addressing_bits") == 0) {
         uint64_t addressing_bits;
-        if (!value.getAsInteger(0, addressing_bits)) {
+        if (!value.getAsInteger(10, addressing_bits)) {
           addressable_bits.SetLowmemAddressableBits(addressing_bits);
         }
       } else if (key.compare("high_mem_addressing_bits") == 0) {
         uint64_t addressing_bits;
-        if (!value.getAsInteger(0, addressing_bits)) {
+        if (!value.getAsInteger(10, addressing_bits)) {
           addressable_bits.SetHighmemAddressableBits(addressing_bits);
         }
       } else if (key == "added-binaries") {
@@ -6022,7 +6022,7 @@ std::string ProcessGDBRemote::HarmonizeThreadIdsForProfileData(
       if (profileDataExtractor.GetNameColonValue(usec_name, usec_value)) {
         if (usec_name == "thread_used_usec") {
           has_used_usec = true;
-          usec_value.getAsInteger(0, curr_used_usec);
+          usec_value.getAsInteger(10, curr_used_usec);
         } else {
           // We didn't find what we want, it is probably an older version. Bail
           // out.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -540,10 +540,10 @@ void ProcessGDBRemote::BuildDynamicRegisterInfo(bool force) {
           } else if (name == "alt-name") {
             reg_info.alt_name.SetString(value);
           } else if (name == "bitsize") {
-            if (!value.getAsInteger(10, reg_info.byte_size))
+            if (!value.getAsInteger(BASE_10, reg_info.byte_size))
               reg_info.byte_size /= CHAR_BIT;
           } else if (name == "offset") {
-            value.getAsInteger(10, reg_info.byte_offset);
+            value.getAsInteger(BASE_10, reg_info.byte_offset);
           } else if (name == "encoding") {
             const Encoding encoding = Args::StringToEncoding(value);
             if (encoding != eEncodingInvalid)
@@ -597,9 +597,9 @@ void ProcessGDBRemote::BuildDynamicRegisterInfo(bool force) {
           } else if (name == "set") {
             reg_info.set_name.SetString(value);
           } else if (name == "gcc" || name == "ehframe") {
-            value.getAsInteger(0, reg_info.regnum_ehframe);
+            value.getAsInteger(BASE_AUTOSENSE, reg_info.regnum_ehframe);
           } else if (name == "dwarf") {
-            value.getAsInteger(0, reg_info.regnum_dwarf);
+            value.getAsInteger(BASE_AUTOSENSE, reg_info.regnum_dwarf);
           } else if (name == "generic") {
             reg_info.regnum_generic = Args::StringToGenericRegister(value);
           } else if (name == "container-regs") {
@@ -2452,11 +2452,11 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
     while (stop_packet.GetNameColonValue(key, value)) {
       if (key.compare("metype") == 0) {
         // exception type in big endian hex
-        value.getAsInteger(16, exc_type);
+        value.getAsInteger(BASE_16, exc_type);
       } else if (key.compare("medata") == 0) {
         // exception data in big endian hex
         uint64_t x;
-        value.getAsInteger(16, x);
+        value.getAsInteger(BASE_16, x);
         exc_data.push_back(x);
       } else if (key.compare("thread") == 0) {
         // thread-id
@@ -2479,7 +2479,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         while (!value.empty()) {
           llvm::StringRef pc_str;
           std::tie(pc_str, value) = value.split(',');
-          if (pc_str.getAsInteger(16, pc))
+          if (pc_str.getAsInteger(BASE_16, pc))
             pc = LLDB_INVALID_ADDRESS;
           m_thread_pcs.push_back(pc);
         }
@@ -2499,10 +2499,10 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
       } else if (key.compare("name") == 0) {
         thread_name = std::string(value);
       } else if (key.compare("qaddr") == 0) {
-        value.getAsInteger(16, thread_dispatch_qaddr);
+        value.getAsInteger(BASE_16, thread_dispatch_qaddr);
       } else if (key.compare("dispatch_queue_t") == 0) {
         queue_vars_valid = true;
-        value.getAsInteger(16, dispatch_queue_t);
+        value.getAsInteger(BASE_16, dispatch_queue_t);
       } else if (key.compare("qname") == 0) {
         queue_vars_valid = true;
         StringExtractor name_extractor(value);
@@ -2515,7 +2515,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
                          .Default(eQueueKindUnknown);
         queue_vars_valid = queue_kind != eQueueKindUnknown;
       } else if (key.compare("qserialnum") == 0) {
-        if (!value.getAsInteger(10, queue_serial_number))
+        if (!value.getAsInteger(BASE_10, queue_serial_number))
           queue_vars_valid = true;
       } else if (key.compare("reason") == 0) {
         reason = std::string(value);
@@ -2541,7 +2541,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         std::tie(addr_str, bytes_str) = value.split('=');
         if (!addr_str.empty() && !bytes_str.empty()) {
           lldb::addr_t mem_cache_addr = LLDB_INVALID_ADDRESS;
-          if (!addr_str.getAsInteger(16, mem_cache_addr)) {
+          if (!addr_str.getAsInteger(BASE_16, mem_cache_addr)) {
             StringExtractor bytes(bytes_str);
             const size_t byte_size = bytes.GetBytesLeft() / 2;
             WritableDataBufferSP data_buffer_sp(
@@ -2556,7 +2556,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
                  key.compare("awatch") == 0) {
         // Support standard GDB remote stop reply packet 'TAAwatch:addr'
         lldb::addr_t wp_addr = LLDB_INVALID_ADDRESS;
-        value.getAsInteger(16, wp_addr);
+        value.getAsInteger(BASE_16, wp_addr);
 
         WatchpointResourceSP wp_resource_sp =
             m_watchpoint_resource_list.FindByAddress(wp_addr);
@@ -2594,17 +2594,17 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         description = std::string(ostr.GetString());
       } else if (key.compare("addressing_bits") == 0) {
         uint64_t addressing_bits;
-        if (!value.getAsInteger(10, addressing_bits)) {
+        if (!value.getAsInteger(BASE_10, addressing_bits)) {
           addressable_bits.SetAddressableBits(addressing_bits);
         }
       } else if (key.compare("low_mem_addressing_bits") == 0) {
         uint64_t addressing_bits;
-        if (!value.getAsInteger(10, addressing_bits)) {
+        if (!value.getAsInteger(BASE_10, addressing_bits)) {
           addressable_bits.SetLowmemAddressableBits(addressing_bits);
         }
       } else if (key.compare("high_mem_addressing_bits") == 0) {
         uint64_t addressing_bits;
-        if (!value.getAsInteger(10, addressing_bits)) {
+        if (!value.getAsInteger(BASE_10, addressing_bits)) {
           addressable_bits.SetHighmemAddressableBits(addressing_bits);
         }
       } else if (key == "added-binaries") {
@@ -2614,7 +2614,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         while (!value.empty()) {
           llvm::StringRef pc_str;
           std::tie(pc_str, value) = value.split(',');
-          if (pc_str.getAsInteger(16, pc))
+          if (pc_str.getAsInteger(BASE_16, pc))
             pc = LLDB_INVALID_ADDRESS;
           added_binaries.push_back(pc);
         }
@@ -2628,7 +2628,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         detailed_binaries_info = StructuredData::ParseJSON(json);
       } else if (key.size() == 2 && ::isxdigit(key[0]) && ::isxdigit(key[1])) {
         uint32_t reg = UINT32_MAX;
-        if (!key.getAsInteger(16, reg))
+        if (!key.getAsInteger(BASE_16, reg))
           expedited_register_map[reg] = std::string(std::move(value));
       }
       // swbreak and hwbreak are also expected keys, but we don't need to
@@ -3082,7 +3082,7 @@ llvm::Error ProcessGDBRemote::ParseMultiMemReadPacket(
   // Sizes are separated by a `,`.
   for (llvm::StringRef size_str : llvm::split(sizes_str, ',')) {
     uint64_t read_size;
-    if (size_str.getAsInteger(16, read_size))
+    if (size_str.getAsInteger(BASE_16, read_size))
       return llvm::createStringErrorV(
           "MultiMemRead response has invalid size string: {0}", size_str);
 
@@ -6022,7 +6022,7 @@ std::string ProcessGDBRemote::HarmonizeThreadIdsForProfileData(
       if (profileDataExtractor.GetNameColonValue(usec_name, usec_value)) {
         if (usec_name == "thread_used_usec") {
           has_used_usec = true;
-          usec_value.getAsInteger(10, curr_used_usec);
+          usec_value.getAsInteger(BASE_10, curr_used_usec);
         } else {
           // We didn't find what we want, it is probably an older version. Bail
           // out.
@@ -6803,7 +6803,7 @@ ParseMultiBreakpointResponse(llvm::StringRef response_str) {
       return true;
     }
     uint8_t error_code = 0;
-    if (token.drop_front(1).getAsInteger(16, error_code))
+    if (token.drop_front(1).getAsInteger(BASE_16, error_code))
       results.push_back(0xff);
     else
       results.push_back(error_code);


### PR DESCRIPTION
The documentation for qSpeedTest says

```
send packet: qSpeedTest:response_size:response-size;
read packet: data:<response data>

response-size is a hex encoded unsigned number up to 64 bits in size.
```

debugserver implements qSpeedTest as per this documentation, but lldb sends the number in decimal (base 10), and lldb-server parses it as base 10.  I changed lldb and lldb-server to base 16.  This is a maintenance command used by lldb developers exclusivley, so IMO I'm not handling a migration for old/new servers or defining a new packet or key.  I was running some packet transmission tests with debugserver and noticed debugserver was sending much larger packets than requested; that's the kind of failure you see when there is a mismatch.

I audited all uses of `getAsInteger()` that pass a 0 for the radix, meaning auto-detect the radix, in the gdb-remote dir and changed nearly all of them to specify either base 10 or base 16.  There were two places where we were using auto-sensing on a base 16 number (and no "0x" prefix), which would parse incorrectly if an [a-f] letter did not occur.

There is one use of `getAsInteger(0,...)` that is still in place, for pasing the `qRegisterInfo` eh-frame/dwarf register numbers. Our documentation for these keys specifies that they may be base 10 or base 16 if prefixed with 0x. This is unlike anywhere else in gdb remote serial protocol, and smells like something I probably stuck in there 15+ years ago because I've never liked the ambiguity about number bases in the protocol and I made this half-hearted stab at encouraging use of "0x".

It is always fun to see the inconsistencies as you review multiple packets.  qProcessInfo returns keys like pid/gid/ppid in base 16. qfProcessInfo returns the same keys in base 10.  qHostInfo returns cputype/cpusubtype (a Mach-O way of specifying a target cpu) in base 10, qProcessInfo returns the same keys in base 16.  There's so many of these kinds of little inconsistencies :/