### PR TITLE
[lldb-dap] Migrate unknownRequest, subtleFrames and longpath

### DIFF
--- a/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
+++ b/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
@@ -6,15 +6,16 @@ the program lives at a path longer than the Windows MAX_PATH limit (260).
 import os
 import shutil
 
-import lldbdap_testcase
-from lldbsuite.test.decorators import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test.decorators import skipUnlessWindows
+from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import ExitedEvent, LaunchArgs, TerminatedEvent
 
 MAX_PATH = 260
 
 
 @skipUnlessWindows
-class TestDAP_launch_longPath(lldbdap_testcase.DAPTestCaseBase):
+class TestDAP_launch_longPath(DAPTestCaseBase):
     def _long_path(self, path):
         return lldbutil.get_extended_windows_path(path)
 
@@ -44,12 +45,10 @@ class TestDAP_launch_longPath(lldbdap_testcase.DAPTestCaseBase):
         shutil.copyfile(program, self._long_path(long_program))
         self.assertGreater(len(os.path.abspath(long_program)), MAX_PATH)
 
-        self.create_debug_adapter()
-        self.launch_and_configurationDone(long_program)
+        session = self.create_session()
+        process_event = session.launch(LaunchArgs(long_program))
 
-        process_event = self.dap_server.wait_for_event(["process"])
-        self.assertIsNotNone(process_event, "lldb-dap sent a process event")
-        name = process_event["body"]["name"]
+        name = process_event.body.name
         self.assertGreater(
             len(name), MAX_PATH, "process event name must not be truncated"
         )
@@ -58,4 +57,4 @@ class TestDAP_launch_longPath(lldbdap_testcase.DAPTestCaseBase):
             self._normalize(long_program),
         )
 
-        self.dap_server.wait_for_event(["terminated", "exited"])
+        session.wait_for_any_event((TerminatedEvent, ExitedEvent), after=process_event)

--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
@@ -4,11 +4,11 @@ Test lldb-dap stack trace response
 
 from lldbsuite.test.decorators import add_test_categories
 from lldbsuite.test.lldbtest import line_number
-from lldbsuite.test.tools.lldb_dap import testcase
-from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StackTraceArgs
+from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 
-class TestDAP_subtleFrames(testcase.DAPTestCaseBase):
+class TestDAP_subtleFrames(DAPTestCaseBase):
     @add_test_categories(["libc++"])
     def test_subtleFrames(self):
         """
@@ -24,7 +24,7 @@ class TestDAP_subtleFrames(testcase.DAPTestCaseBase):
         stop_event = session.verify_stopped_on_breakpoint(bps, after=ctx.process_event)
 
         thread_id = self.expect_not_none(stop_event.body.threadId)
-        resp = session.send_request(StackTraceArgs(thread_id)).result()
+        resp = session.stack_trace(thread_id)
         frames = resp.body.stackFrames
         for f in frames:
             if "__function" in f.name:

--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
@@ -2,28 +2,33 @@
 Test lldb-dap stack trace response
 """
 
-
-import dap_server
-from lldbsuite.test.decorators import *
-
-import lldbdap_testcase
-from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import add_test_categories
+from lldbsuite.test.lldbtest import line_number
+from lldbsuite.test.tools.lldb_dap import testcase
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StackTraceArgs
 
 
-class TestDAP_subtleFrames(lldbdap_testcase.DAPTestCaseBase):
+class TestDAP_subtleFrames(testcase.DAPTestCaseBase):
     @add_test_categories(["libc++"])
     def test_subtleFrames(self):
         """
         Internal stack frames (such as the ones used by `std::function`) are marked as "subtle".
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
+        session = self.build_and_create_session()
         source = "main.cpp"
-        self.set_source_breakpoints(source, [line_number(source, "BREAK HERE")])
-        self.continue_to_next_stop()
+        with session.configure(LaunchArgs(program)) as ctx:
+            bp_line = line_number(source, "BREAK HERE")
+            bps = session.resolve_source_breakpoints(source, [bp_line])
 
-        frames = self.get_stackFrames()
+        stop_event = session.verify_stopped_on_breakpoint(bps, after=ctx.process_event)
+
+        thread_id = self.expect_not_none(stop_event.body.threadId)
+        resp = session.send_request(StackTraceArgs(thread_id)).result()
+        frames = resp.body.stackFrames
         for f in frames:
-            if "__function" in f["name"]:
-                self.assertEqual(f["presentationHint"], "subtle")
-        self.assertTrue(any(f.get("presentationHint") == "subtle" for f in frames))
+            if "__function" in f.name:
+                self.assertEqual(f.presentationHint, "subtle")
+        self.assertTrue(any(f.presentationHint == "subtle" for f in frames))
+
+        session.continue_to_exit()

--- a/lldb/test/API/tools/lldb-dap/unknown/TestDAP_unknownRequest.py
+++ b/lldb/test/API/tools/lldb-dap/unknown/TestDAP_unknownRequest.py
@@ -2,34 +2,45 @@
 Test lldb-dap unknown request.
 """
 
-import lldbdap_testcase
+from dataclasses import dataclass
+from typing import Optional
+
+from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import EmptyBodyResponse, LaunchArgs
 
 
-class TestDAP_unknown_request(lldbdap_testcase.DAPTestCaseBase):
+@dataclass(frozen=True)
+class UnknownArgs:
+    foo: Optional[str] = None
+    id: Optional[int] = None
+
+    command_ = "unknown"
+    response_class_ = EmptyBodyResponse
+
+
+class TestDAP_unknown_request(DAPTestCaseBase):
     """
     Tests handling of unknown request.
     """
 
-    def test_no_arguments(self):
+    def test(self):
+        session = self.build_and_create_session()
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
-        self.dap_server.request_configurationDone()
-        self.dap_server.wait_for_stopped()
+        process_event = session.launch(LaunchArgs(program, stopOnEntry=True))
+        session.verify_stopped_on_entry(after=process_event)
 
-        response = self.dap_server.request_custom("unknown")
-        self.assertFalse(response["success"])
-        self.assertEqual(response["body"]["error"]["format"], "unknown request")
+        # Test without arguments.
+        unknown_args = UnknownArgs()
+        response = session.send_request(unknown_args).error()
+        resp_body = self.expect_not_none(response.body)
+        resp_error = self.expect_not_none(resp_body.error)
+        self.assertEqual(resp_error.format, "unknown request")
 
-        self.continue_to_exit()
+        # Test with arguments.
+        unknown_args = UnknownArgs(foo="bar", id=42)
+        response = session.send_request(unknown_args).error()
+        resp_body = self.expect_not_none(response.body)
+        resp_error = self.expect_not_none(resp_body.error)
+        self.assertEqual(resp_error.format, "unknown request")
 
-    def test_with_arguments(self):
-        program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, stopOnEntry=True)
-        self.dap_server.request_configurationDone()
-        self.dap_server.wait_for_stopped()
-
-        response = self.dap_server.request_custom("unknown", {"foo": "bar", "id": 42})
-        self.assertFalse(response["success"])
-        self.assertEqual(response["body"]["error"]["format"], "unknown request")
-
-        self.continue_to_exit()
+        session.continue_to_exit()


### PR DESCRIPTION
Migrated tests:
- TestDAP_unknownRequest.py
- TestDAP_subtleFrames.py
- TestDAP_launch_longPath.py