### PR TITLE
[lldb][test] Skip frame-recognizer argument tests on WebAssembly

### DIFF
--- a/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
+++ b/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
@@ -372,6 +372,7 @@ class FrameRecognizerTestCase(TestBase):
             substrs=["frame 0 is recognized by recognizer.MyFrameRecognizer"],
         )
 
+    @skipIfWasm  # $arg1/$arg2 need argument registers, unsupported on WebAssembly.
     def test_frame_recognizer_not_only_first_instruction(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
The recognizer reads arguments through $arg1/$arg2, which resolve via argument registers. WebAssembly has no argument registers and no ABI plugin, and these tests build without debug info, so there is no location to read the arguments from and they come back as zero.