### PR TITLE
[SCEV] Fix MSan uninitialized value in createSCEV

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -8098,7 +8098,7 @@ const SCEV *ScalarEvolution::createSCEV(Value *V) {
       // Try to use ptrtoaddr for subtracts with at least one ptrtoint
       // operand. While we don't model ptrtoint directly in SCEV, the
       // difference between two pointer addresses is well-defined.
-      Value *PtrLHS, *PtrRHS;
+      Value *PtrLHS = nullptr, *PtrRHS = nullptr;
       bool HasPtrLHS = match(BO->LHS, m_PtrToInt(m_Value(PtrLHS)));
       bool HasPtrRHS = match(BO->RHS, m_PtrToInt(m_Value(PtrRHS)));
       if (HasPtrLHS || HasPtrRHS) {


### PR DESCRIPTION
In #180244 (8e76c3f0d29a), handling of Instruction::Sub in
createSCEV declared PtrLHS and PtrRHS as uninitialized local variables.
When only one side matched m_PtrToInt, the other variable remained
uninitialized. Passing it by value to GetOp copied uninitialized shadow
bytes, causing MemorySanitizer to report use-of-uninitialized-value.

Initialize PtrLHS and PtrRHS to nullptr upon declaration.

Assisted-by: Gemini
