### PR TITLE
[mlir][toy] Fix Ch6/Ch7 llvm-lowering tests

### DIFF
--- a/mlir/test/Examples/Toy/Ch6/llvm-lowering.mlir
+++ b/mlir/test/Examples/Toy/Ch6/llvm-lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: toyc-ch6 %s -emit=llvm -opt
+// RUN: toyc-ch6 %s -emit=llvm -opt 2>&1 | FileCheck %s
 
 toy.func @main() {
   %0 = toy.constant dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>
@@ -20,4 +20,4 @@ toy.func @main() {
 // CHECK: @printf
 // CHECK-SAME: 9.000000e+00
 // CHECK: @printf
-// CHECK-SAME: 3.000000e+01
+// CHECK-SAME: 3.600000e+01

--- a/mlir/test/Examples/Toy/Ch7/llvm-lowering.mlir
+++ b/mlir/test/Examples/Toy/Ch7/llvm-lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: toyc-ch7 %s -emit=llvm -opt
+// RUN: toyc-ch7 %s -emit=llvm -opt 2>&1 | FileCheck %s
 
 toy.func @main() {
   %0 = toy.constant dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>
@@ -20,4 +20,4 @@ toy.func @main() {
 // CHECK: @printf
 // CHECK-SAME: 9.000000e+00
 // CHECK: @printf
-// CHECK-SAME: 3.000000e+01
+// CHECK-SAME: 3.600000e+01


### PR DESCRIPTION
Add missing `| FileCheck %s` to `RUN` lines so `CHECK` lines can be verified. Also correct the expected result from `30` to `36`. The result should be `6*6=36`.

The example in the tutorial is correct (`3.600000e+01`). https://mlir.llvm.org/docs/Tutorials/Toy/Ch-6/