### PR TITLE
[libc++] Rename pre-commit CI workflows

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -30,7 +30,7 @@ SCRAPE_INTERVAL_SECONDS = 5 * 60
 # This metric name is also used as a key in the job->name map.
 GITHUB_WORKFLOW_TO_TRACK = {
     "CI Checks": "github_llvm_premerge_checks",
-    "Build and Test libc++": "github_libcxx_premerge_checks",
+    "[libc++] Conformance tests": "github_libcxx_premerge_checks",
 }
 
 # Lists the Github jobs to track for a given workflow. The key is the stable
@@ -175,7 +175,7 @@ def create_and_append_libcxx_aggregates(workflow_metrics: list[JobMetrics]):
         if not isinstance(job, JobMetrics):
             continue
         # Only want libc++ jobs.
-        if job.workflow_name != "Build and Test libc++":
+        if job.workflow_name != "[libc++] Conformance tests":
             continue
         if job.workflow_id not in aggregate_data.keys():
             aggregate_data[job.workflow_id] = [job]
@@ -312,7 +312,7 @@ def github_get_metrics(
             continue
 
         libcxx_testing = False
-        if task.name == "Build and Test libc++":
+        if task.name == "[libc++] Conformance tests":
             libcxx_testing = True
 
         if task.status == "completed":

--- a/.ci/metrics/metrics_test.py
+++ b/.ci/metrics/metrics_test.py
@@ -100,7 +100,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697961000000000,
                 completed_at_ns=1755698349000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage1_test2",
@@ -111,7 +111,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755698060000000000,
                 completed_at_ns=1755698417000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage1_test3",
@@ -122,7 +122,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697961000000000,
                 completed_at_ns=1755698785000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
         ]
         metrics.create_and_append_libcxx_aggregates(test_metrics)
@@ -150,7 +150,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697961000000000,
                 completed_at_ns=1755698349000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage1_test2",
@@ -161,7 +161,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755698060000000000,
                 completed_at_ns=1755698417000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage1_test3",
@@ -172,7 +172,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697961000000000,
                 completed_at_ns=1755698785000000000,
                 workflow_id=25,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
         ]
         metrics.create_and_append_libcxx_aggregates(test_metrics)
@@ -211,7 +211,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697053000000000,
                 completed_at_ns=1755698507000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage1_test2",
@@ -222,7 +222,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697058000000000,
                 completed_at_ns=1755697885000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage2_test1",
@@ -233,7 +233,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755698513000000000,
                 completed_at_ns=1755699093000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage2_test2",
@@ -244,7 +244,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755698514000000000,
                 completed_at_ns=1755698987000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage2_test3",
@@ -255,7 +255,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755698514000000000,
                 completed_at_ns=1755699334000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage3_test1",
@@ -266,7 +266,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755709012000000000,
                 completed_at_ns=1755709931000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage3_test2",
@@ -277,7 +277,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755709146000000000,
                 completed_at_ns=1755709980000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "libcxx_stage3_test3",
@@ -288,7 +288,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755709136000000000,
                 completed_at_ns=1755709514000000000,
                 workflow_id=17,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
         ]
         metrics.create_and_append_libcxx_aggregates(test_metrics)
@@ -341,7 +341,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755697961000000000,
                 completed_at_ns=1755698349000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "ci_test2", 3, 20, 1, 2000, 2200, 2400, 37, "premerge_test"
@@ -355,7 +355,7 @@ class TestMetrics(unittest.TestCase):
                 started_at_ns=1755698060000000000,
                 completed_at_ns=1755698417000000000,
                 workflow_id=3,
-                workflow_name="Build and Test libc++",
+                workflow_name="[libc++] Conformance tests",
             ),
             metrics.JobMetrics(
                 "ci_test3", 7, 35, 1, 3000, 3200, 3400, 85, "premerge_test"

--- a/.github/workflows/libcxx-benchmark-commit.yml
+++ b/.github/workflows/libcxx-benchmark-commit.yml
@@ -2,7 +2,7 @@
 # This workflow is intended to be triggered manually or via the Github API. As such,
 # it requires several inputs that allow customizing its behavior.
 
-name: Benchmark libc++ commit
+name: "[libc++] Run benchmark suite against commit"
 
 permissions:
   contents: read

--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -5,7 +5,7 @@
 # and tagged appropriately. The selection of which Docker image version is used by the libc++
 # CI nodes at any given point is controlled from the workflow files themselves.
 
-name: Build Docker images for libc++ CI
+name: "[libc++] Build CI Docker images"
 
 permissions:
   contents: read

--- a/.github/workflows/libcxx-pr-benchmark.yml
+++ b/.github/workflows/libcxx-pr-benchmark.yml
@@ -7,7 +7,7 @@
 # That will cause the specified benchmarks to be run on the PR and on the pull-request target, and
 # their results to be compared.
 
-name: Benchmark libc++ PR
+name: "[libc++] Benchmark PR"
 
 permissions:
   contents: read

--- a/.github/workflows/libcxx-pr-check-generated-files.yml
+++ b/.github/workflows/libcxx-pr-check-generated-files.yml
@@ -1,4 +1,4 @@
-name: "Check libc++ generated files"
+name: "[libc++] Check generated files"
 on:
   pull_request:
     paths:

--- a/.github/workflows/libcxx-pr-conformance-tests.yaml
+++ b/.github/workflows/libcxx-pr-conformance-tests.yaml
@@ -1,4 +1,5 @@
-# This file defines pre-commit CI for libc++, libc++abi, and libunwind (on Github).
+# This file defines a workflow that runs conformance tests for libc++, libc++abi and libunwind when
+# a PR is created or updated.
 #
 # We split the configurations in multiple stages with the intent of saving compute time
 # when a job fails early in the pipeline. This is why the jobs are marked as `continue-on-error: false`.
@@ -12,7 +13,7 @@
 # under the assumption that if the "smoke tests" fail, then the other configurations will likely fail in the same way.
 # However, stage 3 does not fail fast, as it's more likely that any one job failing is a flake or a configuration-specific
 #
-name: Build and Test libc++
+name: "[libc++] Conformance tests"
 on:
   pull_request:
     paths:
@@ -21,7 +22,7 @@ on:
       - 'libunwind/**'
       - 'runtimes/**'
       - 'cmake/**'
-      - '.github/workflows/libcxx-build-and-test.yaml'
+      - '.github/workflows/libcxx-pr-conformance-tests.yaml'
   schedule:
     # Run nightly at 08:00 UTC (aka 00:00 Pacific, aka 03:00 Eastern)
     - cron: '0 8 * * *'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/llvm/llvm-project/badge)](https://securityscorecards.dev/viewer/?uri=github.com/llvm/llvm-project)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8273/badge)](https://www.bestpractices.dev/projects/8273)
-[![libc++](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml/badge.svg?branch=main&event=schedule)](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml?query=event%3Aschedule)
+[![libc++](https://github.com/llvm/llvm-project/actions/workflows/libcxx-pr-conformance-tests.yaml/badge.svg?branch=main&event=schedule)](https://github.com/llvm/llvm-project/actions/workflows/libcxx-pr-conformance-tests.yaml?query=event%3Aschedule)
 
 Welcome to the LLVM project!
 

--- a/libcxx/docs/Contributing.rst
+++ b/libcxx/docs/Contributing.rst
@@ -272,7 +272,7 @@ The libcxx linux premerge testing can run on one of three sets of runner
 groups. The three runner group names are ``llvm-premerge-libcxx-runners``,
 ``llvm-premerge-libcxx-release-runners`` and ``llvm-premerge-libcxx-next-runners``.
 The runner set currently in use is controlled by the contents of
-https://github.com/llvm/llvm-project/blob/main/.github/workflows/libcxx-build-and-test.yaml.
+https://github.com/llvm/llvm-project/blob/main/.github/workflows/libcxx-pr-conformance-tests.yaml.
 By default, it uses ``llvm-premerge-libcxx-runners``. To switch to one of the
 other runner sets, just replace all uses of ``llvm-premerge-libcxx-runners`` in
 the yaml file with the desired runner set.

--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -237,7 +237,7 @@ Design Documents
 Build Bots and Test Coverage
 ============================
 
-* `Github Actions CI pipeline <https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml>`_
+* `Github Actions CI pipeline <https://github.com/llvm/llvm-project/actions/workflows/libcxx-pr-conformance-tests.yaml>`_
 * `Buildkite CI pipeline <https://buildkite.com/llvm-project/libcxx-ci>`_
 * `LLVM Buildbot Builders <https://lab.llvm.org/buildbot>`_
 * :ref:`Adding New CI Jobs <AddingNewCIJobs>`


### PR DESCRIPTION
Since we're expanding libc++'s pre-commit CI to add other types of tests, (e.g. tools tests, performance tests, etc), it makes sense to be a bit more precise about what each workflow does, and to use a consistent pattern across workflow names.

Also, update stale references to old names in the documentation and in some infrastructure scripts.