### PR TITLE
[SPIRV] Emit NonSemantic DebugTypeComposite and DebugTypeMember.

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
@@ -378,10 +378,10 @@ MCRegister SPIRVNonSemanticDebugHandler::getCachedOpStringReg(StringRef S) {
 
 MCRegister SPIRVNonSemanticDebugHandler::emitAndCacheScopePathOpStringReg(
     const DIScope *Scope, SPIRV::ModuleAnalysisInfo &MAI) {
-  MCRegister Reg = emitOpStringIfNew(getDebugFullPath(Scope), MAI);
-  if (Scope)
-    ScopeToPathOpStringReg[Scope] = Reg;
-  return Reg;
+  auto [It, Inserted] = ScopeToPathOpStringReg.try_emplace(Scope, MCRegister());
+  if (Inserted)
+    It->second = emitOpStringIfNew(getDebugFullPath(Scope), MAI);
+  return It->second;
 }
 
 MCRegister SPIRVNonSemanticDebugHandler::getCachedScopePathOpStringReg(

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
@@ -12,6 +12,7 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRVUtils.h"
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/IR/DebugInfo.h"
@@ -41,17 +42,18 @@ static std::optional<MCRegister> lookupOptReg(const MapT &Map,
 }
 
 /// Partition \p Ty into \p BasicTypes, \p PointerTypes, \p SubroutineTypes,
-/// and \p VectorTypes for NSDI emission. Used when iterating
-/// DebugInfoFinder.types(); each DI node is seen once, so no recursion into
-/// pointer bases. Other composites and non-pointer derived kinds are ignored
-/// because they are not yet supported. Only types that are supported (later
-/// used) are partitioned.
+/// \p VectorTypes, \p ArrayTypes, and \p CompositeTypes for NSDI emission. Used
+/// when iterating DebugInfoFinder.types(); each DI node is seen once, so no
+/// recursion into pointer bases. Non-pointer derived kinds are ignored because
+/// they are not yet supported. Only types that are supported (later used) are
+/// partitioned.
 static void
 partitionTypes(const DIType *Ty, SmallVector<const DIBasicType *> &BasicTypes,
                SmallVector<const DIDerivedType *> &PointerTypes,
                SmallVector<const DISubroutineType *> &SubroutineTypes,
                SmallVector<const DICompositeType *> &VectorTypes,
-               SmallVector<const DICompositeType *> &ArrayTypes) {
+               SmallVector<const DICompositeType *> &ArrayTypes,
+               SmallVector<const DICompositeType *> &CompositeTypes) {
   if (const auto *BT = dyn_cast<DIBasicType>(Ty)) {
     BasicTypes.push_back(BT);
     return;
@@ -77,6 +79,10 @@ partitionTypes(const DIType *Ty, SmallVector<const DIBasicType *> &BasicTypes,
         VectorTypes.push_back(CT);
       else
         ArrayTypes.push_back(CT);
+    } else if (CT->getTag() == dwarf::DW_TAG_structure_type ||
+               CT->getTag() == dwarf::DW_TAG_class_type ||
+               CT->getTag() == dwarf::DW_TAG_union_type) {
+      CompositeTypes.push_back(CT);
     }
     return;
   }
@@ -168,6 +174,22 @@ static uint32_t transDebugFlags(const DINode *DN) {
   return Flags;
 }
 
+// Map a DWARF composite tag to a NonSemantic.Shader.DebugInfo Composite Type
+// value: Class 0, Structure 1, Union 2.
+static uint32_t mapCompositeTypeTag(unsigned Tag) {
+  switch (Tag) {
+  case dwarf::DW_TAG_class_type:
+    return 0;
+  case dwarf::DW_TAG_structure_type:
+    return 1;
+  case dwarf::DW_TAG_union_type:
+    return 2;
+  default:
+    reportFatalInternalError("unexpected DWARF composite tag " + Twine(Tag) +
+                             ". Expecting 0, 1 or 2");
+  }
+}
+
 } // namespace
 
 SPIRVNonSemanticDebugHandler::SPIRVNonSemanticDebugHandler(AsmPrinter &AP)
@@ -211,6 +233,7 @@ void SPIRVNonSemanticDebugHandler::beginModule(Module *M) {
   SubroutineTypes.clear();
   VectorTypes.clear();
   ArrayTypes.clear();
+  CompositeTypes.clear();
   SubprogramDeclarations.clear();
   GlobalVariableDebugInfoMap.clear();
   DebugFunctionDeclarationRegs.clear();
@@ -265,7 +288,7 @@ void SPIRVNonSemanticDebugHandler::beginModule(Module *M) {
   Finder.processModule(*M);
   llvm::for_each(Finder.types(), [&](DIType *Ty) {
     partitionTypes(Ty, BasicTypes, PointerTypes, SubroutineTypes, VectorTypes,
-                   ArrayTypes);
+                   ArrayTypes, CompositeTypes);
   });
 
   for (const DISubprogram *SP : Finder.subprograms()) {
@@ -554,6 +577,21 @@ SPIRVNonSemanticDebugHandler::resolveDebugFunctionDeclarationParent(
   return lookupOptReg(CUToCompilationUnitDbgReg, ParentCU);
 }
 
+std::optional<MCRegister> SPIRVNonSemanticDebugHandler::resolveTypeScopeParent(
+    const DIScope *Scope) const {
+  // When the scope is itself a type (e.g. a struct nested in another struct),
+  // the parent is that enclosing type's debug id.
+  if (const auto *Ty = dyn_cast_or_null<DIType>(Scope))
+    return lookupOptReg(DebugTypeRegs, Ty);
+
+  // For a file, compile-unit, namespace, or absent scope, the parent is the
+  // first module DebugCompilationUnit.
+  if (CompileUnits.empty())
+    return std::nullopt;
+
+  return lookupOptReg(CUToCompilationUnitDbgReg, CompileUnits[0].TheCU);
+}
+
 std::optional<MCRegister>
 SPIRVNonSemanticDebugHandler::emitDebugFunctionDeclaration(
     const DISubprogram *SP, MCRegister VoidTypeReg, MCRegister I32TypeReg,
@@ -770,6 +808,81 @@ std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeArray(
                      ExtInstSetReg, Ops, MAI);
 }
 
+std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeMember(
+    const DIDerivedType *M, MCRegister VoidTypeReg, MCRegister I32TypeReg,
+    MCRegister ExtInstSetReg, SPIRV::ModuleAnalysisInfo &MAI) {
+  // The member type must already be in DebugTypeRegs.
+  auto TyRegOpt = lookupOptReg(DebugTypeRegs, M->getBaseType());
+  if (!TyRegOpt)
+    return std::nullopt;
+
+  MCRegister NameReg = getCachedOpStringReg(M->getName());
+  MCRegister FileStrReg = getCachedScopePathOpStringReg(
+      M->getFile(), /*UseEmptyPathIfNullScope=*/true);
+  MCRegister SrcReg = getOrEmitDebugSourceForFileStrReg(FileStrReg, VoidTypeReg,
+                                                        ExtInstSetReg, MAI);
+  MCRegister LineReg =
+      emitOpConstantI32(static_cast<uint32_t>(M->getLine()), I32TypeReg, MAI);
+
+  // DIDerivedType members carry no column, so emit 0.
+  MCRegister ColReg = emitOpConstantI32(0, I32TypeReg, MAI);
+  MCRegister OffsetReg = emitOpConstantI32(
+      static_cast<uint32_t>(M->getOffsetInBits()), I32TypeReg, MAI);
+  MCRegister SizeReg = emitOpConstantI32(
+      static_cast<uint32_t>(M->getSizeInBits()), I32TypeReg, MAI);
+  MCRegister FlagsReg = emitOpConstantI32(transDebugFlags(M), I32TypeReg, MAI);
+
+  // NonSemantic DebugTypeMember has no Parent operand: the composite references
+  // its members, not the reverse.
+  //
+  // FIXME: Static members are not handled yet: their constant initializer is
+  // available but is not emitted as the optional Value operand, and under DWARF
+  // 5 a static member is tagged DW_TAG_variable, which the caller's member loop
+  // skips.
+  return emitExtInst(SPIRV::NonSemanticExtInst::DebugTypeMember, VoidTypeReg,
+                     ExtInstSetReg,
+                     {NameReg, *TyRegOpt, SrcReg, LineReg, ColReg, OffsetReg,
+                      SizeReg, FlagsReg},
+                     MAI);
+}
+
+std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeComposite(
+    const DICompositeType *CT, ArrayRef<MCRegister> MemberRegs,
+    MCRegister VoidTypeReg, MCRegister I32TypeReg, MCRegister ExtInstSetReg,
+    SPIRV::ModuleAnalysisInfo &MAI) {
+  auto ParentRegOpt = resolveTypeScopeParent(CT->getScope());
+  if (!ParentRegOpt)
+    return std::nullopt;
+
+  MCRegister NameReg = getCachedOpStringReg(CT->getName());
+  MCRegister LinkageReg = getCachedOpStringReg(CT->getIdentifier());
+  MCRegister FileStrReg = getCachedScopePathOpStringReg(
+      CT->getFile(), /*UseEmptyPathIfNullScope=*/true);
+  MCRegister SrcReg = getOrEmitDebugSourceForFileStrReg(FileStrReg, VoidTypeReg,
+                                                        ExtInstSetReg, MAI);
+
+  MCRegister TagReg =
+      emitOpConstantI32(mapCompositeTypeTag(CT->getTag()), I32TypeReg, MAI);
+  MCRegister LineReg =
+      emitOpConstantI32(static_cast<uint32_t>(CT->getLine()), I32TypeReg, MAI);
+  MCRegister ColReg = emitOpConstantI32(0, I32TypeReg, MAI);
+
+  // A forward declaration has no known size or members: Size is DebugInfoNone.
+  MCRegister SizeReg = CachedDebugInfoNoneReg;
+  if (!CT->isForwardDecl())
+    SizeReg = emitOpConstantI32(static_cast<uint32_t>(CT->getSizeInBits()),
+                                I32TypeReg, MAI);
+
+  MCRegister FlagsReg = emitOpConstantI32(transDebugFlags(CT), I32TypeReg, MAI);
+
+  SmallVector<MCRegister> Ops = {NameReg,    TagReg,  SrcReg,
+                                 LineReg,    ColReg,  *ParentRegOpt,
+                                 LinkageReg, SizeReg, FlagsReg};
+  Ops.append(MemberRegs.begin(), MemberRegs.end());
+  return emitExtInst(SPIRV::NonSemanticExtInst::DebugTypeComposite, VoidTypeReg,
+                     ExtInstSetReg, Ops, MAI);
+}
+
 void SPIRVNonSemanticDebugHandler::emitNonSemanticDebugStrings(
     SPIRV::ModuleAnalysisInfo &MAI) {
   if (CompileUnits.empty())
@@ -798,6 +911,28 @@ void SPIRVNonSemanticDebugHandler::emitNonSemanticDebugStrings(
     emitOpStringIfNew(SP->getName(), MAI);
     emitOpStringIfNew(SP->getLinkageName(), MAI);
     ScopeToPathOpStringReg[SP] = emitOpStringIfNew(getDebugFullPath(SP), MAI);
+  }
+
+  // Cache the OpStrings each DebugTypeComposite and its DebugTypeMembers use:
+  // the composite name, identifier (linkage name), and path, plus each member
+  // name and path.
+  for (const DICompositeType *CT : CompositeTypes) {
+    emitOpStringIfNew(CT->getName(), MAI);
+    emitOpStringIfNew(CT->getIdentifier(), MAI);
+    MCRegister PathReg =
+        emitOpStringIfNew(getDebugFullPath(CT->getFile()), MAI);
+    if (const DIFile *F = CT->getFile())
+      ScopeToPathOpStringReg[F] = PathReg;
+    for (const DINode *Element : CT->getElements()) {
+      const auto *M = dyn_cast<DIDerivedType>(Element);
+      if (!M || M->getTag() != dwarf::DW_TAG_member)
+        continue;
+      emitOpStringIfNew(M->getName(), MAI);
+      MCRegister MPathReg =
+          emitOpStringIfNew(getDebugFullPath(M->getFile()), MAI);
+      if (const DIFile *MF = M->getFile())
+        ScopeToPathOpStringReg[MF] = MPathReg;
+    }
   }
 
   for (const auto &[GV, _] : GlobalVariableDebugInfoMap) {
@@ -955,6 +1090,25 @@ void SPIRVNonSemanticDebugHandler::emitNonSemanticGlobalDebugInfo(
     if (auto DeclReg = emitDebugFunctionDeclaration(SP, VoidTypeReg, I32TypeReg,
                                                     ExtInstSetReg, MAI))
       DebugFunctionDeclarationRegs[SP] = *DeclReg;
+  }
+
+  // Emit DebugTypeMember and DebugTypeComposite for each struct, class, or
+  // union. Each member is emitted before the composite that lists it, so the
+  // Members operand references already-defined ids. A member whose type is not
+  // in DebugTypeRegs is skipped.
+  for (const DICompositeType *CT : CompositeTypes) {
+    SmallVector<MCRegister> MemberRegs;
+    for (const DINode *Element : CT->getElements()) {
+      const auto *M = dyn_cast<DIDerivedType>(Element);
+      if (!M || M->getTag() != dwarf::DW_TAG_member)
+        continue;
+      if (auto MemberReg = emitDebugTypeMember(M, VoidTypeReg, I32TypeReg,
+                                               ExtInstSetReg, MAI))
+        MemberRegs.push_back(*MemberReg);
+    }
+    if (auto CompReg = emitDebugTypeComposite(CT, MemberRegs, VoidTypeReg,
+                                              I32TypeReg, ExtInstSetReg, MAI))
+      DebugTypeRegs[CT] = *CompReg;
   }
 
   // Emit DebugGlobalVariable for each collected DIGlobalVariable.

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
@@ -376,6 +376,14 @@ MCRegister SPIRVNonSemanticDebugHandler::getCachedOpStringReg(StringRef S) {
   return It->second;
 }
 
+MCRegister SPIRVNonSemanticDebugHandler::emitAndCacheScopePathOpStringReg(
+    const DIScope *Scope, SPIRV::ModuleAnalysisInfo &MAI) {
+  MCRegister Reg = emitOpStringIfNew(getDebugFullPath(Scope), MAI);
+  if (Scope)
+    ScopeToPathOpStringReg[Scope] = Reg;
+  return Reg;
+}
+
 MCRegister SPIRVNonSemanticDebugHandler::getCachedScopePathOpStringReg(
     const DIScope *Scope, bool UseEmptyPathIfNullScope) {
   if (!Scope) {
@@ -832,8 +840,10 @@ std::optional<MCRegister> SPIRVNonSemanticDebugHandler::emitDebugTypeMember(
       static_cast<uint32_t>(M->getSizeInBits()), I32TypeReg, MAI);
   MCRegister FlagsReg = emitOpConstantI32(transDebugFlags(M), I32TypeReg, MAI);
 
-  // NonSemantic DebugTypeMember has no Parent operand: the composite references
-  // its members, not the reverse.
+  // In NonSemantic.Shader.DebugInfo a DebugTypeMember has no Parent operand:
+  // only the composite references its members. This is by design, it drops the
+  // Parent that OpenCL.DebugInfo.100 had, and it avoids a composite/member
+  // reference cycle.
   //
   // FIXME: Static members are not handled yet: their constant initializer is
   // available but is not emitted as the optional Value operand, and under DWARF
@@ -910,7 +920,7 @@ void SPIRVNonSemanticDebugHandler::emitNonSemanticDebugStrings(
   for (const DISubprogram *SP : SubprogramDeclarations) {
     emitOpStringIfNew(SP->getName(), MAI);
     emitOpStringIfNew(SP->getLinkageName(), MAI);
-    ScopeToPathOpStringReg[SP] = emitOpStringIfNew(getDebugFullPath(SP), MAI);
+    emitAndCacheScopePathOpStringReg(SP, MAI);
   }
 
   // Cache the OpStrings each DebugTypeComposite and its DebugTypeMembers use:
@@ -919,29 +929,20 @@ void SPIRVNonSemanticDebugHandler::emitNonSemanticDebugStrings(
   for (const DICompositeType *CT : CompositeTypes) {
     emitOpStringIfNew(CT->getName(), MAI);
     emitOpStringIfNew(CT->getIdentifier(), MAI);
-    MCRegister PathReg =
-        emitOpStringIfNew(getDebugFullPath(CT->getFile()), MAI);
-    if (const DIFile *F = CT->getFile())
-      ScopeToPathOpStringReg[F] = PathReg;
+    emitAndCacheScopePathOpStringReg(CT->getFile(), MAI);
     for (const DINode *Element : CT->getElements()) {
       const auto *M = dyn_cast<DIDerivedType>(Element);
       if (!M || M->getTag() != dwarf::DW_TAG_member)
         continue;
       emitOpStringIfNew(M->getName(), MAI);
-      MCRegister MPathReg =
-          emitOpStringIfNew(getDebugFullPath(M->getFile()), MAI);
-      if (const DIFile *MF = M->getFile())
-        ScopeToPathOpStringReg[MF] = MPathReg;
+      emitAndCacheScopePathOpStringReg(M->getFile(), MAI);
     }
   }
 
   for (const auto &[GV, _] : GlobalVariableDebugInfoMap) {
     emitOpStringIfNew(GV->getName(), MAI);
     emitOpStringIfNew(GV->getLinkageName(), MAI);
-    SmallString<128> Path = getDebugFullPath(GV->getFile());
-    MCRegister PathReg = emitOpStringIfNew(Path, MAI);
-    if (const DIFile *F = GV->getFile())
-      ScopeToPathOpStringReg[F] = PathReg;
+    emitAndCacheScopePathOpStringReg(GV->getFile(), MAI);
   }
 
   CachedEmptyStringReg = emitOpStringIfNew("", MAI);

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
@@ -70,6 +70,9 @@ class SPIRVNonSemanticDebugHandler : public DebugHandlerBase {
   // DICompositeType nodes with DW_TAG_array_type that are not vectors,
   // partitioned in beginModule().
   SmallVector<const DICompositeType *> ArrayTypes;
+  // DICompositeType nodes with DW_TAG_structure_type, DW_TAG_class_type, or
+  // DW_TAG_union_type, partitioned in beginModule() for DebugTypeComposite.
+  SmallVector<const DICompositeType *> CompositeTypes;
 
   // Filled in emitNonSemanticGlobalDebugInfo(): DI types to their result
   // registers.
@@ -335,6 +338,30 @@ private:
                                                MCRegister ExtInstSetReg,
                                                SPIRV::ModuleAnalysisInfo &MAI);
 
+  /// Emit \c DebugTypeMember for the data member \p M (a \c DIDerivedType with
+  /// \c DW_TAG_member). Operands: Name, Type, Source, Line, Column, Offset,
+  /// Size, Flags. NonSemantic \c DebugTypeMember carries no Parent operand: the
+  /// enclosing \c DebugTypeComposite references its members, not the reverse.
+  ///
+  /// \returns The result id register on success. Returns \c std::nullopt and
+  /// emits nothing if \p M's type has not been emitted into \c DebugTypeRegs.
+  std::optional<MCRegister> emitDebugTypeMember(const DIDerivedType *M,
+                                                MCRegister VoidTypeReg,
+                                                MCRegister I32TypeReg,
+                                                MCRegister ExtInstSetReg,
+                                                SPIRV::ModuleAnalysisInfo &MAI);
+
+  /// Emit \c DebugTypeComposite for the struct, class, or union \p CT, listing
+  /// the already-emitted \p MemberRegs in its Members operand. A forward
+  /// declaration emits \c DebugInfoNone for Size and no members.
+  ///
+  /// \returns The result id register on success. Returns \c std::nullopt and
+  /// emits nothing if the Parent scope cannot be resolved.
+  std::optional<MCRegister> emitDebugTypeComposite(
+      const DICompositeType *CT, ArrayRef<MCRegister> MemberRegs,
+      MCRegister VoidTypeReg, MCRegister I32TypeReg, MCRegister ExtInstSetReg,
+      SPIRV::ModuleAnalysisInfo &MAI);
+
   /// Map a \c DISubroutineType::getTypeArray() element to an operand register
   /// for
   /// \c DebugTypeFunction. Non-null \p Ty resolves via \c DebugTypeRegs; if the
@@ -378,6 +405,14 @@ private:
   /// id.
   std::optional<MCRegister>
   resolveDebugFunctionDeclarationParent(const DISubprogram *SP) const;
+
+  /// Resolve the \c Parent operand for a type instruction (\c
+  /// DebugTypeComposite) from its \p Scope: an emitted debug type id when \p
+  /// Scope is a \c DIType in \c DebugTypeRegs (a type nested in another type),
+  /// otherwise the first module \c DebugCompilationUnit.
+  /// \returns \c std::nullopt when \p Scope is a \c DIType that has not been
+  /// emitted, or when there is no compile unit.
+  std::optional<MCRegister> resolveTypeScopeParent(const DIScope *Scope) const;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
@@ -210,8 +210,10 @@ private:
   MCRegister getCachedOpStringReg(StringRef S);
 
   /// Section 7 only: emit the path \c OpString for \p Scope and cache it under
-  /// \p Scope when non-null. Returns the \c OpString result id, which is still
-  /// emitted when \p Scope is null but not cached.
+  /// \p Scope. Returns the \c OpString result id. A \p Scope already seen
+  /// returns the cached id without rebuilding the path. A null \p Scope maps to
+  /// the empty path and is cached like any other, though section 10 reads it
+  /// through \c getCachedScopePathOpStringReg, which handles null separately.
   MCRegister emitAndCacheScopePathOpStringReg(const DIScope *Scope,
                                               SPIRV::ModuleAnalysisInfo &MAI);
 

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
@@ -209,6 +209,12 @@ private:
   /// section 7 did not complete.
   MCRegister getCachedOpStringReg(StringRef S);
 
+  /// Section 7 only: emit the path \c OpString for \p Scope and cache it under
+  /// \p Scope when non-null. Returns the \c OpString result id, which is still
+  /// emitted when \p Scope is null but not cached.
+  MCRegister emitAndCacheScopePathOpStringReg(const DIScope *Scope,
+                                              SPIRV::ModuleAnalysisInfo &MAI);
+
   /// Section 10 only: lookup path \c OpString id for \p Scope from
   /// \c ScopeToPathOpStringReg; asserts if missing or invalid. When
   /// \p UseEmptyPathIfNullScope is true and \p Scope is null, returns

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-skip-type-not-in-regs.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-skip-type-not-in-regs.ll
@@ -1,9 +1,10 @@
 ; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; A DIGlobalVariable whose type is a structure composite that is not yet
-; supported and thus never emitted into DebugTypeRegs. The whole
-; DebugGlobalVariable is skipped rather than referencing a missing type id.
+; A DIGlobalVariable whose type is a pointer with no DWARF address space, which
+; emitDebugTypePointer skips for lack of a storage class, so the type is never
+; in DebugTypeRegs. The whole DebugGlobalVariable is skipped rather than
+; referencing a missing type id. The skip is durable as more types are supported.
 
 ; CHECK-DAG: [[EXT:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-DAG: OpExtInst {{.*}} DebugCompilationUnit
@@ -24,11 +25,11 @@ entry:
 !2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !4, splitDebugInlining: false, nameTableKind: None)
 !3 = !DIFile(filename: "t.c", directory: "/tmp")
 !4 = !{!0}
-!8 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !3, line: 1, size: 32, elements: !18)
+!8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !9 = distinct !DISubprogram(name: "f", scope: !3, file: !3, line: 1, type: !16, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2)
 !10 = !DILocation(line: 2, column: 1, scope: !9)
 !12 = !{i32 7, !"Dwarf Version", i32 5}
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !16 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !17)
 !17 = !{null}
-!18 = !{}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-static-member.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-static-member.ll
@@ -1,9 +1,11 @@
 ; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; DIGlobalVariable with a static data member declaration. The backend does not
-; emit DebugTypeMember yet, so the Static Member Declaration operand cannot be
-; resolved and the whole DebugGlobalVariable is skipped.
+; DIGlobalVariable with a static data member declaration whose member type is a
+; pointer with no DWARF address space. emitDebugTypePointer skips that type, so
+; the member is not emitted, the Static Member Declaration operand cannot be
+; resolved, and the whole DebugGlobalVariable is skipped. Durable as more member
+; types are supported.
 
 ; CHECK-DAG: [[EXT:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-DAG: OpExtInst {{.*}} [[EXT]] DebugCompilationUnit
@@ -34,7 +36,8 @@ entry:
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !16 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !17)
 !17 = !{null}
-!20 = !DIDerivedType(tag: DW_TAG_member, name: "member", scope: !22, file: !3, line: 2, baseType: !8, size: 32, flags: DIFlagStaticMember)
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "member", scope: !22, file: !3, line: 2, baseType: !24, size: 32, flags: DIFlagStaticMember)
 !21 = !{!20}
 !22 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !3, line: 1, size: 32, elements: !23, identifier: "_ZTS1A")
 !23 = !{!20}
+!24 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !8, size: 64)

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-static-member.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-static-member.ll
@@ -4,8 +4,7 @@
 ; DIGlobalVariable with a static data member declaration whose member type is a
 ; pointer with no DWARF address space. emitDebugTypePointer skips that type, so
 ; the member is not emitted, the Static Member Declaration operand cannot be
-; resolved, and the whole DebugGlobalVariable is skipped. Durable as more member
-; types are supported.
+; resolved, and the whole DebugGlobalVariable is skipped.
 
 ; CHECK-DAG: [[EXT:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-DAG: OpExtInst {{.*}} [[EXT]] DebugCompilationUnit

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-array-of-composite-drop.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-array-of-composite-drop.ll
@@ -1,0 +1,37 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV --implicit-check-not=DebugTypeArray
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; An array whose element is a composite is dropped. Arrays are emitted before
+; composites, so the element has no id yet when emitDebugTypeArray runs and the
+; whole DebugTypeArray is skipped. The composite itself is still emitted.
+; Emitting the DebugType* nodes in dependency order, tracked in
+; https://github.com/llvm/llvm-project/issues/211850, would emit the
+; DebugTypeArray and change the expected output of this test.
+
+; CHECK-SPIRV: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV: DebugTypeComposite
+
+define spir_func void @test() !dbg !11 {
+entry:
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1, !2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4)
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !DIFile(filename: "array-of-struct.hlsl", directory: "/src")
+
+; S arr[4]. Only the array is retained; S is reached through its element type.
+!4 = !{!5}
+!5 = !DICompositeType(tag: DW_TAG_array_type, baseType: !7, size: 128, elements: !6)
+!6 = !{!DISubrange(count: 4)}
+!7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !3, line: 1, size: 32, elements: !8)
+!8 = !{!9}
+!9 = !DIDerivedType(tag: DW_TAG_member, name: "x", file: !3, line: 2, baseType: !10, size: 32)
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!12 = !DISubroutineType(types: !13)
+!13 = !{null}

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite-nested-drop.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite-nested-drop.ll
@@ -1,0 +1,42 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV --implicit-check-not=DebugTypeMember
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Composites are emitted in a single DebugInfoFinder pass. Outer is discovered
+; before Inner, so when Outer is emitted its Inner-typed member has no id yet
+; and is dropped. Inner is emitted next, and its basic-type member survives.
+; Only one DebugTypeMember is emitted here, for Inner.x. Emitting composites in
+; dependency order, would add a second DebugTypeMember for Outer.inner
+; (see https://github.com/llvm/llvm-project/issues/211850).
+
+; Both composites are still emitted.
+; CHECK-SPIRV: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV: DebugTypeComposite
+; CHECK-SPIRV: DebugTypeMember
+; CHECK-SPIRV: DebugTypeComposite
+
+define spir_func void @test() !dbg !12 {
+entry:
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1, !2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4)
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !DIFile(filename: "composite.hlsl", directory: "/src")
+
+; Only Outer is retained. Inner is reached solely through Outer's member, so the
+; finder visits Outer first and Inner second.
+!4 = !{!5}
+!5 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Outer", file: !3, line: 1, size: 32, elements: !6)
+!6 = !{!7}
+!7 = !DIDerivedType(tag: DW_TAG_member, name: "inner", file: !3, line: 2, baseType: !8, size: 32)
+!8 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", file: !3, line: 5, size: 32, elements: !9)
+!9 = !{!10}
+!10 = !DIDerivedType(tag: DW_TAG_member, name: "x", file: !3, line: 6, baseType: !11, size: 32)
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!12 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 10, type: !13, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!13 = !DISubroutineType(types: !14)
+!14 = !{null}

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite-skip-member-not-in-regs.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite-skip-member-not-in-regs.ll
@@ -1,0 +1,33 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV --implicit-check-not=DebugTypeMember
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A member whose type is not in DebugTypeRegs is skipped rather than referenced
+; with a dangling id. The one member here has a pointer type with no DWARF
+; address space, which emitDebugTypePointer skips for lack of a storage class,
+; so no DebugTypeMember is emitted. The composite itself is still emitted, with
+; no members. The skip is orthogonal to later type support.
+
+; CHECK-SPIRV: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV: OpExtInst {{%[0-9]+}} {{%[0-9]+}} DebugTypeComposite
+
+define spir_func void @test() !dbg !13 {
+entry:
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1, !2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4)
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !DIFile(filename: "composite.hlsl", directory: "/src")
+!4 = !{!5}
+!5 = !DICompositeType(tag: DW_TAG_structure_type, name: "K", file: !3, line: 1, size: 64, elements: !6)
+!6 = !{!7}
+!7 = !DIDerivedType(tag: DW_TAG_member, name: "p", file: !3, line: 2, baseType: !8, size: 64)
+!8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !9, size: 64)
+!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 10, type: !14, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!14 = !DISubroutineType(types: !15)
+!15 = !{null}

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite-static-member-skipped.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite-static-member-skipped.ll
@@ -1,15 +1,15 @@
 ; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV --implicit-check-not=DebugTypeMember
 ; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; A member whose type is not in DebugTypeRegs is skipped. The one member here
-; has a pointer type with no DWARF address space, which emitDebugTypePointer
-; skips for lack of a storage class, so no DebugTypeMember is emitted. The
-; composite itself is still emitted, with no members.
+; Under DWARF 5 a static data member is a DIDerivedType tagged DW_TAG_variable,
+; not DW_TAG_member, so the member loop skips it and no DebugTypeMember is
+; emitted. The composite is still emitted, with no members. Adding support
+; for this is tracked in https://github.com/llvm/llvm-project/issues/211842.
 
 ; CHECK-SPIRV: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-SPIRV: OpExtInst {{%[0-9]+}} {{%[0-9]+}} DebugTypeComposite
 
-define spir_func void @test() !dbg !13 {
+define spir_func void @test() !dbg !10 {
 entry:
   ret void
 }
@@ -22,11 +22,10 @@ entry:
 !2 = !{i32 2, !"Debug Info Version", i32 3}
 !3 = !DIFile(filename: "composite.hlsl", directory: "/src")
 !4 = !{!5}
-!5 = !DICompositeType(tag: DW_TAG_structure_type, name: "K", file: !3, line: 1, size: 64, elements: !6)
+!5 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !3, line: 1, size: 32, elements: !6)
 !6 = !{!7}
-!7 = !DIDerivedType(tag: DW_TAG_member, name: "p", file: !3, line: 2, baseType: !8, size: 64)
-!8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !9, size: 64)
-!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!13 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 10, type: !14, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
-!14 = !DISubroutineType(types: !15)
-!15 = !{null}
+!7 = !DIDerivedType(tag: DW_TAG_variable, name: "sm", scope: !5, file: !3, line: 2, baseType: !8, flags: DIFlagStaticMember)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 1, type: !11, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-composite.ll
@@ -1,0 +1,56 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A struct, class, or union lowers to DebugTypeComposite, with one
+; DebugTypeMember per data member. Members carry no Parent operand and are
+; emitted before the composite that lists them. A forward-declared composite
+; emits DebugInfoNone for Size and no members. Tag is 1 for a structure.
+
+; CHECK-SPIRV: [[ext:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV-DAG: [[void:%[0-9]+]] = OpTypeVoid
+; CHECK-SPIRV-DAG: [[i32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: [[str_int:%[0-9]+]] = OpString "int"
+; CHECK-SPIRV-DAG: [[str_float:%[0-9]+]] = OpString "float"
+; CHECK-SPIRV-DAG: [[str_S:%[0-9]+]] = OpString "S"
+; CHECK-SPIRV-DAG: [[str_a:%[0-9]+]] = OpString "a"
+; CHECK-SPIRV-DAG: [[str_b:%[0-9]+]] = OpString "b"
+; CHECK-SPIRV-DAG: [[str_Fwd:%[0-9]+]] = OpString "Fwd"
+; CHECK-SPIRV-DAG: [[c0:%[0-9]+]] = OpConstant [[i32]] 0{{$}}
+; CHECK-SPIRV-DAG: [[c1:%[0-9]+]] = OpConstant [[i32]] 1{{$}}
+; CHECK-SPIRV-DAG: [[c32:%[0-9]+]] = OpConstant [[i32]] 32{{$}}
+; CHECK-SPIRV-DAG: [[c64:%[0-9]+]] = OpConstant [[i32]] 64{{$}}
+; CHECK-SPIRV-DAG: [[c16:%[0-9]+]] = OpConstant [[i32]] 16{{$}}
+; CHECK-SPIRV-DAG: [[dbgnone:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugInfoNone
+; CHECK-SPIRV-DAG: [[ds:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugSource
+; CHECK-SPIRV-DAG: [[cu:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugCompilationUnit
+; CHECK-SPIRV-DAG: [[basic_int:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugTypeBasic [[str_int]]
+; CHECK-SPIRV-DAG: [[basic_float:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugTypeBasic [[str_float]]
+; CHECK-SPIRV-DAG: [[member_a:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugTypeMember [[str_a]] [[basic_int]] [[ds]] {{%[0-9]+}} [[c0]] [[c0]] [[c32]] [[c0]]{{$}}
+; CHECK-SPIRV-DAG: [[member_b:%[0-9]+]] = OpExtInst [[void]] [[ext]] DebugTypeMember [[str_b]] [[basic_float]] [[ds]] {{%[0-9]+}} [[c0]] [[c32]] [[c32]] [[c0]]{{$}}
+; CHECK-SPIRV-DAG: OpExtInst [[void]] [[ext]] DebugTypeComposite [[str_S]] [[c1]] [[ds]] {{%[0-9]+}} [[c0]] [[cu]] {{%[0-9]+}} [[c64]] [[c0]] [[member_a]] [[member_b]]{{$}}
+; A forward declaration carries FlagFwdDecl (16) in its Flags operand.
+; CHECK-SPIRV-DAG: OpExtInst [[void]] [[ext]] DebugTypeComposite [[str_Fwd]] [[c1]] [[ds]] {{%[0-9]+}} [[c0]] [[cu]] {{%[0-9]+}} [[dbgnone]] [[c16]]{{$}}
+
+define spir_func void @test() !dbg !13 {
+entry:
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1, !2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4)
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !DIFile(filename: "composite.hlsl", directory: "/src")
+!4 = !{!5, !12}
+!5 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !3, line: 1, size: 64, elements: !6)
+!6 = !{!7, !9}
+!7 = !DIDerivedType(tag: DW_TAG_member, name: "a", file: !3, line: 2, baseType: !8, size: 32)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !DIDerivedType(tag: DW_TAG_member, name: "b", file: !3, line: 3, baseType: !10, size: 32, offset: 32)
+!10 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+!12 = !DICompositeType(tag: DW_TAG_structure_type, name: "Fwd", file: !3, line: 5, flags: DIFlagFwdDecl)
+!13 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 10, type: !14, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!14 = !DISubroutineType(types: !15)
+!15 = !{null}

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer-to-composite-drop.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer-to-composite-drop.ll
@@ -1,0 +1,36 @@
+; RUN: llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV --implicit-check-not=DebugTypePointer
+; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A pointer whose pointee is a composite is dropped. Pointers are emitted before
+; composites, so the pointee has no id yet when emitDebugTypePointer runs.
+; The composite itself is still emitted. Emitting the DebugType*
+; nodes in dependency order, tracked in
+; https://github.com/llvm/llvm-project/issues/211850, would emit the
+; DebugTypePointer and change the expected output of this test
+
+; CHECK-SPIRV: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV: DebugTypeComposite
+
+define spir_func void @test() !dbg !11 {
+entry:
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!1, !2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_HLSL, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4)
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !DIFile(filename: "pointer-to-struct.hlsl", directory: "/src")
+
+; S *p. Only the pointer is retained; S is reached through the pointee.
+!4 = !{!5}
+!5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64, dwarfAddressSpace: 4)
+!7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !3, line: 1, size: 32, elements: !8)
+!8 = !{!9}
+!9 = !DIDerivedType(tag: DW_TAG_member, name: "x", file: !3, line: 2, baseType: !10, size: 32)
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = distinct !DISubprogram(name: "test", scope: !3, file: !3, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!12 = !DISubroutineType(types: !13)
+!13 = !{null}


### PR DESCRIPTION
This PR adds `DebugTypeComposite` (opcode 10) and `DebugTypeMember` (opcode 11):

1. `partitionTypes` clusters `DICompositeType` with `DW_TAG_structure_type`, `DW_TAG_class_type`, or `DW_TAG_union_type`.
2. Each composite emits one `DebugTypeMember` per `DW_TAG_member`, then a `DebugTypeComposite`. Members precede the composite.
3. Tag maps class, structure, and union to 0, 1, and 2. A forward declaration emits `DebugInfoNone` for Size and no members.
4. A member whose type is not in `DebugTypeRegs` is skipped.

`DebugTypeMember` has no Parent operand, per the spec. Only the composite references its members.

Tests in `llvm/test/CodeGen/SPIRV/debug-info/`:

1. `debug-type-composite.ll`: a struct with two members and a forward declaration.
2. `debug-type-composite-skip-member-not-in-regs.ll`: a member whose type is a pointer with no DWARF address space, exercising the skip.

`debug-global-variable-skip-type-not-in-regs.ll` and `debug-global-variable-static-member.ll` assumed composites and members are never emitted. Both now use a no-address-space pointer to avoid disabling the existing test.