### PR TITLE
[llvm][release] Build openmp as runtime in test-release.sh

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -292,7 +292,7 @@ if [ $do_libs = "yes" ]; then
   fi
 fi
 if [ $do_openmp = "yes" ]; then
-  projects="${projects:+$projects;}openmp"
+  runtimes="${runtimes:+$runtimes;}openmp"
 fi
 if [ $do_bolt = "yes" ]; then
   projects="${projects:+$projects;}bolt"


### PR DESCRIPTION
`test_release.sh` tries to build `openmp` as a project, which breaks the build:

```
CMake Error at CMakeLists.txt:155 (message):

  Support for the LLVM_ENABLE_PROJECTS=openmp build mode has been removed.
  Please switch to the bootstrapping build

      cmake -S <llvm-project>/llvm -B build -DLLVM_ENABLE_PROJECTS=clang -DLLVM_ENABLE_RUNTIMES=openmp

  or to the runtimes default build

      cmake -S <llvm-project>/runtimes -B build -DLLVM_ENABLE_RUNTIMES=openmp
```

This patch switches it to a runtime to match.

Tested on `x86_64-pc-linux-gnu`.