### PR TITLE
[clang][sema] CallExprs are constructed for undeduced deleted functions (#208488)

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -15027,6 +15027,10 @@ static ExprResult FinishOverloadedCallExpr(Sema &SemaRef, Scope *S, Expr *Fn,
                                          Fn->getSourceRange(), ULE->getName(),
                                          *CandidateSet, FDecl, Args);
 
+    if (completeFunctionType(SemaRef, FDecl, Fn->getBeginLoc(),
+                             /*Complain=*/true))
+      return ExprError();
+
     // We emitted an error for the unavailable/deleted function call but keep
     // the call in the AST.
     ExprResult Res =

--- a/clang/test/SemaCXX/cxx-deprecated.cpp
+++ b/clang/test/SemaCXX/cxx-deprecated.cpp
@@ -41,8 +41,10 @@ namespace GH98164 {
 template <int>
 auto b() = delete; // #b
 
-decltype(b<0>()) x;
-// expected-error@-1 {{call to deleted function 'b'}}
+decltype(b<0>()) x; // #x
+// expected-error@#x {{call to deleted function 'b'}}
 //   expected-note@#b {{candidate function [with $0 = 0] has been explicitly deleted}}
+// expected-error@#x {{function 'b<0>' with deduced return type cannot be used before it is defined}}
+//   expected-note@#b {{'b<0>' declared here}}
 } // namespace GH98164
 } // namespace cxx20_concept

--- a/clang/test/SemaCXX/deduced-return-type-cxx14.cpp
+++ b/clang/test/SemaCXX/deduced-return-type-cxx14.cpp
@@ -359,7 +359,10 @@ namespace NoReturn {
   auto *g() {} // expected-error {{cannot deduce return type 'auto *' for function with no return statements}}
 
   auto h() = delete; // expected-note {{explicitly deleted}}
+  // expected-note@-1 {{'h' declared here}}
+
   auto x = h(); // expected-error {{call to deleted}}
+  // expected-error@-1 {{function 'h' with deduced return type cannot be used before it is defined}}
 }
 
 namespace UseBeforeComplete {

--- a/clang/test/SemaCXX/deleted-function-deduction-failure.cpp
+++ b/clang/test/SemaCXX/deleted-function-deduction-failure.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++14 -verify %s
+// RUN: %clang_cc1 -fsyntax-only -std=c++17 -verify %s
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -verify %s
+
+
+namespace UndeducedDeletedFunction {
+auto deleted_auto() = delete; // #deleted_auto_decl
+// expected-note@#deleted_auto_decl {{candidate function has been explicitly deleted}}
+// expected-note@#deleted_auto_decl {{'deleted_auto' declared here}}
+
+auto auto_test() {
+  auto x = deleted_auto(); // #auto_use
+  // expected-error@#auto_use {{call to deleted function 'deleted_auto'}}
+  // expected-note@#deleted_auto_decl {{candidate function has been explicitly deleted}}
+  // expected-error@#auto_use {{function 'deleted_auto' with deduced return type cannot be used before it is defined}}
+  // expected-note@#deleted_auto_decl {{'deleted_auto' declared here}}
+  return x;
+}
+
+auto decltype_auto_test() {
+  decltype(auto) x = deleted_auto(); // #decl_type_use
+  // expected-error@#decl_type_use {{call to deleted function 'deleted_auto'}}
+  // expected-note@#deleted_auto_decl {{candidate function has been explicitly deleted}}
+  // expected-error@#decl_type_use {{function 'deleted_auto' with deduced return type cannot be used before it is defined}}
+  // expected-note@#deleted_auto_decl {{'deleted_auto' declared here}}
+  return x;
+}
+
+auto decltype_auto_type_test() {
+  __auto_type x = deleted_auto(); // #__auto_type_use
+  // expected-error@#__auto_type_use {{call to deleted function 'deleted_auto'}}
+  // expected-error@#__auto_type_use {{function 'deleted_auto' with deduced return type cannot be used before it is defined}}
+  return x;
+}
+}
+
+namespace DeletedWithUnresolvedExceptionSpec {
+struct X {};
+
+template <typename T> void failed_exception_spec(T) noexcept(T::value) = delete; // #failed_exception_spec_declared
+// expected-error@#failed_exception_spec_declared {{no member named 'value' in 'DeletedWithUnresolvedExceptionSpec::X'}}
+// expected-note@#failed_exception_used {{in instantiation of exception specification for 'failed_exception_spec<DeletedWithUnresolvedExceptionSpec::X>' requested here}}
+
+void g() {
+  failed_exception_spec(X{}); // #failed_exception_used
+  // expected-error@#failed_exception_used {{call to deleted function 'failed_exception_spec'}}
+  // expected-note@#failed_exception_spec_declared {{candidate function [with T = DeletedWithUnresolvedExceptionSpec::X] has been explicitly deleted}}
+}
+}


### PR DESCRIPTION
The deleted function path of overload resolution always constructed a CallExpr node for the called function even if the function could not be deduced. This case is handled in other paths by DiagnoseUseOfDecl which does perform that test. The delete path cannot use that path though, as DiagnoseUseOfDecl rejects deleted functions, and the entire point of this code is to permit the continued evaluation of code even if the resolved function was deleted.

To fix this we now manually check for a complete type before continuing to construct a potentially bogus CallExpr.