### PR TITLE
[analyzer][NFC] Remove leftover PreElideState stash in copy elision

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -255,8 +255,8 @@ SVal ExprEngine::computeObjectUnderConstruction(
       // also sets the CallOpts flags for us.
       // If the elided copy/move constructor is not supported, there's still
       // benefit in trying to model the non-elided constructor.
-      // Stash our state before trying to elide, as it'll get overwritten.
-      ProgramStateRef PreElideState = State;
+      // Stash the call options before trying to elide, as they'll get
+      // overwritten.
       EvalCallOptions PreElideCallOpts = CallOpts;
 
       SVal V = computeObjectUnderConstruction(


### PR DESCRIPTION
computeObjectUnderConstruction stashed the program state into PreElideState "before trying to elide, as it'll get overwritten", but never used it. That comment and stash are fossils of the old prepareForObjectConstruction, which returned and threaded the state (`std::tie(State, V) = ...`); the failure path then reverted it with `State = PreElideState;`.

The refactor to the SVal-returning computeObjectUnderConstruction (State is now passed by value and the state updates moved to updateObjectsUnderConstruction) dropped that revert but left the stash and comment behind. State is never overwritten here anymore, so remove the dead PreElideState and reword the comment to describe only the CallOpts stash, which is still needed (CallOpts is passed by reference and genuinely overwritten by the elision attempt).

Found with a clang-query matcher over clang/lib/StaticAnalyzer.
Assisted-by: claude