### PR TITLE
[CIR] Allow cir.copy to work across address spaces-

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -122,6 +122,18 @@ class HasAtMostOneOfAttrs<list<string> names> : PredOpTrait<
   HasAtMostOneOfAttrsPred<!foreach(name, names, "$" # name)>
 >;
 
+// Like `SameTypeOperands`, but the operands are pointers that are only required
+// to share the same pointee type; they may still differ in address space (e.g.
+// a `cir.copy` that assigns through an address-space-qualified pointer).
+def SameOperandsPointeeType : PredOpTrait<
+  "all operands have the same pointee type (address spaces may differ)",
+  CPred<[{
+    llvm::all_equal(llvm::map_range($_op.getOperands(), [](mlir::Value v) {
+      return mlir::cast<cir::PointerType>(v.getType()).getPointee();
+    }))
+  }]>
+>;
+
 //===----------------------------------------------------------------------===//
 // CastOp
 //===----------------------------------------------------------------------===//
@@ -4708,7 +4720,7 @@ def CIR_CoReturnOp : CIR_Op<"co_return", [
 //===----------------------------------------------------------------------===//
 
 def CIR_CopyOp : CIR_Op<"copy",[
-  SameTypeOperands,
+  SameOperandsPointeeType,
   DeclareOpInterfaceMethods<PromotableMemOpInterface>
 ]> {
   let summary = "Copies contents from a CIR pointer to another";
@@ -4718,7 +4730,9 @@ def CIR_CopyOp : CIR_Op<"copy",[
 
     The number of bytes copied is inferred from the pointee type. The pointee
     type of `src` and `dst` must match and both must implement the
-    `DataLayoutTypeInterface`.
+    `DataLayoutTypeInterface`. The pointers may differ in address space (e.g.
+    when assigning through an address-space-qualified pointer); when the two
+    pointer types differ, both are printed, `src` first.
 
     The `volatile` keyword indicates that the operation is volatile.
 
@@ -4754,7 +4768,7 @@ def CIR_CopyOp : CIR_Op<"copy",[
     $dst (`align` `(` $dst_alignment^ `)`)?
     (`volatile` $is_volatile^)?
     (`skip_tail_padding` $skip_tail_padding^)?
-    attr-dict `:` qualified(type($dst))
+    attr-dict `:` custom<CopyTypes>(type($src), type($dst))
   }];
   let hasVerifier = 1;
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3296,7 +3296,36 @@ void cir::CoroBodyOp::build(OpBuilder &builder, OperationState &result,
 // CopyOp Definitions
 //===----------------------------------------------------------------------===//
 
+// Prints the pointer type(s) for a `cir.copy`. `src` and `dst` share the same
+// pointee type but may differ in address space; a single type is printed when
+// they match, otherwise both are printed (`src` first).
+static void printCopyTypes(mlir::OpAsmPrinter &printer, mlir::Operation *,
+                           mlir::Type srcType, mlir::Type dstType) {
+  printer.printType(srcType);
+  if (srcType != dstType) {
+    printer << ", ";
+    printer.printType(dstType);
+  }
+}
+
+static mlir::ParseResult parseCopyTypes(mlir::OpAsmParser &parser,
+                                        mlir::Type &srcType,
+                                        mlir::Type &dstType) {
+  if (parser.parseType(srcType))
+    return mlir::failure();
+  if (parser.parseOptionalComma().succeeded()) {
+    if (parser.parseType(dstType))
+      return mlir::failure();
+  } else {
+    dstType = srcType;
+  }
+  return mlir::success();
+}
+
 LogicalResult cir::CopyOp::verify() {
+  // The pointee types of `src` and `dst` are guaranteed to match by the
+  // SameOperandsPointeeType trait; they may still differ in address space.
+
   // A data layout is required for us to know the number of bytes to be copied.
   if (!getType().getPointee().hasTrait<DataLayoutTypeInterface::Trait>())
     return emitError() << "missing data layout for pointee type";

--- a/clang/test/CIR/CodeGen/address-space.c
+++ b/clang/test/CIR/CodeGen/address-space.c
@@ -45,3 +45,16 @@ void baz(int *arg) {
 int __attribute__((address_space(1)))* get_gvar() {
   return gvar;
 }
+
+// C permits assignment of a structd through AS qualified pointers. Make sure we
+// get these right.
+struct S { int a[4]; };
+// CIR-LABEL: cir.func {{.*}} @copy_to_as
+// CIR: cir.copy {{.*}} to {{.*}} : !cir.ptr<!rec_S>, !cir.ptr<!rec_S, target_address_space(1)>
+// LLVM-LABEL: define dso_local void @copy_to_as
+// LLVM: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) align 4 %{{.*}}, ptr align 4 %{{.*}}, i64 16, i1 false)
+// OGCG-LABEL: define dso_local void @copy_to_as
+// OGCG: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) align 4 %{{.*}}, ptr align 4 %{{.*}}, i64 16, i1 false)
+void copy_to_as(struct S __attribute__((address_space(1))) *p, struct S *q) {
+  *p = *q;
+}

--- a/clang/test/CIR/IR/copy.cir
+++ b/clang/test/CIR/IR/copy.cir
@@ -13,4 +13,39 @@ module {
     // CHECK: cir.copy %arg0 to %arg1 skip_tail_padding : !cir.ptr<!rec_S>
     cir.return
   }
+
+  cir.func @noASnoASCopy(%arg0 : !cir.ptr<!rec>, %arg1 : !cir.ptr<!rec>) {
+    cir.copy %arg0 to %arg1 : !cir.ptr<!rec>
+    // CHECK: cir.copy %arg0 to %arg1 : !cir.ptr<!rec_S>
+    cir.return
+  }
+
+  cir.func @noASASCopy(%arg0 : !cir.ptr<!rec>, %arg1 : !cir.ptr<!rec, target_address_space(1)>) {
+    cir.copy %arg0 to %arg1 : !cir.ptr<!rec>, !cir.ptr<!rec, target_address_space(1)>
+    // CHECK: cir.copy %arg0 to %arg1 : !cir.ptr<!rec_S>, !cir.ptr<!rec_S, target_address_space(1)>
+    cir.return
+  }
+ 
+  cir.func @ASnoASCopy(%arg0 : !cir.ptr<!rec, target_address_space(3)>, %arg1 : !cir.ptr<!rec>) {
+    cir.copy %arg0 to %arg1 : !cir.ptr<!rec, target_address_space(3)>, !cir.ptr<!rec>
+    // CHECK: cir.copy %arg0 to %arg1 : !cir.ptr<!rec_S, target_address_space(3)>, !cir.ptr<!rec_S>
+    cir.return
+  }
+  cir.func @diffASASCopy(%arg0 : !cir.ptr<!rec, target_address_space(3)>, %arg1 : !cir.ptr<!rec, target_address_space(4)>) {
+    cir.copy %arg0 to %arg1 : !cir.ptr<!rec, target_address_space(3)>, !cir.ptr<!rec, target_address_space(4)>
+    // CHECK: cir.copy %arg0 to %arg1 : !cir.ptr<!rec_S, target_address_space(3)>, !cir.ptr<!rec_S, target_address_space(4)>
+    cir.return
+  }
+
+  cir.func @sameASASCopy(%arg0 : !cir.ptr<!rec, target_address_space(3)>, %arg1 : !cir.ptr<!rec, target_address_space(3)>) {
+    cir.copy %arg0 to %arg1 : !cir.ptr<!rec, target_address_space(3)>
+    // CHECK: cir.copy %arg0 to %arg1 : !cir.ptr<!rec_S, target_address_space(3)>
+    cir.return
+  }
+
+  cir.func @sameASASCopy2(%arg0 : !cir.ptr<!rec, target_address_space(3)>, %arg1 : !cir.ptr<!rec, target_address_space(3)>) {
+    cir.copy %arg0 to %arg1 : !cir.ptr<!rec, target_address_space(3)>, !cir.ptr<!rec, target_address_space(3)>
+    // CHECK: cir.copy %arg0 to %arg1 : !cir.ptr<!rec_S, target_address_space(3)>
+    cir.return
+  }
 }


### PR DESCRIPTION
LLVM Memcpy supports copying across address spaces, so we should too. IN C, this is legal, and there are no associated AST nodes to reasonably put in a cast, so this patch just legalizes it to match the LLVM behavior.

Note: I've added a 'CopyTypes' printer/parser as well, because it seems unfortunate to make EVERY copy have to show all of its types.