### PR TITLE
[mlir][xegpu] Fix DPAS subgroup layout propagation for broadcast K dim

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
@@ -1067,12 +1067,17 @@ static SmallVector<LayoutRepresentation> enumerateFactorizations(int64_t total,
 // Results are sorted by balance (smallest max-min spread first), with
 // lexicographic order as a tiebreaker.
 //
+// `broadcastDim` (default -1 = none) marks a dimension broadcast across
+// subgroups rather than distributed (e.g. the K/contraction dim of a DPAS
+// operand). Its full extent stays in every subgroup, so rule 1 is skipped for
+// it, but rule 2 (multiple of instData) still applies.
+//
 // Example (2D):
 //   wgShape = [128, 64], instData = [8, 16], sgCount = 32
 //   Returns: [[8,4], [16,2]], corresponding to sgData [16,16] and [8,32].
 static SmallVector<LayoutRepresentation>
 getSgLayoutCandidates(ArrayRef<int64_t> wgShape, ArrayRef<int64_t> instData,
-                      int64_t sgCount) {
+                      int64_t sgCount, int64_t broadcastDim = -1) {
   int64_t rank = wgShape.size();
   assert(rank > 0 && "wgShape must be non-empty");
   assert(static_cast<int64_t>(instData.size()) == rank &&
@@ -1086,11 +1091,18 @@ getSgLayoutCandidates(ArrayRef<int64_t> wgShape, ArrayRef<int64_t> instData,
   for (const auto &sgLayout : allFactorizations) {
     bool valid = true;
     for (int64_t dim = 0; dim < rank; ++dim) {
-      if (wgShape[dim] % sgLayout[dim] != 0) {
-        valid = false;
-        break;
+      // A broadcast dim keeps its full extent in every subgroup; others are
+      // split evenly by sgLayout[dim].
+      int64_t sgData;
+      if (dim == broadcastDim) {
+        sgData = wgShape[dim];
+      } else {
+        if (wgShape[dim] % sgLayout[dim] != 0) {
+          valid = false;
+          break;
+        }
+        sgData = wgShape[dim] / sgLayout[dim];
       }
-      int64_t sgData = wgShape[dim] / sgLayout[dim];
       if (sgData % instData[dim] != 0) {
         valid = false;
         break;
@@ -1345,23 +1357,19 @@ getDpasSubgroupLayouts(
   }
 
   // Get all valid layouts for A, B and C/D operands
-  auto layoutsA = getSgLayoutCandidates(aTy.getShape(), instDataA, numSg);
-  auto layoutsB = getSgLayoutCandidates(bTy.getShape(), instDataB, numSg);
+  auto layoutsA = getSgLayoutCandidates(aTy.getShape(), instDataA, numSg,
+                                        /*broadcastDim=*/aTy.getRank() - 1);
+  auto layoutsB = getSgLayoutCandidates(bTy.getShape(), instDataB, numSg,
+                                        /*broadcastDim=*/bTy.getRank() - 2);
   auto layoutsCD = getSgLayoutCandidates(cdTy.getShape(), instDataCD, numSg);
   if (layoutsA.empty() || layoutsB.empty() || layoutsCD.empty())
     return std::nullopt;
 
   // Pick the best subgroup layout
   std::optional<LayoutRepresentation> bestPick;
-  auto checkAlignedSgDataAB = [&](const LayoutRepresentation &sgLayout) {
-    return aTy.getShape().back() / sgLayout[1] ==
-           bTy.getShape().front() / sgLayout[0];
-  };
   for (auto &sgLayout : layoutsB) {
     if (llvm::is_contained(layoutsA, sgLayout) &&
         llvm::is_contained(layoutsCD, sgLayout)) {
-      if (!checkAlignedSgDataAB(sgLayout))
-        continue;
       // Is in (A and B and CD) and matches consumer -> best pick
       if (consumerSgLayout.has_value() && sgLayout == *consumerSgLayout) {
         bestPick = sgLayout;

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
@@ -279,8 +279,8 @@ gpu.module @test {
 
 // -----
 gpu.module @test {
-  // CHECK-LABEL: for_loop_misaligned_dpas_fail
-  gpu.func @for_loop_misaligned_dpas_fail(%arg0: memref<2048x8192xf16>, %arg1: memref<8192x4096xf16>, %arg2: memref<2048x4096xf32>) kernel attributes {known_block_size = array<i32: 8, 1, 16>} {
+  // CHECK-LABEL: for_loop_dpas_k_broadcast
+  gpu.func @for_loop_dpas_k_broadcast(%arg0: memref<2048x8192xf16>, %arg1: memref<8192x4096xf16>, %arg2: memref<2048x4096xf32>) kernel attributes {known_block_size = array<i32: 8, 1, 16>} {
     %cst = arith.constant dense<0.000000e+00> : vector<128x128xf32>
     %c128 = arith.constant 128 : index
     %c8192 = arith.constant 8192 : index
@@ -294,8 +294,7 @@ gpu.module @test {
       %5 = xegpu.load_nd %4[%block_id_x, %arg3]  : !xegpu.tensor_desc<128x128xf16, #xegpu.block_tdesc_attr<boundary_check = false>> -> vector<128x128xf16>
       %6 = xegpu.create_nd_tdesc %arg1 : memref<8192x4096xf16> -> !xegpu.tensor_desc<128x128xf16, #xegpu.block_tdesc_attr<boundary_check = false>>
       %7 = xegpu.load_nd %6[%arg3, %block_id_y]  : !xegpu.tensor_desc<128x128xf16, #xegpu.block_tdesc_attr<boundary_check = false>> -> vector<128x128xf16>
-      // Couldn not find a layout whose sg_data would be aligned on the reduction dimension.
-      // CHECK: xegpu.dpas %{{.*}} {layout_cd = #xegpu.layout<sg_layout = [2, 4], sg_data = [64, 32]>} :
+      // CHECK: xegpu.dpas %{{.*}} {layout_a = #xegpu.layout<sg_layout = [2, 4], sg_data = [64, 128]>, layout_b = #xegpu.layout<sg_layout = [2, 4], sg_data = [128, 32]>, layout_cd = #xegpu.layout<sg_layout = [2, 4], sg_data = [64, 32]>} :
       %8 = xegpu.dpas %5, %7, %arg4 : vector<128x128xf16>, vector<128x128xf16>, vector<128x128xf32> -> vector<128x128xf32>
       scf.yield %8 : vector<128x128xf32>
     }
@@ -308,8 +307,8 @@ gpu.module @test {
 
 // -----
 gpu.module @test {
-  // CHECK-LABEL: dpas_fails
-  gpu.func @dpas_fails(%arg0: memref<2048x8192xf16>, %arg1: memref<8192x4096xf16>, %arg2: memref<2048x4096xf32>) kernel attributes {known_block_size = array<i32: 8, 1, 16>} {
+  // CHECK-LABEL: dpas_small_k_broadcast
+  gpu.func @dpas_small_k_broadcast(%arg0: memref<2048x8192xf16>, %arg1: memref<8192x4096xf16>, %arg2: memref<2048x4096xf32>) kernel attributes {known_block_size = array<i32: 8, 1, 16>} {
     %cst = arith.constant dense<0.000000e+00> : vector<32x64xf32>
     %c16 = arith.constant 16 : index
     %c8192 = arith.constant 8192 : index
@@ -319,10 +318,9 @@ gpu.module @test {
     %4 = xegpu.create_nd_tdesc %arg0 : memref<2048x8192xf16> -> !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<boundary_check = false>>
     %5 = xegpu.load_nd %4[%block_id_x, %c0]  : !xegpu.tensor_desc<32x16xf16, #xegpu.block_tdesc_attr<boundary_check = false>> -> vector<32x16xf16>
     %6 = xegpu.create_nd_tdesc %arg1 : memref<8192x4096xf16> -> !xegpu.tensor_desc<16x64xf16, #xegpu.block_tdesc_attr<boundary_check = false>>
-    // CHECK: xegpu.load_nd %{{.*}}[%{{.*}}, %{{.*}}]  :
+    // CHECK: xegpu.load_nd %{{.*}}[%{{.*}}, %{{.*}}] <{layout = #xegpu.layout<sg_layout = [2, 4], sg_data = [16, 16]>}> :
     %7 = xegpu.load_nd %6[%c0, %block_id_y]  : !xegpu.tensor_desc<16x64xf16, #xegpu.block_tdesc_attr<boundary_check = false>> -> vector<16x64xf16>
-    // We have 8 SGs, but currently attempt to use only the largest inst size, so the 32x16 A tile is too small -> fail propagation.
-    // CHECK: xegpu.dpas %{{.*}} {layout_cd = #xegpu.layout<sg_layout = [2, 4], sg_data = [16, 16]>} :
+    // CHECK: xegpu.dpas %{{.*}} {layout_a = #xegpu.layout<sg_layout = [2, 4], sg_data = [16, 16]>, layout_b = #xegpu.layout<sg_layout = [2, 4], sg_data = [16, 16]>, layout_cd = #xegpu.layout<sg_layout = [2, 4], sg_data = [16, 16]>} :
     %8 = xegpu.dpas %5, %7, %cst : vector<32x16xf16>, vector<16x64xf16>, vector<32x64xf32> -> vector<32x64xf32>
     %3 = xegpu.create_nd_tdesc %arg2 : memref<2048x4096xf32> -> !xegpu.tensor_desc<32x64xf32, #xegpu.block_tdesc_attr<boundary_check = false>>
     // CHECK: xegpu.store_nd %{{.*}} <{layout = #xegpu.layout<sg_layout = [2, 4], sg_data = [16, 16]>}> :


### PR DESCRIPTION
 This PR fixes an issue in getDpasSubgroupLayouts(): It failed to find valid subgroup layouts for otherwise-legal DPAS ops. It treated the K (contraction) dimension as distributed across subgroups — requiring wgShape % sgLayout == 0 on every dim and gating on a checkAlignedSgDataAB() equality — when K is actually broadcast: its full extent stays in every subgroup. This rejected the only valid candidate, causing layout propagation to bail out.
 
Update the two affected tests, which now propagate successfully instead of failing.

assisted-by-claude