### PR TITLE
[lldb] Fix heap-use-after-free in FileSpec usage

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2728,7 +2728,8 @@ void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result,
     GetHomeInitFile(init_file);
 
   if (!m_skip_app_init_files) {
-    llvm::StringRef program_name = HostInfo::GetProgramFileSpec().GetFilename();
+    FileSpec program_file_spec = HostInfo::GetProgramFileSpec();
+    llvm::StringRef program_name = program_file_spec.GetFilename();
     FileSpec program_init_file;
     GetHomeInitFile(program_init_file, program_name);
     if (FileSystem::Instance().Exists(program_init_file))


### PR DESCRIPTION
After #211394, `FileSpec` stores m_filename as a `SmallString` instead of `ConstString`. When the `FileSpec` goes out of scope / is destructed, a `StringRef` pointing to m_filename is now invalid. Previously it would have worked even after `FileSpec` goes out of scope since `ConstString` stores the string in a global buffer which is never destructed.

This causes heap-use-after-free in `CommandInterpreter` when we use the result of `GetFilename()` on a temporary `FileSpec`. Store the result of `HostInfo::GetProgramFileSpec()` as a variable to prevent it from going out of scope before we're able to call `GetHomeInitFile()`.

Although #211394 introduces this failure, technically speaking this is an existing bug, it was just masked because of how `FileSpec` used to use `ConstString` to force a long lifetime.