### PR TITLE
[scudo] Fix deadlock when forking in primary64.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -544,7 +544,6 @@ u16 SizeClassAllocator64<Config>::popBlocksWithCV(
 
     if (PopulateFreeList) {
       ScopedLock ML(Region->MMLock);
-
       const bool RegionIsExhausted = Region->Exhausted;
       if (!RegionIsExhausted) {
         PopCount = populateFreeListAndPopBlocks(SizeClassAllocator, ClassId,
@@ -562,7 +561,6 @@ u16 SizeClassAllocator64<Config>::popBlocksWithCV(
         Region->isPopulatingFreeList = false;
         Region->FLLockCV.notifyAll(Region->FLLock);
       }
-
       break;
     }
 
@@ -1127,8 +1125,8 @@ void SizeClassAllocator64<Config>::getStats(ScopedString *Str) {
 
   for (uptr I = 0; I < NumClasses; I++) {
     RegionInfo *Region = getRegionInfo(I);
-    ScopedLock L1(Region->MMLock);
-    ScopedLock L2(Region->FLLock);
+    ScopedLock L2(Region->MMLock);
+    ScopedLock L1(Region->FLLock);
     getStats(Str, I, Region);
   }
 }

--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -21,11 +21,14 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdio>
+#include <fstream>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <stdlib.h>
+#include <sys/wait.h>
 #include <thread>
+#include <unistd.h>
 #include <unordered_map>
 #include <vector>
 
@@ -2157,3 +2160,79 @@ TEST(ScudoCombinedTest, VerifyAllBoolTrueConfig) {
   EXPECT_NE(Stats.find("EnableRandomOffset: true"), std::string::npos);
   EXPECT_NE(Stats.find("EnableContiguousRegions: true"), std::string::npos);
 }
+
+#if SCUDO_LINUX
+SCUDO_TYPED_TEST(ScudoCombinedTest, AllocAfterFork) {
+  // Android has a small max maps, but this test is not flaky there.
+  if (!SCUDO_ANDROID) {
+    long MaxMapCount = 0;
+    // If the file can't be accessed, we proceed with the test.
+    std::ifstream Stream("/proc/sys/vm/max_map_count");
+    if (Stream.good()) {
+      Stream >> MaxMapCount;
+      if (MaxMapCount < 200000)
+        TEST_SKIP(
+            "Test might fail when running with fewer than 200000 max maps");
+    }
+  }
+
+  auto *Allocator = this->Allocator.get();
+  std::atomic_bool Stop(false);
+
+  // Create threads that simply allocate and free different sizes.
+  std::vector<std::thread *> Threads;
+  for (size_t N = 0; N < 5; N++) {
+    std::thread *T = new std::thread([&Stop, Allocator] {
+      while (!Stop) {
+        for (size_t SizeLog = 3; SizeLog <= 20; SizeLog++) {
+          const scudo::uptr Size = 1UL << SizeLog;
+          void *P = Allocator->allocate(Size, Origin);
+          if (P) {
+            // Make sure this value is not optimized away.
+            asm volatile("" : : "r,m"(P) : "memory");
+            Allocator->deallocateSized(P, Origin, Size);
+          }
+        }
+      }
+    });
+    Threads.push_back(T);
+  }
+
+  // Create a thread to fork and allocate.
+  for (size_t N = 0; N < 50; N++) {
+    // We need to disable the allocator before fork to ensure no other thread
+    // holds allocator locks during fork.
+    Allocator->disable();
+    pid_t Pid = fork();
+    if (Pid == 0) {
+      // Child process: enable the allocator and allocate.
+      Allocator->enable();
+      for (size_t SizeLog = 3; SizeLog <= 20; SizeLog++) {
+        const scudo::uptr Size = 1UL << SizeLog;
+        void *P = Allocator->allocate(Size, Origin);
+        if (P) {
+          // Make sure this value is not optimized away.
+          asm volatile("" : : "r,m"(P) : "memory");
+          // Make sure we can touch all of the allocation.
+          memset(P, 0x32, Size);
+          Allocator->deallocateSized(P, Origin, Size);
+        }
+      }
+      _exit(10);
+    }
+    // Parent process: enable the allocator and wait for child.
+    Allocator->enable();
+    EXPECT_NE(-1, Pid);
+    int Status;
+    EXPECT_EQ(Pid, waitpid(Pid, &Status, 0));
+    EXPECT_FALSE(WIFSIGNALED(Status));
+    EXPECT_EQ(10, WEXITSTATUS(Status));
+  }
+
+  Stop = true;
+  for (auto Thread : Threads) {
+    Thread->join();
+    delete Thread;
+  }
+}
+#endif


### PR DESCRIPTION
The disable/enable functions were not locking MMLock and FLLock in the correct order, which could lead to a deadlock when forking.

Fixed this, and added a test to verify this.