### PR TITLE
[NFC][analyzer] Apply any_of to detect destructors stack frame

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -49,8 +49,9 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // to outlive the object being destroyed.
     if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
           return isa<CXXDestructorDecl>(Frame.getDecl());
-        }))
+        })) {
       return false;
+    }
 
     if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
       return true;

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -49,7 +49,6 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // to outlive the object being destroyed.
     if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
           return isa<CXXDestructorDecl>(Frame.getDecl());
-          return true;
         }))
       return false;
 

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -47,11 +47,11 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // the warning should be suppressed. When a lifetimebound method
     // is called from a destructor then its return value is not expected
     // to outlive the object being destroyed.
-    for (const StackFrame *DtorSF = CurrentSF; DtorSF;
-         DtorSF = DtorSF->getParent()) {
-      if (isa<CXXDestructorDecl>(DtorSF->getDecl()))
-        return false;
-    }
+    if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
+          return isa<CXXDestructorDecl>(Frame.getDecl());
+          return true;
+        }))
+      return false;
 
     if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
       return true;


### PR DESCRIPTION
Since #210938 is merged I have also applied the same parent-chain helper to detect if a destructor's stack frame is on the current stack. 