### PR TITLE
Delete dead value dependence check.

### DIFF
--- a/clang/lib/AST/ComputeDependence.cpp
+++ b/clang/lib/AST/ComputeDependence.cpp
@@ -44,30 +44,25 @@ ExprDependence clang::computeDependence(UnaryOperator *E,
       toExprDependenceForImpliedType(E->getType()->getDependence()) |
       E->getSubExpr()->getDependence();
 
-  // C++ [temp.dep.constexpr]p5:
-  //   An expression of the form & qualified-id where the qualified-id names a
-  //   dependent member of the current instantiation is value-dependent. An
-  //   expression of the form & cast-expression is also value-dependent if
-  //   evaluating cast-expression as a core constant expression succeeds and
-  //   the result of the evaluation refers to a templated entity that is an
-  //   object with static or thread storage duration or a member function.
+  // [temp.dep.constexpr]p6 has an additional rule for expressions with an
+  // "&".  This rule is not necessary for consistency. The only expressions
+  // which it would apply to that aren't value-dependent anyway are:
   //
-  // What this amounts to is: constant-evaluate the operand and check whether it
-  // refers to a templated entity other than a variable with local storage.
-  if (Ctx.getLangOpts().CPlusPlus && E->getOpcode() == UO_AddrOf &&
-      !(Dep & ExprDependence::Value)) {
-    Expr::EvalResult Result;
-    // FIXME: This doesn't enforce the C++98 constant expression rules.
-    if (E->getSubExpr()->EvaluateAsConstantExpr(Result, Ctx) &&
-        !Result.DiagEmitted && Result.Val.isLValue()) {
-      auto *VD = Result.Val.getLValueBase().dyn_cast<const ValueDecl *>();
-      if (VD && VD->isTemplated()) {
-        auto *VarD = dyn_cast<VarDecl>(VD);
-        if (!VarD || !VarD->hasLocalStorage())
-          Dep |= ExprDependence::ValueInstantiation;
-      }
-    }
-  }
+  // - functions which are part of the current instantiation
+  // - variables which are part of the current instantiation, and are not
+  //   potentially-constant.
+  // - variables which are part of the current instantiation, and have a
+  //   have a non-value-dependent initializer.
+  //
+  // In all these cases, there's a limited number of things you can do with
+  // the pointer.  You can use it as a template argument, in which case
+  // we compute dependency according to [temp.dep.temp].  You can deference it,
+  // which is fine: we either know the value or know we can't compute it.  You
+  // can do pointer comparisons, which we can compute. And for function
+  // pointers, you can call them.  All of this works fine without marking the
+  // pointer value-dependent.
+  //
+  // So we'll just avoid the complexity, and pretend the rule doesn't exist.
 
   return Dep;
 }

--- a/clang/lib/AST/TemplateBase.cpp
+++ b/clang/lib/AST/TemplateBase.cpp
@@ -258,6 +258,54 @@ TemplateArgument::CreatePackCopy(ASTContext &Context,
   return TemplateArgument(Args.copy(Context));
 }
 
+static TemplateArgumentDependence
+TemplateArgumentDependenceForDeclaration(const ValueDecl *D) {
+  auto Deps = TemplateArgumentDependence::None;
+  auto *DC = dyn_cast<DeclContext>(D);
+  if (!DC)
+    DC = D->getDeclContext();
+  if (DC->isDependentContext())
+    Deps = TemplateArgumentDependence::Dependent |
+           TemplateArgumentDependence::Instantiation;
+  return Deps;
+}
+
+
+static TemplateArgumentDependence
+TemplateArgumentDependenceForAPValue(const APValue &Val) {
+  if (Val.isLValue()) {
+    auto Base = Val.getLValueBase();
+    if (auto *D = Base.dyn_cast<const ValueDecl*>()) {
+      return TemplateArgumentDependenceForDeclaration(D);
+    }
+  }
+  if (Val.isStruct()) {
+    auto Deps = TemplateArgumentDependence::None;
+    for (int i = 0, e = Val.getStructNumBases(); i != e; ++i)
+      Deps |= TemplateArgumentDependenceForAPValue(Val.getStructBase(i));
+    for (int i = 0, e = Val.getStructNumFields(); i != e; ++i)
+      Deps |= TemplateArgumentDependenceForAPValue(Val.getStructField(i));
+    for (int i = 0, e = Val.getStructNumVirtualBases(); i != e; ++i)
+      Deps |= TemplateArgumentDependenceForAPValue(Val.getStructVirtualBase(i));
+    llvm::errs() << "DEPS" << (int)Deps << "\n";
+    //assert(0);
+    return Deps;
+  }
+  if (Val.isUnion())
+    return TemplateArgumentDependenceForAPValue(Val.getUnionValue());
+  if (Val.isArray()) {
+    auto Deps = TemplateArgumentDependence::None;
+    for (int i = 0, e = Val.getArrayInitializedElts(); i != e; ++i) {
+      Deps |= TemplateArgumentDependenceForAPValue(Val.getArrayInitializedElt(i));
+    }
+    if (Val.hasArrayFiller())
+      Deps |= TemplateArgumentDependenceForAPValue(Val.getArrayFiller());
+    return Deps;
+  }
+  return TemplateArgumentDependence::None;
+}
+
+
 TemplateArgumentDependence TemplateArgument::getDependence() const {
   auto Deps = TemplateArgumentDependence::None;
   switch (getKind()) {
@@ -277,22 +325,24 @@ TemplateArgumentDependence TemplateArgument::getDependence() const {
     return TemplateArgumentDependence::Dependent |
            TemplateArgumentDependence::Instantiation;
 
-  case Declaration: {
-    auto *DC = dyn_cast<DeclContext>(getAsDecl());
-    if (!DC)
-      DC = getAsDecl()->getDeclContext();
-    if (DC->isDependentContext())
-      Deps = TemplateArgumentDependence::Dependent |
-             TemplateArgumentDependence::Instantiation;
-    return Deps;
+  case Declaration:
+    return TemplateArgumentDependenceForDeclaration(getAsDecl());
+
+  case StructuralValue: {
+    // A StructuralValue can point to a member of the current instantiation.
+    // In this case, it's dependent even though the expression isn't
+    // value-dependent.
+    return TemplateArgumentDependenceForAPValue(getAsStructuralValue());
   }
 
   case NullPtr:
   case Integral:
-  case StructuralValue:
     return TemplateArgumentDependence::None;
 
   case Expression:
+    if (auto *CE = dyn_cast<ConstantExpr>(getAsExpr()))
+      if (CE->hasAPValueResult())
+        return TemplateArgumentDependenceForAPValue(CE->getAPValueResult());
     Deps = toTemplateArgumentDependence(getAsExpr()->getDependence());
     if (isa<PackExpansionExpr>(getAsExpr()))
       Deps |= TemplateArgumentDependence::Dependent |

--- a/clang/test/SemaTemplate/temp_arg_nontype_cxx1z.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype_cxx1z.cpp
@@ -626,3 +626,12 @@ namespace GH118190 {
   template <auto> int x;
   template <int i> int x<i>;
 }
+
+namespace non_value_dependent_current_instantiation {
+// *&xx should not be considered value-dependent: it is always zero.
+template<int x> struct A {
+  static const int xx = 0;
+  void f(decltype(*(int(*)[xx])0)); // expected-note {{previous declaration is here}}
+  void f(decltype(*(int(*)[*&xx])0)); // expected-error {{class member cannot be redeclared}}
+};
+}

--- a/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
@@ -386,3 +386,48 @@ void test() {
     g<X>();
 }
 }
+
+namespace non_value_dependent_current_instantiation_template_argument {
+struct Obj {
+  int a;
+};
+
+template <const int* P>
+struct Target {
+  static constexpr int val = 0;
+};
+
+template <const int& P>
+struct Target2 {
+  static constexpr int val = 0;
+};
+
+union ContainsPtr { const int *p; };
+template <ContainsPtr F>
+struct Target3 {
+  static constexpr int val = 0;
+};
+
+template <typename T>
+struct S {
+  static constexpr Obj o{42};
+
+  void f() {
+    // No error: We should not instantiate Target<&o.a> because it could be
+    // specialized later.
+    switch (1) { case Target<&(o.a)>::val: case 0: ; }
+
+    // Same as above, without "&".
+    switch (1) { case Target2<o.a>::val: case 0: ; }
+
+    // Same as above with function pointer in struct.
+    // FIXME: This is currently broken: Sema will resolve this
+    // even if the TemplateArgument is dependent.  Still searching for the
+    // code that directly queries whether the underlying expression is value-dependent,
+    // instead of looking at the template argument itself.
+    switch (1) { case Target3<ContainsPtr(&o.a)>::val: case 1: ; }  // expected-error {{duplicate case value}} expected-note {{previous}}
+
+    switch (1) { case o.a: case 42: ; } // expected-error {{duplicate case value}} expected-note {{previous}}
+  }
+};
+}


### PR DESCRIPTION
The code which is supposed to enforce [temp.dep.constexpr]p6 (in current numbering) doesn't actually seem to do anything useful; the testcases pass without it.

(Need to investigate a bit more to see if this is actually dead, or we just don't have the right testcases.)