### PR TITLE
[OpenMP] Fix build error after 19857baa71

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -135,7 +135,8 @@ struct EnumSet : public llvm::Bitset<Size> {
 namespace detail {
 template <typename Enum, size_t Size>
 constexpr Enum EnumSetIterator<Enum, Size>::operator*() const {
-  assert(Set.Base::test(At));
+  // Older gcc doesn't like assert(Set.Base::test(At));
+  assert((static_cast<const EnumSet<Enum, Size> &>(Set).test(At)));
   return static_cast<Enum>(At);
 }
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -136,7 +136,7 @@ namespace detail {
 template <typename Enum, size_t Size>
 constexpr Enum EnumSetIterator<Enum, Size>::operator*() const {
   // Older gcc doesn't like assert(Set.Base::test(At));
-  assert((static_cast<const EnumSet<Enum, Size> &>(Set).test(At)));
+  assert((static_cast<const llvm::Bitset<Size> &>(Set).test(At)));
   return static_cast<Enum>(At);
 }
 


### PR DESCRIPTION
Some builders using older versions of gcc encounter this issue:

```
llvm/include/llvm/Frontend/OpenMP/OMP.h:138:14: error: ‘Base’ has not been declared
  138 |   assert(Set.Base::test(At));
      |              ^~~~
```

E.g. https://lab.llvm.org/buildbot/#/builders/10/builds/32524