### PR TITLE
[Passes] Replace PassInfoMixin with {Optional,Required}PassInfoMixin

### DIFF
--- a/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
+++ b/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
@@ -185,7 +185,7 @@ public:
 
 /// Statistics pass for the FunctionPropertiesAnalysis results.
 class FunctionPropertiesStatisticsPass
-    : public PassInfoMixin<FunctionPropertiesStatisticsPass> {
+    : public RequiredPassInfoMixin<FunctionPropertiesStatisticsPass> {
   bool IsPreOptimization;
 
 public:

--- a/llvm/include/llvm/CodeGen/BreakFalseDeps.h
+++ b/llvm/include/llvm/CodeGen/BreakFalseDeps.h
@@ -22,7 +22,7 @@
 
 namespace llvm {
 
-class BreakFalseDepsPass : public PassInfoMixin<BreakFalseDepsPass> {
+class BreakFalseDepsPass : public OptionalPassInfoMixin<BreakFalseDepsPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/MachineCheckDebugify.h
+++ b/llvm/include/llvm/CodeGen/MachineCheckDebugify.h
@@ -23,7 +23,7 @@
 namespace llvm {
 
 class CheckDebugMachineModulePass
-    : public PassInfoMixin<CheckDebugMachineModulePass> {
+    : public RequiredPassInfoMixin<CheckDebugMachineModulePass> {
 public:
   LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };

--- a/llvm/include/llvm/Transforms/Scalar/AlignmentFromAssumptions.h
+++ b/llvm/include/llvm/Transforms/Scalar/AlignmentFromAssumptions.h
@@ -29,7 +29,7 @@ class SCEV;
 class Value;
 
 struct AlignmentFromAssumptionsPass
-    : public PassInfoMixin<AlignmentFromAssumptionsPass> {
+    : public OptionalPassInfoMixin<AlignmentFromAssumptionsPass> {
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   // Glue for old PM.

--- a/llvm/include/llvm/Transforms/Scalar/LogicalSROA.h
+++ b/llvm/include/llvm/Transforms/Scalar/LogicalSROA.h
@@ -22,7 +22,7 @@ namespace llvm {
 
 class Function;
 
-class LogicalSROAPass : public PassInfoMixin<LogicalSROAPass> {
+class LogicalSROAPass : public OptionalPassInfoMixin<LogicalSROAPass> {
 public:
   LogicalSROAPass();
 

--- a/llvm/lib/Target/AArch64/AArch64.h
+++ b/llvm/lib/Target/AArch64/AArch64.h
@@ -21,6 +21,7 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
 #include "llvm/Support/DataTypes.h"
@@ -110,7 +111,7 @@ public:
 };
 
 class AArch64PostLegalizerCombinerPass
-    : public PassInfoMixin<AArch64PostLegalizerCombinerPass> {
+    : public RequiredPassInfoMixin<AArch64PostLegalizerCombinerPass> {
   std::unique_ptr<AArch64PostLegalizerCombinerImplRuleConfig> RuleConfig;
   const AArch64TargetMachine *TM;
 
@@ -205,7 +206,7 @@ void initializeAArch64SRLTDefineSuperRegsLegacyPass(PassRegistry &);
 void initializeSVEShuffleOptsPass(PassRegistry &);
 void initializeAArch64Arm64ECCallLoweringPass(PassRegistry &);
 
-class SVEShuffleOptsPass : public PassInfoMixin<SVEShuffleOptsPass> {
+class SVEShuffleOptsPass : public OptionalPassInfoMixin<SVEShuffleOptsPass> {
   const AArch64TargetMachine &TM;
 
 public:
@@ -336,7 +337,8 @@ public:
                         MachineFunctionAnalysisManager &MFAM);
 };
 
-class AArch64SLSHardeningPass : public PassInfoMixin<AArch64SLSHardeningPass> {
+class AArch64SLSHardeningPass
+    : public RequiredPassInfoMixin<AArch64SLSHardeningPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
@@ -371,7 +373,7 @@ public:
 };
 
 class AArch64LowerHomogeneousPrologEpilogPass
-    : public PassInfoMixin<AArch64LowerHomogeneousPrologEpilogPass> {
+    : public RequiredPassInfoMixin<AArch64LowerHomogeneousPrologEpilogPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };

--- a/llvm/lib/Target/Lanai/Lanai.h
+++ b/llvm/lib/Target/Lanai/Lanai.h
@@ -37,7 +37,7 @@ FunctionPass *createLanaiISelDagLegacyPass(LanaiTargetMachine &TM);
 // createLanaiDelaySlotFillerPass - This pass fills delay slots
 // with useful instructions or nop's
 class LanaiDelaySlotFillerPass
-    : public PassInfoMixin<LanaiDelaySlotFillerPass> {
+    : public RequiredPassInfoMixin<LanaiDelaySlotFillerPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
@@ -48,7 +48,8 @@ createLanaiDelaySlotFillerLegacyPass(const LanaiTargetMachine &TM);
 
 // createLanaiMemAluCombinerPass - This pass combines loads/stores and
 // arithmetic operations.
-class LanaiMemAluCombinerPass : public PassInfoMixin<LanaiMemAluCombinerPass> {
+class LanaiMemAluCombinerPass
+    : public RequiredPassInfoMixin<LanaiMemAluCombinerPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/MSP430/MSP430.h
+++ b/llvm/lib/Target/MSP430/MSP430.h
@@ -50,7 +50,8 @@ public:
 FunctionPass *createMSP430ISelDag(MSP430TargetMachine &TM,
                                   CodeGenOptLevel OptLevel);
 
-class MSP430BranchSelectPass : public PassInfoMixin<MSP430BranchSelectPass> {
+class MSP430BranchSelectPass
+    : public RequiredPassInfoMixin<MSP430BranchSelectPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/X86/X86.h
+++ b/llvm/lib/Target/X86/X86.h
@@ -422,7 +422,7 @@ public:
 FunctionPass *createX86PostLegalizerCombinerLegacy();
 
 class X86PreLegalizerCombinerPass
-    : public PassInfoMixin<X86PreLegalizerCombinerPass> {
+    : public RequiredPassInfoMixin<X86PreLegalizerCombinerPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);


### PR DESCRIPTION
There were a couple passes that landed after the mass migration that
need to be updated to eventually make PassInfoMixin private. For backend
passes I looked at whether LegacyPM passes called skipFunction rather
than whether or not they should be enabled to try and preserve existing
behavior where possible.

We still need to wait a bit in order to avoid PassInfoMixin to a detail
namespace and fully remove isRequired from PassInfoMixin given there are
a lot of out-of-tree passes that have not yet been moved over. I'm
hoping to have patches out within a week.
