### PR TITLE
[clang-tidy] Add llvm-analyzer-unused-program-state-ref check

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/AnalyzerUnusedProgramStateRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/AnalyzerUnusedProgramStateRefCheck.cpp
@@ -42,10 +42,10 @@ void AnalyzerUnusedProgramStateRefCheck::registerMatchers(MatchFinder *Finder) {
                          .bind(VarID),
                      this);
 
-  Finder->addMatcher(
-      decompositionDecl(hasAnyBinding(bindingDecl(hasType(ProgramStateRefType))))
-          .bind(DecompID),
-      this);
+  Finder->addMatcher(decompositionDecl(hasAnyBinding(bindingDecl(
+                                           hasType(ProgramStateRefType))))
+                         .bind(DecompID),
+                     this);
 }
 
 void AnalyzerUnusedProgramStateRefCheck::check(

--- a/clang-tools-extra/clang-tidy/llvm/AnalyzerUnusedProgramStateRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/AnalyzerUnusedProgramStateRefCheck.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AnalyzerUnusedProgramStateRefCheck.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::llvm_check {
+
+namespace {
+AST_MATCHER(VarDecl, isUnusedLocal) {
+  return !Node.isReferenced() && !Node.hasAttr<UnusedAttr>();
+}
+} // namespace
+
+static bool isUnusedProgramStateRef(const BindingDecl *B) {
+  if (B->isReferenced())
+    return false;
+  const auto *TT = B->getType()->getAs<TypedefType>();
+  return TT && TT->getDecl()->getName() == "ProgramStateRef";
+}
+
+static constexpr llvm::StringLiteral DecompID = "decomp";
+static constexpr llvm::StringLiteral VarID = "var";
+
+void AnalyzerUnusedProgramStateRefCheck::registerMatchers(MatchFinder *Finder) {
+  auto ProgramStateRefType =
+      qualType(hasDeclaration(namedDecl(hasName("ProgramStateRef"))));
+
+  Finder->addMatcher(varDecl(hasLocalStorage(), isUnusedLocal(),
+                             hasType(ProgramStateRefType),
+                             unless(anyOf(parmVarDecl(), isInstantiated())))
+                         .bind(VarID),
+                     this);
+
+  Finder->addMatcher(
+      decompositionDecl(hasAnyBinding(bindingDecl(hasType(ProgramStateRefType))))
+          .bind(DecompID),
+      this);
+}
+
+void AnalyzerUnusedProgramStateRefCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  if (const auto *VD = Result.Nodes.getNodeAs<VarDecl>(VarID)) {
+    diag(VD->getLocation(), "unused 'ProgramStateRef' variable %0") << VD;
+    return;
+  }
+
+  // Structured binding. `[[maybe_unused]]` applies to the whole decomposition
+  // rather than the individual bindings, so it is checked here.
+  const auto *Decomp = Result.Nodes.getNodeAs<DecompositionDecl>(DecompID);
+  if (Decomp->hasAttr<UnusedAttr>())
+    return;
+
+  // Only flag when *every* binding is an unused `ProgramStateRef`.
+  if (llvm::all_of(Decomp->bindings(), isUnusedProgramStateRef))
+    diag(Decomp->getLocation(), "unused 'ProgramStateRef' structured binding");
+}
+
+} // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/clang-tidy/llvm/AnalyzerUnusedProgramStateRefCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/AnalyzerUnusedProgramStateRefCheck.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_ANALYZERUNUSEDPROGRAMSTATEREFCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_ANALYZERUNUSEDPROGRAMSTATEREFCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::llvm_check {
+
+/// Finds unused local `clang::ento::ProgramStateRef` variables. These are not
+/// diagnosed by `-Wunused-variable` because `ProgramStateRef` has a non-trivial
+/// destructor, even though it carries no meaningful RAII side effects.
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/llvm/analyzer-unused-program-state-ref.html
+class AnalyzerUnusedProgramStateRefCheck : public ClangTidyCheck {
+public:
+  AnalyzerUnusedProgramStateRefCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace clang::tidy::llvm_check
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_ANALYZERUNUSEDPROGRAMSTATEREFCHECK_H

--- a/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangTidyLLVMModule STATIC
+  AnalyzerUnusedProgramStateRefCheck.cpp
   FormatvStringCheck.cpp
   HeaderGuardCheck.cpp
   IncludeOrderCheck.cpp

--- a/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
@@ -11,6 +11,7 @@
 #include "../readability/ElseAfterReturnCheck.h"
 #include "../readability/NamespaceCommentCheck.h"
 #include "../readability/QualifiedAutoCheck.h"
+#include "AnalyzerUnusedProgramStateRefCheck.h"
 #include "FormatvStringCheck.h"
 #include "HeaderGuardCheck.h"
 #include "IncludeOrderCheck.h"
@@ -31,6 +32,8 @@ namespace {
 class LLVMModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<AnalyzerUnusedProgramStateRefCheck>(
+        "llvm-analyzer-unused-program-state-ref");
     CheckFactories.registerCheck<readability::ElseAfterReturnCheck>(
         "llvm-else-after-return");
     CheckFactories.registerCheck<FormatvStringCheck>("llvm-formatv-string");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -97,6 +97,13 @@ Improvements to clang-tidy
 New checks
 ^^^^^^^^^^
 
+- New :doc:`llvm-analyzer-unused-program-state-ref
+  <clang-tidy/checks/llvm/analyzer-unused-program-state-ref>` check.
+
+  Finds unused local ``clang::ento::ProgramStateRef`` variables, which
+  ``-Wunused-variable`` does not diagnose because the type has a non-trivial
+  destructor.
+
 New check aliases
 ^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -243,6 +243,7 @@ Clang-Tidy Checks
    :doc:`google-runtime-operator <google/runtime-operator>`,
    :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes"
    :doc:`linuxkernel-must-check-errs <linuxkernel/must-check-errs>`,
+   :doc:`llvm-analyzer-unused-program-state-ref <llvm/analyzer-unused-program-state-ref>`,
    :doc:`llvm-formatv-string <llvm/formatv-string>`,
    :doc:`llvm-header-guard <llvm/header-guard>`,
    :doc:`llvm-include-order <llvm/include-order>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/analyzer-unused-program-state-ref.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/analyzer-unused-program-state-ref.rst
@@ -1,0 +1,37 @@
+.. title:: clang-tidy - llvm-analyzer-unused-program-state-ref
+
+llvm-analyzer-unused-program-state-ref
+======================================
+
+Finds unused local ``clang::ento::ProgramStateRef`` variables in Clang Static
+Analyzer code.
+
+``ProgramStateRef`` is an ``IntrusiveRefCntPtr<const ProgramState>``, i.e. a
+reference-counted smart pointer with a non-trivial destructor. Because of that
+destructor, ``-Wunused-variable`` never reports such a variable, even when it is
+declared and never read -- the compiler conservatively assumes the destructor
+might have side effects. ``ProgramStateRef`` carries no meaningful RAII side
+effects, so an unused one is simply dead code, usually left behind after a
+refactoring.
+
+.. code-block:: c++
+
+  void Checker::checkPreCall(const CallEvent &Call, CheckerContext &C) const {
+    ProgramStateRef State = C.getState();
+    // ... State is never used ...
+  }
+
+The declaration above is dead code and can be deleted by hand. For a statement
+that declares several variables at once (``ProgramStateRef A, B;``), each unused
+declarator is reported individually; if only some are unused the others are left
+untouched. A declaration that originates from a macro expansion is still
+reported.
+
+Structured bindings are also handled, e.g.
+
+.. code-block:: c++
+
+  auto [StTrue, StFalse] = State->assume(V); // both unused
+
+is reported. A structured binding is only flagged when *every* binding is an
+unused ``ProgramStateRef``; a partially-used decomposition is left alone.

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/analyzer-unused-program-state-ref.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/analyzer-unused-program-state-ref.cpp
@@ -1,0 +1,97 @@
+// RUN: %check_clang_tidy -std=c++17 %s llvm-analyzer-unused-program-state-ref %t
+
+// Stub that mirrors clang::ento::ProgramStateRef without pulling in the
+// analyzer headers. The check keys on the fully-qualified typedef name.
+// The user-declared destructor makes it non-trivially destructible, exactly
+// like the real IntrusiveRefCntPtr, so -Wunused-variable stays silent.
+namespace clang {
+namespace ento {
+template <class T>
+struct IntrusiveRefCntPtr {
+  IntrusiveRefCntPtr();
+  ~IntrusiveRefCntPtr();
+};
+class ProgramState;
+typedef IntrusiveRefCntPtr<const ProgramState> ProgramStateRef;
+} // namespace ento
+} // namespace clang
+
+using clang::ento::ProgramStateRef;
+
+ProgramStateRef getState();
+void use(ProgramStateRef State);
+
+// Aggregate returned by value, decomposed via structured bindings, mirroring
+// the analyzer's `std::pair<ProgramStateRef, ProgramStateRef>` from
+// `ProgramState::assume()`.
+struct StatePair {
+  ProgramStateRef first;
+  ProgramStateRef second;
+};
+struct MixedPair {
+  ProgramStateRef first;
+  int second;
+};
+StatePair assume();
+MixedPair mixedAssume();
+
+void unused_local() {
+  ProgramStateRef State = getState();
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: unused 'ProgramStateRef' variable 'State' [llvm-analyzer-unused-program-state-ref]
+}
+
+void unused_no_init() {
+  ProgramStateRef State;
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: unused 'ProgramStateRef' variable 'State' [llvm-analyzer-unused-program-state-ref]
+}
+
+void used_read() {
+  ProgramStateRef State = getState();
+  use(State);
+}
+
+void parameter_is_ignored(ProgramStateRef State) {}
+
+void maybe_unused_is_ignored() {
+  [[maybe_unused]] ProgramStateRef State = getState();
+}
+
+void multi_all_unused() {
+  ProgramStateRef A, B;
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: unused 'ProgramStateRef' variable 'A' [llvm-analyzer-unused-program-state-ref]
+  // CHECK-MESSAGES: :[[@LINE-2]]:22: warning: unused 'ProgramStateRef' variable 'B' [llvm-analyzer-unused-program-state-ref]
+}
+
+void multi_mixed() {
+  ProgramStateRef A, B = getState();
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: unused 'ProgramStateRef' variable 'A' [llvm-analyzer-unused-program-state-ref]
+  use(B);
+}
+
+#define DECLARE_STATE ProgramStateRef State = getState();
+void from_macro() {
+  DECLARE_STATE
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: unused 'ProgramStateRef' variable 'State' [llvm-analyzer-unused-program-state-ref]
+}
+
+void structured_binding_all_unused() {
+  auto [StTrue, StFalse] = assume();
+  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: unused 'ProgramStateRef' structured binding [llvm-analyzer-unused-program-state-ref]
+}
+
+void structured_binding_partially_used() {
+  // A partially-used decomposition is out of scope; leave it alone.
+  auto [StTrue, StFalse] = assume();
+  use(StTrue);
+}
+
+void structured_binding_maybe_unused() {
+  [[maybe_unused]] auto [StTrue, StFalse] = assume();
+}
+
+void structured_binding_non_program_state_ref() {
+  // Not all bindings are ProgramStateRef; out of scope.
+  auto [State, Count] = mixedAssume();
+  use(State);
+}
+


### PR DESCRIPTION
Adds a new llvm-module check that flags unused local `clang::ento::ProgramStateRef` variables. `ProgramStateRef` is an `IntrusiveRefCntPtr<const ProgramState>`, whose non-trivial destructor causes `-Wunused-variable` to stay silent even though the type carries no meaningful RAII side effects, so an unused one is just dead code.

Assisted-by: claude