### PR TITLE
[flang][semantics] Accept BOZ initializers for C enum values

### DIFF
--- a/flang/include/flang/Parser/tools.h
+++ b/flang/include/flang/Parser/tools.h
@@ -43,6 +43,10 @@ const Name &GetFirstName(const Variable &);
 const Name &GetFirstName(const EntityDecl &);
 const Name &GetFirstName(const AccObject &);
 
+// Checks whether a scalar-int-constant-expr is a direct BOZ literal constant,
+// rather than an expression that contains one.
+bool IsBOZLiteral(const ScalarIntConstantExpr &);
+
 // When a parse tree node is an instance of a specific type wrapped in
 // layers of packaging, return a pointer to that object.
 // Implemented with mutually recursive template functions that are

--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -513,6 +513,11 @@ public:
     AnalyzeAndNoteUses(x, /*isDefinition=*/true);
     return false;
   }
+  bool Pre(const parser::Enumerator &x) {
+    const auto &init{
+        std::get<std::optional<parser::ScalarIntConstantExpr>>(x.t)};
+    return !init || !parser::IsBOZLiteral(*init);
+  }
   bool Pre(const parser::DataStmtObject &);
   void Post(const parser::DataStmtObject &);
   bool Pre(const parser::DataImpliedDo &);

--- a/flang/lib/Parser/tools.cpp
+++ b/flang/lib/Parser/tools.cpp
@@ -137,7 +137,7 @@ const Name &GetFirstName(const AccObject &x) {
 }
 
 bool IsBOZLiteral(const ScalarIntConstantExpr &x) {
-  const Expr &expr{x.thing.thing.thing.value()};
+  const Expr &expr{UnwrapRef<Expr>(x)};
   const auto *literal{std::get_if<LiteralConstant>(&expr.u)};
   return literal && std::holds_alternative<BOZLiteralConstant>(literal->u);
 }

--- a/flang/lib/Parser/tools.cpp
+++ b/flang/lib/Parser/tools.cpp
@@ -136,6 +136,12 @@ const Name &GetFirstName(const AccObject &x) {
       [](const auto &y) -> const Name & { return GetFirstName(y); }, x.u);
 }
 
+bool IsBOZLiteral(const ScalarIntConstantExpr &x) {
+  const Expr &expr{x.thing.thing.thing.value()};
+  const auto *literal{std::get_if<LiteralConstant>(&expr.u)};
+  return literal && std::holds_alternative<BOZLiteralConstant>(literal->u);
+}
+
 const CoindexedNamedObject *GetCoindexedNamedObject(const DataRef &base) {
   return common::visit(
       common::visitors{

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6146,7 +6146,7 @@ bool DeclarationVisitor::Pre(const parser::Enumerator &enumerator) {
   if (auto &init{std::get<std::optional<parser::ScalarIntConstantExpr>>(
           enumerator.t)}) {
     std::optional<std::int64_t> value;
-    const parser::Expr &expr{init->thing.thing.thing.value()};
+    const parser::Expr &expr{parser::UnwrapRef<parser::Expr>(*init)};
     if (parser::IsBOZLiteral(*init)) {
       // F2023 7.6.1 errata f23/013: a BOZ enumerator initializer
       // has the value specified by INT(boz-literal-constant, C_INT).

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6145,8 +6145,24 @@ bool DeclarationVisitor::Pre(const parser::Enumerator &enumerator) {
 
   if (auto &init{std::get<std::optional<parser::ScalarIntConstantExpr>>(
           enumerator.t)}) {
-    Walk(*init); // Resolve names in expression before evaluation.
-    if (auto value{EvaluateInt64(context(), *init)}) {
+    std::optional<std::int64_t> value;
+    const parser::Expr &expr{init->thing.thing.thing.value()};
+    if (parser::IsBOZLiteral(*init)) {
+      // F2023 7.6.1 errata f23/013: a BOZ enumerator initializer
+      // has the value specified by INT(boz-literal-constant, C_INT).
+      const evaluate::DynamicType cIntType{
+          TypeCategory::Integer, evaluate::CInteger::kind};
+      if (MaybeExpr maybeExpr{EvaluateExpr(expr)}) {
+        if (auto converted{
+                evaluate::ConvertToType(cIntType, std::move(*maybeExpr))}) {
+          value = evaluate::ToInt64(FoldExpr(std::move(*converted)));
+        }
+      }
+    } else {
+      Walk(*init); // Resolve names in expression before evaluation.
+      value = EvaluateInt64(context(), *init);
+    }
+    if (value) {
       // Cast all init expressions to C_INT so that they can then be
       // safely incremented (see 7.6 Note 2).
       enumerationState_.value = static_cast<int>(*value);

--- a/flang/test/Semantics/modfile31.f90
+++ b/flang/test/Semantics/modfile31.f90
@@ -15,6 +15,12 @@ module m1
     enumerator :: oak, beech = -rank(x)*x(1), pine, poplar = brown
   end enum
 
+  ! F2023 7.6.1 errata f23/013: BOZ enumerator initializers are
+  ! interpreted as INT(boz, C_INT), and following enumerators increment.
+  enum, bind(C)
+    enumerator :: boz = z'2a', after_boz
+  end enum
+
 end
 
 !Expect: m1.mod
@@ -31,5 +37,6 @@ end
 !intrinsic::rank
 !integer(4),parameter::pine=-3_4
 !integer(4),parameter::poplar=3_4
+!integer(4),parameter::boz=42_4
+!integer(4),parameter::after_boz=43_4
 !end
-

--- a/flang/test/Semantics/resolve60.f90
+++ b/flang/test/Semantics/resolve60.f90
@@ -11,6 +11,12 @@
 
   integer(yellow) anint4
 
+  ! F2023 7.6.1 errata f23/013: an interoperable enumerator may be
+  ! initialized by a BOZ literal, with the value of INT(boz, C_INT).
+  enum, bind(C)
+    enumerator :: boz = z'2a', after_boz
+  end enum
+
   enum, bind(C)
     enumerator :: square, cicrle
     !ERROR: 'square' is already declared in this scoping unit


### PR DESCRIPTION
Fortran 2023 7.6.1 errata f23/013 changes R762 so an interoperable enumerator may be a named-constant initialized by a boz-literal-constant, and specifies the value as INT(boz-literal-constant, C_INT).

Handle that named-constant restriction directly in enum resolution while preserving the usual scalar integer expression checks for non-enumerator contexts. This mirrors the general named-constant initializer path, which already converts BOZ values through the declared type before folding.