### PR TITLE
[libc][test][NFC] Fix compiler warnings in libc tests

### DIFF
--- a/libc/test/integration/src/pthread/pthread_barrier_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_barrier_test.cpp
@@ -26,7 +26,7 @@
 pthread_barrier_t barrier;
 LIBC_NAMESPACE::cpp::Atomic<int> counter;
 
-void *increment_counter_and_wait(void *args) {
+void *increment_counter_and_wait(void *) {
   counter.fetch_add(1);
   return reinterpret_cast<void *>(
       LIBC_NAMESPACE::pthread_barrier_wait(&barrier));
@@ -102,7 +102,7 @@ void reused_barrier_test() {
   LIBC_NAMESPACE::pthread_barrier_destroy(&barrier);
 }
 
-void *barrier_wait(void *in) {
+void *barrier_wait(void *) {
   return reinterpret_cast<void *>(
       LIBC_NAMESPACE::pthread_barrier_wait(&barrier));
 }

--- a/libc/test/src/signal/sigaltstack_test.cpp
+++ b/libc/test/src/signal/sigaltstack_test.cpp
@@ -33,7 +33,7 @@ static void handler(int) {
   // out or mapped to a register.
   uint8_t var[LOCAL_VAR_SIZE];
   for (int i = 0; i < LOCAL_VAR_SIZE; ++i)
-    var[i] = i;
+    var[i] = static_cast<uint8_t>(i);
   // Verify that array is completely on the alt_stack.
   for (int i = 0; i < LOCAL_VAR_SIZE; ++i) {
     if (!(uintptr_t(var + i) < uintptr_t(alt_stack + ALT_STACK_SIZE) &&

--- a/libc/test/src/time/localtime_r_test.cpp
+++ b/libc/test/src/time/localtime_r_test.cpp
@@ -11,15 +11,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcLocaltimeR, ValidUnixTimestamp0) {
-  struct tm input = {.tm_sec = 0,
-                     .tm_min = 0,
-                     .tm_hour = 0,
-                     .tm_mday = 0,
-                     .tm_mon = 0,
-                     .tm_year = 0,
-                     .tm_wday = 0,
-                     .tm_yday = 0,
-                     .tm_isdst = 0};
+  struct tm input = {};
   const time_t timer = 0;
 
   struct tm *result = LIBC_NAMESPACE::localtime_r(&timer, &input);
@@ -52,15 +44,7 @@ TEST(LlvmLibcLocaltimeR, NullPtr) {
 // This will be resolved a new pull request.
 
 TEST(LlvmLibcLocaltimeR, ValidUnixTimestamp) {
-  struct tm input = {.tm_sec = 0,
-                     .tm_min = 0,
-                     .tm_hour = 0,
-                     .tm_mday = 0,
-                     .tm_mon = 0,
-                     .tm_year = 0,
-                     .tm_wday = 0,
-                     .tm_yday = 0,
-                     .tm_isdst = 0};
+  struct tm input = {};
   const time_t timer = 1756595338;
   struct tm *result = LIBC_NAMESPACE::localtime_r(&timer, &input);
 
@@ -76,15 +60,7 @@ TEST(LlvmLibcLocaltimeR, ValidUnixTimestamp) {
 }
 
 TEST(LlvmLibcLocaltimeR, ValidUnixTimestampNegative) {
-  struct tm input = {.tm_sec = 0,
-                     .tm_min = 0,
-                     .tm_hour = 0,
-                     .tm_mday = 0,
-                     .tm_mon = 0,
-                     .tm_year = 0,
-                     .tm_wday = 0,
-                     .tm_yday = 0,
-                     .tm_isdst = 0};
+  struct tm input = {};
   const time_t timer = -1756595338;
   struct tm *result = LIBC_NAMESPACE::localtime_r(&timer, &input);
 


### PR DESCRIPTION
Resolved compiler warnings in several libc unit and integration tests:

- Fixed -Wmissing-designated-field-initializers in localtime_r_test.cpp by using zero-initialisation instead of partial designated initialisers.
- Fixed -Wimplicit-int-conversion in sigaltstack_test.cpp by explicitly casting the loop index to uint8_t.
- Fixed -Wunused-parameter in pthread_barrier_test.cpp by omitting unused parameter names in function definitions.

Assisted-by: Automated tooling, human reviewed.