### PR TITLE
[libc] Add POSIX redirection header specifications in YAML

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -24,6 +24,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.memory
     libc.include.net_if
     libc.include.netinet_in
     libc.include.netinet_tcp
@@ -45,16 +46,19 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.strings
     libc.include.sys_auxv
     libc.include.sys_epoll
+    libc.include.sys_fcntl
     libc.include.sys_ioctl
     libc.include.sys_mman
     libc.include.sys_param
     libc.include.sys_personality
+    libc.include.sys_poll
     libc.include.sys_prctl
     libc.include.sys_queue
     libc.include.sys_random
     libc.include.sys_resource
     libc.include.sys_select
     libc.include.sys_sendfile
+    libc.include.sys_signal
     libc.include.sys_socket
     libc.include.sys_stat
     libc.include.sys_statvfs
@@ -63,6 +67,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_types
     libc.include.sys_uio
     libc.include.sys_un
+    libc.include.sys_unistd
     libc.include.sys_utsname
     libc.include.sys_wait
     libc.include.syscall

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -10,8 +10,11 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.inttypes
     libc.include.langinfo
     libc.include.libgen
+    libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.memory
+    libc.include.net_if
     libc.include.search
     libc.include.setjmp
     libc.include.stdbit
@@ -23,10 +26,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.uchar
     libc.include.wchar
     libc.include.wctype
-
     libc.include.sys_param
     libc.include.sys_personality
-
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll
 )

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -10,11 +10,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.inttypes
     libc.include.langinfo
     libc.include.libgen
-    libc.include.locale
     libc.include.malloc
     libc.include.math
-    libc.include.memory
-    libc.include.net_if
     libc.include.search
     libc.include.setjmp
     libc.include.stdbit
@@ -26,8 +23,10 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.uchar
     libc.include.wchar
     libc.include.wctype
+
     libc.include.sys_param
     libc.include.sys_personality
+
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll
 )

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -24,6 +24,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.memory
     libc.include.net_if
     libc.include.netinet_in
     libc.include.netinet_tcp
@@ -46,16 +47,19 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.strings
     libc.include.sys_auxv
     libc.include.sys_epoll
+    libc.include.sys_fcntl
     libc.include.sys_ioctl
     libc.include.sys_mman
     libc.include.sys_param
     libc.include.sys_personality
+    libc.include.sys_poll
     libc.include.sys_prctl
     libc.include.sys_queue
     libc.include.sys_random
     libc.include.sys_resource
     libc.include.sys_select
     libc.include.sys_sendfile
+    libc.include.sys_signal
     libc.include.sys_socket
     libc.include.sys_stat
     libc.include.sys_statvfs
@@ -64,6 +68,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_types
     libc.include.sys_uio
     libc.include.sys_un
+    libc.include.sys_unistd
     libc.include.sys_utsname
     libc.include.sys_wait
     libc.include.syscall

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -24,6 +24,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.locale
     libc.include.malloc
     libc.include.math
+    libc.include.memory
     libc.include.net_if
     libc.include.netinet_in
     libc.include.netinet_tcp
@@ -46,11 +47,13 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.strings
     libc.include.sys_auxv
     libc.include.sys_epoll
+    libc.include.sys_fcntl
     libc.include.sys_ioctl
     libc.include.sys_ipc
     libc.include.sys_mman
     libc.include.sys_param
     libc.include.sys_personality
+    libc.include.sys_poll
     libc.include.sys_prctl
     libc.include.sys_queue
     libc.include.sys_random
@@ -58,6 +61,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_select
     libc.include.sys_sem
     libc.include.sys_sendfile
+    libc.include.sys_signal
     libc.include.sys_socket
     libc.include.sys_stat
     libc.include.sys_statvfs
@@ -67,6 +71,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_ucontext
     libc.include.sys_uio
     libc.include.sys_un
+    libc.include.sys_unistd
     libc.include.sys_utsname
     libc.include.sys_wait
     libc.include.syscall

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -65,6 +65,14 @@ add_header_macro(
 )
 
 add_header_macro(
+  sys_fcntl
+  ../libc/include/sys/fcntl.yaml
+  sys/fcntl.h
+  DEPENDS
+    .fcntl
+)
+
+add_header_macro(
   dlfcn
   ../libc/include/dlfcn.yaml
   dlfcn.h
@@ -283,6 +291,14 @@ add_header_macro(
 )
 
 add_header_macro(
+  memory
+  ../libc/include/memory.yaml
+  memory.h
+  DEPENDS
+    .string
+)
+
+add_header_macro(
   strings
   ../libc/include/strings.yaml
   strings.h
@@ -385,6 +401,14 @@ add_header_macro(
 )
 
 add_header_macro(
+  sys_signal
+  ../libc/include/sys/signal.yaml
+  sys/signal.h
+  DEPENDS
+    .signal
+)
+
+add_header_macro(
   stdbit
   ../libc/include/stdbit.yaml
   stdbit.h
@@ -459,6 +483,14 @@ add_header_macro(
     .llvm-libc-types.ssize_t
     .llvm-libc-types.uid_t
     .llvm-libc-types.__getoptargv_t
+)
+
+add_header_macro(
+  sys_unistd
+  ../libc/include/sys/unistd.yaml
+  sys/unistd.h
+  DEPENDS
+    .unistd
 )
 
 add_header_macro(
@@ -1061,6 +1093,14 @@ add_header_macro(
     .llvm-libc-types.nfds_t
     .llvm-libc-macros.poll-macros
   )
+
+add_header_macro(
+  sys_poll
+  ../libc/include/sys/poll.yaml
+  sys/poll.h
+  DEPENDS
+    .poll
+)
 
 add_header_macro(
   nl_types

--- a/libc/include/memory.yaml
+++ b/libc/include/memory.yaml
@@ -1,0 +1,5 @@
+header: memory.h
+public_includes:
+  - string.h
+standards:
+  - posix

--- a/libc/include/sys/fcntl.yaml
+++ b/libc/include/sys/fcntl.yaml
@@ -1,0 +1,5 @@
+header: sys/fcntl.h
+public_includes:
+  - fcntl.h
+standards:
+  - posix

--- a/libc/include/sys/poll.yaml
+++ b/libc/include/sys/poll.yaml
@@ -1,0 +1,5 @@
+header: sys/poll.h
+public_includes:
+  - poll.h
+standards:
+  - posix

--- a/libc/include/sys/signal.yaml
+++ b/libc/include/sys/signal.yaml
@@ -1,0 +1,5 @@
+header: sys/signal.h
+public_includes:
+  - signal.h
+standards:
+  - posix

--- a/libc/include/sys/unistd.yaml
+++ b/libc/include/sys/unistd.yaml
@@ -1,0 +1,5 @@
+header: sys/unistd.h
+public_includes:
+  - unistd.h
+standards:
+  - posix


### PR DESCRIPTION
Add header YAML specifications for memory.h, sys/poll.h, sys/unistd.h, sys/fcntl.h, and sys/signal.h using public_includes.

POSIX.1-2017 and historical X/Open System Interfaces (XSI) standards define these headers as alternate or legacy header locations that forward to string.h, poll.h, unistd.h, fcntl.h, and signal.h respectively. The YAML header specs allow hdrgen to generate the public headers automatically with proper license headers and guards.

Updated Linux target headers.txt configuration files to register the new public header targets for installation.

Assisted-by: Automated tooling, human reviewed.