### PR TITLE
[clang-format] Correctly annotate C# UTF 8 string literals

### DIFF
--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -461,11 +461,11 @@ bool FormatTokenLexer::tryMergeCSharpUtf8StringLiteral() {
   if (Tokens.size() < 2)
     return false;
 
-  auto Suffix = Tokens.back();
-  if (Suffix->isNot(tok::identifier) || Suffix->TokenText != "u8")
+  const auto *Suffix = Tokens.back();
+  if (Suffix->TokenText != "u8" || Suffix->hasWhitespaceBefore())
     return false;
 
-  const auto String = *(Tokens.end() - 2);
+  auto *String = *(Tokens.end() - 2);
   if (String->isNot(tok::string_literal))
     return false;
 

--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -208,6 +208,8 @@ void FormatTokenLexer::tryMergePreviousTokens() {
         return;
       if (tryMergeCSharpStringLiteral())
         return;
+      if (tryMergeCSharpUtf8StringLiteral())
+        return;
       if (tryTransformCSharpForEach())
         return;
       if (tryMergeTokens(CSharpNullConditionalLSquare,
@@ -452,6 +454,28 @@ bool FormatTokenLexer::tryMergeCSharpStringLiteral() {
   Prefix->ColumnWidth += String->ColumnWidth;
   Prefix->setType(TT_CSharpStringLiteral);
   Tokens.erase(Tokens.end() - 1);
+  return true;
+}
+
+bool FormatTokenLexer::tryMergeCSharpUtf8StringLiteral() {
+  if (Tokens.size() < 2)
+    return false;
+
+  auto Suffix = Tokens.back();
+  if (Suffix->isNot(tok::identifier) || Suffix->TokenText != "u8")
+    return false;
+
+  const auto String = *(Tokens.end() - 2);
+  if (String->isNot(tok::string_literal))
+    return false;
+
+  String->Tok.setKind(tok::utf8_string_literal);
+  String->TokenText =
+      StringRef(String->TokenText.begin(),
+                Suffix->TokenText.end() - String->TokenText.begin());
+  String->ColumnWidth += Suffix->ColumnWidth;
+  String->setFinalizedType(TT_CSharpStringLiteral);
+  Tokens.pop_back();
   return true;
 }
 
@@ -854,6 +878,7 @@ void FormatTokenLexer::handleCSharpVerbatimAndInterpolatedStrings() {
 
   bool Verbatim = false;
   bool Interpolated = false;
+  const bool Utf8 = TokenText.ends_with("u8");
   if (TokenText.starts_with(R"($@")") || TokenText.starts_with(R"(@$")")) {
     Verbatim = true;
     Interpolated = true;
@@ -873,6 +898,9 @@ void FormatTokenLexer::handleCSharpVerbatimAndInterpolatedStrings() {
 
   const auto End = Lex->getBuffer().end();
   Offset = lexCSharpString(Offset, End, Verbatim, Interpolated);
+
+  if (Utf8)
+    Offset += 2;
 
   // Make no attempt to format code properly if a verbatim string is
   // unterminated.

--- a/clang/lib/Format/FormatTokenLexer.h
+++ b/clang/lib/Format/FormatTokenLexer.h
@@ -52,6 +52,7 @@ private:
   bool tryMergeNSStringLiteral();
   bool tryMergeJSPrivateIdentifier();
   bool tryMergeCSharpStringLiteral();
+  bool tryMergeCSharpUtf8StringLiteral();
   bool tryMergeCSharpKeywordVariables();
   bool tryMergeNullishCoalescingEqual();
   bool tryTransformCSharpForEach();

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -4576,12 +4576,12 @@ TEST_F(TokenAnnotatorTest, CSharpUtf8StringLiterals) {
   ASSERT_EQ(Tokens.size(), 6u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::utf8_string_literal, TT_CSharpStringLiteral);
 
-  Tokens = annotate("var text = $\"text/plain\"u8;", Style);
+  Tokens = annotate("var text = @\"text/plain\"u8;", Style);
 
   ASSERT_EQ(Tokens.size(), 6u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::utf8_string_literal, TT_CSharpStringLiteral);
 
-  Tokens = annotate("var text = $\"text/plain\" u8;", Style);
+  Tokens = annotate("var text = \"text/plain\" u8;", Style);
 
   ASSERT_EQ(Tokens.size(), 7u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::string_literal, TT_Unknown);

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -4570,7 +4570,7 @@ TEST_F(TokenAnnotatorTest, AttributeSquares) {
 }
 
 TEST_F(TokenAnnotatorTest, CSharpUtf8StringLiterals) {
-  const auto Style = getGoogleStyle(FormatStyle::LK_CSharp);
+  const auto Style = getLLVMStyle(FormatStyle::LK_CSharp);
   auto Tokens = annotate("var text = \"text/plain\"u8;", Style);
 
   ASSERT_EQ(Tokens.size(), 6u) << Tokens;
@@ -4580,6 +4580,12 @@ TEST_F(TokenAnnotatorTest, CSharpUtf8StringLiterals) {
 
   ASSERT_EQ(Tokens.size(), 6u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::utf8_string_literal, TT_CSharpStringLiteral);
+
+  Tokens = annotate("var text = $\"text/plain\" u8;", Style);
+
+  ASSERT_EQ(Tokens.size(), 7u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::string_literal, TT_Unknown);
+  EXPECT_TOKEN(Tokens[4], tok::identifier, TT_Unknown);
 }
 
 } // namespace

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -4569,6 +4569,19 @@ TEST_F(TokenAnnotatorTest, AttributeSquares) {
   EXPECT_TRUE(Tokens[15]->EndsCppAttributeGroup);
 }
 
+TEST_F(TokenAnnotatorTest, CSharpUtf8StringLiterals) {
+  const auto Style = getGoogleStyle(FormatStyle::LK_CSharp);
+  auto Tokens = annotate("var text = \"text/plain\"u8;", Style);
+
+  ASSERT_EQ(Tokens.size(), 6u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::utf8_string_literal, TT_CSharpStringLiteral);
+
+  Tokens = annotate("var text = $\"text/plain\"u8;", Style);
+
+  ASSERT_EQ(Tokens.size(), 6u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::utf8_string_literal, TT_CSharpStringLiteral);
+}
+
 } // namespace
 } // namespace format
 } // namespace clang


### PR DESCRIPTION
Fixes #210506