### PR TITLE
[libc++] Fix Python selection in the macOS benchmark jobs

### DIFF
--- a/.github/workflows/libcxx-benchmark-commit.yml
+++ b/.github/workflows/libcxx-benchmark-commit.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           brew update
           brew install ninja cmake python@3.14
-          echo "$(brew --prefix python@3.14)/libexec/bin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix python@3.14)/bin" >> "$GITHUB_PATH"
 
       - name: Diagnose tools in use
         run: |

--- a/.github/workflows/libcxx-pr-benchmark.yml
+++ b/.github/workflows/libcxx-pr-benchmark.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           brew update
           brew install ninja cmake python@3.14
-          echo "$(brew --prefix python@3.14)/libexec/bin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix python@3.14)/bin" >> "$GITHUB_PATH"
 
       - name: Diagnose tools in use
         run: |


### PR DESCRIPTION
The macOS benchmark jobs install python 3.14 via Homebrew but added the wrong prefix (<prefix>/libexec/bin) instead of <prefix>/bin to the PATH.