### PR TITLE
[analyzer][Z3] Fix z3-bitint-arithmetic.c test RUN line

### DIFF
--- a/clang/test/Analysis/z3/z3-bitint-arithmetic.c
+++ b/clang/test/Analysis/z3/z3-bitint-arithmetic.c
@@ -1,4 +1,5 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection \
+// RUN:   -fexperimental-max-bitint-width=1024 \
 // RUN:   -analyzer-constraints=unsupported-z3 -verify %s
 // REQUIRES: z3
 


### PR DESCRIPTION
I used to get these errors on M4 with `LLVM_ENABLE_Z3_SOLVER`:

```
error: 'expected-error' diagnostics seen but not expected:
  File clang/test/Analysis/z3/z3-bitint-arithmetic.c Line 26: unsigned _BitInt of bit sizes greater than 128 not supported
  File clang/test/Analysis/z3/z3-bitint-arithmetic.c Line 29: unsigned _BitInt of bit sizes greater than 128 not supported
```

Fixes up #210525
Another nail in the coffin of #184695