### PR TITLE
[Mips] Do not fold select(cond, binop(x, a), binop(x, b)) when the a/b is legal imm

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -3064,6 +3064,14 @@ public:
     return Value == 0;
   }
 
+  /// Return true if the specified immediate is legal immediate operation,
+  /// that is the target has instructions which can perform the operation
+  /// with the immediate without having to materialize the immediate into a
+  /// register.
+  virtual bool isLegalImmediate(unsigned Opc, const SDValue Val) const {
+    return false;
+  }
+
   /// Given a shuffle vector SVI representing a vector splat, return a new
   /// scalar type of size equal to SVI's scalar type if the new type is more
   /// profitable. Returns nullptr otherwise. For example under MVE float splats

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -30920,23 +30920,31 @@ SDValue DAGCombiner::foldSelectOfBinops(SDNode *N) {
 
   // Fold select(cond, binop(x, y), binop(z, y))
   //  --> binop(select(cond, x, z), y)
+  // unless x or z are legal immediate operands for binop, in which case
+  // executing the binops first is faster
   if (N1.getOperand(1) == N2.getOperand(1)) {
     SDValue N10 = N1.getOperand(0);
     SDValue N20 = N2.getOperand(0);
-    SDValue NewSel = DAG.getSelect(DL, N10.getValueType(), N0, N10, N20);
-    SDNodeFlags Flags = N1->getFlags() & N2->getFlags();
-    SDValue NewBinOp =
-        DAG.getNode(BinOpc, DL, OpVTs, {NewSel, N1.getOperand(1)}, Flags);
-    return SDValue(NewBinOp.getNode(), N1.getResNo());
+    if (!TLI.isLegalImmediate(BinOpc, N10) &&
+        !TLI.isLegalImmediate(BinOpc, N20)) {
+      SDValue NewSel = DAG.getSelect(DL, N10.getValueType(), N0, N10, N20);
+      SDNodeFlags Flags = N1->getFlags() & N2->getFlags();
+      SDValue NewBinOp =
+          DAG.getNode(BinOpc, DL, OpVTs, {NewSel, N1.getOperand(1)}, Flags);
+      return SDValue(NewBinOp.getNode(), N1.getResNo());
+    }
   }
 
   // Fold select(cond, binop(x, y), binop(x, z))
   //  --> binop(x, select(cond, y, z))
+  // unless y or z are legal immediate operands for binop
   if (N1.getOperand(0) == N2.getOperand(0)) {
     SDValue N11 = N1.getOperand(1);
     SDValue N21 = N2.getOperand(1);
     // Second op VT might be different (e.g. shift amount type)
-    if (N11.getValueType() == N21.getValueType()) {
+    if (N11.getValueType() == N21.getValueType() &&
+        !TLI.isLegalImmediate(BinOpc, N11) &&
+        !TLI.isLegalImmediate(BinOpc, N21)) {
       SDValue NewSel = DAG.getSelect(DL, N11.getValueType(), N0, N11, N21);
       SDNodeFlags Flags = N1->getFlags() & N2->getFlags();
       SDValue NewBinOp =

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -4501,6 +4501,29 @@ bool MipsTargetLowering::isLegalAddImmediate(int64_t Imm) const {
   return isInt<16>(Imm);
 }
 
+bool MipsTargetLowering::isLegalImmediate(unsigned Opc,
+                                          const SDValue Val) const {
+  switch (Opc) {
+  case ISD::ADD:
+  case ISD::AND:
+  case ISD::OR:
+  case ISD::XOR:
+  case ISD::SETCC:
+    switch (Val.getNode()->getOpcode()) {
+    case MipsISD::Lo:
+    case MipsISD::GPRel:
+      return true;
+    default:
+      if (auto Const = dyn_cast<ConstantSDNode>(Val)) {
+        return isInt<16>(Const->getSExtValue());
+      }
+    }
+    break;
+  }
+
+  return false;
+}
+
 unsigned MipsTargetLowering::getJumpTableEncoding() const {
   if (!isPositionIndependent())
     return MachineJumpTableInfo::EK_BlockAddress;

--- a/llvm/lib/Target/Mips/MipsISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsISelLowering.h
@@ -496,6 +496,7 @@ using TargetRegisterClass = MCRegisterClass;
 
     bool isLegalICmpImmediate(int64_t Imm) const override;
     bool isLegalAddImmediate(int64_t Imm) const override;
+    bool isLegalImmediate(unsigned Opc, const SDValue Value) const override;
 
     unsigned getJumpTableEncoding() const override;
     SDValue getPICJumpTableRelocBase(SDValue Table,

--- a/llvm/test/CodeGen/Mips/cmov.ll
+++ b/llvm/test/CodeGen/Mips/cmov.ll
@@ -1,9 +1,10 @@
-; RUN: llc -mtriple=mips     -mcpu=mips32                 -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMOV
-; RUN: llc -mtriple=mips     -mcpu=mips32 -regalloc=basic -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMOV
-; RUN: llc -mtriple=mips     -mcpu=mips32r2               -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMOV
+; RUN: llc -mtriple=mips     -mcpu=mips32                 -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMOV,32-CPIC
+; RUN: llc -mtriple=mips     -mcpu=mips32 -regalloc=basic -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMOV,32-CPIC
+; RUN: llc -mtriple=mips     -mcpu=mips32r2               -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMOV,32-CPIC
+; RUN: llc -mtriple=mips     -mcpu=mips32                 -relocation-model=static -mgpopt -mattr=+noabicalls < %s | FileCheck %s -check-prefixes=ALL,32-CMOV,32-CGP
 ; RUN: llc -mtriple=mips     -mcpu=mips32r6               -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,32-CMP
-; RUN: llc -mtriple=mips64el -mcpu=mips4                  -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,64-CMOV
-; RUN: llc -mtriple=mips64el -mcpu=mips64                 -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,64-CMOV
+; RUN: llc -mtriple=mips64el -mcpu=mips4                  -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,64-CMOV,64-CPIC
+; RUN: llc -mtriple=mips64el -mcpu=mips64                 -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,64-CMOV,64-CPIC
 ; RUN: llc -mtriple=mips64el -mcpu=mips64r6               -relocation-model=pic < %s | FileCheck %s -check-prefixes=ALL,64-CMP
 
 @i1 = global [3 x i32] [i32 1, i32 2, i32 3], align 4
@@ -11,10 +12,15 @@
 
 ; ALL-LABEL: cmov1:
 
-; 32-CMOV-DAG:  lw $[[R0:[0-9]+]], %got(i3)
-; 32-CMOV-DAG:  addiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got(i1)
-; 32-CMOV-DAG:  movn $[[R0]], $[[R1]], $4
-; 32-CMOV-DAG:  lw $2, 0($[[R0]])
+; 32-CPIC-DAG:  lw $[[R0:[0-9]+]], %got(i3)
+; 32-CPIC-DAG:  addiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got(i1)
+; 32-CPIC-DAG:  movn $[[R0]], $[[R1]], $4
+; 32-CPIC-DAG:  lw $2, 0($[[R0]])
+
+; 32-CGP-DAG:   lui $[[R1:[0-9]+]], %hi(i1)
+; 32-CGP-DAG:   addiu $[[R1]], $[[R1]], %lo(i1)
+; 32-CGP-DAG:   lw $[[R0:[0-9]+]], %gp_rel(i3)($gp)
+; 32-CGP-DAG:   movn $[[R0]], $[[R1]], $4
 
 ; 32-CMP-DAG:   lw $[[R0:[0-9]+]], %got(i3)
 ; 32-CMP-DAG:   addiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got(i1)
@@ -23,9 +29,9 @@
 ; 32-CMP-DAG:   or $[[T2:[0-9]+]], $[[T0]], $[[T1]]
 ; 32-CMP-DAG:   lw $2, 0($[[T2]])
 
-; 64-CMOV-DAG:  ldr $[[R0:[0-9]+]]
-; 64-CMOV-DAG:  ld $[[R1:[0-9]+]], %got_disp(i1)
-; 64-CMOV-DAG:  movn $[[R0]], $[[R1]], $4
+; 64-CPIC-DAG:  ldr $[[R0:[0-9]+]]
+; 64-CPIC-DAG:  ld $[[R1:[0-9]+]], %got_disp(i1)
+; 64-CPIC-DAG:  movn $[[R0]], $[[R1]], $4
 
 ; 64-CMP-DAG:   ld $[[R0:[0-9]+]], %got_disp(i3)(
 ; 64-CMP-DAG:   daddiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got_disp(i1)
@@ -51,10 +57,14 @@ entry:
 
 ; ALL-LABEL: cmov2:
 
-; 32-CMOV-DAG:  addiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got(d)
-; 32-CMOV-DAG:  addiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got(c)
-; 32-CMOV-DAG:  movn  $[[R1]], $[[R0]], $4
-; 32-CMOV-DAG:  lw $2, 0($[[R0]])
+; 32-CPIC-DAG:  addiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got(d)
+; 32-CPIC-DAG:  addiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got(c)
+; 32-CPIC-DAG:  movn  $[[R1]], $[[R0]], $4
+; 32-CPIC-DAG:  lw $2, 0($[[R0]])
+
+; 32-CGP-DAG:  addiu $[[R1:[0-9]+]], $gp, %gp_rel(d)
+; 32-CGP-DAG:  addiu $[[R0:[0-9]+]], $gp, %gp_rel(c)
+; 32-CGP-DAG:  movn $[[R1]], $[[R0]], $4
 
 ; 32-CMP-DAG:   addiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got(d)
 ; 32-CMP-DAG:   addiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got(c)

--- a/llvm/test/CodeGen/Mips/llvm-ir/select-globaladdr.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/select-globaladdr.ll
@@ -1,20 +1,27 @@
-; RUN: llc < %s -mattr +noabicalls -mgpopt | FileCheck %s -check-prefixes=MIPS64
-
-target triple = "mips64-unknown-linux-muslabi64"
+; RUN: llc < %s -mtriple=mips   -mattr +noabicalls -mgpopt | FileCheck %s -check-prefixes=MIPS32
+; RUN: llc < %s -mtriple=mips64 -mattr +noabicalls -mgpopt | FileCheck %s -check-prefixes=MIPS64
 
 @.str = external constant [6 x i8]
 @.str.1 = external constant [6 x i8]
 
 define ptr @tst_select_ptr_ptr(i1 %tobool.not) {
+; MIPS32-LABEL: tst_select_ptr_ptr:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    andi $[[R0:[0-9]+]], $4, 1
+; MIPS32-NEXT:    addiu $[[T0:[0-9]+]], $gp, %gp_rel(.str)
+; MIPS32-NEXT:    addiu $[[T1:[0-9]+]], $gp, %gp_rel(.str.1)
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    movn $[[T0]], $[[T1]], $[[R0]]
+
 ; MIPS64-LABEL: tst_select_ptr_ptr:
 ; MIPS64:       # %bb.0: # %entry
-; MIPS64-NEXT:    sll $1, $4, 0
-; MIPS64-NEXT:    andi $1, $1, 1
-; MIPS64-NEXT:    daddiu $2, $zero, %gp_rel(.str)
-; MIPS64-NEXT:    daddiu $3, $zero, %gp_rel(.str.1)
-; MIPS64-NEXT:    movn $2, $3, $1
+; MIPS64-NEXT:    sll $[[R0:[0-9]+]], $4, 0
+; MIPS64-NEXT:    andi $[[R0]], $[[R0]], 1
+; MIPS64-NEXT:    daddiu $[[T0:[0-9]+]], $gp, %gp_rel(.str)
+; MIPS64-NEXT:    daddiu $[[T1:[0-9]+]], $gp, %gp_rel(.str.1)
 ; MIPS64-NEXT:    jr $ra
-; MIPS64-NEXT:    daddu $2, $gp, $2
+; MIPS64-NEXT:    movn $[[T0]], $[[T1]], $[[R0]]
+
 entry:
   %cond = select i1 %tobool.not, ptr @.str.1, ptr @.str
   ret ptr %cond


### PR DESCRIPTION
Do not optimize (select (op a b) (op a c)) into (op a (select b c)) when b or c are legal immediates for op.  This may needlessly materialize b and c into registers.  This also results in code gen failure on MIPS when selecting between gp relative addresses.

Fixes #212057 