### PR TITLE
[libc++] Defer removal of two escape hatches to LLVM 25

### DIFF
--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -60,15 +60,16 @@ Potentially breaking changes
 Announcements About Future Releases
 -----------------------------------
 
+- ``std::allocator`` is trivially default constructible since LLVM 22. In LLVM 23 and LLVM 24, the ``_LIBCPP_DEPRECATED_ABI_NON_TRIVIAL_ALLOCATOR``
+  macro was provided as an escape hatch to revert that change. This escape hatch will be removed in LLVM 25 if there is no
+  evidence of it being useful.
+
+- ``bitset::operator[]`` returns ``bool`` since LLVM 22, fixing a conformance bug. In LLVM 23 and LLVM 24, the ``_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF``
+  macro was provided as an escape hatch to revert that change. This escape hatch will be removed in LLVM 25 if there is no
+  evidence of it being useful.
 
 ABI Affecting Changes
 ---------------------
-
-- TODO: ``std::allocator`` is trivially default constructible since LLVM 22. In LLVM 23, the ``_LIBCPP_DEPRECATED_ABI_NON_TRIVIAL_ALLOCATOR``
-  macro was provided as an escape hatch, but it has been removed in LLVM 24 since there was no evidence of it being useful.
-
-- TODO: ``bitset::operator[]`` returns ``bool`` since LLVM 22, fixing a conformance bug. In LLVM 23, the ``_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF``
-  macro was provided as an escape hatch, but it has been removed in LLVM 24 since there was no evidence of it being useful.
 
 Build System Changes
 --------------------

--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -60,13 +60,13 @@ Potentially breaking changes
 Announcements About Future Releases
 -----------------------------------
 
-- ``std::allocator`` is trivially default constructible since LLVM 22. In LLVM 23 and LLVM 24, the ``_LIBCPP_DEPRECATED_ABI_NON_TRIVIAL_ALLOCATOR``
-  macro was provided as an escape hatch to revert that change. This escape hatch will be removed in LLVM 25 if there is no
-  evidence of it being useful.
+- ``std::allocator`` is trivially default constructible since LLVM 22. In LLVM 23 and LLVM 24, the
+  ``_LIBCPP_DEPRECATED_ABI_NON_TRIVIAL_ALLOCATOR`` macro was provided as an escape hatch to revert that change.
+  This escape hatch will be removed in LLVM 25 if there is no evidence of it being useful.
 
-- ``bitset::operator[]`` returns ``bool`` since LLVM 22, fixing a conformance bug. In LLVM 23 and LLVM 24, the ``_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF``
-  macro was provided as an escape hatch to revert that change. This escape hatch will be removed in LLVM 25 if there is no
-  evidence of it being useful.
+- ``bitset::operator[]`` returns ``bool`` since LLVM 22, fixing a conformance bug. In LLVM 23 and LLVM 24, the
+  ``_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF`` macro was provided as an escape hatch to revert
+  that change. This escape hatch will be removed in LLVM 25 if there is no evidence of it being useful.
 
 ABI Affecting Changes
 ---------------------

--- a/libcxx/include/__memory/allocator.h
+++ b/libcxx/include/__memory/allocator.h
@@ -60,7 +60,7 @@ struct __non_trivially_default_constructible_if<true, _Unique> {
 
 template <class _Tp>
 class allocator
-// TODO(LLVM 24): Remove the opt-out
+// TODO(LLVM 25): Remove the opt-out
 #ifdef _LIBCPP_DEPRECATED_ABI_NON_TRIVIAL_ALLOCATOR
     : __non_trivially_default_constructible_if<!is_void<_Tp>::value, allocator<_Tp> >
 #endif

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -680,7 +680,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset& flip(size_t __pos);
 
   // element access:
-  // TODO(LLVM 24): Remove the opt-out
+  // TODO(LLVM 25): Remove the opt-out
 #  ifndef _LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator[](size_t __p) const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__p < _Size, "bitset::operator[] index out of bounds");


### PR DESCRIPTION
Rather than removing the escape hatches for trivially default constructible allocator and bitset's const reference type in LLVM 24, keep them around for another release since they have not been widely deployed yet.