### PR TITLE
[XRay][test] Raise fdr-mode.cpp unwrite threshold to deflake it

### DIFF
--- a/compiler-rt/test/xray/TestCases/Posix/fdr-mode.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/fdr-mode.cpp
@@ -8,7 +8,7 @@
 // RUN: env XRAY_OPTIONS="patch_premain=false \
 // RUN:     xray_logfile_base=fdr-unwrite-test- xray_mode=xray-fdr \
 // RUN:     verbosity=1" \
-// RUN: env XRAY_FDR_OPTIONS="func_duration_threshold_us=5000" \
+// RUN: env XRAY_FDR_OPTIONS="func_duration_threshold_us=100000" \
 // RUN:     %run %t 2>&1 | FileCheck %s
 // RUN: ls fdr-logging-test-* | head -1 | tr -d '\n' > %t.log
 // RUN: %llvm_xray convert --symbolize --output-format=yaml -instr_map=%t \
@@ -106,8 +106,12 @@ int main(int argc, char *argv[]) {
 // TRACE-DAG: - { type: 0, func-id: [[FIDARG:[0-9]+]], function: 'fArg(int)', args: [ 1 ], cpu: {{.*}}, thread: [[THREAD2]], process: [[PROCESS]], kind: function-enter-arg, tsc: {{[0-9]+}}, data: '' }
 // TRACE-DAG: - { type: 0, func-id: [[FIDARG]], function: 'fArg(int)', cpu: {{.*}}, thread: [[THREAD2]], process: [[PROCESS]], kind: function-exit, tsc: {{[0-9]+}}, data: '' }
 
-// Assert that when unwriting is enabled with a high threshold time, all the function records are erased. A CPU switch could erroneously fail this test, but
-// is unlikely given the test program.
+// Assert that when unwriting is enabled with a threshold well above any trivial
+// function's runtime, all the function records are erased. The threshold is set
+// high so that scheduling jitter (preemption or a CPU migration inflating a
+// function's measured wall-clock duration) cannot push a short function over the
+// threshold and leave a stray record, which used to flake this test on busy
+// bots.
 // Even with a high threshold, arg1 logging is never unwritten.
 // UNWRITE: header:
 // UNWRITE: records:


### PR DESCRIPTION
It was observed failing on `sanitizer-aarch64-linux` ([build 40750](https://lab.llvm.org/buildbot/#/builders/51/builds/40750)).

The failure is in the `UNWRITE` run (`XRAY_FDR_OPTIONS="func_duration_threshold_us=5000"`), which asserts that every short function record is "unwritten" (rewound) except arg1-logging records. In the failing output an `fA()` enter/exit pair survived:

```
<stdin>:9:  - { func-id: 3, function: 'fA()', cpu: 0, thread: 1909237, kind: function-enter, tsc: 1784775492023431847 }
<stdin>:10: - { func-id: 3, function: 'fA()', cpu: 0, thread: 1909237, kind: function-exit,  tsc: 1784775492029462345 }
<stdin>:11: - { func-id: 4, function: 'fArg(int)', args: [ 1 ], ..., kind: function-enter-arg, ... }
```

so `UNWRITE-NEXT` (and `UNWRITE-NOT: function-enter`) no longer hold.

FDR mode only rewinds a function's enter record when its exit lands within the threshold (`XRayFDRController::functionExit`: `TSC - LastFunctionEntryTSC < CycleThreshold`).

```
1784775492029462345 - 1784775492023431847 = 6,030,498 cycles / 1 GHz = 6.03 ms  >  5 ms threshold
```

i.e. the thread was preempted for ~6 ms mid-function, so the record was (correctly, by the runtime's own rule) not unwritten.

The proposed fix is to raise the `UNWRITE` run's `func_duration_threshold_us` from `5000` to `100000`, so realistic
scheduling jitter cannot push a short function over the threshold. This mirrors the accepted fix for the sibling test in
[PR #186611](https://github.com/llvm/llvm-project/pull/186611) (`basic-filtering.cpp`), which flaked the same way.
