### PR TITLE
[lldb-dap][Windows] Respect debug-heap setting when launching

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -453,6 +453,11 @@ class _LocalProcess(_BaseProcess):
         self._delayafterterminate = 0.1
 
     @property
+    def args(self):
+        assert self._proc is not None, "No process"
+        return self._proc.args
+
+    @property
     def pid(self):
         assert self._proc is not None, "No process"
         return self._proc.pid

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -539,7 +539,12 @@ class _LocalProcess(_BaseProcess):
 class _RemoteProcess(_BaseProcess):
     def __init__(self, install_remote):
         self._pid = None
+        self._args = None
         self._install_remote = install_remote
+
+    @property
+    def args(self):
+        assert self._args
 
     @property
     def pid(self):
@@ -582,6 +587,7 @@ class _RemoteProcess(_BaseProcess):
                 "remote_platform.Launch('%s', '%s') failed: %s" % (dst_path, args, err)
             )
         self._pid = launch_info.GetProcessID()
+        self._args = args
 
     def terminate(self):
         lldb.remote_platform.Kill(self._pid)

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb_dap/session.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb_dap/session.py
@@ -448,7 +448,7 @@ class Session:
 
     def verify_reverse_process_exited(self, exit_code: Optional[int] = None):
         if process := self._reverse_process:
-            proc_exit_code = process.poll()
+            proc_exit_code = process.wait(timeout=1.0)
             if proc_exit_code is None:
                 raise DAPError(
                     f"process is still running, "

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
@@ -1,0 +1,66 @@
+"""
+Test lldb-dap launch request.
+"""
+
+from lldbsuite.test.decorators import skipUnlessWindows
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, Console
+from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from typing import List
+
+
+@skipUnlessWindows
+class TestDAP_launch_win_debug_heap(DAPTestCaseBase):
+    """
+    Test that lldb-dap respects the debug heap setting on Windows when launching in an integrated terminal.
+    """
+
+    def run_with(self, *, env: List[str] = [], init_commands: List[str] = []):
+        program = self.getBuildArtifact("a.out")
+        session = self.build_and_create_session()
+        process_event = session.launch(
+            LaunchArgs(
+                program=program,
+                env=env,
+                initCommands=init_commands,
+                console=Console.INTEGRATED_TERMINAL,
+            )
+        )
+        session.verify_process_exited(after=process_event)
+
+        output = session.get_stdout()
+        self.assertTrue(output, "expect program output")
+
+        return "\n".join(l for l in output.splitlines() if l.startswith("env["))
+
+    def test_default(self):
+        env_output = self.run_with()
+        self.assertIn("_NO_DEBUG_HEAP=1", env_output)
+
+    def test_default_overwrite(self):
+        env_output = self.run_with(env=["_NO_DEBUG_HEAP=2"])
+        self.assertIn("_NO_DEBUG_HEAP=2", env_output)
+
+    def test_enabled(self):
+        env_output = self.run_with(
+            init_commands=[
+                "settings set platform.plugin.windows.disable-debug-heap true"
+            ],
+        )
+        self.assertIn("_NO_DEBUG_HEAP=1", env_output)
+
+    def test_disabled(self):
+        env_output = self.run_with(
+            init_commands=[
+                "settings set platform.plugin.windows.disable-debug-heap false"
+            ]
+        )
+        self.assertNotIn("_NO_DEBUG_HEAP", env_output)
+
+    def test_disabled_overwrite(self):
+        env_output = self.run_with(
+            env=["_NO_DEBUG_HEAP=2"],
+            init_commands=[
+                "settings set platform.plugin.windows.disable-debug-heap false"
+            ],
+        )
+        self.assertIn("_NO_DEBUG_HEAP=2", env_output)

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
@@ -2,12 +2,13 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipUnlessWindows
+from lldbsuite.test.decorators import skipUnlessWindows, skipIfBuildType
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, Console
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from typing import List
 
 
+@skipIfBuildType(["debug"])
 @skipUnlessWindows
 class TestDAP_launch_win_debug_heap(DAPTestCaseBase):
     """
@@ -31,10 +32,6 @@ class TestDAP_launch_win_debug_heap(DAPTestCaseBase):
         self.assertTrue(output, "expect program output")
 
         return "\n".join(l for l in output.splitlines() if l.startswith("env["))
-
-    def test_default(self):
-        env_output = self.run_with()
-        self.assertIn("_NO_DEBUG_HEAP=1", env_output)
 
     def test_default_overwrite(self):
         env_output = self.run_with(env=["_NO_DEBUG_HEAP=2"])

--- a/lldb/test/API/tools/lldb-dap/launch/io/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/launch/io/main.cpp
@@ -26,13 +26,6 @@ int main(int argc, char *argv[]) {
     std::cout << "[STDOUT][FROM_ENV]: " << env << "\n";
     std::cerr << "[STDERR][FROM_ENV]: " << env << "\n";
   }
-#ifdef _WIN32
-  const char *win_nodebugheap = std::getenv("_NO_DEBUG_HEAP");
-  if (!win_nodebugheap || std::strcmp(win_nodebugheap, "1") != 0) {
-    std::cout << "Invalid or missing _NO_DEBUG_HEAP\n";
-    return 1;
-  }
-#endif
   if (read_stdin) {
     std::string line;
     if (std::getline(std::cin, line)) {

--- a/lldb/test/API/tools/lldb-dap/launch/io/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/launch/io/main.cpp
@@ -26,6 +26,13 @@ int main(int argc, char *argv[]) {
     std::cout << "[STDOUT][FROM_ENV]: " << env << "\n";
     std::cerr << "[STDERR][FROM_ENV]: " << env << "\n";
   }
+#ifdef _WIN32
+  const char *win_nodebugheap = std::getenv("_NO_DEBUG_HEAP");
+  if (!win_nodebugheap || std::strcmp(win_nodebugheap, "1") != 0) {
+    std::cout << "Invalid or missing _NO_DEBUG_HEAP\n";
+    return 1;
+  }
+#endif
   if (read_stdin) {
     std::string line;
     if (std::getline(std::cin, line)) {

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -130,6 +130,8 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
         self.assertIn(program, request["arguments"]["args"])
         self.assertIn("foobar", request["arguments"]["args"])
         self.assertIn("FOO", request["arguments"]["env"])
+        if sys.platform == "win32":
+            self.assertIn("_NO_DEBUG_HEAP", request["arguments"]["env"])
 
         breakpoint_line = line_number(source, "// breakpoint")
 
@@ -150,6 +152,10 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
         # We verify we were able to set the environment
         env = self.dap_server.request_evaluate("foo")["body"]["result"]
         self.assertIn("bar", env)
+
+        if sys.platform == "win32":
+            env = self.dap_server.request_evaluate("nodebugheap")["body"]["result"]
+            self.assertIn('"1"', env)
 
         self.continue_to_exit()
 

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/main.c
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/main.c
@@ -8,6 +8,7 @@
 
 int main(int argc, char *argv[]) {
   const char *foo = getenv("FOO");
+  const char *nodebugheap = getenv("_NO_DEBUG_HEAP");
   int counter = 1;
 
   return 0; // breakpoint

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -96,6 +96,13 @@ RunInTerminal(DAP &dap, const protocol::LaunchRequestArguments &arguments) {
     return llvm::make_error<DAPError>(
         "program must be set to when using runInTerminal");
 
+  llvm::StringMap<protocol::String> env = arguments.env;
+#ifdef _WIN32
+  if (dap.debugger.GetSetting("platform.plugin.windows.disable-debug-heap")
+          .GetBooleanValue(true))
+    env.try_emplace("_NO_DEBUG_HEAP", "1");
+#endif
+
   dap.is_attach = true;
   lldb::SBAttachInfo attach_info;
 
@@ -113,8 +120,8 @@ RunInTerminal(DAP &dap, const protocol::LaunchRequestArguments &arguments) {
 #endif
 
   llvm::json::Object reverse_request = CreateRunInTerminalReverseRequest(
-      arguments.configuration.program, arguments.args, arguments.env,
-      arguments.cwd, comm_file->GetPath(), debugger_pid, arguments.stdio,
+      arguments.configuration.program, arguments.args, env, arguments.cwd,
+      comm_file->GetPath(), debugger_pid, arguments.stdio,
       arguments.console == protocol::eConsoleExternalTerminal);
   dap.SendReverseRequest<LogFailureResponseHandler>("runInTerminal",
                                                     std::move(reverse_request));


### PR DESCRIPTION
In #212126, a setting was added to control the heap used when debugging on Windows. By default, we disable the debug-heap with `_NO_DEBUG_HEAP=1`. When launching a program from lldb-dap with `integratedTerminal` or `externalTerminal`, we need to tell the client about that variable.

This adds the variable in the runInTerminal reverse request if needed.

Closes #201690.