### PR TITLE
[lldb] Restore autosense for expedited memory-cache address parsing

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2541,7 +2541,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         std::tie(addr_str, bytes_str) = value.split('=');
         if (!addr_str.empty() && !bytes_str.empty()) {
           lldb::addr_t mem_cache_addr = LLDB_INVALID_ADDRESS;
-          if (!addr_str.getAsInteger(BASE_16, mem_cache_addr)) {
+          if (!addr_str.getAsInteger(BASE_AUTOSENSE, mem_cache_addr)) {
             StringExtractor bytes(bytes_str);
             const size_t byte_size = bytes.GetBytesLeft() / 2;
             WritableDataBufferSP data_buffer_sp(


### PR DESCRIPTION
PR #211495 changed the expedited "memory:<addr>=<bytes>" address parse in SetThreadStopInfo from autosense (radix 0) to explicit base 16. debugserver sends this address with a "0x" prefix, and StringRef::getAsInteger only strips that prefix in autosense mode. With an explicit base 16 the parse stops at the 'x' and fails, so the expedited stack bytes are never seeded into the L1 memory cache.

Restore BASE_AUTOSENSE here, matching the documented format for this key (0x hex, 0 octal, otherwise decimal). Fixes TestExpeditedStackMemory.py.