### PR TITLE
[Clang] [NFC] Update OptionalUnsigned ctor to only reject signed integers

### DIFF
--- a/clang/include/clang/Basic/OptionalUnsigned.h
+++ b/clang/include/clang/Basic/OptionalUnsigned.h
@@ -31,9 +31,8 @@ template <class T> struct OptionalUnsigned {
     assert(has_value());
   }
 
-  template <typename SignedInt,
-            std::enable_if_t<std::is_signed_v<SignedInt>, bool> = false>
-  OptionalUnsigned(SignedInt) = delete;
+  template <class U, std::enable_if_t<std::is_signed_v<U>, bool> = false>
+  OptionalUnsigned(U) = delete;
 
   constexpr static OptionalUnsigned
   fromInternalRepresentation(underlying_type Rep) {

--- a/clang/include/clang/Basic/OptionalUnsigned.h
+++ b/clang/include/clang/Basic/OptionalUnsigned.h
@@ -30,7 +30,10 @@ template <class T> struct OptionalUnsigned {
   OptionalUnsigned(T Val) : Rep(static_cast<underlying_type>(Val) + 1) {
     assert(has_value());
   }
-  OptionalUnsigned(int) = delete;
+
+  template <typename SignedInt,
+            std::enable_if_t<std::is_signed_v<SignedInt>, bool> = false>
+  OptionalUnsigned(SignedInt) = delete;
 
   constexpr static OptionalUnsigned
   fromInternalRepresentation(underlying_type Rep) {


### PR DESCRIPTION
Currently, the `OptionalUnsigned(int) = delete;` constructor means that constructing e.g. an `OptionalOrUnsigned<uint64_t>` from an `unsigned` fails because overload resolution is ambiguous (because `unsigned` -> `int` and `unsigned` -> `uint64_t` are both valid conversions). This patch adds a constraint to make sure the deleted constructor only catches signed integer types.

This is needed for #212319.