### PR TITLE
[clang][doc][SYCL] Add SYCL driver and device library release notes to ReleaseNotes.md

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -503,8 +503,9 @@ features cannot lower the translation-unit ABI level;
 - The SYCL runtime shared library has been renamed from `libsycl.so` to
   `libLLVMSYCL.so` to align with LLVM naming conventions.
 
-- In SYCL mode, the compiler driver automatically provides the necessary SYCL
-  header include paths to both the host and device compilers.
+- When SYCL based compilation is enabled, the compiler driver automatically
+  provides the necessary SYCL header include paths to both the host and
+  device compilations.
 
 - SYCL runtime library linking is now supported on Windows. When `-fsycl` is
   specified, Clang automatically adds `/MD` if no explicit CRT flag is present,

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -503,8 +503,8 @@ features cannot lower the translation-unit ABI level;
 - The SYCL runtime shared library has been renamed from `libsycl.so` to
   `libLLVMSYCL.so` to align with LLVM naming conventions.
 
-- SYCL header include paths are now added automatically for both host and
-  device compilations.
+- In SYCL mode, the compiler driver automatically provides the necessary SYCL
+  header include paths to both the host and device compilers.
 
 - SYCL runtime library linking is now supported on Windows. When `-fsycl` is
   specified, Clang automatically adds `/MD` if no explicit CRT flag is present,
@@ -515,9 +515,8 @@ features cannot lower the translation-unit ABI level;
 - Fixed `-nolibsycl` being silently ignored on Linux: the SYCL runtime library
   was unconditionally added to the link line even when the flag was passed.
 
-- SYCL device compilations targeting SPIR-V now automatically link
-  `libclang_rt.builtins.bc` at compile time via `-mlink-builtin-bitcode`.
-  Pass `--no-offloadlib` to opt out.
+- SYCL device compilations targeting SPIR-V now automatically link compiler
+  builtin functions at compile time. Pass `--no-offloadlib` to opt out.
 
 ## Additional Information
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -493,6 +493,32 @@ features cannot lower the translation-unit ABI level;
 
 #### Improvements
 
+- SYCL compilations now default to `-std=c++17` when no explicit language
+  standard is specified. Standards below C++17 are rejected with a diagnostic.
+
+- Clang now assumes the default target for SYCL device compilation is 64-bit
+  SPIR-V and diagnoses if a non-supporting target is specified on the command
+  line. (#GH167358)
+
+- The SYCL runtime shared library has been renamed from `libsycl.so` to
+  `libLLVMSYCL.so` to align with LLVM naming conventions.
+
+- SYCL header include paths are now added automatically for both host and
+  device compilations.
+
+- SYCL runtime library linking is now supported on Windows. When `-fsycl` is
+  specified, Clang automatically adds `/MD` if no explicit CRT flag is present,
+  links the appropriate debug (`LLVMSYCLd.lib`) or release (`LLVMSYCL.lib`)
+  library, and rejects static CRT flags (`/MT`, `/MTd`) with a diagnostic. Use
+  `-nolibsycl` to suppress automatic library linking.
+
+- Fixed `-nolibsycl` being silently ignored on Linux: the SYCL runtime library
+  was unconditionally added to the link line even when the flag was passed.
+
+- SYCL device compilations targeting SPIR-V now automatically link
+  `libclang_rt.builtins.bc` at compile time via `-mlink-builtin-bitcode`.
+  Pass `--no-offloadlib` to opt out.
+
 ## Additional Information
 
 A wide variety of additional information is available on the [Clang web


### PR DESCRIPTION
Ports the SYCL driver entries from PR #200449 (which targeted the now-removed ReleaseNotes.rst) to ReleaseNotes.md, and adds an entry for compile-time device library linking via -mlink-builtin-bitcode (#196656).