### PR TITLE
[mlir][vector] Disallow vector broadcast along scalable dim

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
@@ -73,6 +73,8 @@ public:
     //   %x = [%b,%b,%b,%b] : n-D
     if (srcRank < dstRank) {
       // Duplication.
+      if (dstType.getScalableDims()[0])
+        return failure();
       VectorType resType = VectorType::Builder(dstType).dropDim(0);
       Value bcst =
           vector::BroadcastOp::create(rewriter, loc, resType, op.getSource());

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
@@ -74,7 +74,9 @@ public:
     if (srcRank < dstRank) {
       // Duplication.
       if (dstType.getScalableDims()[0])
-        return failure();
+        return rewriter.notifyMatchFailure(
+            op, "Vector broadcasting over a scalable dimension is not "
+                "currently supported");
       VectorType resType = VectorType::Builder(dstType).dropDim(0);
       Value bcst =
           vector::BroadcastOp::create(rewriter, loc, resType, op.getSource());

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
@@ -242,6 +242,18 @@ func.func @broadcast_vec2d_from_vec1d_scalable(%arg0: vector<[2]xf32>) -> vector
 
 // -----
 
+// TODO: Add support for scalable vectors
+
+func.func @broadcast_vec2d_from_vec1d_scalable_leading(%arg0: vector<2xf32>) -> vector<[4]x2xf32> {
+  %0 = vector.broadcast %arg0 : vector<2xf32> to vector<[4]x2xf32>
+  return %0 : vector<[4]x2xf32>
+}
+// CHECK-LABEL: @broadcast_vec2d_from_vec1d_scalable_leading
+// CHECK-SAME:  %[[A:.*]]: vector<2xf32>)
+// CHECK: vector.broadcast %[[A]] : vector<2xf32> to vector<[4]x2xf32>
+
+// -----
+
 func.func @broadcast_vec2d_from_index_vec1d(%arg0: vector<2xindex>) -> vector<3x2xindex> {
   %0 = vector.broadcast %arg0 : vector<2xindex> to vector<3x2xindex>
   return %0 : vector<3x2xindex>

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
@@ -242,35 +242,6 @@ func.func @broadcast_vec2d_from_vec1d_scalable(%arg0: vector<[2]xf32>) -> vector
 
 // -----
 
-// TODO: Add support for scalable vectors
-
-func.func @broadcast_vec2d_from_vec1d_scalable_leading(%arg0: vector<2xf32>) -> vector<[4]x2xf32> {
-  %0 = vector.broadcast %arg0 : vector<2xf32> to vector<[4]x2xf32>
-  return %0 : vector<[4]x2xf32>
-}
-// CHECK-LABEL: @broadcast_vec2d_from_vec1d_scalable_leading
-// CHECK-SAME:  %[[A:.*]]: vector<2xf32>)
-// CHECK: vector.broadcast %[[A]] : vector<2xf32> to vector<[4]x2xf32>
-
-// -----
-
-// TODO: Add support for scalable vectors
-
-func.func @broadcast_vec2d_from_vec1d_scalable_inner(%arg0: vector<2xf32>) -> vector<3x[4]x2xf32> {
-  %0 = vector.broadcast %arg0 : vector<2xf32> to vector<3x[4]x2xf32>
-  return %0 : vector<3x[4]x2xf32>
-}
-// CHECK-LABEL: @broadcast_vec2d_from_vec1d_scalable_inner
-// CHECK-SAME:  %[[A:.*]]: vector<2xf32>)
-// CHECK:       %[[T0:.*]] = ub.poison : vector<3x[4]x2xf32>
-// CHECK:       %[[T1:.*]] = vector.broadcast %[[A]] : vector<2xf32> to vector<[4]x2xf32>
-// CHECK:       %[[T2:.*]] = vector.insert %[[T1]], %[[T0]] [0] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
-// CHECK:       %[[T3:.*]] = vector.insert %[[T1]], %[[T2]] [1] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
-// CHECK:       %[[T4:.*]] = vector.insert %[[T1]], %[[T3]] [2] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
-// CHECK:       return %[[T4]] : vector<3x[4]x2xf32>
-
-// -----
-
 func.func @broadcast_vec2d_from_index_vec1d(%arg0: vector<2xindex>) -> vector<3x2xindex> {
   %0 = vector.broadcast %arg0 : vector<2xindex> to vector<3x2xindex>
   return %0 : vector<3x2xindex>

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
@@ -254,6 +254,23 @@ func.func @broadcast_vec2d_from_vec1d_scalable_leading(%arg0: vector<2xf32>) -> 
 
 // -----
 
+// TODO: Add support for scalable vectors
+
+func.func @broadcast_vec2d_from_vec1d_scalable_inner(%arg0: vector<2xf32>) -> vector<3x[4]x2xf32> {
+  %0 = vector.broadcast %arg0 : vector<2xf32> to vector<3x[4]x2xf32>
+  return %0 : vector<3x[4]x2xf32>
+}
+// CHECK-LABEL: @broadcast_vec2d_from_vec1d_scalable_inner
+// CHECK-SAME:  %[[A:.*]]: vector<2xf32>)
+// CHECK:       %[[T0:.*]] = ub.poison : vector<3x[4]x2xf32>
+// CHECK:       %[[T1:.*]] = vector.broadcast %[[A]] : vector<2xf32> to vector<[4]x2xf32>
+// CHECK:       %[[T2:.*]] = vector.insert %[[T1]], %[[T0]] [0] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
+// CHECK:       %[[T3:.*]] = vector.insert %[[T1]], %[[T2]] [1] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
+// CHECK:       %[[T4:.*]] = vector.insert %[[T1]], %[[T3]] [2] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
+// CHECK:       return %[[T4]] : vector<3x[4]x2xf32>
+
+// -----
+
 func.func @broadcast_vec2d_from_index_vec1d(%arg0: vector<2xindex>) -> vector<3x2xindex> {
   %0 = vector.broadcast %arg0 : vector<2xindex> to vector<3x2xindex>
   return %0 : vector<3x2xindex>

--- a/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
+++ b/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
@@ -209,6 +209,33 @@ func.func @broadcast_scalable_duplication(%arg0: vector<[32]xf32>) -> vector<1x[
   return %res : vector<1x[32]xf32>
 }
 
+// TODO: Add support for scalable vectors
+
+// CHECK-LABEL: @broadcast_vec2d_from_vec1d_scalable_leading
+// CHECK-SAME:  %[[A:.*]]: vector<2xf32>)
+// CHECK: vector.broadcast %[[A]] : vector<2xf32> to vector<[4]x2xf32>
+
+func.func @broadcast_vec2d_from_vec1d_scalable_leading(%arg0: vector<2xf32>) -> vector<[4]x2xf32> {
+  %0 = vector.broadcast %arg0 : vector<2xf32> to vector<[4]x2xf32>
+  return %0 : vector<[4]x2xf32>
+}
+
+// TODO: Add support for scalable vectors
+
+// CHECK-LABEL: @broadcast_vec2d_from_vec1d_scalable_inner
+// CHECK-SAME:  %[[A:.*]]: vector<2xf32>)
+// CHECK:       %[[T0:.*]] = ub.poison : vector<3x[4]x2xf32>
+// CHECK:       %[[T1:.*]] = vector.broadcast %[[A]] : vector<2xf32> to vector<[4]x2xf32>
+// CHECK:       %[[T2:.*]] = vector.insert %[[T1]], %[[T0]] [0] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
+// CHECK:       %[[T3:.*]] = vector.insert %[[T1]], %[[T2]] [1] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
+// CHECK:       %[[T4:.*]] = vector.insert %[[T1]], %[[T3]] [2] : vector<[4]x2xf32> into vector<3x[4]x2xf32>
+// CHECK:       return %[[T4]] : vector<3x[4]x2xf32>
+
+func.func @broadcast_vec2d_from_vec1d_scalable_inner(%arg0: vector<2xf32>) -> vector<3x[4]x2xf32> {
+  %0 = vector.broadcast %arg0 : vector<2xf32> to vector<3x[4]x2xf32>
+  return %0 : vector<3x[4]x2xf32>
+}
+
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %f = transform.structured.match ops{["func.func"]} in %module_op


### PR DESCRIPTION
Broadcasts from vectors to higher rank vectors get lowered recursively by iterating over leading dimensions to create "size(dimension)" insert ops. This cannot be done for scalable dimensions whose size is unknown. This PR prevents such transforms from occurring by stopping if the leading dimension is scalable.