### PR TITLE
AMDGPU: Avoid dropping poison when extracting a high element

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -4640,7 +4640,10 @@ bool AMDGPUDAGToDAGISel::SelectBITOP3(SDValue In, SDValue &Src0, SDValue &Src1,
 }
 
 SDValue AMDGPUDAGToDAGISel::getHi16Elt(SDValue In) const {
-  if (In.isUndef())
+  if (In.getOpcode() == ISD::POISON)
+    return CurDAG->getPOISON(MVT::i32);
+
+  if (In.getOpcode() == ISD::UNDEF)
     return CurDAG->getUNDEF(MVT::i32);
 
   if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(In)) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -204,6 +204,13 @@ class is_canonicalized_2<SDPatternOperator op> : PatFrag<
     const SITargetLowering &Lowering =
               *static_cast<const SITargetLowering *>(getTargetLowering());
 
+    // A poison operand is trivially canonical, but packing it is
+    // pointless. Leave those to the cheaper build_vector-with-undef
+    // patterns rather than materializing a v_pack for a don't-care
+    // lane.
+    if (N->getOperand(0).isUndef() || N->getOperand(1).isUndef())
+      return false;
+
     return Lowering.isCanonicalized(*CurDAG, N->getOperand(0)) &&
       Lowering.isCanonicalized(*CurDAG, N->getOperand(1));
    }]> {


### PR DESCRIPTION
Haven't found a case where this matters, but I want to stop finding
this instance of the is-undef-get-undef pattern.