### PR TITLE
[analyzer][NFC] Remove unused ProgramStateRef local variables

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
@@ -424,7 +424,7 @@ static const char* GetCFNumberTypeStr(uint64_t i) {
 #endif
 
 void CFNumberChecker::checkPreStmt(const CallExpr *CE,
-                                         CheckerContext &C) const {
+                                   CheckerContext &C) const {
   const FunctionDecl *FD = C.getCalleeDecl(CE);
   if (!FD)
     return;

--- a/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
@@ -425,7 +425,6 @@ static const char* GetCFNumberTypeStr(uint64_t i) {
 
 void CFNumberChecker::checkPreStmt(const CallExpr *CE,
                                          CheckerContext &C) const {
-  ProgramStateRef state = C.getState();
   const FunctionDecl *FD = C.getCalleeDecl(CE);
   if (!FD)
     return;

--- a/clang/lib/StaticAnalyzer/Checkers/ExprInspectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ExprInspectionChecker.cpp
@@ -456,8 +456,6 @@ void ExprInspectionChecker::analyzerDenote(const CallExpr *CE,
     return;
   }
 
-  ProgramStateRef State = C.getState();
-
   C.addTransition(C.getState()->set<DenotedSymbols>(Sym, E));
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3554,7 +3554,6 @@ void MallocChecker::checkEscapeOnReturn(const ReturnStmt *S,
     return;
 
   // Check if we are returning a symbol.
-  ProgramStateRef State = C.getState();
   SVal RetVal = C.getSVal(E);
   SymbolRef Sym = RetVal.getAsSymbol();
   if (!Sym)

--- a/clang/lib/StaticAnalyzer/Checkers/ObjCSuperDeallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ObjCSuperDeallocChecker.cpp
@@ -242,8 +242,6 @@ SuperDeallocBRVisitor::VisitNode(const ExplodedNode *Succ,
   if (Satisfied)
     return nullptr;
 
-  ProgramStateRef State = Succ->getState();
-
   bool CalledNow =
       Succ->getState()->contains<CalledSuperDealloc>(ReceiverSymbol);
   bool CalledBefore =

--- a/clang/lib/StaticAnalyzer/Checkers/PointerArithChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerArithChecker.cpp
@@ -168,7 +168,6 @@ void PointerArithChecker::reportPointerArithMisuse(const Expr *E,
   if (SR.isInvalid())
     return;
 
-  ProgramStateRef State = C.getState();
   const MemRegion *Region = C.getSVal(E).getAsRegion();
   if (!Region)
     return;

--- a/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
@@ -197,7 +197,6 @@ const MemRegion *VAListChecker::getVAListAsRegion(SVal SV, const Expr *E,
 
 void VAListChecker::checkPreStmt(const VAArgExpr *VAA,
                                  CheckerContext &C) const {
-  ProgramStateRef State = C.getState();
   const Expr *ArgExpr = VAA->getSubExpr();
   const MemRegion *VAList = getVAListAsRegion(C.getSVal(ArgExpr), ArgExpr, C);
   if (!VAList)

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2664,7 +2664,6 @@ assumeCondition(const Stmt *ConditionStmt, ExplodedNode *N) {
 
   DefinedSVal V = X.castAs<DefinedSVal>();
 
-  ProgramStateRef StTrue, StFalse;
   return State->assume(V);
 }
 


### PR DESCRIPTION
Several checkers and ExprEngine declare a ProgramStateRef local that is never read (typically `State = C.getState();` immediately followed by code that re-fetches the state directly). These are not flagged by -Wunused-variable because ProgramStateRef has a non-trivial destructor.

Found with a clang-query matcher over clang/lib/StaticAnalyzer.
Assisted-by: claude