### PR TITLE
[NFC][X86] Add getMemoryOperandIdx helper function

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -268,14 +268,11 @@ classifySecondInstInMacroFusion(const MCInst &MI, const MCInstrInfo &MCII) {
 
 /// Check if the instruction uses RIP relative addressing.
 static bool isRIPRelative(const MCInst &MI, const MCInstrInfo &MCII) {
-  unsigned Opcode = MI.getOpcode();
-  const MCInstrDesc &Desc = MCII.get(Opcode);
-  uint64_t TSFlags = Desc.TSFlags;
-  unsigned CurOp = X86II::getOperandBias(Desc);
-  int MemoryOperand = X86II::getMemoryOperandNo(TSFlags);
+  const MCInstrDesc &Desc = MCII.get(MI.getOpcode());
+  int MemoryOperand = X86II::getMemoryOperandIdx(Desc);
   if (MemoryOperand < 0)
     return false;
-  unsigned BaseRegNum = MemoryOperand + CurOp + X86::AddrBaseReg;
+  unsigned BaseRegNum = MemoryOperand + X86::AddrBaseReg;
   MCRegister BaseReg = MI.getOperand(BaseRegNum).getReg();
   return (BaseReg == X86::RIP);
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -312,9 +312,7 @@ uint8_t X86AsmBackend::determinePaddingPrefix(const MCInst &Inst) const {
   uint64_t TSFlags = Desc.TSFlags;
 
   // Determine where the memory operand starts, if present.
-  int MemoryOperand = X86II::getMemoryOperandNo(TSFlags);
-  if (MemoryOperand != -1)
-    MemoryOperand += X86II::getOperandBias(Desc);
+  int MemoryOperand = X86II::getMemoryOperandIdx(Desc);
 
   MCRegister SegmentReg;
   if (MemoryOperand >= 0) {

--- a/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
@@ -1155,6 +1155,16 @@ inline int getMemoryOperandNo(uint64_t TSFlags) {
   }
 }
 
+/// \returns the operand index for the first field of the memory operand,
+/// adjusted with getOperandBias(), or -1 if the instruction has no memory
+/// operands.
+inline int getMemoryOperandIdx(const MCInstrDesc &Desc) {
+  int MemRefIdx = getMemoryOperandNo(Desc.TSFlags);
+  if (MemRefIdx < 0)
+    return -1;
+  return MemRefIdx + getOperandBias(Desc);
+}
+
 /// \returns true if the register is a XMM.
 inline bool isXMMReg(MCRegister Reg) {
   static_assert(X86::XMM15 - X86::XMM0 == 15,

--- a/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
@@ -1158,11 +1158,9 @@ inline int getMemoryOperandNo(uint64_t TSFlags) {
 /// \returns the operand index for the first field of the memory operand,
 /// adjusted with getOperandBias(), or -1 if the instruction has no memory
 /// operands.
-inline int getMemoryOperandIdx(const MCInstrDesc &Desc,
-                               bool MustExist = false) {
+inline int getMemoryOperandIdx(const MCInstrDesc &Desc) {
   int MemRefIdx = getMemoryOperandNo(Desc.TSFlags);
-  assert((!MustExist || MemRefIdx >= 0) && "Expected a memory operand");
-  if (!MustExist && MemRefIdx < 0)
+  if (MemRefIdx < 0)
     return -1;
   return MemRefIdx + getOperandBias(Desc);
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
@@ -1158,9 +1158,11 @@ inline int getMemoryOperandNo(uint64_t TSFlags) {
 /// \returns the operand index for the first field of the memory operand,
 /// adjusted with getOperandBias(), or -1 if the instruction has no memory
 /// operands.
-inline int getMemoryOperandIdx(const MCInstrDesc &Desc) {
+inline int getMemoryOperandIdx(const MCInstrDesc &Desc,
+                               bool MustExist = false) {
   int MemRefIdx = getMemoryOperandNo(Desc.TSFlags);
-  if (MemRefIdx < 0)
+  assert((!MustExist || MemRefIdx >= 0) && "Expected a memory operand");
+  if (!MustExist && MemRefIdx < 0)
     return -1;
   return MemRefIdx + getOperandBias(Desc);
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86InstPrinterCommon.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86InstPrinterCommon.cpp
@@ -429,9 +429,7 @@ void X86InstPrinterCommon::printInstFlags(const MCInst *MI, raw_ostream &O,
     O << "\t{disp32}";
 
   // Determine where the memory operand starts, if present
-  int MemoryOperand = X86II::getMemoryOperandNo(TSFlags);
-  if (MemoryOperand != -1)
-    MemoryOperand += X86II::getOperandBias(Desc);
+  int MemoryOperand = X86II::getMemoryOperandIdx(Desc);
 
   // Address-Size override prefix
   if (Flags & X86::IP_HAS_AD_SIZE &&

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCCodeEmitter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCCodeEmitter.cpp
@@ -893,14 +893,13 @@ void X86MCCodeEmitter::emitMemModRMByte(
 PrefixKind X86MCCodeEmitter::emitPrefixImpl(unsigned &CurOp, const MCInst &MI,
                                             const MCSubtargetInfo &STI,
                                             SmallVectorImpl<char> &CB) const {
-  uint64_t TSFlags = MCII.get(MI.getOpcode()).TSFlags;
+  const MCInstrDesc &Desc = MCII.get(MI.getOpcode());
+  uint64_t TSFlags = Desc.TSFlags;
   // Determine where the memory operand starts, if present.
-  int MemoryOperand = X86II::getMemoryOperandNo(TSFlags);
+  int MemoryOperand = X86II::getMemoryOperandIdx(Desc);
   // Emit segment override opcode prefix as needed.
-  if (MemoryOperand != -1) {
-    MemoryOperand += CurOp;
+  if (MemoryOperand != -1)
     emitSegmentOverridePrefix(MemoryOperand + X86::AddrSegmentReg, MI, CB);
-  }
 
   // Emit the repeat opcode prefix as needed.
   unsigned Flags = MI.getFlags();

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCLFIRewriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCLFIRewriter.cpp
@@ -38,11 +38,9 @@ static bool isSyscall(const MCInst &Inst) {
 // Find the index of the memory operand if it has an %fs segment override.
 // Returns -1 if there is no memory operand or no %fs override.
 static int findFSMemOperand(const MCInst &Inst, const MCInstrInfo &InstInfo) {
-  const MCInstrDesc &Desc = InstInfo.get(Inst.getOpcode());
-  int MemRefIdx = X86II::getMemoryOperandNo(Desc.TSFlags);
-  if (MemRefIdx < 0)
+  int MemIdx = X86II::getMemoryOperandIdx(InstInfo.get(Inst.getOpcode()));
+  if (MemIdx < 0)
     return -1;
-  int MemIdx = MemRefIdx + X86II::getOperandBias(Desc);
   const MCOperand &Seg = Inst.getOperand(MemIdx + X86::AddrSegmentReg);
   if (Seg.isReg() && Seg.getReg() == X86::FS)
     return MemIdx;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -740,10 +740,9 @@ std::optional<uint64_t> X86MCInstrAnalysis::evaluateMemoryOperandAddress(
     const MCInst &Inst, const MCSubtargetInfo *STI, uint64_t Addr,
     uint64_t Size) const {
   const MCInstrDesc &MCID = Info->get(Inst.getOpcode());
-  int MemOpStart = X86II::getMemoryOperandNo(MCID.TSFlags);
+  int MemOpStart = X86II::getMemoryOperandIdx(MCID);
   if (MemOpStart == -1)
     return std::nullopt;
-  MemOpStart += X86II::getOperandBias(MCID);
 
   const MCOperand &SegReg = Inst.getOperand(MemOpStart + X86::AddrSegmentReg);
   const MCOperand &BaseReg = Inst.getOperand(MemOpStart + X86::AddrBaseReg);
@@ -767,10 +766,9 @@ X86MCInstrAnalysis::getMemoryOperandRelocationOffset(const MCInst &Inst,
   if (Inst.getOpcode() != X86::LEA64r)
     return std::nullopt;
   const MCInstrDesc &MCID = Info->get(Inst.getOpcode());
-  int MemOpStart = X86II::getMemoryOperandNo(MCID.TSFlags);
+  int MemOpStart = X86II::getMemoryOperandIdx(MCID);
   if (MemOpStart == -1)
     return std::nullopt;
-  MemOpStart += X86II::getOperandBias(MCID);
   const MCOperand &SegReg = Inst.getOperand(MemOpStart + X86::AddrSegmentReg);
   const MCOperand &BaseReg = Inst.getOperand(MemOpStart + X86::AddrBaseReg);
   const MCOperand &IndexReg = Inst.getOperand(MemOpStart + X86::AddrIndexReg);

--- a/llvm/lib/Target/X86/X86AvoidStoreForwardingBlocks.cpp
+++ b/llvm/lib/Target/X86/X86AvoidStoreForwardingBlocks.cpp
@@ -294,9 +294,7 @@ static unsigned getYMMtoXMMStoreOpcode(unsigned StoreOpcode) {
 }
 
 static int getAddrOffset(const MachineInstr *MI) {
-  int AddrOffset = X86II::getMemoryOperandIdx(MI->getDesc());
-  assert(AddrOffset != -1 && "Expected Memory Operand");
-  return AddrOffset;
+  return X86II::getMemoryOperandIdx(MI->getDesc(), /*MustExist=*/true);
 }
 
 static MachineOperand &getBaseOperand(MachineInstr *MI) {

--- a/llvm/lib/Target/X86/X86AvoidStoreForwardingBlocks.cpp
+++ b/llvm/lib/Target/X86/X86AvoidStoreForwardingBlocks.cpp
@@ -294,10 +294,8 @@ static unsigned getYMMtoXMMStoreOpcode(unsigned StoreOpcode) {
 }
 
 static int getAddrOffset(const MachineInstr *MI) {
-  const MCInstrDesc &Descl = MI->getDesc();
-  int AddrOffset = X86II::getMemoryOperandNo(Descl.TSFlags);
+  int AddrOffset = X86II::getMemoryOperandIdx(MI->getDesc());
   assert(AddrOffset != -1 && "Expected Memory Operand");
-  AddrOffset += X86II::getOperandBias(Descl);
   return AddrOffset;
 }
 

--- a/llvm/lib/Target/X86/X86AvoidStoreForwardingBlocks.cpp
+++ b/llvm/lib/Target/X86/X86AvoidStoreForwardingBlocks.cpp
@@ -294,7 +294,9 @@ static unsigned getYMMtoXMMStoreOpcode(unsigned StoreOpcode) {
 }
 
 static int getAddrOffset(const MachineInstr *MI) {
-  return X86II::getMemoryOperandIdx(MI->getDesc(), /*MustExist=*/true);
+  int AddrOffset = X86II::getMemoryOperandIdx(MI->getDesc());
+  assert(AddrOffset >= 0 && "Expected a memory operand");
+  return AddrOffset;
 }
 
 static MachineOperand &getBaseOperand(MachineInstr *MI) {

--- a/llvm/lib/Target/X86/X86DomainReassignment.cpp
+++ b/llvm/lib/Target/X86/X86DomainReassignment.cpp
@@ -528,12 +528,10 @@ static bool usedAsAddr(const MachineInstr &MI, Register Reg,
   if (!MI.mayLoadOrStore())
     return false;
 
-  const MCInstrDesc &Desc = TII->get(MI.getOpcode());
-  int MemOpStart = X86II::getMemoryOperandNo(Desc.TSFlags);
+  int MemOpStart = X86II::getMemoryOperandIdx(TII->get(MI.getOpcode()));
   if (MemOpStart == -1)
     return false;
 
-  MemOpStart += X86II::getOperandBias(Desc);
   for (unsigned MemOpIdx = MemOpStart,
                 MemOpEnd = MemOpStart + X86::AddrNumOperands;
        MemOpIdx < MemOpEnd; ++MemOpIdx) {
@@ -564,10 +562,7 @@ void X86DomainReassignmentImpl::buildClosure(Closure &C, Register Reg) {
     // Do not add registers which are used in address calculation, they will be
     // added to a different closure.
     int OpEnd = DefMI->getNumOperands();
-    const MCInstrDesc &Desc = DefMI->getDesc();
-    int MemOp = X86II::getMemoryOperandNo(Desc.TSFlags);
-    if (MemOp != -1)
-      MemOp += X86II::getOperandBias(Desc);
+    int MemOp = X86II::getMemoryOperandIdx(DefMI->getDesc());
     for (int OpIdx = 0; OpIdx < OpEnd; ++OpIdx) {
       if (OpIdx == MemOp) {
         // skip address calculation.

--- a/llvm/lib/Target/X86/X86FixupLEAs.cpp
+++ b/llvm/lib/Target/X86/X86FixupLEAs.cpp
@@ -653,10 +653,8 @@ void FixupLEAsImpl::processInstruction(MachineBasicBlock::iterator &I,
                                        MachineBasicBlock &MBB) {
   // Process a load, store, or LEA instruction.
   MachineInstr &MI = *I;
-  const MCInstrDesc &Desc = MI.getDesc();
-  int AddrOffset = X86II::getMemoryOperandNo(Desc.TSFlags);
+  int AddrOffset = X86II::getMemoryOperandIdx(MI.getDesc());
   if (AddrOffset >= 0) {
-    AddrOffset += X86II::getOperandBias(Desc);
     MachineOperand &p = MI.getOperand(AddrOffset + X86::AddrBaseReg);
     if (p.isReg() && p.getReg() != X86::ESP) {
       seekLEAFixup(p, I, MBB);

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -3977,8 +3977,8 @@ bool X86InstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 static int getJumpTableIndexFromAddr(const MachineInstr &MI) {
-  int MemRefBegin = X86II::getMemoryOperandIdx(MI.getDesc());
-  assert(MemRefBegin >= 0 && "instr should have memory operand");
+  int MemRefBegin =
+      X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
 
   const MachineOperand &MO = MI.getOperand(MemRefBegin + X86::AddrDisp);
   if (!MO.isJTI())

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -3977,8 +3977,8 @@ bool X86InstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 static int getJumpTableIndexFromAddr(const MachineInstr &MI) {
-  int MemRefBegin =
-      X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
+  int MemRefBegin = X86II::getMemoryOperandIdx(MI.getDesc());
+  assert(MemRefBegin >= 0 && "Expected a memory operand");
 
   const MachineOperand &MO = MI.getOperand(MemRefBegin + X86::AddrDisp);
   if (!MO.isJTI())

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -3650,12 +3650,12 @@ int X86::getFirstAddrOperandIdx(const MachineInstr &MI) {
   // Directly invoke the MC-layer routine for real (i.e., non-pseudo)
   // instructions (fast case).
   if (!X86II::isPseudo(Desc.TSFlags)) {
-    int MemRefIdx = X86II::getMemoryOperandNo(Desc.TSFlags);
+    int MemRefIdx = X86II::getMemoryOperandIdx(Desc);
     if (MemRefIdx >= 0)
-      return MemRefIdx + X86II::getOperandBias(Desc);
+      return MemRefIdx;
 #ifdef EXPENSIVE_CHECKS
     assert(none_of(Desc.operands(), IsMemOp) &&
-           "Got false negative from X86II::getMemoryOperandNo()!");
+           "Got false negative from X86II::getMemoryOperandIdx()!");
 #endif
     return -1;
   }
@@ -3977,10 +3977,8 @@ bool X86InstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 static int getJumpTableIndexFromAddr(const MachineInstr &MI) {
-  const MCInstrDesc &Desc = MI.getDesc();
-  int MemRefBegin = X86II::getMemoryOperandNo(Desc.TSFlags);
+  int MemRefBegin = X86II::getMemoryOperandIdx(MI.getDesc());
   assert(MemRefBegin >= 0 && "instr should have memory operand");
-  MemRefBegin += X86II::getOperandBias(Desc);
 
   const MachineOperand &MO = MI.getOperand(MemRefBegin + X86::AddrDisp);
   if (!MO.isJTI())
@@ -4577,12 +4575,9 @@ static unsigned getLoadStoreRegOpcode(Register Reg,
 std::optional<ExtAddrMode>
 X86InstrInfo::getAddrModeFromMemoryOp(const MachineInstr &MemI,
                                       const TargetRegisterInfo *TRI) const {
-  const MCInstrDesc &Desc = MemI.getDesc();
-  int MemRefBegin = X86II::getMemoryOperandNo(Desc.TSFlags);
+  int MemRefBegin = X86II::getMemoryOperandIdx(MemI.getDesc());
   if (MemRefBegin < 0)
     return std::nullopt;
-
-  MemRefBegin += X86II::getOperandBias(Desc);
 
   auto &BaseOp = MemI.getOperand(MemRefBegin + X86::AddrBaseReg);
   if (!BaseOp.isReg()) // Can be an MO_FrameIndex
@@ -4701,12 +4696,9 @@ bool X86InstrInfo::getMemOperandsWithOffsetWidth(
     const MachineInstr &MemOp, SmallVectorImpl<const MachineOperand *> &BaseOps,
     int64_t &Offset, bool &OffsetIsScalable, LocationSize &Width,
     const TargetRegisterInfo *TRI) const {
-  const MCInstrDesc &Desc = MemOp.getDesc();
-  int MemRefBegin = X86II::getMemoryOperandNo(Desc.TSFlags);
+  int MemRefBegin = X86II::getMemoryOperandIdx(MemOp.getDesc());
   if (MemRefBegin < 0)
     return false;
-
-  MemRefBegin += X86II::getOperandBias(Desc);
 
   const MachineOperand *BaseOp =
       &MemOp.getOperand(MemRefBegin + X86::AddrBaseReg);

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -189,7 +189,7 @@ inline static bool isMem(const MachineInstr &MI, unsigned Op) {
 inline static bool isAddMemInstrWithRelocation(const MachineInstr &MI) {
   unsigned Op = MI.getOpcode();
   if (Op == X86::ADD64rm || Op == X86::ADD64mr_ND || Op == X86::ADD64rm_ND) {
-    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTTPOFF)
       return true;
@@ -221,7 +221,7 @@ inline static bool isMemInstrWithGOTPCREL(const MachineInstr &MI) {
   case X86::SBB64rm:
   case X86::SUB64rm:
   case X86::XOR64rm: {
-    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTPCREL)
       return true;

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -189,7 +189,8 @@ inline static bool isMem(const MachineInstr &MI, unsigned Op) {
 inline static bool isAddMemInstrWithRelocation(const MachineInstr &MI) {
   unsigned Op = MI.getOpcode();
   if (Op == X86::ADD64rm || Op == X86::ADD64mr_ND || Op == X86::ADD64rm_ND) {
-    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+    assert(MemOpNo >= 0 && "Expected a memory operand");
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTTPOFF)
       return true;
@@ -221,7 +222,8 @@ inline static bool isMemInstrWithGOTPCREL(const MachineInstr &MI) {
   case X86::SBB64rm:
   case X86::SUB64rm:
   case X86::XOR64rm: {
-    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+    assert(MemOpNo >= 0 && "Expected a memory operand");
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTPCREL)
       return true;

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -189,8 +189,7 @@ inline static bool isMem(const MachineInstr &MI, unsigned Op) {
 inline static bool isAddMemInstrWithRelocation(const MachineInstr &MI) {
   unsigned Op = MI.getOpcode();
   if (Op == X86::ADD64rm || Op == X86::ADD64mr_ND || Op == X86::ADD64rm_ND) {
-    int MemOpNo = X86II::getMemoryOperandNo(MI.getDesc().TSFlags) +
-                  X86II::getOperandBias(MI.getDesc());
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTTPOFF)
       return true;
@@ -222,8 +221,7 @@ inline static bool isMemInstrWithGOTPCREL(const MachineInstr &MI) {
   case X86::SBB64rm:
   case X86::SUB64rm:
   case X86::XOR64rm: {
-    int MemOpNo = X86II::getMemoryOperandNo(MI.getDesc().TSFlags) +
-                  X86II::getOperandBias(MI.getDesc());
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTPCREL)
       return true;

--- a/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
+++ b/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
@@ -326,8 +326,7 @@ bool X86OptimizeLEAsImpl::chooseBestLEA(
     const SmallVectorImpl<MachineInstr *> &List, const MachineInstr &MI,
     MachineInstr *&BestLEA, int64_t &AddrDispShift, int &Dist) {
   const MCInstrDesc &Desc = MI.getDesc();
-  int MemOpNo = X86II::getMemoryOperandNo(Desc.TSFlags) +
-                X86II::getOperandBias(Desc);
+  int MemOpNo = X86II::getMemoryOperandIdx(Desc);
 
   BestLEA = nullptr;
 
@@ -428,15 +427,12 @@ bool X86OptimizeLEAsImpl::isReplaceable(const MachineInstr &First,
     MachineInstr &MI = *MO.getParent();
 
     // Get the number of the first memory operand.
-    const MCInstrDesc &Desc = MI.getDesc();
-    int MemOpNo = X86II::getMemoryOperandNo(Desc.TSFlags);
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
 
     // If the use instruction has no memory operand - the LEA is not
     // replaceable.
     if (MemOpNo < 0)
       return false;
-
-    MemOpNo += X86II::getOperandBias(Desc);
 
     // If the address base of the use instruction is not the LEA def register -
     // the LEA is not replaceable.
@@ -492,14 +488,11 @@ bool X86OptimizeLEAsImpl::removeRedundantAddrCalc(MemOpMap &LEAs) {
       continue;
 
     // Get the number of the first memory operand.
-    const MCInstrDesc &Desc = MI.getDesc();
-    int MemOpNo = X86II::getMemoryOperandNo(Desc.TSFlags);
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
 
     // If instruction has no memory operand - skip it.
     if (MemOpNo < 0)
       continue;
-
-    MemOpNo += X86II::getOperandBias(Desc);
 
     // Do not call chooseBestLEA if there was no matching LEA
     auto Insns = LEAs.find(getMemOpKey(MI, MemOpNo));
@@ -653,10 +646,7 @@ bool X86OptimizeLEAsImpl::removeRedundantLEAs(MemOpMap &LEAs) {
           }
 
           // Get the number of the first memory operand.
-          const MCInstrDesc &Desc = MI.getDesc();
-          int MemOpNo =
-              X86II::getMemoryOperandNo(Desc.TSFlags) +
-              X86II::getOperandBias(Desc);
+          int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
 
           // Update address base.
           MO.setReg(FirstVReg);

--- a/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
+++ b/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
@@ -326,7 +326,7 @@ bool X86OptimizeLEAsImpl::chooseBestLEA(
     const SmallVectorImpl<MachineInstr *> &List, const MachineInstr &MI,
     MachineInstr *&BestLEA, int64_t &AddrDispShift, int &Dist) {
   const MCInstrDesc &Desc = MI.getDesc();
-  int MemOpNo = X86II::getMemoryOperandIdx(Desc);
+  int MemOpNo = X86II::getMemoryOperandIdx(Desc, /*MustExist=*/true);
 
   BestLEA = nullptr;
 
@@ -646,7 +646,8 @@ bool X86OptimizeLEAsImpl::removeRedundantLEAs(MemOpMap &LEAs) {
           }
 
           // Get the number of the first memory operand.
-          int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+          int MemOpNo =
+              X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
 
           // Update address base.
           MO.setReg(FirstVReg);

--- a/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
+++ b/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
@@ -326,7 +326,8 @@ bool X86OptimizeLEAsImpl::chooseBestLEA(
     const SmallVectorImpl<MachineInstr *> &List, const MachineInstr &MI,
     MachineInstr *&BestLEA, int64_t &AddrDispShift, int &Dist) {
   const MCInstrDesc &Desc = MI.getDesc();
-  int MemOpNo = X86II::getMemoryOperandIdx(Desc, /*MustExist=*/true);
+  int MemOpNo = X86II::getMemoryOperandIdx(Desc);
+  assert(MemOpNo >= 0 && "Expected a memory operand");
 
   BestLEA = nullptr;
 
@@ -646,8 +647,8 @@ bool X86OptimizeLEAsImpl::removeRedundantLEAs(MemOpMap &LEAs) {
           }
 
           // Get the number of the first memory operand.
-          int MemOpNo =
-              X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
+          int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+          assert(MemOpNo >= 0 && "Expected a memory operand");
 
           // Update address base.
           MO.setReg(FirstVReg);

--- a/llvm/lib/Target/X86/X86SuppressAPXForReloc.cpp
+++ b/llvm/lib/Target/X86/X86SuppressAPXForReloc.cpp
@@ -108,7 +108,8 @@ static bool handleInstructionWithEGPR(MachineFunction &MF,
   MachineRegisterInfo *MRI = &MF.getRegInfo();
   auto suppressEGPRInInstrWithReloc = [&](MachineInstr &MI,
                                           ArrayRef<unsigned> OpNoArray) {
-    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+    assert(MemOpNo >= 0 && "Expected a memory operand");
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTTPOFF ||
         MO.getTargetFlags() == X86II::MO_GOTPCREL) {
@@ -177,16 +178,16 @@ static bool handleNDDOrNFInstructions(MachineFunction &MF,
       case X86::ADD64rm_NF:
       case X86::ADD64mr_NF_ND:
       case X86::ADD64rm_NF_ND: {
-        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(),
-                                                 /*MustExist=*/true);
+        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+        assert(MemOpNo >= 0 && "Expected a memory operand");
         const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
         if (MO.getTargetFlags() == X86II::MO_GOTTPOFF)
           llvm_unreachable("Unexpected NF instruction!");
         break;
       }
       case X86::ADD64rm_ND: {
-        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(),
-                                                 /*MustExist=*/true);
+        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+        assert(MemOpNo >= 0 && "Expected a memory operand");
         const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
         if (MO.getTargetFlags() == X86II::MO_GOTTPOFF ||
             MO.getTargetFlags() == X86II::MO_GOTPCREL) {

--- a/llvm/lib/Target/X86/X86SuppressAPXForReloc.cpp
+++ b/llvm/lib/Target/X86/X86SuppressAPXForReloc.cpp
@@ -108,7 +108,7 @@ static bool handleInstructionWithEGPR(MachineFunction &MF,
   MachineRegisterInfo *MRI = &MF.getRegInfo();
   auto suppressEGPRInInstrWithReloc = [&](MachineInstr &MI,
                                           ArrayRef<unsigned> OpNoArray) {
-    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(), /*MustExist=*/true);
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTTPOFF ||
         MO.getTargetFlags() == X86II::MO_GOTPCREL) {
@@ -177,14 +177,16 @@ static bool handleNDDOrNFInstructions(MachineFunction &MF,
       case X86::ADD64rm_NF:
       case X86::ADD64mr_NF_ND:
       case X86::ADD64rm_NF_ND: {
-        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(),
+                                                 /*MustExist=*/true);
         const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
         if (MO.getTargetFlags() == X86II::MO_GOTTPOFF)
           llvm_unreachable("Unexpected NF instruction!");
         break;
       }
       case X86::ADD64rm_ND: {
-        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
+        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc(),
+                                                 /*MustExist=*/true);
         const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
         if (MO.getTargetFlags() == X86II::MO_GOTTPOFF ||
             MO.getTargetFlags() == X86II::MO_GOTPCREL) {

--- a/llvm/lib/Target/X86/X86SuppressAPXForReloc.cpp
+++ b/llvm/lib/Target/X86/X86SuppressAPXForReloc.cpp
@@ -108,8 +108,7 @@ static bool handleInstructionWithEGPR(MachineFunction &MF,
   MachineRegisterInfo *MRI = &MF.getRegInfo();
   auto suppressEGPRInInstrWithReloc = [&](MachineInstr &MI,
                                           ArrayRef<unsigned> OpNoArray) {
-    int MemOpNo = X86II::getMemoryOperandNo(MI.getDesc().TSFlags) +
-                  X86II::getOperandBias(MI.getDesc());
+    int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
     const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
     if (MO.getTargetFlags() == X86II::MO_GOTTPOFF ||
         MO.getTargetFlags() == X86II::MO_GOTPCREL) {
@@ -178,16 +177,14 @@ static bool handleNDDOrNFInstructions(MachineFunction &MF,
       case X86::ADD64rm_NF:
       case X86::ADD64mr_NF_ND:
       case X86::ADD64rm_NF_ND: {
-        int MemOpNo = X86II::getMemoryOperandNo(MI.getDesc().TSFlags) +
-                      X86II::getOperandBias(MI.getDesc());
+        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
         const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
         if (MO.getTargetFlags() == X86II::MO_GOTTPOFF)
           llvm_unreachable("Unexpected NF instruction!");
         break;
       }
       case X86::ADD64rm_ND: {
-        int MemOpNo = X86II::getMemoryOperandNo(MI.getDesc().TSFlags) +
-                      X86II::getOperandBias(MI.getDesc());
+        int MemOpNo = X86II::getMemoryOperandIdx(MI.getDesc());
         const MachineOperand &MO = MI.getOperand(X86::AddrDisp + MemOpNo);
         if (MO.getTargetFlags() == X86II::MO_GOTTPOFF ||
             MO.getTargetFlags() == X86II::MO_GOTPCREL) {


### PR DESCRIPTION
The pattern of computing a memory operand index via `X86II::getMemoryOperandNo(Desc.TSFlags) + X86II::getOperandBias(Desc)` occurs in a number of places in the X86 backend. This patch puts that logic into a helper function called `getMemoryOperandIdx` and simplifies instances across the backend.