### PR TITLE
[Clang] Treat line directives as header names.

### DIFF
--- a/clang-tools-extra/clangd/unittests/PreambleTests.cpp
+++ b/clang-tools-extra/clangd/unittests/PreambleTests.cpp
@@ -171,13 +171,6 @@ TEST(PreamblePatchTest, ContainsNewIncludes) {
                                           Field(&Inclusion::HashLine, 4))));
 }
 
-TEST(PreamblePatchTest, MainFileIsEscaped) {
-  auto Includes = collectPatchedIncludes("#include <a.h>", "", "file\"name.cpp")
-                      .MainFileIncludes;
-  EXPECT_THAT(Includes, ElementsAre(AllOf(Field(&Inclusion::Written, "<a.h>"),
-                                          Field(&Inclusion::HashLine, 0))));
-}
-
 TEST(PreamblePatchTest, PatchesPreambleIncludes) {
   MockFS FS;
   IgnoreDiagnostics Diags;

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -2549,6 +2549,15 @@ public:
   /// in ""'s.
   bool GetIncludeFilenameSpelling(SourceLocation Loc,StringRef &Buffer);
 
+  /// Turn the specified lexer token into a fully checked and spelled
+  /// filename, e.g. as an operand of \#line and \#.
+  ///
+  /// The caller is expected to provide a buffer that is large enough to hold
+  /// the spelling of the filename, but is also expected to handle the case
+  /// when this method decides to use a different buffer.
+  ///
+  void GetLineDirectiveFilenameSpelling(SourceLocation Loc, StringRef &Buffer);
+
   /// Given a "foo" or \<foo> reference, look up the indicated file.
   ///
   /// Returns std::nullopt on failure.  \p isAngled indicates whether the file

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -529,8 +529,7 @@ static SourceLocation ReadOriginalFileName(CompilerInstance &CI,
   Preprocessor &PP = CI.getPreprocessor();
   SmallString<128> HeaderNameBuffer;
   StringRef HeaderName = PP.getSpelling(T, HeaderNameBuffer);
-  if (PP.GetIncludeFilenameSpelling(T.getLocation(), HeaderName))
-    return SourceLocation();
+  PP.GetLineDirectiveFilenameSpelling(T.getLocation(), HeaderName);
 
   RawLexer->LexFromRawLexer(T);
   if (T.isNot(tok::eof) && !T.isAtStartOfLine())

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -522,18 +522,21 @@ static SourceLocation ReadOriginalFileName(CompilerInstance &CI,
       return SourceLocation();
   }
 
-  RawLexer->LexFromRawLexer(T);
-  if (T.isAtStartOfLine() || T.getKind() != tok::string_literal)
+  RawLexer->LexIncludeFilename(T);
+  if (T.isAtStartOfLine() || T.getKind() != tok::header_name)
     return SourceLocation();
 
-  StringLiteralParser Literal(T, CI.getPreprocessor(),
-                              StringLiteralEvalMethod::Unevaluated);
-  if (Literal.hadError)
+  Preprocessor &PP = CI.getPreprocessor();
+  SmallString<128> HeaderNameBuffer;
+  StringRef HeaderName = PP.getSpelling(T, HeaderNameBuffer);
+  if (PP.GetIncludeFilenameSpelling(T.getLocation(), HeaderName))
     return SourceLocation();
+
   RawLexer->LexFromRawLexer(T);
   if (T.isNot(tok::eof) && !T.isAtStartOfLine())
     return SourceLocation();
-  InputFile = Literal.GetString().str();
+
+  InputFile = HeaderName.str();
 
   if (IsModuleMap)
     CI.getSourceManager().AddLineNote(

--- a/clang/lib/Frontend/PrintPreprocessedOutput.cpp
+++ b/clang/lib/Frontend/PrintPreprocessedOutput.cpp
@@ -258,11 +258,11 @@ void PrintPPOutputPPCallbacks::WriteLineInfo(unsigned LineNo,
   // Emit #line directives or GNU line markers depending on what mode we're in.
   if (UseLineDirectives) {
     *OS << "#line" << ' ' << LineNo << ' ' << '"';
-    OS->write_escaped(CurFilename);
+    *OS << CurFilename;
     *OS << '"';
   } else {
     *OS << '#' << ' ' << LineNo << ' ' << '"';
-    OS->write_escaped(CurFilename);
+    *OS << CurFilename;
     *OS << '"';
 
     if (ExtraLen)

--- a/clang/lib/Frontend/Rewrite/InclusionRewriter.cpp
+++ b/clang/lib/Frontend/Rewrite/InclusionRewriter.cpp
@@ -122,13 +122,13 @@ void InclusionRewriter::WriteLineInfo(StringRef Filename, int Line,
     return;
   if (UseLineDirectives) {
     OS << "#line" << ' ' << Line << ' ' << '"';
-    OS.write_escaped(Filename);
+    OS << Filename;
     OS << '"';
   } else {
     // Use GNU linemarkers as described here:
     // http://gcc.gnu.org/onlinedocs/cpp/Preprocessor-Output.html
     OS << '#' << ' ' << Line << ' ' << '"';
-    OS.write_escaped(Filename);
+    OS << Filename;
     OS << '"';
     if (!Extra.empty())
       OS << Extra;

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1599,21 +1599,6 @@ static bool GetLineValue(Token &DigitTok, unsigned &Val,
   return false;
 }
 
-// Unlike header-names, line directive only support filenames in double quotes
-// but does support empty filenames.
-static void GetFilenameSpellingForLineDirective(const Preprocessor &PP,
-                                                SourceLocation Loc,
-                                                StringRef &Buffer) {
-  // Get the text form of the filename.
-  assert(!Buffer.empty() && "Can't have tokens with empty spellings!");
-  if (Buffer.size() < 2 || Buffer.front() != '"' || Buffer.back() != '"') {
-    PP.Diag(Loc, diag::err_pp_line_invalid_filename);
-    Buffer = StringRef();
-    return;
-  }
-  Buffer = Buffer.substr(1, Buffer.size() - 2);
-}
-
 /// Handle a \#line directive: C99 6.10.4.
 ///
 /// The two acceptable forms are:
@@ -1660,7 +1645,7 @@ void Preprocessor::HandleLineDirective() {
   } else {
     SmallString<128> FilenameBuffer;
     StringRef Filename = getSpelling(StrTok, FilenameBuffer);
-    GetFilenameSpellingForLineDirective(*this, StrTok.getLocation(), Filename);
+    GetLineDirectiveFilenameSpelling(StrTok.getLocation(), Filename);
     FilenameID = SourceMgr.getLineTableFilenameID(Filename);
 
     // Verify that there is nothing after the string, other than EOD.  Because
@@ -1798,7 +1783,7 @@ void Preprocessor::HandleDigitDirective(Token &DigitTok) {
   } else {
     SmallString<128> FilenameBuffer;
     StringRef Filename = getSpelling(StrTok, FilenameBuffer);
-    GetFilenameSpellingForLineDirective(*this, StrTok.getLocation(), Filename);
+    GetLineDirectiveFilenameSpelling(StrTok.getLocation(), Filename);
     // If a filename was present, read any flags that are present.
     if (ReadLineMarkerFlags(IsFileEntry, IsFileExit, FileKind, *this))
       return;
@@ -1996,6 +1981,18 @@ bool Preprocessor::GetIncludeFilenameSpelling(SourceLocation Loc,
   // Skip the brackets.
   Buffer = Buffer.substr(1, Buffer.size()-2);
   return isAngled;
+}
+
+void Preprocessor::GetLineDirectiveFilenameSpelling(SourceLocation Loc,
+                                                    StringRef &Buffer) {
+  // Get the text form of the filename.
+  assert(!Buffer.empty() && "Can't have tokens with empty spellings!");
+  if (Buffer.size() < 2 || Buffer.front() != '"' || Buffer.back() != '"') {
+    Diag(Loc, diag::err_pp_line_invalid_filename);
+    Buffer = StringRef();
+    return;
+  }
+  Buffer = Buffer.substr(1, Buffer.size() - 2);
 }
 
 /// Push a token onto the token stream containing an annotation.

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1599,6 +1599,21 @@ static bool GetLineValue(Token &DigitTok, unsigned &Val,
   return false;
 }
 
+// Unlike header-names, line directive only support filenames in double quotes
+// but does support empty filenames.
+static void GetFilenameSpellingForLineDirective(const Preprocessor &PP,
+                                                SourceLocation Loc,
+                                                StringRef &Buffer) {
+  // Get the text form of the filename.
+  assert(!Buffer.empty() && "Can't have tokens with empty spellings!");
+  if (Buffer.size() < 2 || Buffer.front() != '"' || Buffer.back() != '"') {
+    PP.Diag(Loc, diag::err_pp_line_invalid_filename);
+    Buffer = StringRef();
+    return;
+  }
+  Buffer = Buffer.substr(1, Buffer.size() - 2);
+}
+
 /// Handle a \#line directive: C99 6.10.4.
 ///
 /// The two acceptable forms are:
@@ -1632,35 +1647,21 @@ void Preprocessor::HandleLineDirective() {
 
   int FilenameID = -1;
   Token StrTok;
-  Lex(StrTok);
+  LexHeaderName(StrTok);
 
   // If the StrTok is "eod", then it wasn't present.  Otherwise, it must be a
   // string followed by eod.
   if (StrTok.is(tok::eod))
     ; // ok
-  else if (StrTok.isNot(tok::string_literal)) {
+  else if (StrTok.isNot(tok::header_name)) {
     Diag(StrTok, diag::err_pp_line_invalid_filename);
     DiscardUntilEndOfDirective();
     return;
-  } else if (StrTok.hasUDSuffix()) {
-    Diag(StrTok, diag::err_invalid_string_udl);
-    DiscardUntilEndOfDirective();
-    return;
   } else {
-    // Parse and validate the string, converting it into a unique ID.
-    StringLiteralParser Literal(StrTok, *this,
-                                StringLiteralEvalMethod::Unevaluated);
-    assert(Literal.isOrdinary() && "Didn't allow wide strings in");
-    if (Literal.hadError) {
-      DiscardUntilEndOfDirective();
-      return;
-    }
-    if (Literal.Pascal) {
-      Diag(StrTok, diag::err_pp_linemarker_invalid_filename);
-      DiscardUntilEndOfDirective();
-      return;
-    }
-    FilenameID = SourceMgr.getLineTableFilenameID(Literal.GetString());
+    SmallString<128> FilenameBuffer;
+    StringRef Filename = getSpelling(StrTok, FilenameBuffer);
+    GetFilenameSpellingForLineDirective(*this, StrTok.getLocation(), Filename);
+    FilenameID = SourceMgr.getLineTableFilenameID(Filename);
 
     // Verify that there is nothing after the string, other than EOD.  Because
     // of C99 6.10.4p5, macros that expand to empty tokens are ok.
@@ -1778,7 +1779,7 @@ void Preprocessor::HandleDigitDirective(Token &DigitTok) {
     return;
 
   Token StrTok;
-  Lex(StrTok);
+  LexHeaderName(StrTok);
 
   bool IsFileEntry = false, IsFileExit = false;
   int FilenameID = -1;
@@ -1790,29 +1791,14 @@ void Preprocessor::HandleDigitDirective(Token &DigitTok) {
     Diag(StrTok, diag::ext_pp_gnu_line_directive);
     // Treat this like "#line NN", which doesn't change file characteristics.
     FileKind = SourceMgr.getFileCharacteristic(DigitTok.getLocation());
-  } else if (StrTok.isNot(tok::string_literal)) {
+  } else if (StrTok.isNot(tok::header_name)) {
     Diag(StrTok, diag::err_pp_linemarker_invalid_filename);
     DiscardUntilEndOfDirective();
     return;
-  } else if (StrTok.hasUDSuffix()) {
-    Diag(StrTok, diag::err_invalid_string_udl);
-    DiscardUntilEndOfDirective();
-    return;
   } else {
-    // Parse and validate the string, converting it into a unique ID.
-    StringLiteralParser Literal(StrTok, *this,
-                                StringLiteralEvalMethod::Unevaluated);
-    assert(Literal.isOrdinary() && "Didn't allow wide strings in");
-    if (Literal.hadError) {
-      DiscardUntilEndOfDirective();
-      return;
-    }
-    if (Literal.Pascal) {
-      Diag(StrTok, diag::err_pp_linemarker_invalid_filename);
-      DiscardUntilEndOfDirective();
-      return;
-    }
-
+    SmallString<128> FilenameBuffer;
+    StringRef Filename = getSpelling(StrTok, FilenameBuffer);
+    GetFilenameSpellingForLineDirective(*this, StrTok.getLocation(), Filename);
     // If a filename was present, read any flags that are present.
     if (ReadLineMarkerFlags(IsFileEntry, IsFileExit, FileKind, *this))
       return;
@@ -1821,8 +1807,8 @@ void Preprocessor::HandleDigitDirective(Token &DigitTok) {
 
     // Exiting to an empty string means pop to the including file, so leave
     // FilenameID as -1 in that case.
-    if (!(IsFileExit && Literal.GetString().empty()))
-      FilenameID = SourceMgr.getLineTableFilenameID(Literal.GetString());
+    if (!(IsFileExit && Filename.empty()))
+      FilenameID = SourceMgr.getLineTableFilenameID(Filename);
   }
 
   // Create a line note with this information.

--- a/clang/test/Frontend/linemarker-invalid-escape.c
+++ b/clang/test/Frontend/linemarker-invalid-escape.c
@@ -1,5 +1,0 @@
-// RUN: %clang_cc1 -emit-llvm -o - -verify %s
-
-# 1 "original\x12source.c" // expected-error {{invalid escape sequence '\x12' in an unevaluated string literal}}
-
-int x = 0;

--- a/clang/test/Frontend/rewrite-includes.c
+++ b/clang/test/Frontend/rewrite-includes.c
@@ -32,20 +32,20 @@ static int unused;
 // CHECK-NEXT: {{^}}#include "rewrite-includes1.h"{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes1.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 7 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes1.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes1.h" 1{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#pragma clang system_header{{$}}
 // CHECK-NEXT: {{^}}#endif /* expanded by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes1.h" 3{{$}}
+// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes1.h" 3{{$}}
 // CHECK-NEXT: {{^}}int included_line1;{{$}}
 // CHECK-NEXT: {{^}}#if defined(__CLANG_REWRITTEN_INCLUDES) || defined(__CLANG_REWRITTEN_SYSTEM_INCLUDES) /* rewrite-includes2.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#include "rewrite-includes2.h"{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes2.h expanded by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 3 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes1.h" 3{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes2.h" 1 3{{$}}
+// CHECK-NEXT: {{^}}# 3 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes1.h" 3{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes2.h" 1 3{{$}}
 // CHECK-NEXT: {{^}}int included_line2;{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes2.h expanded by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 4 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes1.h" 2 3{{$}}
+// CHECK-NEXT: {{^}}# 4 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes1.h" 2 3{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes1.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 8 "{{.*}}rewrite-includes.c" 2{{$}}
 // CHECK-NEXT: {{^}}#ifdef FIRST{{$}}
@@ -54,7 +54,7 @@ static int unused;
 // CHECK-NEXT: {{^}}#include HEADER{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes3.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 10 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes3.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes3.h" 1{{$}}
 // CHECK-NEXT: {{^}}unsigned int included_line3 = -10;{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes3.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 11 "{{.*}}rewrite-includes.c" 2{{$}}
@@ -73,7 +73,7 @@ static int unused;
 // CHECK-NEXT: {{^}} {{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes5.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 16 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes5.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes5.h" 1{{$}}
 // CHECK-NEXT: {{^}}int included_line5;{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes5.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 17 "{{.*}}rewrite-includes.c" 2{{$}}
@@ -81,11 +81,11 @@ static int unused;
 // CHECK-NEXT: {{^}}#include "rewrite-includes6.h" // comment{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes6.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 17 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes6.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes6.h" 1{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#pragma once{{$}}
 // CHECK-NEXT: {{^}}#endif /* expanded by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes6.h"{{$}}
+// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes6.h"{{$}}
 // CHECK-NEXT: {{^}}int included_line6;{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes6.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 18 "{{.*}}rewrite-includes.c" 2{{$}}
@@ -100,12 +100,12 @@ static int unused;
 // CHECK-NEXT: {{^}}#include "rewrite-includes7.h"{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes7.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 21 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes7.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes7.h" 1{{$}}
 // CHECK-NEXT: {{^}}#ifndef REWRITE_INCLUDES_7{{$}}
 // CHECK-NEXT: {{^}}#define REWRITE_INCLUDES_7{{$}}
 // CHECK-NEXT: {{^}}int included_line7;{{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
-// CHECK-NEXT: {{^}}# 5 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes7.h"{{$}}
+// CHECK-NEXT: {{^}}# 5 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes7.h"{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes7.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 22 "{{.*}}rewrite-includes.c" 2{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* expanded by -frewrite-includes */{{$}}
@@ -117,53 +117,53 @@ static int unused;
 // CHECK-NEXT: {{^}}#include "rewrite-includes8.h"{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes8.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 23 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes8.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes8.h" 1{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if __has_include_next(<rewrite-includes8.h>){{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
 // CHECK-NEXT: {{^}}#endif /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* evaluated by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes8.h"{{$}}
+// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes8.h"{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if 0{{$}}
 // CHECK-NEXT: {{^}}#elif __has_include(<rewrite-includes8.hfail>){{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
 // CHECK-NEXT: {{^}}#endif /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#elif 0 /* evaluated by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 3 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes8.h"{{$}}
+// CHECK-NEXT: {{^}}# 3 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes8.h"{{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
-// CHECK-NEXT: {{^}}# 4 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes8.h"{{$}}
+// CHECK-NEXT: {{^}}# 4 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes8.h"{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if !__has_include("rewrite-includes8.h"){{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
 // CHECK-NEXT: {{^}}#endif /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* evaluated by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 5 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes8.h"{{$}}
+// CHECK-NEXT: {{^}}# 5 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes8.h"{{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
-// CHECK-NEXT: {{^}}# 6 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes8.h"{{$}}
+// CHECK-NEXT: {{^}}# 6 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes8.h"{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes8.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 24 "{{.*}}rewrite-includes.c" 2{{$}}
 // CHECK-NEXT: {{^}}#if defined(__CLANG_REWRITTEN_INCLUDES) /* rewrite-includes9.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#include "rewrite-includes9.h"{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes9.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 24 "{{.*}}rewrite-includes.c"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes9.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes9.h" 1{{$}}
 // CHECK-NEXT: {{^}}#if 0 /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if __has_include_next(<rewrite-includes9.h>){{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
 // CHECK-NEXT: {{^}}#endif /* disabled by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#if 1 /* evaluated by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes9.h"{{$}}
+// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes9.h"{{$}}
 // CHECK-NEXT: {{^}}#if defined(__CLANG_REWRITTEN_INCLUDES) /* rewrite-includes9.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}#include_next <rewrite-includes9.h>{{$}}
 // CHECK-NEXT: {{^}}#else /* rewrite-includes9.h expanded by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes9.h"{{$}}
-// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\\\)NextIncludes(/|\\\\)}}rewrite-includes9.h" 1{{$}}
+// CHECK-NEXT: {{^}}# 2 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes9.h"{{$}}
+// CHECK-NEXT: {{^}}# 1 "{{.*[/\\]Inputs(/|\\)NextIncludes(/|\\)}}rewrite-includes9.h" 1{{$}}
 // CHECK-NEXT: {{^}}int included_line9;{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes9.h expanded by -frewrite-includes */{{$}}
-// CHECK-NEXT: {{^}}# 3 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes9.h" 2{{$}}
+// CHECK-NEXT: {{^}}# 3 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes9.h" 2{{$}}
 // CHECK-NEXT: {{^}}#endif{{$}}
-// CHECK-NEXT: {{^}}# 4 "{{.*[/\\]Inputs(/|\\\\)}}rewrite-includes9.h"{{$}}
+// CHECK-NEXT: {{^}}# 4 "{{.*[/\\]Inputs(/|\\)}}rewrite-includes9.h"{{$}}
 // CHECK-NEXT: {{^}}#endif /* rewrite-includes9.h expanded by -frewrite-includes */{{$}}
 // CHECK-NEXT: {{^}}# 25 "{{.*}}rewrite-includes.c" 2{{$}}
 // CHECK-NEXT: {{^}}static int unused;{{$}}

--- a/clang/test/Modules/cxx20-hu-05.cpp
+++ b/clang/test/Modules/cxx20-hu-05.cpp
@@ -29,4 +29,4 @@ int baz(int);
 #endif // __GUARD
 
 // CHECK-HU:  ====== C++20 Module structure ======
-// CHECK-HU-NEXT:  Header Unit '.{{/|\\\\?}}hu-01.h' is the Primary Module at index #1
+// CHECK-HU-NEXT:  Header Unit '.{{/|\\}}hu-01.h' is the Primary Module at index #1

--- a/clang/test/Modules/cxx20-hu-06.cpp
+++ b/clang/test/Modules/cxx20-hu-06.cpp
@@ -65,4 +65,4 @@ inline int bar(int x) {
   return FORTYTWO;
 }
 #endif
-// CHECK-IMP: remark: importing module '.{{/|\\\\?}}hu-01.h' from 'hu-01.pcm'
+// CHECK-IMP: remark: importing module '.{{/|\\}}hu-01.h' from 'hu-01.pcm'

--- a/clang/test/Parser/cxx11-user-defined-literals.cpp
+++ b/clang/test/Parser/cxx11-user-defined-literals.cpp
@@ -3,8 +3,8 @@
 // A ud-suffix cannot be used on string literals in a whole bunch of contexts:
 
 #include "foo"_bar // expected-error {{expected "FILENAME" or <FILENAME>}}
-#line 1 "foo"_bar // expected-error {{user-defined suffix cannot be used here}}
-# 1 "foo"_bar 1 // expected-error {{user-defined suffix cannot be used here}}
+#line 1 "foo"_bar // expected-error {{invalid filename for #line directive}}
+# 1 "foo"_bar 1 // expected-error {{invalid filename for #line directive}}
 #ident "foo"_bar // expected-error {{user-defined suffix cannot be used here}}
 _Pragma("foo"_bar) // expected-error {{user-defined suffix cannot be used here}}
 #pragma comment(lib, "foo"_bar) // expected-error {{user-defined suffix cannot be used here}}

--- a/clang/test/Preprocessor/line-directive-output.c
+++ b/clang/test/Preprocessor/line-directive-output.c
@@ -75,8 +75,20 @@ extern int z;
 # 44 "A.c"
 # 49 "A.c"
 
-// CHECK: # 50 "a\n.c"
+// CHECK: # 50 "a\\n.c"
 # 50 "a\n.c"
+
+// CHECK: # 1 "c:\\moo\\zar\\haz.h"
+#line 1 "c:\moo\zar\haz.h"
+
+// CHECK # 1 "original\x12source.c"
+# 1 "original\x12source.c"
+
+// CHECK # 1 "original\u1234"
+# 1 "original\u1234"
+
+// CHECK # 1 "original\u{1234}"
+# 1 "original\u{1234}"
 
 # 1 "system.h" 3
 # 2

--- a/clang/test/Preprocessor/line-directive-output.c
+++ b/clang/test/Preprocessor/line-directive-output.c
@@ -75,10 +75,10 @@ extern int z;
 # 44 "A.c"
 # 49 "A.c"
 
-// CHECK: # 50 "a\\n.c"
+// CHECK: # 50 "a\n.c"
 # 50 "a\n.c"
 
-// CHECK: # 1 "c:\\moo\\zar\\haz.h"
+// CHECK: # 1 "c:\moo\zar\haz.h"
 #line 1 "c:\moo\zar\haz.h"
 
 // CHECK # 1 "original\x12source.c"

--- a/clang/test/Preprocessor/line-directive.c
+++ b/clang/test/Preprocessor/line-directive.c
@@ -130,3 +130,9 @@ undefined t; // expected-error {{unknown type name 'undefined'}}
 #line 130 "\x12"
 # 131 U"hello" // expected-error {{invalid filename for line marker directive}}
 # 132 "\x13" // expected-warning {{this style of line directive is a GNU extension}}
+
+#line 0 // expected-warning {{#line directive with zero argument is a GNU extension}}
+// #UNTERMINATED
+#line 1 "foo\""
+// expected-warning@#UNTERMINATED {{missing terminating '"' character}}
+// expected-warning@#UNTERMINATED {{extra tokens at end of #line directive}}

--- a/clang/test/Preprocessor/line-directive.c
+++ b/clang/test/Preprocessor/line-directive.c
@@ -127,6 +127,6 @@ undefined t; // expected-error {{unknown type name 'undefined'}}
 // expected-error@-1{{MAIN2}}
 
 #line 129 L"wide" // expected-error {{invalid filename for #line directive}}
-#line 130 "\x12" // expected-error {{invalid escape sequence '\x12' in an unevaluated string literal}}
+#line 130 "\x12"
 # 131 U"hello" // expected-error {{invalid filename for line marker directive}}
-# 132 "\x13" // expected-error {{invalid escape sequence '\x13' in an unevaluated string literal}}
+# 132 "\x13" // expected-warning {{this style of line directive is a GNU extension}}

--- a/clang/test/Preprocessor/line-directive.c
+++ b/clang/test/Preprocessor/line-directive.c
@@ -136,3 +136,6 @@ undefined t; // expected-error {{unknown type name 'undefined'}}
 #line 1 "foo\""
 // expected-warning@#UNTERMINATED {{missing terminating '"' character}}
 // expected-warning@#UNTERMINATED {{extra tokens at end of #line directive}}
+
+#line 1 <> // expected-error {{invalid filename for #line directive}}
+#line 1 <foo> // expected-error {{invalid filename for #line directive}}

--- a/clang/test/VFS/external-names-multi-overlay.c
+++ b/clang/test/VFS/external-names-multi-overlay.c
@@ -9,7 +9,7 @@
 // RUN: %clang_cc1 -Werror -I %t/A -ivfsoverlay %t/vfs/a-b-fb.yaml -ivfsoverlay %t/vfs/empty.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=FROM_B %s
 // RUN: %clang_cc1 -Werror -I %t/B -ivfsoverlay %t/vfs/a-b-ft.yaml -ivfsoverlay %t/vfs/empty.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=FROM_B %s
 // RUN: %clang_cc1 -Werror -I %t/B -ivfsoverlay %t/vfs/a-b-fb.yaml -ivfsoverlay %t/vfs/empty.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=FROM_B %s
-// FROM_B: # 1 "{{.*(/|\\\\)B(/|\\\\)}}Header.h"
+// FROM_B: # 1 "{{.*(/|\\)B(/|\\)}}Header.h"
 // FROM_B: // Header.h in B
 
 //--- main.c

--- a/clang/test/VFS/fallback.c
+++ b/clang/test/VFS/fallback.c
@@ -25,9 +25,9 @@
 // Both B.h and C.h are in both folders
 // RUN: %clang_cc1 -Werror -I %t/Both/UseFirst -ivfsoverlay %t/vfs/both.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=IN_UF %s
 
-// IN_UF: # 1 "{{.*(/|\\\\)UseFirst(/|\\\\)}}B.h"
+// IN_UF: # 1 "{{.*(/|\\)UseFirst(/|\\)}}B.h"
 // IN_UF-NEXT: // B.h in UseFirst
-// IN_UF: # 1 "{{.*(/|\\\\)UseFirst(/|\\\\)}}C.h"
+// IN_UF: # 1 "{{.*(/|\\)UseFirst(/|\\)}}C.h"
 // IN_UF-NEXT: // C.h in UseFirst
 
 // Base missing, so now they are only in UseFirst
@@ -36,25 +36,25 @@
 // UseFirst missing, fallback to Base
 // RUN: %clang_cc1 -Werror -I %t/BaseOnly/UseFirst -ivfsoverlay %t/vfs/base-only.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=IN_BASE %s
 
-// IN_BASE: # 1 "{{.*(/|\\\\)Base(/|\\\\)}}B.h"
+// IN_BASE: # 1 "{{.*(/|\\)Base(/|\\)}}B.h"
 // IN_BASE-NEXT: // B.h in Base
-// IN_BASE: # 1 "{{.*(/|\\\\)Base(/|\\\\)}}C.h"
+// IN_BASE: # 1 "{{.*(/|\\)Base(/|\\)}}C.h"
 // IN_BASE-NEXT: // C.h in Base
 
 // B.h missing from UseFirst
 // RUN: %clang_cc1 -Werror -I %t/BFallback/UseFirst -ivfsoverlay %t/vfs/b-fallback.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=B_FALLBACK %s
 
-// B_FALLBACK: # 1 "{{.*(/|\\\\)Base(/|\\\\)}}B.h"
+// B_FALLBACK: # 1 "{{.*(/|\\)Base(/|\\)}}B.h"
 // B_FALLBACK-NEXT: // B.h in Base
-// B_FALLBACK: # 1 "{{.*(/|\\\\)UseFirst(/|\\\\)}}C.h"
+// B_FALLBACK: # 1 "{{.*(/|\\)UseFirst(/|\\)}}C.h"
 // B_FALLBACK-NEXT: // C.h in UseFirst
 
 // C.h missing from UseFirst
 // RUN: %clang_cc1 -Werror -I %t/CFallback/UseFirst -ivfsoverlay %t/vfs/c-fallback.yaml -E -C %t/main.c 2>&1 | FileCheck --check-prefix=C_FALLBACK %s
 
-// C_FALLBACK: # 1 "{{.*(/|\\\\)UseFirst(/|\\\\)}}B.h"
+// C_FALLBACK: # 1 "{{.*(/|\\)UseFirst(/|\\)}}B.h"
 // C_FALLBACK-NEXT: // B.h in UseFirst
-// C_FALLBACK: # 1 "{{.*(/|\\\\)Base(/|\\\\)}}C.h"
+// C_FALLBACK: # 1 "{{.*(/|\\)Base(/|\\)}}C.h"
 // C_FALLBACK-NEXT: // C.h in Base
 
 //--- main.c


### PR DESCRIPTION
We treated line directives as being unevaluated string literal. However
  - The standard has no such restriction - or rather the standard has different, unclear restriction (https://wg21.link/CWG2693)
  - Because of Windows paths, it's common for "C:\foo\bar" to be used, and these should not form escape sequences.

To remain consistent with other implementations, we do not allow `#line 1 <>` at this time. We do however support `#line 1 ""` to avoid a breaking change.

Fixes a regression introduced by #201413