### PR TITLE
Add release note for LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -454,6 +454,8 @@ Makes programs 10x faster by doing Special New Thing.
 * A new `diagnostics report` command (aliased `bugreport`) assembles a diagnostics bundle and files
   a pre-filled GitHub issue, pointing at the bundle to attach. The GitHub reporter is built by
   default and can be disabled with the `LLDB_ENABLE_GITHUB_BUG_REPORTER=OFF` CMake option.
+* The script interpreter plugins are now built as shared libraries by default on Darwin and FreeBSD
+  (`LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS=ON`).
 
 #### Deprecated APIs
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -455,7 +455,7 @@ Makes programs 10x faster by doing Special New Thing.
   a pre-filled GitHub issue, pointing at the bundle to attach. The GitHub reporter is built by
   default and can be disabled with the `LLDB_ENABLE_GITHUB_BUG_REPORTER=OFF` CMake option.
 * The script interpreter plugins are now built as shared libraries by default on Darwin and FreeBSD
-  (`LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS=ON`).
+  (`LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS=ON`). This can be opted into on Linux also.
 
 #### Deprecated APIs
 


### PR DESCRIPTION
https://discourse.llvm.org/t/update-on-breaking-the-lldb-python-revlock/90995/