### PR TITLE
[NFC][SPIR-V] Reuse PartialOrderingVisitor DominatorTree in structurizer splitter

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -312,14 +312,18 @@ class SPIRVStructurizerImpl {
 
     void invalidate() {
       PDT.recalculate(F);
-      DT.recalculate(F);
       POV.emplace(F);
+    }
+
+    const DomTreeBuilder::BBDomTree &getDT() const {
+      return POV->getDominatorTree();
     }
 
     // Returns the list of blocks that belong to a SPIR-V loop construct,
     // including the continue construct.
     std::vector<BasicBlock *> getLoopConstructBlocks(BasicBlock *Header,
                                                      BasicBlock *Merge) {
+      const DomTreeBuilder::BBDomTree &DT = getDT();
       assert(DT.dominates(Header, Merge));
       std::vector<BasicBlock *> Output;
       POV->partialOrderVisit(*Header, [&](BasicBlock *BB) {
@@ -336,6 +340,7 @@ class SPIRVStructurizerImpl {
     // Returns the list of blocks that belong to a SPIR-V selection construct.
     std::vector<BasicBlock *>
     getSelectionConstructBlocks(DivergentConstruct *Node) {
+      const DomTreeBuilder::BBDomTree &DT = getDT();
       assert(DT.dominates(Node->Header, Node->Merge));
       BlockSet OutsideBlocks;
       OutsideBlocks.insert(Node->Merge);
@@ -362,6 +367,7 @@ class SPIRVStructurizerImpl {
     // Returns the list of blocks that belong to a SPIR-V switch construct.
     std::vector<BasicBlock *> getSwitchConstructBlocks(BasicBlock *Header,
                                                        BasicBlock *Merge) {
+      const DomTreeBuilder::BBDomTree &DT = getDT();
       assert(DT.dominates(Header, Merge));
 
       std::vector<BasicBlock *> Output;
@@ -382,6 +388,7 @@ class SPIRVStructurizerImpl {
     // Returns the list of blocks that belong to a SPIR-V case construct.
     std::vector<BasicBlock *> getCaseConstructBlocks(BasicBlock *Target,
                                                      BasicBlock *Merge) {
+      const DomTreeBuilder::BBDomTree &DT = getDT();
       assert(DT.dominates(Target, Merge));
 
       std::vector<BasicBlock *> Output;

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -100,6 +100,10 @@ public:
   // Build the visitor to operate on the function F.
   PartialOrderingVisitor(Function &F);
 
+  // Returns the dominator tree computed for the function this visitor
+  // operates on.
+  const DomTreeBuilder::BBDomTree &getDominatorTree() const { return DT; }
+
   // Returns true is |LHS| comes before |RHS| in the partial ordering.
   // If |LHS| and |RHS| have the same rank, the traversal order determines the
   // order (order is stable).


### PR DESCRIPTION
Based on the discussion in https://github.com/llvm/llvm-project/pull/211198