### PR TITLE
[Sema] Fix crash on function declaration inside nested expansion statements

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2891,11 +2891,10 @@ Decl *TemplateDeclInstantiator::VisitFunctionDecl(
     Function->setLocalExternDecl();
 
   DeclContext *LexicalDC = Owner;
-  if (!isFriend && D->isOutOfLine() && !D->isLocalExternDecl()) {
-    assert(D->getDeclContext()->isFileContext());
+  if (!isFriend && D->isOutOfLine() && !D->isLocalExternDecl() &&
+      D->getDeclContext()->isFileContext()) {
     LexicalDC = D->getDeclContext();
-  }
-  else if (D->isLocalExternDecl()) {
+  } else if (D->isLocalExternDecl()) {
     LexicalDC = SemaRef.CurContext;
   }
 

--- a/clang/test/SemaTemplate/GH210512.cpp
+++ b/clang/test/SemaTemplate/GH210512.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++26 -verify %s
+// expected-no-diagnostics
+
+void foo() {
+  template for (auto x : {1, 3}) {
+    template for (auto x : {1, 0}) { void bar(); }
+  }
+}


### PR DESCRIPTION
`VisitFunctionDecl` asserts that out-of-line non-local-extern function declarations must have file context as their `DeclContext`. With C++26 expansion statements (`template for`), the `DeclContext` can be a `CXXExpansionStmtDecl`, which is not file context, triggering the assertion.
Replace the assertion with a conditional check, matching the pattern already used in `VisitCXXMethodDecl` for the same `isOutOfLine()` case.

Fixes #210512