### PR TITLE
AMDGPU: Use ProcessorAlias for legacy arch names

### DIFF
--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -274,7 +274,7 @@ public:
   }
 
   /// Check whether the CPU string is valid.
-  virtual bool isCPUStringValid(StringRef CPU) const {
+  bool isCPUStringValid(StringRef CPU) const {
     auto Found = llvm::lower_bound(ProcDesc, CPU);
     return Found != ProcDesc.end() && StringRef(Found->key()) == CPU;
   }

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -2136,6 +2136,13 @@ class ProcessorModel<string n, SchedMachineModel m, list<SubtargetFeature> f,
   let SchedModel = m;
 }
 
+// Defines an alternate name 'n' for the processor 'alias', resolving
+// to the same subtarget features and scheduling model.
+class ProcessorAlias<string n, string alias> {
+  string Name = n;
+  string Alias = alias;
+}
+
 //===----------------------------------------------------------------------===//
 // InstrMapping - This class is used to create mapping tables to relate
 // instructions with each other based on the values specified in RowFields,

--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -1276,12 +1276,6 @@ def ProcessorFeatures {
   list<SubtargetFeature> Generic = [FeatureFPARMv8, FeatureNEON, FeatureETE];
 }
 
-// Define an alternative name for a given Processor.
-class ProcessorAlias<string n, string alias> {
-  string Name = n;
-  string Alias = alias;
-}
-
 // A note on scheduling models - we do not have exact models for each core and
 // attempt to use the "best equivalent" that we have for those that are
 // missing. -mcpu=generic uses a cortex-a510 model to get good scheduling

--- a/llvm/lib/Target/AMDGPU/GCNProcessors.td
+++ b/llvm/lib/Target/AMDGPU/GCNProcessors.td
@@ -24,33 +24,21 @@ def : ProcessorModel<"gfx600", SIFullSpeedModel,
   FeatureISAVersion6_0_0.Features
 >;
 
-def : ProcessorModel<"tahiti", SIFullSpeedModel,
-  FeatureISAVersion6_0_0.Features
->;
+def : ProcessorAlias<"tahiti", "gfx600">;
 
 def : ProcessorModel<"gfx601", SIQuarterSpeedModel,
   FeatureISAVersion6_0_1.Features
 >;
 
-def : ProcessorModel<"pitcairn", SIQuarterSpeedModel,
-  FeatureISAVersion6_0_1.Features
->;
-
-def : ProcessorModel<"verde", SIQuarterSpeedModel,
-  FeatureISAVersion6_0_1.Features
->;
+def : ProcessorAlias<"pitcairn", "gfx601">;
+def : ProcessorAlias<"verde", "gfx601">;
 
 def : ProcessorModel<"gfx602", SIQuarterSpeedModel,
   FeatureISAVersion6_0_2.Features
 >;
 
-def : ProcessorModel<"hainan", SIQuarterSpeedModel,
-  FeatureISAVersion6_0_2.Features
->;
-
-def : ProcessorModel<"oland", SIQuarterSpeedModel,
-  FeatureISAVersion6_0_2.Features
->;
+def : ProcessorAlias<"hainan", "gfx602">;
+def : ProcessorAlias<"oland", "gfx602">;
 
 //===------------------------------------------------------------===//
 // GCN GFX7 (Sea Islands (CI)).
@@ -60,17 +48,13 @@ def : ProcessorModel<"gfx700", SIQuarterSpeedModel,
   FeatureISAVersion7_0_0.Features
 >;
 
-def : ProcessorModel<"kaveri", SIQuarterSpeedModel,
-  FeatureISAVersion7_0_0.Features
->;
+def : ProcessorAlias<"kaveri", "gfx700">;
 
 def : ProcessorModel<"gfx701", SIFullSpeedModel,
   FeatureISAVersion7_0_1.Features
 >;
 
-def : ProcessorModel<"hawaii", SIFullSpeedModel,
-  FeatureISAVersion7_0_1.Features
->;
+def : ProcessorAlias<"hawaii", "gfx701">;
 
 def : ProcessorModel<"gfx702", SIQuarterSpeedModel,
   FeatureISAVersion7_0_2.Features
@@ -80,21 +64,14 @@ def : ProcessorModel<"gfx703", SIQuarterSpeedModel,
   FeatureISAVersion7_0_3.Features
 >;
 
-def : ProcessorModel<"kabini", SIQuarterSpeedModel,
-  FeatureISAVersion7_0_3.Features
->;
-
-def : ProcessorModel<"mullins", SIQuarterSpeedModel,
-  FeatureISAVersion7_0_3.Features
->;
+def : ProcessorAlias<"kabini", "gfx703">;
+def : ProcessorAlias<"mullins", "gfx703">;
 
 def : ProcessorModel<"gfx704", SIQuarterSpeedModel,
   FeatureISAVersion7_0_4.Features
 >;
 
-def : ProcessorModel<"bonaire", SIQuarterSpeedModel,
-  FeatureISAVersion7_0_4.Features
->;
+def : ProcessorAlias<"bonaire", "gfx704">;
 
 def : ProcessorModel<"gfx705", SIQuarterSpeedModel,
   FeatureISAVersion7_0_5.Features
@@ -108,53 +85,34 @@ def : ProcessorModel<"gfx801", SIQuarterSpeedModel,
   FeatureISAVersion8_0_1.Features
 >;
 
-def : ProcessorModel<"carrizo", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_1.Features
->;
+def : ProcessorAlias<"carrizo", "gfx801">;
 
 def : ProcessorModel<"gfx802", SIQuarterSpeedModel,
   FeatureISAVersion8_0_2.Features
 >;
 
-def : ProcessorModel<"iceland", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_2.Features
->;
-
-def : ProcessorModel<"tonga", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_2.Features
->;
+def : ProcessorAlias<"iceland", "gfx802">;
+def : ProcessorAlias<"tonga", "gfx802">;
 
 def : ProcessorModel<"gfx803", SIQuarterSpeedModel,
   FeatureISAVersion8_0_3.Features
 >;
 
-def : ProcessorModel<"fiji", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_3.Features
->;
-
-def : ProcessorModel<"polaris10", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_3.Features
->;
-
-def : ProcessorModel<"polaris11", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_3.Features
->;
+def : ProcessorAlias<"fiji", "gfx803">;
+def : ProcessorAlias<"polaris10", "gfx803">;
+def : ProcessorAlias<"polaris11", "gfx803">;
 
 def : ProcessorModel<"gfx805", SIQuarterSpeedModel,
   FeatureISAVersion8_0_5.Features
 >;
 
-def : ProcessorModel<"tongapro", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_5.Features
->;
+def : ProcessorAlias<"tongapro", "gfx805">;
 
 def : ProcessorModel<"gfx810", SIQuarterSpeedModel,
   FeatureISAVersion8_1_0.Features
 >;
 
-def : ProcessorModel<"stoney", SIQuarterSpeedModel,
-  FeatureISAVersion8_1_0.Features
->;
+def : ProcessorAlias<"stoney", "gfx810">;
 
 //===------------------------------------------------------------===//
 // GCN GFX9.

--- a/llvm/test/TableGen/ProcessorAlias.td
+++ b/llvm/test/TableGen/ProcessorAlias.td
@@ -1,0 +1,24 @@
+// RUN: llvm-tblgen -gen-subtarget -I %p/../../include %s 2>&1 | FileCheck %s
+// Verify that ProcessorAlias entries are emitted into the CPU subtype table
+// alongside real processors, resolving to their canonical processor's
+// features and scheduling model, and that the table stays sorted by key.
+
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+def FeatureA : SubtargetFeature<"feature-a", "HasA", "true", "">;
+
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, [FeatureA]>;
+def ProcB : ProcessorModel<"cpu-b", NoSchedModel, []>;
+
+// An alias resolves to an existing processor and is emitted as its own entry.
+def : ProcessorAlias<"alias-of-a", "cpu-a">;
+
+// The subtype table has 3 entries (2 processors + 1 alias) sorted by key:
+// alias-of-a, cpu-a, cpu-b. The alias carries cpu-a's feature mask (bit 0 set).
+// CHECK: extern const llvm::SubtargetSubTypeKVStorage< 3,
+// CHECK:      { sizeof(SubtargetSubTypeKV) * 3 + {{[0-9]+}}, { { { 0x1ULL,{{.*}} }, {{.*}}, 0 },
+// CHECK-NEXT: { sizeof(SubtargetSubTypeKV) * 2 + {{[0-9]+}}, { { { 0x1ULL,{{.*}} }, {{.*}}, 0 },
+// CHECK-NEXT: { sizeof(SubtargetSubTypeKV) * 1 + {{[0-9]+}}, { { { 0x0ULL,{{.*}} }, {{.*}}, 0 },
+// CHECK: "\000alias-of-a\000cpu-a\000cpu-b\000"

--- a/llvm/test/TableGen/ProcessorAliasErrors.td
+++ b/llvm/test/TableGen/ProcessorAliasErrors.td
@@ -1,0 +1,34 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %t/non-existent.td 2>&1 \
+// RUN:   | FileCheck %t/non-existent.td -DFILE=%t/non-existent.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %t/dup-processor.td 2>&1 \
+// RUN:   | FileCheck %t/dup-processor.td -DFILE=%t/dup-processor.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %t/dup-alias.td 2>&1 \
+// RUN:   | FileCheck %t/dup-alias.td -DFILE=%t/dup-alias.td --implicit-check-not="error:"
+
+// Verify the ProcessorAlias validation performed by the subtarget emitter.
+
+//--- non-existent.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, []>;
+// An alias must resolve to an existing processor.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: Alias 'bad-alias' references a non-existent Processor 'cpu-missing'
+def : ProcessorAlias<"bad-alias", "cpu-missing">;
+
+//--- dup-processor.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, []>;
+// An alias name must not collide with a real processor.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: Alias 'cpu-a' duplicates an existing Processor
+def : ProcessorAlias<"cpu-a", "cpu-a">;
+
+//--- dup-alias.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, []>;
+def DupA : ProcessorAlias<"dup", "cpu-a">;
+// Two aliases must not share the same name.
+// CHECK: [[FILE]]:[[#@LINE+1]]:5: error: Alias 'dup' duplicates an existing alias
+def DupB : ProcessorAlias<"dup", "cpu-a">;

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -286,24 +286,44 @@ static void checkDuplicateCPUFeatures(StringRef CPUName,
 std::pair<unsigned, unsigned>
 SubtargetEmitter::cpuKeyValues(raw_ostream &OS,
                                const FeatureMapTy &FeatureMap) {
-  // Gather and sort processor information
   std::vector<const Record *> ProcessorList =
       Records.getAllDerivedDefinitions("Processor");
-  llvm::sort(ProcessorList, LessRecordFieldName());
 
-  // In the string table, include the aliases as well.
+  StringMap<const Record *> ProcessorMap;
+  for (const Record *Processor : ProcessorList)
+    ProcessorMap[Processor->getValueAsString("Name")] = Processor;
+
+  // Maps each emitted CPU name (processor or alias) to the processor record it
+  // resolves to. Keying by name detects duplicates on insertion.
+  StringMap<const Record *> SubTypeEntries;
+  for (const Record *Processor : ProcessorList)
+    SubTypeEntries[Processor->getValueAsString("Name")] = Processor;
+
   std::vector<const Record *> ProcessorAliasList =
       Records.getAllDerivedDefinitionsIfDefined("ProcessorAlias");
-  SmallVector<StringRef> Names;
-  Names.reserve(ProcessorList.size() + ProcessorAliasList.size());
-  for (const Record *Processor : ProcessorList)
-    Names.push_back(Processor->getValueAsString("Name"));
-  for (const Record *Rec : ProcessorAliasList)
-    Names.push_back(Rec->getValueAsString("Name"));
-  llvm::sort(Names);
+  for (const Record *Rec : ProcessorAliasList) {
+    StringRef Name = Rec->getValueAsString("Name");
+    StringRef Alias = Rec->getValueAsString("Alias");
+    auto It = ProcessorMap.find(Alias);
+    if (It == ProcessorMap.end())
+      PrintFatalError(Rec, "Alias '" + Name +
+                               "' references a non-existent Processor '" +
+                               Alias + "'");
+    if (!SubTypeEntries.try_emplace(Name, It->second).second)
+      PrintFatalError(
+          Rec, "Alias '" + Name + "' duplicates an existing " +
+                   (ProcessorMap.contains(Name) ? "Processor" : "alias"));
+  }
+
+  // The table must stay sorted by key for the binary search in the lookups.
+  std::vector<std::pair<StringRef, const Record *>> SortedEntries;
+  SortedEntries.reserve(SubTypeEntries.size());
+  for (const auto &Entry : SubTypeEntries)
+    SortedEntries.emplace_back(Entry.getKey(), Entry.getValue());
+  llvm::sort(SortedEntries, llvm::less_first());
 
   StringToOffsetTable StrTab;
-  for (StringRef Name : Names)
+  for (const auto &[Name, Proc] : SortedEntries)
     StrTab.GetOrAddStringOffset(Name);
 
   // Note that unlike `FeatureKeyValues`, here we do not need to check for
@@ -311,24 +331,25 @@ SubtargetEmitter::cpuKeyValues(raw_ostream &OS,
   // constructor calls `getSchedModels` to build a `CodeGenSchedModels` object,
   // which does the duplicate processor check.
 
+  unsigned Total = SortedEntries.size();
+
   // Begin processor table.
   OS << "// Sorted (by key) array of values for CPU subtype.\n"
-     << "extern const llvm::SubtargetSubTypeKVStorage< " << ProcessorList.size()
-     << ", " << (StrTab.size() + 1) << "> " << Target
-     << "SubTypeKVStorage = {\n  {\n";
+     << "extern const llvm::SubtargetSubTypeKVStorage< " << Total << ", "
+     << (StrTab.size() + 1) << "> " << Target << "SubTypeKVStorage = {\n  {\n";
 
-  for (const auto &[Idx, Processor] : enumerate(ProcessorList)) {
-    StringRef Name = Processor->getValueAsString("Name");
+  for (const auto &[Idx, Entry] : enumerate(SortedEntries)) {
+    const auto &[Name, Processor] = Entry;
     ConstRecVec FeatureList = Processor->getValueAsListOfDefs("Features");
     ConstRecVec TuneFeatureList =
         Processor->getValueAsListOfDefs("TuneFeatures");
 
-    // Warn the user if there are duplicate processor features or tune
-    // features.
-    checkDuplicateCPUFeatures(Name, FeatureList, TuneFeatureList);
+    // Aliases share the canonical processor's already-checked feature lists.
+    if (Name == Processor->getValueAsString("Name"))
+      checkDuplicateCPUFeatures(Name, FeatureList, TuneFeatureList);
 
-    OS << "   { sizeof(SubtargetSubTypeKV) * " << (ProcessorList.size() - Idx)
-       << " + " << StrTab.GetOrAddStringOffset(Name) << ", ";
+    OS << "   { sizeof(SubtargetSubTypeKV) * " << (Total - Idx) << " + "
+       << StrTab.GetOrAddStringOffset(Name) << ", ";
 
     printFeatureMask(OS, FeatureList, FeatureMap);
     OS << ", ";
@@ -344,7 +365,7 @@ SubtargetEmitter::cpuKeyValues(raw_ostream &OS,
   // End processor table.
   OS << "};\n";
 
-  return {ProcessorList.size(), StrTab.size() + 1};
+  return {Total, StrTab.size() + 1};
 }
 
 //
@@ -1990,10 +2011,6 @@ void SubtargetEmitter::parseFeaturesFunction(raw_ostream &OS) {
     return;
   }
 
-  if (Target == "AArch64")
-    OS << "  CPU = AArch64::resolveCPUAlias(CPU);\n"
-       << "  TuneCPU = AArch64::resolveCPUAlias(TuneCPU);\n";
-
   OS << "  InitMCProcessorInfo(CPU, TuneCPU, FS);\n"
      << "  const FeatureBitset &Bits = getFeatureBits();\n";
 
@@ -2068,11 +2085,6 @@ void SubtargetEmitter::emitGenMCSubtargetInfo(raw_ostream &OS) {
     OS << "  unsigned getHwMode(enum HwModeType type = HwMode_Default) const "
           "final;\n";
   }
-  if (Target == "AArch64")
-    OS << "  bool isCPUStringValid(StringRef CPU) const final {\n"
-       << "    CPU = AArch64::resolveCPUAlias(CPU);\n"
-       << "    return MCSubtargetInfo::isCPUStringValid(CPU);\n"
-       << "  }\n";
   OS << "};\n";
   emitHwModeCheck(Target + "GenMCSubtargetInfo", OS, /*IsMC=*/true);
 }
@@ -2105,8 +2117,6 @@ FeatureMapTy SubtargetEmitter::emitEnums(raw_ostream &OS) {
 SubtargetEmitter::MCDescInfo
 SubtargetEmitter::emitMCDesc(raw_ostream &OS, const FeatureMapTy &FeatureMap) {
   IfDefEmitter IfDef(OS, "GET_SUBTARGETINFO_MC_DESC");
-  if (Target == "AArch64")
-    OS << "#include \"llvm/TargetParser/AArch64TargetParser.h\"\n\n";
   NamespaceEmitter LlvmNS(OS, "llvm");
 
   MCDescInfo Res;
@@ -2127,9 +2137,6 @@ SubtargetEmitter::emitMCDesc(raw_ostream &OS, const FeatureMapTy &FeatureMap) {
   OS << "\nstatic inline MCSubtargetInfo *create" << Target
      << "MCSubtargetInfoImpl("
      << "const Triple &TT, StringRef CPU, StringRef TuneCPU, StringRef FS) {\n";
-  if (Target == "AArch64")
-    OS << "  CPU = AArch64::resolveCPUAlias(CPU);\n"
-       << "  TuneCPU = AArch64::resolveCPUAlias(TuneCPU);\n";
   OS << "  return new " << Target
      << "GenMCSubtargetInfo(TT, CPU, TuneCPU, FS, ";
   OS << "StringTable(" << Target << "SubTypeKVStorage.Strings), ";
@@ -2163,8 +2170,6 @@ void SubtargetEmitter::emitTargetDesc(raw_ostream &OS) {
   OS << "#include \"llvm/ADT/BitmaskEnum.h\"\n";
   OS << "#include \"llvm/Support/Debug.h\"\n";
   OS << "#include \"llvm/Support/raw_ostream.h\"\n\n";
-  if (Target == "AArch64")
-    OS << "#include \"llvm/TargetParser/AArch64TargetParser.h\"\n\n";
   parseFeaturesFunction(OS);
 }
 
@@ -2264,11 +2269,7 @@ void SubtargetEmitter::emitCtor(raw_ostream &OS, MCDescInfo DescInfo) {
   OS << ClassName << "::" << ClassName << "(const Triple &TT, StringRef CPU, "
      << "StringRef TuneCPU, StringRef FS)\n";
 
-  if (Target == "AArch64")
-    OS << "  : TargetSubtargetInfo(TT, AArch64::resolveCPUAlias(CPU),\n"
-       << "                        AArch64::resolveCPUAlias(TuneCPU), FS, ";
-  else
-    OS << "  : TargetSubtargetInfo(TT, CPU, TuneCPU, FS, ";
+  OS << "  : TargetSubtargetInfo(TT, CPU, TuneCPU, FS, ";
   OS << "StringTable(" << Target << "SubTypeKVStorage.Strings), ";
   if (DescInfo.NumFeatures)
     OS << "ArrayRef(" << Target << "FeatureKVStorage.Features), ";


### PR DESCRIPTION
Older targets have aliasing names which were previously implemented
by defining a second copy of the processor, identical except for the name
Use the recently improved tablegen mechanism for defining name-only aliases.
This dedupliates some redundant table entries, like the sched model.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>