### PR TITLE
X86: Use ProcessorAlias for duplicated processor names (NFC)

### DIFF
--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -274,7 +274,7 @@ public:
   }
 
   /// Check whether the CPU string is valid.
-  virtual bool isCPUStringValid(StringRef CPU) const {
+  bool isCPUStringValid(StringRef CPU) const {
     auto Found = llvm::lower_bound(ProcDesc, CPU);
     return Found != ProcDesc.end() && StringRef(Found->key()) == CPU;
   }

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -2136,6 +2136,13 @@ class ProcessorModel<string n, SchedMachineModel m, list<SubtargetFeature> f,
   let SchedModel = m;
 }
 
+// Defines an alternate name 'n' for the processor 'alias', resolving
+// to the same subtarget features and scheduling model.
+class ProcessorAlias<string n, string alias> {
+  string Name = n;
+  string Alias = alias;
+}
+
 //===----------------------------------------------------------------------===//
 // InstrMapping - This class is used to create mapping tables to relate
 // instructions with each other based on the values specified in RowFields,

--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -1276,12 +1276,6 @@ def ProcessorFeatures {
   list<SubtargetFeature> Generic = [FeatureFPARMv8, FeatureNEON, FeatureETE];
 }
 
-// Define an alternative name for a given Processor.
-class ProcessorAlias<string n, string alias> {
-  string Name = n;
-  string Alias = alias;
-}
-
 // A note on scheduling models - we do not have exact models for each core and
 // attempt to use the "best equivalent" that we have for those that are
 // missing. -mcpu=generic uses a cortex-a510 model to get good scheduling

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -1897,8 +1897,8 @@ def : Proc<"i486",            [FeatureX87],
                               [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
 def : Proc<"i586",            [FeatureX87, FeatureCX8],
                               [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-def : Proc<"pentium",         [FeatureX87, FeatureCX8],
-                              [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium", "i586">;
+
 def : Proc<"pentium-mmx", [FeatureX87, FeatureCX8, FeatureMMX],
                           [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
 def : ProcessorAlias<"pentium_mmx", "pentium-mmx">;

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -1899,26 +1899,24 @@ def : Proc<"i586",            [FeatureX87, FeatureCX8],
                               [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
 def : Proc<"pentium",         [FeatureX87, FeatureCX8],
                               [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-foreach P = ["pentium-mmx", "pentium_mmx"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureMMX],
-                [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : Proc<"pentium-mmx", [FeatureX87, FeatureCX8, FeatureMMX],
+                          [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium_mmx", "pentium-mmx">;
 def : Proc<"i686", [FeatureX87, FeatureCX8, FeatureCMOV],
                    [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-foreach P = ["pentiumpro", "pentium_pro"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureCMOV, FeatureNOPL],
-                [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
-foreach P = ["pentium2", "pentium_ii"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureMMX, FeatureCMOV,
-                          FeatureFXSR, FeatureNOPL],
-                        [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
-foreach P = ["pentium3", "pentium3m", "pentium_iii_no_xmm_regs", "pentium_iii"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureMMX,
-                 FeatureSSE1, FeatureFXSR, FeatureNOPL, FeatureCMOV],
-                [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : Proc<"pentiumpro", [FeatureX87, FeatureCX8, FeatureCMOV, FeatureNOPL],
+                         [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium_pro", "pentiumpro">;
+def : Proc<"pentium2", [FeatureX87, FeatureCX8, FeatureMMX, FeatureCMOV,
+                        FeatureFXSR, FeatureNOPL],
+                       [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium_ii", "pentium2">;
+def : Proc<"pentium3", [FeatureX87, FeatureCX8, FeatureMMX,
+                        FeatureSSE1, FeatureFXSR, FeatureNOPL, FeatureCMOV],
+                       [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium3m", "pentium3">;
+def : ProcessorAlias<"pentium_iii_no_xmm_regs", "pentium3">;
+def : ProcessorAlias<"pentium_iii", "pentium3">;
 
 // Enable the PostRAScheduler for SSE2 and SSE3 class cpus.
 // The intent is to enable it for pentium4 which is the current default
@@ -1930,19 +1928,18 @@ foreach P = ["pentium3", "pentium3m", "pentium_iii_no_xmm_regs", "pentium_iii"] 
 // measure to avoid performance surprises, in case clang's default cpu
 // changes slightly.
 
-foreach P = ["pentium_m", "pentium-m"] in {
-def : ProcModel<P, GenericPostRAModel,
+def : ProcModel<"pentium_m", GenericPostRAModel,
                 [FeatureX87, FeatureCX8, FeatureMMX, FeatureSSE2,
                 FeatureFXSR, FeatureNOPL, FeatureCMOV],
                 [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : ProcessorAlias<"pentium-m", "pentium_m">;
 
-foreach P = ["pentium4", "pentium4m", "pentium_4"] in {
-  def : ProcModel<P, GenericPostRAModel,
-                  [FeatureX87, FeatureCX8, FeatureMMX, FeatureSSE2,
-                   FeatureFXSR, FeatureNOPL, FeatureCMOV],
-                  [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : ProcModel<"pentium4", GenericPostRAModel,
+                [FeatureX87, FeatureCX8, FeatureMMX, FeatureSSE2,
+                 FeatureFXSR, FeatureNOPL, FeatureCMOV],
+                [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium4m", "pentium4">;
+def : ProcessorAlias<"pentium_4", "pentium4">;
 
 // Intel Quark.
 def : Proc<"lakemont", [FeatureCX8],
@@ -1955,12 +1952,11 @@ def : ProcModel<"yonah", SandyBridgeModel,
                 [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
 
 // NetBurst.
-foreach P = ["prescott", "pentium_4_sse3"] in {
-  def : ProcModel<P, GenericPostRAModel,
-                  [FeatureX87, FeatureCX8, FeatureMMX, FeatureSSE3,
-                  FeatureFXSR, FeatureNOPL, FeatureCMOV],
-                  [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : ProcModel<"prescott", GenericPostRAModel,
+                [FeatureX87, FeatureCX8, FeatureMMX, FeatureSSE3,
+                FeatureFXSR, FeatureNOPL, FeatureCMOV],
+                [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"pentium_4_sse3", "prescott">;
 def : ProcModel<"nocona", GenericPostRAModel, [
   FeatureX87,
   FeatureCX8,
@@ -1978,8 +1974,7 @@ def : ProcModel<"nocona", GenericPostRAModel, [
 ]>;
 
 // Intel Core 2 Solo/Duo.
-foreach P = ["core2", "core_2_duo_ssse3"] in {
-def : ProcModel<P, SandyBridgeModel, [
+def : ProcModel<"core2", SandyBridgeModel, [
   FeatureX87,
   FeatureCX8,
   FeatureCMOV,
@@ -1996,9 +1991,8 @@ def : ProcModel<P, SandyBridgeModel, [
   TuningSlowUAMem16,
   TuningInsertVZEROUPPER
 ]>;
-}
-foreach P = ["penryn", "core_2_duo_sse4_1"] in {
-def : ProcModel<P, SandyBridgeModel, [
+def : ProcessorAlias<"core_2_duo_ssse3", "core2">;
+def : ProcModel<"penryn", SandyBridgeModel, [
   FeatureX87,
   FeatureCX8,
   FeatureCMOV,
@@ -2015,77 +2009,74 @@ def : ProcModel<P, SandyBridgeModel, [
   TuningSlowUAMem16,
   TuningInsertVZEROUPPER
 ]>;
-}
+def : ProcessorAlias<"core_2_duo_sse4_1", "penryn">;
 
 // Atom CPUs.
-foreach P = ["bonnell", "atom"] in {
-  def : ProcModel<P, AtomModel, ProcessorFeatures.AtomFeatures,
-                  ProcessorFeatures.AtomTuning>;
-}
+def : ProcModel<"bonnell", AtomModel, ProcessorFeatures.AtomFeatures,
+                ProcessorFeatures.AtomTuning>;
+def : ProcessorAlias<"atom", "bonnell">;
 
-foreach P = ["silvermont", "slm", "atom_sse4_2"] in {
-  def : ProcModel<P, SLMModel, ProcessorFeatures.SLMFeatures,
-                  ProcessorFeatures.SLMTuning>;
-}
+def : ProcModel<"silvermont", SLMModel, ProcessorFeatures.SLMFeatures,
+                ProcessorFeatures.SLMTuning>;
+def : ProcessorAlias<"slm", "silvermont">;
+def : ProcessorAlias<"atom_sse4_2", "silvermont">;
 
 def : ProcModel<"atom_sse4_2_movbe", SLMModel, ProcessorFeatures.GLMFeatures,
                 ProcessorFeatures.SLMTuning>;
 def : ProcModel<"goldmont", SLMModel, ProcessorFeatures.GLMFeatures,
                 ProcessorFeatures.GLMTuning>;
-foreach P = ["goldmont_plus", "goldmont-plus"] in {
-  def : ProcModel<P, SLMModel, ProcessorFeatures.GLPFeatures,
-                  ProcessorFeatures.GLPTuning>;
-}
+def : ProcModel<"goldmont_plus", SLMModel, ProcessorFeatures.GLPFeatures,
+                ProcessorFeatures.GLPTuning>;
+def : ProcessorAlias<"goldmont-plus", "goldmont_plus">;
 def : ProcModel<"tremont", SLMModel, ProcessorFeatures.TRMFeatures,
                 ProcessorFeatures.TRMTuning>;
 
 // "Arrandale" along with corei3 and corei5
-foreach P = ["nehalem", "corei7", "core_i7_sse4_2"] in {
-  def : ProcModel<P, SandyBridgeModel, ProcessorFeatures.NHMFeatures,
-                  ProcessorFeatures.NHMTuning>;
-}
+def : ProcModel<"nehalem", SandyBridgeModel, ProcessorFeatures.NHMFeatures,
+                ProcessorFeatures.NHMTuning>;
+def : ProcessorAlias<"corei7", "nehalem">;
+def : ProcessorAlias<"core_i7_sse4_2", "nehalem">;
 
 // Westmere is the corei3/i5/i7 path from nehalem to sandybridge
-foreach P = ["westmere", "core_aes_pclmulqdq"] in {
-  def : ProcModel<P, SandyBridgeModel, ProcessorFeatures.WSMFeatures,
-                  ProcessorFeatures.WSMTuning>;
-}
+def : ProcModel<"westmere", SandyBridgeModel, ProcessorFeatures.WSMFeatures,
+                ProcessorFeatures.WSMTuning>;
+def : ProcessorAlias<"core_aes_pclmulqdq", "westmere">;
 
-foreach P = ["sandybridge", "corei7-avx", "core_2nd_gen_avx"] in {
-  def : ProcModel<P, SandyBridgeModel, ProcessorFeatures.SNBFeatures,
-                  ProcessorFeatures.SNBTuning>;
-}
+def : ProcModel<"sandybridge", SandyBridgeModel, ProcessorFeatures.SNBFeatures,
+                ProcessorFeatures.SNBTuning>;
+def : ProcessorAlias<"corei7-avx", "sandybridge">;
+def : ProcessorAlias<"core_2nd_gen_avx", "sandybridge">;
 
-foreach P = ["ivybridge", "core-avx-i", "core_3rd_gen_avx"] in {
-  def : ProcModel<P, SandyBridgeModel, ProcessorFeatures.IVBFeatures,
-                  ProcessorFeatures.IVBTuning>;
-}
+def : ProcModel<"ivybridge", SandyBridgeModel, ProcessorFeatures.IVBFeatures,
+                ProcessorFeatures.IVBTuning>;
+def : ProcessorAlias<"core-avx-i", "ivybridge">;
+def : ProcessorAlias<"core_3rd_gen_avx", "ivybridge">;
 
-foreach P = ["haswell", "core-avx2", "core_4th_gen_avx", "core_4th_gen_avx_tsx"] in {
-  def : ProcModel<P, HaswellModel, ProcessorFeatures.HSWFeatures,
-                  ProcessorFeatures.HSWTuning>;
-}
+def : ProcModel<"haswell", HaswellModel, ProcessorFeatures.HSWFeatures,
+                ProcessorFeatures.HSWTuning>;
+def : ProcessorAlias<"core-avx2", "haswell">;
+def : ProcessorAlias<"core_4th_gen_avx", "haswell">;
+def : ProcessorAlias<"core_4th_gen_avx_tsx", "haswell">;
 
-foreach P = ["broadwell", "core_5th_gen_avx", "core_5th_gen_avx_tsx"] in {
-  def : ProcModel<P, BroadwellModel, ProcessorFeatures.BDWFeatures,
-                  ProcessorFeatures.BDWTuning>;
-}
+def : ProcModel<"broadwell", BroadwellModel, ProcessorFeatures.BDWFeatures,
+                ProcessorFeatures.BDWTuning>;
+def : ProcessorAlias<"core_5th_gen_avx", "broadwell">;
+def : ProcessorAlias<"core_5th_gen_avx_tsx", "broadwell">;
 
 def : ProcModel<"skylake", SkylakeClientModel, ProcessorFeatures.SKLFeatures,
                 ProcessorFeatures.SKLTuning>;
 
 // FIXME: define KNL scheduler model
-foreach P = ["knl", "mic_avx512"] in {
-  def : ProcModel<P, HaswellModel, ProcessorFeatures.KNLFeatures,
-                  ProcessorFeatures.KNLTuning>;
-}
+def : ProcModel<"knl", HaswellModel, ProcessorFeatures.KNLFeatures,
+                ProcessorFeatures.KNLTuning>;
+def : ProcessorAlias<"mic_avx512", "knl">;
 def : ProcModel<"knm", HaswellModel, ProcessorFeatures.KNMFeatures,
                 ProcessorFeatures.KNLTuning>;
 
-foreach P = ["skylake-avx512", "skx", "skylake_avx512"] in {
-  def : ProcModel<P, SkylakeServerModel, ProcessorFeatures.SKXFeatures,
-                  ProcessorFeatures.SKXTuning>;
-}
+def : ProcModel<"skylake-avx512", SkylakeServerModel, ProcessorFeatures.SKXFeatures,
+                ProcessorFeatures.SKXTuning>;
+def : ProcessorAlias<"skx", "skylake-avx512">;
+def : ProcessorAlias<"skylake_avx512", "skylake-avx512">;
 
 def : ProcModel<"cascadelake", SkylakeServerModel,
                 ProcessorFeatures.CLXFeatures, ProcessorFeatures.CLXTuning>;
@@ -2093,16 +2084,14 @@ def : ProcModel<"cooperlake", SkylakeServerModel,
                 ProcessorFeatures.CPXFeatures, ProcessorFeatures.CPXTuning>;
 def : ProcModel<"cannonlake", SkylakeServerModel,
                 ProcessorFeatures.CNLFeatures, ProcessorFeatures.CNLTuning>;
-foreach P = ["icelake-client", "icelake_client"] in {
-def : ProcModel<P, IceLakeModel,
+def : ProcModel<"icelake-client", IceLakeModel,
                 ProcessorFeatures.ICLFeatures, ProcessorFeatures.ICLTuning>;
-}
+def : ProcessorAlias<"icelake_client", "icelake-client">;
 def : ProcModel<"rocketlake", IceLakeModel,
                 ProcessorFeatures.ICLFeatures, ProcessorFeatures.ICLTuning>;
-foreach P = ["icelake-server", "icelake_server"] in {
-def : ProcModel<P, IceLakeModel,
+def : ProcModel<"icelake-server", IceLakeModel,
                 ProcessorFeatures.ICXFeatures, ProcessorFeatures.ICXTuning>;
-}
+def : ProcessorAlias<"icelake_server", "icelake-server">;
 def : ProcModel<"tigerlake", IceLakeModel,
                 ProcessorFeatures.TGLFeatures, ProcessorFeatures.TGLTuning>;
 def : ProcModel<"sapphirerapids", SapphireRapidsModel,
@@ -2112,26 +2101,23 @@ def : ProcModel<"alderlake", AlderlakePModel,
 // FIXME: Use Gracemont Schedule Model when it is ready.
 def : ProcModel<"gracemont", AlderlakePModel,
                 ProcessorFeatures.ADLFeatures, ProcessorFeatures.GRTTuning>;
-foreach P = ["sierraforest", "grandridge"] in {
-  def : ProcModel<P, AlderlakePModel, ProcessorFeatures.SRFFeatures,
+def : ProcModel<"sierraforest", AlderlakePModel, ProcessorFeatures.SRFFeatures,
                 ProcessorFeatures.GRTTuning>;
-}
+def : ProcessorAlias<"grandridge", "sierraforest">;
 def : ProcModel<"raptorlake", AlderlakePModel,
                 ProcessorFeatures.ADLFeatures, ProcessorFeatures.ADLTuning>;
 def : ProcModel<"meteorlake", AlderlakePModel,
                 ProcessorFeatures.ADLFeatures, ProcessorFeatures.ADLTuning>;
 def : ProcModel<"arrowlake", AlderlakePModel,
                 ProcessorFeatures.ARLFeatures, ProcessorFeatures.ADLTuning>;
-foreach P = ["arrowlake-s", "arrowlake_s"] in {
-def : ProcModel<P, AlderlakePModel,
+def : ProcModel<"arrowlake-s", AlderlakePModel,
                 ProcessorFeatures.ARLSFeatures, ProcessorFeatures.ADLTuning>;
-}
+def : ProcessorAlias<"arrowlake_s", "arrowlake-s">;
 def : ProcModel<"lunarlake", LunarlakePModel, ProcessorFeatures.ARLSFeatures,
                 ProcessorFeatures.ADLTuning>;
-foreach P = ["pantherlake", "wildcatlake"] in {
-def : ProcModel<P, AlderlakePModel,
+def : ProcModel<"pantherlake", AlderlakePModel,
                 ProcessorFeatures.PTLFeatures, ProcessorFeatures.ADLTuning>;
-}
+def : ProcessorAlias<"wildcatlake", "pantherlake">;
 def : ProcModel<"novalake", AlderlakePModel, ProcessorFeatures.NVLFeatures,
                 ProcessorFeatures.NVLTuning>;
 
@@ -2141,10 +2127,9 @@ def : ProcModel<"emeraldrapids", SapphireRapidsModel,
                 ProcessorFeatures.SPRFeatures, ProcessorFeatures.SPRTuning>;
 def : ProcModel<"graniterapids", SapphireRapidsModel,
                 ProcessorFeatures.GNRFeatures, ProcessorFeatures.GNRTuning>;
-foreach P = ["graniterapids-d", "graniterapids_d"] in {
-def : ProcModel<P, SapphireRapidsModel,
+def : ProcModel<"graniterapids-d", SapphireRapidsModel,
                 ProcessorFeatures.GNRDFeatures, ProcessorFeatures.GNRTuning>;
-}
+def : ProcessorAlias<"graniterapids_d", "graniterapids-d">;
 def : ProcModel<"diamondrapids", SapphireRapidsModel,
                 ProcessorFeatures.DMRFeatures, ProcessorFeatures.DMRTuning>;
 
@@ -2157,37 +2142,38 @@ def : Proc<"k6-2", [FeatureX87, FeatureCX8, FeatureMMX, FeaturePRFCHW],
 def : Proc<"k6-3", [FeatureX87, FeatureCX8, FeatureMMX, FeaturePRFCHW],
                    [TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
 
-foreach P = ["athlon", "athlon-tbird"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureCMOV, FeatureMMX, FeaturePRFCHW,
-                 FeatureNOPL],
-                [TuningSlowSHLD, TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : Proc<"athlon", [FeatureX87, FeatureCX8, FeatureCMOV, FeatureMMX,
+                      FeaturePRFCHW, FeatureNOPL],
+                     [TuningSlowSHLD, TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"athlon-tbird", "athlon">;
 
-foreach P = ["athlon-4", "athlon-xp", "athlon-mp"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureCMOV,
-                 FeatureSSE1, FeatureMMX, FeaturePRFCHW, FeatureFXSR, FeatureNOPL],
-                [TuningSlowSHLD, TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
-}
+def : Proc<"athlon-4", [FeatureX87, FeatureCX8, FeatureCMOV,
+                        FeatureSSE1, FeatureMMX, FeaturePRFCHW, FeatureFXSR,
+                        FeatureNOPL],
+                       [TuningSlowSHLD, TuningSlowUAMem16, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"athlon-xp", "athlon-4">;
+def : ProcessorAlias<"athlon-mp", "athlon-4">;
 
-foreach P = ["k8", "opteron", "athlon64", "athlon-fx"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureSSE2, FeatureMMX, FeaturePRFCHW,
-                 FeatureFXSR, FeatureNOPL, FeatureX86_64, FeatureCMOV],
-                [TuningFastScalarShiftMasks, TuningSlowSHLD, TuningSlowUAMem16,
-                 TuningSBBDepBreaking, TuningInsertVZEROUPPER]>;
-}
+def : Proc<"k8", [FeatureX87, FeatureCX8, FeatureSSE2, FeatureMMX, FeaturePRFCHW,
+                  FeatureFXSR, FeatureNOPL, FeatureX86_64, FeatureCMOV],
+                 [TuningFastScalarShiftMasks, TuningSlowSHLD, TuningSlowUAMem16,
+                  TuningSBBDepBreaking, TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"opteron", "k8">;
+def : ProcessorAlias<"athlon64", "k8">;
+def : ProcessorAlias<"athlon-fx", "k8">;
 
-foreach P = ["k8-sse3", "opteron-sse3", "athlon64-sse3"] in {
-  def : Proc<P, [FeatureX87, FeatureCX8, FeatureSSE3, FeatureMMX, FeaturePRFCHW,
-                 FeatureFXSR, FeatureNOPL, FeatureCX16, FeatureCMOV,
-                 FeatureX86_64],
-                [TuningFastScalarShiftMasks, TuningSlowSHLD, TuningSlowUAMem16,
-                 TuningSBBDepBreaking, TuningInsertVZEROUPPER]>;
-}
+def : Proc<"k8-sse3", [FeatureX87, FeatureCX8, FeatureSSE3, FeatureMMX,
+                       FeaturePRFCHW, FeatureFXSR, FeatureNOPL, FeatureCX16,
+                       FeatureCMOV, FeatureX86_64],
+                      [TuningFastScalarShiftMasks, TuningSlowSHLD,
+                       TuningSlowUAMem16, TuningSBBDepBreaking,
+                       TuningInsertVZEROUPPER]>;
+def : ProcessorAlias<"opteron-sse3", "k8-sse3">;
+def : ProcessorAlias<"athlon64-sse3", "k8-sse3">;
 
-foreach P = ["amdfam10", "barcelona"] in {
-  def : Proc<P, ProcessorFeatures.BarcelonaFeatures,
-             ProcessorFeatures.BarcelonaTuning>;
-}
+def : Proc<"amdfam10", ProcessorFeatures.BarcelonaFeatures,
+                       ProcessorFeatures.BarcelonaTuning>;
+def : ProcessorAlias<"barcelona", "amdfam10">;
 
 // Bobcat
 def : Proc<"btver1", ProcessorFeatures.BtVer1Features,
@@ -2226,10 +2212,9 @@ def : ProcModel<"znver6", Znver4Model, ProcessorFeatures.ZN6Features,
 
 // Hygon CPUs.
 
-foreach P = ["c86-4g-m4", "c86-4g-m6"] in {
-def : ProcModel<P, C864GM4Model, ProcessorFeatures.C864GM4Features,
+def : ProcModel<"c86-4g-m4", C864GM4Model, ProcessorFeatures.C864GM4Features,
                 ProcessorFeatures.C864GM4Tuning>;
-}
+def : ProcessorAlias<"c86-4g-m6", "c86-4g-m4">;
 def : ProcModel<"c86-4g-m7", C864GM7Model, ProcessorFeatures.C864GM7Features,
                 ProcessorFeatures.C864GM7Tuning>;
 def : ProcModel<"c86-4g-m8", C864GM8Model, ProcessorFeatures.C864GM8Features,

--- a/llvm/test/TableGen/ProcessorAlias.td
+++ b/llvm/test/TableGen/ProcessorAlias.td
@@ -1,0 +1,24 @@
+// RUN: llvm-tblgen -gen-subtarget -I %p/../../include %s 2>&1 | FileCheck %s
+// Verify that ProcessorAlias entries are emitted into the CPU subtype table
+// alongside real processors, resolving to their canonical processor's
+// features and scheduling model, and that the table stays sorted by key.
+
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+def FeatureA : SubtargetFeature<"feature-a", "HasA", "true", "">;
+
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, [FeatureA]>;
+def ProcB : ProcessorModel<"cpu-b", NoSchedModel, []>;
+
+// An alias resolves to an existing processor and is emitted as its own entry.
+def : ProcessorAlias<"alias-of-a", "cpu-a">;
+
+// The subtype table has 3 entries (2 processors + 1 alias) sorted by key:
+// alias-of-a, cpu-a, cpu-b. The alias carries cpu-a's feature mask (bit 0 set).
+// CHECK: extern const llvm::SubtargetSubTypeKVStorage< 3,
+// CHECK:      { sizeof(SubtargetSubTypeKV) * 3 + {{[0-9]+}}, { { { 0x1ULL,{{.*}} }, {{.*}}, 0 },
+// CHECK-NEXT: { sizeof(SubtargetSubTypeKV) * 2 + {{[0-9]+}}, { { { 0x1ULL,{{.*}} }, {{.*}}, 0 },
+// CHECK-NEXT: { sizeof(SubtargetSubTypeKV) * 1 + {{[0-9]+}}, { { { 0x0ULL,{{.*}} }, {{.*}}, 0 },
+// CHECK: "\000alias-of-a\000cpu-a\000cpu-b\000"

--- a/llvm/test/TableGen/ProcessorAliasErrors.td
+++ b/llvm/test/TableGen/ProcessorAliasErrors.td
@@ -1,0 +1,34 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %t/non-existent.td 2>&1 \
+// RUN:   | FileCheck %t/non-existent.td -DFILE=%t/non-existent.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %t/dup-processor.td 2>&1 \
+// RUN:   | FileCheck %t/dup-processor.td -DFILE=%t/dup-processor.td --implicit-check-not="error:"
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %t/dup-alias.td 2>&1 \
+// RUN:   | FileCheck %t/dup-alias.td -DFILE=%t/dup-alias.td --implicit-check-not="error:"
+
+// Verify the ProcessorAlias validation performed by the subtarget emitter.
+
+//--- non-existent.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, []>;
+// An alias must resolve to an existing processor.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: Alias 'bad-alias' references a non-existent Processor 'cpu-missing'
+def : ProcessorAlias<"bad-alias", "cpu-missing">;
+
+//--- dup-processor.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, []>;
+// An alias name must not collide with a real processor.
+// CHECK: [[FILE]]:[[#@LINE+1]]:1: error: Alias 'cpu-a' duplicates an existing Processor
+def : ProcessorAlias<"cpu-a", "cpu-a">;
+
+//--- dup-alias.td
+include "llvm/Target/Target.td"
+def MyTarget : Target;
+def ProcA : ProcessorModel<"cpu-a", NoSchedModel, []>;
+def DupA : ProcessorAlias<"dup", "cpu-a">;
+// Two aliases must not share the same name.
+// CHECK: [[FILE]]:[[#@LINE+1]]:5: error: Alias 'dup' duplicates an existing alias
+def DupB : ProcessorAlias<"dup", "cpu-a">;

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -286,24 +286,44 @@ static void checkDuplicateCPUFeatures(StringRef CPUName,
 std::pair<unsigned, unsigned>
 SubtargetEmitter::cpuKeyValues(raw_ostream &OS,
                                const FeatureMapTy &FeatureMap) {
-  // Gather and sort processor information
   std::vector<const Record *> ProcessorList =
       Records.getAllDerivedDefinitions("Processor");
-  llvm::sort(ProcessorList, LessRecordFieldName());
 
-  // In the string table, include the aliases as well.
+  StringMap<const Record *> ProcessorMap;
+  for (const Record *Processor : ProcessorList)
+    ProcessorMap[Processor->getValueAsString("Name")] = Processor;
+
+  // Maps each emitted CPU name (processor or alias) to the processor record it
+  // resolves to. Keying by name detects duplicates on insertion.
+  StringMap<const Record *> SubTypeEntries;
+  for (const Record *Processor : ProcessorList)
+    SubTypeEntries[Processor->getValueAsString("Name")] = Processor;
+
   std::vector<const Record *> ProcessorAliasList =
       Records.getAllDerivedDefinitionsIfDefined("ProcessorAlias");
-  SmallVector<StringRef> Names;
-  Names.reserve(ProcessorList.size() + ProcessorAliasList.size());
-  for (const Record *Processor : ProcessorList)
-    Names.push_back(Processor->getValueAsString("Name"));
-  for (const Record *Rec : ProcessorAliasList)
-    Names.push_back(Rec->getValueAsString("Name"));
-  llvm::sort(Names);
+  for (const Record *Rec : ProcessorAliasList) {
+    StringRef Name = Rec->getValueAsString("Name");
+    StringRef Alias = Rec->getValueAsString("Alias");
+    auto It = ProcessorMap.find(Alias);
+    if (It == ProcessorMap.end())
+      PrintFatalError(Rec, "Alias '" + Name +
+                               "' references a non-existent Processor '" +
+                               Alias + "'");
+    if (!SubTypeEntries.try_emplace(Name, It->second).second)
+      PrintFatalError(
+          Rec, "Alias '" + Name + "' duplicates an existing " +
+                   (ProcessorMap.contains(Name) ? "Processor" : "alias"));
+  }
+
+  // The table must stay sorted by key for the binary search in the lookups.
+  std::vector<std::pair<StringRef, const Record *>> SortedEntries;
+  SortedEntries.reserve(SubTypeEntries.size());
+  for (const auto &Entry : SubTypeEntries)
+    SortedEntries.emplace_back(Entry.getKey(), Entry.getValue());
+  llvm::sort(SortedEntries, llvm::less_first());
 
   StringToOffsetTable StrTab;
-  for (StringRef Name : Names)
+  for (const auto &[Name, Proc] : SortedEntries)
     StrTab.GetOrAddStringOffset(Name);
 
   // Note that unlike `FeatureKeyValues`, here we do not need to check for
@@ -311,24 +331,25 @@ SubtargetEmitter::cpuKeyValues(raw_ostream &OS,
   // constructor calls `getSchedModels` to build a `CodeGenSchedModels` object,
   // which does the duplicate processor check.
 
+  unsigned Total = SortedEntries.size();
+
   // Begin processor table.
   OS << "// Sorted (by key) array of values for CPU subtype.\n"
-     << "extern const llvm::SubtargetSubTypeKVStorage< " << ProcessorList.size()
-     << ", " << (StrTab.size() + 1) << "> " << Target
-     << "SubTypeKVStorage = {\n  {\n";
+     << "extern const llvm::SubtargetSubTypeKVStorage< " << Total << ", "
+     << (StrTab.size() + 1) << "> " << Target << "SubTypeKVStorage = {\n  {\n";
 
-  for (const auto &[Idx, Processor] : enumerate(ProcessorList)) {
-    StringRef Name = Processor->getValueAsString("Name");
+  for (const auto &[Idx, Entry] : enumerate(SortedEntries)) {
+    const auto &[Name, Processor] = Entry;
     ConstRecVec FeatureList = Processor->getValueAsListOfDefs("Features");
     ConstRecVec TuneFeatureList =
         Processor->getValueAsListOfDefs("TuneFeatures");
 
-    // Warn the user if there are duplicate processor features or tune
-    // features.
-    checkDuplicateCPUFeatures(Name, FeatureList, TuneFeatureList);
+    // Aliases share the canonical processor's already-checked feature lists.
+    if (Name == Processor->getValueAsString("Name"))
+      checkDuplicateCPUFeatures(Name, FeatureList, TuneFeatureList);
 
-    OS << "   { sizeof(SubtargetSubTypeKV) * " << (ProcessorList.size() - Idx)
-       << " + " << StrTab.GetOrAddStringOffset(Name) << ", ";
+    OS << "   { sizeof(SubtargetSubTypeKV) * " << (Total - Idx) << " + "
+       << StrTab.GetOrAddStringOffset(Name) << ", ";
 
     printFeatureMask(OS, FeatureList, FeatureMap);
     OS << ", ";
@@ -344,7 +365,7 @@ SubtargetEmitter::cpuKeyValues(raw_ostream &OS,
   // End processor table.
   OS << "};\n";
 
-  return {ProcessorList.size(), StrTab.size() + 1};
+  return {Total, StrTab.size() + 1};
 }
 
 //
@@ -1990,10 +2011,6 @@ void SubtargetEmitter::parseFeaturesFunction(raw_ostream &OS) {
     return;
   }
 
-  if (Target == "AArch64")
-    OS << "  CPU = AArch64::resolveCPUAlias(CPU);\n"
-       << "  TuneCPU = AArch64::resolveCPUAlias(TuneCPU);\n";
-
   OS << "  InitMCProcessorInfo(CPU, TuneCPU, FS);\n"
      << "  const FeatureBitset &Bits = getFeatureBits();\n";
 
@@ -2068,11 +2085,6 @@ void SubtargetEmitter::emitGenMCSubtargetInfo(raw_ostream &OS) {
     OS << "  unsigned getHwMode(enum HwModeType type = HwMode_Default) const "
           "final;\n";
   }
-  if (Target == "AArch64")
-    OS << "  bool isCPUStringValid(StringRef CPU) const final {\n"
-       << "    CPU = AArch64::resolveCPUAlias(CPU);\n"
-       << "    return MCSubtargetInfo::isCPUStringValid(CPU);\n"
-       << "  }\n";
   OS << "};\n";
   emitHwModeCheck(Target + "GenMCSubtargetInfo", OS, /*IsMC=*/true);
 }
@@ -2105,8 +2117,6 @@ FeatureMapTy SubtargetEmitter::emitEnums(raw_ostream &OS) {
 SubtargetEmitter::MCDescInfo
 SubtargetEmitter::emitMCDesc(raw_ostream &OS, const FeatureMapTy &FeatureMap) {
   IfDefEmitter IfDef(OS, "GET_SUBTARGETINFO_MC_DESC");
-  if (Target == "AArch64")
-    OS << "#include \"llvm/TargetParser/AArch64TargetParser.h\"\n\n";
   NamespaceEmitter LlvmNS(OS, "llvm");
 
   MCDescInfo Res;
@@ -2127,9 +2137,6 @@ SubtargetEmitter::emitMCDesc(raw_ostream &OS, const FeatureMapTy &FeatureMap) {
   OS << "\nstatic inline MCSubtargetInfo *create" << Target
      << "MCSubtargetInfoImpl("
      << "const Triple &TT, StringRef CPU, StringRef TuneCPU, StringRef FS) {\n";
-  if (Target == "AArch64")
-    OS << "  CPU = AArch64::resolveCPUAlias(CPU);\n"
-       << "  TuneCPU = AArch64::resolveCPUAlias(TuneCPU);\n";
   OS << "  return new " << Target
      << "GenMCSubtargetInfo(TT, CPU, TuneCPU, FS, ";
   OS << "StringTable(" << Target << "SubTypeKVStorage.Strings), ";
@@ -2163,8 +2170,6 @@ void SubtargetEmitter::emitTargetDesc(raw_ostream &OS) {
   OS << "#include \"llvm/ADT/BitmaskEnum.h\"\n";
   OS << "#include \"llvm/Support/Debug.h\"\n";
   OS << "#include \"llvm/Support/raw_ostream.h\"\n\n";
-  if (Target == "AArch64")
-    OS << "#include \"llvm/TargetParser/AArch64TargetParser.h\"\n\n";
   parseFeaturesFunction(OS);
 }
 
@@ -2264,11 +2269,7 @@ void SubtargetEmitter::emitCtor(raw_ostream &OS, MCDescInfo DescInfo) {
   OS << ClassName << "::" << ClassName << "(const Triple &TT, StringRef CPU, "
      << "StringRef TuneCPU, StringRef FS)\n";
 
-  if (Target == "AArch64")
-    OS << "  : TargetSubtargetInfo(TT, AArch64::resolveCPUAlias(CPU),\n"
-       << "                        AArch64::resolveCPUAlias(TuneCPU), FS, ";
-  else
-    OS << "  : TargetSubtargetInfo(TT, CPU, TuneCPU, FS, ";
+  OS << "  : TargetSubtargetInfo(TT, CPU, TuneCPU, FS, ";
   OS << "StringTable(" << Target << "SubTypeKVStorage.Strings), ";
   if (DescInfo.NumFeatures)
     OS << "ArrayRef(" << Target << "FeatureKVStorage.Features), ";


### PR DESCRIPTION
Many X86 processors were defined multiple times under different names,
emitting an identical ProcessorModel for each spelling and duplicating
the feature masks, tune features, and scheduling model index in the subtype
table.

Define each processor once under its canonical name and express the
alternate spellings with ProcessorAlias, using the tablegen alias
mechanism. This deduplicates the redundant subtype table entries and saves
about 4.6k with the new alias table.

Co-Authored-By: Claude (Claude-Opus-4.8) <noreply@anthropic.com>