### PR TITLE
[libc][baremetal] track some potential codegen optimization for thumbv8 target

### DIFF
--- a/libc/src/__support/block.h
+++ b/libc/src/__support/block.h
@@ -246,19 +246,44 @@ public:
   /// @returns Whether the block is unavailable for allocation.
   LIBC_INLINE bool used() const { return !next() || !next().prev_free(); }
 
-  /// Marks this block as in use.
-  LIBC_INLINE void mark_used() const {
-    LIBC_ASSERT(next() && "last block is always considered used");
-    BlockRef next_block = next();
+  /// Marks this block as in use with pre-computed next_block.
+  LIBC_INLINE void mark_used(BlockRef next_block) const {
+    LIBC_ASSERT(next_block && "last block is always considered used");
     next_block.store_next(next_block.load_next() & ~PREV_FREE_MASK);
+  }
+
+  /// Marks this block as in use.
+  LIBC_INLINE void mark_used() const { mark_used(next()); }
+
+  /// Marks this block as free using pre-computed next_block and outer_size.
+  LIBC_INLINE void mark_free(BlockRef next_block, size_t outer_size) const {
+    LIBC_ASSERT(next_block && "last block is always considered used");
+    next_block.store_next(next_block.load_next() | PREV_FREE_MASK);
+    next_block.store_prev(outer_size);
   }
 
   /// Marks this block as free.
   LIBC_INLINE void mark_free() const {
-    LIBC_ASSERT(next() && "last block is always considered used");
-    BlockRef next_block = next();
-    next_block.store_next(next_block.load_next() | PREV_FREE_MASK);
-    next_block.store_prev(outer_size());
+    size_t next_val = load_next();
+    mark_free(next_from_val(next_val), next_val & SIZE_MASK);
+  }
+
+  LIBC_INLINE size_t load_next_val() const { return load_next(); }
+
+  LIBC_INLINE BlockRef next_from_val(size_t next_value) const {
+    if (next_value & LAST_MASK)
+      return BlockRef();
+    return BlockRef(nonnull_header_ptr() + (next_value & SIZE_MASK));
+  }
+
+  LIBC_INLINE BlockRef prev_free_from_val(size_t next_value) const {
+    if (!(next_value & PREV_FREE_MASK))
+      return BlockRef();
+    return BlockRef(nonnull_header_ptr() - load_prev());
+  }
+
+  LIBC_INLINE size_t outer_size_from_val(size_t next_value) const {
+    return next_value & SIZE_MASK;
   }
 
   LIBC_INLINE bool is_usable_space_aligned(size_t alignment) const {
@@ -441,11 +466,23 @@ optional<BlockRef> BlockRef::init(ByteSpan region) {
   if (block_start + HEADER_SIZE > last_start)
     return {};
 
+  // Preserve calculated block size in register during header writes, avoiding
+  // redundant memory reloads and address recomputations.
+  // In LLVM-MCA for Cortex-M33, this shows the following difference:
+  // Baseline MCA Throughput:  67 instructions, 67.0 cycles / iteration
+  // Optimized MCA Throughput: 50 instructions, 55.0 cycles / iteration
+  // MCA Speedup:             +21.8% faster (-12.0 cycles saved per
+  // split()/init() call)
+  auto *block_ptr = reinterpret_cast<cpp::byte *>(block_start);
   auto *last_start_ptr = reinterpret_cast<cpp::byte *>(last_start);
-  BlockRef block =
-      as_block({reinterpret_cast<cpp::byte *>(block_start), last_start_ptr});
+  size_t outer_size = last_start - block_start;
+
+  BlockRef block(block_ptr);
+  block.store_next(outer_size);
+
+  BlockRef last_block(last_start_ptr);
   make_last_block(last_start_ptr);
-  block.mark_free();
+  block.mark_free(last_block, outer_size);
   return block;
 }
 
@@ -493,6 +530,9 @@ optional<BlockRef> BlockRef::split(size_t new_inner_size,
   LIBC_ASSERT(usable_space_alignment % MIN_ALIGN == 0 &&
               "alignment must be a multiple of MIN_ALIGN");
 
+  size_t orig_next_val = load_next();
+  size_t orig_outer_size = orig_next_val & SIZE_MASK;
+
   // Compute the minimum outer size that produces a block of at least
   // `new_inner_size`.
   size_t min_outer_size = outer_size(cpp::max(new_inner_size, PREV_FIELD_SIZE));
@@ -506,19 +546,30 @@ optional<BlockRef> BlockRef::split(size_t new_inner_size,
   LIBC_ASSERT(new_outer_size % MIN_ALIGN == 0 &&
               "new size must be aligned to MIN_ALIGN");
 
-  if (outer_size() < new_outer_size ||
-      outer_size() - new_outer_size < HEADER_SIZE)
+  if (orig_outer_size < new_outer_size ||
+      orig_outer_size - new_outer_size < HEADER_SIZE)
     return {};
 
-  bool was_free = !used();
+  // Preserve calculated block size in register during header writes, avoiding
+  // redundant memory reloads and address recomputations.
+  // In LLVM-MCA for Cortex-M33, this shows the following difference:
+  // Baseline MCA Throughput:  67 instructions, 67.0 cycles / iteration
+  // Optimized MCA Throughput: 50 instructions, 55.0 cycles / iteration
+  // MCA Speedup:             +21.8% faster (-12.0 cycles saved per
+  // split()/init() call)
+  BlockRef old_next = next_from_val(orig_next_val);
+  bool was_free = old_next && old_next.prev_free();
 
-  ByteSpan new_region = region().subspan(new_outer_size);
-  store_next((load_next() & ~SIZE_MASK) | new_outer_size);
+  size_t rem_outer_size = orig_outer_size - new_outer_size;
+  cpp::byte *new_block_ptr = nonnull_header_ptr() + new_outer_size;
+  BlockRef new_block(new_block_ptr);
 
-  BlockRef new_block = as_block(new_region);
-  new_block.mark_free();
+  store_next((orig_next_val & ~SIZE_MASK) | new_outer_size);
+
+  new_block.store_next(rem_outer_size);
+  new_block.mark_free(old_next, rem_outer_size);
   if (was_free)
-    mark_free();
+    mark_free(new_block, new_outer_size);
 
   LIBC_ASSERT(new_block.is_usable_space_aligned(usable_space_alignment) &&
               "usable space must have requested alignment");

--- a/libc/src/__support/block.h
+++ b/libc/src/__support/block.h
@@ -31,8 +31,14 @@ namespace LIBC_NAMESPACE_DECL {
 
 /// Returns the value rounded down to the nearest multiple of alignment.
 LIBC_INLINE constexpr size_t align_down(size_t value, size_t alignment) {
-  // Note this shouldn't overflow since the result will always be <= value.
-  return (value / alignment) * alignment;
+#if defined(__builtin_align_down) ||                                           \
+    (defined(__has_builtin) && __has_builtin(__builtin_align_down))
+  return __builtin_align_down(value, alignment);
+#else
+  // Compiler cannot optimize out udiv and mul even if we provide
+  // __builtin_assume((alignment & (alignment - 1)) == 0);
+  return value & ~(alignment - 1);
+#endif
 }
 
 /// Returns the value rounded up to the nearest multiple of alignment. May wrap

--- a/libc/src/__support/freelist.cpp
+++ b/libc/src/__support/freelist.cpp
@@ -32,16 +32,35 @@ void FreeList::push(Node *node) {
 
 void FreeList::remove(Node *node) {
   LIBC_ASSERT(begin_ && "cannot remove from empty list");
+  // Hoist loads for `prev`, `next`, and `begin` right at function entry to
+  // enable
+  // register caching and paired load (ldrd) optimization on Thumb targets.
+  //
+  // Target: Cortex-M33 (thumbv8m.main-none-eabi)
+  //
+  // Simplified llvm-mca report:
+  // Before (individual loads):
+  //   Instructions:      1400
+  //   Total Cycles:      1501
+  //   IPC:               0.93
+  //   Block RThroughput: 14.0
+  //
+  // After (hoisted / paired loads):
+  //   Instructions:      1300
+  //   Total Cycles:      1401
+  //   IPC:               0.93
+  //   Block RThroughput: 13.0
+  Node *prev = node->prev;
   Node *next = node->next;
+  Node *begin = begin_;
   if (node == next) {
-    LIBC_ASSERT(node == begin_ &&
+    LIBC_ASSERT(node == begin &&
                 "a self-referential node must be the only element");
     begin_ = nullptr;
   } else {
-    Node *prev = node->prev;
     prev->next = next;
     next->prev = prev;
-    if (begin_ == node)
+    if (begin == node)
       begin_ = next;
   }
 }

--- a/libc/src/__support/freelist.h
+++ b/libc/src/__support/freelist.h
@@ -28,7 +28,9 @@ namespace LIBC_NAMESPACE_DECL {
 /// fragmentation.
 class FreeList {
 public:
-  class Node {
+  // Providing alignment allows compiler to emit paired store load instructions
+  // on Thumb targets.
+  class alignas(BlockRef::MIN_ALIGN) Node {
   public:
     /// @returns The block containing this node.
     LIBC_INLINE BlockRef block() const {

--- a/libc/src/__support/freelist_heap.h
+++ b/libc/src/__support/freelist_heap.h
@@ -111,7 +111,15 @@ LIBC_INLINE void *FreeListHeap::allocate_impl(size_t alignment, size_t size) {
   if (block_info.prev)
     free_store.insert(block_info.prev);
 
-  block_info.block.mark_used();
+  // Reuse unmasked size register across allocation header updates instead of
+  // re-executing bic instructions after memory loads.
+  // In LLVM-MCA for Cortex-M33, this shows the following difference:
+  // Baseline MCA Throughput:  10 instructions, 10.0 cycles / iteration
+  // Optimized MCA Throughput: 3 instructions, 3.0 cycles / iteration
+  // MCA Speedup:             -7.0 cycles saved per mark_used call
+  BlockRef next_block =
+      block_info.next ? block_info.next : block_info.block.next();
+  block_info.block.mark_used(next_block);
   return block_info.block.usable_space();
 }
 
@@ -144,14 +152,23 @@ LIBC_INLINE void FreeListHeap::free(void *ptr) {
   LIBC_ASSERT(is_valid_ptr(bytes) && "Invalid pointer");
 
   BlockRef block = BlockRef::from_usable_space(bytes);
-  LIBC_ASSERT(block.next() && "sentinel last block cannot be freed");
+
+  // Cache size and next to avoid repeated loads of load_next().
+  // In LLVM-MCA for Cortex-M33, this shows the following difference:
+  // Baseline MCA Throughput:  48.01 cycles / iteration (40 instructions)
+  // Optimized MCA Throughput: 40.01 cycles / iteration (35 instructions)
+  // MCA Speedup:             +16.7% faster (-8.0 cycles per free() invocation)
+  size_t next_val = block.load_next_val();
+  size_t outer_sz = block.outer_size_from_val(next_val);
+  BlockRef next = block.next_from_val(next_val);
+  BlockRef prev_free = block.prev_free_from_val(next_val);
+
+  LIBC_ASSERT(next && "sentinel last block cannot be freed");
   LIBC_ASSERT(block.used() && "double free");
-  block.mark_free();
+
+  block.mark_free(next, outer_sz);
 
   // Can we combine with the left or right blocks?
-  BlockRef prev_free = block.prev_free();
-  BlockRef next = block.next();
-
   if (prev_free) {
     // Remove from free store and merge.
     free_store.remove(prev_free);

--- a/libc/test/src/__support/block_test.cpp
+++ b/libc/test/src/__support/block_test.cpp
@@ -422,7 +422,9 @@ TEST(LlvmLibcBlockTest, AllocateAlreadyAligned) {
 TEST(LlvmLibcBlockTest, AllocateNeedsAlignment) {
   constexpr size_t kN = 1024;
 
-  array<byte, kN> bytes;
+  // overalign (larger than block alignment) the start address to avoid user
+  // payload falling in super-aligned address
+  alignas(BlockRef::MIN_ALIGN * 4) array<byte, kN> bytes;
   auto result = BlockRef::init(bytes);
   ASSERT_TRUE(result.has_value());
   BlockRef block = *result;
@@ -459,7 +461,9 @@ TEST(LlvmLibcBlockTest, AllocateNeedsAlignment) {
 TEST(LlvmLibcBlockTest, PreviousBlockMergedIfNotFirst) {
   constexpr size_t kN = 1024;
 
-  array<byte, kN> bytes;
+  // overalign (larger than block alignment) the start address to avoid user
+  // payload falling in super-aligned address
+  alignas(BlockRef::MIN_ALIGN * 4) array<byte, kN> bytes;
   auto result = BlockRef::init(bytes);
   ASSERT_TRUE(result.has_value());
   BlockRef block = *result;
@@ -497,7 +501,9 @@ TEST(LlvmLibcBlockTest, CanRemergeBlockAllocations) {
   // This is the same setup as with the `AllocateNeedsAlignment` test case.
   constexpr size_t kN = 1024;
 
-  array<byte, kN> bytes;
+  // overalign (larger than block alignment) the start address to avoid user
+  // payload falling in super-aligned address
+  alignas(BlockRef::MIN_ALIGN * 4) array<byte, kN> bytes;
   auto result = BlockRef::init(bytes);
   ASSERT_TRUE(result.has_value());
   BlockRef block = *result;

--- a/libc/test/src/__support/block_test.cpp
+++ b/libc/test/src/__support/block_test.cpp
@@ -377,13 +377,12 @@ TEST(LlvmLibcBlockTest, Allocate) {
   }
 
   // Ensure we can allocate a byte at every guaranteeable alignment.
-  for (size_t i = 1; i < kN / BlockRef::MIN_ALIGN; ++i) {
+  for (size_t alignment = BlockRef::MIN_ALIGN; alignment < kN; alignment *= 2) {
     array<byte, kN> bytes;
     auto result = BlockRef::init(bytes);
     ASSERT_TRUE(result.has_value());
     BlockRef block = *result;
 
-    size_t alignment = i * BlockRef::MIN_ALIGN;
     if (BlockRef::min_size_for_allocation(alignment, 1) > block.inner_size())
       continue;
 
@@ -434,8 +433,9 @@ TEST(LlvmLibcBlockTest, AllocateNeedsAlignment) {
   // it. We want to explicitly test that the block will split into one before
   // it.
   size_t alignment = BlockRef::MIN_ALIGN;
-  while (block.is_usable_space_aligned(alignment))
-    alignment += BlockRef::MIN_ALIGN;
+  while (block.is_usable_space_aligned(alignment) &&
+         alignment < block.inner_size() / 2)
+    alignment *= 2;
 
   auto [aligned_block, prev, next] = BlockRef::allocate(block, alignment, 10);
 
@@ -475,8 +475,9 @@ TEST(LlvmLibcBlockTest, PreviousBlockMergedIfNotFirst) {
   // it. We want to explicitly test that the block will split into one before
   // it.
   size_t alignment = BlockRef::MIN_ALIGN;
-  while (newblock.is_usable_space_aligned(alignment))
-    alignment += BlockRef::MIN_ALIGN;
+  while (newblock.is_usable_space_aligned(alignment) &&
+         alignment < newblock.inner_size() / 2)
+    alignment *= 2;
 
   // Ensure we can allocate in the new block.
   auto [aligned_block, prev, next] = BlockRef::allocate(newblock, alignment, 1);
@@ -512,8 +513,9 @@ TEST(LlvmLibcBlockTest, CanRemergeBlockAllocations) {
   // it. We want to explicitly test that the block will split into one before
   // it.
   size_t alignment = BlockRef::MIN_ALIGN;
-  while (block.is_usable_space_aligned(alignment))
-    alignment += BlockRef::MIN_ALIGN;
+  while (block.is_usable_space_aligned(alignment) &&
+         alignment < block.inner_size() / 2)
+    alignment *= 2;
 
   auto [aligned_block, prev, next] = BlockRef::allocate(block, alignment, 1);
 


### PR DESCRIPTION
Apply some manually picked `llvm-mca` proved optimizations for bare metal targets.

1. show compiler the alignment to allow paired store/load instructions.
2. adjust align_down computation and fix the corresponding test. The previous test is using non-power-of-2 alignment values
3. hoist load/store and cache values for places where the compiler cannot eliminate via GVN.

For those who are interested, exploration is done by sub-agent tasks. The prompt is roughly in the following form:

> Compile the code for Cortex-M33. Slice the baremetal heap code into clusters of codeblocks in a form that one can extract straightline code for `llvm-mca` for core logic and launch 32 subagents. Evenly assign jobs to individual subagent to scan bottlenecks and suboptimal codegen based on `llvm-mca`. Each agent extract the code in their own work directory to avoid affecting each other. Subagent should report back their to `/tmp/<id>-summary.md`. Only record suggested code change if `llvm-mca` proves quality improvement. When all subagents complete their tasks, summarize to `/tmp/summary.md`.

I highly suggest that programmers should still scan through all the suggestions; many of the results are still invalid or really minor. The agent multitasking is powerful to provide possible options while steering is still highly needed, at least based on my current experience. For the `align_down` case, for instance, I made a manual investigation on Compiler Explorer and added more context.

Assisted-by: Gemini based automation tool (human-in-the-loop).