### PR TITLE
[analyzer] Match dangling subobjects by their base region in DanglingPtrDeref

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -107,8 +107,7 @@ DanglingPtrDerefBRVisitor::VisitNode(const ExplodedNode *N,
       S, BRC.getSourceManager(), N->getStackFrame());
   return std::make_shared<PathDiagnosticEventPiece>(
       Pos,
-      (llvm::Twine() + getRegionName(SourceRegion) + " is destroyed here")
-          .str(),
+      (getRegionName(SourceRegion) + llvm::Twine(" is destroyed here")).str(),
       true);
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -69,9 +69,9 @@ void DanglingPtrDeref::checkPostCall(const CallEvent &Call,
 static std::string getRegionName(const MemRegion *Reg) {
   // FIXME: Once the checker supports heap allocation, more region kinds
   // should be handled to produce the correct descriptive name.
-  if (const std::string RegName = Reg->getDescriptiveName(); !RegName.empty())
+  if (const std::string &RegName = Reg->getDescriptiveName(); !RegName.empty())
     return RegName;
-  return "the region";
+  llvm_unreachable("unhandled region");
 }
 
 void DanglingPtrDeref::reportUseAfterScope(const MemRegion *Region,

--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -66,13 +66,21 @@ void DanglingPtrDeref::checkPostCall(const CallEvent &Call,
   }
 }
 
+static std::string getRegionName(const MemRegion *Reg) {
+  // FIXME: Once the checker supports heap allocation, more region kinds
+  // should be handled to produce the correct descriptive name.
+  if (const std::string RegName = Reg->getDescriptiveName(); !RegName.empty())
+    return RegName;
+  return "the region";
+}
+
 void DanglingPtrDeref::reportUseAfterScope(const MemRegion *Region,
                                            ExplodedNode *N,
                                            CheckerContext &C) const {
   auto BR = std::make_unique<PathSensitiveBugReport>(
       BugMsg,
-      (llvm::Twine("Use of '") + Region->getString() +
-       "' after its lifetime ended."),
+      (llvm::Twine("Use of ") + getRegionName(Region) +
+       " after its lifetime ended."),
       N);
   BR->addVisitor<DanglingPtrDerefBRVisitor>(Region);
   C.emitReport(std::move(BR));
@@ -99,7 +107,7 @@ DanglingPtrDerefBRVisitor::VisitNode(const ExplodedNode *N,
       S, BRC.getSourceManager(), N->getStackFrame());
   return std::make_shared<PathDiagnosticEventPiece>(
       Pos,
-      (llvm::Twine("'") + SourceRegion->getString() + "' is destroyed here")
+      (llvm::Twine() + getRegionName(SourceRegion) + " is destroyed here")
           .str(),
       true);
 }

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -73,7 +73,7 @@ std::vector<const MemRegion *> lifetime_modeling::getDanglingRegionsAfterReturn(
 
 bool lifetime_modeling::isDeallocated(ProgramStateRef State,
                                       const MemRegion *Region) {
-  return State->contains<DeallocatedSourceSet>(Region);
+  return State->contains<DeallocatedSourceSet>(Region->getBaseRegion());
 }
 
 static ProgramStateRef bindSource(ProgramStateRef State, SVal RetVal,

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -117,13 +117,21 @@ struct MyBuffer {
   char buffer[8];
 };
 struct MyStruct { int x; };
+
 struct Inner { int x; };
+
 struct Outer { struct Inner inner; };
+
+struct A {
+  struct B { int x; };
+  B b;
+};
+
 
 char member_subregion_dangling_deref() {
   const char *p = nullptr;
   {
-    struct MyBuffer tmp_buffer = {};
+    MyBuffer tmp_buffer = {};
     p = tmp_buffer.buffer;
   }
   // expected-note@-1 {{'tmp_buffer.buffer[0]' is destroyed here}}
@@ -133,11 +141,12 @@ char member_subregion_dangling_deref() {
 }
 
 void opaque(const char *);
+void opaque_pp(const char **);
 
 void passing_dangling_to_call() {
   const char *p = nullptr;
   {
-    struct MyBuffer tmp_buffer = {};
+    MyBuffer tmp_buffer = {};
     p = tmp_buffer.buffer;
   }
   // expected-note@-1 {{'tmp_buffer.buffer[0]' is destroyed here}}
@@ -148,17 +157,28 @@ void passing_dangling_to_call() {
 
 char member_subregion_alive_deref() {
   {
-    struct MyBuffer tmp_buffer = {};
+    MyBuffer tmp_buffer = {};
     const char *p = tmp_buffer.buffer;
-    opaque(p); //   no-warning
-    return *p; //   no-warning
+    opaque(p); // no-warning
+    return *p; // no-warning
   }
+}
+
+char member_subregion_alive_deref_pp() {
+  const char *ptr = nullptr;
+  const char **pp = &ptr;
+  {
+    MyBuffer tmp_buffer = {};
+    ptr = tmp_buffer.buffer;
+  }
+  opaque_pp(pp);
+  return **pp; // no-warning  
 }
 
 void arr_elem_subreg_dangling_deref() {
   int *ptr = nullptr;
   {
-    int local_arr[5];
+    int local_arr[4];
     ptr = &local_arr[1];
   }
   // expected-note@-1 {{'local_arr[1]' is destroyed here}}
@@ -167,10 +187,10 @@ void arr_elem_subreg_dangling_deref() {
   // expected-note@-2    {{Use of 'local_arr[1]' after its lifetime ended}}
 }
 
-char member_array_elem__dangling_deref() {
+char member_array_elem_dangling_deref() {
   const char *p = nullptr;
   {
-    struct MyBuffer tmp_buffer = {};
+    MyBuffer tmp_buffer = {};
     p = tmp_buffer.buffer + 3;
   }
   // expected-note@-1 {{'tmp_buffer.buffer[3]' is destroyed here}}
@@ -179,10 +199,22 @@ char member_array_elem__dangling_deref() {
   // expected-note@-2    {{Use of 'tmp_buffer.buffer[3]' after its lifetime ended}}
 }
 
+char member_array_out_of_bounds_dangling_deref() {
+  const char *p = nullptr;
+  {
+    MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer + 10;
+  }
+  // expected-note@-1 {{'tmp_buffer.buffer[10]' is destroyed here}}
+  return *p;
+  // expected-warning@-1 {{Use of 'tmp_buffer.buffer[10]' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer.buffer[10]' after its lifetime ended}}
+}
+
 int struct_field_dangling_deref() {
   int *p = nullptr;
   {
-    struct MyStruct s = {};
+    MyStruct s = {};
     p = &s.x;
   }
   // expected-note@-1 {{'s.x' is destroyed here}}
@@ -194,7 +226,7 @@ int struct_field_dangling_deref() {
 int struct_array_element_dangling_deref() {
   int *p = nullptr;
   {
-    struct MyStruct arr[4] = {};
+    MyStruct arr[4] = {};
     p = &arr[2].x;
   }
   // expected-note@-1 {{'arr[2].x' is destroyed here}}
@@ -206,11 +238,36 @@ int struct_array_element_dangling_deref() {
 int nested_field_dangling_deref() {
   int *p = nullptr;
   {
-    struct Outer o = {};
+    Outer o = {};
     p = &o.inner.x;
   }
   // expected-note@-1 {{'o.inner.x' is destroyed here}}
   return *p;
   // expected-warning@-1 {{Use of 'o.inner.x' after its lifetime ended}}
   // expected-note@-2    {{Use of 'o.inner.x' after its lifetime ended}}
+}
+
+int nested_type_field_dangling_deref() {
+  int *p = nullptr;
+  {
+    A a = {};
+    p = &a.b.x;
+  }
+  // expected-note@-1 {{'a.b.x' is destroyed here}}
+  return *p;
+  // expected-warning@-1 {{Use of 'a.b.x' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'a.b.x' after its lifetime ended}}
+}
+
+char member_subregion_dangling_deref_increment() {
+  const char *p = nullptr;
+  {
+    MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer;
+  }
+  // expected-note@-1 {{'tmp_buffer.buffer[1]' is destroyed here}}
+  p++;
+  return *p;
+  // expected-warning@-1 {{Use of 'tmp_buffer.buffer[1]' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer.buffer[1]' after its lifetime ended}}
 }

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -116,18 +116,20 @@ void inlined_callee_single_report() {
 struct MyBuffer {
   char buffer[8];
 };
+struct MyStruct { int x; };
+struct Inner { int x; };
+struct Outer { struct Inner inner; };
 
-void member_subregion_dangling_deref() {
+char member_subregion_dangling_deref() {
   const char *p = nullptr;
   {
     struct MyBuffer tmp_buffer = {};
     p = tmp_buffer.buffer;
   }
   // expected-note@-1 {{'tmp_buffer.buffer[0]' is destroyed here}}
-  char c = *p;
+  return *p; 
   // expected-warning@-1 {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
   // expected-note@-2    {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
-  (void)c;
 }
 
 void opaque(const char *);
@@ -144,13 +146,12 @@ void passing_dangling_to_call() {
   // expected-note@-2    {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
 }
 
-void member_subregion_alive_deref() {
+char member_subregion_alive_deref() {
   {
     struct MyBuffer tmp_buffer = {};
     const char *p = tmp_buffer.buffer;
     opaque(p); //   no-warning
-    char c = *p; // no-warning
-    (void)c;
+    return *p; //   no-warning
   }
 }
 
@@ -164,4 +165,52 @@ void arr_elem_subreg_dangling_deref() {
   *ptr = 7;
   // expected-warning@-1 {{Use of 'local_arr[1]' after its lifetime ended}}
   // expected-note@-2    {{Use of 'local_arr[1]' after its lifetime ended}}
+}
+
+char member_array_elem__dangling_deref() {
+  const char *p = nullptr;
+  {
+    struct MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer + 3;
+  }
+  // expected-note@-1 {{'tmp_buffer.buffer[3]' is destroyed here}}
+  return *p;
+  // expected-warning@-1 {{Use of 'tmp_buffer.buffer[3]' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer.buffer[3]' after its lifetime ended}}
+}
+
+int struct_field_dangling_deref() {
+  int *p = nullptr;
+  {
+    struct MyStruct s = {};
+    p = &s.x;
+  }
+  // expected-note@-1 {{'s.x' is destroyed here}}
+  return *p;
+  // expected-warning@-1 {{Use of 's.x' after its lifetime ended}}
+  // expected-note@-2    {{Use of 's.x' after its lifetime ended}}
+}
+
+int struct_array_element_dangling_deref() {
+  int *p = nullptr;
+  {
+    struct MyStruct arr[4] = {};
+    p = &arr[2].x;
+  }
+  // expected-note@-1 {{'arr[2].x' is destroyed here}}
+  return *p;
+  // expected-warning@-1 {{Use of 'arr[2].x' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'arr[2].x' after its lifetime ended}}
+}
+
+int nested_field_dangling_deref() {
+  int *p = nullptr;
+  {
+    struct Outer o = {};
+    p = &o.inner.x;
+  }
+  // expected-note@-1 {{'o.inner.x' is destroyed here}}
+  return *p;
+  // expected-warning@-1 {{Use of 'o.inner.x' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'o.inner.x' after its lifetime ended}}
 }

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -112,3 +112,56 @@ void inlined_callee_single_report() {
   // expected-note@-1 {{Calling 'deref_param'}}
   (void)r;
 }
+
+struct MyBuffer {
+  char buffer[8];
+};
+
+void member_subregion_dangling_deref() {
+  const char *p = nullptr;
+  {
+    struct MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer;
+  }
+  // expected-note@-1 {{'tmp_buffer.buffer[0]' is destroyed here}}
+  char c = *p;
+  // expected-warning@-1 {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
+  (void)c;
+}
+
+void opaque(const char *);
+
+void passing_dangling_to_call() {
+  const char *p = nullptr;
+  {
+    struct MyBuffer tmp_buffer = {};
+    p = tmp_buffer.buffer;
+  }
+  // expected-note@-1 {{'tmp_buffer.buffer[0]' is destroyed here}}
+  opaque(p);
+  // expected-warning@-1 {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'tmp_buffer.buffer[0]' after its lifetime ended}}
+}
+
+void member_subregion_alive_deref() {
+  {
+    struct MyBuffer tmp_buffer = {};
+    const char *p = tmp_buffer.buffer;
+    opaque(p); //   no-warning
+    char c = *p; // no-warning
+    (void)c;
+  }
+}
+
+void arr_elem_subreg_dangling_deref() {
+  int *ptr = nullptr;
+  {
+    int local_arr[5];
+    ptr = &local_arr[1];
+  }
+  // expected-note@-1 {{'local_arr[1]' is destroyed here}}
+  *ptr = 7;
+  // expected-warning@-1 {{Use of 'local_arr[1]' after its lifetime ended}}
+  // expected-note@-2    {{Use of 'local_arr[1]' after its lifetime ended}}
+}


### PR DESCRIPTION
Currently the `DanglingPtrDeref` checker only records the whole object's region as deallocated. However, dangling pointers often refer to subobjects (e.g., a struct field or an element of an array). With the change in this PR, `isDeallocated` now checks whether a region's base region is in the `DeallocatedSourceSet`.