### PR TITLE
[X86] Avoid call-frame pushes when FI LEA needs stack alignment padding

### DIFF
--- a/llvm/lib/Target/X86/X86CallFrameOptimization.cpp
+++ b/llvm/lib/Target/X86/X86CallFrameOptimization.cpp
@@ -496,6 +496,26 @@ void X86CallFrameOptimizationImpl::collectCallInfo(
     if (*MMI != nullptr)
       return;
 
+  // If the push sequence needs alignment padding, PEI emits a stack adjust
+  // before the pushes and then resolves frame-index LEAs against that
+  // adjusted RSP. The LEA then captures the padding address instead of the
+  // local (PR210756). Keep the mov-to-stack form in that case.
+  if (!isAligned(TFL->getStackAlign(), Context.ExpectedDist)) {
+    for (MachineBasicBlock::iterator J = std::next(FrameSetup);
+         J != Context.Call->getIterator(); ++J) {
+      switch (J->getOpcode()) {
+      case X86::LEA16r:
+      case X86::LEA32r:
+      case X86::LEA64_32r:
+      case X86::LEA64r:
+        for (const MachineOperand &MO : J->operands())
+          if (MO.isFI())
+            return;
+        break;
+      }
+    }
+  }
+
   Context.UsePush = true;
 }
 

--- a/llvm/test/CodeGen/X86/call-frame-opt-stack-addr.ll
+++ b/llvm/test/CodeGen/X86/call-frame-opt-stack-addr.ll
@@ -1,0 +1,27 @@
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu -mattr=+avx -frame-pointer=all | FileCheck %s
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu -mattr=+avx -frame-pointer=all -no-x86-call-frame-opt | FileCheck %s
+
+; Passing the address of a stack local as a stack argument must not be
+; rewritten into a push sequence. X86CallFrameOptimization would leave the
+; LEA of the frame index inside the call-frame window; PEI then resolves it
+; against RSP after alignment padding for the pushes, so the callee receives
+; the wrong pointer (PR210756).
+
+declare preserve_allcc void @sink(i64, i64, i64, i64, i64, i64, ptr)
+
+; CHECK-LABEL: test_stack_addr_arg:
+; CHECK:        movq    $42, {{.*}}(%rbp)
+; Address of the local must stay RBP-relative (or an equivalent correct
+; materialization), and must be written into the outgoing arg slot with a
+; store — not captured as RSP after call-frame alignment and then pushed.
+; CHECK:        leaq    {{.*}}(%rbp), %[[ADDR:.*]]
+; CHECK:        movq    %[[ADDR]], {{.*}}(%rsp)
+; CHECK-NOT:    pushq
+; CHECK:        callq   sink
+define preserve_allcc void @test_stack_addr_arg() {
+entry:
+  %local = alloca [4 x i64], align 8
+  store i64 42, ptr %local, align 8
+  call preserve_allcc void @sink(i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, ptr %local)
+  ret void
+}


### PR DESCRIPTION
When `X86CallFrameOptimization` rewrites outgoing argument stores into pushes and the push byte count is not stack-aligned, PEI emits alignment padding before the pushes. A frame-index `LEA` that remains inside that call-frame window is then resolved against the padded RSP, so the callee can receive the address of the padding instead of the local. This showed up with `preserve_all` + AVX + frame pointers, where stack realignment forces RSP-relative locals (see the repro in #210756).

Refuse the push transform for a call site when the push distance needs alignment padding and a frame-index LEA appears between frame setup and the call. The mov-to-stack form is kept, which PEI lowers correctly. Aligned push sequences that materialize stack addresses (as in existing `movtopush` coverage) are unchanged.

Fixes #210756

Assisted-by: Cursor Agent