### PR TITLE
[ELF,SPARC] Add the GOT header entry and place R_SPARC_JMP_SLOT in .plt

### DIFF
--- a/lld/ELF/Arch/SPARCV9.cpp
+++ b/lld/ELF/Arch/SPARCV9.cpp
@@ -27,6 +27,7 @@ public:
                      const uint8_t *loc) const override;
   RelType getDynRel(RelType type) const override;
   int64_t getImplicitAddend(const uint8_t *buf, RelType type) const override;
+  void writeGotHeader(uint8_t *buf) const override;
   void writePlt(uint8_t *buf, const Symbol &sym,
                 uint64_t pltEntryAddr) const override;
   template <class ELFT, class RelTy>
@@ -46,8 +47,10 @@ SPARCV9::SPARCV9(Ctx &ctx) : TargetInfo(ctx) {
   pltRel = R_SPARC_JMP_SLOT;
   relativeRel = R_SPARC_RELATIVE;
   symbolicRel = R_SPARC_64;
+  gotHeaderEntriesNum = 1;
   pltEntrySize = 32;
   pltHeaderSize = 4 * pltEntrySize;
+  usesGotPlt = false;
 
   defaultCommonPageSize = 8192;
   defaultMaxPageSize = 0x100000;
@@ -322,6 +325,11 @@ void SPARCV9::relocate(uint8_t *loc, const Relocation &rel,
   default:
     llvm_unreachable("unknown relocation");
   }
+}
+
+void SPARCV9::writeGotHeader(uint8_t *buf) const {
+  // _GLOBAL_OFFSET_TABLE_[0] = _DYNAMIC
+  write64be(buf, ctx.in.dynamic->getVA());
 }
 
 void SPARCV9::writePlt(uint8_t *buf, const Symbol & /*sym*/,

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -750,13 +750,15 @@ template <class PltSection, class GotPltSection>
 static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
                         RelocationBaseSection &rel, RelType type, Symbol &sym) {
   plt.addEntry(sym);
+  RelExpr expr = sym.isPreemptible ? R_ADDEND : R_ABS;
+  if (!ctx.target->usesGotPlt) {
+    rel.addReloc(
+        {type, &plt, sym.getPltOffset(ctx), sym.isPreemptible, sym, 0, expr});
+    return;
+  }
   gotPlt.addEntry(sym);
-  if (sym.isPreemptible)
-    rel.addReloc(
-        {type, &gotPlt, sym.getGotPltOffset(ctx), true, sym, 0, R_ADDEND});
-  else
-    rel.addReloc(
-        {type, &gotPlt, sym.getGotPltOffset(ctx), false, sym, 0, R_ABS});
+  rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx), sym.isPreemptible, sym,
+                0, expr});
 }
 
 void elf::addGotEntry(Ctx &ctx, Symbol &sym) {

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -182,11 +182,15 @@ uint64_t Symbol::getGotPltOffset(Ctx &ctx) const {
          ctx.target->gotEntrySize;
 }
 
+uint64_t Symbol::getPltOffset(Ctx &ctx) const {
+  if (isInIplt)
+    return getPltIdx(ctx) * ctx.target->ipltEntrySize;
+  return ctx.in.plt->headerSize + getPltIdx(ctx) * ctx.target->pltEntrySize;
+}
+
 uint64_t Symbol::getPltVA(Ctx &ctx) const {
-  uint64_t outVA = isInIplt ? ctx.in.iplt->getVA() +
-                                  getPltIdx(ctx) * ctx.target->ipltEntrySize
-                            : ctx.in.plt->getVA() + ctx.in.plt->headerSize +
-                                  getPltIdx(ctx) * ctx.target->pltEntrySize;
+  uint64_t outVA = (isInIplt ? ctx.in.iplt->getVA() : ctx.in.plt->getVA()) +
+                   getPltOffset(ctx);
 
   // While linking microMIPS code PLT code are always microMIPS
   // code. Set the less-significant bit to track that fact.

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -198,6 +198,7 @@ public:
   uint64_t getGotVA(Ctx &) const;
   uint64_t getGotPltOffset(Ctx &) const;
   uint64_t getGotPltVA(Ctx &) const;
+  uint64_t getPltOffset(Ctx &) const;
   uint64_t getPltVA(Ctx &) const;
   uint64_t getSize() const;
   OutputSection *getOutputSection() const;

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -1521,9 +1521,14 @@ void RelocationBaseSection::finalizeContents() {
   else
     getParent()->link = 0;
 
-  if (ctx.in.relaPlt.get() == this && ctx.in.gotPlt->getParent()) {
-    getParent()->flags |= ELF::SHF_INFO_LINK;
-    getParent()->info = ctx.in.gotPlt->getParent()->sectionIndex;
+  if (ctx.in.relaPlt.get() == this) {
+    InputSection *sec = ctx.target->usesGotPlt
+                            ? static_cast<InputSection *>(ctx.in.gotPlt.get())
+                            : static_cast<InputSection *>(ctx.in.plt.get());
+    if (sec->getParent()) {
+      getParent()->flags |= ELF::SHF_INFO_LINK;
+      getParent()->info = sec->getParent()->sectionIndex;
+    }
   }
 }
 

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -172,6 +172,11 @@ public:
   // On PPC ELF V2 abi, the first entry in the .got is the .TOC.
   unsigned gotHeaderEntriesNum = 0;
 
+  // True if the dynamic linker resolves a PLT entry by writing the target
+  // address to a GotPltSection slot (named .plt on PPC). SPARC instead has it
+  // rewrite the PLT entry's instructions, so pltRel applies to .plt.
+  bool usesGotPlt = true;
+
   // On PPC ELF V2 abi, the dynamic section needs DT_PPC64_OPT (DT_LOPROC + 3)
   // to be set to 0x2 if there can be multiple TOC's. Although we do not emit
   // multiple TOC's, there can be a mix of TOC and NOTOC addressing which

--- a/lld/test/ELF/sparcv9-plt.s
+++ b/lld/test/ELF/sparcv9-plt.s
@@ -1,0 +1,66 @@
+# REQUIRES: sparc
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=sparcv9 b.s -o b.o
+# RUN: ld.lld -shared b.o -soname=b.so -o b.so
+# RUN: llvm-mc --position-independent -filetype=obj -triple=sparcv9 a.s -o a.o
+# RUN: ld.lld a.o b.so -o a
+# RUN: llvm-readelf -S -d -r -s a | FileCheck %s --implicit-check-not=.got.plt
+# RUN: llvm-objdump -d -z -j .text -j .plt --no-print-imm-hex a | FileCheck --check-prefix=DIS %s
+
+## SPARC has no .got.plt. The dynamic linker rewrites the PLT entries in place,
+## so .plt is writable and DT_PLTGOT points at it, and .rela.plt names .plt in
+## its sh_info.
+# CHECK: [ 5] .rela.plt RELA {{[0-9a-f]+}} {{[0-9a-f]+}} 000048 18 AI 1 7 8
+# CHECK: [ 7] .plt PROGBITS 0000000000300320 {{[0-9a-f]+}} 0000e0 00 WAX
+# CHECK: (PLTGOT) 0x300320
+
+## R_SPARC_JMP_SLOT applies to the PLT entry rather than to a .got.plt slot.
+# CHECK:      Relocation section '.rela.plt' {{.*}} contains 3 entries:
+# CHECK:      00000000003003a0 {{.*}} R_SPARC_JMP_SLOT {{.*}} weak + 0
+# CHECK-NEXT: 00000000003003c0 {{.*}} R_SPARC_JMP_SLOT {{.*}} bar + 0
+# CHECK-NEXT: 00000000003003e0 {{.*}} R_SPARC_JMP_SLOT {{.*}} foo + 0
+
+# CHECK:      0000000000000000 0 FUNC WEAK   DEFAULT UND weak
+# CHECK-NEXT: 0000000000000000 0 FUNC GLOBAL DEFAULT UND bar
+# CHECK-NEXT: 00000000003003e0 0 FUNC GLOBAL DEFAULT UND foo
+
+# DIS:      <_start>:
+# DIS-NEXT:   call 0x3003c0
+# DIS-NEXT:   nop
+# DIS-NEXT:   call 0x3003a0
+# DIS-NEXT:   nop
+
+## The four reserved entries are left zeroed, as GNU ld leaves them. The
+## dynamic linker writes the resolver code into .PLT0 and .PLT1 at startup.
+# DIS:          0000000000300320 <.plt>:
+# DIS-COUNT-32:   unimp 0
+
+## Each entry puts its own offset from .plt into %g1 and branches to .PLT1,
+## which the dynamic linker redirects to the resolver.
+# DIS-NEXT:   3003a0: 03 00 00 80 sethi 128, %g1
+# DIS-NEXT:           30 6f ff e7 ba,a %xcc, 0x300340
+# DIS:        3003c0: 03 00 00 a0 sethi 160, %g1
+# DIS-NEXT:           30 6f ff df ba,a %xcc, 0x300340
+# DIS:        3003e0: 03 00 00 c0 sethi 192, %g1
+# DIS-NEXT:           30 6f ff d7 ba,a %xcc, 0x300340
+
+#--- a.s
+.globl _start
+.weak weak
+_start:
+  call bar
+  nop
+  call weak
+  nop
+## Taking foo's address forces a canonical PLT.
+  sethi %pc22(foo), %g1
+  or    %g1, %pc10(foo), %g1
+
+#--- b.s
+.globl bar, weak, foo
+.type bar,@function
+.type weak,@function
+.type foo,@function
+bar:
+weak:
+foo:

--- a/lld/test/ELF/sparcv9-reloc-got.s
+++ b/lld/test/ELF/sparcv9-reloc-got.s
@@ -10,22 +10,25 @@
 # RUN:   FileCheck %s --check-prefixes=HEX,CHECK
 
 # RELOC:      .rela.dyn {
-# RELOC-NEXT:   0x300360 R_SPARC_GLOB_DAT b 0x0
+# RELOC-NEXT:   0x300368 R_SPARC_GLOB_DAT b 0x0
 # RELOC-NEXT: }
 
+# NM: 00000000003002a0 d _DYNAMIC
 # NM: 0000000000300360 d _GLOBAL_OFFSET_TABLE_
-# NM: 0000000000400370 d a
+# NM: 0000000000400378 d a
 
+## .got[0] holds the address of _DYNAMIC.
 # HEX:      Contents of section .got:
-# HEX-NEXT: 300360 00000000 00000000 00000000 00400370
+# HEX-NEXT: 300360 00000000 003002a0 00000000 00000000
+# HEX-NEXT: 300370 00000000 00400378
 
-## a: &.got[1] - _GLOBAL_OFFSET_TABLE_ = 0x300368 - 0x300360 = 8
-## b: &.got[0] - _GLOBAL_OFFSET_TABLE_ = 0x300360 - 0x300360 = 0
+## a: &.got[2] - _GLOBAL_OFFSET_TABLE_ = 0x300370 - 0x300360 = 16
+## b: &.got[1] - _GLOBAL_OFFSET_TABLE_ = 0x300368 - 0x300360 = 8
 # CHECK:      sethi 0, %o0
-# CHECK-NEXT: or %o0, 8, %o0
+# CHECK-NEXT: or %o0, 16, %o0
 # CHECK-NEXT: sethi 0, %o1
-# CHECK-NEXT: or %o1, 0, %o1
-# CHECK-NEXT: ldx [%l7+8], %o2
+# CHECK-NEXT: or %o1, 8, %o1
+# CHECK-NEXT: ldx [%l7+16], %o2
 
 # RUN: ld.lld --apply-dynamic-relocs %t.o %t1.so -o %t2
 # RUN: llvm-objdump -s -j .got %t2 | FileCheck --check-prefix=HEX %s


### PR DESCRIPTION
The SPARC dynamic linker finds _DYNAMIC by dereferencing the GOT pointer
register (glibc elf_machine_dynamic), so reserve .got[0] for it. It
resolves a PLT entry by rewriting the entry's instructions (glibc
sparc64_fixup_plt), so R_SPARC_JMP_SLOT applies to .plt and there is no
.got.plt.

Add TargetInfo::usesGotPlt, which SPARC sets to false, and use it to
place the relocation and derive the sh_info of .rela.plt. The four
reserved PLT entries stay zeroed, as with GNU ld; the dynamic linker
fills in .PLT0 and .PLT1 at startup.

Co-authored-by: Kirill A. Korinsky <kirill@korins.ky>
Co-authored-by: LemonBoy <thatlemon@gmail.com>
