### PR TITLE
release/23.x: [MachO] Preserve weak linkage for aliases (#198148)

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2646,7 +2646,9 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
     return;
   }
 
-  if (GA.hasExternalLinkage() || !MAI.getWeakRefDirective())
+  if (MAI.isMachO())
+    emitLinkage(&GA, Name);
+  else if (GA.hasExternalLinkage() || !MAI.getWeakRefDirective())
     OutStreamer->emitSymbolAttribute(Name, MCSA_Global);
   else if (GA.hasWeakLinkage() || GA.hasLinkOnceLinkage())
     OutStreamer->emitSymbolAttribute(Name, MCSA_WeakReference);

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -443,7 +443,12 @@ void MachObjectWriter::writeNlist(MachSymbolData &MSD, const MCAssembler &Asm) {
   // The Mach-O streamer uses the lowest 16-bits of the flags for the 'desc'
   // value.
   bool EncodeAsAltEntry = IsAlias && OrigSymbol.isAltEntry();
-  W.write<uint16_t>(Symbol->getEncodedFlags(EncodeAsAltEntry));
+  uint16_t Flags = Symbol->getEncodedFlags(EncodeAsAltEntry);
+  // Preserve the aliasee's flags while adding alias-specific flags,
+  // such as N_WEAK_DEF emitted by .weak_definition.
+  if (IsAlias)
+    Flags |= OrigSymbol.getEncodedFlags(EncodeAsAltEntry);
+  W.write<uint16_t>(Flags);
   if (is64Bit())
     W.write<uint64_t>(Address);
   else

--- a/llvm/test/CodeGen/AArch64/macho-weak-alias.ll
+++ b/llvm/test/CodeGen/AArch64/macho-weak-alias.ll
@@ -1,0 +1,17 @@
+; RUN: llc -mtriple=aarch64-apple-macosx13.0.0 -filetype=obj %s -o %t.o
+; RUN: llvm-nm -m %t.o | FileCheck %s
+
+define internal void @foo_internal() {
+  ret void
+}
+
+@foo_default = weak_odr alias void (), ptr @foo_internal
+@foo_hidden = weak_odr hidden alias void (), ptr @foo_internal
+
+define weak_odr hidden void @foo_defined() {
+  ret void
+}
+
+; CHECK-DAG: weak external _foo_default
+; CHECK-DAG: weak private external _foo_hidden
+; CHECK-DAG: weak private external _foo_defined


### PR DESCRIPTION
Mach-O aliases with weak or linkonce linkage were emitted as weak references, which is appropriate for undefined references but not for alias definitions. Emit Mach-O aliases through the same linkage path as other global definitions so weak aliases get .weak_definition.

When writing aliased symbols, keep the aliasee flags and include the alias symbol's own flags so N_WEAK_DEF is preserved in the Mach-O n_desc field.

Fixes #111321

#196047 was closed as a duplicate of #111321.