### PR TITLE
[mlir][OpenACC] Keep ThreadY active for inner-combine-fed worker reductions

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1241,9 +1241,7 @@ static bool hasUnsafeEffectsWhenBroadening(Operation *op) {
 }
 
 /// True when \p accumulator is the destination of a separate block-scoped
-/// acc.reduction_combine (an inner-level combine that fills its per-worker
-/// shared slot), so it holds one distinct partial per worker row rather than a
-/// worker-wide broadcast.
+/// combine, so it holds a distinct per-worker partial rather than a broadcast.
 static bool isFedByInnerBlockCombine(acc::PrivateLocalOp accumulator,
                                      Operation *selfCombine) {
   if (!accumulator)
@@ -1289,14 +1287,9 @@ static void classifyThreadYCombine(ThreadYBroadeningInfo &info,
     return;
   }
 
-  // A block_y + thread_y accumulator that is itself fed by an inner
-  // block-scoped combine holds one distinct partial per worker row (each row's
-  // shared slot was filled by the inner combine). Reducing it into the
-  // destination must therefore run on every worker row; predicating it to
-  // ThreadY row zero would drop the other workers' partials. This differs from
-  // a plain worker accumulate, which lowers to a worker-wide all_reduce that
-  // already broadcasts the total, and so must stay row-zero to avoid
-  // multiplying by the worker count.
+  // A block_y+thread_y accumulator fed by an inner block-scoped combine holds
+  // a distinct partial per worker row, so its combine runs on every row; a
+  // plain worker accumulate broadcasts via all_reduce and stays row-zero.
   if (hasThreadY && hasBlock &&
       isThreadYPrivate(srcPrivate, /*allowBlock=*/true, computeRegion) &&
       isFedByInnerBlockCombine(srcPrivate, combineOp)) {

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -1240,6 +1240,32 @@ static bool hasUnsafeEffectsWhenBroadening(Operation *op) {
   return !op->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
 }
 
+/// True when \p accumulator is the destination of a separate block-scoped
+/// acc.reduction_combine (an inner-level combine that fills its per-worker
+/// shared slot), so it holds one distinct partial per worker row rather than a
+/// worker-wide broadcast.
+static bool isFedByInnerBlockCombine(acc::PrivateLocalOp accumulator,
+                                     Operation *selfCombine) {
+  if (!accumulator)
+    return false;
+  for (Operation *user : accumulator.getResult().getUsers()) {
+    if (user == selfCombine)
+      continue;
+    auto combineOp = dyn_cast<acc::ReductionCombineOp>(user);
+    if (!combineOp ||
+        unwrapMemRefConversion(combineOp.getDestMemref()).getDefiningOp() !=
+            accumulator.getOperation())
+      continue;
+    SmallVector<mlir::acc::GPUParallelDimAttr> parDims =
+        getReductionCombineParDims(combineOp);
+    if (llvm::any_of(parDims, [](mlir::acc::GPUParallelDimAttr d) {
+          return d.isAnyBlock();
+        }))
+      return true;
+  }
+  return false;
+}
+
 /// Records whether \p combineOp requires ThreadY to remain active.
 static void classifyThreadYCombine(ThreadYBroadeningInfo &info,
                                    Operation *combineOp, Value src, Value dest,
@@ -1259,6 +1285,21 @@ static void classifyThreadYCombine(ThreadYBroadeningInfo &info,
                             getPrivatizeOp(destPrivate, computeRegion);
   if (hasThreadY && hasBlock &&
       isThreadYPrivate(srcPrivate, hasPrivateDest, computeRegion)) {
+    info.hasActiveWorkerCombine = true;
+    return;
+  }
+
+  // A block_y + thread_y accumulator that is itself fed by an inner
+  // block-scoped combine holds one distinct partial per worker row (each row's
+  // shared slot was filled by the inner combine). Reducing it into the
+  // destination must therefore run on every worker row; predicating it to
+  // ThreadY row zero would drop the other workers' partials. This differs from
+  // a plain worker accumulate, which lowers to a worker-wide all_reduce that
+  // already broadcasts the total, and so must stay row-zero to avoid
+  // multiplying by the worker count.
+  if (hasThreadY && hasBlock &&
+      isThreadYPrivate(srcPrivate, /*allowBlock=*/true, computeRegion) &&
+      isFedByInnerBlockCombine(srcPrivate, combineOp)) {
     info.hasActiveWorkerCombine = true;
     return;
   }


### PR DESCRIPTION
Example:
```fortran
res = 0
!$cuf kernel do(2) <<< *, (32,8) >>> reduce(+:res)
do j2 = 1, n2
  do j1 = 1, n1
    res = res + a(j1, j2)
  end do
end do
```
In this code the reduction accumulator is per-(block_y, thread_y): each worker row's shared slot is filled by an inner block-scoped combine, so the rows hold distinct partials. The final combine into the result was classified as not "worker-private" (block_y+thread_y into a global dest), so it fell back to the ThreadY row-zero path and dropped every worker but row 0 — a 2D SUM returned -1 instead of -4.
Fix: keep ThreadY active for a block_y+thread_y accumulator that is fed by an inner block-scoped combine (distinct per-worker partials). A plain worker accumulate still lowers to a worker-wide all_reduce that broadcasts the total, so it correctly stays row-zero and is not multiplied by the worker count.
