### PR TITLE
[AMDGPU] Pipeline DS_READ_B128 with F16 MFMA on gfx950

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -20,9 +20,17 @@
 namespace llvm {
 
 class AMDGPUTargetMachine;
+class GCNSubtarget;
+class ScheduleDAGMutation;
 class LazyCallGraph;
 class GCNTargetMachine;
 class TargetMachine;
+
+/// Whether the gfx950 DS_READ/MFMA fragment scheduling tune is enabled.
+bool isMFMAFragmentSchedulerEnabled(const GCNSubtarget &ST);
+
+std::unique_ptr<ScheduleDAGMutation>
+createMFMAFragmentPostRASchedOrderDAGMutation();
 
 // GlobalISel passes
 void initializeAMDGPUPreLegalizerCombinerPass(PassRegistry &);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1456,6 +1456,8 @@ GCNTargetMachine::createPostMachineScheduler(MachineSchedContext *C) const {
   DAG->addMutation(createAMDGPUExportClusteringDAGMutation());
   DAG->addMutation(createAMDGPUBarrierLatencyDAGMutation(C->MF));
   DAG->addMutation(createAMDGPUHazardLatencyDAGMutation(C->MF));
+  if (isMFMAFragmentSchedulerEnabled(ST))
+    DAG->addMutation(createMFMAFragmentPostRASchedOrderDAGMutation());
   return DAG;
 }
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -24,6 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "GCNSchedStrategy.h"
+#include "AMDGPU.h"
 #include "AMDGPUIGroupLP.h"
 #include "GCNHazardRecognizer.h"
 #include "GCNRegPressure.h"
@@ -31,6 +32,7 @@
 #include "Utils/AMDGPUBaseInfo.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/CodeGen/CalcSpillWeights.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineBlockFrequencyInfo.h"
@@ -42,6 +44,8 @@
 #include "llvm/MC/MCSchedule.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/ErrorHandling.h"
+
+#include <limits>
 
 #define DEBUG_TYPE "machine-scheduler"
 
@@ -83,6 +87,42 @@ static cl::opt<unsigned> PendingQueueLimit(
     cl::desc(
         "Max (Available+Pending) size to inspect pending queue (0 disables)"),
     cl::init(256));
+
+static cl::opt<bool> EnableMFMAFragmentSchedulerOpt(
+    "amdgpu-enable-mfma-fragment-scheduler", cl::Hidden,
+    cl::desc("Enable gfx950 DS_READ/MFMA fragment scheduling"), cl::init(true));
+
+bool llvm::isMFMAFragmentSchedulerEnabled(const GCNSubtarget &ST) {
+  return EnableMFMAFragmentSchedulerOpt && ST.hasGFX950Insts();
+}
+
+struct MFMAFragmentSchedSettings {
+  // These values encode the gfx950 sequence measured for DS_READ_B128 feeding
+  // V_MFMA_F32_32X32X16_F16. They must not be applied to other subtargets.
+
+  // Maximum DS_READ/MFMA fragment-window size before the first MFMA is picked
+  // in a scheduling region.
+  unsigned PrologueWindow = 4;
+
+  // Number of DS_READs and MFMAs in one steady-state pipeline group. This also
+  // defines the target DS_READ maturity spacing and the minimum useful MFMA
+  // fanout of a pull-forward producer.
+  unsigned PipelineGroupSize = 2;
+
+  // Maximum number of DS_READs used to fill an MFMA issue-resource stall. It
+  // currently follows the pipeline group size, but is a separate policy.
+  unsigned MaxDSReadsInMFMAStall = PipelineGroupSize;
+
+  // Maximum effective stall allowed when forcing an MFMA drain consumer over
+  // another DS_READ to maintain the fragment drain burst pattern.
+  unsigned MaxDrainMFMAStall = 8;
+
+  // Maximum number of trailing MFMAs that the bottom boundary may reserve as
+  // an epilogue before yielding fragment-pipeline work to the top boundary.
+  unsigned BottomEpilogueMFMAs = 4;
+};
+
+static constexpr MFMAFragmentSchedSettings MFMAFragmentSched;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 #define DUMP_MAX_REG_PRESSURE
@@ -132,6 +172,8 @@ static cl::opt<unsigned, false, VGPRThresholdParser> VGPRThresholdPercentOpt(
 
 const unsigned ScheduleMetrics::ScaleFactor = 100;
 
+static bool hasMFMAFragmentPipeline(const ScheduleDAGMI &DAG);
+
 GCNSchedStrategy::GCNSchedStrategy(const MachineSchedContext *C)
     : GenericScheduler(C), TargetOccupancy(0), MF(nullptr),
       DownwardTracker(*C->LIS), UpwardTracker(*C->LIS), HasHighPressure(false) {
@@ -143,8 +185,14 @@ void GCNSchedStrategy::initialize(ScheduleDAGMI *DAG) {
   GenericScheduler::initialize(DAG);
 
   MF = &DAG->MF;
+  resetFragmentWindows();
 
   const GCNSubtarget &ST = MF->getSubtarget<GCNSubtarget>();
+  // The subtarget option only makes the tune available. Keep the generic
+  // scheduler completely unchanged for regions without the DS_READ/MFMA data
+  // flow this policy models.
+  EnableMFMAFragmentScheduler =
+      isMFMAFragmentSchedulerEnabled(ST) && hasMFMAFragmentPipeline(*DAG);
 
   SGPRExcessLimit =
       Context->RegClassInfo->getNumAllocatableRegs(&AMDGPU::SGPR_32RegClass);
@@ -238,6 +286,553 @@ static bool canUsePressureDiffs(const SUnit &SU) {
       return false;
   }
   return true;
+}
+
+static bool isTargetDSReadOpcode(unsigned Opcode) {
+  switch (Opcode) {
+  case AMDGPU::DS_READ_B128:
+  case AMDGPU::DS_READ_B128_gfx9:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool isTargetMFMAOpcode(unsigned Opcode) {
+  switch (Opcode) {
+  case AMDGPU::V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64:
+    return true;
+  default:
+    return false;
+  }
+}
+
+template <typename PredicateT>
+static bool hasBundledMI(const MachineInstr *MI, PredicateT Predicate) {
+  if (!MI)
+    return false;
+
+  if (Predicate(*MI))
+    return true;
+
+  if (!MI->isBundle())
+    return false;
+
+  MachineBasicBlock::const_instr_iterator BundleI = MI->getIterator();
+  for (++BundleI;
+       BundleI != MI->getParent()->instr_end() && BundleI->isBundledWithPred();
+       ++BundleI) {
+    if (Predicate(*BundleI))
+      return true;
+  }
+
+  return false;
+}
+
+static bool isDSReadLike(const SUnit *SU) {
+  if (!SU)
+    return false;
+
+  return hasBundledMI(SU->getInstr(), [](const MachineInstr &MI) {
+    return isTargetDSReadOpcode(MI.getOpcode());
+  });
+}
+
+static bool isMFMALike(const SUnit *SU) {
+  if (!SU)
+    return false;
+
+  return hasBundledMI(SU->getInstr(), [](const MachineInstr &MI) {
+    return isTargetMFMAOpcode(MI.getOpcode());
+  });
+}
+
+static bool hasMFMAFragmentPipeline(const ScheduleDAGMI &DAG) {
+  for (const SUnit &SU : DAG.SUnits) {
+    if (!isDSReadLike(&SU))
+      continue;
+    for (const SDep &Succ : SU.Succs)
+      if (Succ.getKind() == SDep::Data && isMFMALike(Succ.getSUnit()))
+        return true;
+  }
+  return false;
+}
+
+static bool isSafeMFMAFragmentRampUpFiller(const SUnit *SU) {
+  if (!SU || isDSReadLike(SU) || isMFMALike(SU))
+    return false;
+
+  // This tune does not model buffered-load maturity windows or available
+  // in-flight memory capacity. Keep memory operations, calls, barriers, and
+  // other side effects under the normal scheduler policy.
+  return !hasBundledMI(SU->getInstr(), [](const MachineInstr &MI) {
+    return MI.mayLoadOrStore() || MI.isCall() || MI.isTerminator() ||
+           MI.isBarrier() || MI.hasUnmodeledSideEffects();
+  });
+}
+
+static unsigned getBoundaryReadyCycle(const SchedBoundary &Zone,
+                                      const SUnit *SU) {
+  return Zone.isTop() ? SU->TopReadyCycle : SU->BotReadyCycle;
+}
+
+static unsigned getReadyStall(const SchedBoundary &Zone, const SUnit *SU) {
+  unsigned ReadyCycle = getBoundaryReadyCycle(Zone, SU);
+  unsigned CurrCycle = Zone.getCurrCycle();
+  return ReadyCycle > CurrCycle ? ReadyCycle - CurrCycle : 0;
+}
+
+static unsigned getIssueStall(SchedBoundary &Zone, SUnit *SU) {
+  if (!SU || !SU->hasReservedResource || !Zone.SchedModel ||
+      !Zone.SchedModel->hasInstrSchedModel())
+    return 0;
+
+  const MCSchedClassDesc *SC = Zone.DAG->getSchedClass(SU);
+  unsigned Stall = 0;
+  for (const MCWriteProcResEntry &PE :
+       make_range(Zone.SchedModel->getWriteProcResBegin(SC),
+                  Zone.SchedModel->getWriteProcResEnd(SC))) {
+    unsigned NextCycle;
+    unsigned InstanceIdx;
+    std::tie(NextCycle, InstanceIdx) = Zone.getNextResourceCycle(
+        SC, PE.ProcResourceIdx, PE.ReleaseAtCycle, PE.AcquireAtCycle);
+    (void)InstanceIdx;
+    if (NextCycle > Zone.getCurrCycle())
+      Stall = std::max(Stall, NextCycle - Zone.getCurrCycle());
+  }
+
+  return Stall;
+}
+
+static unsigned getEffectiveStall(SchedBoundary &Zone, SUnit *SU) {
+  return std::max(getReadyStall(Zone, SU), getIssueStall(Zone, SU));
+}
+
+static bool consumesThisDSRead(const SUnit *SU, const SUnit *Pred) {
+  if (!isMFMALike(SU) || !isDSReadLike(Pred))
+    return false;
+
+  for (const SDep &PredDep : SU->Preds) {
+    if (PredDep.getSUnit() == Pred)
+      return true;
+  }
+
+  return false;
+}
+
+static bool hasScheduledMFMASuccessor(const SUnit *SU) {
+  if (!isDSReadLike(SU))
+    return false;
+
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (isMFMALike(Succ) && Succ->isScheduled)
+      return true;
+  }
+
+  return false;
+}
+
+enum class PipeKind {
+  // Not part of the DS_READ/MFMA fragment pipeline.
+  None,
+
+  // A DS_READ that may produce an operand fragment for an MFMA.
+  FragmentProducer,
+
+  // An MFMA with no remaining scheduler-model dependency stall.
+  ReadyMFMA,
+
+  // An MFMA whose scheduler-model dependency-ready cycle is still ahead of
+  // the current scheduling boundary.
+  PendingMFMA,
+};
+
+static PipeKind classifyPipeKind(SchedBoundary &Zone, SUnit *SU) {
+  if (isDSReadLike(SU))
+    return PipeKind::FragmentProducer;
+
+  if (isMFMALike(SU))
+    return getReadyStall(Zone, SU) ? PipeKind::PendingMFMA
+                                   : PipeKind::ReadyMFMA;
+
+  return PipeKind::None;
+}
+
+static unsigned getNumDSReadsToUnlockClosestMFMA(const SUnit *SU) {
+  // For every unscheduled MFMA successor, count its other unscheduled DS_READ
+  // predecessors. Return the minimum count, excluding SU itself, to prefer the
+  // DS_READ that can unlock any MFMA with the fewest additional reads.
+  if (!isDSReadLike(SU))
+    return std::numeric_limits<unsigned>::max();
+
+  unsigned MinRemaining = std::numeric_limits<unsigned>::max();
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    unsigned Remaining = 0;
+    for (const SDep &PredDep : Succ->Preds) {
+      const SUnit *Pred = PredDep.getSUnit();
+      if (!isDSReadLike(Pred) || Pred == SU || Pred->isScheduled)
+        continue;
+      ++Remaining;
+    }
+
+    MinRemaining = std::min(MinRemaining, Remaining);
+  }
+
+  return MinRemaining;
+}
+
+static unsigned
+countScheduledDSReadPredsToMFMASuccessorAfter(const SUnit *SU,
+                                              const SUnit *Succ) {
+  unsigned Count = 0;
+  for (const SDep &PredDep : Succ->Preds) {
+    const SUnit *Pred = PredDep.getSUnit();
+    if (!isDSReadLike(Pred))
+      continue;
+    if (Pred == SU || Pred->isScheduled)
+      ++Count;
+  }
+
+  return Count;
+}
+
+static unsigned
+countUnscheduledDSReadPredsToMFMASuccessorAfter(const SUnit *SU,
+                                                const SUnit *Succ) {
+  unsigned Count = 0;
+  for (const SDep &PredDep : Succ->Preds) {
+    const SUnit *Pred = PredDep.getSUnit();
+    if (!isDSReadLike(Pred) || Pred == SU || Pred->isScheduled)
+      continue;
+    ++Count;
+  }
+
+  return Count;
+}
+
+static bool
+hasUnscheduledNonDSReadPredsToMFMASuccessorAfter(const SUnit *SU,
+                                                 const SUnit *Succ) {
+  for (const SDep &PredDep : Succ->Preds) {
+    const SUnit *Pred = PredDep.getSUnit();
+    if (isDSReadLike(Pred) || Pred == SU || Pred->isScheduled)
+      continue;
+    return true;
+  }
+
+  return false;
+}
+
+static unsigned countMFMASuccessorsUnlockedBy(const SUnit *SU) {
+  if (!isDSReadLike(SU))
+    return 0;
+
+  unsigned Count = 0;
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    if (hasUnscheduledNonDSReadPredsToMFMASuccessorAfter(SU, Succ))
+      continue;
+
+    if (countUnscheduledDSReadPredsToMFMASuccessorAfter(SU, Succ) == 0)
+      ++Count;
+  }
+
+  return Count;
+}
+
+static unsigned countMFMASuccessorsUnlockedByAfterFiller(const SUnit *SU,
+                                                         const SUnit *Filler) {
+  if (!isDSReadLike(SU) || !isMFMALike(Filler))
+    return 0;
+
+  unsigned Count = 0;
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled || Succ == Filler)
+      continue;
+
+    bool HasFillerPred = false;
+    bool Blocked = false;
+    for (const SDep &PredDep : Succ->Preds) {
+      const SUnit *Pred = PredDep.getSUnit();
+      if (Pred == SU || Pred->isScheduled)
+        continue;
+
+      if (Pred == Filler) {
+        HasFillerPred = true;
+        continue;
+      }
+
+      Blocked = true;
+      break;
+    }
+
+    if (!Blocked && HasFillerPred)
+      ++Count;
+  }
+
+  return Count;
+}
+
+static unsigned getBestMFMASuccessorMissingDSReadPredsAfter(const SUnit *SU) {
+  if (!isDSReadLike(SU))
+    return std::numeric_limits<unsigned>::max();
+
+  unsigned BestMissing = std::numeric_limits<unsigned>::max();
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    if (hasUnscheduledNonDSReadPredsToMFMASuccessorAfter(SU, Succ))
+      continue;
+
+    unsigned Missing =
+        countUnscheduledDSReadPredsToMFMASuccessorAfter(SU, Succ);
+    BestMissing = std::min(BestMissing, Missing);
+  }
+
+  return BestMissing;
+}
+
+static unsigned getBestMFMASuccessorScheduledDSReadPredsAfter(const SUnit *SU) {
+  if (!isDSReadLike(SU))
+    return 0;
+
+  unsigned BestMissing = getBestMFMASuccessorMissingDSReadPredsAfter(SU);
+  if (BestMissing == std::numeric_limits<unsigned>::max())
+    return 0;
+
+  unsigned BestScheduled = 0;
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    if (hasUnscheduledNonDSReadPredsToMFMASuccessorAfter(SU, Succ))
+      continue;
+
+    if (countUnscheduledDSReadPredsToMFMASuccessorAfter(SU, Succ) !=
+        BestMissing)
+      continue;
+
+    BestScheduled = std::max(
+        BestScheduled, countScheduledDSReadPredsToMFMASuccessorAfter(SU, Succ));
+  }
+
+  return BestScheduled;
+}
+
+static unsigned getBestMFMASuccessorNodeNumAfter(const SUnit *SU) {
+  if (!isDSReadLike(SU))
+    return std::numeric_limits<unsigned>::max();
+
+  unsigned BestMissing = getBestMFMASuccessorMissingDSReadPredsAfter(SU);
+  if (BestMissing == std::numeric_limits<unsigned>::max())
+    return std::numeric_limits<unsigned>::max();
+
+  unsigned BestNodeNum = std::numeric_limits<unsigned>::max();
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    if (hasUnscheduledNonDSReadPredsToMFMASuccessorAfter(SU, Succ))
+      continue;
+
+    if (countUnscheduledDSReadPredsToMFMASuccessorAfter(SU, Succ) !=
+        BestMissing)
+      continue;
+
+    BestNodeNum = std::min(BestNodeNum, Succ->NodeNum);
+  }
+
+  return BestNodeNum;
+}
+
+static unsigned
+countMFMASuccessorsWithFewMissingDSReadPredsAfter(const SUnit *SU,
+                                                  unsigned MaxMissing) {
+  if (!isDSReadLike(SU))
+    return 0;
+
+  unsigned Count = 0;
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    if (hasUnscheduledNonDSReadPredsToMFMASuccessorAfter(SU, Succ))
+      continue;
+
+    unsigned Missing =
+        countUnscheduledDSReadPredsToMFMASuccessorAfter(SU, Succ);
+    if (Missing <= MaxMissing)
+      ++Count;
+  }
+
+  return Count;
+}
+
+struct MFMAFragmentProducerScore {
+  bool Valid = false;
+  unsigned BestSuccNode = std::numeric_limits<unsigned>::max();
+  unsigned BestMissingDS = std::numeric_limits<unsigned>::max();
+  unsigned BestScheduledDS = 0;
+  unsigned Unlocks = 0;
+  unsigned NearUnlocks = 0;
+};
+
+static MFMAFragmentProducerScore
+getDirectFragmentProducerScore(const SUnit *SU) {
+  MFMAFragmentProducerScore Score;
+  if (!isDSReadLike(SU))
+    return Score;
+
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!isMFMALike(Succ) || Succ->isScheduled)
+      continue;
+
+    unsigned Missing =
+        countUnscheduledDSReadPredsToMFMASuccessorAfter(SU, Succ);
+    unsigned Scheduled =
+        countScheduledDSReadPredsToMFMASuccessorAfter(SU, Succ);
+
+    Score.Valid = true;
+    if (Missing < Score.BestMissingDS) {
+      Score.BestMissingDS = Missing;
+      Score.BestSuccNode = Succ->NodeNum;
+      Score.BestScheduledDS = Scheduled;
+      continue;
+    }
+
+    if (Missing == Score.BestMissingDS) {
+      Score.BestSuccNode = std::min(Score.BestSuccNode, Succ->NodeNum);
+      Score.BestScheduledDS = std::max(Score.BestScheduledDS, Scheduled);
+    }
+  }
+
+  if (!Score.Valid)
+    return Score;
+
+  Score.Unlocks = countMFMASuccessorsUnlockedBy(SU);
+  Score.NearUnlocks = countMFMASuccessorsWithFewMissingDSReadPredsAfter(SU, 1);
+  return Score;
+}
+
+static unsigned countDSReadSpacingFillers(SchedBoundary &Zone,
+                                          const SUnit *DSRead) {
+  if (!isDSReadLike(DSRead))
+    return 0;
+
+  SmallPtrSet<SUnit *, 16> Seen;
+  unsigned Fillers = 0;
+  auto TryFiller = [&](SUnit *SU) {
+    if (!SU || SU->isScheduled || !Seen.insert(SU).second || !isMFMALike(SU))
+      return;
+    if (consumesThisDSRead(SU, DSRead))
+      return;
+    if (getIssueStall(Zone, SU) != 0)
+      return;
+    if (getEffectiveStall(Zone, SU) > MFMAFragmentSched.MaxDrainMFMAStall)
+      return;
+
+    ++Fillers;
+  };
+
+  for (SUnit *SU : Zone.Available)
+    TryFiller(SU);
+  for (SUnit *SU : Zone.Pending)
+    TryFiller(SU);
+
+  return Fillers;
+}
+
+static unsigned countIssueReadyFragmentProducers(SchedBoundary &Zone) {
+  SmallPtrSet<SUnit *, 16> Seen;
+  unsigned Count = 0;
+  auto Consider = [&](SUnit *SU) {
+    if (!SU || SU->isScheduled || !Seen.insert(SU).second ||
+        !isDSReadLike(SU) || getEffectiveStall(Zone, SU) != 0)
+      return;
+    ++Count;
+  };
+  for (SUnit *SU : Zone.Available)
+    Consider(SU);
+  for (SUnit *SU : Zone.Pending)
+    Consider(SU);
+  return Count;
+}
+
+static bool
+isBetterPrologueFragmentScore(const MFMAFragmentProducerScore &TryScore,
+                              const MFMAFragmentProducerScore &CandScore) {
+  if (TryScore.Valid != CandScore.Valid)
+    return TryScore.Valid;
+  if (!TryScore.Valid)
+    return false;
+
+  if (TryScore.BestMissingDS != CandScore.BestMissingDS)
+    return TryScore.BestMissingDS < CandScore.BestMissingDS;
+  if (TryScore.Unlocks != CandScore.Unlocks)
+    return TryScore.Unlocks > CandScore.Unlocks;
+  if (TryScore.BestScheduledDS != CandScore.BestScheduledDS)
+    return TryScore.BestScheduledDS > CandScore.BestScheduledDS;
+  if (TryScore.BestSuccNode != CandScore.BestSuccNode)
+    return TryScore.BestSuccNode < CandScore.BestSuccNode;
+  return false;
+}
+
+static bool mergePrologueFragmentScore(MFMAFragmentProducerScore &Best,
+                                       MFMAFragmentProducerScore TryScore) {
+  if (!TryScore.Valid)
+    return false;
+
+  if (!Best.Valid || isBetterPrologueFragmentScore(TryScore, Best)) {
+    Best = TryScore;
+    return true;
+  }
+
+  return false;
+}
+
+static MFMAFragmentProducerScore
+getReachableFragmentProducerScoreImpl(const SUnit *SU,
+                                      SmallPtrSetImpl<const SUnit *> &Visited,
+                                      unsigned DepthLeft) {
+  MFMAFragmentProducerScore Best;
+  if (!SU || SU->isScheduled || !Visited.insert(SU).second)
+    return Best;
+
+  mergePrologueFragmentScore(Best, getDirectFragmentProducerScore(SU));
+  if (!DepthLeft)
+    return Best;
+
+  for (const SDep &SuccDep : SU->Succs) {
+    const SUnit *Succ = SuccDep.getSUnit();
+    if (!Succ || Succ->isScheduled || isMFMALike(Succ))
+      continue;
+
+    mergePrologueFragmentScore(Best, getReachableFragmentProducerScoreImpl(
+                                         Succ, Visited, DepthLeft - 1));
+  }
+
+  return Best;
+}
+
+static MFMAFragmentProducerScore
+getReachableFragmentProducerScore(const SUnit *SU) {
+  SmallPtrSet<const SUnit *, 8> Visited;
+  return getReachableFragmentProducerScoreImpl(SU, Visited, 6);
 }
 
 void GCNSchedStrategy::getRegisterPressures(
@@ -452,6 +1047,1189 @@ static SUnit *pickOnlyChoice(SchedBoundary &Zone,
   return nullptr;
 }
 
+static bool hasReadyMFMAPending(SchedBoundary &Zone) {
+  for (SUnit *SU : Zone.Pending)
+    if (classifyPipeKind(Zone, SU) == PipeKind::ReadyMFMA)
+      return true;
+  return false;
+}
+
+static bool shouldKeepAvailableUnlockingProducer(
+    SchedBoundary &Zone, const SUnit *SU, unsigned LiveFragments,
+    unsigned MaxWindow, bool LastPickWasDSRead, bool HasPickedMFMA,
+    unsigned MFMAsSinceLastDSRead,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  return SU && isDSReadLike(SU) && HasPickedMFMA && !LastPickWasDSRead &&
+         MFMAsSinceLastDSRead >= MFMAFragmentSched.PipelineGroupSize &&
+         LiveFragments < MaxWindow && countMFMASuccessorsUnlockedBy(SU) != 0 &&
+         hasReadyMFMAPending(Zone);
+}
+
+static bool tryReadyStall(GenericSchedulerBase::SchedCandidate &TryCand,
+                          GenericSchedulerBase::SchedCandidate &Cand,
+                          SchedBoundary &Zone) {
+  if (!TryCand.SU || !Cand.SU)
+    return false;
+
+  unsigned TryStall = getReadyStall(Zone, TryCand.SU);
+  unsigned CandStall = getReadyStall(Zone, Cand.SU);
+  if (TryStall == CandStall)
+    return false;
+
+  if (tryLess(TryStall, CandStall, TryCand, Cand, GenericSchedulerBase::Stall))
+    return true;
+
+  return false;
+}
+
+static unsigned getRecentDSReadSpacing(
+    PipeKind Kind, const SUnit *SU,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  unsigned MinSpacing = MFMAFragmentSched.PipelineGroupSize;
+  unsigned BestSpacing = std::numeric_limits<unsigned>::max();
+  if (Kind != PipeKind::ReadyMFMA && Kind != PipeKind::PendingMFMA)
+    return MinSpacing;
+  if (!MinSpacing)
+    return MinSpacing;
+
+  for (const auto &DSRead : RecentDSReadUnrelatedMFMAs)
+    if (consumesThisDSRead(SU, DSRead.first))
+      BestSpacing = std::min(BestSpacing, DSRead.second);
+  if (BestSpacing == std::numeric_limits<unsigned>::max())
+    return MinSpacing;
+  return BestSpacing;
+}
+
+static bool hasRecentDSReadSpacingDebt(
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!MFMAFragmentSched.PipelineGroupSize)
+    return false;
+
+  for (const auto &DSRead : RecentDSReadUnrelatedMFMAs)
+    if (DSRead.second < MFMAFragmentSched.PipelineGroupSize)
+      return true;
+
+  return false;
+}
+
+static bool consumesImmatureRecentDSRead(
+    const SUnit *SU,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!isMFMALike(SU) || !MFMAFragmentSched.PipelineGroupSize)
+    return false;
+
+  for (const auto &DSRead : RecentDSReadUnrelatedMFMAs)
+    if (DSRead.second < MFMAFragmentSched.PipelineGroupSize &&
+        consumesThisDSRead(SU, DSRead.first))
+      return true;
+
+  return false;
+}
+
+static bool isRecentDSReadSpacingAlternative(
+    SchedBoundary &Zone, SUnit *SU,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!SU || !MFMAFragmentSched.PipelineGroupSize ||
+      RecentDSReadUnrelatedMFMAs.empty())
+    return false;
+
+  PipeKind Kind = classifyPipeKind(Zone, SU);
+  if (Kind == PipeKind::FragmentProducer)
+    return getEffectiveStall(Zone, SU) == 0 &&
+           getDirectFragmentProducerScore(SU).Valid;
+
+  if (Kind != PipeKind::ReadyMFMA && Kind != PipeKind::PendingMFMA)
+    return false;
+
+  if (consumesImmatureRecentDSRead(SU, RecentDSReadUnrelatedMFMAs))
+    return false;
+
+  if (getIssueStall(Zone, SU) != 0)
+    return false;
+
+  if (Kind == PipeKind::ReadyMFMA)
+    return true;
+
+  return getEffectiveStall(Zone, SU) <= MFMAFragmentSched.MaxDrainMFMAStall;
+}
+
+static bool shouldPreferBoundaryForRecentDSReadSpacing(
+    SchedBoundary &PreferredZone,
+    GenericSchedulerBase::SchedCandidate &PreferredCand,
+    GenericSchedulerBase::SchedCandidate &OtherCand,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!PreferredCand.isValid() || !OtherCand.isValid())
+    return false;
+
+  if (!consumesImmatureRecentDSRead(OtherCand.SU, RecentDSReadUnrelatedMFMAs))
+    return false;
+
+  return isRecentDSReadSpacingAlternative(PreferredZone, PreferredCand.SU,
+                                          RecentDSReadUnrelatedMFMAs);
+}
+
+static bool isPullForwardUnlockingProducer(
+    SchedBoundary &Zone, SUnit *SU, unsigned LiveFragments,
+    unsigned UsefulWindow, bool LastPickWasDSRead, bool HasPickedMFMA,
+    bool AllowFullWindow,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!MFMAFragmentSched.PipelineGroupSize)
+    return false;
+
+  if (!HasPickedMFMA || LastPickWasDSRead || !isDSReadLike(SU))
+    return false;
+
+  if (AllowFullWindow ? LiveFragments > UsefulWindow
+                      : LiveFragments >= UsefulWindow)
+    return false;
+
+  if (getEffectiveStall(Zone, SU) != 0)
+    return false;
+
+  if (!getDirectFragmentProducerScore(SU).Valid)
+    return false;
+
+  if (countMFMASuccessorsUnlockedBy(SU) < MFMAFragmentSched.PipelineGroupSize)
+    return false;
+
+  return countDSReadSpacingFillers(Zone, SU) >=
+         MFMAFragmentSched.PipelineGroupSize;
+}
+
+static bool isBetterPullForwardProducer(SchedBoundary &Zone, SUnit *Try,
+                                        SUnit *Cand) {
+  unsigned TryUnlocks = countMFMASuccessorsUnlockedBy(Try);
+  unsigned CandUnlocks = Cand ? countMFMASuccessorsUnlockedBy(Cand) : 0;
+  if (TryUnlocks != CandUnlocks)
+    return TryUnlocks > CandUnlocks;
+
+  unsigned TryFillers = countDSReadSpacingFillers(Zone, Try);
+  unsigned CandFillers = Cand ? countDSReadSpacingFillers(Zone, Cand) : 0;
+  if (TryFillers != CandFillers)
+    return TryFillers > CandFillers;
+
+  MFMAFragmentProducerScore TryScore = getReachableFragmentProducerScore(Try);
+  MFMAFragmentProducerScore CandScore = getReachableFragmentProducerScore(Cand);
+  if (isBetterPrologueFragmentScore(TryScore, CandScore))
+    return true;
+  if (isBetterPrologueFragmentScore(CandScore, TryScore))
+    return false;
+
+  return !Cand || Try->NodeNum < Cand->NodeNum;
+}
+
+static SUnit *findPullForwardUnlockingProducer(
+    SchedBoundary &Zone, GenericSchedulerBase::SchedCandidate &Cand,
+    unsigned LiveFragments, unsigned UsefulWindow, bool LastPickWasDSRead,
+    bool HasPickedMFMA,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!Cand.isValid())
+    return nullptr;
+
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+  if (CandK != PipeKind::None && CandK != PipeKind::FragmentProducer &&
+      CandK != PipeKind::ReadyMFMA)
+    return nullptr;
+
+  bool AllowFullWindow = CandK == PipeKind::ReadyMFMA;
+  if (isPullForwardUnlockingProducer(
+          Zone, Cand.SU, LiveFragments, UsefulWindow, LastPickWasDSRead,
+          HasPickedMFMA, AllowFullWindow, RecentDSReadUnrelatedMFMAs))
+    return nullptr;
+
+  SUnit *Best = nullptr;
+  for (SUnit *SU : Zone.Available) {
+    bool IsPullForwardProducer = isPullForwardUnlockingProducer(
+        Zone, SU, LiveFragments, UsefulWindow, LastPickWasDSRead, HasPickedMFMA,
+        AllowFullWindow, RecentDSReadUnrelatedMFMAs);
+    if (!IsPullForwardProducer)
+      continue;
+
+    if (!Best || isBetterPullForwardProducer(Zone, SU, Best))
+      Best = SU;
+  }
+
+  return Best;
+}
+
+static bool tryRecentDSReadSpacing(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    bool HasPickedMFMA,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs) {
+  if (!TryCand.SU || !Cand.SU || !HasPickedMFMA ||
+      !MFMAFragmentSched.PipelineGroupSize ||
+      RecentDSReadUnrelatedMFMAs.empty())
+    return false;
+
+  PipeKind TryK = classifyPipeKind(Zone, TryCand.SU);
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+  if ((TryK != PipeKind::ReadyMFMA && TryK != PipeKind::PendingMFMA) ||
+      (CandK != PipeKind::ReadyMFMA && CandK != PipeKind::PendingMFMA))
+    return false;
+
+  unsigned TrySpacing =
+      getRecentDSReadSpacing(TryK, TryCand.SU, RecentDSReadUnrelatedMFMAs);
+  unsigned CandSpacing =
+      getRecentDSReadSpacing(CandK, Cand.SU, RecentDSReadUnrelatedMFMAs);
+  if (TrySpacing == CandSpacing)
+    return false;
+
+  if (tryGreater(TrySpacing, CandSpacing, TryCand, Cand,
+                 GenericSchedulerBase::Stall))
+    return true;
+
+  return false;
+}
+
+bool GCNSchedStrategy::tryMFMAFragmentOpener(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    const FragmentWindowState &FWS, bool EnablePrologueSetupBias) const {
+  PipeKind TryK = classifyPipeKind(Zone, TryCand.SU);
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+  bool TryProducer = TryK == PipeKind::FragmentProducer;
+  bool CandProducer = CandK == PipeKind::FragmentProducer;
+  unsigned EffectiveUsefulWindow =
+      FWS.HasPickedMFMA
+          ? FWS.UsefulWindow
+          : std::min(FWS.UsefulWindow, MFMAFragmentSched.PrologueWindow);
+
+  // Opener: build the four-fragment window and use independent address setup
+  // to cover otherwise exposed DS_READ latency.
+  // Once the four-fragment opener is full, finish useful address setup for
+  // the next fragment microcluster before selecting the first MFMA.  The
+  // setup does not grow the live-fragment window and fills cycles that would
+  // otherwise be exposed LDS latency.
+  if (!FWS.HasPickedMFMA && FWS.LiveFragments >= EffectiveUsefulWindow) {
+    bool TryMFMA = TryK == PipeKind::ReadyMFMA || TryK == PipeKind::PendingMFMA;
+    bool CandMFMA =
+        CandK == PipeKind::ReadyMFMA || CandK == PipeKind::PendingMFMA;
+    bool TrySetup = TryK == PipeKind::None &&
+                    getReachableFragmentProducerScore(TryCand.SU).Valid;
+    bool CandSetup = CandK == PipeKind::None &&
+                     getReachableFragmentProducerScore(Cand.SU).Valid;
+    if ((TrySetup && CandMFMA) || (CandSetup && TryMFMA)) {
+      if (TrySetup) {
+        TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+        return true;
+      }
+
+      Cand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+  }
+
+  if (!FWS.HasPickedMFMA && FWS.LiveFragments >= EffectiveUsefulWindow &&
+      (TryProducer || CandProducer) && TryK != CandK) {
+    // PrologueWindow is a hard cap. Even a producer that immediately unlocks
+    // another MFMA belongs to the post-MFMA1 microcluster once the two direct
+    // and two prefetched opener fragments have been issued.
+    if (!TryProducer) {
+      TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+
+    Cand.Reason = GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  if (EnablePrologueSetupBias && !FWS.HasPickedMFMA && FWS.LiveFragments == 0 &&
+      TryProducer != CandProducer) {
+    SUnit *ProducerSU = TryProducer ? TryCand.SU : Cand.SU;
+    SUnit *SetupSU = TryProducer ? Cand.SU : TryCand.SU;
+    MFMAFragmentProducerScore ProducerScore =
+        getReachableFragmentProducerScore(ProducerSU);
+    MFMAFragmentProducerScore SetupScore =
+        getReachableFragmentProducerScore(SetupSU);
+
+    if (SetupScore.Valid &&
+        !isBetterPrologueFragmentScore(ProducerScore, SetupScore)) {
+      if (!TryProducer) {
+        TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+        return true;
+      }
+
+      Cand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+  }
+
+  if (!FWS.HasPickedMFMA) {
+    MFMAFragmentProducerScore TryScore =
+        getReachableFragmentProducerScore(TryCand.SU);
+    MFMAFragmentProducerScore CandScore =
+        getReachableFragmentProducerScore(Cand.SU);
+
+    if (isBetterPrologueFragmentScore(TryScore, CandScore)) {
+      TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+
+    if (isBetterPrologueFragmentScore(CandScore, TryScore)) {
+      Cand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+
+    if (EnablePrologueSetupBias && TryK == PipeKind::None &&
+        CandK == PipeKind::None && TryScore.Valid && CandScore.Valid &&
+        TryCand.SU->getHeight() != Cand.SU->getHeight()) {
+      if (tryLess(TryCand.SU->getHeight(), Cand.SU->getHeight(), TryCand, Cand,
+                  GenericSchedulerBase::TopPathReduce))
+        return true;
+
+      return false;
+    }
+  }
+
+  if (TryK == PipeKind::FragmentProducer &&
+      CandK == PipeKind::FragmentProducer) {
+    MFMAFragmentProducerScore TryScore =
+        getReachableFragmentProducerScore(TryCand.SU);
+    MFMAFragmentProducerScore CandScore =
+        getReachableFragmentProducerScore(Cand.SU);
+
+    if (isBetterPrologueFragmentScore(TryScore, CandScore)) {
+      TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+
+    if (isBetterPrologueFragmentScore(CandScore, TryScore)) {
+      Cand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool GCNSchedStrategy::tryMFMASteadyState(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    const FragmentWindowState &FWS, unsigned EffectiveMaxWindow) const {
+  PipeKind TryK = classifyPipeKind(Zone, TryCand.SU);
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+  auto ShouldStaggerPendingMFMA = [&](PipeKind Kind, const SUnit *SU) {
+    return Kind == PipeKind::PendingMFMA && FWS.LastPickWasDSRead &&
+           FWS.HasPickedMFMA && consumesThisDSRead(SU, FWS.LastDSRead);
+  };
+
+  bool TryStagger = ShouldStaggerPendingMFMA(TryK, TryCand.SU);
+  bool CandStagger = ShouldStaggerPendingMFMA(CandK, Cand.SU);
+  bool TryProducer = TryK == PipeKind::FragmentProducer;
+  bool CandProducer = CandK == PipeKind::FragmentProducer;
+  auto IsIssueReadyMFMA = [&](PipeKind Kind, SUnit *SU) {
+    return Kind == PipeKind::ReadyMFMA && getIssueStall(Zone, SU) == 0;
+  };
+  bool TryFiller = IsIssueReadyMFMA(TryK, TryCand.SU);
+  bool CandFiller = IsIssueReadyMFMA(CandK, Cand.SU);
+  auto IsDrainBurstMFMA = [&](PipeKind Kind, SUnit *SU) {
+    if (Kind == PipeKind::ReadyMFMA)
+      return getIssueStall(Zone, SU) == 0;
+    if (Kind != PipeKind::PendingMFMA || getIssueStall(Zone, SU) != 0)
+      return false;
+    return getEffectiveStall(Zone, SU) <= MFMAFragmentSched.MaxDrainMFMAStall;
+  };
+  bool TryDrainBurstMFMA = IsDrainBurstMFMA(TryK, TryCand.SU);
+  bool CandDrainBurstMFMA = IsDrainBurstMFMA(CandK, Cand.SU);
+  auto ConsumesImmatureRecentDSRead = [&](PipeKind Kind, const SUnit *SU) {
+    return (Kind == PipeKind::ReadyMFMA || Kind == PipeKind::PendingMFMA) &&
+           consumesImmatureRecentDSRead(SU, FWS.RecentDSReadUnrelatedMFMAs);
+  };
+  bool TryConsumesImmatureDSRead =
+      ConsumesImmatureRecentDSRead(TryK, TryCand.SU);
+  bool CandConsumesImmatureDSRead =
+      ConsumesImmatureRecentDSRead(CandK, Cand.SU);
+  unsigned TryRecentDSReadSpacing =
+      getRecentDSReadSpacing(TryK, TryCand.SU, FWS.RecentDSReadUnrelatedMFMAs);
+  unsigned CandRecentDSReadSpacing =
+      getRecentDSReadSpacing(CandK, Cand.SU, FWS.RecentDSReadUnrelatedMFMAs);
+  bool TryUnrelatedDrainMFMA = TryDrainBurstMFMA && !TryConsumesImmatureDSRead;
+  bool CandUnrelatedDrainMFMA =
+      CandDrainBurstMFMA && !CandConsumesImmatureDSRead;
+  auto IsUsefulSpacingProducer = [&](PipeKind Kind, SUnit *SU) {
+    return Kind == PipeKind::FragmentProducer && FWS.HasPickedMFMA &&
+           MFMAFragmentSched.PipelineGroupSize &&
+           getEffectiveStall(Zone, SU) == 0 &&
+           FWS.LiveFragments < FWS.MaxWindow &&
+           getDirectFragmentProducerScore(SU).Valid;
+  };
+  bool TryUsefulSpacingProducer = IsUsefulSpacingProducer(TryK, TryCand.SU);
+  bool CandUsefulSpacingProducer = IsUsefulSpacingProducer(CandK, Cand.SU);
+  auto IsUnderfilledSpacingProducer = [&](PipeKind Kind, SUnit *SU) {
+    return Kind == PipeKind::FragmentProducer && FWS.HasPickedMFMA &&
+           MFMAFragmentSched.PipelineGroupSize && !FWS.LastPickWasDSRead &&
+           getEffectiveStall(Zone, SU) == 0 &&
+           getDirectFragmentProducerScore(SU).Valid &&
+           countDSReadSpacingFillers(Zone, SU) <
+               MFMAFragmentSched.PipelineGroupSize;
+  };
+  bool TryUnderfilledSpacingProducer =
+      IsUnderfilledSpacingProducer(TryK, TryCand.SU);
+  bool CandUnderfilledSpacingProducer =
+      IsUnderfilledSpacingProducer(CandK, Cand.SU);
+  auto IsHideableUnlockingProducer = [&](PipeKind Kind, const SUnit *SU,
+                                         const SUnit *Filler) {
+    return Kind == PipeKind::FragmentProducer && FWS.HasPickedMFMA &&
+           !FWS.LastPickWasDSRead &&
+           FWS.MFMAsSinceLastDSRead >= MFMAFragmentSched.PipelineGroupSize &&
+           FWS.LiveFragments < EffectiveMaxWindow &&
+           (countMFMASuccessorsUnlockedBy(SU) != 0 ||
+            countMFMASuccessorsUnlockedByAfterFiller(SU, Filler) != 0);
+  };
+  bool TryHideableProducer =
+      IsHideableUnlockingProducer(TryK, TryCand.SU, Cand.SU);
+  bool CandHideableProducer =
+      IsHideableUnlockingProducer(CandK, Cand.SU, TryCand.SU);
+
+  // Steady state: mature each new DS_READ with unrelated MFMAs, and prefer
+  // reads that can start the next useful two-fragment microcluster.
+  if (FWS.HasPickedMFMA && MFMAFragmentSched.PipelineGroupSize &&
+      !FWS.RecentDSReadUnrelatedMFMAs.empty()) {
+    if (TryDrainBurstMFMA && CandDrainBurstMFMA &&
+        TryRecentDSReadSpacing != CandRecentDSReadSpacing) {
+      if (tryGreater(TryRecentDSReadSpacing, CandRecentDSReadSpacing, TryCand,
+                     Cand, GenericSchedulerBase::Stall))
+        return true;
+
+      return false;
+    }
+
+    if (TryConsumesImmatureDSRead && CandUnrelatedDrainMFMA) {
+      Cand.Reason = GenericSchedulerBase::Stall;
+      return true;
+    }
+
+    if (CandConsumesImmatureDSRead && TryUnrelatedDrainMFMA) {
+      TryCand.Reason = GenericSchedulerBase::Stall;
+      return true;
+    }
+
+    if (TryConsumesImmatureDSRead && CandUsefulSpacingProducer) {
+      Cand.Reason = GenericSchedulerBase::Stall;
+      return true;
+    }
+
+    if (CandConsumesImmatureDSRead && TryUsefulSpacingProducer) {
+      TryCand.Reason = GenericSchedulerBase::Stall;
+      return true;
+    }
+  }
+
+  if (TryStagger && CandFiller) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (CandStagger && TryFiller) {
+    TryCand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (TryStagger && CandProducer && getEffectiveStall(Zone, Cand.SU) == 0) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (CandStagger && TryProducer && getEffectiveStall(Zone, TryCand.SU) == 0) {
+    TryCand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (TryUnderfilledSpacingProducer && CandUnrelatedDrainMFMA) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (CandUnderfilledSpacingProducer && TryUnrelatedDrainMFMA) {
+    TryCand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (TryHideableProducer && CandFiller) {
+    TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  if (CandHideableProducer && TryFiller) {
+    Cand.Reason = GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  // Finish a two-read DS microcluster before draining unrelated MFMAs to avoid
+  // the gfx950 lone-DS issue-cycle penalty.
+  bool TryDrainMFMA = TryDrainBurstMFMA;
+  bool CandDrainMFMA = CandDrainBurstMFMA;
+  if (FWS.HasPickedMFMA && FWS.LastPickWasDSRead &&
+      FWS.LiveFragments < EffectiveMaxWindow &&
+      ((TryProducer && CandDrainMFMA) || (CandProducer && TryDrainMFMA))) {
+    bool NeedsSecondDS =
+        FWS.DSReadsSinceLastMFMA < MFMAFragmentSched.PipelineGroupSize;
+    if (NeedsSecondDS) {
+      if (TryProducer) {
+        TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+        return true;
+      }
+
+      Cand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+  }
+
+  if (FWS.HasPickedMFMA &&
+      FWS.MFMAsSinceLastDSRead < MFMAFragmentSched.PipelineGroupSize &&
+      ((TryDrainBurstMFMA && CandProducer) ||
+       (CandDrainBurstMFMA && TryProducer))) {
+    if (TryDrainBurstMFMA) {
+      TryCand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+
+    Cand.Reason = GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  return false;
+}
+
+bool GCNSchedStrategy::tryMFMAFragmentCandidate(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    const FragmentWindowState &FWS, bool EnablePrologueSetupBias) const {
+  // Follow the generic try* protocol: return true when the policy chooses
+  // either candidate and set the reason on the preferred candidate. Return
+  // false only when the policy has no preference.
+  if (!TryCand.SU || !Cand.SU)
+    return false;
+
+  unsigned EffectiveUsefulWindow =
+      FWS.HasPickedMFMA
+          ? FWS.UsefulWindow
+          : std::min(FWS.UsefulWindow, MFMAFragmentSched.PrologueWindow);
+  bool IsSteadyState =
+      FWS.HasPickedMFMA || FWS.LiveFragments >= EffectiveUsefulWindow;
+  unsigned EffectiveMaxWindow =
+      IsSteadyState ? EffectiveUsefulWindow : FWS.MaxWindow;
+
+  if (tryMFMAFragmentOpener(TryCand, Cand, Zone, FWS, EnablePrologueSetupBias))
+    return true;
+  if (tryMFMASteadyState(TryCand, Cand, Zone, FWS, EffectiveMaxWindow))
+    return true;
+  if (tryMFMAResourceStall(TryCand, Cand, Zone, FWS, EffectiveMaxWindow))
+    return true;
+  if (tryMFMAProducerOrder(TryCand, Cand, Zone))
+    return true;
+  return tryMFMAWindowFallback(TryCand, Cand, Zone, FWS, EffectiveUsefulWindow,
+                               EffectiveMaxWindow);
+}
+
+bool GCNSchedStrategy::tryMFMAProducerOrder(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone) const {
+  if (classifyPipeKind(Zone, TryCand.SU) != PipeKind::FragmentProducer ||
+      classifyPipeKind(Zone, Cand.SU) != PipeKind::FragmentProducer)
+    return false;
+
+  // Prefer the producer closest to making an MFMA ready. The successive
+  // tie-breakers make this ordering deterministic without changing the DAG.
+  unsigned TryBestMissing =
+      getBestMFMASuccessorMissingDSReadPredsAfter(TryCand.SU);
+  unsigned CandBestMissing =
+      getBestMFMASuccessorMissingDSReadPredsAfter(Cand.SU);
+  if (TryBestMissing != CandBestMissing)
+    return tryLess(TryBestMissing, CandBestMissing, TryCand, Cand,
+                   GenericSchedulerBase::TopPathReduce);
+
+  unsigned TrySuccNode = getBestMFMASuccessorNodeNumAfter(TryCand.SU);
+  unsigned CandSuccNode = getBestMFMASuccessorNodeNumAfter(Cand.SU);
+  if (TrySuccNode != CandSuccNode)
+    return tryLess(TrySuccNode, CandSuccNode, TryCand, Cand,
+                   GenericSchedulerBase::TopPathReduce);
+
+  unsigned TryScheduled =
+      getBestMFMASuccessorScheduledDSReadPredsAfter(TryCand.SU);
+  unsigned CandScheduled =
+      getBestMFMASuccessorScheduledDSReadPredsAfter(Cand.SU);
+  if (TryScheduled != CandScheduled)
+    return tryGreater(TryScheduled, CandScheduled, TryCand, Cand,
+                      GenericSchedulerBase::TopPathReduce);
+
+  unsigned TryUnlocks = countMFMASuccessorsUnlockedBy(TryCand.SU);
+  unsigned CandUnlocks = countMFMASuccessorsUnlockedBy(Cand.SU);
+  if (TryUnlocks != CandUnlocks)
+    return tryGreater(TryUnlocks, CandUnlocks, TryCand, Cand,
+                      GenericSchedulerBase::TopPathReduce);
+
+  unsigned TryRemaining = getNumDSReadsToUnlockClosestMFMA(TryCand.SU);
+  unsigned CandRemaining = getNumDSReadsToUnlockClosestMFMA(Cand.SU);
+  if (TryRemaining != CandRemaining)
+    return tryLess(TryRemaining, CandRemaining, TryCand, Cand,
+                   GenericSchedulerBase::TopPathReduce);
+
+  return false;
+}
+
+bool GCNSchedStrategy::tryMFMAResourceStall(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    const FragmentWindowState &FWS, unsigned EffectiveMaxWindow) const {
+  PipeKind TryK = classifyPipeKind(Zone, TryCand.SU);
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+  bool TryProducer = TryK == PipeKind::FragmentProducer;
+  bool CandProducer = CandK == PipeKind::FragmentProducer;
+  bool TryIssueStalledMFMA =
+      TryK == PipeKind::ReadyMFMA && getIssueStall(Zone, TryCand.SU) != 0;
+  bool CandIssueStalledMFMA =
+      CandK == PipeKind::ReadyMFMA && getIssueStall(Zone, Cand.SU) != 0;
+
+  // Fill a short MFMA issue gap with a useful read when possible, but drain
+  // the window rather than admitting unbounded fragments.
+  if ((TryIssueStalledMFMA && CandProducer) ||
+      (CandIssueStalledMFMA && TryProducer)) {
+    bool TryIsProducer = TryProducer;
+    SUnit *ProducerSU = TryIsProducer ? TryCand.SU : Cand.SU;
+    SUnit *MFMA = TryIssueStalledMFMA ? TryCand.SU : Cand.SU;
+    bool HasWindowHeadroom =
+        !FWS.HasPickedMFMA || FWS.LiveFragments < EffectiveMaxWindow;
+    bool CanFillIssueGap =
+        getEffectiveStall(Zone, ProducerSU) <= getIssueStall(Zone, MFMA) &&
+        HasWindowHeadroom &&
+        (!FWS.HasPickedMFMA ||
+         FWS.DSReadsSinceLastMFMA < MFMAFragmentSched.MaxDSReadsInMFMAStall);
+
+    if (CanFillIssueGap) {
+      (TryIsProducer ? TryCand : Cand).Reason = GenericSchedulerBase::Stall;
+      return true;
+    }
+
+    (TryIssueStalledMFMA ? TryCand : Cand).Reason =
+        GenericSchedulerBase::RegExcess;
+    return true;
+  }
+
+  if (TryIssueStalledMFMA && CandIssueStalledMFMA) {
+    unsigned TryIssueStall = getIssueStall(Zone, TryCand.SU);
+    unsigned CandIssueStall = getIssueStall(Zone, Cand.SU);
+    if (TryIssueStall != CandIssueStall)
+      return tryLess(TryIssueStall, CandIssueStall, TryCand, Cand,
+                     GenericSchedulerBase::Stall);
+  }
+
+  if (FWS.LiveFragments < EffectiveMaxWindow)
+    return false;
+
+  bool TryMFMA = TryK == PipeKind::ReadyMFMA;
+  bool CandMFMA = CandK == PipeKind::ReadyMFMA;
+  if ((TryMFMA && CandProducer) || (CandMFMA && TryProducer)) {
+    (TryMFMA ? TryCand : Cand).Reason = GenericSchedulerBase::RegExcess;
+    return true;
+  }
+
+  if (TryMFMA && CandMFMA)
+    return tryReadyStall(TryCand, Cand, Zone);
+
+  return false;
+}
+
+bool GCNSchedStrategy::tryMFMAWindowFallback(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    const FragmentWindowState &FWS, unsigned EffectiveUsefulWindow,
+    unsigned EffectiveMaxWindow) const {
+  PipeKind TryK = classifyPipeKind(Zone, TryCand.SU);
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+
+  if (TryK == PipeKind::PendingMFMA || CandK == PipeKind::PendingMFMA) {
+    if (TryK != CandK) {
+      (TryK != PipeKind::PendingMFMA ? TryCand : Cand).Reason =
+          GenericSchedulerBase::Stall;
+      return true;
+    }
+    return tryReadyStall(TryCand, Cand, Zone);
+  }
+
+  bool TryProducer = TryK == PipeKind::FragmentProducer;
+  bool CandProducer = CandK == PipeKind::FragmentProducer;
+  if (FWS.LiveFragments < EffectiveUsefulWindow &&
+      TryProducer != CandProducer) {
+    (TryProducer ? TryCand : Cand).Reason = GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  bool TryReadyMFMA =
+      TryK == PipeKind::ReadyMFMA && getIssueStall(Zone, TryCand.SU) == 0;
+  bool CandReadyMFMA =
+      CandK == PipeKind::ReadyMFMA && getIssueStall(Zone, Cand.SU) == 0;
+  if (FWS.LiveFragments >= EffectiveUsefulWindow &&
+      TryReadyMFMA != CandReadyMFMA) {
+    (TryReadyMFMA ? TryCand : Cand).Reason =
+        GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  if (FWS.LiveFragments >= EffectiveMaxWindow && TryProducer != CandProducer) {
+    (TryProducer ? Cand : TryCand).Reason = GenericSchedulerBase::RegExcess;
+    return true;
+  }
+
+  return false;
+}
+
+bool GCNSchedStrategy::shouldKeepMFMAFragmentCandidate(
+    GenericSchedulerBase::SchedCandidate &TryCand,
+    GenericSchedulerBase::SchedCandidate &Cand, SchedBoundary &Zone,
+    const FragmentWindowState &FWS) const {
+  // tryCandidate() compares TryCand against an incumbent Cand. Some generic
+  // heuristics run before the fragment policy, so protect an already selected
+  // pipeline candidate from being replaced by a locally attractive choice
+  // that would break DS maturity spacing or producer ordering.
+  if (!TryCand.SU || !Cand.SU)
+    return false;
+
+  PipeKind TryK = classifyPipeKind(Zone, TryCand.SU);
+  PipeKind CandK = classifyPipeKind(Zone, Cand.SU);
+
+  bool TryIsStaggeredPendingMFMA =
+      TryK == PipeKind::PendingMFMA && FWS.LastPickWasDSRead &&
+      FWS.HasPickedMFMA && consumesThisDSRead(TryCand.SU, FWS.LastDSRead);
+  bool CandIsReadyMFMA =
+      CandK == PipeKind::ReadyMFMA && getIssueStall(Zone, Cand.SU) == 0;
+  if (TryIsStaggeredPendingMFMA && CandIsReadyMFMA) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  auto IsDrainMFMA = [&](PipeKind Kind, SUnit *SU) {
+    if (Kind == PipeKind::ReadyMFMA)
+      return getIssueStall(Zone, SU) == 0;
+    if (Kind != PipeKind::PendingMFMA)
+      return false;
+    if (getIssueStall(Zone, SU) != 0)
+      return false;
+    return getEffectiveStall(Zone, SU) <= MFMAFragmentSched.MaxDrainMFMAStall;
+  };
+
+  auto ConsumesImmatureRecentDSRead = [&](PipeKind Kind, const SUnit *SU) {
+    if (Kind != PipeKind::ReadyMFMA && Kind != PipeKind::PendingMFMA)
+      return false;
+    return consumesImmatureRecentDSRead(SU, FWS.RecentDSReadUnrelatedMFMAs);
+  };
+  bool TryConsumesImmatureDSRead =
+      ConsumesImmatureRecentDSRead(TryK, TryCand.SU);
+  bool CandUnrelatedDrainMFMA = IsDrainMFMA(CandK, Cand.SU) &&
+                                !ConsumesImmatureRecentDSRead(CandK, Cand.SU);
+  bool CandUsefulSpacingProducer =
+      CandK == PipeKind::FragmentProducer && FWS.HasPickedMFMA &&
+      MFMAFragmentSched.PipelineGroupSize &&
+      getEffectiveStall(Zone, Cand.SU) == 0 &&
+      FWS.LiveFragments < FWS.MaxWindow &&
+      getDirectFragmentProducerScore(Cand.SU).Valid;
+  if (FWS.HasPickedMFMA && MFMAFragmentSched.PipelineGroupSize &&
+      !FWS.RecentDSReadUnrelatedMFMAs.empty() &&
+      IsDrainMFMA(TryK, TryCand.SU) && IsDrainMFMA(CandK, Cand.SU) &&
+      getRecentDSReadSpacing(CandK, Cand.SU, FWS.RecentDSReadUnrelatedMFMAs) >
+          getRecentDSReadSpacing(TryK, TryCand.SU,
+                                 FWS.RecentDSReadUnrelatedMFMAs)) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (FWS.HasPickedMFMA && MFMAFragmentSched.PipelineGroupSize &&
+      !FWS.RecentDSReadUnrelatedMFMAs.empty() && TryConsumesImmatureDSRead &&
+      CandUnrelatedDrainMFMA) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  if (FWS.HasPickedMFMA && MFMAFragmentSched.PipelineGroupSize &&
+      !FWS.RecentDSReadUnrelatedMFMAs.empty() && TryConsumesImmatureDSRead &&
+      CandUsefulSpacingProducer) {
+    Cand.Reason = GenericSchedulerBase::Stall;
+    return true;
+  }
+
+  bool TryIsReadyMFMA =
+      TryK == PipeKind::ReadyMFMA && getIssueStall(Zone, TryCand.SU) == 0;
+  bool CandIsHideableProducer =
+      CandK == PipeKind::FragmentProducer && FWS.HasPickedMFMA &&
+      !FWS.LastPickWasDSRead &&
+      FWS.MFMAsSinceLastDSRead >= MFMAFragmentSched.PipelineGroupSize &&
+      FWS.LiveFragments < FWS.MaxWindow &&
+      (countMFMASuccessorsUnlockedBy(Cand.SU) != 0 ||
+       countMFMASuccessorsUnlockedByAfterFiller(Cand.SU, TryCand.SU) != 0);
+  if (TryIsReadyMFMA && CandIsHideableProducer) {
+    Cand.Reason = GenericSchedulerBase::TopPathReduce;
+    return true;
+  }
+
+  if (TryK == PipeKind::FragmentProducer &&
+      CandK == PipeKind::FragmentProducer) {
+    MFMAFragmentProducerScore TryScore =
+        getReachableFragmentProducerScore(TryCand.SU);
+    MFMAFragmentProducerScore CandScore =
+        getReachableFragmentProducerScore(Cand.SU);
+    if (isBetterPrologueFragmentScore(CandScore, TryScore)) {
+      Cand.Reason = GenericSchedulerBase::TopPathReduce;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static bool
+tryBidirectionalReadyStall(GenericSchedulerBase::SchedCandidate &TryCand,
+                           GenericSchedulerBase::SchedCandidate &Cand,
+                           SchedBoundary &TryZone, SchedBoundary &CandZone) {
+  if (!TryCand.SU || !Cand.SU)
+    return false;
+
+  unsigned TryStall = getReadyStall(TryZone, TryCand.SU);
+  unsigned CandStall = getReadyStall(CandZone, Cand.SU);
+  if (TryStall == CandStall)
+    return false;
+
+  if (tryLess(TryStall, CandStall, TryCand, Cand, GenericSchedulerBase::Stall))
+    return TryCand.Reason != GenericSchedulerBase::NoCand;
+
+  return false;
+}
+
+static bool isTopDownBiasCandidate(SchedBoundary &Zone, SUnit *SU) {
+  PipeKind Kind = classifyPipeKind(Zone, SU);
+  return Kind != PipeKind::None && Kind != PipeKind::PendingMFMA;
+}
+
+static bool shouldPreferTopOverBottomStalledDS(
+    SchedBoundary &Top, SchedBoundary &Bot,
+    GenericSchedulerBase::SchedCandidate &TopCand,
+    GenericSchedulerBase::SchedCandidate &BotCand) {
+  if (!TopCand.isValid() || !BotCand.isValid())
+    return false;
+
+  if (classifyPipeKind(Bot, BotCand.SU) != PipeKind::FragmentProducer ||
+      getReadyStall(Bot, BotCand.SU) == 0)
+    return false;
+
+  PipeKind TopKind = classifyPipeKind(Top, TopCand.SU);
+  if (TopKind == PipeKind::FragmentProducer)
+    return getReadyStall(Top, TopCand.SU) == 0;
+
+  if (TopKind != PipeKind::ReadyMFMA)
+    return false;
+
+  return getReadyStall(Top, TopCand.SU) == 0;
+}
+
+static SUnit *findTopMFMAFillerForRecentDS(
+    SchedBoundary &Top, SUnit *TopSU, bool HasPickedMFMA,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs,
+    bool &FillerPending) {
+  if (!TopSU || !HasPickedMFMA ||
+      classifyPipeKind(Top, TopSU) != PipeKind::FragmentProducer ||
+      !hasRecentDSReadSpacingDebt(RecentDSReadUnrelatedMFMAs))
+    return nullptr;
+
+  SUnit *Best = nullptr;
+  unsigned BestBenefit = 0;
+  unsigned BestConsumedSpacing = 0;
+  unsigned BestStall = std::numeric_limits<unsigned>::max();
+  unsigned BestReadyStall = std::numeric_limits<unsigned>::max();
+  bool BestPending = false;
+  auto TryFiller = [&](SUnit *SU, bool IsPending) {
+    if (!SU || SU->isScheduled || !isMFMALike(SU))
+      return;
+    if (getIssueStall(Top, SU) != 0)
+      return;
+
+    unsigned Benefit = 0;
+    unsigned ConsumedSpacing = MFMAFragmentSched.PipelineGroupSize;
+    for (const auto &DSRead : RecentDSReadUnrelatedMFMAs) {
+      if (DSRead.second >= MFMAFragmentSched.PipelineGroupSize)
+        continue;
+
+      if (consumesThisDSRead(SU, DSRead.first)) {
+        ConsumedSpacing = std::min(ConsumedSpacing, DSRead.second);
+        continue;
+      }
+
+      Benefit += MFMAFragmentSched.PipelineGroupSize - DSRead.second;
+    }
+    if (!Benefit || ConsumedSpacing == 0)
+      return;
+
+    unsigned Stall = getEffectiveStall(Top, SU);
+    if (Stall > MFMAFragmentSched.MaxDrainMFMAStall)
+      return;
+
+    unsigned ReadyStall = getReadyStall(Top, SU);
+    bool Better = !Best;
+    if (!Better && Benefit != BestBenefit)
+      Better = Benefit > BestBenefit;
+    if (!Better && Benefit == BestBenefit &&
+        ConsumedSpacing != BestConsumedSpacing)
+      Better = ConsumedSpacing > BestConsumedSpacing;
+    if (!Better && Benefit == BestBenefit &&
+        ConsumedSpacing == BestConsumedSpacing && Stall != BestStall)
+      Better = Stall < BestStall;
+    if (!Better && Benefit == BestBenefit &&
+        ConsumedSpacing == BestConsumedSpacing && Stall == BestStall &&
+        ReadyStall != BestReadyStall)
+      Better = ReadyStall < BestReadyStall;
+    if (!Better && Benefit == BestBenefit &&
+        ConsumedSpacing == BestConsumedSpacing && Stall == BestStall &&
+        ReadyStall == BestReadyStall && IsPending != BestPending)
+      Better = IsPending < BestPending;
+    if (!Better && Benefit == BestBenefit &&
+        ConsumedSpacing == BestConsumedSpacing && Stall == BestStall &&
+        ReadyStall == BestReadyStall && IsPending == BestPending)
+      Better = SU->NodeNum < Best->NodeNum;
+
+    if (Better) {
+      Best = SU;
+      BestBenefit = Benefit;
+      BestConsumedSpacing = ConsumedSpacing;
+      BestStall = Stall;
+      BestReadyStall = ReadyStall;
+      BestPending = IsPending;
+    }
+  };
+
+  for (SUnit *SU : Top.Available)
+    TryFiller(SU, false);
+  for (SUnit *SU : Top.Pending)
+    TryFiller(SU, true);
+
+  if (!Best)
+    return nullptr;
+
+  FillerPending = BestPending;
+  return Best;
+}
+
+static SUnit *findTopMFMAFillerForRecentDS(
+    SchedBoundary &Top, GenericSchedulerBase::SchedCandidate &TopCand,
+    bool HasPickedMFMA,
+    const DenseMap<const SUnit *, unsigned> &RecentDSReadUnrelatedMFMAs,
+    bool &FillerPending) {
+  if (!TopCand.isValid())
+    return nullptr;
+
+  return findTopMFMAFillerForRecentDS(Top, TopCand.SU, HasPickedMFMA,
+                                      RecentDSReadUnrelatedMFMAs,
+                                      FillerPending);
+}
+
+static SUnit *findBottomMFMAFillerForStalledDS(
+    SchedBoundary &Bot, GenericSchedulerBase::SchedCandidate &BotCand,
+    bool HasPickedMFMA,
+    DenseMap<const SUnit *, unsigned> &DeferredDSReadFillers,
+    bool &FillerPending) {
+  if (!BotCand.isValid())
+    return nullptr;
+
+  if (classifyPipeKind(Bot, BotCand.SU) != PipeKind::FragmentProducer ||
+      !HasPickedMFMA || !hasScheduledMFMASuccessor(BotCand.SU))
+    return nullptr;
+
+  unsigned &DeferredFillers = DeferredDSReadFillers[BotCand.SU];
+  // Bottom-up sees a fragment's consumer before its producer. Reserve one
+  // extra MFMA slot because the closest scheduled MFMA can be that consumer;
+  // only the remaining slots are unrelated latency-hiding work in final order.
+  if (DeferredFillers > MFMAFragmentSched.PipelineGroupSize)
+    return nullptr;
+
+  SUnit *Best = nullptr;
+  unsigned BestStall = std::numeric_limits<unsigned>::max();
+  unsigned BestReadyStall = std::numeric_limits<unsigned>::max();
+  bool BestPending = false;
+  auto TryFiller = [&](SUnit *SU, bool IsPending) {
+    if (!SU || SU->isScheduled || !isMFMALike(SU))
+      return;
+    if (consumesThisDSRead(SU, BotCand.SU))
+      return;
+
+    unsigned Stall = getEffectiveStall(Bot, SU);
+    if (Stall > MFMAFragmentSched.MaxDrainMFMAStall)
+      return;
+
+    unsigned ReadyStall = getReadyStall(Bot, SU);
+    if (!Best || Stall < BestStall ||
+        (Stall == BestStall && ReadyStall < BestReadyStall)) {
+      Best = SU;
+      BestStall = Stall;
+      BestReadyStall = ReadyStall;
+      BestPending = IsPending;
+    }
+  };
+
+  for (SUnit *SU : Bot.Available)
+    TryFiller(SU, false);
+  for (SUnit *SU : Bot.Pending)
+    TryFiller(SU, true);
+
+  if (!Best)
+    return nullptr;
+
+  ++DeferredFillers;
+  FillerPending = BestPending;
+  return Best;
+}
+
+void GCNSchedStrategy::updateFragmentWindow(SUnit *SU, bool IsTopNode) {
+  FragmentWindowState &FWS = IsTopNode ? TopFragmentWindow : BotFragmentWindow;
+  SchedBoundary &Zone = IsTopNode ? Top : Bot;
+  if (isDSReadLike(SU)) {
+    FWS.DeferredDSReadFillers.erase(SU);
+    ++FWS.LiveFragments;
+    if (FWS.HasPickedMFMA)
+      ++FWS.DSReadsSinceLastMFMA;
+    FWS.LastDSRead = SU;
+    FWS.MFMAsSinceLastDSRead = 0;
+    FWS.UnrelatedMFMAsSinceLastDSRead = 0;
+    FWS.RecentDSReadUnrelatedMFMAs[SU] = 0;
+    FWS.LastPickWasDSRead = true;
+    return;
+  }
+
+  FWS.LastPickWasDSRead = false;
+
+  if (isMFMALike(SU)) {
+    bool CompletesDSMicrocluster =
+        FWS.HasPickedMFMA &&
+        FWS.DSReadsSinceLastMFMA >= MFMAFragmentSched.PipelineGroupSize;
+    bool IsUsefulFiller =
+        getReadyStall(Zone, SU) == 0 && getIssueStall(Zone, SU) == 0;
+    FWS.HasPickedMFMA = true;
+    ++FWS.PickedMFMAs;
+    FWS.DSReadsSinceLastMFMA = 0;
+    if (CompletesDSMicrocluster)
+      ++FWS.CompletedDSMicroclusters;
+    if (IsUsefulFiller)
+      ++FWS.MFMAsSinceLastDSRead;
+    if (IsUsefulFiller && !consumesThisDSRead(SU, FWS.LastDSRead))
+      ++FWS.UnrelatedMFMAsSinceLastDSRead;
+    if (MFMAFragmentSched.PipelineGroupSize) {
+      SmallVector<const SUnit *, 8> MatureDSReads;
+      for (auto &DSRead : FWS.RecentDSReadUnrelatedMFMAs) {
+        if (consumesThisDSRead(SU, DSRead.first)) {
+          MatureDSReads.push_back(DSRead.first);
+          continue;
+        }
+        if (IsUsefulFiller) {
+          ++DSRead.second;
+          if (MFMAFragmentSched.PipelineGroupSize &&
+              DSRead.second > MFMAFragmentSched.PipelineGroupSize)
+            MatureDSReads.push_back(DSRead.first);
+        }
+      }
+      for (const SUnit *DSRead : MatureDSReads)
+        FWS.RecentDSReadUnrelatedMFMAs.erase(DSRead);
+    }
+    if (FWS.LiveFragments)
+      --FWS.LiveFragments;
+  }
+}
+
+void GCNSchedStrategy::resetFragmentWindows() {
+  TopFragmentWindow = FragmentWindowState();
+  BotFragmentWindow = FragmentWindowState();
+}
+
+bool GCNSchedStrategy::tryCandidate(SchedCandidate &Cand,
+                                    SchedCandidate &TryCand,
+                                    SchedBoundary *Zone) const {
+  if (!EnableMFMAFragmentScheduler)
+    return GenericScheduler::tryCandidate(Cand, TryCand, Zone);
+
+  if (!Cand.isValid()) {
+    TryCand.Reason = FirstValid;
+    return true;
+  }
+
+  if (tryGreater(biasPhysReg(TryCand.SU, TryCand.AtTop),
+                 biasPhysReg(Cand.SU, Cand.AtTop), TryCand, Cand, PhysReg))
+    return TryCand.Reason != NoCand;
+
+  if (DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.Excess, Cand.RPDelta.Excess, TryCand, Cand,
+                  RegExcess, TRI, DAG->MF))
+    return TryCand.Reason != NoCand;
+
+  if (DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.CriticalMax, Cand.RPDelta.CriticalMax,
+                  TryCand, Cand, RegCritical, TRI, DAG->MF))
+    return TryCand.Reason != NoCand;
+
+  bool SameBoundary = Zone != nullptr;
+  if (SameBoundary) {
+    const FragmentWindowState &FWS =
+        Zone->isTop() ? TopFragmentWindow : BotFragmentWindow;
+    if (tryRecentDSReadSpacing(TryCand, Cand, *Zone, FWS.HasPickedMFMA,
+                               FWS.RecentDSReadUnrelatedMFMAs))
+      return TryCand.Reason != NoCand;
+
+    if (shouldKeepMFMAFragmentCandidate(TryCand, Cand, *Zone, FWS))
+      return false;
+
+    if (tryMFMAFragmentCandidate(TryCand, Cand, *Zone, FWS, true))
+      return TryCand.Reason != NoCand;
+
+    if (Rem.IsAcyclicLatencyLimited && !Zone->getCurrMOps() &&
+        tryLatency(TryCand, Cand, *Zone))
+      return TryCand.Reason != NoCand;
+
+    if (tryLess(Zone->getLatencyStallCycles(TryCand.SU),
+                Zone->getLatencyStallCycles(Cand.SU), TryCand, Cand, Stall))
+      return TryCand.Reason != NoCand;
+  }
+
+  unsigned CandZoneCluster = Cand.AtTop ? TopClusterID : BotClusterID;
+  unsigned TryCandZoneCluster = TryCand.AtTop ? TopClusterID : BotClusterID;
+  bool CandIsClusterSucc =
+      isTheSameCluster(CandZoneCluster, Cand.SU->ParentClusterIdx);
+  bool TryCandIsClusterSucc =
+      isTheSameCluster(TryCandZoneCluster, TryCand.SU->ParentClusterIdx);
+
+  if (tryGreater(TryCandIsClusterSucc, CandIsClusterSucc, TryCand, Cand,
+                 Cluster))
+    return TryCand.Reason != NoCand;
+
+  if (SameBoundary) {
+    if (tryLess(getWeakLeft(TryCand.SU, TryCand.AtTop),
+                getWeakLeft(Cand.SU, Cand.AtTop), TryCand, Cand, Weak))
+      return TryCand.Reason != NoCand;
+  }
+
+  if (DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.CurrentMax, Cand.RPDelta.CurrentMax, TryCand,
+                  Cand, RegMax, TRI, DAG->MF))
+    return TryCand.Reason != NoCand;
+
+  if (SameBoundary) {
+    TryCand.initResourceDelta(DAG, SchedModel);
+    if (tryLess(TryCand.ResDelta.CritResources, Cand.ResDelta.CritResources,
+                TryCand, Cand, ResourceReduce))
+      return TryCand.Reason != NoCand;
+    if (tryGreater(TryCand.ResDelta.DemandedResources,
+                   Cand.ResDelta.DemandedResources, TryCand, Cand,
+                   ResourceDemand))
+      return TryCand.Reason != NoCand;
+
+    if (!RegionPolicy.DisableLatencyHeuristic && TryCand.Policy.ReduceLatency &&
+        !Rem.IsAcyclicLatencyLimited && tryLatency(TryCand, Cand, *Zone))
+      return TryCand.Reason != NoCand;
+
+    if ((Zone->isTop() && TryCand.SU->NodeNum < Cand.SU->NodeNum) ||
+        (!Zone->isTop() && TryCand.SU->NodeNum > Cand.SU->NodeNum)) {
+      TryCand.Reason = NodeOrder;
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void GCNSchedStrategy::printCandidateDecision(const SchedCandidate &Current,
                                               const SchedCandidate &Preferred) {
   LLVM_DEBUG({
@@ -510,6 +2288,29 @@ void GCNSchedStrategy::pickNodeFromQueue(SchedBoundary &Zone,
       Cand.setBest(TryCand);
     } else {
       printCandidateDecision(TryCand, Cand);
+    }
+  }
+
+  if (EnableMFMAFragmentScheduler) {
+    const FragmentWindowState &FWS =
+        Zone.isTop() ? TopFragmentWindow : BotFragmentWindow;
+    if (SUnit *PullForwardProducer = findPullForwardUnlockingProducer(
+            Zone, Cand, FWS.LiveFragments, FWS.UsefulWindow,
+            FWS.LastPickWasDSRead, FWS.HasPickedMFMA,
+            FWS.RecentDSReadUnrelatedMFMAs)) {
+      Cand.reset(ZonePolicy);
+      Cand.SU = PullForwardProducer;
+      Cand.AtTop = Zone.isTop();
+      Cand.Reason = TopPathReduce;
+      return;
+    }
+
+    if (shouldKeepAvailableUnlockingProducer(
+            Zone, Cand.SU, FWS.LiveFragments, FWS.MaxWindow,
+            FWS.LastPickWasDSRead, FWS.HasPickedMFMA, FWS.MFMAsSinceLastDSRead,
+            FWS.RecentDSReadUnrelatedMFMAs)) {
+      Cand.Reason = TopPathReduce;
+      return;
     }
   }
 
@@ -620,7 +2421,284 @@ SUnit *GCNSchedStrategy::pickNodeBidirectional(bool &IsTopNode,
   PickedPending = BotPending && TopPending;
 
   TryCand.Reason = NoCand;
-  if (BotPending || TopPending) {
+  unsigned TopEffectiveUsefulWindow =
+      TopFragmentWindow.HasPickedMFMA
+          ? TopFragmentWindow.UsefulWindow
+          : std::min(TopFragmentWindow.UsefulWindow,
+                     MFMAFragmentSched.PrologueWindow);
+  bool HasTopFragmentPipelineCandidate =
+      TopCand.isValid() && classifyPipeKind(Top, TopCand.SU) != PipeKind::None;
+  bool BiasActiveFragmentWindowTopDown =
+      EnableMFMAFragmentScheduler &&
+      (!TopFragmentWindow.HasPickedMFMA
+           ? TopFragmentWindow.LiveFragments >= TopEffectiveUsefulWindow
+           : TopFragmentWindow.LiveFragments >= TopEffectiveUsefulWindow ||
+                 HasTopFragmentPipelineCandidate ||
+                 !TopFragmentWindow.RecentDSReadUnrelatedMFMAs.empty() ||
+                 TopFragmentWindow.MFMAsSinceLastDSRead <
+                     MFMAFragmentSched.PipelineGroupSize);
+  bool IsFirstFragmentMFMA =
+      !TopFragmentWindow.HasPickedMFMA && isMFMALike(TopCand.SU);
+  bool IsOverfullTopFragmentProducer =
+      TopCand.isValid() &&
+      classifyPipeKind(Top, TopCand.SU) == PipeKind::FragmentProducer &&
+      TopFragmentWindow.LiveFragments >= TopEffectiveUsefulWindow;
+  bool TopCandHasFragmentWork =
+      TopCand.isValid() &&
+      (classifyPipeKind(Top, TopCand.SU) != PipeKind::None ||
+       getReachableFragmentProducerScore(TopCand.SU).Valid);
+  bool IsFragmentPrologue =
+      EnableMFMAFragmentScheduler && !TopFragmentWindow.HasPickedMFMA &&
+      (TopFragmentWindow.LiveFragments != 0 || TopCandHasFragmentWork);
+  SUnit *PrologueMFMA = nullptr;
+  bool PrologueMFMAPending = false;
+  if (IsFragmentPrologue && IsOverfullTopFragmentProducer) {
+    auto ConsiderMFMA = [&](SUnit *SU, bool FromPending) {
+      if (!isMFMALike(SU))
+        return;
+      if (!PrologueMFMA ||
+          getEffectiveStall(Top, SU) < getEffectiveStall(Top, PrologueMFMA) ||
+          (getEffectiveStall(Top, SU) == getEffectiveStall(Top, PrologueMFMA) &&
+           SU->NodeNum < PrologueMFMA->NodeNum)) {
+        PrologueMFMA = SU;
+        PrologueMFMAPending = FromPending;
+      }
+    };
+    for (SUnit *SU : Top.Available)
+      ConsiderMFMA(SU, false);
+    for (SUnit *SU : Top.Pending)
+      ConsiderMFMA(SU, true);
+  }
+  SUnit *SteadyStateMFMA = nullptr;
+  bool SteadyStateMFMAPending = false;
+  bool NeedsSteadyStateFillers =
+      TopFragmentWindow.CompletedDSMicroclusters >= 2 &&
+      TopFragmentWindow.MFMAsSinceLastDSRead <
+          MFMAFragmentSched.PipelineGroupSize;
+  if (EnableMFMAFragmentScheduler && TopFragmentWindow.HasPickedMFMA &&
+      TopCand.isValid() &&
+      classifyPipeKind(Top, TopCand.SU) == PipeKind::FragmentProducer &&
+      (TopFragmentWindow.DSReadsSinceLastMFMA >=
+           MFMAFragmentSched.PipelineGroupSize ||
+       NeedsSteadyStateFillers)) {
+    auto ConsiderMFMA = [&](SUnit *SU, bool FromPending) {
+      if (!isMFMALike(SU) ||
+          getEffectiveStall(Top, SU) > MFMAFragmentSched.MaxDrainMFMAStall)
+        return;
+      bool IsUnrelated = !consumesImmatureRecentDSRead(
+          SU, TopFragmentWindow.RecentDSReadUnrelatedMFMAs);
+      bool BestIsUnrelated =
+          SteadyStateMFMA &&
+          !consumesImmatureRecentDSRead(
+              SteadyStateMFMA, TopFragmentWindow.RecentDSReadUnrelatedMFMAs);
+      bool Better =
+          !SteadyStateMFMA || (IsUnrelated != BestIsUnrelated && IsUnrelated);
+      if (SteadyStateMFMA && IsUnrelated == BestIsUnrelated) {
+        unsigned Stall = getEffectiveStall(Top, SU);
+        unsigned BestStall = getEffectiveStall(Top, SteadyStateMFMA);
+        Better = Stall < BestStall ||
+                 (Stall == BestStall && SU->NodeNum < SteadyStateMFMA->NodeNum);
+      }
+      if (Better) {
+        SteadyStateMFMA = SU;
+        SteadyStateMFMAPending = FromPending;
+      }
+    };
+    for (SUnit *SU : Top.Available)
+      ConsiderMFMA(SU, false);
+    for (SUnit *SU : Top.Pending)
+      ConsiderMFMA(SU, true);
+  }
+  SUnit *RampUpFiller = nullptr;
+  bool RampUpFillerPending = false;
+  SUnit *RampUpMFMA = PrologueMFMA ? PrologueMFMA : SteadyStateMFMA;
+  if (RampUpMFMA && TopFragmentWindow.PickedMFMAs < 2 &&
+      getEffectiveStall(Top, RampUpMFMA) != 0) {
+    auto ConsiderFiller = [&](SUnit *SU, bool FromPending) {
+      if (!isSafeMFMAFragmentRampUpFiller(SU) ||
+          getEffectiveStall(Top, SU) != 0)
+        return;
+      if (!RampUpFiller || SU->NodeNum < RampUpFiller->NodeNum) {
+        RampUpFiller = SU;
+        RampUpFillerPending = FromPending;
+      }
+    };
+    for (SUnit *SU : Top.Available)
+      ConsiderFiller(SU, false);
+    for (SUnit *SU : Top.Pending)
+      ConsiderFiller(SU, true);
+  }
+  SUnit *MicroclusterDS = nullptr;
+  bool MicroclusterDSPending = false;
+  unsigned ReadyFragmentProducers = countIssueReadyFragmentProducers(Top);
+  bool NeedsSecondClusterDS = TopFragmentWindow.HasPickedMFMA &&
+                              TopFragmentWindow.LastPickWasDSRead &&
+                              TopFragmentWindow.DSReadsSinceLastMFMA <
+                                  MFMAFragmentSched.PipelineGroupSize;
+  bool StartReadyMicrocluster =
+      TopFragmentWindow.HasPickedMFMA && !TopFragmentWindow.LastPickWasDSRead &&
+      ReadyFragmentProducers >= 2 &&
+      TopFragmentWindow.MFMAsSinceLastDSRead >=
+          (TopFragmentWindow.CompletedDSMicroclusters < 2
+               ? 1
+               : MFMAFragmentSched.PipelineGroupSize);
+  if (EnableMFMAFragmentScheduler &&
+      TopFragmentWindow.LiveFragments < TopFragmentWindow.MaxWindow &&
+      (StartReadyMicrocluster || NeedsSecondClusterDS)) {
+    auto ConsiderDS = [&](SUnit *SU, bool FromPending) {
+      if (!isDSReadLike(SU) || getEffectiveStall(Top, SU) != 0)
+        return;
+      if (!MicroclusterDS ||
+          isBetterPullForwardProducer(Top, SU, MicroclusterDS)) {
+        MicroclusterDS = SU;
+        MicroclusterDSPending = FromPending;
+      }
+    };
+    for (SUnit *SU : Top.Available)
+      ConsiderDS(SU, false);
+    for (SUnit *SU : Top.Pending)
+      ConsiderDS(SU, true);
+  }
+
+  // Bottom-up picks are committed in reverse program order. Complete their
+  // microcluster here as well; otherwise intervening bottom MFMA picks fix
+  // each producer at a separate point before top scheduling can group it.
+  SUnit *BottomMicroclusterDS = nullptr;
+  bool BottomMicroclusterDSPending = false;
+  bool BottomNeedsSecondClusterDS = BotFragmentWindow.HasPickedMFMA &&
+                                    BotFragmentWindow.LastPickWasDSRead &&
+                                    BotFragmentWindow.DSReadsSinceLastMFMA <
+                                        MFMAFragmentSched.PipelineGroupSize;
+  if (EnableMFMAFragmentScheduler &&
+      BotFragmentWindow.LiveFragments < BotFragmentWindow.MaxWindow &&
+      BottomNeedsSecondClusterDS) {
+    auto ConsiderDS = [&](SUnit *SU, bool FromPending) {
+      if (!isDSReadLike(SU) || getEffectiveStall(Bot, SU) != 0)
+        return;
+      if (!BottomMicroclusterDS ||
+          isBetterPullForwardProducer(Bot, SU, BottomMicroclusterDS)) {
+        BottomMicroclusterDS = SU;
+        BottomMicroclusterDSPending = FromPending;
+      }
+    };
+    for (SUnit *SU : Bot.Available)
+      ConsiderDS(SU, false);
+    for (SUnit *SU : Bot.Pending)
+      ConsiderDS(SU, true);
+  }
+  bool BottomFillerPending = false;
+  bool TopFillerPending = false;
+  bool TopCandIsFragmentProducer =
+      TopCand.isValid() &&
+      classifyPipeKind(Top, TopCand.SU) == PipeKind::FragmentProducer;
+  bool TopCandIsPullForwardProducer =
+      TopCandIsFragmentProducer &&
+      isPullForwardUnlockingProducer(
+          Top, TopCand.SU, TopFragmentWindow.LiveFragments,
+          TopFragmentWindow.UsefulWindow, TopFragmentWindow.LastPickWasDSRead,
+          TopFragmentWindow.HasPickedMFMA, /*AllowFullWindow=*/true,
+          TopFragmentWindow.RecentDSReadUnrelatedMFMAs);
+  SUnit *TopFiller =
+      !EnableMFMAFragmentScheduler || TopCandIsPullForwardProducer
+          ? nullptr
+          : findTopMFMAFillerForRecentDS(
+                Top, TopCand, TopFragmentWindow.HasPickedMFMA,
+                TopFragmentWindow.RecentDSReadUnrelatedMFMAs, TopFillerPending);
+  SUnit *BottomFiller =
+      !EnableMFMAFragmentScheduler || TopCandIsFragmentProducer
+          ? nullptr
+          : findBottomMFMAFillerForStalledDS(
+                Bot, BotCand, BotFragmentWindow.HasPickedMFMA,
+                BotFragmentWindow.DeferredDSReadFillers, BottomFillerPending);
+  bool BottomEpilogueIsFull =
+      EnableMFMAFragmentScheduler &&
+      (TopFragmentWindow.HasPickedMFMA || IsFragmentPrologue) &&
+      TopCand.isValid() && BotCand.isValid() && isMFMALike(BotCand.SU) &&
+      BotFragmentWindow.MFMAsSinceLastDSRead >=
+          MFMAFragmentSched.BottomEpilogueMFMAs;
+  if (RampUpFiller) {
+    Cand.reset(TopPolicy);
+    Cand.SU = RampUpFiller;
+    Cand.AtTop = true;
+    Cand.Reason = Stall;
+    PickedPending = RampUpFillerPending;
+  } else if (PrologueMFMA) {
+    Cand.reset(TopPolicy);
+    Cand.SU = PrologueMFMA;
+    Cand.AtTop = true;
+    Cand.Reason = Stall;
+    PickedPending = PrologueMFMAPending;
+  } else if (MicroclusterDS) {
+    Cand.reset(TopPolicy);
+    Cand.SU = MicroclusterDS;
+    Cand.AtTop = true;
+    Cand.Reason = TopPathReduce;
+    PickedPending = MicroclusterDSPending;
+  } else if (SteadyStateMFMA) {
+    Cand.reset(TopPolicy);
+    Cand.SU = SteadyStateMFMA;
+    Cand.AtTop = true;
+    Cand.Reason = Stall;
+    PickedPending = SteadyStateMFMAPending;
+  } else if (BottomEpilogueIsFull) {
+    // Keep the bottom boundary from consuming the accumulator chain that the
+    // top boundary needs for repeated DS/MFMA steady-state groups. Bottom may
+    // still form a compact, deliberately loose MFMA epilogue.
+    Cand.setBest(TopCand);
+    PickedPending = TopPending;
+  } else if (BottomMicroclusterDS) {
+    Cand.reset(BotPolicy);
+    Cand.SU = BottomMicroclusterDS;
+    Cand.AtTop = false;
+    Cand.Reason = BotPathReduce;
+    PickedPending = BottomMicroclusterDSPending;
+  } else if (IsFragmentPrologue && TopCand.isValid() &&
+             !IsOverfullTopFragmentProducer) {
+    // Keep the opener on one boundary. Bottom-up picks have an independent
+    // fragment count and can otherwise inflate the final linear prologue past
+    // PrologueWindow even when the top window is already full.
+    Cand.setBest(TopCand);
+    PickedPending = TopPending;
+  } else if (TopFiller) {
+    Cand.reset(TopPolicy);
+    Cand.SU = TopFiller;
+    Cand.AtTop = true;
+    Cand.Reason = Stall;
+    PickedPending = TopFillerPending;
+  } else if (EnableMFMAFragmentScheduler &&
+             shouldPreferBoundaryForRecentDSReadSpacing(
+                 Top, TopCand, BotCand,
+                 TopFragmentWindow.RecentDSReadUnrelatedMFMAs)) {
+    Cand.setBest(TopCand);
+    PickedPending = TopPending;
+  } else if (EnableMFMAFragmentScheduler &&
+             shouldPreferBoundaryForRecentDSReadSpacing(
+                 Bot, BotCand, TopCand,
+                 BotFragmentWindow.RecentDSReadUnrelatedMFMAs)) {
+    Cand.setBest(BotCand);
+    PickedPending = BotPending;
+  } else if (BottomFiller) {
+    Cand.reset(BotPolicy);
+    Cand.SU = BottomFiller;
+    Cand.AtTop = false;
+    Cand.Reason = Stall;
+    PickedPending = BottomFillerPending;
+  } else if (BiasActiveFragmentWindowTopDown && TopCand.isValid() &&
+             !IsOverfullTopFragmentProducer &&
+             (IsFirstFragmentMFMA || isTopDownBiasCandidate(Top, TopCand.SU))) {
+    Cand.setBest(TopCand);
+    PickedPending = TopPending;
+  } else if (EnableMFMAFragmentScheduler &&
+             shouldPreferTopOverBottomStalledDS(Top, Bot, TopCand, BotCand)) {
+    Cand.setBest(TopCand);
+    PickedPending = TopPending;
+  } else if (EnableMFMAFragmentScheduler &&
+             tryBidirectionalReadyStall(TryCand, Cand,
+                                        TryCand.AtTop ? Top : Bot,
+                                        Cand.AtTop ? Top : Bot)) {
+    Cand.setBest(TryCand);
+    PickedPending = Cand.AtTop ? TopPending : BotPending;
+  } else if (BotPending || TopPending) {
     PickedPending |= tryPendingCandidate(Cand, TopCand, nullptr);
   } else {
     tryCandidate(Cand, TryCand, nullptr);
@@ -658,6 +2736,16 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
                           /*IsBottomUp=*/false);
         assert(TopCand.Reason != NoCand && "failed to find a candidate");
         SU = TopCand.SU;
+      }
+      if (EnableMFMAFragmentScheduler) {
+        bool TopFillerPending = false;
+        if (SUnit *TopFiller = findTopMFMAFillerForRecentDS(
+                Top, SU, TopFragmentWindow.HasPickedMFMA,
+                TopFragmentWindow.RecentDSReadUnrelatedMFMAs,
+                TopFillerPending)) {
+          SU = TopFiller;
+          PickedPending = TopFillerPending;
+        }
       }
       IsTopNode = true;
     } else if (RegionPolicy.OnlyBottomUp) {
@@ -704,6 +2792,15 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
 }
 
 void GCNSchedStrategy::schedNode(SUnit *SU, bool IsTopNode) {
+  if (EnableMFMAFragmentScheduler) {
+    updateFragmentWindow(SU, IsTopNode);
+    // Fragment policy participates in candidate comparison. A pick changes
+    // the pipeline phase seen by both boundaries, so neither cached candidate
+    // remains valid for the next comparison.
+    TopCand.SU = nullptr;
+    BotCand.SU = nullptr;
+  }
+
   if (useGCNTrackers()) {
     MachineInstr *MI = SU->getInstr();
     IsTopNode ? (void)DownwardTracker.advance(MI, false)
@@ -766,6 +2863,21 @@ bool GCNSchedStrategy::tryPendingCandidate(SchedCandidate &Cand,
 
   bool SameBoundary = Zone != nullptr;
   if (SameBoundary) {
+    const FragmentWindowState &FWS =
+        Zone->isTop() ? TopFragmentWindow : BotFragmentWindow;
+    if (EnableMFMAFragmentScheduler &&
+        tryRecentDSReadSpacing(TryCand, Cand, *Zone, FWS.HasPickedMFMA,
+                               FWS.RecentDSReadUnrelatedMFMAs))
+      return TryCand.Reason != NoCand;
+
+    if (EnableMFMAFragmentScheduler &&
+        shouldKeepMFMAFragmentCandidate(TryCand, Cand, *Zone, FWS))
+      return false;
+
+    if (EnableMFMAFragmentScheduler &&
+        tryMFMAFragmentCandidate(TryCand, Cand, *Zone, FWS, true))
+      return TryCand.Reason != NoCand;
+
     TryCand.initResourceDelta(DAG, SchedModel);
     if (tryLess(TryCand.ResDelta.CritResources, Cand.ResDelta.CritResources,
                 TryCand, Cand, ResourceReduce))
@@ -819,6 +2931,16 @@ bool GCNMaxILPSchedStrategy::tryCandidate(SchedCandidate &Cand,
 
   bool SameBoundary = Zone != nullptr;
   if (SameBoundary) {
+    const FragmentWindowState &FWS =
+        Zone->isTop() ? TopFragmentWindow : BotFragmentWindow;
+    if (EnableMFMAFragmentScheduler &&
+        shouldKeepMFMAFragmentCandidate(TryCand, Cand, *Zone, FWS))
+      return false;
+
+    if (EnableMFMAFragmentScheduler &&
+        tryMFMAFragmentCandidate(TryCand, Cand, *Zone, FWS, true))
+      return TryCand.Reason != NoCand;
+
     // Prioritize instructions that read unbuffered resources by stall cycles.
     if (tryLess(Zone->getLatencyStallCycles(TryCand.SU),
                 Zone->getLatencyStallCycles(Cand.SU), TryCand, Cand, Stall))
@@ -3248,6 +5370,8 @@ void GCNPostScheduleDAGMILive::schedule() {
     SavedMutations.clear();
     SavedMutations.swap(Mutations);
     addMutation(createIGroupLPDAGMutation(AMDGPU::SchedulingPhase::PostRA));
+    if (isMFMAFragmentSchedulerEnabled(MF.getSubtarget<GCNSubtarget>()))
+      addMutation(createMFMAFragmentPostRASchedOrderDAGMutation());
   }
 
   ScheduleDAGMI::schedule();

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -74,6 +74,13 @@ protected:
   bool tryPendingCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,
                            SchedBoundary *Zone) const;
 
+  bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,
+                    SchedBoundary *Zone) const override;
+
+  void updateFragmentWindow(SUnit *SU, bool IsTopNode);
+
+  void resetFragmentWindows();
+
   void printCandidateDecision(const SchedCandidate &Current,
                               const SchedCandidate &Preferred);
 
@@ -110,7 +117,117 @@ protected:
 
   bool UseGCNTrackers = false;
 
+  bool EnableMFMAFragmentScheduler = false;
+
   std::optional<bool> GCNTrackersOverride;
+
+  struct FragmentWindowState {
+    // Number of scheduled DS_READ fragments whose MFMA uses have not yet been
+    // scheduled from this boundary.
+    unsigned LiveFragments = 0;
+    // Prefer draining at four live fragments. Permit two extra fragments only
+    // to finish a two-read microcluster or attach an odd tail read to it.
+    unsigned UsefulWindow = 4;
+    unsigned MaxWindow = 6;
+
+    // State used to enforce DS/DS microclusters and count unrelated MFMAs
+    // between a DS_READ and its first consumer.
+    const SUnit *LastDSRead = nullptr;
+    unsigned MFMAsSinceLastDSRead = 0;
+    unsigned UnrelatedMFMAsSinceLastDSRead = 0;
+    unsigned DSReadsSinceLastMFMA = 0;
+
+    // Ramp-up ends after the first two MFMAs. Steady state begins after the
+    // first two post-opener DS microclusters have been drained.
+    unsigned PickedMFMAs = 0;
+    unsigned CompletedDSMicroclusters = 0;
+
+    // For each recent DS_READ, count MFMAs that do not consume it. Entries are
+    // removed once the required spacing is reached or a consumer is issued.
+    DenseMap<const SUnit *, unsigned> RecentDSReadUnrelatedMFMAs;
+
+    // Bottom-up scheduling sees consumers before producers. Track how many
+    // unrelated MFMAs have already been reserved ahead of each deferred read.
+    DenseMap<const SUnit *, unsigned> DeferredDSReadFillers;
+    bool LastPickWasDSRead = false;
+    bool HasPickedMFMA = false;
+  };
+
+  /// Apply the DS_READ/MFMA policy in precedence order. Each subordinate try*
+  /// routine either selects one candidate and records its reason, or returns
+  /// false without changing the comparison. Generic latency and node-order
+  /// heuristics run only when none of these fragment rules has a preference.
+  bool tryMFMAFragmentCandidate(SchedCandidate &TryCand, SchedCandidate &Cand,
+                                SchedBoundary &Zone,
+                                const FragmentWindowState &FWS,
+                                bool EnablePrologueSetupBias) const;
+
+  /// Hide the maturity window of recently issued DS_READs and form the
+  /// repeating two-read/two-MFMA pipeline. In particular, avoid consuming a
+  /// recent read while an unrelated MFMA can issue, finish a two-read
+  /// microcluster, and then drain enough MFMAs before starting the next pair:
+  ///
+  ///   DS4 MFMA(DS4) DS5 MFMA  ->  DS4 DS5 MFMA(unrelated) MFMA(...)
+  ///
+  /// A non-memory filler may take an otherwise exposed slot. Another buffered
+  /// load may not: it creates a new maturity obligation not modeled here.
+  bool tryMFMASteadyState(SchedCandidate &TryCand, SchedCandidate &Cand,
+                          SchedBoundary &Zone, const FragmentWindowState &FWS,
+                          unsigned EffectiveMaxWindow) const;
+
+  /// Build a bounded four-read opener before the first MFMA. Prefer useful
+  /// address setup and other non-memory setup once the reads are available,
+  /// but do not admit a fifth read before beginning to drain the window:
+  ///
+  ///   DS0 DS1 DS2 DS3 DS4 DS5 MFMA0
+  ///                ->
+  ///   DS0 DS1 DS2 DS3 <setup> MFMA0 DS4 DS5
+  bool tryMFMAFragmentOpener(SchedCandidate &TryCand, SchedCandidate &Cand,
+                             SchedBoundary &Zone,
+                             const FragmentWindowState &FWS,
+                             bool EnablePrologueSetupBias) const;
+
+  /// Order two DS_READ producers by how close each is to unlocking an MFMA.
+  /// Prefer fewer remaining unscheduled DS predecessors, then use stable DAG
+  /// properties as deterministic tie-breakers. This prevents breadth-first
+  /// selection from constructing a long prologue of unrelated reads.
+  bool tryMFMAProducerOrder(SchedCandidate &TryCand, SchedCandidate &Cand,
+                            SchedBoundary &Zone) const;
+
+  /// Handle MFMA issue stalls and the hard live-fragment cap. A ready producer
+  /// may occupy a short MFMA resource stall when the fragment window has room:
+  ///
+  ///   MFMA(stalled) <idle>  ->  DS(next pair) MFMA
+  ///
+  /// Otherwise prefer draining an MFMA instead of extending an overfull
+  /// fragment window. Register-pressure criteria have already run before this
+  /// policy, so this rule cannot override spilling or critical pressure.
+  bool tryMFMAResourceStall(SchedCandidate &TryCand, SchedCandidate &Cand,
+                            SchedBoundary &Zone, const FragmentWindowState &FWS,
+                            unsigned EffectiveMaxWindow) const;
+
+  /// Apply the final window-shape preferences after the more specific rules
+  /// decline: avoid pending MFMAs, fill an underfull useful window with a
+  /// producer, drain a full useful window with a ready MFMA, and reject another
+  /// producer at the hard maximum. This is deliberately last because it knows
+  /// only the window shape, not which choice best hides a particular read.
+  bool tryMFMAWindowFallback(SchedCandidate &TryCand, SchedCandidate &Cand,
+                             SchedBoundary &Zone,
+                             const FragmentWindowState &FWS,
+                             unsigned EffectiveUsefulWindow,
+                             unsigned EffectiveMaxWindow) const;
+
+  /// Protect an incumbent chosen by the fragment policy when subsequent
+  /// generic candidate comparisons revisit the same boundary. This mirrors
+  /// the steady-state preferences that would otherwise be lost merely because
+  /// the preferred node became Cand rather than TryCand.
+  bool shouldKeepMFMAFragmentCandidate(SchedCandidate &TryCand,
+                                       SchedCandidate &Cand,
+                                       SchedBoundary &Zone,
+                                       const FragmentWindowState &FWS) const;
+
+  FragmentWindowState TopFragmentWindow;
+  FragmentWindowState BotFragmentWindow;
 
 public:
   // schedule() have seen register pressure over the critical limits and had to

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -12,14 +12,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "GCNSubtarget.h"
+#include "AMDGPU.h"
 #include "AMDGPUCallLowering.h"
 #include "AMDGPUInstructionSelector.h"
 #include "AMDGPULegalizerInfo.h"
 #include "AMDGPURegisterBankInfo.h"
 #include "AMDGPUSelectionDAGInfo.h"
 #include "AMDGPUTargetMachine.h"
+#include "SIInstrInfo.h"
 #include "SIMachineFunctionInfo.h"
 #include "Utils/AMDGPUBaseInfo.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/CodeGen/GlobalISel/InlineAsmLowering.h"
 #include "llvm/CodeGen/MachineScheduler.h"
@@ -28,6 +31,7 @@
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
 #include <algorithm>
+#include <limits>
 
 using namespace llvm;
 
@@ -52,6 +56,131 @@ static cl::opt<unsigned>
     NSAThreshold("amdgpu-nsa-threshold",
                  cl::desc("Number of addresses from which to enable MIMG NSA."),
                  cl::init(2), cl::Hidden);
+
+template <typename PredicateT>
+static bool hasBundledMI(const MachineInstr &MI, PredicateT Pred) {
+  if (Pred(MI))
+    return true;
+
+  if (MI.getOpcode() != TargetOpcode::BUNDLE)
+    return false;
+
+  MachineBasicBlock::const_instr_iterator It = MI.getIterator();
+  for (++It; It != MI.getParent()->instr_end() && It->isBundledWithPred();
+       ++It) {
+    if (Pred(*It))
+      return true;
+  }
+
+  return false;
+}
+
+static bool isPostRADSReadFragmentProducer(const MachineInstr &MI) {
+  return hasBundledMI(MI, [](const MachineInstr &BundledMI) {
+    switch (BundledMI.getOpcode()) {
+    case AMDGPU::DS_READ_B128:
+    case AMDGPU::DS_READ_B128_gfx9:
+      return true;
+    default:
+      return false;
+    }
+  });
+}
+
+static bool isPostRAMFMAFragmentConsumer(const MachineInstr &MI) {
+  return hasBundledMI(MI, [](const MachineInstr &BundledMI) {
+    return BundledMI.getOpcode() ==
+           AMDGPU::V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64;
+  });
+}
+
+static bool isMFMAFragmentPipelineInstr(const SUnit &SU) {
+  const MachineInstr *MI = SU.getInstr();
+  return MI && (isPostRADSReadFragmentProducer(*MI) ||
+                isPostRAMFMAFragmentConsumer(*MI));
+}
+
+namespace {
+
+class MFMAFragmentPostRASchedOrderMutation : public ScheduleDAGMutation {
+  static bool hasPipelineDataPred(const SUnit &SU) {
+    return llvm::any_of(SU.Preds, [](const SDep &Pred) {
+      return Pred.getKind() == SDep::Data && Pred.getSUnit() &&
+             isMFMAFragmentPipelineInstr(*Pred.getSUnit());
+    });
+  }
+
+  static unsigned getFirstPipelineDataSucc(const SUnit &SU) {
+    unsigned FirstSucc = std::numeric_limits<unsigned>::max();
+    for (const SDep &Succ : SU.Succs)
+      if (Succ.getKind() == SDep::Data && Succ.getSUnit() &&
+          isMFMAFragmentPipelineInstr(*Succ.getSUnit()))
+        FirstSucc = std::min(FirstSucc, Succ.getSUnit()->NodeNum);
+    return FirstSucc;
+  }
+
+  static bool isPipelineProducer(const SUnit &SU) {
+    return getFirstPipelineDataSucc(SU) !=
+               std::numeric_limits<unsigned>::max() &&
+           !hasPipelineDataPred(SU);
+  }
+
+public:
+  void apply(ScheduleDAGInstrs *DAG) override {
+    bool HasFragmentPipeline = llvm::any_of(DAG->SUnits, [](const SUnit &SU) {
+      const MachineInstr *MI = SU.getInstr();
+      if (!MI || !isPostRADSReadFragmentProducer(*MI))
+        return false;
+      return llvm::any_of(SU.Succs, [](const SDep &Succ) {
+        return Succ.getKind() == SDep::Data && Succ.getSUnit()->getInstr() &&
+               isPostRAMFMAFragmentConsumer(*Succ.getSUnit()->getInstr());
+      });
+    });
+    if (!HasFragmentPipeline)
+      return;
+
+    SmallVector<SUnit *, 16> OrderedSUs;
+    SmallVector<SUnit *, 8> ProducerRun;
+
+    auto FlushProducerRun = [&]() {
+      // Pre-RA scheduling can place several producers together. Order only
+      // such a run by its earliest pipeline consumer; retain NodeNum as a
+      // deterministic tie-break. Consumers otherwise keep their pre-RA order.
+      llvm::stable_sort(ProducerRun, [](const SUnit *LHS, const SUnit *RHS) {
+        unsigned LHSFirstSucc = getFirstPipelineDataSucc(*LHS);
+        unsigned RHSFirstSucc = getFirstPipelineDataSucc(*RHS);
+        return std::tie(LHSFirstSucc, LHS->NodeNum) <
+               std::tie(RHSFirstSucc, RHS->NodeNum);
+      });
+      OrderedSUs.append(ProducerRun);
+      ProducerRun.clear();
+    };
+
+    for (SUnit &SU : DAG->SUnits) {
+      if (!isMFMAFragmentPipelineInstr(SU))
+        continue;
+      if (isPipelineProducer(SU)) {
+        ProducerRun.push_back(&SU);
+        continue;
+      }
+      FlushProducerRun();
+      OrderedSUs.push_back(&SU);
+    }
+    FlushProducerRun();
+
+    // Keep post-RA scheduling from undoing the selected DS_READ/MFMA sequence.
+    // Artificial edges affect scheduling order only and add no data latency.
+    for (auto [Prev, SU] : llvm::zip(OrderedSUs, llvm::drop_begin(OrderedSUs)))
+      DAG->addEdge(SU, SDep(Prev, SDep::Artificial));
+  }
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<ScheduleDAGMutation>
+llvm::createMFMAFragmentPostRASchedOrderDAGMutation() {
+  return std::make_unique<MFMAFragmentPostRASchedOrderMutation>();
+}
 
 GCNSubtarget::~GCNSubtarget() = default;
 

--- a/llvm/test/CodeGen/AMDGPU/mfma-fragment-scheduler-node-order.mir
+++ b/llvm/test/CodeGen/AMDGPU/mfma-fragment-scheduler-node-order.mir
@@ -1,0 +1,144 @@
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler \
+# RUN:   -verify-misched -amdgpu-enable-mfma-fragment-scheduler=true -o - %s \
+# RUN:   | FileCheck %s
+
+# These functions have the same dependency graph but different textual orders.
+# The fragment producer score uses the NodeNum of the earliest MFMA successor
+# as its final preference. Since NodeNum follows MIR order, that tie-break makes
+# the enabled schedules differ. Keep this test separate from the primary
+# pipeline test: this one documents the current deterministic tie-break, not a
+# preferred latency-hiding schedule.
+
+--- |
+  define amdgpu_kernel void @node_order_clustered() {
+    ret void
+  }
+
+  define amdgpu_kernel void @node_order_adjacent() {
+    ret void
+  }
+...
+
+---
+name: node_order_clustered
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: node_order_clustered
+    ; CHECK: [[DS_BASE0:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[DS_BASE1:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INDEX0:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INDEX1:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[ACC:%[0-9]+]]:vreg_512_align2 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[FILLER_BASE:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: SCHED_BARRIER 0
+    ; CHECK-NEXT: [[DS0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[DS_BASE0]], 0, 0, implicit $exec
+    ; CHECK-NEXT: [[DS1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[DS_BASE0]], 16, 0, implicit $exec
+    ; CHECK-NEXT: [[DS2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[DS_BASE1]], 32, 0, implicit $exec
+    ; CHECK-NEXT: [[SHL0:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32 1, [[INDEX0]], implicit $exec
+    ; CHECK-NEXT: [[ADDR0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL0]], implicit $exec
+    ; CHECK-NEXT: [[DS3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 48, 0, implicit $exec
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32 1, [[INDEX1]], implicit $exec
+    ; CHECK-NEXT: [[ADDR1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL1]], implicit $exec
+    ; CHECK-NEXT: [[FILLER0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 1, [[FILLER_BASE]], implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS1]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[DS4:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR1]], 64, 0, implicit $exec
+    ; CHECK-NEXT: [[DS5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 80, 0, implicit $exec
+    ; CHECK-NEXT: [[FILLER1:%[0-9]+]]:vgpr_32 = V_XOR_B32_e32 3, [[FILLER0]], implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS2]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[DS6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR1]], 96, 0, implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS0]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS4]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS4]], [[DS2]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: dead [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS5]], [[DS6]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: S_ENDPGM 0, implicit [[FILLER1]]
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vgpr_32 = IMPLICIT_DEF
+    %2:vgpr_32 = IMPLICIT_DEF
+    %3:vgpr_32 = IMPLICIT_DEF
+    %4:vreg_512_align2 = IMPLICIT_DEF
+    %30:vgpr_32 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    %10:av_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec
+    %11:av_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec
+    %12:av_128_align2 = DS_READ_B128_gfx9 %1, 32, 0, implicit $exec
+    %20:vgpr_32 = V_LSHLREV_B32_e32 1, %2, implicit $exec
+    %21:vgpr_32 = V_ADD_U32_e32 64, %20, implicit $exec
+    %22:vgpr_32 = V_LSHLREV_B32_e32 1, %3, implicit $exec
+    %23:vgpr_32 = V_ADD_U32_e32 64, %22, implicit $exec
+    %13:av_128_align2 = DS_READ_B128_gfx9 %21, 48, 0, implicit $exec
+    %14:av_128_align2 = DS_READ_B128_gfx9 %23, 64, 0, implicit $exec
+    %15:av_128_align2 = DS_READ_B128_gfx9 %21, 80, 0, implicit $exec
+    %16:av_128_align2 = DS_READ_B128_gfx9 %23, 96, 0, implicit $exec
+    %31:vgpr_32 = V_ADD_U32_e32 1, %30, implicit $exec
+    %32:vgpr_32 = V_XOR_B32_e32 3, %31, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %11, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %10, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %14, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %14, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %16, %4, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %32
+...
+
+---
+name: node_order_adjacent
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: node_order_adjacent
+    ; CHECK: [[DS_BASE0:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[DS_BASE1:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INDEX0:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INDEX1:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[ACC:%[0-9]+]]:vreg_512_align2 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[FILLER_BASE:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+    ; CHECK-NEXT: SCHED_BARRIER 0
+    ; CHECK-NEXT: [[DS0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[DS_BASE0]], 0, 0, implicit $exec
+    ; CHECK-NEXT: [[DS1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[DS_BASE0]], 16, 0, implicit $exec
+    ; CHECK-NEXT: [[DS2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[DS_BASE1]], 32, 0, implicit $exec
+    ; CHECK-NEXT: [[SHL0:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32 1, [[INDEX0]], implicit $exec
+    ; CHECK-NEXT: [[ADDR0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL0]], implicit $exec
+    ; CHECK-NEXT: [[DS3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 48, 0, implicit $exec
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32 1, [[INDEX1]], implicit $exec
+    ; CHECK-NEXT: [[ADDR1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL1]], implicit $exec
+    ; CHECK-NEXT: [[FILLER0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 1, [[FILLER_BASE]], implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS1]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[DS4:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR1]], 64, 0, implicit $exec
+    ; CHECK-NEXT: [[DS5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 80, 0, implicit $exec
+    ; CHECK-NEXT: [[FILLER1:%[0-9]+]]:vgpr_32 = V_XOR_B32_e32 3, [[FILLER0]], implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS2]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[DS6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR1]], 96, 0, implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS0]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS4]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS4]], [[DS2]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: dead [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS5]], [[DS6]], [[ACC]], 0, 0, 0, implicit $mode, implicit $exec
+    ; CHECK-NEXT: S_ENDPGM 0, implicit [[FILLER1]]
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vgpr_32 = IMPLICIT_DEF
+    %2:vgpr_32 = IMPLICIT_DEF
+    %3:vgpr_32 = IMPLICIT_DEF
+    %4:vreg_512_align2 = IMPLICIT_DEF
+    %30:vgpr_32 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    %20:vgpr_32 = V_LSHLREV_B32_e32 1, %2, implicit $exec
+    %21:vgpr_32 = V_ADD_U32_e32 64, %20, implicit $exec
+    %22:vgpr_32 = V_LSHLREV_B32_e32 1, %3, implicit $exec
+    %23:vgpr_32 = V_ADD_U32_e32 64, %22, implicit $exec
+    %10:av_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec
+    %11:av_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec
+    %31:vgpr_32 = V_ADD_U32_e32 1, %30, implicit $exec
+    %32:vgpr_32 = V_XOR_B32_e32 3, %31, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %11, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %12:av_128_align2 = DS_READ_B128_gfx9 %1, 32, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %13:av_128_align2 = DS_READ_B128_gfx9 %21, 48, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %10, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %14:av_128_align2 = DS_READ_B128_gfx9 %23, 64, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %14, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %14, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %15:av_128_align2 = DS_READ_B128_gfx9 %21, 80, 0, implicit $exec
+    %16:av_128_align2 = DS_READ_B128_gfx9 %23, 96, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %16, %4, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %32
+...

--- a/llvm/test/CodeGen/AMDGPU/mfma-fragment-scheduler.mir
+++ b/llvm/test/CodeGen/AMDGPU/mfma-fragment-scheduler.mir
@@ -1,0 +1,381 @@
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler -verify-misched -o - %s | FileCheck --check-prefix=ENABLED %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler -verify-misched -amdgpu-enable-mfma-fragment-scheduler=false -o - %s | FileCheck --check-prefix=DISABLED %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler -verify-misched -amdgpu-enable-mfma-fragment-scheduler=true -o - %s | FileCheck --check-prefix=ENABLED %s
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler -verify-misched -amdgpu-enable-mfma-fragment-scheduler=true -o - %s | FileCheck --check-prefix=EXTRA-ENABLED %s
+--- |
+  define amdgpu_kernel void @fragment_pipeline_clustered() {
+    ret void
+  }
+
+  define amdgpu_kernel void @fragment_pipeline_adjacent() {
+    ret void
+  }
+
+  define amdgpu_kernel void @fragment_pipeline_extra_long() {
+    ret void
+  }
+
+  define amdgpu_kernel void @fragment_pipeline_long() {
+    ret void
+  }
+
+...
+
+---
+name: fragment_pipeline_clustered
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; This input deliberately places every DS_READ before every MFMA. The
+    ; enabled scheduler prioritizes the four fragments that feed the first
+    ; three MFMAs, uses address calculations as opening fillers, and preserves
+    ; an additional ready DS_READ microcluster before MFMA1. The filler chain
+    ; defined by MFMA1 then contributes to hiding the remaining fragment
+    ; latency before MFMA2.
+
+
+    ; DISABLED-LABEL: name: fragment_pipeline_clustered
+    ; DISABLED:       SCHED_BARRIER 0
+    ; DISABLED-NEXT:  [[DS0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; DISABLED-NEXT:  [[DS1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; DISABLED-NEXT:  [[ACC:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS1]], [[ACC]],
+    ; DISABLED-NEXT:  [[DS2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 32,
+    ; DISABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS2]], [[ACC]],
+    ; DISABLED-NEXT:  [[DS3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 48,
+    ; DISABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS0]], [[ACC]],
+
+    ; ENABLED-LABEL: name: fragment_pipeline_clustered
+    ; ENABLED:       SCHED_BARRIER 0
+    ; ENABLED-NEXT:  [[DS0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; ENABLED-NEXT:  [[DS1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; ENABLED-NEXT:  [[DS2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 32,
+    ; ENABLED-NEXT:  [[DS3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 48,
+    ; ENABLED-NEXT:  [[SHL0:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32
+    ; ENABLED-NEXT:  [[ADDR0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL0]],
+    ; ENABLED-NEXT:  [[SHL1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32
+    ; ENABLED-NEXT:  [[ADDR1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL1]],
+    ; ENABLED-NEXT:  [[ACC:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS1]], [[ACC]],
+    ; ENABLED-NEXT:  [[DS4:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 64,
+    ; ENABLED-NEXT:  [[DS5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR1]], 80,
+    ; ENABLED-NEXT:  [[FILLER0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 1,
+    ; ENABLED-NEXT:  [[FILLER1:%[0-9]+]]:vgpr_32 = V_XOR_B32_e32 3, [[FILLER0]],
+    ; ENABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS2]], [[ACC]],
+    ; ENABLED-NEXT:  [[DS6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 96,
+    ; ENABLED:       [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS0]], [[ACC]],
+    ; ENABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS4]], [[ACC]],
+    ; ENABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS4]], [[DS2]], [[ACC]],
+    ; ENABLED-NEXT:  dead [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS5]], [[DS6]], [[ACC]],
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vgpr_32 = IMPLICIT_DEF
+    %2:vgpr_32 = IMPLICIT_DEF
+    %3:vgpr_32 = IMPLICIT_DEF
+    %4:vreg_512_align2 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    %10:av_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec
+    %11:av_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec
+    %12:av_128_align2 = DS_READ_B128_gfx9 %1, 32, 0, implicit $exec
+    %20:vgpr_32 = V_LSHLREV_B32_e32 1, %2, implicit $exec
+    %21:vgpr_32 = V_ADD_U32_e32 64, %20, implicit $exec
+    %22:vgpr_32 = V_LSHLREV_B32_e32 1, %3, implicit $exec
+    %23:vgpr_32 = V_ADD_U32_e32 64, %22, implicit $exec
+    %13:av_128_align2 = DS_READ_B128_gfx9 %1, 48, 0, implicit $exec
+    %14:av_128_align2 = DS_READ_B128_gfx9 %23, 64, 0, implicit $exec
+    %15:av_128_align2 = DS_READ_B128_gfx9 %21, 80, 0, implicit $exec
+    %16:av_128_align2 = DS_READ_B128_gfx9 %23, 96, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %11, %4, 0, 0, 0, implicit-def %30:vgpr_32, implicit $mode, implicit $exec
+    %31:vgpr_32 = V_ADD_U32_e32 1, %30, implicit $exec
+    %32:vgpr_32 = V_XOR_B32_e32 3, %31, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %10, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %14, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %14, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %16, %4, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %32
+...
+
+---
+name: fragment_pipeline_adjacent
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; This input deliberately places each MFMA next to the DS_READ operands
+    ; that make it available, providing little opportunity to hide LDS latency.
+    ; It has the same dependency graph as fragment_pipeline_clustered. The
+    ; enabled scheduler still constructs a four-fragment opener with address
+    ; fillers, then moves the next three DS_READs into a microcluster after
+    ; MFMA1 instead of retaining the input's DS/MFMA adjacency.
+
+
+    ; DISABLED-LABEL: name: fragment_pipeline_adjacent
+    ; DISABLED:       SCHED_BARRIER 0
+    ; DISABLED-NEXT:  [[DS0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; DISABLED-NEXT:  [[DS1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; DISABLED-NEXT:  [[ACC:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS1]], [[ACC]],
+    ; DISABLED-NEXT:  [[DS2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 32,
+    ; DISABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS2]], [[ACC]],
+    ; DISABLED-NEXT:  [[DS3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 48,
+    ; DISABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS0]], [[ACC]],
+
+    ; ENABLED-LABEL: name: fragment_pipeline_adjacent
+    ; ENABLED:       SCHED_BARRIER 0
+    ; ENABLED-NEXT:  [[DS0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; ENABLED-NEXT:  [[DS1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; ENABLED-NEXT:  [[DS2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 32,
+    ; ENABLED-NEXT:  [[DS3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 48,
+    ; ENABLED-NEXT:  [[SHL0:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32
+    ; ENABLED-NEXT:  [[ADDR0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL0]],
+    ; ENABLED-NEXT:  [[SHL1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32
+    ; ENABLED-NEXT:  [[ADDR1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[SHL1]],
+    ; ENABLED-NEXT:  [[ACC:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS1]], [[ACC]],
+    ; ENABLED-NEXT:  [[DS4:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 64,
+    ; ENABLED-NEXT:  [[DS5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR1]], 80,
+    ; ENABLED-NEXT:  [[FILLER0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 1,
+    ; ENABLED-NEXT:  [[FILLER1:%[0-9]+]]:vgpr_32 = V_XOR_B32_e32 3, [[FILLER0]],
+    ; ENABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS0]], [[DS2]], [[ACC]],
+    ; ENABLED-NEXT:  [[DS6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[ADDR0]], 96,
+    ; ENABLED:       [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS0]], [[ACC]],
+    ; ENABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS3]], [[DS4]], [[ACC]],
+    ; ENABLED-NEXT:  [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS4]], [[DS2]], [[ACC]],
+    ; ENABLED-NEXT:  dead [[ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[DS5]], [[DS6]], [[ACC]],
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vgpr_32 = IMPLICIT_DEF
+    %2:vgpr_32 = IMPLICIT_DEF
+    %3:vgpr_32 = IMPLICIT_DEF
+    %4:vreg_512_align2 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    %20:vgpr_32 = V_LSHLREV_B32_e32 1, %2, implicit $exec
+    %21:vgpr_32 = V_ADD_U32_e32 64, %20, implicit $exec
+    %22:vgpr_32 = V_LSHLREV_B32_e32 1, %3, implicit $exec
+    %23:vgpr_32 = V_ADD_U32_e32 64, %22, implicit $exec
+    %10:av_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec
+    %11:av_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %11, %4, 0, 0, 0, implicit-def %30:vgpr_32, implicit $mode, implicit $exec
+    %12:av_128_align2 = DS_READ_B128_gfx9 %1, 32, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %13:av_128_align2 = DS_READ_B128_gfx9 %1, 48, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %10, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %14:av_128_align2 = DS_READ_B128_gfx9 %23, 64, 0, implicit $exec
+    %31:vgpr_32 = V_ADD_U32_e32 1, %30, implicit $exec
+    %32:vgpr_32 = V_XOR_B32_e32 3, %31, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %14, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %14, %12, %4, 0, 0, 0, implicit $mode, implicit $exec
+    %15:av_128_align2 = DS_READ_B128_gfx9 %21, 80, 0, implicit $exec
+    %16:av_128_align2 = DS_READ_B128_gfx9 %23, 96, 0, implicit $exec
+    %4:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %16, %4, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %32
+...
+
+---
+name: fragment_pipeline_extra_long
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; All DS addresses are ready up front. The checks record a four-read
+    ; opener, the one-MFMA ramp-up group, repeated DS/DS/MFMA/MFMA steady-state
+    ; groups, and a relaxed MFMA-only epilogue.
+    ; EXTRA-ENABLED-LABEL: name: fragment_pipeline_extra_long
+    ; EXTRA-ENABLED:       SCHED_BARRIER 0
+    ; EXTRA-ENABLED-NEXT:  [[XL_D0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 32,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 48,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D0]], [[XL_D1]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D4:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 64,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 80,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D0]], [[XL_D2]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 96,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D7:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 112,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D3]], [[XL_D0]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D3]], [[XL_D4]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D8:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 128,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D9:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 144,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D4]], [[XL_D2]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D5]], [[XL_D6]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D10:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 160,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D11:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 176,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D5]], [[XL_D7]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D8]], [[XL_D5]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D12:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 192,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D13:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 208,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D8]], [[XL_D9]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D9]], [[XL_D7]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D14:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 224,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D15:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 240,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D10]], [[XL_D11]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D10]], [[XL_D12]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D16:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 256,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D17:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 272,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D13]], [[XL_D10]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D13]], [[XL_D14]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D18:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 288,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D19:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 304,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D14]], [[XL_D12]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D15]], [[XL_D16]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D20:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 320,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D21:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 336,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D15]], [[XL_D17]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D18]], [[XL_D15]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_D22:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 352,
+    ; EXTRA-ENABLED-NEXT:  [[XL_D23:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 368,
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D18]], [[XL_D19]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D19]], [[XL_D17]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D20]], [[XL_D21]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D20]], [[XL_D22]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  dead [[XL_ACC]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[XL_D23]], [[XL_D20]], [[XL_ACC]],
+    ; EXTRA-ENABLED-NEXT:  S_ENDPGM 0
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vreg_512_align2 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    %10:av_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec
+    %11:av_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec
+    %12:av_128_align2 = DS_READ_B128_gfx9 %0, 32, 0, implicit $exec
+    %13:av_128_align2 = DS_READ_B128_gfx9 %0, 48, 0, implicit $exec
+    %14:av_128_align2 = DS_READ_B128_gfx9 %0, 64, 0, implicit $exec
+    %15:av_128_align2 = DS_READ_B128_gfx9 %0, 80, 0, implicit $exec
+    %16:av_128_align2 = DS_READ_B128_gfx9 %0, 96, 0, implicit $exec
+    %17:av_128_align2 = DS_READ_B128_gfx9 %0, 112, 0, implicit $exec
+    %18:av_128_align2 = DS_READ_B128_gfx9 %0, 128, 0, implicit $exec
+    %19:av_128_align2 = DS_READ_B128_gfx9 %0, 144, 0, implicit $exec
+    %20:av_128_align2 = DS_READ_B128_gfx9 %0, 160, 0, implicit $exec
+    %21:av_128_align2 = DS_READ_B128_gfx9 %0, 176, 0, implicit $exec
+    %22:av_128_align2 = DS_READ_B128_gfx9 %0, 192, 0, implicit $exec
+    %23:av_128_align2 = DS_READ_B128_gfx9 %0, 208, 0, implicit $exec
+    %24:av_128_align2 = DS_READ_B128_gfx9 %0, 224, 0, implicit $exec
+    %25:av_128_align2 = DS_READ_B128_gfx9 %0, 240, 0, implicit $exec
+    %26:av_128_align2 = DS_READ_B128_gfx9 %0, 256, 0, implicit $exec
+    %27:av_128_align2 = DS_READ_B128_gfx9 %0, 272, 0, implicit $exec
+    %28:av_128_align2 = DS_READ_B128_gfx9 %0, 288, 0, implicit $exec
+    %29:av_128_align2 = DS_READ_B128_gfx9 %0, 304, 0, implicit $exec
+    %30:av_128_align2 = DS_READ_B128_gfx9 %0, 320, 0, implicit $exec
+    %31:av_128_align2 = DS_READ_B128_gfx9 %0, 336, 0, implicit $exec
+    %32:av_128_align2 = DS_READ_B128_gfx9 %0, 352, 0, implicit $exec
+    %33:av_128_align2 = DS_READ_B128_gfx9 %0, 368, 0, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %11, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %12, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %10, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %14, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %14, %12, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %16, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %17, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %18, %15, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %18, %19, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %19, %17, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %20, %21, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %20, %22, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %23, %20, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %23, %24, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %24, %22, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %25, %26, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %25, %27, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %28, %25, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %28, %29, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %29, %27, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %30, %31, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %30, %32, %1, 0, 0, 0, implicit $mode, implicit $exec
+    dead %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %33, %30, %1, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0
+...
+
+
+---
+name: fragment_pipeline_long
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; The disabled scheduler repeatedly places an MFMA next to the DS_READ
+    ; that completes its operand pair.
+    ; DISABLED-LABEL: name: fragment_pipeline_long
+    ; DISABLED:       [[D0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; DISABLED-NEXT:  [[D1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; DISABLED-NEXT:  [[A:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[D0]], [[D1]], [[A]],
+    ; DISABLED:       [[D5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 80,
+    ; DISABLED-NEXT:  [[D6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 96,
+    ; DISABLED-NEXT:  [[A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[D5]], [[D6]], [[A]],
+    ; DISABLED:       [[D10:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 160,
+    ; DISABLED-NEXT:  [[D11:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 176,
+    ; DISABLED-NEXT:  [[A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[D10]], [[D11]], [[A]],
+
+    ; ENABLED-LABEL: name: fragment_pipeline_long
+    ; ENABLED:       SCHED_BARRIER 0
+    ; ENABLED-NEXT:  [[L_D0:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 0,
+    ; ENABLED-NEXT:  [[L_D1:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 16,
+    ; ENABLED-NEXT:  [[L_D2:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 32,
+    ; ENABLED-NEXT:  [[L_D3:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 48,
+    ; ENABLED-NEXT:  [[L_XOR:%[0-9]+]]:vgpr_32 = V_XOR_B32_e32
+    ; ENABLED-NEXT:  [[L_ADDR4:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 96, [[L_XOR]],
+    ; ENABLED-NEXT:  [[L_SHL:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e32
+    ; ENABLED-NEXT:  [[L_ADDR5:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64, [[L_SHL]],
+    ; ENABLED-NEXT:  [[L_A:%[0-9]+]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D0]], [[L_D1]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_D4:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_ADDR4]], 64,
+    ; ENABLED-NEXT:  [[L_D5:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_ADDR5]], 80,
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D0]], [[L_D2]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_D6:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 96,
+    ; ENABLED-NEXT:  [[L_D7:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 112,
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D3]], [[L_D0]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D3]], [[L_D4]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_D8:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 128,
+    ; ENABLED-NEXT:  [[L_D9:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 {{%[0-9]+}}, 144,
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D4]], [[L_D2]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D5]], [[L_D6]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_NEXT_ADDR:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64,
+    ; ENABLED-NEXT:  [[L_D10:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_NEXT_ADDR]], 160,
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D5]], [[L_D7]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_D11:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_NEXT_ADDR]], 176,
+    ; ENABLED-NEXT:  [[L_D12:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_NEXT_ADDR]], 192,
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D8]], [[L_D5]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D8]], [[L_D9]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D9]], [[L_D7]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_D13:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_NEXT_ADDR]], 208,
+    ; ENABLED-NEXT:  [[L_D14:%[0-9]+]]:av_128_align2 = DS_READ_B128_gfx9 [[L_NEXT_ADDR]], 224,
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D10]], [[L_D11]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D10]], [[L_D12]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D13]], [[L_D10]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D13]], [[L_D14]], [[L_A]],
+    ; ENABLED-NEXT:  dead [[L_A]]:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 [[L_D14]], [[L_D12]], [[L_A]],
+    ; ENABLED-NEXT:  [[L_FILL0:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 64,
+    ; ENABLED-NEXT:  dead [[L_FILL1:%[0-9]+]]:vgpr_32 = V_XOR_B32_e32 3, [[L_FILL0]],
+    ; ENABLED-NEXT:  S_ENDPGM 0
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:vreg_512_align2 = IMPLICIT_DEF
+    %40:vgpr_32 = IMPLICIT_DEF
+    %41:vgpr_32 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    %10:av_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec
+    %11:av_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec
+    %12:av_128_align2 = DS_READ_B128_gfx9 %0, 32, 0, implicit $exec
+    %42:vgpr_32 = V_LSHLREV_B32_e32 1, %40, implicit $exec
+    %43:vgpr_32 = V_ADD_U32_e32 64, %42, implicit $exec
+    %44:vgpr_32 = V_XOR_B32_e32 3, %41, implicit $exec
+    %45:vgpr_32 = V_ADD_U32_e32 96, %44, implicit $exec
+    %13:av_128_align2 = DS_READ_B128_gfx9 %0, 48, 0, implicit $exec
+    %14:av_128_align2 = DS_READ_B128_gfx9 %45, 64, 0, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %11, %1, 0, 0, 0, implicit-def %30:vgpr_32, implicit $mode, implicit $exec
+    %31:vgpr_32 = V_ADD_U32_e32 64, %30, implicit $exec
+    %34:vgpr_32 = V_XOR_B32_e32 3, %31, implicit $exec
+    %15:av_128_align2 = DS_READ_B128_gfx9 %43, 80, 0, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %10, %12, %1, 0, 0, 0, implicit-def %35:vgpr_32, implicit $mode, implicit $exec
+    %16:av_128_align2 = DS_READ_B128_gfx9 %35, 96, 0, implicit $exec
+    %17:av_128_align2 = DS_READ_B128_gfx9 %35, 112, 0, implicit $exec
+    %18:av_128_align2 = DS_READ_B128_gfx9 %35, 128, 0, implicit $exec
+    %19:av_128_align2 = DS_READ_B128_gfx9 %35, 144, 0, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %10, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %13, %14, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %14, %12, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %16, %1, 0, 0, 0, implicit-def %32:vgpr_32, implicit $mode, implicit $exec
+    %33:vgpr_32 = V_ADD_U32_e32 64, %32, implicit $exec
+    %20:av_128_align2 = DS_READ_B128_gfx9 %33, 160, 0, implicit $exec
+    %21:av_128_align2 = DS_READ_B128_gfx9 %33, 176, 0, implicit $exec
+    %22:av_128_align2 = DS_READ_B128_gfx9 %33, 192, 0, implicit $exec
+    %23:av_128_align2 = DS_READ_B128_gfx9 %33, 208, 0, implicit $exec
+    %24:av_128_align2 = DS_READ_B128_gfx9 %33, 224, 0, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %15, %17, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %18, %15, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %18, %19, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %19, %17, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %20, %21, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %20, %22, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %23, %20, %1, 0, 0, 0, implicit $mode, implicit $exec
+    %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %23, %24, %1, 0, 0, 0, implicit $mode, implicit $exec
+    dead %1:vreg_512_align2 = V_MFMA_F32_32X32X16_F16_mac_vgprcd_e64 %24, %22, %1, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0
+...


### PR DESCRIPTION
DS_READ_B128 results remain buffered for several issue cycles before an MFMA can consume them without waiting. Independent MFMAs can cover that latency, but the generic bidirectional scheduler does not recognize this relationship. It can issue a large block of reads before the first MFMA or consume a new fragment before enough independent work has run.

Add a gfx950-specific straight-line pipeline for DS_READ_B128 and V_MFMA_F32_32X32X16_F16. Start with a bounded group of prefetched fragments, then alternate pairs of reads with groups of independent MFMAs. Pairing reads also avoids the higher issue latency observed for an isolated DS read on gfx950.

Keep the number of live fragments bounded and prefer reads that make an MFMA available sooner. Coordinate the top and bottom scheduling boundaries so bottom-up scheduling does not drain the accumulator chain needed to sustain the pipeline. Existing register-pressure and resource criteria remain higher-priority constraints.

Use ready non-memory instructions to cover any latency left during ramp-up. Buffered loads are not selected for this role because they introduce another maturity window and consume memory capacity that this policy does not model.

Preserve the selected DS_READ/MFMA order through post-RA scheduling, which could otherwise undo parts of the pipeline. The tune is enabled by default on gfx950 and can be disabled with -amdgpu-enable-mfma-fragment-scheduler=false. It is limited to a single MI scheduling region and does not pipeline across loop iterations.

Add MIR coverage for the opener, ramp-up, repeated steady-state groups, MFMA epilogue, textual-order tie breaking, default enablement, and the explicit disable path.

Co-authored by codex gpt-5.6-sol