### PR TITLE
[NFC][ELF] Use hasPhdrsCommands() wrapper instead of direct access

### DIFF
--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -4546,7 +4546,7 @@ template <class ELFT> void elf::createSyntheticSections(Ctx &ctx) {
   // Add .relro_padding if DATA_SEGMENT_RELRO_END is used; otherwise, add the
   // section in the absence of PHDRS/SECTIONS commands.
   if (ctx.arg.zRelro &&
-      ((ctx.script->phdrsCommands.empty() && !ctx.script->hasSectionsCommand) ||
+      ((!ctx.script->hasPhdrsCommands() && !ctx.script->hasSectionsCommand) ||
        ctx.script->seenRelroEnd)) {
     ctx.in.relroPadding = std::make_unique<RelroPaddingSection>(ctx);
     add(*ctx.in.relroPadding);


### PR DESCRIPTION
This is the only place outside of LinkerScript/ScriptParser that
directly accesses the phdrsCommands member, introduced in 5a58e98c2018
("[ELF] Align the end of PT_GNU_RELRO associated PT_LOAD to a
common-page-size boundary (#66042)").