### PR TITLE
[flang][cuda] Fix CUFPredefinedVarToGPU for a shared builtin address_of

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFPredefinedVarToGPU.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFPredefinedVarToGPU.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace fir {
 #define GEN_PASS_DEF_CUFPREDEFINEDVARTOGPU
@@ -80,7 +81,8 @@ static void
 processDeclareOp(mlir::OpBuilder &builder, mlir::Location loc,
                  fir::DeclareOp declareOp, llvm::StringRef builtinVar,
                  llvm::SmallVectorImpl<mlir::Value> &gpuValues,
-                 llvm::SmallVectorImpl<mlir::Operation *> &opsToDelete) {
+                 llvm::SmallVectorImpl<mlir::Operation *> &opsToDelete,
+                 llvm::SmallPtrSetImpl<mlir::Operation *> &memrefDefiningOps) {
   if (declareOp.getUniqName().str().compare(builtinVar) == 0) {
     for (mlir::OpOperand &use : declareOp.getResult().getUses()) {
       fir::CoordinateOp coordOp =
@@ -94,8 +96,11 @@ processDeclareOp(mlir::OpBuilder &builder, mlir::Location loc,
       opsToDelete.push_back(coordOp);
     }
     opsToDelete.push_back(declareOp.getOperation());
-    if (declareOp.getMemref().getDefiningOp())
-      opsToDelete.push_back(declareOp.getMemref().getDefiningOp());
+    // The backing fir.address_of may be shared by several declares (e.g. after
+    // CSE coalesces them when a device routine is inlined into a kernel).
+    // Collect it de-duplicated and erase it only once all declares are gone.
+    if (mlir::Operation *memrefOp = declareOp.getMemref().getDefiningOp())
+      memrefDefiningOps.insert(memrefOp);
   }
 }
 
@@ -135,19 +140,25 @@ struct CUFPredefinedVarToGPU
                                                     blockdims);
 
     llvm::SmallVector<mlir::Operation *> opsToDelete;
+    llvm::SmallPtrSet<mlir::Operation *, 4> memrefDefiningOps;
     region.walk([&](fir::DeclareOp declareOp) {
       processDeclareOp(builder, loc, declareOp, mangleBuiltin(threadidx),
-                       threadids, opsToDelete);
+                       threadids, opsToDelete, memrefDefiningOps);
       processDeclareOp(builder, loc, declareOp, mangleBuiltin(blockidx),
-                       blockids, opsToDelete);
+                       blockids, opsToDelete, memrefDefiningOps);
       processDeclareOp(builder, loc, declareOp, mangleBuiltin(blockdim),
-                       blockdims, opsToDelete);
+                       blockdims, opsToDelete, memrefDefiningOps);
       processDeclareOp(builder, loc, declareOp, mangleBuiltin(griddim),
-                       griddims, opsToDelete);
+                       griddims, opsToDelete, memrefDefiningOps);
     });
 
     for (auto *op : opsToDelete)
       op->erase();
+    // Erase each backing fir.address_of once, and only if no other user (e.g. a
+    // non-predefined declare) still references it.
+    for (auto *op : memrefDefiningOps)
+      if (op->use_empty())
+        op->erase();
   }
 
   void runOnOperation() override {

--- a/flang/test/Fir/CUDA/predefined-variables.mlir
+++ b/flang/test/Fir/CUDA/predefined-variables.mlir
@@ -418,3 +418,29 @@ func.func @_QMoutermodPouter(%arg0: !fir.ref<!fir.array<?x?xf64>> {fir.bindc_nam
 // CHECK-NOT: _QM__fortran_builtinsE__builtin_blockidx
 // CHECK-NOT: _QM__fortran_builtinsE__builtin_griddim
 // CHECK-NOT: _QM__fortran_builtinsE__builtin_threadidx
+
+// -----
+
+// A single fir.address_of shared by two declares must not be erased while a
+// declare still uses it.
+func.func @_QMdevmodPkernel() attributes {cuf.proc_attr = #cuf.cuda_proc<global>, no_inline} {
+  %0 = fir.address_of(@_QM__fortran_builtinsE__builtin_threadidx) : !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>
+  %1 = fir.declare %0 {uniq_name = "_QM__fortran_builtinsE__builtin_threadidx"} : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>) -> !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>
+  %2 = fir.declare %0 {uniq_name = "_QM__fortran_builtinsE__builtin_threadidx"} : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>) -> !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>
+  %3 = fir.alloca i32 {bindc_name = "a"}
+  %4 = fir.alloca i32 {bindc_name = "b"}
+  %5 = fir.coordinate_of %1, x : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>) -> !fir.ref<i32>
+  %6 = fir.load %5 : !fir.ref<i32>
+  fir.store %6 to %3 : !fir.ref<i32>
+  %7 = fir.coordinate_of %2, x : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>) -> !fir.ref<i32>
+  %8 = fir.load %7 : !fir.ref<i32>
+  fir.store %8 to %4 : !fir.ref<i32>
+  return
+}
+
+// CHECK-LABEL: func.func @_QMdevmodPkernel
+// CHECK-NOT: _QM__fortran_builtinsE__builtin_threadidx
+// CHECK: %[[TID:.*]] = nvvm.read.ptx.sreg.tid.x : i32
+// CHECK: %[[ADD:.*]] = arith.addi %[[TID]], %c1{{.*}} : i32
+// CHECK: fir.store %[[ADD]] to %{{.*}} : !fir.ref<i32>
+// CHECK: fir.store %[[ADD]] to %{{.*}} : !fir.ref<i32>


### PR DESCRIPTION
`CUFPredefinedVarToGPU` rewrites references to the predefined CUDA builtins
(`threadidx`/`blockidx`/`blockdim`/`griddim`) into GPU special-register reads.
For each predefined-var `fir.declare` it also erased the declare's backing
`fir.address_of`. That assumed every declare owns a
private `address_of`, which is only true before CSE. Once a single
`fir.address_of` of a builtin is shared by several `fir.declare`s — e.g. after a
`device` routine is inlined into a `global` kernel and CSE coalesces the
duplicated `address_of` ops — the pass queued that one op for deletion once per
declare and erased it while another declare still used it, thus aborting compilation with
`'fir.address_of' op operation destroyed but still has uses` error.

With this PR, the backing ops are collected into a de-duplicated set and erased
after all predefined declares are gone, and only when `use_empty()`. This makes
the deletion safe regardless of how many declares share an
`address_of`, and leaves it untouched if any other user
remains.