### PR TITLE
[SystemZ][z/OS] Add text flag when parsing json

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Core/Serialization/JSONFormat/JSONFormatImpl.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Core/Serialization/JSONFormat/JSONFormatImpl.cpp
@@ -55,7 +55,7 @@ llvm::Expected<Value> readJSON(llvm::StringRef Path) {
         .build();
   }
 
-  auto BufferOrError = llvm::MemoryBuffer::getFile(Path);
+  auto BufferOrError = llvm::MemoryBuffer::getFile(Path, /*IsText=*/true);
   if (!BufferOrError) {
     const std::error_code EC = BufferOrError.getError();
     return ErrorBuilder::create(EC, ErrorMessages::FailedToReadFile, Path,


### PR DESCRIPTION
This patch adds the text flag when we are opening json files to parse. 

This fixes the following two lit failures on z/OS

```
FAIL: Clang :: Analysis/Scalable/TypeConstrainedPointers/type-constrained-pointers.cpp
FAIL: Clang :: Analysis/Scalable/TypeConstrainedPointers/wpa-result-serialization.test
```