### PR TITLE
[clang][Sema] Preserve CV qualifiers when applying pointer and funcref attributes

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -371,6 +371,8 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed an issue where `__typeof__` incorrectly rejected cv-qualified function types.
 
+- Fixed a bug where top-level CV qualifiers (such as ``const``) were dropped from pointers modified by Microsoft pointer attributes (like ``__ptr32`` and ``__ptr64``) and WebAssembly's ``__funcref``.
+
 - Fixed an issue where we tried to compare invalid NTTPs for variable declarations, which ended up in hitting an assertion with a constrained non-plain-auto NTTP, which we don't quite implement yet. (#GH208658)
 
 - Fixed a crash when a using-declaration naming an unresolvable member of a

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -7313,7 +7313,10 @@ static bool handleMSPointerTypeQualifierAttr(TypeProcessingState &State,
   if (ASIdx != LangAS::Default)
     Pointee = S.Context.getAddrSpaceQualType(
         S.Context.removeAddrSpaceQualType(Pointee), ASIdx);
-  Type = State.getAttributedType(A, Type, S.Context.getPointerType(Pointee));
+
+  QualType Equivalent = S.Context.getQualifiedType(
+      S.Context.getPointerType(Pointee), Type.getQualifiers());
+  Type = State.getAttributedType(A, Type, Equivalent);
   return false;
 }
 
@@ -7352,7 +7355,10 @@ static bool HandleWebAssemblyFuncrefAttr(TypeProcessingState &State,
   QualType Pointee = QT->getPointeeType();
   Pointee = S.Context.getAddrSpaceQualType(
       S.Context.removeAddrSpaceQualType(Pointee), ASIdx);
-  QT = State.getAttributedType(A, QT, S.Context.getPointerType(Pointee));
+
+  QualType Equivalent = S.Context.getQualifiedType(
+      S.Context.getPointerType(Pointee), QT.getQualifiers());
+  QT = State.getAttributedType(A, QT, Equivalent);
   return false;
 }
 

--- a/clang/test/SemaCXX/ms-ptr-qualifiers.cpp
+++ b/clang/test/SemaCXX/ms-ptr-qualifiers.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsyntax-only -fms-extensions -verify %s
+
+void test_const_qualifier() {
+  int A = 0;
+  int *const __ptr64 B = &A; // expected-note {{variable 'B' declared const here}}
+  B += 1; // expected-error {{cannot assign to variable 'B' with const-qualified type 'int *const __ptr64'}}
+
+  int *__ptr32 const C = &A; // expected-note {{variable 'C' declared const here}}
+  C = nullptr; // expected-error {{cannot assign to variable 'C' with const-qualified type 'int *const __ptr32'}}
+}
+
+void test_type_traits() {
+  static_assert(!__is_same(int *, int *const), "");
+  static_assert(!__is_same(int *__ptr32, int *__ptr32 const), "");
+  static_assert(!__is_same(int *__ptr64, int *__ptr64 const), "");
+  static_assert(!__is_same(int *__sptr __ptr32, int *__sptr __ptr32 const), "");
+  static_assert(!__is_same(int *__uptr __ptr32, int *__uptr __ptr32 const), "");
+  static_assert(!__is_same(int *__ptr32, int *__ptr32 volatile), "");
+}

--- a/clang/test/SemaCXX/wasm-funcref.cpp
+++ b/clang/test/SemaCXX/wasm-funcref.cpp
@@ -11,3 +11,6 @@ int get(int);
 IntIntFuncref getFuncref() {
     return get;
 }
+
+static_assert(!__is_same(IntIntFuncref, const IntIntFuncref), "");
+static_assert(!__is_same(int(*__funcref)(int), int(*const __funcref)(int)), "");


### PR DESCRIPTION
This patch fixes a bug in handleMSPointerTypeQualifierAttr and HandleWebAssemblyFuncrefAttr where applying these pointer attributes would implicitly drop top-level CV qualifiers (like `const`, `volatile`, and `restrict`) from the pointer type.