### PR TITLE
[IR][NFC] Rename insertDbgValueIntrinsic -> insertDbgValue

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -6413,8 +6413,8 @@ void CGDebugInfo::EmitPseudoVariable(CGBuilderTy &Builder,
                                   Type, false, llvm::DINode::FlagArtificial);
 
   if (auto InsertPoint = Value->getInsertionPointAfterDef()) {
-    DBuilder.insertDbgValueIntrinsic(Value, D, DBuilder.createExpression(), DIL,
-                                     *InsertPoint);
+    DBuilder.insertDbgValue(Value, D, DBuilder.createExpression(), DIL,
+                            *InsertPoint);
   }
 }
 

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -1157,22 +1157,21 @@ namespace llvm {
                               unsigned Line, StringRef Name = "",
                               DINodeArray Elements = nullptr);
 
-    /// Insert a new llvm.dbg.declare intrinsic call.
+    /// Insert a new #dbg_declare record.
     /// \param Storage     llvm::Value of the variable
     /// \param VarInfo     Variable's debug info descriptor.
     /// \param Expr        A complex location expression.
     /// \param DL          Debug info location.
-    /// \param InsertAtEnd Location for the new intrinsic.
-    LLVM_ABI DbgInstPtr insertDeclare(llvm::Value *Storage,
-                                      DILocalVariable *VarInfo,
+    /// \param InsertAtEnd Location for the new record.
+    LLVM_ABI DbgInstPtr insertDeclare(Value *Storage, DILocalVariable *VarInfo,
                                       DIExpression *Expr, const DILocation *DL,
                                       BasicBlock *InsertAtEnd);
 
-    /// Insert a new llvm.dbg.assign intrinsic call.
+    /// Insert a new #dbg_assign record.
     /// \param LinkedInstr   Instruction with a DIAssignID to link with the new
-    ///                      intrinsic. The intrinsic will be inserted after
-    ///                      this instruction.
-    /// \param Val           The value component of this dbg.assign.
+    ///                      record. The record will be inserted after this
+    ///                      instruction.
+    /// \param Val           The value component of this #dbg_assign.
     /// \param SrcVar        Variable's debug info descriptor.
     /// \param ValExpr       A complex location expression to modify \p Val.
     /// \param Addr          The address component (store destination).
@@ -1188,47 +1187,46 @@ namespace llvm {
                                         DIExpression *AddrExpr,
                                         const DILocation *DL);
 
-    /// Insert a new llvm.dbg.declare intrinsic call.
+    /// Insert a new #dbg_declare record.
     /// \param Storage      llvm::Value of the variable
     /// \param VarInfo      Variable's debug info descriptor.
     /// \param Expr         A complex location expression.
     /// \param DL           Debug info location.
-    /// \param InsertPt     Location for the new intrinsic.
+    /// \param InsertPt     Location for the new record.
     LLVM_ABI DbgInstPtr insertDeclare(llvm::Value *Storage,
                                       DILocalVariable *VarInfo,
                                       DIExpression *Expr, const DILocation *DL,
                                       InsertPosition InsertPt);
 
-    /// Insert a new llvm.dbg.declare_value intrinsic call.
+    /// Insert a new #dbg_declare_value record.
     /// \param Storage      llvm::Value of the variable
     /// \param VarInfo      Variable's debug info descriptor.
     /// \param Expr         A complex location expression.
     /// \param DL           Debug info location.
-    /// \param InsertPt     Location for the new intrinsic.
-    LLVM_ABI DbgInstPtr insertDeclareValue(llvm::Value *Storage,
+    /// \param InsertPt     Location for the new record.
+    LLVM_ABI DbgInstPtr insertDeclareValue(Value *Storage,
                                            DILocalVariable *VarInfo,
                                            DIExpression *Expr,
                                            const DILocation *DL,
                                            InsertPosition InsertPt);
 
-    /// Insert a new llvm.dbg.label intrinsic call.
+    /// Insert a new #dbg_label record.
     /// \param LabelInfo    Label's debug info descriptor.
     /// \param DL           Debug info location.
-    /// \param InsertBefore Location for the new intrinsic.
+    /// \param InsertPt     Location for the new record.
     LLVM_ABI DbgInstPtr insertLabel(DILabel *LabelInfo, const DILocation *DL,
                                     InsertPosition InsertPt);
 
-    /// Insert a new llvm.dbg.value intrinsic call.
+    /// Insert a new #dbg_value record.
     /// \param Val          llvm::Value of the variable
     /// \param VarInfo      Variable's debug info descriptor.
     /// \param Expr         A complex location expression.
     /// \param DL           Debug info location.
-    /// \param InsertPt     Location for the new intrinsic.
-    LLVM_ABI DbgInstPtr insertDbgValueIntrinsic(llvm::Value *Val,
-                                                DILocalVariable *VarInfo,
-                                                DIExpression *Expr,
-                                                const DILocation *DL,
-                                                InsertPosition InsertPt);
+    /// \param InsertPt     Location for the new record.
+    LLVM_ABI DbgInstPtr insertDbgValue(llvm::Value *Val,
+                                       DILocalVariable *VarInfo,
+                                       DIExpression *Expr, const DILocation *DL,
+                                       InsertPosition InsertPt);
 
     /// Replace the vtable holder in the given type.
     ///

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -1155,7 +1155,7 @@ DILexicalBlock *DIBuilder::createLexicalBlock(DIScope *Scope, DIFile *File,
 DbgInstPtr DIBuilder::insertDeclare(Value *Storage, DILocalVariable *VarInfo,
                                     DIExpression *Expr, const DILocation *DL,
                                     BasicBlock *InsertAtEnd) {
-  // If this block already has a terminator then insert this intrinsic before
+  // If this block already has a terminator then insert this record before
   // the terminator. Otherwise, put it at the end of the block.
   Instruction *InsertBefore = InsertAtEnd->getTerminatorOrNull();
   return insertDeclare(Storage, VarInfo, Expr, DL,
@@ -1194,11 +1194,9 @@ static Value *getDbgIntrinsicValueImpl(LLVMContext &VMContext, Value *V) {
   return MetadataAsValue::get(VMContext, ValueAsMetadata::get(V));
 }
 
-DbgInstPtr DIBuilder::insertDbgValueIntrinsic(llvm::Value *Val,
-                                              DILocalVariable *VarInfo,
-                                              DIExpression *Expr,
-                                              const DILocation *DL,
-                                              InsertPosition InsertPt) {
+DbgInstPtr DIBuilder::insertDbgValue(Value *Val, DILocalVariable *VarInfo,
+                                     DIExpression *Expr, const DILocation *DL,
+                                     InsertPosition InsertPt) {
   DbgVariableRecord *DVR =
       DbgVariableRecord::createDbgVariableRecord(Val, VarInfo, Expr, DL);
   insertDbgVariableRecord(DVR, InsertPt);

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1907,7 +1907,7 @@ LLVMDbgRecordRef LLVMDIBuilderInsertDeclareRecordAtEnd(
 LLVMDbgRecordRef LLVMDIBuilderInsertDbgValueRecordBefore(
     LLVMDIBuilderRef Builder, LLVMValueRef Val, LLVMMetadataRef VarInfo,
     LLVMMetadataRef Expr, LLVMMetadataRef DebugLoc, LLVMValueRef Instr) {
-  DbgInstPtr DbgInst = unwrap(Builder)->insertDbgValueIntrinsic(
+  DbgInstPtr DbgInst = unwrap(Builder)->insertDbgValue(
       unwrap(Val), unwrap<DILocalVariable>(VarInfo), unwrap<DIExpression>(Expr),
       unwrap<DILocation>(DebugLoc),
       Instr ? InsertPosition(unwrap<Instruction>(Instr)->getIterator())
@@ -1925,7 +1925,7 @@ LLVMDbgRecordRef LLVMDIBuilderInsertDbgValueRecordBefore(
 LLVMDbgRecordRef LLVMDIBuilderInsertDbgValueRecordAtEnd(
     LLVMDIBuilderRef Builder, LLVMValueRef Val, LLVMMetadataRef VarInfo,
     LLVMMetadataRef Expr, LLVMMetadataRef DebugLoc, LLVMBasicBlockRef Block) {
-  DbgInstPtr DbgInst = unwrap(Builder)->insertDbgValueIntrinsic(
+  DbgInstPtr DbgInst = unwrap(Builder)->insertDbgValue(
       unwrap(Val), unwrap<DILocalVariable>(VarInfo), unwrap<DIExpression>(Expr),
       unwrap<DILocation>(DebugLoc),
       Block ? InsertPosition(unwrap(Block)->end()) : nullptr);

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -1311,9 +1311,8 @@ static void fixupDebugInfoPostExtraction(Function &OldFunc, Function &NewFunc,
                         &NewFunc.getEntryBlock());
       return;
     }
-    DIB.insertDbgValueIntrinsic(
-        NewLoc, DR->getVariable(), Expr, DR->getDebugLoc(),
-        NewFunc.getEntryBlock().getTerminator()->getIterator());
+    DIB.insertDbgValue(NewLoc, DR->getVariable(), Expr, DR->getDebugLoc(),
+                       NewFunc.getEntryBlock().getTerminator()->getIterator());
   };
   for (auto [Input, NewVal] : zip_equal(Inputs, NewValues)) {
     SmallVector<DbgVariableRecord *, 1> DPUsers;

--- a/llvm/lib/Transforms/Utils/Debugify.cpp
+++ b/llvm/lib/Transforms/Utils/Debugify.cpp
@@ -240,8 +240,7 @@ bool llvm::applyDebugifyMetadata(
       auto LocalVar = DIB.createAutoVariable(SP, Name, File, Loc->getLine(),
                                              getCachedDIType(V->getType()),
                                              /*AlwaysPreserve=*/true);
-      DIB.insertDbgValueIntrinsic(V, LocalVar, DIB.createExpression(), Loc,
-                                  InsertPt);
+      DIB.insertDbgValue(V, LocalVar, DIB.createExpression(), Loc, InsertPt);
     };
 
     for (BasicBlock &BB : F) {

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -1040,12 +1040,12 @@ TEST_F(IRBuilderTest, DIBuilder) {
     DILocalVariable *VarY =
         DIB.createAutoVariable(BarSP, "Y", File, 2, IntType, true);
     { /* dbg.value | DbgVariableRecord::Value */
-      ExpectOrder(DIB.insertDbgValueIntrinsic(I, VarX, DIB.createExpression(),
-                                              VarLoc, I->getIterator()),
+      ExpectOrder(DIB.insertDbgValue(I, VarX, DIB.createExpression(), VarLoc,
+                                     I->getIterator()),
                   I->getIterator());
       // Check inserting at end of the block works as with labels.
-      DbgInstPtr VarXValue = DIB.insertDbgValueIntrinsic(
-          I, VarX, DIB.createExpression(), VarLoc, BB);
+      DbgInstPtr VarXValue =
+          DIB.insertDbgValue(I, VarX, DIB.createExpression(), VarLoc, BB);
       I = Builder.CreateAlloca(Builder.getInt32Ty());
       ExpectOrder(VarXValue, I->getIterator());
       EXPECT_EQ(BB->getTrailingDbgRecords(), nullptr);

--- a/llvm/unittests/Transforms/Utils/CloningTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CloningTest.cpp
@@ -513,7 +513,7 @@ protected:
         DBuilder.createAutoVariable(Subprogram, "x", File, 5, IntType, true);
     auto *DL = DILocation::get(Subprogram->getContext(), 5, 0, Subprogram);
     DBuilder.insertDeclare(Alloca, Variable, E, DL, Store->getIterator());
-    DBuilder.insertDbgValueIntrinsic(AllocaContent, Variable, E, DL, Entry);
+    DBuilder.insertDbgValue(AllocaContent, Variable, E, DL, Entry);
     // Also create an inlined variable.
     // Create a distinct struct type that we should not duplicate during
     // cloning).

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -833,7 +833,7 @@ def LLVM_DbgValueOp : LLVM_DbgIntrOp<"dbg.value", "value",
 
     llvm::Module *module = builder.GetInsertBlock()->getModule();
     llvm::DIBuilder debugInfoBuilder(*module);
-    debugInfoBuilder.insertDbgValueIntrinsic(
+    debugInfoBuilder.insertDbgValue(
         moduleTranslation.lookupValue(opInst.getOperand(0)),
         llvm::cast<llvm::DILocalVariable>(
             moduleTranslation.translateDebugInfo($varInfo)),


### PR DESCRIPTION
Rename `insertDbgValueIntrinsic` to `insertDbgValue`, which is consistent with the other insert helpers like `insertDbgAssign`, `insertDeclare`, etc.
Also use debug record instead of intrinsic terminology in doc comments.