### PR TITLE
[llvm] Forward declare VirtualFileSystem

### DIFF
--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -29,6 +29,7 @@
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -46,9 +47,6 @@ namespace llvm {
 class Error;
 class raw_ostream;
 class MemoryBuffer;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 } // namespace llvm
 
 namespace clang {

--- a/clang/include/clang/Basic/SanitizerSpecialCaseList.h
+++ b/clang/include/clang/Basic/SanitizerSpecialCaseList.h
@@ -18,16 +18,10 @@
 #include "clang/Basic/Sanitizers.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SpecialCaseList.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <memory>
 #include <utility>
 #include <vector>
-
-namespace llvm {
-namespace vfs {
-class FileSystem;
-}
-} // namespace llvm
-
 namespace clang {
 
 class SanitizerSpecialCaseList : public llvm::SpecialCaseList {

--- a/clang/include/clang/CIR/LowerToLLVM.h
+++ b/clang/include/clang/CIR/LowerToLLVM.h
@@ -13,14 +13,12 @@
 #define CLANG_CIR_LOWERTOLLVM_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <memory>
 
 namespace llvm {
 class LLVMContext;
 class Module;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 } // namespace llvm
 
 namespace mlir {

--- a/clang/include/clang/CodeGen/BackendUtil.h
+++ b/clang/include/clang/CodeGen/BackendUtil.h
@@ -11,6 +11,7 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <memory>
 
 namespace llvm {
@@ -19,9 +20,6 @@ template <typename T> class Expected;
 template <typename T> class IntrusiveRefCntPtr;
 class Module;
 class MemoryBufferRef;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 } // namespace llvm
 
 namespace clang {

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -16,16 +16,13 @@
 #include "clang/AST/ASTConsumer.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 namespace llvm {
   class Constant;
   class LLVMContext;
   class Module;
   class StringRef;
-
-  namespace vfs {
-  class FileSystem;
-  }
 }
 
 // Prefix of the name of the artificial inline frame.

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -28,6 +28,7 @@
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 #include <map>
 #include <set>
@@ -36,9 +37,6 @@
 
 namespace llvm {
 class Triple;
-namespace vfs {
-class FileSystem;
-}
 namespace cl {
 class ExpansionContext;
 }

--- a/clang/include/clang/Driver/ModulesDriver.h
+++ b/clang/include/clang/Driver/ModulesDriver.h
@@ -18,10 +18,7 @@
 #include "clang/Basic/LLVM.h"
 #include "clang/Driver/Types.h"
 #include "llvm/Support/Error.h"
-
-namespace llvm::vfs {
-class FileSystem;
-} // namespace llvm::vfs
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 namespace clang {
 class DiagnosticsEngine;

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -26,6 +26,7 @@
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/VersionTuple.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cassert>
@@ -43,11 +44,6 @@ class ArgList;
 class DerivedArgList;
 
 } // namespace opt
-namespace vfs {
-
-class FileSystem;
-
-} // namespace vfs
 } // namespace llvm
 
 namespace clang {

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -21,14 +21,9 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <optional>
 #include <system_error>
-
-namespace llvm {
-namespace vfs {
-class FileSystem;
-}
-} // namespace llvm
 
 namespace clang {
 namespace format {

--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -39,6 +39,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Bitstream/BitstreamWriter.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -52,11 +53,6 @@ namespace llvm {
 
 class MemoryBuffer;
 
-namespace vfs {
-
-class FileSystem;
-
-} // namespace vfs
 } // namespace llvm
 
 namespace clang {

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 #include <memory>
 #include <string>
@@ -37,12 +38,6 @@ namespace opt {
 class ArgList;
 
 } // namespace opt
-
-namespace vfs {
-
-class FileSystem;
-
-} // namespace vfs
 
 } // namespace llvm
 

--- a/clang/include/clang/Frontend/PrecompiledPreamble.h
+++ b/clang/include/clang/Frontend/PrecompiledPreamble.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MD5.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <cstddef>
 #include <memory>
 #include <system_error>
@@ -26,9 +27,6 @@
 namespace llvm {
 class MemoryBuffer;
 class MemoryBufferRef;
-namespace vfs {
-class FileSystem;
-}
 } // namespace llvm
 
 namespace clang {

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -39,6 +39,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Transforms/Utils/SanitizerStats.h"
 #include <optional>
 
@@ -52,10 +53,6 @@ class DataLayout;
 class FunctionType;
 class LLVMContext;
 class IndexedInstrProfReader;
-
-namespace vfs {
-class FileSystem;
-}
 
 namespace abi {
 class ArgInfo;

--- a/llvm/include/llvm/CodeGen/MIRSampleProfile.h
+++ b/llvm/include/llvm/CodeGen/MIRSampleProfile.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/Support/Discriminator.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <memory>
 #include <string>
 
@@ -26,10 +27,6 @@ class AnalysisUsage;
 class MachineBlockFrequencyInfo;
 class MachineFunction;
 class Module;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 using namespace sampleprof;
 

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -18,6 +18,7 @@
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Discriminator.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 #include <functional>
 #include <string>
@@ -34,9 +35,6 @@ class raw_ostream;
 enum class RunOutliner;
 
 template <typename T> class IntrusiveRefCntPtr;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -27,6 +27,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/TargetParser/Triple.h"
 #include <forward_list>
 #include <map>
@@ -42,10 +43,6 @@ class OpenMPIRBuilder;
 class Loop;
 class LoopAnalysis;
 class LoopInfo;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 /// Move the instruction after an InsertPoint to the beginning of another
 /// BasicBlock.

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -30,6 +30,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
@@ -51,10 +52,6 @@ class IndexedInstrProfReader;
 namespace object {
 class BuildIDFetcher;
 } // namespace object
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 namespace coverage {
 

--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -13,7 +13,6 @@
 
 #ifndef LLVM_PROFILEDATA_INSTRPROFREADER_H
 #define LLVM_PROFILEDATA_INSTRPROFREADER_H
-
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/ProfileSummary.h"
@@ -32,6 +31,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
 #include "llvm/Support/SwapByteOrder.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -44,10 +44,6 @@
 namespace llvm {
 
 class InstrProfReader;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 /// A file format agnostic iterator over profiling data.
 template <class record_type = NamedInstrProfRecord,

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -241,6 +241,7 @@
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <array>
 #include <cstdint>
 #include <list>
@@ -254,10 +255,6 @@ namespace llvm {
 
 class raw_ostream;
 class Twine;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 namespace sampleprof {
 

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -29,6 +29,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <climits>
@@ -40,10 +41,6 @@
 #include <vector>
 
 namespace llvm {
-
-namespace vfs {
-class FileSystem;
-}
 
 class StringSaver;
 class ElementCount;

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -20,13 +20,10 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SMLoc.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <vector>
 
 namespace llvm {
-
-namespace vfs {
-class FileSystem;
-} // end namespace vfs
 
 class raw_ostream;
 class SMDiagnostic;

--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -14,6 +14,7 @@
 
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <memory>
 #include <string>
 #include <utility>
@@ -22,10 +23,6 @@
 namespace llvm {
 class MemoryBuffer;
 class StringRef;
-
-namespace vfs {
-class FileSystem;
-}
 
 /// This is a utility class used to parse user-provided text files with
 /// "special case lists" for code sanitizers. Such files are used to

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -27,6 +27,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -214,8 +215,6 @@ public:
     return !(*this == RHS);
   }
 };
-
-class FileSystem;
 
 namespace detail {
 

--- a/llvm/include/llvm/Support/VirtualFileSystemFwd.h
+++ b/llvm/include/llvm/Support/VirtualFileSystemFwd.h
@@ -1,0 +1,36 @@
+//===- VirtualFileSystemFwd.h - Virtual File System Forward -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// Contains the forward declaration for vfs::FileSystem, as well as the
+/// IntrusiveRefCntPtrInfo specialization for it. This allows the
+/// vfs::FileSystem class to be used with IntrusiveRefCntPtr without including
+/// its full definition.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_VIRTUALFILESYSTEMFWD_H
+#define LLVM_SUPPORT_VIRTUALFILESYSTEMFWD_H
+
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Compiler.h"
+
+namespace llvm {
+namespace vfs {
+class FileSystem;
+} // namespace vfs
+
+template <> struct LLVM_ABI IntrusiveRefCntPtrInfo<::llvm::vfs::FileSystem> {
+  static unsigned useCount(const ::llvm::vfs::FileSystem *FS);
+  static void retain(::llvm::vfs::FileSystem *FS);
+  static void release(::llvm::vfs::FileSystem *FS);
+};
+
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_VIRTUALFILESYSTEMFWD_H

--- a/llvm/include/llvm/Transforms/IPO/SampleProfile.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfile.h
@@ -19,6 +19,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <string>
 
 namespace llvm {
@@ -31,10 +32,6 @@ LLVM_ABI extern cl::opt<int> ProfileInlineGrowthLimit;
 LLVM_ABI extern cl::opt<int> ProfileInlineLimitMin;
 LLVM_ABI extern cl::opt<int> ProfileInlineLimitMax;
 LLVM_ABI extern cl::opt<bool> SortProfiledSCC;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 /// The sample profiler data loader pass.
 class SampleProfileLoaderPass

--- a/llvm/include/llvm/Transforms/Instrumentation/MemProfUse.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/MemProfUse.h
@@ -17,15 +17,12 @@
 #include "llvm/ProfileData/DataAccessProf.h"
 #include "llvm/ProfileData/MemProf.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 namespace llvm {
 class IndexedInstrProfReader;
 class Module;
 class TargetLibraryInfo;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 class MemProfUsePass : public OptionalPassInfoMixin<MemProfUsePass> {
 public:

--- a/llvm/include/llvm/Transforms/Instrumentation/SanitizerBinaryMetadata.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/SanitizerBinaryMetadata.h
@@ -18,12 +18,10 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Transforms/Utils/Instrumentation.h"
 
 namespace llvm {
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 struct SanitizerBinaryMetadataOptions {
   bool Covered = false;

--- a/llvm/include/llvm/Transforms/Instrumentation/SanitizerCoverage.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/SanitizerCoverage.h
@@ -19,13 +19,11 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SpecialCaseList.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Transforms/Utils/Instrumentation.h"
 
 namespace llvm {
 class Module;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 /// This is the ModuleSanitizerCoverage pass used in the new pass manager. The
 /// pass instruments functions for coverage, adds initialization calls to the

--- a/llvm/include/llvm/Transforms/Utils/SampleProfileLoaderBaseImpl.h
+++ b/llvm/include/llvm/Transforms/Utils/SampleProfileLoaderBaseImpl.h
@@ -40,6 +40,7 @@
 #include "llvm/ProfileData/SampleProfReader.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/GenericDomTree.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/SampleProfileInference.h"
 #include "llvm/Transforms/Utils/SampleProfileLoaderBaseUtil.h"
@@ -47,10 +48,6 @@
 namespace llvm {
 using namespace sampleprof;
 using namespace sampleprofutil;
-
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 
 #define DEBUG_TYPE "sample-profile-impl"
 

--- a/llvm/include/llvm/WindowsDriver/MSVCPaths.h
+++ b/llvm/include/llvm/WindowsDriver/MSVCPaths.h
@@ -12,15 +12,12 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 #include <string>
 
 namespace llvm {
-
-namespace vfs {
-class FileSystem;
-}
 
 enum class SubDirectoryType {
   Bin,

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -2996,3 +2996,16 @@ const char OverlayFileSystem::ID = 0;
 const char ProxyFileSystem::ID = 0;
 const char InMemoryFileSystem::ID = 0;
 const char RedirectingFileSystem::ID = 0;
+
+unsigned ::llvm::IntrusiveRefCntPtrInfo<FileSystem>::useCount(
+    const FileSystem *FS) {
+  return FS->UseCount();
+}
+
+void ::llvm::IntrusiveRefCntPtrInfo<FileSystem>::retain(FileSystem *FS) {
+  FS->Retain();
+}
+
+void ::llvm::IntrusiveRefCntPtrInfo<FileSystem>::release(FileSystem *FS) {
+  FS->Release();
+}

--- a/mlir/include/mlir/Target/LLVMIR/Export.h
+++ b/mlir/include/mlir/Target/LLVMIR/Export.h
@@ -10,14 +10,12 @@
 #define MLIR_TARGET_LLVMIR_EXPORT_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 #include <memory>
 
 namespace llvm {
 class LLVMContext;
 class Module;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 } // namespace llvm
 
 namespace mlir {

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/FPEnv.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 namespace llvm {
 class BasicBlock;
@@ -36,9 +37,6 @@ class Function;
 class IRBuilderBase;
 class OpenMPIRBuilder;
 class Value;
-namespace vfs {
-class FileSystem;
-} // namespace vfs
 } // namespace llvm
 
 namespace mlir {

--- a/polly/include/polly/ScopInliner.h
+++ b/polly/include/polly/ScopInliner.h
@@ -13,12 +13,7 @@
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/IR/PassManager.h"
-
-namespace llvm {
-namespace vfs {
-class FileSystem;
-}
-} // namespace llvm
+#include "llvm/Support/VirtualFileSystemFwd.h"
 
 namespace polly {
 class ScopInlinerPass : public llvm::OptionalPassInfoMixin<ScopInlinerPass> {


### PR DESCRIPTION
This adds a new header that adds an explicit forward declaration for VirtualFileSystem, as well as a specialization of IntrusiveRefCntPtrInfo for this class. This allows for code that uses
`IntrusiveRefCntPtr<vfs::FileSystem>` to compile when building LLVM as a dylib on Windows, without having to include the full VirtualFileSystem.h header.

The effort to build LLVM as a dylib is tracked in #109483.