### PR TITLE
[SystemZ][z/OS] Add the OF_Text flag to read .ll files and parse assembly files

### DIFF
--- a/llvm/lib/AsmParser/Parser.cpp
+++ b/llvm/lib/AsmParser/Parser.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<Module> llvm::parseAssemblyFile(StringRef Filename,
                                                 LLVMContext &Context,
                                                 SlotMapping *Slots) {
   ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
-      MemoryBuffer::getFileOrSTDIN(Filename);
+      MemoryBuffer::getFileOrSTDIN(Filename, /*IsText=*/true);
   if (std::error_code EC = FileOrErr.getError()) {
     Err = SMDiagnostic(Filename, SourceMgr::DK_Error,
                        "Could not open input file: " + EC.message());

--- a/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
+++ b/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
@@ -73,7 +73,7 @@ namespace {
 struct TempFile {
   std::string Filename;
   FileRemover Remover;
-  bool init(const std::string &Ext, bool IsText);
+  bool init(const std::string &Ext, bool IsText = false);
   bool writeBitcode(const Module &M) const;
   bool writeAssembly(const Module &M) const;
   std::unique_ptr<Module> readBitcode(LLVMContext &Context) const;
@@ -106,7 +106,7 @@ struct ValueMapping {
 
 } // end namespace
 
-bool TempFile::init(const std::string &Ext, bool IsText = false) {
+bool TempFile::init(const std::string &Ext, bool IsText) {
   SmallVector<char, 64> Vector;
   LLVM_DEBUG(dbgs() << " - create-temp-file\n");
   if (auto EC = sys::fs::createTemporaryFile("uselistorder", Ext, Vector,

--- a/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
+++ b/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
@@ -73,7 +73,7 @@ namespace {
 struct TempFile {
   std::string Filename;
   FileRemover Remover;
-  bool init(const std::string &Ext);
+  bool init(const std::string &Ext, bool IsText);
   bool writeBitcode(const Module &M) const;
   bool writeAssembly(const Module &M) const;
   std::unique_ptr<Module> readBitcode(LLVMContext &Context) const;
@@ -106,10 +106,12 @@ struct ValueMapping {
 
 } // end namespace
 
-bool TempFile::init(const std::string &Ext) {
+bool TempFile::init(const std::string &Ext, bool IsText = false) {
   SmallVector<char, 64> Vector;
   LLVM_DEBUG(dbgs() << " - create-temp-file\n");
-  if (auto EC = sys::fs::createTemporaryFile("uselistorder", Ext, Vector)) {
+  if (auto EC = sys::fs::createTemporaryFile("uselistorder", Ext, Vector,
+                                             IsText ? sys::fs::OF_Text
+                                                    : sys::fs::OF_None)) {
     errs() << "verify-uselistorder: error: " << EC.message() << "\n";
     return true;
   }
@@ -367,7 +369,7 @@ static void verifyAfterRoundTrip(const Module &M,
 
 static void verifyBitcodeUseListOrder(const Module &M) {
   TempFile F;
-  if (F.init("bc"))
+  if (F.init("bc", /*IsText=*/false))
     report_fatal_error("failed to initialize bitcode file");
 
   if (F.writeBitcode(M))
@@ -379,7 +381,7 @@ static void verifyBitcodeUseListOrder(const Module &M) {
 
 static void verifyAssemblyUseListOrder(const Module &M) {
   TempFile F;
-  if (F.init("ll"))
+  if (F.init("ll", /*IsText=*/true))
     report_fatal_error("failed to initialize assembly file");
 
   if (F.writeAssembly(M))


### PR DESCRIPTION
This patch allows us to parse .ll files in verify-uselistorder correctly and fixes failures in any testcase that uses this tool.