### PR TITLE
[HashRecognize] Fix compiler crash on missing latch compare instruction

### DIFF
--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -512,7 +512,8 @@ std::variant<PolynomialInfo, StringRef> HashRecognize::recognizeCRC() const {
   BasicBlock *Latch = L.getLoopLatch();
   BasicBlock *Exit = L.getExitBlock();
   const PHINode *IndVar = L.getCanonicalInductionVariable();
-  if (!Latch || !Exit || !IndVar || L.getNumBlocks() != 1)
+  if (!Latch || !Exit || !IndVar || L.getNumBlocks() != 1 ||
+      !L.getLatchCmpInst())
     return "Loop not in canonical form";
   unsigned TC = SE.getSmallConstantTripCount(&L);
   if (!TC)

--- a/llvm/test/Analysis/HashRecognize/cyclic-redundancy-check.ll
+++ b/llvm/test/Analysis/HashRecognize/cyclic-redundancy-check.ll
@@ -858,6 +858,31 @@ exit:                                              ; preds = %loop
   ret i16 %crc.next
 }
 
+define i16 @not.crc.latch.cond.not.icmp(i16 %crc.init) {
+; CHECK-LABEL: 'not.crc.latch.cond.not.icmp'
+; CHECK-NEXT:  Did not find a hash algorithm
+; CHECK-NEXT:  Reason: Loop not in canonical form
+;
+entry:
+  br label %loop
+
+loop:                                              ; preds = %loop, %entry
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  %crc = phi i16 [ %crc.init, %entry ], [ %crc.next, %loop ]
+  %crc.shl = shl i16 %crc, 1
+  %crc.xor = xor i16 %crc.shl, 4129
+  %check.sb = icmp slt i16 %crc, 0
+  %crc.next = select i1 %check.sb, i16 %crc.xor, i16 %crc.shl
+  %iv.next = add nuw nsw i32 %iv, 1
+  %exit.cond.lo = icmp samesign ult i32 %iv, 7
+  %exit.cond.hi = icmp samesign ult i32 %iv, 100
+  %exit.cond = and i1 %exit.cond.lo, %exit.cond.hi
+  br i1 %exit.cond, label %loop, label %exit
+
+exit:                                              ; preds = %loop
+  ret i16 %crc.next
+}
+
 define i16 @not.crc.tc.exceeds.data.bw(i16 %crc.init) {
 ; CHECK-LABEL: 'not.crc.tc.exceeds.data.bw'
 ; CHECK-NEXT:  Did not find a hash algorithm


### PR DESCRIPTION
It is never checked whether a candidate loop `L` is latched by a compare instruction, yet `L.getLatchCmpInst()` is added to the `Roots` for `containsUnreachable`. If a loop is predicated on anything other than a compare instruction, `getLatchCmpInst()` returns `nullptr`, causing `containsUnreachable` to crash when calling `isa<PHINode>`. To fix, consider loops where `L.getLatchCmpInst()` is null to be not in canonical form, and reject them.
- Crash: https://godbolt.org/z/Tboo4jo5Y

Assisted-by: Claude Opus 5