### PR TITLE
[HIP] Link profile runtime in device-only lld path

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -133,6 +133,7 @@ void AMDGCN::Linker::constructLldCommand(Compilation &C, const JobAction &JA,
   LldArgs.append({"-o", Output.getFilename()});
   for (auto Input : Inputs)
     LldArgs.push_back(Input.getFilename());
+  TC.addProfileRTLibs(Args, LldArgs);
 
   // Look for archive of bundled bitcode in arguments, and add temporary files
   // for the extracted archive of bitcode to inputs.

--- a/clang/test/Driver/hip-profile-rocm-runtime.hip
+++ b/clang/test/Driver/hip-profile-rocm-runtime.hip
@@ -1,11 +1,11 @@
 // REQUIRES: x86-registered-target, amdgpu-registered-target
 // UNSUPPORTED: system-windows
 
-// Build a fake resource dir containing both the base profile runtime and the
-// ROCm device-profile runtime so the driver's existence check passes.
-// RUN: rm -rf %t && mkdir -p %t/lib/x86_64-unknown-linux
+// Build a fake resource dir containing host and device profile runtimes.
+// RUN: rm -rf %t && mkdir -p %t/lib/x86_64-unknown-linux %t/lib/amdgcn-amd-amdhsa
 // RUN: touch %t/lib/x86_64-unknown-linux/libclang_rt.profile.a
 // RUN: touch %t/lib/x86_64-unknown-linux/libclang_rt.profile_rocm.a
+// RUN: touch %t/lib/amdgcn-amd-amdhsa/libclang_rt.profile.a
 // RUN: touch %t.o
 
 // HIP host link with PGO links clang_rt.profile_rocm.
@@ -31,3 +31,10 @@
 // RUN:   | FileCheck -check-prefix=HOST-PGO %s
 // HOST-PGO: "{{.*}}libclang_rt.profile.a"
 // HOST-PGO-NOT: libclang_rt.profile_rocm.a
+
+// HIP device-only link with PGO links the device profile runtime.
+// RUN: %clang -### -x hip --offload-device-only --target=x86_64-unknown-linux \
+// RUN: --offload-arch=gfx90a -fprofile-generate -resource-dir=%t \
+// RUN: -nogpuinc -nogpulib %s 2>&1 \
+// RUN: | FileCheck -check-prefix=HIP-DEVICE-PGO %s
+// HIP-DEVICE-PGO: "{{.*}}lld" {{.*}}"{{.*}}lib{{/|\\\\}}amdgcn-amd-amdhsa{{/|\\\\}}libclang_rt.profile.a"


### PR DESCRIPTION
HIP device-only code object links can use the direct lld path in HIPAMD.cpp. That path did not add the profile runtime, so device-only builds with profile generation missed `libclang_rt.profile.a`.

This patch adds the normal profile runtime handling to that linker path and covers it with a driver test.