### PR TITLE
[DropAssumes] Print drop-deref in pipeline where appropriate

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/DropUnnecessaryAssumes.h
+++ b/llvm/include/llvm/Transforms/Scalar/DropUnnecessaryAssumes.h
@@ -23,6 +23,9 @@ struct DropUnnecessaryAssumesPass
       : DropDereferenceable(DropDereferenceable) {}
 
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
 private:
   bool DropDereferenceable;

--- a/llvm/lib/Transforms/Scalar/DropUnnecessaryAssumes.cpp
+++ b/llvm/lib/Transforms/Scalar/DropUnnecessaryAssumes.cpp
@@ -152,3 +152,11 @@ DropUnnecessaryAssumesPass::run(Function &F, FunctionAnalysisManager &FAM) {
   }
   return PreservedAnalyses::all();
 }
+
+void DropUnnecessaryAssumesPass::printPipeline(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName) {
+  static_cast<PassInfoMixin<DropUnnecessaryAssumesPass> *>(this)->printPipeline(
+      OS, MapClassName2PassName);
+  if (DropDereferenceable)
+    OS << "<drop-deref>";
+}

--- a/llvm/test/Other/new-pm-print-pipeline.ll
+++ b/llvm/test/Other/new-pm-print-pipeline.ll
@@ -123,3 +123,6 @@
 
 ; RUN: opt -disable-output -disable-verify -print-pipeline-passes -passes='module(asan<>,asan<kernel;use-after-scope>)' < %s | FileCheck %s --match-full-lines --check-prefixes=CHECK-37
 ; CHECK-37: asan<>,asan<kernel;use-after-scope>
+
+; RUN: opt -disable-output -disable-verify -print-pipeline-passes -passes='drop-unnecessary-assumes,drop-unnecessary-assumes<drop-deref>' < %s | FileCheck %s --check-prefixes=CHECK-38
+; CHECK-38: drop-unnecessary-assumes,drop-unnecessary-assumes<drop-deref>


### PR DESCRIPTION
drop-deref was added as an option in #166947 and is parsed correctly, but is not serialized. This can make it difficult to reduce test cases, especially automatically with llvm/utils/reduce_pipeline.py.

This patch implements printPipeline() to serialize drop-deref where appropriate.