### PR TITLE
[profcheck][coro] Add Branch Weights in to select in replaceSwitchResumeCoroFree.

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -206,6 +206,12 @@ static void replaceSwitchResumeCoroFree(const coro::Shape &Shape,
     auto *Null = ConstantPointerNull::get(cast<PointerType>(CF->getType()));
     Value *Replacement =
         Builder.CreateSelect(IsElided, Null, FramePtr, "coro.free");
+    // Add unknown branch weights to the select since whether the frame is
+    // heap-allocated or elided cannot be determined.
+    applyProfMetadataIfEnabled(Replacement, [&](Instruction *Inst) {
+      setExplicitlyUnknownBranchWeightsIfProfiled(*Inst, DEBUG_TYPE,
+                                                  Inst->getFunction());
+    });
     CF->replaceAllUsesWith(Replacement);
     CF->eraseFromParent();
   }

--- a/llvm/test/Transforms/Coroutines/coro-split-00.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-00.ll
@@ -1,7 +1,7 @@
 ; Tests that coro-split pass splits the coroutine into f, f.resume and f.destroy
 ; RUN: opt < %s -passes='cgscc(coro-split),simplifycfg,early-cse' -S | FileCheck %s
 
-define ptr @f() presplitcoroutine !func_sanitize !0 {
+define ptr @f() presplitcoroutine !func_sanitize !0 !prof !1 {
 entry:
   %id = call token @llvm.coro.id(i32 0, ptr null, ptr @f, ptr null)
   %need.alloc = call i1 @llvm.coro.alloc(token %id)
@@ -39,18 +39,20 @@ entry:
   ret void
 }
 
-; CHECK-LABEL: @f() !func_sanitize !0 {
+; CHECK-LABEL: define ptr @f()
+; CHECK-SAME: !prof [[PROF1:![0-9]+]] !func_sanitize !{{[0-9]+}} {
 ; CHECK: call ptr @malloc
 ; CHECK: @llvm.coro.begin(token %id, ptr %phi)
 ; CHECK: store ptr @f.resume, ptr %hdl
-; CHECK: %[[SEL:.+]] = select i1 %need.alloc, ptr @f.destroy, ptr @f.cleanup
+; CHECK: %[[SEL:.+]] = select i1 %need.alloc, ptr @f.destroy, ptr @f.cleanup, !prof [[PROF2:![0-9]+]]
 ; CHECK: store ptr %[[SEL]], ptr %destroy.addr
 ; CHECK: call void @print(i32 0)
 ; CHECK-NOT: call void @print(i32 1)
 ; CHECK-NOT: call void @free(
 ; CHECK: ret ptr %hdl
 
-; CHECK-LABEL: @f.resume({{.*}}) {
+; CHECK-LABEL: @f.resume(
+; CHECK-SAME: !prof [[PROF1]] {
 ; CHECK: %[[DESTROY_ADDR:.+]] = getelementptr inbounds i8, ptr %hdl, i64 8
 ; CHECK-NEXT: %[[DESTROY:.+]] = load ptr, ptr %[[DESTROY_ADDR]]
 ; CHECK-NEXT: %[[IS_ELIDED:.+]] = icmp eq ptr %[[DESTROY]], @f.cleanup
@@ -58,23 +60,25 @@ entry:
 ; CHECK-NOT: call void @print(i32 0)
 ; CHECK: call void @print(i32 1)
 ; CHECK-NOT: call void @print(i32 0)
-; CHECK: %[[CORO_FREE:.+]] = select i1 %[[IS_ELIDED]], ptr null, ptr %hdl
+; CHECK: %[[CORO_FREE:.+]] = select i1 %[[IS_ELIDED]], ptr null, ptr %hdl, !prof [[PROF2:![0-9]+]]
 ; CHECK-NEXT: call void @free(ptr %[[CORO_FREE]])
 ; CHECK: ret void
 
-; CHECK-LABEL: @f.destroy({{.*}}) {
+; CHECK-LABEL: @f.destroy(
+; CHECK-SAME: !prof [[PROF1]] {
 ; CHECK-NOT: call ptr @malloc
 ; CHECK-NOT: call void @print(
 ; CHECK: call void @free(
 ; CHECK: ret void
 
-; CHECK-LABEL: @f.cleanup({{.*}}) {
+; CHECK-LABEL: @f.cleanup( 
+; CHECK-SAME: !prof [[PROF1]] {
 ; CHECK-NOT: call ptr @malloc
 ; CHECK-NOT: call void @print(
 ; CHECK-NOT: call void @free(
 ; CHECK: ret void
 
-; CHECK-LABEL: @f.noalloc(ptr noundef nonnull align 8 dereferenceable(24) %{{.*}})
+; CHECK-LABEL: @f.noalloc(
 ; CHECK-NOT: call ptr @malloc
 ; CHECK: call void @print(i32 0)
 ; CHECK-NOT: call void @print(i32 1)
@@ -97,4 +101,8 @@ declare void @print(i32)
 declare void @free(ptr) willreturn allockind("free") "alloc-family"="malloc"
 
 !0 = !{i32 846595819, ptr null}
+!1 = !{!"function_entry_count", i64 1000}
 attributes #1 = { coro_elide_safe }
+; CHECK: [[PROF1]] = !{!"function_entry_count", i64 1000}
+; CHECK: [[PROF2]] = !{!"unknown", !"coro-split"}
+;

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -7,9 +7,6 @@ CodeGen/WinEH/wineh-statenumbering.ll
 DebugInfo/AArch64/ir-outliner.ll
 DebugInfo/Generic/block-asan.ll
 Transforms/AtomicExpand/ARM/atomic-expansion-v7.ll
-Transforms/Coroutines/coro-split-00.ll
-Transforms/Coroutines/coro-split-addrspace.ll
-Transforms/Coroutines/coro-split-resume-fallthrough-destroy-slot.ll
 Transforms/CrossDSOCFI/basic.ll
 Transforms/CrossDSOCFI/cfi_functions.ll
 Transforms/CrossDSOCFI/thumb.ll


### PR DESCRIPTION
The previous https://github.com/llvm/llvm-project/pull/184466 didn't fix the PGO profile in select instruction in [replaceSwitchResumeCoroFree](https://github.com/jinhuang1102/llvm-project/blob/98668ee1485aa47e97cbb900bc22e0d9e1c8d795/llvm/lib/Transforms/Coroutines/CoroSplit.cpp#L207) function in `CoroSplit.cpp` so triggered a profile verification failure: https://lab.llvm.org/buildbot/#/builders/223/builds/7899

This PR attach unknown branch weights to the created `select` instruction see the comment for more information.

Cmake config:
```
cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DLLVM_LIT_ARGS=--exclude-xfail -DLLVM_ENABLE_PROFCHECK=ON ../llvm-project/llvm
```

Verified by
```
$ bin/llvm-lit -v /usr/local/google/home/jingold/llvm-project/llvm/test/Transforms/Coroutines
-- Testing: 170 tests, 128 workers --
PASS: LLVM :: Transforms/Coroutines/coro-spill-defs-before-corobegin.ll (1 of 170)
...
PASS: LLVM :: Transforms/Coroutines/coro-split-resume-entry-count.ll (121 of 170)
PASS: LLVM :: Transforms/Coroutines/coro-split-resume-entry-count-no-suspend.ll (149 of 170)
PASS: LLVM :: Transforms/Coroutines/coro-split-resume-fallthrough-destroy-slot.ll (155 of 170)
...
PASS: LLVM :: Transforms/Coroutines/coro-readnone-02.ll (170 of 170)

Testing Time: 0.70s

Total Discovered Tests: 170
  Passed: 170 (100.00%)
```