### PR TITLE
[Codegen] Replace any_of with is_contained. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.h
+++ b/llvm/include/llvm/CodeGen/ValueTypes.h
@@ -595,6 +595,8 @@ namespace llvm {
     LLVM_ABI TypeSize getExtendedSizeInBits() const LLVM_READONLY;
   };
 
+  inline bool operator==(MVT::SimpleValueType SVT, EVT VT) { return VT == SVT; }
+
   inline raw_ostream &operator<<(raw_ostream &OS, const EVT &V) {
     V.print(OS);
     return OS;

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -714,7 +714,7 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     // v2i64 types get converted to cmp+bif hence the cost of 2
     if (LT.second == MVT::v2i64)
       return LT.first * 2;
-    if (any_of(ValidMinMaxTys, equal_to(LT.second)))
+    if (is_contained(ValidMinMaxTys, LT.second))
       return LT.first;
     break;
   }
@@ -751,7 +751,7 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     // need to extend the type, as it uses shr(qadd(shl, shl)).
     unsigned Instrs =
         LT.second.getScalarSizeInBits() == RetTy->getScalarSizeInBits() ? 1 : 4;
-    if (any_of(ValidSatTys, equal_to(LT.second)))
+    if (is_contained(ValidSatTys, LT.second))
       return LT.first * Instrs;
 
     TypeSize TS = getDataLayout().getTypeSizeInBits(RetTy);
@@ -768,7 +768,7 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
                                      MVT::v2i64,   MVT::nxv16i8, MVT::nxv8i16,
                                      MVT::nxv4i32, MVT::nxv2i64};
     auto LT = getTypeLegalizationCost(RetTy);
-    if (any_of(ValidAbsTys, equal_to(LT.second)))
+    if (is_contained(ValidAbsTys, LT.second))
       return LT.first;
     break;
   }
@@ -776,7 +776,7 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     static const auto ValidAbsTys = {MVT::v4i16, MVT::v8i16, MVT::v2i32,
                                      MVT::v4i32, MVT::v2i64};
     auto LT = getTypeLegalizationCost(RetTy);
-    if (any_of(ValidAbsTys, equal_to(LT.second)) &&
+    if (is_contained(ValidAbsTys, LT.second) &&
         LT.second.getScalarSizeInBits() == RetTy->getScalarSizeInBits())
       return LT.first;
     break;
@@ -5037,9 +5037,8 @@ InstructionCost AArch64TTIImpl::getCmpSelInstrCost(
       static const auto ValidFP16MinMaxTys = {MVT::v4f16, MVT::v8f16};
 
       auto LT = getTypeLegalizationCost(ValTy);
-      if (any_of(ValidMinMaxTys, equal_to(LT.second)) ||
-          (ST->hasFullFP16() &&
-           any_of(ValidFP16MinMaxTys, equal_to(LT.second))))
+      if (is_contained(ValidMinMaxTys, LT.second) ||
+          (ST->hasFullFP16() && is_contained(ValidFP16MinMaxTys, LT.second)))
         return LT.first;
     }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -936,7 +936,7 @@ GCNTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
       InstRate = getFullRateInstrCost();
 
     static const auto ValidSatTys = {MVT::v2i16, MVT::v4i16};
-    if (any_of(ValidSatTys, equal_to(LT.second)))
+    if (is_contained(ValidSatTys, LT.second))
       NElts = 1;
     break;
   }

--- a/llvm/lib/Target/NVPTX/NVPTXUtilities.h
+++ b/llvm/lib/Target/NVPTX/NVPTXUtilities.h
@@ -84,7 +84,7 @@ inline auto packed_types() {
 
 // Checks if the type VT can fit into a single register.
 inline bool isPackedVectorTy(EVT VT) {
-  return any_of(packed_types(), equal_to(VT));
+  return is_contained(packed_types(), VT);
 }
 
 // Checks if two or more of the type ET can fit into a single register.

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -3997,7 +3997,7 @@ static bool isAnyInRange(ArrayRef<int> Mask, int Low, int Hi) {
 
 /// Return true if the value of any element in Mask is the zero sentinel value.
 static bool isAnyZero(ArrayRef<int> Mask) {
-  return llvm::any_of(Mask, equal_to(SM_SentinelZero));
+  return llvm::is_contained(Mask, SM_SentinelZero);
 }
 
 /// Return true if Val is undef or if its value falls within the

--- a/llvm/lib/Transforms/Utils/LoopUnroll.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnroll.cpp
@@ -1729,7 +1729,7 @@ llvm::canParallelizeReductionWhenUnrolling(PHINode &Phi, Loop *L,
       RecurKind::FMaximumNum, RecurKind::FMulAdd};
   // Skip unsupported reductions, including sub, any-of and find-last.
   // TODO: Handle sub, any-of and find-last reductions.
-  if (!any_of(ValidRKs, equal_to(RK)))
+  if (!is_contained(ValidRKs, RK))
     return std::nullopt;
 
   if (RdxDesc.hasExactFPMath())


### PR DESCRIPTION
A new operator== for SVT and EVT was apparently needed with reverse operands.