### PR TITLE
[lldb] Add GetSizeType to TypeSystemClang to retrieve `size_t`

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -227,6 +227,8 @@ public:
 
   virtual CompilerType GetPointerDiffType(bool is_signed) = 0;
 
+  virtual CompilerType GetSizeType() = 0;
+
   virtual unsigned GetPtrAuthKey(lldb::opaque_compiler_type_t type) = 0;
 
   virtual unsigned

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2414,6 +2414,14 @@ CompilerType TypeSystemClang::GetPointerDiffType(bool is_signed) {
   return GetType(getASTContext().getUnsignedPointerDiffType());
 }
 
+CompilerType TypeSystemClang::GetSizeType() {
+  // Check if builtin types are initialized.
+  if (!getASTContext().VoidPtrTy)
+    return {};
+
+  return GetType(getASTContext().getSizeType());
+}
+
 void TypeSystemClang::DumpDeclContextHiearchy(clang::DeclContext *decl_ctx) {
   if (decl_ctx) {
     DumpDeclContextHiearchy(decl_ctx->getParent());

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -512,6 +512,8 @@ public:
 
   CompilerType GetPointerDiffType(bool is_signed) override;
 
+  CompilerType GetSizeType() override;
+
   // Floating point functions
 
   static CompilerType GetFloatTypeFromBitSize(clang::ASTContext *ast,

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -349,6 +349,7 @@ TEST_F(TestTypeSystemClang, TestBuiltinTypeForEmptyTriple) {
   EXPECT_FALSE(ast.GetIntTypeFromBitSize(8, /*is_signed=*/false));
   EXPECT_FALSE(ast.GetPointerDiffType(/*is_signed=*/true));
   EXPECT_FALSE(ast.GetPointerDiffType(/*is_signed=*/false));
+  EXPECT_FALSE(ast.GetSizeType());
 
   CompilerType record_type =
       ast.CreateRecordType(nullptr, OptionalClangModuleID(), "Record",
@@ -374,6 +375,12 @@ TEST_F(TestTypeSystemClang, TestGetPointerDiffType) {
   EXPECT_EQ(
       llvm::expectedToOptional(uptrdiff_t.GetByteSize(nullptr)).value_or(0),
       m_ast->GetPointerByteSize());
+}
+
+TEST_F(TestTypeSystemClang, TestGetSizeType) {
+  CompilerType size_type = m_ast->GetSizeType();
+  EXPECT_EQ(size_type.GetDisplayTypeName(), "__size_t");
+  EXPECT_FALSE(size_type.IsSigned());
 }
 
 TEST_F(TestTypeSystemClang, TestGetBuiltinTypeByName_BitInt) {


### PR DESCRIPTION
This will be used to implement operator `sizeof` for DIL.