### PR TITLE
[clang] Add missing VisitAtomicTypeLoc to TypeLoc.cpp GetContainedAutoTypeLocVisitor

### DIFF
--- a/clang/lib/AST/TypeLoc.cpp
+++ b/clang/lib/AST/TypeLoc.cpp
@@ -817,6 +817,10 @@ namespace {
 
     // Only these types can contain the desired 'auto' type.
 
+    TypeLoc VisitAtomicTypeLoc(AtomicTypeLoc T) {
+      return Visit(T.getValueLoc());
+    }
+
     TypeLoc VisitQualifiedTypeLoc(QualifiedTypeLoc T) {
       return Visit(T.getUnqualifiedLoc());
     }

--- a/clang/test/SemaCXX/atomic-auto.cpp
+++ b/clang/test/SemaCXX/atomic-auto.cpp
@@ -1,8 +1,7 @@
-// RUN: %clang_cc1 -verify -pedantic %s -std=c++20
+// RUN: %clang_cc1 -verify %s -std=c++20
 
 template<typename T> concept C = false; // expected-note {{because 'false' evaluated to false}}
 
 void test() {
-  _Atomic C<> auto &foo = 42; // expected-warning {{'_Atomic' is a C11 extension}} \
-                              // expected-error {{deduced type 'int' does not satisfy 'C<>'}}
+  _Atomic C<> auto &foo = 42; // expected-error {{deduced type 'int' does not satisfy 'C<>'}}
 };

--- a/clang/test/SemaCXX/atomic-auto.cpp
+++ b/clang/test/SemaCXX/atomic-auto.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -verify -pedantic %s -std=c++20
+
+template<typename T> concept C = false; // expected-note {{because 'false' evaluated to false}}
+
+void test() {
+  _Atomic C<> auto &foo = 42; // expected-warning {{'_Atomic' is a C11 extension}} \
+                              // expected-error {{deduced type 'int' does not satisfy 'C<>'}}
+};


### PR DESCRIPTION
This PR adds the missing VisitAtomicTypeLoc method to TypeLoc.cpp GetContainedAutoTypeLocVisitor.

Fixes #211556 ICE.

Assisted-by: Codex