### PR TITLE
[AMDGPU] Fold fsub into fma_mix via free neg_lo modifier

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUGISel.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGISel.td
@@ -217,6 +217,14 @@ def gi_vop3_mad_mix_mods_ext :
     GIComplexOperandMatcher<s64, "selectVOP3PMadMixModsExt">,
     GIComplexPatternEquiv<VOP3PMadMixModsExt>;
 
+def gi_vop3_mad_mix_mods_neg :
+    GIComplexOperandMatcher<s64, "selectVOP3PMadMixModsNeg">,
+    GIComplexPatternEquiv<VOP3PMadMixModsNeg>;
+
+def gi_vop3_mad_mix_mods_ext_neg :
+    GIComplexOperandMatcher<s64, "selectVOP3PMadMixModsExtNeg">,
+    GIComplexPatternEquiv<VOP3PMadMixModsExtNeg>;
+
 // Separate load nodes are defined to glue m0 initialization in
 // SelectionDAG. The GISel selector can just insert m0 initialization
 // directly before selecting a glue-less load, so hide this

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -4360,6 +4360,25 @@ bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixMods(SDValue In, SDValue &Src,
   return true;
 }
 
+bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixModsExtNeg(SDValue In, SDValue &Src,
+                                                     SDValue &SrcMods) const {
+  unsigned Mods = 0;
+  if (!SelectVOP3PMadMixModsImpl(In, Src, Mods, MVT::f16))
+    return false;
+  SrcMods =
+      CurDAG->getTargetConstant(Mods ^ SISrcMods::NEG, SDLoc(In), MVT::i32);
+  return true;
+}
+
+bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixModsNeg(SDValue In, SDValue &Src,
+                                                  SDValue &SrcMods) const {
+  unsigned Mods = 0;
+  SelectVOP3PMadMixModsImpl(In, Src, Mods, MVT::f16);
+  SrcMods =
+      CurDAG->getTargetConstant(Mods ^ SISrcMods::NEG, SDLoc(In), MVT::i32);
+  return true;
+}
+
 bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixBF16ModsExt(SDValue In, SDValue &Src,
                                                       SDValue &SrcMods) const {
   unsigned Mods = 0;
@@ -4374,6 +4393,25 @@ bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixBF16Mods(SDValue In, SDValue &Src,
   unsigned Mods = 0;
   SelectVOP3PMadMixModsImpl(In, Src, Mods, MVT::bf16);
   SrcMods = CurDAG->getTargetConstant(Mods, SDLoc(In), MVT::i32);
+  return true;
+}
+
+bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixBF16ModsExtNeg(
+    SDValue In, SDValue &Src, SDValue &SrcMods) const {
+  unsigned Mods = 0;
+  if (!SelectVOP3PMadMixModsImpl(In, Src, Mods, MVT::bf16))
+    return false;
+  SrcMods =
+      CurDAG->getTargetConstant(Mods ^ SISrcMods::NEG, SDLoc(In), MVT::i32);
+  return true;
+}
+
+bool AMDGPUDAGToDAGISel::SelectVOP3PMadMixBF16ModsNeg(SDValue In, SDValue &Src,
+                                                      SDValue &SrcMods) const {
+  unsigned Mods = 0;
+  SelectVOP3PMadMixModsImpl(In, Src, Mods, MVT::bf16);
+  SrcMods =
+      CurDAG->getTargetConstant(Mods ^ SISrcMods::NEG, SDLoc(In), MVT::i32);
   return true;
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -267,10 +267,18 @@ private:
   bool SelectVOP3PMadMixModsExt(SDValue In, SDValue &Src,
                                 SDValue &SrcMods) const;
   bool SelectVOP3PMadMixMods(SDValue In, SDValue &Src, SDValue &SrcMods) const;
+  bool SelectVOP3PMadMixModsExtNeg(SDValue In, SDValue &Src,
+                                   SDValue &SrcMods) const;
+  bool SelectVOP3PMadMixModsNeg(SDValue In, SDValue &Src,
+                                SDValue &SrcMods) const;
   bool SelectVOP3PMadMixBF16ModsExt(SDValue In, SDValue &Src,
                                     SDValue &SrcMods) const;
   bool SelectVOP3PMadMixBF16Mods(SDValue In, SDValue &Src,
                                  SDValue &SrcMods) const;
+  bool SelectVOP3PMadMixBF16ModsExtNeg(SDValue In, SDValue &Src,
+                                       SDValue &SrcMods) const;
+  bool SelectVOP3PMadMixBF16ModsNeg(SDValue In, SDValue &Src,
+                                    SDValue &SrcMods) const;
 
   bool SelectBITOP3(SDValue In, SDValue &Src0, SDValue &Src1, SDValue &Src2,
                    SDValue &Tbl) const;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -7267,6 +7267,40 @@ AMDGPUInstructionSelector::selectVOP3PMadMixMods(MachineOperand &Root) const {
   }};
 }
 
+InstructionSelector::ComplexRendererFns
+AMDGPUInstructionSelector::selectVOP3PMadMixModsExtNeg(
+    MachineOperand &Root) const {
+  Register Src;
+  unsigned Mods;
+  bool Matched;
+  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
+  if (!Matched)
+    return {};
+
+  return {{
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addImm(Mods ^ SISrcMods::NEG);
+      } // src_mods
+  }};
+}
+
+InstructionSelector::ComplexRendererFns
+AMDGPUInstructionSelector::selectVOP3PMadMixModsNeg(
+    MachineOperand &Root) const {
+  Register Src;
+  unsigned Mods;
+  bool Matched;
+  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
+
+  return {{
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addImm(Mods ^ SISrcMods::NEG);
+      } // src_mods
+  }};
+}
+
 bool AMDGPUInstructionSelector::selectSBarrierSignalIsfirst(
     MachineInstr &I, Intrinsic::ID IntrID) const {
   MachineBasicBlock *MBB = I.getParent();

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
@@ -352,6 +352,8 @@ private:
                                                           bool &Matched) const;
   ComplexRendererFns selectVOP3PMadMixModsExt(MachineOperand &Root) const;
   ComplexRendererFns selectVOP3PMadMixMods(MachineOperand &Root) const;
+  ComplexRendererFns selectVOP3PMadMixModsExtNeg(MachineOperand &Root) const;
+  ComplexRendererFns selectVOP3PMadMixModsNeg(MachineOperand &Root) const;
 
   void renderTruncImm32(MachineInstrBuilder &MIB, const MachineInstr &MI,
                         int OpIdx = -1) const;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -886,10 +886,6 @@ def fmaxnum_like_nnan : NeverNaNPats<(ops node:$src0, node:$src1),
    (fmaxnum node:$src0, node:$src1)]
 >;
 
-def fsub_nnan : NeverNaNPats<(ops node:$src0, node:$src1),
-  [(fsub node:$src0, node:$src1)]
->;
-
 def fminnum_like_oneuse : PatFrags<(ops node:$src0, node:$src1),
   [(fminnum_ieee_oneuse node:$src0, node:$src1),
    (fminnum_oneuse node:$src0, node:$src1)]

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -886,6 +886,10 @@ def fmaxnum_like_nnan : NeverNaNPats<(ops node:$src0, node:$src1),
    (fmaxnum node:$src0, node:$src1)]
 >;
 
+def fsub_nnan : NeverNaNPats<(ops node:$src0, node:$src1),
+  [(fsub node:$src0, node:$src1)]
+>;
+
 def fminnum_like_oneuse : PatFrags<(ops node:$src0, node:$src1),
   [(fminnum_ieee_oneuse node:$src0, node:$src1),
    (fminnum_oneuse node:$src0, node:$src1)]

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -913,6 +913,11 @@ def VOP3PModsNeg : SDNodeXForm<timm, [{
   return CurDAG->getTargetConstant(Mods, SDLoc(N), MVT::i32);
 }]>;
 
+def XorSISrcModsNeg : SDNodeXForm<timm, [{
+  return CurDAG->getTargetConstant(N->getZExtValue() ^ SISrcMods::NEG,
+                                    SDLoc(N), MVT::i32);
+}]>;
+
 def VOP3PModsNegs : SDNodeXForm<timm, [{
   unsigned Mods = SISrcMods::OP_SEL_1;
   if (N->getZExtValue())

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -913,11 +913,6 @@ def VOP3PModsNeg : SDNodeXForm<timm, [{
   return CurDAG->getTargetConstant(Mods, SDLoc(N), MVT::i32);
 }]>;
 
-def XorSISrcModsNeg : SDNodeXForm<timm, [{
-  return CurDAG->getTargetConstant(N->getZExtValue() ^ SISrcMods::NEG,
-                                    SDLoc(N), MVT::i32);
-}]>;
-
 def VOP3PModsNegs : SDNodeXForm<timm, [{
   unsigned Mods = SISrcMods::OP_SEL_1;
   if (N->getZExtValue())
@@ -1727,8 +1722,12 @@ def VOP3OpSelMods  : ComplexPattern<untyped, 2, "SelectVOP3OpSelMods">;
 
 def VOP3PMadMixModsExt : ComplexPattern<untyped, 2, "SelectVOP3PMadMixModsExt">;
 def VOP3PMadMixMods : ComplexPattern<untyped, 2, "SelectVOP3PMadMixMods">;
+def VOP3PMadMixModsExtNeg : ComplexPattern<untyped, 2, "SelectVOP3PMadMixModsExtNeg">;
+def VOP3PMadMixModsNeg : ComplexPattern<untyped, 2, "SelectVOP3PMadMixModsNeg">;
 def VOP3PMadMixBF16ModsExt : ComplexPattern<untyped, 2, "SelectVOP3PMadMixBF16ModsExt">;
 def VOP3PMadMixBF16Mods : ComplexPattern<untyped, 2, "SelectVOP3PMadMixBF16Mods">;
+def VOP3PMadMixBF16ModsExtNeg : ComplexPattern<untyped, 2, "SelectVOP3PMadMixBF16ModsExtNeg">;
+def VOP3PMadMixBF16ModsNeg : ComplexPattern<untyped, 2, "SelectVOP3PMadMixBF16ModsNeg">;
 
 def VINTERPMods  : ComplexPattern<untyped, 2, "SelectVINTERPMods">;
 def VINTERPModsHi  : ComplexPattern<untyped, 2, "SelectVINTERPModsHi">;

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -286,15 +286,15 @@ multiclass MadFmaMixFP32Pats<SDPatternOperator fma_like,
 
   // (fsub x, y) -> (fma y, -1.0, x)
   def : GCNPat <
-    (f32 (fsub (f32 (VOP3PMadMixModsExtPat VT:$src0, i32:$src0_mods)),
-               (f32 (VOP3PMadMixModsPat f32:$src1, i32:$src1_mods)))),
+    (f32 (fsub_nnan (f32 (VOP3PMadMixModsExtPat VT:$src0, i32:$src0_mods)),
+                    (f32 (VOP3PMadMixModsPat f32:$src1, i32:$src1_mods)))),
     (mix_inst $src1_mods, $src1, (i32 ImmMods), (i32 NegOneImm), $src0_mods, $src0,
               DSTCLAMP.NONE)>;
 
   // (fsub x, y) -> (fma y, -1.0, x)
   def : GCNPat <
-    (f32 (fsub (f32 (VOP3PMadMixModsPat f32:$src0, i32:$src0_mods)),
-               (f32 (VOP3PMadMixModsExtPat VT:$src1, i32:$src1_mods)))),
+    (f32 (fsub_nnan (f32 (VOP3PMadMixModsPat f32:$src0, i32:$src0_mods)),
+                    (f32 (VOP3PMadMixModsExtPat VT:$src1, i32:$src1_mods)))),
     (mix_inst $src1_mods, $src1, (i32 ImmMods), (i32 NegOneImm), $src0_mods, $src0,
               DSTCLAMP.NONE)>;
 }

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -245,8 +245,9 @@ multiclass MadFmaMixFP32Pats<SDPatternOperator fma_like,
                              ValueType VT = f16> {
   defvar VOP3PMadMixModsPat = !if (!eq(VT, bf16), VOP3PMadMixBF16Mods, VOP3PMadMixMods);
   defvar VOP3PMadMixModsExtPat = !if (!eq(VT, bf16), VOP3PMadMixBF16ModsExt, VOP3PMadMixModsExt);
+  defvar VOP3PMadMixModsNegPat = !if (!eq(VT, bf16), VOP3PMadMixBF16ModsNeg, VOP3PMadMixModsNeg);
+  defvar VOP3PMadMixModsExtNegPat = !if (!eq(VT, bf16), VOP3PMadMixBF16ModsExtNeg, VOP3PMadMixModsExtNeg);
   defvar OneImm = !if (!eq(VT, bf16), CONST.BF16_ONE, CONST.FP16_ONE);
-  defvar NegOneImm = !if (!eq(VT, bf16), CONST.BF16_NEG_ONE, CONST.FP16_NEG_ONE);
   defvar ImmMods = !if (!eq(VT, bf16), !or(SRCMODS.OP_SEL_0, SRCMODS.OP_SEL_1), SRCMODS.OP_SEL_1);
   // At least one of the operands needs to be an fpextend of an f16
   // for this to be worthwhile, so we need three patterns here.
@@ -287,15 +288,15 @@ multiclass MadFmaMixFP32Pats<SDPatternOperator fma_like,
   // (fsub x, y) -> (fma (-y), 1.0, x)
   def : GCNPat <
     (f32 (fsub (f32 (VOP3PMadMixModsExtPat VT:$src0, i32:$src0_mods)),
-               (f32 (VOP3PMadMixModsPat f32:$src1, i32:$src1_mods)))),
-    (mix_inst (XorSISrcModsNeg $src1_mods), $src1, (i32 ImmMods), (i32 OneImm), $src0_mods, $src0,
+               (f32 (VOP3PMadMixModsNegPat f32:$src1, i32:$src1_mods)))),
+    (mix_inst $src1_mods, $src1, (i32 ImmMods), (i32 OneImm), $src0_mods, $src0,
               DSTCLAMP.NONE)>;
 
   // (fsub x, y) -> (fma (-y), 1.0, x)
   def : GCNPat <
     (f32 (fsub (f32 (VOP3PMadMixModsPat f32:$src0, i32:$src0_mods)),
-               (f32 (VOP3PMadMixModsExtPat VT:$src1, i32:$src1_mods)))),
-    (mix_inst (XorSISrcModsNeg $src1_mods), $src1, (i32 ImmMods), (i32 OneImm), $src0_mods, $src0,
+               (f32 (VOP3PMadMixModsExtNegPat VT:$src1, i32:$src1_mods)))),
+    (mix_inst $src1_mods, $src1, (i32 ImmMods), (i32 OneImm), $src0_mods, $src0,
               DSTCLAMP.NONE)>;
 }
 

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -284,18 +284,18 @@ multiclass MadFmaMixFP32Pats<SDPatternOperator fma_like,
     (mix_inst $src0_mods, $src0, $src1_mods, $src1, (i32 SRCMODS.NEG), (i32 0),
               DSTCLAMP.NONE)>;
 
-  // (fsub x, y) -> (fma y, -1.0, x)
+  // (fsub x, y) -> (fma (-y), 1.0, x)
   def : GCNPat <
-    (f32 (fsub_nnan (f32 (VOP3PMadMixModsExtPat VT:$src0, i32:$src0_mods)),
-                    (f32 (VOP3PMadMixModsPat f32:$src1, i32:$src1_mods)))),
-    (mix_inst $src1_mods, $src1, (i32 ImmMods), (i32 NegOneImm), $src0_mods, $src0,
+    (f32 (fsub (f32 (VOP3PMadMixModsExtPat VT:$src0, i32:$src0_mods)),
+               (f32 (VOP3PMadMixModsPat f32:$src1, i32:$src1_mods)))),
+    (mix_inst (XorSISrcModsNeg $src1_mods), $src1, (i32 ImmMods), (i32 OneImm), $src0_mods, $src0,
               DSTCLAMP.NONE)>;
 
-  // (fsub x, y) -> (fma y, -1.0, x)
+  // (fsub x, y) -> (fma (-y), 1.0, x)
   def : GCNPat <
-    (f32 (fsub_nnan (f32 (VOP3PMadMixModsPat f32:$src0, i32:$src0_mods)),
-                    (f32 (VOP3PMadMixModsExtPat VT:$src1, i32:$src1_mods)))),
-    (mix_inst $src1_mods, $src1, (i32 ImmMods), (i32 NegOneImm), $src0_mods, $src0,
+    (f32 (fsub (f32 (VOP3PMadMixModsPat f32:$src0, i32:$src0_mods)),
+               (f32 (VOP3PMadMixModsExtPat VT:$src1, i32:$src1_mods)))),
+    (mix_inst (XorSISrcModsNeg $src1_mods), $src1, (i32 ImmMods), (i32 OneImm), $src0_mods, $src0,
               DSTCLAMP.NONE)>;
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-mul.ll
@@ -42,16 +42,12 @@ define amdgpu_vs float @test_f16_to_f32_sub_ext_mul_rhs(float %x, half %y, half 
 define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_mul(<4 x half> %x, <4 x half> %y, <4 x float> %z) {
 ; GFX9-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul:
 ; GFX9-DENORM:       ; %bb.0: ; %entry
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v0, v0, v2
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v1, v1, v3
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v8, v1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v2, v4
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v3, v5
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v8, v6
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v9, v7
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v2, v0, v2
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v3, v1, v3
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v4, 1.0, v2 op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v5, 1.0, v2 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v6, 1.0, v3 op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v7, 1.0, v3 op_sel:[0,0,1] op_sel_hi:[0,1,1]
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul:
@@ -76,14 +72,10 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_mul_rhs(<4 x float> %x
 ; GFX9-DENORM:       ; %bb.0: ; %.entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v4, 1.0, v0 op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v4, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v5, 1.0, v2 op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v5, 1.0, v3 op_sel:[1,0,0] op_sel_hi:[1,1,0]
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul_rhs:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-mul.ll
@@ -42,12 +42,16 @@ define amdgpu_vs float @test_f16_to_f32_sub_ext_mul_rhs(float %x, half %y, half 
 define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_mul(<4 x half> %x, <4 x half> %y, <4 x float> %z) {
 ; GFX9-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul:
 ; GFX9-DENORM:       ; %bb.0: ; %entry
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v2, v0, v2
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v3, v1, v3
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, v4, -1.0, v2 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, v5, -1.0, v2 op_sel:[0,0,1] op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, v6, -1.0, v3 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, v7, -1.0, v3 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v0, v0, v2
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v1, v1, v3
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v2, v0
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v8, v1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v2, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v3, v5
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v8, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v9, v7
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul:
@@ -72,10 +76,14 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_mul_rhs(<4 x float> %x
 ; GFX9-DENORM:       ; %bb.0: ; %.entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, v4, -1.0, v0 op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, v4, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, v5, -1.0, v2 op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, v5, -1.0, v3 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul_rhs:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-neg-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-neg-mul.ll
@@ -83,16 +83,12 @@ entry:
 define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_neg_mul(<4 x half> %x, <4 x half> %y, <4 x float> %z) {
 ; GFX9-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul:
 ; GFX9-DENORM:       ; %bb.0: ; %entry
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v0, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v1, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v8, v1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v2, v4
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v3, v5
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v8, v6
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v9, v7
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v2, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v3, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v4, 1.0, v2 op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v5, 1.0, v2 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v6, 1.0, v3 op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v7, 1.0, v3 op_sel:[0,0,1] op_sel_hi:[0,1,1]
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul:
@@ -117,16 +113,12 @@ entry:
 define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_neg_ext_mul(<4 x half> %x, <4 x half> %y, <4 x float> %z) {
 ; GFX9-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul:
 ; GFX9-DENORM:       ; %bb.0: ; %entry
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v0, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v1, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v8, v1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v2, v4
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v3, v5
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v8, v6
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v9, v7
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v2, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v3, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v4, 1.0, v2 op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v5, 1.0, v2 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v6, 1.0, v3 op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v7, 1.0, v3 op_sel:[0,0,1] op_sel_hi:[0,1,1]
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul:
@@ -154,14 +146,10 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_neg_mul2(<4 x float> %
 ; GFX9-DENORM:       ; %bb.0: ; %entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v4, 1.0, v0 op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v4, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v5, 1.0, v2 op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v5, 1.0, v3 op_sel:[1,0,0] op_sel_hi:[1,1,0]
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul2:
@@ -187,14 +175,10 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_neg_ext_mul2(<4 x float> %
 ; GFX9-DENORM:       ; %bb.0: ; %entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
-; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
-; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v4, 1.0, v0 op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v4, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v5, 1.0, v2 op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v5, 1.0, v3 op_sel:[1,0,0] op_sel_hi:[1,1,0]
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul2:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-neg-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-neg-mul.ll
@@ -83,12 +83,16 @@ entry:
 define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_neg_mul(<4 x half> %x, <4 x half> %y, <4 x float> %z) {
 ; GFX9-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul:
 ; GFX9-DENORM:       ; %bb.0: ; %entry
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v2, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v3, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, v4, -1.0, v2 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, v5, -1.0, v2 op_sel:[0,0,1] op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, v6, -1.0, v3 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, v7, -1.0, v3 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v0, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v1, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v2, v0
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v8, v1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v2, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v3, v5
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v8, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v9, v7
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul:
@@ -113,12 +117,16 @@ entry:
 define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_neg_ext_mul(<4 x half> %x, <4 x half> %y, <4 x float> %z) {
 ; GFX9-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul:
 ; GFX9-DENORM:       ; %bb.0: ; %entry
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v2, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_pk_mul_f16 v3, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, v4, -1.0, v2 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, v5, -1.0, v2 op_sel:[0,0,1] op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, v6, -1.0, v3 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, v7, -1.0, v3 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v0, v0, v2 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_pk_mul_f16 v1, v1, v3 neg_lo:[0,1] neg_hi:[0,1]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v2, v0
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v8, v1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v2, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v3, v5
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v8, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v9, v7
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul:
@@ -146,10 +154,14 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_neg_mul2(<4 x float> %
 ; GFX9-DENORM:       ; %bb.0: ; %entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, v4, -1.0, v0 op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, v4, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, v5, -1.0, v2 op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, v5, -1.0, v3 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul2:
@@ -175,10 +187,14 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_neg_ext_mul2(<4 x float> %
 ; GFX9-DENORM:       ; %bb.0: ; %entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, v4, -1.0, v0 op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, v4, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, v5, -1.0, v2 op_sel_hi:[1,1,0]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, v5, -1.0, v3 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul2:

--- a/llvm/test/CodeGen/AMDGPU/bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/bf16.ll
@@ -31025,16 +31025,16 @@ define bfloat @v_round_bf16(bfloat %a) #0 {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_lshlrev_b32_e32 v1, 16, v0
+; GFX1250-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_trunc_f32_e32 v2, v1
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v2, -1.0, v0 op_sel:[0,1,0] op_sel_hi:[0,1,1]
+; GFX1250-NEXT:    v_trunc_f32_e32 v1, v0
+; GFX1250-NEXT:    v_sub_f32_e32 v2, v0, v1
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_cmp_ge_f32_e64 s0, |v0|, 0.5
-; GFX1250-NEXT:    v_cndmask_b32_e64 v0, 0, 1.0, s0
+; GFX1250-NEXT:    v_cmp_ge_f32_e64 s0, |v2|, 0.5
+; GFX1250-NEXT:    v_cndmask_b32_e64 v2, 0, 1.0, s0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_bfi_b32 v0, 0x7fffffff, v0, v1
-; GFX1250-NEXT:    v_add_f32_e32 v0, v2, v0
+; GFX1250-NEXT:    v_bfi_b32 v0, 0x7fffffff, v2, v0
+; GFX1250-NEXT:    v_add_f32_e32 v0, v1, v0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-NEXT:    v_cvt_pk_bf16_f32 v0, v0, s0
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/bf16.ll
@@ -31025,16 +31025,16 @@ define bfloat @v_round_bf16(bfloat %a) #0 {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX1250-NEXT:    v_lshlrev_b32_e32 v1, 16, v0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_trunc_f32_e32 v1, v0
-; GFX1250-NEXT:    v_sub_f32_e32 v2, v0, v1
+; GFX1250-NEXT:    v_trunc_f32_e32 v2, v1
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v2, 1.0, v0 op_sel:[0,1,0] op_sel_hi:[0,1,1]
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_cmp_ge_f32_e64 s0, |v2|, 0.5
-; GFX1250-NEXT:    v_cndmask_b32_e64 v2, 0, 1.0, s0
+; GFX1250-NEXT:    v_cmp_ge_f32_e64 s0, |v0|, 0.5
+; GFX1250-NEXT:    v_cndmask_b32_e64 v0, 0, 1.0, s0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_bfi_b32 v0, 0x7fffffff, v2, v0
-; GFX1250-NEXT:    v_add_f32_e32 v0, v1, v0
+; GFX1250-NEXT:    v_bfi_b32 v0, 0x7fffffff, v0, v1
+; GFX1250-NEXT:    v_add_f32_e32 v0, v2, v0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-NEXT:    v_cvt_pk_bf16_f32 v0, v0, s0
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/fpext-free.ll
+++ b/llvm/test/CodeGen/AMDGPU/fpext-free.ll
@@ -623,18 +623,16 @@ define float @fsub_fpext_fmul_f16_to_f32(half %x, half %y, float %z) #0 {
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v0.l, v0.l, v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_fmul_f16_to_f32:
 ; GFX11-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v0, v0, v1
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fmul_f16_to_f32:
@@ -678,18 +676,16 @@ define float @fsub_fpext_fmul_f16_to_f32_commute(float %x, half %y, half %z) #0 
 ; GFX11-F32DENORM-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-F32DENORM-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-F32DENORM-TRUE16-NEXT:    v_mul_f16_e32 v1.l, v1.l, v2.l
-; GFX11-F32DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-F32DENORM-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-F32DENORM-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX11-F32DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-F32DENORM-TRUE16-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,0]
 ; GFX11-F32DENORM-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-F32DENORM-FAKE16-LABEL: fsub_fpext_fmul_f16_to_f32_commute:
 ; GFX11-F32DENORM-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-F32DENORM-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-F32DENORM-FAKE16-NEXT:    v_mul_f16_e32 v1, v1, v2
-; GFX11-F32DENORM-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-F32DENORM-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-F32DENORM-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX11-F32DENORM-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-F32DENORM-FAKE16-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,0]
 ; GFX11-F32DENORM-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fmul_f16_to_f32_commute:
@@ -727,18 +723,16 @@ define float @fsub_fpext_fneg_fmul_f16_to_f32(half %x, half %y, float %z) #0 {
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mul_f16_e64 v0.l, v0.l, -v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_fneg_fmul_f16_to_f32:
 ; GFX11-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e64 v0, v0, -v1
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fneg_fmul_f16_to_f32:
@@ -777,18 +771,16 @@ define float @fsub_fneg_fpext_fmul_f16_to_f32(half %x, half %y, float %z) #0 {
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mul_f16_e64 v0.l, v0.l, -v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fneg_fpext_fmul_f16_to_f32:
 ; GFX11-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e64 v0, v0, -v1
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fneg_fpext_fmul_f16_to_f32:
@@ -891,12 +883,10 @@ define float @fsub_fpext_muladd_mul_f16_to_f32(half %x, half %y, float %z, half 
 ; GFX11-TRUE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v0.h, v3.l, v4.l
+; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v3.l, v3.l, v4.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v0.h, v0.l, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v3.l, v0.l, v1.l
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v3 op_sel_hi:[0,1,1]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
@@ -905,19 +895,34 @@ define float @fsub_fpext_muladd_mul_f16_to_f32(half %x, half %y, float %z, half 
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v3, v3, v4
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-FAKE16-NEXT:    v_fmac_f16_e32 v3, v0, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v3
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, -v2, 1.0, v3 op_sel_hi:[0,1,1]
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX89-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
-; GFX89:       ; %bb.0: ; %entry
-; GFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX89-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX89-NEXT:    v_fma_f16 v0, v0, v1, v3
-; GFX89-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX89-NEXT:    v_sub_f32_e32 v0, v0, v2
-; GFX89-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-F32FLUSH-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
+; GFX9-F32FLUSH:       ; %bb.0: ; %entry
+; GFX9-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-F32FLUSH-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX9-F32FLUSH-NEXT:    v_fma_f16 v0, v0, v1, v3
+; GFX9-F32FLUSH-NEXT:    v_mad_mix_f32 v0, -v2, 1.0, v0 op_sel_hi:[0,1,1]
+; GFX9-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-F32DENORM-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
+; GFX9-F32DENORM:       ; %bb.0: ; %entry
+; GFX9-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-F32DENORM-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX9-F32DENORM-NEXT:    v_fma_f16 v0, v0, v1, v3
+; GFX9-F32DENORM-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9-F32DENORM-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX9-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX8-NEXT:    v_fma_f16 v0, v0, v1, v3
+; GFX8-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX8-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %mul = fmul half %u, %v
   %fma = call half @llvm.fmuladd.f16(half %x, half %y, half %mul)
@@ -996,12 +1001,10 @@ define float @fsub_fpext_muladd_mul_f16_to_f32_commute(float %x, half %y, half %
 ; GFX11-TRUE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v1.h, v3.l, v4.l
+; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v3.l, v3.l, v4.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v1.h, v1.l, v2.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v3.l, v1.l, v2.l
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v3, 1.0, v0 op_sel_hi:[1,1,0]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
@@ -1010,19 +1013,34 @@ define float @fsub_fpext_muladd_mul_f16_to_f32_commute(float %x, half %y, half %
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v3, v3, v4
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-FAKE16-NEXT:    v_fmac_f16_e32 v3, v1, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v3
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, -v3, 1.0, v0 op_sel_hi:[1,1,0]
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX89-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX89:       ; %bb.0: ; %entry
-; GFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX89-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX89-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX89-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX89-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX89-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-F32FLUSH-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
+; GFX9-F32FLUSH:       ; %bb.0: ; %entry
+; GFX9-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-F32FLUSH-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX9-F32FLUSH-NEXT:    v_fma_f16 v1, v1, v2, v3
+; GFX9-F32FLUSH-NEXT:    v_mad_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,0]
+; GFX9-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-F32DENORM-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
+; GFX9-F32DENORM:       ; %bb.0: ; %entry
+; GFX9-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-F32DENORM-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX9-F32DENORM-NEXT:    v_fma_f16 v1, v1, v2, v3
+; GFX9-F32DENORM-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9-F32DENORM-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX9-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX8-NEXT:    v_fma_f16 v1, v1, v2, v3
+; GFX8-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX8-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %mul = fmul half %u, %v
   %fma = call half @llvm.fmuladd.f16(half %y, half %z, half %mul)

--- a/llvm/test/CodeGen/AMDGPU/fpext-free.ll
+++ b/llvm/test/CodeGen/AMDGPU/fpext-free.ll
@@ -623,16 +623,18 @@ define float @fsub_fpext_fmul_f16_to_f32(half %x, half %y, float %z) #0 {
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v0.l, v0.l, v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_fmul_f16_to_f32:
 ; GFX11-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v0, v0, v1
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fmul_f16_to_f32:
@@ -676,16 +678,18 @@ define float @fsub_fpext_fmul_f16_to_f32_commute(float %x, half %y, half %z) #0 
 ; GFX11-F32DENORM-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-F32DENORM-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-F32DENORM-TRUE16-NEXT:    v_mul_f16_e32 v1.l, v1.l, v2.l
-; GFX11-F32DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-F32DENORM-TRUE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,0]
+; GFX11-F32DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-F32DENORM-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; GFX11-F32DENORM-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-F32DENORM-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-F32DENORM-FAKE16-LABEL: fsub_fpext_fmul_f16_to_f32_commute:
 ; GFX11-F32DENORM-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-F32DENORM-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-F32DENORM-FAKE16-NEXT:    v_mul_f16_e32 v1, v1, v2
-; GFX11-F32DENORM-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-F32DENORM-FAKE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,0]
+; GFX11-F32DENORM-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-F32DENORM-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-F32DENORM-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-F32DENORM-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fmul_f16_to_f32_commute:
@@ -723,16 +727,18 @@ define float @fsub_fpext_fneg_fmul_f16_to_f32(half %x, half %y, float %z) #0 {
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mul_f16_e64 v0.l, v0.l, -v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_fneg_fmul_f16_to_f32:
 ; GFX11-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e64 v0, v0, -v1
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fneg_fmul_f16_to_f32:
@@ -771,16 +777,18 @@ define float @fsub_fneg_fpext_fmul_f16_to_f32(half %x, half %y, float %z) #0 {
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_mul_f16_e64 v0.l, v0.l, -v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fneg_fpext_fmul_f16_to_f32:
 ; GFX11-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e64 v0, v0, -v1
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fneg_fpext_fmul_f16_to_f32:
@@ -883,10 +891,12 @@ define float @fsub_fpext_muladd_mul_f16_to_f32(half %x, half %y, float %z, half 
 ; GFX11-TRUE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v3.l, v3.l, v4.l
+; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v0.h, v3.l, v4.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v3.l, v0.l, v1.l
-; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v3 op_sel_hi:[0,1,1]
+; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v0.h, v0.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
@@ -895,34 +905,19 @@ define float @fsub_fpext_muladd_mul_f16_to_f32(half %x, half %y, float %z, half 
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v3, v3, v4
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-FAKE16-NEXT:    v_fmac_f16_e32 v3, v0, v1
-; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v2, -1.0, v3 op_sel_hi:[0,1,1]
+; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v3
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v2
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX9-F32FLUSH-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
-; GFX9-F32FLUSH:       ; %bb.0: ; %entry
-; GFX9-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-F32FLUSH-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX9-F32FLUSH-NEXT:    v_fma_f16 v0, v0, v1, v3
-; GFX9-F32FLUSH-NEXT:    v_mad_mix_f32 v0, v2, -1.0, v0 op_sel_hi:[0,1,1]
-; GFX9-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-F32DENORM-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
-; GFX9-F32DENORM:       ; %bb.0: ; %entry
-; GFX9-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-F32DENORM-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX9-F32DENORM-NEXT:    v_fma_f16 v0, v0, v1, v3
-; GFX9-F32DENORM-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-F32DENORM-NEXT:    v_sub_f32_e32 v0, v0, v2
-; GFX9-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX8-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
-; GFX8:       ; %bb.0: ; %entry
-; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX8-NEXT:    v_fma_f16 v0, v0, v1, v3
-; GFX8-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX8-NEXT:    v_sub_f32_e32 v0, v0, v2
-; GFX8-NEXT:    s_setpc_b64 s[30:31]
+; GFX89-LABEL: fsub_fpext_muladd_mul_f16_to_f32:
+; GFX89:       ; %bb.0: ; %entry
+; GFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX89-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX89-NEXT:    v_fma_f16 v0, v0, v1, v3
+; GFX89-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX89-NEXT:    v_sub_f32_e32 v0, v0, v2
+; GFX89-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %mul = fmul half %u, %v
   %fma = call half @llvm.fmuladd.f16(half %x, half %y, half %mul)
@@ -1001,10 +996,12 @@ define float @fsub_fpext_muladd_mul_f16_to_f32_commute(float %x, half %y, half %
 ; GFX11-TRUE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v3.l, v3.l, v4.l
+; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v1.h, v3.l, v4.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v3.l, v1.l, v2.l
-; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v3, -1.0, v0 op_sel_hi:[1,1,0]
+; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v1.h, v1.l, v2.l
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
@@ -1013,34 +1010,19 @@ define float @fsub_fpext_muladd_mul_f16_to_f32_commute(float %x, half %y, half %
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v3, v3, v4
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-FAKE16-NEXT:    v_fmac_f16_e32 v3, v1, v2
-; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v3, -1.0, v0 op_sel_hi:[1,1,0]
+; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v3
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX9-F32FLUSH-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX9-F32FLUSH:       ; %bb.0: ; %entry
-; GFX9-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-F32FLUSH-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX9-F32FLUSH-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX9-F32FLUSH-NEXT:    v_mad_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,0]
-; GFX9-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-F32DENORM-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX9-F32DENORM:       ; %bb.0: ; %entry
-; GFX9-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-F32DENORM-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX9-F32DENORM-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX9-F32DENORM-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX9-F32DENORM-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX9-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX8-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX8:       ; %bb.0: ; %entry
-; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX8-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX8-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX8-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX8-NEXT:    s_setpc_b64 s[30:31]
+; GFX89-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
+; GFX89:       ; %bb.0: ; %entry
+; GFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX89-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX89-NEXT:    v_fma_f16 v1, v1, v2, v3
+; GFX89-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX89-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX89-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %mul = fmul half %u, %v
   %fma = call half @llvm.fmuladd.f16(half %y, half %z, half %mul)

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-bf16.ll
@@ -715,7 +715,9 @@ define float @v_mad_mix_f32_negbf16lo_add_bf16lo(bfloat %src0, bfloat %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v0, -1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -743,7 +745,9 @@ define float @v_mad_mix_f32_negabsbf16lo_add_bf16lo(bfloat %src0, bfloat %src1) 
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, |v0|, -1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e64 v0, v1, |v0|
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -770,7 +774,9 @@ define float @v_mad_mix_f32_bf16lo_add_negf32(bfloat %src0, float %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v1, -1.0, v0 op_sel:[0,1,0] op_sel_hi:[0,1,1]
+; GFX1250-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.neg = fneg float %src1
@@ -796,7 +802,9 @@ define float @v_mad_mix_f32_bf16lo_add_negabsf32(bfloat %src0, float %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, |v1|, -1.0, v0 op_sel:[0,1,0] op_sel_hi:[0,1,1]
+; GFX1250-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.abs = call float @llvm.fabs.f32(float %src1)
@@ -850,7 +858,9 @@ define float @v_mad_mix_f32_negprecvtbf16lo_add_bf16lo(i32 %src0.arg, bfloat %sr
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v0, -1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x bfloat>
   %src0 = extractelement <2 x bfloat> %src0.arg.bc, i32 0
@@ -878,12 +888,25 @@ define float @v_mad_mix_f32_absprecvtbf16lo_add_bf16lo(i32 %src0.arg, bfloat %sr
 }
 
 define float @v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo(i32 %src0.arg, bfloat %src1)  {
-; GFX1250-LABEL: v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo:
-; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, |v0|, -1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
-; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-FAKE16-LABEL: v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo:
+; GFX1250-FAKE16:       ; %bb.0:
+; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-FAKE16-NEXT:    v_and_b32_e32 v0, 0x7fff, v0
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1250-FAKE16-NEXT:    v_dual_lshlrev_b32 v1, 16, v1 :: v_dual_lshlrev_b32 v0, 16, v0
+; GFX1250-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1250-REAL16-LABEL: v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo:
+; GFX1250-REAL16:       ; %bb.0:
+; GFX1250-REAL16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-REAL16-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-REAL16-NEXT:    v_and_b16 v0.l, 0x7fff, v0.l
+; GFX1250-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1250-REAL16-NEXT:    v_dual_lshlrev_b32 v1, 16, v1 :: v_dual_lshlrev_b32 v0, 16, v0
+; GFX1250-REAL16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; GFX1250-REAL16-NEXT:    s_set_pc_i64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x bfloat>
   %src0 = extractelement <2 x bfloat> %src0.arg.bc, i32 0
   %src0.fabs = call bfloat @llvm.fabs.bf16(bfloat %src0)
@@ -1356,7 +1379,9 @@ define float @v_mad_mix_f32_bf16lo_sub_bf16lo(bfloat %src0, bfloat %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v1, -1.0, v0 op_sel:[0,1,0] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -1369,7 +1394,9 @@ define float @v_mad_mix_f32_absbf16lo_sub_bf16lo(bfloat %src0, bfloat %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v1, -1.0, |v0| op_sel:[0,1,0] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -1383,7 +1410,10 @@ define float @v_mad_mix_f32_bf16hi_fsub_bf16hi(i32 %src0, i32 %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v1, -1.0, v0 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX1250-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16
@@ -1402,7 +1432,10 @@ define float @v_mad_mix_f32_absbf16hi_fsub_bf16hi(i32 %src0, i32 %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, v1, -1.0, |v0| op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
+; GFX1250-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-bf16.ll
@@ -715,9 +715,7 @@ define float @v_mad_mix_f32_negbf16lo_add_bf16lo(bfloat %src0, bfloat %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e32 v0, v1, v0
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v0, 1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -745,9 +743,7 @@ define float @v_mad_mix_f32_negabsbf16lo_add_bf16lo(bfloat %src0, bfloat %src1) 
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e64 v0, v1, |v0|
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -|v0|, 1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -774,9 +770,7 @@ define float @v_mad_mix_f32_bf16lo_add_negf32(bfloat %src0, float %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v1, 1.0, v0 op_sel:[0,1,0] op_sel_hi:[0,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.neg = fneg float %src1
@@ -802,9 +796,7 @@ define float @v_mad_mix_f32_bf16lo_add_negabsf32(bfloat %src0, float %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e64 v0, v0, |v1|
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -|v1|, 1.0, v0 op_sel:[0,1,0] op_sel_hi:[0,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.abs = call float @llvm.fabs.f32(float %src1)
@@ -858,9 +850,7 @@ define float @v_mad_mix_f32_negprecvtbf16lo_add_bf16lo(i32 %src0.arg, bfloat %sr
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e32 v0, v1, v0
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v0, 1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x bfloat>
   %src0 = extractelement <2 x bfloat> %src0.arg.bc, i32 0
@@ -888,25 +878,12 @@ define float @v_mad_mix_f32_absprecvtbf16lo_add_bf16lo(i32 %src0.arg, bfloat %sr
 }
 
 define float @v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo(i32 %src0.arg, bfloat %src1)  {
-; GFX1250-FAKE16-LABEL: v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo:
-; GFX1250-FAKE16:       ; %bb.0:
-; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-FAKE16-NEXT:    v_and_b32_e32 v0, 0x7fff, v0
-; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-FAKE16-NEXT:    v_dual_lshlrev_b32 v1, 16, v1 :: v_dual_lshlrev_b32 v0, 16, v0
-; GFX1250-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-REAL16-LABEL: v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo:
-; GFX1250-REAL16:       ; %bb.0:
-; GFX1250-REAL16-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-REAL16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-REAL16-NEXT:    v_and_b16 v0.l, 0x7fff, v0.l
-; GFX1250-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-REAL16-NEXT:    v_dual_lshlrev_b32 v1, 16, v1 :: v_dual_lshlrev_b32 v0, 16, v0
-; GFX1250-REAL16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; GFX1250-REAL16-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: v_mad_mix_f32_negabsprecvtbf16lo_add_bf16lo:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -|v0|, 1.0, v1 op_sel:[0,1,0] op_sel_hi:[1,1,1]
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x bfloat>
   %src0 = extractelement <2 x bfloat> %src0.arg.bc, i32 0
   %src0.fabs = call bfloat @llvm.fabs.bf16(bfloat %src0)
@@ -1379,9 +1356,7 @@ define float @v_mad_mix_f32_bf16lo_sub_bf16lo(bfloat %src0, bfloat %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v1, 1.0, v0 op_sel:[0,1,0] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -1394,9 +1369,7 @@ define float @v_mad_mix_f32_absbf16lo_sub_bf16lo(bfloat %src0, bfloat %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_dual_lshlrev_b32 v0, 16, v0 :: v_dual_lshlrev_b32 v1, 16, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v1, 1.0, |v0| op_sel:[0,1,0] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.ext = fpext bfloat %src0 to float
   %src1.ext = fpext bfloat %src1 to float
@@ -1410,10 +1383,7 @@ define float @v_mad_mix_f32_bf16hi_fsub_bf16hi(i32 %src0, i32 %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
-; GFX1250-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v1, 1.0, v0 op_sel:[1,1,1] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16
@@ -1432,10 +1402,7 @@ define float @v_mad_mix_f32_absbf16hi_fsub_bf16hi(i32 %src0, i32 %src1)  {
 ; GFX1250:       ; %bb.0:
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-NEXT:    v_and_b32_e32 v0, 0xffff0000, v0
-; GFX1250-NEXT:    v_and_b32_e32 v1, 0xffff0000, v1
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v1, 1.0, |v0| op_sel:[1,1,1] op_sel_hi:[1,1,1]
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-bf16.ll
@@ -1417,6 +1417,18 @@ define float @v_mad_mix_f32_absbf16hi_fsub_bf16hi(i32 %src0, i32 %src1)  {
   ret float %result
 }
 
+define float @v_mad_mix_f32_f32_sub_bf16lo(float %src0, bfloat %src1)  {
+; GFX1250-LABEL: v_mad_mix_f32_f32_sub_bf16lo:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_fma_mix_f32_bf16 v0, -v1, 1.0, v0 op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
+  %src1.ext = fpext bfloat %src1 to float
+  %result = fsub float %src0, %src1.ext
+  ret float %result
+}
+
 declare bfloat @llvm.fabs.bf16(bfloat) #2
 declare <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat>) #2
 declare float @llvm.fabs.f32(float) #2

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -2943,11 +2943,23 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half>
 }
 
 define float @v_mad_mix_f32_negf16lo_add_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, -1.0, v1 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -2960,7 +2972,9 @@ define float @v_mad_mix_f32_negf16lo_add_f16lo(half %src0, half %src1)  {
 ; SDAG-GFX906-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
 ; SDAG-GFX906:       ; %bb.0:
 ; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, v0, -1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
@@ -3097,11 +3111,23 @@ define float @v_mad_mix_f32_absf16lo_add_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, -1.0, v1 op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, v1, |v0|
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, v1, |v0|
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GFX900:       ; %bb.0:
@@ -3114,7 +3140,9 @@ define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, |v0|, -1.0, v1 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX906-NEXT:    v_sub_f32_e64 v0, v1, |v0|
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
@@ -3140,6 +3168,15 @@ define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, v1, |v0|
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -3202,11 +3239,21 @@ define float @v_mad_mix_f32_f16lo_add_f32(half %src0, float %src1)  {
 }
 
 define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[0,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_add_negf32:
 ; GFX900:       ; %bb.0:
@@ -3218,7 +3265,8 @@ define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_add_negf32:
@@ -3241,6 +3289,14 @@ define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.neg = fneg float %src1
   %result = fadd float %src0.ext, %src1.neg
@@ -3294,11 +3350,21 @@ define float @v_mad_mix_f32_f16lo_add_absf32(half %src0, float %src1)  {
 }
 
 define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v1|, -1.0, v0 op_sel_hi:[0,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, v0, |v1|
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, v0, |v1|
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
 ; GFX900:       ; %bb.0:
@@ -3310,7 +3376,8 @@ define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, |v1|, -1.0, v0 op_sel_hi:[0,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX906-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
@@ -3333,6 +3400,14 @@ define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; CI-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, v0, |v1|
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.abs = call float @llvm.fabs.f32(float %src1)
   %src1.neg.abs = fneg float %src1.abs
@@ -3488,11 +3563,23 @@ define float @v_mad_mix_clamp_f32_f16hi_add_f16hi(<2 x half> %src0, <2 x half> %
 }
 
 define float @v_mad_mix_f32_negprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, -1.0, v1 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3505,7 +3592,9 @@ define float @v_mad_mix_f32_negprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1) 
 ; SDAG-GFX906-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
 ; SDAG-GFX906:       ; %bb.0:
 ; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, v0, -1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
@@ -3638,11 +3727,23 @@ define float @v_mad_mix_f32_absprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1) 
 }
 
 define float @v_mad_mix_f32_negabsprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, -1.0, v1 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0.l|
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3655,7 +3756,9 @@ define float @v_mad_mix_f32_negabsprecvtf16lo_add_f16lo(i32 %src0.arg, half %src
 ; SDAG-GFX906-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
 ; SDAG-GFX906:       ; %bb.0:
 ; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, |v0|, -1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
@@ -3877,11 +3980,25 @@ define float @v_mad_mix_f32_precvtabsf16hi_add_f16lo(i32 %src0.arg, half %src1) 
 }
 
 define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3894,7 +4011,9 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %
 ; SDAG-GFX906-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; SDAG-GFX906:       ; %bb.0:
 ; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, v0, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
@@ -4071,11 +4190,25 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_add_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0.l|
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -4088,7 +4221,9 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, ha
 ; SDAG-GFX906-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; SDAG-GFX906:       ; %bb.0:
 ; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, |v0|, -1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, |v0| dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
@@ -5655,11 +5790,23 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo(i32 %src0.arg, ha
 }
 
 define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5672,7 +5819,9 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
@@ -5698,6 +5847,15 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.ext = fpext half %src1 to float
   %result = fsub float %src0.ext, %src1.ext
@@ -5705,11 +5863,23 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, |v0| op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5722,7 +5892,9 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, |v0| op_sel_hi:[1,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
@@ -5749,6 +5921,15 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-CI-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5764,11 +5945,29 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
 ; GFX900:       ; %bb.0:
@@ -5781,7 +5980,9 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
@@ -5809,6 +6010,18 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16
   %src0.i16 = trunc i32 %src0.hi to i16
@@ -5822,11 +6035,29 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 }
 
 define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GFX900:       ; %bb.0:
@@ -5839,7 +6070,9 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
@@ -5868,6 +6101,18 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-CI-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5887,6 +6132,59 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
   %src0.ext.abs = call float @llvm.fabs.f32(float %src0.ext)
   %src1.ext = fpext half %src1.fp16 to float
   %result = fsub float %src0.ext.abs, %src1.ext
+  ret float %result
+}
+
+; The fsub -> fma_mix rewrite is only sound when nnan is known: HW
+; fma_mix(NaN, -1.0, x) preserves the NaN's sign, while IEEE fsub(x, NaN)
+; flips it.
+define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
+; GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX900-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GFX9GEN:       ; %bb.0:
+; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9GEN-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
+;
+; VI-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; VI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; VI-NEXT:    s_setpc_b64 s[30:31]
+;
+; CI-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; CI:       ; %bb.0:
+; CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; CI-NEXT:    s_setpc_b64 s[30:31]
+  %src0.ext = fpext half %src0 to float
+  %src1.ext = fpext half %src1 to float
+  %result = fsub nnan float %src0.ext, %src1.ext
   ret float %result
 }
 

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -2943,23 +2943,11 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half>
 }
 
 define float @v_mad_mix_f32_negf16lo_add_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -2969,13 +2957,11 @@ define float @v_mad_mix_f32_negf16lo_add_f16lo(half %src0, half %src1)  {
 ; SDAG-GFX900-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
 ; SDAG-GFX9GEN:       ; %bb.0:
@@ -3001,12 +2987,6 @@ define float @v_mad_mix_f32_negf16lo_add_f16lo(half %src0, half %src1)  {
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3014,12 +2994,6 @@ define float @v_mad_mix_f32_negf16lo_add_f16lo(half %src0, half %src1)  {
 ; GISEL-GFX900-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GISEL-GFX900-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GISEL-GFX900-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_negf16lo_add_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -3111,23 +3085,11 @@ define float @v_mad_mix_f32_absf16lo_add_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, v1, |v0|
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, v1, |v0|
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GFX900:       ; %bb.0:
@@ -3137,13 +3099,11 @@ define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, v1, |v0|
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX906-NEXT:    v_sub_f32_e64 v0, v1, |v0|
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GFX9GEN:       ; %bb.0:
@@ -3177,6 +3137,14 @@ define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
 ; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, v1, |v0|
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, v1, |v0|
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -3239,21 +3207,11 @@ define float @v_mad_mix_f32_f16lo_add_f32(half %src0, float %src1)  {
 }
 
 define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[0,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_add_negf32:
 ; GFX900:       ; %bb.0:
@@ -3262,12 +3220,11 @@ define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[0,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_add_negf32:
 ; GFX9GEN:       ; %bb.0:
@@ -3297,6 +3254,13 @@ define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
 ; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.neg = fneg float %src1
   %result = fadd float %src0.ext, %src1.neg
@@ -3350,21 +3314,11 @@ define float @v_mad_mix_f32_f16lo_add_absf32(half %src0, float %src1)  {
 }
 
 define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, v0, |v1|
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, v0, |v1|
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v1|, 1.0, v0 op_sel_hi:[0,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
 ; GFX900:       ; %bb.0:
@@ -3373,12 +3327,11 @@ define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX906-NEXT:    v_sub_f32_e64 v0, v0, |v1|
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -|v1|, 1.0, v0 op_sel_hi:[0,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
 ; GFX9GEN:       ; %bb.0:
@@ -3408,6 +3361,13 @@ define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
 ; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, v0, |v1|
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.abs = call float @llvm.fabs.f32(float %src1)
   %src1.neg.abs = fneg float %src1.abs
@@ -3563,23 +3523,11 @@ define float @v_mad_mix_clamp_f32_f16hi_add_f16hi(<2 x half> %src0, <2 x half> %
 }
 
 define float @v_mad_mix_f32_negprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3589,13 +3537,11 @@ define float @v_mad_mix_f32_negprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1) 
 ; SDAG-GFX900-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
 ; SDAG-GFX9GEN:       ; %bb.0:
@@ -3621,12 +3567,6 @@ define float @v_mad_mix_f32_negprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1) 
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3634,12 +3574,6 @@ define float @v_mad_mix_f32_negprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1) 
 ; GISEL-GFX900-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GISEL-GFX900-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GISEL-GFX900-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_negprecvtf16lo_add_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -3727,23 +3661,11 @@ define float @v_mad_mix_f32_absprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1) 
 }
 
 define float @v_mad_mix_f32_negabsprecvtf16lo_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0.l|
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3753,13 +3675,11 @@ define float @v_mad_mix_f32_negabsprecvtf16lo_add_f16lo(i32 %src0.arg, half %src
 ; SDAG-GFX900-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
 ; SDAG-GFX9GEN:       ; %bb.0:
@@ -3785,12 +3705,6 @@ define float @v_mad_mix_f32_negabsprecvtf16lo_add_f16lo(i32 %src0.arg, half %src
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3798,12 +3712,6 @@ define float @v_mad_mix_f32_negabsprecvtf16lo_add_f16lo(i32 %src0.arg, half %src
 ; GISEL-GFX900-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GISEL-GFX900-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GISEL-GFX900-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_negabsprecvtf16lo_add_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -3980,25 +3888,11 @@ define float @v_mad_mix_f32_precvtabsf16hi_add_f16lo(i32 %src0.arg, half %src1) 
 }
 
 define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -4008,13 +3902,11 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %
 ; SDAG-GFX900-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; SDAG-GFX9GEN:       ; %bb.0:
@@ -4041,12 +3933,6 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4055,12 +3941,6 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %
 ; GISEL-GFX900-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GISEL-GFX900-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GISEL-GFX900-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -4190,25 +4070,11 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_add_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0.l|
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -4218,13 +4084,11 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, ha
 ; SDAG-GFX900-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, |v0| dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; SDAG-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX906-NEXT:    v_sub_f32_e32 v0, v1, v0
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX9GEN-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; SDAG-GFX9GEN:       ; %bb.0:
@@ -4251,12 +4115,6 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, ha
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4265,12 +4123,6 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, ha
 ; GISEL-GFX900-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GISEL-GFX900-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GISEL-GFX900-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -5790,23 +5642,11 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo(i32 %src0.arg, ha
 }
 
 define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5816,13 +5656,11 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
 ; GFX9GEN:       ; %bb.0:
@@ -5856,6 +5694,14 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 ; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.ext = fpext half %src1 to float
   %result = fsub float %src0.ext, %src1.ext
@@ -5863,23 +5709,11 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5889,13 +5723,11 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GFX9GEN:       ; %bb.0:
@@ -5930,6 +5762,14 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-CI-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5945,29 +5785,11 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
 ; GFX900:       ; %bb.0:
@@ -5977,13 +5799,11 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
 ; GFX9GEN:       ; %bb.0:
@@ -6022,6 +5842,14 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16
   %src0.i16 = trunc i32 %src0.hi to i16
@@ -6035,29 +5863,11 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 }
 
 define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; SDAG-GFX1100-TRUE16:       ; %bb.0:
-; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; SDAG-GFX1100-FAKE16:       ; %bb.0:
-; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; SDAG-GFX1100-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GFX900:       ; %bb.0:
@@ -6067,13 +5877,11 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GFX9GEN:       ; %bb.0:
@@ -6113,6 +5921,14 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-CI-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -6139,11 +5955,11 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; fma_mix(NaN, -1.0, x) preserves the NaN's sign, while IEEE fsub(x, NaN)
 ; flips it.
 define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
 ; GFX900:       ; %bb.0:
@@ -6153,11 +5969,11 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
-; GFX906:       ; %bb.0:
-; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
-; GFX906-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; SDAG-GFX906:       ; %bb.0:
+; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
 ; GFX9GEN:       ; %bb.0:
@@ -6182,6 +5998,23 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GISEL-GFX906:       ; %bb.0:
+; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.ext = fpext half %src1 to float
   %result = fsub nnan float %src0.ext, %src1.ext

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -3085,11 +3085,11 @@ define float @v_mad_mix_f32_absf16lo_add_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GFX900:       ; %bb.0:
@@ -3099,11 +3099,11 @@ define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, v1, |v0|
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GFX9GEN:       ; %bb.0:
@@ -3128,23 +3128,6 @@ define float @v_mad_mix_f32_negabsf16lo_add_f16lo(half %src0, half %src1)  {
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e64 v0, |v0|
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, v1, |v0|
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, v1, |v0|
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_negabsf16lo_add_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -3207,11 +3190,11 @@ define float @v_mad_mix_f32_f16lo_add_f32(half %src0, float %src1)  {
 }
 
 define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[0,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[0,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_add_negf32:
 ; GFX900:       ; %bb.0:
@@ -3220,11 +3203,11 @@ define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[0,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[0,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_add_negf32:
 ; GFX9GEN:       ; %bb.0:
@@ -3246,21 +3229,6 @@ define float @v_mad_mix_f32_f16lo_add_negf32(half %src0, float %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negf32:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.neg = fneg float %src1
   %result = fadd float %src0.ext, %src1.neg
@@ -3314,11 +3282,11 @@ define float @v_mad_mix_f32_f16lo_add_absf32(half %src0, float %src1)  {
 }
 
 define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v1|, 1.0, v0 op_sel_hi:[0,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v1|, 1.0, v0 op_sel_hi:[0,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
 ; GFX900:       ; %bb.0:
@@ -3327,11 +3295,11 @@ define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -|v1|, 1.0, v0 op_sel_hi:[0,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -|v1|, 1.0, v0 op_sel_hi:[0,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
 ; GFX9GEN:       ; %bb.0:
@@ -3353,21 +3321,6 @@ define float @v_mad_mix_f32_f16lo_add_negabsf32(half %src0, float %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; CI-NEXT:    v_sub_f32_e64 v0, v0, |v1|
 ; CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, v0, |v1|
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_add_negabsf32:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, v0, |v1|
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.abs = call float @llvm.fabs.f32(float %src1)
   %src1.neg.abs = fneg float %src1.abs
@@ -5642,11 +5595,11 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo(i32 %src0.arg, ha
 }
 
 define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5656,11 +5609,11 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
 ; GFX9GEN:       ; %bb.0:
@@ -5685,23 +5638,6 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.ext = fpext half %src1 to float
   %result = fsub float %src0.ext, %src1.ext
@@ -5709,11 +5645,11 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5723,11 +5659,11 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel_hi:[1,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GFX9GEN:       ; %bb.0:
@@ -5753,23 +5689,6 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-CI-LABEL: v_mad_mix_f32_absf16lo_sub_f16lo:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5785,11 +5704,11 @@ define float @v_mad_mix_f32_absf16lo_sub_f16lo(half %src0, half %src1)  {
 }
 
 define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
 ; GFX900:       ; %bb.0:
@@ -5799,11 +5718,11 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
 ; GFX9GEN:       ; %bb.0:
@@ -5830,26 +5749,6 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_f16hi_fsub_f16hi:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.hi = lshr i32 %src0, 16
   %src1.hi = lshr i32 %src1, 16
   %src0.i16 = trunc i32 %src0.hi to i16
@@ -5863,11 +5762,11 @@ define float @v_mad_mix_f32_f16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 }
 
 define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GFX900:       ; %bb.0:
@@ -5877,11 +5776,11 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e64 v0, |v0|, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, |v0| op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GFX9GEN:       ; %bb.0:
@@ -5909,26 +5808,6 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
 ; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GISEL-GFX906-NEXT:    v_sub_f32_e64 v0, |v0|, v1
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
-;
 ; GISEL-CI-LABEL: v_mad_mix_f32_absf16hi_fsub_f16hi:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5951,15 +5830,15 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
   ret float %result
 }
 
-; The fsub -> fma_mix rewrite is only sound when nnan is known: HW
-; fma_mix(NaN, -1.0, x) preserves the NaN's sign, while IEEE fsub(x, NaN)
-; flips it.
+; Same as above but with the fsub marked nnan, which should fold identically
+; since the rewrite negates via the free src1 neg_lo modifier rather than an
+; actual multiply by -1.0, so it is sound for NaN inputs too.
 define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
 ; GFX900:       ; %bb.0:
@@ -5969,11 +5848,11 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
 ; GFX900-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
-; SDAG-GFX906:       ; %bb.0:
-; SDAG-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
-; SDAG-GFX906-NEXT:    s_setpc_b64 s[30:31]
+; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_fma_mix_f32 v0, -v1, 1.0, v0 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
 ; GFX9GEN:       ; %bb.0:
@@ -5998,23 +5877,6 @@ define float @v_mad_mix_f32_f16lo_sub_f16lo_nnan(half %src0, half %src1)  {
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX906-LABEL: v_mad_mix_f32_f16lo_sub_f16lo_nnan:
-; GISEL-GFX906:       ; %bb.0:
-; GISEL-GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-GFX906-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GISEL-GFX906-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GISEL-GFX906-NEXT:    s_setpc_b64 s[30:31]
   %src0.ext = fpext half %src0 to float
   %src1.ext = fpext half %src1 to float
   %result = fsub nnan float %src0.ext, %src1.ext


### PR DESCRIPTION
Rewrite the fsub->fma_mix pattern as `fma((-y), 1.0, x)` using the free neg_lo modifier

instead of multiplying by -1.0 (which doesn't always flip the sign of NaN), use the hardware free neg_lo bit, which does a true sign flip. As a result, now the fold always matches fsub actual behavior instead of only in the common case (non-NaN FP numbers)
