### PR TITLE
[BOLT] Release pseudo-probe decoder after emit

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -427,6 +427,11 @@ public:
     PseudoProbeDecoder = Decoder;
   }
 
+  /// Release the pseudo probe decoder once probes have been updated, freeing its
+  /// (potentially large) address-to-probe maps before later, memory-heavy
+  /// phases such as debug info rewriting.
+  void resetPseudoProbeDecoder() { PseudoProbeDecoder.reset(); }
+
   /// Return BinaryFunction containing a given \p Address or nullptr if
   /// no registered function contains the \p Address.
   ///

--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -427,8 +427,8 @@ public:
     PseudoProbeDecoder = Decoder;
   }
 
-  /// Release the pseudo probe decoder once probes have been updated, freeing its
-  /// (potentially large) address-to-probe maps before later, memory-heavy
+  /// Release the pseudo probe decoder once probes have been updated, freeing
+  /// its (potentially large) address-to-probe maps before later, memory-heavy
   /// phases such as debug info rewriting.
   void resetPseudoProbeDecoder() { PseudoProbeDecoder.reset(); }
 

--- a/bolt/lib/Rewrite/PseudoProbeRewriter.cpp
+++ b/bolt/lib/Rewrite/PseudoProbeRewriter.cpp
@@ -104,6 +104,13 @@ Error PseudoProbeRewriter::postEmitFinalizer() {
     parsePseudoProbe();
   updatePseudoProbes();
 
+  // The decoder's address-to-probe maps can be very large and are no longer
+  // needed once probes have been updated. Release both our reference and the
+  // one held by BinaryContext so the memory is freed before the memory-heavy
+  // debug info rewriting phase runs.
+  BC.resetPseudoProbeDecoder();
+  ProbeDecoderPtr.reset();
+
   return Error::success();
 }
 

--- a/bolt/lib/Rewrite/SDTRewriter.cpp
+++ b/bolt/lib/Rewrite/SDTRewriter.cpp
@@ -156,6 +156,8 @@ Error SDTRewriter::postEmitFinalizer() {
     SDTNotePatcher->addLE64Patch(SDTInfo.PCOffset, NewAddress);
   }
 
+  SDTMarkers.clear();
+
   return Error::success();
 }
 


### PR DESCRIPTION
PseudoProbeRewriter builds sizable data structures and then hold onto them after they are needed.
PseudoProbeRewriter::postEmitFinalizer() parses the input .pseudo_probe sections into an MCPseudoProbeDecoder whose address-to-probe and GUID-to-function-desc maps can be very large (tens of GiB on big binaries with many probes). This is not used again once probes have been updated, yet they survive into the memory-heavy DWARF rewrite (updateDebugInfo), directly inflating BOLT's peak RSS at the worst possible time.

This frees them at the end of the postEmitFinalizer() calls, before updateDebugInfo runs.

Stacked on top of the .dwo DIE diff, in large binaries you should observe ~17% peak RSS wins if your
build uses pseudo probe maps.