### PR TITLE
[SimplifyCFG] Bail out on trivial cases in `mergeNestedCondBranch`

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8694,6 +8694,10 @@ static bool mergeNestedCondBranch(CondBrInst *BI, DomTreeUpdater *DTU) {
 
   BasicBlock *BB3 = BB1BI->getSuccessor(0);
   BasicBlock *BB4 = BB1BI->getSuccessor(1);
+  // Bail out on trivial cases to avoid bothering to handle the special case in
+  // the code below.
+  if (BB3 == BB4)
+    return false;
   IRBuilder<> Builder(BI);
   BI->setCondition(
       Builder.CreateXor(BI->getCondition(), BB1BI->getCondition()));

--- a/llvm/test/Transforms/SimplifyCFG/branch-nested.ll
+++ b/llvm/test/Transforms/SimplifyCFG/branch-nested.ll
@@ -339,6 +339,39 @@ bb4:
   ret void
 }
 
+define void @fold_nested_branch_same_dest(i1 %cond1, i1 %cond2, i1 %cond3) {
+; CHECK-LABEL: define void @fold_nested_branch_same_dest(
+; CHECK-SAME: i1 [[COND1:%.*]], i1 [[COND2:%.*]], i1 [[COND3:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[COND2_NOT:%.*]] = xor i1 [[COND2]], true
+; CHECK-NEXT:    [[BRMERGE:%.*]] = select i1 [[COND1]], i1 true, i1 [[COND2_NOT]]
+; CHECK-NEXT:    ret void
+;
+entry:
+  br i1 %cond1, label %bb2, label %else
+
+else:
+  br i1 %cond2, label %bb0, label %common.ret
+
+bb0:
+  br i1 %cond1, label %bb1, label %bb2
+
+bb2:
+  br i1 %cond3, label %exit1, label %exit2
+
+bb1:
+  br i1 %cond3, label %exit1, label %exit2
+
+exit1:
+  br label %common.ret
+
+exit2:
+  br label %common.ret
+
+common.ret:
+  ret void
+}
+
 !0 = !{!"branch_weights", i32 1, i32 2}
 !1 = !{!"branch_weights", i32 3, i32 4}
 !2 = !{!"branch_weights", i32 5, i32 6}


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/212300.

When BB3 is identical to BB4, it is no longer profitable to perform this fold, since it creates an unused xor instruction. The DomTree update issue is also easy to fix. But I think this solution is better.

The following IR was dumped just before this function:
```
define void @func(i1 %cond1, i1 %cond2, i1 %cond3) {
entry:
  br i1 %cond1, label %bb2, label %else

else:                                             ; preds = %entry
  br i1 %cond2, label %bb0, label %common.ret

bb0:                                              ; preds = %else
  br i1 %cond1, label %bb1, label %bb2

bb2:                                              ; preds = %bb0, %entry
  br i1 %cond3, label %common.ret, label %common.ret

bb1:                                              ; preds = %bb0
  br i1 %cond3, label %common.ret, label %common.ret

common.ret:                                       ; preds = %bb2, %bb1, %bb2, %bb1, %else
  ret void
}
```
The previous functions will simplify it. So the reproducer cannot be further reduced.

