### PR TITLE
[Docs] Update contribution guide to remove the single-commit requirement

### DIFF
--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -29,8 +29,10 @@ let people know you are working on it.
 Then try to reproduce and fix the bug with upstream LLVM. Start by building
 LLVM from source as described in {doc}`GettingStarted` and
 use the built binaries to reproduce the failure described in the bug. Use
-a debug build (`-DCMAKE_BUILD_TYPE=Debug`) or a build with assertions
-(`-DLLVM_ENABLE_ASSERTIONS=On`, enabled for Debug builds).
+a build with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`). If you want to build
+LLVM in Debug mode, consider using `LLVM_PARALLEL_LINK_JOBS` and set the linker
+to anything other than GNU `ld` (e.g. `lld` or `mold`); otherwise, you'll likely
+run out of memory unless you have a lot of RAM.
 
 ### Reporting a Security Issue
 
@@ -51,7 +53,12 @@ Once you have a patch ready, it is time to submit it. The patch should:
 * conform to the {doc}`CodingStandards`. You can use the [clang-format-diff.py] or [git-clang-format] tools to automatically format your patch properly.
 * not contain any unrelated changes
 * be an isolated change. Independent changes should be submitted as separate patches as this makes reviewing easier.
-* have a single commit, up-to-date with the upstream `origin/main` branch, and don't have merges.
+
+```{note}
+It's ok for a patch to contain multiple commits; we use the 'Squash and Merge'
+button on GitHub when merging PRs, i.e. all commits will be combined into a
+single one by GitHub at merge time.
+```
 
 (format patches)=
 

--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -32,7 +32,7 @@ use the built binaries to reproduce the failure described in the bug.
 
 Use a Release build (`-DCMAKE_BUILD_TYPE=Release` with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`).
 If you want to build LLVM in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`), consider using
-`LLVM_PARALLEL_LINK_JOBS` and set the linker to anything other than GNU `ld`
+`-DLLVM_PARALLEL_LINK_JOBS=number` and set the linker to anything other than GNU `ld`
 (e.g. `lld` or `mold`, by passing `-DLLVM_USE_LINKER=lld` or `-DLLVM_USE_LINKER=mold`);
 otherwise, you'll likely run out of memory unless you have a lot of RAM.
 

--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -36,8 +36,6 @@ If you want to build LLVM in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`), consider u
 (e.g. `lld` or `mold`, by passing `-DLLVM_USE_LINKER=lld` or `-DLLVM_USE_LINKER=mold`);
 otherwise, you'll likely run out of memory unless you have a lot of RAM.
 
-Irrespective of build type (Release or Debug), you may also want to pass
-`-DLLVM_UNREACHABLE_OPTIMIZE=OFF` to get crash messages from `llvm_unreachable()`.
 See also {doc}`CMake` for more information about how to build LLVM.
 
 ### Reporting a Security Issue

--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -31,7 +31,7 @@ LLVM from source as described in {doc}`GettingStarted` and
 use the built binaries to reproduce the failure described in the bug.
 
 Use a Release build (`-DCMAKE_BUILD_TYPE=Release`) with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`).
-If you want to build LLVM in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`), consider using
+If you want to build LLVM in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`) instead, consider using
 `-DLLVM_PARALLEL_LINK_JOBS=number` and set the linker to anything other than GNU `ld`
 (e.g. `lld` or `mold`, by passing `-DLLVM_USE_LINKER=lld` or `-DLLVM_USE_LINKER=mold`);
 otherwise, you'll likely run out of memory unless you have a lot of RAM.

--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -30,7 +30,7 @@ Then try to reproduce and fix the bug with upstream LLVM. Start by building
 LLVM from source as described in {doc}`GettingStarted` and
 use the built binaries to reproduce the failure described in the bug.
 
-Use a Release build (`-DCMAKE_BUILD_TYPE=Release` with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`).
+Use a Release build (`-DCMAKE_BUILD_TYPE=Release`) with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`).
 If you want to build LLVM in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`), consider using
 `-DLLVM_PARALLEL_LINK_JOBS=number` and set the linker to anything other than GNU `ld`
 (e.g. `lld` or `mold`, by passing `-DLLVM_USE_LINKER=lld` or `-DLLVM_USE_LINKER=mold`);

--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -55,9 +55,15 @@ Once you have a patch ready, it is time to submit it. The patch should:
 * be an isolated change. Independent changes should be submitted as separate patches as this makes reviewing easier.
 
 ```{note}
-It's ok for a patch to contain multiple commits; we use the 'Squash and Merge'
-button on GitHub when merging PRs, i.e. all commits will be combined into a
-single one by GitHub at merge time.
+When a PR is accepted and submitted into mainline, all changes from the PR are combined into a single commit using GitHub's "Squash and Merge" button. (We don't use merge commits on LLVM's mainline.) Because of that policy, the series of commits inside a PR branch does not make it into the "permanent record", and is thus not of critical importance.
+
+However, in order to make it easy for reviewers to understand the changes being made during the course of a PR review, it is recommended to follow these guidelines:
+
+- When opening a new PR, prefer to have a single (or small number) of commits on your branch, up-to-date with the upstream `origin/main` branch, and without merges. (This might involve rebasing your local branch prior to creating a PR.)
+
+- Once a PR has been sent for review, prefer to not rebase or modify existing commits already seen by reviewers. Any changes in response to review commits should be added as a new commit on top of the existing ones. If the PR is blocked by merge-conflicts, you should generally resolve the issue by merging main into your PR branch as a separate commit, rather than by rebasing.
+
+Also, be aware that the PR's description/first-comment will be used as the commit message of the final squashed commit. Make sure the PR description contains the message you wish to use, does not contain anything extraneous, and that you update it if the PR evolves during the review. Note: while GitHub copies commit messages into the PR description when initially creating a PR, subsequent messages are ignored; updates must be made directly to the PR description.
 ```
 
 (format patches)=

--- a/llvm/docs/Contributing.md
+++ b/llvm/docs/Contributing.md
@@ -28,11 +28,17 @@ let people know you are working on it.
 
 Then try to reproduce and fix the bug with upstream LLVM. Start by building
 LLVM from source as described in {doc}`GettingStarted` and
-use the built binaries to reproduce the failure described in the bug. Use
-a build with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`). If you want to build
-LLVM in Debug mode, consider using `LLVM_PARALLEL_LINK_JOBS` and set the linker
-to anything other than GNU `ld` (e.g. `lld` or `mold`); otherwise, you'll likely
-run out of memory unless you have a lot of RAM.
+use the built binaries to reproduce the failure described in the bug.
+
+Use a Release build (`-DCMAKE_BUILD_TYPE=Release` with assertions (`-DLLVM_ENABLE_ASSERTIONS=On`).
+If you want to build LLVM in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`), consider using
+`LLVM_PARALLEL_LINK_JOBS` and set the linker to anything other than GNU `ld`
+(e.g. `lld` or `mold`, by passing `-DLLVM_USE_LINKER=lld` or `-DLLVM_USE_LINKER=mold`);
+otherwise, you'll likely run out of memory unless you have a lot of RAM.
+
+Irrespective of build type (Release or Debug), you may also want to pass
+`-DLLVM_UNREACHABLE_OPTIMIZE=OFF` to get crash messages from `llvm_unreachable()`.
+See also {doc}`CMake` for more information about how to build LLVM.
 
 ### Reporting a Security Issue
 


### PR DESCRIPTION
This policy in the docs probably predates LLVM using github, because it’s fairly irrelevant how many commits a PR actually has as we use squash+merge anyway, and I at least find PRs easier to review if the contributor uses multiple commits as that way I have an easy way of checking what changed since my last review.

The docs also recommend building LLVM in debug mode, but this is hard to do unless you have a lot of RAM or know the right CMake flags, so I updated that part as well.

