### PR TITLE
[InstCombine] Fold icmp ptrtoaddr x, ptrtoaddr y -> icmp x, y

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -6548,6 +6548,8 @@ Instruction *InstCombinerImpl::foldICmpWithCastOp(ICmpInst &ICmp) {
 
   // Turn icmp (ptrtoint x), (ptrtoint/c) into a compare of the input if the
   // integer type is the same size as the pointer type.
+  // TODO: for icmp (ptrtoaddr), (ptrtoaddr), we don't need this check;
+  // currently it is always false if the pointer has non-address bits.
   auto CompatibleSizes = [&](Type *PtrTy, Type *IntTy) {
     if (isa<VectorType>(PtrTy)) {
       PtrTy = cast<VectorType>(PtrTy)->getElementType();

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -6555,13 +6555,18 @@ Instruction *InstCombinerImpl::foldICmpWithCastOp(ICmpInst &ICmp) {
     }
     return DL.getPointerTypeSizeInBits(PtrTy) == IntTy->getIntegerBitWidth();
   };
-  if (CastOp0->getOpcode() == Instruction::PtrToInt &&
+  if (isa<PtrToIntInst, PtrToAddrInst>(CastOp0) &&
       CompatibleSizes(SrcTy, DestTy)) {
     Value *NewOp1 = nullptr;
     if (auto *PtrToIntOp1 = dyn_cast<PtrToIntOperator>(ICmp.getOperand(1))) {
       Value *PtrSrc = PtrToIntOp1->getOperand(0);
       if (PtrSrc->getType() == Op0Src->getType())
         NewOp1 = PtrToIntOp1->getOperand(0);
+    } else if (auto *PtrToAddrOp1 =
+                   dyn_cast<PtrToAddrOperator>(ICmp.getOperand(1))) {
+      Value *PtrSrc = PtrToAddrOp1->getOperand(0);
+      if (PtrSrc->getType() == Op0Src->getType())
+        NewOp1 = PtrToAddrOp1->getOperand(0);
     } else if (auto *RHSC = dyn_cast<Constant>(ICmp.getOperand(1))) {
       NewOp1 = ConstantExpr::getIntToPtr(RHSC, SrcTy);
     }

--- a/llvm/test/Transforms/InstCombine/cast_ptr.ll
+++ b/llvm/test/Transforms/InstCombine/cast_ptr.ll
@@ -47,6 +47,17 @@ define i1 @test2_ptrtoaddr(ptr %a, ptr %b) {
   ret i1 %r
 }
 
+define i1 @test2_ptrtoaddr_ptrtoint(ptr %a, ptr %b) {
+; CHECK-LABEL: @test2_ptrtoaddr_ptrtoint(
+; CHECK-NEXT:    [[R:%.*]] = icmp eq ptr [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %ta = ptrtoint ptr %a to i32
+  %tb = ptrtoaddr ptr %b to i32
+  %r = icmp eq i32 %ta, %tb
+  ret i1 %r
+}
+
 ; These casts should be folded away.
 
 define i1 @test2_as2_same_int(ptr addrspace(2) %a, ptr addrspace(2) %b) {
@@ -67,6 +78,17 @@ define i1 @test2_as2_same_int_ptrtoaddr(ptr addrspace(2) %a, ptr addrspace(2) %b
 ;
   %ta = ptrtoaddr ptr addrspace(2) %a to i16
   %tb = ptrtoaddr ptr addrspace(2) %b to i16
+  %r = icmp eq i16 %ta, %tb
+  ret i1 %r
+}
+
+define i1 @test2_as2_same_int_ptrtoint(ptr addrspace(2) %a, ptr addrspace(2) %b) {
+; CHECK-LABEL: @test2_as2_same_int_ptrtoint(
+; CHECK-NEXT:    [[R:%.*]] = icmp eq ptr addrspace(2) [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %ta = ptrtoaddr ptr addrspace(2) %a to i16
+  %tb = ptrtoint ptr addrspace(2) %b to i16
   %r = icmp eq i16 %ta, %tb
   ret i1 %r
 }
@@ -112,6 +134,19 @@ define i1 @test2_diff_as_ptrtoaddr(ptr %p, ptr addrspace(1) %q) {
   ret i1 %r0
 }
 
+define i1 @test2_diff_as_ptrtoaddr_ptrtoint(ptr %p, ptr addrspace(1) %q) {
+; CHECK-LABEL: @test2_diff_as_ptrtoaddr_ptrtoint(
+; CHECK-NEXT:    [[I0:%.*]] = ptrtoint ptr [[P:%.*]] to i32
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoaddr ptr addrspace(1) [[Q:%.*]] to i32
+; CHECK-NEXT:    [[R0:%.*]] = icmp sge i32 [[I0]], [[I1]]
+; CHECK-NEXT:    ret i1 [[R0]]
+;
+  %i0 = ptrtoint ptr %p to i32
+  %i1 = ptrtoaddr ptr addrspace(1) %q to i32
+  %r0 = icmp sge i32 %i0, %i1
+  ret i1 %r0
+}
+
 ; These casts should not be folded away.
 
 define i1 @test2_diff_as_global(ptr addrspace(1) %q) {
@@ -138,6 +173,18 @@ define i1 @test2_diff_as_global_ptrtoaddr(ptr addrspace(1) %q) {
   ret i1 %r0
 }
 
+define i1 @test2_diff_as_global_ptrtoaddr_ptrtoint(ptr addrspace(1) %q) {
+; CHECK-LABEL: @test2_diff_as_global_ptrtoaddr_ptrtoint(
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoint ptr addrspace(1) [[Q:%.*]] to i32
+; CHECK-NEXT:    [[R0:%.*]] = icmp sge i32 [[I1]], ptrtoaddr (ptr @global to i32)
+; CHECK-NEXT:    ret i1 [[R0]]
+;
+  %i0 = ptrtoaddr ptr @global to i32
+  %i1 = ptrtoint ptr addrspace(1) %q to i32
+  %r0 = icmp sge i32 %i1, %i0
+  ret i1 %r0
+}
+
 ; These casts should also be folded away.
 
 define i1 @test3(ptr %a) {
@@ -157,6 +204,16 @@ define i1 @test3_ptrtoaddr(ptr %a) {
 ;
   %ta = ptrtoaddr ptr %a to i32
   %r = icmp eq i32 %ta, ptrtoaddr (ptr @global to i32)
+  ret i1 %r
+}
+
+define i1 @test3_ptrtoaddr_ptrtoint(ptr %a) {
+; CHECK-LABEL: @test3_ptrtoaddr_ptrtoint(
+; CHECK-NEXT:    [[R:%.*]] = icmp eq ptr [[A:%.*]], @global
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %ta = ptrtoaddr ptr %a to i32
+  %r = icmp eq i32 %ta, ptrtoint (ptr @global to i32)
   ret i1 %r
 }
 

--- a/llvm/test/Transforms/InstCombine/cast_ptr.ll
+++ b/llvm/test/Transforms/InstCombine/cast_ptr.ll
@@ -36,6 +36,17 @@ define i1 @test2(ptr %a, ptr %b) {
   ret i1 %r
 }
 
+define i1 @test2_ptrtoaddr(ptr %a, ptr %b) {
+; CHECK-LABEL: @test2_ptrtoaddr(
+; CHECK-NEXT:    [[R:%.*]] = icmp eq ptr [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %ta = ptrtoaddr ptr %a to i32
+  %tb = ptrtoaddr ptr %b to i32
+  %r = icmp eq i32 %ta, %tb
+  ret i1 %r
+}
+
 ; These casts should be folded away.
 
 define i1 @test2_as2_same_int(ptr addrspace(2) %a, ptr addrspace(2) %b) {
@@ -45,6 +56,17 @@ define i1 @test2_as2_same_int(ptr addrspace(2) %a, ptr addrspace(2) %b) {
 ;
   %ta = ptrtoint ptr addrspace(2) %a to i16
   %tb = ptrtoint ptr addrspace(2) %b to i16
+  %r = icmp eq i16 %ta, %tb
+  ret i1 %r
+}
+
+define i1 @test2_as2_same_int_ptrtoaddr(ptr addrspace(2) %a, ptr addrspace(2) %b) {
+; CHECK-LABEL: @test2_as2_same_int_ptrtoaddr(
+; CHECK-NEXT:    [[R:%.*]] = icmp eq ptr addrspace(2) [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %ta = ptrtoaddr ptr addrspace(2) %a to i16
+  %tb = ptrtoaddr ptr addrspace(2) %b to i16
   %r = icmp eq i16 %ta, %tb
   ret i1 %r
 }
@@ -77,6 +99,19 @@ define i1 @test2_diff_as(ptr %p, ptr addrspace(1) %q) {
   ret i1 %r0
 }
 
+define i1 @test2_diff_as_ptrtoaddr(ptr %p, ptr addrspace(1) %q) {
+; CHECK-LABEL: @test2_diff_as_ptrtoaddr(
+; CHECK-NEXT:    [[I0:%.*]] = ptrtoaddr ptr [[P:%.*]] to i32
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoaddr ptr addrspace(1) [[Q:%.*]] to i32
+; CHECK-NEXT:    [[R0:%.*]] = icmp sge i32 [[I0]], [[I1]]
+; CHECK-NEXT:    ret i1 [[R0]]
+;
+  %i0 = ptrtoaddr ptr %p to i32
+  %i1 = ptrtoaddr ptr addrspace(1) %q to i32
+  %r0 = icmp sge i32 %i0, %i1
+  ret i1 %r0
+}
+
 ; These casts should not be folded away.
 
 define i1 @test2_diff_as_global(ptr addrspace(1) %q) {
@@ -91,6 +126,18 @@ define i1 @test2_diff_as_global(ptr addrspace(1) %q) {
   ret i1 %r0
 }
 
+define i1 @test2_diff_as_global_ptrtoaddr(ptr addrspace(1) %q) {
+; CHECK-LABEL: @test2_diff_as_global_ptrtoaddr(
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoaddr ptr addrspace(1) [[Q:%.*]] to i32
+; CHECK-NEXT:    [[R0:%.*]] = icmp sge i32 [[I1]], ptrtoaddr (ptr @global to i32)
+; CHECK-NEXT:    ret i1 [[R0]]
+;
+  %i0 = ptrtoaddr ptr @global to i32
+  %i1 = ptrtoaddr ptr addrspace(1) %q to i32
+  %r0 = icmp sge i32 %i1, %i0
+  ret i1 %r0
+}
+
 ; These casts should also be folded away.
 
 define i1 @test3(ptr %a) {
@@ -100,6 +147,16 @@ define i1 @test3(ptr %a) {
 ;
   %ta = ptrtoint ptr %a to i32
   %r = icmp eq i32 %ta, ptrtoint (ptr @global to i32)
+  ret i1 %r
+}
+
+define i1 @test3_ptrtoaddr(ptr %a) {
+; CHECK-LABEL: @test3_ptrtoaddr(
+; CHECK-NEXT:    [[R:%.*]] = icmp eq ptr [[A:%.*]], @global
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %ta = ptrtoaddr ptr %a to i32
+  %r = icmp eq i32 %ta, ptrtoaddr (ptr @global to i32)
   ret i1 %r
 }
 


### PR DESCRIPTION
Similar to the existing ptrtoint fold; this is valid, because icmp only
compares address bits. This addresses optimization regressions when
generating ptrtoaddr for pointer subtractions.
