### PR TITLE
[docs] Remove release notes for backported changes

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -419,9 +419,6 @@ features cannot lower the translation-unit ABI level;
 
 #### Arm and AArch64 Support
 
-- On AArch64 Windows targets, `-mbranch-protection=standard` and `-mbranch-protection=pac-ret`
-  now uses the B-key by default.
-
 #### Android Support
 
 #### Windows Support

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -70,9 +70,6 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the AArch64 Backend
 
-* On AArch64 Windows targets, return address signing now uses the B-key by
-  default because Windows unwind information only supports B-key signing.
-
 ### Changes to the AMDGPU Backend
 
 * Replaced `xnack` and `sramecc` target features with `amdgpu.xnack`


### PR DESCRIPTION
Commit 68f703f3e58a52c41b39dfc654a675560b6c5614 added these release notes, but this commit was backported to the 23.x release branch in 47e2df730a099583f16fc6fe64f0d2ffc5b7a16a (included in the 23.1.0 RC 1 tag).

Therefore, remove these release notes from the main branch (where they would have been included in the 24.x release notes).