### PR TITLE
[mlir][PDL] Use free-function cast for derived PDL values

### DIFF
--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -461,9 +461,7 @@ struct ProcessDerivedPDLValue : public ProcessPDLValueBasedOn<T, BaseT> {
   }
   using ProcessPDLValueBasedOn<T, BaseT>::verifyAsArg;
 
-  static T processAsArg(BaseT baseValue) {
-    return baseValue.template cast<T>();
-  }
+  static T processAsArg(BaseT baseValue) { return mlir::cast<T>(baseValue); }
   using ProcessPDLValueBasedOn<T, BaseT>::processAsArg;
 
   static void processAsResult(PatternRewriter &, PDLResultList &results,

--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/TypeName.h"
 #include <optional>
 

--- a/mlir/unittests/IR/PatternMatchTest.cpp
+++ b/mlir/unittests/IR/PatternMatchTest.cpp
@@ -33,9 +33,6 @@ TEST(OpRewritePatternTest, GetGeneratedNames) {
   ASSERT_EQ(ops.size(), 1u);
   ASSERT_EQ(ops.front().getStringRef(), test::OpB::getOperationName());
 }
-} // end anonymous namespace
-
-namespace {
 LogicalResult anOpRewritePatternFunc(test::OpA op, PatternRewriter &rewriter) {
   return failure();
 }
@@ -51,5 +48,15 @@ TEST(AnOpRewritePatternTest, PatternFuncAttributes) {
   ASSERT_EQ(pattern->getGeneratedOps().size(), 1U);
   ASSERT_EQ(pattern->getGeneratedOps().front().getStringRef(),
             test::OpB::getOperationName());
+}
+
+ShapedType rewriteShapedType(PatternRewriter & /*rewriter*/, ShapedType type,
+                             IntegerAttr /*rank*/) {
+  return type;
+}
+
+TEST(PDLPatternModuleTest, RegisterDerivedRewriteFunction) {
+  PDLPatternModule patterns;
+  patterns.registerRewriteFunction("rewrite_shaped_type", rewriteShapedType);
 }
 } // end anonymous namespace


### PR DESCRIPTION
Following "[mlir] Remove deprecated cast member functions (#135556) (0078cf79adc2f24a168bc774cba1f39dda5e3752)",`Type::cast` and `Attribute::cast` are no longer available.

Update ProcessDerivedPDLValue to use `mlir::cast<T>(baseValue)` . Add a regression test for a rewrite function taking `ShapedType` and `IntegerAttr`.

