### PR TITLE
[libc++] Guard explicit ABI annotations for Clang >= 21

### DIFF
--- a/libcxx/include/__configuration/namespace.h
+++ b/libcxx/include/__configuration/namespace.h
@@ -46,7 +46,7 @@
 #  define _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS
 #endif
 
-#ifdef _LIBCPP_COMPILER_CLANG_BASED
+#if defined(_LIBCPP_COMPILER_CLANG_BASED) && (!defined(_LIBCPP_CLANG_VER) || _LIBCPP_CLANG_VER >= 2101)
 #  define _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS                                                                         \
     _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS                                                                                \
     _Pragma(_LIBCPP_TOSTRING(clang attribute _LibcxxExplicitABIAnnotations.push(                                       \


### PR DESCRIPTION
Clang < 21 doesn't support `__visibility__` with #pragma clang attribute
(PragmaAttributeSupport was added in afc6c2bb9b43). Since the macro
already has an empty fallback for gcc (added by 6f3328e), gate it on the required version.