### PR TITLE
[lldb][Windows] Preserve breakpoint locations across process exit

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -612,7 +612,7 @@ void ProcessWindows::OnExitProcess(uint32_t exit_code) {
     ModuleSP executable_module = target->GetExecutableModule();
     ModuleList unloaded_modules;
     unloaded_modules.Append(executable_module);
-    target->ModulesDidUnload(unloaded_modules, true);
+    target->ModulesDidUnload(unloaded_modules, false);
   }
 
   SetExitStatus(exit_code, /*exit_string=*/"");

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 
 
 class BreakpointLocationsTestCase(TestBase):
-    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24528")
     def test_enable(self):
         """Test breakpoint enable/disable for a breakpoint ID with multiple locations."""
         self.build()


### PR DESCRIPTION
`ProcessWindows::OnExitProcess` unloads the executable module with `delete_locations=true`, which deletes the target's breakpoint locations when the debuggee exits. Other platforms keep them, so inspecting a breakpoint after the process died returns no location on Windows.

Pass `delete_locations=false` to match the other platforms.