### PR TITLE
[libc++][NFC] Inline fstream functions into the class body

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -1500,15 +1500,28 @@ public:
   using native_handle_type = typename basic_filebuf<_CharT, _Traits>::native_handle_type;
 #    endif
 
-  _LIBCPP_HIDE_FROM_ABI basic_fstream();
+  _LIBCPP_HIDE_FROM_ABI basic_fstream() : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {}
   _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(const char* __s,
-                                               ios_base::openmode __mode = ios_base::in | ios_base::out);
+                                               ios_base::openmode __mode = ios_base::in | ios_base::out)
+      : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
+    if (__sb_.open(__s, __mode) == nullptr)
+      this->setstate(ios_base::failbit);
+  }
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(const wchar_t* __s,
-                                               ios_base::openmode __mode = ios_base::in | ios_base::out);
+                                               ios_base::openmode __mode = ios_base::in | ios_base::out)
+      : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
+    if (__sb_.open(__s, __mode) == nullptr)
+      this->setstate(ios_base::failbit);
+  }
 #    endif
+
   _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(const string& __s,
-                                               ios_base::openmode __mode = ios_base::in | ios_base::out);
+                                               ios_base::openmode __mode = ios_base::in | ios_base::out)
+      : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
+    if (__sb_.open(__s, __mode) == nullptr)
+      this->setstate(ios_base::failbit);
+  }
 
 #    if _LIBCPP_STD_VER >= 17
   template <class _Tp, class = enable_if_t<is_same_v<_Tp, filesystem::path>>>
@@ -1516,24 +1529,55 @@ public:
       : basic_fstream(__p.c_str(), __mode) {}
 #    endif // _LIBCPP_STD_VER >= 17
 
-  _LIBCPP_HIDE_FROM_ABI basic_fstream(basic_fstream&& __rhs);
+  _LIBCPP_HIDE_FROM_ABI basic_fstream(basic_fstream&& __rhs)
+      : basic_iostream<char_type, traits_type>(std::move(__rhs)), __sb_(std::move(__rhs.__sb_)) {
+    this->set_rdbuf(std::addressof(__sb_));
+  }
 
-  _LIBCPP_HIDE_FROM_ABI basic_fstream& operator=(basic_fstream&& __rhs);
+  _LIBCPP_HIDE_FROM_ABI basic_fstream& operator=(basic_fstream&& __rhs) {
+    basic_iostream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
+    return *this;
+  }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(basic_fstream& __rhs);
+  _LIBCPP_HIDE_FROM_ABI void swap(basic_fstream& __rhs) {
+    basic_iostream<char_type, traits_type>::swap(__rhs);
+    __sb_.swap(__rhs.__sb_);
+  }
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI basic_filebuf<char_type, traits_type>* rdbuf() const;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI basic_filebuf<char_type, traits_type>* rdbuf() const {
+    return const_cast<basic_filebuf<char_type, traits_type>*>(std::addressof(__sb_));
+  }
+
 #    if _LIBCPP_STD_VER >= 26
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() const noexcept {
     return rdbuf()->native_handle();
   }
 #    endif
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
-  _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const { return __sb_.is_open(); }
+
+  _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out) {
+    if (__sb_.open(__s, __mode))
+      this->clear();
+    else
+      this->setstate(ios_base::failbit);
+  }
+
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out) {
+    if (__sb_.open(__s, __mode))
+      this->clear();
+    else
+      this->setstate(ios_base::failbit);
+  }
 #    endif
-  _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+  _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out) {
+    if (__sb_.open(__s, __mode))
+      this->clear();
+    else
+      this->setstate(ios_base::failbit);
+  }
 
 #    if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI void
@@ -1542,104 +1586,18 @@ public:
   }
 #    endif // _LIBCPP_STD_VER >= 17
 
-  _LIBCPP_HIDE_FROM_ABI void close();
+  _LIBCPP_HIDE_FROM_ABI void close() {
+    if (__sb_.close() == nullptr)
+      this->setstate(ios_base::failbit);
+  }
 
 private:
   basic_filebuf<char_type, traits_type> __sb_;
 };
 
 template <class _CharT, class _Traits>
-inline basic_fstream<_CharT, _Traits>::basic_fstream()
-    : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {}
-
-template <class _CharT, class _Traits>
-inline basic_fstream<_CharT, _Traits>::basic_fstream(const char* __s, ios_base::openmode __mode)
-    : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
-  if (__sb_.open(__s, __mode) == nullptr)
-    this->setstate(ios_base::failbit);
-}
-
-#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-template <class _CharT, class _Traits>
-inline basic_fstream<_CharT, _Traits>::basic_fstream(const wchar_t* __s, ios_base::openmode __mode)
-    : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
-  if (__sb_.open(__s, __mode) == nullptr)
-    this->setstate(ios_base::failbit);
-}
-#    endif
-
-template <class _CharT, class _Traits>
-inline basic_fstream<_CharT, _Traits>::basic_fstream(const string& __s, ios_base::openmode __mode)
-    : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
-  if (__sb_.open(__s, __mode) == nullptr)
-    this->setstate(ios_base::failbit);
-}
-
-// extension
-template <class _CharT, class _Traits>
-inline basic_fstream<_CharT, _Traits>::basic_fstream(basic_fstream&& __rhs)
-    : basic_iostream<char_type, traits_type>(std::move(__rhs)), __sb_(std::move(__rhs.__sb_)) {
-  this->set_rdbuf(std::addressof(__sb_));
-}
-
-template <class _CharT, class _Traits>
-inline basic_fstream<_CharT, _Traits>& basic_fstream<_CharT, _Traits>::operator=(basic_fstream&& __rhs) {
-  basic_iostream<char_type, traits_type>::operator=(std::move(__rhs));
-  __sb_ = std::move(__rhs.__sb_);
-  return *this;
-}
-
-template <class _CharT, class _Traits>
-inline void basic_fstream<_CharT, _Traits>::swap(basic_fstream& __rhs) {
-  basic_iostream<char_type, traits_type>::swap(__rhs);
-  __sb_.swap(__rhs.__sb_);
-}
-
-template <class _CharT, class _Traits>
 inline _LIBCPP_HIDE_FROM_ABI void swap(basic_fstream<_CharT, _Traits>& __x, basic_fstream<_CharT, _Traits>& __y) {
   __x.swap(__y);
-}
-
-template <class _CharT, class _Traits>
-inline basic_filebuf<_CharT, _Traits>* basic_fstream<_CharT, _Traits>::rdbuf() const {
-  return const_cast<basic_filebuf<char_type, traits_type>*>(std::addressof(__sb_));
-}
-
-template <class _CharT, class _Traits>
-inline bool basic_fstream<_CharT, _Traits>::is_open() const {
-  return __sb_.is_open();
-}
-
-template <class _CharT, class _Traits>
-void basic_fstream<_CharT, _Traits>::open(const char* __s, ios_base::openmode __mode) {
-  if (__sb_.open(__s, __mode))
-    this->clear();
-  else
-    this->setstate(ios_base::failbit);
-}
-
-#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-template <class _CharT, class _Traits>
-void basic_fstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmode __mode) {
-  if (__sb_.open(__s, __mode))
-    this->clear();
-  else
-    this->setstate(ios_base::failbit);
-}
-#    endif
-
-template <class _CharT, class _Traits>
-void basic_fstream<_CharT, _Traits>::open(const string& __s, ios_base::openmode __mode) {
-  if (__sb_.open(__s, __mode))
-    this->clear();
-  else
-    this->setstate(ios_base::failbit);
-}
-
-template <class _CharT, class _Traits>
-inline void basic_fstream<_CharT, _Traits>::close() {
-  if (__sb_.close() == nullptr)
-    this->setstate(ios_base::failbit);
 }
 
 #    if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1


### PR DESCRIPTION
The `fstream` member functions are all really short, so inlining them removes quite a bit of boiler plate code.
