### PR TITLE
[DebugInfo] Treat tag offsets as non-emitting

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3551,6 +3551,10 @@ public:
     /// Return the number of elements in the operand (1 + args).
     LLVM_ABI unsigned getSize() const;
 
+    /// Return true if CodeGen handles this operand without adding bytes to the
+    /// DWARF expression.
+    LLVM_ABI bool isNonEmitting() const;
+
     /// Append the elements of this operand to \p V.
     void appendToVector(SmallVectorImpl<uint64_t> &V) const {
       V.append(get(), get() + getSize());

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -26,6 +26,19 @@ using namespace llvm;
 
 #define DEBUG_TYPE "dwarfdebug"
 
+/// Return whether the rest of the expression needs the complex register path.
+/// We use this to decide whether we can emit a simple register location and
+/// whether a subregister needs to be masked. Non-emitting operations don't
+/// affect either decision, so look past them.
+static bool isRemainingExpressionComplex(const DIExpressionCursor &ExprCursor) {
+  for (DIExpression::ExprOperand Op : ExprCursor) {
+    if (Op.isNonEmitting())
+      continue;
+    return Op.getOp() != dwarf::DW_OP_LLVM_fragment;
+  }
+  return false;
+}
+
 void DwarfExpression::emitConstu(uint64_t Value) {
   if (Value < 32)
     emitOp(dwarf::DW_OP_lit0 + Value);
@@ -295,10 +308,8 @@ bool DwarfExpression::addMachineRegExpression(const TargetRegisterInfo &TRI,
     return false;
   }
 
-  bool HasComplexExpression = false;
   auto Op = ExprCursor.peek();
-  if (Op && Op->getOp() != dwarf::DW_OP_LLVM_fragment)
-    HasComplexExpression = true;
+  bool HasComplexExpression = isRemainingExpressionComplex(ExprCursor);
 
   // If the register can only be described by a complex expression (i.e.,
   // multiple subregisters) it doesn't safely compose with another complex
@@ -348,9 +359,7 @@ bool DwarfExpression::addMachineRegExpression(const TargetRegisterInfo &TRI,
     DwarfRegs.clear();
     // If we need to mask out a subregister, do it now, unless the next
     // operation would emit an OpPiece anyway.
-    auto NextOp = ExprCursor.peek();
-    if (SubRegisterSizeInBits && NextOp &&
-        (NextOp->getOp() != dwarf::DW_OP_LLVM_fragment))
+    if (SubRegisterSizeInBits && isRemainingExpressionComplex(ExprCursor))
       maskSubRegister();
     return true;
   }
@@ -415,9 +424,7 @@ bool DwarfExpression::addMachineRegExpression(const TargetRegisterInfo &TRI,
 
   // If we need to mask out a subregister, do it now, unless the next
   // operation would emit an OpPiece anyway.
-  auto NextOp = ExprCursor.peek();
-  if (SubRegisterSizeInBits && NextOp &&
-      (NextOp->getOp() != dwarf::DW_OP_LLVM_fragment))
+  if (SubRegisterSizeInBits && isRemainingExpressionComplex(ExprCursor))
     maskSubRegister();
 
   return true;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -308,7 +308,6 @@ bool DwarfExpression::addMachineRegExpression(const TargetRegisterInfo &TRI,
     return false;
   }
 
-  auto Op = ExprCursor.peek();
   bool HasComplexExpression = isRemainingExpressionComplex(ExprCursor);
 
   // If the register can only be described by a complex expression (i.e.,
@@ -384,6 +383,17 @@ bool DwarfExpression::addMachineRegExpression(const TargetRegisterInfo &TRI,
     return false;
   }
 
+  // Consume leading tag offsets before matching the register expression.
+  // Record the tag offset here because addExpression won't see a consumed
+  // operation.
+  while (auto Op = ExprCursor.peek()) {
+    if (Op->getOp() != dwarf::DW_OP_LLVM_tag_offset)
+      break;
+    TagOffset = Op->getArg(0);
+    ExprCursor.take();
+  }
+
+  auto Op = ExprCursor.peek();
   auto Reg = DwarfRegs[0];
   int SignedOffset = 0;
   assert(!Reg.isSubRegister() && "full register expected");

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -1757,6 +1757,10 @@ unsigned DIExpression::ExprOperand::getSize() const {
   }
 }
 
+bool DIExpression::ExprOperand::isNonEmitting() const {
+  return getOp() == dwarf::DW_OP_LLVM_tag_offset;
+}
+
 bool DIExpression::isValid() const {
   for (auto I = expr_op_begin(), E = expr_op_end(); I != E; ++I) {
     // Check that there's space for the operand.
@@ -1878,11 +1882,12 @@ bool DIExpression::isComplex() const {
   if (getNumElements() == 0)
     return false;
 
-  // If there are any elements other than fragment or tag_offset, then some
-  // kind of complex computation occurs.
+  // Tag offsets are non-emitting. They, fragments, and location operands don't
+  // perform a computation by themselves.
   for (const auto &It : expr_ops()) {
+    if (It.isNonEmitting())
+      continue;
     switch (It.getOp()) {
-    case dwarf::DW_OP_LLVM_tag_offset:
     case dwarf::DW_OP_LLVM_fragment:
     case dwarf::DW_OP_LLVM_arg:
       continue;
@@ -2323,17 +2328,19 @@ DIExpression *DIExpression::appendToStack(const DIExpression *Expr,
                       }) &&
          "Can't append this op");
 
-  // Append a DW_OP_deref after Expr's current op list if it's non-empty and
-  // has no DW_OP_stack_value.
-  //
-  // Match .* DW_OP_stack_value (DW_OP_LLVM_fragment A B)?.
-  std::optional<FragmentInfo> FI = Expr->getFragmentInfo();
-  unsigned DropUntilStackValue = FI ? 3 : 0;
-  ArrayRef<uint64_t> ExprOpsBeforeFragment =
-      Expr->getElements().drop_back(DropUntilStackValue);
-  bool NeedsDeref = (Expr->getNumElements() > DropUntilStackValue) &&
-                    (ExprOpsBeforeFragment.back() != dwarf::DW_OP_stack_value);
-  bool NeedsStackValue = NeedsDeref || ExprOpsBeforeFragment.empty();
+  // DIExpression stores opcodes and their arguments in a flat array. Walk the
+  // parsed operations to find the last opcode that determines whether the
+  // expression already ends in DW_OP_stack_value.
+  std::optional<uint64_t> LastValueOp;
+  for (auto Op : Expr->expr_ops()) {
+    if (Op.isNonEmitting() ||
+        Op.getOp() == dwarf::DW_OP_LLVM_fragment)
+      continue;
+    LastValueOp = Op.getOp();
+  }
+  bool NeedsDeref =
+      LastValueOp && *LastValueOp != dwarf::DW_OP_stack_value;
+  bool NeedsStackValue = NeedsDeref || !LastValueOp;
 
   // Append a DW_OP_deref after Expr's current op list if needed, then append
   // the new ops, and finally ensure that a single DW_OP_stack_value is present.

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -2333,13 +2333,11 @@ DIExpression *DIExpression::appendToStack(const DIExpression *Expr,
   // expression already ends in DW_OP_stack_value.
   std::optional<uint64_t> LastValueOp;
   for (auto Op : Expr->expr_ops()) {
-    if (Op.isNonEmitting() ||
-        Op.getOp() == dwarf::DW_OP_LLVM_fragment)
+    if (Op.isNonEmitting() || Op.getOp() == dwarf::DW_OP_LLVM_fragment)
       continue;
     LastValueOp = Op.getOp();
   }
-  bool NeedsDeref =
-      LastValueOp && *LastValueOp != dwarf::DW_OP_stack_value;
+  bool NeedsDeref = LastValueOp && *LastValueOp != dwarf::DW_OP_stack_value;
   bool NeedsStackValue = NeedsDeref || !LastValueOp;
 
   // Append a DW_OP_deref after Expr's current op list if needed, then append

--- a/llvm/test/DebugInfo/X86/di-expression-tag-offset-register.ll
+++ b/llvm/test/DebugInfo/X86/di-expression-tag-offset-register.ll
@@ -1,0 +1,51 @@
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj -o - %s | llvm-dwarfdump - | FileCheck %s
+
+; Tag offsets emit no expression bytes, so skip them when deciding whether a
+; register expression is complex.
+
+define void @registers(i64 %tag_only, i32 %simple_subreg,
+                       i32 %complex_subreg) !dbg !5 {
+  #dbg_value(i64 %tag_only, !9,
+             !DIExpression(DW_OP_LLVM_tag_offset, 7), !12)
+  #dbg_value(i32 %simple_subreg, !10,
+             !DIExpression(DW_OP_LLVM_tag_offset, 8,
+                           DW_OP_LLVM_fragment, 0, 32), !12)
+  #dbg_value(i32 %complex_subreg, !14,
+             !DIExpression(DW_OP_LLVM_tag_offset, 9,
+                           DW_OP_plus_uconst, 1), !12)
+  ret void, !dbg !12
+}
+
+; A tag-only expression stays in a register.
+; CHECK: DW_OP_reg5 RDI)
+; CHECK: DW_AT_LLVM_tag_offset (0x07)
+; CHECK: DW_AT_name ("tag_only")
+
+; A tag before a fragment keeps the subregister location simple.
+; CHECK: DW_OP_reg4 RSI, DW_OP_piece 0x4)
+; CHECK: DW_AT_LLVM_tag_offset (0x08)
+; CHECK: DW_AT_name ("simple_subreg")
+
+; A real operation after the tag uses the complex register path and masks the
+; 32-bit value before applying the operation.
+; CHECK: DW_OP_breg1 RDX+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_plus_uconst 0x1)
+; CHECK: DW_AT_LLVM_tag_offset (0x09)
+; CHECK: DW_AT_name ("complex_subreg")
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1,
+                             emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.c", directory: "/")
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DISubprogram(name: "registers", scope: !1, file: !1,
+                            type: !6, spFlags: DISPFlagDefinition, unit: !0)
+!6 = !DISubroutineType(types: !7)
+!7 = !{null}
+!9 = !DILocalVariable(name: "tag_only", scope: !5, type: !11)
+!10 = !DILocalVariable(name: "simple_subreg", scope: !5, type: !11)
+!11 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!12 = !DILocation(line: 1, scope: !5)
+!14 = !DILocalVariable(name: "complex_subreg", scope: !5, type: !15)
+!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/llvm/test/DebugInfo/X86/di-expression-tag-offset-register.ll
+++ b/llvm/test/DebugInfo/X86/di-expression-tag-offset-register.ll
@@ -4,7 +4,7 @@
 ; register expression is complex.
 
 define void @registers(i64 %tag_only, i32 %simple_subreg,
-                       i32 %complex_subreg) !dbg !5 {
+                       i32 %complex_subreg, i32 %unfolded_subreg) !dbg !5 {
   #dbg_value(i64 %tag_only, !9,
              !DIExpression(DW_OP_LLVM_tag_offset, 7), !12)
   #dbg_value(i32 %simple_subreg, !10,
@@ -13,6 +13,9 @@ define void @registers(i64 %tag_only, i32 %simple_subreg,
   #dbg_value(i32 %complex_subreg, !14,
              !DIExpression(DW_OP_LLVM_tag_offset, 9,
                            DW_OP_plus_uconst, 1), !12)
+  #dbg_value(i32 %unfolded_subreg, !16,
+             !DIExpression(DW_OP_LLVM_tag_offset, 10,
+                           DW_OP_constu, 2, DW_OP_mul), !12)
   ret void, !dbg !12
 }
 
@@ -26,11 +29,16 @@ define void @registers(i64 %tag_only, i32 %simple_subreg,
 ; CHECK: DW_AT_LLVM_tag_offset (0x08)
 ; CHECK: DW_AT_name ("simple_subreg")
 
-; A real operation after the tag uses the complex register path and masks the
-; 32-bit value before applying the operation.
-; CHECK: DW_OP_breg1 RDX+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_plus_uconst 0x1)
+; A tag doesn't prevent folding a register offset into DW_OP_breg.
+; CHECK: DW_OP_breg1 RDX+1)
 ; CHECK: DW_AT_LLVM_tag_offset (0x09)
 ; CHECK: DW_AT_name ("complex_subreg")
+
+; A non-foldable operation still uses the complex register path and masks the
+; subregister before applying the operation.
+; CHECK: DW_OP_breg2 RCX+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_lit2, DW_OP_mul)
+; CHECK: DW_AT_LLVM_tag_offset (0x0a)
+; CHECK: DW_AT_name ("unfolded_subreg")
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3}
@@ -49,3 +57,4 @@ define void @registers(i64 %tag_only, i32 %simple_subreg,
 !12 = !DILocation(line: 1, scope: !5)
 !14 = !DILocalVariable(name: "complex_subreg", scope: !5, type: !15)
 !15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!16 = !DILocalVariable(name: "unfolded_subreg", scope: !5, type: !15)

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -4795,6 +4795,47 @@ TEST_F(DIExpressionTest, appendToStackAssert) {
   EXPECT_EQ(Expr->getElements(), ArrayRef<uint64_t>(Expected));
 }
 
+TEST_F(DIExpressionTest, appendToStackSkipsTagOffset) {
+  // DW_OP_LLVM_tag_offset doesn't emit anything, so it shouldn't make
+  // appendToStack add a DW_OP_deref.
+  DIExpression *Expr =
+      DIExpression::get(Context, {dwarf::DW_OP_LLVM_tag_offset, uint64_t{3}});
+  uint64_t Ops[] = {
+      dwarf::DW_OP_LLVM_convert, 32, dwarf::DW_ATE_signed,
+      dwarf::DW_OP_LLVM_convert, 64, dwarf::DW_ATE_signed,
+  };
+  Expr = DIExpression::appendToStack(Expr, Ops);
+
+  uint64_t Expected[] = {dwarf::DW_OP_LLVM_tag_offset,
+                         3,
+                         dwarf::DW_OP_LLVM_convert,
+                         32,
+                         dwarf::DW_ATE_signed,
+                         dwarf::DW_OP_LLVM_convert,
+                         64,
+                         dwarf::DW_ATE_signed,
+                         dwarf::DW_OP_stack_value};
+  EXPECT_EQ(Expr->getElements(), ArrayRef<uint64_t>(Expected));
+}
+
+TEST_F(DIExpressionTest, TagOffsetsAreNotComplex) {
+  // Tag offsets don't emit anything, so they don't make an expression complex.
+  // Keep looking past them for an operation that does.
+  auto *TagOffset =
+      DIExpression::get(Context, {dwarf::DW_OP_LLVM_tag_offset, uint64_t{1}});
+  EXPECT_FALSE(TagOffset->isComplex());
+
+  auto *TagOffsetAndFragment = DIExpression::get(
+      Context, {dwarf::DW_OP_LLVM_tag_offset, uint64_t{1},
+                dwarf::DW_OP_LLVM_fragment, uint64_t{0}, uint64_t{32}});
+  EXPECT_FALSE(TagOffsetAndFragment->isComplex());
+
+  auto *TagOffsetAndOperation =
+      DIExpression::get(Context, {dwarf::DW_OP_LLVM_tag_offset, uint64_t{1},
+                                  dwarf::DW_OP_plus_uconst, uint64_t{1}});
+  EXPECT_TRUE(TagOffsetAndOperation->isComplex());
+}
+
 typedef MetadataTest DIObjCPropertyTest;
 
 TEST_F(DIObjCPropertyTest, get) {


### PR DESCRIPTION
DW_OP_LLVM_tag_offset doesn't emit anything into the DWARF expression, so look past it when deciding whether a register expression is complex or whether appendToStack needs to add a dereference.

Tested with make check.