### PR TITLE
[CodeView] Write 128bit ints as LF_(U)OCTWORD

### DIFF
--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
@@ -222,8 +222,11 @@ private:
                                 const Twine &Comment = "");
   void emitEncodedUnsignedInteger(const uint64_t &Value,
                                   const Twine &Comment = "");
+  void emitEncodedAPSInt(const APSInt &Value, const Twine &Comment = "");
+
   Error writeEncodedSignedInteger(const int64_t &Value);
   Error writeEncodedUnsignedInteger(const uint64_t &Value);
+  Error writeEncodedAPSInt(const APSInt &Value);
 
   void incrStreamedLen(const uint64_t &Len) {
     if (isStreaming())

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewRecordIO.h
@@ -33,6 +33,7 @@ class CodeViewRecordStreamer {
 public:
   virtual void emitBytes(StringRef Data) = 0;
   virtual void emitIntValue(uint64_t Value, unsigned Size) = 0;
+  virtual void emitAPSIntValue(const APSInt &Value, unsigned ByteSize) = 0;
   virtual void emitBinaryData(StringRef Data) = 0;
   virtual void AddComment(const Twine &T) = 0;
   virtual void AddRawComment(const Twine &T) = 0;
@@ -98,19 +99,25 @@ public:
     return Error::success();
   }
 
-  template <typename T> Error mapInteger(T &Value, const Twine &Comment = "") {
+  template <typename T>
+  Error mapWriteInteger(const T &Value, const Twine &Comment = "") {
     if (isStreaming()) {
       emitComment(Comment);
-      Streamer->emitIntValue((int)Value, sizeof(T));
+      Streamer->emitIntValue(Value, sizeof(T));
       incrStreamedLen(sizeof(T));
       return Error::success();
     }
 
-    if (isWriting())
-      return Writer->writeInteger(Value);
-
-    return Reader->readInteger(Value);
+    return Writer->writeInteger(Value);
   }
+
+  template <typename T> Error mapInteger(T &Value, const Twine &Comment = "") {
+    if (isReading())
+      return Reader->readInteger(Value);
+    return mapWriteInteger(Value, Comment);
+  }
+
+  Error mapWriteInt128(const APSInt &Value, const Twine &Comment = "");
 
   template <typename T> Error mapEnum(T &Value, const Twine &Comment = "") {
     if (!isStreaming() && sizeof(Value) > maxFieldLength())
@@ -218,15 +225,10 @@ public:
   }
 
 private:
-  void emitEncodedSignedInteger(const int64_t &Value,
-                                const Twine &Comment = "");
-  void emitEncodedUnsignedInteger(const uint64_t &Value,
-                                  const Twine &Comment = "");
-  void emitEncodedAPSInt(const APSInt &Value, const Twine &Comment = "");
-
-  Error writeEncodedSignedInteger(const int64_t &Value);
-  Error writeEncodedUnsignedInteger(const uint64_t &Value);
-  Error writeEncodedAPSInt(const APSInt &Value);
+  Error mapWriteEncodedSignedInteger(const APSInt &Value,
+                                     const Twine &Comment = "");
+  Error mapWriteEncodedUnsignedInteger(const APSInt &Value,
+                                       const Twine &Comment = "");
 
   void incrStreamedLen(const uint64_t &Len) {
     if (isStreaming())

--- a/llvm/include/llvm/Support/BinaryStreamWriter.h
+++ b/llvm/include/llvm/Support/BinaryStreamWriter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMWRITER_H
 #define LLVM_SUPPORT_BINARYSTREAMWRITER_H
 
+#include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/StringRef.h"

--- a/llvm/include/llvm/Support/BinaryStreamWriter.h
+++ b/llvm/include/llvm/Support/BinaryStreamWriter.h
@@ -65,6 +65,15 @@ public:
     return writeBytes(Buffer);
   }
 
+  /// Write \p Value as a 128 bit integer (possibly truncated).
+  ///
+  /// \p Value is expected to be in native endian as it is byte swapped if
+  /// needed.
+  ///
+  /// \returns a success error code if the data was successfully written,
+  /// otherwise returns an appropriate error code.
+  LLVM_ABI Error writeInt128(const APSInt &Value);
+
   /// Similar to writeInteger
   template <typename T> Error writeEnum(T Num) {
     static_assert(std::is_enum<T>::value,

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -3376,8 +3376,8 @@ void CodeViewDebug::emitConstantSymbolRecord(const DIType *DTy, APSInt &Value,
 
   OS.AddComment("Value");
 
-  // Encoded integers shouldn't need more than 10 bytes.
-  uint8_t Data[10];
+  // Encoded integers shouldn't need more than 18 bytes.
+  uint8_t Data[18];
   BinaryStreamWriter Writer(Data, llvm::endianness::little);
   CodeViewRecordIO IO(Writer);
   cantFail(IO.mapEncodedInteger(Value));

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -86,6 +86,15 @@ public:
     OS->emitIntValueInHex(Value, Size);
   }
 
+  void emitAPSIntValue(const APSInt &Value, unsigned ByteSize) override {
+    if (Value.getBitWidth() != ByteSize * 8) {
+      APSInt Trunc = Value.extOrTrunc(ByteSize * 8);
+      OS->emitIntValue(Value);
+    } else {
+      OS->emitIntValue(Value);
+    }
+  }
+
   void emitBinaryData(StringRef Data) override { OS->emitBinaryData(Data); }
 
   void AddComment(const Twine &T) override { OS->AddComment(T); }

--- a/llvm/lib/DebugInfo/CodeView/CodeViewRecordIO.cpp
+++ b/llvm/lib/DebugInfo/CodeView/CodeViewRecordIO.cpp
@@ -190,19 +190,11 @@ Error CodeViewRecordIO::mapEncodedInteger(uint64_t &Value,
 }
 
 Error CodeViewRecordIO::mapEncodedInteger(APSInt &Value, const Twine &Comment) {
-  if (isStreaming()) {
-    // FIXME: We also need to handle big values here, but it's
-    //        not clear how we can excercise this code path yet.
-    if (Value.isSigned())
-      emitEncodedSignedInteger(Value.getSExtValue(), Comment);
-    else
-      emitEncodedUnsignedInteger(Value.getZExtValue(), Comment);
-  } else if (isWriting()) {
-    if (Value.isSigned())
-      return writeEncodedSignedInteger(
-          Value.isSingleWord() ? Value.getSExtValue() : INT64_MIN);
-    return writeEncodedUnsignedInteger(Value.getLimitedValue());
-  } else
+  if (isStreaming())
+    emitEncodedAPSInt(Value, Comment);
+  else if (isWriting())
+    return writeEncodedAPSInt(Value);
+  else
     return consume(*Reader, Value);
   return Error::success();
 }
@@ -390,4 +382,51 @@ Error CodeViewRecordIO::writeEncodedUnsignedInteger(const uint64_t &Value) {
   }
 
   return Error::success();
+}
+
+Error CodeViewRecordIO::writeEncodedAPSInt(const APSInt &Value) {
+  if (LLVM_LIKELY(Value.isSingleWord())) {
+    if (Value.isSigned())
+      return writeEncodedSignedInteger(Value.getSExtValue());
+    return writeEncodedUnsignedInteger(Value.getZExtValue());
+  }
+
+  // Width > 64 bit, write a 128 bit integer.
+  TypeLeafKind Leaf = Value.isSigned() ? LF_OCTWORD : LF_UOCTWORD;
+  if (auto EC = Writer->writeInteger<uint16_t>(Leaf))
+    return EC;
+
+  APSInt Trunc = Value.extOrTrunc(128);
+  if constexpr (endianness::native == endianness::big)
+    Trunc = Trunc.byteSwap();
+
+  if (auto EC = Writer->writeBytes(
+          {reinterpret_cast<const uint8_t *>(Trunc.getRawData()), 16}))
+    return EC;
+
+  return Error::success();
+}
+
+void CodeViewRecordIO::emitEncodedAPSInt(const APSInt &Value,
+                                         const Twine &Comment) {
+  if (LLVM_LIKELY(Value.isSingleWord())) {
+    if (Value.isSigned())
+      emitEncodedSignedInteger(Value.getSExtValue(), Comment);
+    else
+      emitEncodedUnsignedInteger(Value.getZExtValue(), Comment);
+
+    return;
+  }
+
+  // Width > 64 bit, write a 128 bit integer.
+  TypeLeafKind Leaf = Value.isSigned() ? LF_OCTWORD : LF_UOCTWORD;
+  Streamer->emitIntValue(Leaf, 2);
+  emitComment(Comment);
+  APSInt Trunc = Value.extOrTrunc(128);
+  if constexpr (endianness::native == endianness::big)
+    Trunc = Trunc.byteSwap();
+
+  Streamer->emitBinaryData(
+      {reinterpret_cast<const char *>(Value.getRawData()), 16});
+  incrStreamedLen(2 + 16);
 }

--- a/llvm/lib/DebugInfo/CodeView/CodeViewRecordIO.cpp
+++ b/llvm/lib/DebugInfo/CodeView/CodeViewRecordIO.cpp
@@ -148,55 +148,57 @@ Error CodeViewRecordIO::mapInteger(TypeIndex &TypeInd, const Twine &Comment) {
   return Error::success();
 }
 
+Error CodeViewRecordIO::mapWriteInt128(const APSInt &Value,
+                                       const Twine &Comment) {
+  if (isStreaming()) {
+    emitComment(Comment);
+    Streamer->emitAPSIntValue(Value, 16);
+    incrStreamedLen(16);
+    return Error::success();
+  }
+
+  return Writer->writeInt128(Value);
+}
+
 Error CodeViewRecordIO::mapEncodedInteger(int64_t &Value,
                                           const Twine &Comment) {
-  if (isStreaming()) {
-    if (Value >= 0)
-      emitEncodedUnsignedInteger(static_cast<uint64_t>(Value), Comment);
-    else
-      emitEncodedSignedInteger(Value, Comment);
-  } else if (isWriting()) {
-    if (Value >= 0) {
-      if (auto EC = writeEncodedUnsignedInteger(static_cast<uint64_t>(Value)))
-        return EC;
-    } else {
-      if (auto EC = writeEncodedSignedInteger(Value))
-        return EC;
-    }
-  } else {
+  if (isReading()) {
     APSInt N;
     if (auto EC = consume(*Reader, N))
       return EC;
     Value = N.getExtValue();
+    return Error::success();
   }
 
-  return Error::success();
+  if (Value >= 0)
+    return mapWriteEncodedUnsignedInteger(APSInt(APInt(Value, 64), true),
+                                          Comment);
+
+  return mapWriteEncodedSignedInteger(APSInt(APInt(64, Value, true), false),
+                                      Comment);
 }
 
 Error CodeViewRecordIO::mapEncodedInteger(uint64_t &Value,
                                           const Twine &Comment) {
-  if (isStreaming())
-    emitEncodedUnsignedInteger(Value, Comment);
-  else if (isWriting()) {
-    if (auto EC = writeEncodedUnsignedInteger(Value))
-      return EC;
-  } else {
+  if (isReading()) {
     APSInt N;
     if (auto EC = consume(*Reader, N))
       return EC;
     Value = N.getZExtValue();
+    return Error::success();
   }
-  return Error::success();
+  return mapWriteEncodedUnsignedInteger(APSInt(APInt(64, Value), true),
+                                        Comment);
 }
 
 Error CodeViewRecordIO::mapEncodedInteger(APSInt &Value, const Twine &Comment) {
-  if (isStreaming())
-    emitEncodedAPSInt(Value, Comment);
-  else if (isWriting())
-    return writeEncodedAPSInt(Value);
-  else
+  if (isReading())
     return consume(*Reader, Value);
-  return Error::success();
+
+  if (Value.isUnsigned())
+    return mapWriteEncodedUnsignedInteger(Value, Comment);
+
+  return mapWriteEncodedSignedInteger(Value, Comment);
 }
 
 Error CodeViewRecordIO::mapStringZ(StringRef &Value, const Twine &Comment) {
@@ -270,163 +272,77 @@ Error CodeViewRecordIO::mapStringZVectorZ(std::vector<StringRef> &Value,
   return Error::success();
 }
 
-void CodeViewRecordIO::emitEncodedSignedInteger(const int64_t &Value,
-                                                const Twine &Comment) {
-  // FIXME: There are no test cases covering this function.
-  // This may be because we always consider enumerators to be unsigned.
-  // See FIXME at CodeViewDebug.cpp : CodeViewDebug::lowerTypeEnum.
-  if (Value < LF_NUMERIC && Value >= 0) {
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 2);
-    incrStreamedLen(2);
-  } else if (Value >= std::numeric_limits<int8_t>::min() &&
-             Value <= std::numeric_limits<int8_t>::max()) {
-    Streamer->emitIntValue(LF_CHAR, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 1);
-    incrStreamedLen(3);
-  } else if (Value >= std::numeric_limits<int16_t>::min() &&
-             Value <= std::numeric_limits<int16_t>::max()) {
-    Streamer->emitIntValue(LF_SHORT, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 2);
-    incrStreamedLen(4);
-  } else if (Value >= std::numeric_limits<int32_t>::min() &&
-             Value <= std::numeric_limits<int32_t>::max()) {
-    Streamer->emitIntValue(LF_LONG, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 4);
-    incrStreamedLen(6);
-  } else {
-    Streamer->emitIntValue(LF_QUADWORD, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 8);
-    incrStreamedLen(10);
+Error CodeViewRecordIO::mapWriteEncodedSignedInteger(const APSInt &APValue,
+                                                     const Twine &Comment) {
+  assert(APValue.isSigned());
+
+  if (LLVM_UNLIKELY(!APValue.isSingleWord())) {
+    // All values >64 bit are encoded as 128 bit integers (possibly truncated).
+    if (Error Err = mapWriteInteger<uint16_t>(LF_OCTWORD))
+      return Err;
+    return mapWriteInt128(APValue, Comment);
   }
+
+  int64_t Value = APValue.getSExtValue();
+
+  if (Value < LF_NUMERIC && Value >= 0)
+    return mapWriteInteger(static_cast<uint16_t>(Value), Comment);
+
+  if (Value >= std::numeric_limits<int8_t>::min() &&
+      Value <= std::numeric_limits<int8_t>::max()) {
+    if (Error Err = mapWriteInteger<uint16_t>(LF_CHAR))
+      return Err;
+    return mapWriteInteger(static_cast<int8_t>(Value), Comment);
+  }
+
+  if (Value >= std::numeric_limits<int16_t>::min() &&
+      Value <= std::numeric_limits<int16_t>::max()) {
+    if (Error Err = mapWriteInteger<uint16_t>(LF_SHORT))
+      return Err;
+    return mapWriteInteger(static_cast<int16_t>(Value), Comment);
+  }
+
+  if (Value >= std::numeric_limits<int32_t>::min() &&
+      Value <= std::numeric_limits<int32_t>::max()) {
+    if (Error Err = mapWriteInteger<uint16_t>(LF_LONG))
+      return Err;
+    return mapWriteInteger(static_cast<int32_t>(Value), Comment);
+  }
+
+  if (Error Err = mapWriteInteger<uint16_t>(LF_QUADWORD))
+    return Err;
+  return mapWriteInteger(Value, Comment);
 }
 
-void CodeViewRecordIO::emitEncodedUnsignedInteger(const uint64_t &Value,
-                                                  const Twine &Comment) {
-  if (Value < LF_NUMERIC) {
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 2);
-    incrStreamedLen(2);
-  } else if (Value <= std::numeric_limits<uint16_t>::max()) {
-    Streamer->emitIntValue(LF_USHORT, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 2);
-    incrStreamedLen(4);
-  } else if (Value <= std::numeric_limits<uint32_t>::max()) {
-    Streamer->emitIntValue(LF_ULONG, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 4);
-    incrStreamedLen(6);
-  } else {
-    Streamer->emitIntValue(LF_UQUADWORD, 2);
-    emitComment(Comment);
-    Streamer->emitIntValue(Value, 8);
-    incrStreamedLen(10);
-  }
-}
+Error CodeViewRecordIO::mapWriteEncodedUnsignedInteger(const APSInt &APValue,
+                                                       const Twine &Comment) {
+  assert(APValue.isUnsigned());
 
-Error CodeViewRecordIO::writeEncodedSignedInteger(const int64_t &Value) {
-  if (Value < LF_NUMERIC && Value >= 0) {
-    if (auto EC = Writer->writeInteger<int16_t>(Value))
-      return EC;
-  } else if (Value >= std::numeric_limits<int8_t>::min() &&
-             Value <= std::numeric_limits<int8_t>::max()) {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_CHAR))
-      return EC;
-    if (auto EC = Writer->writeInteger<int8_t>(Value))
-      return EC;
-  } else if (Value >= std::numeric_limits<int16_t>::min() &&
-             Value <= std::numeric_limits<int16_t>::max()) {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_SHORT))
-      return EC;
-    if (auto EC = Writer->writeInteger<int16_t>(Value))
-      return EC;
-  } else if (Value >= std::numeric_limits<int32_t>::min() &&
-             Value <= std::numeric_limits<int32_t>::max()) {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_LONG))
-      return EC;
-    if (auto EC = Writer->writeInteger<int32_t>(Value))
-      return EC;
-  } else {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_QUADWORD))
-      return EC;
-    if (auto EC = Writer->writeInteger(Value))
-      return EC;
-  }
-  return Error::success();
-}
-
-Error CodeViewRecordIO::writeEncodedUnsignedInteger(const uint64_t &Value) {
-  if (Value < LF_NUMERIC) {
-    if (auto EC = Writer->writeInteger<uint16_t>(Value))
-      return EC;
-  } else if (Value <= std::numeric_limits<uint16_t>::max()) {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_USHORT))
-      return EC;
-    if (auto EC = Writer->writeInteger<uint16_t>(Value))
-      return EC;
-  } else if (Value <= std::numeric_limits<uint32_t>::max()) {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_ULONG))
-      return EC;
-    if (auto EC = Writer->writeInteger<uint32_t>(Value))
-      return EC;
-  } else {
-    if (auto EC = Writer->writeInteger<uint16_t>(LF_UQUADWORD))
-      return EC;
-    if (auto EC = Writer->writeInteger(Value))
-      return EC;
+  if (LLVM_UNLIKELY(!APValue.isSingleWord())) {
+    // All values >64 bit are encoded as 128 bit integers (possibly truncated).
+    if (Error Err = mapWriteInteger<uint16_t>(LF_UOCTWORD))
+      return Err;
+    return mapWriteInt128(APValue, Comment);
   }
 
-  return Error::success();
-}
+  uint64_t Value = APValue.getZExtValue();
 
-Error CodeViewRecordIO::writeEncodedAPSInt(const APSInt &Value) {
-  if (LLVM_LIKELY(Value.isSingleWord())) {
-    if (Value.isSigned())
-      return writeEncodedSignedInteger(Value.getSExtValue());
-    return writeEncodedUnsignedInteger(Value.getZExtValue());
+  if (Value < LF_NUMERIC)
+    return mapWriteInteger(static_cast<uint16_t>(Value), Comment);
+
+  if (Value <= std::numeric_limits<uint16_t>::max()) {
+    if (Error Err = mapWriteInteger<uint16_t>(LF_USHORT))
+      return Err;
+    return mapWriteInteger(static_cast<uint16_t>(Value), Comment);
   }
 
-  // Width > 64 bit, write a 128 bit integer.
-  TypeLeafKind Leaf = Value.isSigned() ? LF_OCTWORD : LF_UOCTWORD;
-  if (auto EC = Writer->writeInteger<uint16_t>(Leaf))
-    return EC;
-
-  APSInt Trunc = Value.extOrTrunc(128);
-  if constexpr (endianness::native == endianness::big)
-    Trunc = Trunc.byteSwap();
-
-  if (auto EC = Writer->writeBytes(
-          {reinterpret_cast<const uint8_t *>(Trunc.getRawData()), 16}))
-    return EC;
-
-  return Error::success();
-}
-
-void CodeViewRecordIO::emitEncodedAPSInt(const APSInt &Value,
-                                         const Twine &Comment) {
-  if (LLVM_LIKELY(Value.isSingleWord())) {
-    if (Value.isSigned())
-      emitEncodedSignedInteger(Value.getSExtValue(), Comment);
-    else
-      emitEncodedUnsignedInteger(Value.getZExtValue(), Comment);
-
-    return;
+  if (Value <= std::numeric_limits<uint32_t>::max()) {
+    if (Error Err = mapWriteInteger<uint16_t>(LF_ULONG))
+      return Err;
+    return mapWriteInteger(static_cast<uint32_t>(Value), Comment);
   }
 
-  // Width > 64 bit, write a 128 bit integer.
-  TypeLeafKind Leaf = Value.isSigned() ? LF_OCTWORD : LF_UOCTWORD;
-  Streamer->emitIntValue(Leaf, 2);
-  emitComment(Comment);
-  APSInt Trunc = Value.extOrTrunc(128);
-  if constexpr (endianness::native == endianness::big)
-    Trunc = Trunc.byteSwap();
-
-  Streamer->emitBinaryData(
-      {reinterpret_cast<const char *>(Value.getRawData()), 16});
-  incrStreamedLen(2 + 16);
+  if (Error Err = mapWriteInteger<uint16_t>(LF_UQUADWORD))
+    return Err;
+  return mapWriteInteger(Value, Comment);
 }

--- a/llvm/lib/DebugInfo/CodeView/RecordSerialization.cpp
+++ b/llvm/lib/DebugInfo/CodeView/RecordSerialization.cpp
@@ -96,6 +96,28 @@ Error llvm::codeview::consume(BinaryStreamReader &Reader, APSInt &Num) {
     Num = APSInt(APInt(64, N, false), true);
     return Error::success();
   }
+  case LF_OCTWORD: {
+    ArrayRef<uint8_t> Data;
+    if (auto EC = Reader.readBytes(Data, 16))
+      return EC;
+    uint64_t N[2];
+    std::memcpy(N, Data.data(), sizeof(N));
+    Num = APSInt(APInt(128, {N, 2}), false);
+    if constexpr (endianness::native == endianness::big)
+      Num = Num.byteSwap();
+    return Error::success();
+  }
+  case LF_UOCTWORD: {
+    ArrayRef<uint8_t> Data;
+    if (auto EC = Reader.readBytes(Data, 16))
+      return EC;
+    uint64_t N[2];
+    std::memcpy(N, Data.data(), sizeof(N));
+    Num = APSInt(APInt(128, {N, 2}), true);
+    if constexpr (endianness::native == endianness::big)
+      Num = Num.byteSwap();
+    return Error::success();
+  }
   }
   return make_error<CodeViewError>(cv_error_code::corrupt_record,
                                    "Buffer contains invalid APSInt type");

--- a/llvm/lib/DebugInfo/CodeView/TypeIndex.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeIndex.cpp
@@ -50,6 +50,8 @@ static const SimpleTypeEntry SimpleTypeNames[] = {
     {"unsigned __int64*", SimpleTypeKind::UInt64},
     {"__int128*", SimpleTypeKind::Int128},
     {"unsigned __int128*", SimpleTypeKind::UInt128},
+    {"__int128*", SimpleTypeKind::Int128Oct},
+    {"unsigned __int128*", SimpleTypeKind::UInt128Oct},
     {"__half*", SimpleTypeKind::Float16},
     {"float*", SimpleTypeKind::Float32},
     {"float*", SimpleTypeKind::Float32PartialPrecision},

--- a/llvm/lib/DebugInfo/CodeView/TypeIndexDiscovery.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeIndexDiscovery.cpp
@@ -42,23 +42,43 @@ static inline uint32_t getEncodedIntegerLength(ArrayRef<uint8_t> Data) {
   if (N < LF_NUMERIC)
     return 2;
 
-  assert(N <= LF_UQUADWORD);
+  switch (N) {
+  case LF_CHAR:
+    return 2 + 1;
 
-  constexpr uint32_t Sizes[] = {
-      1,  // LF_CHAR
-      2,  // LF_SHORT
-      2,  // LF_USHORT
-      4,  // LF_LONG
-      4,  // LF_ULONG
-      4,  // LF_REAL32
-      8,  // LF_REAL64
-      10, // LF_REAL80
-      16, // LF_REAL128
-      8,  // LF_QUADWORD
-      8,  // LF_UQUADWORD
-  };
+  case LF_SHORT:
+  case LF_USHORT:
+    return 2 + 2;
 
-  return 2 + Sizes[N - LF_NUMERIC];
+  case LF_LONG:
+  case LF_ULONG:
+  case LF_REAL32:
+  case LF_COMPLEX32:
+    return 2 + 4;
+
+  case LF_REAL48:
+    return 2 + 6;
+
+  case LF_REAL64:
+  case LF_COMPLEX64:
+  case LF_QUADWORD:
+  case LF_UQUADWORD:
+    return 2 + 8;
+
+  case LF_REAL80:
+  case LF_COMPLEX80:
+    return 2 + 10;
+
+  case LF_REAL128:
+  case LF_COMPLEX128:
+  case LF_OCTWORD:
+  case LF_UOCTWORD:
+    return 2 + 16;
+
+  default:
+    assert(false && "Unknown numeric type");
+    return 2;
+  }
 }
 
 static inline uint32_t getCStringLength(ArrayRef<uint8_t> Data) {

--- a/llvm/lib/DebugInfo/CodeView/TypeIndexDiscovery.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeIndexDiscovery.cpp
@@ -7,9 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/CodeView/TypeIndexDiscovery.h"
-#include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/Support/Endian.h"
+#include <wtypes.h>
 
 using namespace llvm;
 using namespace llvm::codeview;
@@ -42,43 +43,38 @@ static inline uint32_t getEncodedIntegerLength(ArrayRef<uint8_t> Data) {
   if (N < LF_NUMERIC)
     return 2;
 
-  switch (N) {
-  case LF_CHAR:
-    return 2 + 1;
+  assert(N <= LF_DATE && (N <= LF_COMPLEX128 || N >= LF_OCTWORD));
+  constexpr uint32_t Sizes[] = {
+      1,  // LF_CHAR
+      2,  // LF_SHORT
+      2,  // LF_USHORT
+      4,  // LF_LONG
+      4,  // LF_ULONG
+      4,  // LF_REAL32
+      8,  // LF_REAL64
+      10, // LF_REAL80
+      16, // LF_REAL128
+      8,  // LF_QUADWORD
+      8,  // LF_UQUADWORD
+      6,  // LF_REAL48
+      4,  // LF_COMPLEX32
+      8,  // LF_COMPLEX64
+      10, // LF_COMPLEX80
+      16, // LF_COMPLEX128
+      0,  // LF_VARSTRING (variable length)
+      0,  // 0x8011 (Unused)
+      0,  // 0x8012 (Unused)
+      0,  // 0x8013 (Unused)
+      0,  // 0x8014 (Unused)
+      0,  // 0x8015 (Unused)
+      0,  // 0x8016 (Unused)
+      16, // LF_OCTWORD
+      16, // LF_UOCTWORD
+      16, // LF_DECIMAL (sizeof(DECIMAL))
+      8,  // LF_DATE (sizeof(DATE))
+  };
 
-  case LF_SHORT:
-  case LF_USHORT:
-    return 2 + 2;
-
-  case LF_LONG:
-  case LF_ULONG:
-  case LF_REAL32:
-  case LF_COMPLEX32:
-    return 2 + 4;
-
-  case LF_REAL48:
-    return 2 + 6;
-
-  case LF_REAL64:
-  case LF_COMPLEX64:
-  case LF_QUADWORD:
-  case LF_UQUADWORD:
-    return 2 + 8;
-
-  case LF_REAL80:
-  case LF_COMPLEX80:
-    return 2 + 10;
-
-  case LF_REAL128:
-  case LF_COMPLEX128:
-  case LF_OCTWORD:
-  case LF_UOCTWORD:
-    return 2 + 16;
-
-  default:
-    assert(false && "Unknown numeric type");
-    return 2;
-  }
+  return 2 + Sizes[N - LF_NUMERIC];
 }
 
 static inline uint32_t getCStringLength(ArrayRef<uint8_t> Data) {

--- a/llvm/lib/DebugInfo/CodeView/TypeIndexDiscovery.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeIndexDiscovery.cpp
@@ -10,7 +10,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/Support/Endian.h"
-#include <wtypes.h>
 
 using namespace llvm;
 using namespace llvm::codeview;

--- a/llvm/lib/Support/BinaryStreamWriter.cpp
+++ b/llvm/lib/Support/BinaryStreamWriter.cpp
@@ -32,6 +32,21 @@ Error BinaryStreamWriter::writeBytes(ArrayRef<uint8_t> Buffer) {
   return Error::success();
 }
 
+Error BinaryStreamWriter::writeInt128(const APSInt &Value) {
+  bool SameEndianess = Stream.getEndian() == endianness::native;
+  // Avoid copying the value if it is in the expected shape.
+  if (Value.getBitWidth() == 128 && SameEndianess)
+    return writeBytes(
+        {reinterpret_cast<const uint8_t *>(Value.getRawData()), 16});
+
+  APInt Trunc = Value.extOrTrunc(128);
+  if (!SameEndianess)
+    Trunc = Trunc.byteSwap();
+
+  return writeBytes(
+      {reinterpret_cast<const uint8_t *>(Trunc.getRawData()), 16});
+}
+
 Error BinaryStreamWriter::writeULEB128(uint64_t Value) {
   uint8_t EncodedBytes[10] = {0};
   unsigned Size = encodeULEB128(Value, &EncodedBytes[0]);

--- a/llvm/test/DebugInfo/COFF/integer-128.ll
+++ b/llvm/test/DebugInfo/COFF/integer-128.ll
@@ -19,32 +19,42 @@
 ;
 ; ASM-LABEL: .short	4359                            # Record kind: S_CONSTANT
 ; ASM-NEXT:  .long	4110                            # Type
-; ASM-NEXT:  .byte	0x0a, 0x80, 0xff, 0xff          # Value
-; ASM-NEXT:  .byte	0xff, 0xff, 0xff, 0xff
-; ASM-NEXT:  .byte	0xff, 0xff
+; ASM-NEXT:  .byte	0x18, 0x80, 0x00, 0x00          # Value
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
+; ASM-NEXT:  .byte	0x00, 0x00, 0x01, 0x00
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
+; ASM-NEXT:  .byte	0x00, 0x00
 ; ASM-NEXT:  .asciz	"test::u128"                    # Name
 ; ASM-NEXT:  .p2align	2
 ;
 ; ASM-LABEL: .short	4359                            # Record kind: S_CONSTANT
 ; ASM-NEXT:  .long	4111                            # Type
-; ASM-NEXT:  .byte	0x09, 0x80, 0x00, 0x00          # Value
+; ASM-NEXT:  .byte	0x17, 0x80, 0x00, 0x00          # Value
 ; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
-; ASM-NEXT:  .byte	0x00, 0x80
+; ASM-NEXT:  .byte	0x00, 0x00, 0xff, 0xff
+; ASM-NEXT:  .byte	0xff, 0xff, 0xff, 0xff
+; ASM-NEXT:  .byte	0xff, 0xff
 ; ASM-NEXT:  .asciz	"test::s128"                    # Name
 ; ASM-NEXT:  .p2align	2
 ;
 ; ASM-LABEL: .short	0x1203                          # Record kind: LF_FIELDLIST
 ; ASM-NEXT:  .short	0x1502                          # Member kind: Enumerator ( LF_ENUMERATE )
 ; ASM-NEXT:  .short	0x3                             # Attrs: Public
-; ASM-NEXT:  .short	0x800a
-; ASM-NEXT:  .quad	0xffffffffffffffff              # EnumValue
+; ASM-NEXT:  .short	0x8018
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00          # EnumValue
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
+; ASM-NEXT:  .byte	0x01, 0x00, 0x00, 0x00
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
 ; ASM-NEXT:  .asciz	"unsval"                        # Name
 ;
 ; ASM-LABEL: .short	0x1203                          # Record kind: LF_FIELDLIST
 ; ASM-NEXT:  .short	0x1502                          # Member kind: Enumerator ( LF_ENUMERATE )
 ; ASM-NEXT:  .short	0x3                             # Attrs: Public
-; ASM-NEXT:  .short	0x8009
-; ASM-NEXT:  .quad	0x8000000000000000              # EnumValue
+; ASM-NEXT:  .short	0x8017
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00          # EnumValue
+; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
+; ASM-NEXT:  .byte	0xff, 0xff, 0xff, 0xff
+; ASM-NEXT:  .byte	0xff, 0xff, 0xff, 0xff
 ; ASM-NEXT:  .asciz	"sigval"                        # Name
 
 ; ------------------------------------------------------------------------------

--- a/llvm/test/DebugInfo/COFF/integer-128.ll
+++ b/llvm/test/DebugInfo/COFF/integer-128.ll
@@ -41,20 +41,14 @@
 ; ASM-NEXT:  .short	0x1502                          # Member kind: Enumerator ( LF_ENUMERATE )
 ; ASM-NEXT:  .short	0x3                             # Attrs: Public
 ; ASM-NEXT:  .short	0x8018
-; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00          # EnumValue
-; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
-; ASM-NEXT:  .byte	0x01, 0x00, 0x00, 0x00
-; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
+; ASM-NEXT:  .asciz	"\000\000\000\000\000\000\000\000\001\000\000\000\000\000\000" # EnumValue
 ; ASM-NEXT:  .asciz	"unsval"                        # Name
 ;
 ; ASM-LABEL: .short	0x1203                          # Record kind: LF_FIELDLIST
 ; ASM-NEXT:  .short	0x1502                          # Member kind: Enumerator ( LF_ENUMERATE )
 ; ASM-NEXT:  .short	0x3                             # Attrs: Public
 ; ASM-NEXT:  .short	0x8017
-; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00          # EnumValue
-; ASM-NEXT:  .byte	0x00, 0x00, 0x00, 0x00
-; ASM-NEXT:  .byte	0xff, 0xff, 0xff, 0xff
-; ASM-NEXT:  .byte	0xff, 0xff, 0xff, 0xff
+; ASM-NEXT:  .ascii	"\000\000\000\000\000\000\000\000\377\377\377\377\377\377\377\377" # EnumValue
 ; ASM-NEXT:  .asciz	"sigval"                        # Name
 
 ; ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes how 128-bit integers are read and written in CodeView. Before, we only supported 64-bit ints. Anything larger would be truncated. CodeView does have a way of encoding 128-bit values: `LF_(U)OCTWORD`. We can use this here.

The main issue for us is that the Microsoft tools don't support this well. For the DIA SDK, [`IDiaSymbol::get_value`](https://learn.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/idiasymbol-get-value) succeeds, but the returned `VARIANT` is of type `VT_ERROR`. The Visual Studio debugger also fails to print 128-bit values.
This isn't due to an incorrect encoding on our side. `pdbtool` from https://github.com/microsoft/pdb-rs can read the values just fine.

I still think we should write `LF_(U)OCTWORD` here. MSVC doesn't support `__int128`, so Clang is alone here. If the user wants a 128 bit value, they should get it. Rust is also a user of 128-bit integers - they're available as `u128`. However, they generate a struct with 64-bit high and low words, so we're not changing anything for them.