### PR TITLE
[SampleProfile] Fix symbol partitioning in Eytzinger name table

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1064,6 +1064,9 @@ public:
     return CallsiteSamples;
   }
 
+  /// Return whether this top-level function profile is context sensitive.
+  bool isContextSensitiveTopLevel() const { return !CallsiteSamples.empty(); }
+
   /// Returns vtable access samples for the C++ types collected in this
   /// function.
   const CallsiteTypeMap &getCallsiteTypeCounts() const {

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -479,7 +479,7 @@ SampleProfileWriterExtBinaryBase::writeEytzingerNameTableSection(
     const SampleContext &Ctx = I.second.getContext();
     uint64_t GUID = Ctx.getFunction().getHashCode();
     if (TopLevelGUIDs.insert(GUID).second) {
-      if (Ctx.hasContext())
+      if (!I.second.getCallsiteSamples().empty())
         CSKeys.emplace_back(GUID);
       else
         FlatKeys.emplace_back(GUID);

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -479,7 +479,7 @@ SampleProfileWriterExtBinaryBase::writeEytzingerNameTableSection(
     const SampleContext &Ctx = I.second.getContext();
     uint64_t GUID = Ctx.getFunction().getHashCode();
     if (TopLevelGUIDs.insert(GUID).second) {
-      if (!I.second.getCallsiteSamples().empty())
+      if (I.second.isContextSensitiveTopLevel())
         CSKeys.emplace_back(GUID);
       else
         FlatKeys.emplace_back(GUID);
@@ -661,7 +661,7 @@ static void splitProfileMapToTwo(const SampleProfileMap &ProfileMap,
                                  SampleProfileMap &ContextProfileMap,
                                  SampleProfileMap &NoContextProfileMap) {
   for (const auto &I : ProfileMap) {
-    if (I.second.getCallsiteSamples().size())
+    if (I.second.isContextSensitiveTopLevel())
       ContextProfileMap.insert({I.first, I.second});
     else
       NoContextProfileMap.insert({I.first, I.second});

--- a/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
+++ b/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
@@ -1,0 +1,25 @@
+# RUN: llvm-profdata merge --sample --extbinary --use-md5 --split-layout \
+# RUN:   --sample-profile-write-eytzinger-name-tables %s -o %t.xfdo
+# RUN: llvm-profdata show --sample --show-sec-info-only %t.xfdo > %t.secinfo
+# RUN: FileCheck %s -input-file %t.secinfo
+# Extract and verify the Eytzinger span counts (NumCS, NumFlat,
+# NumInlinees) from NameTableSection to ensure correct symbol
+# partitioning.
+# RUN: %python -c "import re; off = int(re.search(r'NameTableSection - Offset: (\d+)', open(r'%t.secinfo').read()).group(1)); d = open(r'%t.xfdo', 'rb').read()[off:off+3]; print(list(d))" | FileCheck %s --check-prefix=COUNTS
+
+# CHECK: ProfileSummarySection - Offset: {{.*}}, Size: {{.*}}, Flags: {}
+# CHECK: NameTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {eytzinger,fixlenmd5}
+# CHECK: FuncOffsetTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {}
+# CHECK: LBRProfileSection - Offset: {{.*}}, Size: {{.*}}, Flags: {}
+# CHECK: FuncOffsetTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {flat}
+# CHECK: LBRProfileSection - Offset: {{.*}}, Size: {{.*}}, Flags: {flat}
+
+# COUNTS: [1, 1, 1]
+
+main:1000:10
+ 1: 1000
+ 2: foo:500
+  1: 500
+
+leaf_func:100:5
+ 1: 100


### PR DESCRIPTION
This patch fixes the symbol partitioning between context-sensitive
and flat profiles in writeEytzingerNameTableSection.

In split-layout profiles, top-level symbols in the Eytzinger name
table are partitioned into two bins -- context-sensitive and flat keys
-- so that they form parallel arrays with function offsets.

Without this patch, writeEytzingerNameTableSection uses:

  if (Ctx.hasContext())

to decide which bin to use even though splitProfileMapToTwo uses:

  if (!I.second.getCallsiteSamples().empty())

to partition the profile.  This difference causes certain symbols to
be classified into FlatKeys in the name table but into
ContextProfileMap in the LBR profile.

The patch fixes the problem by using the same condition to partition
keys.

This misclassification happens to top-level symbols (like main or
un-inlined root callers) that lack context delimiters in their
function names (hasContext() == false) but still contain inlined
callees in their profile hierarchies.

RFC:
https://discourse.llvm.org/t/rfc-faster-sample-profile-loading/90957/8

Assisted-by: Antigravity
