### PR TITLE
[Polly] Fix memory leak in DependenceAnalysis::Result::abandonDepende…

### DIFF
--- a/polly/lib/Analysis/DependenceInfo.cpp
+++ b/polly/lib/Analysis/DependenceInfo.cpp
@@ -862,7 +862,7 @@ const Dependences &DependenceAnalysis::Result::recomputeDependences(
 
 void DependenceAnalysis::Result::abandonDependences() {
   for (std::unique_ptr<Dependences> &Deps : D)
-    Deps.release();
+    Deps.reset();
 }
 
 DependenceAnalysis::Result polly::runDependenceAnalysis(Scop &S) {


### PR DESCRIPTION
abandonDependences() uses unique_ptr::release() which releases
ownership without freeing the Dependences object, causing a memory
leak. Use unique_ptr::reset() instead to properly delete the object
before nullifying the pointer.

The issue was found when AddressSanitizer is enabled in the build.