### PR TITLE
[RISCV] Add TuneNoDefaultUnroll to spacemit-x60

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -908,7 +908,8 @@ def SPACEMIT_X60 : RISCVProcessorModel<"spacemit-x60",
                                         TuneOptimizedNF4SegmentLoadStore,
                                         TuneEnableSelectOptimize,
                                         TuneVXRMPipelineFlush,
-                                        TunePreferAscendingLoadStore]> {
+                                        TunePreferAscendingLoadStore,
+                                        TuneNoDefaultUnroll]> {
   let MVendorID = 0x710;
   let MArchID = 0x8000000058000001;
   let MImpID = 0x1000000049772200;


### PR DESCRIPTION
This feature has been added to generic CPUs in #135318 and we don't
see any significant regression on `spacemit-x60`.
