### PR TITLE
[libc] Fix float128-to-integer conversion UB 

### DIFF
--- a/libc/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/src/__support/FPUtil/CMakeLists.txt
@@ -310,6 +310,7 @@ add_header_library(
     libc.src.__support.macros.attributes
     libc.src.__support.macros.config
     libc.src.__support.uint128
+    libc.src.__support.CPP.limits
 )
 
 add_subdirectory(generic)

--- a/libc/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/src/__support/FPUtil/CMakeLists.txt
@@ -303,6 +303,7 @@ add_header_library(
     .comparison_operations
     .dyadic_float
     libc.hdr.stdint_proxy
+    libc.src.__support.CPP.limits
     libc.src.__support.CPP.type_traits
     libc.src.__support.FPUtil.generic.add_sub
     libc.src.__support.FPUtil.generic.div
@@ -310,7 +311,6 @@ add_header_library(
     libc.src.__support.macros.attributes
     libc.src.__support.macros.config
     libc.src.__support.uint128
-    libc.src.__support.CPP.limits
 )
 
 add_subdirectory(generic)

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -472,8 +472,7 @@ template <size_t Bits> struct DyadicFloat {
       // exponents coming in to this function _shouldn't_ be that large). The
       // result should always end up as a positive size_t.
       size_t shift = -static_cast<size_t>(exponent);
-      size_t limit =
-          static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits);
+      size_t limit = cpp::numeric_limits<MantissaType>::digits;
       if (shift >= limit)
         new_mant = 0;
       else

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -472,10 +472,9 @@ template <size_t Bits> struct DyadicFloat {
       // exponents coming in to this function _shouldn't_ be that large). The
       // result should always end up as a positive size_t.
       size_t exp = -static_cast<size_t>(exponent);
-      size_t limit = static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits);
+      size_t limit =
+          static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits);
       size_t shift = exp < limit ? exp : limit;
-      new_mant >>= shift;
-
       new_mant >>= shift;
     }
 

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -471,9 +471,11 @@ template <size_t Bits> struct DyadicFloat {
       // to avoid undefined behavior negating INT_MIN as an integer (although
       // exponents coming in to this function _shouldn't_ be that large). The
       // result should always end up as a positive size_t.
-      size_t shift = cpp::min(
-          -static_cast<size_t>(exponent),
-          static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits));
+      size_t exp = -static_cast<size_t>(exponent);
+      size_t limit = static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits);
+      size_t shift = exp < limit ? exp : limit;
+      new_mant >>= shift;
+
       new_mant >>= shift;
     }
 

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -471,11 +471,13 @@ template <size_t Bits> struct DyadicFloat {
       // to avoid undefined behavior negating INT_MIN as an integer (although
       // exponents coming in to this function _shouldn't_ be that large). The
       // result should always end up as a positive size_t.
-      size_t exp = -static_cast<size_t>(exponent);
+      size_t shift = -static_cast<size_t>(exponent);
       size_t limit =
           static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits);
-      size_t shift = exp < limit ? exp : limit;
-      new_mant >>= shift;
+      if (shift >= limit)
+        new_mant = 0;
+      else
+        new_mant >>= shift;
     }
 
     if (sign.is_neg()) {

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -471,7 +471,9 @@ template <size_t Bits> struct DyadicFloat {
       // to avoid undefined behavior negating INT_MIN as an integer (although
       // exponents coming in to this function _shouldn't_ be that large). The
       // result should always end up as a positive size_t.
-      size_t shift = -static_cast<size_t>(exponent);
+      size_t shift = cpp::min(
+          -static_cast<size_t>(exponent),
+          static_cast<size_t>(cpp::numeric_limits<MantissaType>::digits));
       new_mant >>= shift;
     }
 

--- a/libc/src/__support/FPUtil/float128.h
+++ b/libc/src/__support/FPUtil/float128.h
@@ -10,6 +10,7 @@
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT128_H
 
 #include "hdr/stdint_proxy.h"
+#include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/cast.h"
 #include "src/__support/FPUtil/comparison_operations.h"
@@ -69,13 +70,29 @@ struct Float128 {
 
   template <typename T, cpp::enable_if_t<cpp::is_integral_v<T>, int> = 0>
   LIBC_INLINE constexpr explicit operator T() const {
+    constexpr T MIN_T = cpp::numeric_limits<T>::min();
+    constexpr T MAX_T = cpp::numeric_limits<T>::max();
     FPBits<Float128> x_bits(*this);
     // Raise FE_INVALID for inf and NaN
     if (x_bits.is_inf_or_nan()) {
       raise_except_if_required(FE_INVALID);
+      return x_bits.is_neg() ? MIN_T : MAX_T;
     }
-    int x_bits_exp =
-        x_bits.get_explicit_exponent() - FPBits<Float128>::FRACTION_LEN;
+    int exponent = x_bits.get_explicit_exponent();
+    constexpr int EXPONENT_LIMIT = cpp::is_signed_v<T>
+                                       ? static_cast<int>(sizeof(T) * 8) - 1
+                                       : static_cast<int>(sizeof(T) * 8);
+    if (exponent > EXPONENT_LIMIT) {
+      raise_except_if_required(FE_INVALID);
+      return x_bits.is_neg() ? MIN_T : MAX_T;
+    } else if (exponent == EXPONENT_LIMIT) {
+      if (x_bits.is_pos() || x_bits.get_mantissa() != 0) {
+        raise_except_if_required(FE_INVALID);
+        return x_bits.is_neg() ? MIN_T : MAX_T;
+      }
+    }
+
+    int x_bits_exp = exponent - FPBits<Float128>::FRACTION_LEN;
     // sign * 2^(exp-bias) * mantissa
     DyadicFloat<FPBits<Float128>::STORAGE_LEN> xd(
         x_bits.sign(), x_bits_exp, x_bits.get_explicit_mantissa());

--- a/libc/src/__support/FPUtil/float128.h
+++ b/libc/src/__support/FPUtil/float128.h
@@ -79,9 +79,7 @@ struct Float128 {
       return x_bits.is_neg() ? MIN_T : MAX_T;
     }
     int exponent = x_bits.get_explicit_exponent();
-    constexpr int EXPONENT_LIMIT = cpp::is_signed_v<T>
-                                       ? static_cast<int>(sizeof(T) * 8) - 1
-                                       : static_cast<int>(sizeof(T) * 8);
+    constexpr int EXPONENT_LIMIT = cpp::numeric_limits<T>::digits;
     if (exponent > EXPONENT_LIMIT) {
       raise_except_if_required(FE_INVALID);
       return x_bits.is_neg() ? MIN_T : MAX_T;

--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -49,8 +49,6 @@ add_fp_unittest(
     libc.hdr.limits_macros
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.float128
-  COMPILE_OPTIONS
-    "-fsanitize=address"
 )
 
 # TODO: Temporally disable bfloat16 test until MPCommon target is updated

--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -49,6 +49,8 @@ add_fp_unittest(
     libc.hdr.limits_macros
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.float128
+  COMPILE_OPTIONS
+    "-fsanitize=address"
 )
 
 # TODO: Temporally disable bfloat16 test until MPCommon target is updated

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -88,7 +88,6 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
   ASSERT_EQ(static_cast<unsigned>(Float128(0U)), 0U);
-  EXPECT_FP_EXCEPTION(0);
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
@@ -123,7 +122,6 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(1e-300)), 0LL);
   ASSERT_EQ(static_cast<int>(Float128(0.5)), 0);
   ASSERT_EQ(static_cast<int>(Float128(-0.5)), 0);
-  EXPECT_FP_EXCEPTION(0);
 }
 
 TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
@@ -142,5 +140,4 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
 
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   ASSERT_EQ(static_cast<unsigned>(Float128(2147483648.0)), 2147483648U);
-  EXPECT_FP_EXCEPTION(0);
 }

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -87,7 +87,7 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MAX)), LLONG_MAX);
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
-  ASSERT_EQ(static_cast<unsigned>(Float128(0U)), 0U);
+  ASSERT_FP_EXCEPTION(0);
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
@@ -139,4 +139,5 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
 
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   ASSERT_EQ(static_cast<unsigned>(Float128(2147483648.0)), 2147483648U);
+  ASSERT_FP_EXCEPTION(0);
 }

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -121,6 +121,7 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<int>(Float128(-1e-300)), 0);
   ASSERT_EQ(static_cast<int>(Float128(0.5)), 0);
   ASSERT_EQ(static_cast<int>(Float128(-0.5)), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_INVALID), 0);
 }
 
 TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
@@ -139,4 +140,5 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
 
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   ASSERT_EQ(static_cast<unsigned>(Float128(2147483648.0)), 2147483648U);
+  EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_INVALID), 0);
 }

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -87,7 +87,7 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MAX)), LLONG_MAX);
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
-  ASSERT_FP_EXCEPTION(0);
+  EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_INVALID), 0);
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
@@ -139,5 +139,4 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
 
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   ASSERT_EQ(static_cast<unsigned>(Float128(2147483648.0)), 2147483648U);
-  ASSERT_FP_EXCEPTION(0);
 }

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -80,24 +80,50 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<int>(Float128(-1.9)), -1);
   ASSERT_EQ(static_cast<int>(Float128(1.9f)), 1);
 
-  // Extreme values
+  // Border values
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   ASSERT_EQ(static_cast<int>(Float128(INT_MAX)), INT_MAX);
   ASSERT_EQ(static_cast<int>(Float128(INT_MIN)), INT_MIN);
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MAX)), LLONG_MAX);
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
   ASSERT_EQ(static_cast<unsigned>(Float128(0U)), 0U);
-  volatile int a = static_cast<int>(Float128(
-      1e300)); // This might not give any error but gives a wrong value for now
+  EXPECT_FP_EXCEPTION(0);
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
-  ASSERT_EQ(static_cast<int>(FPBits::quiet_nan().get_val()), 0);
+  ASSERT_EQ(static_cast<int>(FPBits::quiet_nan().get_val()), INT_MAX);
   EXPECT_FP_EXCEPTION(FE_INVALID);
 
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
-  ASSERT_EQ(static_cast<int>(FPBits::inf().get_val()), 0);
+  ASSERT_EQ(static_cast<int>(FPBits::inf().get_val()), INT_MAX);
   EXPECT_FP_EXCEPTION(FE_INVALID);
+
+  // Extreme values
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<int>(Float128(1e300)), INT_MAX);
+  EXPECT_FP_EXCEPTION(FE_INVALID);
+
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<int>(Float128(-1e300)), INT_MIN);
+  EXPECT_FP_EXCEPTION(FE_INVALID);
+
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<int>(FPBits::inf(Sign::NEG).get_val()), INT_MIN);
+  EXPECT_FP_EXCEPTION(FE_INVALID);
+
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<int>(FPBits::inf(Sign::POS).get_val()), INT_MAX);
+  EXPECT_FP_EXCEPTION(FE_INVALID);
+
+  // Small values
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<int>(Float128(1e-300)), 0);
+  ASSERT_EQ(static_cast<int>(Float128(-1e-300)), 0);
+  ASSERT_EQ(static_cast<long long>(Float128(1e-300)), 0LL);
+  ASSERT_EQ(static_cast<int>(Float128(0.5)), 0);
+  ASSERT_EQ(static_cast<int>(Float128(-0.5)), 0);
+  EXPECT_FP_EXCEPTION(0);
 }
 
 TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
@@ -108,4 +134,13 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
   ASSERT_TRUE(Float128(7U) == Float128(7.0f));
   ASSERT_TRUE(Float128(-7LL) == Float128(-7.0));
   ASSERT_TRUE(Float128(123456789LL) == Float128(123456789.0));
+
+  // 2147483648.0 or 2^31 is out of bound in signed and not in unsigned
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<int>(Float128(2147483648.0)), INT_MAX);
+  EXPECT_FP_EXCEPTION(FE_INVALID);
+
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+  ASSERT_EQ(static_cast<unsigned>(Float128(2147483648.0)), 2147483648U);
+  EXPECT_FP_EXCEPTION(0);
 }

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -119,7 +119,6 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   ASSERT_EQ(static_cast<int>(Float128(1e-300)), 0);
   ASSERT_EQ(static_cast<int>(Float128(-1e-300)), 0);
-  ASSERT_EQ(static_cast<long long>(Float128(1e-300)), 0LL);
   ASSERT_EQ(static_cast<int>(Float128(0.5)), 0);
   ASSERT_EQ(static_cast<int>(Float128(-0.5)), 0);
 }

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -87,7 +87,8 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
   ASSERT_EQ(static_cast<unsigned>(Float128(0U)), 0U);
-  volatile int a = static_cast<int>(Float128(1e300));
+  volatile int a = static_cast<int>(Float128(
+      1e300)); // This might not give any error but gives a wrong value for now
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -87,8 +87,7 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
   ASSERT_EQ(static_cast<unsigned>(Float128(0U)), 0U);
-  int a = static_cast<int>(Float128(1e300));
-  (void)a;
+  volatile int a = static_cast<int>(Float128(1e300));
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -87,6 +87,8 @@ TEST(LlvmLibcFloat128Test, IntegerConversion) {
   ASSERT_EQ(static_cast<long long>(Float128(LLONG_MIN)), LLONG_MIN);
   ASSERT_EQ(static_cast<unsigned>(Float128(UINT_MAX)), UINT_MAX);
   ASSERT_EQ(static_cast<unsigned>(Float128(0U)), 0U);
+  int a = static_cast<int>(Float128(1e300));
+  (void)a;
 
   // FP exceptions
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/200565#discussion_r3643991194
This tries to fix the recent issue pointed out in the above comment about undefined behavior for float128 in the case of extremely large values and extremely small values.