### PR TITLE
[flang][OpenMP] Inline the firstprivate array copy instead of calling Assign()

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
@@ -19,6 +19,7 @@
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "flang/Optimizer/HLFIR/Passes.h"
 #include "flang/Optimizer/OpenMP/Passes.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
@@ -38,6 +39,57 @@ static llvm::cl::opt<bool> inlineAllocatableExprAssignFlag(
     llvm::cl::desc("Enable inlining of allocatable assignments when RHS is an "
                    "hlfir.expr (e.g., from hlfir.elemental)"),
     llvm::cl::init(false));
+
+/// Is \p assign an `omp.private` copy region copying the mold to the clone?
+///
+/// The copy region's entry-block arguments are the mold and the freshly
+/// allocated clone, which cannot overlap, so the copy needs no aliasing check.
+/// The body is unrestricted, so match only the shape lowering emits:
+///
+/// \code
+///   ^bb0(%mold, %clone):
+///     %0 = fir.load %mold          // boxed privatizer only
+///     hlfir.assign %0 to %clone
+/// \endcode
+///
+/// A POINTER privatizer is excluded: firstprivate copies the association, so
+/// mold and clone share data and the copy aliases. It is lowered with fir.store
+/// today, not hlfir.assign, so the guard only covers a future codegen change.
+static bool isOmpPrivateCopyInAssign(hlfir::AssignOp assign) {
+  auto privateOp = llvm::dyn_cast_or_null<mlir::omp::PrivateClauseOp>(
+      assign->getParentRegion()->getParentOp());
+  if (!privateOp)
+    return false;
+  mlir::Region &copyRegion = privateOp.getCopyRegion();
+  if (assign->getParentRegion() != &copyRegion)
+    return false;
+
+  // Only the entry block: another block's arguments are not the mold/clone
+  // pair.
+  mlir::Block &entry = copyRegion.front();
+  if (assign->getBlock() != &entry || entry.getNumArguments() != 2)
+    return false;
+
+  mlir::Value mold = privateOp.getCopyMoldArg();
+  if (assign.getLhs() != privateOp.getCopyPrivateArg())
+    return false;
+
+  // A POINTER firstprivate copies the association, so the data aliases.
+  auto isPointer = [](mlir::Value v) -> bool {
+    auto boxTy =
+        mlir::dyn_cast<fir::BaseBoxType>(fir::unwrapRefType(v.getType()));
+    return boxTy && boxTy.isPointer();
+  };
+  if (isPointer(mold))
+    return false;
+
+  mlir::Value rhs = assign.getRhs();
+  if (rhs == mold)
+    return true;
+  // A boxed privatizer loads the mold's descriptor first.
+  auto load = rhs.getDefiningOp<fir::LoadOp>();
+  return load && load.getMemref() == mold;
+}
 
 namespace {
 /// Expand hlfir.assign of array RHS to array LHS into a loop nest
@@ -104,7 +156,7 @@ public:
 
     bool rhsNeedsTemporary = false;
     if (rhs.isArray() && !mlir::isa<hlfir::ExprType>(rhs.getType()) &&
-        !assign.getTemporaryLhs()) {
+        !assign.getTemporaryLhs() && !isOmpPrivateCopyInAssign(assign)) {
       fir::AliasAnalysis aliasAnalysis;
       mlir::AliasResult aliasRes = aliasAnalysis.alias(lhs, rhs);
       if (!aliasRes.isNo()) {

--- a/flang/test/HLFIR/inline-hlfir-assign.fir
+++ b/flang/test/HLFIR/inline-hlfir-assign.fir
@@ -496,3 +496,100 @@ func.func @_QPtest_scalar_ref_from_lhs(%arg0: !fir.ref<!fir.array<10xf32>>) {
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
+
+// The copy-in writes the clone, which is distinct from the mold, so it inlines
+// even though alias analysis cannot prove it from the block arguments alone.
+omp.private {type = firstprivate} @_QFtestEc_firstprivate : !fir.box<!fir.array<1xf64>> copy {
+^bb0(%arg0: !fir.ref<!fir.box<!fir.array<1xf64>>>, %arg1: !fir.ref<!fir.box<!fir.array<1xf64>>>):
+  %0 = fir.load %arg0 : !fir.ref<!fir.box<!fir.array<1xf64>>>
+  hlfir.assign %0 to %arg1 : !fir.box<!fir.array<1xf64>>, !fir.ref<!fir.box<!fir.array<1xf64>>>
+  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.array<1xf64>>>)
+}
+// CHECK-LABEL:   omp.private {type = firstprivate} @_QFtestEc_firstprivate : !fir.box<!fir.array<1xf64>> copy {
+// CHECK:         ^bb0(%[[ORIG:.*]]: !fir.ref<!fir.box<!fir.array<1xf64>>>, %[[CLONE:.*]]: !fir.ref<!fir.box<!fir.array<1xf64>>>):
+// CHECK:           %[[RHS:.*]] = fir.load %[[ORIG]] : !fir.ref<!fir.box<!fir.array<1xf64>>>
+// CHECK:           %[[LHS:.*]] = fir.load %[[CLONE]] : !fir.ref<!fir.box<!fir.array<1xf64>>>
+// CHECK:           fir.do_loop
+// CHECK-NOT:       hlfir.assign %[[RHS]] to %[[CLONE]]
+// CHECK:           omp.yield(%[[CLONE]] : !fir.ref<!fir.box<!fir.array<1xf64>>>)
+// CHECK:         }
+
+// An assignment in the copy region that does not write the clone keeps its
+// aliasing check.
+omp.private {type = firstprivate} @_QFtestEd_firstprivate : !fir.box<!fir.array<1xf64>> copy {
+^bb0(%arg0: !fir.ref<!fir.box<!fir.array<1xf64>>>, %arg1: !fir.ref<!fir.box<!fir.array<1xf64>>>):
+  %0 = fir.load %arg1 : !fir.ref<!fir.box<!fir.array<1xf64>>>
+  hlfir.assign %0 to %arg0 : !fir.box<!fir.array<1xf64>>, !fir.ref<!fir.box<!fir.array<1xf64>>>
+  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.array<1xf64>>>)
+}
+// CHECK-LABEL:   omp.private {type = firstprivate} @_QFtestEd_firstprivate : !fir.box<!fir.array<1xf64>> copy {
+// CHECK:         ^bb0(%[[ORIG2:.*]]: !fir.ref<!fir.box<!fir.array<1xf64>>>, %[[CLONE2:.*]]: !fir.ref<!fir.box<!fir.array<1xf64>>>):
+// CHECK:           %[[RHS2:.*]] = fir.load %[[CLONE2]] : !fir.ref<!fir.box<!fir.array<1xf64>>>
+// CHECK:           hlfir.assign %[[RHS2]] to %[[ORIG2]] : !fir.box<!fir.array<1xf64>>, !fir.ref<!fir.box<!fir.array<1xf64>>>
+// CHECK:           omp.yield(%[[CLONE2]] : !fir.ref<!fir.box<!fir.array<1xf64>>>)
+// CHECK:         }
+
+// A copy-region assignment whose RHS is rooted in the clone rather than the
+// original can overlap the LHS, so it keeps its aliasing check.
+omp.private {type = firstprivate} @_QFtestEe_firstprivate : !fir.box<!fir.array<2xf64>> copy {
+^bb0(%arg0: !fir.ref<!fir.box<!fir.array<2xf64>>>, %arg1: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+  %0 = fir.load %arg1 : !fir.ref<!fir.box<!fir.array<2xf64>>>
+  hlfir.assign %0 to %arg1 : !fir.box<!fir.array<2xf64>>, !fir.ref<!fir.box<!fir.array<2xf64>>>
+  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.array<2xf64>>>)
+}
+// CHECK-LABEL:   omp.private {type = firstprivate} @_QFtestEe_firstprivate : !fir.box<!fir.array<2xf64>> copy {
+// CHECK:         ^bb0(%[[ORIG3:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>, %[[CLONE3:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+// CHECK:           %[[RHS3:.*]] = fir.load %[[CLONE3]] : !fir.ref<!fir.box<!fir.array<2xf64>>>
+// CHECK:           hlfir.assign %[[RHS3]] to %[[CLONE3]] : !fir.box<!fir.array<2xf64>>, !fir.ref<!fir.box<!fir.array<2xf64>>>
+// CHECK:           omp.yield(%[[CLONE3]] : !fir.ref<!fir.box<!fir.array<2xf64>>>)
+// CHECK:         }
+
+// An RHS from a call may designate unrelated memory, so it keeps its aliasing
+// check.
+func.func private @get_box(!fir.ref<!fir.box<!fir.array<2xf64>>>) -> !fir.box<!fir.array<2xf64>>
+omp.private {type = firstprivate} @_QFtestEf_firstprivate : !fir.box<!fir.array<2xf64>> copy {
+^bb0(%arg0: !fir.ref<!fir.box<!fir.array<2xf64>>>, %arg1: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+  %0 = fir.call @get_box(%arg0) : (!fir.ref<!fir.box<!fir.array<2xf64>>>) -> !fir.box<!fir.array<2xf64>>
+  hlfir.assign %0 to %arg1 : !fir.box<!fir.array<2xf64>>, !fir.ref<!fir.box<!fir.array<2xf64>>>
+  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.array<2xf64>>>)
+}
+// CHECK-LABEL:   omp.private {type = firstprivate} @_QFtestEf_firstprivate : !fir.box<!fir.array<2xf64>> copy {
+// CHECK:         ^bb0(%[[ORIG4:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>, %[[CLONE4:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+// CHECK:           %[[RHS4:.*]] = fir.call @get_box(%[[ORIG4]])
+// CHECK:           hlfir.assign %[[RHS4]] to %[[CLONE4]] : !fir.box<!fir.array<2xf64>>, !fir.ref<!fir.box<!fir.array<2xf64>>>
+// CHECK:           omp.yield(%[[CLONE4]] : !fir.ref<!fir.box<!fir.array<2xf64>>>)
+// CHECK:         }
+
+// Argument 1 of a block other than the entry block is not the clone, so an
+// assignment writing it keeps its aliasing check.
+omp.private {type = firstprivate} @_QFtestEg_firstprivate : !fir.box<!fir.array<2xf64>> copy {
+^bb0(%arg0: !fir.ref<!fir.box<!fir.array<2xf64>>>, %arg1: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+  %0 = fir.load %arg0 : !fir.ref<!fir.box<!fir.array<2xf64>>>
+  cf.br ^bb1(%arg0, %arg0 : !fir.ref<!fir.box<!fir.array<2xf64>>>, !fir.ref<!fir.box<!fir.array<2xf64>>>)
+^bb1(%a: !fir.ref<!fir.box<!fir.array<2xf64>>>, %b: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+  hlfir.assign %0 to %b : !fir.box<!fir.array<2xf64>>, !fir.ref<!fir.box<!fir.array<2xf64>>>
+  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.array<2xf64>>>)
+}
+// CHECK-LABEL:   omp.private {type = firstprivate} @_QFtestEg_firstprivate : !fir.box<!fir.array<2xf64>> copy {
+// CHECK:         ^bb0(%[[ORIG5:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>, %[[CLONE5:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+// CHECK:           %[[RHS5:.*]] = fir.load %[[ORIG5]]
+// CHECK:           cf.br ^bb1
+// CHECK:         ^bb1(%[[A:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>, %[[B:.*]]: !fir.ref<!fir.box<!fir.array<2xf64>>>):
+// CHECK:           hlfir.assign %[[RHS5]] to %[[B]] : !fir.box<!fir.array<2xf64>>, !fir.ref<!fir.box<!fir.array<2xf64>>>
+// CHECK:         }
+
+// A POINTER firstprivate shares data between mold and clone, so the copy
+// aliases and keeps its check despite matching the shape. Guards a future
+// codegen change; lowering uses fir.store, not hlfir.assign, today.
+omp.private {type = firstprivate} @_QFtestEp_firstprivate : !fir.box<!fir.ptr<!fir.array<?xf64>>> copy {
+^bb0(%arg0: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, %arg1: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>):
+  %0 = fir.load %arg0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>
+  hlfir.assign %0 to %arg1 : !fir.box<!fir.ptr<!fir.array<?xf64>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>
+  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+}
+// CHECK-LABEL:   omp.private {type = firstprivate} @_QFtestEp_firstprivate : !fir.box<!fir.ptr<!fir.array<?xf64>>> copy {
+// CHECK:         ^bb0(%[[MOLD:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, %[[CLONE:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>):
+// CHECK:           %[[RHS:.*]] = fir.load %[[MOLD]]
+// CHECK:           hlfir.assign %[[RHS]] to %[[CLONE]] : !fir.box<!fir.ptr<!fir.array<?xf64>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>
+// CHECK:           omp.yield(%[[CLONE]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+// CHECK:         }


### PR DESCRIPTION
The copy region of an `omp.private` firstprivate privatizer holds an `hlfir.assign` from the original host variable to the privatized clone:

```mlir
omp.private {type = firstprivate} @_QFkEc_firstprivate_box_1xf64 : !fir.box<!fir.array<1xf64>> init {
  ...
} copy {
^bb0(%arg0: !fir.ref<!fir.box<!fir.array<1xf64>>>, %arg1: !fir.ref<!fir.box<!fir.array<1xf64>>>):
  %0 = fir.load %arg0 : !fir.ref<!fir.box<!fir.array<1xf64>>>
  hlfir.assign %0 to %arg1 : !fir.box<!fir.array<1xf64>>, !fir.ref<!fir.box<!fir.array<1xf64>>>
  omp.yield(%arg1 : !fir.ref<!fir.box<!fir.array<1xf64>>>)
}
```

`InlineHLFIRAssign` declines to expand it: both sides are block arguments, `fir::AliasAnalysis` reports `MayAlias`, and `ArraySectionAnalyzer` returns `Unknown`. The assignment therefore lowers to a `_FortranAAssign` runtime call.

That call is not available in device code. This does not link today:

```fortran
subroutine k(a, b, n, c)
  real(8), intent(in)    :: a(*)
  real(8), intent(inout) :: b(*)
  integer, intent(in)    :: n
  real(8), intent(in)    :: c(1)
  integer :: i
  !$omp target teams distribute parallel do firstprivate(c)
  do i = 1, n
     b(i) = a(i) * c(1)
  end do
end subroutine
```

```
$ flang -fopenmp --offload-arch=gfx90a -O3 t.f90
ld.lld: error: undefined symbol: _FortranAAssign
```

Eight bytes of data, and it needs the runtime.

The op already documents the invariant that makes the aliasing question moot — from `OpenMPOps.td`:

> `%arg0` is the original host variable. `%arg1` represents the memory allocated for this private variable.

The clone is fresh memory allocated by the init region, so it cannot overlap the original. This patch skips the aliasing check for an assignment in a copy region whose LHS is that clone block argument, and the existing inlining then produces a plain element loop.

Alias analysis is not the right place for it: classifying `%arg1` as `SourceKind::Allocate` describes the *descriptor*, not the data it points at, so the query still comes back `MayAlias`. Proving the data is fresh means reasoning from the copy region into the init region.

An assignment in the copy region that does not write the clone keeps its aliasing check; there is a test for that.

### Results

gfx90a, one-element `real(8)` array, upstream at `02c51adb8ff2`:

| | before | after |
|---|---|---|
| offload link | `undefined symbol: _FortranAAssign` | links |
| `_FortranAAssign` in device IR | 3 (1 decl, 2 calls) | 0 |
| ScratchSize, device compile | 208 B/lane | 112 B/lane |
| result on MI210 | does not link | `2.0`, correct |

`ninja check-flang` is clean: 4602 passed, 11 expected failures, 190 unsupported, no failures.

The kernel still reports `Dynamic Stack: True` after this change. That is #211132, the un-inlined device-outlined target region, not this.

Fixes #203890. The downstream report is ROCm/llvm-project#2909, where the same runtime call shows up as a ~35 KB/lane spill and an occupancy collapse rather than a link failure. I have only verified the upstream half here — I cannot rebuild the AFAR drop that report is against.
