### PR TITLE
[Flang][OpenMP] Add support for -fopenmp-target-fast

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4244,11 +4244,11 @@ def fno_openmp_target_new_runtime : Flag<["-"], "fno-openmp-target-new-runtime">
   Group<f_Group>, Flags<[HelpHidden]>, Visibility<[ClangOption, CC1Option]>;
 def fopenmp_target_fast : Flag<["-"], "fopenmp-target-fast">,
   Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
-  Visibility<[ClangOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   HelpText<"Assert common GPU usage patterns to enable OpenMP runtime optimizations">;
 def fno_openmp_target_fast : Flag<["-"], "fno-openmp-target-fast">,
   Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
-  Visibility<[ClangOption]>;
+  Visibility<[ClangOption, FlangOption]>;
 defm openmp_optimistic_collapse : BoolFOption<"openmp-optimistic-collapse",
   LangOpts<"OpenMPOptimisticCollapse">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option]>,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -757,15 +757,34 @@ void Flang::addOffloadOptions(Compilation &C, const InputInfoList &Inputs,
     // generating code for a device, so that only the relevant code is emitted.
     CmdArgs.push_back("-fopenmp-is-target-device");
 
+    // -fopenmp-target-fast implies -fopenmp-assume-no-thread-state and
+    // -fopenmp-assume-no-nested-parallelism, and forces -O3 unless an
+    // explicit optimization level was requested.
+    bool TargetFastUsed =
+        Args.hasFlag(options::OPT_fopenmp_target_fast,
+                     options::OPT_fno_openmp_target_fast, false);
+
+    if (TargetFastUsed && !Args.hasArg(options::OPT_O_Group))
+      CmdArgs.push_back("-O3");
+
     // When in OpenMP offloading mode, enable debugging on the device.
     Args.AddAllArgs(CmdArgs, options::OPT_fopenmp_target_debug_EQ);
     if (Args.hasFlag(options::OPT_fopenmp_target_debug,
                      options::OPT_fno_openmp_target_debug, /*Default=*/false))
       CmdArgs.push_back("-fopenmp-target-debug");
-    if (Args.hasArg(options::OPT_fopenmp_assume_no_thread_state))
+
+    // Handle -fopenmp-assume-no-thread-state (implied by target-fast)
+    if (Args.hasFlag(options::OPT_fopenmp_assume_no_thread_state,
+                     options::OPT_fno_openmp_assume_no_thread_state,
+                     /*Default=*/TargetFastUsed))
       CmdArgs.push_back("-fopenmp-assume-no-thread-state");
-    if (Args.hasArg(options::OPT_fopenmp_assume_no_nested_parallelism))
+
+    // Handle -fopenmp-assume-no-nested-parallelism (implied by target-fast)
+    if (Args.hasFlag(options::OPT_fopenmp_assume_no_nested_parallelism,
+                     options::OPT_fno_openmp_assume_no_nested_parallelism,
+                     /*Default=*/TargetFastUsed))
       CmdArgs.push_back("-fopenmp-assume-no-nested-parallelism");
+
     if (!Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
                       true))
       CmdArgs.push_back("-nogpulib");

--- a/flang/test/Driver/openmp-target-fast-flag.f90
+++ b/flang/test/Driver/openmp-target-fast-flag.f90
@@ -1,0 +1,35 @@
+! REQUIRES: amdgpu-registered-target
+
+! -fopenmp-target-fast is a meta-flag: on the OpenMP offload device compilation
+! it implies -fopenmp-assume-no-thread-state and
+! -fopenmp-assume-no-nested-parallelism, and forces -O3 unless an explicit
+! optimization level is requested. It is only enabled when explicitly
+! requested; -Ofast does not enable it. -fno-openmp-target-fast disables it.
+
+! RUN: %flang -### -fopenmp --offload-arch=gfx90a -nogpulib -O0 %s 2>&1 \
+! RUN:   | FileCheck -check-prefixes=DefaultTState,DefaultNoNestParallel %s
+
+! RUN: %flang -### -fopenmp --offload-arch=gfx90a -nogpulib -O0 -fopenmp-target-fast %s 2>&1 \
+! RUN:   | FileCheck -check-prefixes=TState,NestParallel %s
+
+! RUN: %flang -### -fopenmp --offload-arch=gfx90a -nogpulib -fopenmp-target-fast %s 2>&1 \
+! RUN:   | FileCheck -check-prefixes=O3,TState,NestParallel %s
+
+! RUN: %flang -### -fopenmp --offload-arch=gfx90a -nogpulib -O3 -fno-openmp-target-fast %s 2>&1 \
+! RUN:   | FileCheck -check-prefixes=DefaultTState,DefaultNoNestParallel %s
+
+! -Ofast must NOT enable target-fast.
+! RUN: %flang -### -fopenmp --offload-arch=gfx90a -nogpulib -Ofast %s 2>&1 \
+! RUN:   | FileCheck -check-prefixes=DefaultTState,DefaultNoNestParallel %s
+
+! O3: "-O3"
+
+! TState: "-fopenmp-assume-no-thread-state"
+! TState-NOT: "-fno-openmp-assume-no-thread-state"
+! DefaultTState-NOT: "-f{{(no-)?}}openmp-assume-no-thread-state"
+
+! NestParallel: "-fopenmp-assume-no-nested-parallelism"
+! NestParallel-NOT: "-fno-openmp-assume-no-nested-parallelism"
+! DefaultNoNestParallel-NOT: "-f{{(no-)?}}openmp-assume-no-nested-parallelism"
+
+end program


### PR DESCRIPTION
The `-fopenmp-target-fast` is a meta flag that enables several optimizations for device code.