### PR TITLE
[ELF] Fix -Wc++11-narrowing error in addPltEntry

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -750,15 +750,16 @@ template <class PltSection, class GotPltSection>
 static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
                         RelocationBaseSection &rel, RelType type, Symbol &sym) {
   plt.addEntry(sym);
-  RelExpr expr = sym.isPreemptible ? R_ADDEND : R_ABS;
+  bool isPreemptible = sym.isPreemptible;
+  RelExpr expr = isPreemptible ? R_ADDEND : R_ABS;
   if (!ctx.target->usesGotPlt) {
     rel.addReloc(
-        {type, &plt, sym.getPltOffset(ctx), sym.isPreemptible, sym, 0, expr});
+        {type, &plt, sym.getPltOffset(ctx), isPreemptible, sym, 0, expr});
     return;
   }
   gotPlt.addEntry(sym);
-  rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx), sym.isPreemptible, sym,
-                0, expr});
+  rel.addReloc(
+      {type, &gotPlt, sym.getGotPltOffset(ctx), isPreemptible, sym, 0, expr});
 }
 
 void elf::addGotEntry(Ctx &ctx, Symbol &sym) {


### PR DESCRIPTION
PR #212161 passes the `uint8_t isPreemptible : 1` bit-field straight
into a braced-init-list slot whose parameter type is `bool`.
Older clang (<20 ?) incorrectly rejects it.

```
error: non-constant-expression cannot be narrowed from type 'uint8_t' (aka 'unsigned char') to 'bool' in initializer list [-Wc++11-narrowing]
```