### PR TITLE
[LangRef] Clarify interaction of noalias and synchronization

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -1522,6 +1522,12 @@ Currently, only the following parameter attributes are defined:
     met. For further details, please see the discussion of the NoAlias response
     in {ref}`alias analysis <Must, May,  or No>`.
 
+    `noalias` also applies to accesses from other threads, unless they
+    happen-before function entry, or function exit happens-before them. This
+    means that conflicting concurrent accesses from other threads either need
+    to be based on the noalias pointer, or else be appropriately synchronized
+    *outside* the function.
+
     Note that this definition of `noalias` is intentionally similar
     to the definition of `restrict` in C99 for function arguments.
 


### PR DESCRIPTION
Noalias applies to accesses on other threads, but this was not very clear in existing wording, because "during the execution of the function" is somewhat ambiguous.

Explicitly mention that it applies to accesses from other threads. This means that conflicting accesses (i.e. not read-read) need to either happen-before function entry, or function exit needs to happen-before them, otherwise behavior is undefined. For accesses not based on the noalias pointer, this requires synchronization *outside* the function.