### PR TITLE
[Clang] Treat the body of an expansion statement with expansion size 0 as discarded

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -328,6 +328,19 @@ protected:
     SourceLocation DeferLoc;
   };
 
+  class CXXExpansionStmtPatternBitfields {
+    friend class CXXExpansionStmtPattern;
+    friend class ASTStmtReader;
+
+    LLVM_PREFERRED_TYPE(StmtBitfields)
+    unsigned : NumStmtBits;
+
+    /// Whether the expansion size has already been computed for this, in which
+    /// case it is cached in the CXXExpansionStmtPattern.
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned HasExpansionSize : 1;
+  };
+
   //===--- Expression bitfields classes ---===//
 
   class ExprBitfields {
@@ -1348,6 +1361,7 @@ protected:
     ReturnStmtBitfields ReturnStmtBits;
     SwitchCaseBitfields SwitchCaseBits;
     DeferStmtBitfields DeferStmtBits;
+    CXXExpansionStmtPatternBitfields CXXExpansionStmtPatternBits;
 
     // Expressions
     ExprBitfields ExprBits;

--- a/clang/include/clang/AST/StmtCXX.h
+++ b/clang/include/clang/AST/StmtCXX.h
@@ -672,9 +672,23 @@ public:
 /// \see CXXExpansionStmtDecl for more documentation on expansion statements.
 class CXXExpansionStmtPattern final
     : public Stmt,
-      llvm::TrailingObjects<CXXExpansionStmtPattern, Stmt *> {
+      llvm::TrailingObjects<CXXExpansionStmtPattern, Stmt *,
+                            OptionalUnsigned<std::uint64_t>> {
   friend class ASTStmtReader;
   friend TrailingObjects;
+
+public:
+  using ExpansionSize = OptionalUnsigned<std::uint64_t>;
+
+private:
+  size_t numTrailingObjects(OverloadToken<Stmt *>) const {
+    return getNumSubStmts();
+  }
+
+  size_t
+  numTrailingObjects(OverloadToken<ExpansionSize>) const {
+    return CXXExpansionStmtPatternBits.HasExpansionSize;
+  }
 
 public:
   enum class ExpansionStmtKind : uint8_t {
@@ -726,15 +740,19 @@ private:
     COUNT_Iterating,
   };
 
-  CXXExpansionStmtPattern(ExpansionStmtKind PatternKind, EmptyShell Empty);
+  CXXExpansionStmtPattern(ExpansionStmtKind PatternKind, bool HasExpansionSize,
+                          EmptyShell Empty);
   CXXExpansionStmtPattern(ExpansionStmtKind PatternKind,
                           CXXExpansionStmtDecl *ESD, Stmt *Init,
                           DeclStmt *ExpansionVar, SourceLocation LParenLoc,
-                          SourceLocation ColonLoc, SourceLocation RParenLoc);
+                          SourceLocation ColonLoc, SourceLocation RParenLoc,
+                          ExpansionSize Size);
 
 public:
-  static CXXExpansionStmtPattern *
-  CreateEmpty(ASTContext &Context, EmptyShell Empty, ExpansionStmtKind Kind);
+  static CXXExpansionStmtPattern *CreateEmpty(ASTContext &Context,
+                                              EmptyShell Empty,
+                                              ExpansionStmtKind Kind,
+                                              bool HasExpansionSize);
 
   /// Create a dependent expansion statement pattern.
   static CXXExpansionStmtPattern *
@@ -748,20 +766,23 @@ public:
   CreateDestructuring(ASTContext &Context, CXXExpansionStmtDecl *ESD,
                       Stmt *Init, DeclStmt *ExpansionVar,
                       Stmt *DecompositionDeclStmt, SourceLocation LParenLoc,
-                      SourceLocation ColonLoc, SourceLocation RParenLoc);
+                      SourceLocation ColonLoc, SourceLocation RParenLoc,
+                      ExpansionSize Size);
 
   /// Create an enumerating expansion statement pattern.
   static CXXExpansionStmtPattern *
   CreateEnumerating(ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
                     DeclStmt *ExpansionVar, SourceLocation LParenLoc,
-                    SourceLocation ColonLoc, SourceLocation RParenLoc);
+                    SourceLocation ColonLoc, SourceLocation RParenLoc,
+                    ExpansionSize Size);
 
   /// Create an iterating expansion statement pattern.
   static CXXExpansionStmtPattern *
   CreateIterating(ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
                   DeclStmt *ExpansionVar, DeclStmt *Range, DeclStmt *Begin,
                   DeclStmt *Iter, SourceLocation LParenLoc,
-                  SourceLocation ColonLoc, SourceLocation RParenLoc);
+                  SourceLocation ColonLoc, SourceLocation RParenLoc,
+                  ExpansionSize Size);
 
   SourceLocation getLParenLoc() const { return LParenLoc; }
   SourceLocation getColonLoc() const { return ColonLoc; }
@@ -924,14 +945,26 @@ public:
     getSubStmt(EXPANSION_INITIALIZER) = S;
   }
 
+  // Get the expansion size, if known.
+  ExpansionSize getExpansionSize() const {
+    if (!CXXExpansionStmtPatternBits.HasExpansionSize)
+      return std::nullopt;
+    return *getTrailingObjects<ExpansionSize>();
+  }
+
+  void setExpansionSize(ExpansionSize Size) {
+    assert(CXXExpansionStmtPatternBits.HasExpansionSize);
+    *getTrailingObjects<ExpansionSize>() = Size;
+  }
+
   child_range children() {
-    return child_range(getTrailingObjects(),
-                       getTrailingObjects() + getNumSubStmts());
+    return child_range(getTrailingObjects<Stmt*>(),
+                       getTrailingObjects<Stmt*>() + getNumSubStmts());
   }
 
   const_child_range children() const {
-    return const_child_range(getTrailingObjects(),
-                             getTrailingObjects() + getNumSubStmts());
+    return const_child_range(getTrailingObjects<Stmt*>(),
+                             getTrailingObjects<Stmt*>() + getNumSubStmts());
   }
 
   static bool classof(const Stmt *T) {
@@ -940,19 +973,19 @@ public:
 
 private:
   template <typename... Args>
-  static CXXExpansionStmtPattern *AllocateAndConstruct(ASTContext &Context,
-                                                       ExpansionStmtKind Kind,
-                                                       Args &&...Arguments);
+  static CXXExpansionStmtPattern *
+  AllocateAndConstruct(ASTContext &Context, ExpansionStmtKind Kind,
+                       bool HasExpansionSize, Args &&...Arguments);
 
   static unsigned getNumSubStmts(ExpansionStmtKind Kind);
   Stmt *getSubStmt(unsigned Idx) const {
     assert(Idx < getNumSubStmts());
-    return getTrailingObjects()[Idx];
+    return getTrailingObjects<Stmt*>()[Idx];
   }
 
   Stmt *&getSubStmt(unsigned Idx) {
     assert(Idx < getNumSubStmts());
-    return getTrailingObjects()[Idx];
+    return getTrailingObjects<Stmt*>()[Idx];
   }
 };
 

--- a/clang/include/clang/AST/StmtCXX.h
+++ b/clang/include/clang/AST/StmtCXX.h
@@ -685,8 +685,7 @@ private:
     return getNumSubStmts();
   }
 
-  size_t
-  numTrailingObjects(OverloadToken<ExpansionSize>) const {
+  size_t numTrailingObjects(OverloadToken<ExpansionSize>) const {
     return CXXExpansionStmtPatternBits.HasExpansionSize;
   }
 
@@ -958,13 +957,13 @@ public:
   }
 
   child_range children() {
-    return child_range(getTrailingObjects<Stmt*>(),
-                       getTrailingObjects<Stmt*>() + getNumSubStmts());
+    return child_range(getTrailingObjects<Stmt *>(),
+                       getTrailingObjects<Stmt *>() + getNumSubStmts());
   }
 
   const_child_range children() const {
-    return const_child_range(getTrailingObjects<Stmt*>(),
-                             getTrailingObjects<Stmt*>() + getNumSubStmts());
+    return const_child_range(getTrailingObjects<Stmt *>(),
+                             getTrailingObjects<Stmt *>() + getNumSubStmts());
   }
 
   static bool classof(const Stmt *T) {
@@ -980,12 +979,12 @@ private:
   static unsigned getNumSubStmts(ExpansionStmtKind Kind);
   Stmt *getSubStmt(unsigned Idx) const {
     assert(Idx < getNumSubStmts());
-    return getTrailingObjects<Stmt*>()[Idx];
+    return getTrailingObjects<Stmt *>()[Idx];
   }
 
   Stmt *&getSubStmt(unsigned Idx) {
     assert(Idx < getNumSubStmts());
-    return getTrailingObjects<Stmt*>()[Idx];
+    return getTrailingObjects<Stmt *>()[Idx];
   }
 };
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15873,11 +15873,9 @@ public:
 
   StmtResult FinishCXXExpansionStmt(Stmt *Expansion, Stmt *Body);
 
-  StmtResult BuildCXXEnumeratingExpansionStmtPattern(Decl *ESD, Stmt *Init,
-                                                     Stmt *ExpansionVar,
-                                                     SourceLocation LParenLoc,
-                                                     SourceLocation ColonLoc,
-                                                     SourceLocation RParenLoc);
+  CXXExpansionStmtPattern *BuildCXXEnumeratingExpansionStmtPattern(
+      Decl *ESD, Stmt *Init, Stmt *ExpansionVar, SourceLocation LParenLoc,
+      SourceLocation ColonLoc, SourceLocation RParenLoc);
 
   StmtResult BuildNonEnumeratingCXXExpansionStmtPattern(
       CXXExpansionStmtDecl *ESD, Stmt *Init, DeclStmt *ExpansionVarStmt,
@@ -15887,8 +15885,9 @@ public:
 
   ExprResult BuildCXXExpansionSelectExpr(InitListExpr *Range, Expr *Idx);
 
-  std::optional<uint64_t>
-  ComputeExpansionSize(CXXExpansionStmtPattern *Expansion);
+  /// Compute the expansion size of an iterating expansion statement.
+  CXXExpansionStmtPattern::ExpansionSize
+  ComputeIteratingExpansionSize(VarDecl *RangeVar, SourceLocation ColonLoc);
   ///@}
 };
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -7577,7 +7577,7 @@ ASTNodeImporter::VisitCXXExpansionStmtPattern(CXXExpansionStmtPattern *S) {
   case CXXExpansionStmtPattern::ExpansionStmtKind::Enumerating:
     return CXXExpansionStmtPattern::CreateEnumerating(
         Importer.getToContext(), ToESD, ToInit, ToExpansionVar, ToLParenLoc,
-        ToColonLoc, ToRParenLoc);
+        ToColonLoc, ToRParenLoc, S->getExpansionSize());
 
   case CXXExpansionStmtPattern::ExpansionStmtKind::Iterating: {
     auto ToRange = importChecked(Err, S->getRangeVarStmt());
@@ -7588,7 +7588,8 @@ ASTNodeImporter::VisitCXXExpansionStmtPattern(CXXExpansionStmtPattern *S) {
 
     return CXXExpansionStmtPattern::CreateIterating(
         Importer.getToContext(), ToESD, ToInit, ToExpansionVar, ToRange,
-        ToBegin, ToIter, ToLParenLoc, ToColonLoc, ToRParenLoc);
+        ToBegin, ToIter, ToLParenLoc, ToColonLoc, ToRParenLoc,
+        S->getExpansionSize());
   }
 
   case CXXExpansionStmtPattern::ExpansionStmtKind::Destructuring: {
@@ -7599,7 +7600,8 @@ ASTNodeImporter::VisitCXXExpansionStmtPattern(CXXExpansionStmtPattern *S) {
 
     return CXXExpansionStmtPattern::CreateDestructuring(
         Importer.getToContext(), ToESD, ToInit, ToExpansionVar,
-        ToDecompositionDeclStmt, ToLParenLoc, ToColonLoc, ToRParenLoc);
+        ToDecompositionDeclStmt, ToLParenLoc, ToColonLoc, ToRParenLoc,
+        S->getExpansionSize());
   }
 
   case CXXExpansionStmtPattern::ExpansionStmtKind::Dependent: {

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -128,25 +128,34 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 }
 
 CXXExpansionStmtPattern::CXXExpansionStmtPattern(ExpansionStmtKind PatternKind,
+                                                 bool HasExpansionSize,
                                                  EmptyShell Empty)
-    : Stmt(CXXExpansionStmtPatternClass, Empty), PatternKind(PatternKind) {}
+    : Stmt(CXXExpansionStmtPatternClass, Empty), PatternKind(PatternKind) {
+  CXXExpansionStmtPatternBits.HasExpansionSize = HasExpansionSize;
+}
 
 CXXExpansionStmtPattern::CXXExpansionStmtPattern(
     ExpansionStmtKind PatternKind, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, SourceLocation LParenLoc, SourceLocation ColonLoc,
-    SourceLocation RParenLoc)
+    SourceLocation RParenLoc, ExpansionSize Size)
     : Stmt(CXXExpansionStmtPatternClass), PatternKind(PatternKind),
       LParenLoc(LParenLoc), ColonLoc(ColonLoc), RParenLoc(RParenLoc),
       ParentDecl(ESD) {
   setInit(Init);
   setExpansionVarStmt(ExpansionVar);
   setBody(nullptr);
+
+  CXXExpansionStmtPatternBits.HasExpansionSize = Size.has_value();
+  if (Size.has_value())
+    *getTrailingObjects<ExpansionSize>() = Size;
 }
 
 template <typename... Args>
 CXXExpansionStmtPattern *CXXExpansionStmtPattern::AllocateAndConstruct(
-    ASTContext &Context, ExpansionStmtKind Kind, Args &&...Arguments) {
-  std::size_t Size = totalSizeToAlloc<Stmt *>(getNumSubStmts(Kind));
+    ASTContext &Context, ExpansionStmtKind Kind, bool HasExpansionSize,
+    Args &&...Arguments) {
+  std::size_t Size = totalSizeToAlloc<Stmt *, ExpansionSize>(
+      getNumSubStmts(Kind), HasExpansionSize);
   void *Mem = Context.Allocate(Size, alignof(CXXExpansionStmtPattern));
   return new (Mem)
       CXXExpansionStmtPattern(Kind, std::forward<Args>(Arguments)...);
@@ -157,9 +166,10 @@ CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateDependent(
     DeclStmt *ExpansionVar, Expr *ExpansionInitializer,
     SourceLocation LParenLoc, SourceLocation ColonLoc,
     SourceLocation RParenLoc) {
-  CXXExpansionStmtPattern *Pattern =
-      AllocateAndConstruct(Context, ExpansionStmtKind::Dependent, ESD, Init,
-                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc);
+  CXXExpansionStmtPattern *Pattern = AllocateAndConstruct(
+      Context, ExpansionStmtKind::Dependent, /*HasExpansionSize=*/false, ESD,
+      Init, ExpansionVar, LParenLoc, ColonLoc, RParenLoc,
+      /*Size=*/std::nullopt);
   Pattern->setExpansionInitializer(ExpansionInitializer);
   return Pattern;
 }
@@ -168,37 +178,38 @@ CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateDestructuring(
     ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, Stmt *DecompositionDeclStmt,
     SourceLocation LParenLoc, SourceLocation ColonLoc,
-    SourceLocation RParenLoc) {
+    SourceLocation RParenLoc, ExpansionSize Size) {
   CXXExpansionStmtPattern *Pattern =
-      AllocateAndConstruct(Context, ExpansionStmtKind::Destructuring, ESD, Init,
-                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc);
+      AllocateAndConstruct(Context, ExpansionStmtKind::Destructuring, Size.has_value(), ESD, Init,
+                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc, Size);
   Pattern->setDecompositionDeclStmt(DecompositionDeclStmt);
   return Pattern;
 }
 
 CXXExpansionStmtPattern *
 CXXExpansionStmtPattern::CreateEmpty(ASTContext &Context, EmptyShell Empty,
-                                     ExpansionStmtKind Kind) {
-  return AllocateAndConstruct(Context, Kind, Empty);
+                                     ExpansionStmtKind Kind, bool HasExpansionSize) {
+  return AllocateAndConstruct(Context, Kind, HasExpansionSize, HasExpansionSize,
+                              Empty);
 }
 
 CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateEnumerating(
     ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, SourceLocation LParenLoc, SourceLocation ColonLoc,
-    SourceLocation RParenLoc) {
-  return AllocateAndConstruct(Context, ExpansionStmtKind::Enumerating, ESD,
+    SourceLocation RParenLoc, ExpansionSize Size) {
+  return AllocateAndConstruct(Context, ExpansionStmtKind::Enumerating, Size.has_value(), ESD,
                               Init, ExpansionVar, LParenLoc, ColonLoc,
-                              RParenLoc);
+                              RParenLoc, Size);
 }
 
 CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateIterating(
     ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, DeclStmt *Range, DeclStmt *Begin, DeclStmt *Iter,
     SourceLocation LParenLoc, SourceLocation ColonLoc,
-    SourceLocation RParenLoc) {
+    SourceLocation RParenLoc, ExpansionSize Size) {
   CXXExpansionStmtPattern *Pattern =
-      AllocateAndConstruct(Context, ExpansionStmtKind::Iterating, ESD, Init,
-                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc);
+      AllocateAndConstruct(Context, ExpansionStmtKind::Iterating, Size.has_value(), ESD, Init,
+                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc, Size);
   Pattern->setRangeVarStmt(Range);
   Pattern->setBeginVarStmt(Begin);
   Pattern->setIterVarStmt(Iter);

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -177,18 +177,19 @@ CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateDependent(
 CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateDestructuring(
     ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, Stmt *DecompositionDeclStmt,
-    SourceLocation LParenLoc, SourceLocation ColonLoc,
-    SourceLocation RParenLoc, ExpansionSize Size) {
-  CXXExpansionStmtPattern *Pattern =
-      AllocateAndConstruct(Context, ExpansionStmtKind::Destructuring, Size.has_value(), ESD, Init,
-                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc, Size);
+    SourceLocation LParenLoc, SourceLocation ColonLoc, SourceLocation RParenLoc,
+    ExpansionSize Size) {
+  CXXExpansionStmtPattern *Pattern = AllocateAndConstruct(
+      Context, ExpansionStmtKind::Destructuring, Size.has_value(), ESD, Init,
+      ExpansionVar, LParenLoc, ColonLoc, RParenLoc, Size);
   Pattern->setDecompositionDeclStmt(DecompositionDeclStmt);
   return Pattern;
 }
 
 CXXExpansionStmtPattern *
 CXXExpansionStmtPattern::CreateEmpty(ASTContext &Context, EmptyShell Empty,
-                                     ExpansionStmtKind Kind, bool HasExpansionSize) {
+                                     ExpansionStmtKind Kind,
+                                     bool HasExpansionSize) {
   return AllocateAndConstruct(Context, Kind, HasExpansionSize, HasExpansionSize,
                               Empty);
 }
@@ -197,19 +198,19 @@ CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateEnumerating(
     ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, SourceLocation LParenLoc, SourceLocation ColonLoc,
     SourceLocation RParenLoc, ExpansionSize Size) {
-  return AllocateAndConstruct(Context, ExpansionStmtKind::Enumerating, Size.has_value(), ESD,
-                              Init, ExpansionVar, LParenLoc, ColonLoc,
-                              RParenLoc, Size);
+  return AllocateAndConstruct(Context, ExpansionStmtKind::Enumerating,
+                              Size.has_value(), ESD, Init, ExpansionVar,
+                              LParenLoc, ColonLoc, RParenLoc, Size);
 }
 
 CXXExpansionStmtPattern *CXXExpansionStmtPattern::CreateIterating(
     ASTContext &Context, CXXExpansionStmtDecl *ESD, Stmt *Init,
     DeclStmt *ExpansionVar, DeclStmt *Range, DeclStmt *Begin, DeclStmt *Iter,
-    SourceLocation LParenLoc, SourceLocation ColonLoc,
-    SourceLocation RParenLoc, ExpansionSize Size) {
-  CXXExpansionStmtPattern *Pattern =
-      AllocateAndConstruct(Context, ExpansionStmtKind::Iterating, Size.has_value(), ESD, Init,
-                           ExpansionVar, LParenLoc, ColonLoc, RParenLoc, Size);
+    SourceLocation LParenLoc, SourceLocation ColonLoc, SourceLocation RParenLoc,
+    ExpansionSize Size) {
+  CXXExpansionStmtPattern *Pattern = AllocateAndConstruct(
+      Context, ExpansionStmtKind::Iterating, Size.has_value(), ESD, Init,
+      ExpansionVar, LParenLoc, ColonLoc, RParenLoc, Size);
   Pattern->setRangeVarStmt(Range);
   Pattern->setBeginVarStmt(Begin);
   Pattern->setIterVarStmt(Iter);

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2371,6 +2371,20 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
 
   MisleadingIndentationChecker MIChecker(*this, MSK_for, ForLoc);
 
+  // If this is an expansion statement with a known expansion size of 0, parse
+  // the body as a discarded statement.
+  bool ShouldEnterDiscardedContext = false;
+  if (ESD && ForRangeStmt.isUsable()) {
+    auto *Pattern = ForRangeStmt.getAs<CXXExpansionStmtPattern>();
+    ShouldEnterDiscardedContext = Pattern->getExpansionSize() == 0u;
+  }
+
+  EnterExpressionEvaluationContext PotentiallyDiscarded(
+      Actions, Sema::ExpressionEvaluationContext::DiscardedStatement,
+      /*LambdaContextDecl=*/nullptr,
+      Sema::ExpressionEvaluationContextRecord::EK_Other,
+      ShouldEnterDiscardedContext);
+
   // Read the body statement.
   StmtResult Body(ParseStatement(TrailingElseLoc));
 

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/ScopeExit.h"
 
 using namespace clang;
+using ExpansionSize = CXXExpansionStmtPattern::ExpansionSize;
 
 namespace {
 struct IterableExpansionStmtData {
@@ -74,32 +75,6 @@ static bool FinalizeExpansionVar(Sema &S, VarDecl *ExpansionVar,
 static auto InitListContainsPack(const InitListExpr *ILE) {
   return llvm::any_of(ILE->inits(),
                       [](const Expr *E) { return isa<PackExpansionExpr>(E); });
-}
-
-static bool HasDependentSize(const DeclContext *CurContext,
-                             const CXXExpansionStmtPattern *Pattern) {
-  switch (Pattern->getKind()) {
-  case CXXExpansionStmtPattern::ExpansionStmtKind::Enumerating: {
-    auto *SelectExpr = cast<CXXExpansionSelectExpr>(
-        Pattern->getExpansionVariable()->getInit());
-    return InitListContainsPack(SelectExpr->getRangeExpr());
-  }
-
-  case CXXExpansionStmtPattern::ExpansionStmtKind::Iterating:
-    // Even if the size isn't technically dependent, delay expansion until
-    // we're no longer in a template since evaluating a lambda declared in
-    // a template doesn't work too well.
-    assert(CurContext->isExpansionStmt());
-    return CurContext->getParent()->isDependentContext();
-
-  case CXXExpansionStmtPattern::ExpansionStmtKind::Dependent:
-    return true;
-
-  case CXXExpansionStmtPattern::ExpansionStmtKind::Destructuring:
-    return false;
-  }
-
-  llvm_unreachable("invalid pattern kind");
 }
 
 static IterableExpansionStmtData TryBuildIterableExpansionStmtInitializer(
@@ -359,12 +334,21 @@ StmtResult Sema::ActOnCXXExpansionStmtPattern(
       LifetimeExtendTemps);
 }
 
-StmtResult Sema::BuildCXXEnumeratingExpansionStmtPattern(
+CXXExpansionStmtPattern *Sema::BuildCXXEnumeratingExpansionStmtPattern(
     Decl *ESD, Stmt *Init, Stmt *ExpansionVar, SourceLocation LParenLoc,
     SourceLocation ColonLoc, SourceLocation RParenLoc) {
+  // The expansion size is known if the expansion-initializer contains no
+  // pack expansions.
+  auto *VD = cast<VarDecl>(cast<DeclStmt>(ExpansionVar)->getSingleDecl());
+  auto *SelectExpr = cast<CXXExpansionSelectExpr>(VD->getInit());
+  bool SizeIsKnown = !InitListContainsPack(SelectExpr->getRangeExpr());
+  ExpansionSize Size =
+      SizeIsKnown ? ExpansionSize(SelectExpr->getRangeExpr()->getNumInits())
+                  : std::nullopt;
+
   return CXXExpansionStmtPattern::CreateEnumerating(
       Context, cast<CXXExpansionStmtDecl>(ESD), Init,
-      cast<DeclStmt>(ExpansionVar), LParenLoc, ColonLoc, RParenLoc);
+      cast<DeclStmt>(ExpansionVar), LParenLoc, ColonLoc, RParenLoc, Size);
 }
 
 StmtResult Sema::BuildNonEnumeratingCXXExpansionStmtPattern(
@@ -426,9 +410,11 @@ StmtResult Sema::BuildNonEnumeratingCXXExpansionStmtPattern(
     if (FinalizeExpansionVar(*this, ExpansionVar, Deref.get()))
       return StmtError();
 
+    auto *RangeVar = cast<VarDecl>(Data.RangeDecl->getSingleDecl());
+    ExpansionSize Size = ComputeIteratingExpansionSize(RangeVar, ColonLoc);
     return CXXExpansionStmtPattern::CreateIterating(
         Context, ESD, Init, ExpansionVarStmt, Data.RangeDecl, Data.BeginDecl,
-        Data.IterDecl, LParenLoc, ColonLoc, RParenLoc);
+        Data.IterDecl, LParenLoc, ColonLoc, RParenLoc, Size);
   }
 
   // If not, try destructuring.
@@ -489,8 +475,12 @@ StmtResult Sema::BuildNonEnumeratingCXXExpansionStmtPattern(
   if (FinalizeExpansionVar(*this, ExpansionVar, Select))
     return StmtError();
 
+  // We only build a destructuring expansion statement once the initializer
+  // is no longer dependent; thus, the expansion size is always known.
+  ExpansionSize Size = DD->bindings().size();
   return CXXExpansionStmtPattern::CreateDestructuring(
-      Context, ESD, Init, ExpansionVarStmt, DS, LParenLoc, ColonLoc, RParenLoc);
+      Context, ESD, Init, ExpansionVarStmt, DS, LParenLoc, ColonLoc, RParenLoc,
+      Size);
 }
 
 StmtResult Sema::FinishCXXExpansionStmt(Stmt *Exp, Stmt *Body) {
@@ -502,18 +492,14 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Exp, Stmt *Body) {
          "should not rebuild expansion statement after instantiation");
 
   Expansion->setBody(Body);
-  if (HasDependentSize(CurContext, Expansion))
+  ExpansionSize NumInstantiations = Expansion->getExpansionSize();
+  if (!NumInstantiations.has_value())
     return Expansion;
 
   // Now that we're expanding this, exit the context of the expansion stmt
   // so that we no longer treat this as dependent.
   ContextRAII CtxGuard(*this, CurContext->getParent(),
                        /*NewThis=*/false);
-
-  // This can fail if this is an iterating expansion statement.
-  std::optional<uint64_t> NumInstantiations = ComputeExpansionSize(Expansion);
-  if (!NumInstantiations)
-    return StmtError();
 
   // Collect preamble statements.
   //
@@ -598,13 +584,19 @@ ExprResult Sema::BuildCXXExpansionSelectExpr(InitListExpr *Range, Expr *Idx) {
   return Range->getInit(I);
 }
 
-std::optional<uint64_t>
-Sema::ComputeExpansionSize(CXXExpansionStmtPattern *Expansion) {
-  if (Expansion->isEnumerating())
-    return cast<CXXExpansionSelectExpr>(
-               Expansion->getExpansionVariable()->getInit())
-        ->getRangeExpr()
-        ->getNumInits();
+CXXExpansionStmtPattern::ExpansionSize
+Sema::ComputeIteratingExpansionSize(VarDecl *RangeVar, SourceLocation Loc) {
+  // Even if the size isn't technically dependent, delay expansion until
+  // we're no longer in a template since evaluating a lambda declared in
+  // a template doesn't work too well.
+  assert(CurContext->isExpansionStmt());
+  if (CurContext->getParent()->isDependentContext())
+    return std::nullopt;
+
+  // Computing the expansion size should happen outside the dependent
+  // expansion statement context.
+  ContextRAII CtxGuard(*this, CurContext->getParent(),
+                       /*NewThis=*/false);
 
   // [stmt.expand]p5.2 (CWG3131): N is the result of evaluating the expression
   //
@@ -615,14 +607,12 @@ Sema::ComputeExpansionSize(CXXExpansionStmtPattern *Expansion) {
   //    for (; b != e; ++b) ++result;
   //    return result;
   // }()
-  if (Expansion->isIterating()) {
-    SourceLocation Loc = Expansion->getColonLoc();
-    EnterExpressionEvaluationContext ExprEvalCtx(
-        *this, ExpressionEvaluationContext::ConstantEvaluated);
+  EnterExpressionEvaluationContext ExprEvalCtx(
+      *this, ExpressionEvaluationContext::ConstantEvaluated);
 
-    // TODO: Build the lambda and evaluate it.
-    Diag(Loc, diag::err_iterating_expansion_stmt_unsupported);
-    return std::nullopt;
+  // TODO: Build the lambda and evaluate it.
+  Diag(Loc, diag::err_iterating_expansion_stmt_unsupported);
+  return std::nullopt;
 
 #if 0 // This will be used once we support iterating expansion statements.
     Expr::EvalResult ER;
@@ -640,8 +630,4 @@ Sema::ComputeExpansionSize(CXXExpansionStmtPattern *Expansion) {
     assert(ER.Val.getInt().isNonNegative());
     return ER.Val.getInt().getZExtValue();
 #endif
-  }
-
-  assert(Expansion->isDestructuring());
-  return Expansion->getDecompositionDecl()->bindings().size();
 }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3651,20 +3651,6 @@ static bool hasDeducedReturnType(FunctionDecl *FD) {
   return FPT->getReturnType()->isUndeducedType();
 }
 
-/// Determine whether a return statement encountered in the current context
-/// is allowed to partake in return type deduction.
-static bool AllowReturnTypeDeductionInCurrentContext(Sema &S) {
-  // C++1z: discarded return statements are not considered when deducing a
-  // return type.
-  //
-  // Also ignore return statements within an unexpanded expansion statement
-  // since we'll revisit them anyway once we expand it; this way, we don't
-  // have to try and compute the expansion size ahead of time to figure out
-  // if it is 0 (and if the expansion statement body is thus discarded).
-  return !S.ExprEvalContexts.back().isDiscardedStatementContext() &&
-         !S.CurContext->isExpansionStmt();
-}
-
 /// Build a return statement that is in a discarded context.
 static StmtResult BuildDiscardedReturnStmt(Sema &S, Expr *RetValExp,
                                            SourceLocation ReturnLoc) {
@@ -3693,8 +3679,8 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
   bool HasDeducedReturnType =
       CurLambda && hasDeducedReturnType(CurLambda->CallOperator);
 
-  if ((HasDeducedReturnType || CurCap->HasImplicitReturnType) &&
-      !AllowReturnTypeDeductionInCurrentContext(*this))
+  if (ExprEvalContexts.back().isDiscardedStatementContext() &&
+      (HasDeducedReturnType || CurCap->HasImplicitReturnType))
     return BuildDiscardedReturnStmt(*this, RetValExp, ReturnLoc);
 
   if (HasDeducedReturnType) {
@@ -4031,7 +4017,7 @@ Sema::ActOnReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
 
   StmtResult R =
       BuildReturnStmt(ReturnLoc, RetVal.get(), /*AllowRecovery=*/true);
-  if (R.isInvalid() || !AllowReturnTypeDeductionInCurrentContext(*this))
+  if (R.isInvalid() || ExprEvalContexts.back().isDiscardedStatementContext())
     return R;
 
   VarDecl *VD =
@@ -4141,8 +4127,10 @@ StmtResult Sema::BuildReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
     }
   }
 
-  if (FnRetType->getContainedAutoType() &&
-      !AllowReturnTypeDeductionInCurrentContext(*this))
+  // C++1z: discarded return statements are not considered when deducing a
+  // return type.
+  if (ExprEvalContexts.back().isDiscardedStatementContext() &&
+      FnRetType->getContainedAutoType())
     return BuildDiscardedReturnStmt(*this, RetValExp, ReturnLoc);
 
   // FIXME: Add a flag to the ScopeInfo to indicate whether we're performing

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3651,6 +3651,34 @@ static bool hasDeducedReturnType(FunctionDecl *FD) {
   return FPT->getReturnType()->isUndeducedType();
 }
 
+/// Determine whether a return statement encountered in the current context
+/// is allowed to partake in return type deduction.
+static bool AllowReturnTypeDeductionInCurrentContext(Sema &S) {
+  // C++1z: discarded return statements are not considered when deducing a
+  // return type.
+  //
+  // Also ignore return statements within an unexpanded expansion statement
+  // since we'll revisit them anyway once we expand it; this way, we don't
+  // have to try and compute the expansion size ahead of time to figure out
+  // if it is 0 (and if the expansion statement body is thus discarded).
+  return !S.ExprEvalContexts.back().isDiscardedStatementContext() &&
+         !S.CurContext->isExpansionStmt();
+}
+
+/// Build a return statement that is in a discarded context.
+static StmtResult BuildDiscardedReturnStmt(Sema &S, Expr *RetValExp,
+                                           SourceLocation ReturnLoc) {
+  if (RetValExp) {
+    ExprResult ER =
+        S.ActOnFinishFullExpr(RetValExp, ReturnLoc, /*DiscardedValue=*/false);
+    if (ER.isInvalid())
+      return StmtError();
+    RetValExp = ER.get();
+  }
+  return ReturnStmt::Create(S.Context, ReturnLoc, RetValExp,
+                            /* NRVOCandidate=*/nullptr);
+}
+
 StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
                                          Expr *RetValExp,
                                          NamedReturnInfo &NRInfo,
@@ -3665,18 +3693,9 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
   bool HasDeducedReturnType =
       CurLambda && hasDeducedReturnType(CurLambda->CallOperator);
 
-  if (ExprEvalContexts.back().isDiscardedStatementContext() &&
-      (HasDeducedReturnType || CurCap->HasImplicitReturnType)) {
-    if (RetValExp) {
-      ExprResult ER =
-          ActOnFinishFullExpr(RetValExp, ReturnLoc, /*DiscardedValue*/ false);
-      if (ER.isInvalid())
-        return StmtError();
-      RetValExp = ER.get();
-    }
-    return ReturnStmt::Create(Context, ReturnLoc, RetValExp,
-                              /* NRVOCandidate=*/nullptr);
-  }
+  if ((HasDeducedReturnType || CurCap->HasImplicitReturnType) &&
+      !AllowReturnTypeDeductionInCurrentContext(*this))
+    return BuildDiscardedReturnStmt(*this, RetValExp, ReturnLoc);
 
   if (HasDeducedReturnType) {
     FunctionDecl *FD = CurLambda->CallOperator;
@@ -4012,7 +4031,7 @@ Sema::ActOnReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
 
   StmtResult R =
       BuildReturnStmt(ReturnLoc, RetVal.get(), /*AllowRecovery=*/true);
-  if (R.isInvalid() || ExprEvalContexts.back().isDiscardedStatementContext())
+  if (R.isInvalid() || !AllowReturnTypeDeductionInCurrentContext(*this))
     return R;
 
   VarDecl *VD =
@@ -4122,20 +4141,9 @@ StmtResult Sema::BuildReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
     }
   }
 
-  // C++1z: discarded return statements are not considered when deducing a
-  // return type.
-  if (ExprEvalContexts.back().isDiscardedStatementContext() &&
-      FnRetType->getContainedAutoType()) {
-    if (RetValExp) {
-      ExprResult ER =
-          ActOnFinishFullExpr(RetValExp, ReturnLoc, /*DiscardedValue*/ false);
-      if (ER.isInvalid())
-        return StmtError();
-      RetValExp = ER.get();
-    }
-    return ReturnStmt::Create(Context, ReturnLoc, RetValExp,
-                              /* NRVOCandidate=*/nullptr);
-  }
+  if (FnRetType->getContainedAutoType() &&
+      !AllowReturnTypeDeductionInCurrentContext(*this))
+    return BuildDiscardedReturnStmt(*this, RetValExp, ReturnLoc);
 
   // FIXME: Add a flag to the ScopeInfo to indicate whether we're performing
   // deduction.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -9512,9 +9512,8 @@ StmtResult TreeTransform<Derived>::TransformCXXExpansionStmtPattern(
 
     NewPattern = CXXExpansionStmtPattern::CreateIterating(
         SemaRef.Context, NewESD, Init, ExpansionVar.getAs<DeclStmt>(),
-        RangeVarDS, Begin.getAs<DeclStmt>(),
-        Iter.getAs<DeclStmt>(), S->getLParenLoc(), S->getColonLoc(),
-        S->getRParenLoc(), Size);
+        RangeVarDS, Begin.getAs<DeclStmt>(), Iter.getAs<DeclStmt>(),
+        S->getLParenLoc(), S->getColonLoc(), S->getRParenLoc(), Size);
 
     SemaRef.ApplyForRangeOrExpansionStatementLifetimeExtension(
         NewPattern->getRangeVar(), LifetimeExtendTemps);

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -9487,9 +9487,9 @@ StmtResult TreeTransform<Derived>::TransformCXXExpansionStmtPattern(
     if (ExpansionVar.isInvalid())
       return StmtError();
 
-    NewPattern = CXXExpansionStmtPattern::CreateEnumerating(
-        SemaRef.Context, NewESD, Init, ExpansionVar.getAs<DeclStmt>(),
-        S->getLParenLoc(), S->getColonLoc(), S->getRParenLoc());
+    NewPattern = SemaRef.BuildCXXEnumeratingExpansionStmtPattern(
+        NewESD, Init, ExpansionVar.getAs<DeclStmt>(), S->getLParenLoc(),
+        S->getColonLoc(), S->getRParenLoc());
   } else if (S->isIterating()) {
     StmtResult Begin = TransformStmtInParentContext(S->getBeginVarStmt());
     StmtResult Iter = TransformStmtInParentContext(S->getIterVarStmt());
@@ -9504,11 +9504,17 @@ StmtResult TreeTransform<Derived>::TransformCXXExpansionStmtPattern(
     if (ExpansionVar.isInvalid())
       return StmtError();
 
+    // Compute the expansion size if possible.
+    DeclStmt *RangeVarDS = Range.getAs<DeclStmt>();
+    VarDecl *RangeVar = cast<VarDecl>(RangeVarDS->getSingleDecl());
+    CXXExpansionStmtPattern::ExpansionSize Size =
+        SemaRef.ComputeIteratingExpansionSize(RangeVar, S->getColonLoc());
+
     NewPattern = CXXExpansionStmtPattern::CreateIterating(
         SemaRef.Context, NewESD, Init, ExpansionVar.getAs<DeclStmt>(),
-        Range.getAs<DeclStmt>(), Begin.getAs<DeclStmt>(),
+        RangeVarDS, Begin.getAs<DeclStmt>(),
         Iter.getAs<DeclStmt>(), S->getLParenLoc(), S->getColonLoc(),
-        S->getRParenLoc());
+        S->getRParenLoc(), Size);
 
     SemaRef.ApplyForRangeOrExpansionStatementLifetimeExtension(
         NewPattern->getRangeVar(), LifetimeExtendTemps);
@@ -9535,6 +9541,13 @@ StmtResult TreeTransform<Derived>::TransformCXXExpansionStmtPattern(
     // here.
     llvm_unreachable("destructuring pattern should never be instantiated");
   }
+
+  // If the expansion size is 0, treat the body as a discarded statement.
+  EnterExpressionEvaluationContext PotentiallyDiscarded(
+      SemaRef, Sema::ExpressionEvaluationContext::DiscardedStatement,
+      /*LambdaContextDecl=*/nullptr,
+      Sema::ExpressionEvaluationContextRecord::EK_Other,
+      NewPattern->getExpansionSize() == 0u);
 
   StmtResult Body = getDerived().TransformStmt(S->getBody());
   if (Body.isInvalid())

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -1784,13 +1784,15 @@ void ASTStmtReader::VisitCXXForRangeStmt(CXXForRangeStmt *S) {
 
 void ASTStmtReader::VisitCXXExpansionStmtPattern(CXXExpansionStmtPattern *S) {
   VisitStmt(S);
-  Record.skipInts(1); // Skip kind.
+  Record.skipInts(2); // Skip kind and whether there is an expansion size.
   S->LParenLoc = readSourceLocation();
   S->ColonLoc = readSourceLocation();
   S->RParenLoc = readSourceLocation();
   S->ParentDecl = cast<CXXExpansionStmtDecl>(Record.readDeclRef());
   for (Stmt *&SubStmt : S->children())
     SubStmt = Record.readSubStmt();
+  if (S->CXXExpansionStmtPatternBits.HasExpansionSize)
+    S->setExpansionSize(Record.readInt());
 }
 
 void ASTStmtReader::VisitCXXExpansionStmtInstantiation(
@@ -3666,7 +3668,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       S = CXXExpansionStmtPattern::CreateEmpty(
           Context, Empty,
           static_cast<CXXExpansionStmtPattern::ExpansionStmtKind>(
-              Record[ASTStmtReader::NumStmtFields]));
+              Record[ASTStmtReader::NumStmtFields]),
+          Record[ASTStmtReader::NumStmtFields + 1]);
       break;
 
     case STMT_CXX_EXPANSION_INSTANTIATION:

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -1760,12 +1760,15 @@ void ASTStmtWriter::VisitCXXForRangeStmt(CXXForRangeStmt *S) {
 void ASTStmtWriter::VisitCXXExpansionStmtPattern(CXXExpansionStmtPattern *S) {
   VisitStmt(S);
   Record.push_back(static_cast<unsigned>(S->getKind()));
+  Record.push_back(S->getExpansionSize().has_value());
   Record.AddSourceLocation(S->getLParenLoc());
   Record.AddSourceLocation(S->getColonLoc());
   Record.AddSourceLocation(S->getRParenLoc());
   Record.AddDeclRef(S->getDecl());
   for (Stmt *SubStmt : S->children())
     Record.AddStmt(SubStmt);
+  if (CXXExpansionStmtPattern::ExpansionSize Size = S->getExpansionSize())
+    Record.push_back(*Size);
   Code = serialization::STMT_CXX_EXPANSION_PATTERN;
 }
 

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
@@ -1701,3 +1701,11 @@ auto not_ignored2() {
 
 static_assert(__is_same(decltype(not_ignored2()), int));
 }
+
+namespace gh212088 {
+void f() {
+  struct S {};
+  template for (const int &x : []{return S();}()) {
+  }
+}
+}

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
@@ -1606,3 +1606,98 @@ T tf() {
 
 template long tf<long>();
 }
+
+// Check that we ignore return statements in the body of an expansion statement
+// with expansion size 0 for the purposes of return-type deduction.
+namespace gh212086 {
+auto ignored() {
+  template for (auto x : {}) {
+    return 3;
+  }
+  return 1.3;
+}
+
+static_assert(__is_same(decltype(ignored()), double));
+
+auto ignored_swapped() {
+  template for (auto x : {}) {
+    return 1.3;
+  }
+  return 3;
+}
+
+static_assert(__is_same(decltype(ignored_swapped()), int));
+
+auto ignored2() {
+  template for (auto x : {}) {
+    return x;
+  }
+}
+
+static_assert(__is_same(decltype(ignored2()), void));
+
+auto ignored3() {
+  template for (auto x : Empty()) {
+    return 3;
+  }
+  return 1.3;
+}
+
+static_assert(__is_same(decltype(ignored3()), double));
+
+auto ignored4() {
+  template for (auto x : Empty()) {
+    return x;
+  }
+}
+
+static_assert(__is_same(decltype(ignored4()), void));
+
+template <typename>
+auto ignored_template() {
+  template for (auto x : {}) {
+    return 3;
+  }
+  return 1.3;
+}
+
+template auto ignored_template<int>();
+static_assert(__is_same(decltype(ignored_template<int>()), double));
+
+template <typename>
+auto ignored_template2() {
+  template for (auto x : {}) {
+    return x;
+  }
+}
+
+template auto ignored_template2<int>();
+static_assert(__is_same(decltype(ignored_template2<int>()), void));
+
+template <typename T>
+auto ignored_template3() {
+  template for (T x : {}) {
+    return x;
+  }
+}
+
+template auto ignored_template3<int>();
+static_assert(__is_same(decltype(ignored_template3<int>()), void));
+
+auto not_ignored() {
+  int a[1]{};
+  template for (auto x : a) {
+    return 3;
+  }
+  return 1.3; // expected-error {{'auto' in return type deduced as 'double' here but deduced as 'int' in earlier return statement}}
+}
+
+auto not_ignored2() {
+  int a[1]{};
+  template for (auto x : a) {
+    return x;
+  }
+}
+
+static_assert(__is_same(decltype(not_ignored2()), int));
+}

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
@@ -1701,11 +1701,3 @@ auto not_ignored2() {
 
 static_assert(__is_same(decltype(not_ignored2()), int));
 }
-
-namespace gh212088 {
-void f() {
-  struct S {};
-  template for (const int &x : []{return S();}()) {
-  }
-}
-}


### PR DESCRIPTION
This patch updates the body of an expansion statement to be a discarded statement if the expansion size evaluates to 0, i.e. it is treated like the discarded branch of an `if constexpr`; this requires a bit of refactoring since we now need to compute the expansion size before we parse/instantiate the body (which is fine, since it doesn’t depend on the body).

The computed expansion size is stored in the `CXXExpansionStmtPattern` so we don’t need to compute it again when we expand it, this doesn’t really matter for enumerating and destructuring expansion statements, but it will become important once we support iterating expansion statements.

Fixes #212086.