### PR TITLE
[MC][NFC] Remove some virtual function from MCAsmInfo

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -374,6 +374,9 @@ protected:
   /// absolute difference.
   bool DwarfFDESymbolsUseAbsDiff = false;
 
+  /// The optional specifier to use for the relative FDE symbol references.
+  uint16_t DwarfFDERelSymbolSpec = 0;
+
   /// True if DWARF `.file directory' directive syntax is used by
   /// default.
   bool EnableDwarfFileDirectoryDefault = true;
@@ -484,16 +487,15 @@ public:
                                                     unsigned Encoding,
                                                     MCStreamer &Streamer) const;
 
-  virtual const MCExpr *getExprForFDESymbol(const MCSymbol *Sym,
-                                            unsigned Encoding,
-                                            MCStreamer &Streamer) const;
+  const MCExpr *getExprForFDESymbol(const MCSymbol *Sym, unsigned Encoding,
+                                    MCStreamer &Streamer) const;
 
   /// Return true if C is an acceptable character inside a symbol name.
-  virtual bool isAcceptableChar(char C) const;
+  bool isAcceptableChar(char C) const;
 
   /// Return true if the identifier \p Name does not need quotes to be
   /// syntactically correct.
-  virtual bool isValidUnquotedName(StringRef Name) const;
+  bool isValidUnquotedName(StringRef Name) const;
 
   llvm::DenseSet<llvm::CachedHashStringRef> &getReservedIdentifiers() {
     return ReservedIdentifiers;
@@ -721,7 +723,7 @@ public:
   }
 
   /// Set whether target want to use AsmParser to parse inlineasm.
-  virtual void setParseInlineAsmUsingAsmParser(bool Value) {
+  void setParseInlineAsmUsingAsmParser(bool Value) {
     ParseInlineAsmUsingAsmParser = Value;
   }
 
@@ -729,10 +731,7 @@ public:
   bool preserveAsmComments() const { return PreserveAsmComments; }
 
   /// Set whether assembly (inline or otherwise) should be parsed.
-  virtual void setPreserveAsmComments(bool Value) {
-    PreserveAsmComments = Value;
-  }
-
+  void setPreserveAsmComments(bool Value) { PreserveAsmComments = Value; }
 
   bool shouldUseLogicalShr() const { return UseLogicalShr; }
 

--- a/llvm/include/llvm/MC/MCAsmInfoXCOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoXCOFF.h
@@ -19,11 +19,6 @@ protected:
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
   bool useCodeAlign(const MCSection &Sec) const final;
-
-public:
-  // Return true only when C is an acceptable character inside a
-  // MCSymbolXCOFF.
-  bool isAcceptableChar(char C) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -61,15 +61,19 @@ MCAsmInfo::getExprForPersonalitySymbol(const MCSymbol *Sym,
   return getExprForFDESymbol(Sym, Encoding, Streamer);
 }
 
-const MCExpr *
-MCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
-                               unsigned Encoding,
-                               MCStreamer &Streamer) const {
-  if (!(Encoding & dwarf::DW_EH_PE_pcrel))
-    return MCSymbolRefExpr::create(Sym, Streamer.getContext());
-
+const MCExpr *MCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
+                                             unsigned Encoding,
+                                             MCStreamer &Streamer) const {
   MCContext &Context = Streamer.getContext();
   const MCExpr *Res = MCSymbolRefExpr::create(Sym, Context);
+
+  if (!(Encoding & dwarf::DW_EH_PE_pcrel))
+    return Res;
+  if (DwarfFDERelSymbolSpec) {
+    assert(Encoding & dwarf::DW_EH_PE_sdata4 && "Unexpected encoding");
+    return MCSpecifierExpr::create(Res, DwarfFDERelSymbolSpec, Context);
+  }
+
   MCSymbol *PCSym = Context.createTempSymbol();
   Streamer.emitLabel(PCSym);
   const MCExpr *PC = MCSymbolRefExpr::create(PCSym, Context);
@@ -77,10 +81,23 @@ MCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
 }
 
 bool MCAsmInfo::isAcceptableChar(char C) const {
+  // For AIX assembler, symbols may consist of numeric digits, underscores,
+  // periods, uppercase or lowercase letters, orany combination of these.
+  // QualName is allowed for a MCSymbolXCOFF, and QualName contains '[' and ']'.
+  //
+  // Others also allow '$'. HLASM (SystemZ) also allows '#'.
+
+  if (isAlnum(C) || C == '_' || C == '.')
+    return true;
+  if (C == '[' || C == ']')
+    return isAIX();
   if (C == '@')
     return doesAllowAtInName();
-
-  return isAlnum(C) || C == '_' || C == '$' || C == '.';
+  if (C == '$')
+    return !isAIX();
+  if (C == '#')
+    return isHLASM();
+  return false;
 }
 
 bool MCAsmInfo::isValidUnquotedName(StringRef Name) const {
@@ -94,7 +111,7 @@ bool MCAsmInfo::isValidUnquotedName(StringRef Name) const {
       return false;
   }
 
-  return true;
+  return !getReservedIdentifiers().contains(CachedHashStringRef(Name.lower()));
 }
 
 bool MCAsmInfo::shouldOmitSectionDirective(StringRef SectionName) const {

--- a/llvm/lib/MC/MCAsmInfoXCOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoXCOFF.cpp
@@ -47,18 +47,6 @@ MCAsmInfoXCOFF::MCAsmInfoXCOFF(const MCTargetOptions &Options)
   ExceptionsType = ExceptionHandling::AIX;
 }
 
-bool MCAsmInfoXCOFF::isAcceptableChar(char C) const {
-  // QualName is allowed for a MCSymbolXCOFF, and
-  // QualName contains '[' and ']'.
-  if (C == '[' || C == ']')
-    return true;
-
-  // For AIX assembler, symbols may consist of numeric digits,
-  // underscores, periods, uppercase or lowercase letters, or
-  // any combination of these.
-  return isAlnum(C) || C == '_' || C == '.';
-}
-
 bool MCAsmInfoXCOFF::useCodeAlign(const MCSection &Sec) const {
   return static_cast<const MCSectionXCOFF &>(Sec).getKind().isText();
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -30,22 +30,11 @@ RISCVMCAsmInfo::RISCVMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
   ExceptionsType = ExceptionHandling::DwarfCFI;
   Data16bitsDirective = "\t.half\t";
   Data32bitsDirective = "\t.word\t";
-}
-
-const MCExpr *RISCVMCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
-                                                  unsigned Encoding,
-                                                  MCStreamer &Streamer) const {
-  if (!(Encoding & dwarf::DW_EH_PE_pcrel))
-    return MCAsmInfo::getExprForFDESymbol(Sym, Encoding, Streamer);
-
   // The default symbol subtraction results in an ADD/SUB relocation pair.
   // Processing this relocation pair is problematic when linker relaxation is
   // enabled, so we follow binutils in using the R_RISCV_32_PCREL relocation
   // for the FDE initial location.
-  MCContext &Ctx = Streamer.getContext();
-  const MCExpr *ME = MCSymbolRefExpr::create(Sym, Ctx);
-  assert(Encoding & dwarf::DW_EH_PE_sdata4 && "Unexpected encoding");
-  return MCSpecifierExpr::create(ME, ELF::R_RISCV_32_PCREL, Ctx);
+  DwarfFDERelSymbolSpec = ELF::R_RISCV_32_PCREL;
 }
 
 void RISCVMCAsmInfo::printSpecifierExpr(raw_ostream &OS,

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
@@ -27,8 +27,6 @@ public:
   explicit RISCVMCAsmInfo(const Triple &TargetTriple,
                           const MCTargetOptions &Options);
 
-  const MCExpr *getExprForFDESymbol(const MCSymbol *Sym, unsigned Encoding,
-                                    MCStreamer &Streamer) const override;
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
 };

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.cpp
@@ -43,29 +43,8 @@ SparcELFMCAsmInfo::SparcELFMCAsmInfo(const Triple &TheTriple,
   ExceptionsType = ExceptionHandling::DwarfCFI;
 
   UsesELFSectionDirectiveForBSS = true;
-}
 
-const MCExpr*
-SparcELFMCAsmInfo::getExprForPersonalitySymbol(const MCSymbol *Sym,
-                                               unsigned Encoding,
-                                               MCStreamer &Streamer) const {
-  if (Encoding & dwarf::DW_EH_PE_pcrel) {
-    MCContext &Ctx = Streamer.getContext();
-    return MCSpecifierExpr::create(Sym, ELF::R_SPARC_DISP32, Ctx);
-  }
-
-  return MCAsmInfo::getExprForPersonalitySymbol(Sym, Encoding, Streamer);
-}
-
-const MCExpr*
-SparcELFMCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
-                                       unsigned Encoding,
-                                       MCStreamer &Streamer) const {
-  if (Encoding & dwarf::DW_EH_PE_pcrel) {
-    MCContext &Ctx = Streamer.getContext();
-    return MCSpecifierExpr::create(Sym, ELF::R_SPARC_DISP32, Ctx);
-  }
-  return MCAsmInfo::getExprForFDESymbol(Sym, Encoding, Streamer);
+  DwarfFDERelSymbolSpec = ELF::R_SPARC_DISP32;
 }
 
 void SparcELFMCAsmInfo::printSpecifierExpr(raw_ostream &OS,

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.h
@@ -26,13 +26,6 @@ public:
   explicit SparcELFMCAsmInfo(const Triple &TheTriple,
                              const MCTargetOptions &Options);
 
-  const MCExpr*
-  getExprForPersonalitySymbol(const MCSymbol *Sym, unsigned Encoding,
-                              MCStreamer &Streamer) const override;
-  const MCExpr* getExprForFDESymbol(const MCSymbol *Sym,
-                                    unsigned Encoding,
-                                    MCStreamer &Streamer) const override;
-
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
 };

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
@@ -59,10 +59,6 @@ SystemZMCAsmInfoGOFF::SystemZMCAsmInfoGOFF(const Triple &TT,
   initializeAtSpecifiers(atSpecifiers);
 }
 
-bool SystemZMCAsmInfoGOFF::isAcceptableChar(char C) const {
-  return MCAsmInfo::isAcceptableChar(C) || C == '#';
-}
-
 void SystemZMCAsmInfoGOFF::printSpecifierExpr(
     raw_ostream &OS, const MCSpecifierExpr &Expr) const {
   switch (Expr.getSpecifier()) {

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
@@ -27,7 +27,6 @@ class SystemZMCAsmInfoGOFF : public MCAsmInfoGOFF {
 public:
   explicit SystemZMCAsmInfoGOFF(const Triple &TT,
                                 const MCTargetOptions &Options);
-  bool isAcceptableChar(char C) const override;
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -186,34 +186,6 @@ X86MCAsmInfoMicrosoftMASM::X86MCAsmInfoMicrosoftMASM(
   AllowAtAtStartOfIdentifier = true;
 }
 
-static bool isValidX86UnquotedName(const MCAsmInfo &MAI, StringRef Name) {
-  if (!MAI.MCAsmInfo::isValidUnquotedName(Name))
-    return false;
-  // Only Intel-syntax output needs to avoid register/keyword collisions; AT&T
-  // disambiguates registers with '%' and doesn't treat `byte`, `ptr`, etc. as
-  // keywords.
-  if (MAI.getOutputAssemblerDialect() == 0)
-    return true;
-  return !MAI.getReservedIdentifiers().contains(
-      CachedHashStringRef(Name.lower()));
-}
-
-bool X86MCAsmInfoDarwin::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, Name);
-}
-
-bool X86ELFMCAsmInfo::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, Name);
-}
-
-bool X86MCAsmInfoMicrosoft::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, Name);
-}
-
-bool X86MCAsmInfoGNUCOFF::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, Name);
-}
-
 void X86MCAsmInfoGNUCOFF::anchor() { }
 
 X86MCAsmInfoGNUCOFF::X86MCAsmInfoGNUCOFF(const Triple &Triple,

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
@@ -28,7 +28,6 @@ class X86MCAsmInfoDarwin : public MCAsmInfoDarwin {
 public:
   explicit X86MCAsmInfoDarwin(const Triple &Triple,
                               const MCTargetOptions &Options);
-  bool isValidUnquotedName(StringRef Name) const override;
 };
 
 struct X86_64MCAsmInfoDarwin : public X86MCAsmInfoDarwin {
@@ -45,7 +44,6 @@ class X86ELFMCAsmInfo : public MCAsmInfoELF {
 public:
   explicit X86ELFMCAsmInfo(const Triple &Triple,
                            const MCTargetOptions &Options);
-  bool isValidUnquotedName(StringRef Name) const override;
 };
 
 class X86MCAsmInfoMicrosoft : public MCAsmInfoMicrosoft {
@@ -54,7 +52,6 @@ class X86MCAsmInfoMicrosoft : public MCAsmInfoMicrosoft {
 public:
   explicit X86MCAsmInfoMicrosoft(const Triple &Triple,
                                  const MCTargetOptions &Options);
-  bool isValidUnquotedName(StringRef Name) const override;
 };
 
 class X86MCAsmInfoMicrosoftMASM : public X86MCAsmInfoMicrosoft {
@@ -71,7 +68,6 @@ class X86MCAsmInfoGNUCOFF : public MCAsmInfoGNUCOFF {
 public:
   explicit X86MCAsmInfoGNUCOFF(const Triple &Triple,
                                const MCTargetOptions &Options);
-  bool isValidUnquotedName(StringRef Name) const override;
 };
 
 namespace X86 {

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -536,7 +536,12 @@ static MCAsmInfo *createX86MCAsmInfo(const MCRegisterInfo &MRI,
     // The default is ELF.
     MAI = new X86ELFMCAsmInfo(TheTriple, Options);
   }
-  populateReservedIdentifiers(*MAI, MRI);
+
+  // Only Intel-syntax output needs to avoid register/keyword collisions; AT&T
+  // disambiguates registers with '%' and doesn't treat `byte`, `ptr`, etc. as
+  // keywords.
+  if (MAI->getOutputAssemblerDialect() != 0)
+    populateReservedIdentifiers(*MAI, MRI);
 
   // Initialize initial frame state.
   // Calculate amount of bytes used for return address storing

--- a/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
+++ b/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
@@ -33,8 +33,7 @@ namespace {
 // Determine if a promotion alias should be created for a symbol name.
 static bool allowPromotionAlias(const std::string &Name) {
   // Promotion aliases are used only in inline assembly. It's safe to
-  // simply skip unusual names. Subset of MCAsmInfo::isAcceptableChar()
-  // and MCAsmInfoXCOFF::isAcceptableChar().
+  // simply skip unusual names. Subset of MCAsmInfo::isAcceptableChar().
   for (const char &C : Name) {
     if (isAlnum(C) || C == '_' || C == '.')
       continue;


### PR DESCRIPTION
The MCAsmInfo vtable is currently 144B (no anchor)/152B (anchor) large
-- and there are 49 of these in an all-target libLLVM.so. Some of these
are not needed or can be easily removed. This removes 5 vtable entries.

Some notes on the remaining functions -- I think this vtable can be
removed entirely without too much effort:

- getStackSection can also be removed, this is ELF-only; unfortunately
  this will require code duplication between AsmPrinter and
  MCELFStreamer.

- getExprForPersonalitySymbol is single-use and two-overrides (Darwin on
  x86-64, AArch64), likely removable.

- shouldOmitSectionDirective has three override modes -- COFF (disallow
  for COMDAT/unique section), AMDGPU (4 .hsa sections), and always-omit
  (NVPTX, SPIRV). This is only called from printSwitchToSection, so COFF
  is no problem, always-omit needs a flag, leaving AMDGPU.

- useCodeAlign can probably be replaced by Sec.isText(), although not
  NFC (e.g. Darwin non-pure instructions).

- getMaxInstLength is AMDGPU-only and only used in the disassembler and
  for estimating inline assembly size. The code can likely be moved to
  the disassembler, but doing so is not NFC w.r.t. inlineasm.

- setUseIntegratedAssembler is ARM-only and only used to workaround a
  binutils bug that was fixed in 2014. Likely removable, but not NFC.

- printSwitchToSection is inherently file-format specific. Maybe replace
  with a raw function pointer taking MCAsmInfo as parameter?

- printSpecifierExpr likewise.

- evaluateAsRelocatableImpl likewise.

- ~MCAsmInfo -- I don't think any subclass has additional members, but I
  haven't checked in detail.
