### PR TITLE
[lldb] Resolve WebAssembly shadow-stack locals against the frame base

### DIFF
--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -10,11 +10,16 @@
 #define LLDB_CORE_ARCHITECTURE_H
 
 #include "lldb/Core/PluginInterface.h"
+#include "lldb/Core/Value.h"
 #include "lldb/Target/DynamicRegisterInfo.h"
 #include "lldb/Target/MemoryTagManager.h"
 #include "lldb/Target/RegisterContextUnwind.h"
 
+#include <optional>
+
 namespace lldb_private {
+
+class StackFrame;
 
 class Architecture : public PluginInterface {
 public:
@@ -70,6 +75,17 @@ public:
   /// used for WebAssembly, where a function begins with a local variable
   /// declaration header.
   virtual Address SkipFunctionHeader(Address addr) const { return addr; }
+
+  /// Return the value to seed a variable's DWARF location expression with, or
+  /// std::nullopt to evaluate it with an empty stack.
+  ///
+  /// A location is normally self-contained, but some architectures express it
+  /// relative to the frame base without DW_OP_fbreg, taking the frame base as
+  /// the initial stack value. WebAssembly does this for shadow-stack locals.
+  virtual std::optional<Value>
+  GetVariableLocationInitialValue(StackFrame &frame) const {
+    return std::nullopt;
+  }
 
   /// Get \a load_addr as a callable code load address for this target
   ///

--- a/lldb/source/Plugins/Architecture/Wasm/ArchitectureWasm.cpp
+++ b/lldb/source/Plugins/Architecture/Wasm/ArchitectureWasm.cpp
@@ -8,9 +8,13 @@
 
 #include "Plugins/Architecture/Wasm/ArchitectureWasm.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Value.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Symbol/SymbolContext.h"
+#include "lldb/Target/StackFrame.h"
 #include "lldb/Utility/ArchSpec.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
 using namespace lldb_private;
 using namespace lldb;
@@ -52,4 +56,18 @@ Address ArchitectureWasm::SkipFunctionHeader(Address addr) const {
 
   addr.Slide(symbol_addr + header_size - this_addr);
   return addr;
+}
+
+std::optional<Value>
+ArchitectureWasm::GetVariableLocationInitialValue(StackFrame &frame) const {
+  Scalar frame_base;
+  if (llvm::Error error = frame.GetFrameBaseValue(frame_base)) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), std::move(error),
+                   "failed to get the WebAssembly frame base: {0}");
+    return std::nullopt;
+  }
+  Value value;
+  value.GetScalar() = frame_base;
+  value.SetValueType(Value::ValueType::LoadAddress);
+  return value;
 }

--- a/lldb/source/Plugins/Architecture/Wasm/ArchitectureWasm.h
+++ b/lldb/source/Plugins/Architecture/Wasm/ArchitectureWasm.h
@@ -28,6 +28,9 @@ public:
   /// so the address lands on the first instruction.
   Address SkipFunctionHeader(Address addr) const override;
 
+  std::optional<Value>
+  GetVariableLocationInitialValue(StackFrame &frame) const override;
+
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);
   ArchitectureWasm() = default;

--- a/lldb/source/ValueObject/ValueObjectVariable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVariable.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/Core/Address.h"
 #include "lldb/Core/AddressRange.h"
+#include "lldb/Core/Architecture.h"
 #include "lldb/Core/Declaration.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/Value.h"
@@ -159,8 +160,13 @@ bool ValueObjectVariable::UpdateValue() {
             sc.function->GetAddress().GetLoadAddress(target);
     }
     Value old_value(m_value);
-    llvm::Expected<Value> maybe_value = expr_list.Evaluate(
-        &exe_ctx, nullptr, loclist_base_load_addr, nullptr, nullptr);
+    std::optional<Value> initial_value;
+    if (Architecture *arch = target ? target->GetArchitecturePlugin() : nullptr)
+      if (StackFrame *frame = exe_ctx.GetFramePtr())
+        initial_value = arch->GetVariableLocationInitialValue(*frame);
+    llvm::Expected<Value> maybe_value =
+        expr_list.Evaluate(&exe_ctx, nullptr, loclist_base_load_addr,
+                           initial_value ? &*initial_value : nullptr, nullptr);
 
     if (maybe_value) {
       m_value = *maybe_value;


### PR DESCRIPTION
A local in a WebAssembly shadow-stack frame has a location expression that is a bare stack operation, such as DW_OP_plus_uconst, which takes the frame base as its implicit initial operand rather than DW_OP_fbreg. LLDB evaluated the location with an empty stack, so the variable failed to resolve with a stack underflow.

Add an Architecture hook, GetVariableLocationInitialValue, that provides the value to seed a variable's location expression with, and implement it in the WebAssembly Architecture plugin to return the frame base.

Assisted-by: Claude