### PR TITLE
[Offload] Decouple CUDA source from NVPTX syncthreads assumption

### DIFF
--- a/clang/lib/Headers/__clang_gpu_device_functions.h
+++ b/clang/lib/Headers/__clang_gpu_device_functions.h
@@ -329,7 +329,7 @@ __GPU_DEVICE__ int __fns(unsigned int __mask, unsigned int __base,
 //===----------------------------------------------------------------------===//
 
 // CUDA provides __syncthreads as an NVPTX compiler builtin directly.
-#if !defined(__CUDA__)
+#if !defined(__NVPTX__)
 __GPU_DEVICE__ void __syncthreads(void) { __gpu_sync_threads(); }
 #endif
 


### PR DESCRIPTION
With the introduction of offloading via LLVM, the frontend language will not necessarily determine the backend target anymore. Thus it is necessary to guard against NVPTX instead of CUDA, since we could have CUDA-language device code targeting a non-NVPTX backend, where Clang does not provide __syncthreads as an NVPTX builtin and the generic shim is still needed.

This also avoids duplicate definitions on NVPTX. Clang already provides `__syncthreads` as an NVPTX target builtin, so `__clang_gpu_device_functions.h` should not also define an inline `__syncthreads` shim for NVPTX targets.
