### PR TITLE
Fix error reported by -Wrange-loop-construct

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp
@@ -34,7 +34,7 @@ Align getAlign(const DataLayout &DL, const GlobalVariable *GV) {
 void copyMetadataForWidenedLoad(LoadInst &Dest, const LoadInst &Source) {
   SmallVector<std::pair<unsigned, MDNode *>, 8> MD;
   Source.getAllMetadata(MD);
-  for (const auto [ID, N] : MD) {
+  for (const auto &[ID, N] : MD) {
     switch (ID) {
     case LLVMContext::MD_dbg:
     case LLVMContext::MD_invariant_load:


### PR DESCRIPTION
One system I'm building on adds -Wrange-loop-construct to the list of -W<group> options.  This results in the compile error:

```
/home/perry/llvm/Woz/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp:37:19: error: loop variable '[ID, N]' creates a copy from type 'std::pair<unsigned int, llvm::MDNode *> const' [-Werror,-Wrange-loop-construct]
  for (const auto [ID, N] : MD) {
                  ^
/home/perry/llvm/Woz/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp:37:8: note: use reference type 'std::pair<unsigned int, llvm::MDNode *> const &' to prevent copying
  for (const auto [ID, N] : MD) {
       ^~~~~~~~~~~~~~~~~~~~
                  &
1 error generated.
```