### PR TITLE
[llvm][ADT] Mark llvm::IntrusiveRefCntPtr with the warn_unused attribute

### DIFF
--- a/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
@@ -11,8 +11,6 @@
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/FileSystemOptions.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/Support/VirtualFileSystem.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -28,7 +26,6 @@ MATCHER_P(line, N, "") { return arg->Line == (unsigned)N; }
 TEST(RecordedIncludesTest, Match) {
   // We're using synthetic data, but need a FileManager to obtain FileEntry*s.
   // Ensure it doesn't do any actual IO.
-  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   FileManager FM(FileSystemOptions{});
   FileEntryRef A = FM.getVirtualFileRef("/path/a", /*Size=*/0, time_t{});
   FileEntryRef B = FM.getVirtualFileRef("/path/b", /*Size=*/0, time_t{});
@@ -48,7 +45,6 @@ TEST(RecordedIncludesTest, Match) {
 }
 
 TEST(RecordedIncludesTest, MatchVerbatim) {
-  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   FileManager FM(FileSystemOptions{});
   Includes Inc;
 
@@ -79,8 +75,6 @@ TEST(RecordedIncludesTest, MatchVerbatim) {
 }
 
 TEST(RecordedIncludesTest, MatchVerbatimMixedAbsoluteRelative) {
-  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
-  FS->setCurrentWorkingDirectory("/working");
   FileManager FM(FileSystemOptions{});
   Includes Inc;
 

--- a/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h
+++ b/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h
@@ -60,6 +60,7 @@
 #ifndef LLVM_ADT_INTRUSIVEREFCNTPTR_H
 #define LLVM_ADT_INTRUSIVEREFCNTPTR_H
 
+#include "llvm/Support/Compiler.h"
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -170,7 +171,7 @@ template <typename T> struct IntrusiveRefCntPtrInfo {
 /// This class increments its pointee's reference count when it is created, and
 /// decrements its refcount when it's destroyed (or is changed to point to a
 /// different object).
-template <typename T> class [[gnu::warn_unused]] IntrusiveRefCntPtr {
+template <typename T> class LLVM_ATTRIBUTE_WARN_UNUSED IntrusiveRefCntPtr {
   T *Obj = nullptr;
 
 public:

--- a/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h
+++ b/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h
@@ -170,7 +170,7 @@ template <typename T> struct IntrusiveRefCntPtrInfo {
 /// This class increments its pointee's reference count when it is created, and
 /// decrements its refcount when it's destroyed (or is changed to point to a
 /// different object).
-template <typename T> class IntrusiveRefCntPtr {
+template <typename T> class [[gnu::warn_unused]] IntrusiveRefCntPtr {
   T *Obj = nullptr;
 
 public:

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -239,7 +239,7 @@
 #endif
 
 #if __has_attribute(warn_unused)
-#define LLVM_ATTRIBUTE_WARN_UNUSED [[gnu::warn_unused]]
+#define LLVM_ATTRIBUTE_WARN_UNUSED __attribute__((warn_unused))
 #else
 #define LLVM_ATTRIBUTE_WARN_UNUSED
 #endif

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -238,6 +238,12 @@
 #define LLVM_ATTRIBUTE_USED
 #endif
 
+#if __has_attribute(warn_unused)
+#define LLVM_ATTRIBUTE_WARN_UNUSED [[gnu::warn_unused]]
+#else
+#define LLVM_ATTRIBUTE_WARN_UNUSED
+#endif
+
 // Only enabled for clang:
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587
 // GCC may produce "warning: 'retain' attribute ignored" (despite

--- a/llvm/unittests/ADT/IntrusiveRefCntPtrTest.cpp
+++ b/llvm/unittests/ADT/IntrusiveRefCntPtrTest.cpp
@@ -38,6 +38,8 @@ TYPED_TEST(IntrusiveRefCntPtrTest, RefCountedBaseCopyDoesNotLeak) {
     TypeParam *S2 = new TypeParam(*S1);
     IntrusiveRefCntPtr<TypeParam> R2 = S2;
     EXPECT_EQ(2, NumInstances);
+    (void)R1;
+    (void)R2;
   }
   EXPECT_EQ(0, NumInstances);
 }
@@ -49,6 +51,7 @@ TYPED_TEST(IntrusiveRefCntPtrTest, InteropsWithUniquePtr) {
     IntrusiveRefCntPtr<TypeParam> R1 = std::move(S1);
     EXPECT_EQ(1, NumInstances);
     EXPECT_EQ(S1, nullptr);
+    (void)R1;
   }
   EXPECT_EQ(0, NumInstances);
 }
@@ -91,6 +94,7 @@ TEST(IntrusiveRefCntPtr, UsesTraitsToRetainAndRelease) {
   {
     InterceptRefCounted *I = new InterceptRefCounted(&Released, &Retained);
     IntrusiveRefCntPtr<InterceptRefCounted> R = I;
+    (void)R;
   }
   EXPECT_TRUE(Released);
   EXPECT_TRUE(Retained);

--- a/llvm/unittests/Support/VirtualOutputBackendTest.cpp
+++ b/llvm/unittests/Support/VirtualOutputBackendTest.cpp
@@ -65,7 +65,7 @@ static Error createCustomError() {
 
 TEST(VirtualOutputBackendTest, construct) {
   MockOutputBackendData Data;
-  auto B = createMockBackend(Data);
+  [[maybe_unused]] auto B = createMockBackend(Data);
   EXPECT_EQ(0, Data.Cloned);
   EXPECT_EQ(0, Data.FilesCreated);
 }


### PR DESCRIPTION
IntrusiveRefCntPtr has non-trivial ctor/dtor, thus unused variables wouldn't trigger a warning by default. However, they should. https://clang.llvm.org/docs/AttributeReference.html#warn-unused

Let's mark the class with this attribute get warned about them.

This would have helped catching #211518 and #211517.
Supersedes #211647.