### PR TITLE
[orc-rt] Reorder wrapper-fn args to trailing-callback style.

### DIFF
--- a/orc-rt/docs/CodingConventions.md
+++ b/orc-rt/docs/CodingConventions.md
@@ -59,3 +59,30 @@ the `Error` type; `orc_rt_log_formatCheck` is the `formatCheck` function in the
 C++ code follows the LLVM Coding Standards directly: symbols live in real
 namespaces (e.g. `orc_rt`), types/values/variables are `PascalCase`, functions
 are `camelBack`, and macros are `UPPER_CASE`.
+
+## Parameter ordering for asynchronous APIs
+
+Many ORC-RT entry points are asynchronous: they take a completion callback that
+is invoked, possibly on another thread, when the operation finishes. Because C
+has no closures, such a callback is paired with an opaque context (a `void *`
+supplied by the caller, or a framework-issued token such as a call id) that is
+threaded back to it. To keep these APIs learnable as a family, order their
+parameters consistently:
+
+1. The primary handle or receiver (e.g. `orc_rt_SessionRef`) comes first.
+2. The call inputs follow (e.g. a target/tag, an argument buffer).
+3. The completion callback comes next, immediately followed by its context.
+4. The context/token is always **last** -- in both the call and the callback
+   signature.
+
+For example, `orc_rt_WrapperFunction` is
+`(S, ArgBytes, Return, CallId)` and its return callback
+`orc_rt_WrapperFunctionReturn` is `(S, ResultBytes, CallId)`: the `CallId`
+token that the framework threads from the call to its completion is last in
+both. C++ helpers that mirror these signatures (e.g. `WrapperFunction::handle`)
+follow the same order, appending any implementation-only parameters (such as a
+serializer or handler) after the token.
+
+This ordering is a convention, not a hard rule; where an existing API or an
+external interface being wrapped dictates otherwise, match that instead.
+

--- a/orc-rt/include/orc-rt-c/WrapperFunction.h
+++ b/orc-rt/include/orc-rt-c/WrapperFunction.h
@@ -55,20 +55,21 @@ typedef struct {
  * Asynchronous return function for an orc-rt wrapper function.
  */
 typedef void (*orc_rt_WrapperFunctionReturn)(
-    orc_rt_SessionRef S, uint64_t CallId,
-    orc_rt_WrapperFunctionBuffer ResultBytes);
+    orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ResultBytes,
+    uint64_t CallId);
 
 /**
  * orc-rt wrapper function prototype.
  *
- * ArgBytes contains the serialized arguments for the wrapper function.
  * Session holds a reference to the session object.
- * CallId holds a pointer to the context object for this particular call.
+ * ArgBytes contains the serialized arguments for the wrapper function.
  * Return holds a pointer to the return function.
+ * CallId holds a pointer to the context object for this particular call.
  */
-typedef void (*orc_rt_WrapperFunction)(orc_rt_SessionRef S, uint64_t CallId,
+typedef void (*orc_rt_WrapperFunction)(orc_rt_SessionRef S,
+                                       orc_rt_WrapperFunctionBuffer ArgBytes,
                                        orc_rt_WrapperFunctionReturn Return,
-                                       orc_rt_WrapperFunctionBuffer ArgBytes);
+                                       uint64_t CallId);
 
 /**
  * Zero-initialize an orc_rt_WrapperFunctionBuffer.

--- a/orc-rt/include/orc-rt/InProcessControllerAccess.h
+++ b/orc-rt/include/orc-rt/InProcessControllerAccess.h
@@ -112,8 +112,8 @@ public:
   void callController(OnControllerCallReturn OnComplete,
                       orc_rt_ControllerHandlerTag T,
                       WrapperFunctionBuffer ArgBytes) override;
-  void sendWrapperResult(uint64_t CallId,
-                         WrapperFunctionBuffer ResultBytes) override;
+  void sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                         uint64_t CallId) override;
 
 private:
   uint64_t registerPendingHandler(OnControllerCallReturn OnComplete);

--- a/orc-rt/include/orc-rt/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/SPSWrapperFunction.h
@@ -19,10 +19,9 @@
 #include "orc-rt/WrapperFunction.h"
 
 #define ORC_RT_SPS_WRAPPER(Name, SPSSig, Handle)                               \
-  static void Name(orc_rt_SessionRef S, uint64_t CallId,                       \
-                   orc_rt_WrapperFunctionReturn Return,                        \
-                   orc_rt_WrapperFunctionBuffer ArgBytes) {                    \
-    orc_rt::SPSWrapperFunction<SPSSig>::handle(S, CallId, Return, ArgBytes,    \
+  static void Name(orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes, \
+                   orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {     \
+    orc_rt::SPSWrapperFunction<SPSSig>::handle(S, ArgBytes, Return, CallId,    \
                                                Handle);                        \
   }
 
@@ -130,10 +129,10 @@ template <typename SPSSig> struct SPSWrapperFunction {
   }
 
   template <typename Handler>
-  static void handle(orc_rt_SessionRef S, uint64_t CallId,
-                     orc_rt_WrapperFunctionReturn Return,
-                     WrapperFunctionBuffer ArgBytes, Handler &&H) {
-    WrapperFunction::handle(S, CallId, Return, std::move(ArgBytes),
+  static void handle(orc_rt_SessionRef S, WrapperFunctionBuffer ArgBytes,
+                     orc_rt_WrapperFunctionReturn Return, uint64_t CallId,
+                     Handler &&H) {
+    WrapperFunction::handle(S, std::move(ArgBytes), Return, CallId,
                             WrapperFunctionSPSSerializer<SPSSig>(),
                             std::forward<Handler>(H));
   }
@@ -141,10 +140,10 @@ template <typename SPSSig> struct SPSWrapperFunction {
   /// Convenience override that takes ArgBytes as an
   /// orc_rt_WrapperFunctionBuffer.
   template <typename Handler>
-  static void handle(orc_rt_SessionRef S, uint64_t CallId,
-                     orc_rt_WrapperFunctionReturn Return,
-                     orc_rt_WrapperFunctionBuffer ArgBytes, Handler &&H) {
-    handle(S, CallId, Return, WrapperFunctionBuffer(ArgBytes),
+  static void handle(orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+                     orc_rt_WrapperFunctionReturn Return, uint64_t CallId,
+                     Handler &&H) {
+    handle(S, WrapperFunctionBuffer(ArgBytes), Return, CallId,
            std::forward<Handler>(H));
   }
 };

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -217,8 +217,8 @@ public:
                                 WrapperFunctionBuffer ArgBytes) = 0;
 
     /// Send the result of the given wrapper function call to the controller.
-    virtual void sendWrapperResult(uint64_t CallId,
-                                   WrapperFunctionBuffer ResultBytes) = 0;
+    virtual void sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                                   uint64_t CallId) = 0;
 
     /// Notify the Session that the controller has disconnected.
     ///
@@ -237,9 +237,9 @@ public:
     /// Ask the Session to run the given wrapper function.
     ///
     /// Subclasses must not call this method after notifyDisconnected is called.
-    void handleWrapperCall(uint64_t CallId, orc_rt_WrapperFunction Fn,
-                           WrapperFunctionBuffer ArgBytes) {
-      S.handleWrapperCall(CallId, Fn, std::move(ArgBytes));
+    void handleWrapperCall(orc_rt_WrapperFunction Fn,
+                           WrapperFunctionBuffer ArgBytes, uint64_t CallId) {
+      S.handleWrapperCall(Fn, std::move(ArgBytes), CallId);
     }
 
     /// Complete a controller call with a result the controller returned, by
@@ -559,8 +559,8 @@ private:
   void shutdownServices(std::vector<Service *> ToNotify);
   void completeShutdown();
 
-  void handleWrapperCall(uint64_t CallId, orc_rt_WrapperFunction Fn,
-                         WrapperFunctionBuffer ArgBytes) {
+  void handleWrapperCall(orc_rt_WrapperFunction Fn,
+                         WrapperFunctionBuffer ArgBytes, uint64_t CallId) {
     TaskGroup::Token T(ManagedCodeTaskGroup);
     if (!T) {
       // The ManagedCodeTaskGroup is only closed after detach, so if token
@@ -572,7 +572,7 @@ private:
 
     Dispatch([this, CallId, Fn, ArgBytes = std::move(ArgBytes),
               T = std::move(T)]() mutable {
-      Fn(wrap(this), CallId, &wrapperReturn, ArgBytes.release());
+      Fn(wrap(this), ArgBytes.release(), &wrapperReturn, CallId);
     });
   }
 
@@ -618,9 +618,10 @@ private:
     OnComplete.Wrapped(disconnectError());
   }
 
-  void sendWrapperResult(uint64_t CallId, WrapperFunctionBuffer ResultBytes);
-  static void wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,
-                            orc_rt_WrapperFunctionBuffer ResultBytes);
+  void sendWrapperResult(WrapperFunctionBuffer ResultBytes, uint64_t CallId);
+  static void wrapperReturn(orc_rt_SessionRef S,
+                            orc_rt_WrapperFunctionBuffer ResultBytes,
+                            uint64_t CallId);
 
   ExecutorProcessInfo EPI;
   DispatchFn Dispatch;

--- a/orc-rt/include/orc-rt/WrapperFunction.h
+++ b/orc-rt/include/orc-rt/WrapperFunction.h
@@ -143,14 +143,14 @@ using WFHandlerTraits = CallableTraitsHelper<WFHandlerTraitsImplAdapter, C>;
 
 template <typename Serializer> class StructuredYieldBase {
 public:
-  StructuredYieldBase(orc_rt_SessionRef S, uint64_t CallId,
-                      orc_rt_WrapperFunctionReturn Return, Serializer &&Z)
-      : S(S), CallId(CallId), Return(Return), Z(std::forward<Serializer>(Z)) {}
+  StructuredYieldBase(orc_rt_SessionRef S, orc_rt_WrapperFunctionReturn Return,
+                      uint64_t CallId, Serializer &&Z)
+      : S(S), Return(Return), CallId(CallId), Z(std::forward<Serializer>(Z)) {}
 
 protected:
   orc_rt_SessionRef S;
-  uint64_t CallId;
   orc_rt_WrapperFunctionReturn Return;
+  uint64_t CallId;
   std::decay_t<Serializer> Z;
 };
 
@@ -163,12 +163,13 @@ public:
   using StructuredYieldBase<Serializer>::StructuredYieldBase;
   void operator()(RetT &&R) {
     if (auto ResultBytes = this->Z.result().serialize(std::forward<RetT>(R)))
-      this->Return(this->S, this->CallId, ResultBytes->release());
+      this->Return(this->S, ResultBytes->release(), this->CallId);
     else
-      this->Return(this->S, this->CallId,
+      this->Return(this->S,
                    WrapperFunctionBuffer::createOutOfBandError(
                        "Could not serialize wrapper function result data")
-                       .release());
+                       .release(),
+                   this->CallId);
   }
 };
 
@@ -178,7 +179,7 @@ class StructuredYield<std::tuple<>, Serializer>
 public:
   using StructuredYieldBase<Serializer>::StructuredYieldBase;
   void operator()() {
-    this->Return(this->S, this->CallId, WrapperFunctionBuffer().release());
+    this->Return(this->S, WrapperFunctionBuffer().release(), this->CallId);
   }
 };
 
@@ -255,12 +256,11 @@ struct WrapperFunction {
   ///
   ///
   ///   static void adder_add_async_sps_wrapper(
-  ///       orc_rt_SessionRef S, uint64_t CallId,
-  ///       orc_rt_WrapperFunctionReturn Return,
-  ///       orc_rt_WrapperFunctionBuffer ArgBytes) {
+  ///       orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+  ///       orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
   ///     using SPSSig = SPSString(SPSExecutorAddr, int32_t, bool);
   ///     SPSWrapperFunction<SPSSig>::handle(
-  ///         S, CallId, Return, ArgBytes,
+  ///         S, ArgBytes, Return, CallId,
   ///         WrapperFunction::handleWithAsyncMethod(&MyClass::myMethod));
   ///   }
   ///   @endcode
@@ -317,12 +317,11 @@ struct WrapperFunction {
   ///
   ///
   ///   static void adder_add_sync_sps_wrapper(
-  ///       orc_rt_SessionRef S, uint64_t CallId,
-  ///       orc_rt_WrapperFunctionReturn Return,
-  ///       orc_rt_WrapperFunctionBuffer ArgBytes) {
+  ///       orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+  ///       orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
   ///     using SPSSig = SPSString(SPSExecutorAddr, int32_t, bool);
   ///     SPSWrapperFunction<SPSSig>::handle(
-  ///         S, CallId, Return, ArgBytes,
+  ///         S, ArgBytes, Return, CallId,
   ///         WrapperFunction::handleWithSyncMethod(&Adder::addSync));
   ///   }
   ///   @endcode
@@ -371,10 +370,9 @@ struct WrapperFunction {
   /// This utility deserializes and serializes arguments and return values
   /// (using the given Serializer), and calls the given handler.
   template <typename Serializer, typename Handler>
-  static void handle(orc_rt_SessionRef S, uint64_t CallId,
-                     orc_rt_WrapperFunctionReturn Return,
-                     WrapperFunctionBuffer ArgBytes, Serializer &&Z,
-                     Handler &&H) {
+  static void handle(orc_rt_SessionRef S, WrapperFunctionBuffer ArgBytes,
+                     orc_rt_WrapperFunctionReturn Return, uint64_t CallId,
+                     Serializer &&Z, Handler &&H) {
     typedef detail::WFHandlerTraits<Handler> HandlerTraits;
     typedef typename HandlerTraits::ArgTupleType ArgTuple;
     typedef typename HandlerTraits::YieldType Yield;
@@ -383,19 +381,20 @@ struct WrapperFunction {
     typedef typename CallableArgInfo<Yield>::args_tuple_type RetTupleType;
 
     if (ArgBytes.getOutOfBandError())
-      return Return(S, CallId, ArgBytes.release());
+      return Return(S, ArgBytes.release(), CallId);
 
     if (auto Args = Z.arguments().template deserialize<ArgTuple>(ArgBytes))
       std::apply(HandlerTraits::forwardArgsAsRequested(bind_front(
                      std::forward<Handler>(H),
                      detail::StructuredYield<RetTupleType, Serializer>(
-                         S, CallId, Return, std::move(Z)))),
+                         S, Return, CallId, std::move(Z)))),
                  *Args);
     else
-      Return(S, CallId,
+      Return(S,
              WrapperFunctionBuffer::createOutOfBandError(
                  "Could not deserialize wrapper function arg data")
-                 .release());
+                 .release(),
+             CallId);
   }
 };
 

--- a/orc-rt/lib/executor/InProcessControllerAccess.cpp
+++ b/orc-rt/lib/executor/InProcessControllerAccess.cpp
@@ -215,7 +215,7 @@ void InProcessControllerAccess::callController(
 }
 
 void InProcessControllerAccess::sendWrapperResult(
-    uint64_t CallId, WrapperFunctionBuffer ResultBytes) {
+    WrapperFunctionBuffer ResultBytes, uint64_t CallId) {
   assert(C && "sendWrapperResult called before connect");
   if (C->EnterMessageScope(C)) {
     C->ReturnWrapperResult(C->IPEPC, CallId, ResultBytes.release());
@@ -245,8 +245,8 @@ void InProcessControllerAccess::doDisconnect() {
 
 void InProcessControllerAccess::callWrapper(
     uint64_t CallId, void *Fn, orc_rt_WrapperFunctionBuffer ArgBytes) {
-  handleWrapperCall(CallId, reinterpret_cast<orc_rt_WrapperFunction>(Fn),
-                    WrapperFunctionBuffer(ArgBytes));
+  handleWrapperCall(reinterpret_cast<orc_rt_WrapperFunction>(Fn),
+                    WrapperFunctionBuffer(ArgBytes), CallId);
 }
 
 void InProcessControllerAccess::callWrapperEntry(

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -360,15 +360,16 @@ void Session::completeShutdown() {
   CV.notify_all();
 }
 
-void Session::sendWrapperResult(uint64_t CallId,
-                                WrapperFunctionBuffer ResultBytes) {
+void Session::sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                                uint64_t CallId) {
   if (auto TmpCA = std::atomic_load(&CA))
-    TmpCA->sendWrapperResult(CallId, std::move(ResultBytes));
+    TmpCA->sendWrapperResult(std::move(ResultBytes), CallId);
 }
 
-void Session::wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,
-                            orc_rt_WrapperFunctionBuffer ResultBytes) {
-  unwrap(S)->sendWrapperResult(CallId, WrapperFunctionBuffer(ResultBytes));
+void Session::wrapperReturn(orc_rt_SessionRef S,
+                            orc_rt_WrapperFunctionBuffer ResultBytes,
+                            uint64_t CallId) {
+  unwrap(S)->sendWrapperResult(WrapperFunctionBuffer(ResultBytes), CallId);
 }
 
 // --- C API Implementation ---

--- a/orc-rt/test/unit/DirectCaller.h
+++ b/orc-rt/test/unit/DirectCaller.h
@@ -22,8 +22,9 @@ private:
     virtual ~DirectResultSender() {}
     virtual void send(orc_rt_SessionRef S,
                       orc_rt::WrapperFunctionBuffer ResultBytes) = 0;
-    static void send(orc_rt_SessionRef S, uint64_t CallId,
-                     orc_rt_WrapperFunctionBuffer ResultBytes) {
+    static void send(orc_rt_SessionRef S,
+                     orc_rt_WrapperFunctionBuffer ResultBytes,
+                     uint64_t CallId) {
       std::unique_ptr<DirectResultSender>(
           reinterpret_cast<DirectResultSender *>(
               static_cast<uintptr_t>(CallId)))
@@ -59,8 +60,8 @@ public:
                   orc_rt::WrapperFunctionBuffer ArgBytes) {
     auto DR =
         makeDirectResultSender(std::forward<HandleResultFn>(HandleResult));
-    Fn(S, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(DR.release())),
-       DirectResultSender::send, ArgBytes.release());
+    Fn(S, ArgBytes.release(), DirectResultSender::send,
+       static_cast<uint64_t>(reinterpret_cast<uintptr_t>(DR.release())));
   }
 
 private:

--- a/orc-rt/test/unit/InProcessControllerAccessTest.cpp
+++ b/orc-rt/test/unit/InProcessControllerAccessTest.cpp
@@ -280,10 +280,10 @@ TEST(InProcessControllerAccessTest, DisconnectDrainsPendingCalls) {
 
 // Wrapper function that echoes ArgBytes back as the result. Used to exercise
 // the controller-initiated wrapper-call path without pulling in SPS.
-static void echoWrapper(orc_rt_SessionRef S, uint64_t CallId,
-                        orc_rt_WrapperFunctionReturn Return,
-                        orc_rt_WrapperFunctionBuffer ArgBytes) {
-  Return(S, CallId, ArgBytes);
+static void echoWrapper(orc_rt_SessionRef S,
+                        orc_rt_WrapperFunctionBuffer ArgBytes,
+                        orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
+  Return(S, ArgBytes, CallId);
 }
 
 TEST(InProcessControllerAccessTest, CallFromControllerSuccess) {

--- a/orc-rt/test/unit/SPSWrapperFunctionTest.cpp
+++ b/orc-rt/test/unit/SPSWrapperFunctionTest.cpp
@@ -33,11 +33,12 @@ ORC_RT_SPS_WRAPPER(add_via_function_sps_wrapper, int32_t(int32_t, int32_t),
 
 using namespace orc_rt;
 
-static void void_noop_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void void_noop_sps_wrapper(orc_rt_SessionRef S,
+                                  orc_rt_WrapperFunctionBuffer ArgBytes,
                                   orc_rt_WrapperFunctionReturn Return,
-                                  orc_rt_WrapperFunctionBuffer ArgBytes) {
+                                  uint64_t CallId) {
   SPSWrapperFunction<void()>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void()> Return) { Return(); });
 }
 
@@ -51,11 +52,12 @@ TEST(SPSWrapperFunctionUtilsTest, VoidNoop) {
   EXPECT_TRUE(Ran);
 }
 
-static void add_via_lambda_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void add_via_lambda_sps_wrapper(orc_rt_SessionRef S,
+                                       orc_rt_WrapperFunctionBuffer ArgBytes,
                                        orc_rt_WrapperFunctionReturn Return,
-                                       orc_rt_WrapperFunctionBuffer ArgBytes) {
+                                       uint64_t CallId) {
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void(int32_t)> Return, int32_t X, int32_t Y) {
         Return(X + Y);
       });
@@ -77,12 +79,11 @@ TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunction) {
   EXPECT_EQ(Result, 42);
 }
 
-static void
-add_via_function_pointer_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
-                                     orc_rt_WrapperFunctionReturn Return,
-                                     orc_rt_WrapperFunctionBuffer ArgBytes) {
+static void add_via_function_pointer_sps_wrapper(
+    orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+    orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::handle(
-      S, CallId, Return, ArgBytes, &add_via_function);
+      S, ArgBytes, Return, CallId, &add_via_function);
 }
 
 TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunctionPointer) {
@@ -93,12 +94,11 @@ TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunctionPointer) {
   EXPECT_EQ(Result, 42);
 }
 
-static void
-round_trip_string_via_span_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
-                                       orc_rt_WrapperFunctionReturn Return,
-                                       orc_rt_WrapperFunctionBuffer ArgBytes) {
+static void round_trip_string_via_span_sps_wrapper(
+    orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+    orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
   SPSWrapperFunction<SPSString(SPSString)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void(std::string)> Return, span<const char> S) {
         Return({S.data(), S.size()});
       });
@@ -116,11 +116,12 @@ TEST(SPSWrapperFunctionUtilsTest, RoundTripStringViaSpan) {
   EXPECT_EQ(Result, "hello, world!");
 }
 
-static void improbable_feat_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void improbable_feat_sps_wrapper(orc_rt_SessionRef S,
+                                        orc_rt_WrapperFunctionBuffer ArgBytes,
                                         orc_rt_WrapperFunctionReturn Return,
-                                        orc_rt_WrapperFunctionBuffer ArgBytes) {
+                                        uint64_t CallId) {
   SPSWrapperFunction<SPSError(bool)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void(Error)> Return, bool LuckyHat) {
         if (LuckyHat)
           Return(Error::success());
@@ -152,11 +153,12 @@ TEST(SPSWrapperFunctionUtilsTest, TransparentConversionErrorFailureCase) {
   EXPECT_EQ(ErrMsg, "crushed by boulder");
 }
 
-static void halve_number_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void halve_number_sps_wrapper(orc_rt_SessionRef S,
+                                     orc_rt_WrapperFunctionBuffer ArgBytes,
                                      orc_rt_WrapperFunctionReturn Return,
-                                     orc_rt_WrapperFunctionBuffer ArgBytes) {
+                                     uint64_t CallId) {
   SPSWrapperFunction<SPSExpected<int32_t>(int32_t)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void(Expected<int32_t>)> Return, int N) {
         if (N % 2 == 0)
           Return(N >> 1);
@@ -203,13 +205,12 @@ public:
 };
 } // namespace orc_rt
 
-static void
-handle_with_reference_types_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
-                                        orc_rt_WrapperFunctionReturn Return,
-                                        orc_rt_WrapperFunctionBuffer ArgBytes) {
+static void handle_with_reference_types_sps_wrapper(
+    orc_rt_SessionRef S, orc_rt_WrapperFunctionBuffer ArgBytes,
+    orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
   SPSWrapperFunction<void(
       SPSOpCounter<0>, SPSOpCounter<1>, SPSOpCounter<2>,
-      SPSOpCounter<3>)>::handle(S, CallId, Return, ArgBytes,
+      SPSOpCounter<3>)>::handle(S, ArgBytes, Return, CallId,
                                 [](move_only_function<void()> Return,
                                    OpCounter<0>, OpCounter<1> &,
                                    const OpCounter<2> &,
@@ -276,11 +277,12 @@ public:
 };
 } // namespace
 
-static void adder_add_async_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void adder_add_async_sps_wrapper(orc_rt_SessionRef S,
+                                        orc_rt_WrapperFunctionBuffer ArgBytes,
                                         orc_rt_WrapperFunctionReturn Return,
-                                        orc_rt_WrapperFunctionBuffer ArgBytes) {
+                                        uint64_t CallId) {
   SPSWrapperFunction<int32_t(SPSExecutorAddr, int32_t, int32_t)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       WrapperFunction::handleWithAsyncMethod(&Adder::addAsync));
 }
 
@@ -295,11 +297,12 @@ TEST(SPSWrapperFunctionUtilsTest, HandleWtihAsyncMethod) {
   EXPECT_EQ(Result, 42);
 }
 
-static void adder_add_sync_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void adder_add_sync_sps_wrapper(orc_rt_SessionRef S,
+                                       orc_rt_WrapperFunctionBuffer ArgBytes,
                                        orc_rt_WrapperFunctionReturn Return,
-                                       orc_rt_WrapperFunctionBuffer ArgBytes) {
+                                       uint64_t CallId) {
   SPSWrapperFunction<int32_t(SPSExecutorAddr, int32_t, int32_t)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       WrapperFunction::handleWithSyncMethod(&Adder::addSync));
 }
 

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -203,13 +203,13 @@ public:
 
     runOrPost([this, CId, T, ArgBytes = std::move(ArgBytes)]() mutable {
       auto Fn = reinterpret_cast<orc_rt_WrapperFunction>(T);
-      Fn(reinterpret_cast<orc_rt_SessionRef>(this), CId, ccReturn,
-         ArgBytes.release());
+      Fn(reinterpret_cast<orc_rt_SessionRef>(this), ArgBytes.release(),
+         ccReturn, CId);
     });
   }
 
-  void sendWrapperResult(uint64_t CallId,
-                         WrapperFunctionBuffer ResultBytes) override {
+  void sendWrapperResult(WrapperFunctionBuffer ResultBytes,
+                         uint64_t CallId) override {
     // Respond to a simulated call by the controller.
     ConnectGuard CG;
     Session::OnControllerCallReturnFn OnComplete;
@@ -269,7 +269,7 @@ public:
             "Controller disconnected"));
       });
 
-    handleWrapperCall(CId, Fn, std::move(ArgBytes));
+    handleWrapperCall(Fn, std::move(ArgBytes), CId);
   }
 
 private:
@@ -280,8 +280,9 @@ private:
       Work();
   }
 
-  static void ccReturn(orc_rt_SessionRef S, uint64_t CallId,
-                       orc_rt_WrapperFunctionBuffer ResultBytes) {
+  static void ccReturn(orc_rt_SessionRef S,
+                       orc_rt_WrapperFunctionBuffer ResultBytes,
+                       uint64_t CallId) {
     // Abuse "session" to refer to the ControllerAccess object.
     // We can just re-use sendFunctionResult for this.
     reinterpret_cast<MockControllerAccess *>(S)->returnFromController(
@@ -638,7 +639,7 @@ public:
                       WrapperFunctionBuffer) override {
     failControllerCallInline(std::move(OnComplete));
   }
-  void sendWrapperResult(uint64_t, WrapperFunctionBuffer) override {}
+  void sendWrapperResult(WrapperFunctionBuffer, uint64_t) override {}
 };
 
 TEST(ControllerAccessTest, SynchronousCallControllerFailureRunsInline) {
@@ -666,11 +667,12 @@ TEST(ControllerAccessTest, SynchronousCallControllerFailureRunsInline) {
   EXPECT_EQ(ErrMsg, "disconnected");
 }
 
-static void add_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void add_sps_wrapper(orc_rt_SessionRef S,
+                            orc_rt_WrapperFunctionBuffer ArgBytes,
                             orc_rt_WrapperFunctionReturn Return,
-                            orc_rt_WrapperFunctionBuffer ArgBytes) {
+                            uint64_t CallId) {
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void(int32_t)> Return, int32_t X, int32_t Y) {
         Return(X + Y);
       });
@@ -679,10 +681,10 @@ static void add_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
 // Wrapper handler that echoes its argument bytes straight back as the result.
 // Used to exercise the C callController entry point without pulling in SPS
 // (de)serialization -- the payload is opaque to the code under test.
-static void echo_wrapper(orc_rt_SessionRef S, uint64_t CallId,
-                         orc_rt_WrapperFunctionReturn Return,
-                         orc_rt_WrapperFunctionBuffer ArgBytes) {
-  Return(S, CallId, ArgBytes);
+static void echo_wrapper(orc_rt_SessionRef S,
+                         orc_rt_WrapperFunctionBuffer ArgBytes,
+                         orc_rt_WrapperFunctionReturn Return, uint64_t CallId) {
+  Return(S, ArgBytes, CallId);
 }
 
 // Captures what orc_rt_Session_callController threads back to its C return
@@ -802,11 +804,12 @@ TEST(ControllerAccessTest, CallFromController) {
 // Stashes Return, via the address passed as the wrapper call's argument,
 // instead of calling it -- simulating a wrapper function that defers
 // completion past its own return.
-static void deferred_wrapper(orc_rt_SessionRef S, uint64_t CallId,
+static void deferred_wrapper(orc_rt_SessionRef S,
+                             orc_rt_WrapperFunctionBuffer ArgBytes,
                              orc_rt_WrapperFunctionReturn Return,
-                             orc_rt_WrapperFunctionBuffer ArgBytes) {
+                             uint64_t CallId) {
   SPSWrapperFunction<void(SPSExecutorAddr)>::handle(
-      S, CallId, Return, ArgBytes,
+      S, ArgBytes, Return, CallId,
       [](move_only_function<void()> Return, ExecutorAddr P) {
         *P.toPtr<move_only_function<void()> *>() = std::move(Return);
       });


### PR DESCRIPTION
Bring the wrapper-function call and return prototypes into line with the convention adopted for orc_rt_Session_callController: the session handle comes first, then the payload buffer, then the completion callback immediately followed by its threaded token, with the token last.

  orc_rt_WrapperFunctionReturn: (S, CallId, ResultBytes)
                             -> (S, ResultBytes, CallId)
  orc_rt_WrapperFunction:       (S, CallId, Return, ArgBytes)
                             -> (S, ArgBytes, Return, CallId)

The C++ adapters that mirror these signatures are updated to match -- WrapperFunction::handle, SPSWrapperFunction::handle, the ORC_RT_SPS_WRAPPER macro, and StructuredYield -- along with the Session dispatch path and the affected unit tests. No functional change beyond argument order.