### PR TITLE
[CI] Drop replacement comment in monolithic-* workflows

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -9,8 +9,7 @@
 
 #
 # This script performs a monolithic build of the monorepo and runs the tests of
-# most projects on Linux. This should be replaced by per-project scripts that
-# run only the relevant tests.
+# most projects on Linux.
 #
 
 source .ci/utils.sh

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -9,8 +9,7 @@
 
 #
 # This script performs a monolithic build of the monorepo and runs the tests of
-# most projects on Windows. This should be replaced by per-project scripts that
-# run only the relevant tests.
+# most projects on Windows.
 #
 
 source .ci/utils.sh


### PR DESCRIPTION
These workflows have been around for a while and I don't think we have any plans to migrate to per project specific testing given how the LLVM build is currently wired up. I believe these comments were from an era where it was believed that testing would look a lot more like libc++ across the board with projects contributing all of their own individual configurations.