### PR TITLE
[lldb] Classify embedded formatter sections in WebAssembly objects

### DIFF
--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/BinaryFormat/Wasm.h"
 #include "llvm/Support/CheckedArithmetic.h"
@@ -614,6 +615,16 @@ static SectionType GetSectionTypeFromName(llvm::StringRef Name) {
   return eSectionTypeOther;
 }
 
+/// A `section` attribute on a data variable lands in a named data segment on
+/// wasm, not a top-level custom section, so formatter sections appear as
+/// segment names rather than section names.
+static SectionType GetSegmentTypeFromName(llvm::StringRef Name) {
+  return llvm::StringSwitch<SectionType>(Name)
+      .Case(".lldbsummaries", eSectionTypeLLDBTypeSummaries)
+      .Case(".lldbformatters", eSectionTypeLLDBFormatters)
+      .Default(eSectionTypeData);
+}
+
 std::optional<ObjectFileWasm::section_info>
 ObjectFileWasm::GetSectionInfo(uint32_t section_id) {
   for (const section_info &sect_info : m_sect_infos) {
@@ -780,7 +791,7 @@ void ObjectFileWasm::CreateSections(SectionList &unified_section_list) {
         /*obj_file=*/this,
         ++segment_id << 8, // 1-based segment index, shifted by 8 bits to avoid
                            // collision with section IDs.
-        ConstString(segment.name), eSectionTypeData,
+        ConstString(segment.name), GetSegmentTypeFromName(segment.name),
         /*file_vm_addr=*/file_vm_addr,
         /*vm_size=*/segment.size,
         /*file_offset=*/file_offset,
@@ -857,18 +868,23 @@ bool ObjectFileWasm::SetLoadAddress(Target &target, lldb::addr_t load_address,
   for (size_t sect_idx = 0; sect_idx < num_sections; ++sect_idx) {
     SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
     lldb::addr_t section_load_addr;
-    if (section_sp->GetType() == eSectionTypeData ||
-        section_sp->GetType() == eSectionTypeZeroFill) {
-      // Data and BSS sections live in linear memory, a separate address space
-      // from code (the top two bits of the 64-bit address encode the space: 0
-      // for Memory, 1 for Object/code), so place the section at its virtual
-      // address in the Memory space while preserving the module id.
+    switch (section_sp->GetType()) {
+    case eSectionTypeData:
+    case eSectionTypeZeroFill:
+    case eSectionTypeLLDBTypeSummaries:
+    case eSectionTypeLLDBFormatters:
+      // These all live in linear memory, a separate address space from code
+      // (the top two bits of the 64-bit address encode the space: 0 for Memory,
+      // 1 for Object/code), so place the section at its virtual address in the
+      // Memory space while preserving the module id.
       section_load_addr = (load_address & ~(uint64_t(0b11) << 62)) |
                           section_sp->GetFileAddress();
-    } else {
+      break;
+    default:
       // Code (and other) sections are addressed by their offset within the
       // module in the Object address space.
       section_load_addr = load_address | section_sp->GetFileOffset();
+      break;
     }
     if (target.SetSectionLoadAddress(section_sp, section_load_addr))
       ++num_loaded_sections;

--- a/lldb/test/Shell/ObjectFile/wasm/wasm-formatter-sections.yaml
+++ b/lldb/test/Shell/ObjectFile/wasm/wasm-formatter-sections.yaml
@@ -1,0 +1,72 @@
+# REQUIRES: webassembly
+
+# Embedded data formatters are placed by a `section` attribute on a data
+# variable, which on wasm lands in a named data segment rather than a top-level
+# custom section. Recognize the well-known formatter segment names so the
+# data-formatter loader can find them, and map the segments into linear memory
+# like any other data segment.
+
+# RUN: yaml2obj %s -o %t.wasm
+# RUN: %lldb %t.wasm \
+# RUN:   -o "target modules dump sections" \
+# RUN:   -o "target modules load --file %t.wasm --slide 0x4000000000000000" \
+# RUN:   -o "target modules dump sections" \
+# RUN:   -o exit 2>&1 | FileCheck %s
+
+# The formatter segments are typed as formatter sections, not plain data, and
+# their file address is their linear-memory address (from the init expr).
+# CHECK-LABEL: File Address
+# CHECK-DAG: lldb-formatters      {{.*}}[0x0000000000010000-0x0000000000010004)
+# CHECK-DAG: lldb-type-summaries  {{.*}}[0x0000000000010010-0x0000000000010014)
+
+# After loading the module in the Object space (top bit set), the formatter
+# segments stay in the Memory space at their linear address like other data.
+# CHECK-LABEL: Load Address
+# CHECK-DAG: lldb-formatters      {{.*}}[0x0000000000010000-0x0000000000010004)
+# CHECK-DAG: lldb-type-summaries  {{.*}}[0x0000000000010010-0x0000000000010014)
+
+--- !WASM
+FileHeader:
+  Version: 0x1
+Sections:
+  - Type: TYPE
+    Signatures:
+      - Index: 0
+        ParamTypes: []
+        ReturnTypes:
+          - I32
+  - Type: FUNCTION
+    FunctionTypes: [ 0 ]
+  - Type: MEMORY
+    Memories:
+      - Minimum: 0x2
+  - Type: CODE
+    Functions:
+      - Index: 0
+        Locals: []
+        Body: 412A0F0B
+  - Type: DATA
+    Segments:
+      - SectionOffset:   6
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           65536
+        Content:          'DEADBEEF'
+      - SectionOffset:   16
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           65552
+        Content:          'CAFEBABE'
+  - Type: CUSTOM
+    Name: name
+    FunctionNames:
+      - Index: 0
+        Name: get_42
+    DataSegmentNames:
+      - Index: 0
+        Name: .lldbformatters
+      - Index: 1
+        Name: .lldbsummaries
+...


### PR DESCRIPTION
A `section` attribute on a data variable is placed in a named data segment on WebAssembly rather than a top-level custom section, so the .lldbformatters and .lldbsummaries segments that carry embedded data formatters were classified as plain data. The data-formatter loader looks these up by section type, so embedded summaries and synthetic child providers were never registered for a Wasm module.

Map the two formatter segment names to their section types when creating sections, and place the segments in linear memory like other data so their contents resolve. This mirrors the ELF and Mach-O object file plugins.

Assisted-by: Claude