### PR TITLE
[LAA][NFC] Factor out MemoryDepChecker::isStoreLoadForwardingConflict

### DIFF
--- a/llvm/include/llvm/Analysis/LoopAccessAnalysis.h
+++ b/llvm/include/llvm/Analysis/LoopAccessAnalysis.h
@@ -235,6 +235,37 @@ public:
            std::numeric_limits<uint64_t>::max();
   }
 
+  /// Returns true if a memory dependence at byte distance \p Distance between
+  /// a store (with element size \p TypeByteSize bytes) widened to
+  /// \p VectorStoreSize bytes and a subsequent load of \p LoadElementSize bytes
+  /// would prevent store-to-load forwarding.
+  ///
+  /// The conflicting store must still be likely to be in the store buffer, i.e.
+  /// \c Distance / VectorStoreSize is below 8 * TypeByteSize iterations. Given
+  /// that, the load overruns from the widened store it starts in into the next
+  /// one when either:
+  ///   (a) it starts misaligned, \c R = \c Distance % VectorStoreSize bytes
+  ///       below a widened-store boundary, and is wider than those \c R bytes
+  ///       (\p LoadElementSize > \c R), or
+  ///   (b) it starts aligned (\c R == 0) but is itself wider than the widened
+  ///       store window (\p LoadElementSize > \p VectorStoreSize).
+  /// A \p LoadElementSize of 0 (the default) leaves the load width unknown and
+  /// disables both terms. Passing \p VectorStoreSize makes (a) reduce to "any
+  /// misalignment conflicts" and (b) never fire, matching the original,
+  /// width-agnostic predicate.
+  static bool isStoreLoadForwardingConflict(uint64_t Distance,
+                                            uint64_t VectorStoreSize,
+                                            uint64_t TypeByteSize,
+                                            uint64_t LoadElementSize = 0) {
+    assert(VectorStoreSize != 0 && "Expected non-zero vector store size");
+    const uint64_t NumItersForStoreLoadThroughMemory = 8 * TypeByteSize;
+    if (Distance / VectorStoreSize >= NumItersForStoreLoadThroughMemory)
+      return false;
+    if (uint64_t R = Distance % VectorStoreSize)
+      return LoadElementSize > R;
+    return LoadElementSize > VectorStoreSize;
+  }
+
   /// Return safe power-of-2 number of elements, which do not prevent store-load
   /// forwarding, multiplied by the size of the elements in bits.
   uint64_t getStoreLoadForwardSafeDistanceInBits() const {

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1934,20 +1934,16 @@ bool MemoryDepChecker::couldPreventStoreLoadForward(uint64_t Distance,
   //   place. Vectorizing in such cases does not make sense.
   // Store-load forwarding distance.
 
-  // After this many iterations store-to-load forwarding conflicts should not
-  // cause any slowdowns.
-  const uint64_t NumItersForStoreLoadThroughMemory = 8 * TypeByteSize;
   // Maximum vector factor.
   uint64_t MaxVFWithoutSLForwardIssuesPowerOf2 =
       std::min(VectorizerParams::MaxVectorWidth * TypeByteSize,
                MaxStoreLoadForwardSafeDistanceInBits);
 
-  // Compute the smallest VF at which the store and load would be misaligned.
+  // Compute the smallest VF at which the store and load would be misaligned
+  // and recent enough to still be in the store buffer.
   for (uint64_t VF = 2 * TypeByteSize;
        VF <= MaxVFWithoutSLForwardIssuesPowerOf2; VF *= 2) {
-    // If the number of vector iteration between the store and the load are
-    // small we could incur conflicts.
-    if (Distance % VF && Distance / VF < NumItersForStoreLoadThroughMemory) {
+    if (isStoreLoadForwardingConflict(Distance, VF, TypeByteSize, VF)) {
       MaxVFWithoutSLForwardIssuesPowerOf2 = (VF >> 1);
       break;
     }


### PR DESCRIPTION
Extract the store-to-load forwarding conflict predicate used inside
MemoryDepChecker::couldPreventStoreLoadForward into a static helper so it
can be shared with other consumers (e.g. the SLP vectorizer's STLF cost
model).

The helper takes an optional LoadElementSize so callers that know the load
width can ask whether the load actually straddles two widened stores:
  (a) a misaligned load that starts R = Distance % VectorStoreSize bytes
      below a widened-store boundary overruns into the next store only if it
      is wider than those R bytes (LoadElementSize > R), and
  (b) an aligned load (R == 0) overruns only if it is itself wider than the
      widened store window (LoadElementSize > VectorStoreSize).
LoadElementSize defaults to 0 (unknown width, both terms disabled).
couldPreventStoreLoadForward passes VF as the load width, so (a) reduces to
"any misalignment conflicts" and (b) never fires -- identical to the
previous width-agnostic predicate. No functional change.

The helper asserts VectorStoreSize is non-zero rather than guarding against
it in the return expression: all callers pass a non-zero value (the loop
here starts VF at 2 * TypeByteSize), and a zero divisor would be UB.