### PR TITLE
[libc++] Reduce sequence container benchmark size ladder

### DIFF
--- a/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
@@ -57,7 +57,7 @@ void sequence_container_benchmarks(std::string container) {
   static constexpr std::size_t BatchSize = 32;
 
   auto bench = [&](std::string operation, auto f) {
-    benchmark::RegisterBenchmark(container + "::" + operation, f)->Arg(32)->Arg(1024)->Arg(8192);
+    benchmark::RegisterBenchmark(container + "::" + operation, f)->Arg(32)->Arg(8192);
   };
 
   /////////////////////////


### PR DESCRIPTION
The sequence containers were registered for 32, 1024 and 8192. This patch drops the mid-size point to get roughly a 30% speedup when running the benchmarks.