### PR TITLE
llvm-mca: Stop defaulting to "native" for the CPU

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -114,6 +114,8 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the LLVM tools
 
+* llvm-mca no longer defaults -mcpu to "native"
+
 ### Changes to LLDB
 
 #### Windows

--- a/llvm/test/tools/llvm-mca/AMDGPU/subarch-triple-no-mcpu.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/subarch-triple-no-mcpu.s
@@ -1,0 +1,10 @@
+# With an AMDGPU subarch triple and no -mcpu, llvm-mca must resolve
+# the processor from the triple's subarch field rather than analyzing
+# with no CPU.
+#
+# RUN: llvm-mca -mtriple=amdgpu9.0a --iterations=1 < %s | FileCheck %s
+
+v_add_f64 v[0:1], v[0:1], v[2:3]
+
+# CHECK: Iterations:        1
+# CHECK: Instructions:      1

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -15,7 +15,8 @@
 //      -o <file>
 //
 // The target defaults to the host target.
-// The cpu defaults to the 'native' host cpu.
+// The cpu is derived from the triple if not specified; pass -mcpu=native to
+// select the host cpu.
 // The output defaults to standard output.
 //
 //===----------------------------------------------------------------------===//
@@ -91,7 +92,7 @@ static cl::opt<std::string>
 static cl::opt<std::string>
     MCPU("mcpu",
          cl::desc("Target a specific cpu type (-mcpu=help for details)"),
-         cl::value_desc("cpu-name"), cl::cat(ToolOptions), cl::init("native"));
+         cl::value_desc("cpu-name"), cl::cat(ToolOptions), cl::init(""));
 
 static cl::list<std::string>
     MATTRS("mattr", cl::CommaSeparated,

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -435,9 +435,6 @@ int main(int argc, char **argv) {
   if (WantsCPUHelp)
     return 0;
 
-  if (!STI->isCPUStringValid(MCPU))
-    return 1;
-
   if (!STI->getSchedModel().hasInstrSchedModel()) {
     WithColor::error()
         << "unable to find instruction-level scheduling information for"


### PR DESCRIPTION
This would warn whenever using a triple that isn't for the host
architecture. Other tools don't do this. Copy what llc does and
default to no cpu.