### PR TITLE
[SPIR-V] Fix hex float exponent for f64 Inf/NaN literals

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -87,17 +87,19 @@ void SPIRVInstPrinter::printOpConstantVarOps(const MCInst *MI,
     APFloat FP = NumVarOps == 1 ? APFloat(APInt(32, Imm).bitsToFloat())
                                 : APFloat(APInt(64, Imm).bitsToDouble());
 
-    // Print infinity and NaN as hex floats.
+    // Print infinity and NaN as hex floats. The exponent depends on the
+    // actual width of FP (f32 vs f64), not a fixed constant.
     // TODO: Make sure subnormal numbers are handled correctly as they may also
     // require hex float notation.
-    if (FP.isInfinity()) {
-      if (FP.isNegative())
-        O << '-';
-      O << "0x1p+128";
-      return;
-    }
-    if (FP.isNaN()) {
-      O << "0x1.8p+128";
+    if (FP.isInfinity() || FP.isNaN()) {
+      unsigned MaxExp = APFloat::semanticsMaxExponent(FP.getSemantics()) + 1;
+      if (FP.isInfinity()) {
+        if (FP.isNegative())
+          O << '-';
+        O << "0x1p+" << MaxExp;
+      } else {
+        O << "0x1.8p+" << MaxExp;
+      }
       return;
     }
 

--- a/llvm/test/CodeGen/SPIRV/literals.ll
+++ b/llvm/test/CodeGen/SPIRV/literals.ll
@@ -12,6 +12,9 @@
 ; CHECK-DAG: OpConstant %[[#F32]] 0x1p+128{{$}}
 ; CHECK-DAG: OpConstant %[[#F32]] -0x1p+128{{$}}
 ; CHECK-DAG: OpConstant %[[#F32]] 0x1.8p+128{{$}}
+; CHECK-DAG: OpConstant %[[#F64]] 0x1p+1024{{$}}
+; CHECK-DAG: OpConstant %[[#F64]] -0x1p+1024{{$}}
+; CHECK-DAG: OpConstant %[[#F64]] 0x1.8p+1024{{$}}
 
 define void @main() {
 entry:
@@ -27,5 +30,11 @@ entry:
   store float 0xFFF0000000000000, ptr %ninf, align 4
   %nan = alloca float, align 4
   store float 0x7FF8000000000000, ptr %nan, align 4
+  %dinf = alloca double, align 8
+  store double 0x7FF0000000000000, ptr %dinf, align 8
+  %dninf = alloca double, align 8
+  store double 0xFFF0000000000000, ptr %dninf, align 8
+  %dnan = alloca double, align 8
+  store double 0x7FF8000000000000, ptr %dnan, align 8
   ret void
 }


### PR DESCRIPTION
The asm printer hardcoded the f32 exponent (+128) when printing Inf/NaN as hex floats, so f64 Inf/NaN literals were misencoded and silently reassembled as finite values by consumers

Derive the exponent from the operand actual semantic instead