### PR TITLE
[SPIRV] Emit NonSemantic DebugTypeArray.

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
@@ -752,9 +752,17 @@ std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeArray(
     const auto *SR = dyn_cast<DISubrange>(Element);
     if (!SR)
       continue;
+    // A DIVariable count (a variable-length array) is not a ConstantInt, so it
+    // maps to 0 here. DebugTypeArray also allows a DebugLocalVariable or
+    // DebugGlobalVariable id for it, but no frontend we target emits one. A
+    // constant wider than 32 bits maps to 0 too, since the count operand is a
+    // 32-bit OpConstant and such an array cannot occur in a shader.
     uint32_t Count = 0;
-    if (const auto *CI = dyn_cast_if_present<ConstantInt *>(SR->getCount()))
-      Count = static_cast<uint32_t>(CI->getZExtValue());
+    if (const auto *CI = dyn_cast_if_present<ConstantInt *>(SR->getCount())) {
+      const APInt &Value = CI->getValue();
+      if (Value.getActiveBits() <= 32)
+        Count = static_cast<uint32_t>(Value.getZExtValue());
+    }
     Ops.push_back(emitOpConstantI32(Count, I32TypeReg, MAI));
   }
 

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
@@ -50,7 +50,8 @@ static void
 partitionTypes(const DIType *Ty, SmallVector<const DIBasicType *> &BasicTypes,
                SmallVector<const DIDerivedType *> &PointerTypes,
                SmallVector<const DISubroutineType *> &SubroutineTypes,
-               SmallVector<const DICompositeType *> &VectorTypes) {
+               SmallVector<const DICompositeType *> &VectorTypes,
+               SmallVector<const DICompositeType *> &ArrayTypes) {
   if (const auto *BT = dyn_cast<DIBasicType>(Ty)) {
     BasicTypes.push_back(BT);
     return;
@@ -60,8 +61,23 @@ partitionTypes(const DIType *Ty, SmallVector<const DIBasicType *> &BasicTypes,
     return;
   }
   if (const auto *CT = dyn_cast<DICompositeType>(Ty)) {
-    if (CT->getTag() == dwarf::DW_TAG_array_type && CT->isVector())
-      VectorTypes.push_back(CT);
+    if (CT->getTag() == dwarf::DW_TAG_array_type) {
+      // A vector is an array with DINode::FlagVector. A plain array is the
+      // same tag without it. A matrix is also lowered to a DW_TAG_array_type
+      // (two subranges), so it is indistinguishable from a 2D array here and
+      // is emitted as a DebugTypeArray.
+      //
+      // FIXME: Emitting a matrix as a DebugTypeArray is valid but loses the
+      // matrix shape. DWARF has no matrix tag, so distinguishing a matrix needs
+      // a new DINode flag analogous to FlagVector, set on the array, plus a way
+      // to carry column-major vs row-major traits. Array-of-vectors alone would
+      // not disambiguate a matrix from a genuine array of vectors. Once the
+      // frontend marks matrices, route them to a DebugTypeMatrix path here.
+      if (CT->isVector())
+        VectorTypes.push_back(CT);
+      else
+        ArrayTypes.push_back(CT);
+    }
     return;
   }
   const auto *DT = dyn_cast<DIDerivedType>(Ty);
@@ -194,6 +210,7 @@ void SPIRVNonSemanticDebugHandler::beginModule(Module *M) {
   PointerTypes.clear();
   SubroutineTypes.clear();
   VectorTypes.clear();
+  ArrayTypes.clear();
   SubprogramDeclarations.clear();
   GlobalVariableDebugInfoMap.clear();
   DebugFunctionDeclarationRegs.clear();
@@ -247,7 +264,8 @@ void SPIRVNonSemanticDebugHandler::beginModule(Module *M) {
   DebugInfoFinder Finder;
   Finder.processModule(*M);
   llvm::for_each(Finder.types(), [&](DIType *Ty) {
-    partitionTypes(Ty, BasicTypes, PointerTypes, SubroutineTypes, VectorTypes);
+    partitionTypes(Ty, BasicTypes, PointerTypes, SubroutineTypes, VectorTypes,
+                   ArrayTypes);
   });
 
   for (const DISubprogram *SP : Finder.subprograms()) {
@@ -712,6 +730,38 @@ std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeVector(
                      ExtInstSetReg, {BTIt->second, CountReg}, MAI);
 }
 
+std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeArray(
+    const DICompositeType *AT, MCRegister ExtInstSetReg,
+    SPIRV::ModuleAnalysisInfo &MAI) {
+  // The element (base) type must already be in DebugTypeRegs. Unlike
+  // DebugTypeVector, the element may be any debug type, not only a basic type.
+  auto BaseRegOpt = lookupOptReg(DebugTypeRegs, AT->getBaseType());
+  if (!BaseRegOpt)
+    return std::nullopt;
+
+  MCRegister VoidTypeReg = getOrEmitOpTypeVoidReg(MAI);
+  MCRegister I32TypeReg = getOrEmitOpTypeInt32Reg(MAI);
+
+  SmallVector<MCRegister> Ops;
+  Ops.push_back(*BaseRegOpt);
+
+  // One component count per DISubrange, in DWARF subrange order. Emit 0 for
+  // counts that are not a compile-time constant (dynamic arrays). This matches
+  // OpTypeRuntimeArray.
+  for (const DINode *Element : AT->getElements()) {
+    const auto *SR = dyn_cast<DISubrange>(Element);
+    if (!SR)
+      continue;
+    uint32_t Count = 0;
+    if (const auto *CI = dyn_cast_if_present<ConstantInt *>(SR->getCount()))
+      Count = static_cast<uint32_t>(CI->getZExtValue());
+    Ops.push_back(emitOpConstantI32(Count, I32TypeReg, MAI));
+  }
+
+  return emitExtInst(SPIRV::NonSemanticExtInst::DebugTypeArray, VoidTypeReg,
+                     ExtInstSetReg, Ops, MAI);
+}
+
 void SPIRVNonSemanticDebugHandler::emitNonSemanticDebugStrings(
     SPIRV::ModuleAnalysisInfo &MAI) {
   if (CompileUnits.empty())
@@ -875,6 +925,14 @@ void SPIRVNonSemanticDebugHandler::emitNonSemanticGlobalDebugInfo(
   for (const DIDerivedType *PT : PointerTypes) {
     if (auto PtrReg = emitDebugTypePointer(PT, ExtInstSetReg, MAI))
       DebugTypeRegs[PT] = *PtrReg;
+  }
+
+  // Emit DebugTypeArray for each collected array type. Placed after the basic,
+  // vector, and pointer types so an array over any of them can resolve its
+  // element id. An array whose element type was not emitted is skipped.
+  for (const DICompositeType *AT : ArrayTypes) {
+    if (auto ArrReg = emitDebugTypeArray(AT, ExtInstSetReg, MAI))
+      DebugTypeRegs[AT] = *ArrReg;
   }
 
   // Emit DebugTypeFunction for each distinct DISubroutineType.

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
@@ -67,6 +67,9 @@ class SPIRVNonSemanticDebugHandler : public DebugHandlerBase {
   // DICompositeType nodes with DW_TAG_array_type and DINode::FlagVector,
   // partitioned from DebugInfoFinder.types() in beginModule().
   SmallVector<const DICompositeType *> VectorTypes;
+  // DICompositeType nodes with DW_TAG_array_type that are not vectors,
+  // partitioned in beginModule().
+  SmallVector<const DICompositeType *> ArrayTypes;
 
   // Filled in emitNonSemanticGlobalDebugInfo(): DI types to their result
   // registers.
@@ -316,6 +319,21 @@ private:
   std::optional<MCRegister> emitDebugTypeVector(const DICompositeType *VT,
                                                 MCRegister ExtInstSetReg,
                                                 SPIRV::ModuleAnalysisInfo &MAI);
+
+  /// Emit \c DebugTypeArray for the array composite type \p AT.
+  ///
+  /// Emits the element (base) type id followed by one Component Count per
+  /// \c DISubrange, in DWARF subrange order. A count that is not a
+  /// compile-time constant is emitted as 0, matching \c OpTypeRuntimeArray. A
+  /// matrix arrives here as a multi-subrange array and is emitted with one
+  /// count per dimension.
+  ///
+  /// \returns The result id register on success. Returns \c std::nullopt and
+  /// emits nothing if \p AT's element type has not been emitted into
+  /// \c DebugTypeRegs.
+  std::optional<MCRegister> emitDebugTypeArray(const DICompositeType *AT,
+                                               MCRegister ExtInstSetReg,
+                                               SPIRV::ModuleAnalysisInfo &MAI);
 
   /// Map a \c DISubroutineType::getTypeArray() element to an operand register
   /// for

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-array-skip-element-not-in-regs.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-array-skip-element-not-in-regs.ll
@@ -1,0 +1,35 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; emitDebugTypeArray emits nothing when the element type is not in DebugTypeRegs.
+; The element here is a pointer with no DWARF address space, which
+; emitDebugTypePointer skips for lack of a storage class. The pointer stays out
+; of DebugTypeRegs regardless of later type support, so the array is skipped.
+
+; CHECK-SPIRV: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV-NOT: DebugTypeArray
+
+define spir_func void @test() !dbg !6 {
+entry:
+  %a = alloca [4 x ptr], align 8
+    #dbg_declare(ptr %a, !10, !DIExpression(), !14)
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "array.hlsl", directory: "/src")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = distinct !DISubprogram(name: "test", scope: !1, file: !1, line: 1, type: !7, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !9)
+!7 = !DISubroutineType(types: !8)
+!8 = !{null}
+!9 = !{}
+!10 = !DILocalVariable(name: "a", scope: !6, file: !1, line: 2, type: !11)
+!11 = !DICompositeType(tag: DW_TAG_array_type, baseType: !12, size: 256, elements: !13)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !15, size: 64)
+!13 = !{!DISubrange(count: 4)}
+!14 = !DILocation(line: 2, column: 10, scope: !6)
+!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-array.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-array.ll
@@ -1,0 +1,68 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV --implicit-check-not=DebugTypeMatrix
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A DW_TAG_array_type without DIFlagVector lowers to DebugTypeArray, one
+; component count per subrange. A runtime-sized subrange emits count 0. An
+; array of a vector references the element's DebugTypeVector.
+;
+; Clang emits matrix types two-subrange DW_TAG_array_type, so it lowers to
+; DebugTypeArray. This is checked by --implicit-check-not=DebugTypeMatrix.
+; If Clang starts emitting matrix types, this will fail.
+
+; CHECK-SPIRV: [[ext:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV-DAG: [[void:%[0-9]+]] = OpTypeVoid
+; CHECK-SPIRV-DAG: [[i32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: [[str_float:%[0-9]+]] = OpString "float"
+; CHECK-SPIRV-DAG: [[c0:%[0-9]+]] = OpConstant [[i32]] 0{{$}}
+; CHECK-SPIRV-DAG: [[c3:%[0-9]+]] = OpConstant [[i32]] 3{{$}}
+; CHECK-SPIRV-DAG: [[c4:%[0-9]+]] = OpConstant [[i32]] 4{{$}}
+; CHECK-SPIRV-DAG: [[basic_float:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugTypeBasic [[str_float]]
+; CHECK-SPIRV-DAG: [[vec_float3:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugTypeVector [[basic_float]] [[c3]]
+; CHECK-SPIRV-DAG: OpExtInst [[void]] [[ext]] DebugTypeArray [[basic_float]] [[c4]]{{$}}
+; CHECK-SPIRV-DAG: OpExtInst [[void]] [[ext]] DebugTypeArray [[basic_float]] [[c4]] [[c3]]{{$}}
+; CHECK-SPIRV-DAG: OpExtInst [[void]] [[ext]] DebugTypeArray [[basic_float]] [[c0]]{{$}}
+; CHECK-SPIRV-DAG: OpExtInst [[void]] [[ext]] DebugTypeArray [[vec_float3]] [[c4]]{{$}}
+
+define spir_func void @test() !dbg !6 {
+entry:
+  %a1 = alloca [4 x float], align 16
+  %a2 = alloca [3 x [4 x float]], align 16
+  %ar = alloca [0 x float], align 16
+  %av = alloca [4 x <3 x float>], align 16
+    #dbg_declare(ptr %a1, !10, !DIExpression(), !14)
+    #dbg_declare(ptr %a2, !15, !DIExpression(), !17)
+    #dbg_declare(ptr %ar, !18, !DIExpression(), !19)
+    #dbg_declare(ptr %av, !23, !DIExpression(), !26)
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "array.hlsl", directory: "/src")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = distinct !DISubprogram(name: "test", scope: !1, file: !1, line: 1, type: !7, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !9)
+!7 = !DISubroutineType(types: !8)
+!8 = !{null}
+!9 = !{}
+!10 = !DILocalVariable(name: "a1", scope: !6, file: !1, line: 2, type: !11)
+!11 = !DICompositeType(tag: DW_TAG_array_type, baseType: !12, size: 128, elements: !13)
+!12 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+!13 = !{!DISubrange(count: 4)}
+!14 = !DILocation(line: 2, column: 10, scope: !6)
+!15 = !DILocalVariable(name: "a2", scope: !6, file: !1, line: 3, type: !16)
+!16 = !DICompositeType(tag: DW_TAG_array_type, baseType: !12, size: 384, elements: !20)
+!17 = !DILocation(line: 3, column: 10, scope: !6)
+!18 = !DILocalVariable(name: "ar", scope: !6, file: !1, line: 4, type: !21)
+!19 = !DILocation(line: 4, column: 8, scope: !6)
+!20 = !{!DISubrange(count: 4), !DISubrange(count: 3)}
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !12, size: 0, elements: !22)
+!22 = !{!DISubrange(lowerBound: 0)}
+!23 = !DILocalVariable(name: "av", scope: !6, file: !1, line: 5, type: !24)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 384, elements: !27)
+!25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !12, size: 96, flags: DIFlagVector, elements: !28)
+!26 = !DILocation(line: 5, column: 8, scope: !6)
+!27 = !{!DISubrange(count: 4)}
+!28 = !{!DISubrange(count: 3)}


### PR DESCRIPTION
This PR adds `DebugTypeArray` to `SPIRVNonSemanticDebugHandler`:

1. `partitionTypes` buckets `DICompositeType` nodes tagged `DW_TAG_array_type` without `DINode::FlagVector` (vectors are emitted separately).
2. `emitNonSemanticGlobalDebugInfo` emits one `DebugTypeArray` per node after the pointer types and records the id in `DebugTypeRegs`.
3. `emitDebugTypeArray` appends one `OpConstant` component count per `DISubrange`, in subrange order. A subrange with no constant count emits 0, matching `OpTypeRuntimeArray`. An array whose element type is not in `DebugTypeRegs` is skipped.

Clang lowers a matrix to a `DW_TAG_array_type` with two subranges in `CGDebugInfo::CreateType(const ConstantMatrixType *)`, so an HLSL `float4x4` emits as a `DebugTypeArray` with two counts. `DebugTypeMatrix` needs a distinguishing flag from the frontend. 

Added a couple of tests in `llvm/test/CodeGen/SPIRV/debug-info/`:

1. `debug-type-array.ll` covers a 1D array, a 2D array, a runtime-sized array, and an array of vectors, and asserts that we are not emitting `DebugTypeMatrix` (this will need to be changed when/if we start emitting them).
2. `debug-type-array-skip-element-not-in-regs.ll` tests arrays of types that cannot have debug info (I used array of pointers wit no DWARF address space).