### PR TITLE
[AMDGPU] Unpack V_PK_MOV_B32 for MFMA co-issue

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
@@ -21,9 +21,11 @@
 #include "AMDGPU.h"
 #include "GCNSubtarget.h"
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+#include "SIDefines.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/CodeGen/MachinePostDominators.h"
 #include "llvm/CodeGen/TargetSchedule.h"
@@ -65,10 +67,10 @@ private:
   // Here, we have overwritten v0 before we use it. This function checks if
   // unpacking can lead to such a situation.
   bool canUnpackingClobberRegister(const MachineInstr &MI);
-  // Unpack and insert F32 packed instructions, such as V_PK_MUL, V_PK_ADD, and
-  // V_PK_FMA. Currently, only V_PK_MUL, V_PK_ADD, V_PK_FMA are supported for
-  // this transformation.
-  void performF32Unpacking(MachineInstr &I);
+  // Unpack and insert packed instructions, such as V_PK_MUL, V_PK_ADD,
+  // V_PK_FMA, and V_PK_MOV. Currently, V_PK_MUL, V_PK_ADD, V_PK_FMA, and
+  // V_PK_MOV are supported for this transformation.
+  void performUnpacking(MachineInstr &I);
   // Select corresponding unpacked instruction
   uint32_t mapToUnpackedOpcode(MachineInstr &I);
   // Creates the unpacked instruction to be inserted. Adds source modifiers to
@@ -524,6 +526,20 @@ bool SIPreEmitPeephole::canUnpackingClobberRegister(const MachineInstr &MI) {
   // op_sel_hi modifiers.
   Register UnpackedDstReg = TRI->getSubReg(DstReg, AMDGPU::sub0);
 
+  if (OpCode == AMDGPU::V_PK_MOV_B32) {
+    const MachineOperand *Src1MO =
+        TII->getNamedOperand(MI, AMDGPU::OpName::src1);
+    if (!Src1MO || !Src1MO->isReg())
+      return false;
+
+    unsigned Src1Mods =
+        TII->getNamedOperand(MI, AMDGPU::OpName::src1_modifiers)->getImm();
+    Register HiSrcReg = Src1Mods & SISrcMods::OP_SEL_0
+                            ? TRI->getSubReg(Src1MO->getReg(), AMDGPU::sub1)
+                            : TRI->getSubReg(Src1MO->getReg(), AMDGPU::sub0);
+    return TRI->regsOverlap(UnpackedDstReg, HiSrcReg);
+  }
+
   const MachineOperand *Src0MO = TII->getNamedOperand(MI, AMDGPU::OpName::src0);
   if (Src0MO && Src0MO->isReg()) {
     Register SrcReg0 = Src0MO->getReg();
@@ -571,16 +587,18 @@ bool SIPreEmitPeephole::canUnpackingClobberRegister(const MachineInstr &MI) {
 
 uint32_t SIPreEmitPeephole::mapToUnpackedOpcode(MachineInstr &I) {
   unsigned Opcode = I.getOpcode();
-  // Use 64 bit encoding to allow use of VOP3 instructions.
+  switch (Opcode) {
+  // Use 64 bit encoding to allow use of arithmetic VOP3 instructions.
   // VOP3 e64 instructions allow source modifiers
   // e32 instructions don't allow source modifiers.
-  switch (Opcode) {
   case AMDGPU::V_PK_ADD_F32:
     return AMDGPU::V_ADD_F32_e64;
   case AMDGPU::V_PK_MUL_F32:
     return AMDGPU::V_MUL_F32_e64;
   case AMDGPU::V_PK_FMA_F32:
     return AMDGPU::V_FMA_F32_e64;
+  case AMDGPU::V_PK_MOV_B32:
+    return AMDGPU::V_MOV_B32_e32;
   default:
     return std::numeric_limits<uint32_t>::max();
   }
@@ -700,7 +718,7 @@ void SIPreEmitPeephole::collectUnpackingCandidates(
   }
 }
 
-void SIPreEmitPeephole::performF32Unpacking(MachineInstr &I) {
+void SIPreEmitPeephole::performUnpacking(MachineInstr &I) {
   const MachineOperand &DstOp = I.getOperand(0);
 
   uint32_t UnpackedOpcode = mapToUnpackedOpcode(I);
@@ -737,6 +755,26 @@ MachineInstrBuilder SIPreEmitPeephole::createUnpackedMI(MachineInstr &I,
   unsigned OpCode = I.getOpcode();
   Register UnpackedDstReg = IsHiBits ? TRI->getSubReg(DstReg, AMDGPU::sub1)
                                      : TRI->getSubReg(DstReg, AMDGPU::sub0);
+
+  if (UnpackedOpcode == AMDGPU::V_MOV_B32_e32) {
+    MachineInstrBuilder NewMI = BuildMI(MBB, I, DL, TII->get(UnpackedOpcode));
+    NewMI.addDef(UnpackedDstReg);
+    const MachineOperand &SrcMO = IsHiBits ? *SrcMO1 : *SrcMO0;
+    unsigned SrcMods =
+        TII->getNamedOperand(I, IsHiBits ? AMDGPU::OpName::src1_modifiers
+                                         : AMDGPU::OpName::src0_modifiers)
+            ->getImm();
+
+    if (SrcMO.isImm()) {
+      NewMI.addImm(SrcMO.getImm());
+    } else {
+      unsigned SrcSubReg =
+          SrcMods & SISrcMods::OP_SEL_0 ? AMDGPU::sub1 : AMDGPU::sub0;
+      Register UnpackedSrcReg = TRI->getSubReg(SrcMO.getReg(), SrcSubReg);
+      NewMI.addReg(UnpackedSrcReg, getRegState(SrcMO));
+    }
+    return NewMI;
+  }
 
   int64_t ClampVal = TII->getNamedOperand(I, AMDGPU::OpName::clamp)->getImm();
   unsigned Src0Mods =
@@ -857,7 +895,7 @@ bool SIPreEmitPeephole::run(MachineFunction &MF, MachineLoopInfo *LoopInfo) {
       collectUnpackingCandidates(MI, InstrsToUnpack, NumMFMACycles);
     }
     for (MachineInstr *MI : InstrsToUnpack) {
-      performF32Unpacking(*MI);
+      performUnpacking(*MI);
     }
   }
 

--- a/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
+++ b/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
@@ -469,6 +469,7 @@ body:             |
     ; GFX950-NEXT: $vgpr5 = V_MOV_B32_e32 killed $sgpr15, implicit $exec, implicit $exec
     ; GFX950-NEXT: $vgpr16 = V_MOV_B32_e32 killed $sgpr31, implicit $exec
     ; GFX950-NEXT: $vgpr17 = V_MOV_B32_e32 killed $vgpr4, implicit $exec
+    ; GFX950-NEXT: renamable $vgpr16_vgpr17 = V_PK_MOV_B32 12, killed $sgpr28_sgpr29, 8, killed $vgpr16_vgpr17, 0, 0, 0, 0, 0, implicit $exec
     ; GFX950-NEXT: S_ENDPGM 0
     ;
     early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
@@ -487,6 +488,7 @@ body:             |
     $vgpr4 = V_MOV_B32_e32 killed $sgpr14, implicit $exec, implicit $exec
     $vgpr5 = V_MOV_B32_e32 killed $sgpr15, implicit $exec, implicit $exec
     renamable $vgpr16_vgpr17 = V_PK_MOV_B32 12, killed $sgpr30_sgpr31, 8, killed $vgpr4_vgpr5, 0, 0, 0, 0, 0, implicit $exec
+    renamable $vgpr16_vgpr17 = V_PK_MOV_B32 12, killed $sgpr28_sgpr29, 8, killed $vgpr16_vgpr17, 0, 0, 0, 0, 0, implicit $exec
     S_ENDPGM 0
 
 

--- a/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
+++ b/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
@@ -440,6 +440,58 @@ body:             |
 
 ...
 ---
+name:            test_pk_mov_unpacking_b32
+tracksRegLiveness: true
+
+liveins:
+  - { reg: '$sgpr4_sgpr5' }
+
+body:             |
+  bb.0.entry:
+    liveins: $sgpr4_sgpr5
+    ; GFX950-LABEL: name: test_pk_mov_unpacking_b32
+    ; GFX950: liveins: $sgpr4_sgpr5
+    ; GFX950-NEXT: {{  $}}
+    ; GFX950-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
+    ; GFX950-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
+    ; GFX950-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
+    ; GFX950-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
+    ; GFX950-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
+    ; GFX950-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
+    ; GFX950-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
+    ; GFX950-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
+    ; GFX950-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
+    ; GFX950-NEXT: $vgpr6_vgpr7 = V_MOV_B64_e32 killed $sgpr50_sgpr51, implicit $exec, implicit $sgpr48_sgpr49_sgpr50_sgpr51, implicit $exec
+    ; GFX950-NEXT: early-clobber renamable $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_32X32X16_F16_e64 killed $vgpr0_vgpr1_vgpr2_vgpr3, killed $vgpr4_vgpr5_vgpr6_vgpr7, 0, 0, 0, 0, implicit $mode, implicit $exec
+    ; GFX950-NEXT: $vgpr4 = V_MOV_B32_e32 killed $sgpr14, implicit $exec, implicit $exec
+    ; GFX950-NEXT: $vgpr5 = V_MOV_B32_e32 killed $sgpr15, implicit $exec, implicit $exec
+    ; GFX950-NEXT: $vgpr16 = V_MOV_B32_e32 killed $sgpr31, implicit $exec
+    ; GFX950-NEXT: $vgpr17 = V_MOV_B32_e32 killed $vgpr4, implicit $exec
+    ; GFX950-NEXT: S_ENDPGM 0
+    ;
+    early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
+    renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
+    S_WAITCNT 49279
+    renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
+    renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
+    early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
+    early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
+    S_WAITCNT 49279
+    $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
+    $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
+    $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
+    $vgpr6_vgpr7 = V_MOV_B64_e32 killed $sgpr50_sgpr51, implicit $exec, implicit $sgpr48_sgpr49_sgpr50_sgpr51, implicit $exec
+    renamable $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_32X32X16_F16_e64 killed $vgpr0_vgpr1_vgpr2_vgpr3, killed $vgpr4_vgpr5_vgpr6_vgpr7, 0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr4 = V_MOV_B32_e32 killed $sgpr14, implicit $exec, implicit $exec
+    $vgpr5 = V_MOV_B32_e32 killed $sgpr15, implicit $exec, implicit $exec
+    renamable $vgpr16_vgpr17 = V_PK_MOV_B32 12, killed $sgpr30_sgpr31, 8, killed $vgpr4_vgpr5, 0, 0, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+
+
+...
+---
 name:            test_pk_fma_unpacking_f32
 tracksRegLiveness: true
 


### PR DESCRIPTION
Teach `SIPreEmitPeephole` to unpack `V_PK_MOV_B32` into two `V_MOV_B32_e32` instructions so they can co-issue with overlapping MFMAs.

The patch also avoids unpacking when writing the low destination would clobber the source needed by the high move.

Tests cover both successful unpacking and fail unpacking in case of clobber.

Fixes #161453
