### PR TITLE
[libc++][NFC] Rename the streambuf members

### DIFF
--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -145,6 +145,18 @@ public:
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
 
+  struct _GetArea {
+    char_type* __begin_;
+    char_type* __current_;
+    char_type* __end_;
+  };
+
+  struct _PutArea {
+    char_type* __begin_;
+    char_type* __current_;
+    char_type* __end_;
+  };
+
   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
 
@@ -259,67 +271,53 @@ public:
 protected:
   basic_streambuf() {}
   basic_streambuf(const basic_streambuf& __sb)
-      : __loc_(__sb.__loc_),
-        __binp_(__sb.__binp_),
-        __ninp_(__sb.__ninp_),
-        __einp_(__sb.__einp_),
-        __bout_(__sb.__bout_),
-        __nout_(__sb.__nout_),
-        __eout_(__sb.__eout_) {}
+      : __loc_(__sb.__loc_), __get_area_(__sb.__get_area_), __put_area_(__sb.__put_area_) {}
 
   basic_streambuf& operator=(const basic_streambuf& __sb) {
-    __loc_  = __sb.__loc_;
-    __binp_ = __sb.__binp_;
-    __ninp_ = __sb.__ninp_;
-    __einp_ = __sb.__einp_;
-    __bout_ = __sb.__bout_;
-    __nout_ = __sb.__nout_;
-    __eout_ = __sb.__eout_;
+    __loc_      = __sb.__loc_;
+    __get_area_ = __sb.__get_area_;
+    __put_area_ = __sb.__put_area_;
     return *this;
   }
 
   void swap(basic_streambuf& __sb) {
     std::swap(__loc_, __sb.__loc_);
-    std::swap(__binp_, __sb.__binp_);
-    std::swap(__ninp_, __sb.__ninp_);
-    std::swap(__einp_, __sb.__einp_);
-    std::swap(__bout_, __sb.__bout_);
-    std::swap(__nout_, __sb.__nout_);
-    std::swap(__eout_, __sb.__eout_);
+    std::swap(__get_area_, __sb.__get_area_);
+    std::swap(__put_area_, __sb.__put_area_);
   }
 
   // 27.6.2.3.2 Get area:
-  _LIBCPP_HIDE_FROM_ABI char_type* eback() const { return __binp_; }
-  _LIBCPP_HIDE_FROM_ABI char_type* gptr() const { return __ninp_; }
-  _LIBCPP_HIDE_FROM_ABI char_type* egptr() const { return __einp_; }
+  _LIBCPP_HIDE_FROM_ABI char_type* eback() const { return __get_area_.__begin_; }
+  _LIBCPP_HIDE_FROM_ABI char_type* gptr() const { return __get_area_.__current_; }
+  _LIBCPP_HIDE_FROM_ABI char_type* egptr() const { return __get_area_.__end_; }
 
-  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void gbump(int __n) { __ninp_ += __n; }
+  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void gbump(int __n) { __get_area_.__current_ += __n; }
 
   // gbump takes an int, so it might not be able to represent the offset we want to add.
-  _LIBCPP_HIDE_FROM_ABI void __gbump_ptrdiff(ptrdiff_t __n) { __ninp_ += __n; }
+  _LIBCPP_HIDE_FROM_ABI void __gbump_ptrdiff(ptrdiff_t __n) { __get_area_.__current_ += __n; }
 
-  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void setg(char_type* __gbeg, char_type* __gnext, char_type* __gend) {
-    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__gbeg, __gnext), "[gbeg, gnext) must be a valid range");
-    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__gbeg, __gend), "[gbeg, gend) must be a valid range");
-    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__gnext, __gend), "[gnext, gend) must be a valid range");
-    __binp_ = __gbeg;
-    __ninp_ = __gnext;
-    __einp_ = __gend;
+  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void setg(char_type* __begin, char_type* __current, char_type* __end) {
+    _LIBCPP_ASSERT_VALID_INPUT_RANGE(
+        std::__is_valid_range(__begin, __current), "[begin, current) must be a valid range");
+    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__begin, __end), "[begin, end) must be a valid range");
+    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__current, __end), "[current, end) must be a valid range");
+    _GetArea __tmp = {__begin, __current, __end}; // This is a temporary for C++03 compatibility
+    __get_area_    = __tmp;
   }
 
   // 27.6.2.3.3 Put area:
-  _LIBCPP_HIDE_FROM_ABI char_type* pbase() const { return __bout_; }
-  _LIBCPP_HIDE_FROM_ABI char_type* pptr() const { return __nout_; }
-  _LIBCPP_HIDE_FROM_ABI char_type* epptr() const { return __eout_; }
+  _LIBCPP_HIDE_FROM_ABI char_type* pbase() const { return __put_area_.__begin_; }
+  _LIBCPP_HIDE_FROM_ABI char_type* pptr() const { return __put_area_.__current_; }
+  _LIBCPP_HIDE_FROM_ABI char_type* epptr() const { return __put_area_.__end_; }
 
-  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void pbump(int __n) { __nout_ += __n; }
+  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void pbump(int __n) { __put_area_.__current_ += __n; }
 
-  _LIBCPP_HIDE_FROM_ABI void __pbump(streamsize __n) { __nout_ += __n; }
+  _LIBCPP_HIDE_FROM_ABI void __pbump(streamsize __n) { __put_area_.__current_ += __n; }
 
-  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void setp(char_type* __pbeg, char_type* __pend) {
-    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__pbeg, __pend), "[pbeg, pend) must be a valid range");
-    __bout_ = __nout_ = __pbeg;
-    __eout_           = __pend;
+  inline _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8 void setp(char_type* __begin, char_type* __end) {
+    _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__begin, __end), "[begin, end) must be a valid range");
+    _PutArea __tmp = {__begin, __begin, __end}; // This is a temporary for C++03 compatibility
+    __put_area_    = __tmp;
   }
 
   // 27.6.2.4 virtual functions:
@@ -413,12 +411,8 @@ protected:
 
 private:
   locale __loc_;
-  char_type* __binp_ = nullptr;
-  char_type* __ninp_ = nullptr;
-  char_type* __einp_ = nullptr;
-  char_type* __bout_ = nullptr;
-  char_type* __nout_ = nullptr;
-  char_type* __eout_ = nullptr;
+  _GetArea __get_area_ = {};
+  _PutArea __put_area_ = {};
 
   template <class _CharT2, class _Traits2, class _Allocator>
   _LIBCPP_HIDE_FROM_ABI friend basic_istream<_CharT2, _Traits2>&

--- a/libcxx/test/std/input.output/stream.buffers/streambuf/streambuf.protected/streambuf.get.area/setg.assert.pass.cpp
+++ b/libcxx/test/std/input.output/stream.buffers/streambuf/streambuf.protected/streambuf.get.area/setg.assert.pass.cpp
@@ -44,17 +44,17 @@ void test() {
   {
     streambuf<CharT> buff;
     TEST_LIBCPP_ASSERT_FAILURE(
-        buff.setg(std::begin(arr) + 1, std::begin(arr), std::end(arr)), "[gbeg, gnext) must be a valid range");
+        buff.setg(std::begin(arr) + 1, std::begin(arr), std::end(arr)), "[begin, current) must be a valid range");
   }
   {
     streambuf<CharT> buff;
     TEST_LIBCPP_ASSERT_FAILURE(
-        buff.setg(std::begin(arr) + 1, std::begin(arr) + 1, std::begin(arr)), "[gbeg, gend) must be a valid range");
+        buff.setg(std::begin(arr) + 1, std::begin(arr) + 1, std::begin(arr)), "[begin, end) must be a valid range");
   }
   {
     streambuf<CharT> buff;
     TEST_LIBCPP_ASSERT_FAILURE(
-        buff.setg(std::begin(arr), std::begin(arr) + 3, std::begin(arr) + 2), "[gnext, gend) must be a valid range");
+        buff.setg(std::begin(arr), std::begin(arr) + 3, std::begin(arr) + 2), "[current, end) must be a valid range");
   }
 }
 

--- a/libcxx/test/std/input.output/stream.buffers/streambuf/streambuf.protected/streambuf.put.area/setp.assert.pass.cpp
+++ b/libcxx/test/std/input.output/stream.buffers/streambuf/streambuf.protected/streambuf.put.area/setp.assert.pass.cpp
@@ -43,7 +43,7 @@ void test() {
 
   {
     streambuf<CharT> buff;
-    TEST_LIBCPP_ASSERT_FAILURE(buff.setp(std::begin(arr) + 3, std::begin(arr)), "[pbeg, pend) must be a valid range");
+    TEST_LIBCPP_ASSERT_FAILURE(buff.setp(std::begin(arr) + 3, std::begin(arr)), "[begin, end) must be a valid range");
   }
 }
 


### PR DESCRIPTION
This refactors `streambuf` to contain a `_GetArea` and a `_PutArea`. This makes the code significantly easier to read, since the pointers belonging together are bundled in a struct.
