### PR TITLE
[SCEV] Avoid building throwaway nodes in SCEVURem_match (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
@@ -313,6 +313,13 @@ template <typename Op0_t, typename Op1_t> struct SCEVURem_match {
     if (!SCEVPatternMatch::match(Expr, m_scev_Add(m_scev_Mul(Mul), m_SCEV(A))))
       return false;
 
+    // URem is represented as `A - ((A udiv B) * B)`. Only construct the complex
+    // SCEV expression, the multiply of the expression to check has a UDiv
+    // operand.
+    if (none_of(Mul->operands(),
+                [](const SCEV *Op) { return isa<SCEVUDivExpr>(Op); }))
+      return false;
+
     const auto MatchURemWithDivisor = [&](const SCEV *B) {
       // (SomeExpr + (-(SomeExpr / B) * B)).
       if (Expr == SE.getURemExpr(A, B))

--- a/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
@@ -314,7 +314,7 @@ template <typename Op0_t, typename Op1_t> struct SCEVURem_match {
       return false;
 
     // URem is represented as `A - ((A udiv B) * B)`. Only construct the complex
-    // SCEV expression, the multiply of the expression to check has a UDiv
+    // SCEV expression, if the multiply of the expression to check has a UDiv
     // operand.
     if (none_of(Mul->operands(),
                 [](const SCEV *Op) { return isa<SCEVUDivExpr>(Op); }))


### PR DESCRIPTION
URem matching currently constructs rather complex
`A - ((A udiv B) * B)` expressions just to check if the given expression is an URem op.

Exit early without building the expression, if neither of the operands is UDiv.

This gives significant compile-time improvements end-to-end:

* stage1-O3: -0.23%
* stage1-ReleaseThinLTO: -0.24%
* stage1-ReleaseLTO-g: -0.18%
* stage1-aarch64-O3: -0.21%
* stage2-O3: -0.23%

https://llvm-compile-time-tracker.com/compare.php?from=5771cd03344ba3a8df7ed364b6f98451b68fcb30&to=597567670167f7c60be659389bd22b773fbac4ac&stat=instructions:u