### PR TITLE
[TableGen] Add register-info statistics

### DIFF
--- a/llvm/test/TableGen/aarch64-register-info-stats.td
+++ b/llvm/test/TableGen/aarch64-register-info-stats.td
@@ -1,0 +1,18 @@
+// REQUIRES: asserts
+// RUN: llvm-tblgen -gen-register-info -stats \
+// RUN:   -I %p/../../lib/Target/AArch64 -I %p/../../include \
+// RUN:   %s -o %t.inc 2>&1 | FileCheck %s
+
+// Keep changes to the size of AArch64's generated register model visible.
+
+include "llvm/Target/Target.td"
+include "AArch64RegisterInfo.td"
+
+def TestInstrInfo : InstrInfo;
+def TestTarget : Target {
+  let InstructionSet = TestInstrInfo;
+}
+
+// CHECK-DAG: 83 register-info-emitter - Number of explicit register classes
+// CHECK-DAG: 447 register-info-emitter - Number of synthesized register classes
+// CHECK-DAG: 190 register-info-emitter - Number of register pressure sets

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -54,8 +54,7 @@ using namespace llvm;
 #define DEBUG_TYPE "register-info-emitter"
 
 STATISTIC(NumExplicitRegClasses, "Number of explicit register classes");
-STATISTIC(NumSynthesizedRegClasses,
-          "Number of synthesized register classes");
+STATISTIC(NumSynthesizedRegClasses, "Number of synthesized register classes");
 STATISTIC(NumRegPressureSets, "Number of register pressure sets");
 
 static cl::OptionCategory RegisterInfoCat("Options for -gen-register-info");
@@ -80,8 +79,8 @@ public:
     RegBank.computeDerivedInfo();
 
     const auto &RegClasses = RegBank.getRegClasses();
-    NumExplicitRegClasses = llvm::count_if(
-        RegClasses, [](const CodeGenRegisterClass &RC) {
+    NumExplicitRegClasses =
+        llvm::count_if(RegClasses, [](const CodeGenRegisterClass &RC) {
           return RC.getDef() != nullptr;
         });
     NumSynthesizedRegClasses = RegClasses.size() - NumExplicitRegClasses;

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SparseBitVector.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/Support/Casting.h"
@@ -50,6 +51,13 @@
 
 using namespace llvm;
 
+#define DEBUG_TYPE "register-info-emitter"
+
+STATISTIC(NumExplicitRegClasses, "Number of explicit register classes");
+STATISTIC(NumSynthesizedRegClasses,
+          "Number of synthesized register classes");
+STATISTIC(NumRegPressureSets, "Number of register pressure sets");
+
 static cl::OptionCategory RegisterInfoCat("Options for -gen-register-info");
 
 static cl::opt<bool>
@@ -70,6 +78,14 @@ public:
   RegisterInfoEmitter(const RecordKeeper &R)
       : Records(R), Target(R), RegBank(Target.getRegBank()) {
     RegBank.computeDerivedInfo();
+
+    const auto &RegClasses = RegBank.getRegClasses();
+    NumExplicitRegClasses = llvm::count_if(
+        RegClasses, [](const CodeGenRegisterClass &RC) {
+          return RC.getDef() != nullptr;
+        });
+    NumSynthesizedRegClasses = RegClasses.size() - NumExplicitRegClasses;
+    NumRegPressureSets = RegBank.getNumRegPressureSets();
   }
 
   // runEnums - Print out enum values for all of the registers.


### PR DESCRIPTION
Add statistics for the numbers of explicit and synthesized register classes, along with the number of register pressure sets. This makes growth in the generated register model easier to spot since it can be surprising.

Assisted-by: codex