### PR TITLE
[mlir][arith] Gate min/max expansion in arith-expand behind include-min-max

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Arith/Transforms/Passes.h
@@ -68,8 +68,15 @@ void populateExpandF8E8M0Patterns(RewritePatternSet &patterns);
 /// Add patterns to expand scaling ExtF/TruncF ops to equivalent arith ops
 void populateExpandScalingExtTruncPatterns(RewritePatternSet &patterns);
 
-/// Add patterns to expand the min/max ops (`arith.maximumf`/`minimumf`/
-/// `maxnumf`/`minnumf` and the signed/unsigned integer `max`/`min`) into
+/// Add patterns to expand the floating-point min/max ops (`arith.maximumf`/
+/// `minimumf`/`maxnumf`/`minnumf`) into `cmpf` + `select` sequences.
+void populateExpandMinMaxFPatterns(RewritePatternSet &patterns);
+
+/// Add patterns to expand the signed/unsigned integer min/max ops
+/// (`arith.maxsi`/`maxui`/`minsi`/`minui`) into `cmpi` + `select` sequences.
+void populateExpandMinMaxIPatterns(RewritePatternSet &patterns);
+
+/// Add patterns to expand both the floating-point and integer min/max ops into
 /// `cmpf`/`cmpi` + `select` sequences. These ops also have a direct
 /// arith-to-llvm lowering, so pipelines that run arith-to-llvm may prefer to
 /// skip this expansion.

--- a/mlir/include/mlir/Dialect/Arith/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Arith/Transforms/Passes.h
@@ -68,6 +68,13 @@ void populateExpandF8E8M0Patterns(RewritePatternSet &patterns);
 /// Add patterns to expand scaling ExtF/TruncF ops to equivalent arith ops
 void populateExpandScalingExtTruncPatterns(RewritePatternSet &patterns);
 
+/// Add patterns to expand the min/max ops (`arith.maximumf`/`minimumf`/
+/// `maxnumf`/`minnumf` and the signed/unsigned integer `max`/`min`) into
+/// `cmpf`/`cmpi` + `select` sequences. These ops also have a direct
+/// arith-to-llvm lowering, so pipelines that run arith-to-llvm may prefer to
+/// skip this expansion.
+void populateExpandMinMaxPatterns(RewritePatternSet &patterns);
+
 /// Add patterns to expand `arith.flush_denormals` into integer arithmetic
 /// (bitcast + bit masks + compare + select). Only matches IEEE-like
 /// floating-point types.

--- a/mlir/include/mlir/Dialect/Arith/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Arith/Transforms/Passes.td
@@ -25,14 +25,21 @@ def ArithExpandOpsPass : Pass<"arith-expand"> {
               /*default=*/"false",
               "Enable expansion of `arith.flush_denormals` on IEEE-like "
               "floating-point types">,
-       Option<"includeMinMax", "include-min-max", "bool", /*default=*/"true",
-              "Enable expansion of the min/max ops (maximumf/minimumf/maxnumf/"
-              "minnumf and the signed/unsigned integer max/min). These ops "
-              "also have a direct arith-to-llvm lowering to the "
-              "`llvm.intr.maximum/minimum/maxnum/minnum` (and smax/umax/...) "
+       Option<"includeMinMaxF", "include-min-max-f", "bool", /*default=*/"true",
+              "Enable expansion of the floating-point min/max ops "
+              "(maximumf/minimumf/maxnumf/minnumf). These ops also have a "
+              "direct arith-to-llvm lowering to the "
+              "`llvm.intr.maximum/minimum/maxnum/minnum` intrinsics; disable "
+              "this so pipelines that run arith-to-llvm can use those "
+              "single-instruction lowerings instead of the cmpf/select "
+              "expansion">,
+       Option<"includeMinMaxI", "include-min-max-i", "bool", /*default=*/"true",
+              "Enable expansion of the signed/unsigned integer min/max ops "
+              "(maxsi/maxui/minsi/minui). These ops also have a direct "
+              "arith-to-llvm lowering to the `llvm.intr.smax/umax/smin/umin` "
               "intrinsics; disable this so pipelines that run arith-to-llvm "
               "can use those single-instruction lowerings instead of the "
-              "cmpf/select expansion">,
+              "cmpi/select expansion">,
   ];
 }
 

--- a/mlir/include/mlir/Dialect/Arith/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Arith/Transforms/Passes.td
@@ -25,7 +25,7 @@ def ArithExpandOpsPass : Pass<"arith-expand"> {
               /*default=*/"false",
               "Enable expansion of `arith.flush_denormals` on IEEE-like "
               "floating-point types">,
-       Option<"includeMinMaxF", "include-min-max-f", "bool", /*default=*/"true",
+       Option<"includeMinMaxF", "include-min-max-f", "bool", /*default=*/"false",
               "Enable expansion of the floating-point min/max ops "
               "(maximumf/minimumf/maxnumf/minnumf). These ops also have a "
               "direct arith-to-llvm lowering to the "
@@ -33,7 +33,7 @@ def ArithExpandOpsPass : Pass<"arith-expand"> {
               "this so pipelines that run arith-to-llvm can use those "
               "single-instruction lowerings instead of the cmpf/select "
               "expansion">,
-       Option<"includeMinMaxI", "include-min-max-i", "bool", /*default=*/"true",
+       Option<"includeMinMaxI", "include-min-max-i", "bool", /*default=*/"false",
               "Enable expansion of the signed/unsigned integer min/max ops "
               "(maxsi/maxui/minsi/minui). These ops also have a direct "
               "arith-to-llvm lowering to the `llvm.intr.smax/umax/smin/umin` "

--- a/mlir/include/mlir/Dialect/Arith/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Arith/Transforms/Passes.td
@@ -25,6 +25,14 @@ def ArithExpandOpsPass : Pass<"arith-expand"> {
               /*default=*/"false",
               "Enable expansion of `arith.flush_denormals` on IEEE-like "
               "floating-point types">,
+       Option<"includeMinMax", "include-min-max", "bool", /*default=*/"true",
+              "Enable expansion of the min/max ops (maximumf/minimumf/maxnumf/"
+              "minnumf and the signed/unsigned integer max/min). These ops "
+              "also have a direct arith-to-llvm lowering to the "
+              "`llvm.intr.maximum/minimum/maxnum/minnum` (and smax/umax/...) "
+              "intrinsics; disable this so pipelines that run arith-to-llvm "
+              "can use those single-instruction lowerings instead of the "
+              "cmpf/select expansion">,
   ];
 }
 

--- a/mlir/lib/Dialect/Arith/Transforms/ExpandOps.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/ExpandOps.cpp
@@ -840,22 +840,30 @@ struct ArithExpandOpsPass
     // clang-format on
 
     // The min/max ops also have a direct arith-to-llvm lowering to the
-    // `llvm.intr.maximum`/`minimum`/... intrinsics, which are a single hardware
-    // instruction on many targets. Only expand them into cmpf/cmpi + select
-    // when requested, so pipelines that run arith-to-llvm can keep the
-    // intrinsic lowering.
-    if (includeMinMax) {
-      arith::populateExpandMinMaxPatterns(patterns);
+    // `llvm.intr.maximum`/`minimum`/... (and smax/umax/...) intrinsics, which
+    // are a single hardware instruction on many targets. Only expand them into
+    // cmpf/cmpi + select when requested, so pipelines that run arith-to-llvm
+    // can keep the intrinsic lowering. The float and integer ops are gated
+    // separately.
+    if (includeMinMaxF) {
+      arith::populateExpandMinMaxFPatterns(patterns);
+      // clang-format off
+      target.addIllegalOp<
+        arith::MaximumFOp,
+        arith::MinimumFOp,
+        arith::MaxNumFOp,
+        arith::MinNumFOp
+      >();
+      // clang-format on
+    }
+    if (includeMinMaxI) {
+      arith::populateExpandMinMaxIPatterns(patterns);
       // clang-format off
       target.addIllegalOp<
         arith::MaxSIOp,
         arith::MaxUIOp,
         arith::MinSIOp,
-        arith::MinUIOp,
-        arith::MaximumFOp,
-        arith::MinimumFOp,
-        arith::MaxNumFOp,
-        arith::MinNumFOp
+        arith::MinUIOp
       >();
       // clang-format on
     }
@@ -951,19 +959,31 @@ void mlir::arith::populateExpandFlushDenormalsPatterns(
   patterns.add<FlushDenormalsOpConverter>(patterns.getContext());
 }
 
-void mlir::arith::populateExpandMinMaxPatterns(RewritePatternSet &patterns) {
+void mlir::arith::populateExpandMinMaxFPatterns(RewritePatternSet &patterns) {
   // clang-format off
   patterns.add<
-    MaxMinIOpConverter<MaxSIOp, arith::CmpIPredicate::sgt>,
-    MaxMinIOpConverter<MaxUIOp, arith::CmpIPredicate::ugt>,
-    MaxMinIOpConverter<MinSIOp, arith::CmpIPredicate::slt>,
-    MaxMinIOpConverter<MinUIOp, arith::CmpIPredicate::ult>,
     MaximumMinimumFOpConverter<MaximumFOp, arith::CmpFPredicate::UGT>,
     MaximumMinimumFOpConverter<MinimumFOp, arith::CmpFPredicate::ULT>,
     MaxNumMinNumFOpConverter<MaxNumFOp, arith::CmpFPredicate::UGT>,
     MaxNumMinNumFOpConverter<MinNumFOp, arith::CmpFPredicate::ULT>
    >(patterns.getContext());
   // clang-format on
+}
+
+void mlir::arith::populateExpandMinMaxIPatterns(RewritePatternSet &patterns) {
+  // clang-format off
+  patterns.add<
+    MaxMinIOpConverter<MaxSIOp, arith::CmpIPredicate::sgt>,
+    MaxMinIOpConverter<MaxUIOp, arith::CmpIPredicate::ugt>,
+    MaxMinIOpConverter<MinSIOp, arith::CmpIPredicate::slt>,
+    MaxMinIOpConverter<MinUIOp, arith::CmpIPredicate::ult>
+   >(patterns.getContext());
+  // clang-format on
+}
+
+void mlir::arith::populateExpandMinMaxPatterns(RewritePatternSet &patterns) {
+  populateExpandMinMaxFPatterns(patterns);
+  populateExpandMinMaxIPatterns(patterns);
 }
 
 void mlir::arith::populateArithExpandOpsPatterns(RewritePatternSet &patterns) {

--- a/mlir/lib/Dialect/Arith/Transforms/ExpandOps.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/ExpandOps.cpp
@@ -823,7 +823,8 @@ struct ArithExpandOpsPass
     RewritePatternSet patterns(&getContext());
     ConversionTarget target(getContext());
 
-    arith::populateArithExpandOpsPatterns(patterns);
+    arith::populateCeilFloorDivExpandOpsPatterns(patterns);
+    arith::populateExpandScalingExtTruncPatterns(patterns);
 
     target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<vector::VectorDialect>();
@@ -833,17 +834,31 @@ struct ArithExpandOpsPass
       arith::CeilDivSIOp,
       arith::CeilDivUIOp,
       arith::FloorDivSIOp,
-      arith::MaxSIOp,
-      arith::MaxUIOp,
-      arith::MinSIOp,
-      arith::MinUIOp,
-      arith::MaximumFOp,
-      arith::MinimumFOp,
-      arith::MaxNumFOp,
-      arith::MinNumFOp,
       arith::ScalingExtFOp,
       arith::ScalingTruncFOp
     >();
+    // clang-format on
+
+    // The min/max ops also have a direct arith-to-llvm lowering to the
+    // `llvm.intr.maximum`/`minimum`/... intrinsics, which are a single hardware
+    // instruction on many targets. Only expand them into cmpf/cmpi + select
+    // when requested, so pipelines that run arith-to-llvm can keep the
+    // intrinsic lowering.
+    if (includeMinMax) {
+      arith::populateExpandMinMaxPatterns(patterns);
+      // clang-format off
+      target.addIllegalOp<
+        arith::MaxSIOp,
+        arith::MaxUIOp,
+        arith::MinSIOp,
+        arith::MinUIOp,
+        arith::MaximumFOp,
+        arith::MinimumFOp,
+        arith::MaxNumFOp,
+        arith::MinNumFOp
+      >();
+      // clang-format on
+    }
 
     if (includeBf16)
       arith::populateExpandBFloat16Patterns(patterns);
@@ -936,9 +951,7 @@ void mlir::arith::populateExpandFlushDenormalsPatterns(
   patterns.add<FlushDenormalsOpConverter>(patterns.getContext());
 }
 
-void mlir::arith::populateArithExpandOpsPatterns(RewritePatternSet &patterns) {
-  populateCeilFloorDivExpandOpsPatterns(patterns);
-  populateExpandScalingExtTruncPatterns(patterns);
+void mlir::arith::populateExpandMinMaxPatterns(RewritePatternSet &patterns) {
   // clang-format off
   patterns.add<
     MaxMinIOpConverter<MaxSIOp, arith::CmpIPredicate::sgt>,
@@ -951,4 +964,10 @@ void mlir::arith::populateArithExpandOpsPatterns(RewritePatternSet &patterns) {
     MaxNumMinNumFOpConverter<MinNumFOp, arith::CmpFPredicate::ULT>
    >(patterns.getContext());
   // clang-format on
+}
+
+void mlir::arith::populateArithExpandOpsPatterns(RewritePatternSet &patterns) {
+  populateCeilFloorDivExpandOpsPatterns(patterns);
+  populateExpandScalingExtTruncPatterns(patterns);
+  populateExpandMinMaxPatterns(patterns);
 }

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -111,13 +111,15 @@ void buildGPUPassPipeline(OpPassManager &pm,
   {
     arith::ArithExpandOpsPassOptions arithExpandOptions;
     arithExpandOptions.includeF8E8M0 = true;
-    // Do not expand the min/max ops (arith.maximumf/minimumf/...) into
-    // cmpf + select here: they are lowered directly to the
-    // `llvm.intr.maximum`/`minimum`/... intrinsics (single hardware
-    // instructions) by the later arith-to-llvm conversion. Expanding them
-    // regresses e.g. flash-attention softmax, whose running-max is
-    // arith.maximumf-heavy.
-    arithExpandOptions.includeMinMax = false;
+    // Do not expand the min/max ops (arith.maximumf/minimumf/..., maxsi/...)
+    // into cmpf/cmpi + select here: they are lowered directly to the
+    // `llvm.intr.maximum`/`minimum`/... (and smax/umax/...) intrinsics (single
+    // hardware instructions) by the later arith-to-llvm conversion. Expanding
+    // the float ops regresses e.g. flash-attention softmax, whose running-max
+    // is arith.maximumf-heavy; the integer ops are kept as intrinsics for the
+    // same reason.
+    arithExpandOptions.includeMinMaxF = false;
+    arithExpandOptions.includeMinMaxI = false;
     pm.addNestedPass<gpu::GPUModuleOp>(
         arith::createArithExpandOpsPass(arithExpandOptions));
   }

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -111,15 +111,6 @@ void buildGPUPassPipeline(OpPassManager &pm,
   {
     arith::ArithExpandOpsPassOptions arithExpandOptions;
     arithExpandOptions.includeF8E8M0 = true;
-    // Do not expand the min/max ops (arith.maximumf/minimumf/..., maxsi/...)
-    // into cmpf/cmpi + select here: they are lowered directly to the
-    // `llvm.intr.maximum`/`minimum`/... (and smax/umax/...) intrinsics (single
-    // hardware instructions) by the later arith-to-llvm conversion. Expanding
-    // the float ops regresses e.g. flash-attention softmax, whose running-max
-    // is arith.maximumf-heavy; the integer ops are kept as intrinsics for the
-    // same reason.
-    arithExpandOptions.includeMinMaxF = false;
-    arithExpandOptions.includeMinMaxI = false;
     pm.addNestedPass<gpu::GPUModuleOp>(
         arith::createArithExpandOpsPass(arithExpandOptions));
   }

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -111,6 +111,13 @@ void buildGPUPassPipeline(OpPassManager &pm,
   {
     arith::ArithExpandOpsPassOptions arithExpandOptions;
     arithExpandOptions.includeF8E8M0 = true;
+    // Do not expand the min/max ops (arith.maximumf/minimumf/...) into
+    // cmpf + select here: they are lowered directly to the
+    // `llvm.intr.maximum`/`minimum`/... intrinsics (single hardware
+    // instructions) by the later arith-to-llvm conversion. Expanding them
+    // regresses e.g. flash-attention softmax, whose running-max is
+    // arith.maximumf-heavy.
+    arithExpandOptions.includeMinMax = false;
     pm.addNestedPass<gpu::GPUModuleOp>(
         arith::createArithExpandOpsPass(arithExpandOptions));
   }

--- a/mlir/test/Dialect/Arith/expand-ops-min-max.mlir
+++ b/mlir/test/Dialect/Arith/expand-ops-min-max.mlir
@@ -1,0 +1,64 @@
+// Default (include-min-max=true): the min/max ops are expanded into
+// cmpf/cmpi + select sequences.
+// RUN: mlir-opt %s -arith-expand -split-input-file | FileCheck %s --check-prefix=EXPAND
+
+// include-min-max=false: the min/max ops are left untouched so that a later
+// arith-to-llvm conversion can lower them to the single-instruction
+// llvm.intr.maximum/minimum/... intrinsics.
+// RUN: mlir-opt %s -arith-expand="include-min-max=false" -split-input-file | FileCheck %s --check-prefix=KEEP
+
+// EXPAND-LABEL: func @maximumf
+// KEEP-LABEL:   func @maximumf
+func.func @maximumf(%a: f32, %b: f32) -> f32 {
+  // EXPAND: arith.cmpf ugt
+  // EXPAND: arith.select
+  // EXPAND: arith.cmpf uno
+  // EXPAND: arith.select
+  // EXPAND-NOT: arith.maximumf
+  // KEEP: arith.maximumf
+  // KEEP-NOT: arith.select
+  %result = arith.maximumf %a, %b : f32
+  return %result : f32
+}
+
+// -----
+
+// EXPAND-LABEL: func @minnumf
+// KEEP-LABEL:   func @minnumf
+func.func @minnumf(%a: f32, %b: f32) -> f32 {
+  // EXPAND: arith.cmpf ult
+  // EXPAND: arith.select
+  // EXPAND-NOT: arith.minnumf
+  // KEEP: arith.minnumf
+  // KEEP-NOT: arith.select
+  %result = arith.minnumf %a, %b : f32
+  return %result : f32
+}
+
+// -----
+
+// EXPAND-LABEL: func @maxsi
+// KEEP-LABEL:   func @maxsi
+func.func @maxsi(%a: i32, %b: i32) -> i32 {
+  // EXPAND: arith.cmpi sgt
+  // EXPAND: arith.select
+  // EXPAND-NOT: arith.maxsi
+  // KEEP: arith.maxsi
+  // KEEP-NOT: arith.select
+  %result = arith.maxsi %a, %b : i32
+  return %result : i32
+}
+
+// -----
+
+// Even with min/max expansion disabled, the other expansions (here
+// ceildivsi) still run.
+
+// EXPAND-LABEL: func @ceildivi_still_expands
+// KEEP-LABEL:   func @ceildivi_still_expands
+func.func @ceildivi_still_expands(%a: i32, %b: i32) -> i32 {
+  // EXPAND-NOT: arith.ceildivsi
+  // KEEP-NOT: arith.ceildivsi
+  %result = arith.ceildivsi %a, %b : i32
+  return %result : i32
+}

--- a/mlir/test/Dialect/Arith/expand-ops-min-max.mlir
+++ b/mlir/test/Dialect/Arith/expand-ops-min-max.mlir
@@ -1,51 +1,81 @@
-// Default (include-min-max=true): the min/max ops are expanded into
-// cmpf/cmpi + select sequences.
+// Default (both min/max groups expanded): the ops become cmpf/cmpi + select.
 // RUN: mlir-opt %s -arith-expand -split-input-file | FileCheck %s --check-prefix=EXPAND
 
-// include-min-max=false: the min/max ops are left untouched so that a later
-// arith-to-llvm conversion can lower them to the single-instruction
-// llvm.intr.maximum/minimum/... intrinsics.
-// RUN: mlir-opt %s -arith-expand="include-min-max=false" -split-input-file | FileCheck %s --check-prefix=KEEP
+// include-min-max-f=false: only the float ops are kept; integer ops still expand.
+// RUN: mlir-opt %s -arith-expand="include-min-max-f=false" -split-input-file | FileCheck %s --check-prefix=KEEPF
 
-// EXPAND-LABEL: func @maximumf
-// KEEP-LABEL:   func @maximumf
+// include-min-max-i=false: only the integer ops are kept; float ops still expand.
+// RUN: mlir-opt %s -arith-expand="include-min-max-i=false" -split-input-file | FileCheck %s --check-prefix=KEEPI
+
+// Both disabled: all min/max ops are kept.
+// RUN: mlir-opt %s -arith-expand="include-min-max-f=false include-min-max-i=false" -split-input-file | FileCheck %s --check-prefix=KEEPALL
+
+// EXPAND-LABEL:  func @maximumf
+// KEEPF-LABEL:   func @maximumf
+// KEEPI-LABEL:   func @maximumf
+// KEEPALL-LABEL: func @maximumf
 func.func @maximumf(%a: f32, %b: f32) -> f32 {
   // EXPAND: arith.cmpf ugt
   // EXPAND: arith.select
-  // EXPAND: arith.cmpf uno
-  // EXPAND: arith.select
   // EXPAND-NOT: arith.maximumf
-  // KEEP: arith.maximumf
-  // KEEP-NOT: arith.select
+  // KEEPF: arith.maximumf
+  // KEEPF-NOT: arith.select
+  // KEEPI: arith.cmpf ugt
+  // KEEPI-NOT: arith.maximumf
+  // KEEPALL: arith.maximumf
+  // KEEPALL-NOT: arith.select
   %result = arith.maximumf %a, %b : f32
   return %result : f32
 }
 
 // -----
 
-// EXPAND-LABEL: func @minnumf
-// KEEP-LABEL:   func @minnumf
+// EXPAND-LABEL:  func @minnumf
+// KEEPF-LABEL:   func @minnumf
+// KEEPI-LABEL:   func @minnumf
+// KEEPALL-LABEL: func @minnumf
 func.func @minnumf(%a: f32, %b: f32) -> f32 {
   // EXPAND: arith.cmpf ult
-  // EXPAND: arith.select
   // EXPAND-NOT: arith.minnumf
-  // KEEP: arith.minnumf
-  // KEEP-NOT: arith.select
+  // KEEPF: arith.minnumf
+  // KEEPI: arith.cmpf ult
+  // KEEPALL: arith.minnumf
   %result = arith.minnumf %a, %b : f32
   return %result : f32
 }
 
 // -----
 
-// EXPAND-LABEL: func @maxsi
-// KEEP-LABEL:   func @maxsi
+// EXPAND-LABEL:  func @maxsi
+// KEEPF-LABEL:   func @maxsi
+// KEEPI-LABEL:   func @maxsi
+// KEEPALL-LABEL: func @maxsi
 func.func @maxsi(%a: i32, %b: i32) -> i32 {
   // EXPAND: arith.cmpi sgt
-  // EXPAND: arith.select
   // EXPAND-NOT: arith.maxsi
-  // KEEP: arith.maxsi
-  // KEEP-NOT: arith.select
+  // KEEPF: arith.cmpi sgt
+  // KEEPF-NOT: arith.maxsi
+  // KEEPI: arith.maxsi
+  // KEEPI-NOT: arith.select
+  // KEEPALL: arith.maxsi
+  // KEEPALL-NOT: arith.select
   %result = arith.maxsi %a, %b : i32
+  return %result : i32
+}
+
+// -----
+
+// EXPAND-LABEL:  func @minui
+// KEEPF-LABEL:   func @minui
+// KEEPI-LABEL:   func @minui
+// KEEPALL-LABEL: func @minui
+func.func @minui(%a: i32, %b: i32) -> i32 {
+  // EXPAND: arith.cmpi ult
+  // EXPAND-NOT: arith.minui
+  // KEEPF: arith.cmpi ult
+  // KEEPI: arith.minui
+  // KEEPALL: arith.minui
+  %result = arith.minui %a, %b : i32
   return %result : i32
 }
 
@@ -54,11 +84,11 @@ func.func @maxsi(%a: i32, %b: i32) -> i32 {
 // Even with min/max expansion disabled, the other expansions (here
 // ceildivsi) still run.
 
-// EXPAND-LABEL: func @ceildivi_still_expands
-// KEEP-LABEL:   func @ceildivi_still_expands
+// EXPAND-LABEL:  func @ceildivi_still_expands
+// KEEPALL-LABEL: func @ceildivi_still_expands
 func.func @ceildivi_still_expands(%a: i32, %b: i32) -> i32 {
   // EXPAND-NOT: arith.ceildivsi
-  // KEEP-NOT: arith.ceildivsi
+  // KEEPALL-NOT: arith.ceildivsi
   %result = arith.ceildivsi %a, %b : i32
   return %result : i32
 }

--- a/mlir/test/Dialect/Arith/expand-ops-min-max.mlir
+++ b/mlir/test/Dialect/Arith/expand-ops-min-max.mlir
@@ -1,94 +1,100 @@
-// Default (both min/max groups expanded): the ops become cmpf/cmpi + select.
-// RUN: mlir-opt %s -arith-expand -split-input-file | FileCheck %s --check-prefix=EXPAND
+// Default (min/max expansion disabled): the ops are kept as-is so a later
+// arith-to-llvm lowering can map them to the min/max intrinsics.
+// RUN: mlir-opt %s -arith-expand -split-input-file | FileCheck %s --check-prefix=DEFAULT
 
-// include-min-max-f=false: only the float ops are kept; integer ops still expand.
-// RUN: mlir-opt %s -arith-expand="include-min-max-f=false" -split-input-file | FileCheck %s --check-prefix=KEEPF
+// include-min-max-f=true: only the float ops expand into cmpf + select; the
+// integer ops are kept (integer expansion still off by default).
+// RUN: mlir-opt %s -arith-expand="include-min-max-f=true" -split-input-file | FileCheck %s --check-prefix=EXPANDF
 
-// include-min-max-i=false: only the integer ops are kept; float ops still expand.
-// RUN: mlir-opt %s -arith-expand="include-min-max-i=false" -split-input-file | FileCheck %s --check-prefix=KEEPI
+// include-min-max-i=true: only the integer ops expand into cmpi + select; the
+// float ops are kept (float expansion still off by default).
+// RUN: mlir-opt %s -arith-expand="include-min-max-i=true" -split-input-file | FileCheck %s --check-prefix=EXPANDI
 
-// Both disabled: all min/max ops are kept.
-// RUN: mlir-opt %s -arith-expand="include-min-max-f=false include-min-max-i=false" -split-input-file | FileCheck %s --check-prefix=KEEPALL
+// Both enabled: all min/max ops are expanded.
+// RUN: mlir-opt %s -arith-expand="include-min-max-f=true include-min-max-i=true" -split-input-file | FileCheck %s --check-prefix=EXPANDALL
 
-// EXPAND-LABEL:  func @maximumf
-// KEEPF-LABEL:   func @maximumf
-// KEEPI-LABEL:   func @maximumf
-// KEEPALL-LABEL: func @maximumf
+// DEFAULT-LABEL:   func @maximumf
+// EXPANDF-LABEL:   func @maximumf
+// EXPANDI-LABEL:   func @maximumf
+// EXPANDALL-LABEL: func @maximumf
 func.func @maximumf(%a: f32, %b: f32) -> f32 {
-  // EXPAND: arith.cmpf ugt
-  // EXPAND: arith.select
-  // EXPAND-NOT: arith.maximumf
-  // KEEPF: arith.maximumf
-  // KEEPF-NOT: arith.select
-  // KEEPI: arith.cmpf ugt
-  // KEEPI-NOT: arith.maximumf
-  // KEEPALL: arith.maximumf
-  // KEEPALL-NOT: arith.select
+  // DEFAULT: arith.maximumf
+  // DEFAULT-NOT: arith.select
+  // EXPANDF: arith.cmpf ugt
+  // EXPANDF: arith.select
+  // EXPANDF-NOT: arith.maximumf
+  // EXPANDI: arith.maximumf
+  // EXPANDI-NOT: arith.select
+  // EXPANDALL: arith.cmpf ugt
+  // EXPANDALL: arith.select
+  // EXPANDALL-NOT: arith.maximumf
   %result = arith.maximumf %a, %b : f32
   return %result : f32
 }
 
 // -----
 
-// EXPAND-LABEL:  func @minnumf
-// KEEPF-LABEL:   func @minnumf
-// KEEPI-LABEL:   func @minnumf
-// KEEPALL-LABEL: func @minnumf
+// DEFAULT-LABEL:   func @minnumf
+// EXPANDF-LABEL:   func @minnumf
+// EXPANDI-LABEL:   func @minnumf
+// EXPANDALL-LABEL: func @minnumf
 func.func @minnumf(%a: f32, %b: f32) -> f32 {
-  // EXPAND: arith.cmpf ult
-  // EXPAND-NOT: arith.minnumf
-  // KEEPF: arith.minnumf
-  // KEEPI: arith.cmpf ult
-  // KEEPALL: arith.minnumf
+  // DEFAULT: arith.minnumf
+  // EXPANDF: arith.cmpf ult
+  // EXPANDF-NOT: arith.minnumf
+  // EXPANDI: arith.minnumf
+  // EXPANDALL: arith.cmpf ult
+  // EXPANDALL-NOT: arith.minnumf
   %result = arith.minnumf %a, %b : f32
   return %result : f32
 }
 
 // -----
 
-// EXPAND-LABEL:  func @maxsi
-// KEEPF-LABEL:   func @maxsi
-// KEEPI-LABEL:   func @maxsi
-// KEEPALL-LABEL: func @maxsi
+// DEFAULT-LABEL:   func @maxsi
+// EXPANDF-LABEL:   func @maxsi
+// EXPANDI-LABEL:   func @maxsi
+// EXPANDALL-LABEL: func @maxsi
 func.func @maxsi(%a: i32, %b: i32) -> i32 {
-  // EXPAND: arith.cmpi sgt
-  // EXPAND-NOT: arith.maxsi
-  // KEEPF: arith.cmpi sgt
-  // KEEPF-NOT: arith.maxsi
-  // KEEPI: arith.maxsi
-  // KEEPI-NOT: arith.select
-  // KEEPALL: arith.maxsi
-  // KEEPALL-NOT: arith.select
+  // DEFAULT: arith.maxsi
+  // DEFAULT-NOT: arith.select
+  // EXPANDF: arith.maxsi
+  // EXPANDF-NOT: arith.select
+  // EXPANDI: arith.cmpi sgt
+  // EXPANDI-NOT: arith.maxsi
+  // EXPANDALL: arith.cmpi sgt
+  // EXPANDALL-NOT: arith.maxsi
   %result = arith.maxsi %a, %b : i32
   return %result : i32
 }
 
 // -----
 
-// EXPAND-LABEL:  func @minui
-// KEEPF-LABEL:   func @minui
-// KEEPI-LABEL:   func @minui
-// KEEPALL-LABEL: func @minui
+// DEFAULT-LABEL:   func @minui
+// EXPANDF-LABEL:   func @minui
+// EXPANDI-LABEL:   func @minui
+// EXPANDALL-LABEL: func @minui
 func.func @minui(%a: i32, %b: i32) -> i32 {
-  // EXPAND: arith.cmpi ult
-  // EXPAND-NOT: arith.minui
-  // KEEPF: arith.cmpi ult
-  // KEEPI: arith.minui
-  // KEEPALL: arith.minui
+  // DEFAULT: arith.minui
+  // EXPANDF: arith.minui
+  // EXPANDI: arith.cmpi ult
+  // EXPANDI-NOT: arith.minui
+  // EXPANDALL: arith.cmpi ult
+  // EXPANDALL-NOT: arith.minui
   %result = arith.minui %a, %b : i32
   return %result : i32
 }
 
 // -----
 
-// Even with min/max expansion disabled, the other expansions (here
-// ceildivsi) still run.
+// Regardless of the min/max gating, the other expansions (here ceildivsi)
+// always run.
 
-// EXPAND-LABEL:  func @ceildivi_still_expands
-// KEEPALL-LABEL: func @ceildivi_still_expands
+// DEFAULT-LABEL:   func @ceildivi_still_expands
+// EXPANDALL-LABEL: func @ceildivi_still_expands
 func.func @ceildivi_still_expands(%a: i32, %b: i32) -> i32 {
-  // EXPAND-NOT: arith.ceildivsi
-  // KEEPALL-NOT: arith.ceildivsi
+  // DEFAULT-NOT: arith.ceildivsi
+  // EXPANDALL-NOT: arith.ceildivsi
   %result = arith.ceildivsi %a, %b : i32
   return %result : i32
 }

--- a/mlir/test/Dialect/Arith/expand-ops.mlir
+++ b/mlir/test/Dialect/Arith/expand-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -arith-expand="include-bf16=true include-f8e8m0=true include-f4e2m1=true" -verify-diagnostics -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -arith-expand="include-bf16=true include-f8e8m0=true include-f4e2m1=true include-min-max-f=true include-min-max-i=true" -verify-diagnostics -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -arith-expand -split-input-file -verify-diagnostics | FileCheck %s --check-prefix=SCHECK
 
 // Test ceil divide with signed integer

--- a/mlir/test/Dialect/EmitC/arith/ops.mlir
+++ b/mlir/test/Dialect/EmitC/arith/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -arith-expand -convert-arith-to-emitc %s | FileCheck %s
+// RUN: mlir-opt -arith-expand="include-min-max-f=true include-min-max-i=true" -convert-arith-to-emitc %s | FileCheck %s
 
 /// This file checks the combined `-arith-expand | -convert-arith-to-emitc`
 /// pipeline with intentionally minimal FileCheck coverage.


### PR DESCRIPTION
`arith-expand` expanded `arith.maximumf`/`minimumf`/`maxnumf`/`minnumf` and the signed/unsigned integer max/min ops into `cmpf`/`cmpi` + `select` sequences. These ops also have a direct arith-to-llvm lowering to the `llvm.intr.maximum`/`minimum`/... intrinsics, which are a single hardware instruction on many targets. Pipelines that run arith-to-llvm after arith-expand (e.g. the GPU-to-XeVM pipeline) therefore paid a large, avoidable overhead.

Add an `include-min-max` option (default `true`, preserving existing behavior) that controls whether these min/max ops are expanded. The min/max converters are factored into a new `populateExpandMinMaxPatterns`; the ceil/floor-div and scaling ext/trunc expansions (which have no LLVM lowering) always run. Set `include-min-max=false` in the GPU-to-XeVM pipeline so the intrinsic lowering is used.