### PR TITLE
[libc++] Drop char8_t instantiation from string benchmarks

### DIFF
--- a/libcxx/test/benchmarks/containers/string.bench.cpp
+++ b/libcxx/test/benchmarks/containers/string.bench.cpp
@@ -36,10 +36,6 @@ void bench(std::string name, Func func, Mod modifier = {}) {
     func(std::type_identity<char>(), state);
   })->Apply(modifier);
 
-  benchmark::RegisterBenchmark(rename(name, "u8string"), [=](benchmark::State& state) {
-    func(std::type_identity<char8_t>(), state);
-  })->Apply(modifier);
-
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
   benchmark::RegisterBenchmark(rename(name, "wstring"), [=](benchmark::State& state) {
     func(std::type_identity<wchar_t>(), state);


### PR DESCRIPTION
The string benchmarks instantiated every benchmark for char, char8_t and wchar_t. char8_t exercises the same code paths as char, so drop it to get roughly a 30% speedup on this benchmark time.