### PR TITLE
clang/AMDGPU: Migrate cc1 tests to subarch triples (6)

### DIFF
--- a/clang/test/CIR/CodeGenHIP/amdgcn-buffer-rsrc-type.hip
+++ b/clang/test/CIR/CodeGenHIP/amdgcn-buffer-rsrc-type.hip
@@ -1,16 +1,16 @@
 #include "../CodeGenCUDA/Inputs/cuda.h"
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 struct BufferResourceHolder {

--- a/clang/test/CIR/CodeGenHIP/attr-target-amdgpu.hip
+++ b/clang/test/CIR/CodeGenHIP/attr-target-amdgpu.hip
@@ -5,68 +5,69 @@
 // Default behavior for gfx90a: test_default has no target-features,
 // test_explicit_attr has only the delta (+gfx11-insts).
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
-// RUN:            -fcuda-is-device -target-cpu gfx90a -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple=amdgpu9.0a-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR-GFX90A %s --input-file=%t.cir
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
-// RUN:            -fcuda-is-device -target-cpu gfx90a -emit-llvm %s -o %t.cir.ll
+// RUN: %clang_cc1 -triple=amdgpu9.0a-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.cir.ll
 // RUN: FileCheck --check-prefix=LLVM-GFX90A %s --input-file=%t.cir.ll
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
-// RUN:            -fcuda-is-device -target-cpu gfx90a -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple=amdgpu9.0a-amd-amdhsa -x hip \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM-GFX90A %s --input-file=%t.ll
 
 // With -target-feature, both functions get the delta feature.
 // gfx1030 defaults to wavefrontsize32, so +wavefrontsize64 is a delta.
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
-// RUN:            -fcuda-is-device -target-cpu gfx1030 -target-feature +wavefrontsize64 \
+// RUN: %clang_cc1 -triple=amdgpu10.30-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -target-feature +wavefrontsize64 \
 // RUN:            -emit-cir %s -o %t-cmdline.cir
 // RUN: FileCheck --check-prefix=CIR-CMDLINE %s --input-file=%t-cmdline.cir
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
-// RUN:            -fcuda-is-device -target-cpu gfx1030 -target-feature +wavefrontsize64 \
+// RUN: %clang_cc1 -triple=amdgpu10.30-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -target-feature +wavefrontsize64 \
 // RUN:            -emit-llvm %s -o %t-cmdline.cir.ll
 // RUN: FileCheck --check-prefix=LLVM-CMDLINE %s --input-file=%t-cmdline.cir.ll
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
-// RUN:            -fcuda-is-device -target-cpu gfx1030 -target-feature +wavefrontsize64 \
+// RUN: %clang_cc1 -triple=amdgpu10.30-amd-amdhsa -x hip \
+// RUN:            -fcuda-is-device -target-feature +wavefrontsize64 \
 // RUN:            -emit-llvm %s -o %t-cmdline.ll
 // RUN: FileCheck --check-prefix=LLVM-CMDLINE %s --input-file=%t-cmdline.ll
 
-// gfx90a + no extra features: test_default has only target-cpu, no
-// target-features. test_explicit_attr has cpu + only the per-function delta.
+// gfx90a + no extra features: the processor is encoded in the triple's
+// subarch, so there is no target-cpu attribute. test_default has no
+// target-features. test_explicit_attr has only the per-function delta.
 
 // CIR-GFX90A:      cir.func{{.*}} @_Z12test_defaultv()
-// CIR-GFX90A-SAME: "cir.target-cpu" = "gfx90a"
+// CIR-GFX90A-NOT:  "cir.target-cpu"
 // CIR-GFX90A-NOT:  "cir.target-features"
 
 // CIR-GFX90A:      cir.func{{.*}} @_Z18test_explicit_attrv()
-// CIR-GFX90A-SAME: "cir.target-cpu" = "gfx90a"
+// CIR-GFX90A-NOT:  "cir.target-cpu"
 // CIR-GFX90A-SAME: "cir.target-features" = "+gfx11-insts"
 
 // LLVM-GFX90A: define{{.*}} @_Z12test_defaultv(){{.*}} #[[ATTR_DEFAULT_90A:[0-9]+]]
 // LLVM-GFX90A: define{{.*}} @_Z18test_explicit_attrv(){{.*}} #[[ATTR_EXPLICIT_90A:[0-9]+]]
-// LLVM-GFX90A-DAG: attributes #[[ATTR_DEFAULT_90A]] = {{.*}}"target-cpu"="gfx90a"
+// LLVM-GFX90A-NOT: attributes #[[ATTR_DEFAULT_90A]] = {{.*}}"target-cpu"
 // LLVM-GFX90A-NOT: attributes #[[ATTR_DEFAULT_90A]] = {{.*}}"target-features"
-// LLVM-GFX90A-DAG: attributes #[[ATTR_EXPLICIT_90A]] = {{.*}}"target-cpu"="gfx90a"{{.*}}"target-features"="+gfx11-insts"
+// LLVM-GFX90A-DAG: attributes #[[ATTR_EXPLICIT_90A]] = {{.*}}"target-features"="+gfx11-insts"
 
 // gfx1030 + cmdline +wavefrontsize64: test_default gets the cmdline delta;
 // test_explicit_attr gets both the per-function and cmdline deltas.
 
 // CIR-CMDLINE:      cir.func{{.*}} @_Z12test_defaultv()
-// CIR-CMDLINE-SAME: "cir.target-cpu" = "gfx1030"
+// CIR-CMDLINE-NOT:  "cir.target-cpu"
 // CIR-CMDLINE-SAME: "cir.target-features" = "+wavefrontsize64"
 
 // CIR-CMDLINE:      cir.func{{.*}} @_Z18test_explicit_attrv()
-// CIR-CMDLINE-SAME: "cir.target-cpu" = "gfx1030"
+// CIR-CMDLINE-NOT:  "cir.target-cpu"
 // CIR-CMDLINE-SAME: "cir.target-features" = "{{[^"]*}}+gfx11-insts{{[^"]*}}+wavefrontsize64{{[^"]*}}"
 
 // LLVM-CMDLINE: define{{.*}} @_Z12test_defaultv(){{.*}} #[[ATTR_DEFAULT_1030:[0-9]+]]
 // LLVM-CMDLINE: define{{.*}} @_Z18test_explicit_attrv(){{.*}} #[[ATTR_EXPLICIT_1030:[0-9]+]]
-// LLVM-CMDLINE-DAG: attributes #[[ATTR_DEFAULT_1030]] = {{.*}}"target-cpu"="gfx1030"{{.*}}"target-features"="+wavefrontsize64"
-// LLVM-CMDLINE-DAG: attributes #[[ATTR_EXPLICIT_1030]] = {{.*}}"target-cpu"="gfx1030"{{.*}}"target-features"="{{[^"]*}}+gfx11-insts{{[^"]*}}+wavefrontsize64{{[^"]*}}"
+// LLVM-CMDLINE-DAG: attributes #[[ATTR_DEFAULT_1030]] = {{.*}}"target-features"="+wavefrontsize64"
+// LLVM-CMDLINE-DAG: attributes #[[ATTR_EXPLICIT_1030]] = {{.*}}"target-features"="{{[^"]*}}+gfx11-insts{{[^"]*}}+wavefrontsize64{{[^"]*}}"
 
 __global__ void test_default() {}
 

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn-extended-image.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn-extended-image.hip
@@ -1,18 +1,18 @@
 #include "../CodeGenCUDA/Inputs/cuda.h"
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -target-feature +extended-image-insts \
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -target-feature +extended-image-insts \
 // RUN:            -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -target-feature +extended-image-insts \
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -target-feature +extended-image-insts \
 // RUN:            -fcuda-is-device -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1100 -target-feature +extended-image-insts \
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 \
+// RUN: -target-feature +extended-image-insts \
 // RUN:            -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn-gfx1250.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn-gfx1250.hip
@@ -1,14 +1,14 @@
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1250 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu12.50-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1250 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu12.50-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1250 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu12.50-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 #define __device__ __attribute__((device))

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn-image.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn-image.hip
@@ -1,16 +1,16 @@
 #include "../CodeGenCUDA/Inputs/cuda.h"
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 typedef float float4 __attribute__((ext_vector_type(4)));

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn-logb-scalbn.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn-logb-scalbn.hip
@@ -1,16 +1,16 @@
 #include "../CodeGenCUDA/Inputs/cuda.h"
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1100 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu11.00-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 // CIR-LABEL: @_Z11test_logbfff

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn-vi-f16.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn-vi-f16.hip
@@ -1,53 +1,53 @@
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu tonga -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu8.02-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx900 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu9.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1010 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu10.10-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1012 -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu10.12-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu tonga -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu8.02-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx900 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu9.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1010 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu10.10-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu gfx1012 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu10.12-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu tonga -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu8.02-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx900 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu9.00-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1010 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu10.10-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu gfx1012 -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu10.12-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 #define __device__ __attribute__((device))

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn.hip
@@ -1,14 +1,14 @@
 // REQUIRES: amdgpu-registered-target
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu tahiti -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple amdgpu6.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
-// RUN:            -target-cpu tahiti -fcuda-is-device -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple amdgpu6.00-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
-// RUN:            -target-cpu tahiti -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple amdgpu6.00-amd-amdhsa -x hip -std=c++11 \
+// RUN: -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 #define __device__ __attribute__((device))

--- a/clang/test/CIR/CodeGenHIP/target-features.hip
+++ b/clang/test/CIR/CodeGenHIP/target-features.hip
@@ -2,52 +2,53 @@
 
 // REQUIRES: amdgpu-registered-target
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
-// RUN:            -fcuda-is-device -target-cpu gfx900 -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple=amdgpu9.00-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR %s --input-file=%t.cir
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
-// RUN:            -fcuda-is-device -target-cpu gfx900 -emit-llvm %s -o %t.cir.ll
+// RUN: %clang_cc1 -triple=amdgpu9.00-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.cir.ll
 // RUN: FileCheck --check-prefix=LLVM %s --input-file=%t.cir.ll
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
-// RUN:            -fcuda-is-device -target-cpu gfx900 -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple=amdgpu9.00-amd-amdhsa -x hip \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM %s --input-file=%t.ll
 
 // Verify that with extra target-features differing from the CPU baseline,
 // only the delta (differing features) is emitted on cir.target-features.
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN: %clang_cc1 -triple=amdgpu9.00-amd-amdhsa -x hip -fclangir \
 // RUN:            -fcuda-is-device -target-cpu gfx900 -mxnack \
 // RUN:            -emit-cir %s -o %t-delta.cir
 // RUN: FileCheck --check-prefix=CIR-DELTA %s --input-file=%t-delta.cir
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN: %clang_cc1 -triple=amdgpu9.00-amd-amdhsa -x hip -fclangir \
 // RUN:            -fcuda-is-device -target-cpu gfx900 -mxnack \
 // RUN:            -emit-llvm %s -o %t-delta.cir.ll
 // RUN: FileCheck --check-prefix=LLVM-DELTA %s --input-file=%t-delta.cir.ll
 
-// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
+// RUN: %clang_cc1 -triple=amdgpu9.00-amd-amdhsa -x hip \
 // RUN:            -fcuda-is-device -target-cpu gfx900 -mxnack \
 // RUN:            -emit-llvm %s -o %t-delta.ll
 // RUN: FileCheck --check-prefix=LLVM-DELTA %s --input-file=%t-delta.ll
 
-// AMDGPU with gfx900: target-cpu is set, target-features is absent.
+// AMDGPU with gfx900: the processor is encoded in the triple's subarch, so
+// neither target-cpu nor target-features is emitted.
 
 // CIR: cir.func{{.*}} @_Z6kernelv()
-// CIR-SAME: "cir.target-cpu" = "gfx900"
+// CIR-NOT: cir.target-cpu
 // CIR-NOT: cir.target-features
 __global__ void kernel() {}
 
 // CIR: cir.func{{.*}} @_Z9device_fnv()
-// CIR-SAME: "cir.target-cpu" = "gfx900"
+// CIR-NOT: cir.target-cpu
 // CIR-NOT: cir.target-features
 __device__ void device_fn() {}
 
 // LLVM: define{{.*}} void @_Z6kernelv(){{.*}} #[[K_ATTR:[0-9]+]]
 // LLVM: define{{.*}} void @_Z9device_fnv(){{.*}} #[[D_ATTR:[0-9]+]]
-// LLVM-DAG: attributes #[[K_ATTR]] = {{.*}}"target-cpu"="gfx900"
-// LLVM-DAG: attributes #[[D_ATTR]] = {{.*}}"target-cpu"="gfx900"
+// LLVM-NOT: attributes #[[K_ATTR]] = {{.*}}"target-cpu"
+// LLVM-NOT: attributes #[[D_ATTR]] = {{.*}}"target-cpu"
 
 // AMDGPU with gfx900 + xnack enabled via -mxnack: emitted as module flag.
 

--- a/clang/test/CIR/CodeGenOpenMP/target-map-llvm-device.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-map-llvm-device.c
@@ -1,17 +1,17 @@
 // Two-step host-BC ->  device pipeline that mirrors the offloading driver.
 //
 // Step 1: Host compilation to bitcode (provides offload entry info to device pass).
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa \
 // RUN:   -fclangir -emit-llvm-bc %s -o %t-cir-host.bc
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa \
 // RUN:   -emit-llvm-bc %s -o %t-ogcg-host.bc
 //
 // Step 2: Device compilation using host BC.
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -fopenmp -fopenmp-is-target-device \
+// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -fopenmp -fopenmp-is-target-device \
 // RUN:   -fopenmp-host-ir-file-path %t-cir-host.bc \
 // RUN:   -fclangir -emit-llvm %s -o - \
 // RUN:   | FileCheck %s --check-prefix=LLVM
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -fopenmp -fopenmp-is-target-device \
+// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -fopenmp -fopenmp-is-target-device \
 // RUN:   -fopenmp-host-ir-file-path %t-ogcg-host.bc \
 // RUN:   -emit-llvm %s -o - \
 // RUN:   | FileCheck %s --check-prefix=OGCG

--- a/clang/test/CIR/CodeGenOpenMP/target-map-llvm-host.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-map-llvm-host.c
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fopenmp \
-// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa -fclangir -emit-llvm %s -o - \
+// RUN:   -fopenmp-targets=amdgpu-amd-amdhsa -fclangir -emit-llvm %s -o - \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fopenmp \
-// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa -emit-llvm %s -o - \
+// RUN:   -fopenmp-targets=amdgpu-amd-amdhsa -emit-llvm %s -o - \
 // RUN:   | FileCheck %s --check-prefix=OGCG
 
 void use(int);

--- a/clang/test/CIR/CodeGenOpenMP/target-map.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-map.c
@@ -1,9 +1,9 @@
 // Host compilation (x86 host, AMDGPU offload target): no address space on allocas.
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -emit-cir -fclangir %s -o - \
+// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa -emit-cir -fclangir %s -o - \
 // RUN:   | FileCheck %s --check-prefix=CIR-HOST
 
 // Device compilation (AMDGPU): allocas in private address space, addrspacecast for map info.
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -fopenmp -fopenmp-is-target-device \
+// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -fopenmp -fopenmp-is-target-device \
 // RUN:   -emit-cir -fclangir %s -o - \
 // RUN:   | FileCheck %s --check-prefix=CIR-DEVICE
 


### PR DESCRIPTION
Rewrite CIR/CodeGenHIP cc1 test RUN lines to the new subarch triple form,
dropping the redundant -target-cpu, and regenerate autogenerated CHECK
lines.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>