### PR TITLE
[libc] Add missing standard and Linux header macros

### DIFF
--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -23,10 +23,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.uchar
     libc.include.wchar
     libc.include.wctype
-
     libc.include.sys_param
     libc.include.sys_personality
-
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll
 )

--- a/libc/include/llvm-libc-macros/endian-macros.h
+++ b/libc/include/llvm-libc-macros/endian-macros.h
@@ -1,9 +1,14 @@
-//===-- Definition of macros from endian.h --------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from endian.h.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_MACROS_ENDIAN_MACROS_H
@@ -14,6 +19,10 @@
 #define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
 #define BIG_ENDIAN __ORDER_BIG_ENDIAN__
 #define BYTE_ORDER __BYTE_ORDER__
+
+#define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#define __BYTE_ORDER __BYTE_ORDER__
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 

--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -1,9 +1,14 @@
-//===-- Definition of macros from limits.h --------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from limits.h.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_MACROS_LIMITS_MACROS_H
@@ -247,6 +252,10 @@
 #define PTHREAD_DESTRUCTOR_ITERATIONS _POSIX_THREAD_DESTRUCTOR_ITERATIONS
 #endif
 
+#ifndef _POSIX_HOST_NAME_MAX
+#define _POSIX_HOST_NAME_MAX 255
+#endif
+
 #ifdef __linux__
 
 #ifndef PATH_MAX
@@ -256,6 +265,10 @@
 #ifndef NAME_MAX
 #define NAME_MAX 255
 #endif // NAME_MAX
+
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 64
+#endif // HOST_NAME_MAX
 
 #endif // __linux__
 

--- a/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
@@ -1,9 +1,14 @@
-//===-- Definition of macros from sys/stat.h ------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux specific declarations of macros from sys/stat.h.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H
@@ -44,6 +49,12 @@
 #define S_IROTH 00004
 #define S_IWOTH 00002
 #define S_IXOTH 00001
+
+#define S_IREAD S_IRUSR
+#define S_IWRITE S_IWUSR
+#define S_IEXEC S_IXUSR
+
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO)
 
 #define UTIME_NOW ((1L << 30) - 1L)
 #define UTIME_OMIT ((1L << 30) - 2L)

--- a/libc/include/llvm-libc-macros/linux/unistd-macros.h
+++ b/libc/include/llvm-libc-macros/linux/unistd-macros.h
@@ -66,4 +66,15 @@
                       (long)(arg4), (long)(arg5), (long)(arg6))
 #define syscall(...) __syscall_helper(__VA_ARGS__, 0, 1, 2, 3, 4, 5, 6)
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression)                                         \
+  (__extension__({                                                             \
+    long __result;                                                             \
+    do {                                                                       \
+      __result = (long)(expression);                                           \
+    } while (__result == -1L && errno == EINTR);                               \
+    __result;                                                                  \
+  }))
+#endif
+
 #endif // LLVM_LIBC_MACROS_LINUX_UNISTD_MACROS_H


### PR DESCRIPTION
Add missing header macro constants:

* endian-macros.h: __BYTE_ORDER, __LITTLE_ENDIAN, and __BIG_ENDIAN
* sys-stat-macros.h: S_IREAD, S_IWRITE, S_IEXEC, and ACCESSPERMS
* limits-macros.h: _POSIX_HOST_NAME_MAX and HOST_NAME_MAX
* unistd-macros.h: TEMP_FAILURE_RETRY

POSIX.1-2017 specifies _POSIX_HOST_NAME_MAX as 255. The Linux gethostname(2) man page specifies HOST_NAME_MAX as 64. The double-underscore byte order macros and TEMP_FAILURE_RETRY macro follow the Linux and GNU C library conventions.

Assisted-by: Automated tooling, human reviewed.