### PR TITLE
[Darwin] Improve ld64 based configs

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -678,24 +678,13 @@ if(CMAKE_HOST_APPLE AND APPLE)
       find_program(CMAKE_XCRUN NAMES xcrun)
     endif()
 
-    # First, check if there's ld-classic, which is ld64 in newer SDKs.
+    # Check for ld on apple platform. LD64 is the legacy name.
     if(CMAKE_XCRUN)
-      execute_process(COMMAND ${CMAKE_XCRUN} -find ld-classic
+      execute_process(COMMAND ${CMAKE_XCRUN} -find ld
         OUTPUT_VARIABLE LD64_EXECUTABLE
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()
-      find_program(LD64_EXECUTABLE NAMES ld-classic DOC "The ld64 linker")
-    endif()
-
-    # Otherwise look for ld directly.
-    if(NOT LD64_EXECUTABLE)
-        if(CMAKE_XCRUN)
-          execute_process(COMMAND ${CMAKE_XCRUN} -find ld
-            OUTPUT_VARIABLE LD64_EXECUTABLE
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-        else()
-          find_program(LD64_EXECUTABLE NAMES ld DOC "The ld64 linker")
-        endif()
+      find_program(LD64_EXECUTABLE NAMES ld DOC "The apple static linker")
     endif()
   endif()
 

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -184,7 +184,9 @@ if asan_rtlib:
 if config.osx_sysroot:
     ld64_cmd = "{} -syslibroot {}".format(ld64_cmd, config.osx_sysroot)
 elif config.osx_xcrun:
-    osx_sysroot = subprocess.check_output([config.osx_xcrun, "--show-sdk-path"], text=True)
+    osx_sysroot = subprocess.check_output(
+        [config.osx_xcrun, "--show-sdk-path"], text=True
+    )
     ld64_cmd = "{} -syslibroot {}".format(ld64_cmd, osx_sysroot)
 
 ocamlc_command = "%s ocamlc -cclib -L%s %s" % (

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -183,6 +183,9 @@ if asan_rtlib:
     ld64_cmd = "env DYLD_INSERT_LIBRARIES={} {}".format(asan_rtlib, ld64_cmd)
 if config.osx_sysroot:
     ld64_cmd = "{} -syslibroot {}".format(ld64_cmd, config.osx_sysroot)
+elif config.osx_xcrun:
+    osx_sysroot = subprocess.check_output([config.osx_xcrun, "--show-sdk-path"], text=True)
+    ld64_cmd = "{} -syslibroot {}".format(ld64_cmd, osx_sysroot)
 
 ocamlc_command = "%s ocamlc -cclib -L%s %s" % (
     config.ocamlfind_executable,
@@ -692,13 +695,6 @@ def have_ld64_plugin_support():
         return False
 
     if config.ld64_executable == "":
-        return False
-
-    ld_cmd = subprocess.Popen([config.ld64_executable, "-v"], stderr=subprocess.PIPE)
-    ld_out = ld_cmd.stderr.read().decode()
-    ld_cmd.wait()
-
-    if "ld64" not in ld_out or "LTO" not in ld_out:
         return False
 
     return True

--- a/llvm/test/lit.site.cfg.py.in
+++ b/llvm/test/lit.site.cfg.py.in
@@ -20,6 +20,7 @@ config.python_executable = "@Python3_EXECUTABLE@"
 config.gold_executable = "@GOLD_EXECUTABLE@"
 config.ld64_executable = "@LD64_EXECUTABLE@"
 config.osx_sysroot = path(r"@CMAKE_OSX_SYSROOT@")
+config.osx_xcrun = path(r"@CMAKE_XCRUN@")
 config.ocamlfind_executable = "@OCAMLFIND@"
 config.have_ocamlopt = @HAVE_OCAMLOPT@
 config.ocaml_flags = "@OCAMLFLAGS@"


### PR DESCRIPTION
Improve and fix the llvm configurations so that:
* Do not look for ld64 when building or testing. The new apple linker is
  compatible with the classic ld64 and the ld64 is removed in Xcode 27.
  Build and test should not fall back to ld64 or use `-ld-classic`.
* For LTO lit tests, they will fail if `CMAKE_OSX_SYSROOT` is not
  specified. Fix the tests so that inferred SYSROOT also work with those
  tests.
