### PR TITLE
[sanitizer_common][tests] Skip MemoryMapping::ParseUnixMemoryProfile …

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_procmaps_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_procmaps_test.cpp
@@ -90,6 +90,8 @@ Size:                 12 kB
 Rss:                  12 kB
 )";
 
+#    if !SANITIZER_NETBSD
+// Test fails to link with NetBSD 10.1 /usr/bin/ld.
 TEST(MemoryMapping, ParseUnixMemoryProfile) {
   struct entry {
     uptr p;
@@ -132,6 +134,7 @@ TEST(MemoryMapping, ParseUnixMemoryProfileTruncated) {
   }
   UnmapOrDie(mem, 2 * page);
 }
+#  endif
 #  endif
 
 }  // namespace __sanitizer


### PR DESCRIPTION
…etc. on NetBSD

The `Sanitizer-x86_64-Test` test doesn't link on NetBSD/amd64 10.1:

```
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
SANITIZER_TEST_OBJECTS.sanitizer_procmaps_test.cpp.x86_64.o: in function `__sanitizer::MemoryMapping_ParseUnixMemoryProfile_Test::TestBody()':
sanitizer_procmaps_test.cpp:(.text._ZN11__sanitizer41MemoryMapping_ParseUnixMemoryProfile_Test8TestBodyEv+0x52): undefined reference to `__sanitizer::ParseUnixMemoryProfile(void (*)(unsigned long, unsigned long, bool, unsigned long*), unsigned long*, char*, unsigned long)'
/usr/bin/ld: SANITIZER_TEST_OBJECTS.sanitizer_procmaps_test.cpp.x86_64.o: in function `__sanitizer::MemoryMapping_ParseUnixMemoryProfileTruncated_Test::TestBody()':
sanitizer_procmaps_test.cpp:(.text._ZN11__sanitizer50MemoryMapping_ParseUnixMemoryProfileTruncated_Test8TestBodyEv+0x17a): undefined reference to `__sanitizer::ParseUnixMemoryProfile(void (*)(unsigned long, unsigned long, bool, unsigned long*), unsigned long*, char*, unsigned long)'

```

Fixed by skipping the affected subtest.

Tested on `amd64-pc-netbsd10.1` and `x86_64-pc-linux-gnu`.