### PR TITLE
[mlir] Fix alignment assertion for empty DenseArrayAttr

### DIFF
--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -160,6 +160,9 @@ def Builtin_DenseArrayRawDataParameter : ArrayRefParameter<
           $_allocator.allocate($_self.size(), alignof(uint64_t)));
       llvm::uninitialized_copy($_self, alloc);
       $_dst = ArrayRef<char>(alloc, $_self.size());
+    } else {
+      // Align possibly unaligned empty range.
+      $_dst = {};
     }
   }];
 }

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/APSInt.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
+#include "llvm/Support/Alignment.h"
 #include "llvm/Support/Endian.h"
 #include <optional>
 
@@ -822,6 +823,7 @@ Attribute DenseArrayAttrImpl<T>::parse(AsmParser &parser, Type odsType) {
 template <typename T>
 DenseArrayAttrImpl<T>::operator ArrayRef<T>() const {
   ArrayRef<char> raw = getRawData();
+  assert(llvm::isAddrAligned(llvm::Align(alignof(T)), raw.data()));
   assert((raw.size() % sizeof(T)) == 0);
   return ArrayRef<T>(reinterpret_cast<const T *>(raw.data()),
                      raw.size() / sizeof(T));

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -19,9 +19,9 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/Support/Alignment.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
-#include "llvm/Support/Alignment.h"
 #include "llvm/Support/Endian.h"
 #include <optional>
 


### PR DESCRIPTION
After #207274, libc++ fails __assume_aligned assertion in __assume_valid_range.

https://lab.llvm.org/buildbot/#/builders/25/builds/18994

`DenseArrayAttrImpl<T>::operator ArrayRef<T>()` is just a cast of
`raw.data()`. `raw` is aligned copy of range from
from BytecodeReader done by
Builtin_DenseArrayRawDataParameter allocator.
However, if range is empty, aligned copying was
omitted, leaving unaligned `ArrayRef<char>`.

The fix is to replace unaligned `ArrayRef<>` with
aligned default constructed.
