### PR TITLE
[Flang][OpenMP] Remove present modifier application on descriptor

### DIFF
--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -761,8 +761,7 @@ class MapInfoFinalizationPass
       return mapTypeFlag;
     }
 
-    flags |=
-        MapFlags::to | (mapTypeFlag & (MapFlags::implicit | MapFlags::present));
+    flags |= MapFlags::to | (mapTypeFlag & MapFlags::implicit);
 
     // Descriptors for objects will always be copied. This is because the
     // descriptor can be rematerialized by the compiler, and so the address

--- a/flang/test/Lower/OpenMP/defaultmap.f90
+++ b/flang/test/Lower/OpenMP/defaultmap.f90
@@ -9,7 +9,7 @@ subroutine defaultmap_allocatable_present()
     integer, dimension(:), allocatable :: arr
 
 ! CHECK: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(implicit, present) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
-! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(always, implicit, present, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "arr"}
+! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(always, implicit, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "arr"}
 !$omp target defaultmap(present: allocatable)
     arr(1) = 10
 !$omp end target


### PR DESCRIPTION
This was a minor change upstreamed in the original PR: https://github.com/llvm/llvm-project/pull/208133

However, it is a modification that needs a little more thought from a specification perspective before it is rolled out, there's a number of code bases that depend on the presence modifier being applied only to the underlying data. However, this leads to inconsistencies when a user makes use of any reference semantic modifiers when mapping as they SHOULD be allowed to specify present applying to the descriptor. So, we need to work out what the correct defualt behaviour is, and regardless of the default support a user intentionally specifying presence application on a descriptor via reference semantics.

For now, we will revert to previous state.