### PR TITLE
[libc++][CI] TEMP: investigate macOS LNT install failure (DO NOT MERGE)

### DIFF
--- a/.github/workflows/libcxx-investigate-lnt.yml
+++ b/.github/workflows/libcxx-investigate-lnt.yml
@@ -1,0 +1,80 @@
+# TEMPORARY — DO NOT MERGE.
+#
+# This workflow exists only to reproduce and investigate the LNT installation
+# failure seen on the macOS self-hosted benchmark runners:
+#
+#   https://github.com/llvm/llvm-project/actions/runs/30092892111/job/89479960018
+#
+# The benchmark job installs `python@3.14` via Homebrew and prepends
+# `$(brew --prefix python@3.14)/libexec/bin` to the PATH. That directory only
+# provides *unversioned* `python`/`pip` symlinks -- it has no `python3`. So a
+# `python3` invocation (used by run-benchmarks to create the venv) still
+# resolves to Apple's `/usr/bin/python3` (3.9.6), and `pip install llvm-lnt`
+# then fails because every llvm-lnt release requires Python >= 3.10.
+#
+# This job mirrors the benchmark setup, dumps the relevant diagnostics, then
+# reproduces the failure and validates a candidate fix on the same runners.
+
+name: Investigate LNT install failure (macOS)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/libcxx-investigate-lnt.yml'
+
+jobs:
+  investigate:
+    runs-on: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+    steps:
+      - name: Install python@3.14 via Homebrew (same as the benchmark job)
+        run: |
+          brew update
+          brew install python@3.14
+          echo "$(brew --prefix python@3.14)/libexec/bin" >> "$GITHUB_PATH"
+
+      - name: Diagnose which python3 / pip3 are actually on PATH
+        run: |
+          echo "PATH=${PATH}"
+          echo "--- which -a python3 python pip3 pip ---"
+          which -a python3 python pip3 pip || true
+          echo "--- versions ---"
+          echo "python3 -> $(command -v python3): $(python3 --version 2>&1)"
+          echo "python  -> $(command -v python)  : $(python  --version 2>&1)"
+          prefix="$(brew --prefix python@3.14)"
+          echo "--- brew --prefix python@3.14 = ${prefix} ---"
+          echo "libexec/bin (this is what we add to PATH -- note: no python3):"
+          ls -l "${prefix}/libexec/bin"
+          echo "bin (this one DOES contain python3/pip3):"
+          ls -l "${prefix}/bin"
+
+      - name: Reproduce the failure -- venv via 'python3' + pip install llvm-lnt
+        run: |
+          set -x
+          venv="$(mktemp -d)/venv"
+          python3 -m venv "${venv}"
+          "${venv}/bin/python" --version
+          "${venv}/bin/pip" --version
+          # This is the exact command that fails in the benchmark job. We expect
+          # it to fail here too; capture the status instead of aborting the job
+          # so the candidate-fix step below still runs.
+          if "${venv}/bin/pip" install llvm-lnt; then
+            echo "::warning::UNEXPECTED: 'pip install llvm-lnt' succeeded with python3"
+          else
+            echo "::notice::REPRODUCED: 'pip install llvm-lnt' failed with python3 (Apple 3.9.6), as in CI"
+          fi
+
+      - name: Candidate fix -- venv via 'python3.14' + pip install llvm-lnt
+        run: |
+          set -x
+          venv="$(mktemp -d)/venv"
+          python3.14 -m venv "${venv}"
+          "${venv}/bin/python" --version
+          "${venv}/bin/pip" install llvm-lnt
+          "${venv}/bin/lnt" --help | head -n 5
+          echo "::notice::FIX CONFIRMED: 'pip install llvm-lnt' works when the venv uses python3.14"

--- a/.github/workflows/libcxx-investigate-lnt.yml
+++ b/.github/workflows/libcxx-investigate-lnt.yml
@@ -1,19 +1,20 @@
 # TEMPORARY — DO NOT MERGE.
 #
-# This workflow exists only to reproduce and investigate the LNT installation
-# failure seen on the macOS self-hosted benchmark runners:
+# This workflow reproduces the macOS benchmark job end-to-end in order to
+# investigate (and validate the fix for) the LNT installation failure seen at:
 #
 #   https://github.com/llvm/llvm-project/actions/runs/30092892111/job/89479960018
 #
-# The benchmark job installs `python@3.14` via Homebrew and prepends
-# `$(brew --prefix python@3.14)/libexec/bin` to the PATH. That directory only
-# provides *unversioned* `python`/`pip` symlinks -- it has no `python3`. So a
-# `python3` invocation (used by run-benchmarks to create the venv) still
-# resolves to Apple's `/usr/bin/python3` (3.9.6), and `pip install llvm-lnt`
-# then fails because every llvm-lnt release requires Python >= 3.10.
+# It mirrors the macOS matrix entry of libcxx-benchmark-commit.yml as closely as
+# possible -- same runner, Xcode, Homebrew deps, and the same `run-benchmarks`
+# invocation -- but scoped to a single quick benchmark (hash.bench.cpp) so the
+# whole flow runs fast.
 #
-# This job mirrors the benchmark setup, dumps the relevant diagnostics, then
-# reproduces the failure and validates a candidate fix on the same runners.
+# The one intentional difference is the fix under test: we add
+# `$(brew --prefix python@3.14)/bin` to PATH (it contains a real `python3`)
+# instead of `.../libexec/bin` (which only has unversioned `python`/`pip`, so a
+# bare `python3` fell through to Apple's 3.9.6 and llvm-lnt -- which needs
+# Python >= 3.10 -- could not be installed).
 
 name: Investigate LNT install failure (macOS)
 
@@ -27,54 +28,51 @@ on:
       - '.github/workflows/libcxx-investigate-lnt.yml'
 
 jobs:
-  investigate:
+  run-benchmarks:
     runs-on: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
     env:
+      COMPILER: clang++
       DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+      # Pinned to the same commit the failing job benchmarked.
+      COMMIT: 62b809a37aac6cf2f64e99e9efba89dd8731920d
+      BENCHMARK_SUITE_VERSION: 62b809a37aac6cf2f64e99e9efba89dd8731920d
+      FILTER: hash.bench.cpp
     steps:
-      - name: Install python@3.14 via Homebrew (same as the benchmark job)
+      - name: Checkout the LLVM monorepo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # We benchmark arbitrary historical commits, which requires the full history to be available.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install dependencies via Homebrew
         run: |
           brew update
-          brew install python@3.14
-          echo "$(brew --prefix python@3.14)/libexec/bin" >> "$GITHUB_PATH"
+          brew install ninja cmake python@3.14
+          # FIX under test: use the dir that provides a real `python3`/`pip3`,
+          # not libexec/bin (which only has unversioned python/pip).
+          echo "$(brew --prefix python@3.14)/bin" >> "$GITHUB_PATH"
 
-      - name: Diagnose which python3 / pip3 are actually on PATH
+      - name: Diagnose tools in use
         run: |
-          echo "PATH=${PATH}"
-          echo "--- which -a python3 python pip3 pip ---"
-          which -a python3 python pip3 pip || true
-          echo "--- versions ---"
+          cmake --version
+          ninja --version
+          "${COMPILER}" --version
           echo "python3 -> $(command -v python3): $(python3 --version 2>&1)"
-          echo "python  -> $(command -v python)  : $(python  --version 2>&1)"
-          prefix="$(brew --prefix python@3.14)"
-          echo "--- brew --prefix python@3.14 = ${prefix} ---"
-          echo "libexec/bin (this is what we add to PATH -- note: no python3):"
-          ls -l "${prefix}/libexec/bin"
-          echo "bin (this one DOES contain python3/pip3):"
-          ls -l "${prefix}/bin"
 
-      - name: Reproduce the failure -- venv via 'python3' + pip install llvm-lnt
+      - name: Run the benchmarks
         run: |
-          set -x
-          venv="$(mktemp -d)/venv"
-          python3 -m venv "${venv}"
-          "${venv}/bin/python" --version
-          "${venv}/bin/pip" --version
-          # This is the exact command that fails in the benchmark job. We expect
-          # it to fail here too; capture the status instead of aborting the job
-          # so the candidate-fix step below still runs.
-          if "${venv}/bin/pip" install llvm-lnt; then
-            echo "::warning::UNEXPECTED: 'pip install llvm-lnt' succeeded with python3"
-          else
-            echo "::notice::REPRODUCED: 'pip install llvm-lnt' failed with python3 (Apple 3.9.6), as in CI"
+          filter_arg=()
+          if [ -n "${FILTER}" ]; then
+            filter_arg=(--filter "${FILTER}")
           fi
+          libcxx/utils/ci/lnt/run-benchmarks                            \
+            --test-suite-commit "${BENCHMARK_SUITE_VERSION}"            \
+            --machine macos-26.5-arm64                                  \
+            --compiler "${COMPILER}"                                    \
+            --benchmark-commit "${COMMIT}"                              \
+            "${filter_arg[@]}"                                          \
+            --output "${COMMIT}.json"
 
-      - name: Candidate fix -- venv via 'python3.14' + pip install llvm-lnt
-        run: |
-          set -x
-          venv="$(mktemp -d)/venv"
-          python3.14 -m venv "${venv}"
-          "${venv}/bin/python" --version
-          "${venv}/bin/pip" install llvm-lnt
-          "${venv}/bin/lnt" --help | head -n 5
-          echo "::notice::FIX CONFIRMED: 'pip install llvm-lnt' works when the venv uses python3.14"
+          cat "${COMMIT}.json"

--- a/.github/workflows/libcxx-investigate-lnt.yml
+++ b/.github/workflows/libcxx-investigate-lnt.yml
@@ -15,6 +15,11 @@
 # instead of `.../libexec/bin` (which only has unversioned `python`/`pip`, so a
 # bare `python3` fell through to Apple's 3.9.6 and llvm-lnt -- which needs
 # Python >= 3.10 -- could not be installed).
+#
+# It also attempts the "Submit to LNT" step against production lnt.llvm.org.
+# This is expected to fail for now because the target test suite has not been
+# created on the server yet; the point is to observe what that failure looks
+# like on the runner.
 
 name: Investigate LNT install failure (macOS)
 
@@ -76,3 +81,12 @@ jobs:
             --output "${COMMIT}.json"
 
           cat "${COMMIT}.json"
+
+      - name: Submit to LNT
+        env:
+          LNT_URL: http://lnt.llvm.org
+        run: |
+          libcxx/utils/ci/lnt/submit-benchmarks             \
+            --lnt-url "${LNT_URL}"                          \
+            --test-suite libcxx2                            \
+            "${COMMIT}.json"


### PR DESCRIPTION
Reproduces and diagnoses the LNT installation failure on the macOS self-hosted benchmark runners:
https://github.com/llvm/llvm-project/actions/runs/30092892111/job/89479960018