### PR TITLE
[lldb] Extract type lookup by name from Itanium ABI

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_library(lldbPluginCPPRuntime PLUGIN
   CommandObjectCPlusPlus.cpp
+  CommonABIRuntime.cpp
   CPPLanguageRuntime.cpp
   ItaniumABIRuntime.cpp
   VerboseTrapFrameRecognizer.cpp

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.cpp
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CommonABIRuntime.h"
+
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Utility/LLDBLog.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+CommonABIRuntime::CommonABIRuntime(Process *process) : m_process(process) {}
+
+lldb::TypeSP
+CommonABIRuntime::LookupTypeByName(llvm::StringRef type_name,
+                                   lldb::ModuleSP preferred_module) const {
+  Log *log = GetLog(LLDBLog::Object);
+
+  ConstString const_lookup_name(type_name);
+  TypeList class_types;
+  // First look in the module that the vtable symbol came from and
+  // look for a single exact match.
+  TypeResults results;
+  TypeQuery query(const_lookup_name.GetStringRef(),
+                  TypeQueryOptions::e_exact_match |
+                      TypeQueryOptions::e_strict_namespaces |
+                      TypeQueryOptions::e_find_one);
+  if (preferred_module) {
+    preferred_module->FindTypes(query, results);
+    TypeSP type_sp = results.GetFirstType();
+    if (type_sp)
+      class_types.Insert(type_sp);
+  }
+
+  // If we didn't find a symbol, then move on to the entire module
+  // list in the target and get as many unique matches as possible
+  if (class_types.Empty()) {
+    query.SetFindOne(false);
+    m_process->GetTarget().GetImages().FindTypes(nullptr, query, results);
+    for (const auto &type_sp : results.GetTypeMap().Types())
+      class_types.Insert(type_sp);
+  }
+
+  lldb::TypeSP type_sp;
+  if (class_types.Empty()) {
+    LLDB_LOG(log, "Failed to find '{0}'", type_name);
+    return {};
+  }
+
+  if (class_types.GetSize() == 1) {
+    type_sp = class_types.GetTypeAtIndex(0);
+    if (!type_sp)
+      return {};
+    if (!TypeSystemClang::IsCXXClassType(type_sp->GetForwardCompilerType()))
+      return {};
+
+    return type_sp;
+  }
+
+  if (log) {
+    LLDB_LOG(log,
+             "'{0}' has multiple matching dynamic "
+             "types:",
+             type_name);
+    for (size_t i = 0; i < class_types.GetSize(); i++) {
+      type_sp = class_types.GetTypeAtIndex(i);
+      if (type_sp) {
+        LLDB_LOG(log, "[{0}]: uid={1:x}, type-name='{2}'", i, type_sp->GetID(),
+                 type_sp->GetName());
+      }
+    }
+  }
+
+  for (size_t i = 0; i < class_types.GetSize(); i++) {
+    type_sp = class_types.GetTypeAtIndex(i);
+    if (type_sp) {
+      if (TypeSystemClang::IsCXXClassType(type_sp->GetForwardCompilerType())) {
+        LLDB_LOG(log,
+                 "'{0}' has multiple matching dynamic types, "
+                 "picking this one: [{1}] uid={2:x}, type-name='{3}'\n",
+                 type_name, i, type_sp->GetID(), type_sp->GetName());
+        return type_sp;
+      }
+    }
+  }
+
+  LLDB_LOG(log,
+           "'{0}' has multiple matching dynamic types, didn't find a C++ match",
+           type_name);
+  return {};
+}

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_LANGUAGERUNTIME_CPLUSPLUS_COMMONABIRUNTIME_H
+#define LLDB_SOURCE_PLUGINS_LANGUAGERUNTIME_CPLUSPLUS_COMMONABIRUNTIME_H
+
+#include "lldb/Target/Process.h"
+
+#include <mutex>
+
+namespace lldb_private {
+
+class CommonABIRuntime {
+public:
+  virtual ~CommonABIRuntime() = default;
+
+protected:
+  CommonABIRuntime(Process *process);
+
+  lldb::TypeSP LookupTypeByName(llvm::StringRef type_name,
+                                lldb::ModuleSP preferred_module) const;
+
+protected:
+  Process *m_process;
+  std::mutex m_mutex;
+};
+
+} // namespace lldb_private
+
+#endif

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
@@ -19,7 +19,8 @@ using namespace lldb_private;
 
 static const char *vtable_demangled_prefix = "vtable for ";
 
-ItaniumABIRuntime::ItaniumABIRuntime(Process *process) : m_process(process) {}
+ItaniumABIRuntime::ItaniumABIRuntime(Process *process)
+    : CommonABIRuntime(process) {}
 
 bool ItaniumABIRuntime::IsVTableSymbol(Mangled &mangled) const {
   return mangled.GetDemangledName().GetStringRef().starts_with(
@@ -54,93 +55,17 @@ ItaniumABIRuntime::GetTypeInfo(ValueObject &in_value,
       lookup_name.append(class_name.data(), class_name.size());
 
       type_info.SetName(class_name);
-      ConstString const_lookup_name(lookup_name);
-      TypeList class_types;
-      ModuleSP module_sp = vtable_info.symbol->CalculateSymbolContextModule();
-      // First look in the module that the vtable symbol came from and
-      // look for a single exact match.
-      TypeResults results;
-      TypeQuery query(const_lookup_name.GetStringRef(),
-                      TypeQueryOptions::e_exact_match |
-                          TypeQueryOptions::e_strict_namespaces |
-                          TypeQueryOptions::e_find_one);
-      if (module_sp) {
-        module_sp->FindTypes(query, results);
-        TypeSP type_sp = results.GetFirstType();
-        if (type_sp)
-          class_types.Insert(type_sp);
-      }
-
-      // If we didn't find a symbol, then move on to the entire module
-      // list in the target and get as many unique matches as possible
-      if (class_types.Empty()) {
-        query.SetFindOne(false);
-        m_process->GetTarget().GetImages().FindTypes(nullptr, query, results);
-        for (const auto &type_sp : results.GetTypeMap().Types())
-          class_types.Insert(type_sp);
-      }
-
-      lldb::TypeSP type_sp;
-      if (class_types.Empty()) {
-        LLDB_LOGF(log, "0x%16.16" PRIx64 ": is not dynamic\n",
-                  in_value.GetPointerValue().address);
-        return TypeAndOrName();
-      }
-      if (class_types.GetSize() == 1) {
-        type_sp = class_types.GetTypeAtIndex(0);
-        if (type_sp) {
-          if (TypeSystemClang::IsCXXClassType(
-                  type_sp->GetForwardCompilerType())) {
-            LLDB_LOGF(log,
-                      "0x%16.16" PRIx64
-                      ": static-type = '%s' has dynamic type: uid={0x%" PRIx64
-                      "}, type-name='%s'\n",
-                      in_value.GetPointerValue().address,
-                      in_value.GetTypeName().AsCString(""), type_sp->GetID(),
-                      type_sp->GetName().GetCString());
-            type_info.SetTypeSP(type_sp);
-          }
-        }
-      } else {
-        size_t i;
-        if (log) {
-          for (i = 0; i < class_types.GetSize(); i++) {
-            type_sp = class_types.GetTypeAtIndex(i);
-            if (type_sp) {
-              LLDB_LOGF(log,
-                        "0x%16.16" PRIx64
-                        ": static-type = '%s' has multiple matching dynamic "
-                        "types: uid={0x%" PRIx64 "}, type-name='%s'\n",
-                        in_value.GetPointerValue().address,
-                        in_value.GetTypeName().AsCString(""), type_sp->GetID(),
-                        type_sp->GetName().GetCString());
-            }
-          }
-        }
-
-        for (i = 0; i < class_types.GetSize(); i++) {
-          type_sp = class_types.GetTypeAtIndex(i);
-          if (type_sp) {
-            if (TypeSystemClang::IsCXXClassType(
-                    type_sp->GetForwardCompilerType())) {
-              LLDB_LOGF(log,
-                        "0x%16.16" PRIx64 ": static-type = '%s' has multiple "
-                        "matching dynamic types, picking "
-                        "this one: uid={0x%" PRIx64 "}, type-name='%s'\n",
-                        in_value.GetPointerValue().address,
-                        in_value.GetTypeName().AsCString(""), type_sp->GetID(),
-                        type_sp->GetName().GetCString());
-              type_info.SetTypeSP(type_sp);
-            }
-          }
-        }
-
+      TypeSP type_sp = LookupTypeByName(
+          class_name, vtable_info.symbol->CalculateSymbolContextModule());
+      if (type_sp) {
         LLDB_LOGF(log,
                   "0x%16.16" PRIx64
-                  ": static-type = '%s' has multiple matching dynamic "
-                  "types, didn't find a C++ match\n",
+                  ": static-type = '%s' has dynamic type: uid={0x%" PRIx64
+                  "}, type-name='%s'\n",
                   in_value.GetPointerValue().address,
-                  in_value.GetTypeName().AsCString(""));
+                  in_value.GetTypeName().AsCString(""), type_sp->GetID(),
+                  type_sp->GetName().GetCString());
+        type_info.SetTypeSP(std::move(type_sp));
       }
       if (type_info)
         SetDynamicTypeInfo(vtable_info.addr, type_info);

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_LANGUAGERUNTIME_CPLUSPLUS_ITANIUMABIRUNTIME_H
 #define LLDB_SOURCE_PLUGINS_LANGUAGERUNTIME_CPLUSPLUS_ITANIUMABIRUNTIME_H
 
+#include "CommonABIRuntime.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/ValueObject/ValueObject.h"
 
@@ -16,7 +17,7 @@
 
 namespace lldb_private {
 
-class ItaniumABIRuntime {
+class ItaniumABIRuntime : public CommonABIRuntime {
 public:
   ItaniumABIRuntime(Process *process);
 
@@ -50,9 +51,6 @@ private:
   using DynamicTypeCache = std::map<Address, TypeAndOrName>;
 
   DynamicTypeCache m_dynamic_type_map;
-  std::mutex m_mutex;
-
-  Process *m_process;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
This adds the `CommonABIRuntime` as a base for all C++ ABIs and moves `LookupTypeByName` into it, so it can be reused.