### PR TITLE
[IR] Remove deprecated BranchInst

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -1850,16 +1850,15 @@ val fold_successors : (llbasicblock -> 'a -> 'a) -> llvalue -> 'a -> 'a
 
 (** {7 Operations on branches} *)
 
-(** [is_conditional v] returns true if the branch instruction [v] is conditional.
-    See the method [llvm::BranchInst::isConditional]. *)
+(** [is_conditional v] returns true if the branch instruction [v] is conditional. *)
 val is_conditional : llvalue -> bool
 
 (** [condition v] return the condition of the branch instruction [v].
-    See the method [llvm::BranchInst::getCondition]. *)
+    See the method [llvm::CondBrInst::getCondition]. *)
 val condition : llvalue -> llvalue
 
 (** [set_condition v c] sets the condition of the branch instruction [v] to the value [c].
-    See the method [llvm::BranchInst::setCondition]. *)
+    See the method [llvm::CondBrInst::setCondition]. *)
 val set_condition : llvalue -> llvalue -> unit
 
 (** [get_branch c] returns a description of the branch instruction [c]. *)

--- a/llvm/include/llvm/IR/InstVisitor.h
+++ b/llvm/include/llvm/IR/InstVisitor.h
@@ -222,18 +222,11 @@ public:
     return static_cast<SubClass *>(this)->visitTerminator(I);
   }
   RetTy visitUncondBrInst(UncondBrInst &I) {
-    return static_cast<SubClass *>(this)->visitBranchInst(I);
-  }
-  RetTy visitCondBrInst(CondBrInst &I) {
-    return static_cast<SubClass *>(this)->visitBranchInst(I);
-  }
-  // Suppress warning for BranchInst. Replace with Instruction once BranchInst
-  // is removed.
-  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-  RetTy visitBranchInst(BranchInst &I) {
     return static_cast<SubClass *>(this)->visitTerminator(I);
   }
-  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
+  RetTy visitCondBrInst(CondBrInst &I) {
+    return static_cast<SubClass *>(this)->visitTerminator(I);
+  }
   RetTy visitSwitchInst(SwitchInst &I) {
     return static_cast<SubClass *>(this)->visitTerminator(I);
   }

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3126,76 +3126,13 @@ struct OperandTraits<ReturnInst> : public VariadicOperandTraits<ReturnInst> {};
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(ReturnInst, Value)
 
 //===----------------------------------------------------------------------===//
-//                               BranchInst Class
-//===----------------------------------------------------------------------===//
-
-//===---------------------------------------------------------------------------
-/// Conditional or Unconditional Branch instruction.
-///
-class LLVM_DEPRECATED("Use UncondBrInst/CondBrInst/Instruction instead", "")
-    BranchInst : public Instruction {
-protected:
-  BranchInst(Type *Ty, unsigned Opcode, AllocInfo AllocInfo,
-             InsertPosition InsertBefore = nullptr)
-      : Instruction(Ty, Opcode, AllocInfo, InsertBefore) {}
-
-public:
-  LLVM_DEPRECATED("Use UncondBrInst::Create instead", "UncondBrInst::Create")
-  static BranchInst *Create(BasicBlock *IfTrue,
-                            InsertPosition InsertBefore = nullptr);
-
-  LLVM_DEPRECATED("Use CondBrInst::Create instead", "CondBrInst::Create")
-  static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *IfFalse,
-                            Value *Cond, InsertPosition InsertBefore = nullptr);
-
-  /// Transparently provide more efficient getOperand methods.
-  DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
-
-  // Defined out-of-line below to access CondBrInst.
-  LLVM_DEPRECATED("Use isa<UncondBrInst> instead", "isa<UncondBrInst>")
-  bool isUnconditional() const;
-  LLVM_DEPRECATED("Use isa<CondBrInst> instead", "isa<CondBrInst>")
-  bool isConditional() const;
-
-  LLVM_DEPRECATED("Cast to CondBrInst", "")
-  Value *getCondition() const;
-  LLVM_DEPRECATED("Cast to CondBrInst", "")
-  void setCondition(Value *V);
-
-  /// Swap the successors of this branch instruction.
-  ///
-  /// Swaps the successors of the branch instruction. This also swaps any
-  /// branch weight metadata associated with the instruction so that it
-  /// continues to map correctly to each operand.
-  LLVM_DEPRECATED("Cast to CondBrInst", "")
-  void swapSuccessors();
-
-  // Methods for support type inquiry through isa, cast, and dyn_cast:
-  static bool classof(const Instruction *I) {
-    return (I->getOpcode() == Instruction::UncondBr ||
-            I->getOpcode() == Instruction::CondBr);
-  }
-  static bool classof(const Value *V) {
-    return isa<Instruction>(V) && classof(cast<Instruction>(V));
-  }
-};
-
-// Suppress deprecation warnings from BranchInst.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-
-template <>
-struct OperandTraits<BranchInst> : public VariadicOperandTraits<BranchInst> {};
-
-DEFINE_TRANSPARENT_OPERAND_ACCESSORS(BranchInst, Value)
-
-//===----------------------------------------------------------------------===//
 //                               UncondBrInst Class
 //===----------------------------------------------------------------------===//
 
 //===---------------------------------------------------------------------------
 /// Unconditional Branch instruction.
 ///
-class UncondBrInst : public BranchInst {
+class UncondBrInst : public Instruction {
   constexpr static IntrusiveOperandsAllocMarker AllocMarker{1};
 
   UncondBrInst(const UncondBrInst &BI);
@@ -3217,15 +3154,6 @@ public:
   /// Transparently provide more efficient getOperand methods.
   DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
 
-private:
-  // Hide methods.
-  using BranchInst::getCondition;
-  using BranchInst::isConditional;
-  using BranchInst::isUnconditional;
-  using BranchInst::setCondition;
-  using BranchInst::swapSuccessors;
-
-public:
   unsigned getNumSuccessors() const { return 1; }
 
   BasicBlock *getSuccessor(unsigned i = 0) const {
@@ -3270,7 +3198,7 @@ DEFINE_TRANSPARENT_OPERAND_ACCESSORS(UncondBrInst, Value)
 //===---------------------------------------------------------------------------
 /// Conditional Branch instruction.
 ///
-class CondBrInst : public BranchInst {
+class CondBrInst : public Instruction {
   constexpr static IntrusiveOperandsAllocMarker AllocMarker{3};
 
   CondBrInst(const CondBrInst &BI);
@@ -3284,11 +3212,6 @@ protected:
   friend class Instruction;
 
   LLVM_ABI CondBrInst *cloneImpl() const;
-
-private:
-  // Hide methods.
-  using BranchInst::isConditional;
-  using BranchInst::isUnconditional;
 
 public:
   static CondBrInst *Create(Value *Cond, BasicBlock *IfTrue,
@@ -3346,40 +3269,6 @@ struct OperandTraits<CondBrInst> : public FixedNumOperandTraits<CondBrInst, 3> {
 };
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(CondBrInst, Value)
-
-//===----------------------------------------------------------------------===//
-//                     BranchInst Out-Of-Line Functions
-//===----------------------------------------------------------------------===//
-
-inline BranchInst *BranchInst::Create(BasicBlock *IfTrue,
-                                      InsertPosition InsertBefore) {
-  return UncondBrInst::Create(IfTrue, InsertBefore);
-}
-
-inline BranchInst *BranchInst::Create(BasicBlock *IfTrue, BasicBlock *IfFalse,
-                                      Value *Cond,
-                                      InsertPosition InsertBefore) {
-  return CondBrInst::Create(Cond, IfTrue, IfFalse, InsertBefore);
-}
-
-inline bool BranchInst::isConditional() const { return isa<CondBrInst>(this); }
-inline bool BranchInst::isUnconditional() const {
-  return isa<UncondBrInst>(this);
-}
-
-inline Value *BranchInst::getCondition() const {
-  return cast<CondBrInst>(this)->getCondition();
-}
-inline void BranchInst::setCondition(Value *V) {
-  cast<CondBrInst>(this)->setCondition(V);
-}
-
-inline void BranchInst::swapSuccessors() {
-  cast<CondBrInst>(this)->swapSuccessors();
-}
-
-// Suppress deprecation warnings from BranchInst.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 //===----------------------------------------------------------------------===//
 //                               SwitchInst Class

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -1208,18 +1208,15 @@ UnreachableInst::UnreachableInst(LLVMContext &Context,
 //                        UncondBrInst Implementation
 //===----------------------------------------------------------------------===//
 
-// Suppress deprecation warnings from BranchInst.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-
 UncondBrInst::UncondBrInst(BasicBlock *Target, InsertPosition InsertBefore)
-    : BranchInst(Type::getVoidTy(Target->getContext()), Instruction::UncondBr,
-                 AllocMarker, InsertBefore) {
+    : Instruction(Type::getVoidTy(Target->getContext()), Instruction::UncondBr,
+                  AllocMarker, InsertBefore) {
   Op<-1>() = Target;
 }
 
 UncondBrInst::UncondBrInst(const UncondBrInst &BI)
-    : BranchInst(Type::getVoidTy(BI.getContext()), Instruction::UncondBr,
-                 AllocMarker) {
+    : Instruction(Type::getVoidTy(BI.getContext()), Instruction::UncondBr,
+                  AllocMarker) {
   Op<-1>() = BI.Op<-1>();
   SubclassOptionalData = BI.SubclassOptionalData;
 }
@@ -1235,8 +1232,8 @@ void CondBrInst::AssertOK() {
 
 CondBrInst::CondBrInst(Value *Cond, BasicBlock *IfTrue, BasicBlock *IfFalse,
                        InsertPosition InsertBefore)
-    : BranchInst(Type::getVoidTy(IfTrue->getContext()), Instruction::CondBr,
-                 AllocMarker, InsertBefore) {
+    : Instruction(Type::getVoidTy(IfTrue->getContext()), Instruction::CondBr,
+                  AllocMarker, InsertBefore) {
   // Assign in order of operand index to make use-list order predictable.
   Op<-3>() = Cond;
   Op<-2>() = IfTrue;
@@ -1247,8 +1244,8 @@ CondBrInst::CondBrInst(Value *Cond, BasicBlock *IfTrue, BasicBlock *IfFalse,
 }
 
 CondBrInst::CondBrInst(const CondBrInst &BI)
-    : BranchInst(Type::getVoidTy(BI.getContext()), Instruction::CondBr,
-                 AllocMarker) {
+    : Instruction(Type::getVoidTy(BI.getContext()), Instruction::CondBr,
+                  AllocMarker) {
   // Assign in order of operand index to make use-list order predictable.
   Op<-3>() = BI.Op<-3>();
   Op<-2>() = BI.Op<-2>();
@@ -1263,9 +1260,6 @@ void CondBrInst::swapSuccessors() {
   // expectations.
   swapProfMetadata();
 }
-
-// Suppress deprecation warnings from BranchInst.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 //===----------------------------------------------------------------------===//
 //                        AllocaInst Implementation

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -138,12 +138,6 @@ TEST(InstructionsTest, UncondBrInst) {
 
   const UncondBrInst *b0 = UncondBrInst::Create(bb0);
 
-  // Test legacy BranchInst API.
-  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-  EXPECT_TRUE(cast<BranchInst>(b0)->isUnconditional());
-  EXPECT_FALSE(cast<BranchInst>(b0)->isConditional());
-  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
-
   EXPECT_EQ(1U, b0->getNumSuccessors());
 
   // check num operands
@@ -170,12 +164,6 @@ TEST(InstructionsTest, CondBrInst) {
   Constant* One = ConstantInt::getTrue(Int1);
 
   CondBrInst *b1 = CondBrInst::Create(One, bb0, bb1);
-
-  // Test legacy BranchInst API.
-  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
-  EXPECT_FALSE(cast<BranchInst>(b1)->isUnconditional());
-  EXPECT_TRUE(cast<BranchInst>(b1)->isConditional());
-  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
   EXPECT_EQ(2U, b1->getNumSuccessors());
 


### PR DESCRIPTION
The migration to UncondBr/CondBr was finished in LLVM 23. BranchInst has
no remaining uses in-tree. Let's finish this by removing BranchInst.

https://discourse.llvm.org/t/rfc-split-branchinst-into-uncondbr-and-condbr/90022

Deprecated with: https://github.com/llvm/llvm-project/pull/187314
