### PR TITLE
[flang] Fix host association for ASYNCHRONOUS/VOLATILE in submodules

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6429,7 +6429,8 @@ Symbol &DeclarationVisitor::HandleAttributeStmt(
     // these can be set on a symbol that is host-assoc or use-assoc
     if (!symbol &&
         (currScope().kind() == Scope::Kind::Subprogram ||
-            currScope().kind() == Scope::Kind::BlockConstruct)) {
+            currScope().kind() == Scope::Kind::BlockConstruct ||
+            currScope().IsSubmodule())) {
       if (auto *hostSymbol{FindSymbol(name)}) {
         symbol = &MakeHostAssocSymbol(name, *hostSymbol);
       }

--- a/flang/test/Lower/submodule-async-volatile.f90
+++ b/flang/test/Lower/submodule-async-volatile.f90
@@ -1,0 +1,43 @@
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
+
+! Test that ASYNCHRONOUS/VOLATILE statements in a submodule correctly
+! host-associate variables from the ancestor module rather than creating
+! new local symbols. GitHub issue #208362.
+!
+! Before the fix, n and k were given fresh submodule-scoped symbols
+! (_QMm1SsubmodEn / _QMm1SsubmodEk). Verify they resolve to the module
+! globals and that no submodule-mangled name appears in the function body.
+
+module m1
+  integer :: n = 1, k = 2
+  interface
+    module subroutine sub()
+    end subroutine
+  end interface
+end module m1
+
+submodule(m1) submod
+  volatile :: n
+  asynchronous :: k
+contains
+  ! CHECK-LABEL: func @_QMm1Psub
+  ! No submodule-mangled entity should appear inside the subroutine.
+  ! CHECK-NOT: _QMm1Ssubmod
+  ! n and k must resolve to the module globals.
+  ! CHECK-DAG: %[[N:.*]] = fir.address_of(@_QMm1En) : !fir.ref<i32>
+  ! CHECK-DAG: %[[K:.*]] = fir.address_of(@_QMm1Ek) : !fir.ref<i32>
+  ! CHECK-DAG: hlfir.declare %[[N]] {uniq_name = "_QMm1En"}
+  ! CHECK-DAG: hlfir.declare %[[K]] {uniq_name = "_QMm1Ek"}
+  ! FIXME: The volatile/asynchronous fortran_attrs are not propagated to the
+  ! hlfir.declare or fir.ref type for host-associated variables (this affects
+  ! regular subprograms too, not just submodules).
+  ! See https://github.com/llvm/llvm-project/issues/208588.
+  module subroutine sub()
+    implicit none
+    if (n /= 1) print *, 'Error n=', n
+    if (k /= 2) print *, 'Error k=', k
+  end subroutine
+end submodule submod
+
+! CHECK: fir.global @_QMm1Ek : i32
+! CHECK: fir.global @_QMm1En : i32

--- a/flang/test/Semantics/misc-declarations.f90
+++ b/flang/test/Semantics/misc-declarations.f90
@@ -43,3 +43,28 @@ module m
     real, intent(in) :: x(..)[*]
   end
 end module
+
+! Submodule host-association: same C867/C868-equivalent constraints apply
+! when VOLATILE names a host variable from the ancestor module.
+module m2
+  real :: smCoarray[*]
+  type :: hasCoarray2
+    real, allocatable :: coarray[:]
+  end type
+  type(hasCoarray2) :: smCoarrayComp
+  interface
+    module subroutine smProc()
+    end subroutine
+  end interface
+end module
+submodule(m2) sm2
+  !ERROR: VOLATILE attribute may not apply to a coarray accessed by USE or host association
+  volatile :: smCoarray
+  !ERROR: VOLATILE attribute may not apply to a type with a coarray ultimate component accessed by USE or host association
+  volatile :: smCoarrayComp
+  volatile :: smProc
+contains
+  !ERROR: VOLATILE attribute may apply only to a variable
+  module subroutine smProc()
+  end subroutine
+end submodule

--- a/flang/test/Semantics/symbol05.f90
+++ b/flang/test/Semantics/symbol05.f90
@@ -115,3 +115,29 @@ subroutine s7
   !DEF: /s7/j VOLATILE Use INTEGER(4)
   volatile :: j
 end subroutine
+
+!DEF: /m8 Module
+module m8
+  !DEF: /m8/n PRIVATE ObjectEntity INTEGER(4)
+  integer, private :: n = 1
+  !DEF: /m8/k PUBLIC ObjectEntity INTEGER(4)
+  integer :: k = 2
+end module
+!REF: /m8
+!DEF: /m8/subm Module
+submodule(m8) subm
+  ! VOLATILE/ASYNCHRONOUS on host-associated module variables create HostAssoc
+  ! symbols in the submodule scope (F2023 19.5.1.4 p1).
+  !DEF: /m8/subm/n PRIVATE, VOLATILE HostAssoc INTEGER(4)
+  volatile :: n
+  !DEF: /m8/subm/k ASYNCHRONOUS, PUBLIC HostAssoc INTEGER(4)
+  asynchronous :: k
+end submodule
+!REF: /m8
+!REF: /m8/subm
+!DEF: /m8/subm/subsubm Module
+submodule(m8:subm) subsubm
+  ! Attributes accumulate through sub-submodule chains.
+  !DEF: /m8/subm/subsubm/k ASYNCHRONOUS, PUBLIC, VOLATILE HostAssoc INTEGER(4)
+  volatile :: k
+end submodule


### PR DESCRIPTION
In `HandleAttributeStmt`, when an `ASYNCHRONOUS` or `VOLATILE` statement
names a variable not already in the current scope, flang creates a
host-association symbol — but only for `Subprogram` and `BlockConstruct`
scopes. Submodule scopes have kind `Module`, so the check excluded them.
This caused a fresh `EntityDetails` symbol (zero-initialized) to be
created instead of a `HostAssocDetails` symbol pointing at the ancestor
module variable, producing value 0 instead of the initialized value.

Fix: extend the condition to also fire when `currScope().IsSubmodule()`.
`Scope::FindSymbol` already traverses into the parent module for
submodules, so the host variable is found correctly.

Note: the `volatile`/`asynchronous` `fortran_attrs` are not propagated
to `hlfir.declare` for host-associated variables in general (subprograms,
BLOCK constructs, and submodules); that is a separate lowering issue
tracked in #208588.

Fixes #208362

Assisted-By: AI