### PR TITLE
workflows/release-documentation: Remove permission check from validation job

### DIFF
--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -59,13 +59,6 @@ jobs:
           sparse-checkout: |
             .github/workflows/
 
-      - name: Check Permissions
-        uses: ./.github/workflows/require-team-membership
-        with:
-          team-slug: llvm-release-managers
-          LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
-          LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
-
       - name: Validate Input
         uses: ./.github/workflows/validate-release-version
         with:

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -47,9 +47,6 @@ jobs:
   release-man-pages-validate-input:
     name: Release Man Pages Validate Input
     runs-on: ubuntu-24.04
-    environment:
-      name: release
-      deployment: false
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
The only job in this workflow that we actually need to restrict to release managers is the upload-man-pages job which has write access to the releases and the upload-release-artifact composite action that job is using has this permission check in it already.  

The benefit of removing this check is that it allows us to test most of this workflow when we submit a PR.  We also don't need to use an environment for the first job any more.