### PR TITLE
[libc++] Removing traiilng whitespace at line end in CMakeLists.txt

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -680,7 +680,7 @@ set(files
   __pstl/cpu_algos/find_if.h
   __pstl/cpu_algos/for_each.h
   __pstl/cpu_algos/merge.h
-  __pstl/cpu_algos/mismatch.h  
+  __pstl/cpu_algos/mismatch.h
   __pstl/cpu_algos/stable_sort.h
   __pstl/cpu_algos/transform.h
   __pstl/cpu_algos/transform_reduce.h


### PR DESCRIPTION
Follow-up to #209291.