### PR TITLE
[SLP]Remove accidental commenting out the code

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -30777,8 +30777,8 @@ public:
           V.getTreeCost(TreeCost, VL, ReductionCost, RdxRootInst);
       LLVM_DEBUG(dbgs() << "SLP: Found cost = " << Cost
                         << " for ordered reduction\n");
-      if (Cost > -SLPCostThreshold/* ||
-          (Cost == -SLPCostThreshold && V.getTreeSize() > 1)*/) {
+      if (Cost > -SLPCostThreshold ||
+          (Cost == -SLPCostThreshold && V.getTreeSize() > 1)) {
         if (Cost.isValid())
           V.getORE()->emit([&]() {
             return OptimizationRemarkMissed(SV_NAME, "HorSLPNotBeneficial",

--- a/llvm/test/Transforms/SLPVectorizer/X86/extractelements-vector-ops-shuffle.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/extractelements-vector-ops-shuffle.ll
@@ -4,20 +4,25 @@
 define double @test() {
 ; CHECK-LABEL: define double @test() {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = load <2 x double>, ptr getelementptr inbounds ([13 x double], ptr null, i64 0, i64 5), align 8
-; CHECK-NEXT:    [[TMP1:%.*]] = load <2 x double>, ptr getelementptr inbounds ([13 x double], ptr null, i64 0, i64 8), align 16
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <2 x double> [[TMP0]], <2 x double> [[TMP1]], <2 x i32> <i32 1, i32 3>
-; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <2 x double> [[TMP2]], <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
-; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x double> [[TMP3]], <4 x double> <double 0.000000e+00, double 0.000000e+00, double poison, double poison>, <4 x i32> <i32 4, i32 5, i32 0, i32 1>
+; CHECK-NEXT:    [[TMP0:%.*]] = load double, ptr getelementptr inbounds ([13 x double], ptr null, i64 0, i64 5), align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = load double, ptr getelementptr inbounds ([13 x double], ptr null, i64 0, i64 6), align 16
+; CHECK-NEXT:    [[TMP2:%.*]] = load double, ptr getelementptr inbounds ([13 x double], ptr null, i64 0, i64 8), align 16
+; CHECK-NEXT:    [[TMP3:%.*]] = load double, ptr getelementptr inbounds ([13 x double], ptr null, i64 0, i64 9), align 8
+; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <4 x double> <double 0.000000e+00, double 0.000000e+00, double poison, double poison>, double [[TMP1]], i64 2
+; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <4 x double> [[TMP8]], double [[TMP3]], i64 3
 ; CHECK-NEXT:    [[TMP5:%.*]] = fmul <4 x double> [[TMP4]], zeroinitializer
 ; CHECK-NEXT:    [[TMP6:%.*]] = call reassoc nsz double @llvm.vector.reduce.fadd.v4f64(double 0.000000e+00, <4 x double> [[TMP5]])
 ; CHECK-NEXT:    [[TMP7:%.*]] = fmul double [[TMP6]], 0.000000e+00
 ; CHECK-NEXT:    store double [[TMP7]], ptr null, align 16
 ; CHECK-NEXT:    br label [[BB:%.*]]
 ; CHECK:       bb:
-; CHECK-NEXT:    [[TMP8:%.*]] = shufflevector <2 x double> [[TMP1]], <2 x double> [[TMP0]], <4 x i32> <i32 1, i32 0, i32 3, i32 2>
-; CHECK-NEXT:    [[TMP9:%.*]] = fmul <4 x double> [[TMP8]], zeroinitializer
-; CHECK-NEXT:    [[TMP16:%.*]] = call double @llvm.vector.reduce.fadd.v4f64(double -0.000000e+00, <4 x double> [[TMP9]])
+; CHECK-NEXT:    [[TMP9:%.*]] = fmul double [[TMP3]], 0.000000e+00
+; CHECK-NEXT:    [[TMP10:%.*]] = fmul double [[TMP2]], 0.000000e+00
+; CHECK-NEXT:    [[TMP11:%.*]] = fadd double [[TMP10]], [[TMP9]]
+; CHECK-NEXT:    [[TMP12:%.*]] = fmul double [[TMP1]], 0.000000e+00
+; CHECK-NEXT:    [[TMP13:%.*]] = fadd double [[TMP12]], [[TMP11]]
+; CHECK-NEXT:    [[TMP14:%.*]] = fmul double [[TMP0]], 0.000000e+00
+; CHECK-NEXT:    [[TMP16:%.*]] = fadd double [[TMP14]], [[TMP13]]
 ; CHECK-NEXT:    ret double [[TMP16]]
 ;
 entry:

--- a/llvm/test/Transforms/SLPVectorizer/X86/ordered-reductions.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/ordered-reductions.ll
@@ -5,10 +5,18 @@ define float @test1(<2 x float> %retval.i69.sroa.0.0.copyload.i.i) {
 ; CHECK-LABEL: define float @test1(
 ; CHECK-SAME: <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], <2 x float> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd <4 x float> [[TMP0]], zeroinitializer
-; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <4 x float> [[TMP1]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float [[TMP2]], <4 x float> [[TMP1]])
+; CHECK-NEXT:    [[A_I_SROA_5_8_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[A_I_SROA_0_0_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_I_I:%.*]] = fadd float [[A_I_SROA_0_0_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[A_I616_SROA_0_4_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_1_I_I:%.*]] = fadd float [[A_I616_SROA_0_4_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[ADD_I597_1_I_I:%.*]] = fadd float [[ADD_I629_1_I_I]], [[ADD_I629_1_I_I]]
+; CHECK-NEXT:    [[A_I616_SROA_8_12_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_3_I_I:%.*]] = fadd float [[A_I616_SROA_8_12_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[ADD_I629_2_I_I:%.*]] = fadd float [[A_I_SROA_5_8_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[ADD_I195_1_I_I:%.*]] = fadd float [[ADD_I629_I_I]], [[ADD_I597_1_I_I]]
+; CHECK-NEXT:    [[ADD_I195_2_I_I:%.*]] = fadd float [[ADD_I629_2_I_I]], [[ADD_I195_1_I_I]]
+; CHECK-NEXT:    [[TMP3:%.*]] = fadd float [[ADD_I629_3_I_I]], [[ADD_I195_2_I_I]]
 ; CHECK-NEXT:    ret float [[TMP3]]
 ;
 entry:
@@ -31,13 +39,21 @@ define float @test2(<2 x float> %retval.i69.sroa.0.0.copyload.i.i) {
 ; CHECK-LABEL: define float @test2(
 ; CHECK-SAME: <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], <2 x float> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd <4 x float> [[TMP0]], <float -0.000000e+00, float 0.000000e+00, float 0.000000e+00, float -0.000000e+00>
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP1]], <4 x float> <float 0.000000e+00, float poison, float poison, float 0.000000e+00>, <4 x i32> <i32 4, i32 1, i32 2, i32 7>
-; CHECK-NEXT:    [[TMP3:%.*]] = fadd <4 x float> [[TMP1]], [[TMP2]]
-; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <4 x float> [[TMP3]], i64 0
-; CHECK-NEXT:    [[OP_RDX:%.*]] = fadd float 1.000000e+00, [[TMP4]]
-; CHECK-NEXT:    [[TMP5:%.*]] = call float @llvm.vector.reduce.fadd.v4f32(float [[OP_RDX]], <4 x float> [[TMP3]])
+; CHECK-NEXT:    [[A_I_SROA_5_8_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_2_I_I:%.*]] = fadd float [[A_I_SROA_5_8_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[A_I_SROA_0_0_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_I_I:%.*]] = fadd float [[A_I_SROA_0_0_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[ADD_I597_I_I:%.*]] = fadd float [[ADD_I629_I_I]], [[ADD_I629_I_I]]
+; CHECK-NEXT:    [[A_I616_SROA_0_4_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_1_I_I:%.*]] = fadd float [[A_I616_SROA_0_4_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[ADD_I725_1_I_I:%.*]] = fadd float [[ADD_I629_1_I_I]], 1.000000e+00
+; CHECK-NEXT:    [[ADD_I597_1_I_I:%.*]] = fadd float [[ADD_I629_1_I_I]], [[ADD_I725_1_I_I]]
+; CHECK-NEXT:    [[A_I616_SROA_8_12_VEC_EXTRACT_I_I:%.*]] = extractelement <2 x float> [[RETVAL_I69_SROA_0_0_COPYLOAD_I_I]], i64 0
+; CHECK-NEXT:    [[ADD_I629_3_I_I:%.*]] = fadd float [[A_I616_SROA_8_12_VEC_EXTRACT_I_I]], 0.000000e+00
+; CHECK-NEXT:    [[ADD_I597_2_I_I:%.*]] = fadd float [[ADD_I629_2_I_I]], [[ADD_I629_2_I_I]]
+; CHECK-NEXT:    [[ADD_I195_1_I_I:%.*]] = fadd float [[ADD_I597_I_I]], [[ADD_I597_1_I_I]]
+; CHECK-NEXT:    [[ADD_I195_2_I_I:%.*]] = fadd float [[ADD_I597_2_I_I]], [[ADD_I195_1_I_I]]
+; CHECK-NEXT:    [[TMP5:%.*]] = fadd float [[ADD_I629_3_I_I]], [[ADD_I195_2_I_I]]
 ; CHECK-NEXT:    ret float [[TMP5]]
 ;
 entry:


### PR DESCRIPTION
Removed the accindentally commented out code, causing regressions with
ordered reductions
