### PR TITLE
[SPIR-V] Fix SPIRVTools download step failing on rerun

### DIFF
--- a/llvm/tools/spirv-tools/CMakeLists.txt
+++ b/llvm/tools/spirv-tools/CMakeLists.txt
@@ -19,9 +19,7 @@ if (NOT SPIRV_DIS OR NOT SPIRV_VAL OR NOT SPIRV_AS OR NOT SPIRV_LINK)
     BINARY_DIR ${BINARY_DIR}
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${BINARY_DIR} --target spirv-dis spirv-val spirv-as spirv-link
     BUILD_BYPRODUCTS ${BINARY_DIR}/tools/spirv-dis ${BINARY_DIR}/tools/spirv-val ${BINARY_DIR}/tools/spirv-as ${BINARY_DIR}/tools/spirv-link
-    DOWNLOAD_COMMAND git clone https://github.com/KhronosGroup/SPIRV-Tools.git SPIRVTools &&
-      cd SPIRVTools &&
-      ${Python3_EXECUTABLE} utils/git-sync-deps
+    PATCH_COMMAND ${Python3_EXECUTABLE} utils/git-sync-deps
     UPDATE_COMMAND git pull origin main &&
       ${Python3_EXECUTABLE} utils/git-sync-deps
     # Don't auto-update on every build.


### PR DESCRIPTION
Customized DOWNLOAD_COMMAND ran a raw `git clone`, which fails with "destination path already exists" whenever ninja reruns the download step against an already cloned checkout. Use the native GIT_REPOSITORY/GIT_TAG (with default DOWNLOAD_COMMAND) step instead, which handles this case correctly