### PR TITLE
[SimplifyCFG] Don't create new unreachable BB in `turnSwitchRangeIntoICmp`

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6144,8 +6144,7 @@ bool SimplifyCFGOpt::turnSwitchRangeIntoICmp(SwitchInst *SI,
   if (!HasDefault) {
     BasicBlock *OrigDefaultBlock = SI->getDefaultDest();
     OrigDefaultBlock->removePredecessor(BB);
-    if (!is_contained(NewBI->successors(), OrigDefaultBlock))
-      Updates.push_back({DominatorTree::Delete, BB, OrigDefaultBlock});
+    Updates.push_back({DominatorTree::Delete, BB, OrigDefaultBlock});
   }
 
   // Drop the switch.

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6141,15 +6141,22 @@ bool SimplifyCFGOpt::turnSwitchRangeIntoICmp(SwitchInst *SI,
 
   // Clean up the default block - it may have phis or other instructions before
   // the unreachable terminator.
-  if (!HasDefault)
-    createUnreachableSwitchDefault(SI, DTU);
+  SmallVector<DominatorTree::UpdateType, 2> Updates;
+  if (!HasDefault) {
+    BasicBlock *OrigDefaultBlock = SI->getDefaultDest();
+    OrigDefaultBlock->removePredecessor(BB);
+    if (!is_contained(NewBI->successors(), OrigDefaultBlock))
+      Updates.push_back({DominatorTree::Delete, BB, OrigDefaultBlock});
+  }
 
   // Drop the switch.
   SI->eraseFromParent();
 
-  if (DTU && isa<UncondBrInst>(NewBI))
-    DTU->applyUpdates({{DominatorTree::Delete, BB, OtherDest}});
+  if (isa<UncondBrInst>(NewBI))
+    Updates.push_back({DominatorTree::Delete, BB, OtherDest});
 
+  if (DTU)
+    DTU->applyUpdates(Updates);
   return true;
 }
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6139,8 +6139,7 @@ bool SimplifyCFGOpt::turnSwitchRangeIntoICmp(SwitchInst *SI,
       PHI.removeIncomingValue(SI->getParent());
   }
 
-  // Clean up the default block - it may have phis or other instructions before
-  // the unreachable terminator.
+  // Clean up the default block.
   SmallVector<DominatorTree::UpdateType, 2> Updates;
   if (!HasDefault) {
     BasicBlock *OrigDefaultBlock = SI->getDefaultDest();


### PR DESCRIPTION
Previously we relied on `createUnreachableSwitchDefault` to remove incoming edges in phi nodes and update DT. However, it also creates a new unreachable BB and updates the default destination of the switch instruction, which is about to be replaced by a branch instruction. This patch inlines the function and removes logic about the new BB, to make sure the DT is updated correctly.

This issue cannot be reproduced via -simplifycfg-require-and-preserve-domtree=1. I just found it by checking DT in requestResimplify (will be added after fixing all existing issues). The following test covers this case:
https://github.com/llvm/llvm-project/blob/5bc304c65494702d9d4928ff6cb369e6e6496e53/llvm/test/Transforms/SimplifyCFG/switch-range-to-icmp.ll#L38-L73
