### PR TITLE
[mlir][OpenACC] Support partial ThreadX reduction launches

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -561,7 +561,11 @@ def ACCCGToGPU : InterfacePass<"acc-cg-to-gpu", "mlir::FunctionOpInterface"> {
         "16384",
         "Maximum thread-private stack allocation in bytes.">,
     Option<"subgroupSize", "subgroup-size", "int64_t", "32",
-        "Subgroup size used for block-dimension alignment and reductions.">
+        "Subgroup size used for block-dimension alignment and reductions.">,
+    Option<"alignThreadXReductions", "align-thread-x-reductions", "bool",
+        "true",
+        "Align ThreadX reduction launches to the subgroup size even when "
+        "ThreadY and ThreadZ widths are one.">
   ];
   let dependentDialects = [
     "mlir::arith::ArithDialect",

--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -561,11 +561,7 @@ def ACCCGToGPU : InterfacePass<"acc-cg-to-gpu", "mlir::FunctionOpInterface"> {
         "16384",
         "Maximum thread-private stack allocation in bytes.">,
     Option<"subgroupSize", "subgroup-size", "int64_t", "32",
-        "Subgroup size used for block-dimension alignment and reductions.">,
-    Option<"alignThreadXReductions", "align-thread-x-reductions", "bool",
-        "true",
-        "Align ThreadX reduction launches to the subgroup size even when "
-        "ThreadY and ThreadZ widths are one.">
+        "Subgroup size used for block-dimension alignment and reductions.">
   ];
   let dependentDialects = [
     "mlir::arith::ArithDialect",

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1019,7 +1019,6 @@ LogicalResult ACCCGToGPULowering::rewrite() {
     // - Per-row workgroup barriers require blockDim.x aligned to subgroupSize
     bool isShuffleEnabled = false;
     bool alignThreadXReduction =
-        options.alignThreadXReductions ||
         getConstantIntValue(launch.getBlockSizeY()) != 1 ||
         getConstantIntValue(launch.getBlockSizeZ()) != 1;
 
@@ -3858,7 +3857,6 @@ public:
     options.maxWorkgroupSharedMemory = maxWorkgroupSharedMemory;
     options.maxThreadPrivateStack = maxThreadPrivateStack;
     options.subgroupSize = subgroupSize;
-    options.alignThreadXReductions = alignThreadXReductions;
 
     // Try to get cached parent analysis first, fall back to local analysis.
     std::optional<std::reference_wrapper<acc::OpenACCSupport>> cachedAnalysis =

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1018,12 +1018,17 @@ LogicalResult ACCCGToGPULowering::rewrite() {
     // - Subgroup reductions (gpu.all_reduce) require full subgroups
     // - Per-row workgroup barriers require blockDim.x aligned to subgroupSize
     bool isShuffleEnabled = false;
+    bool alignThreadXReduction =
+        options.alignThreadXReductions ||
+        getConstantIntValue(launch.getBlockSizeY()) != 1 ||
+        getConstantIntValue(launch.getBlockSizeZ()) != 1;
 
     launch.walk([&](gpu::AllReduceOp allReduce) -> WalkResult {
       ArrayRef<mlir::acc::GPUParallelDimAttr> parDims =
           mlir::acc::getParDimsAttr(allReduce).getArray();
       for (auto parDim : parDims) {
-        if (parDim.isThreadX() || parDim.isThreadY()) {
+        if (parDim.isThreadY() ||
+            (alignThreadXReduction && parDim.isThreadX())) {
           // Shuffle are enabled. Need to adjust the ThreadX length.
           isShuffleEnabled = true;
           return WalkResult::interrupt();
@@ -1041,7 +1046,8 @@ LogicalResult ACCCGToGPULowering::rewrite() {
             ArrayRef<mlir::acc::GPUParallelDimAttr> parDims =
                 mlir::acc::getParDimsAttr(allReduce).getArray();
             for (auto parDim : parDims) {
-              if (parDim.isThreadX() || parDim.isThreadY()) {
+              if (parDim.isThreadY() ||
+                  (alignThreadXReduction && parDim.isThreadX())) {
                 isShuffleEnabled = true;
                 return WalkResult::interrupt();
               }
@@ -1059,6 +1065,7 @@ LogicalResult ACCCGToGPULowering::rewrite() {
 
       Value curBlockDimX = launch.getBlockSizeX();
       Value curBlockDimY = launch.getBlockSizeY();
+      Value curBlockDimZ = launch.getBlockSizeZ();
 
       // Emit a report on changing parallelism.
       accSupport.emitRemark(computeRegion, [&]() {
@@ -1085,38 +1092,47 @@ LogicalResult ACCCGToGPULowering::rewrite() {
 
       std::optional<int64_t> constBlockDimX = getConstantIntValue(curBlockDimX);
       std::optional<int64_t> constBlockDimY = getConstantIntValue(curBlockDimY);
+      std::optional<int64_t> constBlockDimZ = getConstantIntValue(curBlockDimZ);
 
       // Skip subgroup alignment only when the total thread count is already
       // below a subgroup (constant blockDim.x in 2..subgroupSize-1 and
-      // constant blockDim.y == 1). If blockDim.y > 1 or is unknown, padding
-      // blockDim.x to a subgroup is still required so subgroups don't cross
-      // row boundaries for row-local shuffle/ThreadY-barrier reductions.
+      // constant blockDim.y/z == 1). If blockDim.y/z > 1 or is unknown,
+      // padding blockDim.x to a subgroup is still required so subgroups don't
+      // cross row boundaries for row-local shuffle/ThreadY-barrier reductions.
       bool skipAlign = false;
-      if (constBlockDimX && constBlockDimY && *constBlockDimX > 1 &&
-          *constBlockDimX < subgroupSize && *constBlockDimY == 1) {
+      if (constBlockDimX && constBlockDimY && constBlockDimZ &&
+          *constBlockDimX > 1 && *constBlockDimX < subgroupSize &&
+          *constBlockDimY == 1 && *constBlockDimZ == 1) {
         skipAlign = true;
       }
 
-      // Update both the ThreadX length and the number of ThreadY.
-      // When the original blockDim.x and blockDim.y are compile-time
+      // Update the ThreadX length and the numbers of ThreadY and ThreadZ.
+      // When the original block dimensions are compile-time
       // constants, compute the adjusted dimensions as constants directly so
       // that the GpuKernelOutliningPass can set `known_block_size` on the
       // outlined gpu.func.
-      Value newBlockDimX, newBlockDimY;
-      if (constBlockDimX && constBlockDimY) {
+      Value newBlockDimX, newBlockDimY, newBlockDimZ;
+      if (constBlockDimX && constBlockDimY && constBlockDimZ) {
         int64_t bdx = *constBlockDimX;
         int64_t bdy = *constBlockDimY;
+        int64_t bdz = *constBlockDimZ;
         int64_t alignedBdx =
             ((bdx + subgroupAlignMask) / subgroupSize) * subgroupSize;
-        int64_t numThreads = bdx * bdy;
-        int64_t newBdy = std::max<int64_t>(1, numThreads / alignedBdx);
+        int64_t numXYThreads = bdx * bdy;
+        int64_t numThreads = numXYThreads * bdz;
+        int64_t newBdy = std::max<int64_t>(1, numXYThreads / alignedBdx);
+        int64_t newBdz =
+            std::max<int64_t>(1, numThreads / (alignedBdx * newBdy));
         newBlockDimX =
             arith::ConstantIndexOp::create(rewriter, loc, alignedBdx);
         newBlockDimY = arith::ConstantIndexOp::create(rewriter, loc, newBdy);
+        newBlockDimZ = arith::ConstantIndexOp::create(rewriter, loc, newBdz);
       } else {
-        // numThreads = blockDim.x * blockDim.y
-        Value numThreads =
+        // numXYThreads = blockDim.x * blockDim.y
+        Value numXYThreads =
             arith::MulIOp::create(rewriter, loc, curBlockDimX, curBlockDimY);
+        Value numThreads =
+            arith::MulIOp::create(rewriter, loc, numXYThreads, curBlockDimZ);
         // blockDim.x = ((blockDim.x + mask) / subgroupSize) * subgroupSize
         Value cstMask =
             arith::ConstantIndexOp::create(rewriter, loc, subgroupAlignMask);
@@ -1128,16 +1144,23 @@ LogicalResult ACCCGToGPULowering::rewrite() {
             arith::DivUIOp::create(rewriter, loc, padded, cstSubgroupSize);
         newBlockDimX = arith::MulIOp::create(rewriter, loc, subgroupsRequired,
                                              cstSubgroupSize);
-        // blockDim.y = max(1, numThreads / blockDim.x)
+        // blockDim.y = max(1, numXYThreads / blockDim.x)
         Value quotient =
-            arith::DivUIOp::create(rewriter, loc, numThreads, newBlockDimX);
+            arith::DivUIOp::create(rewriter, loc, numXYThreads, newBlockDimX);
         Value cst1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
         newBlockDimY = arith::MaxUIOp::create(rewriter, loc, cst1, quotient);
+        // blockDim.z = max(1, numThreads / (blockDim.x * blockDim.y))
+        Value newNumXYThreads =
+            arith::MulIOp::create(rewriter, loc, newBlockDimX, newBlockDimY);
+        quotient =
+            arith::DivUIOp::create(rewriter, loc, numThreads, newNumXYThreads);
+        newBlockDimZ = arith::MaxUIOp::create(rewriter, loc, cst1, quotient);
       }
 
       if (!skipAlign) {
         launch.getBlockSizeXMutable().assign(newBlockDimX);
         launch.getBlockSizeYMutable().assign(newBlockDimY);
+        launch.getBlockSizeZMutable().assign(newBlockDimZ);
       }
     }
   }
@@ -3835,6 +3858,7 @@ public:
     options.maxWorkgroupSharedMemory = maxWorkgroupSharedMemory;
     options.maxThreadPrivateStack = maxThreadPrivateStack;
     options.subgroupSize = subgroupSize;
+    options.alignThreadXReductions = alignThreadXReductions;
 
     // Try to get cached parent analysis first, fall back to local analysis.
     std::optional<std::reference_wrapper<acc::OpenACCSupport>> cachedAnalysis =

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu{align-thread-x-reductions=false}))" | FileCheck %s --check-prefix=PARTIAL
 
 // A per-thread array accumulator (memref.alloca) for a block+thread reduction is
 // reduced element-by-element across the parallel dimensions with gpu.all_reduce -
@@ -250,6 +251,98 @@ func.func @rank_two_partial_bounds_strided_layout() {
         stride(%step : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
         : memref<3x4xi32, strided<[8, 2]>>
+        {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// PARTIAL-LABEL: func.func @partial_thread_x_reduction
+// PARTIAL: %[[C16:.*]] = arith.constant 16 : index
+// PARTIAL-NOT: arith.constant 31 : index
+// PARTIAL: gpu.launch
+// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C16]],
+// PARTIAL: gpu.all_reduce add
+func.func @partial_thread_x_reduction() {
+  %c1 = arith.constant 1 : index
+  %c16 = arith.constant 16 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c16 {par_dim = #acc.par_dim<thread_x>}
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
+    %c2 = arith.constant 2 : index
+    %local = memref.alloca() : memref<2xi32>
+    %bounds = acc.bounds extent(%c2 : index)
+    acc.reduction_accumulate_array %local bounds(%bounds) <add>
+        : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// PARTIAL-LABEL: func.func @thread_y_reduction_still_aligned
+// PARTIAL: %[[C32:.*]] = arith.constant 32 : index
+// PARTIAL: gpu.launch
+// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C32]],
+func.func @thread_y_reduction_still_aligned() {
+  %c1 = arith.constant 1 : index
+  %c16 = arith.constant 16 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %ty = acc.par_width %c16 {par_dim = #acc.par_dim<thread_y>}
+  acc.compute_region launch(%kbx = %bx, %kty = %ty) {
+    %c0_i32 = arith.constant 0 : i32
+    %local = memref.alloca() : memref<i32>
+    acc.reduction_accumulate %c0_i32 to %local <add>
+        : i32 -> memref<i32>
+        {par_dims = #acc<par_dims[block_x, thread_y]>}
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// A ThreadX-only reduction still needs aligned rows when ThreadY is greater
+// than one, because a physical subgroup must not contain multiple logical rows.
+//
+// PARTIAL-LABEL: func.func @thread_x_reduction_with_thread_y_width
+// PARTIAL: %[[C32_ROWS:.*]] = arith.constant 32 : index
+// PARTIAL: gpu.launch
+// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C32_ROWS]],
+func.func @thread_x_reduction_with_thread_y_width() {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c16 = arith.constant 16 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c16 {par_dim = #acc.par_dim<thread_x>}
+  %ty = acc.par_width %c2 {par_dim = #acc.par_dim<thread_y>}
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx, %kty = %ty) {
+    %c0_i32 = arith.constant 0 : i32
+    %local = memref.alloca() : memref<i32>
+    acc.reduction_accumulate %c0_i32 to %local <add>
+        : i32 -> memref<i32>
+        {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.yield
+  } {origin = "acc.parallel"}
+  return
+}
+
+// ThreadZ rows have the same subgroup-packing constraint as ThreadY rows.
+//
+// PARTIAL-LABEL: func.func @thread_x_reduction_with_thread_z_width
+// PARTIAL: %[[C352_Z_ROWS:.*]] = arith.constant 352 : index
+// PARTIAL: %[[C2_Z_ROWS:.*]] = arith.constant 2 : index
+// PARTIAL: gpu.launch
+// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C352_Z_ROWS]], %{{.*}} = %{{.*}}, %{{.*}} = %[[C2_Z_ROWS]])
+func.func @thread_x_reduction_with_thread_z_width() {
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %c341 = arith.constant 341 : index
+  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+  %tx = acc.par_width %c341 {par_dim = #acc.par_dim<thread_x>}
+  %tz = acc.par_width %c3 {par_dim = #acc.par_dim<thread_z>}
+  acc.compute_region launch(%kbx = %bx, %ktx = %tx, %ktz = %tz) {
+    %c0_i32 = arith.constant 0 : i32
+    %local = memref.alloca() : memref<i32>
+    acc.reduction_accumulate %c0_i32 to %local <add>
+        : i32 -> memref<i32>
         {par_dims = #acc<par_dims[block_x, thread_x]>}
     acc.yield
   } {origin = "acc.parallel"}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -1,5 +1,4 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu))" | FileCheck %s
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(acc-cg-to-gpu{align-thread-x-reductions=false}))" | FileCheck %s --check-prefix=PARTIAL
 
 // A per-thread array accumulator (memref.alloca) for a block+thread reduction is
 // reduced element-by-element across the parallel dimensions with gpu.all_reduce -
@@ -257,12 +256,12 @@ func.func @rank_two_partial_bounds_strided_layout() {
   return
 }
 
-// PARTIAL-LABEL: func.func @partial_thread_x_reduction
-// PARTIAL: %[[C16:.*]] = arith.constant 16 : index
-// PARTIAL-NOT: arith.constant 31 : index
-// PARTIAL: gpu.launch
-// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C16]],
-// PARTIAL: gpu.all_reduce add
+// CHECK-LABEL: func.func @partial_thread_x_reduction
+// CHECK: %[[C16:.*]] = arith.constant 16 : index
+// CHECK-NOT: arith.constant 31 : index
+// CHECK: gpu.launch
+// CHECK-SAME: threads({{.*}}) in (%{{.*}} = %[[C16]],
+// CHECK: gpu.all_reduce add
 func.func @partial_thread_x_reduction() {
   %c1 = arith.constant 1 : index
   %c16 = arith.constant 16 : index
@@ -279,10 +278,10 @@ func.func @partial_thread_x_reduction() {
   return
 }
 
-// PARTIAL-LABEL: func.func @thread_y_reduction_still_aligned
-// PARTIAL: %[[C32:.*]] = arith.constant 32 : index
-// PARTIAL: gpu.launch
-// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C32]],
+// CHECK-LABEL: func.func @thread_y_reduction_still_aligned
+// CHECK: %[[C32:.*]] = arith.constant 32 : index
+// CHECK: gpu.launch
+// CHECK-SAME: threads({{.*}}) in (%{{.*}} = %[[C32]],
 func.func @thread_y_reduction_still_aligned() {
   %c1 = arith.constant 1 : index
   %c16 = arith.constant 16 : index
@@ -302,10 +301,10 @@ func.func @thread_y_reduction_still_aligned() {
 // A ThreadX-only reduction still needs aligned rows when ThreadY is greater
 // than one, because a physical subgroup must not contain multiple logical rows.
 //
-// PARTIAL-LABEL: func.func @thread_x_reduction_with_thread_y_width
-// PARTIAL: %[[C32_ROWS:.*]] = arith.constant 32 : index
-// PARTIAL: gpu.launch
-// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C32_ROWS]],
+// CHECK-LABEL: func.func @thread_x_reduction_with_thread_y_width
+// CHECK: %[[C32_ROWS:.*]] = arith.constant 32 : index
+// CHECK: gpu.launch
+// CHECK-SAME: threads({{.*}}) in (%{{.*}} = %[[C32_ROWS]],
 func.func @thread_x_reduction_with_thread_y_width() {
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -326,11 +325,11 @@ func.func @thread_x_reduction_with_thread_y_width() {
 
 // ThreadZ rows have the same subgroup-packing constraint as ThreadY rows.
 //
-// PARTIAL-LABEL: func.func @thread_x_reduction_with_thread_z_width
-// PARTIAL: %[[C352_Z_ROWS:.*]] = arith.constant 352 : index
-// PARTIAL: %[[C2_Z_ROWS:.*]] = arith.constant 2 : index
-// PARTIAL: gpu.launch
-// PARTIAL-SAME: threads({{.*}}) in (%{{.*}} = %[[C352_Z_ROWS]], %{{.*}} = %{{.*}}, %{{.*}} = %[[C2_Z_ROWS]])
+// CHECK-LABEL: func.func @thread_x_reduction_with_thread_z_width
+// CHECK: %[[C352_Z_ROWS:.*]] = arith.constant 352 : index
+// CHECK: %[[C2_Z_ROWS:.*]] = arith.constant 2 : index
+// CHECK: gpu.launch
+// CHECK-SAME: threads({{.*}}) in (%{{.*}} = %[[C352_Z_ROWS]], %{{.*}} = %{{.*}}, %{{.*}} = %[[C2_Z_ROWS]])
 func.func @thread_x_reduction_with_thread_z_width() {
   %c1 = arith.constant 1 : index
   %c3 = arith.constant 3 : index


### PR DESCRIPTION
Example:
```fortran
!$acc parallel loop collapse(2) num_gangs(10) reduction(+:a)
do i = 1, n
  do j = 1, n
    do k = 1, m
      a(k) = a(k) + x(k,i) * y(k,j)
    end do
  end do
end do
```

In this code, ACCCG pads ThreadX to the subgroup size because `gpu.all_reduce` uses subgroup shuffles. This unnecessarily increases private reduction storage when only one Y/Z row is active.

Fix: preserve partial ThreadX launches for a single row, while retaining alignment when Y/Z rows could share a subgroup.
