### PR TITLE
[AArch64] Remove unused GPR32arg register class (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -249,7 +249,6 @@ def GPR64z : RegisterOperand<GPR64> {
 }
 
 // GPR argument registers.
-def GPR32arg : RegisterClass<"AArch64", [i32], 32, (sequence "W%u", 0, 7)>;
 def GPR64arg : RegisterClass<"AArch64", [i64], 64, (sequence "X%u", 0, 7)>;
 
 // GPR register classes which include WZR/XZR AND SP/WSP. This is not a

--- a/llvm/test/TableGen/aarch64-register-info-stats.td
+++ b/llvm/test/TableGen/aarch64-register-info-stats.td
@@ -13,6 +13,6 @@ def TestTarget : Target {
   let InstructionSet = TestInstrInfo;
 }
 
-// CHECK-DAG: 83 register-info-emitter - Number of explicit register classes
-// CHECK-DAG: 447 register-info-emitter - Number of synthesized register classes
+// CHECK-DAG: 82 register-info-emitter - Number of explicit register classes
+// CHECK-DAG: 446 register-info-emitter - Number of synthesized register classes
 // CHECK-DAG: 189 register-info-emitter - Number of register pressure sets


### PR DESCRIPTION
GPR32arg was added alongside GPR64arg in fcbec02ea6fb, but has no users outside the register info generated by TableGen.

Assisted-by: codex