### PR TITLE
[flang][acc] Emit NYI messages for unsupported directives

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Passes.h
+++ b/flang/include/flang/Optimizer/OpenACC/Passes.h
@@ -33,6 +33,9 @@ std::unique_ptr<mlir::Pass> createACCOptimizeFirstprivateMapPass();
 std::unique_ptr<mlir::Pass> createACCRecipeBufferizationPass();
 std::unique_ptr<mlir::Pass> createACCUseDeviceCanonicalizerPass();
 
+/// Populate the OpenACC pass pipeline that runs at HLFIR level.
+void populateHLFIROpenACCPassPipeline(mlir::PassManager &pm);
+
 } // namespace acc
 } // namespace fir
 

--- a/flang/include/flang/Optimizer/OpenACC/Passes.td
+++ b/flang/include/flang/Optimizer/OpenACC/Passes.td
@@ -11,6 +11,15 @@
 
 include "mlir/Pass/PassBase.td"
 
+def ACCEmitNYIFlang
+    : Pass<"acc-emit-nyi-flang", "mlir::ModuleOp"> {
+  let summary = "Emit not-yet-implemented messages for OpenACC";
+  let description = [{
+    Emits not-yet-implemented messages for OpenACC directives that are not yet
+    supported through code generation.
+  }];
+}
+
 def ACCInitializeFIRAnalyses
     : Pass<"acc-initialize-fir-analyses", "mlir::ModuleOp"> {
   let summary = "Initialize FIR analyses for OpenACC passes";
@@ -18,9 +27,14 @@ def ACCInitializeFIRAnalyses
     This pass initializes analyses that can be used by subsequent OpenACC passes
     in the pipeline. It creates and caches the OpenACCSupport analysis with a
     FIR-specific implementation that can handle FIR types and operations.
-    It also initializes FIR's AliasAnalysis for use in OpenACC passes.
+    It can also initialize FIR's AliasAnalysis for use in OpenACC passes.
     This pass needs to rerun if any analyses were invalidated by MLIR's framework.
   }];
+  let options = [
+    Option<"addFIRAliasAnalysis", "add-fir-alias-analysis", "bool",
+           /*default=*/"true",
+           "Initialize FIR AliasAnalysis for use by subsequent OpenACC passes.">
+  ];
   // In addition to pre-registering the needed analyses, this pass also
   // pre-registers the dialects that various OpenACC passes may generate.
   let dependentDialects = ["fir::FIROpsDialect", "hlfir::hlfirDialect",

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -139,6 +139,7 @@ struct MLIRToLLVMPassPipelineConfig : public FlangEPCallBacks {
   std::string PreferVectorWidth = ""; ///< Set prefer-vector-width attribute for
                                       ///< functions.
   bool NSWOnLoopVarInc = true; ///< Add nsw flag to loop variable increments.
+  bool EnableOpenACC = false; ///< Enable OpenACC lowering.
   bool EnableOpenMP = false; ///< Enable OpenMP lowering.
   bool EnableOpenMPIsTargetDevice =
       false; ///< Compiling for an OpenMP target device.

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -760,6 +760,10 @@ void CodeGenAction::generateLLVMIR() {
   config.PreferVectorWidth = opts.PreferVectorWidth;
 
   if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
+          Fortran::common::LanguageFeature::OpenACC))
+    config.EnableOpenACC = true;
+
+  if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
           Fortran::common::LanguageFeature::OpenMP))
     config.EnableOpenMP = true;
 

--- a/flang/lib/Optimizer/OpenACC/Transforms/ACCEmitNYIFlang.cpp
+++ b/flang/lib/Optimizer/OpenACC/Transforms/ACCEmitNYIFlang.cpp
@@ -1,0 +1,112 @@
+//===- ACCEmitNYIFlang.cpp - Emit NYI diagnostics for OpenACC ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/OpenACC/Passes.h"
+#include "mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include <optional>
+
+namespace fir::acc {
+#define GEN_PASS_DEF_ACCEMITNYIFLANG
+#include "flang/Optimizer/OpenACC/Passes.h.inc"
+} // namespace fir::acc
+
+namespace {
+
+static std::optional<llvm::StringRef>
+getOpenACCDirectiveName(mlir::Operation *op) {
+  return llvm::TypeSwitch<mlir::Operation *, std::optional<llvm::StringRef>>(op)
+      .Case<mlir::acc::ParallelOp>(
+          [](auto parallel) -> std::optional<llvm::StringRef> {
+            return parallel.getCombined() ? "parallel loop" : "parallel";
+          })
+      .Case<mlir::acc::KernelsOp>(
+          [](auto kernels) -> std::optional<llvm::StringRef> {
+            return kernels.getCombined() ? "kernels loop" : "kernels";
+          })
+      .Case<mlir::acc::SerialOp>(
+          [](auto serial) -> std::optional<llvm::StringRef> {
+            return serial.getCombined() ? "serial loop" : "serial";
+          })
+      .Case<mlir::acc::DataOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "data"; })
+      .Case<mlir::acc::LoopOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "loop"; })
+      .Case<mlir::acc::EnterDataOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "enter data"; })
+      .Case<mlir::acc::ExitDataOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "exit data"; })
+      .Case<mlir::acc::HostDataOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "host_data"; })
+      .Case<mlir::acc::InitOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "init"; })
+      .Case<mlir::acc::ShutdownOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "shutdown"; })
+      .Case<mlir::acc::UpdateOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "update"; })
+      .Case<mlir::acc::SetOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "set"; })
+      .Case<mlir::acc::WaitOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "wait"; })
+      .Case<mlir::acc::AtomicReadOp, mlir::acc::AtomicWriteOp,
+            mlir::acc::AtomicUpdateOp, mlir::acc::AtomicCaptureOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "atomic"; })
+      .Case<mlir::acc::RoutineOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "routine"; })
+      .Case<mlir::acc::DeclareEnterOp, mlir::acc::DeclareExitOp,
+            mlir::acc::DeclareOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "declare"; })
+      .Case<mlir::acc::CacheOp>(
+          [](auto) -> std::optional<llvm::StringRef> { return "cache"; })
+      .Default([](mlir::Operation *) -> std::optional<llvm::StringRef> {
+        return std::nullopt;
+      });
+}
+
+class ACCEmitNYIFlang
+    : public fir::acc::impl::ACCEmitNYIFlangBase<ACCEmitNYIFlang> {
+public:
+  void runOnOperation() override {
+    mlir::acc::OpenACCSupport &accSupport =
+        getAnalysis<mlir::acc::OpenACCSupport>();
+    bool emittedError = false;
+
+    // Check source-level directives first so that Flang's fatal TODO reports
+    // the directive rather than one of its decomposed clause operations.
+    // Pre-order ensures combined compute ops are seen before nested ops.
+    getOperation().walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      std::optional<llvm::StringRef> directiveName =
+          getOpenACCDirectiveName(op);
+      if (!directiveName)
+        return;
+      (void)accSupport.emitNYI(op->getLoc(), llvm::Twine("OpenACC ") +
+                                                 *directiveName + " directive");
+      emittedError = true;
+    });
+
+    // Diagnose any remaining OpenACC operation as a fallback.
+    getOperation().walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      if (getOpenACCDirectiveName(op) ||
+          mlir::isa<mlir::acc::YieldOp, mlir::acc::TerminatorOp>(op) ||
+          !mlir::isa<mlir::acc::OpenACCDialect>(op->getDialect()))
+        return;
+      (void)accSupport.emitNYI(op->getLoc(), llvm::Twine("OpenACC operation ") +
+                                                 op->getName().getStringRef());
+      emittedError = true;
+    });
+
+    if (emittedError)
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/flang/lib/Optimizer/OpenACC/Transforms/ACCInitializeFIRAnalyses.cpp
+++ b/flang/lib/Optimizer/OpenACC/Transforms/ACCInitializeFIRAnalyses.cpp
@@ -35,14 +35,18 @@ class ACCInitializeFIRAnalysesPass
     : public fir::acc::impl::ACCInitializeFIRAnalysesBase<
           ACCInitializeFIRAnalysesPass> {
 public:
+  using ACCInitializeFIRAnalysesBase::ACCInitializeFIRAnalysesBase;
+
   void runOnOperation() override {
     // Initialize OpenACCSupport with FIR-specific implementation.
     auto &openACCSupport = getAnalysis<mlir::acc::OpenACCSupport>();
     openACCSupport.setImplementation(fir::acc::FIROpenACCSupportAnalysis());
 
-    // Initialize AliasAnalysis with FIR-specific implementation.
-    auto &aliasAnalysis = getAnalysis<mlir::AliasAnalysis>();
-    aliasAnalysis.addAnalysisImplementation(fir::AliasAnalysis());
+    if (addFIRAliasAnalysis) {
+      // Initialize AliasAnalysis with FIR-specific implementation.
+      auto &aliasAnalysis = getAnalysis<mlir::AliasAnalysis>();
+      aliasAnalysis.addAnalysisImplementation(fir::AliasAnalysis());
+    }
 
     // Mark all analyses as preserved since this pass only initializes them
     markAllAnalysesPreserved();

--- a/flang/lib/Optimizer/OpenACC/Transforms/ACCPipeline.cpp
+++ b/flang/lib/Optimizer/OpenACC/Transforms/ACCPipeline.cpp
@@ -1,0 +1,21 @@
+//===- ACCPipeline.cpp - OpenACC flang pass pipelines ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/OpenACC/Passes.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace fir::acc {
+
+void populateHLFIROpenACCPassPipeline(mlir::PassManager &pm) {
+  ACCInitializeFIRAnalysesOptions opts;
+  opts.addFIRAliasAnalysis = false;
+  pm.addPass(createACCInitializeFIRAnalyses(opts));
+  pm.addPass(createACCEmitNYIFlang());
+}
+
+} // namespace fir::acc

--- a/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_flang_library(FIROpenACCTransforms
   ACCDeclareActionConversion.cpp
+  ACCEmitNYIFlang.cpp
   ACCInitializeFIRAnalyses.cpp
+  ACCPipeline.cpp
   ACCOptimizeFirstprivateMap.cpp
   ACCRecipeBufferization.cpp
   ACCUseDeviceCanonicalizer.cpp

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -489,6 +489,9 @@ void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
 void createMLIRToLLVMPassPipeline(mlir::PassManager &pm,
                                   MLIRToLLVMPassPipelineConfig &config,
                                   llvm::StringRef inputFilename) {
+  if (config.EnableOpenACC)
+    fir::acc::populateHLFIROpenACCPassPipeline(pm);
+
   fir::EnableOpenMP enableOpenMP = fir::EnableOpenMP::None;
   if (config.EnableOpenMP)
     enableOpenMP = fir::EnableOpenMP::Full;

--- a/flang/test/Driver/openacc-nyi.f90
+++ b/flang/test/Driver/openacc-nyi.f90
@@ -1,0 +1,199 @@
+! Verify that OpenACC NYI diagnostics are delayed until code generation and
+! use Flang's TODO facility for every source-level directive.
+
+! RUN: split-file %s %t
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/parallel.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/kernels.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/serial.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/parallel-loop.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/kernels-loop.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/serial-loop.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/data.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/loop.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/enter-data.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/exit-data.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/host-data.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/init.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/shutdown.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/update.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/set.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/wait.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/atomic.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/routine.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/declare.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/declare-module-global.f90
+! RUN: %flang_fc1 -fopenacc -emit-hlfir %t/cache.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/parallel.f90 2>&1 | FileCheck %t/parallel.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/kernels.f90 2>&1 | FileCheck %t/kernels.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/serial.f90 2>&1 | FileCheck %t/serial.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/parallel-loop.f90 2>&1 | FileCheck %t/parallel-loop.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/kernels-loop.f90 2>&1 | FileCheck %t/kernels-loop.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/serial-loop.f90 2>&1 | FileCheck %t/serial-loop.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/data.f90 2>&1 | FileCheck %t/data.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/loop.f90 2>&1 | FileCheck %t/loop.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/enter-data.f90 2>&1 | FileCheck %t/enter-data.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/exit-data.f90 2>&1 | FileCheck %t/exit-data.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/host-data.f90 2>&1 | FileCheck %t/host-data.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/init.f90 2>&1 | FileCheck %t/init.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/shutdown.f90 2>&1 | FileCheck %t/shutdown.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/update.f90 2>&1 | FileCheck %t/update.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/set.f90 2>&1 | FileCheck %t/set.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/wait.f90 2>&1 | FileCheck %t/wait.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/atomic.f90 2>&1 | FileCheck %t/atomic.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/routine.f90 2>&1 | FileCheck %t/routine.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/declare.f90 2>&1 | FileCheck %t/declare.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/declare-module-global.f90 2>&1 | FileCheck %t/declare-module-global.f90
+! RUN: %not_todo_cmd %flang -fopenacc -S -emit-llvm %t/cache.f90 2>&1 | FileCheck %t/cache.f90
+
+!--- parallel.f90
+! CHECK: not yet implemented: OpenACC parallel directive
+subroutine test
+  !$acc parallel
+  !$acc end parallel
+end
+
+!--- kernels.f90
+! CHECK: not yet implemented: OpenACC kernels directive
+subroutine test
+  !$acc kernels
+  !$acc end kernels
+end
+
+!--- serial.f90
+! CHECK: not yet implemented: OpenACC serial directive
+subroutine test
+  !$acc serial
+  !$acc end serial
+end
+
+!--- parallel-loop.f90
+! CHECK: not yet implemented: OpenACC parallel loop directive
+subroutine test
+  integer i
+  !$acc parallel loop
+  do i = 1, 10
+  end do
+end
+
+!--- kernels-loop.f90
+! CHECK: not yet implemented: OpenACC kernels loop directive
+subroutine test
+  integer i
+  !$acc kernels loop
+  do i = 1, 10
+  end do
+end
+
+!--- serial-loop.f90
+! CHECK: not yet implemented: OpenACC serial loop directive
+subroutine test
+  integer i
+  !$acc serial loop
+  do i = 1, 10
+  end do
+end
+
+!--- data.f90
+! CHECK: not yet implemented: OpenACC data directive
+subroutine test(a)
+  real a
+  !$acc data copy(a)
+  !$acc end data
+end
+
+!--- loop.f90
+! CHECK: not yet implemented: OpenACC loop directive
+subroutine test
+  integer i
+  !$acc loop
+  do i = 1, 10
+  end do
+end
+
+!--- enter-data.f90
+! CHECK: not yet implemented: OpenACC enter data directive
+subroutine test(a)
+  real a
+  !$acc enter data copyin(a)
+end
+
+!--- exit-data.f90
+! CHECK: not yet implemented: OpenACC exit data directive
+subroutine test(a)
+  real a
+  !$acc exit data delete(a)
+end
+
+!--- host-data.f90
+! CHECK: not yet implemented: OpenACC host_data directive
+subroutine test(a)
+  real a
+  !$acc host_data use_device(a)
+  !$acc end host_data
+end
+
+!--- init.f90
+! CHECK: not yet implemented: OpenACC init directive
+subroutine test
+  !$acc init
+end
+
+!--- shutdown.f90
+! CHECK: not yet implemented: OpenACC shutdown directive
+subroutine test
+  !$acc shutdown
+end
+
+!--- update.f90
+! CHECK: not yet implemented: OpenACC update directive
+subroutine test(a)
+  real a
+  !$acc update device(a)
+end
+
+!--- set.f90
+! CHECK: not yet implemented: OpenACC set directive
+subroutine test
+  !$acc set device_num(0)
+end
+
+!--- wait.f90
+! CHECK: not yet implemented: OpenACC wait directive
+subroutine test
+  !$acc wait
+end
+
+!--- atomic.f90
+! CHECK: not yet implemented: OpenACC atomic directive
+subroutine test(a)
+  integer a
+  !$acc atomic update
+  a = a + 1
+end
+
+!--- routine.f90
+! CHECK: not yet implemented: OpenACC routine directive
+subroutine test
+  !$acc routine seq
+end
+
+!--- declare.f90
+! CHECK: not yet implemented: OpenACC declare directive
+subroutine test
+  real a
+  !$acc declare create(a)
+end
+
+!--- declare-module-global.f90
+! CHECK: not yet implemented: OpenACC declare directive
+module test
+  real :: a
+  !$acc declare create(a)
+end module
+
+!--- cache.f90
+! CHECK: not yet implemented: OpenACC cache directive
+subroutine test(a)
+  real a(10)
+  !$acc cache(a)
+end

--- a/flang/test/Transforms/OpenACC/acc-emit-nyi-flang.fir
+++ b/flang/test/Transforms/OpenACC/acc-emit-nyi-flang.fir
@@ -1,0 +1,128 @@
+// RUN: fir-opt %s --acc-emit-nyi-flang --verify-diagnostics
+
+func.func @acc_func() attributes {
+  acc.routine_info = #acc.routine_info<[@acc_func_routine]>
+} {
+  return
+}
+
+// expected-error @+1 {{not yet implemented: OpenACC routine directive}}
+acc.routine @acc_func_routine func(@acc_func)
+
+func.func @directives(%ptr: !llvm.ptr, %v: memref<i32>,
+                      %x: memref<i32>, %value: i32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // expected-error @+1 {{not yet implemented: OpenACC parallel directive}}
+  acc.parallel {
+    acc.yield
+  }
+  // expected-error @+1 {{not yet implemented: OpenACC kernels directive}}
+  acc.kernels {
+    acc.terminator
+  }
+  // expected-error @+1 {{not yet implemented: OpenACC serial directive}}
+  acc.serial {
+    acc.yield
+  }
+
+  // expected-error @+1 {{not yet implemented: OpenACC parallel loop directive}}
+  acc.parallel combined(loop) {
+    // expected-error @+1 {{not yet implemented: OpenACC loop directive}}
+    acc.loop combined(parallel) control(%iv : index) = (%c0 : index)
+        to (%c1 : index) step (%c1 : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>]}
+    acc.terminator
+  }
+  // expected-error @+1 {{not yet implemented: OpenACC kernels loop directive}}
+  acc.kernels combined(loop) {
+    // expected-error @+1 {{not yet implemented: OpenACC loop directive}}
+    acc.loop combined(kernels) control(%iv : index) = (%c0 : index)
+        to (%c1 : index) step (%c1 : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>]}
+    acc.terminator
+  }
+  // expected-error @+1 {{not yet implemented: OpenACC serial loop directive}}
+  acc.serial combined(loop) {
+    // expected-error @+1 {{not yet implemented: OpenACC loop directive}}
+    acc.loop combined(serial) control(%iv : index) = (%c0 : index)
+        to (%c1 : index) step (%c1 : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>]}
+    acc.terminator
+  }
+
+  // expected-error @+1 {{not yet implemented: OpenACC data directive}}
+  acc.data {
+    acc.terminator
+  } attributes {defaultAttr = #acc<defaultvalue none>}
+  // expected-error @+1 {{not yet implemented: OpenACC loop directive}}
+  acc.loop control(%iv : index) = (%c0 : index) to (%c1 : index)
+      step (%c1 : index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+
+  // expected-error @+1 {{not yet implemented: OpenACC operation acc.copyin}}
+  %copyin = acc.copyin varPtr(%ptr : !llvm.ptr) varType(i32) -> !llvm.ptr
+  // expected-error @+1 {{not yet implemented: OpenACC enter data directive}}
+  acc.enter_data dataOperands(%copyin : !llvm.ptr)
+  // expected-error @+1 {{not yet implemented: OpenACC operation acc.getdeviceptr}}
+  %devicePtr = acc.getdeviceptr varPtr(%ptr : !llvm.ptr) varType(i32) -> !llvm.ptr
+  // expected-error @+1 {{not yet implemented: OpenACC exit data directive}}
+  acc.exit_data dataOperands(%devicePtr : !llvm.ptr)
+
+  // expected-error @+1 {{not yet implemented: OpenACC operation acc.use_device}}
+  %useDevice = acc.use_device varPtr(%ptr : !llvm.ptr) varType(i32) -> !llvm.ptr
+  // expected-error @+1 {{not yet implemented: OpenACC host_data directive}}
+  acc.host_data dataOperands(%useDevice : !llvm.ptr) {
+    acc.terminator
+  }
+
+  // expected-error @+1 {{not yet implemented: OpenACC init directive}}
+  acc.init
+  // expected-error @+1 {{not yet implemented: OpenACC shutdown directive}}
+  acc.shutdown
+  // expected-error @+1 {{not yet implemented: OpenACC set directive}}
+  acc.set attributes {device_type = #acc.device_type<nvidia>}
+  // expected-error @+1 {{not yet implemented: OpenACC wait directive}}
+  acc.wait
+
+  // expected-error @+1 {{not yet implemented: OpenACC operation acc.update_device}}
+  %updateDevice = acc.update_device varPtr(%ptr : !llvm.ptr) varType(i32) -> !llvm.ptr
+  // expected-error @+1 {{not yet implemented: OpenACC update directive}}
+  acc.update dataOperands(%updateDevice : !llvm.ptr)
+
+  // expected-error @+1 {{not yet implemented: OpenACC atomic directive}}
+  acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+  // expected-error @+1 {{not yet implemented: OpenACC atomic directive}}
+  acc.atomic.write %x = %value : memref<i32>, i32
+  // expected-error @+1 {{not yet implemented: OpenACC atomic directive}}
+  acc.atomic.update %x : memref<i32> {
+  ^bb0(%old: i32):
+    acc.yield %old : i32
+  }
+  // expected-error @+1 {{not yet implemented: OpenACC atomic directive}}
+  acc.atomic.capture {
+    // expected-error @+1 {{not yet implemented: OpenACC atomic directive}}
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    // expected-error @+1 {{not yet implemented: OpenACC atomic directive}}
+    acc.atomic.write %x = %value : memref<i32>, i32
+  }
+
+  // expected-error @+1 {{not yet implemented: OpenACC cache directive}}
+  %cache = acc.cache varPtr(%ptr : !llvm.ptr) varType(i32) -> !llvm.ptr
+
+  // expected-error @+1 {{not yet implemented: OpenACC declare directive}}
+  acc.declare_enter dataOperands(%copyin : !llvm.ptr)
+  // expected-error @+1 {{not yet implemented: OpenACC declare directive}}
+  acc.declare_exit dataOperands(%copyin : !llvm.ptr)
+  // expected-error @+1 {{not yet implemented: OpenACC declare directive}}
+  acc.declare dataOperands(%copyin : !llvm.ptr) {
+    acc.terminator
+  }
+
+  return
+}


### PR DESCRIPTION
Add an OpenACC MLIR pass that emits not-yet-implemented messages for unsupported directives immediately after HLFIR generation. This allows OpenACC dialect operations to be emitted with -emit-hlfir while making full compilation fail early with clear diagnostics, instead of later when unhandled OpenACC operations reach LLVM dialect conversion.