### PR TITLE
[ADT] Skip initial empty string in StringTable iterator

### DIFF
--- a/llvm/include/llvm/ADT/StringTable.h
+++ b/llvm/include/llvm/ADT/StringTable.h
@@ -140,7 +140,8 @@ public:
     Offset offset() const { return O; }
   };
 
-  constexpr Iterator begin() const { return Iterator(*this, 0); }
+  // Skip empty string at the start.
+  constexpr Iterator begin() const { return Iterator(*this, 1); }
   constexpr Iterator end() const { return Iterator(*this, size() - 1); }
 };
 

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -965,7 +965,7 @@ static StringRef sanitizeFunctionName(StringRef funcName) {
 static DenseMap<StringRef, LibFunc>
 buildIndexMap(const llvm::StringTable &StandardNames) {
   DenseMap<StringRef, LibFunc> Indices;
-  unsigned Idx = 0;
+  unsigned Idx = 1; // 0 is NotLibFunc.
   Indices.reserve(LibFunc::NumLibFuncs);
   for (const auto &Func : StandardNames)
     Indices[Func] = static_cast<LibFunc>(Idx++);

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -124,7 +124,7 @@ static void Help(StringTable CPUNames, ArrayRef<SubtargetFeatureKV> FeatTable) {
 
   // Print the CPU table.
   errs() << "Available CPUs for this target:\n\n";
-  for (auto &CPUName : drop_begin(CPUNames)) {
+  for (auto &CPUName : CPUNames) {
     // Skip apple-latest, as that's only meant to be used in
     // disassemblers/debuggers, and we don't want normal code to be built with
     // it as an -mcpu=
@@ -159,7 +159,7 @@ static void cpuHelp(StringTable CPUNames) {
 
   // Print the CPU table.
   errs() << "Available CPUs for this target:\n\n";
-  for (auto &CPU : llvm::drop_begin(CPUNames)) {
+  for (auto &CPU : CPUNames) {
     // Skip apple-latest, as that's only meant to be used in
     // disassemblers/debuggers, and we don't want normal code to be built with
     // it as an -mcpu=

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -2864,7 +2864,7 @@ PassBuilder::parseRegAllocFilter(StringRef FilterName) {
 
 LLVM_ATTRIBUTE_NOINLINE static void printPassNameList(StringTable PassNames,
                                                       raw_ostream &OS) {
-  for (StringRef PassName : drop_begin(PassNames))
+  for (StringRef PassName : PassNames)
     OS << "  " << PassName << '\n';
 }
 
@@ -2872,7 +2872,6 @@ LLVM_ATTRIBUTE_NOINLINE static void
 printPassNameListWithParams(StringTable PassNames, raw_ostream &OS) {
   auto I = PassNames.begin();
   auto End = PassNames.end();
-  ++I;
   while (I != End) {
     StringRef Name = *I;
     ++I;


### PR DESCRIPTION
StringTable requires the first string to be empty, but this is never
useful for users that iterate over all strings in the table. Skip it by
default before drop_begin() on StringTable iteration scatters further
throughout the code base.
