### PR TITLE
[X86] Match (FM)ADDSUB patterns from target shuffles as well as ISD::VECTOR_SHUFFLE

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -43988,14 +43988,15 @@ static bool isAddSubOrSubAdd(SDNode *N, const X86Subtarget &Subtarget,
       !VT.getSimpleVT().isFloatingPoint())
     return false;
 
-  // We only handle target-independent shuffles.
-  // FIXME: It would be easy and harmless to use the target shuffle mask
-  // extraction tool to support more.
-  if (N->getOpcode() != ISD::VECTOR_SHUFFLE)
+  SmallVector<int, 16> Mask;
+  SmallVector<SDValue, 2> OpInputs;
+  if (!getTargetShuffleInputs(SDValue(N, 0), OpInputs, Mask, DAG) ||
+      OpInputs.size() != 2 || isAnyZero(Mask) ||
+      OpInputs[0].getValueType() != VT || OpInputs[1].getValueType() != VT)
     return false;
 
-  SDValue V1 = N->getOperand(0);
-  SDValue V2 = N->getOperand(1);
+  SDValue V1 = OpInputs[0];
+  SDValue V2 = OpInputs[1];
 
   // Make sure we have an FADD and an FSUB.
   if ((V1.getOpcode() != ISD::FADD && V1.getOpcode() != ISD::FSUB) ||
@@ -44023,7 +44024,6 @@ static bool isAddSubOrSubAdd(SDNode *N, const X86Subtarget &Subtarget,
       return false;
   }
 
-  ArrayRef<int> Mask = cast<ShuffleVectorSDNode>(N)->getMask();
   bool Op0Even;
   if (!isAddSubOrSubAddMask(Mask, Op0Even))
     return false;
@@ -44043,20 +44043,21 @@ static bool isAddSubOrSubAdd(SDNode *N, const X86Subtarget &Subtarget,
 static SDValue combineShuffleToFMAddSub(SDNode *N, const SDLoc &DL,
                                         const X86Subtarget &Subtarget,
                                         SelectionDAG &DAG) {
-  // We only handle target-independent shuffles.
-  // FIXME: It would be easy and harmless to use the target shuffle mask
-  // extraction tool to support more.
-  if (N->getOpcode() != ISD::VECTOR_SHUFFLE)
-    return SDValue();
-
-  MVT VT = N->getSimpleValueType(0);
+  EVT VT = N->getValueType(0);
   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
   if (!Subtarget.hasAnyFMA() || !TLI.isTypeLegal(VT))
     return SDValue();
 
+  SmallVector<int, 16> Mask;
+  SmallVector<SDValue, 2> OpInputs;
+  if (!getTargetShuffleInputs(SDValue(N, 0), OpInputs, Mask, DAG) ||
+      OpInputs.size() != 2 || isAnyZero(Mask) ||
+      OpInputs[0].getValueType() != VT || OpInputs[1].getValueType() != VT)
+    return SDValue();
+
   // We're trying to match (shuffle fma(a, b, c), X86Fmsub(a, b, c).
-  SDValue Op0 = N->getOperand(0);
-  SDValue Op1 = N->getOperand(1);
+  SDValue Op0 = OpInputs[0];
+  SDValue Op1 = OpInputs[1];
   SDValue FMAdd = Op0, FMSub = Op1;
   if (FMSub.getOpcode() != X86ISD::FMSUB)
     std::swap(FMAdd, FMSub);
@@ -44068,7 +44069,6 @@ static SDValue combineShuffleToFMAddSub(SDNode *N, const SDLoc &DL,
     return SDValue();
 
   // Check for correct shuffle mask.
-  ArrayRef<int> Mask = cast<ShuffleVectorSDNode>(N)->getMask();
   bool Op0Even;
   if (!isAddSubOrSubAddMask(Mask, Op0Even))
     return SDValue();

--- a/llvm/test/CodeGen/X86/fmaddsub-combine.ll
+++ b/llvm/test/CodeGen/X86/fmaddsub-combine.ll
@@ -141,14 +141,12 @@ define <8 x double> @mul_addsub_pd512_partial(<8 x double> %C, <8 x double> %D, 
 ; NOFMA-NEXT:    vmulpd %ymm2, %ymm0, %ymm0
 ; NOFMA-NEXT:    vmulpd %ymm3, %ymm1, %ymm1
 ; NOFMA-NEXT:    vsubpd %ymm5, %ymm1, %ymm2
-; NOFMA-NEXT:    vsubpd %ymm4, %ymm0, %ymm3
-; NOFMA-NEXT:    vaddpd %ymm4, %ymm0, %ymm0
-; NOFMA-NEXT:    vblendpd {{.*#+}} ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3]
 ; NOFMA-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; NOFMA-NEXT:    vshufpd {{.*#+}} xmm1 = xmm1[1,0]
 ; NOFMA-NEXT:    vextractf128 $1, %ymm5, %xmm3
 ; NOFMA-NEXT:    vshufpd {{.*#+}} xmm3 = xmm3[1,0]
 ; NOFMA-NEXT:    vaddsd %xmm3, %xmm1, %xmm1
+; NOFMA-NEXT:    vaddsubpd %ymm4, %ymm0, %ymm0
 ; NOFMA-NEXT:    vextractf128 $1, %ymm2, %xmm3
 ; NOFMA-NEXT:    vunpcklpd {{.*#+}} xmm1 = xmm3[0],xmm1[0]
 ; NOFMA-NEXT:    vinsertf128 $1, %xmm1, %ymm2, %ymm1
@@ -159,14 +157,12 @@ define <8 x double> @mul_addsub_pd512_partial(<8 x double> %C, <8 x double> %D, 
 ; FMA3_256-NEXT:    vmulpd %ymm2, %ymm0, %ymm0
 ; FMA3_256-NEXT:    vmulpd %ymm3, %ymm1, %ymm1
 ; FMA3_256-NEXT:    vsubpd %ymm5, %ymm1, %ymm2
-; FMA3_256-NEXT:    vsubpd %ymm4, %ymm0, %ymm3
-; FMA3_256-NEXT:    vaddpd %ymm4, %ymm0, %ymm0
-; FMA3_256-NEXT:    vblendpd {{.*#+}} ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3]
 ; FMA3_256-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; FMA3_256-NEXT:    vshufpd {{.*#+}} xmm1 = xmm1[1,0]
 ; FMA3_256-NEXT:    vextractf128 $1, %ymm5, %xmm3
 ; FMA3_256-NEXT:    vshufpd {{.*#+}} xmm3 = xmm3[1,0]
 ; FMA3_256-NEXT:    vaddsd %xmm3, %xmm1, %xmm1
+; FMA3_256-NEXT:    vaddsubpd %ymm4, %ymm0, %ymm0
 ; FMA3_256-NEXT:    vextractf128 $1, %ymm2, %xmm3
 ; FMA3_256-NEXT:    vunpcklpd {{.*#+}} xmm1 = xmm3[0],xmm1[0]
 ; FMA3_256-NEXT:    vinsertf128 $1, %xmm1, %ymm2, %ymm1
@@ -193,14 +189,12 @@ define <8 x double> @mul_addsub_pd512_partial(<8 x double> %C, <8 x double> %D, 
 ; FMA4-NEXT:    vmulpd %ymm2, %ymm0, %ymm0
 ; FMA4-NEXT:    vmulpd %ymm3, %ymm1, %ymm1
 ; FMA4-NEXT:    vsubpd %ymm5, %ymm1, %ymm2
-; FMA4-NEXT:    vsubpd %ymm4, %ymm0, %ymm3
-; FMA4-NEXT:    vaddpd %ymm4, %ymm0, %ymm0
-; FMA4-NEXT:    vblendpd {{.*#+}} ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3]
 ; FMA4-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; FMA4-NEXT:    vshufpd {{.*#+}} xmm1 = xmm1[1,0]
 ; FMA4-NEXT:    vextractf128 $1, %ymm5, %xmm3
 ; FMA4-NEXT:    vshufpd {{.*#+}} xmm3 = xmm3[1,0]
 ; FMA4-NEXT:    vaddsd %xmm3, %xmm1, %xmm1
+; FMA4-NEXT:    vaddsubpd %ymm4, %ymm0, %ymm0
 ; FMA4-NEXT:    vextractf128 $1, %ymm2, %xmm3
 ; FMA4-NEXT:    vunpcklpd {{.*#+}} xmm1 = xmm3[0],xmm1[0]
 ; FMA4-NEXT:    vinsertf128 $1, %xmm1, %ymm2, %ymm1

--- a/llvm/test/CodeGen/X86/fmsubadd-combine.ll
+++ b/llvm/test/CodeGen/X86/fmsubadd-combine.ll
@@ -169,19 +169,16 @@ define <8 x double> @mul_subadd_pd512_partial(<8 x double> %C, <8 x double> %D, 
 ; FMA3_256-LABEL: mul_subadd_pd512_partial:
 ; FMA3_256:       # %bb.0:
 ; FMA3_256-NEXT:    vmulpd %ymm3, %ymm1, %ymm1
-; FMA3_256-NEXT:    vmovapd %ymm2, %ymm3
-; FMA3_256-NEXT:    vfmadd213pd {{.*#+}} ymm3 = (ymm0 * ymm3) + ymm4
-; FMA3_256-NEXT:    vaddpd %ymm5, %ymm1, %ymm6
-; FMA3_256-NEXT:    vfmsub213pd {{.*#+}} ymm2 = (ymm0 * ymm2) - ymm4
-; FMA3_256-NEXT:    vblendpd {{.*#+}} ymm0 = ymm3[0],ymm2[1],ymm3[2],ymm2[3]
+; FMA3_256-NEXT:    vaddpd %ymm5, %ymm1, %ymm3
 ; FMA3_256-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; FMA3_256-NEXT:    vshufpd {{.*#+}} xmm1 = xmm1[1,0]
-; FMA3_256-NEXT:    vextractf128 $1, %ymm5, %xmm2
-; FMA3_256-NEXT:    vshufpd {{.*#+}} xmm2 = xmm2[1,0]
-; FMA3_256-NEXT:    vsubsd %xmm2, %xmm1, %xmm1
-; FMA3_256-NEXT:    vextractf128 $1, %ymm6, %xmm2
+; FMA3_256-NEXT:    vextractf128 $1, %ymm5, %xmm5
+; FMA3_256-NEXT:    vshufpd {{.*#+}} xmm5 = xmm5[1,0]
+; FMA3_256-NEXT:    vsubsd %xmm5, %xmm1, %xmm1
+; FMA3_256-NEXT:    vfmsubadd213pd {{.*#+}} ymm0 = (ymm2 * ymm0) -/+ ymm4
+; FMA3_256-NEXT:    vextractf128 $1, %ymm3, %xmm2
 ; FMA3_256-NEXT:    vunpcklpd {{.*#+}} xmm1 = xmm2[0],xmm1[0]
-; FMA3_256-NEXT:    vinsertf128 $1, %xmm1, %ymm6, %ymm1
+; FMA3_256-NEXT:    vinsertf128 $1, %xmm1, %ymm3, %ymm1
 ; FMA3_256-NEXT:    retq
 ;
 ; FMA3_512-LABEL: mul_subadd_pd512_partial:
@@ -203,18 +200,16 @@ define <8 x double> @mul_subadd_pd512_partial(<8 x double> %C, <8 x double> %D, 
 ; FMA4-LABEL: mul_subadd_pd512_partial:
 ; FMA4:       # %bb.0:
 ; FMA4-NEXT:    vmulpd %ymm3, %ymm1, %ymm1
-; FMA4-NEXT:    vfmaddpd {{.*#+}} ymm3 = (ymm0 * ymm2) + ymm4
-; FMA4-NEXT:    vaddpd %ymm5, %ymm1, %ymm6
-; FMA4-NEXT:    vfmsubpd {{.*#+}} ymm0 = (ymm0 * ymm2) - ymm4
-; FMA4-NEXT:    vblendpd {{.*#+}} ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3]
+; FMA4-NEXT:    vaddpd %ymm5, %ymm1, %ymm3
 ; FMA4-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; FMA4-NEXT:    vshufpd {{.*#+}} xmm1 = xmm1[1,0]
-; FMA4-NEXT:    vextractf128 $1, %ymm5, %xmm2
-; FMA4-NEXT:    vshufpd {{.*#+}} xmm2 = xmm2[1,0]
-; FMA4-NEXT:    vsubsd %xmm2, %xmm1, %xmm1
-; FMA4-NEXT:    vextractf128 $1, %ymm6, %xmm2
+; FMA4-NEXT:    vextractf128 $1, %ymm5, %xmm5
+; FMA4-NEXT:    vshufpd {{.*#+}} xmm5 = xmm5[1,0]
+; FMA4-NEXT:    vsubsd %xmm5, %xmm1, %xmm1
+; FMA4-NEXT:    vfmsubaddpd {{.*#+}} ymm0 = (ymm0 * ymm2) -/+ ymm4
+; FMA4-NEXT:    vextractf128 $1, %ymm3, %xmm2
 ; FMA4-NEXT:    vunpcklpd {{.*#+}} xmm1 = xmm2[0],xmm1[0]
-; FMA4-NEXT:    vinsertf128 $1, %xmm1, %ymm6, %ymm1
+; FMA4-NEXT:    vinsertf128 $1, %xmm1, %ymm3, %ymm1
 ; FMA4-NEXT:    retq
   %A = fmul contract <8 x double> %C, %D
   %i = fadd contract <8 x double> %A, %B


### PR DESCRIPTION
Allows us to match X86ISD::ADDSUB/FMSUBADD/FMADDSUB after shuffle lowering