### PR TITLE
[libc] Add missing sys/types.h integer and BSD/System V type definitions

### DIFF
--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -23,10 +23,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.uchar
     libc.include.wchar
     libc.include.wctype
-
     libc.include.sys_param
     libc.include.sys_personality
-
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll
 )

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -38,8 +38,23 @@ add_header(cookie_io_functions_t HDR cookie_io_functions_t.h DEPENDS .off64_t .s
 add_header(cpu_set_t HDR cpu_set_t.h)
 add_header(double_t HDR double_t.h)
 add_header(DIR HDR DIR.h)
+add_header(caddr_t HDR caddr_t.h)
 add_header(dev_t HDR dev_t.h)
 add_header(div_t HDR div_t.h)
+add_header(id_t HDR id_t.h)
+add_header(ino64_t HDR ino64_t.h)
+add_header(u_int HDR u_int.h)
+add_header(u_int16_t HDR u_int16_t.h)
+add_header(u_int8_t HDR u_int8_t.h)
+add_header(u_long HDR u_long.h)
+add_header(u_short HDR u_short.h)
+add_header(ulong HDR ulong.h)
+add_header(ushort HDR ushort.h)
+add_header(useconds_t HDR useconds_t.h)
+add_header(__off_t HDR __off_t.h)
+add_header(__off64_t HDR __off64_t.h)
+add_header(__uint64_t HDR __uint64_t.h)
+
 add_header(errno_t HDR errno_t.h DEPENDS libc.include.llvm-libc-macros.annex_k_macros)
 add_header(
   constraint_handler_t

--- a/libc/include/llvm-libc-types/__off64_t.h
+++ b/libc/include/llvm-libc-types/__off64_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of __off64_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES___OFF64_T_H
+#define LLVM_LIBC_TYPES___OFF64_T_H
+
+typedef __INT64_TYPE__ __off64_t;
+
+#endif // LLVM_LIBC_TYPES___OFF64_T_H

--- a/libc/include/llvm-libc-types/__off_t.h
+++ b/libc/include/llvm-libc-types/__off_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of __off_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES___OFF_T_H
+#define LLVM_LIBC_TYPES___OFF_T_H
+
+typedef __INT64_TYPE__ __off_t;
+
+#endif // LLVM_LIBC_TYPES___OFF_T_H

--- a/libc/include/llvm-libc-types/__uint64_t.h
+++ b/libc/include/llvm-libc-types/__uint64_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of __uint64_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES___UINT64_T_H
+#define LLVM_LIBC_TYPES___UINT64_T_H
+
+typedef __UINT64_TYPE__ __uint64_t;
+
+#endif // LLVM_LIBC_TYPES___UINT64_T_H

--- a/libc/include/llvm-libc-types/caddr_t.h
+++ b/libc/include/llvm-libc-types/caddr_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of caddr_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_CADDR_T_H
+#define LLVM_LIBC_TYPES_CADDR_T_H
+
+typedef char *caddr_t;
+
+#endif // LLVM_LIBC_TYPES_CADDR_T_H

--- a/libc/include/llvm-libc-types/id_t.h
+++ b/libc/include/llvm-libc-types/id_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of id_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_ID_T_H
+#define LLVM_LIBC_TYPES_ID_T_H
+
+typedef __UINT32_TYPE__ id_t;
+
+#endif // LLVM_LIBC_TYPES_ID_T_H

--- a/libc/include/llvm-libc-types/ino64_t.h
+++ b/libc/include/llvm-libc-types/ino64_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of ino64_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_INO64_T_H
+#define LLVM_LIBC_TYPES_INO64_T_H
+
+typedef __UINT64_TYPE__ ino64_t;
+
+#endif // LLVM_LIBC_TYPES_INO64_T_H

--- a/libc/include/llvm-libc-types/u_int.h
+++ b/libc/include/llvm-libc-types/u_int.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of u_int type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_U_INT_H
+#define LLVM_LIBC_TYPES_U_INT_H
+
+typedef unsigned int u_int;
+
+#endif // LLVM_LIBC_TYPES_U_INT_H

--- a/libc/include/llvm-libc-types/u_int16_t.h
+++ b/libc/include/llvm-libc-types/u_int16_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of u_int16_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_U_INT16_T_H
+#define LLVM_LIBC_TYPES_U_INT16_T_H
+
+typedef __UINT16_TYPE__ u_int16_t;
+
+#endif // LLVM_LIBC_TYPES_U_INT16_T_H

--- a/libc/include/llvm-libc-types/u_int8_t.h
+++ b/libc/include/llvm-libc-types/u_int8_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of u_int8_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_U_INT8_T_H
+#define LLVM_LIBC_TYPES_U_INT8_T_H
+
+typedef __UINT8_TYPE__ u_int8_t;
+
+#endif // LLVM_LIBC_TYPES_U_INT8_T_H

--- a/libc/include/llvm-libc-types/u_long.h
+++ b/libc/include/llvm-libc-types/u_long.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of u_long type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_U_LONG_H
+#define LLVM_LIBC_TYPES_U_LONG_H
+
+typedef unsigned long u_long;
+
+#endif // LLVM_LIBC_TYPES_U_LONG_H

--- a/libc/include/llvm-libc-types/u_short.h
+++ b/libc/include/llvm-libc-types/u_short.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of u_short type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_U_SHORT_H
+#define LLVM_LIBC_TYPES_U_SHORT_H
+
+typedef unsigned short u_short;
+
+#endif // LLVM_LIBC_TYPES_U_SHORT_H

--- a/libc/include/llvm-libc-types/ulong.h
+++ b/libc/include/llvm-libc-types/ulong.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of ulong type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_ULONG_H
+#define LLVM_LIBC_TYPES_ULONG_H
+
+typedef unsigned long ulong;
+
+#endif // LLVM_LIBC_TYPES_ULONG_H

--- a/libc/include/llvm-libc-types/useconds_t.h
+++ b/libc/include/llvm-libc-types/useconds_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of useconds_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_USECONDS_T_H
+#define LLVM_LIBC_TYPES_USECONDS_T_H
+
+typedef __UINT32_TYPE__ useconds_t;
+
+#endif // LLVM_LIBC_TYPES_USECONDS_T_H

--- a/libc/include/llvm-libc-types/ushort.h
+++ b/libc/include/llvm-libc-types/ushort.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of ushort type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_USHORT_H
+#define LLVM_LIBC_TYPES_USHORT_H
+
+typedef unsigned short ushort;
+
+#endif // LLVM_LIBC_TYPES_USHORT_H

--- a/libc/include/sys/types.yaml
+++ b/libc/include/sys/types.yaml
@@ -4,15 +4,19 @@ standards:
 types:
   - type_name: blkcnt_t
   - type_name: blksize_t
+  - type_name: caddr_t
   - type_name: clockid_t
   - type_name: dev_t
   - type_name: gid_t
+  - type_name: id_t
   - type_name: ino_t
+  - type_name: ino64_t
   - type_name: key_t
   - type_name: loff_t
   - type_name: mode_t
   - type_name: nlink_t
   - type_name: off_t
+  - type_name: off64_t
   - type_name: pid_t
   - type_name: pthread_attr_t
   - type_name: pthread_cond_t
@@ -29,6 +33,17 @@ types:
   - type_name: suseconds_t
   - type_name: time_t
   - type_name: u_char
+  - type_name: u_int
+  - type_name: u_int16_t
   - type_name: u_int32_t
+  - type_name: u_int8_t
+  - type_name: u_long
+  - type_name: u_short
   - type_name: uid_t
   - type_name: uint
+  - type_name: ulong
+  - type_name: useconds_t
+  - type_name: ushort
+  - type_name: __off_t
+  - type_name: __off64_t
+  - type_name: __uint64_t


### PR DESCRIPTION
Add missing type definitions to llvm-libc-types and sys/types.yaml:

* POSIX standard types: id_t, useconds_t
* BSD and System V compatibility typedefs: caddr_t, u_int, u_int8_t, u_int16_t, u_long, u_short, ulong, ushort
* Large File Support (LFS) and Linux kernel internal types: ino64_t, off64_t, __off_t, __off64_t, __uint64_t

POSIX.1-2017 defines id_t and useconds_t in sys/types.h. The BSD and System V standards specify the legacy unsigned integer shorthand types, and Linux kernel/glibc interfaces use the double-underscore prefix offset and integer types.

Assisted-by: Automated tooling, human reviewed.