### PR TITLE
[LAA] Use dereferenceable assumption for dereferenceable_or_null pointers

### DIFF
--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -227,8 +227,10 @@ static bool evaluatePtrAddRecAtMaxBTCWillNotWrap(
   uint64_t DerefBytes = StartPtrV->getPointerDereferenceableBytes(
       DL, CheckForNonNull, /*CanBeFreed=*/nullptr);
 
+  // If the deref size is only known when the pointer is non-null, ignore it
+  // here and fall back to a dereferenceable assumption below.
   if (DerefBytes && CheckForNonNull)
-    return false;
+    DerefBytes = 0;
 
   const SCEV *Step = AR->getStepRecurrence(SE);
   Type *WiderTy = SE.getWiderType(MaxBTC->getType(), Step->getType());

--- a/llvm/test/Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
+++ b/llvm/test/Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
@@ -1439,6 +1439,64 @@ loop.end:
   ret i64 %retval
 }
 
+; TODO: The dereferenceable_or_null attribute alone is not enough to prove the accesses
+; are safe, but combined with the dereferenceable assumption on the same pointer
+; we can vectorize the early-exit loop.
+define i8 @early_exit_deref_or_null_arg_with_deref_assumption(ptr dereferenceable_or_null(16) %ptr) nofree nosync {
+; CHECK-LABEL: define i8 @early_exit_deref_or_null_arg_with_deref_assumption(
+; CHECK-SAME: ptr dereferenceable_or_null(16) [[PTR:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[LEN_GEP:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 8
+; CHECK-NEXT:    [[LEN:%.*]] = load i64, ptr [[LEN_GEP]], align 4
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[PTR]], i64 [[LEN]]) ]
+; CHECK-NEXT:    [[NC:%.*]] = icmp ne i64 [[LEN]], 0
+; CHECK-NEXT:    br i1 [[NC]], label %[[SCALAR_PH:.*]], label %[[DEOPT:.*]]
+; CHECK:       [[SCALAR_PH]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ], [ 0, %[[SCALAR_PH]] ]
+; CHECK-NEXT:    [[ELEMENT_GEP:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 [[IV]]
+; CHECK-NEXT:    [[ELEMENT:%.*]] = load i8, ptr [[ELEMENT_GEP]], align 1
+; CHECK-NEXT:    [[RC:%.*]] = icmp eq i8 [[ELEMENT]], 1
+; CHECK-NEXT:    br i1 [[RC]], label %[[EXIT:.*]], label %[[LATCH]]
+; CHECK:       [[LATCH]]:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i64 [[IV]], 1
+; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV_NEXT]], [[LEN]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[DEOPT_LOOPEXIT:.*]], label %[[LOOP]]
+; CHECK:       [[DEOPT_LOOPEXIT]]:
+; CHECK-NEXT:    br label %[[DEOPT]]
+; CHECK:       [[DEOPT]]:
+; CHECK-NEXT:    unreachable
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    [[ELEMENT_LCSSA:%.*]] = phi i8 [ [[ELEMENT]], %[[LOOP]] ]
+; CHECK-NEXT:    ret i8 [[ELEMENT_LCSSA]]
+;
+entry:
+  %len_gep = getelementptr inbounds nuw i8, ptr %ptr, i64 8
+  %len = load i64, ptr %len_gep, align 4
+  call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %ptr, i64 %len) ]
+  %nc = icmp ne i64 %len, 0
+  br i1 %nc, label %loop, label %deopt
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %latch ]
+  %element_gep = getelementptr inbounds nuw i8, ptr %ptr, i64 %iv
+  %element = load i8, ptr %element_gep, align 1
+  %rc = icmp eq i8 %element, 1
+  br i1 %rc, label %exit, label %latch
+
+latch:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %len
+  br i1 %ec, label %deopt, label %loop
+
+deopt:
+  unreachable
+
+exit:
+  ret i8 %element
+}
+
 ; Multiple deref assumes that are all too small must not allow vectorizing.
 define i64 @early_exit_deref_assumption_multiple_too_small(ptr noalias %p1, ptr noalias %p2) nofree nosync {
 ; CHECK-LABEL: define i64 @early_exit_deref_assumption_multiple_too_small(

--- a/llvm/test/Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
+++ b/llvm/test/Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
@@ -1493,7 +1493,7 @@ define i8 @early_exit_deref_or_null_arg_with_deref_assumption(ptr dereferenceabl
 ; CHECK:       [[DEOPT_LOOPEXIT]]:
 ; CHECK-NEXT:    br label %[[DEOPT]]
 ; CHECK:       [[DEOPT]]:
-; CHECK-NEXT:    unreachable
+; CHECK-NEXT:    ret i8 0
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    [[ELEMENT_LCSSA:%.*]] = phi i8 [ [[ELEMENT]], %[[LOOP]] ], [ [[TMP5]], %[[VECTOR_EARLY_EXIT]] ]
 ; CHECK-NEXT:    ret i8 [[ELEMENT_LCSSA]]
@@ -1518,7 +1518,7 @@ latch:
   br i1 %ec, label %deopt, label %loop
 
 deopt:
-  unreachable
+  ret i8 0
 
 exit:
   ret i8 %element

--- a/llvm/test/Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
+++ b/llvm/test/Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
@@ -1439,7 +1439,7 @@ loop.end:
   ret i64 %retval
 }
 
-; TODO: The dereferenceable_or_null attribute alone is not enough to prove the accesses
+; The dereferenceable_or_null attribute alone is not enough to prove the accesses
 ; are safe, but combined with the dereferenceable assumption on the same pointer
 ; we can vectorize the early-exit loop.
 define i8 @early_exit_deref_or_null_arg_with_deref_assumption(ptr dereferenceable_or_null(16) %ptr) nofree nosync {
@@ -1450,25 +1450,52 @@ define i8 @early_exit_deref_or_null_arg_with_deref_assumption(ptr dereferenceabl
 ; CHECK-NEXT:    [[LEN:%.*]] = load i64, ptr [[LEN_GEP]], align 4
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[PTR]], i64 [[LEN]]) ]
 ; CHECK-NEXT:    [[NC:%.*]] = icmp ne i64 [[LEN]], 0
-; CHECK-NEXT:    br i1 [[NC]], label %[[SCALAR_PH:.*]], label %[[DEOPT:.*]]
+; CHECK-NEXT:    br i1 [[NC]], label %[[SCALAR_PH1:.*]], label %[[DEOPT:.*]]
+; CHECK:       [[SCALAR_PH1]]:
+; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[LEN]], 4
+; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
+; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[LEN]], 4
+; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[LEN]], [[N_MOD_VF]]
+; CHECK-NEXT:    br label %[[LOOP1:.*]]
+; CHECK:       [[LOOP1]]:
+; CHECK-NEXT:    [[IV1:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY_INTERIM:.*]] ]
+; CHECK-NEXT:    [[ELEMENT_GEP1:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 [[IV1]]
+; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x i8>, ptr [[ELEMENT_GEP1]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <4 x i8> [[WIDE_LOAD]], splat (i8 1)
+; CHECK-NEXT:    [[TMP2:%.*]] = freeze <4 x i1> [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> [[TMP2]])
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[IV1]], 4
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[TMP3]], label %[[VECTOR_EARLY_EXIT:.*]], label %[[VECTOR_BODY_INTERIM]]
+; CHECK:       [[VECTOR_BODY_INTERIM]]:
+; CHECK-NEXT:    br i1 [[TMP4]], label %[[MIDDLE_BLOCK:.*]], label %[[LOOP1]], !llvm.loop [[LOOP18:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[LEN]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[CMP_N]], label %[[DEOPT_LOOPEXIT:.*]], label %[[SCALAR_PH]]
+; CHECK:       [[VECTOR_EARLY_EXIT]]:
+; CHECK-NEXT:    [[FIRST_ACTIVE_LANE:%.*]] = call i64 @llvm.experimental.cttz.elts.i64.v4i1(<4 x i1> [[TMP1]], i1 false)
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i8> [[WIDE_LOAD]], i64 [[FIRST_ACTIVE_LANE]]
+; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[SCALAR_PH]]:
+; CHECK-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i64 [ [[N_VEC]], %[[MIDDLE_BLOCK]] ], [ 0, %[[SCALAR_PH1]] ]
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
-; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ], [ 0, %[[SCALAR_PH]] ]
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ], [ [[BC_RESUME_VAL]], %[[SCALAR_PH]] ]
 ; CHECK-NEXT:    [[ELEMENT_GEP:%.*]] = getelementptr inbounds nuw i8, ptr [[PTR]], i64 [[IV]]
 ; CHECK-NEXT:    [[ELEMENT:%.*]] = load i8, ptr [[ELEMENT_GEP]], align 1
 ; CHECK-NEXT:    [[RC:%.*]] = icmp eq i8 [[ELEMENT]], 1
-; CHECK-NEXT:    br i1 [[RC]], label %[[EXIT:.*]], label %[[LATCH]]
+; CHECK-NEXT:    br i1 [[RC]], label %[[EXIT]], label %[[LATCH]]
 ; CHECK:       [[LATCH]]:
 ; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i64 [[IV]], 1
 ; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV_NEXT]], [[LEN]]
-; CHECK-NEXT:    br i1 [[EC]], label %[[DEOPT_LOOPEXIT:.*]], label %[[LOOP]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[DEOPT_LOOPEXIT]], label %[[LOOP]], !llvm.loop [[LOOP19:![0-9]+]]
 ; CHECK:       [[DEOPT_LOOPEXIT]]:
 ; CHECK-NEXT:    br label %[[DEOPT]]
 ; CHECK:       [[DEOPT]]:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    [[ELEMENT_LCSSA:%.*]] = phi i8 [ [[ELEMENT]], %[[LOOP]] ]
+; CHECK-NEXT:    [[ELEMENT_LCSSA:%.*]] = phi i8 [ [[ELEMENT]], %[[LOOP]] ], [ [[TMP5]], %[[VECTOR_EARLY_EXIT]] ]
 ; CHECK-NEXT:    ret i8 [[ELEMENT_LCSSA]]
 ;
 entry:


### PR DESCRIPTION
evaluatePtrAddRecAtMaxBTCWillNotWrap currently bails out when
getPointerDereferenceableBytes reports a size that requires the pointer
to be non-null (as with the dereferenceable_or_null attribute), even
when a stronger dereferenceable assumption is available for the same
pointer.

Reset DerefBytes to 0 in that case so we fall through to
getKnowledgeForValue and pick up any dereferenceable assumption. This
lets early-exit loops guarded by such an assumption vectorize.