### PR TITLE
[MacroFusion] Add RunPreRA/RunPostRA to select the scheduling stage

### DIFF
--- a/llvm/include/llvm/Target/TargetMacroFusion.td
+++ b/llvm/include/llvm/Target/TargetMacroFusion.td
@@ -103,10 +103,19 @@ def OneUse : OneUsePred;
 // ```
 //
 // `IsCommutable` means whether we should handle commutable operands.
+//
+// `RunPreRA` and `RunPostRA` control in which scheduling stage the fusion
+// is allowed to fire. MacroFusion runs in both the pre-RA and post-RA machine
+// schedulers; by default a fusion participates in both. Setting one of them to
+// `false` makes the generated predicator return `false` early during that
+// stage (detected via the `NoVRegs` machine function property). At least one
+// of the two must be `true`.
 class Fusion<string name, string fieldName, string desc, list<FusionPredicate> predicates>
   : SubtargetFeature<"fusion-" # name, fieldName, "true", desc> {
   list<FusionPredicate> Predicates = predicates;
   bit IsCommutable = 0;
+  bit RunPreRA = true;
+  bit RunPostRA = true;
 }
 
 // The generated predicator will be like:

--- a/llvm/test/TableGen/MacroFusion.td
+++ b/llvm/test/TableGen/MacroFusion.td
@@ -68,6 +68,20 @@ def TestFirstSameRegFusion: Fusion<"test-first-same-reg", "HasTestFirstSameRegFu
   bit IsCommutable = 1;
 }
 
+// A fusion that only runs in the pre-RA scheduler.
+let RunPostRA = false in
+def TestPreRAOnlyFusion: SimpleFusion<"test-prera-only", "HasTestPreRAOnlyFusion",
+                                      "Test Pre-RA Only Fusion",
+                                      CheckOpcode<[Inst0]>,
+                                      CheckOpcode<[Inst1]>>;
+
+// A fusion that only runs in the post-RA scheduler.
+let RunPreRA = false in
+def TestPostRAOnlyFusion: SimpleFusion<"test-postra-only", "HasTestPostRAOnlyFusion",
+                                       "Test Post-RA Only Fusion",
+                                       CheckOpcode<[Inst0]>,
+                                       CheckOpcode<[Inst1]>>;
+
 // CHECK-PREDICATOR:       #ifdef GET_Test_MACRO_FUSION_PRED_DECL
 // CHECK-PREDICATOR-NEXT:  #undef GET_Test_MACRO_FUSION_PRED_DECL
 // CHECK-PREDICATOR-EMPTY:
@@ -77,6 +91,8 @@ def TestFirstSameRegFusion: Fusion<"test-first-same-reg", "HasTestFirstSameRegFu
 // CHECK-PREDICATOR-NEXT:  bool isTestCommutableFusion(const TargetInstrInfo &, const TargetSubtargetInfo &, const MachineInstr *, const MachineInstr &);
 // CHECK-PREDICATOR-NEXT:  bool isTestFirstSameRegFusion(const TargetInstrInfo &, const TargetSubtargetInfo &, const MachineInstr *, const MachineInstr &);
 // CHECK-PREDICATOR-NEXT:  bool isTestFusion(const TargetInstrInfo &, const TargetSubtargetInfo &, const MachineInstr *, const MachineInstr &);
+// CHECK-PREDICATOR-NEXT:  bool isTestPostRAOnlyFusion(const TargetInstrInfo &, const TargetSubtargetInfo &, const MachineInstr *, const MachineInstr &);
+// CHECK-PREDICATOR-NEXT:  bool isTestPreRAOnlyFusion(const TargetInstrInfo &, const TargetSubtargetInfo &, const MachineInstr *, const MachineInstr &);
 // CHECK-PREDICATOR-NEXT:  bool isTestSingleFusion(const TargetInstrInfo &, const TargetSubtargetInfo &, const MachineInstr *, const MachineInstr &);
 // CHECK-PREDICATOR-EMPTY:
 // CHECK-PREDICATOR-NEXT:  } // namespace llvm
@@ -233,6 +249,80 @@ def TestFirstSameRegFusion: Fusion<"test-first-same-reg", "HasTestFirstSameRegFu
 // CHECK-PREDICATOR-NEXT:      ++NumTestFusionPreRA;
 // CHECK-PREDICATOR-NEXT:    return true;
 // CHECK-PREDICATOR-NEXT:  }
+// CHECK-PREDICATOR-NEXT:  STATISTIC(NumTestPostRAOnlyFusionPostRA, "Times TestPostRAOnlyFusion Triggered (post-ra)");
+// CHECK-PREDICATOR-NEXT:  bool isTestPostRAOnlyFusion(
+// CHECK-PREDICATOR-NEXT:      const TargetInstrInfo &TII,
+// CHECK-PREDICATOR-NEXT:      const TargetSubtargetInfo &STI,
+// CHECK-PREDICATOR-NEXT:      const MachineInstr *FirstMI,
+// CHECK-PREDICATOR-NEXT:      const MachineInstr &SecondMI) {
+// CHECK-PREDICATOR-NEXT:    {{[[]}}{{[[]}}maybe_unused{{[]]}}{{[]]}} auto &MRI = SecondMI.getMF()->getRegInfo();
+// CHECK-PREDICATOR-NEXT:    if (!SecondMI.getMF()->getProperties().hasNoVRegs())
+// CHECK-PREDICATOR-NEXT:      return false;
+// CHECK-PREDICATOR-NEXT:    {
+// CHECK-PREDICATOR-NEXT:      {{[[]}}{{[[]}}maybe_unused{{[]]}}{{[]]}} const MachineInstr *MI = &SecondMI;
+// CHECK-PREDICATOR-NEXT:      if (( MI->getOpcode() != Test::Inst1 ))
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    if (!FirstMI)
+// CHECK-PREDICATOR-NEXT:      return true;
+// CHECK-PREDICATOR-NEXT:    {
+// CHECK-PREDICATOR-NEXT:      {{[[]}}{{[[]}}maybe_unused{{[]]}}{{[]]}} const MachineInstr *MI = FirstMI;
+// CHECK-PREDICATOR-NEXT:      if (( MI->getOpcode() != Test::Inst0 ))
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    if (!SecondMI.getOperand(0).getReg().isVirtual()) {
+// CHECK-PREDICATOR-NEXT:      if (SecondMI.getOperand(0).getReg() != SecondMI.getOperand(1).getReg())
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    {
+// CHECK-PREDICATOR-NEXT:      Register FirstDest = FirstMI->getOperand(0).getReg();
+// CHECK-PREDICATOR-NEXT:      if (FirstDest.isVirtual() && !MRI.hasOneNonDBGUse(FirstDest))
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    if (!(FirstMI->getOperand(0).isReg() &&
+// CHECK-PREDICATOR-NEXT:          SecondMI.getOperand(1).isReg() &&
+// CHECK-PREDICATOR-NEXT:          FirstMI->getOperand(0).getReg() == SecondMI.getOperand(1).getReg()))
+// CHECK-PREDICATOR-NEXT:      return false;
+// CHECK-PREDICATOR-NEXT:    ++NumTestPostRAOnlyFusionPostRA;
+// CHECK-PREDICATOR-NEXT:    return true;
+// CHECK-PREDICATOR-NEXT:  }
+// CHECK-PREDICATOR-NEXT:  STATISTIC(NumTestPreRAOnlyFusionPreRA, "Times TestPreRAOnlyFusion Triggered (pre-ra)");
+// CHECK-PREDICATOR-NEXT:  bool isTestPreRAOnlyFusion(
+// CHECK-PREDICATOR-NEXT:      const TargetInstrInfo &TII,
+// CHECK-PREDICATOR-NEXT:      const TargetSubtargetInfo &STI,
+// CHECK-PREDICATOR-NEXT:      const MachineInstr *FirstMI,
+// CHECK-PREDICATOR-NEXT:      const MachineInstr &SecondMI) {
+// CHECK-PREDICATOR-NEXT:    {{[[]}}{{[[]}}maybe_unused{{[]]}}{{[]]}} auto &MRI = SecondMI.getMF()->getRegInfo();
+// CHECK-PREDICATOR-NEXT:    if (SecondMI.getMF()->getProperties().hasNoVRegs())
+// CHECK-PREDICATOR-NEXT:      return false;
+// CHECK-PREDICATOR-NEXT:    {
+// CHECK-PREDICATOR-NEXT:      {{[[]}}{{[[]}}maybe_unused{{[]]}}{{[]]}} const MachineInstr *MI = &SecondMI;
+// CHECK-PREDICATOR-NEXT:      if (( MI->getOpcode() != Test::Inst1 ))
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    if (!FirstMI)
+// CHECK-PREDICATOR-NEXT:      return true;
+// CHECK-PREDICATOR-NEXT:    {
+// CHECK-PREDICATOR-NEXT:      {{[[]}}{{[[]}}maybe_unused{{[]]}}{{[]]}} const MachineInstr *MI = FirstMI;
+// CHECK-PREDICATOR-NEXT:      if (( MI->getOpcode() != Test::Inst0 ))
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    if (!SecondMI.getOperand(0).getReg().isVirtual()) {
+// CHECK-PREDICATOR-NEXT:      if (SecondMI.getOperand(0).getReg() != SecondMI.getOperand(1).getReg())
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    {
+// CHECK-PREDICATOR-NEXT:      Register FirstDest = FirstMI->getOperand(0).getReg();
+// CHECK-PREDICATOR-NEXT:      if (FirstDest.isVirtual() && !MRI.hasOneNonDBGUse(FirstDest))
+// CHECK-PREDICATOR-NEXT:        return false;
+// CHECK-PREDICATOR-NEXT:    }
+// CHECK-PREDICATOR-NEXT:    if (!(FirstMI->getOperand(0).isReg() &&
+// CHECK-PREDICATOR-NEXT:          SecondMI.getOperand(1).isReg() &&
+// CHECK-PREDICATOR-NEXT:          FirstMI->getOperand(0).getReg() == SecondMI.getOperand(1).getReg()))
+// CHECK-PREDICATOR-NEXT:      return false;
+// CHECK-PREDICATOR-NEXT:    ++NumTestPreRAOnlyFusionPreRA;
+// CHECK-PREDICATOR-NEXT:    return true;
+// CHECK-PREDICATOR-NEXT:  }
 // CHECK-PREDICATOR-NEXT:  STATISTIC(NumTestSingleFusionPreRA, "Times TestSingleFusion Triggered (pre-ra)");
 // CHECK-PREDICATOR-NEXT:  STATISTIC(NumTestSingleFusionPostRA, "Times TestSingleFusion Triggered (post-ra)");
 // CHECK-PREDICATOR-NEXT:  bool isTestSingleFusion(
@@ -304,6 +394,8 @@ def TestFirstSameRegFusion: Fusion<"test-first-same-reg", "HasTestFirstSameRegFu
 // CHECK-SUBTARGET-NEXT:   if (hasFeature(Test::TestCommutableFusion)) Fusions.push_back(llvm::isTestCommutableFusion);
 // CHECK-SUBTARGET-NEXT:   if (hasFeature(Test::TestFirstSameRegFusion)) Fusions.push_back(llvm::isTestFirstSameRegFusion);
 // CHECK-SUBTARGET-NEXT:   if (hasFeature(Test::TestFusion)) Fusions.push_back(llvm::isTestFusion);
+// CHECK-SUBTARGET-NEXT:   if (hasFeature(Test::TestPostRAOnlyFusion)) Fusions.push_back(llvm::isTestPostRAOnlyFusion);
+// CHECK-SUBTARGET-NEXT:   if (hasFeature(Test::TestPreRAOnlyFusion)) Fusions.push_back(llvm::isTestPreRAOnlyFusion);
 // CHECK-SUBTARGET-NEXT:   if (hasFeature(Test::TestSingleFusion)) Fusions.push_back(llvm::isTestSingleFusion);
 // CHECK-SUBTARGET-NEXT:   return Fusions;
 // CHECK-SUBTARGET-NEXT: }

--- a/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
+++ b/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
@@ -20,10 +20,15 @@
 // header file.
 //
 // Each predicator also maintains `Statistic`s that count how often the fusion
-// is matched, split into pre-RA and post-RA counters because both schedulers
-// run MacroFusion.
+// is matched. A fusion that runs in both scheduling stages keeps separate
+// pre-RA and post-RA counters, because both schedulers run MacroFusion.
 //
-// The generated predicator will be like:
+// A fusion can opt out of a scheduling stage via the `RunPreRA`/`RunPostRA`
+// fields. When a stage is disabled, the generated predicator returns `false`
+// early during that stage (detected via the `NoVRegs` machine function
+// property) and only keeps the counter for the stage it actually runs in.
+//
+// A fusion running in both stages will be like:
 //
 // ```
 // STATISTIC(NumNAMEPreRA, "Times NAME Triggered (pre-ra)");
@@ -38,6 +43,23 @@
 //     ++NumNAMEPostRA;
 //   else
 //     ++NumNAMEPreRA;
+//   return true;
+// }
+// ```
+//
+// A fusion restricted to a single stage (e.g. pre-RA only) will be like:
+//
+// ```
+// STATISTIC(NumNAMEPreRA, "Times NAME Triggered (pre-ra)");
+// bool isNAME(const TargetInstrInfo &TII,
+//             const TargetSubtargetInfo &STI,
+//             const MachineInstr *FirstMI,
+//             const MachineInstr &SecondMI) {
+//   auto &MRI = SecondMI.getMF()->getRegInfo();
+//   if (SecondMI.getMF()->getProperties().hasNoVRegs())
+//     return false;
+//   /* Predicates */
+//   ++NumNAMEPreRA;
 //   return true;
 // }
 // ```
@@ -109,15 +131,26 @@ void MacroFusionPredicatorEmitter::emitMacroFusionImpl(
     std::vector<const Record *> Predicates =
         Fusion->getValueAsListOfDefs("Predicates");
     bool IsCommutable = Fusion->getValueAsBit("IsCommutable");
+    bool RunPreRA = Fusion->getValueAsBit("RunPreRA");
+    bool RunPostRA = Fusion->getValueAsBit("RunPostRA");
+
+    if (!RunPreRA && !RunPostRA)
+      PrintFatalError(Fusion->getLoc(),
+                      "Fusion '" + Fusion->getName() +
+                          "' must run in at least one of the pre-RA and "
+                          "post-RA scheduling stages");
 
     // Emit the statistics that count how often this fusion is matched. The
-    // pre-RA and post-RA schedulers both run MacroFusion, so they are split
-    // into separate counters (distinguished below via the `NoVRegs` property)
-    // to avoid conflating the two.
-    OS << "STATISTIC(Num" << Fusion->getName() << "PreRA, \"Times "
-       << Fusion->getName() << " Triggered (pre-ra)\");\n";
-    OS << "STATISTIC(Num" << Fusion->getName() << "PostRA, \"Times "
-       << Fusion->getName() << " Triggered (post-ra)\");\n";
+    // pre-RA and post-RA schedulers both run MacroFusion, so a fusion that
+    // runs in both stages keeps separate counters (distinguished below via the
+    // `NoVRegs` property) to avoid conflating the two. A fusion that opts out
+    // of a stage only needs the counter for the stage it actually runs in.
+    if (RunPreRA)
+      OS << "STATISTIC(Num" << Fusion->getName() << "PreRA, \"Times "
+         << Fusion->getName() << " Triggered (pre-ra)\");\n";
+    if (RunPostRA)
+      OS << "STATISTIC(Num" << Fusion->getName() << "PostRA, \"Times "
+         << Fusion->getName() << " Triggered (post-ra)\");\n";
 
     OS << "bool is" << Fusion->getName() << "(\n";
     OS.indent(4) << "const TargetInstrInfo &TII,\n";
@@ -127,12 +160,33 @@ void MacroFusionPredicatorEmitter::emitMacroFusionImpl(
     OS.indent(2)
         << "[[maybe_unused]] auto &MRI = SecondMI.getMF()->getRegInfo();\n";
 
+    // If the fusion opts out of a scheduling stage, bail out early when we are
+    // running in that stage. The pre-RA scheduler still has virtual registers,
+    // while the post-RA scheduler runs after they have been allocated.
+    if (!RunPreRA) {
+      OS.indent(2) << "if (!SecondMI.getMF()->getProperties().hasNoVRegs())\n";
+      OS.indent(4) << "return false;\n";
+    }
+    if (!RunPostRA) {
+      OS.indent(2) << "if (SecondMI.getMF()->getProperties().hasNoVRegs())\n";
+      OS.indent(4) << "return false;\n";
+    }
+
     emitPredicates(Predicates, IsCommutable, PE, OS);
 
-    OS.indent(2) << "if (SecondMI.getMF()->getProperties().hasNoVRegs())\n";
-    OS.indent(4) << "++Num" << Fusion->getName() << "PostRA;\n";
-    OS.indent(2) << "else\n";
-    OS.indent(4) << "++Num" << Fusion->getName() << "PreRA;\n";
+    // Bump the statistic for the matched stage. When the fusion runs in both
+    // stages we still have to tell them apart at runtime; otherwise the guard
+    // above already established the stage, so a single counter suffices.
+    if (RunPreRA && RunPostRA) {
+      OS.indent(2) << "if (SecondMI.getMF()->getProperties().hasNoVRegs())\n";
+      OS.indent(4) << "++Num" << Fusion->getName() << "PostRA;\n";
+      OS.indent(2) << "else\n";
+      OS.indent(4) << "++Num" << Fusion->getName() << "PreRA;\n";
+    } else if (RunPreRA) {
+      OS.indent(2) << "++Num" << Fusion->getName() << "PreRA;\n";
+    } else {
+      OS.indent(2) << "++Num" << Fusion->getName() << "PostRA;\n";
+    }
 
     OS.indent(2) << "return true;\n";
     OS << "}\n";


### PR DESCRIPTION
MacroFusion runs in both the pre-RA and post-RA machine schedulers.
Add two `bit` fields to the `Fusion` base class, `RunPreRA` and
`RunPostRA`, both defaulting to `true`, so a fusion can opt out of a
scheduling stage. At least one of them must be `true`.

When a stage is disabled, `MacroFusionPredicatorEmitter` emits an early
`return false` guard for that stage (detected via the `NoVRegs` machine
function property) and only keeps the statistic counter for the stage
the fusion actually runs in. A pre-RA-only fusion is generated as:

```cpp
  STATISTIC(NumNAMEPreRA, "Times NAME Triggered (pre-ra)");
  bool isNAME(...) {
    ...
    if (SecondMI.getMF()->getProperties().hasNoVRegs())
      return false;
    /* Predicates */
    ++NumNAMEPreRA;
    return true;
  }
```

Since the guard already establishes the stage, the trailing counter
`if/else` collapses to a single increment, dropping the redundant
`hasNoVRegs()` call and the counter that could never fire.

Assisted-by: TRAE CLI (GPT 5.5)
