### PR TITLE
[IR][NFC] Remove vtables from analysis passes

### DIFF
--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -500,7 +500,7 @@ public:
       return false;
 
     // Construct a new model around the instance returned by the builder.
-    PassPtr.reset(new PassModelT(PassBuilder()));
+    PassPtr = PassModelT::create(PassBuilder());
     return true;
   }
 
@@ -556,7 +556,7 @@ private:
 
   /// Map type from analysis pass ID to pass concept pointer.
   using AnalysisPassMapT =
-      DenseMap<AnalysisKey *, std::unique_ptr<PassConceptT>>;
+      DenseMap<AnalysisKey *, typename PassConceptT::unique_ptr>;
 
   /// Collection of analysis passes, indexed by ID.
   AnalysisPassMapT AnalysisPasses;

--- a/llvm/include/llvm/IR/PassManagerImpl.h
+++ b/llvm/include/llvm/IR/PassManagerImpl.h
@@ -145,7 +145,8 @@ AnalysisManager<IRUnitT, ExtraArgTs...>::getResultImpl(
     }
 
     AnalysisResultListT &ResultList = AnalysisResultLists[&IR];
-    ResultList.emplace_back(ID, P.run(IR, *this, ExtraArgs...));
+    ResultList.emplace_back(
+        ID, P.run(IR, *this, std::forward<ExtraArgTs>(ExtraArgs)...));
 
     PI.runAfterAnalysis(P, IR);
 

--- a/llvm/include/llvm/IR/PassManagerInternal.h
+++ b/llvm/include/llvm/IR/PassManagerInternal.h
@@ -313,7 +313,6 @@ template <typename IRUnitT, typename PassT, typename InvalidatorT,
           typename... ExtraArgTs>
 class AnalysisPassModel final
     : public AnalysisPassConcept<IRUnitT, InvalidatorT, ExtraArgTs...> {
-private:
   using AnalysisPassConceptT =
       AnalysisPassConcept<IRUnitT, InvalidatorT, ExtraArgTs...>;
   using ResultModelT =

--- a/llvm/include/llvm/IR/PassManagerInternal.h
+++ b/llvm/include/llvm/IR/PassManagerInternal.h
@@ -263,18 +263,45 @@ struct AnalysisResultModel
 /// This concept is parameterized over the IR unit that it can run over and
 /// produce an analysis result.
 template <typename IRUnitT, typename InvalidatorT, typename... ExtraArgTs>
-struct AnalysisPassConcept {
-  virtual ~AnalysisPassConcept() = default;
+class AnalysisPassConcept {
+public:
+  using ResultPtrT =
+      typename AnalysisResultConcept<IRUnitT, InvalidatorT>::unique_ptr;
+  using AnalysisManagerT = AnalysisManager<IRUnitT, ExtraArgTs...>;
+
+  struct Deleter {
+    void operator()(AnalysisPassConcept *P) { P->Destroy(*P); }
+  };
+  using unique_ptr = std::unique_ptr<AnalysisPassConcept, Deleter>;
+
+private:
+  using DestroyTy = void (*)(AnalysisPassConcept &);
+  using RunTy = ResultPtrT (*)(AnalysisPassConcept &, IRUnitT &,
+                               AnalysisManagerT &, ExtraArgTs &&...);
+
+  StringRef Name;
+
+  DestroyTy Destroy;
+  RunTy Run;
+
+protected:
+  AnalysisPassConcept(StringRef Name, DestroyTy Destroy, RunTy Run)
+      : Name(Name), Destroy(Destroy), Run(Run) {}
+
+public:
+  // Passes are immovable.
+  AnalysisPassConcept(const AnalysisPassConcept &) = delete;
+  AnalysisPassConcept &operator=(const AnalysisPassConcept &) = delete;
 
   /// Method to run this analysis over a unit of IR.
   /// \returns A unique_ptr to the analysis result object to be queried by
   /// users.
-  virtual typename AnalysisResultConcept<IRUnitT, InvalidatorT>::unique_ptr
-  run(IRUnitT &IR, AnalysisManager<IRUnitT, ExtraArgTs...> &AM,
-      ExtraArgTs... ExtraArgs) = 0;
+  ResultPtrT run(IRUnitT &IR, AnalysisManagerT &AM, ExtraArgTs &&...ExtraArgs) {
+    return Run(*this, IR, AM, std::forward<ExtraArgTs>(ExtraArgs)...);
+  }
 
-  /// Polymorphic method to access the name of a pass.
-  virtual StringRef name() const = 0;
+  /// Get the name of the pass.
+  StringRef name() const { return Name; }
 };
 
 /// Wrapper to model the analysis pass concept.
@@ -284,45 +311,38 @@ struct AnalysisPassConcept {
 /// and produce an object which can be wrapped in a \c AnalysisResultModel.
 template <typename IRUnitT, typename PassT, typename InvalidatorT,
           typename... ExtraArgTs>
-struct AnalysisPassModel
-    : AnalysisPassConcept<IRUnitT, InvalidatorT, ExtraArgTs...> {
-  explicit AnalysisPassModel(PassT Pass) : Pass(std::move(Pass)) {}
-  // We have to explicitly define all the special member functions because MSVC
-  // refuses to generate them.
-  AnalysisPassModel(const AnalysisPassModel &Arg) : Pass(Arg.Pass) {}
-  AnalysisPassModel(AnalysisPassModel &&Arg) : Pass(std::move(Arg.Pass)) {}
-
-  friend void swap(AnalysisPassModel &LHS, AnalysisPassModel &RHS) {
-    using std::swap;
-    swap(LHS.Pass, RHS.Pass);
-  }
-
-  AnalysisPassModel &operator=(AnalysisPassModel RHS) {
-    swap(*this, RHS);
-    return *this;
-  }
-
-  // FIXME: Replace PassT::Result with type traits when we use C++11.
+class AnalysisPassModel final
+    : public AnalysisPassConcept<IRUnitT, InvalidatorT, ExtraArgTs...> {
+private:
+  using AnalysisPassConceptT =
+      AnalysisPassConcept<IRUnitT, InvalidatorT, ExtraArgTs...>;
   using ResultModelT =
       AnalysisResultModel<IRUnitT, PassT, typename PassT::Result, InvalidatorT>;
 
-  /// The model delegates to the \c PassT::run method.
-  ///
-  /// The return is wrapped in an \c AnalysisResultModel.
-  typename ResultModelT::unique_ptr
-  run(IRUnitT &IR, AnalysisManager<IRUnitT, ExtraArgTs...> &AM,
-      ExtraArgTs... ExtraArgs) override {
-    // Call Pass.run in constructor to avoid move of analysis result.
+  PassT Pass;
+
+  static void destroyImpl(AnalysisPassConceptT &Self) {
+    delete static_cast<AnalysisPassModel *>(&Self);
+  }
+
+  static typename ResultModelT::unique_ptr
+  runImpl(AnalysisPassConceptT &Self, IRUnitT &IR,
+          AnalysisManager<IRUnitT, ExtraArgTs...> &AM,
+          ExtraArgTs &&...ExtraArgs) {
+    PassT &Pass = static_cast<AnalysisPassModel &>(Self).Pass;
     return typename ResultModelT::unique_ptr(
         new ResultModelT(Pass, IR, AM, std::forward<ExtraArgTs>(ExtraArgs)...));
   }
 
-  /// The model delegates to a static \c PassT::name method.
-  ///
-  /// The returned string ref must point to constant immutable data!
-  StringRef name() const override { return PassT::name(); }
+  explicit AnalysisPassModel(PassT &&Pass)
+      : AnalysisPassConceptT(PassT::name(), destroyImpl, runImpl),
+        Pass(std::move(Pass)) {}
 
-  PassT Pass;
+public:
+  static typename AnalysisPassConceptT::unique_ptr create(PassT &&Pass) {
+    return typename AnalysisPassConceptT::unique_ptr(
+        new AnalysisPassModel(std::move(Pass)));
+  }
 };
 
 } // end namespace detail


### PR DESCRIPTION
Similar to #209414 but for AnalysisPassConcept. This avoids vtables for
every analysis pass.
