### PR TITLE
[lld-macho] Include ICF safe thunks in balanced partitioning

### DIFF
--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "BPSectionOrderer.h"
+#include "ICF.h"
 #include "InputSection.h"
 #include "OutputSegment.h"
 #include "Relocations.h"
@@ -120,7 +121,14 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     bool compressionSortStartupFunctions, bool verbose) {
   // Collect candidate sections and associated symbols.
   SmallVector<InputSection *> sections;
+  DenseMap<const InputSection *, unsigned> sectionToIdx;
   DenseMap<CachedHashStringRef, std::set<unsigned>> rootSymbolToSectionIdxs;
+  auto addSectionForName = [&](StringRef name, unsigned idx) {
+    auto rootName = lld::utils::getRootSymbol(name);
+    rootSymbolToSectionIdxs[CachedHashStringRef(rootName)].insert(idx);
+    if (auto linkageName = BPOrdererMachO::getResolvedLinkageName(rootName))
+      rootSymbolToSectionIdxs[CachedHashStringRef(*linkageName)].insert(idx);
+  };
   auto addSection = [&](InputSection *isec) {
     if (!isec || isec->data.empty() || !isec->data.data())
       return;
@@ -132,14 +140,11 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     // irrelevant.
     if (isa<ConcatInputSection>(isec) && !isec->isLive(0))
       return;
-    size_t idx = sections.size();
+    unsigned idx = sections.size();
     sections.emplace_back(isec);
-    for (auto *sym : BPOrdererMachO::getSymbols(*isec)) {
-      auto rootName = lld::utils::getRootSymbol(sym->getName());
-      rootSymbolToSectionIdxs[CachedHashStringRef(rootName)].insert(idx);
-      if (auto linkageName = BPOrdererMachO::getResolvedLinkageName(rootName))
-        rootSymbolToSectionIdxs[CachedHashStringRef(*linkageName)].insert(idx);
-    }
+    sectionToIdx.try_emplace(isec, idx);
+    for (auto *sym : BPOrdererMachO::getSymbols(*isec))
+      addSectionForName(sym->getName(), idx);
   };
   for (const auto *file : inputFiles) {
     for (auto *sec : file->sections) {
@@ -151,12 +156,23 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     }
   }
   // ICF safe thunks are linker-created after the input-file section graph is
-  // built. Include them so profile names resolve to the emitted thunks.
+  // built. Include them so profile names resolve to the emitted thunks and the
+  // shared bodies they immediately branch to.
   for (auto *isec : inputSections) {
-    if (llvm::any_of(isec->symbols, [](Defined *sym) {
+    if (!llvm::any_of(isec->symbols, [](Defined *sym) {
           return sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk;
         }))
-      addSection(isec);
+      continue;
+    addSection(isec);
+    for (auto *sym : isec->symbols) {
+      if (sym->identicalCodeFoldingKind != Symbol::ICFFoldKind::Thunk)
+        continue;
+      InputSection *bodyIsec = getBodyForThunkFoldedSym(sym)->isec();
+      auto bodyIdx = sectionToIdx.find(bodyIsec);
+      assert(bodyIdx != sectionToIdx.end() &&
+             "ICF thunk body must be a BP candidate");
+      addSectionForName(sym->getName(), bodyIdx->second);
+    }
   }
 
   auto result = BPOrdererMachO().computeOrder(

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -11,8 +11,10 @@
 #include "OutputSegment.h"
 #include "Relocations.h"
 #include "Symbols.h"
+#include "Target.h"
 #include "lld/Common/BPSectionOrdererBase.inc"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/xxhash.h"
@@ -121,6 +123,11 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
   SmallVector<InputSection *> sections;
   DenseMap<const InputSection *, unsigned> sectionToIdx;
   DenseMap<CachedHashStringRef, std::set<unsigned>> rootSymbolToSectionIdxs;
+  auto isThunk = [](ArrayRef<Defined *> symbols) {
+    return llvm::any_of(symbols, [](Defined *sym) {
+      return sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk;
+    });
+  };
   auto addSectionForName = [&](StringRef name, unsigned idx) {
     auto rootName = lld::utils::getRootSymbol(name);
     rootSymbolToSectionIdxs[CachedHashStringRef(rootName)].insert(idx);
@@ -156,39 +163,23 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
   // ICF safe thunks are linker-created after the input-file section graph is
   // built, so they do not appear in file->sections. Include them through the
   // same path as input-file sections so only live BP candidates are added.
-  for (auto *isec : inputSections) {
-    for (auto *sym : isec->symbols) {
-      if (sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk) {
-        addSection(isec);
-        break;
-      }
-    }
-  }
+  for (auto *isec : inputSections)
+    if (isThunk(isec->symbols))
+      addSection(isec);
 
   // A temporal profile naming an ICF thunk describes execution of both the
   // thunk and the shared body it branches to. Add the body to each name that
-  // resolves to a thunk, following the thunk relocation to find it.
-  for (auto &entry : rootSymbolToSectionIdxs) {
-    auto &sectionIdxs = entry.second;
-    SmallVector<unsigned> bodySectionIdxs;
+  // resolves to a thunk.
+  for (auto &[symbol, sectionIdxs] : rootSymbolToSectionIdxs) {
     for (unsigned idx : sectionIdxs) {
       InputSection *isec = sections[idx];
-      bool isThunk = false;
-      for (auto *sym : isec->symbols) {
-        if (sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk) {
-          isThunk = true;
-          break;
-        }
-      }
-      if (!isThunk)
+      if (!isThunk(isec->symbols))
         continue;
-      for (const Relocation &reloc : isec->relocs) {
-        auto bodyIdx = sectionToIdx.find(reloc.getReferentInputSection());
-        if (bodyIdx != sectionToIdx.end())
-          bodySectionIdxs.push_back(bodyIdx->second);
-      }
+      auto *bodySym = cast<Defined>(target->getThunkBranchTarget(isec));
+      auto bodyIdx = sectionToIdx.find(bodySym->isec());
+      if (bodyIdx != sectionToIdx.end())
+        sectionIdxs.insert(bodyIdx->second);
     }
-    sectionIdxs.insert(bodySectionIdxs.begin(), bodySectionIdxs.end());
   }
 
   auto result = BPOrdererMachO().computeOrder(

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -13,6 +13,7 @@
 #include "Symbols.h"
 #include "lld/Common/BPSectionOrdererBase.inc"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/xxhash.h"
@@ -120,36 +121,44 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
   // Collect candidate sections and associated symbols.
   SmallVector<InputSection *> sections;
   DenseMap<CachedHashStringRef, std::set<unsigned>> rootSymbolToSectionIdxs;
+  DenseSet<InputSection *> seenSections;
+  auto addSection = [&](InputSection *isec) {
+    if (!isec || isec->data.empty() || !isec->data.data())
+      return;
+    // CString section order is handled by
+    // {Deduplicated}CStringSection::finalizeContents()
+    if (isa<CStringInputSection>(isec) || isec->isFinal)
+      return;
+    // ConcatInputSections are entirely live or dead, so the offset is
+    // irrelevant.
+    if (isa<ConcatInputSection>(isec) && !isec->isLive(0))
+      return;
+    if (!seenSections.insert(isec).second)
+      return;
+    size_t idx = sections.size();
+    sections.emplace_back(isec);
+    for (auto *sym : BPOrdererMachO::getSymbols(*isec)) {
+      auto rootName = lld::utils::getRootSymbol(sym->getName());
+      rootSymbolToSectionIdxs[CachedHashStringRef(rootName)].insert(idx);
+      if (auto linkageName =
+              BPOrdererMachO::getResolvedLinkageName(rootName))
+        rootSymbolToSectionIdxs[CachedHashStringRef(*linkageName)].insert(idx);
+    }
+  };
   for (const auto *file : inputFiles) {
     for (auto *sec : file->sections) {
       if (sec->name == section_names::ehFrame &&
           sec->segname == segment_names::text)
         continue;
-      for (auto &subsec : sec->subsections) {
-        auto *isec = subsec.isec;
-        if (!isec || isec->data.empty() || !isec->data.data())
-          continue;
-        // CString section order is handled by
-        // {Deduplicated}CStringSection::finalizeContents()
-        if (isa<CStringInputSection>(isec) || isec->isFinal)
-          continue;
-        // ConcatInputSections are entirely live or dead, so the offset is
-        // irrelevant.
-        if (isa<ConcatInputSection>(isec) && !isec->isLive(0))
-          continue;
-        size_t idx = sections.size();
-        sections.emplace_back(isec);
-        for (auto *sym : BPOrdererMachO::getSymbols(*isec)) {
-          auto rootName = lld::utils::getRootSymbol(sym->getName());
-          rootSymbolToSectionIdxs[CachedHashStringRef(rootName)].insert(idx);
-          if (auto linkageName =
-                  BPOrdererMachO::getResolvedLinkageName(rootName))
-            rootSymbolToSectionIdxs[CachedHashStringRef(*linkageName)].insert(
-                idx);
-        }
-      }
+      for (auto &subsec : sec->subsections)
+        addSection(subsec.isec);
     }
   }
+  // ICF safe thunks are linker-created after the input-file section graph is
+  // built. Include them (and any other synthetic concat sections) so temporal
+  // profile names resolve to the sections that are actually emitted.
+  for (auto *isec : inputSections)
+    addSection(isec);
 
   auto result = BPOrdererMachO().computeOrder(
       profilePath, compressionSortSpecs, forFunctionCompression,

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -140,8 +140,7 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     for (auto *sym : BPOrdererMachO::getSymbols(*isec)) {
       auto rootName = lld::utils::getRootSymbol(sym->getName());
       rootSymbolToSectionIdxs[CachedHashStringRef(rootName)].insert(idx);
-      if (auto linkageName =
-              BPOrdererMachO::getResolvedLinkageName(rootName))
+      if (auto linkageName = BPOrdererMachO::getResolvedLinkageName(rootName))
         rootSymbolToSectionIdxs[CachedHashStringRef(*linkageName)].insert(idx);
     }
   };

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -7,14 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "BPSectionOrderer.h"
-#include "ICF.h"
 #include "InputSection.h"
 #include "OutputSegment.h"
 #include "Relocations.h"
 #include "Symbols.h"
 #include "lld/Common/BPSectionOrdererBase.inc"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/xxhash.h"
@@ -143,7 +141,7 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     unsigned idx = sections.size();
     sections.emplace_back(isec);
     sectionToIdx.try_emplace(isec, idx);
-    for (auto *sym : BPOrdererMachO::getSymbols(*isec))
+    for (auto *sym : isec->symbols)
       addSectionForName(sym->getName(), idx);
   };
   for (const auto *file : inputFiles) {
@@ -156,23 +154,41 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     }
   }
   // ICF safe thunks are linker-created after the input-file section graph is
-  // built. Include them so profile names resolve to the emitted thunks and the
-  // shared bodies they immediately branch to.
+  // built, so they do not appear in file->sections. Include them through the
+  // same path as input-file sections so only live BP candidates are added.
   for (auto *isec : inputSections) {
-    if (!llvm::any_of(isec->symbols, [](Defined *sym) {
-          return sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk;
-        }))
-      continue;
-    addSection(isec);
     for (auto *sym : isec->symbols) {
-      if (sym->identicalCodeFoldingKind != Symbol::ICFFoldKind::Thunk)
-        continue;
-      InputSection *bodyIsec = getBodyForThunkFoldedSym(sym)->isec();
-      auto bodyIdx = sectionToIdx.find(bodyIsec);
-      assert(bodyIdx != sectionToIdx.end() &&
-             "ICF thunk body must be a BP candidate");
-      addSectionForName(sym->getName(), bodyIdx->second);
+      if (sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk) {
+        addSection(isec);
+        break;
+      }
     }
+  }
+
+  // A temporal profile naming an ICF thunk describes execution of both the
+  // thunk and the shared body it branches to. Add the body to each name that
+  // resolves to a thunk, following the thunk relocation to find it.
+  for (auto &entry : rootSymbolToSectionIdxs) {
+    auto &sectionIdxs = entry.second;
+    SmallVector<unsigned> bodySectionIdxs;
+    for (unsigned idx : sectionIdxs) {
+      InputSection *isec = sections[idx];
+      bool isThunk = false;
+      for (auto *sym : isec->symbols) {
+        if (sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk) {
+          isThunk = true;
+          break;
+        }
+      }
+      if (!isThunk)
+        continue;
+      for (const Relocation &reloc : isec->relocs) {
+        auto bodyIdx = sectionToIdx.find(reloc.getReferentInputSection());
+        if (bodyIdx != sectionToIdx.end())
+          bodySectionIdxs.push_back(bodyIdx->second);
+      }
+    }
+    sectionIdxs.insert(bodySectionIdxs.begin(), bodySectionIdxs.end());
   }
 
   auto result = BPOrdererMachO().computeOrder(

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -13,7 +13,7 @@
 #include "Symbols.h"
 #include "lld/Common/BPSectionOrdererBase.inc"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/xxhash.h"
@@ -121,7 +121,6 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
   // Collect candidate sections and associated symbols.
   SmallVector<InputSection *> sections;
   DenseMap<CachedHashStringRef, std::set<unsigned>> rootSymbolToSectionIdxs;
-  DenseSet<InputSection *> seenSections;
   auto addSection = [&](InputSection *isec) {
     if (!isec || isec->data.empty() || !isec->data.data())
       return;
@@ -132,8 +131,6 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     // ConcatInputSections are entirely live or dead, so the offset is
     // irrelevant.
     if (isa<ConcatInputSection>(isec) && !isec->isLive(0))
-      return;
-    if (!seenSections.insert(isec).second)
       return;
     size_t idx = sections.size();
     sections.emplace_back(isec);
@@ -154,10 +151,13 @@ DenseMap<const InputSection *, int> lld::macho::runBalancedPartitioning(
     }
   }
   // ICF safe thunks are linker-created after the input-file section graph is
-  // built. Include them (and any other synthetic concat sections) so temporal
-  // profile names resolve to the sections that are actually emitted.
-  for (auto *isec : inputSections)
-    addSection(isec);
+  // built. Include them so profile names resolve to the emitted thunks.
+  for (auto *isec : inputSections) {
+    if (llvm::any_of(isec->symbols, [](Defined *sym) {
+          return sym->identicalCodeFoldingKind == Symbol::ICFFoldKind::Thunk;
+        }))
+      addSection(isec);
+  }
 
   auto result = BPOrdererMachO().computeOrder(
       profilePath, compressionSortSpecs, forFunctionCompression,

--- a/lld/test/MachO/bp-section-orderer-safe-thunks.s
+++ b/lld/test/MachO/bp-section-orderer-safe-thunks.s
@@ -8,16 +8,16 @@
 ## linker-created ICF thunk. Balanced partitioning must order both that thunk
 ## and the shared _hot_a body that it immediately branches to. _hot_c folds to
 ## another thunk for the same body but is not profiled and must not be promoted.
-# RUN: %lld -arch arm64 -lSystem -e _main -o %t/out %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --bp-compression-sort=none --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=VERBOSE
+# RUN: %lld -arch arm64 -e _main -o %t/out %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=VERBOSE
 # VERBOSE: Ordered 2 sections (12 bytes) using balanced partitioning
 # VERBOSE: Functions for startup: 2 (12 bytes)
 
-# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --bp-compression-sort=none | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=ORDER
+# RUN: %lld -arch arm64 -e _main -o - %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=ORDER
 # ORDER: _hot_a
 # ORDER-NEXT: _hot_b
-# ORDER-NEXT: _main
-# ORDER-NEXT: _cold
-# ORDER-NEXT: _hot_c
+# ORDER-DAG: _main
+# ORDER-DAG: _cold
+# ORDER-DAG: _hot_c
 
 #--- input.s
 .subsections_via_symbols

--- a/lld/test/MachO/bp-section-orderer-safe-thunks.s
+++ b/lld/test/MachO/bp-section-orderer-safe-thunks.s
@@ -4,13 +4,24 @@
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/input.s -o %t/input.o
 # RUN: llvm-profdata merge %t/profile.proftext -o %t/profile.profdata
 
-## The temporal profile names _hot_b, whose input section becomes a
-## linker-created ICF thunk. Balanced partitioning must order both that thunk
-## and the shared _hot_a body that it immediately branches to. _hot_c folds to
-## another thunk for the same body but is not profiled and must not be promoted.
+## Safe-thunk ICF retains the first member, _hot_a, as the shared body and
+## replaces later address-significant members, _hot_b and _hot_c, with thunks.
+## Since _hot_a already names offset zero, no extra internal target symbol is
+## needed. The temporal profile names _hot_b, so balanced partitioning must
+## order that thunk and its _hot_a body. The unprofiled _hot_c thunk must not be
+## promoted.
 # RUN: %lld -arch arm64 -e _main -o %t/out %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=VERBOSE
 # VERBOSE: Ordered 2 sections (12 bytes) using balanced partitioning
 # VERBOSE: Functions for startup: 2 (12 bytes)
+
+# RUN: llvm-objdump --no-show-raw-insn -d %t/out | FileCheck %s --check-prefix=THUNKS
+# THUNKS-LABEL: <_hot_a>:
+# THUNKS-NEXT: {{.*}} mov w0, #0x2a
+# THUNKS-NEXT: {{.*}} ret
+# THUNKS-LABEL: <_hot_b>:
+# THUNKS-NEXT: {{.*}} b {{.*}} <_hot_a>
+# THUNKS-LABEL: <_hot_c>:
+# THUNKS-NEXT: {{.*}} b {{.*}} <_hot_a>
 
 # RUN: %lld -arch arm64 -e _main -o - %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=ORDER
 # ORDER: _hot_a

--- a/lld/test/MachO/bp-section-orderer-safe-thunks.s
+++ b/lld/test/MachO/bp-section-orderer-safe-thunks.s
@@ -5,16 +5,19 @@
 # RUN: llvm-profdata merge %t/profile.proftext -o %t/profile.profdata
 
 ## The temporal profile names _hot_b, whose input section becomes a
-## linker-created ICF thunk. Balanced partitioning must order that thunk.
+## linker-created ICF thunk. Balanced partitioning must order both that thunk
+## and the shared _hot_a body that it immediately branches to. _hot_c folds to
+## another thunk for the same body but is not profiled and must not be promoted.
 # RUN: %lld -arch arm64 -lSystem -e _main -o %t/out %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --bp-compression-sort=none --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=VERBOSE
-# VERBOSE: Ordered 1 sections (4 bytes) using balanced partitioning
-# VERBOSE: Functions for startup: 1 (4 bytes)
+# VERBOSE: Ordered 2 sections (12 bytes) using balanced partitioning
+# VERBOSE: Functions for startup: 2 (12 bytes)
 
 # RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --bp-compression-sort=none | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=ORDER
-# ORDER: _hot_b
+# ORDER: _hot_a
+# ORDER-NEXT: _hot_b
 # ORDER-NEXT: _main
-# ORDER-NEXT: _hot_a
 # ORDER-NEXT: _cold
+# ORDER-NEXT: _hot_c
 
 #--- input.s
 .subsections_via_symbols
@@ -22,6 +25,7 @@
 .addrsig
 .addrsig_sym _hot_a
 .addrsig_sym _hot_b
+.addrsig_sym _hot_c
 
 .text
 .globl _main
@@ -35,6 +39,11 @@ _hot_a:
 
 .globl _hot_b
 _hot_b:
+  mov w0, #42
+  ret
+
+.globl _hot_c
+_hot_c:
   mov w0, #42
   ret
 

--- a/lld/test/MachO/bp-section-orderer-safe-thunks.s
+++ b/lld/test/MachO/bp-section-orderer-safe-thunks.s
@@ -1,0 +1,62 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/input.s -o %t/input.o
+# RUN: llvm-profdata merge %t/profile.proftext -o %t/profile.profdata
+
+## The temporal profile names _hot_b, whose input section becomes a
+## linker-created ICF thunk. Balanced partitioning must order that thunk.
+# RUN: %lld -arch arm64 -lSystem -e _main -o %t/out %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --bp-compression-sort=none --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=VERBOSE
+# VERBOSE: Ordered 1 sections (4 bytes) using balanced partitioning
+# VERBOSE: Functions for startup: 1 (4 bytes)
+
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --icf=safe_thunks --irpgo-profile=%t/profile.profdata --bp-startup-sort=function --bp-compression-sort=none | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=ORDER
+# ORDER: _hot_b
+# ORDER-NEXT: _main
+# ORDER-NEXT: _hot_a
+# ORDER-NEXT: _cold
+
+#--- input.s
+.subsections_via_symbols
+
+.addrsig
+.addrsig_sym _hot_a
+.addrsig_sym _hot_b
+
+.text
+.globl _main
+_main:
+  ret
+
+.globl _hot_a
+_hot_a:
+  mov w0, #42
+  ret
+
+.globl _hot_b
+_hot_b:
+  mov w0, #42
+  ret
+
+.globl _cold
+_cold:
+  mov w0, #1
+  ret
+
+#--- profile.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+1
+# Trace Stream Size:
+1
+# Weight
+1
+hot_b
+
+hot_b
+# Func Hash:
+1111
+# Num Counters:
+1
+# Counter Values:

--- a/lld/test/MachO/bp-section-orderer-safe-thunks.s
+++ b/lld/test/MachO/bp-section-orderer-safe-thunks.s
@@ -60,3 +60,4 @@ hot_b
 # Num Counters:
 1
 # Counter Values:
+1


### PR DESCRIPTION
Mach-O balanced partitioning currently discovers candidate sections by walking the input-file section graph. In `--icf=safe_thunks` mode, address-significant functions can instead be emitted as linker-created thunk sections after that graph has been built. A temporal-profile name then resolves to the dead folded input while the callable section present in the final binary is never eligible for BP ordering.

Factor candidate collection into a helper, then inspect the final `inputSections` set for sections containing a `Defined` symbol marked `ICFFoldKind::Thunk`. This makes emitted ICF safe thunks visible while keeping unrelated synthetic metadata outside BP.

The new arm64 regression folds a profiled address-significant function into a 4-byte safe thunk and verifies both the BP startup count and final symbol order. Without the change, BP orders zero startup sections for that profile; with the change it orders the emitted thunk first.
