### PR TITLE
Reapply "[VPlan] Re-use VPSlotTracker when printing recipes for costs (NFC)." (#209003)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3166,7 +3166,8 @@ void LoopVectorizationPlanner::emitInvalidCostRemarks(
       if (VF.isScalar())
         continue;
 
-      VPCostContext CostCtx(*TLI, *Plan, CM, Config);
+      VPCostContext CostCtx(*TLI, *Plan, CM, Config,
+                            /*ReusePrintingSlotTracker=*/true);
       precomputeCosts(*Plan, VF, CostCtx);
       auto Iter = vp_depth_first_deep(Plan->getVectorLoopRegion()->getEntry());
       for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(Iter)) {
@@ -5601,10 +5602,16 @@ void LoopVectorizationPlanner::plan(ElementCount UserVF, unsigned UserIC) {
 
 VPCostContext::VPCostContext(const TargetLibraryInfo &TLI, const VPlan &Plan,
                              LoopVectorizationCostModel &CM,
-                             VFSelectionContext &Config)
+                             VFSelectionContext &Config,
+                             bool ReusePrintingSlotTracker)
     : TTI(Config.getTTI()), TLI(TLI), LLVMCtx(Plan.getContext()), CM(CM),
       Config(Config), CostKind(Config.CostKind), PSE(Config.getPSE()),
-      L(Config.getLoop()) {}
+      L(Config.getLoop()) {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  if (ReusePrintingSlotTracker)
+    PlanForSlotTracker = &Plan;
+#endif
+}
 
 InstructionCost VPCostContext::getLegacyCost(Instruction *UI,
                                              ElementCount VF) const {
@@ -5764,7 +5771,8 @@ LoopVectorizationPlanner::precomputeCosts(VPlan &Plan, ElementCount VF,
 
 InstructionCost LoopVectorizationPlanner::cost(VPlan &Plan, ElementCount VF,
                                                VPRegisterUsage *RU) const {
-  VPCostContext CostCtx(*TLI, Plan, CM, Config);
+  VPCostContext CostCtx(*TLI, Plan, CM, Config,
+                        /*ReusePrintingSlotTracker=*/true);
   InstructionCost Cost = precomputeCosts(Plan, VF, CostCtx);
 
   // Now compute and add the VPlan-based cost.
@@ -8115,7 +8123,8 @@ bool LoopVectorizePass::processLoop(Loop *L) {
     // Check if it is profitable to vectorize with runtime checks.
     bool ForceVectorization =
         Hints.getForce() == LoopVectorizeHints::FK_Enabled;
-    VPCostContext CostCtx(*TLI, *BestPlanPtr, CM, Config);
+    VPCostContext CostCtx(*TLI, *BestPlanPtr, CM, Config,
+                          /*ReusePrintingSlotTracker=*/true);
     if (!ForceVectorization &&
         !isOutsideLoopWorkProfitable(Checks, VF, L, PSE, CostCtx, *BestPlanPtr,
                                      SEL, Config.getVScaleForTuning())) {

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1894,6 +1894,16 @@ VPCostContext::getOperandInfo(VPValue *V) const {
   return {};
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+VPSlotTracker *VPCostContext::getSlotTracker() {
+  if (!PlanForSlotTracker)
+    return nullptr;
+  if (!SlotTracker)
+    SlotTracker = std::make_unique<VPSlotTracker>(PlanForSlotTracker);
+  return SlotTracker.get();
+}
+#endif
+
 InstructionCost VPCostContext::getScalarizationOverhead(
     Type *ResultTy, ArrayRef<const VPValue *> Operands, ElementCount VF,
     TTI::VectorInstrContext VIC, bool AlwaysIncludeReplicatingR) {

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -41,6 +41,7 @@ class VFSelectionContext;
 class VPBasicBlock;
 class VPRegionBlock;
 class VPlan;
+class VPSlotTracker;
 class Value;
 
 namespace Intrinsic {
@@ -340,7 +341,8 @@ struct VPCostContext {
   std::optional<unsigned> NumPredStores;
 
   VPCostContext(const TargetLibraryInfo &TLI, const VPlan &Plan,
-                LoopVectorizationCostModel &CM, VFSelectionContext &Config);
+                LoopVectorizationCostModel &CM, VFSelectionContext &Config,
+                bool ReusePrintingSlotTracker = false);
 
   /// Return the cost for \p UI with \p VF using the legacy cost model as
   /// fallback until computing the cost of all recipes migrates to VPlan.
@@ -385,6 +387,21 @@ struct VPCostContext {
   /// Returns true if \p ID is a pseudo intrinsic that is dropped via
   /// scalarization rather than widened.
   static bool isFreeScalarIntrinsic(Intrinsic::ID ID);
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  /// Return a VPSlotTracker to re-use for printing, lazily constructing it on
+  /// first use. Returns nullptr if slot-tracker re-use was not requested at
+  /// construction.
+  VPSlotTracker *getSlotTracker();
+
+private:
+  /// VPlan to build the printing VPSlotTracker for, or nullptr if slot-tracker
+  /// re-use was not requested.
+  const VPlan *PlanForSlotTracker = nullptr;
+
+  /// SlotTracker to re-use when printing, lazily constructed by getSlotTracker.
+  std::unique_ptr<VPSlotTracker> SlotTracker;
+#endif
 };
 
 /// This class can be used to assign names to VPValues. For VPValues without

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -331,7 +331,12 @@ InstructionCost VPRecipeBase::cost(ElementCount VF, VPCostContext &Ctx) {
 
   LLVM_DEBUG({
     dbgs() << "Cost of " << RecipeCost << " for VF " << VF << ": ";
-    dump();
+    if (VPSlotTracker *SlotTracker = Ctx.getSlotTracker()) {
+      print(dbgs(), "", *SlotTracker);
+      dbgs() << "\n";
+    } else {
+      dump();
+    }
   });
   return RecipeCost;
 }


### PR DESCRIPTION
This reverts commit 4c7948d06c93e8d233cd4733fd4107f3b68bc7bc. The commit always constructs slot on first use, to fix compile-time regressions in release builds.

Original message:
VPRecipeBase::dump() constructs a fresh VPSlotTracker instance on each call. VPSlotTracker construction requires iterating over all recipes in the plan, to number all VPValues.

To avoid doing lots of unnecessary work when printing VPlan costs, construct a shared VPSlotTracker in VPCostContext, re-used by all prints.

This can speed up debug output for large loops.

PR: https://github.com/llvm/llvm-project/pull/203386