### PR TITLE
[orc-rt] Session::HandlerTag -> orc_rt_ControllerHandlerTag

### DIFF
--- a/orc-rt/include/orc-rt-c/CoreTypes.h
+++ b/orc-rt/include/orc-rt-c/CoreTypes.h
@@ -28,6 +28,11 @@ typedef struct orc_rt_OpaqueError *orc_rt_ErrorRef;
  */
 typedef struct orc_rt_OpaqueSession *orc_rt_SessionRef;
 
+/**
+ * Identifies a handler in the controller that is callable by the executor.
+ */
+typedef void *orc_rt_ControllerHandlerTag;
+
 ORC_RT_C_EXTERN_C_END
 
 #endif /* ORC_RT_C_CORETYPES_H */

--- a/orc-rt/include/orc-rt/InProcessControllerAccess.h
+++ b/orc-rt/include/orc-rt/InProcessControllerAccess.h
@@ -14,6 +14,7 @@
 #ifndef ORC_RT_INPROCESSCONTROLLERACCESS_H
 #define ORC_RT_INPROCESSCONTROLLERACCESS_H
 
+#include "orc-rt-c/CoreTypes.h"
 #include "orc-rt-c/WrapperFunction.h"
 #include "orc-rt/Error.h"
 #include "orc-rt/Session.h"
@@ -40,7 +41,8 @@ public:
 
     /// Accessors to be set by the InProcessEPC instance.
     void *IPEPC = nullptr;
-    void (*CallJITDispatch)(void *IPEPC, uint64_t CallId, void *HandlerTag,
+    void (*CallJITDispatch)(void *IPEPC, uint64_t CallId,
+                            orc_rt_ControllerHandlerTag T,
                             orc_rt_WrapperFunctionBuffer ArgBytes) = nullptr;
     void (*ReturnWrapperResult)(void *IPEPC, uint64_t CallId,
                                 orc_rt_WrapperFunctionBuffer ResultBytes) =
@@ -107,7 +109,8 @@ public:
 
   void disconnect() override;
 
-  void callController(OnControllerCallReturn OnComplete, HandlerTag T,
+  void callController(OnControllerCallReturn OnComplete,
+                      orc_rt_ControllerHandlerTag T,
                       WrapperFunctionBuffer ArgBytes) override;
   void sendWrapperResult(uint64_t CallId,
                          WrapperFunctionBuffer ResultBytes) override;

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -91,10 +91,6 @@ public:
   /// pool.
   using DispatchFn = move_only_function<void(Task)>;
 
-  /// Tag used to identify executor-callable functions in the controller.
-  /// See callController.
-  using HandlerTag = void *;
-
   /// Provides access to the controller.
   class ControllerAccess {
     friend class Session;
@@ -103,8 +99,6 @@ public:
     virtual ~ControllerAccess();
 
   protected:
-    using HandlerTag = Session::HandlerTag;
-
     /// Opaque wrapper for a controller-call result handler.
     ///
     /// ControllerAccess implementations hold these for pending calls but cannot
@@ -218,7 +212,8 @@ public:
     /// managed-code caller's token still covers the handler, and a non-managed
     /// caller needs none (a handler that re-enters managed code must acquire
     /// its own token and handle denial).
-    virtual void callController(OnControllerCallReturn OnComplete, HandlerTag T,
+    virtual void callController(OnControllerCallReturn OnComplete,
+                                orc_rt_ControllerHandlerTag T,
                                 WrapperFunctionBuffer ArgBytes) = 0;
 
     /// Send the result of the given wrapper function call to the controller.
@@ -485,7 +480,8 @@ public:
   /// This method can be called directly, but is expected to be more commonly
   /// called via WrapperFunction::call using a ControllerCaller object (returned
   /// by the controllerCaller method).
-  void callController(OnControllerCallReturnFn OnComplete, HandlerTag T,
+  void callController(OnControllerCallReturnFn OnComplete,
+                      orc_rt_ControllerHandlerTag T,
                       WrapperFunctionBuffer ArgBytes) {
     if (auto TmpCA = std::atomic_load(&CA))
       TmpCA->callController(std::move(OnComplete), T, std::move(ArgBytes));
@@ -500,7 +496,7 @@ public:
   /// Useable as a Caller implementation with WrapperFunction::call.
   class ControllerCaller {
   public:
-    ControllerCaller(Session &S, HandlerTag T) : S(S), T(T) {}
+    ControllerCaller(Session &S, orc_rt_ControllerHandlerTag T) : S(S), T(T) {}
 
     void operator()(OnControllerCallReturnFn &&HandleResult,
                     WrapperFunctionBuffer ArgBytes) {
@@ -509,12 +505,12 @@ public:
 
   private:
     Session &S;
-    HandlerTag T;
+    orc_rt_ControllerHandlerTag T;
   };
 
   /// Get a WrapperFunction::call-compatible Caller that will call the given
   /// handler in the controller via Session::callController.
-  ControllerCaller controllerCaller(HandlerTag T) noexcept {
+  ControllerCaller controllerCaller(orc_rt_ControllerHandlerTag T) noexcept {
     return ControllerCaller(*this, T);
   }
 

--- a/orc-rt/lib/executor/InProcessControllerAccess.cpp
+++ b/orc-rt/lib/executor/InProcessControllerAccess.cpp
@@ -201,7 +201,7 @@ void InProcessControllerAccess::disconnect() {
 }
 
 void InProcessControllerAccess::callController(
-    OnControllerCallReturn OnComplete, HandlerTag T,
+    OnControllerCallReturn OnComplete, orc_rt_ControllerHandlerTag T,
     WrapperFunctionBuffer ArgBytes) {
   assert(C && "callController called before connect");
   if (C->EnterMessageScope(C)) {

--- a/orc-rt/test/unit/InProcessControllerAccessTest.cpp
+++ b/orc-rt/test/unit/InProcessControllerAccessTest.cpp
@@ -32,8 +32,9 @@ class MockIPEPC {
 public:
   using Connection = InProcessControllerAccess::Connection;
 
-  using OnCallJITDispatchFn = move_only_function<void(
-      uint64_t CallId, void *HandlerTag, WrapperFunctionBuffer ArgBytes)>;
+  using OnCallJITDispatchFn =
+      move_only_function<void(uint64_t CallId, orc_rt_ControllerHandlerTag T,
+                              WrapperFunctionBuffer ArgBytes)>;
   using OnReturnWrapperResultFn = move_only_function<void(
       uint64_t CallId, WrapperFunctionBuffer ResultBytes)>;
 
@@ -83,12 +84,12 @@ public:
 
 private:
   static void callJITDispatchEntry(void *IPEPC, uint64_t CallId,
-                                   void *HandlerTag,
+                                   orc_rt_ControllerHandlerTag T,
                                    orc_rt_WrapperFunctionBuffer ArgBytes) {
     auto *Self = static_cast<MockIPEPC *>(IPEPC);
     WrapperFunctionBuffer Buf(ArgBytes);
     if (Self->OnCallJITDispatch)
-      Self->OnCallJITDispatch(CallId, HandlerTag, std::move(Buf));
+      Self->OnCallJITDispatch(CallId, T, std::move(Buf));
   }
 
   static void
@@ -181,7 +182,7 @@ TEST(InProcessControllerAccessTest, OnConnectFailureIsReportedAndDetaches) {
         if (const char *Msg = R.getOutOfBandError())
           CallErr = Msg;
       },
-      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      reinterpret_cast<orc_rt_ControllerHandlerTag>(0xdeadbeef),
       WrapperFunctionBuffer::copyFrom("x", 1));
 
   ASSERT_TRUE(CallErr);
@@ -209,7 +210,7 @@ TEST(InProcessControllerAccessTest, CallControllerSuccess) {
             << "Unexpected out-of-band error: " << R.getOutOfBandError();
         Result = std::string(R.data(), R.size());
       },
-      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      reinterpret_cast<orc_rt_ControllerHandlerTag>(0xdeadbeef),
       WrapperFunctionBuffer::copyFrom("hello", 5));
 
   ASSERT_TRUE(Result);
@@ -237,7 +238,7 @@ TEST(InProcessControllerAccessTest, CallControllerOutOfBandError) {
         if (const char *Msg = R.getOutOfBandError())
           ErrMsg = Msg;
       },
-      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      reinterpret_cast<orc_rt_ControllerHandlerTag>(0xdeadbeef),
       WrapperFunctionBuffer::copyFrom("payload", 7));
 
   ASSERT_TRUE(ErrMsg);
@@ -263,7 +264,7 @@ TEST(InProcessControllerAccessTest, DisconnectDrainsPendingCalls) {
         if (const char *Msg = R.getOutOfBandError())
           ErrMsg = Msg;
       },
-      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      reinterpret_cast<orc_rt_ControllerHandlerTag>(0xdeadbeef),
       WrapperFunctionBuffer::copyFrom("payload", 7));
 
   ASSERT_FALSE(ErrMsg) << "OnComplete fired prematurely";

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -177,7 +177,8 @@ public:
     notifyDisconnected();
   }
 
-  void callController(OnControllerCallReturn OnComplete, HandlerTag T,
+  void callController(OnControllerCallReturn OnComplete,
+                      orc_rt_ControllerHandlerTag T,
                       WrapperFunctionBuffer ArgBytes) override {
     // Simulate a call to the controller by running the requested function via
     // the test-supplied Post hook (or inline, if no hook was provided).
@@ -630,7 +631,8 @@ public:
   DeadControllerAccess(Session &S) : ControllerAccess(S) {}
   void connect(BootstrapInfo) override {}
   void disconnect() override { notifyDisconnected(); }
-  void callController(OnControllerCallReturn OnComplete, HandlerTag,
+  void callController(OnControllerCallReturn OnComplete,
+                      orc_rt_ControllerHandlerTag,
                       WrapperFunctionBuffer) override {
     failControllerCallInline(std::move(OnComplete));
   }
@@ -681,7 +683,7 @@ TEST(ControllerAccessTest, ValidCallToController) {
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
       S.controllerCaller(
-          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+          reinterpret_cast<orc_rt_ControllerHandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
   QueueingRunner<>::runFIFOUntilEmpty(Tasks);
@@ -697,7 +699,7 @@ TEST(ControllerAccessTest, CallToControllerBeforeAttach) {
   Error Err = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
       S.controllerCaller(
-          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+          reinterpret_cast<orc_rt_ControllerHandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) {
         ErrorAsOutParameter _(Err);
         Err = R.takeError();
@@ -718,7 +720,7 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
   Error Err = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
       S.controllerCaller(
-          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+          reinterpret_cast<orc_rt_ControllerHandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) {
         ErrorAsOutParameter _(Err);
         Err = R.takeError();
@@ -853,7 +855,7 @@ TEST(ControllerAccessTest, TryAttachSuccess) {
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
       S.controllerCaller(
-          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+          reinterpret_cast<orc_rt_ControllerHandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
   QueueingRunner<>::runFIFOUntilEmpty(Tasks);
@@ -873,7 +875,7 @@ TEST(ControllerAccessTest, TryAttachFailure) {
   Error CallErr = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
       S.controllerCaller(
-          reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
+          reinterpret_cast<orc_rt_ControllerHandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) {
         ErrorAsOutParameter _(CallErr);
         CallErr = R.takeError();


### PR DESCRIPTION
Replace the `Session::HandlerTag = void*` type alias with orc_rt_ControllerHandlerTag. The intent is both to make this type accessible to the C API, and to rename it to clarify its role as a tag for handlers in the controller that are callable by the executor.