### PR TITLE
[flang][cuda] Accept statement function in device code

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -79,9 +79,14 @@ struct DeviceExprChecker
   using Base::operator();
   Result operator()(const evaluate::ProcedureDesignator &x) const {
     if (const Symbol * sym{x.GetInterfaceSymbol()}) {
+      const Symbol &ultimate{sym->GetUltimate()};
       const auto *subp{
-          sym->GetUltimate().detailsIf<semantics::SubprogramDetails>()};
+          ultimate.detailsIf<semantics::SubprogramDetails>()};
       if (subp) {
+        if (const auto &stmtFunction{subp->stmtFunction()};
+            stmtFunction && IsCUDADeviceContext(&ultimate.owner())) {
+          return (*this)(*stmtFunction);
+        }
         if (auto attrs{subp->cudaSubprogramAttrs()}) {
           if (*attrs == common::CUDASubprogramAttrs::HostDevice ||
               *attrs == common::CUDASubprogramAttrs::Device) {
@@ -103,7 +108,6 @@ struct DeviceExprChecker
         }
       }
 
-      const Symbol &ultimate{sym->GetUltimate()};
       const Scope &scope{ultimate.owner()};
       const Symbol *mod{scope.IsModule() ? scope.symbol() : nullptr};
       // Allow ieee_arithmetic module functions to be called on the device.

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -80,8 +80,7 @@ struct DeviceExprChecker
   Result operator()(const evaluate::ProcedureDesignator &x) const {
     if (const Symbol * sym{x.GetInterfaceSymbol()}) {
       const Symbol &ultimate{sym->GetUltimate()};
-      const auto *subp{
-          ultimate.detailsIf<semantics::SubprogramDetails>()};
+      const auto *subp{ultimate.detailsIf<semantics::SubprogramDetails>()};
       if (subp) {
         if (const auto &stmtFunction{subp->stmtFunction()};
             stmtFunction && IsCUDADeviceContext(&ultimate.owner())) {

--- a/flang/test/Semantics/CUDA/cuf02.cuf
+++ b/flang/test/Semantics/CUDA/cuf02.cuf
@@ -25,6 +25,12 @@ module m
   end
   attributes(device) subroutine s6
     stmtfunc(x) = x + 1. ! ok
+    x = stmtfunc(x) ! ok
+  end
+  attributes(device) subroutine s6_bad
+    badstmt(x) = hostfunc(x)
+    !ERROR: 'hostfunc' may not be called in device code
+    x = badstmt(x)
   end
   !ERROR: A function may not have ATTRIBUTES(GLOBAL) or ATTRIBUTES(GRID_GLOBAL)
   attributes(global) real function f1


### PR DESCRIPTION
Statement functions are inlined during lowering, so they should not be treated as host procedure calls. Recursively validate their expressions to reject any host procedure calls within the body.