### PR TITLE
[ELF,SPARC] Handle more relocation types and fix simm13 field writes

### DIFF
--- a/lld/ELF/Arch/SPARCV9.cpp
+++ b/lld/ELF/Arch/SPARCV9.cpp
@@ -59,6 +59,9 @@ SPARCV9::SPARCV9(Ctx &ctx) : TargetInfo(ctx) {
 RelExpr SPARCV9::getRelExpr(RelType type, const Symbol &s,
                             const uint8_t *loc) const {
   switch (type) {
+  case R_SPARC_8:
+  case R_SPARC_16:
+  case R_SPARC_UA16:
   case R_SPARC_32:
   case R_SPARC_UA32:
   case R_SPARC_64:
@@ -113,6 +116,9 @@ void SPARCV9::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels,
       continue;
 
     // Absolute relocations:
+    case R_SPARC_8:
+    case R_SPARC_16:
+    case R_SPARC_UA16:
     case R_SPARC_32:
     case R_SPARC_UA32:
     case R_SPARC_64:
@@ -124,7 +130,10 @@ void SPARCV9::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels,
     case R_SPARC_HM10:
     case R_SPARC_LM22:
     case R_SPARC_HI22:
+    case R_SPARC_13:
     case R_SPARC_LO10:
+    case R_SPARC_HIX22:
+    case R_SPARC_LOX10:
       expr = R_ABS;
       break;
 
@@ -134,15 +143,22 @@ void SPARCV9::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels,
       continue;
 
     // PC-relative relocations:
+    case R_SPARC_DISP8:
+    case R_SPARC_DISP16:
+    case R_SPARC_DISP32:
+    case R_SPARC_DISP64:
     case R_SPARC_PC10:
     case R_SPARC_PC22:
-    case R_SPARC_DISP32:
+    case R_SPARC_WDISP16:
+    case R_SPARC_WDISP19:
+    case R_SPARC_WDISP22:
     case R_SPARC_WDISP30:
       rs.processR_PC(type, offset, addend, sym);
       continue;
 
     // GOT relocations:
     case R_SPARC_GOT10:
+    case R_SPARC_GOT13:
     case R_SPARC_GOT22:
       expr = R_GOT_OFF;
       break;
@@ -168,11 +184,32 @@ void SPARCV9::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels,
 void SPARCV9::relocate(uint8_t *loc, const Relocation &rel,
                        uint64_t val) const {
   switch (rel.type) {
+  case R_SPARC_8:
+    // V-byte8
+    checkIntUInt(ctx, loc, val, 8, rel);
+    *loc = val;
+    break;
+  case R_SPARC_16:
+  case R_SPARC_UA16:
+    // V-half16
+    checkIntUInt(ctx, loc, val, 16, rel);
+    write16be(loc, val);
+    break;
   case R_SPARC_32:
   case R_SPARC_UA32:
     // V-word32
     checkUInt(ctx, loc, val, 32, rel);
     write32be(loc, val);
+    break;
+  case R_SPARC_DISP8:
+    // V-byte8
+    checkInt(ctx, loc, val, 8, rel);
+    *loc = val;
+    break;
+  case R_SPARC_DISP16:
+    // V-half16
+    checkInt(ctx, loc, val, 16, rel);
+    write16be(loc, val);
     break;
   case R_SPARC_DISP32:
     // V-disp32
@@ -190,21 +227,47 @@ void SPARCV9::relocate(uint8_t *loc, const Relocation &rel,
     checkUInt(ctx, loc, val, 22, rel);
     write32be(loc, (read32be(loc) & ~0x003fffff) | (val & 0x003fffff));
     break;
+  case R_SPARC_13:
+    // V-simm13
+    checkIntUInt(ctx, loc, val, 13, rel);
+    write32be(loc, (read32be(loc) & ~0x00001fff) | (val & 0x00001fff));
+    break;
+  case R_SPARC_GOT13:
+    // V-simm13
+    checkInt(ctx, loc, val, 13, rel);
+    write32be(loc, (read32be(loc) & ~0x00001fff) | (val & 0x00001fff));
+    break;
   case R_SPARC_GOT22:
-  case R_SPARC_PC22:
   case R_SPARC_LM22:
     // T-imm22
     write32be(loc, (read32be(loc) & ~0x003fffff) | ((val >> 10) & 0x003fffff));
     break;
+  case R_SPARC_PC22:
+    // V-disp22
+    checkIntUInt(ctx, loc, val, 32, rel);
+    write32be(loc, (read32be(loc) & ~0x003fffff) | ((val >> 10) & 0x003fffff));
+    break;
   case R_SPARC_HI22:
     // V-imm22
-    checkUInt(ctx, loc, val >> 10, 22, rel);
+    checkUInt(ctx, loc, val, 32, rel);
     write32be(loc, (read32be(loc) & ~0x003fffff) | ((val >> 10) & 0x003fffff));
+    break;
+  case R_SPARC_WDISP22:
+    // V-disp22
+    checkInt(ctx, loc, val, 24, rel);
+    write32be(loc, (read32be(loc) & ~0x003fffff) | ((val >> 2) & 0x003fffff));
     break;
   case R_SPARC_WDISP19:
     // V-disp19
     checkInt(ctx, loc, val, 21, rel);
     write32be(loc, (read32be(loc) & ~0x0007ffff) | ((val >> 2) & 0x0007ffff));
+    break;
+  case R_SPARC_WDISP16:
+    // V-d2/disp14
+    checkInt(ctx, loc, val, 18, rel);
+    write32be(loc, (read32be(loc) & ~0x00303fff) |
+                       (((val >> 2) & 0x0000c000) << 6) |
+                       ((val >> 2) & 0x00003fff));
     break;
   case R_SPARC_GOT10:
   case R_SPARC_PC10:
@@ -213,25 +276,25 @@ void SPARCV9::relocate(uint8_t *loc, const Relocation &rel,
     break;
   case R_SPARC_LO10:
     // T-simm13
-    write32be(loc, (read32be(loc) & ~0x00001fff) | (val & 0x000003ff));
+    write32be(loc, (read32be(loc) & ~0x000003ff) | (val & 0x000003ff));
     break;
   case R_SPARC_64:
+  case R_SPARC_DISP64:
   case R_SPARC_UA64:
     // V-xword64
     write64be(loc, val);
     break;
   case R_SPARC_HH22:
     // V-imm22
-    checkUInt(ctx, loc, val >> 42, 22, rel);
     write32be(loc, (read32be(loc) & ~0x003fffff) | ((val >> 42) & 0x003fffff));
     break;
   case R_SPARC_HM10:
     // T-simm13
-    write32be(loc, (read32be(loc) & ~0x00001fff) | ((val >> 32) & 0x000003ff));
+    write32be(loc, (read32be(loc) & ~0x000003ff) | ((val >> 32) & 0x000003ff));
     break;
   case R_SPARC_H44:
     // V-imm22
-    checkUInt(ctx, loc, val >> 22, 22, rel);
+    checkUInt(ctx, loc, val, 44, rel);
     write32be(loc, (read32be(loc) & ~0x003fffff) | ((val >> 22) & 0x003fffff));
     break;
   case R_SPARC_M44:
@@ -240,12 +303,18 @@ void SPARCV9::relocate(uint8_t *loc, const Relocation &rel,
     break;
   case R_SPARC_L44:
     // T-imm13
-    write32be(loc, (read32be(loc) & ~0x00001fff) | (val & 0x00000fff));
+    write32be(loc, (read32be(loc) & ~0x00000fff) | (val & 0x00000fff));
+    break;
+  case R_SPARC_HIX22:
+    // V-imm22
+    checkUInt(ctx, loc, ~val, 32, rel);
+    write32be(loc, (read32be(loc) & ~0x003fffff) | ((~val >> 10) & 0x003fffff));
     break;
   case R_SPARC_TLS_LE_HIX22:
     // T-imm22
     write32be(loc, (read32be(loc) & ~0x003fffff) | ((~val >> 10) & 0x003fffff));
     break;
+  case R_SPARC_LOX10:
   case R_SPARC_TLS_LE_LOX10:
     // T-simm13
     write32be(loc, (read32be(loc) & ~0x00001fff) | (val & 0x000003ff) | 0x1C00);

--- a/lld/test/ELF/sparcv9-reloc-got.s
+++ b/lld/test/ELF/sparcv9-reloc-got.s
@@ -6,33 +6,35 @@
 # RUN: ld.lld %t.o %t1.so -o %t
 # RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-nm %t | FileCheck --check-prefix=NM %s
-# RUN: llvm-readelf -x .got %t | FileCheck --check-prefix=HEX %s
-# RUN: llvm-objdump -d --no-show-raw-insn --no-print-imm-hex %t | FileCheck %s
+# RUN: llvm-objdump -d -s --no-show-raw-insn --no-print-imm-hex %t | \
+# RUN:   FileCheck %s --check-prefixes=HEX,CHECK
 
 # RELOC:      .rela.dyn {
-# RELOC-NEXT:   0x300358 R_SPARC_GLOB_DAT b 0x0
+# RELOC-NEXT:   0x300360 R_SPARC_GLOB_DAT b 0x0
 # RELOC-NEXT: }
 
-# NM: 0000000000300358 d _GLOBAL_OFFSET_TABLE_
-# NM: 0000000000400368 d a
+# NM: 0000000000300360 d _GLOBAL_OFFSET_TABLE_
+# NM: 0000000000400370 d a
 
-# HEX:      section '.got':
-# HEX-NEXT: 0x00300358 00000000 00000000 00000000 00400368
+# HEX:      Contents of section .got:
+# HEX-NEXT: 300360 00000000 00000000 00000000 00400370
 
-## a: &.got[1] - _GLOBAL_OFFSET_TABLE_ = 0x300360 - 0x300358 = 8
-## b: &.got[0] - _GLOBAL_OFFSET_TABLE_ = 0x300358 - 0x300358 = 0
+## a: &.got[1] - _GLOBAL_OFFSET_TABLE_ = 0x300368 - 0x300360 = 8
+## b: &.got[0] - _GLOBAL_OFFSET_TABLE_ = 0x300360 - 0x300360 = 0
 # CHECK:      sethi 0, %o0
 # CHECK-NEXT: or %o0, 8, %o0
 # CHECK-NEXT: sethi 0, %o1
 # CHECK-NEXT: or %o1, 0, %o1
+# CHECK-NEXT: ldx [%l7+8], %o2
 
 # RUN: ld.lld --apply-dynamic-relocs %t.o %t1.so -o %t2
-# RUN: llvm-readelf -x .got %t2 | FileCheck --check-prefix=HEX %s
+# RUN: llvm-objdump -s -j .got %t2 | FileCheck --check-prefix=HEX %s
 
   sethi %got22(a), %o0
   or    %o0, %got10(a), %o0
   sethi %got22(b), %o1
   or    %o1, %got10(b), %o1
+  ldx   [%l7 + %got13(a)], %o2
 
 .data
 a:

--- a/lld/test/ELF/sparcv9-reloc-pc.s
+++ b/lld/test/ELF/sparcv9-reloc-pc.s
@@ -1,0 +1,61 @@
+# REQUIRES: sparc
+# RUN: llvm-mc -filetype=obj -triple=sparcv9 %s -o %t.o
+
+## Every branch form reaches the same nearby target.
+# RUN: ld.lld %t.o --defsym=w16=_start+0x18 --defsym=w19=_start+0x18 \
+# RUN:   --defsym=w22=_start+0x18 --defsym=w30=_start+0x18 \
+# RUN:   --defsym=far=_start+0x100000 -o %t
+# RUN: llvm-objdump -d -s -j .text --no-print-imm-hex %t | FileCheck %s
+
+## Displacements at the top of each field. R_SPARC_WDISP16 splits its
+## displacement between bits 21:20 and 13:0, so d16hi is only exercised here.
+# RUN: ld.lld %t.o --defsym=w16=_start+0x1fffc --defsym=w19=_start+0x100000 \
+# RUN:   --defsym=w22=_start+0x800004 --defsym=w30=_start+0x80000008 \
+# RUN:   --defsym=far=_start+0x100000 -o %t.limits
+# RUN: llvm-objdump -d %t.limits | FileCheck --check-prefix=LIMITS %s
+
+## R_SPARC_DISP8, R_SPARC_DISP16, R_SPARC_DISP32 and R_SPARC_DISP64 close out
+## .text, each holding target - . = -4, -5, -7 and -11. The 16-, 32- and 64-bit
+## stores are unaligned; SPARC has no unaligned variant of the DISP relocations.
+# CHECK:      Contents of section .text:
+# CHECK:      fcfffbff
+# CHECK-NEXT: fffff9ff ffffffff fffff5
+
+## far - . is 0xffff0 for the sethi and 0xfffec for the or.
+# CHECK:      <_start>:
+# CHECK-NEXT:   0a c8 40 06 brnz %g1, 0x[[#%x,TGT:]]
+# CHECK-NEXT:   02 48 00 05 be %icc, 0x[[#TGT]]
+# CHECK-NEXT:   10 80 00 04 ba 0x[[#TGT]]
+# CHECK-NEXT:   40 00 00 03 call 0x[[#TGT]]
+# CHECK-NEXT:   05 00 03 ff sethi 1023, %g2
+# CHECK-NEXT:   84 10 a3 ec or %g2, 1004, %g2
+
+## w16 - . is 0x1fffc, so d16hi is 0b01 and d16lo is 0x3fff.
+## w19 - . is 0xffffc, w22 - . is 0x7ffffc and w30 - . is 0x7ffffffc.
+# LIMITS:      <_start>:
+# LIMITS-NEXT:   0a d8 7f ff brnz
+# LIMITS-NEXT:   02 4b ff ff be
+# LIMITS-NEXT:   10 9f ff ff ba
+# LIMITS-NEXT:   5f ff ff ff call
+
+.section .text.a,"ax",@progbits
+.globl _start
+_start:
+## R_SPARC_WDISP16, R_SPARC_WDISP19, R_SPARC_WDISP22, R_SPARC_WDISP30
+  brnz    %g1, w16
+  be,pt   %icc, w19
+  ba      w22
+  call    w30
+## R_SPARC_PC22, R_SPARC_PC10
+  sethi   %pc22(far), %g2
+  or      %g2, %pc10(far), %g2
+
+.section .text.b,"ax",@progbits
+target:
+  nop
+
+.section .text.c,"ax",@progbits
+  .byte  target - .
+  .half  target - .
+  .word  target - .
+  .xword target - .

--- a/lld/test/ELF/sparcv9-reloc-range.s
+++ b/lld/test/ELF/sparcv9-reloc-range.s
@@ -1,0 +1,49 @@
+# REQUIRES: sparc
+# RUN: llvm-mc -filetype=obj -triple=sparcv9 %s -o %t.o
+## --threads=1 applies the sections in order, so the diagnostics are ordered.
+# RUN: not ld.lld --threads=1 %t.o --defsym=abs=0x10000 --defsym=big=0x100000000000 \
+# RUN:   --defsym=far=pc+0x8000000 --defsym=huge=pc+0x200000000 -o /dev/null 2>&1 | \
+# RUN:   FileCheck %s --implicit-check-not=error:
+
+## The absolute forms take a signed as well as an unsigned value.
+## R_SPARC_HIX22 encodes the complement of the value, which must fit in 32 bits.
+## The value it reports is that complement, here ~0x10000.
+# CHECK: error: {{.*}}:(.abs+0x0): relocation R_SPARC_8 out of range: 65536 is not in [-128, 255]; references 'abs'
+# CHECK: error: {{.*}}:(.abs+0x2): relocation R_SPARC_16 out of range: 65536 is not in [-32768, 65535]; references 'abs'
+# CHECK: error: {{.*}}:(.abs+0x4): relocation R_SPARC_13 out of range: 65536 is not in [-4096, 8191]; references 'abs'
+# CHECK: error: {{.*}}:(.abs+0x8): relocation R_SPARC_HI22 out of range: 17592186044416 is not in [0, 4294967295]; references 'big'
+# CHECK: error: {{.*}}:(.abs+0xc): relocation R_SPARC_H44 out of range: 17592186044416 is not in [0, 17592186044415]; references 'big'
+# CHECK: error: {{.*}}:(.abs+0x10): relocation R_SPARC_HIX22 out of range: 18446744073709486079 is not in [0, 4294967295]; references 'abs'
+.section .abs,"ax",@progbits
+  .byte abs
+  .balign 2
+  .half abs
+  .balign 4
+  or    %g0, abs, %g1
+  sethi %hi(big), %g1
+  sethi %h44(big), %g1
+  sethi %hix(abs), %g1
+
+## The PC-relative forms are signed, except R_SPARC_PC22, which is a bit field.
+## far and huge are relative to pc, so the displacements do not depend on the
+## output layout.
+# CHECK: error: {{.*}}:(.pcrel+0x0): relocation R_SPARC_DISP8 out of range: 134217728 is not in [-128, 127]; references 'far'
+# CHECK: error: {{.*}}:(.pcrel+0x1): relocation R_SPARC_DISP16 out of range: 134217727 is not in [-32768, 32767]; references 'far'
+# CHECK: error: {{.*}}:(.pcrel+0x3): relocation R_SPARC_DISP32 out of range: 8589934589 is not in [-2147483648, 2147483647]; references 'huge'
+# CHECK: error: {{.*}}:(.pcrel+0x8): relocation R_SPARC_WDISP16 out of range: 134217720 is not in [-131072, 131071]; references 'far'
+# CHECK: error: {{.*}}:(.pcrel+0xc): relocation R_SPARC_WDISP19 out of range: 134217716 is not in [-1048576, 1048575]; references 'far'
+# CHECK: error: {{.*}}:(.pcrel+0x10): relocation R_SPARC_WDISP22 out of range: 134217712 is not in [-8388608, 8388607]; references 'far'
+# CHECK: error: {{.*}}:(.pcrel+0x14): relocation R_SPARC_WDISP30 out of range: 8589934572 is not in [-2147483648, 2147483647]; references 'huge'
+# CHECK: error: {{.*}}:(.pcrel+0x18): relocation R_SPARC_PC22 out of range: 8589934568 is not in [-2147483648, 4294967295]; references 'huge'
+.section .pcrel,"ax",@progbits
+.globl pc
+pc:
+  .byte far - .
+  .half far - .
+  .word huge - .
+  .balign 4
+  brnz  %g1, far
+  be,pt %icc, far
+  ba    far
+  call  huge
+  sethi %pc22(huge), %g5

--- a/lld/test/ELF/sparcv9-reloc.s
+++ b/lld/test/ELF/sparcv9-reloc.s
@@ -1,6 +1,9 @@
 # REQUIRES: sparc
 # RUN: llvm-mc -filetype=obj -triple=sparcv9 %s -o %t.o
-# RUN: ld.lld %t.o --defsym=a=0x0123456789ABCDEF --defsym=b=0x0123456789A --defsym=c=0x01234567 -o %t
+## d/e, f/g and h/i sit at the two ends of the 13-, 16- and 8-bit fields.
+# RUN: ld.lld %t.o --defsym=a=0x0123456789ABCDEF --defsym=b=0x0123456789A --defsym=c=0x01234567 \
+# RUN:   --defsym=d=0x1fff --defsym=e=-0x1000 --defsym=f=0xffff --defsym=g=-0x8000 \
+# RUN:   --defsym=h=0xff --defsym=i=-0x80 --defsym=x=0xffffffff01234567 -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn --no-print-imm-hex %t | FileCheck %s
 # RUN: llvm-objdump -s %t | FileCheck --check-prefix=HEX %s
 
@@ -31,9 +34,66 @@
   sethi %hi(c), %o0
   or    %o0, %lo(c), %o0
 
-## R_SPARC_64, R_SPARC_32
+## R_SPARC_13 takes a signed as well as an unsigned value. The field is a
+## simm13, so the unsigned maximum 0x1fff is written and reads back as -1.
+# CHECK-LABEL: section .ABS_13:
+# CHECK:        mov -1, %o0
+# CHECK-NEXT:   mov -4096, %o1
+.section .ABS_13,"ax",@progbits
+  or    %g0, d, %o0
+  or    %g0, e, %o1
+
+## R_SPARC_HIX22, R_SPARC_LOX10. The pair encodes the complement of the value,
+## so it is limited to values whose upper 32 bits are all ones.
+## sethi(~x >> 10) ^ sext(0x1c00 | (x & 0x3ff)) = 0xfedcb800 ^ 0xfffffffffffffd67
+# CHECK-LABEL: section .ABS_HIX:
+# CHECK:        sethi 4175662, %o0
+# CHECK-NEXT:   xor %o0, -665, %o0
+.section .ABS_HIX,"ax",@progbits
+  sethi %hix(x), %o0
+  xor   %o0, %lox(x), %o0
+
+## R_SPARC_LO10, R_SPARC_HM10 and R_SPARC_L44 write 10, 10 and 12 bits of the
+## simm13 field and leave the remaining bits of the instruction alone, so an
+## immediate of -1024 (0x1c00) survives in the high bits.
+# CHECK-LABEL: section .ABS_MASK:
+# CHECK:        or %o0, -665, %o0
+# CHECK-NEXT:   or %o1, -665, %o1
+# CHECK-NEXT:   or %o2, -1894, %o2
+.section .ABS_MASK,"ax",@progbits
+  or %o0, -1024, %o0
+  .reloc .-4, R_SPARC_LO10, c
+  or %o1, -1024, %o1
+  .reloc .-4, R_SPARC_HM10, a
+  or %o2, -1024, %o2
+  .reloc .-4, R_SPARC_L44, b
+
+## R_SPARC_64, R_SPARC_32, R_SPARC_16, R_SPARC_8, R_SPARC_UA16. R_SPARC_8 and
+## R_SPARC_16 take a signed as well as an unsigned value.
 # HEX-LABEL: section .ABS_DATA:
-# HEX-NEXT:  01234567 89abcdef 01234567
+# HEX-NEXT:  01234567 89abcdef 01234567 ffffff80
+# HEX-NEXT:  0080
 .section .ABS_DATA,"ax",@progbits
   .quad a
   .long c
+  .half f
+  .byte h
+## An odd offset makes the assembler pick the unaligned form.
+  .half g
+  .byte i
+
+## Relocations in a non-SHF_ALLOC section are resolved through getRelExpr.
+## The second group starts at an odd offset, so the assembler picks the
+## unaligned forms.
+# HEX-LABEL: section .debug_info:
+# HEX-NEXT:  ffff8000 01234567 01234567 89abcdef
+# HEX-NEXT:  ffffff01 23456701 23456789 abcdef
+.section .debug_info,"",@progbits
+  .half f
+  .half g
+  .long c
+  .quad a
+  .byte h
+  .half f
+  .long c
+  .quad a


### PR DESCRIPTION
Add the absolute (R_SPARC_8/16/UA16, R_SPARC_13, R_SPARC_HIX22/LOX10),
PC-relative (R_SPARC_DISP8/16/64, R_SPARC_WDISP16/19/22) and GOT
(R_SPARC_GOT13) forms. The assembler emits these, but lld reports
"unknown relocation".

Since aff950e95d4a, R_SPARC_LO10, R_SPARC_HM10 and R_SPARC_L44 clear the
whole simm13 field while writing only its low 10, 10 and 12 bits, dropping
bits that GNU ld preserves. Narrow each mask to the bits it writes.

Give R_SPARC_PC22 its own case, as a displacement needing a range check.
Express the R_SPARC_HI22 and R_SPARC_H44 checks in terms of the unshifted
value to improve the diagnostic, and drop the R_SPARC_HH22 check, which
no 64-bit value can fail.

Co-authored-by: Kirill A. Korinsky <kirill@korins.ky>
Co-authored-by: LemonBoy <thatlemon@gmail.com>
Co-authored-by: Alex Rønne Petersen <alex@alexrp.com>