### PR TITLE
[Clang][Driver] Ignore -fsanitize-kcfi-arity when KCFI is disabled

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1565,7 +1565,7 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
   if (CfiICallNormalizeIntegers)
     CmdArgs.push_back("-fsanitize-cfi-icall-experimental-normalize-integers");
 
-  if (KcfiArity) {
+  if (KcfiArity && Sanitizers.has(SanitizerKind::KCFI)) {
     if (!TC.getTriple().isOSLinux() || !TC.getTriple().isArch64Bit()) {
       TC.getDriver().Diag(clang::diag::err_drv_kcfi_arity_unsupported_target)
           << TC.getTriple().str();

--- a/clang/test/Driver/fsanitize-cfi.c
+++ b/clang/test/Driver/fsanitize-cfi.c
@@ -96,3 +96,7 @@
 
 // RUN: not %clang --target=x86_64-linux-gnu -fsanitize=kcfi,function %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-KCFI-FUNCTION
 // CHECK-KCFI-FUNCTION: error: invalid argument '-fsanitize=kcfi' not allowed with '-fsanitize=function'
+
+// RUN: %clang --target=i386-linux-gnu -c %s -### -fsanitize=address,kcfi -fno-sanitize=kcfi -fsanitize-kcfi-arity 2>&1 | FileCheck %s --check-prefix=CHECK-KCFI-ARITY-DISABLED --implicit-check-not=error: --implicit-check-not=-fsanitize-kcfi-arity
+
+// CHECK-KCFI-ARITY-DISABLED: "-cc1"{{.*}}"-fsanitize=address"


### PR DESCRIPTION
`-fsanitize-kcfi-arity` was still processed after KCFI had been disabled with `-fno-sanitize=kcfi`.

This change only processes `-fsanitize-kcfi-arity` when KCFI remains enabled in the final sanitizer set, avoiding both the unsupported target diagnostic and forwarding the option to cc1.

Adds a regression test for this case.

Assisted-by: GPT 5.5