### PR TITLE
[clang][KCFI] Skip the KCFIPass on Hexagon

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -669,7 +669,8 @@ static void addKCFIPass(const Triple &TargetTriple, const LangOptions &LangOpts,
   // If the back-end supports KCFI operand bundle lowering, skip KCFIPass.
   if (TargetTriple.getArch() == llvm::Triple::x86_64 ||
       TargetTriple.isAArch64(64) || TargetTriple.isRISCV() ||
-      TargetTriple.isARM() || TargetTriple.isThumb())
+      TargetTriple.isARM() || TargetTriple.isThumb() ||
+      TargetTriple.getArch() == llvm::Triple::hexagon)
     return;
 
   // Ensure we lower KCFI operand bundles with -O0.

--- a/clang/test/CodeGen/kcfi-hexagon.c
+++ b/clang/test/CodeGen/kcfi-hexagon.c
@@ -1,0 +1,14 @@
+// Hexagon lowers KCFI operand bundles in the back end. Clang must leave the "kcfi"
+// operand bundles in place for the back end instead of running the middle-end
+// KCFIPass, which would rewrite them into a software llvm.debugtrap check.
+//
+// Verify the bundle survives the optimizer pipeline at both -O0 and -O2 and
+// is not lowered to debugtrap.
+//
+// RUN: %clang_cc1 -triple hexagon-unknown-linux-musl -O0 -fsanitize=kcfi -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple hexagon-unknown-linux-musl -O2 -fsanitize=kcfi -emit-llvm -o - %s | FileCheck %s
+
+// CHECK-LABEL: define {{.*}}void @call(
+// CHECK: call void %{{.*}}() {{.*}}[ "kcfi"(i32 {{-?[0-9]+}}) ]
+// CHECK-NOT: @llvm.debugtrap
+void call(void (*f)(void)) { f(); }


### PR DESCRIPTION
Hexagon implements KCFI operand-bundle lowering in the back end HexagonTargetLowering::EmitKCFICheck emits a KCFI_CHECK pseudo, which HexagonAsmPrinter::LowerKCFI_CHECK expands into a type-hash check and a trap - like PS_crash.

Hexagon was never added to the list in addKCFIPass() of targets whose back end lowers the bundles, so Clang kept running the middle-end KCFIPass for it.

Add Hexagon to the addKCFIPass() early-return so the "kcfi" bundles reach the back end, which then emits the trapping load that actually blocks the call.