### PR TITLE
[clang][test] Add Darwin pragma weak alias IR coverage

### DIFF
--- a/clang/test/CodeGen/pragma-weak-darwin.c
+++ b/clang/test/CodeGen/pragma-weak-darwin.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple arm64-apple-macosx -emit-llvm -o - %s | FileCheck %s
+
+void strong_target(void) {}
+
+#pragma weak weak_alias = strong_target
+
+void use_alias(void) {
+  weak_alias();
+}
+
+// CHECK-DAG: @weak_alias = weak alias void (), ptr @strong_target
+// CHECK-LABEL: define{{.*}} void @strong_target()
+// CHECK-LABEL: define{{.*}} void @use_alias()
+// CHECK: call void @weak_alias()


### PR DESCRIPTION
Add Clang IR coverage for `#pragma weak alias = target` on Darwin.

The test verifies that Clang:

- emits the alias with weak linkage;
- keeps calls referencing the alias instead of replacing them with the aliasee.

This is a test-only follow-up to #198148 and covers the Clang lowering path used by #111321.