### PR TITLE
[NFC][analyzer] Eliminate NodeBuilder in VisitBlockExpr

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -214,13 +214,11 @@ void ExprEngine::VisitBlockExpr(const BlockExpr *BE, ExplodedNode *Pred,
     }
   }
 
-  ExplodedNodeSet Tmp;
-  NodeBuilder Bldr(Pred, Tmp, *currBldrCtx);
-  Bldr.generateNode(BE, Pred, State->BindExpr(BE, Pred->getStackFrame(), V),
-                    nullptr, ProgramPoint::PostLValueKind);
+  ExplodedNode *N = Engine.makeNodeWithBinding(Pred, BE, V, State,
+                                               ProgramPoint::PostLValueKind);
 
   // FIXME: Move all post/pre visits to ::Visit().
-  getCheckerManager().runCheckersForPostStmt(Dst, Tmp, BE, *this);
+  getCheckerManager().runCheckersForPostStmt(Dst, N, BE, *this);
 }
 
 ProgramStateRef


### PR DESCRIPTION
This is part of the commit series that gradually eliminates the class `NodeBuilder` from the analyzer engine.

This is a straightforward case where `makeNodeWithBinding` can be clearly applied.

The node set `Tmp` was superfluous because we can directly pass the node to `runCheckersForPostStmt` where it will be implicitly converted to a one-element set. (There are many precedents for this.)

Also notice that we explicitly pass the `State` to `makeNodeWithBinding` because it can be different from `Pred->getState()` (which would have been used implicitly by the 4-argument form of `makeNodeWithBinding`.)