### PR TITLE
AMDGPU: Validate processor is consistent with subarch in TargetID parsing

### DIFF
--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -1101,10 +1101,11 @@ std::optional<TargetID> TargetID::parse(const Triple &TT,
     return std::nullopt;
 
   // A named processor (i.e. not the empty/generic wildcard, which is resolved
-  // from the triple's subarch) must be a recognized GPU.
+  // from the triple's subarch) must be a recognized GPU that is consistent with
+  // the triple's subarch.
   StringRef CPUName = ProcAndFeatures.split(':').first;
   if (!CPUName.empty() && CPUName != "generic" &&
-      parseArchAMDGCN(CPUName) == GK_NONE)
+      !isCPUValidForSubArch(TT.getSubArch(), CPUName))
     return std::nullopt;
 
   // Parse the processor and its feature modifiers, then construct directly from

--- a/llvm/test/MC/AMDGPU/amdgcn-target-directive-subarch-cpu-field.s
+++ b/llvm/test/MC/AMDGPU/amdgcn-target-directive-subarch-cpu-field.s
@@ -43,16 +43,21 @@
 
 //--- cpu-not-covered.s
 // A processor not covered by the triple's subarch is rejected.
-// NOTCOVERED: {{.*}}: error: target id 'amdgpu12.50-amd-amdhsa-unknown-gfx900' specifies a processor that is not valid for subarch 'amdgpu12.50'
+// FIXME: TargetID::parse now rejects the subarch-incompatible processor, so
+// this reports the generic malformed-target-id diagnostic instead of the more
+// specific "not valid for subarch" message.
+// NOTCOVERED: {{.*}}: error: malformed target id 'amdgpu12.50-amd-amdhsa-unknown-gfx900'
 .amdgcn_target "amdgpu12.50-amd-amdhsa-unknown-gfx900"
 
 //--- cpu-not-covered-same-major.s
 // A sibling processor sharing the major subarch (gfx1251 and gfx1250 are both
 // gfx12.5) is still not covered by a specific subarch (amdgpu12.50).
-// NOTCOVERED-SAME-MAJOR: {{.*}}: error: target id 'amdgpu12.50-amd-amdhsa-unknown-gfx1251' specifies a processor that is not valid for subarch 'amdgpu12.50'
+// FIXME: As above, this now reports the generic malformed-target-id diagnostic.
+// NOTCOVERED-SAME-MAJOR: {{.*}}: error: malformed target id 'amdgpu12.50-amd-amdhsa-unknown-gfx1251'
 .amdgcn_target "amdgpu12.50-amd-amdhsa-unknown-gfx1251"
 
 //--- isa-cpu-not-covered.s
 // The same check applies to .amd_amdgpu_isa.
-// ISA-NOTCOVERED: {{.*}}: error: target id 'amdgpu12.50-amd-amdpal-unknown-gfx900' specifies a processor that is not valid for subarch 'amdgpu12.50'
+// FIXME: As above, this now reports the generic malformed-target-id diagnostic.
+// ISA-NOTCOVERED: {{.*}}: error: malformed target id 'amdgpu12.50-amd-amdpal-unknown-gfx900'
 .amd_amdgpu_isa "amdgpu12.50-amd-amdpal-unknown-gfx900"

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2951,6 +2951,24 @@ TEST(TargetParserTest, testAMDGPUParseTargetIDString) {
   EXPECT_FALSE(TargetID::parseTargetIDString(
       "amdgcn-amd-amdhsa-unknown-gfx900:xnack+:"));
 
+  // A processor inconsistent with the triple's subarch is rejected.
+  EXPECT_TRUE(
+      TargetID::parseTargetIDString("amdgpu9.00-amd-amdhsa-unknown-gfx900")
+          .has_value());
+  EXPECT_FALSE(
+      TargetID::parseTargetIDString("amdgpu9.00-amd-amdhsa-unknown-gfx803"));
+  EXPECT_FALSE(
+      TargetID::parseTargetIDString("amdgpu9.00-amd-amdhsa-unknown-gfx90a"));
+
+  // A major-family subarch accepts any processor it covers, but not one from a
+  // different family or one that is its own major subarch.
+  EXPECT_TRUE(TargetID::parseTargetIDString("amdgpu9-amd-amdhsa-unknown-gfx900")
+                  .has_value());
+  EXPECT_FALSE(
+      TargetID::parseTargetIDString("amdgpu9-amd-amdhsa-unknown-gfx908"));
+  EXPECT_FALSE(
+      TargetID::parseTargetIDString("amdgpu11-amd-amdhsa-unknown-gfx1200"));
+
   // Constructing directly from a triple and processor+features string must
   // also be crash-safe on empty components.
   Triple AMDHSA("amdgcn-amd-amdhsa");


### PR DESCRIPTION
TargetID::parse checked that a named processor was a recognized GPU, but
not that it was consistent with the triple's subarch. A target id like
"amdgpu9.00-amd-amdhsa--gfx803" was accepted even though gfx803 does not
belong to the amdgpu9.00 subarch, silently taking the processor and
ignoring the mismatched subarch.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>