### PR TITLE
[lldb] Stop creating ConstStrings for ObjC framework type names

### DIFF
--- a/lldb/source/Plugins/Language/ObjC/CF.cpp
+++ b/lldb/source/Plugins/Language/ObjC/CF.cpp
@@ -71,10 +71,11 @@ bool lldb_private::formatters::CFBagSummaryProvider(
 
   bool is_type_ok = false; // check to see if this is a CFBag we know about
   if (descriptor->IsCFType()) {
-    ConstString type_name(valobj.GetTypeName());
+    llvm::StringRef type_name(valobj.GetTypeName().GetStringRef());
 
-    static ConstString g_CFBag("__CFBag");
-    static ConstString g_conststruct__CFBag("const struct __CFBag");
+    static constexpr llvm::StringLiteral g_CFBag("__CFBag");
+    static constexpr llvm::StringLiteral g_conststruct__CFBag(
+        "const struct __CFBag");
 
     if (type_name == g_CFBag || type_name == g_conststruct__CFBag) {
       if (valobj.IsPointerType())
@@ -129,9 +130,17 @@ bool lldb_private::formatters::CFBitVectorSummaryProvider(
 
   bool is_type_ok = false; // check to see if this is a CFBag we know about
   if (descriptor->IsCFType()) {
-    ConstString type_name(valobj.GetTypeName());
-    if (type_name == "__CFMutableBitVector" || type_name == "__CFBitVector" ||
-        type_name == "CFMutableBitVectorRef" || type_name == "CFBitVectorRef") {
+    llvm::StringRef type_name(valobj.GetTypeName().GetStringRef());
+
+    static constexpr llvm::StringLiteral g_CFMutableBitVector(
+        "__CFMutableBitVector");
+    static constexpr llvm::StringLiteral g_CFBitVector("__CFBitVector");
+    static constexpr llvm::StringLiteral g_CFMutableBitVectorRef(
+        "CFMutableBitVectorRef");
+    static constexpr llvm::StringLiteral g_CFBitVectorRef("CFBitVectorRef");
+
+    if (type_name == g_CFMutableBitVector || type_name == g_CFBitVector ||
+        type_name == g_CFMutableBitVectorRef || type_name == g_CFBitVectorRef) {
       if (valobj.IsPointerType())
         is_type_ok = true;
     }
@@ -250,12 +259,12 @@ bool lldb_private::formatters::CFBinaryHeapSummaryProvider(
   bool is_type_ok =
       false; // check to see if this is a CFBinaryHeap we know about
   if (descriptor->IsCFType()) {
-    ConstString type_name(valobj.GetTypeName());
+    llvm::StringRef type_name(valobj.GetTypeName().GetStringRef());
 
-    static ConstString g_CFBinaryHeap("__CFBinaryHeap");
-    static ConstString g_conststruct__CFBinaryHeap(
+    static constexpr llvm::StringRef g_CFBinaryHeap("__CFBinaryHeap");
+    static constexpr llvm::StringRef g_conststruct__CFBinaryHeap(
         "const struct __CFBinaryHeap");
-    static ConstString g_CFBinaryHeapRef("CFBinaryHeapRef");
+    static constexpr llvm::StringRef g_CFBinaryHeapRef("CFBinaryHeapRef");
 
     if (type_name == g_CFBinaryHeap ||
         type_name == g_conststruct__CFBinaryHeap ||

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -926,15 +926,15 @@ bool lldb_private::formatters::NSDateSummaryProvider(
   uint64_t date_value_bits = 0;
   double date_value = 0.0;
 
-  ConstString class_name = descriptor->GetClassName();
+  llvm::StringRef class_name = descriptor->GetClassName().GetStringRef();
 
-  static const ConstString g_NSDate("NSDate");
-  static const ConstString g_dunder_NSDate("__NSDate");
-  static const ConstString g_NSTaggedDate("__NSTaggedDate");
-  static const ConstString g_NSCalendarDate("NSCalendarDate");
-  static const ConstString g_NSConstantDate("NSConstantDate");
+  static constexpr llvm::StringLiteral g_NSDate("NSDate");
+  static constexpr llvm::StringLiteral g_dunder_NSDate("__NSDate");
+  static constexpr llvm::StringLiteral g_NSTaggedDate("__NSTaggedDate");
+  static constexpr llvm::StringLiteral g_NSCalendarDate("NSCalendarDate");
+  static constexpr llvm::StringLiteral g_NSConstantDate("NSConstantDate");
 
-  if (class_name.IsEmpty())
+  if (class_name.empty())
     return false;
 
   uint64_t info_bits = 0, value_bits = 0;

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -421,7 +421,8 @@ bool lldb_private::formatters::NSArraySummaryProvider(
     value = 0;
   } else if (class_name_ref == g_NSArray1) {
     value = 1;
-  } else if (class_name_ref == g_NSArrayCF || class_name_ref == g_NSCallStackArray) {
+  } else if (class_name_ref == g_NSArrayCF ||
+             class_name_ref == g_NSCallStackArray) {
     // __NSCFArray and _NSCallStackArray store the number of elements as a
     // pointer-sized value at offset `2 * ptr_size`.
     Status error;
@@ -777,7 +778,8 @@ lldb_private::formatters::NSArraySyntheticFrontEndCreator(
 
   static constexpr llvm::StringLiteral g_NSArrayI("__NSArrayI");
   static constexpr llvm::StringLiteral g_NSConstantArray("NSConstantArray");
-  static constexpr llvm::StringLiteral g_NSArrayI_Transfer("__NSArrayI_Transfer");
+  static constexpr llvm::StringLiteral g_NSArrayI_Transfer(
+      "__NSArrayI_Transfer");
   static constexpr llvm::StringLiteral g_NSFrozenArrayM("__NSFrozenArrayM");
   static constexpr llvm::StringLiteral g_NSArrayM("__NSArrayM");
   static constexpr llvm::StringLiteral g_NSArray0("__NSArray0");
@@ -794,7 +796,7 @@ lldb_private::formatters::NSArraySyntheticFrontEndCreator(
       return (new Foundation1430::NSArrayISyntheticFrontEnd(valobj_sp));
     return (new Foundation1300::NSArrayISyntheticFrontEnd(valobj_sp));
   } else if (class_name_ref == g_NSArrayI_Transfer) {
-      return (new Foundation1436::NSArrayI_TransferSyntheticFrontEnd(valobj_sp));
+    return (new Foundation1436::NSArrayI_TransferSyntheticFrontEnd(valobj_sp));
   } else if (class_name_ref == g_NSConstantArray) {
     return new ConstantArray::NSConstantArraySyntheticFrontEnd(valobj_sp);
   } else if (class_name_ref == g_NSFrozenArrayM) {

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -351,35 +351,38 @@ bool lldb_private::formatters::NSArraySummaryProvider(
   uint64_t value = 0;
 
   ConstString class_name(descriptor->GetClassName());
+  llvm::StringRef class_name_ref(class_name.GetStringRef());
 
-  static const ConstString g_NSArrayI("__NSArrayI");
-  static const ConstString g_NSArrayM("__NSArrayM");
-  static const ConstString g_NSArrayI_Transfer("__NSArrayI_Transfer");
-  static const ConstString g_NSFrozenArrayM("__NSFrozenArrayM");
-  static const ConstString g_NSArray0("__NSArray0");
-  static const ConstString g_NSArray1("__NSSingleObjectArrayI");
-  static const ConstString g_NSArrayCF("__NSCFArray");
-  static const ConstString g_NSArrayMLegacy("__NSArrayM_Legacy");
-  static const ConstString g_NSArrayMImmutable("__NSArrayM_Immutable");
-  static const ConstString g_NSCallStackArray("_NSCallStackArray");
-  static const ConstString g_NSConstantArray("NSConstantArray");
+  static constexpr llvm::StringLiteral g_NSArrayI("__NSArrayI");
+  static constexpr llvm::StringLiteral g_NSArrayM("__NSArrayM");
+  static constexpr llvm::StringLiteral g_NSArrayI_Transfer(
+      "__NSArrayI_Transfer");
+  static constexpr llvm::StringLiteral g_NSFrozenArrayM("__NSFrozenArrayM");
+  static constexpr llvm::StringLiteral g_NSArray0("__NSArray0");
+  static constexpr llvm::StringLiteral g_NSArray1("__NSSingleObjectArrayI");
+  static constexpr llvm::StringLiteral g_NSArrayCF("__NSCFArray");
+  static constexpr llvm::StringLiteral g_NSArrayMLegacy("__NSArrayM_Legacy");
+  static constexpr llvm::StringLiteral g_NSArrayMImmutable(
+      "__NSArrayM_Immutable");
+  static constexpr llvm::StringLiteral g_NSCallStackArray("_NSCallStackArray");
+  static constexpr llvm::StringLiteral g_NSConstantArray("NSConstantArray");
 
-  if (class_name.IsEmpty())
+  if (class_name_ref.empty())
     return false;
 
-  if (class_name == g_NSArrayI) {
+  if (class_name_ref == g_NSArrayI) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                       ptr_size, 0, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSConstantArray) {
+  } else if (class_name_ref == g_NSConstantArray) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size, 8,
                                                       0, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSArrayM) {
+  } else if (class_name_ref == g_NSArrayM) {
     AppleObjCRuntime *apple_runtime =
     llvm::dyn_cast_or_null<AppleObjCRuntime>(runtime);
     Status error;
@@ -391,34 +394,34 @@ bool lldb_private::formatters::NSArraySummaryProvider(
     }
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSArrayI_Transfer) {
+  } else if (class_name_ref == g_NSArrayI_Transfer) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                       ptr_size, 0, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSFrozenArrayM) {
+  } else if (class_name_ref == g_NSFrozenArrayM) {
     Status error;
     value = Foundation1436::__NSFrozenArrayMSize(*process_sp, valobj_addr, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSArrayMLegacy) {
+  } else if (class_name_ref == g_NSArrayMLegacy) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                       ptr_size, 0, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSArrayMImmutable) {
+  } else if (class_name_ref == g_NSArrayMImmutable) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                       ptr_size, 0, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_NSArray0) {
+  } else if (class_name_ref == g_NSArray0) {
     value = 0;
-  } else if (class_name == g_NSArray1) {
+  } else if (class_name_ref == g_NSArray1) {
     value = 1;
-  } else if (class_name == g_NSArrayCF || class_name == g_NSCallStackArray) {
+  } else if (class_name_ref == g_NSArrayCF || class_name_ref == g_NSCallStackArray) {
     // __NSCFArray and _NSCallStackArray store the number of elements as a
     // pointer-sized value at offset `2 * ptr_size`.
     Status error;
@@ -703,7 +706,7 @@ lldb_private::formatters::NSArray1SyntheticFrontEnd::NSArray1SyntheticFrontEnd(
 llvm::Expected<size_t>
 lldb_private::formatters::NSArray1SyntheticFrontEnd::GetIndexOfChildWithName(
     ConstString name) {
-  static const ConstString g_zero("[0]");
+  static constexpr llvm::StringLiteral g_zero("[0]");
 
   if (name == g_zero)
     return 0;
@@ -770,45 +773,44 @@ lldb_private::formatters::NSArraySyntheticFrontEndCreator(
     return nullptr;
 
   ConstString class_name(descriptor->GetClassName());
+  llvm::StringRef class_name_ref(class_name.GetStringRef());
 
-  static const ConstString g_NSArrayI("__NSArrayI");
-  static const ConstString g_NSConstantArray("NSConstantArray");
-  static const ConstString g_NSArrayI_Transfer("__NSArrayI_Transfer");
-  static const ConstString g_NSFrozenArrayM("__NSFrozenArrayM");
-  static const ConstString g_NSArrayM("__NSArrayM");
-  static const ConstString g_NSArray0("__NSArray0");
-  static const ConstString g_NSArray1("__NSSingleObjectArrayI");
-  static const ConstString g_NSArrayMLegacy("__NSArrayM_Legacy");
-  static const ConstString g_NSArrayMImmutable("__NSArrayM_Immutable");
-  static const ConstString g_NSCallStackArray("_NSCallStackArray");
+  static constexpr llvm::StringLiteral g_NSArrayI("__NSArrayI");
+  static constexpr llvm::StringLiteral g_NSConstantArray("NSConstantArray");
+  static constexpr llvm::StringLiteral g_NSArrayI_Transfer("__NSArrayI_Transfer");
+  static constexpr llvm::StringLiteral g_NSFrozenArrayM("__NSFrozenArrayM");
+  static constexpr llvm::StringLiteral g_NSArrayM("__NSArrayM");
+  static constexpr llvm::StringLiteral g_NSArray0("__NSArray0");
+  static constexpr llvm::StringLiteral g_NSArray1("__NSSingleObjectArrayI");
+  static constexpr llvm::StringLiteral g_NSCallStackArray("_NSCallStackArray");
 
-  if (class_name.IsEmpty())
+  if (class_name_ref.empty())
     return nullptr;
 
-  if (class_name == g_NSArrayI) {
+  if (class_name_ref == g_NSArrayI) {
     if (runtime->GetFoundationVersion() >= 1436)
       return (new Foundation1436::NSArrayISyntheticFrontEnd(valobj_sp));
     if (runtime->GetFoundationVersion() >= 1430)
       return (new Foundation1430::NSArrayISyntheticFrontEnd(valobj_sp));
     return (new Foundation1300::NSArrayISyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_NSArrayI_Transfer) {
+  } else if (class_name_ref == g_NSArrayI_Transfer) {
       return (new Foundation1436::NSArrayI_TransferSyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_NSConstantArray) {
+  } else if (class_name_ref == g_NSConstantArray) {
     return new ConstantArray::NSConstantArraySyntheticFrontEnd(valobj_sp);
-  } else if (class_name == g_NSFrozenArrayM) {
+  } else if (class_name_ref == g_NSFrozenArrayM) {
     return (new Foundation1436::NSFrozenArrayMSyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_NSArray0) {
+  } else if (class_name_ref == g_NSArray0) {
     return (new NSArray0SyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_NSArray1) {
+  } else if (class_name_ref == g_NSArray1) {
     return (new NSArray1SyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_NSArrayM) {
+  } else if (class_name_ref == g_NSArrayM) {
     if (runtime->GetFoundationVersion() >= 1437)
       return (new Foundation1437::NSArrayMSyntheticFrontEnd(valobj_sp));
     if (runtime->GetFoundationVersion() >= 1428)
       return (new Foundation1428::NSArrayMSyntheticFrontEnd(valobj_sp));
     if (runtime->GetFoundationVersion() >= 1100)
       return (new Foundation1010::NSArrayMSyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_NSCallStackArray) {
+  } else if (class_name_ref == g_NSCallStackArray) {
     return (new CallStackArray::NSCallStackArraySyntheticFrontEnd(valobj_sp));
   } else {
     auto &map(NSArray_Additionals::GetAdditionalSynthetics());

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -415,23 +415,30 @@ bool lldb_private::formatters::NSDictionarySummaryProvider(
   uint64_t value = 0;
 
   ConstString class_name(descriptor->GetClassName());
+  llvm::StringRef class_name_ref(class_name.GetStringRef());
 
-  static const ConstString g_DictionaryI("__NSDictionaryI");
-  static const ConstString g_DictionaryM("__NSDictionaryM");
-  static const ConstString g_DictionaryMLegacy("__NSDictionaryM_Legacy");
-  static const ConstString g_DictionaryMImmutable("__NSDictionaryM_Immutable");
-  static const ConstString g_DictionaryMFrozen("__NSFrozenDictionaryM");
-  static const ConstString g_Dictionary1("__NSSingleEntryDictionaryI");
-  static const ConstString g_Dictionary0("__NSDictionary0");
-  static const ConstString g_DictionaryCF("__CFDictionary");
-  static const ConstString g_DictionaryNSCF("__NSCFDictionary");
-  static const ConstString g_DictionaryCFRef("CFDictionaryRef");
-  static const ConstString g_ConstantDictionary("NSConstantDictionary");
+  static constexpr llvm::StringLiteral g_DictionaryI("__NSDictionaryI");
+  static constexpr llvm::StringLiteral g_DictionaryM("__NSDictionaryM");
+  static constexpr llvm::StringLiteral g_DictionaryMLegacy(
+      "__NSDictionaryM_Legacy");
+  static constexpr llvm::StringLiteral g_DictionaryMImmutable(
+      "__NSDictionaryM_Immutable");
+  static constexpr llvm::StringLiteral g_DictionaryMFrozen(
+      "__NSFrozenDictionaryM");
+  static constexpr llvm::StringLiteral g_Dictionary1(
+      "__NSSingleEntryDictionaryI");
+  static constexpr llvm::StringLiteral g_Dictionary0("__NSDictionary0");
+  static constexpr llvm::StringLiteral g_DictionaryCF("__CFDictionary");
+  static constexpr llvm::StringLiteral g_DictionaryNSCF("__NSCFDictionary");
+  static constexpr llvm::StringLiteral g_DictionaryCFRef("CFDictionaryRef");
+  static constexpr llvm::StringLiteral g_ConstantDictionary(
+      "NSConstantDictionary");
 
-  if (class_name.IsEmpty())
+  if (class_name_ref.empty())
     return false;
 
-  if (class_name == g_DictionaryI || class_name == g_DictionaryMImmutable) {
+  if (class_name_ref == g_DictionaryI ||
+      class_name_ref == g_DictionaryMImmutable) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                       ptr_size, 0, error);
@@ -439,20 +446,21 @@ bool lldb_private::formatters::NSDictionarySummaryProvider(
       return false;
 
     value &= (is_64bit ? ~0xFC00000000000000UL : ~0xFC000000U);
-  } else if (class_name == g_ConstantDictionary) {
+  } else if (class_name_ref == g_ConstantDictionary) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(
         valobj_addr + 2 * ptr_size, ptr_size, 0, error);
     if (error.Fail())
       return false;
-  } else if (class_name == g_DictionaryM || class_name == g_DictionaryMLegacy ||
-             class_name == g_DictionaryMFrozen) {
+  } else if (class_name_ref == g_DictionaryM ||
+             class_name_ref == g_DictionaryMLegacy ||
+             class_name_ref == g_DictionaryMFrozen) {
     AppleObjCRuntime *apple_runtime =
-    llvm::dyn_cast_or_null<AppleObjCRuntime>(runtime);
+        llvm::dyn_cast_or_null<AppleObjCRuntime>(runtime);
     Status error;
     if (apple_runtime && apple_runtime->GetFoundationVersion() >= 1437) {
-      value = Foundation1437::__NSDictionaryMSize(*process_sp, valobj_addr,
-                                                  error);
+      value =
+          Foundation1437::__NSDictionaryMSize(*process_sp, valobj_addr, error);
     } else {
       value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                         ptr_size, 0, error);
@@ -460,12 +468,13 @@ bool lldb_private::formatters::NSDictionarySummaryProvider(
     }
     if (error.Fail())
       return false;
-  } else if (class_name == g_Dictionary1) {
+  } else if (class_name_ref == g_Dictionary1) {
     value = 1;
-  } else if (class_name == g_Dictionary0) {
+  } else if (class_name_ref == g_Dictionary0) {
     value = 0;
-  } else if (class_name == g_DictionaryCF || class_name == g_DictionaryNSCF ||
-             class_name == g_DictionaryCFRef) {
+  } else if (class_name_ref == g_DictionaryCF ||
+             class_name_ref == g_DictionaryNSCF ||
+             class_name_ref == g_DictionaryCFRef) {
     ExecutionContext exe_ctx(process_sp);
     CFBasicHash cfbh;
     if (!cfbh.Update(valobj_addr, exe_ctx))
@@ -519,27 +528,34 @@ lldb_private::formatters::NSDictionarySyntheticFrontEndCreator(
     return nullptr;
 
   ConstString class_name(descriptor->GetClassName());
+  llvm::StringRef class_name_ref(class_name.GetStringRef());
 
-  static const ConstString g_DictionaryI("__NSDictionaryI");
-  static const ConstString g_DictionaryM("__NSDictionaryM");
-  static const ConstString g_Dictionary1("__NSSingleEntryDictionaryI");
-  static const ConstString g_DictionaryImmutable("__NSDictionaryM_Immutable");
-  static const ConstString g_DictionaryMFrozen("__NSFrozenDictionaryM");
-  static const ConstString g_DictionaryMLegacy("__NSDictionaryM_Legacy");
-  static const ConstString g_Dictionary0("__NSDictionary0");
-  static const ConstString g_DictionaryCF("__CFDictionary");
-  static const ConstString g_DictionaryNSCF("__NSCFDictionary");
-  static const ConstString g_DictionaryCFRef("CFDictionaryRef");
-  static const ConstString g_ConstantDictionary("NSConstantDictionary");
+  static constexpr llvm::StringLiteral g_DictionaryI("__NSDictionaryI");
+  static constexpr llvm::StringLiteral g_DictionaryM("__NSDictionaryM");
+  static constexpr llvm::StringLiteral g_Dictionary1(
+      "__NSSingleEntryDictionaryI");
+  static constexpr llvm::StringLiteral g_DictionaryImmutable(
+      "__NSDictionaryM_Immutable");
+  static constexpr llvm::StringLiteral g_DictionaryMFrozen(
+      "__NSFrozenDictionaryM");
+  static constexpr llvm::StringLiteral g_DictionaryMLegacy(
+      "__NSDictionaryM_Legacy");
+  static constexpr llvm::StringLiteral g_Dictionary0("__NSDictionary0");
+  static constexpr llvm::StringLiteral g_DictionaryCF("__CFDictionary");
+  static constexpr llvm::StringLiteral g_DictionaryNSCF("__NSCFDictionary");
+  static constexpr llvm::StringLiteral g_DictionaryCFRef("CFDictionaryRef");
+  static constexpr llvm::StringLiteral g_ConstantDictionary(
+      "NSConstantDictionary");
 
-  if (class_name.IsEmpty())
+  if (class_name_ref.empty())
     return nullptr;
 
-  if (class_name == g_DictionaryI) {
+  if (class_name_ref == g_DictionaryI) {
     return (new NSDictionaryISyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_ConstantDictionary) {
+  } else if (class_name_ref == g_ConstantDictionary) {
     return (new NSConstantDictionarySyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_DictionaryM || class_name == g_DictionaryMFrozen) {
+  } else if (class_name_ref == g_DictionaryM ||
+             class_name_ref == g_DictionaryMFrozen) {
     if (runtime->GetFoundationVersion() >= 1437) {
       return (new Foundation1437::NSDictionaryMSyntheticFrontEnd(valobj_sp));
     } else if (runtime->GetFoundationVersion() >= 1428) {
@@ -547,12 +563,13 @@ lldb_private::formatters::NSDictionarySyntheticFrontEndCreator(
     } else {
       return (new Foundation1100::NSDictionaryMSyntheticFrontEnd(valobj_sp));
     }
-  } else if (class_name == g_DictionaryMLegacy) {
+  } else if (class_name_ref == g_DictionaryMLegacy) {
     return (new Foundation1100::NSDictionaryMSyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_Dictionary1) {
+  } else if (class_name_ref == g_Dictionary1) {
     return (new NSDictionary1SyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_DictionaryCF || class_name == g_DictionaryNSCF ||
-             class_name == g_DictionaryCFRef) {
+  } else if (class_name_ref == g_DictionaryCF ||
+             class_name_ref == g_DictionaryNSCF ||
+             class_name_ref == g_DictionaryCFRef) {
     return (new NSCFDictionarySyntheticFrontEnd(valobj_sp));
   } else {
     auto &map(NSDictionary_Additionals::GetAdditionalSynthetics());
@@ -928,7 +945,7 @@ lldb_private::formatters::NSDictionary1SyntheticFrontEnd::
 
 llvm::Expected<size_t> lldb_private::formatters::
     NSDictionary1SyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  static const ConstString g_zero("[0]");
+  static constexpr llvm::StringLiteral g_zero("[0]");
   if (name == g_zero)
     return 0;
   return llvm::createStringErrorV("type has no child named '{0}'", name);

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -534,13 +534,10 @@ lldb_private::formatters::NSDictionarySyntheticFrontEndCreator(
   static constexpr llvm::StringLiteral g_DictionaryM("__NSDictionaryM");
   static constexpr llvm::StringLiteral g_Dictionary1(
       "__NSSingleEntryDictionaryI");
-  static constexpr llvm::StringLiteral g_DictionaryImmutable(
-      "__NSDictionaryM_Immutable");
   static constexpr llvm::StringLiteral g_DictionaryMFrozen(
       "__NSFrozenDictionaryM");
   static constexpr llvm::StringLiteral g_DictionaryMLegacy(
       "__NSDictionaryM_Legacy");
-  static constexpr llvm::StringLiteral g_Dictionary0("__NSDictionary0");
   static constexpr llvm::StringLiteral g_DictionaryCF("__CFDictionary");
   static constexpr llvm::StringLiteral g_DictionaryNSCF("__NSCFDictionary");
   static constexpr llvm::StringLiteral g_DictionaryCFRef("CFDictionaryRef");

--- a/lldb/source/Plugins/Language/ObjC/NSError.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSError.cpp
@@ -164,7 +164,7 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    static ConstString g_userInfo("_userInfo");
+    static constexpr llvm::StringLiteral g_userInfo("_userInfo");
     if (name == g_userInfo)
       return 0;
     return llvm::createStringErrorV("type has no child named '{0}'", name);

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -160,10 +160,10 @@ public:
     //   NSString *reason;
     //   NSDictionary *userInfo;
     //   id reserved;
-    static ConstString g_name("name");
-    static ConstString g_reason("reason");
-    static ConstString g_userInfo("userInfo");
-    static ConstString g_reserved("reserved");
+    static constexpr llvm::StringLiteral g_name("name");
+    static constexpr llvm::StringLiteral g_reason("reason");
+    static constexpr llvm::StringLiteral g_userInfo("userInfo");
+    static constexpr llvm::StringLiteral g_reserved("reserved");
     if (name == g_name) return 0;
     if (name == g_reason) return 1;
     if (name == g_userInfo) return 2;

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -62,8 +62,8 @@ public:
 
     m_uint_star_type = ast->GetPointerSizedIntType(false);
 
-    static ConstString g__indexes("_indexes");
-    static ConstString g__length("_length");
+    static constexpr llvm::StringLiteral g__indexes("_indexes");
+    static constexpr llvm::StringLiteral g__length("_length");
 
     ProcessSP process_sp = m_backend.GetProcessSP();
     if (!process_sp)

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -247,24 +247,25 @@ bool lldb_private::formatters::NSSetSummaryProvider(
   uint64_t value = 0;
 
   ConstString class_name(descriptor->GetClassName());
+  llvm::StringRef class_name_ref(class_name.GetStringRef());
 
-  static const ConstString g_SetI("__NSSetI");
-  static const ConstString g_OrderedSetI("__NSOrderedSetI");
-  static const ConstString g_SetM("__NSSetM");
-  static const ConstString g_SetCF("__NSCFSet");
-  static const ConstString g_SetCFRef("CFSetRef");
+  static constexpr llvm::StringLiteral g_SetI("__NSSetI");
+  static constexpr llvm::StringLiteral g_OrderedSetI("__NSOrderedSetI");
+  static constexpr llvm::StringLiteral g_SetM("__NSSetM");
+  static constexpr llvm::StringLiteral g_SetCF("__NSCFSet");
+  static constexpr llvm::StringLiteral g_SetCFRef("CFSetRef");
 
-  if (class_name.IsEmpty())
+  if (class_name_ref.empty())
     return false;
 
-  if (class_name == g_SetI || class_name == g_OrderedSetI) {
+  if (class_name_ref == g_SetI || class_name_ref == g_OrderedSetI) {
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + ptr_size,
                                                       ptr_size, 0, error);
     if (error.Fail())
       return false;
     value &= (is_64bit ? ~0xFC00000000000000UL : ~0xFC000000U);
-  } else if (class_name == g_SetM) {
+  } else if (class_name_ref == g_SetM) {
     AppleObjCRuntime *apple_runtime =
         llvm::dyn_cast_or_null<AppleObjCRuntime>(runtime);
     Status error;
@@ -277,7 +278,7 @@ bool lldb_private::formatters::NSSetSummaryProvider(
     }
     if (error.Fail())
       return false;
-  } else if (class_name == g_SetCF || class_name == g_SetCFRef) {
+  } else if (class_name_ref == g_SetCF || class_name_ref == g_SetCFRef) {
     ExecutionContext exe_ctx(process_sp);
     CFBasicHash cfbh;
     if (!cfbh.Update(valobj_addr, exe_ctx))
@@ -329,19 +330,20 @@ lldb_private::formatters::NSSetSyntheticFrontEndCreator(
     return nullptr;
 
   ConstString class_name = descriptor->GetClassName();
+  llvm::StringRef class_name_ref(class_name.GetStringRef());
 
-  static const ConstString g_SetI("__NSSetI");
-  static const ConstString g_OrderedSetI("__NSOrderedSetI");
-  static const ConstString g_SetM("__NSSetM");
-  static const ConstString g_SetCF("__NSCFSet");
-  static const ConstString g_SetCFRef("CFSetRef");
+  static constexpr llvm::StringLiteral g_SetI("__NSSetI");
+  static constexpr llvm::StringLiteral g_OrderedSetI("__NSOrderedSetI");
+  static constexpr llvm::StringLiteral g_SetM("__NSSetM");
+  static constexpr llvm::StringLiteral g_SetCF("__NSCFSet");
+  static constexpr llvm::StringLiteral g_SetCFRef("CFSetRef");
 
-  if (class_name.IsEmpty())
+  if (class_name_ref.empty())
     return nullptr;
 
-  if (class_name == g_SetI || class_name == g_OrderedSetI) {
+  if (class_name_ref == g_SetI || class_name_ref == g_OrderedSetI) {
     return (new NSSetISyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_SetM) {
+  } else if (class_name_ref == g_SetM) {
     AppleObjCRuntime *apple_runtime =
         llvm::dyn_cast_or_null<AppleObjCRuntime>(runtime);
     if (apple_runtime) {
@@ -354,7 +356,7 @@ lldb_private::formatters::NSSetSyntheticFrontEndCreator(
     } else {
       return (new Foundation1300::NSSetMSyntheticFrontEnd(valobj_sp));
     }
-  } else if (class_name == g_SetCF || class_name == g_SetCFRef) {
+  } else if (class_name_ref == g_SetCF || class_name_ref == g_SetCFRef) {
     return (new NSCFSetSyntheticFrontEnd(valobj_sp));
   } else {
     auto &map(NSSet_Additionals::GetAdditionalSynthetics());


### PR DESCRIPTION
For a given ObjC framework type (e.g. NSArray from Foundation), LLDB may need to do something different to format the type correctly depending on its backing implementation type. Many of these types have well known variants that LLDB knows how to handle, but they need to be identified on a case-by-case basis.

These type names were stored into ConstStrings but don't need to be. Instead we can statically create a StringLiteral to avoid repeated StringRef creation for these type names.