### PR TITLE
[offload] update llvm-gpu-loader the new liboffload allocation API

### DIFF
--- a/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.cpp
+++ b/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.cpp
@@ -96,8 +96,7 @@ static void *copyArgumentVector(int Argc, const char **Argv,
 
   // We allocate enough space for a null terminated array and all the strings.
   void *DevArgv;
-  OFFLOAD_ERR(
-      olMemAlloc(Device, OL_ALLOC_TYPE_HOST, ArgSize + StringLen, &DevArgv));
+  OFFLOAD_ERR(olMemAllocHost(Device, ArgSize + StringLen, &DevArgv));
   if (!DevArgv)
     handleError(
         createStringError("Failed to allocate memory for environment."));

--- a/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.h
+++ b/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.h
@@ -148,6 +148,9 @@ ol_result_t (*olSyncQueue)(ol_queue_handle_t Queue);
 ol_result_t (*olMemAlloc)(ol_device_handle_t Device, ol_alloc_type_t Type,
                           size_t Size, void **AllocationOut);
 
+ol_result_t (*olMemAllocHost)(ol_device_handle_t Device, size_t Size,
+                              void **AllocationOut);
+
 ol_result_t (*olMemFree)(void *Address);
 
 ol_result_t (*olMemcpy)(ol_queue_handle_t Queue, void *DstPtr,
@@ -196,6 +199,7 @@ llvm::Error loadLLVMOffload() {
   DYNAMIC_INIT(olDestroyQueue);
   DYNAMIC_INIT(olSyncQueue);
   DYNAMIC_INIT(olMemAlloc);
+  DYNAMIC_INIT(olMemAllocHost);
   DYNAMIC_INIT(olMemFree);
   DYNAMIC_INIT(olMemcpy);
   DYNAMIC_INIT(olGetDeviceInfo);


### PR DESCRIPTION
PR #209196 split host memory allocations into a dedicated API. Update llvm-gpu-loader to use the new host allocation function introduced by that change.