### PR TITLE
[clang][Tooling] Fix main header matching for headers with special characters.

### DIFF
--- a/clang/lib/Tooling/Inclusions/HeaderIncludes.cpp
+++ b/clang/lib/Tooling/Inclusions/HeaderIncludes.cpp
@@ -340,7 +340,8 @@ bool IncludeCategoryManager::isMainHeader(StringRef IncludeName) const {
   else if (FileStem.equals_insensitive(HeaderStem))
     Matching = FileStem; // example 3)
   if (!Matching.empty()) {
-    llvm::Regex MainIncludeRegex(HeaderStem.str() + Style.IncludeIsMainRegex,
+    llvm::Regex MainIncludeRegex(llvm::Regex::escape(HeaderStem) +
+                                     Style.IncludeIsMainRegex,
                                  llvm::Regex::IgnoreCase);
     if (MainIncludeRegex.match(Matching))
       return true;

--- a/clang/unittests/Tooling/HeaderIncludesTest.cpp
+++ b/clang/unittests/Tooling/HeaderIncludesTest.cpp
@@ -144,6 +144,20 @@ TEST_F(HeaderIncludesTest, InsertAfterMainHeader) {
   EXPECT_NE(Expected, insert(Code, "<a>")) << "Not main header";
 }
 
+TEST_F(HeaderIncludesTest, InsertAfterMainHeaderWithSpecialChars) {
+  std::string Code = "#include \"fix+bar.h\"\n"
+                     "\n"
+                     "int main() {}";
+  std::string Expected = "#include \"fix+bar.h\"\n"
+                         "#include <a>\n"
+                         "\n"
+                         "int main() {}";
+  Style = format::getGoogleStyle(format::FormatStyle::LanguageKind::LK_Cpp)
+              .IncludeStyle;
+  FileName = "fix+bar.cpp";
+  EXPECT_EQ(Expected, insert(Code, "<a>"));
+}
+
 TEST_F(HeaderIncludesTest, InsertMainHeader) {
   Style = format::getGoogleStyle(format::FormatStyle::LanguageKind::LK_Cpp)
               .IncludeStyle;


### PR DESCRIPTION
In Clang Tooling, escape HeaderStem before constructing MainIncludeRegex to prevent special characters (such as '+') from being interpreted as regex operators. Useful for Objective-C where "Foo+Bar.h" headers are very common for categories.