### PR TITLE
[clang-format] Don't case-fix pp-numbers in #include directives

### DIFF
--- a/clang/lib/Format/NumericLiteralCaseFixer.cpp
+++ b/clang/lib/Format/NumericLiteralCaseFixer.cpp
@@ -138,7 +138,25 @@ NumericLiteralCaseFixer::process(const Environment &Env,
   Token Tok;
   tooling::Replacements Result;
 
-  for (bool Skip = false; !Lex.LexFromRawLexer(Tok);) {
+  for (bool Skip = false, AfterHash = false, InInclude = false;
+       !Lex.LexFromRawLexer(Tok);) {
+    // Header names in #include/#import can contain pp-numbers such as the
+    // "16header" in <path/to/16header.h> that lex as numeric_constant but are
+    // not numeric literals, so skip literals on those directive lines.
+    if (Tok.isAtStartOfLine()) {
+      InInclude = false;
+      AfterHash = false;
+    }
+    if (AfterHash) {
+      AfterHash = false;
+      if (Tok.is(tok::raw_identifier)) {
+        const StringRef Kw = Tok.getRawIdentifier();
+        InInclude = (Kw == "include" || Kw == "include_next" || Kw == "import");
+      }
+    }
+    if (Tok.is(tok::hash) && Tok.isAtStartOfLine())
+      AfterHash = true;
+
     // Skip tokens that are too small to contain a formattable literal.
     // Size=2 is the smallest possible literal that could contain formattable
     // components, for example "1u".
@@ -157,7 +175,7 @@ NumericLiteralCaseFixer::process(const Environment &Env,
       continue;
     }
 
-    if (Skip || Tok.isNot(tok::numeric_constant) ||
+    if (Skip || Tok.isNot(tok::numeric_constant) || InInclude ||
         !AffectedRangeMgr.affectsCharSourceRange(
             CharSourceRange::getCharRange(Location, Tok.getEndLoc()))) {
       continue;

--- a/clang/unittests/Format/NumericLiteralCaseTest.cpp
+++ b/clang/unittests/Format/NumericLiteralCaseTest.cpp
@@ -340,6 +340,27 @@ TEST_F(NumericLiteralCaseTest, UnderScoreSeparatorLanguages) {
   verifyFormat("o = 0o0_10_010;", "o = 0O0_10_010;", Style);
 }
 
+TEST_F(NumericLiteralCaseTest, IgnoresIncludeDirectives) {
+  // pp-numbers in a header name lex as numeric_constant but are not numeric
+  // literals, so they must be left untouched.
+  constexpr StringRef A("#include <path/to/16header.h>");
+  constexpr StringRef B("#include_next <16foo.h>");
+  constexpr StringRef C("#import <16bar.h>");
+  // A literal in any other directive must still be formatted.
+  constexpr StringRef D("#define MASK 0xff;");
+  verifyFormat(A);
+  verifyFormat(B);
+  verifyFormat(C);
+  verifyFormat(D);
+
+  auto Style = getLLVMStyle();
+  Style.NumericLiteralCase.HexDigit = FormatStyle::NLCS_Upper;
+  verifyFormat(A, Style);
+  verifyFormat(B, Style);
+  verifyFormat(C, Style);
+  verifyFormat("#define MASK 0xFF;", D, Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
NumericLiteralCaseFixer transformed pp-numbers such as the "16header" in <path/to/16header.h>. These lex as numeric_constant but are not numeric literals, so casing them corrupted header names in #include/#import directives.

Fix skips numeric_constant tokens on #include, #include_next and #import directive lines.

Adresses #200731