### PR TITLE
workflows/release-binaries: Add missing action to checkout

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -385,6 +385,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
+            .github/workflows/require-team-membership
             .github/workflows/upload-release-artifact
             .github/workflows/validate-release-version
             llvm/utils/release/github-upload-release.py


### PR DESCRIPTION
The upload-release-artifact action uses the require-team-membership action so we need to make sure that latter is checkout out when calling upload-release-artifact.