### PR TITLE
AMDGPU: Reject unrecognized amdgpu subarch in TargetID parsing

### DIFF
--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -1100,6 +1100,10 @@ std::optional<TargetID> TargetID::parse(const Triple &TT,
   if (!TT.isAMDGCN())
     return std::nullopt;
 
+  // Filter out unrecognized subarch suffixes.
+  if (TT.getSubArch() == Triple::NoSubArch && TT.getArchName() != "amdgcn")
+    return std::nullopt;
+
   // A named processor (i.e. not the empty/generic wildcard, which is resolved
   // from the triple's subarch) must be a recognized GPU that is consistent with
   // the triple's subarch.

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2969,6 +2969,15 @@ TEST(TargetParserTest, testAMDGPUParseTargetIDString) {
   EXPECT_FALSE(
       TargetID::parseTargetIDString("amdgpu11-amd-amdhsa-unknown-gfx1200"));
 
+  // A subarchless "amdgpu" or an unrecognized "amdgpu<x>" arch is rejected,
+  // even with an otherwise valid processor.
+  EXPECT_FALSE(
+      TargetID::parseTargetIDString("amdgpu-amd-amdhsa-unknown-gfx900"));
+  EXPECT_FALSE(
+      TargetID::parseTargetIDString("amdgpufoo-amd-amdhsa-unknown-gfx900"));
+  EXPECT_FALSE(TargetID::parseTargetIDString("amdgpu-amd-amdhsa-unknown-"));
+  EXPECT_FALSE(TargetID::parseTargetIDString("amdgpufoo-amd-amdhsa-unknown"));
+
   // Constructing directly from a triple and processor+features string must
   // also be crash-safe on empty components.
   Triple AMDHSA("amdgcn-amd-amdhsa");


### PR DESCRIPTION
A bare "amdgpu" or an unrecognized "amdgpu<x>" both parse to the
amdgpu arch with no subarch; TargetID::parse previously accepted them,
taking a named processor and ignoring the missing subarch.

Reject triples with no subarch, unless it uses the legacy spelling.
This is another workaround for Triple not having a proper unknown value
for subarches.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>