### PR TITLE
[lldb] Report the unwound PC for WebAssembly caller frames

### DIFF
--- a/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
@@ -64,9 +64,21 @@ const RegisterSet *RegisterContextWasm::GetRegisterSet(size_t reg_set) {
 
 bool RegisterContextWasm::ReadRegister(const RegisterInfo *reg_info,
                                        RegisterValue &value) {
-  // The only real registers is the PC.
-  if (reg_info->name)
+  // The only real register is the PC.
+  if (reg_info->name) {
+    // A caller frame's PC is the unwound return address, which the base
+    // register context cannot provide because it only sees the innermost
+    // frame's live PC. Use the PC the unwinder recorded for this frame.
+    if (m_concrete_frame_idx > 0) {
+      ThreadWasm &wasm_thread = static_cast<ThreadWasm &>(GetThread());
+      lldb::addr_t pc = wasm_thread.GetConcreteFramePC(m_concrete_frame_idx);
+      if (pc != LLDB_INVALID_ADDRESS) {
+        value.SetUInt(pc, reg_info->byte_size);
+        return true;
+      }
+    }
     return GDBRemoteRegisterContext::ReadRegister(reg_info, value);
+  }
 
   // Read the virtual registers.
   ThreadWasm *thread = static_cast<ThreadWasm *>(&GetThread());

--- a/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
@@ -64,13 +64,14 @@ const RegisterSet *RegisterContextWasm::GetRegisterSet(size_t reg_set) {
 
 bool RegisterContextWasm::ReadRegister(const RegisterInfo *reg_info,
                                        RegisterValue &value) {
+  ThreadWasm &wasm_thread = static_cast<ThreadWasm &>(GetThread());
+
   // The only real register is the PC.
   if (reg_info->name) {
     // A caller frame's PC is the unwound return address, which the base
     // register context cannot provide because it only sees the innermost
     // frame's live PC. Use the PC the unwinder recorded for this frame.
     if (m_concrete_frame_idx > 0) {
-      ThreadWasm &wasm_thread = static_cast<ThreadWasm &>(GetThread());
       lldb::addr_t pc = wasm_thread.GetConcreteFramePC(m_concrete_frame_idx);
       if (pc != LLDB_INVALID_ADDRESS) {
         value.SetUInt(pc, reg_info->byte_size);
@@ -81,9 +82,9 @@ bool RegisterContextWasm::ReadRegister(const RegisterInfo *reg_info,
   }
 
   // Read the virtual registers.
-  ThreadWasm *thread = static_cast<ThreadWasm *>(&GetThread());
-  ProcessWasm *process = static_cast<ProcessWasm *>(thread->GetProcess().get());
-  if (!thread)
+  ProcessWasm *process =
+      static_cast<ProcessWasm *>(wasm_thread.GetProcess().get());
+  if (!process)
     return false;
 
   uint32_t frame_index = m_concrete_frame_idx;

--- a/lldb/source/Plugins/Process/wasm/ThreadWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ThreadWasm.cpp
@@ -12,6 +12,7 @@
 #include "RegisterContextWasm.h"
 #include "UnwindWasm.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Target/Unwind.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -32,6 +33,15 @@ llvm::Expected<std::vector<lldb::addr_t>> ThreadWasm::GetWasmCallStack() {
     return wasm_process->GetWasmCallStack(GetID());
   }
   return llvm::createStringError("no process");
+}
+
+lldb::addr_t ThreadWasm::GetConcreteFramePC(uint32_t concrete_frame_idx) {
+  lldb::addr_t cfa, pc;
+  bool behaves_like_zeroth_frame;
+  if (GetUnwinder().GetFrameInfoAtIndex(concrete_frame_idx, cfa, pc,
+                                        behaves_like_zeroth_frame))
+    return pc;
+  return LLDB_INVALID_ADDRESS;
 }
 
 lldb::RegisterContextSP

--- a/lldb/source/Plugins/Process/wasm/ThreadWasm.h
+++ b/lldb/source/Plugins/Process/wasm/ThreadWasm.h
@@ -25,6 +25,10 @@ public:
   /// Retrieve the current call stack from the WebAssembly remote process.
   llvm::Expected<std::vector<lldb::addr_t>> GetWasmCallStack();
 
+  /// Return the program counter the Wasm unwinder recorded for the given
+  /// concrete frame index, or LLDB_INVALID_ADDRESS if it is unavailable.
+  lldb::addr_t GetConcreteFramePC(uint32_t concrete_frame_idx);
+
   lldb::RegisterContextSP
   CreateRegisterContextForFrame(StackFrame *frame) override;
 


### PR DESCRIPTION
RegisterContextWasm delegated the PC register read to GDBRemoteRegisterContext, which reports the live innermost PC for every frame. Resolving a variable whose DWARF location is a location list in a caller frame therefore chose the entry using the innermost frame's PC instead of the caller's, so the variable read back as unavailable even though its location covered the caller's PC.

Return the program counter the WebAssembly unwinder recorded for the frame (from qWasmCallStack) when reading a caller frame's PC, so the location list entry uses the correct frame.