### PR TITLE
[MC][DXContainer] Avoid reading moved-from ContentEntry

### DIFF
--- a/llvm/lib/MC/DXContainerInfo.cpp
+++ b/llvm/lib/MC/DXContainerInfo.cpp
@@ -206,11 +206,12 @@ void SourceInfoBuilder::computeEntries() {
     SourceInfo::SourceContents::Entry ContentEntry;
     ContentEntry.FileContent = NameContent.second.str();
     ContentEntry.compute();
+    auto ContentSize = ContentEntry.Parameters.ContentSizeInBytes;
     BaseData.Contents.Entries.emplace_back(std::move(ContentEntry));
 
     SourceInfo::SourceNames::Entry NameEntry;
     NameEntry.FileName = NameContent.first;
-    NameEntry.compute(ContentEntry.Parameters.ContentSizeInBytes);
+    NameEntry.compute(ContentSize);
     BaseData.Names.Entries.emplace_back(std::move(NameEntry));
   }
 


### PR DESCRIPTION
While technically correct in this specific case to use the moved value since its a scalar, it might break in the future. For example if the move is overloaded for ContentEntry or its Parameters member.

This fix removes this fragility.