### PR TITLE
[HIP][Driver] Use alternative `/lib64` or `/lib` depending on `amdhip64` library location

### DIFF
--- a/clang/include/clang/Driver/RocmInstallationDetector.h
+++ b/clang/include/clang/Driver/RocmInstallationDetector.h
@@ -267,7 +267,7 @@ public:
                          llvm::opt::ArgStringList &CC1Args) const;
 
   void detectDeviceLibrary();
-  void detectHIPRuntime();
+  void detectHIPRuntime(const llvm::Triple &HostTriple);
 
   /// Get the values for --rocm-device-lib-path arguments
   ArrayRef<std::string> getRocmDeviceLibPathArg() const {

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -456,8 +456,13 @@ void RocmInstallationDetector::detectHIPRuntime() {
     llvm::sys::path::append(BinPath, "bin");
     IncludePath = InstallPath;
     llvm::sys::path::append(IncludePath, "include");
+
+    // Fallback to rocm/lib64 if rocm/lib doesn't exist.
     LibPath = InstallPath;
     llvm::sys::path::append(LibPath, "lib");
+    if (!D.getVFS().exists(LibPath) && D.getVFS().exists(LibPath + "64"))
+      LibPath.append("64");
+
     SharePath = InstallPath;
     llvm::sys::path::append(SharePath, "share");
 

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -368,7 +368,7 @@ RocmInstallationDetector::RocmInstallationDetector(
   }
 
   if (DetectHIPRuntime)
-    detectHIPRuntime();
+    detectHIPRuntime(HostTriple);
 }
 
 void RocmInstallationDetector::detectDeviceLibrary() {
@@ -434,7 +434,8 @@ void RocmInstallationDetector::detectDeviceLibrary() {
   }
 }
 
-void RocmInstallationDetector::detectHIPRuntime() {
+void RocmInstallationDetector::detectHIPRuntime(
+    const llvm::Triple &HostTriple) {
   SmallVector<Candidate, 4> HIPSearchDirs;
   if (!HIPPathArg.empty())
     HIPSearchDirs.emplace_back(HIPPathArg.str());
@@ -457,11 +458,22 @@ void RocmInstallationDetector::detectHIPRuntime() {
     IncludePath = InstallPath;
     llvm::sys::path::append(IncludePath, "include");
 
-    // Fallback to rocm/lib64 if rocm/lib doesn't exist.
-    LibPath = InstallPath;
-    llvm::sys::path::append(LibPath, "lib");
-    if (!D.getVFS().exists(LibPath) && D.getVFS().exists(LibPath + "64"))
-      LibPath.append("64");
+    // ROCm's lib path is the place where the amdhsa64 library is located.
+    // Probe for it and fallback to /rocm/lib if we cannot find it.
+    StringRef LibAmdHip64 =
+        HostTriple.isOSMSVCRT() ? "amdhip64.lib" : "libamdhip64.so";
+    for (StringRef LibPathSuffix : {"lib", "lib64"}) {
+      SmallString<0> LibAmdHip64Location;
+      llvm::sys::path::append(LibAmdHip64Location, InstallPath, LibPathSuffix,
+                              LibAmdHip64);
+      if (FS.exists(LibAmdHip64Location)) {
+        llvm::sys::path::append(LibPath, InstallPath, LibPathSuffix);
+        break;
+      }
+    }
+
+    if (LibPath.empty())
+      llvm::sys::path::append(LibPath, InstallPath, "lib");
 
     SharePath = InstallPath;
     llvm::sys::path::append(SharePath, "share");

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -462,6 +462,7 @@ void RocmInstallationDetector::detectHIPRuntime(
     // Probe for it and fallback to /rocm/lib if we cannot find it.
     StringRef LibAmdHip64 =
         HostTriple.isOSMSVCRT() ? "amdhip64.lib" : "libamdhip64.so";
+    LibPath.clear();
     for (StringRef LibPathSuffix : {"lib", "lib64"}) {
       SmallString<0> LibAmdHip64Location;
       llvm::sys::path::append(LibAmdHip64Location, InstallPath, LibPathSuffix,

--- a/clang/test/Driver/Inputs/rocm/lib/amdhip64.lib
+++ b/clang/test/Driver/Inputs/rocm/lib/amdhip64.lib
@@ -1,0 +1,1 @@
+Intentionally empty.

--- a/clang/test/Driver/Inputs/rocm/lib/libamdhip64.so
+++ b/clang/test/Driver/Inputs/rocm/lib/libamdhip64.so
@@ -1,0 +1,1 @@
+Intentionally empty.

--- a/clang/test/Driver/rocm-detect-libdir.hip
+++ b/clang/test/Driver/rocm-detect-libdir.hip
@@ -1,0 +1,26 @@
+// UNSUPPORTED: system-windows
+
+// Test that /lib64 is used if /lib doesn't exist.
+// RUN: rm -rf %t/*
+// RUN: mkdir -p %t/rocm
+// RUN: cp -R %S/Inputs/rocm/bin %t/rocm/bin
+// RUN: cp -R %S/Inputs/rocm/amdgcn %t/rocm/amdgcn
+// RUN: cp -R %S/Inputs/rocm/include %t/rocm/include
+// RUN: cp -R %S/Inputs/rocm/lib %t/rocm/lib64
+// RUN: %clang -### -target x86_64-linux-gnu --offload-arch=gfx1010 \
+// RUN:   --rocm-path=%t/rocm --hip-link %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=LIB64 %s
+
+// Test that in the presence of both /lib and /lib64, the former is preferred.
+// RUN: cp -R %S/Inputs/rocm/lib %t/rocm/lib
+// RUN: %clang -### -target x86_64-linux-gnu --offload-arch=gfx1010 \
+// RUN:   --rocm-path=%t/rocm --hip-link %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=LIB %s
+
+// LIB64: "[[ROCM:[^"]+/rocm]]/lib64/libamdhip64.so"
+// LIB64: "-L[[ROCM]]/lib64"
+// LIB64-NOT: "[[ROCM]]/lib/libamdhip64.so"
+
+// LIB: "[[ROCM:[^"]+/rocm]]/lib/libamdhip64.so"
+// LIB: "-L[[ROCM]]/lib"
+// LIB-NOT: "[[ROCM]]/lib64/libamdhip64.so"

--- a/clang/test/Driver/rocm-detect-libdir.hip
+++ b/clang/test/Driver/rocm-detect-libdir.hip
@@ -7,15 +7,25 @@
 // RUN: cp -R %S/Inputs/rocm/amdgcn %t/rocm/amdgcn
 // RUN: cp -R %S/Inputs/rocm/include %t/rocm/include
 // RUN: cp -R %S/Inputs/rocm/lib %t/rocm/lib64
+
 // RUN: %clang -### -target x86_64-linux-gnu --offload-arch=gfx1010 \
 // RUN:   --rocm-path=%t/rocm --hip-link %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=LIB64 %s
 
+// RUN: %clang -### -target x86_64-windows-msvc --offload-arch=gfx1010 \
+// RUN:   --rocm-path=%t/rocm --hip-link %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=WIN_LIB64 %s
+
 // Test that in the presence of both /lib and /lib64, the former is preferred.
 // RUN: cp -R %S/Inputs/rocm/lib %t/rocm/lib
+
 // RUN: %clang -### -target x86_64-linux-gnu --offload-arch=gfx1010 \
 // RUN:   --rocm-path=%t/rocm --hip-link %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=LIB %s
+
+// RUN: %clang -### -target x86_64-windows-msvc --offload-arch=gfx1010 \
+// RUN:   --rocm-path=%t/rocm --hip-link %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=WIN_LIB %s
 
 // LIB64: "[[ROCM:[^"]+/rocm]]/lib64/libamdhip64.so"
 // LIB64: "-L[[ROCM]]/lib64"
@@ -24,3 +34,9 @@
 // LIB: "[[ROCM:[^"]+/rocm]]/lib/libamdhip64.so"
 // LIB: "-L[[ROCM]]/lib"
 // LIB-NOT: "[[ROCM]]/lib64/libamdhip64.so"
+
+// WIN_LIB64: "-libpath:{{.*rocm[/\\]lib64}}" "amdhip64.lib"
+// WIN_LIB64-NOT: "-libpath:{{.*rocm[/\\]lib}}" "amdhip64.lib"
+
+// WIN_LIB: "-libpath:{{.*rocm[/\\]lib}}" "amdhip64.lib"
+// WIN_LIB-NOT: "-libpath:{{.*rocm[/\\]lib64}}" "amdhip64.lib"


### PR DESCRIPTION
On non-standard ROCm installations, `libamdhip64.so` may be under `/lib64` instead of `/lib`. To acomodate for these, if `/lib/libamdhip64.so` does not exists and `/lib64` does, use the later.
On windows we check for `amdhip64.lib`.

If both exist `/lib` is preferred.

By default we conservatively use `/lib`.

Related to LCOMPILER-2495.