### PR TITLE
[flang] Add a MLIRToLLVMPassPipeline callbacks for plugins

### DIFF
--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -563,6 +563,36 @@ config.registerHLFIROptEarlyEPCallbacks(
     });
 ```
 
+### Registering Extension Point Passes from a Plugin
+
+To add passes at these extension points from a
+[plugin](#frontend-driver-plugins), register a *pipeline config callback* with
+`fir::registerPassPipelineConfigCallback`
+(`flang/include/flang/Optimizer/Passes/Pipelines.h`). The frontend driver runs
+every registered callback on its `MLIRToLLVMPassPipelineConfig` before it builds
+the pipeline. Register from a static initializer, so the callback is in place as
+soon as the plugin is loaded and before any compilation begins:
+
+```c++
+struct MyPluginRegistration {
+  MyPluginRegistration() {
+    fir::registerPassPipelineConfigCallback(
+        [](MLIRToLLVMPassPipelineConfig &config) {
+          config.registerHLFIROptEarlyEPCallbacks(
+              [](mlir::PassManager &pm, llvm::OptimizationLevel) {
+                pm.addPass(createMyHLFIRPass());
+              });
+        });
+  }
+};
+static MyPluginRegistration myPluginRegistration;
+```
+
+These callbacks run on both the `-emit-fir` path
+(`CodeGenAction::lowerHLFIRToFIR`) and the `-emit-llvm`/`-emit-obj` path
+(`CodeGenAction::generateLLVMIR`), so registering once is enough. The registry
+is append-only and runs callbacks in registration order.
+
 ## LLVM Pass Plugins
 
 Pass plugins are dynamic shared objects that consist of one or more LLVM IR

--- a/flang/include/flang/Optimizer/Passes/Pipelines.h
+++ b/flang/include/flang/Optimizer/Passes/Pipelines.h
@@ -132,6 +132,17 @@ void addLLVMDialectToLLVMPass(mlir::PassManager &pm, llvm::raw_ostream &output);
 /// Use inliner extension point callback to register the default inliner pass.
 void registerDefaultInlinerPass(MLIRToLLVMPassPipelineConfig &config);
 
+/// Register a callback that augments the MLIRToLLVMPassPipelineConfig before
+/// the frontend builds the pipeline. Use this to add passes at the pipeline
+/// extension points from a plugin. Call from a static initializer; callbacks
+/// run in registration order.
+void registerPassPipelineConfigCallback(
+    std::function<void(MLIRToLLVMPassPipelineConfig &)> callback);
+
+/// Run the callbacks registered via registerPassPipelineConfigCallback on
+/// \p config.
+void invokePassPipelineConfigCallbacks(MLIRToLLVMPassPipelineConfig &config);
+
 /// Register the passes used in Flang's MLIR pass pipeline
 /// e.g. --mlir-print-ir-before=<pass> and similar.
 void registerFlangPipelinePasses();

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -633,6 +633,8 @@ void CodeGenAction::lowerHLFIRToFIR() {
       ci.getInvocation().getLoweringOpts().getFPMaxminBehavior();
   if (ci.getInvocation().getLangOpts().OpenMPIsTargetDevice)
     config.EnableOpenMPIsTargetDevice = true;
+  // Give plugins a chance to register passes at the extension points.
+  fir::invokePassPipelineConfigCallbacks(config);
   // Create the pass pipeline
   fir::createHLFIRToFIRPassPipeline(pm, enableOpenMP, config);
   (void)mlir::applyPassManagerCLOptions(pm);
@@ -750,6 +752,9 @@ void CodeGenAction::generateLLVMIR() {
   llvm::Triple pipelineTriple(invoc.getTargetOpts().triple);
   config.SkipConvertComplexPow = pipelineTriple.isAMDGCN();
   fir::registerDefaultInlinerPass(config);
+
+  // Give plugins a chance to register passes at the extension points.
+  fir::invokePassPipelineConfigCallbacks(config);
 
   if (auto vsr = getVScaleRange(ci)) {
     config.VScaleMin = vsr->first;

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -171,6 +171,23 @@ void registerDefaultInlinerPass(MLIRToLLVMPassPipelineConfig &config) {
       });
 }
 
+static std::vector<std::function<void(MLIRToLLVMPassPipelineConfig &)>> &
+getPassPipelineConfigCallbacks() {
+  static std::vector<std::function<void(MLIRToLLVMPassPipelineConfig &)>>
+      callbacks;
+  return callbacks;
+}
+
+void registerPassPipelineConfigCallback(
+    std::function<void(MLIRToLLVMPassPipelineConfig &)> callback) {
+  getPassPipelineConfigCallbacks().push_back(std::move(callback));
+}
+
+void invokePassPipelineConfigCallbacks(MLIRToLLVMPassPipelineConfig &config) {
+  for (auto &callback : getPassPipelineConfigCallbacks())
+    callback(config);
+}
+
 /// Create a pass pipeline for running default optimization passes for
 /// incremental conversion of FIR.
 ///

--- a/flang/unittests/Optimizer/HLFIRExtensionPointsTest.cpp
+++ b/flang/unittests/Optimizer/HLFIRExtensionPointsTest.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Tests for the HLFIR extension points of the HLFIR-to-FIR pass pipeline.
+// Tests for the HLFIR extension points of the HLFIR-to-FIR pass pipeline, and
+// for the pipeline config callback registry plugins use to reach them.
 //
 // The callbacks run when the pipeline is built, so no IR is needed: building
 // the pipeline is enough to observe them.
@@ -125,6 +126,83 @@ TEST(HLFIRExtensionPoint, MarkersAreAtTheDocumentedPositions) {
   EXPECT_LT(earlyMarker, simplify) << pipeline;
   EXPECT_GT(lastMarker, simplify) << pipeline;
   EXPECT_LT(lastMarker, lowerIntrinsics) << pipeline;
+}
+
+// The registry is process-global and append-only, so a callback capturing a
+// local by reference would be re-invoked by a later test with the referent
+// destroyed. Tests record into this process-lifetime recorder instead, and each
+// asserts only on the markers it wrote, so they do not depend on test order.
+struct ConfigCallbackRecorder {
+  std::vector<std::string> order;
+  MLIRToLLVMPassPipelineConfig *seenConfig = nullptr;
+  bool epRan = false;
+
+  void reset() {
+    order.clear();
+    seenConfig = nullptr;
+    epRan = false;
+  }
+  /// Index of \p marker in `order`, or npos.
+  size_t indexOf(llvm::StringRef marker) const {
+    for (size_t i = 0, e = order.size(); i != e; ++i)
+      if (order[i] == marker)
+        return i;
+    return std::string::npos;
+  }
+};
+
+ConfigCallbackRecorder &recorder() {
+  static ConfigCallbackRecorder r;
+  return r;
+}
+
+TEST(PassPipelineConfigCallback, CallbacksRunInRegistrationOrderOnTheConfig) {
+  fir::registerPassPipelineConfigCallback(
+      [](MLIRToLLVMPassPipelineConfig &config) {
+        recorder().order.push_back("order-first");
+        recorder().seenConfig = &config;
+      });
+  fir::registerPassPipelineConfigCallback([](MLIRToLLVMPassPipelineConfig &) {
+    recorder().order.push_back("order-second");
+  });
+
+  recorder().reset();
+  MLIRToLLVMPassPipelineConfig config(llvm::OptimizationLevel::O2);
+  fir::invokePassPipelineConfigCallbacks(config);
+
+  size_t first = recorder().indexOf("order-first");
+  size_t second = recorder().indexOf("order-second");
+  ASSERT_NE(first, std::string::npos);
+  ASSERT_NE(second, std::string::npos);
+  EXPECT_LT(first, second);
+  EXPECT_EQ(recorder().seenConfig, &config);
+}
+
+// The plugin shape: the config callback registers an extension point
+// callback, which then contributes a pass when the pipeline is built.
+TEST(PassPipelineConfigCallback, CanRegisterHLFIRExtensionPoints) {
+  fir::registerPassPipelineConfigCallback(
+      [](MLIRToLLVMPassPipelineConfig &config) {
+        config.registerHLFIROptEarlyEPCallbacks(
+            [](mlir::PassManager &pm, llvm::OptimizationLevel) {
+              recorder().epRan = true;
+              pm.addPass(std::make_unique<MarkerPass>());
+            });
+      });
+
+  recorder().reset();
+  mlir::MLIRContext context;
+  mlir::PassManager pm(&context, mlir::ModuleOp::getOperationName());
+  MLIRToLLVMPassPipelineConfig config(llvm::OptimizationLevel::O2);
+  fir::invokePassPipelineConfigCallbacks(config);
+  fir::createHLFIRToFIRPassPipeline(pm, fir::EnableOpenMP::None, config);
+
+  std::string pipeline;
+  llvm::raw_string_ostream os(pipeline);
+  pm.printAsTextualPipeline(os);
+
+  EXPECT_TRUE(recorder().epRan);
+  EXPECT_NE(pipeline.find("ep-marker"), std::string::npos) << pipeline;
 }
 
 } // namespace


### PR DESCRIPTION
The HLFIR-to-FIR pass pipeline exposes extension points on
MLIRToLLVMPassPipelineConfig, but that config is built inside the frontend, so
plugins has no way to reach it and register passes.

Follow-up to #212194

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>