### PR TITLE
[lldb][test] Do not return a PID in TestGdbClientModuleLoad

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
@@ -59,9 +59,6 @@ class MyResponder(MockGDBServerResponder):
         else:
             return None, False
 
-    def qfThreadInfo(self):
-        return "m47"
-
     def qsThreadInfo(self):
         return "l"
 

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
@@ -63,14 +63,16 @@ class MyResponder(MockGDBServerResponder):
         return "l"
 
     # In the two following functions, we return a PID == PID_MAX_LIMIT so that we do not
-    # use a host program file.
+    # use a host program file. Note that the number is in hex.
+    PID_MAX_LIMIT = "400000"
 
     def qfThreadInfo(self):
-        return "m400000"
+        return f"m{self.PID_MAX_LIMIT}"
 
     def qProcessInfo(self):
-        return "pid:400000;ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(
-            self._triple
+        return "pid:%s;ptrsize:8;endian:little;triple:%s;" % (
+            self.PID_MAX_LIMIT,
+            hex_encode_bytes(self._triple),
         )
 
     def setBreakpoint(self, packet):

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
@@ -72,7 +72,6 @@ class MyResponder(MockGDBServerResponder):
         return "m400000"
 
     def qProcessInfo(self):
-        return "pid:47;ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(
         return "pid:400000;ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(
             self._triple
         )

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
@@ -59,16 +59,8 @@ class MyResponder(MockGDBServerResponder):
         else:
             return None, False
 
-    def qfThreadInfo(self):
-        return "m47"
-
-    def qsThreadInfo(self):
-        return "l"
-
     def qProcessInfo(self):
-        return "pid:47;ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(
-            self._triple
-        )
+        return "ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(self._triple)
 
     def setBreakpoint(self, packet):
         return "OK"

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
@@ -62,6 +62,9 @@ class MyResponder(MockGDBServerResponder):
     def qProcessInfo(self):
         return "ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(self._triple)
 
+    def qC(self):
+        return ""
+
     def setBreakpoint(self, packet):
         return "OK"
 

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGdbClientModuleLoad.py
@@ -59,11 +59,23 @@ class MyResponder(MockGDBServerResponder):
         else:
             return None, False
 
-    def qProcessInfo(self):
-        return "ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(self._triple)
+    def qfThreadInfo(self):
+        return "m47"
 
-    def qC(self):
-        return ""
+    def qsThreadInfo(self):
+        return "l"
+
+    # In the two following functions, we return a PID == PID_MAX_LIMIT so that we do not
+    # use a host program file.
+
+    def qfThreadInfo(self):
+        return "m400000"
+
+    def qProcessInfo(self):
+        return "pid:47;ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(
+        return "pid:400000;ptrsize:8;endian:little;triple:%s;" % hex_encode_bytes(
+            self._triple
+        )
 
     def setBreakpoint(self, packet):
         return "OK"


### PR DESCRIPTION
This test has been flaky on x86 Github CI. It expects: 
[  0] {{.*}} 0x0000000000ee0000 {{.*}}module_load
[  1] {{.*}} 0x0000000000ef0000 {{.*}}[vdso]

However in one run it got:
[ 0] 98FC07B8 0x0000000000ef0000 [vdso] (0xef0000)
[ 1] 75B11BBB-EF8B-5645-B9B1-A7261EC8ABCF-05413284 0x0000000000ed8ed0 /home/gha/actions-runner/bin/Runner.Worker

This happened because the responder says it's debugging PID 0x47, which is usually some root process that we cannot read the /proc/pid/exe link for. However when it is readable, we will assume that is the program file and it replaces the "module_load" entry (this never happened on AArch64 because an AArch64 program file is never compatible with an x86 triple).

In the failing case, 0x47 happened to be a github runner process that lldb could get the exe for. I was able to reproduce this by putting a long sleep in the background and replacing 0x47 with that sleep's PID.

To fix this I am returning the value of `PID_MAX_LIMIT` which is the limit of what `pid_max` can be set to. This should be parsed by lldb into an invalid PID and cause it to give up looking at the host.

I tried returning 0, this found a process somehow, returning no PID at all, again it found a process. The only other way is to make this test connect to a fake remote linux platform first, but this would take much more code to set up.