### PR TITLE
[clang-tidy] add bugprone-nested-switch-label

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp
@@ -58,6 +58,7 @@
 #include "MultipleNewInOneExpressionCheck.h"
 #include "MultipleStatementMacroCheck.h"
 #include "NarrowingConversionsCheck.h"
+#include "NestedSwitchLabelCheck.h"
 #include "NoEscapeCheck.h"
 #include "NonZeroEnumToBoolConversionCheck.h"
 #include "NondeterministicPointerIterationOrderCheck.h"
@@ -235,6 +236,8 @@ public:
         "bugprone-redundant-branch-condition");
     CheckFactories.registerCheck<NarrowingConversionsCheck>(
         "bugprone-narrowing-conversions");
+    CheckFactories.registerCheck<NestedSwitchLabelCheck>(
+        "bugprone-nested-switch-label");
     CheckFactories.registerCheck<NoEscapeCheck>("bugprone-no-escape");
     CheckFactories.registerCheck<NonZeroEnumToBoolConversionCheck>(
         "bugprone-non-zero-enum-to-bool-conversion");

--- a/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
@@ -61,6 +61,7 @@ add_clang_library(clangTidyBugproneModule STATIC
   MultipleNewInOneExpressionCheck.cpp
   MultipleStatementMacroCheck.cpp
   NarrowingConversionsCheck.cpp
+  NestedSwitchLabelCheck.cpp
   NoEscapeCheck.cpp
   NonZeroEnumToBoolConversionCheck.cpp
   NondeterministicPointerIterationOrderCheck.cpp

--- a/clang-tools-extra/clang-tidy/bugprone/NestedSwitchLabelCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NestedSwitchLabelCheck.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NestedSwitchLabelCheck.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::bugprone {
+
+namespace {
+
+static const char SwitchBodyId[] = "switch-body";
+static const char SwitchLabelId[] = "switch-label";
+
+AST_MATCHER_P(SwitchStmt, hasBodyIgnoringAttrs,
+              clang::ast_matchers::internal::Matcher<Stmt>, InnerMatcher) {
+  const Stmt *Body = Node.getBody();
+  while (const auto *Attributed = dyn_cast<AttributedStmt>(Body))
+    Body = Attributed->getSubStmt();
+
+  return InnerMatcher.matches(*Body, Finder, Builder);
+}
+
+} // namespace
+
+void NestedSwitchLabelCheck::registerMatchers(MatchFinder *Finder) {
+  const auto BoundSwitchBody = stmt().bind(SwitchBodyId);
+  const auto CompoundNestedInSwitchBody =
+      compoundStmt(hasAncestor(stmt(equalsBoundNode(SwitchBodyId))));
+  const auto LabelInNestedCompound =
+      switchCase(hasAncestor(CompoundNestedInSwitchBody)).bind(SwitchLabelId);
+
+  Finder->addMatcher(switchStmt(hasBodyIgnoringAttrs(BoundSwitchBody),
+                                forEachSwitchCase(LabelInNestedCompound)),
+                     this);
+}
+
+void NestedSwitchLabelCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *Label = Result.Nodes.getNodeAs<SwitchCase>(SwitchLabelId);
+  diag(Label->getKeywordLoc(),
+       "switch label is nested inside a compound statement other than the "
+       "switch body");
+}
+
+} // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/NestedSwitchLabelCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/NestedSwitchLabelCheck.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_NESTEDSWITCHLABELCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_NESTEDSWITCHLABELCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::bugprone {
+
+/// Finds switch labels nested in compound statements other than the switch
+/// body.
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/bugprone/nested-switch-label.html
+class NestedSwitchLabelCheck : public ClangTidyCheck {
+public:
+  NestedSwitchLabelCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+
+  std::optional<TraversalKind> getCheckTraversalKind() const override {
+    return TK_IgnoreUnlessSpelledInSource;
+  }
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace clang::tidy::bugprone
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BUGPRONE_NESTEDSWITCHLABELCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -97,6 +97,11 @@ Improvements to clang-tidy
 New checks
 ^^^^^^^^^^
 
+- New :doc:`bugprone-nested-switch-label
+  <clang-tidy/checks/bugprone/nested-switch-label>` check.
+
+  Finds switch labels nested in compound statements other than the switch body.
+
 - New :doc:`performance-expensive-value-or
   <clang-tidy/checks/performance/expensive-value-or>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/nested-switch-label.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/nested-switch-label.md
@@ -1,0 +1,27 @@
+```{title} clang-tidy - bugprone-nested-switch-label
+```
+
+# bugprone-nested-switch-label
+
+Finds `case` and `default` labels nested in compound statements other than
+the compound statement that forms the body of their switch. Such labels are
+legal, but their control flow is easy to misread because the switch can jump
+directly into the nested scope.
+
+For example:
+
+```cpp
+switch (value) {
+case 0:
+  if (condition) {
+    first();
+    break;
+  case 1: // Warning: entering here bypasses the condition and first().
+    second();
+    break;
+  }
+  break;
+default:
+  break;
+}
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -127,6 +127,7 @@ Clang-Tidy Checks
    :doc:`bugprone-multiple-new-in-one-expression <bugprone/multiple-new-in-one-expression>`,
    :doc:`bugprone-multiple-statement-macro <bugprone/multiple-statement-macro>`,
    :doc:`bugprone-narrowing-conversions <bugprone/narrowing-conversions>`,
+   :doc:`bugprone-nested-switch-label <bugprone/nested-switch-label>`,
    :doc:`bugprone-no-escape <bugprone/no-escape>`,
    :doc:`bugprone-non-zero-enum-to-bool-conversion <bugprone/non-zero-enum-to-bool-conversion>`,
    :doc:`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>`,

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/nested-switch-label-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/nested-switch-label-cxx20.cpp
@@ -1,0 +1,31 @@
+// RUN: %check_clang_tidy -std=c++20-or-later %s bugprone-nested-switch-label %t
+
+void directLabelInAttributedCompoundBody(int Value) {
+  switch (Value) [[likely]] {
+  case 0:
+    break;
+  }
+}
+
+void attributedCompoundBody(int Value) {
+  switch (Value) [[likely]] {
+    {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}
+
+void attributedBoundaries(int Value, bool Condition) {
+  switch (Value) {
+  [[likely]] case 0:
+    break;
+  case 1:
+    if (Condition) [[likely]] {
+    case 2:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/nested-switch-label.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/nested-switch-label.c
@@ -1,0 +1,101 @@
+// RUN: %check_clang_tidy %s bugprone-nested-switch-label %t
+
+void direct_labels(int value) {
+  switch (value) {
+  case 0:
+  case 1:
+    break;
+  default:
+    break;
+  }
+}
+
+void compound_after_label(int value) {
+  switch (value) {
+  case 0: {
+    break;
+  }
+  default: {
+    break;
+  }
+  }
+}
+
+void direct_label_in_non_compound_body(int value) {
+  switch (value)
+  case 0:
+    break;
+}
+
+void nested_label_in_non_compound_body(int value, int condition) {
+  switch (value)
+    if (condition) {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+}
+
+void nested_label_in_loop_body(int value, int condition) {
+  switch (value)
+    while (condition) {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+}
+
+void nested_compound(int value) {
+  switch (value) {
+    {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    default:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}
+
+void nested_control_flow(int value, int condition) {
+  switch (value) {
+  case 0:
+    if (condition) {
+      ++value;
+      break;
+    case 1:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+    break;
+  }
+}
+
+void nested_label_with_compound(int value, int condition) {
+  switch (value) {
+  case 0:
+    if (condition) {
+    case 1: {
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+    }
+    break;
+  }
+}
+
+void nested_switch(int outer, int inner) {
+  switch (outer) {
+  case 0:
+    switch (inner) {
+    case 1:
+      break;
+    default:
+      break;
+    }
+    break;
+  default:
+    break;
+  }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/nested-switch-label.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/nested-switch-label.cpp
@@ -1,0 +1,137 @@
+// RUN: %check_clang_tidy %s bugprone-nested-switch-label %t
+
+void directLabels(int Value) {
+  switch (Value) {
+  case 0:
+  case 1:
+    break;
+  default:
+    break;
+  }
+}
+
+void compoundAfterLabel(int Value) {
+  switch (Value) {
+  case 0: {
+    break;
+  }
+  default: {
+    break;
+  }
+  }
+}
+
+void directLabelInNonCompoundBody(int Value) {
+  switch (Value)
+  case 0:
+    break;
+}
+
+void nestedLabelInNonCompoundBody(int Value, bool Condition) {
+  switch (Value)
+    if (Condition) {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+}
+
+void nestedLabelInLoopBody(int Value, bool Condition) {
+  switch (Value)
+    while (Condition) {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+}
+
+void nestedCompound(int Value) {
+  switch (Value) {
+    {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    default:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}
+
+void nestedControlFlow(int Value, bool Condition) {
+  switch (Value) {
+  case 0:
+    if (Condition) {
+      ++Value;
+      break;
+    case 1:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+    break;
+  }
+}
+
+void nestedLabelWithCompound(int Value, bool Condition) {
+  switch (Value) {
+  case 0:
+    if (Condition) {
+    case 1: {
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+    }
+    break;
+  }
+}
+
+void nestedSwitch(int Outer, int Inner) {
+  switch (Outer) {
+  case 0:
+    switch (Inner) {
+    case 1:
+      break;
+    default:
+      break;
+    }
+    break;
+  default:
+    break;
+  }
+}
+
+void nestedConsecutiveLabels(int Value) {
+  switch (Value) {
+    {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+    case 1:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}
+
+template <typename T> void nestedTemplate(T Value) {
+  switch (Value) {
+    {
+    case 0:
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}
+
+void instantiateTemplate() { nestedTemplate(0); }
+
+#define CASE_ONE case 1:
+
+void macroLabel(int Value) {
+  switch (Value) {
+    {
+    CASE_ONE
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: switch label is nested inside a compound statement other than the switch body [bugprone-nested-switch-label]
+      break;
+    }
+  }
+}


### PR DESCRIPTION
This check diagnoses case and default labels that are nested inside a compound statement other than the switch body itself. Such labels are legal C/C++ but they create misleading control flow because the switch can jump directly into the inner scope, bypassing the surrounding statements.

For example:

```cpp
switch (value) {
case 0:
  if (condition) {
    first();
    break;
  case 1:        // warning: jumps here bypass `condition` and `first()`
    second();
    break;
  }
  break;
}
```

This pattern is also prohibited by MISRA C:2012 Rule 16.2: 

"Switch labels shall only be used when the most closely-enclosing compound statement is the body of the switch statement."