### PR TITLE
[VPlan] Use DIV nuw when optimizing latch exit user

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1028,6 +1028,8 @@ static VPValue *optimizeLatchExitIVUserViaSCEV(VPlan &Plan, VPValue *Op,
   if (!StartVPV || !StepVPV)
     return nullptr;
 
+  auto *AR = cast<SCEVAddRecExpr>(IncomingSCEV);
+  VPIRFlags::WrapFlagsTy Flags = {AR->hasNoUnsignedWrap(), false};
   Type *StartTy = StartVPV->getScalarType();
   assert(StartTy->isIntOrPtrTy() && "The type must be SCEVable");
   InductionDescriptor::InductionKind Kind =
@@ -1038,7 +1040,7 @@ static VPValue *optimizeLatchExitIVUserViaSCEV(VPlan &Plan, VPValue *Op,
       Instruction::Sub, {ResumeTC, Plan.getConstantInt(TCTy, 1)},
       {/*HasNUW=*/true, /*HasNSW=*/false}, DebugLoc::getUnknown());
   return Builder.createDerivedIV(Kind, /*FPBinOp=*/nullptr, StartVPV, ExitCount,
-                                 StepVPV);
+                                 StepVPV, Flags);
 }
 
 void VPlanTransforms::optimizeInductionLiveOutUsers(

--- a/llvm/test/Transforms/LoopVectorize/iv_outside_user.ll
+++ b/llvm/test/Transforms/LoopVectorize/iv_outside_user.ll
@@ -647,7 +647,7 @@ define i32 @postinc_not_iv_backedge_value(i32 %k)  {
 ; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], {{!llvm.loop ![0-9]+}}
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = sub nuw i32 [[N_VEC]], 1
-; CHECK-NEXT:    [[TMP2:%.*]] = add i32 2, [[TMP1]]
+; CHECK-NEXT:    [[TMP2:%.*]] = add nuw i32 2, [[TMP1]]
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[K]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label %[[FOR_END:.*]], label %[[SCALAR_PH]]
 ; CHECK:       [[SCALAR_PH]]:


### PR DESCRIPTION
Propagate no-unsigned-wrap from the incoming AddRec to the DerivedIV recipe in optimizeLatchExitIVUserViaSCEV.

Proof: https://alive2.llvm.org/ce/z/qBkcsg