### PR TITLE
[clang] Update C++ DR status page

### DIFF
--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -22226,24 +22226,24 @@
     <td>Zero- and default-initialization of cv-qualified <TT>std::meta::info</TT></td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="3202">
+  <tr id="3202">
     <td><a href="https://cplusplus.github.io/CWG/issues/3202.html">3202</a></td>
     <td>[<a href="https://wg21.link/basic.fundamental">basic.fundamental</a>]</td>
-    <td>open</td>
+    <td>NAD</td>
     <td>Status of <TT>const std::meta::info</TT></td>
-    <td align="center">Not resolved</td>
+    <td class="unknown" align="center">Unknown</td>
   </tr>
   <tr class="open" id="3203">
     <td><a href="https://cplusplus.github.io/CWG/issues/3203.html">3203</a></td>
     <td>[<a href="https://wg21.link/dcl.init.general">dcl.init.general</a>]</td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Initialization of signed or unsigned char arrays from <I>string-literal</I></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3204">
     <td><a href="https://cplusplus.github.io/CWG/issues/3204.html">3204</a></td>
     <td>[<a href="https://wg21.link/expr.call">expr.call</a>]</td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Restrictions on arguments for ellipsis parameter</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22257,8 +22257,57 @@
   <tr class="open" id="3206">
     <td><a href="https://cplusplus.github.io/CWG/issues/3206.html">3206</a></td>
     <td>[<a href="https://wg21.link/class.local">class.local</a>]</td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Scattered definition of "local class"</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3207">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3207.html">3207</a></td>
+    <td>[<a href="https://wg21.link/class.spaceship">class.spaceship</a>]</td>
+    <td>tentatively ready</td>
+    <td>Deduced return type of a deleted three-way comparison operator function</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3208">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3208.html">3208</a></td>
+    <td>[<a href="https://wg21.link/basic.life">basic.life</a>]</td>
+    <td>open</td>
+    <td>Base classes of virtual base classes</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3209">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3209.html">3209</a></td>
+    <td>[<a href="https://wg21.link/basic.compound">basic.compound</a>]</td>
+    <td>open</td>
+    <td>Pointer interconvertibility with bit-fields</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3210">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3210.html">3210</a></td>
+    <td>[<a href="https://wg21.link/stmt.expand">stmt.expand</a>]</td>
+    <td>open</td>
+    <td>constexpr for empty destructuring expansion statements</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3211">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3211.html">3211</a></td>
+    <td>[<a href="https://wg21.link/basic.def.odr">basic.def.odr</a>]</td>
+    <td>open</td>
+    <td>Explicitly captured variable is not odr-usable in lambda contract</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3212">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3212.html">3212</a></td>
+    <td>[<a href="https://wg21.link/stmt.if">stmt.if</a>]</td>
+    <td>open</td>
+    <td>Misleading disambiguation rule for nested <TT>if</TT></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3213">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3213.html">3213</a></td>
+    <td>[<a href="https://wg21.link/temp.param">temp.param</a>]</td>
+    <td>open</td>
+    <td>Restrictions on the <I>template-head</I> of a concept definition</td>
     <td align="center">Not resolved</td>
   </tr></table>
 

--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 import sys, os, re, urllib.request
 
-latest_release = 21
+latest_release = 22
 
 clang_www_dir = os.path.dirname(__file__)
 default_issue_list_path = os.path.join(clang_www_dir, 'cwg_index.html')
@@ -17,7 +17,7 @@ class DR:
     return '%s (%s): %s' % (self.number, self.status, self.title)
 
   pattern = re.compile('''
-<TD.*>(?P<section_number>.*) <A href="(?P<section_link>.*)">(?P<section_name>.*)</A>
+<TD.*>(?P<section_number>.*) <A href="\\s*(?P<section_link>.*)">(?P<section_name>.*)</A>
 </TD>
 <TD.*><A HREF="(?P<url>.*)">(?P<number>.*)</A></TD>
 <TD.*>(?P<status>.*)</TD>


### PR DESCRIPTION
On top of updating the status page, this PR updates the `latest_release` constant to 22 and fixes a small `cwg_index.html` parsing issue that arose during the update.