### PR TITLE
[InstCombine][NFC] Reorder isKnownAlways(Mask) check in foldIntrinsicIsFPClass

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1180,6 +1180,12 @@ Instruction *InstCombinerImpl::foldIntrinsicIsFPClass(IntrinsicInst &II) {
   KnownFPClass Known =
       computeKnownFPClass(Src0, Mask, SQ.getWithInstruction(&II));
 
+  // If none of the tests which can return false are possible, fold to true.
+  // fp_class (nnan x), ~(qnan|snan) -> true
+  // fp_class (ninf x), ~(ninf|pinf) -> true
+  if (Known.isKnownAlways(Mask))
+    return replaceInstUsesWith(II, ConstantInt::get(II.getType(), true));
+
   // Clear test bits we know must be false from the source value.
   // fp_class (nnan x), qnan|snan|other -> fp_class (nnan x), other
   // fp_class (ninf x), ninf|pinf|other -> fp_class (ninf x), other
@@ -1188,12 +1194,6 @@ Instruction *InstCombinerImpl::foldIntrinsicIsFPClass(IntrinsicInst &II) {
         1, ConstantInt::get(Src1->getType(), Mask & Known.KnownFPClasses));
     return &II;
   }
-
-  // If none of the tests which can return false are possible, fold to true.
-  // fp_class (nnan x), ~(qnan|snan) -> true
-  // fp_class (ninf x), ~(ninf|pinf) -> true
-  if (Mask == Known.KnownFPClasses)
-    return replaceInstUsesWith(II, ConstantInt::get(II.getType(), true));
 
   return nullptr;
 }

--- a/llvm/test/Transforms/InstCombine/is_fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/is_fpclass.ll
@@ -3922,6 +3922,14 @@ define i1 @test_class_is_not_psub_pnorm_pinf__dynamic(float %arg) #3 {
   ret i1 %class
 }
 
+define i1 @test_class_is_pnorm_subset_of_normal_mask(float nofpclass(nan inf zero sub nnorm) %arg) {
+; CHECK-LABEL: @test_class_is_pnorm_subset_of_normal_mask(
+; CHECK-NEXT:    ret i1 true
+;
+  %class = call i1 @llvm.is.fpclass.f32(float %arg, i32 264)
+  ret i1 %class
+}
+
 ; Make sure we don't take sign bit from NaN operands.
 
 define i1 @minnum_qnan(i32 %x) {


### PR DESCRIPTION
Fixes #189949

The preceding mask-narrowing step already guarantees `Mask` is a subset
of `Known.KnownFPClasses` by the time the old equality check ran, so
`Mask == Known.KnownFPClasses` was already equivalent (see #190504).
This patch replaces that equality check with `Known.isKnownAlways(Mask)`
(matching the SelectionDAG equivalent's naming) and moves it before the
narrowing step, avoiding a redundant worklist re-visit.

Added a regression test in `is_fpclass.ll`.