### PR TITLE
[lldb] Move dynamic type cache to common ABI runtime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.cpp
@@ -95,3 +95,19 @@ CommonABIRuntime::LookupTypeByName(llvm::StringRef type_name,
            type_name);
   return {};
 }
+
+TypeAndOrName
+CommonABIRuntime::GetDynamicTypeInfo(const lldb_private::Address &vtable_addr) {
+  std::lock_guard<std::mutex> locker(m_mutex);
+  DynamicTypeCache::const_iterator pos = m_dynamic_type_map.find(vtable_addr);
+  if (pos == m_dynamic_type_map.end())
+    return TypeAndOrName();
+
+  return pos->second;
+}
+
+void CommonABIRuntime::SetDynamicTypeInfo(
+    const lldb_private::Address &vtable_addr, const TypeAndOrName &type_info) {
+  std::lock_guard<std::mutex> locker(m_mutex);
+  m_dynamic_type_map[vtable_addr] = type_info;
+}

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
@@ -11,6 +11,7 @@
 
 #include "lldb/Target/Process.h"
 
+#include <map>
 #include <mutex>
 
 namespace lldb_private {
@@ -25,9 +26,19 @@ protected:
   lldb::TypeSP LookupTypeByName(llvm::StringRef type_name,
                                 lldb::ModuleSP preferred_module) const;
 
+  TypeAndOrName GetDynamicTypeInfo(const lldb_private::Address &vtable_addr);
+
+  void SetDynamicTypeInfo(const lldb_private::Address &vtable_addr,
+                          const TypeAndOrName &type_info);
+
 protected:
   Process *m_process;
   std::mutex m_mutex;
+
+private:
+  using DynamicTypeCache = std::map<Address, TypeAndOrName>;
+
+  DynamicTypeCache m_dynamic_type_map;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
@@ -251,19 +251,3 @@ ItaniumABIRuntime::GetExceptionObjectForThread(ThreadSP thread_sp) {
 
   return exception;
 }
-
-TypeAndOrName ItaniumABIRuntime::GetDynamicTypeInfo(
-    const lldb_private::Address &vtable_addr) {
-  std::lock_guard<std::mutex> locker(m_mutex);
-  DynamicTypeCache::const_iterator pos = m_dynamic_type_map.find(vtable_addr);
-  if (pos == m_dynamic_type_map.end())
-    return TypeAndOrName();
-  else
-    return pos->second;
-}
-
-void ItaniumABIRuntime::SetDynamicTypeInfo(
-    const lldb_private::Address &vtable_addr, const TypeAndOrName &type_info) {
-  std::lock_guard<std::mutex> locker(m_mutex);
-  m_dynamic_type_map[vtable_addr] = type_info;
-}

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.h
@@ -42,15 +42,6 @@ public:
 private:
   TypeAndOrName GetTypeInfo(ValueObject &in_value,
                             const LanguageRuntime::VTableInfo &vtable_info);
-
-  TypeAndOrName GetDynamicTypeInfo(const lldb_private::Address &vtable_addr);
-
-  void SetDynamicTypeInfo(const lldb_private::Address &vtable_addr,
-                          const TypeAndOrName &type_info);
-
-  using DynamicTypeCache = std::map<Address, TypeAndOrName>;
-
-  DynamicTypeCache m_dynamic_type_map;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
Both the Itanium and the MS ABI want some cache for dynamic types. This moves the functionality from the Itanium ABI to the base class.