### PR TITLE
[libc] Add symbolic constants for si_code values.

### DIFF
--- a/libc/include/llvm-libc-macros/linux/signal-macros.h
+++ b/libc/include/llvm-libc-macros/linux/signal-macros.h
@@ -95,6 +95,39 @@
 #define SIG_IGN __LLVM_LIBC_CAST(reinterpret_cast, void (*)(int), 1)
 #define SIG_HOLD __LLVM_LIBC_CAST(reinterpret_cast, void (*)(int), 2)
 
+// SIGILL si_codes
+#define ILL_ILLOPC 1 // Illegal opcode
+#define ILL_ILLOPN 2 // Illegal operand
+#define ILL_ILLADR 3 // Illegal addressing mode
+#define ILL_ILLTRP 4 // Illegal trap
+#define ILL_PRVOPC 5 // Privileged opcode
+#define ILL_PRVREG 6 // Privileged register
+#define ILL_COPROC 7 // Coprocessor error
+#define ILL_BADSTK 8 // Internal stack error
+
+// SIGFPE si_codes
+#define FPE_INTDIV 1 // Integer divide by zero
+#define FPE_INTOVF 2 // Integer overflow
+#define FPE_FLTDIV 3 // Floating-point divide by zero
+#define FPE_FLTOVF 4 // Floating-point overflow
+#define FPE_FLTUND 5 // Floating-point underflow
+#define FPE_FLTRES 6 // Floating-point inexact result
+#define FPE_FLTINV 7 // Invalid floating-point operation
+#define FPE_FLTSUB 8 // Subscript out of range
+
+// SIGSEGV si_codes
+#define SEGV_MAPERR 1 // Address not mapped to object
+#define SEGV_ACCERR 2 // Invalid permissions for mapped object
+
+// SIGBUS si_codes
+#define BUS_ADRALN 1 // Invalid address alignment
+#define BUS_ADRERR 2 // Non-existent physical address
+#define BUS_OBJERR 3 // Object-specific hardware error
+
+// SIGTRAP si_codes
+#define TRAP_BRKPT 1 // Process breakpoint
+#define TRAP_TRACE 2 // Process trace trap
+
 // SIGCHLD si_codes
 #define CLD_EXITED 1    // child has exited
 #define CLD_KILLED 2    // child was killed
@@ -102,5 +135,12 @@
 #define CLD_TRAPPED 4   // traced child has trapped
 #define CLD_STOPPED 5   // child has stopped
 #define CLD_CONTINUED 6 // stopped child has continued
+
+// Other si_codes.
+#define SI_USER 0       // Sent by kill()
+#define SI_QUEUE (-1)   // Sent by sigqueue()
+#define SI_TIMER (-2)   // Expiration of a timer set by timer_settime()
+#define SI_ASYNCIO (-4) // Completion of an synchronous I/O request
+#define SI_MESGQ (-3)   // Arrival of a message on an empty message queue
 
 #endif // LLVM_LIBC_MACROS_LINUX_SIGNAL_MACROS_H


### PR DESCRIPTION
Extend SIGCHLD-specific `si_code` values, already available in `signal-macros.h` with Linux values for the rest of the signal-specific codes specified in the POSIX.1-2024.