### PR TITLE
[OFFLOAD][L0] Fix zero argurment kernel launch

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Kernel.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Kernel.h
@@ -42,15 +42,13 @@ struct L0LaunchEnvTy {
   ze_group_size_t GroupSizes = {0, 0, 0};
   KernelPropertiesTy &KernelPR;
   bool IsCooperative = false;
-  bool IsPtrArg = false;
   void **ArgPtrs = nullptr;
   std::unique_lock<std::mutex> Lock;
 
   L0LaunchEnvTy(KernelPropertiesTy &KernelPR, KernelArgsTy &KernelArgs,
                 KernelLaunchParamsTy LaunchParams)
       : KernelPR(KernelPR), IsCooperative(KernelArgs.Flags.Cooperative),
-        IsPtrArg(LaunchParams.Args != nullptr), ArgPtrs(LaunchParams.Args),
-        Lock(KernelPR.Mtx, std::defer_lock) {}
+        ArgPtrs(LaunchParams.Args), Lock(KernelPR.Mtx, std::defer_lock) {}
 };
 
 class L0KernelTy : public GenericKernelTy {

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -52,14 +52,9 @@ Error L0QueueTy::dispatchLaunchKernel(ze_kernel_handle_t Kernel,
                                       ze_event_handle_t *WaitEvents) {
   // Unlock KEnv lock after launching the kernel.
   llvm::scope_exit UnlockGuard([&KEnv]() { KEnv.Lock.unlock(); });
-  if (KEnv.IsPtrArg)
-    return CmdList->appendLaunchKernelWithArgs(
-        Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,
-        NumWaitEvents, WaitEvents, KEnv.IsCooperative);
-
-  return CmdList->appendLaunchKernel(Kernel, &KEnv.GroupCounts, SignalEvent,
-                                     NumWaitEvents, WaitEvents,
-                                     KEnv.IsCooperative);
+  return CmdList->appendLaunchKernelWithArgs(
+      Kernel, &KEnv.GroupCounts, &KEnv.GroupSizes, KEnv.ArgPtrs, SignalEvent,
+      NumWaitEvents, WaitEvents, KEnv.IsCooperative);
 }
 
 Error L0QueueTy::memoryFill(void *Ptr, const void *Pattern, size_t PatternSize,


### PR DESCRIPTION
PR #205224 changed the path for kernels with no arguments to not use appendLaunchKernelWithArgs, while at the same time it removed zeKernelSetGroupSize which resulted in incorrect sizing of the kernel.

This PR removes the alternate path and makes sure all launches go through appendLaunchKernelWithArgs.

Alternatively we can restore zeKernelSetGroupSize on the alternate path.