### PR TITLE
[ConstraintElim] Change return type of ConstraintTy::empty to bool (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -225,7 +225,7 @@ struct ConstraintTy {
 
   unsigned size() const { return Coefficients.size(); }
 
-  unsigned empty() const { return Coefficients.empty(); }
+  bool empty() const { return Coefficients.empty(); }
 
   bool isEq() const { return IsEq; }
 


### PR DESCRIPTION
empty() returns a bool, fix return type as pointed out in https://github.com/llvm/llvm-project/pull/212140.