### PR TITLE
[NVPTX] Emit some more PTX directives through target streamer

### DIFF
--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
@@ -12,6 +12,7 @@
 
 #include "NVPTXTargetStreamer.h"
 #include "NVPTXUtilities.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
@@ -181,4 +182,56 @@ void NVPTXAsmTargetStreamer::emitTargetDirective(StringRef Target,
 void NVPTXAsmTargetStreamer::emitAddressSizeDirective(unsigned AddrSize) {
   OS << ".address_size " << AddrSize << "\n"
      << "\n";
+}
+
+void NVPTXAsmTargetStreamer::emitBranchTargetsDirective(
+    ArrayRef<const MCSymbol *> Targets) {
+  const MCAsmInfo &MAI = getStreamer().getContext().getAsmInfo();
+  OS << "\t.branchtargets\n\t\t";
+  interleave(
+      Targets, OS, [&](const MCSymbol *Target) { Target->print(OS, &MAI); },
+      ",\n\t\t");
+  OS << ";\n";
+}
+
+void NVPTXAsmTargetStreamer::emitRegDirective(unsigned SizeInBits,
+                                              StringRef Name,
+                                              std::optional<unsigned> Count) {
+  OS << "\t.reg ";
+  if (SizeInBits == 1)
+    OS << ".pred";
+  else
+    OS << ".b" << SizeInBits;
+
+  OS << " \t" << Name;
+  if (Count)
+    OS << "<" << *Count << ">";
+  OS << ";\n";
+}
+
+void NVPTXAsmTargetStreamer::emitLocalDirective(Align Alignment,
+                                                const MCSymbol *Name,
+                                                uint64_t Size) {
+  const MCAsmInfo &MAI = getStreamer().getContext().getAsmInfo();
+  OS << "\t.local .align " << Alignment.value() << " .b8 \t";
+  Name->print(OS, &MAI);
+  OS << "[" << Size << "];\n";
+}
+
+void NVPTXAsmTargetStreamer::emitAliasDirective(const MCSymbol *Name,
+                                                const MCSymbol *Aliasee) {
+  const MCAsmInfo &MAI = getStreamer().getContext().getAsmInfo();
+  OS << ".alias ";
+  Name->print(OS, &MAI);
+  OS << ", ";
+  Aliasee->print(OS, &MAI);
+  OS << ";\n";
+}
+
+void NVPTXAsmTargetStreamer::emitPragmaDirective(StringRef Pragma) {
+  OS << "\t.pragma \"" << Pragma << "\";\n";
+}
+
+void NVPTXAsmTargetStreamer::emitEmptySectionDirective(StringRef Name) {
+  OS << "\t.section\t" << Name << "\t{\t}\n";
 }

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.h
@@ -9,10 +9,13 @@
 #ifndef LLVM_LIB_TARGET_NVPTX_MCTARGETDESC_NVPTXTARGETSTREAMER_H
 #define LLVM_LIB_TARGET_NVPTX_MCTARGETDESC_NVPTXTARGETSTREAMER_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/MC/MCStreamer.h"
+#include <optional>
 
 namespace llvm {
 class MCSection;
+class MCSymbol;
 class formatted_raw_ostream;
 
 /// Implments NVPTX-specific streamer.
@@ -37,6 +40,29 @@ public:
 
   /// Emit address size used for this PTX module.
   virtual void emitAddressSizeDirective(unsigned AddrSize) {}
+
+  /// Emit the list of branch targets a brx.idx may jump to.
+  virtual void emitBranchTargetsDirective(ArrayRef<const MCSymbol *> Targets) {}
+
+  /// Declare a register \p SizeInBits wide. \p Count declares a numbered bank
+  /// of that many registers sharing \p Name as their prefix, rather than a
+  /// single register named \p Name.
+  virtual void emitRegDirective(unsigned SizeInBits, StringRef Name,
+                                std::optional<unsigned> Count = std::nullopt) {}
+
+  /// Declare \p Size bytes of local (stack) memory named \p Name.
+  virtual void emitLocalDirective(Align Alignment, const MCSymbol *Name,
+                                  uint64_t Size) {}
+
+  /// Emit an alias from \p Name to \p Aliasee.
+  virtual void emitAliasDirective(const MCSymbol *Name,
+                                  const MCSymbol *Aliasee) {}
+
+  /// Emit a pragma governing the code that follows it.
+  virtual void emitPragmaDirective(StringRef Pragma) {}
+
+  /// Emit a section with an empty body.
+  virtual void emitEmptySectionDirective(StringRef Name) {}
 
   /// Outputs the list of the DWARF '.file' directives to the streamer.
   void outputDwarfFileDirectives();
@@ -81,6 +107,21 @@ public:
                            bool HasDebug) override;
 
   void emitAddressSizeDirective(unsigned AddrSize) override;
+
+  void emitBranchTargetsDirective(ArrayRef<const MCSymbol *> Targets) override;
+
+  void emitRegDirective(unsigned SizeInBits, StringRef Name,
+                        std::optional<unsigned> Count) override;
+
+  void emitLocalDirective(Align Alignment, const MCSymbol *Name,
+                          uint64_t Size) override;
+
+  void emitAliasDirective(const MCSymbol *Name,
+                          const MCSymbol *Aliasee) override;
+
+  void emitPragmaDirective(StringRef Pragma) override;
+
+  void emitEmptySectionDirective(StringRef Name) override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -339,9 +339,8 @@ MCOperand NVPTXAsmPrinter::lowerOperand(const MachineOperand &MO) {
     return GetSymbolRef(GetExternalSymbolSymbol(MO.getSymbolName()));
   case MachineOperand::MO_JumpTableIndex:
     // The jump table index names the .branchtargets list emitted for a brx.idx
-    // (see emitFunctionBodyStart); reference it by that label.
-    return GetSymbolRef(
-        OutContext.getOrCreateSymbol("$L_brx_" + Twine(MO.getIndex())));
+    // (see emitJumpTable); reference it by that label.
+    return GetSymbolRef(GetJTISymbol(MO.getIndex()));
   case MachineOperand::MO_GlobalAddress:
     return GetSymbolRef(getSymbol(MO.getGlobal()));
   case MachineOperand::MO_FPImmediate: {
@@ -540,24 +539,23 @@ void NVPTXAsmPrinter::emitCallPrototype(const CallBase &CB,
       << STI.getMaxRequiredAlignment() << " .b8 _[]";
 
   O << ")";
-  if (shouldEmitPTXNoReturn(&CB, TM))
+  if (shouldEmitPTXNoReturn(CB))
     O << " .noreturn";
   O << ";\n";
 }
 
 void NVPTXAsmPrinter::emitJumpTable(const MachineJumpTableEntry &MJT,
-                                    unsigned MJTI, raw_ostream &O) const {
-  O << "$L_brx_" << MJTI << ":\n";
+                                    unsigned MJTI) const {
+  OutStreamer->emitLabel(GetJTISymbol(MJTI));
 
   if (MJT.MBBs.empty())
     return;
 
-  O << "\t.branchtargets\n\t\t";
-  interleave(
-      MJT.MBBs, O,
-      [&](const MachineBasicBlock *MBB) { MBB->getSymbol()->print(O, MAI); },
-      ",\n\t\t");
-  O << ";\n";
+  const auto Targets = to_vector(
+      map_range(MJT.MBBs, [](const MachineBasicBlock *MBB) -> const MCSymbol * {
+        return MBB->getSymbol();
+      }));
+  getTargetStreamer()->emitBranchTargetsDirective(Targets);
 }
 
 // Return true if MBB is the header of a loop marked with
@@ -597,7 +595,7 @@ bool NVPTXAsmPrinter::isLoopHeaderOfNoUnroll(
 void NVPTXAsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {
   AsmPrinter::emitBasicBlockStart(MBB);
   if (isLoopHeaderOfNoUnroll(MBB))
-    OutStreamer->emitRawText(StringRef("\t.pragma \"nounroll\";\n"));
+    getTargetStreamer()->emitPragmaDirective("nounroll");
 }
 
 void NVPTXAsmPrinter::emitFunctionEntryLabel() {
@@ -628,7 +626,7 @@ void NVPTXAsmPrinter::emitFunctionEntryLabel() {
   if (isKernelFunction(*F))
     emitKernelFunctionDirectives(*F, O);
 
-  if (shouldEmitPTXNoReturn(F, TM))
+  if (shouldEmitPTXNoReturn(*F))
     O << ".noreturn";
 
   OutStreamer->emitRawText(O.str());
@@ -662,11 +660,11 @@ void NVPTXAsmPrinter::emitFunctionBodyStart() {
   for (const auto &[Id, CB] : MFI->getCallPrototypes())
     emitCallPrototype(*CB, Id, O);
 
+  OutStreamer->emitRawText(O.str());
+
   if (const MachineJumpTableInfo *MJTI = MF->getJumpTableInfo())
     for (const auto &[Idx, JT] : enumerate(MJTI->getJumpTables()))
-      emitJumpTable(JT, Idx, O);
-
-  OutStreamer->emitRawText(O.str());
+      emitJumpTable(JT, Idx);
 }
 
 void NVPTXAsmPrinter::emitFunctionBodyEnd() {
@@ -674,21 +672,17 @@ void NVPTXAsmPrinter::emitFunctionBodyEnd() {
 }
 
 const MCSymbol *NVPTXAsmPrinter::getFunctionFrameSymbol() const {
-    SmallString<128> Str;
-    raw_svector_ostream(Str) << DEPOTNAME << getFunctionNumber();
-    return OutContext.getOrCreateSymbol(Str);
+  return OutContext.getOrCreateSymbol(DEPOTNAME + Twine(getFunctionNumber()));
 }
 
 void NVPTXAsmPrinter::emitImplicitDef(const MachineInstr *MI) const {
   Register RegNo = MI->getOperand(0).getReg();
-  if (RegNo.isVirtual()) {
+  if (RegNo.isVirtual())
     OutStreamer->AddComment(Twine("implicit-def: ") +
                             getVirtualRegisterName(RegNo));
-  } else {
-    const NVPTXSubtarget &STI = MI->getMF()->getSubtarget<NVPTXSubtarget>();
+  else
     OutStreamer->AddComment(Twine("implicit-def: ") +
-                            STI.getRegisterInfo()->getName(RegNo));
-  }
+                            NVPTXInstPrinter::getRegisterName(RegNo));
   OutStreamer->addBlankLine();
 }
 
@@ -814,7 +808,7 @@ void NVPTXAsmPrinter::emitDeclarationWithName(const Function *F, MCSymbol *S,
   O << "\n";
   emitFunctionParamList(F, O);
   O << "\n";
-  if (shouldEmitPTXNoReturn(F, TM))
+  if (shouldEmitPTXNoReturn(*F))
     O << ".noreturn";
   O << ";\n";
 }
@@ -1049,15 +1043,8 @@ void NVPTXAsmPrinter::emitGlobals(const Module &M) {
 }
 
 void NVPTXAsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
-  SmallString<128> Str;
-  raw_svector_ostream OS(Str);
-
-  MCSymbol *Name = getSymbol(&GA);
-
-  OS << ".alias " << Name->getName() << ", " << GA.getAliaseeObject()->getName()
-     << ";\n";
-
-  OutStreamer->emitRawText(OS.str());
+  getTargetStreamer()->emitAliasDirective(getSymbol(&GA),
+                                          getSymbol(GA.getAliaseeObject()));
 }
 
 NVPTXTargetStreamer *NVPTXAsmPrinter::getTargetStreamer() const {
@@ -1114,7 +1101,7 @@ bool NVPTXAsmPrinter::doFinalization(Module &M) {
   if (hasDebugInfo()) {
     TS->closeLastSection();
     // Emit empty .debug_macinfo section for better support of the empty files.
-    OutStreamer->emitRawText("\t.section\t.debug_macinfo\t{\t}");
+    TS->emitEmptySectionDirective(".debug_macinfo");
   }
 
   // Output last DWARF .file directives, if any.
@@ -1801,25 +1788,22 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
 
 void NVPTXAsmPrinter::setAndEmitFunctionVirtualRegisters(
     const MachineFunction &MF) {
-  SmallString<128> Str;
-  raw_svector_ostream O(Str);
-
-  // Map the global virtual register number to a register class specific
-  // virtual register number starting from 1 with that class.
-  const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+  auto *TS = getTargetStreamer();
 
   // Emit the Fake Stack Object
   const MachineFrameInfo &MFI = MF.getFrameInfo();
-  int64_t NumBytes = MFI.getStackSize();
-  if (NumBytes) {
-    O << "\t.local .align " << MFI.getMaxAlign().value() << " .b8 \t"
-      << DEPOTNAME << getFunctionNumber() << "[" << NumBytes << "];\n";
-    const bool Is64Bit =
-        static_cast<const NVPTXTargetMachine &>(MF.getTarget()).is64Bit();
-    const bool IsLocal64 =
-        MF.getDataLayout().getPointerSizeInBits(ADDRESS_SPACE_LOCAL) == 64;
-    O << "\t.reg .b" << (Is64Bit ? 64 : 32) << " \t%SP;\n"
-      << "\t.reg .b" << (IsLocal64 ? 64 : 32) << " \t%SPL;\n";
+  if (const int64_t NumBytes = MFI.getStackSize()) {
+    TS->emitLocalDirective(MFI.getMaxAlign(), getFunctionFrameSymbol(),
+                           NumBytes);
+
+    // Declare the frame pointers that NVPTXFrameLowering's prologue defines.
+    const NVPTXRegisterInfo *NRI =
+        MF.getSubtarget<NVPTXSubtarget>().getRegisterInfo();
+    for (const Register FrameReg :
+         {NRI->getFrameRegister(MF), NRI->getFrameLocalRegister(MF)})
+      TS->emitRegDirective(
+          NRI->getRegSizeInBits(FrameReg, *MRI).getFixedValue(),
+          NVPTXInstPrinter::getRegisterName(FrameReg));
   }
 
   // Go through all virtual registers to establish the mapping between the
@@ -1836,18 +1820,13 @@ void NVPTXAsmPrinter::setAndEmitFunctionVirtualRegisters(
 
   // Emit declaration of the virtual registers or 'physical' registers for
   // each register class
+  const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
   for (const TargetRegisterClass &RC : TRI->regclasses()) {
-    const unsigned N = VRegMapping[&RC].size();
-
     // Only declare those registers that may be used.
-    if (N) {
-      const StringRef RCName = getNVPTXRegClassName(&RC);
-      const StringRef RCStr = getNVPTXRegClassStr(&RC);
-      O << "\t.reg " << RCName << " \t" << RCStr << "<" << (N + 1) << ">;\n";
-    }
+    if (const unsigned N = VRegMapping[&RC].size())
+      TS->emitRegDirective(TRI->getRegSizeInBits(RC).getFixedValue(),
+                           getNVPTXRegClassStr(&RC), N + 1);
   }
-
-  OutStreamer->emitRawText(O.str());
 }
 
 /// Translate virtual register numbers in DebugInfo locations to their printed
@@ -2346,7 +2325,7 @@ void NVPTXAsmPrinter::printOperand(const MachineInstr *MI, unsigned OpNum,
   case MachineOperand::MO_Register:
     if (MO.getReg().isPhysical()) {
       if (MO.getReg() == NVPTX::VRDepot)
-        O << DEPOTNAME << getFunctionNumber();
+        getFunctionFrameSymbol()->print(O, MAI);
       else
         O << NVPTXInstPrinter::getRegisterName(MO.getReg());
     } else {

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
@@ -17,6 +17,7 @@
 #include "NVPTX.h"
 #include "NVPTXSubtarget.h"
 #include "NVPTXTargetMachine.h"
+#include "NVVMProperties.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -30,6 +31,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Value.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCStreamer.h"
@@ -45,6 +47,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // The ptx syntax and format is very different from that usually seem in a .s
@@ -191,8 +194,27 @@ private:
   void printReturnValStr(const MachineFunction &MF, raw_ostream &O);
   void emitCallPrototype(const CallBase &CB, unsigned UniqueCallSite,
                          raw_ostream &O) const;
-  void emitJumpTable(const MachineJumpTableEntry &MJT, unsigned MJTI,
-                     raw_ostream &O) const;
+  void emitJumpTable(const MachineJumpTableEntry &MJT, unsigned MJTI) const;
+
+  /// Should a .noreturn directive be emitted for \p V, which is either a
+  /// function or a call site?
+  template <typename T> bool shouldEmitPTXNoReturn(const T &V) const {
+    static_assert(std::is_same_v<Function, T> || std::is_base_of_v<CallBase, T>,
+                  "expected a function or a call site");
+
+    const auto &NTM = static_cast<const NVPTXTargetMachine &>(TM);
+    if (!NTM.getSubtargetImpl()->hasNoReturn())
+      return false;
+
+    if (!V.doesNotReturn() || !V.getFunctionType()->getReturnType()->isVoidTy())
+      return false;
+
+    if constexpr (std::is_same_v<Function, T>)
+      return !isKernelFunction(V);
+    else
+      return true;
+  }
+
   bool PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
                        const char *ExtraCode, raw_ostream &) override;
   void printOperand(const MachineInstr *MI, unsigned OpNum, raw_ostream &O);

--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
@@ -25,40 +25,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "nvptx-reg-info"
 
-StringRef llvm::getNVPTXRegClassName(TargetRegisterClass const *RC) {
-  if (RC == &NVPTX::B128RegClass)
-    return ".b128";
-  if (RC == &NVPTX::B64RegClass)
-    // We use untyped (.b) integer registers here as NVCC does.
-    // Correctness of generated code does not depend on register type,
-    // but using .s/.u registers runs into ptxas bug that prevents
-    // assembly of otherwise valid PTX into SASS. Despite PTX ISA
-    // specifying only argument size for fp16 instructions, ptxas does
-    // not allow using .s16 or .u16 arguments for .fp16
-    // instructions. At the same time it allows using .s32/.u32
-    // arguments for .fp16v2 instructions:
-    //
-    //   .reg .b16 rb16
-    //   .reg .s16 rs16
-    //   add.f16 rb16,rb16,rb16; // OK
-    //   add.f16 rs16,rs16,rs16; // Arguments mismatch for instruction 'add'
-    // but:
-    //   .reg .b32 rb32
-    //   .reg .s32 rs32
-    //   add.f16v2 rb32,rb32,rb32; // OK
-    //   add.f16v2 rs32,rs32,rs32; // OK
-    return ".b64";
-  if (RC == &NVPTX::B32RegClass)
-    return ".b32";
-  if (RC == &NVPTX::B16RegClass)
-    return ".b16";
-  if (RC == &NVPTX::B1RegClass)
-    return ".pred";
-  if (RC == &NVPTX::SpecialRegsRegClass)
-    return "!Special!";
-  return "INTERNAL";
-}
-
 StringRef llvm::getNVPTXRegClassStr(TargetRegisterClass const *RC) {
   if (RC == &NVPTX::B128RegClass)
     return "%rq";
@@ -75,8 +41,7 @@ StringRef llvm::getNVPTXRegClassStr(TargetRegisterClass const *RC) {
   return "INTERNAL";
 }
 
-NVPTXRegisterInfo::NVPTXRegisterInfo()
-    : NVPTXGenRegisterInfo(0), StrPool(StrAlloc) {}
+NVPTXRegisterInfo::NVPTXRegisterInfo() : NVPTXGenRegisterInfo(0) {}
 
 #define GET_REGINFO_TARGET_DESC
 #include "NVPTXGenRegisterInfo.inc"

--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.h
@@ -14,8 +14,6 @@
 #define LLVM_LIB_TARGET_NVPTX_NVPTXREGISTERINFO_H
 
 #include "llvm/CodeGen/TargetRegisterInfo.h"
-#include "llvm/Support/StringSaver.h"
-#include <sstream>
 
 #define GET_REGINFO_HEADER
 #include "NVPTXGenRegisterInfo.inc"
@@ -23,9 +21,6 @@
 namespace llvm {
 class NVPTXRegisterInfo : public NVPTXGenRegisterInfo {
 private:
-  // Hold Strings that can be free'd all together with NVPTXRegisterInfo
-  BumpPtrAllocator StrAlloc;
-  UniqueStringSaver StrPool;
   // State for debug register mapping that can be mutated even through a const
   // pointer so that we can get the proper dwarf register encoding during ASM
   // emission.
@@ -50,16 +45,6 @@ public:
   Register getFrameRegister(const MachineFunction &MF) const override;
   Register getFrameLocalRegister(const MachineFunction &MF) const;
 
-  UniqueStringSaver &getStrPool() const {
-    return const_cast<UniqueStringSaver &>(StrPool);
-  }
-
-  const char *getName(unsigned RegNo) const {
-    std::stringstream O;
-    O << "reg" << RegNo;
-    return getStrPool().save(O.str()).data();
-  }
-
   // Manage the debugRegisterMap.  PTX virtual registers for DebugInfo are
   // encoded using the names used in the emitted text of the PTX assembly. This
   // mapping must be managed during assembly emission.
@@ -75,7 +60,6 @@ public:
   int64_t getDwarfRegNumForVirtReg(Register RegNum, bool isEH) const override;
 };
 
-StringRef getNVPTXRegClassName(const TargetRegisterClass *RC);
 StringRef getNVPTXRegClassStr(const TargetRegisterClass *RC);
 
 } // end namespace llvm

--- a/llvm/lib/Target/NVPTX/NVPTXUtilities.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXUtilities.cpp
@@ -12,7 +12,6 @@
 
 #include "NVPTXUtilities.h"
 #include "NVPTX.h"
-#include "NVPTXTargetMachine.h"
 #include "NVVMProperties.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/DataLayout.h"
@@ -102,23 +101,4 @@ Align llvm::getPTXParamAlign(const CallBase *CB, Type *Ty, unsigned Idx,
     DirectCallee = getMaybeBitcastedCallee(CB);
 
   return getPTXParamAlign(DirectCallee, Ty, Idx, DL);
-}
-
-bool llvm::shouldEmitPTXNoReturn(const Value *V, const TargetMachine &TM) {
-  const auto &ST =
-      *static_cast<const NVPTXTargetMachine &>(TM).getSubtargetImpl();
-  if (!ST.hasNoReturn())
-    return false;
-
-  assert((isa<Function>(V) || isa<CallInst>(V)) &&
-         "Expect either a call instruction or a function");
-
-  if (const CallInst *CallI = dyn_cast<CallInst>(V))
-    return CallI->doesNotReturn() &&
-           CallI->getFunctionType()->getReturnType()->isVoidTy();
-
-  const Function *F = cast<Function>(V);
-  return F->doesNotReturn() &&
-         F->getFunctionType()->getReturnType()->isVoidTy() &&
-         !isKernelFunction(*F);
 }

--- a/llvm/lib/Target/NVPTX/NVPTXUtilities.h
+++ b/llvm/lib/Target/NVPTX/NVPTXUtilities.h
@@ -28,7 +28,6 @@
 namespace llvm {
 
 class DataLayout;
-class TargetMachine;
 
 Function *getMaybeBitcastedCallee(const CallBase *CB);
 
@@ -64,8 +63,6 @@ inline unsigned promoteScalarArgumentSize(unsigned size) {
     return 128;
   return size;
 }
-
-bool shouldEmitPTXNoReturn(const Value *V, const TargetMachine &TM);
 
 inline bool shouldPassAsArray(Type *Ty) {
   return Ty->isAggregateType() || Ty->isVectorTy() ||

--- a/llvm/test/CodeGen/NVPTX/alias.ll
+++ b/llvm/test/CodeGen/NVPTX/alias.ll
@@ -19,6 +19,10 @@ define i32 @z() {
   ret i32 %val
 }
 
+; An unnamed aliasee must be referenced by its mangled symbol name.
+define internal i32 @0() { ret i32 0 }
+@unnamed_aliasee = internal alias i32 (), ptr @0
+
 
 attributes #0 = { noreturn }
 
@@ -64,3 +68,4 @@ attributes #0 = { noreturn }
 ; CHECK: .alias d, a;
 ; CHECK: .alias bar, foo;
 ; CHECK: .alias noreturn_alias, noreturn;
+; CHECK: .alias unnamed_aliasee, __unnamed_1;

--- a/llvm/test/CodeGen/NVPTX/arbitrary-fp-to-float.ll
+++ b/llvm/test/CodeGen/NVPTX/arbitrary-fp-to-float.ll
@@ -26,7 +26,6 @@ define float @from_f8e5m2_normal() {
 ; CHECK-LABEL: from_f8e5m2_normal(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1065353216;
 ; CHECK-NEXT:    ret;
@@ -38,7 +37,6 @@ define float @from_f8e5m2_normal() {
 define float @from_f8e5m2_zero() {
 ; CHECK-LABEL: from_f8e5m2_zero(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
@@ -52,7 +50,6 @@ define float @from_f8e5m2_neg_zero() {
 ; CHECK-LABEL: from_f8e5m2_neg_zero(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], -2147483648;
 ; CHECK-NEXT:    ret;
@@ -64,7 +61,6 @@ define float @from_f8e5m2_neg_zero() {
 define float @from_f8e5m2_denorm() {
 ; CHECK-LABEL: from_f8e5m2_denorm(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 931135488;
@@ -78,7 +74,6 @@ define float @from_f8e5m2_inf() {
 ; CHECK-LABEL: from_f8e5m2_inf(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 2139095040;
 ; CHECK-NEXT:    ret;
@@ -90,7 +85,6 @@ define float @from_f8e5m2_inf() {
 define float @from_f8e5m2_nan() {
 ; CHECK-LABEL: from_f8e5m2_nan(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 2143289344;
@@ -104,7 +98,6 @@ define float @from_f8e5m2_max() {
 ; CHECK-LABEL: from_f8e5m2_max(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1197473792;
 ; CHECK-NEXT:    ret;
@@ -116,7 +109,6 @@ define float @from_f8e5m2_max() {
 define float @from_f8e5m2_neg() {
 ; CHECK-LABEL: from_f8e5m2_neg(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], -1082130432;
@@ -183,7 +175,6 @@ define float @from_f8e4m3fn_normal() {
 ; CHECK-LABEL: from_f8e4m3fn_normal(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1065353216;
 ; CHECK-NEXT:    ret;
@@ -195,7 +186,6 @@ define float @from_f8e4m3fn_normal() {
 define float @from_f8e4m3fn_nan() {
 ; CHECK-LABEL: from_f8e4m3fn_nan(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 2143289344;
@@ -210,7 +200,6 @@ define float @from_f8e4m3fn_max() {
 ; CHECK-LABEL: from_f8e4m3fn_max(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1138753536;
 ; CHECK-NEXT:    ret;
@@ -224,7 +213,6 @@ define float @from_f8e4m3fn_not_nan() {
 ; CHECK-LABEL: from_f8e4m3fn_not_nan(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1137704960;
 ; CHECK-NEXT:    ret;
@@ -237,7 +225,6 @@ define float @from_f8e4m3fn_zero() {
 ; CHECK-LABEL: from_f8e4m3fn_zero(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -249,7 +236,6 @@ define float @from_f8e4m3fn_zero() {
 define float @from_f8e4m3fn_denorm() {
 ; CHECK-LABEL: from_f8e4m3fn_denorm(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 989855744;
@@ -313,7 +299,6 @@ define float @from_f6e3m2fn_normal() {
 ; CHECK-LABEL: from_f6e3m2fn_normal(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1065353216;
 ; CHECK-NEXT:    ret;
@@ -325,7 +310,6 @@ define float @from_f6e3m2fn_normal() {
 define float @from_f6e3m2fn_max() {
 ; CHECK-LABEL: from_f6e3m2fn_max(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1105199104;
@@ -339,7 +323,6 @@ define float @from_f6e3m2fn_denorm() {
 ; CHECK-LABEL: from_f6e3m2fn_denorm(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1031798784;
 ; CHECK-NEXT:    ret;
@@ -352,7 +335,6 @@ define float @from_f6e3m2fn_zero() {
 ; CHECK-LABEL: from_f6e3m2fn_zero(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -364,7 +346,6 @@ define float @from_f6e3m2fn_zero() {
 define float @from_f6e3m2fn_neg() {
 ; CHECK-LABEL: from_f6e3m2fn_neg(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], -1082130432;
@@ -429,7 +410,6 @@ define float @from_f6e2m3fn_normal() {
 ; CHECK-LABEL: from_f6e2m3fn_normal(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1065353216;
 ; CHECK-NEXT:    ret;
@@ -441,7 +421,6 @@ define float @from_f6e2m3fn_normal() {
 define float @from_f6e2m3fn_max() {
 ; CHECK-LABEL: from_f6e2m3fn_max(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1089470464;
@@ -455,7 +434,6 @@ define float @from_f6e2m3fn_denorm() {
 ; CHECK-LABEL: from_f6e2m3fn_denorm(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1040187392;
 ; CHECK-NEXT:    ret;
@@ -467,7 +445,6 @@ define float @from_f6e2m3fn_denorm() {
 define float @from_f6e2m3fn_zero() {
 ; CHECK-LABEL: from_f6e2m3fn_zero(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
@@ -532,7 +509,6 @@ define float @from_f4e2m1fn_normal() {
 ; CHECK-LABEL: from_f4e2m1fn_normal(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1065353216;
 ; CHECK-NEXT:    ret;
@@ -545,7 +521,6 @@ define float @from_f4e2m1fn_denorm() {
 ; CHECK-LABEL: from_f4e2m1fn_denorm(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1056964608;
 ; CHECK-NEXT:    ret;
@@ -557,7 +532,6 @@ define float @from_f4e2m1fn_denorm() {
 define float @from_f4e2m1fn_max() {
 ; CHECK-LABEL: from_f4e2m1fn_max(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1086324736;
@@ -619,7 +593,6 @@ define half @from_f8e5m2_to_f16() {
 ; CHECK-LABEL: from_f8e5m2_to_f16(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b16 [func_retval0], 0x3C00;
 ; CHECK-NEXT:    ret;
@@ -631,7 +604,6 @@ define half @from_f8e5m2_to_f16() {
 define double @from_f8e5m2_to_f64() {
 ; CHECK-LABEL: from_f8e5m2_to_f64(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b64 [func_retval0], 4607182418800017408;

--- a/llvm/test/CodeGen/NVPTX/bf16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16x2-instructions.ll
@@ -10,7 +10,6 @@ define <2 x bfloat> @test_ret_const() #0 {
 ; CHECK-LABEL: test_ret_const(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1073758080;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/blocksareclusters-kernel-attr.ll
+++ b/llvm/test/CodeGen/NVPTX/blocksareclusters-kernel-attr.ll
@@ -12,7 +12,6 @@ define ptx_kernel void @kernel1(ptr %input, ptr %output) #0 #1 #2 {
 ; CHECK-NEXT:  .blocksareclusters
 ; CHECK-NEXT:  {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
   ret void
@@ -27,7 +26,6 @@ define ptx_kernel void @kernel2(ptr %input, ptr %output) #0 #3 #4 {
 ; CHECK-NEXT:  .blocksareclusters // @kernel2
 ; CHECK-NEXT:  {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
   ret void
@@ -41,7 +39,6 @@ define ptx_kernel void @kernel3(ptr %input, ptr %output) #0 #5 #6 {
 ; CHECK-NEXT:  .reqnctapercluster 2, 2
 ; CHECK-NEXT:  .blocksareclusters // @kernel3
 ; CHECK-NEXT:  {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/cluster-dim.ll
+++ b/llvm/test/CodeGen/NVPTX/cluster-dim.ll
@@ -7,7 +7,6 @@ define ptx_kernel void @kernel_func_clusterxyz() "nvvm.cluster_dim"="3,5,7" {
 ; CHECK80-LABEL: kernel_func_clusterxyz(
 ; CHECK80:       {
 ; CHECK80-EMPTY:
-; CHECK80-EMPTY:
 ; CHECK80-NEXT:  // %bb.0:
 ; CHECK80-NEXT:    ret;
 ;
@@ -15,7 +14,6 @@ define ptx_kernel void @kernel_func_clusterxyz() "nvvm.cluster_dim"="3,5,7" {
 ; CHECK90:       .explicitcluster
 ; CHECK90-NEXT:  .reqnctapercluster 3, 5, 7
 ; CHECK90-NEXT:  {
-; CHECK90-EMPTY:
 ; CHECK90-EMPTY:
 ; CHECK90-NEXT:  // %bb.0:
 ; CHECK90-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/compute-ptx-value-vts.ll
+++ b/llvm/test/CodeGen/NVPTX/compute-ptx-value-vts.ll
@@ -7,7 +7,6 @@ define <6 x half> @half6() {
 ; CHECK-LABEL: half6(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0+8], 0;
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {0, 0};
@@ -18,7 +17,6 @@ define <6 x half> @half6() {
 define <10 x half> @half10() {
 ; CHECK-LABEL: half10(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0+16], 0;
@@ -32,7 +30,6 @@ define <12 x i8> @byte12() {
 ; CHECK-LABEL: byte12(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0+8], 0;
 ; CHECK-NEXT:    st.param.b64 [func_retval0], 0;
@@ -43,7 +40,6 @@ define <12 x i8> @byte12() {
 define <20 x i8> @byte20() {
 ; CHECK-LABEL: byte20(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0+16], 0;

--- a/llvm/test/CodeGen/NVPTX/empty-type.ll
+++ b/llvm/test/CodeGen/NVPTX/empty-type.ll
@@ -15,7 +15,6 @@ define %empty @ret_empty(i32 %n) {
 ; CHECK-LABEL: ret_empty(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
   ret %empty zeroinitializer
@@ -25,7 +24,6 @@ define %empty @ret_empty(i32 %n) {
 define void @only_empty(%empty %z) {
 ; CHECK-LABEL: only_empty(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
@@ -98,7 +96,6 @@ define ptx_kernel void @kernel(%empty %z, ptr %p, i32 %n) {
 define void @caller() {
 ; CHECK-LABEL: caller(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0: // %entry
 ; CHECK-NEXT:    { // callseq 0, 0

--- a/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
@@ -35,7 +35,6 @@ define <2 x half> @test_ret_const() #0 {
 ; CHECK-LABEL: test_ret_const(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1073757184;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/f32x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f32x2-instructions.ll
@@ -20,7 +20,6 @@ define <2 x float> @test_ret_const() #0 {
 ; CHECK-LABEL: test_ret_const(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {0f3F800000, 0f40000000};
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/fence-proxy-sm90-ptx86.ll
+++ b/llvm/test/CodeGen/NVPTX/fence-proxy-sm90-ptx86.ll
@@ -6,7 +6,6 @@ define void @test_nvvm_fence_proxy_async_generic_acquire_sync_restrict() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_async_generic_acquire_sync_restrict(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.async::generic.acquire.sync_restrict::shared::cluster.cluster;
 ; CHECK-NEXT:    ret;
@@ -17,7 +16,6 @@ define void @test_nvvm_fence_proxy_async_generic_acquire_sync_restrict() {
 define void @test_nvvm_fence_proxy_async_generic_release_sync_restrict() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_async_generic_release_sync_restrict(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster;

--- a/llvm/test/CodeGen/NVPTX/fence-proxy-sm90.ll
+++ b/llvm/test/CodeGen/NVPTX/fence-proxy-sm90.ll
@@ -6,7 +6,6 @@ define void @test_nvvm_fence_proxy_async() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_async(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.async;
 ; CHECK-NEXT:    ret;
@@ -17,7 +16,6 @@ define void @test_nvvm_fence_proxy_async() {
 define void @test_nvvm_fence_proxy_async_global() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_async_global(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.async.global;
@@ -30,7 +28,6 @@ define void @test_nvvm_fence_proxy_async_shared_cluster() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_async_shared_cluster(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.async.shared::cluster;
 ; CHECK-NEXT:    ret;
@@ -41,7 +38,6 @@ define void @test_nvvm_fence_proxy_async_shared_cluster() {
 define void @test_nvvm_fence_proxy_async_shared_cta() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_async_shared_cta(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.async.shared::cta;

--- a/llvm/test/CodeGen/NVPTX/fence-proxy.ll
+++ b/llvm/test/CodeGen/NVPTX/fence-proxy.ll
@@ -6,7 +6,6 @@ define void @test_nvvm_fence_proxy_alias() {
 ; CHECK-LABEL: test_nvvm_fence_proxy_alias(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.proxy.alias;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/fence.ll
+++ b/llvm/test/CodeGen/NVPTX/fence.ll
@@ -11,20 +11,17 @@ define void @fence_acquire_thread() {
 ; SM30-LABEL: fence_acquire_thread(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    ret;
 ;
 ; SM70-LABEL: fence_acquire_thread(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acquire_thread(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    ret;
@@ -37,7 +34,6 @@ define void @fence_acquire_sys() {
 ; SM30-LABEL: fence_acquire_sys(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.sys;
 ; SM30-NEXT:    ret;
@@ -45,14 +41,12 @@ define void @fence_acquire_sys() {
 ; SM70-LABEL: fence_acquire_sys(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.sys;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acquire_sys(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acquire.sys;
@@ -66,7 +60,6 @@ define void @fence_acquire_cta() {
 ; SM30-LABEL: fence_acquire_cta(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -74,14 +67,12 @@ define void @fence_acquire_cta() {
 ; SM70-LABEL: fence_acquire_cta(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acquire_cta(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acquire.cta;
@@ -95,7 +86,6 @@ define void @fence_acquire_cluster() {
 ; SM30-LABEL: fence_acquire_cluster(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -103,14 +93,12 @@ define void @fence_acquire_cluster() {
 ; SM70-LABEL: fence_acquire_cluster(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acquire_cluster(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acquire.cluster;
@@ -124,7 +112,6 @@ define void @fence_acquire_gpu() {
 ; SM30-LABEL: fence_acquire_gpu(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.gl;
 ; SM30-NEXT:    ret;
@@ -132,14 +119,12 @@ define void @fence_acquire_gpu() {
 ; SM70-LABEL: fence_acquire_gpu(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.gpu;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acquire_gpu(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acquire.gpu;
@@ -153,20 +138,17 @@ define void @fence_release_thread() {
 ; SM30-LABEL: fence_release_thread(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    ret;
 ;
 ; SM70-LABEL: fence_release_thread(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_release_thread(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    ret;
@@ -179,7 +161,6 @@ define void @fence_release_sys() {
 ; SM30-LABEL: fence_release_sys(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.sys;
 ; SM30-NEXT:    ret;
@@ -187,14 +168,12 @@ define void @fence_release_sys() {
 ; SM70-LABEL: fence_release_sys(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.sys;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_release_sys(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.release.sys;
@@ -208,7 +187,6 @@ define void @fence_release_cta() {
 ; SM30-LABEL: fence_release_cta(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -216,14 +194,12 @@ define void @fence_release_cta() {
 ; SM70-LABEL: fence_release_cta(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_release_cta(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.release.cta;
@@ -237,7 +213,6 @@ define void @fence_release_cluster() {
 ; SM30-LABEL: fence_release_cluster(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -245,14 +220,12 @@ define void @fence_release_cluster() {
 ; SM70-LABEL: fence_release_cluster(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_release_cluster(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.release.cluster;
@@ -266,7 +239,6 @@ define void @fence_release_gpu() {
 ; SM30-LABEL: fence_release_gpu(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.gl;
 ; SM30-NEXT:    ret;
@@ -274,14 +246,12 @@ define void @fence_release_gpu() {
 ; SM70-LABEL: fence_release_gpu(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.gpu;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_release_gpu(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.release.gpu;
@@ -295,20 +265,17 @@ define void @fence_acq_rel_thread() {
 ; SM30-LABEL: fence_acq_rel_thread(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    ret;
 ;
 ; SM70-LABEL: fence_acq_rel_thread(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acq_rel_thread(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    ret;
@@ -321,7 +288,6 @@ define void @fence_acq_rel_sys() {
 ; SM30-LABEL: fence_acq_rel_sys(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.sys;
 ; SM30-NEXT:    ret;
@@ -329,14 +295,12 @@ define void @fence_acq_rel_sys() {
 ; SM70-LABEL: fence_acq_rel_sys(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.sys;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acq_rel_sys(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acq_rel.sys;
@@ -350,7 +314,6 @@ define void @fence_acq_rel_cta() {
 ; SM30-LABEL: fence_acq_rel_cta(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -358,14 +321,12 @@ define void @fence_acq_rel_cta() {
 ; SM70-LABEL: fence_acq_rel_cta(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acq_rel_cta(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acq_rel.cta;
@@ -379,7 +340,6 @@ define void @fence_acq_rel_cluster() {
 ; SM30-LABEL: fence_acq_rel_cluster(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -387,14 +347,12 @@ define void @fence_acq_rel_cluster() {
 ; SM70-LABEL: fence_acq_rel_cluster(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acq_rel_cluster(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acq_rel.cluster;
@@ -408,7 +366,6 @@ define void @fence_acq_rel_gpu() {
 ; SM30-LABEL: fence_acq_rel_gpu(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.gl;
 ; SM30-NEXT:    ret;
@@ -416,14 +373,12 @@ define void @fence_acq_rel_gpu() {
 ; SM70-LABEL: fence_acq_rel_gpu(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.acq_rel.gpu;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_acq_rel_gpu(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.acq_rel.gpu;
@@ -437,20 +392,17 @@ define void @fence_seq_cst_thread() {
 ; SM30-LABEL: fence_seq_cst_thread(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    ret;
 ;
 ; SM70-LABEL: fence_seq_cst_thread(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_seq_cst_thread(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    ret;
@@ -463,7 +415,6 @@ define void @fence_seq_cst_sys() {
 ; SM30-LABEL: fence_seq_cst_sys(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.sys;
 ; SM30-NEXT:    ret;
@@ -471,14 +422,12 @@ define void @fence_seq_cst_sys() {
 ; SM70-LABEL: fence_seq_cst_sys(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.sc.sys;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_seq_cst_sys(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.sc.sys;
@@ -492,7 +441,6 @@ define void @fence_seq_cst_cta() {
 ; SM30-LABEL: fence_seq_cst_cta(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -500,14 +448,12 @@ define void @fence_seq_cst_cta() {
 ; SM70-LABEL: fence_seq_cst_cta(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.sc.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_seq_cst_cta(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.sc.cta;
@@ -521,7 +467,6 @@ define void @fence_seq_cst_cluster() {
 ; SM30-LABEL: fence_seq_cst_cluster(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.cta;
 ; SM30-NEXT:    ret;
@@ -529,14 +474,12 @@ define void @fence_seq_cst_cluster() {
 ; SM70-LABEL: fence_seq_cst_cluster(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.sc.cta;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_seq_cst_cluster(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.sc.cluster;
@@ -550,7 +493,6 @@ define void @fence_seq_cst_gpu() {
 ; SM30-LABEL: fence_seq_cst_gpu(
 ; SM30:       {
 ; SM30-EMPTY:
-; SM30-EMPTY:
 ; SM30-NEXT:  // %bb.0:
 ; SM30-NEXT:    membar.gl;
 ; SM30-NEXT:    ret;
@@ -558,14 +500,12 @@ define void @fence_seq_cst_gpu() {
 ; SM70-LABEL: fence_seq_cst_gpu(
 ; SM70:       {
 ; SM70-EMPTY:
-; SM70-EMPTY:
 ; SM70-NEXT:  // %bb.0:
 ; SM70-NEXT:    fence.sc.gpu;
 ; SM70-NEXT:    ret;
 ;
 ; SM90-LABEL: fence_seq_cst_gpu(
 ; SM90:       {
-; SM90-EMPTY:
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
 ; SM90-NEXT:    fence.sc.gpu;

--- a/llvm/test/CodeGen/NVPTX/fma.ll
+++ b/llvm/test/CodeGen/NVPTX/fma.ll
@@ -117,7 +117,6 @@ define ptx_device float @f32_iii(float %x) {
 ; CHECK-LABEL: f32_iii(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 1092616192;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/global-cycle-alias.ll
+++ b/llvm/test/CodeGen/NVPTX/global-cycle-alias.ll
@@ -34,7 +34,6 @@ define void @alias_target() {
 ; CHECK-LABEL: alias_target(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
   ret void

--- a/llvm/test/CodeGen/NVPTX/griddepcontrol.ll
+++ b/llvm/test/CodeGen/NVPTX/griddepcontrol.ll
@@ -6,7 +6,6 @@ define void @griddepcontrol() {
 ; CHECK-LABEL: griddepcontrol(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    griddepcontrol.launch_dependents;
 ; CHECK-NEXT:    griddepcontrol.wait;

--- a/llvm/test/CodeGen/NVPTX/i16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i16x2-instructions.ll
@@ -24,7 +24,6 @@ define <2 x i16> @test_ret_const() #0 {
 ; COMMON-LABEL: test_ret_const(
 ; COMMON:       {
 ; COMMON-EMPTY:
-; COMMON-EMPTY:
 ; COMMON-NEXT:  // %bb.0:
 ; COMMON-NEXT:    st.param.b32 [func_retval0], 131073;
 ; COMMON-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/i32x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i32x2-instructions.ll
@@ -19,7 +19,6 @@ define <2 x i32> @test_ret_const() #0 {
 ; CHECK-LABEL: test_ret_const(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {-1, 2};
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/i8x4-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i8x4-instructions.ll
@@ -20,7 +20,6 @@ define <4 x i8> @test_ret_const() #0 {
 ; CHECK-LABEL: test_ret_const(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], -66911489;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/intrinsics.ll
+++ b/llvm/test/CodeGen/NVPTX/intrinsics.ll
@@ -242,7 +242,6 @@ define void @test_exit() {
 ; CHECK-LABEL: test_exit(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    exit;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/jump-table.ll
+++ b/llvm/test/CodeGen/NVPTX/jump-table.ll
@@ -13,7 +13,8 @@ define void @foo(i32 %i) {
 ; PTX60:       {
 ; PTX60-NEXT:    .reg .pred %p<2>;
 ; PTX60-NEXT:    .reg .b32 %r<2>;
-; PTX60-NEXT:  $L_brx_0:
+; PTX60-EMPTY:
+; PTX60-NEXT:  JTI0_0:
 ; PTX60-NEXT:    .branchtargets
 ; PTX60-NEXT:     $L__BB0_2,
 ; PTX60-NEXT:     $L__BB0_3,
@@ -24,7 +25,7 @@ define void @foo(i32 %i) {
 ; PTX60-NEXT:    setp.gt.u32 %p1, %r1, 3;
 ; PTX60-NEXT:    @%p1 bra $L__BB0_6;
 ; PTX60-NEXT:  // %bb.1: // %entry
-; PTX60-NEXT:    brx.idx %r1, $L_brx_0;
+; PTX60-NEXT:    brx.idx %r1, JTI0_0;
 ; PTX60-NEXT:  $L__BB0_2: // %case0
 ; PTX60-NEXT:    st.global.b32 [out], 0;
 ; PTX60-NEXT:    bra.uni $L__BB0_6;
@@ -107,7 +108,8 @@ define i32 @test2(i32 %tmp158) {
 ; PTX60:       {
 ; PTX60-NEXT:    .reg .pred %p<6>;
 ; PTX60-NEXT:    .reg .b32 %r<3>;
-; PTX60-NEXT:  $L_brx_0:
+; PTX60-EMPTY:
+; PTX60-NEXT:  JTI1_0:
 ; PTX60-NEXT:    .branchtargets
 ; PTX60-NEXT:     $L__BB1_6,
 ; PTX60-NEXT:     $L__BB1_7,
@@ -131,7 +133,7 @@ define i32 @test2(i32 %tmp158) {
 ; PTX60-NEXT:    setp.gt.u32 %p2, %r2, 5;
 ; PTX60-NEXT:    @%p2 bra $L__BB1_5;
 ; PTX60-NEXT:  // %bb.12: // %entry
-; PTX60-NEXT:    brx.idx %r2, $L_brx_0;
+; PTX60-NEXT:    brx.idx %r2, JTI1_0;
 ; PTX60-NEXT:  $L__BB1_7: // %bb339
 ; PTX60-NEXT:    st.param.b32 [func_retval0], 12;
 ; PTX60-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/lower-byval-args.ll
+++ b/llvm/test/CodeGen/NVPTX/lower-byval-args.ll
@@ -551,7 +551,6 @@ define dso_local ptx_kernel void @copy_on_store(ptr nocapture noundef readonly %
 ; PTX-LABEL: copy_on_store(
 ; PTX:       {
 ; PTX-EMPTY:
-; PTX-EMPTY:
 ; PTX-NEXT:  // %bb.0: // %bb
 ; PTX-NEXT:    ret;
 bb:

--- a/llvm/test/CodeGen/NVPTX/masked-store-vectors-256.ll
+++ b/llvm/test/CodeGen/NVPTX/masked-store-vectors-256.ll
@@ -253,7 +253,6 @@ define void @global_8xi32_all_mask_off(ptr addrspace(1) %a, ptr addrspace(1) %b)
 ; CHECK-LABEL: global_8xi32_all_mask_off(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
   %a.load = load <8 x i32>, ptr addrspace(1) %a

--- a/llvm/test/CodeGen/NVPTX/naked-fn-with-frame-pointer.ll
+++ b/llvm/test/CodeGen/NVPTX/naked-fn-with-frame-pointer.ll
@@ -8,7 +8,6 @@ define dso_local void @naked() naked "frame-pointer"="all" {
 ; CHECK-32-LABEL: naked(
 ; CHECK-32:       {
 ; CHECK-32-EMPTY:
-; CHECK-32-EMPTY:
 ; CHECK-32-NEXT:  // %bb.0:
 ; CHECK-32-NEXT:    { // callseq 0, 0
 ; CHECK-32-NEXT:    call.uni main, ();
@@ -19,7 +18,6 @@ define dso_local void @naked() naked "frame-pointer"="all" {
 ;
 ; CHECK-64-LABEL: naked(
 ; CHECK-64:       {
-; CHECK-64-EMPTY:
 ; CHECK-64-EMPTY:
 ; CHECK-64-NEXT:  // %bb.0:
 ; CHECK-64-NEXT:    { // callseq 0, 0
@@ -36,7 +34,6 @@ define dso_local void @normal() "frame-pointer"="all" {
 ; CHECK-32-LABEL: normal(
 ; CHECK-32:       {
 ; CHECK-32-EMPTY:
-; CHECK-32-EMPTY:
 ; CHECK-32-NEXT:  // %bb.0:
 ; CHECK-32-NEXT:    { // callseq 1, 0
 ; CHECK-32-NEXT:    call.uni main, ();
@@ -47,7 +44,6 @@ define dso_local void @normal() "frame-pointer"="all" {
 ;
 ; CHECK-64-LABEL: normal(
 ; CHECK-64:       {
-; CHECK-64-EMPTY:
 ; CHECK-64-EMPTY:
 ; CHECK-64-NEXT:  // %bb.0:
 ; CHECK-64-NEXT:    { // callseq 1, 0

--- a/llvm/test/CodeGen/NVPTX/op-fence.ll
+++ b/llvm/test/CodeGen/NVPTX/op-fence.ll
@@ -7,7 +7,6 @@ define void @test_fence_mbarrier_init() {
 ; CHECK-LABEL: test_fence_mbarrier_init(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.mbarrier_init.release.cluster;
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/prmt-const-folding.ll
+++ b/llvm/test/CodeGen/NVPTX/prmt-const-folding.ll
@@ -10,7 +10,6 @@ define void @test_prmt_f4e() {
 ; CHECK-LABEL: test_prmt_f4e(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 50462976;
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 67305985;
@@ -34,7 +33,6 @@ define void @test_prmt_f4e() {
 define void @test_prmt_b4e() {
 ; CHECK-LABEL: test_prmt_b4e(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 84281088;
@@ -60,7 +58,6 @@ define void @test_prmt_ecl() {
 ; CHECK-LABEL: test_prmt_ecl(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 50462976;
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 50462977;
@@ -82,7 +79,6 @@ define void @test_prmt_ecr() {
 ; CHECK-LABEL: test_prmt_ecr(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 0;
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 16843008;
@@ -103,7 +99,6 @@ define void @test_prmt_ecr() {
 define void @test_prmt_rc8() {
 ; CHECK-LABEL: test_prmt_rc8(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 0;
@@ -129,7 +124,6 @@ define void @test_prmt_rc16() {
 ; CHECK-LABEL: test_prmt_rc16(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 16777472;
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 50463490;
@@ -148,7 +142,6 @@ define void @test_prmt_rc16() {
 define void @test_prmt_basic() {
 ; CHECK-LABEL: test_prmt_basic(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.volatile.global.b32 [g], 66051;

--- a/llvm/test/CodeGen/NVPTX/st-param-imm.ll
+++ b/llvm/test/CodeGen/NVPTX/st-param-imm.ll
@@ -22,7 +22,6 @@ define void @st_param_i8_i16() {
 ; CHECK-LABEL: st_param_i8_i16(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 0, 0
 ; CHECK-NEXT:    .param .align 2 .b8 param0[4];
@@ -39,7 +38,6 @@ define void @st_param_i32() {
 ; CHECK-LABEL: st_param_i32(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 1, 0
 ; CHECK-NEXT:    .param .b32 param0;
@@ -54,7 +52,6 @@ define void @st_param_i32() {
 define void @st_param_i64() {
 ; CHECK-LABEL: st_param_i64(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 2, 0
@@ -71,7 +68,6 @@ define void @st_param_f32() {
 ; CHECK-LABEL: st_param_f32(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 3, 0
 ; CHECK-NEXT:    .param .b32 param0;
@@ -86,7 +82,6 @@ define void @st_param_f32() {
 define void @st_param_f64() {
 ; CHECK-LABEL: st_param_f64(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 4, 0
@@ -108,7 +103,6 @@ declare void @call_f64(double)
 define void @st_param_v2_i8_ii() {
 ; CHECK-LABEL: st_param_v2_i8_ii(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 5, 0
@@ -161,7 +155,6 @@ define void @st_param_v2_i16_ii() {
 ; CHECK-LABEL: st_param_v2_i16_ii(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 8, 0
 ; CHECK-NEXT:    .param .align 4 .b8 param0[4];
@@ -212,7 +205,6 @@ define void @st_param_v2_i16_ri(i16 %val) {
 define void @st_param_v2_i32_ii() {
 ; CHECK-LABEL: st_param_v2_i32_ii(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 11, 0
@@ -265,7 +257,6 @@ define void @st_param_v2_i64_ii() {
 ; CHECK-LABEL: st_param_v2_i64_ii(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 14, 0
 ; CHECK-NEXT:    .param .align 16 .b8 param0[16];
@@ -317,7 +308,6 @@ define void @st_param_v2_f32_ii(float %val) {
 ; CHECK-LABEL: st_param_v2_f32_ii(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 17, 0
 ; CHECK-NEXT:    .param .align 8 .b8 param0[8];
@@ -368,7 +358,6 @@ define void @st_param_v2_f32_ri(float %val) {
 define void @st_param_v2_f64_ii(double %val) {
 ; CHECK-LABEL: st_param_v2_f64_ii(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 20, 0
@@ -427,7 +416,6 @@ declare void @call_v2_f64(%struct.double2 alignstack(16))
 define void @st_param_v4_i8_iiii() {
 ; CHECK-LABEL: st_param_v4_i8_iiii(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 23, 0
@@ -774,7 +762,6 @@ define void @st_param_v4_i16_iiii() {
 ; CHECK-LABEL: st_param_v4_i16_iiii(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 38, 0
 ; CHECK-NEXT:    .param .align 8 .b8 param0[8];
@@ -1100,7 +1087,6 @@ define void @st_param_v4_i32_iiii() {
 ; CHECK-LABEL: st_param_v4_i32_iiii(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 53, 0
 ; CHECK-NEXT:    .param .align 16 .b8 param0[16];
@@ -1409,7 +1395,6 @@ define void @st_param_v4_i32_riii(i32 %a) {
 define void @st_param_v4_f32_iiii() {
 ; CHECK-LABEL: st_param_v4_f32_iiii(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 68, 0
@@ -1724,7 +1709,6 @@ declare void @call_v4_f32(%struct.float4 alignstack(16))
 define void @st_param_bfloat() {
 ; CHECK-LABEL: st_param_bfloat(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 83, 0

--- a/llvm/test/CodeGen/NVPTX/store-undef.ll
+++ b/llvm/test/CodeGen/NVPTX/store-undef.ll
@@ -12,7 +12,6 @@ define void @test_store_param_undef() {
 ; CHECK-LABEL: test_store_param_undef(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    { // callseq 0, 0
 ; CHECK-NEXT:    .param .align 16 .b8 param0[32];
@@ -52,7 +51,6 @@ define void @test_store_param_def(i64 %param0, i32 %param1) {
 define void @test_store_undef(ptr %out) {
 ; CHECK-LABEL: test_store_undef(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/switch.ll
+++ b/llvm/test/CodeGen/NVPTX/switch.ll
@@ -8,7 +8,8 @@ define void @pr170051(i32 %cond) {
 ; CHECK:       {
 ; CHECK-NEXT:    .reg .pred %p<2>;
 ; CHECK-NEXT:    .reg .b32 %r<4>;
-; CHECK-NEXT:  $L_brx_0:
+; CHECK-EMPTY:
+; CHECK-NEXT:  JTI0_0:
 ; CHECK-NEXT:    .branchtargets
 ; CHECK-NEXT:     $L__BB0_2,
 ; CHECK-NEXT:     $L__BB0_3,
@@ -34,7 +35,7 @@ define void @pr170051(i32 %cond) {
 ; CHECK-NEXT:  // %bb.4: // %BS_LABEL_1
 ; CHECK-NEXT:    // in Loop: Header=BB0_3 Depth=1
 ; CHECK-NEXT:    mov.b32 %r3, %r1;
-; CHECK-NEXT:    brx.idx %r1, $L_brx_0;
+; CHECK-NEXT:    brx.idx %r1, JTI0_0;
 ; CHECK-NEXT:  $L__BB0_5: // %unreachable
 ; CHECK-NEXT:    // begin inline asm
 ; CHECK-NEXT:    exit;

--- a/llvm/test/CodeGen/NVPTX/tcgen05-alloc.ll
+++ b/llvm/test/CodeGen/NVPTX/tcgen05-alloc.ll
@@ -176,14 +176,12 @@ define void @test_tcgen05_relinquish_alloc_permit_cg1() {
 ; CHECK_PTX64-LABEL: test_tcgen05_relinquish_alloc_permit_cg1(
 ; CHECK_PTX64:       {
 ; CHECK_PTX64-EMPTY:
-; CHECK_PTX64-EMPTY:
 ; CHECK_PTX64-NEXT:  // %bb.0:
 ; CHECK_PTX64-NEXT:    tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;
 ; CHECK_PTX64-NEXT:    ret;
 ;
 ; CHECK_PTX64_SHARED32-LABEL: test_tcgen05_relinquish_alloc_permit_cg1(
 ; CHECK_PTX64_SHARED32:       {
-; CHECK_PTX64_SHARED32-EMPTY:
 ; CHECK_PTX64_SHARED32-EMPTY:
 ; CHECK_PTX64_SHARED32-NEXT:  // %bb.0:
 ; CHECK_PTX64_SHARED32-NEXT:    tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;
@@ -196,14 +194,12 @@ define void @test_tcgen05_relinquish_alloc_permit_cg2() {
 ; CHECK_PTX64-LABEL: test_tcgen05_relinquish_alloc_permit_cg2(
 ; CHECK_PTX64:       {
 ; CHECK_PTX64-EMPTY:
-; CHECK_PTX64-EMPTY:
 ; CHECK_PTX64-NEXT:  // %bb.0:
 ; CHECK_PTX64-NEXT:    tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned;
 ; CHECK_PTX64-NEXT:    ret;
 ;
 ; CHECK_PTX64_SHARED32-LABEL: test_tcgen05_relinquish_alloc_permit_cg2(
 ; CHECK_PTX64_SHARED32:       {
-; CHECK_PTX64_SHARED32-EMPTY:
 ; CHECK_PTX64_SHARED32-EMPTY:
 ; CHECK_PTX64_SHARED32-NEXT:  // %bb.0:
 ; CHECK_PTX64_SHARED32-NEXT:    tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned;

--- a/llvm/test/CodeGen/NVPTX/tcgen05-fence.ll
+++ b/llvm/test/CodeGen/NVPTX/tcgen05-fence.ll
@@ -18,7 +18,6 @@ define void @test_tcgen05_fence() {
 ; CHECK-LABEL: test_tcgen05_fence(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    tcgen05.fence::before_thread_sync;
 ; CHECK-NEXT:    tcgen05.fence::after_thread_sync;
@@ -34,7 +33,6 @@ define void @test_tcgen05_fence() {
 define void @test_tcgen05_wait() {
 ; CHECK-LABEL: test_tcgen05_wait(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    tcgen05.wait::ld.sync.aligned;

--- a/llvm/test/CodeGen/NVPTX/thread-fence.ll
+++ b/llvm/test/CodeGen/NVPTX/thread-fence.ll
@@ -7,7 +7,6 @@ define void @test_fence_acquire() {
 ; CHECK-LABEL: test_fence_acquire(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.acquire.sync_restrict::shared::cluster.cluster;
 ; CHECK-NEXT:    ret;
@@ -20,7 +19,6 @@ define void @test_fence_acquire() {
 define void @test_fence_release() {
 ; CHECK-LABEL: test_fence_release(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    fence.release.sync_restrict::shared::cta.cluster;

--- a/llvm/test/CodeGen/NVPTX/unreachable.ll
+++ b/llvm/test/CodeGen/NVPTX/unreachable.ll
@@ -25,7 +25,6 @@ define ptx_kernel void @kernel_func() {
 ; NO-TRAP-UNREACHABLE-LABEL: kernel_func(
 ; NO-TRAP-UNREACHABLE:       {
 ; NO-TRAP-UNREACHABLE-EMPTY:
-; NO-TRAP-UNREACHABLE-EMPTY:
 ; NO-TRAP-UNREACHABLE-NEXT:  // %bb.0:
 ; NO-TRAP-UNREACHABLE-NEXT:    { // callseq 0, 0
 ; NO-TRAP-UNREACHABLE-NEXT:    call.uni throw, ();
@@ -36,7 +35,6 @@ define ptx_kernel void @kernel_func() {
 ;
 ; NO-TRAP-AFTER-NORETURN-LABEL: kernel_func(
 ; NO-TRAP-AFTER-NORETURN:       {
-; NO-TRAP-AFTER-NORETURN-EMPTY:
 ; NO-TRAP-AFTER-NORETURN-EMPTY:
 ; NO-TRAP-AFTER-NORETURN-NEXT:  // %bb.0:
 ; NO-TRAP-AFTER-NORETURN-NEXT:    { // callseq 0, 0
@@ -50,7 +48,6 @@ define ptx_kernel void @kernel_func() {
 ; TRAP-LABEL: kernel_func(
 ; TRAP:       {
 ; TRAP-EMPTY:
-; TRAP-EMPTY:
 ; TRAP-NEXT:  // %bb.0:
 ; TRAP-NEXT:    { // callseq 0, 0
 ; TRAP-NEXT:    call.uni throw, ();
@@ -59,7 +56,6 @@ define ptx_kernel void @kernel_func() {
 ;
 ; BUG-FIXED-LABEL: kernel_func(
 ; BUG-FIXED:       {
-; BUG-FIXED-EMPTY:
 ; BUG-FIXED-EMPTY:
 ; BUG-FIXED-NEXT:  // %bb.0:
 ; BUG-FIXED-NEXT:    { // callseq 0, 0
@@ -74,13 +70,11 @@ define void @kernel_func_2() {
 ; CHECK-LABEL: kernel_func_2(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    trap; exit;
 ;
 ; BUG-FIXED-LABEL: kernel_func_2(
 ; BUG-FIXED:       {
-; BUG-FIXED-EMPTY:
 ; BUG-FIXED-EMPTY:
 ; BUG-FIXED-NEXT:  // %bb.0:
 ; BUG-FIXED-NEXT:    trap;

--- a/llvm/test/CodeGen/NVPTX/vector-returns.ll
+++ b/llvm/test/CodeGen/NVPTX/vector-returns.ll
@@ -7,7 +7,6 @@ define <3 x i64> @long3() {
 ; CHECK-LABEL: long3(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b64 [func_retval0+16], 0;
 ; CHECK-NEXT:    st.param.v2.b64 [func_retval0], {0, 0};
@@ -19,7 +18,6 @@ define <2 x i64> @long2() {
 ; CHECK-LABEL: long2(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b64 [func_retval0], {0, 0};
 ; CHECK-NEXT:    ret;
@@ -30,7 +28,6 @@ define <1 x i64> @long1() {
 ; CHECK-LABEL: long1(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b64 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -40,7 +37,6 @@ define <1 x i64> @long1() {
 define <5 x i32> @int5() {
 ; CHECK-LABEL: int5(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0+16], 0;
@@ -53,7 +49,6 @@ define <4 x i32> @int4() {
 ; CHECK-LABEL: int4(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v4.b32 [func_retval0], {0, 0, 0, 0};
 ; CHECK-NEXT:    ret;
@@ -63,7 +58,6 @@ define <4 x i32> @int4() {
 define <3 x i32> @int3() {
 ; CHECK-LABEL: int3(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0+8], 0;
@@ -76,7 +70,6 @@ define <2 x i32> @int2() {
 ; CHECK-LABEL: int2(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {0, 0};
 ; CHECK-NEXT:    ret;
@@ -87,7 +80,6 @@ define <1 x i32> @int1() {
 ; CHECK-LABEL: int1(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -97,7 +89,6 @@ define <1 x i32> @int1() {
 define <9 x i16> @short9() {
 ; CHECK-LABEL: short9(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b16 [func_retval0+16], 0;
@@ -111,7 +102,6 @@ define <8 x i16> @short8() {
 ; CHECK-LABEL: short8(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v4.b32 [func_retval0], {0, 0, 0, 0};
 ; CHECK-NEXT:    ret;
@@ -121,7 +111,6 @@ define <8 x i16> @short8() {
 define <7 x i16> @short7() {
 ; CHECK-LABEL: short7(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b16 [func_retval0+12], 0;
@@ -135,7 +124,6 @@ define <5 x i16> @short5() {
 ; CHECK-LABEL: short5(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b16 [func_retval0+8], 0;
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {0, 0};
@@ -147,7 +135,6 @@ define <4 x i16> @short4() {
 ; CHECK-LABEL: short4(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {0, 0};
 ; CHECK-NEXT:    ret;
@@ -157,7 +144,6 @@ define <4 x i16> @short4() {
 define <3 x i16> @short3() {
 ; CHECK-LABEL: short3(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b16 [func_retval0+4], 0;
@@ -170,7 +156,6 @@ define <2 x i16> @short2() {
 ; CHECK-LABEL: short2(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -181,7 +166,6 @@ define <1 x i16> @short1() {
 ; CHECK-LABEL: short1(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b16 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -191,7 +175,6 @@ define <1 x i16> @short1() {
 define <17 x i8> @byte17() {
 ; CHECK-LABEL: byte17(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+16], 0;
@@ -205,7 +188,6 @@ define <16 x i8> @byte16() {
 ; CHECK-LABEL: byte16(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v4.b32 [func_retval0], {0, 0, 0, 0};
 ; CHECK-NEXT:    ret;
@@ -215,7 +197,6 @@ define <16 x i8> @byte16() {
 define <15 x i8> @byte15() {
 ; CHECK-LABEL: byte15(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+14], 0;
@@ -230,7 +211,6 @@ define <9 x i8> @byte9() {
 ; CHECK-LABEL: byte9(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+8], 0;
 ; CHECK-NEXT:    st.param.b64 [func_retval0], 0;
@@ -242,7 +222,6 @@ define <8 x i8> @byte8() {
 ; CHECK-LABEL: byte8(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {0, 0};
 ; CHECK-NEXT:    ret;
@@ -252,7 +231,6 @@ define <8 x i8> @byte8() {
 define <7 x i8> @byte7() {
 ; CHECK-LABEL: byte7(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+6], 0;
@@ -266,7 +244,6 @@ define <5 x i8> @byte5() {
 ; CHECK-LABEL: byte5(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+4], 0;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
@@ -278,7 +255,6 @@ define <4 x i8> @byte4() {
 ; CHECK-LABEL: byte4(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -288,7 +264,6 @@ define <4 x i8> @byte4() {
 define <3 x i8> @byte3() {
 ; CHECK-LABEL: byte3(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b32 [func_retval0], 0;
@@ -300,7 +275,6 @@ define <2 x i8> @byte2() {
 ; CHECK-LABEL: byte2(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b8 [func_retval0], {0, 0};
 ; CHECK-NEXT:    ret;
@@ -311,7 +285,6 @@ define <1 x i8> @byte1() {
 ; CHECK-LABEL: byte1(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0], 0;
 ; CHECK-NEXT:    ret;
@@ -321,7 +294,6 @@ define <1 x i8> @byte1() {
 define <17 x i1> @bit17() {
 ; CHECK-LABEL: bit17(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+16], 0;
@@ -336,7 +308,6 @@ define <17 x i1> @bit17() {
 define <16 x i1> @bit16() {
 ; CHECK-LABEL: bit16(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.v2.b8 [func_retval0+14], {0, 0};
@@ -355,7 +326,6 @@ define <15 x i1> @bit15() {
 ; CHECK-LABEL: bit15(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+14], 0;
 ; CHECK-NEXT:    st.param.v2.b8 [func_retval0+12], {0, 0};
@@ -373,7 +343,6 @@ define <9 x i1> @bit9() {
 ; CHECK-LABEL: bit9(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+8], 0;
 ; CHECK-NEXT:    st.param.v2.b8 [func_retval0+6], {0, 0};
@@ -387,7 +356,6 @@ define <9 x i1> @bit9() {
 define <8 x i1> @bit8() {
 ; CHECK-LABEL: bit8(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+7], 0;
@@ -406,7 +374,6 @@ define <7 x i1> @bit7() {
 ; CHECK-LABEL: bit7(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+6], 0;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+5], 0;
@@ -423,7 +390,6 @@ define <5 x i1> @bit5() {
 ; CHECK-LABEL: bit5(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+4], 0;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+3], 0;
@@ -438,7 +404,6 @@ define <4 x i1> @bit4() {
 ; CHECK-LABEL: bit4(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+3], 0;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+2], 0;
@@ -452,7 +417,6 @@ define <3 x i1> @bit3() {
 ; CHECK-LABEL: bit3(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+2], 0;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+1], 0;
@@ -465,7 +429,6 @@ define <2 x i1> @bit2() {
 ; CHECK-LABEL: bit2(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0+1], 0;
 ; CHECK-NEXT:    st.param.b8 [func_retval0], 0;
@@ -476,7 +439,6 @@ define <2 x i1> @bit2() {
 define <1 x i1> @bit1() {
 ; CHECK-LABEL: bit1(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    st.param.b8 [func_retval0], 0;

--- a/llvm/test/CodeGen/NVPTX/wgmma-sm90a-fence.ll
+++ b/llvm/test/CodeGen/NVPTX/wgmma-sm90a-fence.ll
@@ -10,7 +10,6 @@ define void @test_wgmma_fence_sync_aligned() {
 ; CHECK-LABEL: test_wgmma_fence_sync_aligned(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    wgmma.fence.sync.aligned;
 ; CHECK-NEXT:    ret;
@@ -24,7 +23,6 @@ define void @test_wgmma_commit_group_sync_aligned() {
 ; CHECK-LABEL: test_wgmma_commit_group_sync_aligned(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    wgmma.commit_group.sync.aligned;
 ; CHECK-NEXT:    ret;
@@ -37,7 +35,6 @@ declare void @llvm.nvvm.wgmma.wait_group.sync.aligned(i64)
 define void @test_wgmma_wait_group_sync_aligned() {
 ; CHECK-LABEL: test_wgmma_wait_group_sync_aligned(
 ; CHECK:       {
-; CHECK-EMPTY:
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    wgmma.wait_group.sync.aligned 10;

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/nvptx-basic.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/nvptx-basic.ll.expected
@@ -74,7 +74,6 @@ define void @call_void() {
 ; CHECK-LABEL: call_void(
 ; CHECK:       {
 ; CHECK-EMPTY:
-; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ret;
   ret void


### PR DESCRIPTION
Move `.branchtargets`, `.reg`, `.local`, `.alias`, `.pragma`, and the empty `.debug_macinfo` section out of hand-built strings in `NVPTXAsmPrinter` and into `NVPTXTargetStreamer` hooks.  Opportunistically pulled at a few other threads that could use cleanup as well. 

Three behavior changes: 
1. Jump table labels now come from `MachineFunction::getJTISymbol`, so `$L_brx_<idx>` becomes `JTI<func>_<idx>` and is no longer shared across functions
2. `.alias` names its aliasee by mangled symbol rather than raw IR name, fixing `.alias a, ;` for an unnamed aliasee. 
3. The rest of the test diff is a duplicated blank line that functions with no register declarations no longer emit.

Co-Authored by Opus 5
