### PR TITLE
[clang][NFC]Remove unused variable

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
@@ -501,9 +501,7 @@ RefCountReportVisitor::VisitNode(const ExplodedNode *N, BugReporterContext &BRC,
     if (const CallExpr *CE = dyn_cast<CallExpr>(S)) {
       // Iterate through the parameter expressions and see if the symbol
       // was ever passed as an argument.
-      unsigned i = 0;
-
-      for (auto AI=CE->arg_begin(), AE=CE->arg_end(); AI!=AE; ++AI, ++i) {
+      for (auto AI=CE->arg_begin(), AE=CE->arg_end(); AI!=AE; ++AI) {
 
         // Retrieve the value of the argument.  Is it the symbol
         // we are interested in?

--- a/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
@@ -501,7 +501,7 @@ RefCountReportVisitor::VisitNode(const ExplodedNode *N, BugReporterContext &BRC,
     if (const CallExpr *CE = dyn_cast<CallExpr>(S)) {
       // Iterate through the parameter expressions and see if the symbol
       // was ever passed as an argument.
-      for (auto AI=CE->arg_begin(), AE=CE->arg_end(); AI!=AE; ++AI) {
+      for (auto AI = CE->arg_begin(), AE = CE->arg_end(); AI != AE; ++AI) {
 
         // Retrieve the value of the argument.  Is it the symbol
         // we are interested in?


### PR DESCRIPTION
The patch resolves the following warning.
```bash
clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp:504:16: warning: variable ‘i’ set but not used [-Wunused-but-set-variable=]
  504 |       unsigned i = 0;
      |                ^
```

A count variable was set and incremented inside of a for loop but never actually used inside of the loop or anywhere else in its scope.