### PR TITLE
[Hexagon] Lower vreduce(min|max)((imum)?)

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.h
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.h
@@ -498,6 +498,14 @@ private:
   SDValue LowerHvxPred64ToFp(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerHvxPartialReduceMLA(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerHvxFpSetoeq(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerHvxVecReduceFMinMax(SDValue Op, unsigned PairwiseOpc,
+                                   bool IgnoreNaN, SelectionDAG &DAG) const;
+  SDValue LowerHvxVecReduceFMin(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerHvxVecReduceFMax(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerHvxVecReduceFMinimum(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerHvxVecReduceFMaximum(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerHvxFMinNum(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerHvxFMaxNum(SDValue Op, SelectionDAG &DAG) const;
   SDValue ExpandHvxFpToInt(SDValue Op, SelectionDAG &DAG) const;
   SDValue ExpandHvxIntToFp(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerHvxStore(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -149,8 +149,14 @@ HexagonTargetLowering::initializeHVXLowering() {
       setOperationAction(ISD::FMUL,              T, Legal);
       setOperationAction(ISD::FMINIMUMNUM, T, Legal);
       setOperationAction(ISD::FMAXIMUMNUM, T, Legal);
-      setOperationAction(ISD::FMINNUM, T, Legal);
-      setOperationAction(ISD::FMAXNUM, T, Legal);
+      setOperationAction(ISD::FMINIMUM, T, Legal);
+      setOperationAction(ISD::FMAXIMUM, T, Legal);
+      setOperationAction(ISD::FMINNUM, T, Custom);
+      setOperationAction(ISD::FMAXNUM, T, Custom);
+      setOperationAction(ISD::VECREDUCE_FMIN, T, Custom);
+      setOperationAction(ISD::VECREDUCE_FMAX, T, Custom);
+      setOperationAction(ISD::VECREDUCE_FMINIMUM, T, Custom);
+      setOperationAction(ISD::VECREDUCE_FMAXIMUM, T, Custom);
 
       setOperationAction(ISD::INSERT_SUBVECTOR,  T, Custom);
       setOperationAction(ISD::EXTRACT_SUBVECTOR, T, Custom);
@@ -230,8 +236,14 @@ HexagonTargetLowering::initializeHVXLowering() {
       setOperationAction(ISD::FMUL,           P, Custom);
       setOperationAction(ISD::FMINIMUMNUM, P, Custom);
       setOperationAction(ISD::FMAXIMUMNUM, P, Custom);
+      setOperationAction(ISD::FMINIMUM, P, Custom);
+      setOperationAction(ISD::FMAXIMUM, P, Custom);
       setOperationAction(ISD::FMINNUM, P, Custom);
       setOperationAction(ISD::FMAXNUM, P, Custom);
+      setOperationAction(ISD::VECREDUCE_FMIN, P, Custom);
+      setOperationAction(ISD::VECREDUCE_FMAX, P, Custom);
+      setOperationAction(ISD::VECREDUCE_FMINIMUM, P, Custom);
+      setOperationAction(ISD::VECREDUCE_FMAXIMUM, P, Custom);
       setOperationAction(ISD::SETCC,          P, Custom);
       setOperationAction(ISD::VSELECT,        P, Custom);
 
@@ -3772,6 +3784,8 @@ HexagonTargetLowering::LowerHvxOperation(SDValue Op, SelectionDAG &DAG) const {
       case ISD::FMUL:
       case ISD::FMINIMUMNUM:
       case ISD::FMAXIMUMNUM:
+      case ISD::FMINIMUM:
+      case ISD::FMAXIMUM:
       case ISD::FMINNUM:
       case ISD::FMAXNUM:
       case ISD::MULHS:
@@ -3859,6 +3873,18 @@ HexagonTargetLowering::LowerHvxOperation(SDValue Op, SelectionDAG &DAG) const {
     case ISD::PARTIAL_REDUCE_UMLA:
     case ISD::PARTIAL_REDUCE_SUMLA:
       return LowerHvxPartialReduceMLA(Op, DAG);
+    case ISD::VECREDUCE_FMIN:
+      return LowerHvxVecReduceFMin(Op, DAG);
+    case ISD::VECREDUCE_FMAX:
+      return LowerHvxVecReduceFMax(Op, DAG);
+    case ISD::VECREDUCE_FMINIMUM:
+      return LowerHvxVecReduceFMinimum(Op, DAG);
+    case ISD::VECREDUCE_FMAXIMUM:
+      return LowerHvxVecReduceFMaximum(Op, DAG);
+    case ISD::FMINNUM:
+      return LowerHvxFMinNum(Op, DAG);
+    case ISD::FMAXNUM:
+      return LowerHvxFMaxNum(Op, DAG);
       // clang-format on
   }
 #ifndef NDEBUG
@@ -4389,6 +4415,172 @@ SDValue HexagonTargetLowering::splitVecReduceAdd(SDNode *N,
   // SelectionDAGBuilder. However, we just replace the final result since we
   // have analyzed the input completely.
   return DAG.getNode(ISD::VECREDUCE_ADD, DL, ScalarType, Partial);
+}
+
+// Shared helper for VECREDUCE_FMIN/FMAX/FMINIMUM/FMAXIMUM on HVX float
+// vector types. IgnoreNaN=true (FMIN/FMAX): NaN elements are replaced with
+// the neutral value before the reduction so they don't corrupt the result
+// even when the hardware pairwise instruction propagates NaN.
+// IgnoreNaN=false (FMINIMUM/FMAXIMUM): NaN propagates naturally.
+SDValue HexagonTargetLowering::LowerHvxVecReduceFMinMax(
+    SDValue Op, unsigned PairwiseOpc, bool IgnoreNaN, SelectionDAG &DAG) const {
+  SDLoc DL(Op);
+  SDValue Vec = Op.getOperand(0);
+  MVT VecTy = ty(Vec);
+  SDNodeFlags Flags = Op->getFlags();
+  bool ShouldStripNaN = IgnoreNaN && !Flags.hasNoNaNs();
+
+  // Save original input before NaN stripping; needed for the all-NaN fixup.
+  SDValue OrigVec = Vec;
+  MVT OrigVecTy = VecTy;
+
+  // Replace NaN elements in V with +/-Inf so the tree reduction ignores them.
+  bool IsMax = (Op.getOpcode() == ISD::VECREDUCE_FMAX);
+  auto ReplaceNaN = [&](SDValue V, MVT Ty) -> SDValue {
+    APFloat Neutral = APFloat::getInf(
+        Ty.getVectorElementType().getFltSemantics(), /*Negative=*/IsMax);
+    SDValue NeutralVec = DAG.getConstantFP(Neutral, DL, Ty);
+    EVT BoolTy = getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), Ty);
+    SDValue IsNaN = DAG.getSetCC(DL, BoolTy, V, V, ISD::SETUO);
+    return DAG.getNode(ISD::VSELECT, DL, Ty, IsNaN, NeutralVec, V);
+  };
+
+  // For a pair vector, strip NaN from each half before the cross-half
+  // pairwise reduction so a NaN in one half can't corrupt the other.
+  if (isHvxPairTy(VecTy)) {
+    auto [Lo, Hi] = opSplit(Vec, DL, DAG);
+    MVT SingleTy = ty(Lo);
+    if (ShouldStripNaN) {
+      Lo = ReplaceNaN(Lo, SingleTy);
+      Hi = ReplaceNaN(Hi, SingleTy);
+    }
+    Vec = DAG.getNode(PairwiseOpc, DL, SingleTy, Lo, Hi, Flags);
+    VecTy = SingleTy;
+  } else if (ShouldStripNaN) {
+    Vec = ReplaceNaN(Vec, VecTy);
+  }
+
+  // Tree reduction using VROR + pairwise op. Each iteration rotates the vector
+  // by half the remaining element count (in bytes) and takes element-wise
+  // min/max, halving the active width until element 0 holds the result.
+  unsigned ElemBytes = VecTy.getScalarSizeInBits() / 8;
+  unsigned HwLen = Subtarget.getVectorLength();
+  unsigned NumElems = HwLen / ElemBytes;
+
+  SDValue Curr = Vec;
+  for (unsigned Width = NumElems / 2; Width >= 1; Width /= 2) {
+    SDValue RotAmt = DAG.getConstant(Width * ElemBytes, DL, MVT::i32);
+    SDValue Rotated = DAG.getNode(HexagonISD::VROR, DL, VecTy, Curr, RotAmt);
+    Curr = DAG.getNode(PairwiseOpc, DL, VecTy, Curr, Rotated, Flags);
+  }
+
+  // Extract element 0 as the scalar result.
+  MVT ScalarTy = Op.getSimpleValueType();
+  SDValue Result = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ScalarTy, Curr,
+                               DAG.getConstant(0, DL, MVT::i32));
+
+  // Per llvm.maxnum/minnum semantics, all-NaN input must return NaN.  The
+  // NaN-stripping above replaced every NaN with the neutral value, so an
+  // all-NaN vector produces the neutral value instead.  Fix: if no element
+  // in the original vector was non-NaN, return NaN.
+  if (ShouldStripNaN) {
+    EVT BoolVecTy =
+        getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), OrigVecTy);
+    // IsOrd[i] == 1 iff OrigVec[i] is not NaN.
+    SDValue IsOrd = DAG.getSetCC(DL, BoolVecTy, OrigVec, OrigVec, ISD::SETO);
+    // BoolVecTy is vNi1 with exactly N bits; bitcast to an integer and
+    // check != 0 to detect whether any element was non-NaN.
+    unsigned NumBits = BoolVecTy.getSizeInBits();
+    MVT IntTy = MVT::getIntegerVT(NumBits);
+    SDValue IsOrdInt = DAG.getBitcast(IntTy, IsOrd);
+    SDValue AnyNonNaN = DAG.getSetCC(DL, MVT::i1, IsOrdInt,
+                                     DAG.getConstant(0, DL, IntTy), ISD::SETNE);
+    SDValue NaN = DAG.getConstantFP(APFloat::getNaN(ScalarTy.getFltSemantics()),
+                                    DL, ScalarTy);
+    Result = DAG.getSelect(DL, ScalarTy, AnyNonNaN, Result, NaN);
+  }
+
+  return Result;
+}
+
+SDValue HexagonTargetLowering::LowerHvxVecReduceFMin(SDValue Op,
+                                                     SelectionDAG &DAG) const {
+  return LowerHvxVecReduceFMinMax(Op, ISD::FMINNUM, /*IgnoreNaN=*/true, DAG);
+}
+
+SDValue HexagonTargetLowering::LowerHvxVecReduceFMax(SDValue Op,
+                                                     SelectionDAG &DAG) const {
+  return LowerHvxVecReduceFMinMax(Op, ISD::FMAXNUM, /*IgnoreNaN=*/true, DAG);
+}
+
+SDValue
+HexagonTargetLowering::LowerHvxVecReduceFMinimum(SDValue Op,
+                                                 SelectionDAG &DAG) const {
+  return LowerHvxVecReduceFMinMax(Op, ISD::FMINIMUM, /*IgnoreNaN=*/false, DAG);
+}
+
+SDValue
+HexagonTargetLowering::LowerHvxVecReduceFMaximum(SDValue Op,
+                                                 SelectionDAG &DAG) const {
+  return LowerHvxVecReduceFMinMax(Op, ISD::FMAXIMUM, /*IgnoreNaN=*/false, DAG);
+}
+
+// Lower FMINNUM/FMAXNUM on a single HVX float vector.  These ops must ignore
+// NaN (return the non-NaN operand).  Because the hardware vmin/vmax may
+// propagate NaN, replace NaN in each operand with the neutral value (+/-Inf)
+// before delegating to FMINIMUM/FMAXIMUM.
+SDValue HexagonTargetLowering::LowerHvxFMinNum(SDValue Op,
+                                               SelectionDAG &DAG) const {
+  SDLoc DL(Op);
+  auto A = Op.getOperand(0), B = Op.getOperand(1);
+  auto Ty = ty(Op);
+  auto Flags = Op->getFlags();
+
+  if (!Flags.hasNoNaNs()) {
+    auto &Sem = Ty.getVectorElementType().getFltSemantics();
+    auto PosInf = DAG.getConstantFP(APFloat::getInf(Sem, false), DL, Ty);
+    auto BoolTy =
+        getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), Ty);
+    auto IsNaN_A = DAG.getSetCC(DL, BoolTy, A, A, ISD::SETUO);
+    auto IsNaN_B = DAG.getSetCC(DL, BoolTy, B, B, ISD::SETUO);
+    // Per llvm.minnum: if both operands are NaN, return NaN.  Replace NaN
+    // with +Inf so the hardware min ignores single-operand NaN, then restore
+    // NaN for lanes where both inputs were NaN.
+    auto BothNaN = DAG.getNode(ISD::AND, DL, BoolTy, IsNaN_A, IsNaN_B);
+    A = DAG.getNode(ISD::VSELECT, DL, Ty, IsNaN_A, PosInf, A);
+    B = DAG.getNode(ISD::VSELECT, DL, Ty, IsNaN_B, PosInf, B);
+    auto Res = DAG.getNode(ISD::FMINIMUM, DL, Ty, A, B, Flags);
+    auto NaN = DAG.getConstantFP(APFloat::getNaN(Sem), DL, Ty);
+    return DAG.getNode(ISD::VSELECT, DL, Ty, BothNaN, NaN, Res);
+  }
+  return DAG.getNode(ISD::FMINIMUM, DL, Ty, A, B, Flags);
+}
+
+SDValue HexagonTargetLowering::LowerHvxFMaxNum(SDValue Op,
+                                               SelectionDAG &DAG) const {
+  SDLoc DL(Op);
+  auto A = Op.getOperand(0), B = Op.getOperand(1);
+  auto Ty = ty(Op);
+  auto Flags = Op->getFlags();
+
+  if (!Flags.hasNoNaNs()) {
+    auto &Sem = Ty.getVectorElementType().getFltSemantics();
+    auto NegInf = DAG.getConstantFP(APFloat::getInf(Sem, true), DL, Ty);
+    auto BoolTy =
+        getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), Ty);
+    auto IsNaN_A = DAG.getSetCC(DL, BoolTy, A, A, ISD::SETUO);
+    auto IsNaN_B = DAG.getSetCC(DL, BoolTy, B, B, ISD::SETUO);
+    // Per llvm.maxnum: if both operands are NaN, return NaN.  Replace NaN
+    // with -Inf so the hardware max ignores single-operand NaN, then restore
+    // NaN for lanes where both inputs were NaN.
+    auto BothNaN = DAG.getNode(ISD::AND, DL, BoolTy, IsNaN_A, IsNaN_B);
+    A = DAG.getNode(ISD::VSELECT, DL, Ty, IsNaN_A, NegInf, A);
+    B = DAG.getNode(ISD::VSELECT, DL, Ty, IsNaN_B, NegInf, B);
+    auto Res = DAG.getNode(ISD::FMAXIMUM, DL, Ty, A, B, Flags);
+    auto NaN = DAG.getConstantFP(APFloat::getNaN(Sem), DL, Ty);
+    return DAG.getNode(ISD::VSELECT, DL, Ty, BothNaN, NaN, Res);
+  }
+  return DAG.getNode(ISD::FMAXIMUM, DL, Ty, A, B, Flags);
 }
 
 // When possible, separate an MLA reduction with extended operands but

--- a/llvm/lib/Target/Hexagon/HexagonPatternsHVX.td
+++ b/llvm/lib/Target/Hexagon/HexagonPatternsHVX.td
@@ -676,6 +676,10 @@ let Predicates = [UseHVXV68, UseHVX128B, UseHVXQFloat] in {
   def: OpR_RR_pat<V6_vmax_hf, pf2<fmaxnum>, VecF16, HVF16>;
   def: OpR_RR_pat<V6_vmin_sf, pf2<fminnum>, VecF32, HVF32>;
   def: OpR_RR_pat<V6_vmax_sf, pf2<fmaxnum>, VecF32, HVF32>;
+  def: OpR_RR_pat<V6_vmin_hf, pf2<fminimum>,    VecF16, HVF16>;
+  def: OpR_RR_pat<V6_vmax_hf, pf2<fmaximum>,    VecF16, HVF16>;
+  def: OpR_RR_pat<V6_vmin_sf, pf2<fminimum>,    VecF32, HVF32>;
+  def: OpR_RR_pat<V6_vmax_sf, pf2<fmaximum>,    VecF32, HVF32>;
 }
 
 // V6_veqsf/V6_veqhf use IEEE-754 float equality (NaN != NaN), which correctly
@@ -709,6 +713,10 @@ let Predicates = [UseHVXV68, UseHVX128B, UseHVXIEEEFP] in {
   def: OpR_RR_pat<V6_vfmax_hf, pf2<fmaxnum>, VecF16, HVF16>;
   def: OpR_RR_pat<V6_vfmin_sf, pf2<fminnum>, VecF32, HVF32>;
   def: OpR_RR_pat<V6_vfmax_sf, pf2<fmaxnum>, VecF32, HVF32>;
+  def: OpR_RR_pat<V6_vfmin_hf, pf2<fminimum>,    VecF16, HVF16>;
+  def: OpR_RR_pat<V6_vfmax_hf, pf2<fmaximum>,    VecF16, HVF16>;
+  def: OpR_RR_pat<V6_vfmin_sf, pf2<fminimum>,    VecF32, HVF32>;
+  def: OpR_RR_pat<V6_vfmax_sf, pf2<fmaximum>,    VecF32, HVF32>;
 }
 
 let Predicates = [UseHVX] in {

--- a/llvm/test/CodeGen/Hexagon/vreduce-fminmax-nan-fixup.ll
+++ b/llvm/test/CodeGen/Hexagon/vreduce-fminmax-nan-fixup.ll
@@ -1,0 +1,109 @@
+; RUN: llc -march=hexagon -mattr=+hvxv73,+hvx-length128b %s -o - | FileCheck %s
+;
+; Tests that llvm.minnum/maxnum / llvm.vector.reduce.fmin/fmax correctly return
+; NaN when both (all) inputs are qNaN, per llvm.minnum/maxnum semantics.
+;
+; The backend replaces NaN with the neutral value (+/-Inf) before the hardware
+; min/max, which ignores single-operand NaN correctly but turns all-NaN inputs
+; into the neutral value.  A post-operation fixup restores NaN in those lanes.
+;
+; For VECREDUCE_FMIN/FMAX: the predicate of non-NaN elements is collapsed to a
+; scalar integer; if it is zero (all NaN) the scalar result is overridden with
+; a qNaN constant.
+;
+; For FMINNUM/FMAXNUM: the BothNaN predicate (AND of per-lane IsNaN masks)
+; selects the qNaN constant back into the result vector.
+;
+; With nnan the fixup is dead and must not be emitted.
+
+; CHECK-LABEL: reduce_fmin_v32f32:
+; CHECK:       vmin
+; Fixup: ordered-predicate -> scalar integer -> if zero select qNaN.
+; 0x7FC00000 = 2143289344 is the f32 quiet NaN.
+; CHECK:       cmp.eq({{r[0-9]+}},#0)
+; CHECK:       ##2143289344
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define float @reduce_fmin_v32f32(<32 x float> %x) {
+  %r = call float @llvm.vector.reduce.fmin.v32f32(<32 x float> %x)
+  ret float %r
+}
+
+; With nnan the fixup is unnecessary.
+; CHECK-LABEL: reduce_fmin_v32f32_nnan:
+; CHECK:       vmin
+; CHECK-NOT:   ##2143289344
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define float @reduce_fmin_v32f32_nnan(<32 x float> %x) {
+  %r = call nnan float @llvm.vector.reduce.fmin.v32f32(<32 x float> %x)
+  ret float %r
+}
+
+; CHECK-LABEL: fminnum_v32f32:
+; CHECK:       ##2143289344
+; Fixup: BothNaN = IsNaN(a) AND IsNaN(b).
+; CHECK:       and(
+; CHECK:       vmin
+; CHECK:       vmux
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define <32 x float> @fminnum_v32f32(<32 x float> %a, <32 x float> %b) {
+  %r = call <32 x float> @llvm.minnum.v32f32(<32 x float> %a, <32 x float> %b)
+  ret <32 x float> %r
+}
+
+; With nnan the fixup is unnecessary.
+; CHECK-LABEL: fminnum_v32f32_nnan:
+; CHECK:       vmin
+; CHECK-NOT:   ##2143289344
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define <32 x float> @fminnum_v32f32_nnan(<32 x float> %a, <32 x float> %b) {
+  %r = call nnan <32 x float> @llvm.minnum.v32f32(<32 x float> %a, <32 x float> %b)
+  ret <32 x float> %r
+}
+
+; CHECK-LABEL: reduce_fmax_v32f32:
+; CHECK:       vmax
+; Fixup: ordered-predicate -> scalar integer -> if zero select qNaN.
+; CHECK:       cmp.eq({{r[0-9]+}},#0)
+; CHECK:       ##2143289344
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define float @reduce_fmax_v32f32(<32 x float> %x) {
+  %r = call float @llvm.vector.reduce.fmax.v32f32(<32 x float> %x)
+  ret float %r
+}
+
+; With nnan the fixup is unnecessary.
+; CHECK-LABEL: reduce_fmax_v32f32_nnan:
+; CHECK:       vmax
+; CHECK-NOT:   ##2143289344
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define float @reduce_fmax_v32f32_nnan(<32 x float> %x) {
+  %r = call nnan float @llvm.vector.reduce.fmax.v32f32(<32 x float> %x)
+  ret float %r
+}
+
+; CHECK-LABEL: fmaxnum_v32f32:
+; CHECK:       ##2143289344
+; Fixup: BothNaN = IsNaN(a) AND IsNaN(b).
+; CHECK:       and(
+; CHECK:       vmax
+; CHECK:       vmux
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define <32 x float> @fmaxnum_v32f32(<32 x float> %a, <32 x float> %b) {
+  %r = call <32 x float> @llvm.maxnum.v32f32(<32 x float> %a, <32 x float> %b)
+  ret <32 x float> %r
+}
+
+; With nnan the fixup is unnecessary.
+; CHECK-LABEL: fmaxnum_v32f32_nnan:
+; CHECK:       vmax
+; CHECK-NOT:   ##2143289344
+; CHECK:       .Lfunc_end{{[0-9]+}}:
+define <32 x float> @fmaxnum_v32f32_nnan(<32 x float> %a, <32 x float> %b) {
+  %r = call nnan <32 x float> @llvm.maxnum.v32f32(<32 x float> %a, <32 x float> %b)
+  ret <32 x float> %r
+}
+
+declare float @llvm.vector.reduce.fmin.v32f32(<32 x float>)
+declare <32 x float> @llvm.minnum.v32f32(<32 x float>, <32 x float>)
+declare float @llvm.vector.reduce.fmax.v32f32(<32 x float>)
+declare <32 x float> @llvm.maxnum.v32f32(<32 x float>, <32 x float>)

--- a/llvm/test/CodeGen/Hexagon/vreduce-max-lowering.ll
+++ b/llvm/test/CodeGen/Hexagon/vreduce-max-lowering.ll
@@ -1,0 +1,59 @@
+; RUN: llc -march=hexagon -mattr=+hvxv73,+hvx-length128b %s -o - | FileCheck %s
+
+define dso_local float @reduce_2d_vec(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <32 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmax.v32f32(<32 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_2d_vec
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: .Lfunc_end0
+
+define dso_local float @reduce_2d_pair(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <64 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmax.v64f32(<64 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_2d_pair
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: .Lfunc_end1
+
+define dso_local float @reduce_maximum_vec(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <32 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmaximum.v32f32(<32 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_maximum_vec
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: .Lfunc_end2
+
+define dso_local float @reduce_maximum_pair(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <64 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmaximum.v64f32(<64 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_maximum_pair
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: vmax
+;CHECK: .Lfunc_end3

--- a/llvm/test/CodeGen/Hexagon/vreduce-min-lowering.ll
+++ b/llvm/test/CodeGen/Hexagon/vreduce-min-lowering.ll
@@ -1,0 +1,81 @@
+; RUN: llc -march=hexagon -mattr=+hvxv73,+hvx-length128b %s -o - | FileCheck %s
+
+define dso_local float @reduce_2d_vec(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <32 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmin.v32f32(<32 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_2d_vec
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: .Lfunc_end0
+
+define dso_local float @reduce_2d_pair(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <64 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmin.v64f32(<64 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_2d_pair
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: .Lfunc_end1
+
+
+define dso_local float @reduce_2d_longvec(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <256 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fmin.v256f32(<256 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_2d_longvec
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: .Lfunc_end2
+
+define dso_local float @reduce_minimum_vec(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <32 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fminimum.v32f32(<32 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_minimum_vec
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: .Lfunc_end3
+
+define dso_local float @reduce_minimum_pair(ptr noundef readonly captures(none) %X) local_unnamed_addr {
+entry:
+  %0 = load <64 x float>, ptr %X, align 4
+  %.ripple.reduction = tail call reassoc float @llvm.vector.reduce.fminimum.v64f32(<64 x float> %0)
+  ret float %.ripple.reduction
+}
+;CHECK: reduce_minimum_pair
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: vmin
+;CHECK: .Lfunc_end4


### PR DESCRIPTION
Add custom lowering for VECREDUCE_FMIN/FMAX/FMINIMUM/FMAXIMUM on HVX float vector types. The target-independent default expansion reduces these pairwise using the hardware min/max instruction directly, which does not implement IEEE-754 NaN-propagation semantics: a NaN in the input can silently corrupt the reduction result, and an all-NaN input produces a non-NaN value instead of NaN.

The custom lowering strips NaN elements to the appropriate neutral value (+/-Inf) before the pairwise tree reduction so a NaN can't corrupt other lanes, then fixes up the scalar result to NaN if every input element was NaN.

FMINNUM/FMAXNUM on HVX vector types get the same treatment: NaN operands are replaced with the neutral value before delegating to the hardware min/max, with a fixup to restore NaN when both operands were NaN (per llvm.minnum/maxnum semantics).

Co-authored-by: Kaushik Kulkarni <kauskulk@qti.qualcomm.com>