### PR TITLE
[mlir][acc] Allow for existing declare globals in GPU module under unified memory.

### DIFF
--- a/flang/test/Fir/OpenACC/acc-declare-gpu-module-insertion.fir
+++ b/flang/test/Fir/OpenACC/acc-declare-gpu-module-insertion.fir
@@ -12,12 +12,30 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.conta
     %0 = fir.zero_bits !fir.array<7xf32>
     fir.has_value %0 : !fir.array<7xf32>
   }
+  fir.global @precloned {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.array<1xf32> {
+    %0 = fir.zero_bits !fir.array<1xf32>
+    fir.has_value %0 : !fir.array<1xf32>
+  }
+  fir.global @constant_shared {acc.declare = #acc.declare<dataClause = acc_copyin>} constant : i32 {
+    %0 = arith.constant 42 : i32
+    fir.has_value %0 : i32
+  }
+  gpu.module @acc_gpu_module {
+    fir.global @precloned {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.array<1xf32> {
+      %0 = fir.zero_bits !fir.array<1xf32>
+      fir.has_value %0 : !fir.array<1xf32>
+    }
+  }
 }
 
 // CHECK-LABEL: gpu.module @acc_gpu_module {
+// CHECK: fir.global @precloned {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.array<1xf32>
+// CHECK-NOT: fir.has_value
 // CHECK: fir.global @shared {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.array<7xf32>
 // CHECK-NOT: fir.has_value
 // CHECK: fir.global @initialized_shared {acc.declare = #acc.declare<dataClause = acc_copyin>} : !fir.array<1xf32>
 // CHECK-NOT: fir.has_value
 // CHECK: fir.global @resident {{.*}} : !fir.array<7xf32> {
+// CHECK: fir.has_value
+// CHECK: fir.global @constant_shared {acc.declare = #acc.declare<dataClause = acc_copyin>} constant : i32 {
 // CHECK: fir.has_value

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCDeclareGPUModuleInsertion.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCDeclareGPUModuleInsertion.cpp
@@ -109,21 +109,41 @@ public:
       Operation *deviceGlobal = globalOp.clone();
       auto declareAttr =
           globalOp.getAttrOfType<acc::DeclareAttr>(acc::getDeclareAttrName());
-      if (cudaUnified && declareAttr.getDataClause().getValue() !=
-                             acc::DataClause::acc_declare_device_resident)
+      auto globalVar = dyn_cast<acc::GlobalVariableOpInterface>(&globalOp);
+      bool makeUnifiedDeclaration =
+          cudaUnified &&
+          declareAttr.getDataClause().getValue() !=
+              acc::DataClause::acc_declare_device_resident &&
+          (!globalVar || !globalVar.isConstant());
+      if (makeUnifiedDeclaration)
         makeDeviceGlobalDeclaration(*deviceGlobal);
 
       if (Operation *existing = gpuSymTable.lookup(name.getValue())) {
         // Reuse when structurally equivalent ignoring locations and discardable
         // attrs such as `acc.declare` attributes. Only a different op type or a
         // true definition mismatch is a conflict.
-        if (existing->getName() != globalOp.getName() ||
-            !OperationEquivalence::isEquivalentTo(
-                existing, deviceGlobal,
-                OperationEquivalence::ignoreValueEquivalence,
-                /*markEquivalent=*/nullptr,
-                OperationEquivalence::IgnoreLocations |
-                    OperationEquivalence::IgnoreDiscardableAttrs)) {
+        auto isEquivalent = [](Operation *lhs, Operation *rhs) {
+          return lhs->getName() == rhs->getName() &&
+                 OperationEquivalence::isEquivalentTo(
+                     lhs, rhs, OperationEquivalence::ignoreValueEquivalence,
+                     /*markEquivalent=*/nullptr,
+                     OperationEquivalence::IgnoreLocations |
+                         OperationEquivalence::IgnoreDiscardableAttrs);
+        };
+        if (!isEquivalent(existing, deviceGlobal)) {
+          // Earlier GPU lowering can create a global in the GPU module before
+          // this pass. In unified memory, convert an equivalent pre-existing
+          // global to the declaration form expected for an OpenACC global.
+          if (makeUnifiedDeclaration) {
+            Operation *normalizedExisting = existing->clone();
+            makeDeviceGlobalDeclaration(*normalizedExisting);
+            bool canReuse = isEquivalent(normalizedExisting, deviceGlobal);
+            normalizedExisting->destroy();
+            if (canReuse)
+              makeDeviceGlobalDeclaration(*existing);
+          }
+        }
+        if (!isEquivalent(existing, deviceGlobal)) {
           deviceGlobal->destroy();
           accSupport.emitNYI(globalOp.getLoc(),
                              llvm::Twine("duplicate global symbol '") +


### PR DESCRIPTION
OpenACC declare globals may already exist in the GPU module from earlier GPU lowering. Under unified memory, this pass expects those device copies as declarations, but a pre-existing global may still have an initializer and therefore not match.
This change adapts an otherwise equivalent existing GPU global to declaration form and reuses it; A lit test covers a host/GPU declare global that should be reused as a declaration in the GPU module.