### PR TITLE
[llvm][cas] Fix OnDiskCASLoggerTest.cpp compilation on NetBSD

### DIFF
--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -227,7 +227,7 @@ TEST_F(OnDiskCASLoggerTest, MultiProcess) {
 
   for (auto &PI : PIs) {
     // Note: this is typically <1 second, but account for slow CI systems.
-    auto Result = Wait(PI, /*Timeout=*/15, &Error);
+    auto Result = llvm::sys::Wait(PI, /*Timeout=*/15, &Error);
     ASSERT_TRUE(Error.empty()) << Error;
     ASSERT_EQ(Result.Pid, PI.Pid);
     ASSERT_EQ(Result.ReturnCode, 0);


### PR DESCRIPTION
`CAS/OnDiskCASLoggerTest.cpp` doesn't compile on NetBSD/amd64:

```
In member function `virtual void OnDiskCASLoggerTest_MultiProcess_Test::TestBody()':
llvm/unittests/CAS/OnDiskCASLoggerTest.cpp:230:19: error: reference to `Wait' is ambiguous
  230 |     auto Result = Wait(PI, /*Timeout=*/15, &Error);
      |                   ^~~~
In file included from llvm/unittests/CAS/OnDiskCASLoggerTest.cpp:15:
llvm/include/llvm/Support/Program.h:212:22: note: candidates are: `llvm::sys::ProcessInfo llvm::sys::Wait(const llvm::sys::ProcessInfo&, std::optional<unsigned int>, std::string*, std::optional<llvm::sys::ProcessStatistics>*, bool)'
  212 | LLVM_ABI ProcessInfo Wait(
      |                      ^~~~
In file included from llvm/include/llvm/Support/RWMutex.h:17,
                 from llvm/include/llvm/Support/ThreadPool.h:21,
                 from llvm/unittests/CAS/OnDiskCASLoggerTest.cpp:16:
llvm/include/llvm/Support/Threading.h:60:40: note:                 `llvm::InitStatus llvm::Wait'
   60 |   enum InitStatus { Uninitialized = 0, Wait = 1, Done = 2 };
      |                                        ^~~~
```

This patch removes the ambiguity, matching other uses.

Tested on `amd64-pc-netbsd10.1` and `x86_64-pc-linux-gnu`.