### PR TITLE
[orc-rt] Make ThreadPoolRunner a generic task runner.

### DIFF
--- a/orc-rt/include/orc-rt/ThreadPoolRunner.h
+++ b/orc-rt/include/orc-rt/ThreadPoolRunner.h
@@ -1,4 +1,4 @@
-//===- ThreadPoolRunner.h -- Run wrapper calls in a thread pool -*- C++ -*-===//
+//===- ThreadPoolRunner.h - Run tasks in a thread pool ----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -13,29 +13,24 @@
 #ifndef ORC_RT_THREADPOOLRUNNER_H
 #define ORC_RT_THREADPOOLRUNNER_H
 
-#include "orc-rt/WrapperFunction.h"
 #include "orc-rt/move_only_function.h"
-
-#include "orc-rt-c/CoreTypes.h"
-#include "orc-rt-c/WrapperFunction.h"
 
 #include <condition_variable>
 #include <cstddef>
-#include <cstdint>
 #include <mutex>
 #include <thread>
 #include <vector>
 
 namespace orc_rt {
 
-/// A wrapper-call runner backed by a fixed-size pool of worker threads.
+/// A task runner backed by a fixed-size pool of worker threads.
 ///
-/// Each incoming call is enqueued onto an internal work queue and picked up
+/// Each dispatched task is enqueued onto an internal work queue and picked up
 /// by a worker thread.
 ///
 /// Lifetime: the runner must outlive the Session that uses it. By the time
 /// the runner is destroyed the Session must have shut down — operator()
-/// after destruction begins is a contract violation (asserted). Any calls
+/// after destruction begins is a contract violation (asserted). Any tasks
 /// already pending in the queue at destruction time will be drained by the
 /// workers before they exit.
 class ThreadPoolRunner {
@@ -48,11 +43,9 @@ public:
   ThreadPoolRunner(ThreadPoolRunner &&) = delete;
   ThreadPoolRunner &operator=(ThreadPoolRunner &&) = delete;
 
-  /// Enqueue a wrapper-function call to be run by a worker thread. Must not
-  /// be called once destruction has begun.
-  void operator()(orc_rt_SessionRef S, uint64_t CallId,
-                  orc_rt_WrapperFunctionReturn Return,
-                  orc_rt_WrapperFunction Fn, WrapperFunctionBuffer ArgBytes);
+  /// Enqueue a task to be run by a worker thread. Must not be called once
+  /// destruction has begun.
+  void operator()(move_only_function<void()> Task);
 
 private:
   void workerLoop();

--- a/orc-rt/lib/executor/ThreadPoolRunner.cpp
+++ b/orc-rt/lib/executor/ThreadPoolRunner.cpp
@@ -33,17 +33,12 @@ ThreadPoolRunner::~ThreadPoolRunner() {
     Worker.join();
 }
 
-void ThreadPoolRunner::operator()(orc_rt_SessionRef S, uint64_t CallId,
-                                  orc_rt_WrapperFunctionReturn Return,
-                                  orc_rt_WrapperFunction Fn,
-                                  WrapperFunctionBuffer ArgBytes) {
+void ThreadPoolRunner::operator()(move_only_function<void()> Task) {
   {
     std::scoped_lock<std::mutex> Lock(M);
     assert(!Stop &&
            "operator() called on ThreadPoolRunner after destruction begun");
-    Pending.push_back([=, ArgBytes = std::move(ArgBytes)]() mutable {
-      Fn(S, CallId, Return, ArgBytes.release());
-    });
+    Pending.push_back(std::move(Task));
   }
   CV.notify_one();
 }

--- a/orc-rt/test/unit/ThreadPoolRunnerTest.cpp
+++ b/orc-rt/test/unit/ThreadPoolRunnerTest.cpp
@@ -7,90 +7,47 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/ThreadPoolRunner.h"
-#include "orc-rt/SPSWrapperFunction.h"
 #include "gtest/gtest.h"
 
 #include <atomic>
-#include <cstdint>
 #include <future>
-#include <thread>
 
 using namespace orc_rt;
 
 namespace {
 
-inline orc_rt_SessionRef dummySession() noexcept {
-  return reinterpret_cast<orc_rt_SessionRef>(uintptr_t{0xABCD});
-}
-
-inline orc_rt_WrapperFunctionReturn dummyReturn() noexcept {
-  return [](orc_rt_SessionRef, uint64_t, orc_rt_WrapperFunctionBuffer) {};
-}
-
-template <typename T> WrapperFunctionBuffer serializePtr(T *Ptr) {
-  auto Buf = WrapperFunctionSPSSerializer<void(SPSExecutorAddr)>::arguments()
-                 .serialize(Ptr);
-  assert(Buf && "failed to serialize pointer arg");
-  return std::move(*Buf);
-}
-
-TEST(ThreadPoolRunnerTest, NoCalls) {
+TEST(ThreadPoolRunnerTest, NoTasks) {
   // Check that immediate destruction works as expected.
   ThreadPoolRunner R(1);
 }
 
-static void signalPromise(orc_rt_SessionRef S, uint64_t CallId,
-                          orc_rt_WrapperFunctionReturn Return,
-                          orc_rt_WrapperFunctionBuffer ArgBytes) {
-  SPSWrapperFunction<void(SPSExecutorAddr)>::handle(
-      S, CallId, Return, ArgBytes,
-      [](move_only_function<void()> Return, ExecutorAddr P) {
-        P.toPtr<std::promise<void> *>()->set_value();
-        Return();
-      });
-}
-
-TEST(ThreadPoolRunnerTest, BasicCallExecution) {
-  // Smoke test: dispatch one call on a single-threaded pool, wait for it to
+TEST(ThreadPoolRunnerTest, BasicTaskExecution) {
+  // Smoke test: dispatch one task on a single-threaded pool, wait for it to
   // run, then let the runner destruct.
   std::promise<void> Done;
   std::future<void> DoneF = Done.get_future();
 
   {
     ThreadPoolRunner R(1);
-    R(dummySession(), 0, dummyReturn(), signalPromise, serializePtr(&Done));
+    R([&]() { Done.set_value(); });
     DoneF.get();
   }
 }
 
-static void incrementCounter(orc_rt_SessionRef S, uint64_t CallId,
-                             orc_rt_WrapperFunctionReturn Return,
-                             orc_rt_WrapperFunctionBuffer ArgBytes) {
-  SPSWrapperFunction<void(SPSExecutorAddr)>::handle(
-      S, CallId, Return, ArgBytes,
-      [](move_only_function<void()> Return, ExecutorAddr P) {
-        ++*P.toPtr<std::atomic<size_t> *>();
-        Return();
-      });
-}
-
-TEST(ThreadPoolRunnerTest, SingleThreadMultipleCalls) {
-  // Dispatch multiple calls on a single-threaded pool, wait for all to run,
-  // then let the runner destruct.
-  size_t NumCallsToRun = 10;
-  std::atomic<size_t> CallsRun = 0;
+TEST(ThreadPoolRunnerTest, SingleThreadMultipleTasks) {
+  // Dispatch multiple tasks on a single-threaded pool. Destruction drains all
+  // pending tasks before the worker exits, so every task has run once the
+  // runner has been destroyed.
+  size_t NumTasksToRun = 10;
+  std::atomic<size_t> TasksRun = 0;
 
   {
     ThreadPoolRunner R(1);
-    for (size_t I = 0; I != NumCallsToRun; ++I)
-      R(dummySession(), I, dummyReturn(), incrementCounter,
-        serializePtr(&CallsRun));
-
-    // while (CallsRun.load() < NumCallsToRun)
-    //   std::this_thread::yield();
+    for (size_t I = 0; I != NumTasksToRun; ++I)
+      R([&]() { ++TasksRun; });
   }
 
-  EXPECT_EQ(CallsRun, NumCallsToRun);
+  EXPECT_EQ(TasksRun, NumTasksToRun);
 }
 
 struct ConcurrencyState {
@@ -102,36 +59,11 @@ struct ConcurrencyState {
   std::promise<int> PResult;
 };
 
-static void concurrencyTaskA(orc_rt_SessionRef S, uint64_t CallId,
-                             orc_rt_WrapperFunctionReturn Return,
-                             orc_rt_WrapperFunctionBuffer ArgBytes) {
-  SPSWrapperFunction<void(SPSExecutorAddr)>::handle(
-      S, CallId, Return, ArgBytes,
-      [](move_only_function<void()> Return, ExecutorAddr P) {
-        auto *State = P.toPtr<ConcurrencyState *>();
-        State->P1.set_value(State->FInit.get());
-        State->PResult.set_value(State->F2.get());
-        Return();
-      });
-}
-
-static void concurrencyTaskB(orc_rt_SessionRef S, uint64_t CallId,
-                             orc_rt_WrapperFunctionReturn Return,
-                             orc_rt_WrapperFunctionBuffer ArgBytes) {
-  SPSWrapperFunction<void(SPSExecutorAddr)>::handle(
-      S, CallId, Return, ArgBytes,
-      [](move_only_function<void()> Return, ExecutorAddr P) {
-        auto *State = P.toPtr<ConcurrencyState *>();
-        State->P2.set_value(State->F1.get());
-        Return();
-      });
-}
-
-TEST(ThreadPoolRunnerTest, ConcurrentCalls) {
-  // Check that calls run concurrently when multiple workers are available.
-  // Two calls communicate values back and forth via futures; neither can
-  // complete without the other having started. FResult.get() also serves
-  // as the "all calls have run" wait point before destruction.
+TEST(ThreadPoolRunnerTest, ConcurrentTasks) {
+  // Check that tasks run concurrently when multiple workers are available.
+  // Two tasks communicate values back and forth via futures; neither can
+  // complete without the other having started. FResult.get() also serves as
+  // the "all tasks have run" wait point before destruction.
   std::promise<int> PInit;
   ConcurrencyState State;
   State.FInit = PInit.get_future();
@@ -141,8 +73,11 @@ TEST(ThreadPoolRunnerTest, ConcurrentCalls) {
 
   {
     ThreadPoolRunner R(2);
-    R(dummySession(), 0, dummyReturn(), concurrencyTaskA, serializePtr(&State));
-    R(dummySession(), 1, dummyReturn(), concurrencyTaskB, serializePtr(&State));
+    R([&]() {
+      State.P1.set_value(State.FInit.get());
+      State.PResult.set_value(State.F2.get());
+    });
+    R([&]() { State.P2.set_value(State.F1.get()); });
 
     PInit.set_value(ExpectedValue);
 


### PR DESCRIPTION
Commit 01683dbe7e207 generalized the Session's dispatch mechanism to hand each runner an opaque Task (move_only_function<void()>), and simplified QueueingRunner accordingly, but failed to update ThreadPoolRunner.

Update ThreadPoolRunner to conform to Session's dispatch requirements and update its unit test to dispatch plain tasks rather than wrapper-function calls.