### PR TITLE
[TailDuplication] don't clear NoPHI when no-op

### DIFF
--- a/llvm/lib/CodeGen/TailDuplication.cpp
+++ b/llvm/lib/CodeGen/TailDuplication.cpp
@@ -61,10 +61,6 @@ class EarlyTailDuplicateLegacy : public TailDuplicateBaseLegacy {
 public:
   static char ID;
   EarlyTailDuplicateLegacy() : TailDuplicateBaseLegacy(ID, true) {}
-
-  MachineFunctionProperties getClearedProperties() const override {
-    return MachineFunctionProperties().setNoPHIs();
-  }
 };
 
 } // end anonymous namespace
@@ -97,7 +93,8 @@ bool TailDuplicateBaseLegacy::runOnMachineFunction(MachineFunction &MF) {
   bool MadeChange = false;
   while (Duplicator.tailDuplicateBlocks())
     MadeChange = true;
-
+  if (MadeChange && PreRegAlloc)
+    MF.getProperties().resetNoPHIs();
   return MadeChange;
 }
 

--- a/llvm/test/CodeGen/X86/early-tail-dup-nophis.mir
+++ b/llvm/test/CodeGen/X86/early-tail-dup-nophis.mir
@@ -1,0 +1,12 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -run-pass=early-tailduplication -o - %s | FileCheck %s
+
+---
+# CHECK-LABEL: name: test_nophis
+# CHECK: noPhis: true
+name:            test_nophis
+tracksRegLiveness: true
+noPhis:          true
+body:             |
+  bb.0:
+    RET64
+...


### PR DESCRIPTION
Before, we would unconditionally clear NoPHIs after this pass.

This can lead to false-positive MachineVerifier errors.

"MBB has allocatable live-in but isn't entry, landing-pad, [...]" is conditioned with !NoPHIs, so we would incorrectly trigger it after this pass.