### PR TITLE
AMDGPU/GlobalISel: Test for cs_chain argument from G_EXTRACT_VECTOR_ELT

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-amdgcn-cs-chain.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-amdgcn-cs-chain.ll
@@ -134,4 +134,75 @@ define amdgpu_cs_chain void @chain_preserve_call(<3 x i32> inreg %sgpr, { i32, p
   unreachable
 }
 
+define amdgpu_cs_chain void @chain_call_exec_from_extract(<2 x i32> inreg %vec, <3 x i32> inreg %sgpr, { i32, ptr addrspace(5), i32, i32 } %vgpr) {
+  ; GFX11-LABEL: name: chain_call_exec_from_extract
+  ; GFX11: bb.1 (%ir-block.0):
+  ; GFX11-NEXT:   liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $vgpr8, $vgpr9, $vgpr10, $vgpr11
+  ; GFX11-NEXT: {{  $}}
+  ; GFX11-NEXT:   [[COPY:%[0-9]+]]:_(i32) = COPY $sgpr0
+  ; GFX11-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $sgpr1
+  ; GFX11-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[COPY]](i32), [[COPY1]](i32)
+  ; GFX11-NEXT:   [[COPY2:%[0-9]+]]:_(i32) = COPY $sgpr2
+  ; GFX11-NEXT:   [[COPY3:%[0-9]+]]:_(i32) = COPY $sgpr3
+  ; GFX11-NEXT:   [[COPY4:%[0-9]+]]:_(i32) = COPY $sgpr4
+  ; GFX11-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[COPY2]](i32), [[COPY3]](i32), [[COPY4]](i32)
+  ; GFX11-NEXT:   [[COPY5:%[0-9]+]]:_(i32) = COPY $vgpr8
+  ; GFX11-NEXT:   [[COPY6:%[0-9]+]]:_(p5) = COPY $vgpr9
+  ; GFX11-NEXT:   [[COPY7:%[0-9]+]]:_(i32) = COPY $vgpr10
+  ; GFX11-NEXT:   [[COPY8:%[0-9]+]]:_(i32) = COPY $vgpr11
+  ; GFX11-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
+  ; GFX11-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @callee
+  ; GFX11-NEXT:   [[EVEC:%[0-9]+]]:sreg_32(i32) = G_EXTRACT_VECTOR_ELT [[BUILD_VECTOR]](<2 x i32>), [[C]](i32)
+  ; GFX11-NEXT:   [[GV1:%[0-9]+]]:sgpr_64(p0) = G_GLOBAL_VALUE @callee
+  ; GFX11-NEXT:   [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32), [[UV2:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BUILD_VECTOR1]](<3 x i32>)
+  ; GFX11-NEXT:   [[INTRINSIC_CONVERGENT:%[0-9]+]]:_(i32) = G_INTRINSIC_CONVERGENT intrinsic(@llvm.amdgcn.readfirstlane), [[UV]](i32)
+  ; GFX11-NEXT:   $sgpr0 = COPY [[INTRINSIC_CONVERGENT]](i32)
+  ; GFX11-NEXT:   [[INTRINSIC_CONVERGENT1:%[0-9]+]]:_(i32) = G_INTRINSIC_CONVERGENT intrinsic(@llvm.amdgcn.readfirstlane), [[UV1]](i32)
+  ; GFX11-NEXT:   $sgpr1 = COPY [[INTRINSIC_CONVERGENT1]](i32)
+  ; GFX11-NEXT:   [[INTRINSIC_CONVERGENT2:%[0-9]+]]:_(i32) = G_INTRINSIC_CONVERGENT intrinsic(@llvm.amdgcn.readfirstlane), [[UV2]](i32)
+  ; GFX11-NEXT:   $sgpr2 = COPY [[INTRINSIC_CONVERGENT2]](i32)
+  ; GFX11-NEXT:   $vgpr8 = COPY [[COPY5]](i32)
+  ; GFX11-NEXT:   $vgpr9 = COPY [[COPY6]](p5)
+  ; GFX11-NEXT:   $vgpr10 = COPY [[COPY7]](i32)
+  ; GFX11-NEXT:   $vgpr11 = COPY [[COPY8]](i32)
+  ; GFX11-NEXT:   SI_CS_CHAIN_TC_W32 [[GV1]](p0), @callee, 0, [[EVEC]](i32), amdgpu_allvgprs, implicit $sgpr0, implicit $sgpr1, implicit $sgpr2, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11
+  ;
+  ; GFX10-LABEL: name: chain_call_exec_from_extract
+  ; GFX10: bb.1 (%ir-block.0):
+  ; GFX10-NEXT:   liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $vgpr8, $vgpr9, $vgpr10, $vgpr11
+  ; GFX10-NEXT: {{  $}}
+  ; GFX10-NEXT:   [[COPY:%[0-9]+]]:_(i32) = COPY $sgpr0
+  ; GFX10-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $sgpr1
+  ; GFX10-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[COPY]](i32), [[COPY1]](i32)
+  ; GFX10-NEXT:   [[COPY2:%[0-9]+]]:_(i32) = COPY $sgpr2
+  ; GFX10-NEXT:   [[COPY3:%[0-9]+]]:_(i32) = COPY $sgpr3
+  ; GFX10-NEXT:   [[COPY4:%[0-9]+]]:_(i32) = COPY $sgpr4
+  ; GFX10-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[COPY2]](i32), [[COPY3]](i32), [[COPY4]](i32)
+  ; GFX10-NEXT:   [[COPY5:%[0-9]+]]:_(i32) = COPY $vgpr8
+  ; GFX10-NEXT:   [[COPY6:%[0-9]+]]:_(p5) = COPY $vgpr9
+  ; GFX10-NEXT:   [[COPY7:%[0-9]+]]:_(i32) = COPY $vgpr10
+  ; GFX10-NEXT:   [[COPY8:%[0-9]+]]:_(i32) = COPY $vgpr11
+  ; GFX10-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
+  ; GFX10-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @callee
+  ; GFX10-NEXT:   [[EVEC:%[0-9]+]]:sreg_32(i32) = G_EXTRACT_VECTOR_ELT [[BUILD_VECTOR]](<2 x i32>), [[C]](i32)
+  ; GFX10-NEXT:   [[GV1:%[0-9]+]]:sgpr_64(p0) = G_GLOBAL_VALUE @callee
+  ; GFX10-NEXT:   [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32), [[UV2:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BUILD_VECTOR1]](<3 x i32>)
+  ; GFX10-NEXT:   [[INTRINSIC_CONVERGENT:%[0-9]+]]:_(i32) = G_INTRINSIC_CONVERGENT intrinsic(@llvm.amdgcn.readfirstlane), [[UV]](i32)
+  ; GFX10-NEXT:   $sgpr0 = COPY [[INTRINSIC_CONVERGENT]](i32)
+  ; GFX10-NEXT:   [[INTRINSIC_CONVERGENT1:%[0-9]+]]:_(i32) = G_INTRINSIC_CONVERGENT intrinsic(@llvm.amdgcn.readfirstlane), [[UV1]](i32)
+  ; GFX10-NEXT:   $sgpr1 = COPY [[INTRINSIC_CONVERGENT1]](i32)
+  ; GFX10-NEXT:   [[INTRINSIC_CONVERGENT2:%[0-9]+]]:_(i32) = G_INTRINSIC_CONVERGENT intrinsic(@llvm.amdgcn.readfirstlane), [[UV2]](i32)
+  ; GFX10-NEXT:   $sgpr2 = COPY [[INTRINSIC_CONVERGENT2]](i32)
+  ; GFX10-NEXT:   $vgpr8 = COPY [[COPY5]](i32)
+  ; GFX10-NEXT:   $vgpr9 = COPY [[COPY6]](p5)
+  ; GFX10-NEXT:   $vgpr10 = COPY [[COPY7]](i32)
+  ; GFX10-NEXT:   $vgpr11 = COPY [[COPY8]](i32)
+  ; GFX10-NEXT:   [[COPY9:%[0-9]+]]:_(<4 x s32>) = COPY $sgpr48_sgpr49_sgpr50_sgpr51
+  ; GFX10-NEXT:   $sgpr48_sgpr49_sgpr50_sgpr51 = COPY [[COPY9]](<4 x s32>)
+  ; GFX10-NEXT:   SI_CS_CHAIN_TC_W32 [[GV1]](p0), @callee, 0, [[EVEC]](i32), amdgpu_allvgprs, implicit $sgpr0, implicit $sgpr1, implicit $sgpr2, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $sgpr48_sgpr49_sgpr50_sgpr51
+  %exec = extractelement <2 x i32> %vec, i64 0
+  call void(ptr, i32, <3 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain(ptr @callee, i32 %exec, <3 x i32> inreg %sgpr, { i32, ptr addrspace(5), i32, i32 } %vgpr, i32 0)
+  unreachable
+}
+
 


### PR DESCRIPTION
This is a bug since G_EXTRACT_VECTOR_ELT will end up with a register
class on the dst operand. The combiner will crash because of it.