### PR TITLE
[AArch64] Mark ZT0 register class as non-allocatable

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -1833,12 +1833,13 @@ let isAllocatable = 0 in {
   def MPR128  : RegisterClass<"AArch64", [untyped],  128, (add (sequence "ZAQ%u", 0, 15))> {
     let Size = 128;
   }
+
+  def ZTR : RegisterClass<"AArch64", [untyped], 512, (add ZT0)> {
+    let Size = 512;
+    let DiagnosticType = "InvalidLookupTable";
+  }
 }
 
-def ZTR : RegisterClass<"AArch64", [untyped], 512, (add ZT0)> {
-  let Size = 512;
-  let DiagnosticType = "InvalidLookupTable";
-}
 // SME Register Operands
 // There are three types of SME matrix register operands:
 // * Tiles:

--- a/llvm/test/TableGen/aarch64-register-info-stats.td
+++ b/llvm/test/TableGen/aarch64-register-info-stats.td
@@ -15,4 +15,4 @@ def TestTarget : Target {
 
 // CHECK-DAG: 83 register-info-emitter - Number of explicit register classes
 // CHECK-DAG: 447 register-info-emitter - Number of synthesized register classes
-// CHECK-DAG: 190 register-info-emitter - Number of register pressure sets
+// CHECK-DAG: 189 register-info-emitter - Number of register pressure sets


### PR DESCRIPTION
ZT0 is not available for register allocation, define it with the other non-allocatable SME register classes and avoid an unnecessary pressure set.

Assisted-by: codex