### PR TITLE
[libc++] Rename the test suite used on LNT

### DIFF
--- a/.github/workflows/libcxx-benchmark-commit.yml
+++ b/.github/workflows/libcxx-benchmark-commit.yml
@@ -114,5 +114,5 @@ jobs:
         run: |
           libcxx/utils/ci/lnt/submit-benchmarks             \
             --lnt-url "${LNT_URL}"                          \
-            --test-suite libcxx2                            \
+            --test-suite libcxx                             \
             "${COMMIT}.json"

--- a/libcxx/utils/ci/lnt/run-benchbot
+++ b/libcxx/utils/ci/lnt/run-benchbot
@@ -114,7 +114,7 @@ ${COMPILER} --version
 echo "Benchmark suite version: ${BENCHMARK_SUITE_VERSION}"
 echo "***********************************************"
 
-LNT_TEST_SUITE=libcxx2
+LNT_TEST_SUITE=libcxx
 
 mkdir -p "${RESULTS_DIR}"
 

--- a/libcxx/utils/ci/lnt/schema.yaml
+++ b/libcxx/utils/ci/lnt/schema.yaml
@@ -4,7 +4,7 @@
 # information gathered by the script that runs those benchmarks for
 # uploading with LNT.
 format_version: '2'
-name: libcxx2 # libcxx already exists on lnt.llvm.org, and sadly its schema is not correct
+name: libcxx
 metrics:
 - name: execution_time
   type: Real


### PR DESCRIPTION
The LNT instance on http://lnt.llvm.org was wiped since I created the original schema, and we can now start over clean with a new test suite named `libcxx`.