### PR TITLE
[clang] [test] Fix a new test on mingw

### DIFF
--- a/clang/test/AST/ByteCode/virtual-bases.cpp
+++ b/clang/test/AST/ByteCode/virtual-bases.cpp
@@ -437,7 +437,7 @@ namespace Offsets {
   };
 
   constexpr C c{12};
-#if !defined(_WIN32)
+#if !defined(_WIN32) || defined(__MINGW32__)
 #if __SIZEOF_SIZE_T__ == 8
   static_assert( (fold((char*)&c.c - (char*)&c)) == 12);
   static_assert( (fold((char*)&c.b - (char*)&c)) == 8);


### PR DESCRIPTION
This fixes running a new test that was added in
4b66bacd1fdf02803509b744034f3ab09945157c, in mingw environments.

The quirks that warranted adding the `!defined(_WIN32)` condition in the test aren't actually specific to Windows in general, but specific to MSVC environments - mingw environments behave just like other platforms.

Ideally we'd use `!defined(_MSC_VER)`, however in -cc1 mode, Clang doesn't automatically define `_MSC_VER`; defining it requires setting a command line option that the driver normally passes in MSVC mode. Therefore, qualify the condition as `!defined(_MSC_VER) || defined(__MINGW32__)`.