### PR TITLE
[offload][cmake] Add option to include offload unittests in check-all

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -64,6 +64,7 @@ if(WIN32)
 endif()
 
 option(OFFLOAD_INCLUDE_TESTS "Generate and build offload tests." ${LLVM_INCLUDE_TESTS})
+option(OFFLOAD_RUN_UNITTESTS_BY_DEFAULT "Run offload unit tests as part of check-all." OFF)
 
 # Add path for custom modules
 list(INSERT CMAKE_MODULE_PATH 0

--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -61,11 +61,16 @@ configure_lit_site_cfg(
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/unit/lit.cfg.py)
 
+set(ADD_CHECK_OFFLOAD_ARGS "")
+if(NOT OFFLOAD_RUN_UNITTESTS_BY_DEFAULT)
+  set(ADD_CHECK_OFFLOAD_ARGS "EXCLUDE_FROM_CHECK_ALL")
+endif()
+
 add_offload_testsuite(check-offload
   "Running offload tests"
   ${LIBOMPTARGET_LIT_TESTSUITES}
   ${CMAKE_CURRENT_BINARY_DIR}/unit
-  EXCLUDE_FROM_CHECK_ALL
+  ${ADD_CHECK_OFFLOAD_ARGS}
   DEPENDS ${OFFLOAD_TOOLS} omptarget ${OMP_DEPEND} ${LIBOMPTARGET_TESTED_PLUGINS}
           LLVMOffload OffloadUnitTests
   ARGS ${LIBOMPTARGET_LIT_ARG_LIST})


### PR DESCRIPTION
Offload unittests are excluded from `check-all`, though they are part of `check-offload`.

`check-libomptarget-${target}` tests are a part of `check-all` and `check-offload`, so if we ran `check-offload` we would run the `check-libomptarget-${target}` tests twice.

There's no other top-level target to run the unit tests, so add an option to allow running offload unit tests as part of `check-all`.

We intend to use this on our buildbot.