### PR TITLE
[Flang][OpenMP] Fix interop-var handling and diagnostics (#203959)

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -6322,8 +6322,17 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
     }
   }
 
-  // Helper to get the address of an interop variable from an Object.
+  // Helper to get the address of an interop variable from an Object. A
+  // designator such as arr(1) or rec%obj must lower through genExprAddr so we
+  // obtain the address of the actual scalar element/component with the correct
+  // type, rather than the base symbol address (which would be the whole array,
+  // or null for a component defined inside a derived type).
   auto getInteropVarAddr = [&](const Object &object) -> mlir::Value {
+    if (const auto &designator = object.ref()) {
+      fir::ExtendedValue exv =
+          converter.genExprAddr(*designator, stmtCtx, &loc);
+      return fir::getBase(exv);
+    }
     const semantics::Symbol *sym = object.sym();
     assert(sym && "interop variable must have a symbol");
     mlir::Value addr = converter.getSymbolAddress(*sym);
@@ -6382,7 +6391,6 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
                             .Case("sycl", 4)
                             .Case("hip", 5)
                             .Case("level_zero", 6)
-                            .Case("hsa", 7)
                             .Default(std::nullopt);
             if (frId)
               prefValues.push_back(*frId);

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -6026,14 +6026,90 @@ void OmpStructureChecker::Enter(const parser::OmpClause::ThreadLimit &x) {
 void OmpStructureChecker::Enter(const parser::OpenMPInteropConstruct &x) {
   bool isDependClauseOccurred{false};
   bool hasInitClause{false};
+  bool hasActionClause{false};
   int targetCount{0}, targetSyncCount{0};
-  std::set<const Symbol *> objectSymbolList;
+  std::set<std::string> interopVarNames;
+  // An interop-var must be a scalar variable of integer type. Reject
+  // non-scalar designators (whole arrays, array sections) and non-integer
+  // designators; array elements and scalar derived-type components are valid.
+  auto checkInteropVar = [&](const parser::OmpObject &object,
+                             parser::CharBlock source, bool requireDefinable) {
+    // Type-parameter inquiries (e.g. x%kind) are diagnosed separately by
+    // CheckTypeParamInquiry, so don't also flag them here.
+    if (const Symbol *sym{GetObjectSymbol(object)};
+        sym && IsTypeParamInquiry(*sym)) {
+      return;
+    }
+    const parser::Designator *designator{GetDesignatorFromObj(object)};
+    if (!designator) {
+      // A non-designator OmpObject -- a function reference, a reserved locator
+      // such as omp_all_memory, or a common-block name -- is not a variable and
+      // cannot be an interop-var. Reject it here; otherwise it silently
+      // bypasses validation.
+      context_.Say(source,
+          "The interop variable in an INTEROP construct must be a variable"_err_en_US);
+      return;
+    }
+    // Analyze the designator only to inspect its rank and type. Permit a
+    // whole assumed-size array so the analyzer does not add its own "may not
+    // appear here" error on top of the interop-specific diagnostic below,
+    // keeping a single clean message for any non-scalar interop-var. This
+    // mirrors other OMP-object checks here.
+    evaluate::ExpressionAnalyzer ea{context_};
+    auto restore{ea.AllowWholeAssumedSizeArray(true)};
+    MaybeExpr expr{ea.Analyze(*designator)};
+    if (!expr) {
+      return;
+    }
+    if (expr->Rank() != 0) {
+      context_.Say(source,
+          "The interop variable in an INTEROP construct must be a scalar variable"_err_en_US);
+      return;
+    }
+    // The interop-var must be a scalar integer of omp_interop_kind
+    // (c_intptr_t): the runtime uses its storage as a pointer-sized handle.
+    std::optional<evaluate::DynamicType> type{expr->GetType()};
+    int interopKind{static_cast<int>(
+        context_.targetCharacteristics().integerKindForPointer())};
+    if (!type || type->category() != evaluate::TypeCategory::Integer ||
+        type->kind() != interopKind) {
+      context_.Say(source,
+          "The interop variable in an INTEROP construct must be a scalar integer variable of kind omp_interop_kind"_err_en_US);
+      return;
+    }
+    // An interop-var must be a variable (never a constant). For init and
+    // destroy the runtime stores the handle through the interop-var, so it
+    // must additionally be definable (not an INTENT(IN) dummy, PROTECTED,
+    // etc.). A use clause only reads the handle, so a non-definable variable
+    // (e.g. an INTENT(IN) dummy holding an initialized handle) is acceptable.
+    if (requireDefinable) {
+      if (auto msg{WhyNotDefinable(source, context_.FindScope(source),
+              DefinabilityFlags{}, *expr)}) {
+        context_
+            .Say(source,
+                "The interop variable in an INTEROP construct must be a definable variable"_err_en_US)
+            .Attach(std::move(msg->set_severity(parser::Severity::Because)));
+      }
+    } else if (!evaluate::IsVariable(*expr)) {
+      context_.Say(source,
+          "The interop variable in an INTEROP construct must be a variable"_err_en_US);
+    }
+    // Each interop-var may appear in at most one action-clause. Compare the
+    // full designator in canonical form so distinct array elements or
+    // structure components (e.g. arr(1) vs arr(2)) are allowed, while a
+    // repeated designator is flagged as a duplicate.
+    if (!interopVarNames.insert(expr->AsFortran()).second) {
+      context_.Say(source,
+          "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
+    }
+  };
   const auto &clauseList{std::get<std::optional<parser::OmpClauseList>>(x.v.t)};
   for (const auto &clause : clauseList->v) {
     common::visit(
         common::visitors{
             [&](const parser::OmpClause::Init &initClause) {
               hasInitClause = true;
+              hasActionClause = true;
               if (OmpVerifyModifiers(initClause.v, llvm::omp::OMPC_init,
                       GetContext().directiveSource, context_)) {
 
@@ -6093,50 +6169,48 @@ void OmpStructureChecker::Enter(const parser::OpenMPInteropConstruct &x) {
                   std::get<parser::OmpObject>(initClause.v.t))};
               CheckTypeParamInquiry(
                   clause.source, *interopVar, llvm::omp::Clause::OMPC_init);
-              if (const auto *name{parser::Unwrap<parser::Name>(interopVar)}) {
-                const auto *objectSymbol{name->symbol};
-                if (llvm::is_contained(objectSymbolList, objectSymbol)) {
-                  context_.Say(GetContext().directiveSource,
-                      "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
-                } else {
-                  objectSymbolList.insert(objectSymbol);
-                }
+              if (interopVar) {
+                checkInteropVar(*interopVar, clause.source,
+                    /*requireDefinable=*/true);
               }
             },
             [&](const parser::OmpClause::Depend &dependClause) {
               isDependClauseOccurred = true;
             },
             [&](const parser::OmpClause::Destroy &destroyClause) {
+              hasActionClause = true;
+              if (!destroyClause.v) {
+                context_.Say(GetContext().directiveSource,
+                    "The DESTROY clause on an INTEROP construct must specify an interop variable"_err_en_US);
+                return;
+              }
               const auto *interopVar{
                   parser::Unwrap<parser::OmpObject>(destroyClause.v)};
-              if (const auto *name{parser::Unwrap<parser::Name>(interopVar)}) {
-                const auto *objectSymbol{name->symbol};
-                if (llvm::is_contained(objectSymbolList, objectSymbol)) {
-                  context_.Say(GetContext().directiveSource,
-                      "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
-                } else {
-                  objectSymbolList.insert(objectSymbol);
-                }
+              if (interopVar) {
+                checkInteropVar(*interopVar, clause.source,
+                    /*requireDefinable=*/true);
               }
             },
             [&](const parser::OmpClause::Use &useClause) {
+              hasActionClause = true;
               const auto *interopVar{
                   parser::Unwrap<parser::OmpObject>(useClause.v)};
               CheckTypeParamInquiry(
                   clause.source, *interopVar, llvm::omp::Clause::OMPC_use);
-              if (const auto *name{parser::Unwrap<parser::Name>(interopVar)}) {
-                const auto *objectSymbol{name->symbol};
-                if (llvm::is_contained(objectSymbolList, objectSymbol)) {
-                  context_.Say(GetContext().directiveSource,
-                      "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
-                } else {
-                  objectSymbolList.insert(objectSymbol);
-                }
+              if (interopVar) {
+                checkInteropVar(*interopVar, clause.source,
+                    /*requireDefinable=*/false);
               }
             },
             [&](const auto &) {},
         },
         clause.u);
+  }
+  // At least one action-clause (init, use, or destroy) must appear on an
+  // interop construct; a construct with only e.g. device or depend is invalid.
+  if (!hasActionClause) {
+    context_.Say(GetContext().directiveSource,
+        "At least one action-clause (INIT, USE, or DESTROY) must appear on the INTEROP construct"_err_en_US);
   }
   if (targetCount > 1 || targetSyncCount > 1) {
     context_.Say(GetContext().directiveSource,

--- a/flang/test/Lower/OpenMP/interop.f90
+++ b/flang/test/Lower/OpenMP/interop.f90
@@ -173,3 +173,30 @@ subroutine test_interop_destroy_device(obj, dev)
   integer :: dev
   !$omp interop destroy(obj) device(dev)
 end subroutine
+
+!===============================================================================
+! Interop Init — array element interop-var
+!===============================================================================
+
+!CHECK-LABEL: func.func @_QPtest_interop_init_array_element(
+!CHECK:         %[[EL:.*]] = hlfir.designate %{{.*}} (%{{.*}}) : (!fir.ref<!fir.array<10xi64>>, index) -> !fir.ref<i64>
+!CHECK:         omp.interop.init %[[EL]] : !fir.ref<i64> interop_types([#omp<interop_type(target)>])
+subroutine test_interop_init_array_element(arr)
+  integer(8) :: arr(10)
+  !$omp interop init(target: arr(1))
+end subroutine
+
+!===============================================================================
+! Interop Use — derived-type component interop-var
+!===============================================================================
+
+!CHECK-LABEL: func.func @_QPtest_interop_use_component(
+!CHECK:         %[[COMP:.*]] = hlfir.designate %{{.*}}{"obj"} : (!fir.ref<!fir.type<{{.*}}>>) -> !fir.ref<i64>
+!CHECK:         omp.interop.use %[[COMP]] : !fir.ref<i64>
+subroutine test_interop_use_component(rec)
+  type t
+    integer(8) :: obj
+  end type
+  type(t) :: rec
+  !$omp interop use(rec%obj)
+end subroutine

--- a/flang/test/Parser/OpenMP/interop-construct.f90
+++ b/flang/test/Parser/OpenMP/interop-construct.f90
@@ -3,18 +3,23 @@
 ! RUN: %flang_fc1 -fdebug-dump-parse-tree-no-sema -fopenmp-version=60 %openmp_flags %s | FileCheck --check-prefix="PARSE-TREE" %s
 
 SUBROUTINE test_interop_01()
-  !$OMP INTEROP DEVICE(1)
+  INTEGER(8) :: obj
+  !$OMP INTEROP INIT(TARGETSYNC: obj) DEVICE(1)
   PRINT *,'pass'
 END SUBROUTINE test_interop_01
 
 !UNPARSE: SUBROUTINE test_interop_01
-!UNPARSE: !$OMP INTEROP  DEVICE(1_4)
+!UNPARSE:  INTEGER(KIND=8_4) obj
+!UNPARSE: !$OMP INTEROP INIT(TARGETSYNC: obj) DEVICE(1_4)
 !UNPARSE:  PRINT *, "pass"
 !UNPARSE: END SUBROUTINE test_interop_01
 
 !PARSE-TREE: ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPStandaloneConstruct -> OpenMPInteropConstruct -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = interop
-!PARSE-TREE: | OmpClauseList -> OmpClause -> Device -> OmpDeviceClause
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Init -> OmpInitClause
+!PARSE-TREE: | | Modifier -> OmpInteropType -> Value = Targetsync
+!PARSE-TREE: | | OmpObject -> Designator -> DataRef -> Name = 'obj'
+!PARSE-TREE: | OmpClause -> Device -> OmpDeviceClause
 !PARSE-TREE: | | Scalar -> Integer -> Expr -> LiteralConstant -> IntLiteralConstant = '1'
 !PARSE-TREE: | Flags = {}
 
@@ -22,14 +27,14 @@ END SUBROUTINE test_interop_01
 SUBROUTINE test_interop_02()
   USE omp_lib
   INTEGER(OMP_INTEROP_KIND) :: obj1, obj2, obj3
-  !$OMP INTEROP INIT(TARGETSYNC: obj) USE(obj1) DESTROY(obj3)
+  !$OMP INTEROP INIT(TARGETSYNC: obj2) USE(obj1) DESTROY(obj3)
   PRINT *,'pass'
 END SUBROUTINE test_interop_02
 
 !UNPARSE: SUBROUTINE test_interop_02
 !UNPARSE:  USE :: omp_lib
 !UNPARSE:  INTEGER(KIND=8_4) obj1, obj2, obj3
-!UNPARSE: !$OMP INTEROP  INIT(TARGETSYNC: obj) USE(obj1) DESTROY(obj3)
+!UNPARSE: !$OMP INTEROP  INIT(TARGETSYNC: obj2) USE(obj1) DESTROY(obj3)
 !UNPARSE:  PRINT *, "pass"
 !UNPARSE: END SUBROUTINE test_interop_02
 
@@ -37,7 +42,7 @@ END SUBROUTINE test_interop_02
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = interop
 !PARSE-TREE: | OmpClauseList -> OmpClause -> Init -> OmpInitClause
 !PARSE-TREE: | | Modifier -> OmpInteropType -> Value = Targetsync
-!PARSE-TREE: | | OmpObject -> Designator -> DataRef -> Name = 'obj'
+!PARSE-TREE: | | OmpObject -> Designator -> DataRef -> Name = 'obj2'
 !PARSE-TREE: | OmpClause -> Use -> OmpUseClause -> OmpObject -> Designator -> DataRef -> Name = 'obj1'
 !PARSE-TREE: | OmpClause -> Destroy -> OmpDestroyClause -> OmpObject -> Designator -> DataRef -> Name = 'obj3'
 !PARSE-TREE: | Flags = {}

--- a/flang/test/Semantics/OpenMP/init-clause.f90
+++ b/flang/test/Semantics/OpenMP/init-clause.f90
@@ -24,6 +24,7 @@ end
 
 subroutine f03
   integer :: x, y
+  !ERROR: The interop variable in an INTEROP construct must be a scalar integer variable of kind omp_interop_kind
   !ERROR: The 'depinfo-modifier' is not allowed on INTEROP construct
   !$omp interop init(mutexinoutset(x): y)
 end

--- a/flang/test/Semantics/OpenMP/interop-construct.f90
+++ b/flang/test/Semantics/OpenMP/interop-construct.f90
@@ -28,3 +28,163 @@ SUBROUTINE test_interop_03()
   !$OMP INTEROP INIT(TARGET: obj) DEPEND(INOUT: obj)
   PRINT *, 'pass'
 END SUBROUTINE test_interop_03
+
+SUBROUTINE test_interop_04()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: obj
+  !$OMP INTEROP INIT(TARGETSYNC: obj)
+  !ERROR: The DESTROY clause on an INTEROP construct must specify an interop variable
+  !$OMP INTEROP DESTROY
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_04
+
+SUBROUTINE test_interop_05()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: arr(10)
+  !ERROR: The interop variable in an INTEROP construct must be a scalar variable
+  !$OMP INTEROP INIT(TARGET: arr)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_05
+
+SUBROUTINE test_interop_06()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: arr(10)
+  !ERROR: The interop variable in an INTEROP construct must be a scalar variable
+  !$OMP INTEROP USE(arr(1:5))
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_06
+
+SUBROUTINE test_interop_07()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: arr(10)
+  !ERROR: The interop variable in an INTEROP construct must be a scalar variable
+  !$OMP INTEROP DESTROY(arr)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_07
+
+SUBROUTINE test_interop_08()
+  REAL(8) :: x
+  !ERROR: The interop variable in an INTEROP construct must be a scalar integer variable of kind omp_interop_kind
+  !$OMP INTEROP INIT(TARGET: x)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_08
+
+SUBROUTINE test_interop_09()
+  INTEGER(4) :: obj
+  !ERROR: The interop variable in an INTEROP construct must be a scalar integer variable of kind omp_interop_kind
+  !$OMP INTEROP USE(obj)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_09
+
+SUBROUTINE test_interop_10()
+  INTEGER(4) :: obj
+  !ERROR: The interop variable in an INTEROP construct must be a scalar integer variable of kind omp_interop_kind
+  !$OMP INTEROP DESTROY(obj)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_10
+
+! An array element is a valid interop-var (scalar, of omp_interop_kind) and
+! must be accepted on all action clauses.
+SUBROUTINE test_interop_11()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: arr(10)
+  !$OMP INTEROP INIT(TARGET: arr(1))
+  !$OMP INTEROP USE(arr(1))
+  !$OMP INTEROP DESTROY(arr(1))
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_11
+
+! Uniqueness is compared per complete designator: distinct array elements or
+! structure components are different interop-vars and must be accepted.
+SUBROUTINE test_interop_12()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: arr(10)
+  !$OMP INTEROP INIT(TARGETSYNC: arr(1)) USE(arr(2))
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_12
+
+! Repeating the same designator in two action-clauses is a duplicate.
+SUBROUTINE test_interop_13()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND) :: arr(10)
+  !ERROR: Each interop-var may be specified for at most one action-clause of each INTEROP construct.
+  !$OMP INTEROP INIT(TARGETSYNC: arr(1)) USE(arr(1))
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_13
+
+! init and destroy store the new handle through the interop-var, so it must be
+! a definable variable, not a constant or other non-definable entity.
+SUBROUTINE test_interop_14()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND), PARAMETER :: handle = 0
+  !ERROR: The interop variable in an INTEROP construct must be a definable variable
+  !BECAUSE: 'handle' is not a variable
+  !$OMP INTEROP INIT(TARGETSYNC: handle)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_14
+
+SUBROUTINE test_interop_15(obj)
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND), INTENT(IN) :: obj
+  !ERROR: The interop variable in an INTEROP construct must be a definable variable
+  !BECAUSE: 'obj' is an INTENT(IN) dummy argument
+  !$OMP INTEROP DESTROY(obj)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_15
+
+! A use clause only reads the handle, so it does not require a definable
+! variable, but the interop-var must still be a variable (not a constant).
+SUBROUTINE test_interop_16()
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND), PARAMETER :: handle = 0
+  !ERROR: The interop variable in an INTEROP construct must be a variable
+  !$OMP INTEROP USE(handle)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_16
+
+! An INTENT(IN) dummy holding an initialized handle is a valid use interop-var.
+SUBROUTINE test_interop_17(obj)
+  USE omp_lib
+  INTEGER(OMP_INTEROP_KIND), INTENT(IN) :: obj
+  !$OMP INTEROP USE(obj)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_17
+
+! An interop construct must have at least one action-clause; a construct with
+! only a device (or other non-action) clause is invalid.
+SUBROUTINE test_interop_18(dev)
+  INTEGER :: dev
+  !ERROR: At least one action-clause (INIT, USE, or DESTROY) must appear on the INTEROP construct
+  !$OMP INTEROP DEVICE(dev)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_18
+
+! A non-designator interop-var -- a function reference or a reserved locator
+! such as omp_all_memory -- is not a variable and must be rejected (otherwise
+! it bypasses validation and asserts in lowering).
+SUBROUTINE test_interop_19()
+  INTEGER(8), EXTERNAL :: get_handle
+  !ERROR: The interop variable in an INTEROP construct must be a variable
+  !$OMP INTEROP USE(get_handle())
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_19
+
+SUBROUTINE test_interop_20()
+  !ERROR: The interop variable in an INTEROP construct must be a variable
+  !$OMP INTEROP USE(omp_all_memory)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_20
+
+! The same rejection applies to init and destroy (shared code path).
+SUBROUTINE test_interop_21()
+  INTEGER(8), EXTERNAL :: get_handle
+  !ERROR: The interop variable in an INTEROP construct must be a variable
+  !$OMP INTEROP INIT(TARGET: get_handle())
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_21
+
+SUBROUTINE test_interop_22()
+  !ERROR: The interop variable in an INTEROP construct must be a variable
+  !$OMP INTEROP DESTROY(omp_all_memory)
+  PRINT *, 'pass'
+END SUBROUTINE test_interop_22


### PR DESCRIPTION
This change builds on top of the work done in PR #203959
- Diagnose interop destroy without an interop variable
- Lower array-element / derived-component interop-vars via their designator
- Require interop-var to be a scalar integer of omp_interop_kind
- Remove "hsa" prefer_type (no omp_ifr_hsa in the runtime)
- Fix a latent bug in Parser/OpenMP/interop-construct.f90