### PR TITLE
workflows/llvm-abi-tests: Cache the baseline abi

### DIFF
--- a/.github/workflows/llvm-abi-tests.yml
+++ b/.github/workflows/llvm-abi-tests.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Check for cached baseline ABI
         if: ${{ matrix.name == 'build-baseline' }}
         id: cache
-        uses: actions/cache/restore/@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           key: ${{ matrix.ref}}.abi
           path: |
@@ -155,7 +155,7 @@ jobs:
       - name: Cache baseline ABI
         if: ${{ matrix.name == 'build-baseline' }}
         id: cache
-        uses: actions/cache/save/@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           key: ${{ matrix.ref }}.abi
           path: |

--- a/.github/workflows/llvm-abi-tests.yml
+++ b/.github/workflows/llvm-abi-tests.yml
@@ -93,23 +93,37 @@ jobs:
             ref: ${{ github.sha }}
             repo: ${{ github.repository }}
     steps:
+      - name: Check for cached baseline ABI
+        if: ${{ matrix.name == 'build-baseline' }}
+        id: cache
+        uses: actions/cache/restore/@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          key: ${{ matrix.ref}}.abi
+          path: |
+            ${{ matrix.ref }}.abi
+            llvm.symbols
+
       - name: Download source code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: steps.cache.outputs.cache-hit != 'true'
         with:
           persist-credentials: false
           ref: ${{ matrix.ref }}
           repository: ${{ matrix.repo }}
       - name: Configure
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           mkdir install
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD="" -DLLVM_BUILD_LLVM_DYLIB=ON -DCMAKE_INSTALL_PREFIX="$(pwd)"/install llvm
       - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         # Need to run install-LLVM twice to ensure the symlink is installed (this is a bug).
         run: |
           ninja -C build install-LLVM
           ninja -C build install-LLVM
           ninja -C build install-llvm-headers
       - name: Dump ABI
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           REF: ${{ matrix.ref }}
           ABI_HEADERS: ${{ needs.abi-dump-setup.outputs.ABI_HEADERS }}
@@ -137,6 +151,16 @@ jobs:
         with:
           name: symbol-list
           path: llvm.symbols
+
+      - name: Cache baseline ABI
+        if: ${{ matrix.name == 'build-baseline' }}
+        id: cache
+        uses: actions/cache/save/@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          key: ${{ matrix.ref }}.abi
+          path: |
+            ${{ matrix.ref }}.abi
+            llvm.symbols
 
   abi-compare:
     if: github.repository_owner == 'llvm'

--- a/.github/workflows/llvm-abi-tests.yml
+++ b/.github/workflows/llvm-abi-tests.yml
@@ -154,7 +154,6 @@ jobs:
 
       - name: Cache baseline ABI
         if: ${{ matrix.name == 'build-baseline' }}
-        id: cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           key: ${{ matrix.ref }}.abi


### PR DESCRIPTION
This way we don't need to recompute it for every workflow.