### PR TITLE
Thread Safety Analysis: Honor try-lock branches of a void conditional

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1691,9 +1691,14 @@ ThreadSafetyAnalyzer::getTerminatorTrylockCall(const CFGBlock *Block,
   assert(!Negate && "Must be called with Negate initialized to false");
 
   const Stmt *Cond = Block->getTerminatorCondition();
-  // We don't acquire try-locks on ?: branches, only when its result is used.
-  if (!Cond || isa<ConditionalOperator>(Block->getTerminatorStmt()))
+  if (!Cond)
     return {};
+
+  // We don't acquire try-locks on ?: branches, except when its result is used.
+  if (const auto *COp =
+          dyn_cast_if_present<ConditionalOperator>(Block->getTerminatorStmt()))
+    if (!COp->getType()->isVoidType())
+      return {};
 
   const LocalVarContext &LVarCtx = BlockInfo[Block->getBlockID()].ExitContext;
 

--- a/clang/test/Sema/warn-thread-safety-analysis.c
+++ b/clang/test/Sema/warn-thread-safety-analysis.c
@@ -354,6 +354,25 @@ void test_trylock_conditional(void) {
   mutex_unlock(&mu1);
 }
 
+// How glibc before 2.32 spells assert(): a void conditional operator whose
+// false arm does not return. There is no result to branch on later, so the
+// try-lock is acquired on the branch itself.
+void assert_fail(void) __attribute__((noreturn));
+#define assert_trylock(e) ((e) ? (void)0 : assert_fail())
+
+void test_trylock_void_conditional(void) {
+  assert_trylock(mutex_exclusive_trylock(&mu1));
+  work_data = 1;
+  mutex_unlock(&mu1);
+}
+
+void test_trylock_void_conditional_via_var(void) {
+  int got = mutex_exclusive_trylock(&mu1);
+  assert_trylock(got);
+  work_data = 1;
+  mutex_unlock(&mu1);
+}
+
 // We had a problem where we'd skip all attributes that follow a late-parsed
 // attribute in a single __attribute__.
 void run(void) __attribute__((guarded_by(mu1), guarded_by(mu1))); // expected-warning 2{{only applies to non-static data members and global variables}}

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -2197,6 +2197,30 @@ struct TestTryLock {
     if (mu.TryLock() ? 0 : 1) // expected-note{{mutex acquired here}}
       mu.Unlock();            // expected-warning{{releasing mutex 'mu' that was not held}}
   }                           // expected-warning{{mutex 'mu' is not held on every path through here}}
+
+  // A void conditional operator has no result to branch on later, so unlike
+  // foo13-foo15 the branch itself is honored. This is how glibc before 2.32
+  // spells assert().
+  void foo16() {
+    mu.TryLock() ? static_cast<void>(0) : fail();
+    a = 3;
+    mu.Unlock();
+  }
+
+  void foo17() {
+    !mu.TryLock() ? fail() : static_cast<void>(0);
+    a = 3;
+    mu.Unlock();
+  }
+
+  // Both arms return here, so the join disagrees -- as it would for an if.
+  void foo18() {
+    mu.TryLock() ? static_cast<void>(0) : static_cast<void>(0); // expected-note{{mutex acquired here}} \
+                                                                   expected-warning{{mutex 'mu' is not held on every path through here}}
+    mu.Unlock(); // expected-warning{{releasing mutex 'mu' that was not held}}
+  }
+
+  static void fail() __attribute__((noreturn));
 };  // end TestTrylock
 
 } // end namespace TrylockTest


### PR DESCRIPTION
Try-locks are not acquired on the arms of a `?:`, because the arms would then disagree about whether the capability is held and warn where they join. That reasoning assumes the `?:` produces a result that is branched on later, which is where the acquisition is handled instead.

A void ?: has no such result. Its branch is all there is to interpret, and its arms might not join at all because one of them does not return (this is how glibc before 2.32 spells `assert()`).

So asserting that a try-lock succeeded left the capability unheld on every path, and a function documented to acquire it warned that it did not, if written like so:

  void lock(void) ACQUIRE(mu) {
    int got = trylock();
    assert(got); // warning: expecting mutex 'mu' to be held at the end of function
  }

Only bail out for a `?:` that has a result to be used, so that a void `?:` acquires on its branch like any other terminator (for example, including `&&` and `||`).

Some historical context written by Claude Opus 5 (1M context):
> b0a2a0cf7ddd — Aaron Puchert, 6 Oct 2018, llvm-svn: 343902, D52888 (https://reviews.llvm.org/D52888), titled "Thread safety analysis: Handle conditional expression in getTrylockCallExpr".
> 
>   It did two complementary things in one patch:
> 
>   1. Added ?: support where the result is consumed. The new ConditionalOperator case in getTrylockCallExpr unwraps a ?: whose arms are static booleans, so the trylock is found through it:
> 
>   if (mu.TryLock() ? 1 : 0)   // unwraps to TryLock()
>   if (mu.TryLock() ? 0 : 1)   // unwraps, and flips Negate
> 
>   Those are the foo13/foo14/foo15 tests, added by the same commit.
> 
>   2. Added the opt-out where the ?: itself branches. In getEdgeLockset:
> 
>      const Stmt *Cond = PredBlock->getTerminatorCondition();
>   -  if (!Cond)
>   +  // We don't acquire try-locks on ?: branches, only when its result is used.
>   +  if (!Cond || isa<ConditionalOperator>(PredBlock->getTerminator()))
>        return;
> 
>   The reasoning, from the commit message: "we don't acquire on conditional expression branches, since that is usually not helpful. When joining the branches we would almost certainly get a warning then."
> 
>   Concretely, mu.TryLock() ? A : B branches internally. Acquire on the true edge and A runs with mu held while B doesn't; when the arms rejoin to produce
>   the ?: value, the locksets disagree and you get mutex 'mu' is not held on every path through here. So the patch handles the trylock at the outer branch
>   that consumes the value, and suppresses it at the inner branch that produces it. The message also says it was meant to fix something raised in D52398 —
>   I can't check that, since LLVM's Phabricator is gone.
> 
>   Why that left a hole. The design presumes there is an outer consumer. A void ?: has no value, so half (1) can never fire, while half (2) suppresses
>   unconditionally — nothing handles it. And the "we'd warn at the join" premise fails outright when one arm is noreturn, because the arms never join.
> 
>   One thing worth knowing about its reach. The check has been relocated twice without its condition changing: 4e53032d9bdb (NFC, getTerminator() →
>   getTerminatorStmt()), then f07e2f1aabd1 hoisted it out of getEdgeLockset into the new getTerminatorTrylockCall helper. That helper is now called from
>   two places — getEdgeLockset and getTerminatorTrylockCaps, the latter being the join-warning suppression added in 2026. So since f07e2f1aabd1 the 2018
>   opt-out has also been disabling that newer false-positive suppression for ?: terminators, which is broader than what it was written to do. My change
>   narrows it in both paths at once, which is part of why the foo18 join warning lands where it does.
