### PR TITLE
[llvm][AArch64] Fix the location of PAuth_LR AUT CFI

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -364,10 +364,10 @@ void AArch64PointerAuthImpl::authenticateLR(
       emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym,
                                       AArch64::X15);
 
-      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
       unsigned AutOpc = UseBKey ? AArch64::AUTIB171615 : AArch64::AUTIA171615;
       BuildMI(MBB, MBBI, DL, TII->get(AutOpc))
           .setMIFlag(MachineInstr::FrameDestroy);
+      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
 
       emitMOV(AArch64::LR, AArch64::X17);
     } else if (MFnI->branchProtectionPAuthLR()) {
@@ -385,10 +385,10 @@ void AArch64PointerAuthImpl::authenticateLR(
       BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
           .setMIFlag(MachineInstr::FrameDestroy);
 
-      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
       unsigned AutOpc = UseBKey ? AArch64::AUTIB1716 : AArch64::AUTIA1716;
       BuildMI(MBB, MBBI, DL, TII->get(AutOpc))
           .setMIFlag(MachineInstr::FrameDestroy);
+      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
 
       emitMOV(AArch64::LR, AArch64::X17);
     } else if (Subtarget->hasPAuth()) {
@@ -436,11 +436,11 @@ void AArch64PointerAuthImpl::authenticateLR(
 
   if (MFnI->branchProtectionPAuthLR() && Subtarget->hasPAuthLR()) {
     assert(PACSym && "No PAC instruction to refer to");
-    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
     BuildMI(MBB, MBBI, DL,
             TII->get(UseBKey ? AArch64::AUTIBSPPCi : AArch64::AUTIASPPCi))
         .addSym(PACSym)
         .setMIFlag(MachineInstr::FrameDestroy);
+    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
   } else {
     if (MFnI->branchProtectionPAuthLR()) {
       emitEpiloguePACSymOffsetIntoReg(*TII, MBB, MBBI, DL, PACSym,
@@ -448,13 +448,11 @@ void AArch64PointerAuthImpl::authenticateLR(
 
       BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
           .setMIFlag(MachineInstr::FrameDestroy);
-      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
     }
     BuildMI(MBB, MBBI, DL,
             TII->get(UseBKey ? AArch64::AUTIBSP : AArch64::AUTIASP))
         .setMIFlag(MachineInstr::FrameDestroy);
-    if (!MFnI->branchProtectionPAuthLR())
-      emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
+    emitAUTCFI(MBB, MBBI, EmitAsyncCFI);
   }
 
   if (NeedsWinCFI) {

--- a/llvm/test/CodeGen/AArch64/pauth-lr-tail-call-fpdiff.ll
+++ b/llvm/test/CodeGen/AArch64/pauth-lr-tail-call-fpdiff.ll
@@ -66,23 +66,23 @@ define swifttailcc void @tail_call_fpdiff_a_key(ptr swiftasync %ctx) "branch-pro
 ; COMPAT-NEXT:   adrp x15, .Ltmp0
 ; COMPAT-NEXT:   add x15, x15, :lo12:.Ltmp0
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #12
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   mov x30, x17
 
 ; V83A-NEXT:     mov x17, x30
 ; V83A-NEXT:     adrp x15, .Ltmp0
 ; V83A-NEXT:     add x15, x15, :lo12:.Ltmp0
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autia1716
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     mov x30, x17
 
 ; V9A-NEXT:      mov x17, x30
 ; V9A-NEXT:      adrp x15, .Ltmp0
 ; V9A-NEXT:      add x15, x15, :lo12:.Ltmp0
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autia171615
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      mov x30, x17
 
 ; PAUTH-NEXT:    autia x30, x16
@@ -148,23 +148,23 @@ define swifttailcc void @tail_call_fpdiff_b_key(ptr swiftasync %ctx) "branch-pro
 ; COMPAT-NEXT:   adrp x15, .Ltmp1
 ; COMPAT-NEXT:   add x15, x15, :lo12:.Ltmp1
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #14
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   mov x30, x17
 
 ; V83A-NEXT:     mov x17, x30
 ; V83A-NEXT:     adrp x15, .Ltmp1
 ; V83A-NEXT:     add x15, x15, :lo12:.Ltmp1
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autib1716
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     mov x30, x17
 
 ; V9A-NEXT:      mov x17, x30
 ; V9A-NEXT:      adrp x15, .Ltmp1
 ; V9A-NEXT:      add x15, x15, :lo12:.Ltmp1
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autib171615
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      mov x30, x17
 
 ; PAUTH-NEXT:    autib x30, x16
@@ -217,17 +217,17 @@ define swifttailcc void @tail_call_no_fpdiff_a_key(ptr swiftasync %ctx) "branch-
 ; COMPAT-NEXT:   adrp x16, .Ltmp2
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp2
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #29
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 
 ; V83A-NEXT:     adrp x16, .Ltmp2
 ; V83A-NEXT:     add x16, x16, :lo12:.Ltmp2
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autiasp
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autiasppc .Ltmp2
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 
 ; PAUTH-NEXT:    autiasp
 ; PAUTH-NEXT:    .cfi_negate_ra_state
@@ -280,17 +280,17 @@ define swifttailcc void @tail_call_no_fpdiff_b_key(ptr swiftasync %ctx) "branch-
 ; COMPAT-NEXT:   adrp x16, .Ltmp3
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp3
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #31
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 
 ; V83A-NEXT:     adrp x16, .Ltmp3
 ; V83A-NEXT:     add x16, x16, :lo12:.Ltmp3
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autibsp
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autibsppc .Ltmp3
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 
 ; PAUTH-NEXT:    autibsp
 ; PAUTH-NEXT:    .cfi_negate_ra_state
@@ -355,23 +355,23 @@ define swifttailcc void @indirect_tail_call_fpdiff_a_key(ptr swiftasync %ctx, pt
 ; COMPAT-NEXT:   adrp x15, .Ltmp4
 ; COMPAT-NEXT:   add x15, x15, :lo12:.Ltmp4
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #12
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   mov x30, x17
 
 ; V83A-NEXT:     mov x17, x30
 ; V83A-NEXT:     adrp x15, .Ltmp4
 ; V83A-NEXT:     add x15, x15, :lo12:.Ltmp4
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autia1716
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     mov x30, x17
 
 ; V9A-NEXT:      mov x17, x30
 ; V9A-NEXT:      adrp x15, .Ltmp4
 ; V9A-NEXT:      add x15, x15, :lo12:.Ltmp4
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autia171615
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      mov x30, x17
 
 ; PAUTH-NEXT:    autia x30, x16
@@ -438,23 +438,23 @@ define swifttailcc void @indirect_tail_call_fpdiff_b_key(ptr swiftasync %ctx, pt
 ; COMPAT-NEXT:   adrp x15, .Ltmp5
 ; COMPAT-NEXT:   add x15, x15, :lo12:.Ltmp5
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #14
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   mov x30, x17
 
 ; V83A-NEXT:     mov x17, x30
 ; V83A-NEXT:     adrp x15, .Ltmp5
 ; V83A-NEXT:     add x15, x15, :lo12:.Ltmp5
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autib1716
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     mov x30, x17
 
 ; V9A-NEXT:      mov x17, x30
 ; V9A-NEXT:      adrp x15, .Ltmp5
 ; V9A-NEXT:      add x15, x15, :lo12:.Ltmp5
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autib171615
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      mov x30, x17
 
 ; PAUTH-NEXT:    autib x30, x16
@@ -507,17 +507,17 @@ define swifttailcc void @indirect_tail_call_no_fpdiff_a_key(ptr swiftasync %ctx,
 ; COMPAT-NEXT:   adrp x16, .Ltmp6
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp6
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #29
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 
 ; V83A-NEXT:     adrp x16, .Ltmp6
 ; V83A-NEXT:     add x16, x16, :lo12:.Ltmp6
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autiasp
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autiasppc .Ltmp6
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 
 ; PAUTH-NEXT:    autiasp
 ; PAUTH-NEXT:    .cfi_negate_ra_state
@@ -570,17 +570,17 @@ define swifttailcc void @indirect_tail_call_no_fpdiff_b_key(ptr swiftasync %ctx,
 ; COMPAT-NEXT:   adrp x16, .Ltmp7
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp7
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #31
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 
 ; V83A-NEXT:     adrp x16, .Ltmp7
 ; V83A-NEXT:     add x16, x16, :lo12:.Ltmp7
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autibsp
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autibsppc .Ltmp7
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 
 ; PAUTH-NEXT:    autibsp
 ; PAUTH-NEXT:    .cfi_negate_ra_state

--- a/llvm/test/CodeGen/AArch64/swifttail-ptrauth.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-ptrauth.ll
@@ -51,17 +51,17 @@ define swifttailcc void @caller_to0_from0() "branch-protection-pauth-lr" "sign-r
 ; COMPAT-NEXT:   adrp x16, .Ltmp0
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp0
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #29
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 
 ; V83A-NEXT:     adrp x16, .Ltmp0
 ; V83A-NEXT:     add x16, x16, :lo12:.Ltmp0
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autiasp
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autiasppc .Ltmp0
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 
 ; PAUTH-NEXT:    autiasp
 ; PAUTH-NEXT:    .cfi_negate_ra_state
@@ -115,17 +115,17 @@ define swifttailcc void @caller_to0_from8([8 x i64], i64) "branch-protection-pau
 ; COMPAT-NEXT:   adrp x16, .Ltmp1
 ; COMPAT-NEXT:   add x16, x16, :lo12:.Ltmp1
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #29
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 
 ; V83A-NEXT:     adrp x16, .Ltmp1
 ; V83A-NEXT:     add x16, x16, :lo12:.Ltmp1
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autiasp
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autiasppc .Ltmp1
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 
 ; PAUTH-NEXT:    autiasp
 ; PAUTH-NEXT:    .cfi_negate_ra_state
@@ -178,23 +178,23 @@ define swifttailcc void @caller_to8_from0() "branch-protection-pauth-lr" "sign-r
 ; COMPAT-NEXT:   adrp x15, .Ltmp2
 ; COMPAT-NEXT:   add x15, x15, :lo12:.Ltmp2
 ; COMPAT-NEXT:   hint #39
-; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   hint #12
+; COMPAT-NEXT:   .cfi_set_ra_state 0, 0
 ; COMPAT-NEXT:   mov x30, x17
 
 ; V83A-NEXT:     mov x17, x30
 ; V83A-NEXT:     adrp x15, .Ltmp2
 ; V83A-NEXT:     add x15, x15, :lo12:.Ltmp2
 ; V83A-NEXT:     hint #39
-; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     autia1716
+; V83A-NEXT:     .cfi_set_ra_state 0, 0
 ; V83A-NEXT:     mov x30, x17
 
 ; V9A-NEXT:      mov x17, x30
 ; V9A-NEXT:      adrp x15, .Ltmp2
 ; V9A-NEXT:      add x15, x15, :lo12:.Ltmp2
-; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      autia171615
+; V9A-NEXT:      .cfi_set_ra_state 0, 0
 ; V9A-NEXT:      mov x30, x17
 
 ; PAUTH-NEXT:    autia x30, x16


### PR DESCRIPTION
Unlike PAC CFI, we do not have the same unwinder constraint on PAuth_LR CFI occurring before the PAC instruction. For AUT CFI, like other CFI opcodes, these should always occur after the instruciton that they reference.