### PR TITLE
[SPIR-V] Fix vloada_halfn builtin number

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -1764,7 +1764,7 @@ foreach i = ["", "2", "3", "4", "8", "16"] in {
   }
   defm : DemangledVectorLoadStoreBuiltin<!strconcat("vload", i), 2, 2, 171>;
   defm : DemangledVectorLoadStoreBuiltin<!strconcat("vstore", i), 3, 3, 172>;
-  defm : DemangledVectorLoadStoreBuiltin<!strconcat("vloada_half", i), 2, 2, 174>;
+  defm : DemangledVectorLoadStoreBuiltin<!strconcat("vloada_half", i), 2, 2, 179>;
   defm : DemangledVectorLoadStoreBuiltin<!strconcat("vstorea_half", i), 3, 3, 180>;
 
   // Also create records for each rounding mode.

--- a/llvm/test/CodeGen/SPIRV/opencl/vload_halfn.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/vload_halfn.ll
@@ -12,4 +12,11 @@ define void @test(i64 %a, ptr addrspace(1) %b) {
   ret void
 }
 
+define void @test_aligned(i64 %a, ptr addrspace(1) %b) {
+; CHECK: %[[#]] = OpExtInst %[[#V2FLOAT]] %[[#IMPORT]] vloada_halfn %[[#]] %[[#]] 2
+  %c = call spir_func <2 x float> @_Z12vloada_half2mPU3AS1KDh(i64 %a, ptr addrspace(1) %b)
+  ret void
+}
+
 declare <2 x float> @_Z11vload_half2mPU3AS1KDh(i64, ptr addrspace(1))
+declare <2 x float> @_Z12vloada_half2mPU3AS1KDh(i64, ptr addrspace(1))


### PR DESCRIPTION
vloada_halfn was incorrectly mapped to vload_half builtin number (174) instead of its own (179), causing it to demangle to the wrong OpenCL builtin