### PR TITLE
[mlir][xegpu] Support batched matmul in    VectorToXeGPU ContractionLowering

### DIFF
--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -1001,9 +1001,10 @@ struct ContractionLowering : public OpRewritePattern<vector::ContractionOp> {
 
     if (!getRowMajorMatmulBatchRank(contractOp.getIndexingMapsAttr()))
       return rewriter.notifyMatchFailure(
-          contractOp, "Expects a (batched) row-major matmul: leading dims must "
-                      "be batch dims shared by lhs, rhs, and acc; innermost two "
-                      "dims must be (M, K), (K, N), and (M, N)");
+          contractOp,
+          "Expects a (batched) row-major matmul: leading dims must "
+          "be batch dims shared by lhs, rhs, and acc; innermost two "
+          "dims must be (M, K), (K, N), and (M, N)");
 
     // xegpu.dpas operands are limited to rank 4 (2 batch + 2 core dims).
     if (accType.getRank() > 4)

--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -999,15 +999,17 @@ struct ContractionLowering : public OpRewritePattern<vector::ContractionOp> {
     if (!accType)
       return rewriter.notifyMatchFailure(contractOp, "Expects vector acc");
 
-    if (!getRowMajorMatmulBatchRank(contractOp.getIndexingMapsAttr()))
+    std::optional<int64_t> batchRank =
+        getRowMajorMatmulBatchRank(contractOp.getIndexingMapsAttr());
+    if (!batchRank)
       return rewriter.notifyMatchFailure(
           contractOp,
           "Expects a (batched) row-major matmul: leading dims must "
           "be batch dims shared by lhs, rhs, and acc; innermost two "
           "dims must be (M, K), (K, N), and (M, N)");
 
-    // xegpu.dpas operands are limited to rank 4 (2 batch + 2 core dims).
-    if (accType.getRank() > 4)
+    // xegpu.dpas operands are limited to 2 batch + 2 core dims.
+    if (*batchRank > 2)
       return rewriter.notifyMatchFailure(contractOp,
                                          "Expects operands of rank 4 or less");
 

--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -924,6 +924,63 @@ struct StoreLowering : public OpRewritePattern<vector::StoreOp> {
   }
 };
 
+// If `indexingMaps` describe a (batched) row-major matmul
+//   lhs[b..., m, k], rhs[b..., k, n], acc[b..., m, n]
+// return the number of leading batch dims (0 for a plain 2D matmul);
+// otherwise return std::nullopt.
+static std::optional<int64_t>
+getRowMajorMatmulBatchRank(ArrayAttr indexingMaps) {
+  if (indexingMaps.size() != 3)
+    return std::nullopt;
+
+  AffineMap mapA = cast<AffineMapAttr>(indexingMaps[0]).getValue();
+  AffineMap mapB = cast<AffineMapAttr>(indexingMaps[1]).getValue();
+  AffineMap mapC = cast<AffineMapAttr>(indexingMaps[2]).getValue();
+
+  // The result map exposes the batch dims followed by the core (m, n) dims.
+  if (mapC.getNumResults() < 2)
+    return std::nullopt;
+  int64_t batchRank = mapC.getNumResults() - 2;
+
+  // A single `k` reduction gives batchRank + 3 iteration dims; each operand
+  // map exposes batchRank + 2 dims (batch dims + 2 core dims).
+  unsigned numDims = static_cast<unsigned>(batchRank) + 3;
+  unsigned numOperandResults = static_cast<unsigned>(batchRank) + 2;
+  if (mapA.getNumInputs() != numDims || mapB.getNumInputs() != numDims ||
+      mapC.getNumInputs() != numDims)
+    return std::nullopt;
+  if (mapA.getNumResults() != numOperandResults ||
+      mapB.getNumResults() != numOperandResults)
+    return std::nullopt;
+
+  // Reconstruct the canonical maps from the batch/m/n dims of the result and
+  // the k dim of lhs, then compare against the actual maps.
+  MLIRContext *context = indexingMaps.getContext();
+  ArrayRef<AffineExpr> batchDims = mapC.getResults().take_front(batchRank);
+  AffineExpr m = mapC.getResult(batchRank);
+  AffineExpr n = mapC.getResult(batchRank + 1);
+  AffineExpr k = mapA.getResult(batchRank + 1);
+
+  SmallVector<AffineExpr> aDims = llvm::to_vector(batchDims);
+  aDims.push_back(m);
+  aDims.push_back(k);
+  SmallVector<AffineExpr> bDims = llvm::to_vector(batchDims);
+  bDims.push_back(k);
+  bDims.push_back(n);
+  SmallVector<AffineExpr> cDims = llvm::to_vector(batchDims);
+  cDims.push_back(m);
+  cDims.push_back(n);
+
+  auto expected = ArrayAttr::get(
+      context,
+      {AffineMapAttr::get(AffineMap::get(numDims, 0, aDims, context)),
+       AffineMapAttr::get(AffineMap::get(numDims, 0, bDims, context)),
+       AffineMapAttr::get(AffineMap::get(numDims, 0, cDims, context))});
+  if (indexingMaps != expected)
+    return std::nullopt;
+  return batchRank;
+}
+
 struct ContractionLowering : public OpRewritePattern<vector::ContractionOp> {
   using Base::Base;
 
@@ -935,21 +992,23 @@ struct ContractionLowering : public OpRewritePattern<vector::ContractionOp> {
       return rewriter.notifyMatchFailure(contractOp,
                                          "Expects add combining kind");
 
-    TypedValue<Type> acc = contractOp.getAcc();
-    VectorType accType = dyn_cast<VectorType>(acc.getType());
-    if (!accType || accType.getRank() != 2)
-      return rewriter.notifyMatchFailure(contractOp, "Expects acc 2D vector");
-
-    // Accept only plain 2D data layout.
-    // VNNI packing is applied to DPAS as a separate lowering step.
     TypedValue<VectorType> lhs = contractOp.getLhs();
     TypedValue<VectorType> rhs = contractOp.getRhs();
-    if (lhs.getType().getRank() != 2 || rhs.getType().getRank() != 2)
-      return rewriter.notifyMatchFailure(contractOp,
-                                         "Expects lhs and rhs 2D vectors");
+    TypedValue<Type> acc = contractOp.getAcc();
+    VectorType accType = dyn_cast<VectorType>(acc.getType());
+    if (!accType)
+      return rewriter.notifyMatchFailure(contractOp, "Expects vector acc");
 
-    if (!isRowMajorMatmul(contractOp.getIndexingMapsAttr()))
-      return rewriter.notifyMatchFailure(contractOp, "Invalid indexing maps");
+    if (!getRowMajorMatmulBatchRank(contractOp.getIndexingMapsAttr()))
+      return rewriter.notifyMatchFailure(
+          contractOp, "Expects a (batched) row-major matmul: leading dims must "
+                      "be batch dims shared by lhs, rhs, and acc; innermost two "
+                      "dims must be (M, K), (K, N), and (M, N)");
+
+    // xegpu.dpas operands are limited to rank 4 (2 batch + 2 core dims).
+    if (accType.getRank() > 4)
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "Expects operands of rank 4 or less");
 
     auto dpasOp = xegpu::DpasOp::create(rewriter, loc,
                                         TypeRange{contractOp.getResultType()},

--- a/mlir/test/Conversion/VectorToXeGPU/contract-to-xegpu.mlir
+++ b/mlir/test/Conversion/VectorToXeGPU/contract-to-xegpu.mlir
@@ -180,3 +180,51 @@ func.func @negative_accumulator_shape(%lhs: vector<8x16xf16>, %rhs: vector<16x16
 
 // CHECK-LABEL: @negative_accumulator_shape(
 // CHECK:       vector.contract
+
+// -----
+
+// A batched matmul whose leading dimension is a batch dimension shared across
+// lhs, rhs, and acc lowers to a batched xegpu.dpas.
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @dpas_batched_gemm(%lhs: vector<4x8x16xf16>, %rhs: vector<4x16x16xf16>,
+    %acc: vector<4x8x16xf32>) -> vector<4x8x16xf32> {
+  %3 = vector.contract
+    {indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction"],
+    kind = #vector.kind<add>} %lhs, %rhs, %acc
+    : vector<4x8x16xf16>, vector<4x16x16xf16> into vector<4x8x16xf32>
+  return %3 : vector<4x8x16xf32>
+}
+
+// CHECK-LABEL: @dpas_batched_gemm(
+// CHECK-SAME:  %[[LHS:.+]]: vector<4x8x16xf16>,
+// CHECK-SAME:  %[[RHS:.+]]: vector<4x16x16xf16>,
+// CHECK-SAME:  %[[ACC:.+]]: vector<4x8x16xf32>
+// CHECK:       %[[DPAS:.+]] = xegpu.dpas
+// CHECK-SAME:    %[[LHS]], %[[RHS]], %[[ACC]]
+// CHECK-SAME:    {{.*}}-> vector<4x8x16xf32>
+// CHECK:       return %[[DPAS]]
+
+// -----
+
+// An N-D contraction whose leading dimension is not a batch dimension shared
+// across lhs, rhs, and acc does not map to a (batched) row-major matmul.
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d0, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+func.func @negative_non_batched_nd(%lhs: vector<128x64x64xf16>, %rhs: vector<64x64xf16>,
+    %acc: vector<128x64xf16>) -> vector<128x64xf16> {
+  %3 = vector.contract
+    {indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction"],
+    kind = #vector.kind<add>} %lhs, %rhs, %acc
+    : vector<128x64x64xf16>, vector<64x64xf16> into vector<128x64xf16>
+  return %3 : vector<128x64xf16>
+}
+
+// CHECK-LABEL: @negative_non_batched_nd(
+// CHECK:       vector.contract

--- a/mlir/test/Conversion/VectorToXeGPU/contract-to-xegpu.mlir
+++ b/mlir/test/Conversion/VectorToXeGPU/contract-to-xegpu.mlir
@@ -183,29 +183,30 @@ func.func @negative_accumulator_shape(%lhs: vector<8x16xf16>, %rhs: vector<16x16
 
 // -----
 
-// A batched matmul whose leading dimension is a batch dimension shared across
-// lhs, rhs, and acc lowers to a batched xegpu.dpas.
+// A batched matmul whose leading dimensions are batch dimensions shared across
+// lhs, rhs, and acc lowers to a batched xegpu.dpas. Two batch dims exercise the
+// upper bound (rank 4 = 2 batch + 2 core dims).
 
-#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
-#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-func.func @dpas_batched_gemm(%lhs: vector<4x8x16xf16>, %rhs: vector<4x16x16xf16>,
-    %acc: vector<4x8x16xf32>) -> vector<4x8x16xf32> {
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+func.func @dpas_batched_gemm(%lhs: vector<2x4x8x16xf16>, %rhs: vector<2x4x16x16xf16>,
+    %acc: vector<2x4x8x16xf32>) -> vector<2x4x8x16xf32> {
   %3 = vector.contract
     {indexing_maps = [#map, #map1, #map2],
-    iterator_types = ["parallel", "parallel", "parallel", "reduction"],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
     kind = #vector.kind<add>} %lhs, %rhs, %acc
-    : vector<4x8x16xf16>, vector<4x16x16xf16> into vector<4x8x16xf32>
-  return %3 : vector<4x8x16xf32>
+    : vector<2x4x8x16xf16>, vector<2x4x16x16xf16> into vector<2x4x8x16xf32>
+  return %3 : vector<2x4x8x16xf32>
 }
 
 // CHECK-LABEL: @dpas_batched_gemm(
-// CHECK-SAME:  %[[LHS:.+]]: vector<4x8x16xf16>,
-// CHECK-SAME:  %[[RHS:.+]]: vector<4x16x16xf16>,
-// CHECK-SAME:  %[[ACC:.+]]: vector<4x8x16xf32>
+// CHECK-SAME:  %[[LHS:.+]]: vector<2x4x8x16xf16>,
+// CHECK-SAME:  %[[RHS:.+]]: vector<2x4x16x16xf16>,
+// CHECK-SAME:  %[[ACC:.+]]: vector<2x4x8x16xf32>
 // CHECK:       %[[DPAS:.+]] = xegpu.dpas
 // CHECK-SAME:    %[[LHS]], %[[RHS]], %[[ACC]]
-// CHECK-SAME:    {{.*}}-> vector<4x8x16xf32>
+// CHECK-SAME:    {{.*}}-> vector<2x4x8x16xf32>
 // CHECK:       return %[[DPAS]]
 
 // -----
@@ -227,4 +228,25 @@ func.func @negative_non_batched_nd(%lhs: vector<128x64x64xf16>, %rhs: vector<64x
 }
 
 // CHECK-LABEL: @negative_non_batched_nd(
+// CHECK:       vector.contract
+
+// -----
+
+// A row-major batched matmul with more than 2 batch dims (rank 5) exceeds the
+// xegpu.dpas limit of 2 batch + 2 core dims and is not lowered.
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
+func.func @negative_too_many_batch_dims(%lhs: vector<2x2x4x8x16xf16>, %rhs: vector<2x2x4x16x16xf16>,
+    %acc: vector<2x2x4x8x16xf32>) -> vector<2x2x4x8x16xf32> {
+  %3 = vector.contract
+    {indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"],
+    kind = #vector.kind<add>} %lhs, %rhs, %acc
+    : vector<2x2x4x8x16xf16>, vector<2x2x4x16x16xf16> into vector<2x2x4x8x16xf32>
+  return %3 : vector<2x2x4x8x16xf32>
+}
+
+// CHECK-LABEL: @negative_too_many_batch_dims(
 // CHECK:       vector.contract


### PR DESCRIPTION
  Generalizes ContractionLowering in mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp so that (batched) N-D vector.contract ops lower to xegpu.dpas, not just plain 2D matmuls.