### PR TITLE
[libc++] Consistently install Python and dependencies across macOS CI jobs

### DIFF
--- a/.github/workflows/libcxx-benchmark-commit.yml
+++ b/.github/workflows/libcxx-benchmark-commit.yml
@@ -43,13 +43,12 @@ jobs:
           - lnt-machine: macos-26.5-arm64
             runner: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
             cxx: clang++
-            install-python: false
-            install-macos-dependencies: true
+            running-on: macos
+            xcode-version: '26.5'
           - lnt-machine: linux-x86_64
             runner: llvm-premerge-libcxx-runners
             cxx: clang++-22
-            install-python: true
-            install-macos-dependencies: false
+            running-on: linux
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     env:
@@ -64,21 +63,28 @@ jobs:
           fetch-tags: true
 
       - name: Install Python
-        if: ${{ matrix.install-python }}
+        if: ${{ matrix.running-on == 'linux' }} # installed via Homebrew on macOS
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
 
-      - name: Install Ninja and CMake
-        if: ${{ matrix.install-macos-dependencies }}
+      - name: Select Xcode
+        if: ${{ matrix.running-on == 'macos' }}
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer" >> $GITHUB_ENV
+
+      - name: Install dependencies via Homebrew
+        if: ${{ matrix.running-on == 'macos' }}
         run: |
-          brew install ninja cmake
+          brew update
+          brew install ninja cmake python@3.14
+          echo "$(brew --prefix python@3.14)/libexec/bin" >> "$GITHUB_PATH"
 
       - name: Diagnose tools in use
         run: |
           cmake --version
           ninja --version
           "${COMPILER}" --version
+          python3 --version
 
       - name: Run the benchmarks
         env:

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -198,13 +198,13 @@ jobs:
       matrix:
         include:
         - config: generic-cxx03
-          xcode-version: 26.5
+          xcode-version: '26.5'
         - config: generic-cxx23
-          xcode-version: 26.5
+          xcode-version: '26.5'
         - config: generic-modules
-          xcode-version: 26.5
+          xcode-version: '26.5'
         - config: apple-configuration
-          xcode-version: 26.5
+          xcode-version: '26.5'
         # TODO: These jobs are intended to test back-deployment (building against ToT libc++ but running against an
         #       older system-provided libc++.dylib). Doing this properly would require building the test suite on a
         #       recent macOS using a recent Clang (hence recent Xcode), and then running the actual test suite on an
@@ -216,9 +216,9 @@ jobs:
         #       macOS versions as a way to avoid rotting that configuration, but it doesn't provide a lot of additional
         #       coverage.
         - config: apple-system
-          xcode-version: 26.5
+          xcode-version: '26.5'
         - config: apple-system-hardened
-          xcode-version: 26.5
+          xcode-version: '26.5'
     runs-on: ["self-hosted", "macOS", "apple-runners"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -228,6 +228,7 @@ jobs:
         run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer" >> $GITHUB_ENV
       - name: Install Ninja and CMake
         run: |
+          brew update
           brew install ninja cmake
       - name: Build and test
         run: |

--- a/.github/workflows/libcxx-pr-benchmark.yml
+++ b/.github/workflows/libcxx-pr-benchmark.yml
@@ -92,13 +92,12 @@ jobs:
           - platform: macOS 26.5 arm64
             runner: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
             cxx: clang++
-            install-python: false
-            install-macos-dependencies: true
+            running-on: macos
+            xcode-version: '26.5'
           - platform: Linux x86_64
             runner: llvm-premerge-libcxx-runners
             cxx: clang++-22
-            install-python: true
-            install-macos-dependencies: false
+            running-on: linux
       fail-fast: false
     permissions:
       pull-requests: write
@@ -120,15 +119,28 @@ jobs:
           fetch-tags: true # This job requires access to all the Git branches so it can diff against (usually) main
 
       - name: Install Python
-        if: ${{ matrix.install-python }}
+        if: ${{ matrix.running-on == 'linux' }} # installed via Homebrew on macOS
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
 
-      - name: Install Ninja and CMake
-        if: ${{ matrix.install-macos-dependencies }}
+      - name: Select Xcode
+        if: ${{ matrix.running-on == 'macos' }}
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer" >> $GITHUB_ENV
+
+      - name: Install dependencies via Homebrew
+        if: ${{ matrix.running-on == 'macos' }}
         run: |
-          brew install ninja cmake
+          brew update
+          brew install ninja cmake python@3.14
+          echo "$(brew --prefix python@3.14)/libexec/bin" >> "$GITHUB_PATH"
+
+      - name: Diagnose tools in use
+        run: |
+          cmake --version
+          ninja --version
+          "${COMPILER}" --version
+          python3 --version
 
       - name: Setup virtual environment
         run: |


### PR DESCRIPTION
On the macOS self-hosted runners, we need to install dependencies via Homebrew and pinning the Xcode version is good for reproducibility. This applies the guidelines documented in #211622 to libc++'s CI jobs.