### PR TITLE
[libc] Add system utility headers paths.h, values.h, and sys/cdefs.h …

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -29,6 +29,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.netinet_tcp
     libc.include.netinet_udp
     libc.include.poll
+    libc.include.paths
     libc.include.pthread
     libc.include.sched
     libc.include.search
@@ -44,6 +45,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.string
     libc.include.strings
     libc.include.sys_auxv
+    libc.include.sys_cdefs
     libc.include.sys_epoll
     libc.include.sys_ioctl
     libc.include.sys_mman
@@ -72,6 +74,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.time
     libc.include.uchar
     libc.include.unistd
+    libc.include.values
     libc.include.wchar
     libc.include.wctype
 )

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -12,6 +12,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.libgen
     libc.include.malloc
     libc.include.math
+    libc.include.poll
+    libc.include.paths
     libc.include.search
     libc.include.setjmp
     libc.include.stdbit
@@ -20,13 +22,13 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.stdlib
     libc.include.string
     libc.include.strings
+    libc.include.sys_cdefs
     libc.include.uchar
+    libc.include.values
     libc.include.wchar
     libc.include.wctype
-
     libc.include.sys_param
     libc.include.sys_personality
-
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll
 )

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -30,6 +30,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.netinet_udp
     libc.include.nl_types
     libc.include.poll
+    libc.include.paths
     libc.include.pthread
     libc.include.sched
     libc.include.search
@@ -45,6 +46,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.string
     libc.include.strings
     libc.include.sys_auxv
+    libc.include.sys_cdefs
     libc.include.sys_epoll
     libc.include.sys_ioctl
     libc.include.sys_mman
@@ -73,6 +75,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.time
     libc.include.uchar
     libc.include.unistd
+    libc.include.values
     libc.include.wchar
     libc.include.wctype
 )

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -30,6 +30,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.netinet_udp
     libc.include.nl_types
     libc.include.poll
+    libc.include.paths
     libc.include.pthread
     libc.include.sched
     libc.include.search
@@ -45,6 +46,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.string
     libc.include.strings
     libc.include.sys_auxv
+    libc.include.sys_cdefs
     libc.include.sys_epoll
     libc.include.sys_ioctl
     libc.include.sys_ipc
@@ -77,6 +79,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.uchar
     libc.include.ucontext
     libc.include.unistd
+    libc.include.values
     libc.include.wchar
     libc.include.wctype
 )

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -204,6 +204,22 @@ add_header(
 )
 
 add_header_macro(
+  paths
+  ../libc/include/paths.yaml
+  paths.h
+  DEPENDS
+    .llvm-libc-macros.paths_macros
+)
+
+add_header_macro(
+  values
+  ../libc/include/values.yaml
+  values.h
+  DEPENDS
+    .llvm-libc-macros.values_macros
+)
+
+add_header_macro(
   sysexits
   ../libc/include/sysexits.yaml
   sysexits.h
@@ -708,6 +724,14 @@ add_header(
     sys/queue.h
   DEPENDS
     .llvm-libc-macros.sys_queue_macros
+)
+
+add_header_macro(
+  sys_cdefs
+  ../libc/include/sys/cdefs.yaml
+  sys/cdefs.h
+  DEPENDS
+    .llvm-libc-macros.sys_cdefs_macros
 )
 
 add_header_macro(

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -43,6 +43,18 @@ add_macro_header(
 )
 
 add_macro_header(
+  paths_macros
+  HDR
+    paths-macros.h
+)
+
+add_macro_header(
+  sys_cdefs_macros
+  HDR
+    sys-cdefs-macros.h
+)
+
+add_macro_header(
   assert_macros
   HDR
     assert-macros.h
@@ -139,6 +151,15 @@ add_macro_header(
   limits_macros
   HDR
     limits-macros.h
+)
+
+add_macro_header(
+  values_macros
+  HDR
+    values-macros.h
+  DEPENDS
+    .limits_macros
+    .float_macros
 )
 
 add_macro_header(

--- a/libc/include/llvm-libc-macros/paths-macros.h
+++ b/libc/include/llvm-libc-macros/paths-macros.h
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from paths.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_PATHS_MACROS_H
+#define LLVM_LIBC_MACROS_PATHS_MACROS_H
+
+#define _PATH_DEFPATH "/usr/bin:/bin"
+#define _PATH_STDPATH "/usr/bin:/bin:/usr/sbin:/sbin"
+#define _PATH_BSHELL "/bin/sh"
+#define _PATH_CONSOLE "/dev/console"
+#define _PATH_CSHELL "/bin/csh"
+#define _PATH_DEV "/dev/"
+#define _PATH_DEVNULL "/dev/null"
+#define _PATH_KLOG "/proc/kmsg"
+#define _PATH_MAILDIR "/var/mail"
+#define _PATH_MAN "/usr/share/man"
+#define _PATH_MNTTAB "/etc/fstab"
+#define _PATH_MOUNTED "/etc/mtab"
+#define _PATH_NOLOGIN "/etc/nologin"
+#define _PATH_SENDMAIL "/usr/sbin/sendmail"
+#define _PATH_SHELLS "/etc/shells"
+#define _PATH_TTY "/dev/tty"
+#define _PATH_TMP "/tmp/"
+#define _PATH_VARDB "/var/db/"
+#define _PATH_VARRUN "/var/run/"
+#define _PATH_VARTMP "/var/tmp/"
+
+#endif // LLVM_LIBC_MACROS_PATHS_MACROS_H

--- a/libc/include/llvm-libc-macros/sys-cdefs-macros.h
+++ b/libc/include/llvm-libc-macros/sys-cdefs-macros.h
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from sys/cdefs.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_SYS_CDEFS_MACROS_H
+#define LLVM_LIBC_MACROS_SYS_CDEFS_MACROS_H
+
+#ifdef __cplusplus
+#define __BEGIN_DECLS extern "C" {
+#define __END_DECLS }
+#else
+#define __BEGIN_DECLS
+#define __END_DECLS
+#endif
+
+#ifndef __THROW
+#ifdef __cplusplus
+#define __THROW throw()
+#else
+#define __THROW
+#endif
+#endif
+
+#endif // LLVM_LIBC_MACROS_SYS_CDEFS_MACROS_H

--- a/libc/include/llvm-libc-macros/values-macros.h
+++ b/libc/include/llvm-libc-macros/values-macros.h
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from values.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_VALUES_MACROS_H
+#define LLVM_LIBC_MACROS_VALUES_MACROS_H
+
+#include "float-macros.h"
+#include "limits-macros.h"
+
+#define BITSPERBYTE CHAR_BIT
+#define MAXINT INT_MAX
+#define MININT INT_MIN
+#define MAXSHORT SHRT_MAX
+#define MINSHORT SHRT_MIN
+#define MAXLONG LONG_MAX
+#define MINLONG LONG_MIN
+
+#define MAXDOUBLE DBL_MAX
+#define MINDOUBLE DBL_MIN
+#define MAXFLOAT FLT_MAX
+#define MINFLOAT FLT_MIN
+
+#endif // LLVM_LIBC_MACROS_VALUES_MACROS_H

--- a/libc/include/paths.yaml
+++ b/libc/include/paths.yaml
@@ -1,0 +1,44 @@
+header: paths.h
+standards:
+  - bsd
+macros:
+  - macro_name: _PATH_DEFPATH
+    macro_header: paths-macros.h
+  - macro_name: _PATH_STDPATH
+    macro_header: paths-macros.h
+  - macro_name: _PATH_BSHELL
+    macro_header: paths-macros.h
+  - macro_name: _PATH_CONSOLE
+    macro_header: paths-macros.h
+  - macro_name: _PATH_CSHELL
+    macro_header: paths-macros.h
+  - macro_name: _PATH_DEV
+    macro_header: paths-macros.h
+  - macro_name: _PATH_DEVNULL
+    macro_header: paths-macros.h
+  - macro_name: _PATH_KLOG
+    macro_header: paths-macros.h
+  - macro_name: _PATH_MAILDIR
+    macro_header: paths-macros.h
+  - macro_name: _PATH_MAN
+    macro_header: paths-macros.h
+  - macro_name: _PATH_MNTTAB
+    macro_header: paths-macros.h
+  - macro_name: _PATH_MOUNTED
+    macro_header: paths-macros.h
+  - macro_name: _PATH_NOLOGIN
+    macro_header: paths-macros.h
+  - macro_name: _PATH_SENDMAIL
+    macro_header: paths-macros.h
+  - macro_name: _PATH_SHELLS
+    macro_header: paths-macros.h
+  - macro_name: _PATH_TTY
+    macro_header: paths-macros.h
+  - macro_name: _PATH_TMP
+    macro_header: paths-macros.h
+  - macro_name: _PATH_VARDB
+    macro_header: paths-macros.h
+  - macro_name: _PATH_VARRUN
+    macro_header: paths-macros.h
+  - macro_name: _PATH_VARTMP
+    macro_header: paths-macros.h

--- a/libc/include/sys/cdefs.yaml
+++ b/libc/include/sys/cdefs.yaml
@@ -1,0 +1,10 @@
+header: sys/cdefs.h
+standards:
+  - gnu
+macros:
+  - macro_name: __BEGIN_DECLS
+    macro_header: sys-cdefs-macros.h
+  - macro_name: __END_DECLS
+    macro_header: sys-cdefs-macros.h
+  - macro_name: __THROW
+    macro_header: sys-cdefs-macros.h

--- a/libc/include/values.yaml
+++ b/libc/include/values.yaml
@@ -1,0 +1,26 @@
+header: values.h
+standards:
+  - svid
+macros:
+  - macro_name: BITSPERBYTE
+    macro_header: values-macros.h
+  - macro_name: MAXINT
+    macro_header: values-macros.h
+  - macro_name: MININT
+    macro_header: values-macros.h
+  - macro_name: MAXSHORT
+    macro_header: values-macros.h
+  - macro_name: MINSHORT
+    macro_header: values-macros.h
+  - macro_name: MAXLONG
+    macro_header: values-macros.h
+  - macro_name: MINLONG
+    macro_header: values-macros.h
+  - macro_name: MAXDOUBLE
+    macro_header: values-macros.h
+  - macro_name: MINDOUBLE
+    macro_header: values-macros.h
+  - macro_name: MAXFLOAT
+    macro_header: values-macros.h
+  - macro_name: MINFLOAT
+    macro_header: values-macros.h


### PR DESCRIPTION
…in YAML

Add header YAML specifications and macro headers for paths.h, values.h, and sys/cdefs.h:

* paths.h defines standard system paths from BSD and Linux paths.h(3) man pages such as _PATH_DEVNULL, _PATH_DEFPATH, _PATH_BSHELL, and _PATH_TMP.
* values.h defines legacy System V Interface Definition (SVID) limit macros such as BITSPERBYTE, MAXINT, MININT, MAXDOUBLE, and MINDOUBLE.
* sys/cdefs.h provides C and C++ linkage macro helpers __BEGIN_DECLS, __END_DECLS, and __THROW.

Updated Linux target headers.txt configuration files to register the new public header targets for installation.

Assisted-by: Automated tooling, human reviewed.