### PR TITLE
[libc++][WIP] use linear search instead of binary search for small flat_map

### DIFF
--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -15,6 +15,7 @@
 #include <__algorithm/min.h>
 #include <__algorithm/ranges_adjacent_find.h>
 #include <__algorithm/ranges_equal.h>
+#include <__algorithm/ranges_find.h>
 #include <__algorithm/ranges_inplace_merge.h>
 #include <__algorithm/ranges_sort.h>
 #include <__algorithm/ranges_unique.h>
@@ -64,6 +65,7 @@
 #include <__vector/vector.h>
 #include <initializer_list>
 #include <stdexcept>
+#include <type_traits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -989,6 +991,12 @@ private:
 
   template <class _Self, class _Kp>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 static auto __find_impl(_Self&& __self, const _Kp& __key) {
+    auto __key_iter = std::ranges::find(__self.__containers_.keys, __key);
+    auto __mapped_iter = __corresponding_mapped_it(__self, __key_iter);
+
+    using Res = std::conditional_t<std::is_const_v<std::remove_reference_t<_Self>>, const_iterator, iterator>;
+    return Res(__key_iter, __mapped_iter);
+
     auto __it   = __self.lower_bound(__key);
     auto __last = __self.end();
     if (__it == __last || __self.__compare_(__key, __it->first)) {

--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -66,7 +66,7 @@ void associative_container_benchmarks(std::string container) {
     benchmark::RegisterBenchmark(container + "::" + operation, f)->Arg(0)->Arg(32)->Arg(1024)->Arg(8192);
   };
   auto bench_non_empty = [&](std::string operation, auto f) {
-    benchmark::RegisterBenchmark(container + "::" + operation, f)->Arg(32)->Arg(1024)->Arg(8192);
+    benchmark::RegisterBenchmark(container + "::" + operation, f)->Arg(1)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(1024)->Arg(8192);
   };
 
   static constexpr bool is_multi_key_container =
@@ -692,9 +692,17 @@ void associative_container_benchmarks(std::string container) {
       const std::size_t size = st.range(0);
       std::vector<Value> in  = make_value_types(generate_unique_keys(size));
       Container c(in.begin(), in.end());
+      std::vector<Key> keys;
+      for(size_t i = 0; i <in.size(); ++i) {
+        keys.push_back(get_key(in[getRandomEngine()() % in.size()]));
+      }
+      size_t i = 0;
 
       for (auto _ : st) {
-        auto result = func(c, get_key(in[getRandomEngine()() % in.size()]));
+      //st.PauseTiming();
+      const auto& key =  keys[++i%keys.size()];
+      //st.ResumeTiming();
+        auto result = func(c, key);
         benchmark::DoNotOptimize(c);
         benchmark::DoNotOptimize(result);
         benchmark::ClobberMemory();


### PR DESCRIPTION
Due to much less branch mis-predictions, the linear search perform better than binary search for small flat_map::find operation. Perhaps worth exploring this idea?

In addition, I noticed that in our benchmark, in additional to function under test, we are also measuring the operation "value-to-key", and the operation generating random numbers, which might dominant the benchmark itself.




main (binary search)
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
std::flat_map<int, int>::find(key)/1          1.11 ns         1.11 ns    628151977
std::flat_map<int, int>::find(key)/2          1.55 ns         1.55 ns    419749829
std::flat_map<int, int>::find(key)/4          2.03 ns         2.03 ns    347737965
std::flat_map<int, int>::find(key)/8          2.54 ns         2.53 ns    279486862
std::flat_map<int, int>::find(key)/12         3.10 ns         3.10 ns    237844450
std::flat_map<int, int>::find(key)/16         3.14 ns         3.14 ns    221879893
std::flat_map<int, int>::find(key)/32         4.36 ns         4.35 ns    163135939
std::flat_map<int, int>::find(key)/1024       8.80 ns         8.80 ns     80127288
std::flat_map<int, int>::find(key)/8192       12.2 ns         12.2 ns     57552537
```

my branch (linear search)
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
std::flat_map<int, int>::find(key)/1          1.07 ns         1.07 ns    622870007
std::flat_map<int, int>::find(key)/2          1.47 ns         1.46 ns    508126393
std::flat_map<int, int>::find(key)/4          1.82 ns         1.82 ns    409380666
std::flat_map<int, int>::find(key)/8          2.19 ns         2.18 ns    336228097
std::flat_map<int, int>::find(key)/12         3.15 ns         3.15 ns    220546072
std::flat_map<int, int>::find(key)/16         4.11 ns         4.11 ns    184869733
std::flat_map<int, int>::find(key)/32         4.64 ns         4.64 ns    129644035
std::flat_map<int, int>::find(key)/1024        127 ns          127 ns      5526389
std::flat_map<int, int>::find(key)/8192        933 ns          933 ns       760473
```