### PR TITLE
[RISCV] Resolve an explicit I+E extension set to I

### DIFF
--- a/lld/test/ELF/riscv-attributes.s
+++ b/lld/test/ELF/riscv-attributes.s
@@ -30,6 +30,14 @@
 # RUN: ld.lld -e 0 unrecognized_version.o merge_version_test_input.o -o out3 2>&1 | count 0
 # RUN: llvm-readobj --arch-specific out3 | FileCheck %s --check-prefix=CHECK3
 
+## Merging RVE and RVI yields RVI, because RVE is a subset of RVI.
+# RUN: llvm-mc -filetype=obj -triple=riscv32 rv32i.s -o rv32i.o
+# RUN: llvm-mc -filetype=obj -triple=riscv32 rv32e.s -o rv32e.o
+# RUN: ld.lld -e 0 rv32i.o rv32e.o -o rv32ie 2>&1 | count 0
+# RUN: llvm-readobj --arch-specific rv32ie | FileCheck %s --check-prefix=RV32IE
+# RUN: ld.lld -e 0 rv32e.o rv32i.o -o rv32ei 2>&1 | count 0
+# RUN: llvm-readobj --arch-specific rv32ei | FileCheck %s --check-prefix=RV32IE
+
 # RUN: llvm-mc -filetype=obj -triple=riscv64 invalid_arch1.s -o invalid_arch1.o
 # RUN: not ld.lld invalid_arch1.o 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
 # INVALID_ARCH1: error: invalid_arch1.o:(.riscv.attributes): rv64i2: extension lacks version in expected format
@@ -303,6 +311,29 @@
 .byte 5  # Tag_RISCV_arch
 .asciz "rv64i2p1"
 .Lend:
+
+#--- rv32i.s
+.attribute arch, "rv32i2p1"
+
+#--- rv32e.s
+.attribute arch, "rv32e2p0"
+
+# RV32IE:      BuildAttributes {
+# RV32IE-NEXT:   FormatVersion: 0x41
+# RV32IE-NEXT:   Section 1 {
+# RV32IE-NEXT:     SectionLength: 25
+# RV32IE-NEXT:     Vendor: riscv
+# RV32IE-NEXT:     Tag: Tag_File (0x1)
+# RV32IE-NEXT:     Size: 15
+# RV32IE-NEXT:     FileAttributes {
+# RV32IE-NEXT:       Attribute {
+# RV32IE-NEXT:         Tag: 5
+# RV32IE-NEXT:         TagName: arch
+# RV32IE-NEXT:         Value: rv32i2p1{{$}}
+# RV32IE-NEXT:       }
+# RV32IE-NEXT:     }
+# RV32IE-NEXT:   }
+# RV32IE-NEXT: }
 
 #--- invalid_arch1.s
 .section .riscv.attributes,"",@0x70000003

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -466,6 +466,11 @@ RISCVISAInfo::parseFeatures(unsigned XLen,
       ISAInfo->Exts.erase(ExtName.str());
   }
 
+  // I and E are mutually exclusive. When E is requested, drop the default I
+  // (e.g. injected by the generic CPU) so the two do not conflict.
+  if (ISAInfo->Exts.count("e"))
+    ISAInfo->Exts.erase("i");
+
   return RISCVISAInfo::postProcessAndChecking(std::move(ISAInfo));
 }
 
@@ -966,10 +971,10 @@ void RISCVISAInfo::updateImplication() {
   if (!HasE && !HasI) {
     auto Version = findDefaultVersion("i");
     Exts["i"] = *Version;
+  } else if (HasE && HasI) {
+    // Keep the 32-register i, of which e is a subset.
+    Exts.erase("e");
   }
-
-  if (HasE && HasI)
-    Exts.erase("i");
 }
 
 static constexpr StringLiteral CombineIntoExts[] = {


### PR DESCRIPTION
Linking an rv32i object with an rv32e object merges their arch attributes into an extension map holding both I and E, and createFromExtMap()'s updateImplication() resolved that to E, giving an rv32e output. That is wrong: RVE (16 GPRs) is a subset of RVI (32 GPRs), so a binary combining RVE and RVI code needs the full RVI base.

updateImplication() erased I unconditionally to strip the default I that the generic-rv32/rv64 CPU injects when compiling -march=rv32e, so that the explicitly requested E wins. Move that stripping to parseFeatures(), where the default I and the requested E actually meet: drop I whenever E is present. The only remaining way both bases reach updateImplication() is an explicit extension map (e.g. merged arch attributes), so resolve that in favor of I instead.