### PR TITLE
[VPlan]: During VPRegionBlock::clone, sync the NUW of CanIVInfo

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -778,6 +778,9 @@ VPRegionBlock *VPRegionBlock::clone() {
   if (getHeaderMask())
     NewRegion->createHeaderMask();
 
+  if (CanIV && !hasCanonicalIVNUW())
+    NewRegion->CanIVInfo->clearNUW();
+
   for (VPBlockBase *Block : vp_depth_first_shallow(NewEntry))
     Block->setParent(NewRegion);
   return NewRegion;

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1924,6 +1924,34 @@ TEST_F(VPBasicBlockTest, VPRegionValueClonePropagatesMaterialized) {
   EXPECT_TRUE(ClonedCanIV->isMaterialized());
 }
 
+TEST_F(VPBasicBlockTest, VPRegionBlockCloneSyncsCanonicalIVNUW) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *Preheader = Plan.getEntry();
+  VPBasicBlock *Header = Plan.createVPBasicBlock("header");
+  VPBasicBlock *Latch = Plan.createVPBasicBlock("latch");
+
+  VPBuilder Builder(Latch);
+  Builder.createNaryOp(VPInstruction::BranchOnCond, Plan.getTrue());
+
+  VPRegionBlock *Region = Plan.createLoopRegion(Type::getInt64Ty(C), DebugLoc(),
+                                                "loop", Header, Latch);
+  VPBlockUtils::connectBlocks(Header, Latch);
+  VPBlockUtils::connectBlocks(Preheader, Region);
+  VPBlockUtils::connectBlocks(Region, Plan.getScalarHeader());
+
+  // Loop regions start out with NUW set for their canonical IV.
+  EXPECT_TRUE(Region->hasCanonicalIVNUW());
+
+  // Drop NUW, e.g. as done when the increment is proven to possibly wrap.
+  VPInstruction *Increment = Region->getOrCreateCanonicalIVIncrement();
+  Region->clearCanonicalIVNUW(Increment);
+  EXPECT_FALSE(Region->hasCanonicalIVNUW());
+
+  // The clone must carry over the cleared NUW flag rather than resetting it.
+  VPRegionBlock *Clone = Region->clone();
+  EXPECT_FALSE(Clone->hasCanonicalIVNUW());
+}
+
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
 TEST_F(VPInstructionTest, VPSymbolicValueConstructUserAfterMaterialization) {
   VPlan &Plan = getPlan();


### PR DESCRIPTION
VPRegionBlock::clone() creates the cloned loop region's canonical IV info via createLoopRegion(), which always starts with NUW set. If the original region's canonical IV had already had its NUW flag cleared the clone did not carry that over, leaving the cloned region's CanIVInfo inconsistent with the original. Propagate the cleared NUW flag to the clone so both regions agree on whether the canonical IV is NUW.