### PR TITLE
[lld][Bazel] Allow lld to build with Apple C++ toolchains

### DIFF
--- a/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
@@ -281,6 +281,7 @@ cc_library(
 
 llvm_driver_cc_binary(
     name = "lld",
+    features = ["-layering_check"],
     deps = [":lld-lib"],
 )
 


### PR DESCRIPTION
## Summary

Keep `layering_check` enabled for the lld Bazel package and disable it only for the generated `//lld:lld` driver.

In Bazel consumers using Apple C++ strict module layering, `lld-driver.cpp` can be rejected even though `llvm_driver_cc_binary` directly adds `//llvm:Support` and the compile action contains `Support.cppmap`. The generated file includes:

- `llvm/ADT/ArrayRef.h`
- `llvm/Support/InitLLVM.h`
- `llvm/Support/LLVMDriver.h`

The target-level `features = ["-layering_check"]` override removes strict-layering flags from that generated driver action. All lld libraries continue to inherit the package-wide check.

This remains a draft because the failure depends on the consumer's Apple execution platform and C++ toolchain configuration; LLVM's standalone Bazel configuration does not reproduce it.

## Failure mode

The failure occurs when the Apple C++ toolchain enables strict module-layering enforcement for the generated driver compile action, including `-fmodules-strict-decluse` and module-map arguments. Apple clang then reports that `//lld:lld` does not depend on modules exporting the three headers above.

This was observed with `apple_support` 2.4.0 when its beta layering implementation was enabled through `APPLE_SUPPORT_LAYERING_CHECK_BETA=1`. The same failure was confirmed with `apple_support` 2.6.1, where layering is enabled by default.

Controlled environment:

- LLVM parent: `59b3a0ce7829aeda7f40efdfb3fa004a48fc2ba9`
- Bazel: 9.1.1rc1
- `rules_cc`: 0.2.19
- Apple clang: 21.0.0
- Xcode: 26.5 (17F42)
- arm64 macOS execution platform
- optimized build, AArch64 LLVM target

## Validation

- Reproduced the strict-layering failure against the PR's current parent in the consumer configuration.
- Confirmed with `aquery` that the patch removes `-fmodules-strict-decluse` and module-map arguments only from `lld-driver.cpp`.
- Built `@llvm-project//lld:ld64.lld` successfully in the same consumer configuration after the change.
- Built `@llvm-project//lld:ld64.lld` successfully from `utils/bazel` with both Bazel 9.1.1rc1 and 9.1.1.

The change affects Bazel analysis only; it does not alter lld source or runtime behavior.