### PR TITLE
[MIR2Vec] Handle machine functions with no basic blocks

### DIFF
--- a/llvm/lib/CodeGen/MIR2Vec.cpp
+++ b/llvm/lib/CodeGen/MIR2Vec.cpp
@@ -554,6 +554,9 @@ Embedding MIREmbedder::computeEmbeddings(const MachineBasicBlock &MBB) const {
 Embedding MIREmbedder::computeEmbeddings() const {
   Embedding MFuncVector(Dimension, 0);
 
+  if (MF.empty())
+    return MFuncVector;
+
   // Consider all reachable machine basic blocks in the function
   for (const auto *MBB : depth_first(&MF))
     MFuncVector += computeEmbeddings(*MBB);

--- a/llvm/test/CodeGen/MIR2Vec/empty-machine-function.mir
+++ b/llvm/test/CodeGen/MIR2Vec/empty-machine-function.mir
@@ -6,6 +6,8 @@
 # the zero vector instead.
 
 --- |
+  target triple = "x86_64-unknown-linux-gnu"
+
   define void @no_body() { ret void }
 
   define void @has_body() { ret void }

--- a/llvm/test/CodeGen/MIR2Vec/empty-machine-function.mir
+++ b/llvm/test/CodeGen/MIR2Vec/empty-machine-function.mir
@@ -1,0 +1,35 @@
+# REQUIRES: x86-registered-target
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -run-pass=none -print-mir2vec -mir2vec-vocab-path=%S/Inputs/mir2vec_dummy_3D_vocab.json %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: llvm-ir2vec triplets --mode=mir %s -o /dev/null
+
+# A function whose MIR body is absent embeds to
+# the zero vector instead.
+
+--- |
+  define void @no_body() { ret void }
+
+  define void @has_body() { ret void }
+...
+---
+name:            has_body
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    RET 0
+...
+
+# The function vector is zero and there are no blocks to list.
+
+# CHECK: MIR2Vec embeddings for machine function no_body:
+# CHECK-NEXT: Machine Function vector:  [ 0.00  0.00  0.00 ]
+# CHECK-NEXT: Machine basic block vectors:
+# CHECK-NEXT: Machine instruction vectors:
+
+# A function in the same module still embeds normally: RET = [1.0 1.1 1.2]
+# plus the [0.1 0.1 0.1] immediate operand.
+
+# CHECK-NEXT: MIR2Vec embeddings for machine function has_body:
+# CHECK-NEXT: Machine Function vector:  [ 1.10  1.20  1.30 ]
+# CHECK-NEXT: Machine basic block vectors:
+# CHECK-NEXT: Machine basic block: has_body:BB0:
+# CHECK-NEXT:  [ 1.10  1.20  1.30 ]


### PR DESCRIPTION
depth_first() asserts on an empty MachineFunction, since getEntryNode() dereferences the block list sentinel via front(). Return the zero vector instead, as IR2Vec does for declarations.