### PR TITLE
[analyzer] Fix _Atomic crashes for Z3 symbolic execution

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -31,6 +31,10 @@ public:
     return Ctx.getTypeSize(Ty);
   }
 
+  static inline QualType getSymbolicValueType(QualType Ty) {
+    return Ty.getAtomicUnqualifiedType().getCanonicalType();
+  }
+
   // Returns an appropriate sort, given a QualType and it's bit width.
   static inline llvm::SMTSortRef mkSort(llvm::SMTSolverRef &Solver,
                                         const QualType &Ty, unsigned BitWidth) {
@@ -270,8 +274,14 @@ public:
                                           QualType ToTy, uint64_t ToBitWidth,
                                           QualType FromTy,
                                           uint64_t FromBitWidth) {
-    if ((FromTy.getAtomicUnqualifiedType()->isIntegralOrEnumerationType() &&
-         ToTy.getAtomicUnqualifiedType()->isIntegralOrEnumerationType()) ||
+    FromTy = getSymbolicValueType(FromTy);
+    ToTy = getSymbolicValueType(ToTy);
+
+    if (FromTy == ToTy && FromBitWidth == ToBitWidth)
+      return Exp;
+
+    if ((FromTy->isIntegralOrEnumerationType() &&
+         ToTy->isIntegralOrEnumerationType()) ||
         (FromTy->isAnyPointerType() ^ ToTy->isAnyPointerType()) ||
         (FromTy->isBlockPointerType() ^ ToTy->isBlockPointerType()) ||
         (FromTy->isReferenceType() ^ ToTy->isReferenceType())) {
@@ -467,13 +477,13 @@ public:
   getSymExpr(llvm::SMTSolverRef &Solver, ASTContext &Ctx, SymbolRef Sym,
              QualType &RetTy, bool *hasComparison) {
     if (const SymbolData *SD = dyn_cast<SymbolData>(Sym)) {
-      RetTy = Sym->getType();
+      RetTy = getSymbolicValueType(Sym->getType());
 
       return fromData(Solver, Ctx, SD);
     }
 
     if (const SymbolCast *SC = dyn_cast<SymbolCast>(Sym)) {
-      RetTy = Sym->getType();
+      RetTy = getSymbolicValueType(Sym->getType());
 
       QualType FromTy;
       std::optional<llvm::SMTExprRef> Exp =
@@ -485,11 +495,11 @@ public:
       // e.g. (signed char) (x > 0)
       if (hasComparison)
         *hasComparison = false;
-      return getCastExpr(Solver, Ctx, Exp.value(), FromTy, Sym->getType());
+      return getCastExpr(Solver, Ctx, Exp.value(), FromTy, RetTy);
     }
 
     if (const UnarySymExpr *USE = dyn_cast<UnarySymExpr>(Sym)) {
-      RetTy = Sym->getType();
+      RetTy = getSymbolicValueType(Sym->getType());
 
       QualType OperandTy;
       std::optional<llvm::SMTExprRef> OperandExp =
@@ -523,7 +533,7 @@ public:
       if (Ctx.getTypeSize(OperandTy) != Ctx.getTypeSize(Sym->getType())) {
         if (hasComparison)
           *hasComparison = false;
-        return getCastExpr(Solver, Ctx, UnaryExp, OperandTy, Sym->getType());
+        return getCastExpr(Solver, Ctx, UnaryExp, OperandTy, RetTy);
       }
       return UnaryExp;
     }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h
@@ -26,6 +26,7 @@ namespace ento {
 class SMTConv {
 public:
   static inline uint64_t getSMTBitWidth(ASTContext &Ctx, QualType Ty) {
+    Ty = getSymbolicValueType(Ty);
     if (Ty->isIntegralOrEnumerationType())
       return Ctx.getIntWidth(Ty);
     return Ctx.getTypeSize(Ty);

--- a/clang/test/Analysis/z3/z3-atomic.c
+++ b/clang/test/Analysis/z3/z3-atomic.c
@@ -4,6 +4,7 @@
 // REQUIRES: z3
 // expected-no-diagnostics
 
+// no-crash
 void atomic_bool(_Bool input) {
   _Atomic(_Bool) value = input;
   if (value) {
@@ -13,6 +14,7 @@ void atomic_bool(_Bool input) {
 typedef _Bool B1;
 typedef _Bool B2;
 
+// no-crash
 void atomic_bool_typedef(B1 input) {
   _Atomic(B2) value = input;
   if (value) {

--- a/clang/test/Analysis/z3/z3-atomic.c
+++ b/clang/test/Analysis/z3/z3-atomic.c
@@ -1,0 +1,20 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-checker=core,debug.ExprInspection \
+// RUN:   -analyzer-constraints=unsupported-z3 -verify %s
+// REQUIRES: z3
+// expected-no-diagnostics
+
+void atomic_bool(_Bool input) {
+  _Atomic(_Bool) value = input;
+  if (value) {
+  }
+}
+
+typedef _Bool B1;
+typedef _Bool B2;
+
+void atomic_bool_typedef(B1 input) {
+  _Atomic(B2) value = input;
+  if (value) {
+  }
+}

--- a/clang/test/Analysis/z3/z3-atomic.c
+++ b/clang/test/Analysis/z3/z3-atomic.c
@@ -4,19 +4,17 @@
 // REQUIRES: z3
 // expected-no-diagnostics
 
-// no-crash
 void atomic_bool(_Bool input) {
   _Atomic(_Bool) value = input;
-  if (value) {
+  if (value) { // no-crash
   }
 }
 
 typedef _Bool B1;
 typedef _Bool B2;
 
-// no-crash
 void atomic_bool_typedef(B1 input) {
   _Atomic(B2) value = input;
-  if (value) {
+  if (value) { // no-crash
   }
 }

--- a/clang/test/Analysis/z3/z3-atomic.c
+++ b/clang/test/Analysis/z3/z3-atomic.c
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN: %clang_analyze_cc1 \
 // RUN:   -analyzer-checker=core,debug.ExprInspection \
 // RUN:   -analyzer-constraints=unsupported-z3 -verify %s
 // REQUIRES: z3


### PR DESCRIPTION
This PR fixes _Atomic crashes for Z3 symbolic execution by passing the types through getAtomicUnqualifiedType and getCanonicalType and skip casting in fromCast if FromTy == ToTy && FromBitWidth == ToBitWidth.

Assisted-by: Codex