### PR TITLE
[NFC][llvm][object][GOFF] cleanup GOFFObjectTests

### DIFF
--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -17,10 +17,8 @@ using namespace llvm::object;
 using namespace llvm::GOFF;
 
 namespace {
-char GOFFData[GOFF::RecordLength * 3] = {0x00};
-
-void constructValidGOFF(size_t Size) {
-  StringRef ValidSize(GOFFData, Size);
+void constructValidGOFF(const char *Data, size_t Size) {
+  StringRef ValidSize(Data, Size);
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
           MemoryBufferRef(ValidSize, "dummyGOFF"));
@@ -28,9 +26,9 @@ void constructValidGOFF(size_t Size) {
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 }
 
-void constructInvalidGOFF(size_t Size) {
+void constructInvalidGOFF(const char *Data, size_t Size) {
   // Construct GOFFObject with record of length != multiple of 80.
-  StringRef InvalidData(GOFFData, Size);
+  StringRef InvalidData(Data, Size);
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
           MemoryBufferRef(InvalidData, "dummyGOFF"));
@@ -69,18 +67,20 @@ TEST(GOFFObjectFileTest, createObjectFile) {
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {
+  char GOFFData[GOFF::RecordLength * 3] = {0x00};
   GOFFData[0] = (char)0x03;
   GOFFData[1] = (char)0xF0;
   GOFFData[80] = (char)0x03;
   GOFFData[81] = (char)0x40;
-  constructValidGOFF(160);
-  constructValidGOFF(0);
+  constructValidGOFF(GOFFData, 160);
+  constructValidGOFF(GOFFData, 0);
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectInvalidSize) {
-  constructInvalidGOFF(70);
-  constructInvalidGOFF(79);
-  constructInvalidGOFF(81);
+  char GOFFData[GOFF::RecordLength * 3] = {0x00};
+  constructInvalidGOFF(GOFFData, 70);
+  constructInvalidGOFF(GOFFData, 79);
+  constructInvalidGOFF(GOFFData, 81);
 }
 
 TEST(GOFFObjectFileTest, MissingHDR) {

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -24,6 +24,20 @@ size_t newRecord(std::vector<char> &Data) {
   return Pos;
 }
 
+void addEndRecord(std::vector<char> &GOFFData, uint8_t RecordCount = 0) {
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
+  GOFFData[Pos + 11] = (char)RecordCount;
+}
+
+void addHdrRecord(std::vector<char> &GOFFData, uint8_t ArchLevel = 0) {
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
+  GOFFData[Pos + 50] = (char)ArchLevel;
+}
+
 void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
                   const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
                   uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
@@ -123,14 +137,10 @@ TEST(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
 
   constructValidGOFF(GOFFData.data(), GOFFData.size());
   constructValidGOFF(GOFFData.data(), 0);
@@ -152,9 +162,7 @@ TEST(GOFFObjectFileTest, MissingHDR) {
   GOFFData[Pos] = (char)0x03;
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -171,12 +179,10 @@ TEST(GOFFObjectFileTest, MissingEND) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
 
   // ESD record.
-  Pos = newRecord(GOFFData);
+  size_t Pos = newRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
 
   StringRef Data(GOFFData.data(), GOFFData.size());
@@ -193,9 +199,7 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
 
   // ESD record. Symbol name is Hello.
   addEsdRecord(GOFFData, 0x02, 0x01,
@@ -207,9 +211,7 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
                0x01);
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = 0x03;
-  GOFFData[Pos + 1] = 0x40;
+  addEndRecord(GOFFData);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -234,27 +236,19 @@ TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
   std::vector<char> GOFFData;
 
   // HDR record.
+  addHdrRecord(GOFFData);
+  // ESD record.
   size_t Pos = newRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
-  // ESD record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
   // HDR record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
   // ESD record.
   Pos = newRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -269,9 +263,7 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
   std::vector<char> GOFFContData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFContData);
 
   // ESD record with continuation. Symbol name is Helloworld.
   addEsdRecord(GOFFContData, 0x02, 0x01,
@@ -288,9 +280,7 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
                0x01);
 
   // END record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFContData);
 
   StringRef Data(GOFFContData.data(), GOFFContData.size());
 
@@ -314,12 +304,10 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
   std::vector<char> GOFFContData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFContData);
 
   // ESD record.
-  Pos = newRecord(GOFFContData);
+  size_t Pos = newRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x01;
   GOFFContData[Pos + 3] = (char)0x02;
@@ -343,9 +331,7 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
   GOFFContData[Pos + 4] = (char)0x84;
 
   // END record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFContData);
 
   StringRef Data(GOFFContData.data(), GOFFContData.size());
 
@@ -362,12 +348,10 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   std::vector<char> GOFFContData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFContData);
 
   // ESD record.
-  Pos = newRecord(GOFFContData);
+  size_t Pos = newRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x01;
   GOFFContData[Pos + 3] = (char)0x02;
@@ -391,9 +375,7 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   GOFFContData[Pos + 4] = (char)0x84;
 
   // END record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFContData);
 
   StringRef Data(GOFFContData.data(), GOFFContData.size());
 
@@ -415,12 +397,10 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
   std::vector<char> GOFFContData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFContData);
 
   // ESD record, with continued bit not set.
-  Pos = newRecord(GOFFContData);
+  size_t Pos = newRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
 
   // ESD continuation record.
@@ -429,9 +409,7 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
   GOFFContData[Pos + 1] = (char)0x02;
 
   // END record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFContData);
 
   StringRef Data(GOFFContData.data(), GOFFContData.size());
 
@@ -449,12 +427,10 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
   std::vector<char> GOFFContData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFContData);
 
   // ESD record.
-  Pos = newRecord(GOFFContData);
+  size_t Pos = newRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x01; // Continued to next record.
 
@@ -464,9 +440,7 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
   GOFFContData[Pos + 1] = (char)0x42;
 
   // END record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFContData);
 
   StringRef Data(GOFFContData.data(), GOFFContData.size());
 
@@ -484,9 +458,7 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
 
   // ESD record 1. Symbol name is x.
   addEsdRecord(GOFFData, 0x00, 0x01,
@@ -502,9 +474,7 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
                0x01);
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -528,9 +498,7 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
 
   // ESD record with invalid symbol type 0x05.
   addEsdRecord(GOFFData, 0x05, 0x01,
@@ -538,9 +506,7 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
                0x01);
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -570,12 +536,10 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  addHdrRecord(GOFFData);
 
   // ESD record.
-  Pos = newRecord(GOFFData);
+  size_t Pos = newRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 3] = (char)0x04;
   GOFFData[Pos + 7] = (char)0x01;
@@ -585,9 +549,7 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
   GOFFData[Pos + 72] = (char)0xC8; // Symbol name.
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  addEndRecord(GOFFData);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -611,10 +573,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   std::vector<char> GOFFData;
 
   // HDR record.
-  size_t Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
-  GOFFData[Pos + 50] = (char)0x01;
+  addHdrRecord(GOFFData, 0x01);
 
   // ESD record. Symbol name is var#c.
   addEsdRecord(GOFFData, 0x00, 0x01,
@@ -649,7 +608,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
                0x02);
 
   // TXT record.
-  Pos = newRecord(GOFFData);
+  size_t Pos = newRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0x10;
   GOFFData[Pos + 7] = (char)0x02;
@@ -664,10 +623,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   GOFFData[Pos + 31] = (char)0xf0;
 
   // END record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
-  GOFFData[Pos + 11] = (char)0x06;
+  addEndRecord(GOFFData, 0x06);
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -24,6 +24,52 @@ size_t newRecord(std::vector<char> &Data) {
   return Pos;
 }
 
+void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
+                  const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
+                  uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
+                  uint8_t AdditionalFlags = 0,
+                  uint8_t BehavioralAttributes[10] = nullptr,
+                  uint32_t Length = 0) {
+  size_t Pos = GOFFData.size();
+  GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
+
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)Type;
+  GOFFData[Pos + 7] = (char)ESDID;          // ESDID.
+  GOFFData[Pos + 11] = (char)ParentESDID;   // Parent ESDID.
+  GOFFData[Pos + 24] = (char)(Length >> 24); // Length (big-endian).
+  GOFFData[Pos + 25] = (char)(Length >> 16);
+  GOFFData[Pos + 26] = (char)(Length >> 8);
+  GOFFData[Pos + 27] = (char)(Length);
+  GOFFData[Pos + 40] = (char)NameSpaceID;   // Name Space ID
+  GOFFData[Pos + 41] = (char)AdditionalFlags; // Additional Flags
+
+  if (BehavioralAttributes) {
+    for (size_t Offset=0; Offset < 10; Offset++)
+      GOFFData[Pos + 60 + Offset] = (char)BehavioralAttributes[Offset];
+  }
+
+  GOFFData[Pos + 71] = (char)(Name.size()); // Size of symbol name.
+  size_t StringOffset = Pos + 72; // Start of Symbol name
+  for (uint8_t C : Name) {
+    GOFFData[StringOffset] = (char)C;
+    StringOffset++;
+
+    if (StringOffset == Pos + GOFF::RecordLength) {
+      // If we reach the end of the current record, we need to start a new one.
+      GOFFData[Pos + 1] |= 0x01; // set continuation bit in the current record.
+
+      // start a new continuation record
+      Pos = GOFFData.size();
+      GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
+      GOFFData[Pos] = (char)0x03;
+      GOFFData[Pos + 1] = (char)0x02; // continuation record
+
+      StringOffset = Pos + 3;
+    }
+  }
+}
+
 void constructValidGOFF(const char *Data, size_t Size) {
   StringRef ValidSize(Data, Size);
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
@@ -151,18 +197,14 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0xF0;
 
-  // ESD record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)0x02;
-  GOFFData[Pos + 7] = (char)0x01;
-  GOFFData[Pos + 11] = (char)0x01;
-  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xC8; // Symbol name is Hello.
-  GOFFData[Pos + 73] = (char)0x85;
-  GOFFData[Pos + 74] = (char)0x93;
-  GOFFData[Pos + 75] = (char)0x93;
-  GOFFData[Pos + 76] = (char)0x96;
+  // ESD record. Symbol name is Hello.
+  addEsdRecord(GOFFData, 0x02, 0x01,
+               {0xC8, // H
+                0x85, // e
+                0x93, // l
+                0x93, // l
+                0x96},// o
+               0x01);
 
   // END record.
   Pos = newRecord(GOFFData);
@@ -231,29 +273,19 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0xF0;
 
-  // ESD record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x01;
-  GOFFContData[Pos + 3] = (char)0x02;
-  GOFFContData[Pos + 7] = (char)0x01;
-  GOFFContData[Pos + 11] = (char)0x01;
-  GOFFContData[Pos + 71] = (char)0x0A; // Size of symbol name.
-  GOFFContData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
-  GOFFContData[Pos + 73] = (char)0x85;
-  GOFFContData[Pos + 74] = (char)0x93;
-  GOFFContData[Pos + 75] = (char)0x93;
-  GOFFContData[Pos + 76] = (char)0x96;
-  GOFFContData[Pos + 77] = (char)0xA6;
-  GOFFContData[Pos + 78] = (char)0x96;
-  GOFFContData[Pos + 79] = (char)0x99;
-
-  // ESD continuation record.
-  Pos = newRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x02; // No further continuations.
-  GOFFContData[Pos + 3] = (char)0x93;
-  GOFFContData[Pos + 4] = (char)0x84;
+  // ESD record with continuation. Symbol name is Helloworld.
+  addEsdRecord(GOFFContData, 0x02, 0x01,
+               {0xC8, // H
+                0x85, // e
+                0x93, // l
+                0x93, // l
+                0x96, // o
+                0xA6, // w
+                0x96, // o
+                0x99, // r
+                0x93, // l
+                0x84},// d
+               0x01);
 
   // END record.
   Pos = newRecord(GOFFContData);
@@ -456,26 +488,18 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0xF0;
 
-  // ESD record 1.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)0x00;
-  GOFFData[Pos + 7] = (char)0x01;  // ESDID.
-  GOFFData[Pos + 71] = (char)0x01; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xa7; // Symbol name is x.
+  // ESD record 1. Symbol name is x.
+  addEsdRecord(GOFFData, 0x00, 0x01,
+               {0xa7}); // x
 
-  // ESD record 2.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)0x03;
-  GOFFData[Pos + 7] = (char)0x02;  // ESDID.
-  GOFFData[Pos + 11] = (char)0x01; // Parent ESDID.
-  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xC8; // Symbol name is Hello.
-  GOFFData[Pos + 73] = (char)0x85;
-  GOFFData[Pos + 74] = (char)0x93;
-  GOFFData[Pos + 75] = (char)0x93;
-  GOFFData[Pos + 76] = (char)0x96;
+  // ESD record 2. Symbol name is Hello.
+  addEsdRecord(GOFFData, 0x03, 0x02,
+               {0xC8, // H
+                0x85, // e
+                0x93, // l
+                0x93, // l
+                0x96},// o
+               0x01);
 
   // END record.
   Pos = newRecord(GOFFData);
@@ -508,14 +532,10 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0xF0;
 
-  // ESD record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)0x05;
-  GOFFData[Pos + 7] = (char)0x01;
-  GOFFData[Pos + 11] = (char)0x01;
-  GOFFData[Pos + 71] = (char)0x01; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xC8; // Symbol name.
+  // ESD record with invalid symbol type 0x05.
+  addEsdRecord(GOFFData, 0x05, 0x01,
+               {0xC8}, // H
+               0x01);
 
   // END record.
   Pos = newRecord(GOFFData);
@@ -596,52 +616,37 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   GOFFData[Pos + 1] = (char)0xF0;
   GOFFData[Pos + 50] = (char)0x01;
 
-  // ESD record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 7] = (char)0x01;  // ESDID.
-  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xa5; // Symbol name is v.
-  GOFFData[Pos + 73] = (char)0x81; // Symbol name is a.
-  GOFFData[Pos + 74] = (char)0x99; // Symbol name is r.
-  GOFFData[Pos + 75] = (char)0x7b; // Symbol name is #.
-  GOFFData[Pos + 76] = (char)0x83; // Symbol name is c.
+  // ESD record. Symbol name is var#c.
+  addEsdRecord(GOFFData, 0x00, 0x01,
+               {0xa5, // v
+                0x81, // a
+                0x99, // r
+                0x7b, // #
+                0x83});// c
 
-  // ESD record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)0x01;
-  GOFFData[Pos + 7] = (char)0x02;  // ESDID.
-  GOFFData[Pos + 11] = (char)0x01; // Parent ESDID.
-  GOFFData[Pos + 27] = (char)0x08; // Length.
-  GOFFData[Pos + 40] = (char)0x01; // Name Space ID.
-  GOFFData[Pos + 41] = (char)0x80;
-  GOFFData[Pos + 60] = (char)0x04; // Size of symbol name.
-  GOFFData[Pos + 61] = (char)0x04; // Size of symbol name.
-  GOFFData[Pos + 63] = (char)0x0a; // Size of symbol name.
-  GOFFData[Pos + 66] = (char)0x03; // Size of symbol name.
-  GOFFData[Pos + 71] = (char)0x08; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xc3; // Symbol name is c.
-  GOFFData[Pos + 73] = (char)0x6d; // Symbol name is _.
-  GOFFData[Pos + 74] = (char)0xc3; // Symbol name is c.
-  GOFFData[Pos + 75] = (char)0xd6; // Symbol name is o.
-  GOFFData[Pos + 76] = (char)0xc4; // Symbol name is D.
-  GOFFData[Pos + 77] = (char)0xc5; // Symbol name is E.
-  GOFFData[Pos + 78] = (char)0xf6; // Symbol name is 6.
-  GOFFData[Pos + 79] = (char)0xf4; // Symbol name is 4.
+  // ESD record. Symbol name is c_CoDE64.
+  uint8_t BehavioralAttributes[] = {0x04, 0x04, 0x00, 0x0a,
+                                     0x00, 0x00, 0x03, 0x00,
+                                     0x00, 0x00};
+  addEsdRecord(GOFFData, 0x01, 0x02,
+               {0xc3, // c
+                0x6d, // _
+                0xc3, // c
+                0xd6, // o
+                0xc4, // D
+                0xc5, // E
+                0xf6, // 6
+                0xf4},// 4
+               0x01, 0x00, 0x01, 0x80, BehavioralAttributes, 0x08);
 
-  // ESD record.
-  Pos = newRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)0x02;
-  GOFFData[Pos + 7] = (char)0x03;  // ESDID.
-  GOFFData[Pos + 11] = (char)0x02; // Parent ESDID.
-  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[Pos + 72] = (char)0xa5; // Symbol name is v.
-  GOFFData[Pos + 73] = (char)0x81; // Symbol name is a.
-  GOFFData[Pos + 74] = (char)0x99; // Symbol name is r.
-  GOFFData[Pos + 75] = (char)0x7b; // Symbol name is #.
-  GOFFData[Pos + 76] = (char)0x83; // Symbol name is c.
+  // ESD record. Symbol name is var#c.
+  addEsdRecord(GOFFData, 0x02, 0x03,
+               {0xa5, // v
+                0x81, // a
+                0x99, // r
+                0x7b, // #
+                0x83},// c
+               0x02);
 
   // TXT record.
   Pos = newRecord(GOFFData);

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
+#include <vector>
 
 using namespace llvm;
 using namespace llvm::object;
@@ -67,24 +68,24 @@ TEST(GOFFObjectFileTest, createObjectFile) {
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {
-  char GOFFData[GOFF::RecordLength * 3] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
   GOFFData[0] = (char)0x03;
   GOFFData[1] = (char)0xF0;
   GOFFData[80] = (char)0x03;
   GOFFData[81] = (char)0x40;
-  constructValidGOFF(GOFFData, 160);
-  constructValidGOFF(GOFFData, 0);
+  constructValidGOFF(GOFFData.data(), 160);
+  constructValidGOFF(GOFFData.data(), 0);
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectInvalidSize) {
-  char GOFFData[GOFF::RecordLength * 3] = {0x00};
-  constructInvalidGOFF(GOFFData, 70);
-  constructInvalidGOFF(GOFFData, 79);
-  constructInvalidGOFF(GOFFData, 81);
+  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
+  constructInvalidGOFF(GOFFData.data(), 70);
+  constructInvalidGOFF(GOFFData.data(), 79);
+  constructInvalidGOFF(GOFFData.data(), 81);
 }
 
 TEST(GOFFObjectFileTest, MissingHDR) {
-  char GOFFData[GOFF::RecordLength * 2] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 2, 0x00);
 
   // ESD record.
   GOFFData[0] = (char)0x03;
@@ -93,7 +94,7 @@ TEST(GOFFObjectFileTest, MissingHDR) {
   GOFFData[GOFF::RecordLength] = (char)0x03;
   GOFFData[GOFF::RecordLength + 1] = (char)0x40;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 2);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 2);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -105,7 +106,7 @@ TEST(GOFFObjectFileTest, MissingHDR) {
 }
 
 TEST(GOFFObjectFileTest, MissingEND) {
-  char GOFFData[GOFF::RecordLength * 2] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 2, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -114,7 +115,7 @@ TEST(GOFFObjectFileTest, MissingEND) {
   // ESD record.
   GOFFData[GOFF::RecordLength] = (char)0x03;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 2);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 2);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -125,7 +126,7 @@ TEST(GOFFObjectFileTest, MissingEND) {
 }
 
 TEST(GOFFObjectFileTest, GetSymbolName) {
-  char GOFFData[GOFF::RecordLength * 3] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -147,7 +148,7 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
   GOFFData[GOFF::RecordLength * 2] = 0x03;
   GOFFData[GOFF::RecordLength * 2 + 1] = 0x40;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 3);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 3);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -167,7 +168,7 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
 }
 
 TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
-  char GOFFData[GOFF::RecordLength * 6] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 6, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -186,7 +187,7 @@ TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
   GOFFData[GOFF::RecordLength * 5] = (char)0x03;
   GOFFData[GOFF::RecordLength * 5 + 1] = (char)0x40;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 6);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 6);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -196,7 +197,7 @@ TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
-  char GOFFContData[GOFF::RecordLength * 4] = {0x00};
+  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
 
   // HDR record.
   GOFFContData[0] = (char)0x03;
@@ -228,7 +229,7 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
   GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
   GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData, GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -247,7 +248,7 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
-  char GOFFContData[GOFF::RecordLength * 4] = {0x00};
+  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
 
   // HDR record.
   GOFFContData[0] = (char)0x03;
@@ -279,7 +280,7 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
   GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
   GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData, GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -291,7 +292,7 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
-  char GOFFContData[GOFF::RecordLength * 4] = {0x00};
+  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
 
   // HDR record.
   GOFFContData[0] = (char)0x03;
@@ -323,7 +324,7 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
   GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData, GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -340,7 +341,7 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
 }
 
 TEST(GOFFObjectFileTest, PrevNotContinued) {
-  char GOFFContData[GOFF::RecordLength * 4] = {0x00};
+  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
 
   // HDR record.
   GOFFContData[0] = (char)0x03;
@@ -357,7 +358,7 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
   GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
   GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData, GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -370,7 +371,7 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
-  char GOFFContData[GOFF::RecordLength * 4] = {0x00};
+  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
 
   // HDR record.
   GOFFContData[0] = (char)0x03;
@@ -388,7 +389,7 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
   GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
   GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData, GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -401,7 +402,7 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
 }
 
 TEST(GOFFObjectFileTest, TwoSymbols) {
-  char GOFFData[GOFF::RecordLength * 4] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 4, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -430,7 +431,7 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
   GOFFData[GOFF::RecordLength * 3] = (char)0x03;
   GOFFData[GOFF::RecordLength * 3 + 1] = (char)0x40;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 4);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 4);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -449,7 +450,7 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
 }
 
 TEST(GOFFObjectFileTest, InvalidSymbolType) {
-  char GOFFData[GOFF::RecordLength * 3] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -467,7 +468,7 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
   GOFFData[GOFF::RecordLength * 2] = (char)0x03;
   GOFFData[GOFF::RecordLength * 2 + 1] = (char)0x40;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 3);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 3);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -492,7 +493,7 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
 }
 
 TEST(GOFFObjectFileTest, InvalidERSymbolType) {
-  char GOFFData[GOFF::RecordLength * 3] = {0x00};
+  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -511,7 +512,7 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
   GOFFData[GOFF::RecordLength * 2] = (char)0x03;
   GOFFData[GOFF::RecordLength * 2 + 1] = (char)0x40;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 3);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 3);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -530,7 +531,7 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
 }
 
 TEST(GOFFObjectFileTest, TXTConstruct) {
-  char GOFFData[GOFF::RecordLength * 6] = {};
+  std::vector<char> GOFFData(GOFF::RecordLength * 6, 0x00);
 
   // HDR record.
   GOFFData[0] = (char)0x03;
@@ -600,7 +601,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   GOFFData[GOFF::RecordLength * 5 + 1] = (char)0x40;
   GOFFData[GOFF::RecordLength * 5 + 11] = (char)0x06;
 
-  StringRef Data(GOFFData, GOFF::RecordLength * 6);
+  StringRef Data(GOFFData.data(), GOFF::RecordLength * 6);
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -221,7 +221,7 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -290,7 +290,7 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -384,7 +384,7 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
           MemoryBufferRef(Data, "dummyGOFF"));
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -484,7 +484,7 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -516,7 +516,7 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<SymbolRef::Type> SymbolType = Symbol.getType();
@@ -559,7 +559,7 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<SymbolRef::Type> SymbolType = Symbol.getType();
@@ -633,7 +633,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = dyn_cast<GOFFObjectFile>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
   auto Symbols = GOFFObj->symbols();
   ASSERT_EQ(std::distance(Symbols.begin(), Symbols.end()), 1);
   SymbolRef Symbol = *Symbols.begin();

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -59,11 +59,11 @@ TEST(GOFFObjectFileTest, createObjectFile) {
       0x00, 0x00, 0x00, 0x00,
   };
   ArrayRef<uint8_t> GOFFRef(GOFFData, sizeof(GOFFData));
-  Expected<std::unique_ptr<ObjectFile>> XCOFFObjOrErr =
+  Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createObjectFile(
           MemoryBufferRef(toStringRef(GOFFRef), "dummyGOFF"),
           file_magic::goff_object);
-  ASSERT_THAT_EXPECTED(XCOFFObjOrErr, Succeeded());
+  ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -18,6 +18,12 @@ using namespace llvm::object;
 using namespace llvm::GOFF;
 
 namespace {
+size_t newRecord(std::vector<char> &Data) {
+  size_t Pos = Data.size();
+  Data.resize(Pos + GOFF::RecordLength);
+  return Pos;
+}
+
 void constructValidGOFF(const char *Data, size_t Size) {
   StringRef ValidSize(Data, Size);
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
@@ -68,33 +74,43 @@ TEST(GOFFObjectFileTest, createObjectFile) {
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
-  GOFFData[80] = (char)0x03;
-  GOFFData[81] = (char)0x40;
-  constructValidGOFF(GOFFData.data(), 160);
+  std::vector<char> GOFFData;
+
+  // HDR record.
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
+
+  // END record.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
+
+  constructValidGOFF(GOFFData.data(), GOFFData.size());
   constructValidGOFF(GOFFData.data(), 0);
 }
 
 TEST(GOFFObjectFileTest, ConstructGOFFObjectInvalidSize) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
+  std::vector<char> GOFFData;
+  GOFFData.resize(GOFF::RecordLength * 3);
   constructInvalidGOFF(GOFFData.data(), 70);
   constructInvalidGOFF(GOFFData.data(), 79);
   constructInvalidGOFF(GOFFData.data(), 81);
 }
 
 TEST(GOFFObjectFileTest, MissingHDR) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 2, 0x00);
+  std::vector<char> GOFFData;
 
   // ESD record.
-  GOFFData[0] = (char)0x03;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
 
   // END record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
-  GOFFData[GOFF::RecordLength + 1] = (char)0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 2);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -106,16 +122,18 @@ TEST(GOFFObjectFileTest, MissingHDR) {
 }
 
 TEST(GOFFObjectFileTest, MissingEND) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 2, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 2);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -126,29 +144,32 @@ TEST(GOFFObjectFileTest, MissingEND) {
 }
 
 TEST(GOFFObjectFileTest, GetSymbolName) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
-  GOFFData[GOFF::RecordLength + 3] = (char)0x02;
-  GOFFData[GOFF::RecordLength + 7] = (char)0x01;
-  GOFFData[GOFF::RecordLength + 11] = (char)0x01;
-  GOFFData[GOFF::RecordLength + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[GOFF::RecordLength + 72] = (char)0xC8; // Symbol name is Hello.
-  GOFFData[GOFF::RecordLength + 73] = (char)0x85;
-  GOFFData[GOFF::RecordLength + 74] = (char)0x93;
-  GOFFData[GOFF::RecordLength + 75] = (char)0x93;
-  GOFFData[GOFF::RecordLength + 76] = (char)0x96;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x02;
+  GOFFData[Pos + 7] = (char)0x01;
+  GOFFData[Pos + 11] = (char)0x01;
+  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xC8; // Symbol name is Hello.
+  GOFFData[Pos + 73] = (char)0x85;
+  GOFFData[Pos + 74] = (char)0x93;
+  GOFFData[Pos + 75] = (char)0x93;
+  GOFFData[Pos + 76] = (char)0x96;
 
   // END record.
-  GOFFData[GOFF::RecordLength * 2] = 0x03;
-  GOFFData[GOFF::RecordLength * 2 + 1] = 0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = 0x03;
+  GOFFData[Pos + 1] = 0x40;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 3);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -168,26 +189,32 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
 }
 
 TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 6, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
   // ESD record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
   // END record.
-  GOFFData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 2 + 1] = (char)0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
   // HDR record.
-  GOFFData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 3 + 1] = (char)0xF0;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
   // ESD record.
-  GOFFData[GOFF::RecordLength * 4] = (char)0x03;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
   // END record.
-  GOFFData[GOFF::RecordLength * 5] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 5 + 1] = (char)0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 6);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -197,39 +224,43 @@ TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
-  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
+  std::vector<char> GOFFContData;
 
   // HDR record.
-  GOFFContData[0] = (char)0x03;
-  GOFFContData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFContData[GOFF::RecordLength] = (char)0x03;
-  GOFFContData[GOFF::RecordLength + 1] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 3] = (char)0x02;
-  GOFFContData[GOFF::RecordLength + 7] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 11] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 71] = (char)0x0A; // Size of symbol name.
-  GOFFContData[GOFF::RecordLength + 72] = (char)0xC8; // Symbol name is HelloWorld.
-  GOFFContData[GOFF::RecordLength + 73] = (char)0x85;
-  GOFFContData[GOFF::RecordLength + 74] = (char)0x93;
-  GOFFContData[GOFF::RecordLength + 75] = (char)0x93;
-  GOFFContData[GOFF::RecordLength + 76] = (char)0x96;
-  GOFFContData[GOFF::RecordLength + 77] = (char)0xA6;
-  GOFFContData[GOFF::RecordLength + 78] = (char)0x96;
-  GOFFContData[GOFF::RecordLength + 79] = (char)0x99;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x01;
+  GOFFContData[Pos + 3] = (char)0x02;
+  GOFFContData[Pos + 7] = (char)0x01;
+  GOFFContData[Pos + 11] = (char)0x01;
+  GOFFContData[Pos + 71] = (char)0x0A; // Size of symbol name.
+  GOFFContData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
+  GOFFContData[Pos + 73] = (char)0x85;
+  GOFFContData[Pos + 74] = (char)0x93;
+  GOFFContData[Pos + 75] = (char)0x93;
+  GOFFContData[Pos + 76] = (char)0x96;
+  GOFFContData[Pos + 77] = (char)0xA6;
+  GOFFContData[Pos + 78] = (char)0x96;
+  GOFFContData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  GOFFContData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 2 + 1] = (char)0x02; // No further continuations.
-  GOFFContData[GOFF::RecordLength * 2 + 3] = (char)0x93;
-  GOFFContData[GOFF::RecordLength * 2 + 4] = (char)0x84;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x02; // No further continuations.
+  GOFFContData[Pos + 3] = (char)0x93;
+  GOFFContData[Pos + 4] = (char)0x84;
 
   // END record.
-  GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFFContData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -248,39 +279,43 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
-  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
+  std::vector<char> GOFFContData;
 
   // HDR record.
-  GOFFContData[0] = (char)0x03;
-  GOFFContData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFContData[GOFF::RecordLength] = (char)0x03;
-  GOFFContData[GOFF::RecordLength + 1] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 3] = (char)0x02;
-  GOFFContData[GOFF::RecordLength + 7] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 11] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 71] = (char)0x0A; // Size of symbol name.
-  GOFFContData[GOFF::RecordLength + 72] = (char)0xC8; // Symbol name is HelloWorld.
-  GOFFContData[GOFF::RecordLength + 73] = (char)0x85;
-  GOFFContData[GOFF::RecordLength + 74] = (char)0x93;
-  GOFFContData[GOFF::RecordLength + 75] = (char)0x93;
-  GOFFContData[GOFF::RecordLength + 76] = (char)0x96;
-  GOFFContData[GOFF::RecordLength + 77] = (char)0xA6;
-  GOFFContData[GOFF::RecordLength + 78] = (char)0x96;
-  GOFFContData[GOFF::RecordLength + 79] = (char)0x99;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x01;
+  GOFFContData[Pos + 3] = (char)0x02;
+  GOFFContData[Pos + 7] = (char)0x01;
+  GOFFContData[Pos + 11] = (char)0x01;
+  GOFFContData[Pos + 71] = (char)0x0A; // Size of symbol name.
+  GOFFContData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
+  GOFFContData[Pos + 73] = (char)0x85;
+  GOFFContData[Pos + 74] = (char)0x93;
+  GOFFContData[Pos + 75] = (char)0x93;
+  GOFFContData[Pos + 76] = (char)0x96;
+  GOFFContData[Pos + 77] = (char)0xA6;
+  GOFFContData[Pos + 78] = (char)0x96;
+  GOFFContData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  GOFFContData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 2 + 1] = (char)0x00;
-  GOFFContData[GOFF::RecordLength * 2 + 3] = (char)0x93;
-  GOFFContData[GOFF::RecordLength * 2 + 4] = (char)0x84;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x00;
+  GOFFContData[Pos + 3] = (char)0x93;
+  GOFFContData[Pos + 4] = (char)0x84;
 
   // END record.
-  GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFFContData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -292,39 +327,43 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
-  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
+  std::vector<char> GOFFContData;
 
   // HDR record.
-  GOFFContData[0] = (char)0x03;
-  GOFFContData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFContData[GOFF::RecordLength] = (char)0x03;
-  GOFFContData[GOFF::RecordLength + 1] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 3] = (char)0x02;
-  GOFFContData[GOFF::RecordLength + 7] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 11] = (char)0x01;
-  GOFFContData[GOFF::RecordLength + 71] = (char)0x0A; // Size of symbol name.
-  GOFFContData[GOFF::RecordLength + 72] = (char)0xC8; // Symbol name is HelloWorld.
-  GOFFContData[GOFF::RecordLength + 73] = (char)0x85;
-  GOFFContData[GOFF::RecordLength + 74] = (char)0x93;
-  GOFFContData[GOFF::RecordLength + 75] = (char)0x93;
-  GOFFContData[GOFF::RecordLength + 76] = (char)0x96;
-  GOFFContData[GOFF::RecordLength + 77] = (char)0xA6;
-  GOFFContData[GOFF::RecordLength + 78] = (char)0x96;
-  GOFFContData[GOFF::RecordLength + 79] = (char)0x99;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x01;
+  GOFFContData[Pos + 3] = (char)0x02;
+  GOFFContData[Pos + 7] = (char)0x01;
+  GOFFContData[Pos + 11] = (char)0x01;
+  GOFFContData[Pos + 71] = (char)0x0A; // Size of symbol name.
+  GOFFContData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
+  GOFFContData[Pos + 73] = (char)0x85;
+  GOFFContData[Pos + 74] = (char)0x93;
+  GOFFContData[Pos + 75] = (char)0x93;
+  GOFFContData[Pos + 76] = (char)0x96;
+  GOFFContData[Pos + 77] = (char)0xA6;
+  GOFFContData[Pos + 78] = (char)0x96;
+  GOFFContData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  GOFFContData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 2 + 1] = (char)0x03; // Continued bit set.
-  GOFFContData[GOFF::RecordLength * 2 + 3] = (char)0x93;
-  GOFFContData[GOFF::RecordLength * 2 + 4] = (char)0x84;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x03; // Continued bit set.
+  GOFFContData[Pos + 3] = (char)0x93;
+  GOFFContData[Pos + 4] = (char)0x84;
 
   // END record.
-  GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFFContData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -341,24 +380,28 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
 }
 
 TEST(GOFFObjectFileTest, PrevNotContinued) {
-  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
+  std::vector<char> GOFFContData;
 
   // HDR record.
-  GOFFContData[0] = (char)0x03;
-  GOFFContData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0xF0;
 
   // ESD record, with continued bit not set.
-  GOFFContData[GOFF::RecordLength] = (char)0x03;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
 
   // ESD continuation record.
-  GOFFContData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 2 + 1] = (char)0x02;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x02;
 
   // END record.
-  GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFFContData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -371,25 +414,29 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
 }
 
 TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
-  std::vector<char> GOFFContData(GOFF::RecordLength * 4, 0x00);
+  std::vector<char> GOFFContData;
 
   // HDR record.
-  GOFFContData[0] = (char)0x03;
-  GOFFContData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFContData[GOFF::RecordLength] = (char)0x03;
-  GOFFContData[GOFF::RecordLength + 1] = (char)0x01; // Continued to next record.
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x01; // Continued to next record.
 
   // END continuation record.
-  GOFFContData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 2 + 1] = (char)0x42;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x42;
 
   // END record.
-  GOFFContData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFContData[GOFF::RecordLength * 3 + 1] = (char)0x40;
+  Pos = newRecord(GOFFContData);
+  GOFFContData[Pos] = (char)0x03;
+  GOFFContData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFContData.data(), GOFF::RecordLength * 4);
+  StringRef Data(GOFFContData.data(), GOFFContData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -402,36 +449,40 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
 }
 
 TEST(GOFFObjectFileTest, TwoSymbols) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 4, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
 
   // ESD record 1.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
-  GOFFData[GOFF::RecordLength + 3] = (char)0x00;
-  GOFFData[GOFF::RecordLength + 7] = (char)0x01;  // ESDID.
-  GOFFData[GOFF::RecordLength + 71] = (char)0x01; // Size of symbol name.
-  GOFFData[GOFF::RecordLength + 72] = (char)0xa7; // Symbol name is x.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x00;
+  GOFFData[Pos + 7] = (char)0x01;  // ESDID.
+  GOFFData[Pos + 71] = (char)0x01; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xa7; // Symbol name is x.
 
   // ESD record 2.
-  GOFFData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 2 + 3] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 2 + 7] = (char)0x02;  // ESDID.
-  GOFFData[GOFF::RecordLength * 2 + 11] = (char)0x01; // Parent ESDID.
-  GOFFData[GOFF::RecordLength * 2 + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 72] = (char)0xC8; // Symbol name is Hello.
-  GOFFData[GOFF::RecordLength * 2 + 73] = (char)0x85;
-  GOFFData[GOFF::RecordLength * 2 + 74] = (char)0x93;
-  GOFFData[GOFF::RecordLength * 2 + 75] = (char)0x93;
-  GOFFData[GOFF::RecordLength * 2 + 76] = (char)0x96;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x03;
+  GOFFData[Pos + 7] = (char)0x02;  // ESDID.
+  GOFFData[Pos + 11] = (char)0x01; // Parent ESDID.
+  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xC8; // Symbol name is Hello.
+  GOFFData[Pos + 73] = (char)0x85;
+  GOFFData[Pos + 74] = (char)0x93;
+  GOFFData[Pos + 75] = (char)0x93;
+  GOFFData[Pos + 76] = (char)0x96;
 
   // END record.
-  GOFFData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 3 + 1] = (char)0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 4);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -450,25 +501,28 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
 }
 
 TEST(GOFFObjectFileTest, InvalidSymbolType) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
-  GOFFData[GOFF::RecordLength + 3] = (char)0x05;
-  GOFFData[GOFF::RecordLength + 7] = (char)0x01;
-  GOFFData[GOFF::RecordLength + 11] = (char)0x01;
-  GOFFData[GOFF::RecordLength + 71] = (char)0x01; // Size of symbol name.
-  GOFFData[GOFF::RecordLength + 72] = (char)0xC8; // Symbol name.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x05;
+  GOFFData[Pos + 7] = (char)0x01;
+  GOFFData[Pos + 11] = (char)0x01;
+  GOFFData[Pos + 71] = (char)0x01; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xC8; // Symbol name.
 
   // END record.
-  GOFFData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 2 + 1] = (char)0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 3);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -493,26 +547,29 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
 }
 
 TEST(GOFFObjectFileTest, InvalidERSymbolType) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 3, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
 
   // ESD record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
-  GOFFData[GOFF::RecordLength + 3] = (char)0x04;
-  GOFFData[GOFF::RecordLength + 7] = (char)0x01;
-  GOFFData[GOFF::RecordLength + 11] = (char)0x01;
-  GOFFData[GOFF::RecordLength + 63] = (char)0x03; // Unknown executable type.
-  GOFFData[GOFF::RecordLength + 71] = (char)0x01; // Size of symbol name.
-  GOFFData[GOFF::RecordLength + 72] = (char)0xC8; // Symbol name.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x04;
+  GOFFData[Pos + 7] = (char)0x01;
+  GOFFData[Pos + 11] = (char)0x01;
+  GOFFData[Pos + 63] = (char)0x03; // Unknown executable type.
+  GOFFData[Pos + 71] = (char)0x01; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xC8; // Symbol name.
 
   // END record.
-  GOFFData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 2 + 1] = (char)0x40;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 3);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -531,77 +588,83 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
 }
 
 TEST(GOFFObjectFileTest, TXTConstruct) {
-  std::vector<char> GOFFData(GOFF::RecordLength * 6, 0x00);
+  std::vector<char> GOFFData;
 
   // HDR record.
-  GOFFData[0] = (char)0x03;
-  GOFFData[1] = (char)0xF0;
-  GOFFData[50] = (char)0x01;
+  size_t Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0xF0;
+  GOFFData[Pos + 50] = (char)0x01;
 
   // ESD record.
-  GOFFData[GOFF::RecordLength] = (char)0x03;
-  GOFFData[GOFF::RecordLength + 7] = (char)0x01;  // ESDID.
-  GOFFData[GOFF::RecordLength + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[GOFF::RecordLength + 72] = (char)0xa5; // Symbol name is v.
-  GOFFData[GOFF::RecordLength + 73] = (char)0x81; // Symbol name is a.
-  GOFFData[GOFF::RecordLength + 74] = (char)0x99; // Symbol name is r.
-  GOFFData[GOFF::RecordLength + 75] = (char)0x7b; // Symbol name is #.
-  GOFFData[GOFF::RecordLength + 76] = (char)0x83; // Symbol name is c.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 7] = (char)0x01;  // ESDID.
+  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xa5; // Symbol name is v.
+  GOFFData[Pos + 73] = (char)0x81; // Symbol name is a.
+  GOFFData[Pos + 74] = (char)0x99; // Symbol name is r.
+  GOFFData[Pos + 75] = (char)0x7b; // Symbol name is #.
+  GOFFData[Pos + 76] = (char)0x83; // Symbol name is c.
 
   // ESD record.
-  GOFFData[GOFF::RecordLength * 2] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 2 + 3] = (char)0x01;
-  GOFFData[GOFF::RecordLength * 2 + 7] = (char)0x02;  // ESDID.
-  GOFFData[GOFF::RecordLength * 2 + 11] = (char)0x01; // Parent ESDID.
-  GOFFData[GOFF::RecordLength * 2 + 27] = (char)0x08; // Length.
-  GOFFData[GOFF::RecordLength * 2 + 40] = (char)0x01; // Name Space ID.
-  GOFFData[GOFF::RecordLength * 2 + 41] = (char)0x80;
-  GOFFData[GOFF::RecordLength * 2 + 60] = (char)0x04; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 61] = (char)0x04; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 63] = (char)0x0a; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 66] = (char)0x03; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 71] = (char)0x08; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 2 + 72] = (char)0xc3; // Symbol name is c.
-  GOFFData[GOFF::RecordLength * 2 + 73] = (char)0x6d; // Symbol name is _.
-  GOFFData[GOFF::RecordLength * 2 + 74] = (char)0xc3; // Symbol name is c.
-  GOFFData[GOFF::RecordLength * 2 + 75] = (char)0xd6; // Symbol name is o.
-  GOFFData[GOFF::RecordLength * 2 + 76] = (char)0xc4; // Symbol name is D.
-  GOFFData[GOFF::RecordLength * 2 + 77] = (char)0xc5; // Symbol name is E.
-  GOFFData[GOFF::RecordLength * 2 + 78] = (char)0xf6; // Symbol name is 6.
-  GOFFData[GOFF::RecordLength * 2 + 79] = (char)0xf4; // Symbol name is 4.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x01;
+  GOFFData[Pos + 7] = (char)0x02;  // ESDID.
+  GOFFData[Pos + 11] = (char)0x01; // Parent ESDID.
+  GOFFData[Pos + 27] = (char)0x08; // Length.
+  GOFFData[Pos + 40] = (char)0x01; // Name Space ID.
+  GOFFData[Pos + 41] = (char)0x80;
+  GOFFData[Pos + 60] = (char)0x04; // Size of symbol name.
+  GOFFData[Pos + 61] = (char)0x04; // Size of symbol name.
+  GOFFData[Pos + 63] = (char)0x0a; // Size of symbol name.
+  GOFFData[Pos + 66] = (char)0x03; // Size of symbol name.
+  GOFFData[Pos + 71] = (char)0x08; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xc3; // Symbol name is c.
+  GOFFData[Pos + 73] = (char)0x6d; // Symbol name is _.
+  GOFFData[Pos + 74] = (char)0xc3; // Symbol name is c.
+  GOFFData[Pos + 75] = (char)0xd6; // Symbol name is o.
+  GOFFData[Pos + 76] = (char)0xc4; // Symbol name is D.
+  GOFFData[Pos + 77] = (char)0xc5; // Symbol name is E.
+  GOFFData[Pos + 78] = (char)0xf6; // Symbol name is 6.
+  GOFFData[Pos + 79] = (char)0xf4; // Symbol name is 4.
 
   // ESD record.
-  GOFFData[GOFF::RecordLength * 3] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 3 + 3] = (char)0x02;
-  GOFFData[GOFF::RecordLength * 3 + 7] = (char)0x03;  // ESDID.
-  GOFFData[GOFF::RecordLength * 3 + 11] = (char)0x02; // Parent ESDID.
-  GOFFData[GOFF::RecordLength * 3 + 71] = (char)0x05; // Size of symbol name.
-  GOFFData[GOFF::RecordLength * 3 + 72] = (char)0xa5; // Symbol name is v.
-  GOFFData[GOFF::RecordLength * 3 + 73] = (char)0x81; // Symbol name is a.
-  GOFFData[GOFF::RecordLength * 3 + 74] = (char)0x99; // Symbol name is r.
-  GOFFData[GOFF::RecordLength * 3 + 75] = (char)0x7b; // Symbol name is #.
-  GOFFData[GOFF::RecordLength * 3 + 76] = (char)0x83; // Symbol name is c.
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 3] = (char)0x02;
+  GOFFData[Pos + 7] = (char)0x03;  // ESDID.
+  GOFFData[Pos + 11] = (char)0x02; // Parent ESDID.
+  GOFFData[Pos + 71] = (char)0x05; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xa5; // Symbol name is v.
+  GOFFData[Pos + 73] = (char)0x81; // Symbol name is a.
+  GOFFData[Pos + 74] = (char)0x99; // Symbol name is r.
+  GOFFData[Pos + 75] = (char)0x7b; // Symbol name is #.
+  GOFFData[Pos + 76] = (char)0x83; // Symbol name is c.
 
   // TXT record.
-  GOFFData[GOFF::RecordLength * 4] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 4 + 1] = (char)0x10;
-  GOFFData[GOFF::RecordLength * 4 + 7] = (char)0x02;
-  GOFFData[GOFF::RecordLength * 4 + 23] = (char)0x08; // Data Length.
-  GOFFData[GOFF::RecordLength * 4 + 24] = (char)0x12;
-  GOFFData[GOFF::RecordLength * 4 + 25] = (char)0x34;
-  GOFFData[GOFF::RecordLength * 4 + 26] = (char)0x56;
-  GOFFData[GOFF::RecordLength * 4 + 27] = (char)0x78;
-  GOFFData[GOFF::RecordLength * 4 + 28] = (char)0x9a;
-  GOFFData[GOFF::RecordLength * 4 + 29] = (char)0xbc;
-  GOFFData[GOFF::RecordLength * 4 + 30] = (char)0xde;
-  GOFFData[GOFF::RecordLength * 4 + 31] = (char)0xf0;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x10;
+  GOFFData[Pos + 7] = (char)0x02;
+  GOFFData[Pos + 23] = (char)0x08; // Data Length.
+  GOFFData[Pos + 24] = (char)0x12;
+  GOFFData[Pos + 25] = (char)0x34;
+  GOFFData[Pos + 26] = (char)0x56;
+  GOFFData[Pos + 27] = (char)0x78;
+  GOFFData[Pos + 28] = (char)0x9a;
+  GOFFData[Pos + 29] = (char)0xbc;
+  GOFFData[Pos + 30] = (char)0xde;
+  GOFFData[Pos + 31] = (char)0xf0;
 
   // END record.
-  GOFFData[GOFF::RecordLength * 5] = (char)0x03;
-  GOFFData[GOFF::RecordLength * 5 + 1] = (char)0x40;
-  GOFFData[GOFF::RecordLength * 5 + 11] = (char)0x06;
+  Pos = newRecord(GOFFData);
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x40;
+  GOFFData[Pos + 11] = (char)0x06;
 
-  StringRef Data(GOFFData.data(), GOFF::RecordLength * 6);
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -49,22 +49,22 @@ void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
 
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 3] = (char)Type;
-  GOFFData[Pos + 7] = (char)ESDID;          // ESDID.
-  GOFFData[Pos + 11] = (char)ParentESDID;   // Parent ESDID.
+  GOFFData[Pos + 7] = (char)ESDID;           // ESDID.
+  GOFFData[Pos + 11] = (char)ParentESDID;    // Parent ESDID.
   GOFFData[Pos + 24] = (char)(Length >> 24); // Length (big-endian).
   GOFFData[Pos + 25] = (char)(Length >> 16);
   GOFFData[Pos + 26] = (char)(Length >> 8);
   GOFFData[Pos + 27] = (char)(Length);
-  GOFFData[Pos + 40] = (char)NameSpaceID;   // Name Space ID
+  GOFFData[Pos + 40] = (char)NameSpaceID;     // Name Space ID
   GOFFData[Pos + 41] = (char)AdditionalFlags; // Additional Flags
 
   if (BehavioralAttributes) {
-    for (size_t Offset=0; Offset < 10; Offset++)
+    for (size_t Offset = 0; Offset < 10; Offset++)
       GOFFData[Pos + 60 + Offset] = (char)BehavioralAttributes[Offset];
   }
 
   GOFFData[Pos + 71] = (char)(Name.size()); // Size of symbol name.
-  size_t StringOffset = Pos + 72; // Start of Symbol name
+  size_t StringOffset = Pos + 72;           // Start of Symbol name
   for (uint8_t C : Name) {
     GOFFData[StringOffset] = (char)C;
     StringOffset++;
@@ -203,11 +203,11 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
 
   // ESD record. Symbol name is Hello.
   addEsdRecord(GOFFData, 0x02, 0x01,
-               {0xC8, // H
-                0x85, // e
-                0x93, // l
-                0x93, // l
-                0x96},// o
+               {0xC8,  // H
+                0x85,  // e
+                0x93,  // l
+                0x93,  // l
+                0x96}, // o
                0x01);
 
   // END record.
@@ -221,7 +221,8 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -267,16 +268,16 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
 
   // ESD record with continuation. Symbol name is Helloworld.
   addEsdRecord(GOFFContData, 0x02, 0x01,
-               {0xC8, // H
-                0x85, // e
-                0x93, // l
-                0x93, // l
-                0x96, // o
-                0xA6, // w
-                0x96, // o
-                0x99, // r
-                0x93, // l
-                0x84},// d
+               {0xC8,  // H
+                0x85,  // e
+                0x93,  // l
+                0x93,  // l
+                0x96,  // o
+                0xA6,  // w
+                0x96,  // o
+                0x99,  // r
+                0x93,  // l
+                0x84}, // d
                0x01);
 
   // END record.
@@ -290,7 +291,8 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -384,7 +386,8 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
           MemoryBufferRef(Data, "dummyGOFF"));
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -461,16 +464,15 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
   addHdrRecord(GOFFData);
 
   // ESD record 1. Symbol name is x.
-  addEsdRecord(GOFFData, 0x00, 0x01,
-               {0xa7}); // x
+  addEsdRecord(GOFFData, 0x00, 0x01, {0xa7}); // x
 
   // ESD record 2. Symbol name is Hello.
   addEsdRecord(GOFFData, 0x03, 0x02,
-               {0xC8, // H
-                0x85, // e
-                0x93, // l
-                0x93, // l
-                0x96},// o
+               {0xC8,  // H
+                0x85,  // e
+                0x93,  // l
+                0x93,  // l
+                0x96}, // o
                0x01);
 
   // END record.
@@ -484,7 +486,8 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<StringRef> SymbolNameOrErr = GOFFObj->getSymbolName(Symbol);
@@ -501,8 +504,7 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
   addHdrRecord(GOFFData);
 
   // ESD record with invalid symbol type 0x05.
-  addEsdRecord(GOFFData, 0x05, 0x01,
-               {0xC8}, // H
+  addEsdRecord(GOFFData, 0x05, 0x01, {0xC8}, // H
                0x01);
 
   // END record.
@@ -516,7 +518,8 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<SymbolRef::Type> SymbolType = Symbol.getType();
@@ -559,7 +562,8 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
 
   for (SymbolRef Symbol : GOFFObj->symbols()) {
     Expected<SymbolRef::Type> SymbolType = Symbol.getType();
@@ -577,34 +581,33 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
 
   // ESD record. Symbol name is var#c.
   addEsdRecord(GOFFData, 0x00, 0x01,
-               {0xa5, // v
-                0x81, // a
-                0x99, // r
-                0x7b, // #
-                0x83});// c
+               {0xa5,   // v
+                0x81,   // a
+                0x99,   // r
+                0x7b,   // #
+                0x83}); // c
 
   // ESD record. Symbol name is c_CoDE64.
-  uint8_t BehavioralAttributes[] = {0x04, 0x04, 0x00, 0x0a,
-                                     0x00, 0x00, 0x03, 0x00,
-                                     0x00, 0x00};
+  uint8_t BehavioralAttributes[] = {0x04, 0x04, 0x00, 0x0a, 0x00,
+                                    0x00, 0x03, 0x00, 0x00, 0x00};
   addEsdRecord(GOFFData, 0x01, 0x02,
-               {0xc3, // c
-                0x6d, // _
-                0xc3, // c
-                0xd6, // o
-                0xc4, // D
-                0xc5, // E
-                0xf6, // 6
-                0xf4},// 4
+               {0xc3,  // c
+                0x6d,  // _
+                0xc3,  // c
+                0xd6,  // o
+                0xc4,  // D
+                0xc5,  // E
+                0xf6,  // 6
+                0xf4}, // 4
                0x01, 0x00, 0x01, 0x80, BehavioralAttributes, 0x08);
 
   // ESD record. Symbol name is var#c.
   addEsdRecord(GOFFData, 0x02, 0x03,
-               {0xa5, // v
-                0x81, // a
-                0x99, // r
-                0x7b, // #
-                0x83},// c
+               {0xa5,  // v
+                0x81,  // a
+                0x99,  // r
+                0x7b,  // #
+                0x83}, // c
                0x02);
 
   // TXT record.
@@ -633,7 +636,8 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
 
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 
-  GOFFObjectFile *GOFFObj = static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
+  GOFFObjectFile *GOFFObj =
+      static_cast<GOFFObjectFile *>((*GOFFObjOrErr).get());
   auto Symbols = GOFFObj->symbols();
   ASSERT_EQ(std::distance(Symbols.begin(), Symbols.end()), 1);
   SymbolRef Symbol = *Symbols.begin();

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -26,14 +26,14 @@ size_t addNewRecord(std::vector<char> &Data) {
 void addEndRecord(std::vector<char> &GOFFData, uint8_t RecordCount = 0) {
   size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40;
+  GOFFData[Pos + 1] = (char)0x40; // END record, non-continued.
   GOFFData[Pos + 11] = (char)RecordCount;
 }
 
 void addHdrRecord(std::vector<char> &GOFFData, uint8_t ArchLevel = 0) {
   size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0;
+  GOFFData[Pos + 1] = (char)0xF0; // HDR record, non-continued.
   GOFFData[Pos + 50] = (char)ArchLevel;
 }
 

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -66,12 +66,12 @@ protected:
     GOFFData[Pos + 50] = (char)ArchLevel;
   }
 
-  void
-  addEsdRecord(uint8_t Type, uint8_t ESDID, const std::vector<uint8_t> &Name,
-               uint8_t ParentESDID = 0, uint8_t BindingScope = 0,
-               uint8_t NameSpaceID = 0, uint8_t AdditionalFlags = 0,
-               std::array<uint8_t, 10> BehavioralAttributes = {},
-               uint32_t Length = 0) {
+  void addEsdRecord(uint8_t Type, uint8_t ESDID,
+                    const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
+                    uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
+                    uint8_t AdditionalFlags = 0,
+                    std::array<uint8_t, 10> BehavioralAttributes = {},
+                    uint32_t Length = 0) {
     size_t Pos = GOFFData.size();
     GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
     ++RecordCount;

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -11,7 +11,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
-#include <vector>
 
 using namespace llvm;
 using namespace llvm::object;

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -66,13 +66,13 @@ protected:
     GOFFData[Pos + 50] = (char)ArchLevel;
   }
 
-  void addEsdRecord(uint8_t Type, uint8_t ESDID,
-                    const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
-                    uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
-                    uint8_t AdditionalFlags = 0,
-                    std::array<uint8_t, 10> BehavioralAttributes = {
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-                    uint32_t Length = 0) {
+  void
+  addEsdRecord(uint8_t Type, uint8_t ESDID, const std::vector<uint8_t> &Name,
+               uint8_t ParentESDID = 0, uint8_t BindingScope = 0,
+               uint8_t NameSpaceID = 0, uint8_t AdditionalFlags = 0,
+               std::array<uint8_t, 10> BehavioralAttributes = {0, 0, 0, 0, 0, 0,
+                                                               0, 0, 0, 0},
+               uint32_t Length = 0) {
     size_t Pos = GOFFData.size();
     GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
     ++RecordCount;
@@ -101,7 +101,7 @@ protected:
         // If we reach the end of the current record, we need to start a new
         // one.
         GOFFData[Pos + 1] |= 0x01; // Set continuation bit in the current
-                                    // record.
+                                   // record.
 
         // start a new continuation record
         Pos = GOFFData.size();

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -17,70 +17,6 @@ using namespace llvm::object;
 using namespace llvm::GOFF;
 
 namespace {
-size_t addNewRecord(std::vector<char> &Data) {
-  size_t Pos = Data.size();
-  Data.resize(Pos + GOFF::RecordLength);
-  return Pos;
-}
-
-void addEndRecord(std::vector<char> &GOFFData, uint8_t RecordCount = 0) {
-  size_t Pos = addNewRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0x40; // END record, non-continued.
-  GOFFData[Pos + 11] = (char)RecordCount;
-}
-
-void addHdrRecord(std::vector<char> &GOFFData, uint8_t ArchLevel = 0) {
-  size_t Pos = addNewRecord(GOFFData);
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 1] = (char)0xF0; // HDR record, non-continued.
-  GOFFData[Pos + 50] = (char)ArchLevel;
-}
-
-void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
-                  const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
-                  uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
-                  uint8_t AdditionalFlags = 0,
-                  std::array<uint8_t, 10> BehavioralAttributes = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-                  uint32_t Length = 0) {
-  size_t Pos = GOFFData.size();
-  GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
-
-  GOFFData[Pos] = (char)0x03;
-  GOFFData[Pos + 3] = (char)Type;
-  GOFFData[Pos + 7] = (char)ESDID;           // ESDID.
-  GOFFData[Pos + 11] = (char)ParentESDID;    // Parent ESDID.
-  GOFFData[Pos + 24] = (char)(Length >> 24); // Length (big-endian).
-  GOFFData[Pos + 25] = (char)(Length >> 16);
-  GOFFData[Pos + 26] = (char)(Length >> 8);
-  GOFFData[Pos + 27] = (char)(Length);
-  GOFFData[Pos + 40] = (char)NameSpaceID;     // Name Space ID
-  GOFFData[Pos + 41] = (char)AdditionalFlags; // Additional Flags
-
-  for (size_t Offset = 0; Offset < 10; Offset++)
-    GOFFData[Pos + 60 + Offset] = (char)BehavioralAttributes[Offset];
-
-  GOFFData[Pos + 71] = (char)(Name.size()); // Size of symbol name.
-  size_t StringOffset = Pos + 72;           // Start of Symbol name
-  for (uint8_t C : Name) {
-    GOFFData[StringOffset] = (char)C;
-    StringOffset++;
-
-    if (StringOffset == Pos + GOFF::RecordLength) {
-      // If we reach the end of the current record, we need to start a new one.
-      GOFFData[Pos + 1] |= 0x01; // Set continuation bit in the current record.
-
-      // start a new continuation record
-      Pos = GOFFData.size();
-      GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
-      GOFFData[Pos] = (char)0x03;
-      GOFFData[Pos + 1] = (char)0x02; // continuation record
-
-      StringOffset = Pos + 3;
-    }
-  }
-}
-
 void constructValidGOFF(const char *Data, size_t Size) {
   StringRef ValidSize(Data, Size);
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
@@ -103,10 +39,86 @@ void constructInvalidGOFF(const char *Data, size_t Size) {
                         "of 80 bytes, but is " +
                         std::to_string(Size) + " bytes"));
 }
+
+class GOFFObjectFileTest : public ::testing::Test {
+protected:
+  std::vector<char> GOFFData;
+  uint8_t RecordCount = 0;
+
+  size_t addNewRecord() {
+    size_t Pos = GOFFData.size();
+    GOFFData.resize(Pos + GOFF::RecordLength);
+    ++RecordCount;
+    return Pos;
+  }
+
+  void addEndRecord() {
+    size_t Pos = addNewRecord();
+    GOFFData[Pos] = (char)0x03;
+    GOFFData[Pos + 1] = (char)0x40; // END record, non-continued.
+    GOFFData[Pos + 11] = (char)RecordCount;
+  }
+
+  void addHdrRecord(uint8_t ArchLevel = 0) {
+    size_t Pos = addNewRecord();
+    GOFFData[Pos] = (char)0x03;
+    GOFFData[Pos + 1] = (char)0xF0; // HDR record, non-continued.
+    GOFFData[Pos + 50] = (char)ArchLevel;
+  }
+
+  void addEsdRecord(uint8_t Type, uint8_t ESDID,
+                    const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
+                    uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
+                    uint8_t AdditionalFlags = 0,
+                    std::array<uint8_t, 10> BehavioralAttributes = {
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    uint32_t Length = 0) {
+    size_t Pos = GOFFData.size();
+    GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
+    ++RecordCount;
+
+    GOFFData[Pos] = (char)0x03;
+    GOFFData[Pos + 3] = (char)Type;
+    GOFFData[Pos + 7] = (char)ESDID;           // ESDID.
+    GOFFData[Pos + 11] = (char)ParentESDID;    // Parent ESDID.
+    GOFFData[Pos + 24] = (char)(Length >> 24); // Length (big-endian).
+    GOFFData[Pos + 25] = (char)(Length >> 16);
+    GOFFData[Pos + 26] = (char)(Length >> 8);
+    GOFFData[Pos + 27] = (char)(Length);
+    GOFFData[Pos + 40] = (char)NameSpaceID;     // Name Space ID
+    GOFFData[Pos + 41] = (char)AdditionalFlags; // Additional Flags
+
+    for (size_t Offset = 0; Offset < 10; Offset++)
+      GOFFData[Pos + 60 + Offset] = (char)BehavioralAttributes[Offset];
+
+    GOFFData[Pos + 71] = (char)(Name.size()); // Size of symbol name.
+    size_t StringOffset = Pos + 72;           // Start of Symbol name
+    for (uint8_t C : Name) {
+      GOFFData[StringOffset] = (char)C;
+      StringOffset++;
+
+      if (StringOffset == Pos + GOFF::RecordLength) {
+        // If we reach the end of the current record, we need to start a new
+        // one.
+        GOFFData[Pos + 1] |= 0x01; // Set continuation bit in the current
+                                    // record.
+
+        // start a new continuation record
+        Pos = GOFFData.size();
+        GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
+        ++RecordCount;
+        GOFFData[Pos] = (char)0x03;
+        GOFFData[Pos + 1] = (char)0x02; // continuation record
+
+        StringOffset = Pos + 3;
+      }
+    }
+  }
+};
 } // namespace
 
-TEST(GOFFObjectFileTest, createObjectFile) {
-  const uint8_t GOFFData[] = {
+TEST_F(GOFFObjectFileTest, createObjectFile) {
+  const uint8_t Data[] = {
       0x03, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -122,7 +134,7 @@ TEST(GOFFObjectFileTest, createObjectFile) {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x00,
   };
-  ArrayRef<uint8_t> GOFFRef(GOFFData, sizeof(GOFFData));
+  ArrayRef<uint8_t> GOFFRef(Data, sizeof(Data));
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createObjectFile(
           MemoryBufferRef(toStringRef(GOFFRef), "dummyGOFF"),
@@ -130,36 +142,31 @@ TEST(GOFFObjectFileTest, createObjectFile) {
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 }
 
-TEST(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, ConstructGOFFObjectValidSize) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
 
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   constructValidGOFF(GOFFData.data(), GOFFData.size());
   constructValidGOFF(GOFFData.data(), 0);
 }
 
-TEST(GOFFObjectFileTest, ConstructGOFFObjectInvalidSize) {
-  std::vector<char> GOFFData;
+TEST_F(GOFFObjectFileTest, ConstructGOFFObjectInvalidSize) {
   GOFFData.resize(GOFF::RecordLength * 3);
   constructInvalidGOFF(GOFFData.data(), 70);
   constructInvalidGOFF(GOFFData.data(), 79);
   constructInvalidGOFF(GOFFData.data(), 81);
 }
 
-TEST(GOFFObjectFileTest, MissingHDR) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, MissingHDR) {
   // ESD record.
-  size_t Pos = addNewRecord(GOFFData);
+  size_t Pos = addNewRecord();
   GOFFData[Pos] = (char)0x03;
 
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -172,14 +179,12 @@ TEST(GOFFObjectFileTest, MissingHDR) {
       FailedWithMessage("object file must start with HDR record"));
 }
 
-TEST(GOFFObjectFileTest, MissingEND) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, MissingEND) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
 
   // ESD record.
-  size_t Pos = addNewRecord(GOFFData);
+  size_t Pos = addNewRecord();
   GOFFData[Pos] = (char)0x03;
 
   StringRef Data(GOFFData.data(), GOFFData.size());
@@ -192,14 +197,12 @@ TEST(GOFFObjectFileTest, MissingEND) {
       GOFFObjOrErr, FailedWithMessage("object file must end with END record"));
 }
 
-TEST(GOFFObjectFileTest, GetSymbolName) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, GetSymbolName) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
 
   // ESD record. Symbol name is Hello.
-  addEsdRecord(GOFFData, 0x02, 0x01,
+  addEsdRecord(0x02, 0x01,
                {0xC8,  // H
                 0x85,  // e
                 0x93,  // l
@@ -208,7 +211,7 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
                0x01);
 
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -230,23 +233,21 @@ TEST(GOFFObjectFileTest, GetSymbolName) {
   }
 }
 
-TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, ConcatenatedGOFFFile) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
   // ESD record.
-  size_t Pos = addNewRecord(GOFFData);
+  size_t Pos = addNewRecord();
   GOFFData[Pos] = (char)0x03;
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
   // ESD record.
-  Pos = addNewRecord(GOFFData);
+  Pos = addNewRecord();
   GOFFData[Pos] = (char)0x03;
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -257,14 +258,12 @@ TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
   ASSERT_THAT_EXPECTED(GOFFObjOrErr, Succeeded());
 }
 
-TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
-  std::vector<char> GOFFContData;
-
+TEST_F(GOFFObjectFileTest, ContinuationGetSymbolName) {
   // HDR record.
-  addHdrRecord(GOFFContData);
+  addHdrRecord();
 
   // ESD record with continuation. Symbol name is Helloworld.
-  addEsdRecord(GOFFContData, 0x02, 0x01,
+  addEsdRecord(0x02, 0x01,
                {0xC8,  // H
                 0x85,  // e
                 0x93,  // l
@@ -278,9 +277,9 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
                0x01);
 
   // END record.
-  addEndRecord(GOFFContData);
+  addEndRecord();
 
-  StringRef Data(GOFFContData.data(), GOFFContData.size());
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -299,40 +298,38 @@ TEST(GOFFObjectFileTest, ContinuationGetSymbolName) {
   }
 }
 
-TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
-  std::vector<char> GOFFContData;
-
+TEST_F(GOFFObjectFileTest, ContinuationBitNotSet) {
   // HDR record.
-  addHdrRecord(GOFFContData);
+  addHdrRecord();
 
   // ESD record.
-  size_t Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x01;
-  GOFFContData[Pos + 3] = (char)0x02;
-  GOFFContData[Pos + 7] = (char)0x01;
-  GOFFContData[Pos + 11] = (char)0x01;
-  GOFFContData[Pos + 71] = (char)0x0A; // Size of symbol name.
-  GOFFContData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
-  GOFFContData[Pos + 73] = (char)0x85;
-  GOFFContData[Pos + 74] = (char)0x93;
-  GOFFContData[Pos + 75] = (char)0x93;
-  GOFFContData[Pos + 76] = (char)0x96;
-  GOFFContData[Pos + 77] = (char)0xA6;
-  GOFFContData[Pos + 78] = (char)0x96;
-  GOFFContData[Pos + 79] = (char)0x99;
+  size_t Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x01;
+  GOFFData[Pos + 3] = (char)0x02;
+  GOFFData[Pos + 7] = (char)0x01;
+  GOFFData[Pos + 11] = (char)0x01;
+  GOFFData[Pos + 71] = (char)0x0A; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
+  GOFFData[Pos + 73] = (char)0x85;
+  GOFFData[Pos + 74] = (char)0x93;
+  GOFFData[Pos + 75] = (char)0x93;
+  GOFFData[Pos + 76] = (char)0x96;
+  GOFFData[Pos + 77] = (char)0xA6;
+  GOFFData[Pos + 78] = (char)0x96;
+  GOFFData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x00;
-  GOFFContData[Pos + 3] = (char)0x93;
-  GOFFContData[Pos + 4] = (char)0x84;
+  Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x00;
+  GOFFData[Pos + 3] = (char)0x93;
+  GOFFData[Pos + 4] = (char)0x84;
 
   // END record.
-  addEndRecord(GOFFContData);
+  addEndRecord();
 
-  StringRef Data(GOFFContData.data(), GOFFContData.size());
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -343,40 +340,38 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
                         "preceding record is continued"));
 }
 
-TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
-  std::vector<char> GOFFContData;
-
+TEST_F(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   // HDR record.
-  addHdrRecord(GOFFContData);
+  addHdrRecord();
 
   // ESD record.
-  size_t Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x01;
-  GOFFContData[Pos + 3] = (char)0x02;
-  GOFFContData[Pos + 7] = (char)0x01;
-  GOFFContData[Pos + 11] = (char)0x01;
-  GOFFContData[Pos + 71] = (char)0x0A; // Size of symbol name.
-  GOFFContData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
-  GOFFContData[Pos + 73] = (char)0x85;
-  GOFFContData[Pos + 74] = (char)0x93;
-  GOFFContData[Pos + 75] = (char)0x93;
-  GOFFContData[Pos + 76] = (char)0x96;
-  GOFFContData[Pos + 77] = (char)0xA6;
-  GOFFContData[Pos + 78] = (char)0x96;
-  GOFFContData[Pos + 79] = (char)0x99;
+  size_t Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x01;
+  GOFFData[Pos + 3] = (char)0x02;
+  GOFFData[Pos + 7] = (char)0x01;
+  GOFFData[Pos + 11] = (char)0x01;
+  GOFFData[Pos + 71] = (char)0x0A; // Size of symbol name.
+  GOFFData[Pos + 72] = (char)0xC8; // Symbol name is HelloWorld.
+  GOFFData[Pos + 73] = (char)0x85;
+  GOFFData[Pos + 74] = (char)0x93;
+  GOFFData[Pos + 75] = (char)0x93;
+  GOFFData[Pos + 76] = (char)0x96;
+  GOFFData[Pos + 77] = (char)0xA6;
+  GOFFData[Pos + 78] = (char)0x96;
+  GOFFData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x03; // Continued bit set.
-  GOFFContData[Pos + 3] = (char)0x93;
-  GOFFContData[Pos + 4] = (char)0x84;
+  Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x03; // Continued bit set.
+  GOFFData[Pos + 3] = (char)0x93;
+  GOFFData[Pos + 4] = (char)0x84;
 
   // END record.
-  addEndRecord(GOFFContData);
+  addEndRecord();
 
-  StringRef Data(GOFFContData.data(), GOFFContData.size());
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -393,25 +388,23 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   }
 }
 
-TEST(GOFFObjectFileTest, PrevNotContinued) {
-  std::vector<char> GOFFContData;
-
+TEST_F(GOFFObjectFileTest, PrevNotContinued) {
   // HDR record.
-  addHdrRecord(GOFFContData);
+  addHdrRecord();
 
   // ESD record, with continued bit not set.
-  size_t Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
+  size_t Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
 
   // ESD continuation record.
-  Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x02;
+  Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x02;
 
   // END record.
-  addEndRecord(GOFFContData);
+  addEndRecord();
 
-  StringRef Data(GOFFContData.data(), GOFFContData.size());
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -423,26 +416,24 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
                         "preceded by a continued record"));
 }
 
-TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
-  std::vector<char> GOFFContData;
-
+TEST_F(GOFFObjectFileTest, ContinuationTypeMismatch) {
   // HDR record.
-  addHdrRecord(GOFFContData);
+  addHdrRecord();
 
   // ESD record.
-  size_t Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x01; // Continued to next record.
+  size_t Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x01; // Continued to next record.
 
   // END continuation record.
-  Pos = addNewRecord(GOFFContData);
-  GOFFContData[Pos] = (char)0x03;
-  GOFFContData[Pos + 1] = (char)0x42;
+  Pos = addNewRecord();
+  GOFFData[Pos] = (char)0x03;
+  GOFFData[Pos + 1] = (char)0x42;
 
   // END record.
-  addEndRecord(GOFFContData);
+  addEndRecord();
 
-  StringRef Data(GOFFContData.data(), GOFFContData.size());
+  StringRef Data(GOFFData.data(), GOFFData.size());
 
   Expected<std::unique_ptr<ObjectFile>> GOFFObjOrErr =
       object::ObjectFile::createGOFFObjectFile(
@@ -454,17 +445,15 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
                         "the type of the previous record"));
 }
 
-TEST(GOFFObjectFileTest, TwoSymbols) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, TwoSymbols) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
 
   // ESD record 1. Symbol name is x.
-  addEsdRecord(GOFFData, 0x00, 0x01, {0xa7}); // x
+  addEsdRecord(0x00, 0x01, {0xa7}); // x
 
   // ESD record 2. Symbol name is Hello.
-  addEsdRecord(GOFFData, 0x03, 0x02,
+  addEsdRecord(0x03, 0x02,
                {0xC8,  // H
                 0x85,  // e
                 0x93,  // l
@@ -473,7 +462,7 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
                0x01);
 
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -494,18 +483,16 @@ TEST(GOFFObjectFileTest, TwoSymbols) {
   }
 }
 
-TEST(GOFFObjectFileTest, InvalidSymbolType) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, InvalidSymbolType) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
 
   // ESD record with invalid symbol type 0x05.
-  addEsdRecord(GOFFData, 0x05, 0x01, {0xC8}, // H
+  addEsdRecord(0x05, 0x01, {0xC8}, // H
                0x01);
 
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -532,14 +519,12 @@ TEST(GOFFObjectFileTest, InvalidSymbolType) {
   }
 }
 
-TEST(GOFFObjectFileTest, InvalidERSymbolType) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, InvalidERSymbolType) {
   // HDR record.
-  addHdrRecord(GOFFData);
+  addHdrRecord();
 
   // ESD record.
-  size_t Pos = addNewRecord(GOFFData);
+  size_t Pos = addNewRecord();
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 3] = (char)0x04;
   GOFFData[Pos + 7] = (char)0x01;
@@ -549,7 +534,7 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
   GOFFData[Pos + 72] = (char)0xC8; // Symbol name.
 
   // END record.
-  addEndRecord(GOFFData);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 
@@ -570,14 +555,12 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
   }
 }
 
-TEST(GOFFObjectFileTest, TXTConstruct) {
-  std::vector<char> GOFFData;
-
+TEST_F(GOFFObjectFileTest, TXTConstruct) {
   // HDR record.
-  addHdrRecord(GOFFData, 0x01);
+  addHdrRecord(0x01);
 
   // ESD record. Symbol name is var#c.
-  addEsdRecord(GOFFData, 0x00, 0x01,
+  addEsdRecord(0x00, 0x01,
                {0xa5,   // v
                 0x81,   // a
                 0x99,   // r
@@ -587,7 +570,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   // ESD record. Symbol name is c_CoDE64.
   std::array<uint8_t, 10> BehavioralAttributes = {0x04, 0x04, 0x00, 0x0a, 0x00,
                                                   0x00, 0x03, 0x00, 0x00, 0x00};
-  addEsdRecord(GOFFData, 0x01, 0x02,
+  addEsdRecord(0x01, 0x02,
                {0xc3,  // c
                 0x6d,  // _
                 0xc3,  // c
@@ -599,7 +582,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
                0x01, 0x00, 0x01, 0x80, BehavioralAttributes, 0x08);
 
   // ESD record. Symbol name is var#c.
-  addEsdRecord(GOFFData, 0x02, 0x03,
+  addEsdRecord(0x02, 0x03,
                {0xa5,  // v
                 0x81,  // a
                 0x99,  // r
@@ -608,7 +591,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
                0x02);
 
   // TXT record.
-  size_t Pos = addNewRecord(GOFFData);
+  size_t Pos = addNewRecord();
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0x10;
   GOFFData[Pos + 7] = (char)0x02;
@@ -623,7 +606,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
   GOFFData[Pos + 31] = (char)0xf0;
 
   // END record.
-  addEndRecord(GOFFData, 0x06);
+  addEndRecord();
 
   StringRef Data(GOFFData.data(), GOFFData.size());
 

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -70,8 +70,7 @@ protected:
   addEsdRecord(uint8_t Type, uint8_t ESDID, const std::vector<uint8_t> &Name,
                uint8_t ParentESDID = 0, uint8_t BindingScope = 0,
                uint8_t NameSpaceID = 0, uint8_t AdditionalFlags = 0,
-               std::array<uint8_t, 10> BehavioralAttributes = {0, 0, 0, 0, 0, 0,
-                                                               0, 0, 0, 0},
+               std::array<uint8_t, 10> BehavioralAttributes = {},
                uint32_t Length = 0) {
     size_t Pos = GOFFData.size();
     GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
@@ -95,7 +94,7 @@ protected:
     size_t StringOffset = Pos + 72;           // Start of Symbol name
     for (uint8_t C : Name) {
       GOFFData[StringOffset] = (char)C;
-      StringOffset++;
+      ++StringOffset;
 
       if (StringOffset == Pos + GOFF::RecordLength) {
         // If we reach the end of the current record, we need to start a new

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -17,21 +17,21 @@ using namespace llvm::object;
 using namespace llvm::GOFF;
 
 namespace {
-size_t newRecord(std::vector<char> &Data) {
+size_t addNewRecord(std::vector<char> &Data) {
   size_t Pos = Data.size();
   Data.resize(Pos + GOFF::RecordLength);
   return Pos;
 }
 
 void addEndRecord(std::vector<char> &GOFFData, uint8_t RecordCount = 0) {
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0x40;
   GOFFData[Pos + 11] = (char)RecordCount;
 }
 
 void addHdrRecord(std::vector<char> &GOFFData, uint8_t ArchLevel = 0) {
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0xF0;
   GOFFData[Pos + 50] = (char)ArchLevel;
@@ -157,7 +157,7 @@ TEST(GOFFObjectFileTest, MissingHDR) {
   std::vector<char> GOFFData;
 
   // ESD record.
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
 
   // END record.
@@ -181,7 +181,7 @@ TEST(GOFFObjectFileTest, MissingEND) {
   addHdrRecord(GOFFData);
 
   // ESD record.
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
 
   StringRef Data(GOFFData.data(), GOFFData.size());
@@ -238,14 +238,14 @@ TEST(GOFFObjectFileTest, ConcatenatedGOFFFile) {
   // HDR record.
   addHdrRecord(GOFFData);
   // ESD record.
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   // END record.
   addEndRecord(GOFFData);
   // HDR record.
   addHdrRecord(GOFFData);
   // ESD record.
-  Pos = newRecord(GOFFData);
+  Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   // END record.
   addEndRecord(GOFFData);
@@ -308,7 +308,7 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
   addHdrRecord(GOFFContData);
 
   // ESD record.
-  size_t Pos = newRecord(GOFFContData);
+  size_t Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x01;
   GOFFContData[Pos + 3] = (char)0x02;
@@ -325,7 +325,7 @@ TEST(GOFFObjectFileTest, ContinuationBitNotSet) {
   GOFFContData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  Pos = newRecord(GOFFContData);
+  Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x00;
   GOFFContData[Pos + 3] = (char)0x93;
@@ -352,7 +352,7 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   addHdrRecord(GOFFContData);
 
   // ESD record.
-  size_t Pos = newRecord(GOFFContData);
+  size_t Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x01;
   GOFFContData[Pos + 3] = (char)0x02;
@@ -369,7 +369,7 @@ TEST(GOFFObjectFileTest, ContinuationRecordNotTerminated) {
   GOFFContData[Pos + 79] = (char)0x99;
 
   // ESD continuation record.
-  Pos = newRecord(GOFFContData);
+  Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x03; // Continued bit set.
   GOFFContData[Pos + 3] = (char)0x93;
@@ -402,11 +402,11 @@ TEST(GOFFObjectFileTest, PrevNotContinued) {
   addHdrRecord(GOFFContData);
 
   // ESD record, with continued bit not set.
-  size_t Pos = newRecord(GOFFContData);
+  size_t Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
 
   // ESD continuation record.
-  Pos = newRecord(GOFFContData);
+  Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x02;
 
@@ -432,12 +432,12 @@ TEST(GOFFObjectFileTest, ContinuationTypeMismatch) {
   addHdrRecord(GOFFContData);
 
   // ESD record.
-  size_t Pos = newRecord(GOFFContData);
+  size_t Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x01; // Continued to next record.
 
   // END continuation record.
-  Pos = newRecord(GOFFContData);
+  Pos = addNewRecord(GOFFContData);
   GOFFContData[Pos] = (char)0x03;
   GOFFContData[Pos + 1] = (char)0x42;
 
@@ -541,7 +541,7 @@ TEST(GOFFObjectFileTest, InvalidERSymbolType) {
   addHdrRecord(GOFFData);
 
   // ESD record.
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 3] = (char)0x04;
   GOFFData[Pos + 7] = (char)0x01;
@@ -610,7 +610,7 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
                0x02);
 
   // TXT record.
-  size_t Pos = newRecord(GOFFData);
+  size_t Pos = addNewRecord(GOFFData);
   GOFFData[Pos] = (char)0x03;
   GOFFData[Pos + 1] = (char)0x10;
   GOFFData[Pos + 7] = (char)0x02;

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -70,7 +70,7 @@ void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
 
     if (StringOffset == Pos + GOFF::RecordLength) {
       // If we reach the end of the current record, we need to start a new one.
-      GOFFData[Pos + 1] |= 0x01; // set continuation bit in the current record.
+      GOFFData[Pos + 1] |= 0x01; // Set continuation bit in the current record.
 
       // start a new continuation record
       Pos = GOFFData.size();

--- a/llvm/unittests/Object/GOFFObjectFileTest.cpp
+++ b/llvm/unittests/Object/GOFFObjectFileTest.cpp
@@ -41,7 +41,7 @@ void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
                   const std::vector<uint8_t> &Name, uint8_t ParentESDID = 0,
                   uint8_t BindingScope = 0, uint8_t NameSpaceID = 0,
                   uint8_t AdditionalFlags = 0,
-                  uint8_t BehavioralAttributes[10] = nullptr,
+                  std::array<uint8_t, 10> BehavioralAttributes = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
                   uint32_t Length = 0) {
   size_t Pos = GOFFData.size();
   GOFFData.resize(GOFFData.size() + GOFF::RecordLength);
@@ -57,10 +57,8 @@ void addEsdRecord(std::vector<char> &GOFFData, uint8_t Type, uint8_t ESDID,
   GOFFData[Pos + 40] = (char)NameSpaceID;     // Name Space ID
   GOFFData[Pos + 41] = (char)AdditionalFlags; // Additional Flags
 
-  if (BehavioralAttributes) {
-    for (size_t Offset = 0; Offset < 10; Offset++)
-      GOFFData[Pos + 60 + Offset] = (char)BehavioralAttributes[Offset];
-  }
+  for (size_t Offset = 0; Offset < 10; Offset++)
+    GOFFData[Pos + 60 + Offset] = (char)BehavioralAttributes[Offset];
 
   GOFFData[Pos + 71] = (char)(Name.size()); // Size of symbol name.
   size_t StringOffset = Pos + 72;           // Start of Symbol name
@@ -587,8 +585,8 @@ TEST(GOFFObjectFileTest, TXTConstruct) {
                 0x83}); // c
 
   // ESD record. Symbol name is c_CoDE64.
-  uint8_t BehavioralAttributes[] = {0x04, 0x04, 0x00, 0x0a, 0x00,
-                                    0x00, 0x03, 0x00, 0x00, 0x00};
+  std::array<uint8_t, 10> BehavioralAttributes = {0x04, 0x04, 0x00, 0x0a, 0x00,
+                                                  0x00, 0x03, 0x00, 0x00, 0x00};
   addEsdRecord(GOFFData, 0x01, 0x02,
                {0xc3,  // c
                 0x6d,  // _


### PR DESCRIPTION
This change cleans up the GOFF object file reading unit test based on suggestions from #211632, and a few minor fixes for other issues identified

Namely these are:

1. Remove global data from the test, making all data local to the test being run
2. Fix erroneous reference to XCOFF rather than GOFF
3. Use vector rather statically size arrays for the test data
4. Use helpers to construct the data for repeated record types (we leave trivial and one off cases as-is)
5. Swap uses of dyn_cast for static_cast

I've tried to build these up as simpler logical changes in the commits on this branch, to hopefully aid reviewers by showing each individual transformation.

Assisted by: IBM Bob 2.0.1