### PR TITLE
[SimplifyCFG] Fix DomTree update in `simplifySwitchDefaultBranch`

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -7886,6 +7886,9 @@ static bool simplifySwitchDefaultBranch(SwitchInst *SI, DomTreeUpdater *DTU,
     SIW.addCase(CaseVal, Default, SIW.getSuccessorWeight(0));
     SIW.setSuccessorWeight(0, 0);
   }
+  // If there is a pre-existing case for the constant, the default branch
+  // will be removed rather than being moved. Thus, we are removing an edge
+  // in the CFG, and need to update any PHIs in the default block.
   createUnreachableSwitchDefault(SI, DTU, /*RemoveOrigDefaultBlock=*/CaseIt !=
                                               SI->case_default());
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -7885,14 +7885,9 @@ static bool simplifySwitchDefaultBranch(SwitchInst *SI, DomTreeUpdater *DTU,
     SwitchInstProfUpdateWrapper SIW(*SI);
     SIW.addCase(CaseVal, Default, SIW.getSuccessorWeight(0));
     SIW.setSuccessorWeight(0, 0);
-  } else {
-    // On the other hand, if there is a pre-existing case for the
-    // constant, the default branch will be removed rather than being
-    // moved. Thus, we are removing an edge in the CFG, and need to
-    // update any PHIs in the default block.
-    Default->removePredecessor(SI->getParent());
   }
-  createUnreachableSwitchDefault(SI, DTU, /*RemoveOrigDefaultBlock*/ false);
+  createUnreachableSwitchDefault(SI, DTU, /*RemoveOrigDefaultBlock=*/CaseIt !=
+                                              SI->case_default());
 
   assert(SI->getNumCases() > 0 && "Switch should have at least one case");
   assert(SI->findCaseValue(CaseVal) != SI->case_default() &&


### PR DESCRIPTION
When there is no edge to the original default destination BB, also remove the edge in DT.

This issue cannot be reproduced via -simplifycfg-require-and-preserve-domtree=1. I just found it by checking DT in requestResimplify (will be added after fixing all existing issues). The following test covers this case:
https://github.com/llvm/llvm-project/blob/5bc304c65494702d9d4928ff6cb369e6e6496e53/llvm/test/Transforms/SimplifyCFG/switch-simplify-default.ll#L172-L214
