### PR TITLE
[ELF,SPARC] Support ABS and RELATIVE dynamic relocations

### DIFF
--- a/lld/ELF/Arch/SPARCV9.cpp
+++ b/lld/ELF/Arch/SPARCV9.cpp
@@ -25,6 +25,8 @@ public:
   SPARCV9(Ctx &);
   RelExpr getRelExpr(RelType type, const Symbol &s,
                      const uint8_t *loc) const override;
+  RelType getDynRel(RelType type) const override;
+  int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
   void writePlt(uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   template <class ELFT, class RelTy>
@@ -70,6 +72,23 @@ RelExpr SPARCV9::getRelExpr(RelType type, const Symbol &s,
     Err(ctx) << getErrorLoc(ctx, loc) << "unknown relocation (" << type.v
              << ") against symbol " << &s;
     return R_NONE;
+  }
+}
+
+RelType SPARCV9::getDynRel(RelType type) const {
+  if (type == R_SPARC_64)
+    return type;
+  return R_SPARC_NONE;
+}
+
+int64_t SPARCV9::getImplicitAddend(const uint8_t *buf, RelType type) const {
+  switch (type) {
+  case R_SPARC_64:
+  case R_SPARC_GLOB_DAT:
+    return read64be(buf);
+  default:
+    InternalErr(ctx, buf) << "cannot read addend for relocation " << type;
+    return 0;
   }
 }
 

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1327,9 +1327,10 @@ static SmallVector<StringRef, 0> getSymbolOrderingFile(Ctx &ctx,
 
 static bool getIsRela(Ctx &ctx, opt::InputArgList &args) {
   // The psABI specifies the default relocation entry format.
-  bool rela = is_contained({EM_AARCH64, EM_AMDGPU, EM_HEXAGON, EM_LOONGARCH,
-                            EM_PPC, EM_PPC64, EM_RISCV, EM_S390, EM_X86_64},
-                           ctx.arg.emachine);
+  bool rela =
+      is_contained({EM_AARCH64, EM_AMDGPU, EM_HEXAGON, EM_LOONGARCH, EM_PPC,
+                    EM_PPC64, EM_RISCV, EM_S390, EM_SPARCV9, EM_X86_64},
+                   ctx.arg.emachine);
   // If -z rel or -z rela is specified, use the last option.
   for (auto *arg : args.filtered(OPT_z)) {
     StringRef s(arg->getValue());

--- a/lld/test/ELF/sparcv9-abs-pic.s
+++ b/lld/test/ELF/sparcv9-abs-pic.s
@@ -1,0 +1,28 @@
+# REQUIRES: sparc
+# RUN: llvm-mc -filetype=obj -triple=sparcv9 %s -o %t.o
+# RUN: ld.lld -shared %t.o -o %t.so
+# RUN: llvm-nm %t.so | FileCheck --check-prefix=NM %s
+# RUN: llvm-readobj -r %t.so | FileCheck --check-prefix=RELOC %s
+# RUN: ld.lld -shared --apply-dynamic-relocs %t.o -o %t1.so
+# RUN: llvm-objdump -s -j .data %t1.so | FileCheck --check-prefix=HEX %s
+
+## R_SPARC_64 is an absolute relocation type.
+## In PIC mode, it creates a relative relocation if the symbol is non-preemptable.
+
+# NM: 0000000000300350 d b
+
+# RELOC:      .rela.dyn {
+# RELOC-NEXT:   0x300350 R_SPARC_RELATIVE - 0x300350
+# RELOC-NEXT:   0x300348 R_SPARC_64 a 0x0
+# RELOC-NEXT: }
+
+# HEX:      Contents of section .data:
+# HEX-NEXT: 300348 00000000 00000000 00000000 00300350
+
+.globl a, b
+.hidden b
+
+.data
+.quad a
+b:
+.quad b

--- a/lld/test/ELF/sparcv9-reloc-got.s
+++ b/lld/test/ELF/sparcv9-reloc-got.s
@@ -1,0 +1,39 @@
+# REQUIRES: sparc
+# RUN: llvm-mc -filetype=obj -triple=sparcv9 %s -o %t.o
+# RUN: echo '.globl b; b:' | llvm-mc -filetype=obj -triple=sparcv9 - -o %t1.o
+# RUN: ld.lld -shared %t1.o -soname=t1.so -o %t1.so
+
+# RUN: ld.lld %t.o %t1.so -o %t
+# RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
+# RUN: llvm-nm %t | FileCheck --check-prefix=NM %s
+# RUN: llvm-readelf -x .got %t | FileCheck --check-prefix=HEX %s
+# RUN: llvm-objdump -d --no-show-raw-insn --no-print-imm-hex %t | FileCheck %s
+
+# RELOC:      .rela.dyn {
+# RELOC-NEXT:   0x300358 R_SPARC_GLOB_DAT b 0x0
+# RELOC-NEXT: }
+
+# NM: 0000000000300358 d _GLOBAL_OFFSET_TABLE_
+# NM: 0000000000400368 d a
+
+# HEX:      section '.got':
+# HEX-NEXT: 0x00300358 00000000 00000000 00000000 00400368
+
+## a: &.got[1] - _GLOBAL_OFFSET_TABLE_ = 0x300360 - 0x300358 = 8
+## b: &.got[0] - _GLOBAL_OFFSET_TABLE_ = 0x300358 - 0x300358 = 0
+# CHECK:      sethi 0, %o0
+# CHECK-NEXT: or %o0, 8, %o0
+# CHECK-NEXT: sethi 0, %o1
+# CHECK-NEXT: or %o1, 0, %o1
+
+# RUN: ld.lld --apply-dynamic-relocs %t.o %t1.so -o %t2
+# RUN: llvm-readelf -x .got %t2 | FileCheck --check-prefix=HEX %s
+
+  sethi %got22(a), %o0
+  or    %o0, %got10(a), %o0
+  sethi %got22(b), %o1
+  or    %o1, %got10(b), %o1
+
+.data
+a:
+.quad _GLOBAL_OFFSET_TABLE_


### PR DESCRIPTION
... and test some previously uncovered GOT relocation types.
Test convention follows ppc32-*, which I added in 2019.

The SPARC psABI only defines Elf64_Rela. Add EM_SPARCV9 to getIsRela so
that dynamic relocations use .rela.dyn/.rela.plt instead of the
unsupported SHT_REL form.

Co-authored-by: Kirill A. Korinsky <kirill@korins.ky>