### PR TITLE
[NVPTX] Respect local pointer width for %SPL

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1653,13 +1653,12 @@ void NVPTXAsmPrinter::setAndEmitFunctionVirtualRegisters(
   if (NumBytes) {
     O << "\t.local .align " << MFI.getMaxAlign().value() << " .b8 \t"
       << DEPOTNAME << getFunctionNumber() << "[" << NumBytes << "];\n";
-    if (static_cast<const NVPTXTargetMachine &>(MF.getTarget()).is64Bit()) {
-      O << "\t.reg .b64 \t%SP;\n"
-        << "\t.reg .b64 \t%SPL;\n";
-    } else {
-      O << "\t.reg .b32 \t%SP;\n"
-        << "\t.reg .b32 \t%SPL;\n";
-    }
+    const bool Is64Bit =
+        static_cast<const NVPTXTargetMachine &>(MF.getTarget()).is64Bit();
+    const bool IsLocal64 =
+        MF.getDataLayout().getPointerSizeInBits(ADDRESS_SPACE_LOCAL) == 64;
+    O << "\t.reg .b" << (Is64Bit ? 64 : 32) << " \t%SP;\n"
+      << "\t.reg .b" << (IsLocal64 ? 64 : 32) << " \t%SPL;\n";
   }
 
   // Go through all virtual registers to establish the mapping between the

--- a/llvm/lib/Target/NVPTX/NVPTXFrameLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXFrameLowering.cpp
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "NVPTXFrameLowering.h"
+#include "MCTargetDesc/NVPTXBaseInfo.h"
 #include "NVPTX.h"
 #include "NVPTXRegisterInfo.h"
 #include "NVPTXSubtarget.h"
-#include "NVPTXTargetMachine.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
@@ -44,27 +44,36 @@ void NVPTXFrameLowering::emitPrologue(MachineFunction &MF,
     // in the BB, so giving it no debug location.
     DebugLoc dl = DebugLoc();
 
-    // Emits
-    //   mov %SPL, %depot;
-    //   cvta.local %SP, %SPL;
-    // for local address accesses in MF.
-    bool Is64Bit =
-        static_cast<const NVPTXTargetMachine &>(MF.getTarget()).is64Bit();
+    // Emits the %SPL depot move and, when %SP is used, cvta.local.
+    // Mixed-width targets widen %SPL before cvta.local.
+    const Register FrameReg = NRI->getFrameRegister(MF);
+    const Register FrameLocalReg = NRI->getFrameLocalRegister(MF);
+    const bool Is64Bit = FrameReg == NVPTX::VRFrame64;
+    const bool IsLocal64 = FrameLocalReg == NVPTX::VRFrameLocal64;
     unsigned CvtaLocalOpcode =
         (Is64Bit ? NVPTX::cvta_local_64 : NVPTX::cvta_local_32);
     unsigned MovDepotOpcode =
-        (Is64Bit ? NVPTX::MOV_DEPOT_ADDR_64 : NVPTX::MOV_DEPOT_ADDR);
-    if (!MR.use_empty(NRI->getFrameRegister(MF))) {
+        (IsLocal64 ? NVPTX::MOV_DEPOT_ADDR_64 : NVPTX::MOV_DEPOT_ADDR);
+    if (!MR.use_empty(FrameReg)) {
       // If %SP is not used, do not bother emitting "cvta.local %SP, %SPL".
       MBBI = BuildMI(MBB, MBBI, dl,
                      MF.getSubtarget().getInstrInfo()->get(CvtaLocalOpcode),
-                     NRI->getFrameRegister(MF))
-                 .addReg(NRI->getFrameLocalRegister(MF));
+                     FrameReg)
+                 .addReg(Is64Bit == IsLocal64 ? FrameLocalReg : FrameReg);
+      if (Is64Bit && !IsLocal64) {
+        // Widen %SPL before converting it to a generic pointer.
+        MBBI =
+            BuildMI(MBB, MBBI, dl,
+                    MF.getSubtarget().getInstrInfo()->get(NVPTX::CVT_u64_u32),
+                    FrameReg)
+                .addReg(FrameLocalReg)
+                .addImm(NVPTX::PTXCvtMode::NONE);
+      }
     }
-    if (!MR.use_empty(NRI->getFrameLocalRegister(MF))) {
+    if (!MR.use_empty(FrameLocalReg)) {
       BuildMI(MBB, MBBI, dl,
               MF.getSubtarget().getInstrInfo()->get(MovDepotOpcode),
-              NRI->getFrameLocalRegister(MF))
+              FrameLocalReg)
           .addImm(MF.getFunctionNumber());
     }
   }

--- a/llvm/lib/Target/NVPTX/NVPTXPeephole.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXPeephole.cpp
@@ -91,6 +91,11 @@ static bool isCVTAToLocalCombinationCandidate(MachineInstr &Root) {
   const NVPTXRegisterInfo *NRI =
       MF.getSubtarget<NVPTXSubtarget>().getRegisterInfo();
 
+  // LEA and %SPL must have the same width.
+  if ((GenericAddrDef->getOpcode() == NVPTX::LEA_ADDRi64) !=
+      (NRI->getFrameLocalRegister(MF) == NVPTX::VRFrameLocal64))
+    return false;
+
   // Check the LEA_ADDRi operand is Frame index
   auto &BaseAddrOp = GenericAddrDef->getOperand(1);
   if (BaseAddrOp.isReg() && BaseAddrOp.getReg() == NRI->getFrameRegister(MF)) {

--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
@@ -138,9 +138,9 @@ Register NVPTXRegisterInfo::getFrameRegister(const MachineFunction &MF) const {
 
 Register
 NVPTXRegisterInfo::getFrameLocalRegister(const MachineFunction &MF) const {
-  const NVPTXTargetMachine &TM =
-      static_cast<const NVPTXTargetMachine &>(MF.getTarget());
-  return TM.is64Bit() ? NVPTX::VRFrameLocal64 : NVPTX::VRFrameLocal32;
+  return MF.getDataLayout().getPointerSizeInBits(ADDRESS_SPACE_LOCAL) == 64
+             ? NVPTX::VRFrameLocal64
+             : NVPTX::VRFrameLocal32;
 }
 
 void NVPTXRegisterInfo::clearDebugRegisterMap() const {

--- a/llvm/test/CodeGen/NVPTX/lower-args-gridconstant.ll
+++ b/llvm/test/CodeGen/NVPTX/lower-args-gridconstant.ll
@@ -229,12 +229,12 @@ define ptx_kernel void @multiple_grid_const_escape(ptr byval(%struct.s) align 4 
 ; PTX-SHORT-PTR:       {
 ; PTX-SHORT-PTR-NEXT:    .local .align 4 .b8 __local_depot4[4];
 ; PTX-SHORT-PTR-NEXT:    .reg .b64 %SP;
-; PTX-SHORT-PTR-NEXT:    .reg .b64 %SPL;
+; PTX-SHORT-PTR-NEXT:    .reg .b32 %SPL;
 ; PTX-SHORT-PTR-NEXT:    .reg .b32 %r<5>;
 ; PTX-SHORT-PTR-NEXT:    .reg .b64 %rd<8>;
 ; PTX-SHORT-PTR-NEXT:  prototype_1 : .callprototype (.param .b32 _) _ (.param .b64 _, .param .b64 _, .param .b64 _);
 ; PTX-SHORT-PTR-NEXT:  // %bb.0:
-; PTX-SHORT-PTR-NEXT:    mov.b64 %SPL, __local_depot4;
+; PTX-SHORT-PTR-NEXT:    mov.b32 %SPL, __local_depot4;
 ; PTX-SHORT-PTR-NEXT:    mov.b32 %r1, multiple_grid_const_escape_param_0;
 ; PTX-SHORT-PTR-NEXT:    mov.b32 %r2, multiple_grid_const_escape_param_2;
 ; PTX-SHORT-PTR-NEXT:    cvt.u64.u32 %rd1, %r2;

--- a/llvm/test/CodeGen/NVPTX/peephole-cvta-local-short-ptr.mir
+++ b/llvm/test/CodeGen/NVPTX/peephole-cvta-local-short-ptr.mir
@@ -1,0 +1,26 @@
+# RUN: llc -mtriple=nvptx64 -mcpu=sm_20 -run-pass=nvptx-peephole %s -o - | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: llc -mtriple=nvptx64 -mcpu=sm_20 -nvptx-short-ptr -run-pass=nvptx-peephole %s -o - | FileCheck %s --check-prefixes=CHECK,NOFOLD
+
+# Do not fold a 64-bit LEA onto a 32-bit %SPL.
+
+--- |
+  target triple = "nvptx64-nvidia-cuda"
+
+  define void @test() {
+    ret void
+  }
+...
+---
+name: test
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test
+    ; FOLD: %1:b64 = LEA_ADDRi64 $vrframelocal64, 4
+    ; FOLD-NOT: cvta_to_local_64
+    ; NOFOLD: %0:b64 = LEA_ADDRi64 $vrframe64, 4
+    ; NOFOLD-NEXT: %1:b64 = cvta_to_local_64 killed %0
+    %0:b64 = LEA_ADDRi64 $vrframe64, 4
+    %1:b64 = cvta_to_local_64 killed %0
+    Return
+...

--- a/llvm/test/CodeGen/NVPTX/short-ptr.ll
+++ b/llvm/test/CodeGen/NVPTX/short-ptr.ll
@@ -34,11 +34,28 @@ define void @test2() {
   %v = alloca i8
   %cast = addrspacecast ptr %v to ptr addrspace(5)
   ; CHECK-DEFAULT: .param .b64 param0;
+  ; CHECK-DEFAULT: add.u64 %rd{{.*}}, %SPL, 0;
   ; CHECK-DEFAULT: st.param.b64
   ; CHECK-DEFAULT-32: .param .b32 param0;
+  ; CHECK-DEFAULT-32: add.u32 %r{{.*}}, %SPL, 0;
   ; CHECK-DEFAULT-32: st.param.b32
+  ; CHECK-SHORT-LOCAL: .reg .b32 %SPL;
   ; CHECK-SHORT-LOCAL: .param .b32 param0;
+  ; CHECK-SHORT-LOCAL: add.u32 %r{{.*}}, %SPL, 0;
   ; CHECK-SHORT-LOCAL: st.param.b32
   call void @test1(ptr addrspace(5) %cast)
   ret void
+}
+
+; Exercise the mixed-width prologue for a generic stack temporary.
+define <4 x float> @test3(<4 x float> %v, i32 %i, float %x) {
+  ; CHECK-DEFAULT: mov.b64 %SPL, __local_depot2;
+  ; CHECK-DEFAULT-NEXT: cvta.local.u64 %SP, %SPL;
+  ; CHECK-DEFAULT-32: mov.b32 %SPL, __local_depot2;
+  ; CHECK-DEFAULT-32-NEXT: cvta.local.u32 %SP, %SPL;
+  ; CHECK-SHORT-LOCAL: mov.b32 %SPL, __local_depot2;
+  ; CHECK-SHORT-LOCAL-NEXT: cvt.u64.u32 %SP, %SPL;
+  ; CHECK-SHORT-LOCAL-NEXT: cvta.local.u64 %SP, %SP;
+  %r = insertelement <4 x float> %v, float %x, i32 %i
+  ret <4 x float> %r
 }


### PR DESCRIPTION
With -nvptx-short-ptr on nvptx64, local pointers are 32-bit, but %SPL was declared and initialized as 64-bit. Frame-index lowering then emitted add.u32 with a 64-bit base, which ptxas rejected.

Select, declare, and initialize %SPL using the local pointer width. Widen it when constructing the generic %SP, avoid peephole folds across mismatched widths, and cover both paths.

Fixes the llvm-nvptx-nvidia-win buildbot failure in `short-ptr.ll`, https://lab.llvm.org/buildbot/#/builders/54/builds/21744, introduced in #204346,; I had not noticed this because I didn't realize I needed `LLVM_PTXAS_EXECUTABLE` for my system `ptxas` to be used.