### PR TITLE
AMDGPU: Don't pack a build_vector with an undef/poison lane

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -204,6 +204,13 @@ class is_canonicalized_2<SDPatternOperator op> : PatFrag<
     const SITargetLowering &Lowering =
               *static_cast<const SITargetLowering *>(getTargetLowering());
 
+    // A poison operand is trivially canonical, but packing it is
+    // pointless. Leave those to the cheaper build_vector-with-undef
+    // patterns rather than materializing a v_pack for a don't-care
+    // lane.
+    if (N->getOperand(0).isUndef() || N->getOperand(1).isUndef())
+      return false;
+
     return Lowering.isCanonicalized(*CurDAG, N->getOperand(0)) &&
       Lowering.isCanonicalized(*CurDAG, N->getOperand(1));
    }]> {


### PR DESCRIPTION
Once ISD::POISON is legal it reaches isel and is treated as canonical, so
is_canonicalized_2<build_vector> matched build_vector<x, poison> and selected
a v_pack for a don't-care high lane. Avoids regressions in future patches.

Co-authored-by: Claude (Claude-Opus-4.8)