### PR TITLE
[mlir] Reland SymbolUserTypeInterface with verification proportional to participating IR

### DIFF
--- a/mlir/include/mlir/IR/CMakeLists.txt
+++ b/mlir/include/mlir/IR/CMakeLists.txt
@@ -2,6 +2,8 @@ add_mlir_interface(SymbolInterfaces)
 set(LLVM_TARGET_DEFINITIONS SymbolInterfaces.td)
 mlir_tablegen(SymbolInterfacesAttrInterface.h.inc -gen-attr-interface-decls)
 mlir_tablegen(SymbolInterfacesAttrInterface.cpp.inc -gen-attr-interface-defs)
+mlir_tablegen(SymbolInterfacesTypeInterface.h.inc -gen-type-interface-decls)
+mlir_tablegen(SymbolInterfacesTypeInterface.cpp.inc -gen-type-interface-defs)
 add_mlir_interface(RegionKindInterface)
 
 add_mlir_type_interface(QuantStorageTypeInterface)

--- a/mlir/include/mlir/IR/SymbolInterfaces.td
+++ b/mlir/include/mlir/IR/SymbolInterfaces.td
@@ -228,12 +228,31 @@ def SymbolUserAttrInterface : AttrInterface<"SymbolUserAttrInterface"> {
     interface allows for users of symbols to hook into verification and other
     symbol related utilities that are either costly or otherwise disallowed
     within an operation (e.g., recreating symbol users per op verified rather
-    than per symbol table, or querying symbols usage of sibblings).
+    than per symbol table, or querying symbols usage of siblings).
   }];
   let cppNamespace = "::mlir";
 
   let methods = [
     InterfaceMethod<"Verify the symbol uses held by this attribute of this operation.",
+      "::llvm::LogicalResult", "verifySymbolUses",
+      (ins "::mlir::Operation *":$op,
+           "::mlir::SymbolTableCollection &":$symbolTable)
+    >,
+  ];
+}
+
+def SymbolUserTypeInterface : TypeInterface<"SymbolUserTypeInterface"> {
+  let description = [{
+    This interface describes a type that may use a `Symbol`. This interface
+    allows types to hook into verification that needs a symbol table, which is
+    costly or otherwise disallowed within type construction and uniquing.
+    `op` is the operation whose verification triggered the check and should be
+    used as the anchor for symbol lookups.
+  }];
+  let cppNamespace = "::mlir";
+
+  let methods = [
+    InterfaceMethod<"Verify the symbol uses held by this type of this operation.",
       "::llvm::LogicalResult", "verifySymbolUses",
       (ins "::mlir::Operation *":$op,
            "::mlir::SymbolTableCollection &":$symbolTable)

--- a/mlir/include/mlir/IR/SymbolInterfaces.td
+++ b/mlir/include/mlir/IR/SymbolInterfaces.td
@@ -229,14 +229,6 @@ def SymbolUserAttrInterface : AttrInterface<"SymbolUserAttrInterface"> {
     symbol related utilities that are either costly or otherwise disallowed
     within an operation (e.g., recreating symbol users per op verified rather
     than per symbol table, or querying symbols usage of siblings).
-
-    Implementations must represent the symbols they reference as `SymbolRefAttr`s
-    nested anywhere within their sub-element tree, i.e. reachable by recursive
-    application of `walkImmediateSubElements`, rather than in some other encoding
-    such as a string. This is what lets the symbol machinery cheaply dismiss
-    instances that cannot reference a symbol: an instance with no `SymbolRefAttr`
-    anywhere in its sub-element tree is treated as referencing no symbols, so
-    symbol-table verification may never invoke its `verifySymbolUses`.
   }];
   let cppNamespace = "::mlir";
 

--- a/mlir/include/mlir/IR/SymbolInterfaces.td
+++ b/mlir/include/mlir/IR/SymbolInterfaces.td
@@ -229,6 +229,14 @@ def SymbolUserAttrInterface : AttrInterface<"SymbolUserAttrInterface"> {
     symbol related utilities that are either costly or otherwise disallowed
     within an operation (e.g., recreating symbol users per op verified rather
     than per symbol table, or querying symbols usage of siblings).
+
+    Implementations must represent the symbols they reference as `SymbolRefAttr`s
+    nested anywhere within their sub-element tree, i.e. reachable by recursive
+    application of `walkImmediateSubElements`, rather than in some other encoding
+    such as a string. This is what lets the symbol machinery cheaply dismiss
+    instances that cannot reference a symbol: an instance with no `SymbolRefAttr`
+    anywhere in its sub-element tree is treated as referencing no symbols, so
+    symbol-table verification may never invoke its `verifySymbolUses`.
   }];
   let cppNamespace = "::mlir";
 
@@ -248,6 +256,14 @@ def SymbolUserTypeInterface : TypeInterface<"SymbolUserTypeInterface"> {
     costly or otherwise disallowed within type construction and uniquing.
     `op` is the operation whose verification triggered the check and should be
     used as the anchor for symbol lookups.
+
+    Implementations must represent the symbols they reference as `SymbolRefAttr`s
+    nested anywhere within their sub-element tree, i.e. reachable by recursive
+    application of `walkImmediateSubElements`, rather than in some other encoding
+    such as a string. This is what lets the symbol machinery cheaply dismiss
+    instances that cannot reference a symbol: an instance with no `SymbolRefAttr`
+    anywhere in its sub-element tree is treated as referencing no symbols, so
+    symbol-table verification may never invoke its `verifySymbolUses`.
   }];
   let cppNamespace = "::mlir";
 

--- a/mlir/include/mlir/IR/SymbolTable.h
+++ b/mlir/include/mlir/IR/SymbolTable.h
@@ -500,5 +500,6 @@ ParseResult parseOptionalVisibilityKeyword(OpAsmParser &parser,
 /// Include the generated symbol interfaces.
 #include "mlir/IR/SymbolInterfaces.h.inc"
 #include "mlir/IR/SymbolInterfacesAttrInterface.h.inc"
+#include "mlir/IR/SymbolInterfacesTypeInterface.h.inc"
 
 #endif // MLIR_IR_SYMBOLTABLE_H

--- a/mlir/include/mlir/IR/SymbolTable.h
+++ b/mlir/include/mlir/IR/SymbolTable.h
@@ -242,6 +242,19 @@ public:
   static bool symbolKnownUseEmpty(StringAttr symbol, Region *from);
   static bool symbolKnownUseEmpty(Operation *symbol, Region *from);
 
+  /// Return whether the given type or attribute may transitively contain a
+  /// `SymbolRefAttr`, i.e. whether one is reachable through its sub-element
+  /// tree by recursive application of `walkImmediateSubElements`. A false
+  /// answer is authoritative: the object provably references no symbol, so a
+  /// SymbolUserTypeInterface / SymbolUserAttrInterface implementation that
+  /// honors its contract has a vacuous `verifySymbolUses` and need never be
+  /// visited. A true answer is conservative: mutable-storage kinds, and
+  /// anything containing them, always report true. The answer is a pure
+  /// function of the uniqued, immutable structure, computed once per object and
+  /// cached on the context for its lifetime.
+  static bool mayContainSymbolRefs(Type type);
+  static bool mayContainSymbolRefs(Attribute attr);
+
   /// Attempt to replace all uses of the given symbol 'oldSymbol' with the
   /// provided symbol 'newSymbol' that are nested within the given operation
   /// 'from'. This does not traverse into any nested symbol tables. If there are

--- a/mlir/include/mlir/IR/SymbolTable.h
+++ b/mlir/include/mlir/IR/SymbolTable.h
@@ -242,19 +242,6 @@ public:
   static bool symbolKnownUseEmpty(StringAttr symbol, Region *from);
   static bool symbolKnownUseEmpty(Operation *symbol, Region *from);
 
-  /// Return whether the given type or attribute may transitively contain a
-  /// `SymbolRefAttr`, i.e. whether one is reachable through its sub-element
-  /// tree by recursive application of `walkImmediateSubElements`. A false
-  /// answer is authoritative: the object provably references no symbol, so a
-  /// SymbolUserTypeInterface / SymbolUserAttrInterface implementation that
-  /// honors its contract has a vacuous `verifySymbolUses` and need never be
-  /// visited. A true answer is conservative: mutable-storage kinds, and
-  /// anything containing them, always report true. The answer is a pure
-  /// function of the uniqued, immutable structure, computed once per object and
-  /// cached on the context for its lifetime.
-  static bool mayContainSymbolRefs(Type type);
-  static bool mayContainSymbolRefs(Attribute attr);
-
   /// Attempt to replace all uses of the given symbol 'oldSymbol' with the
   /// provided symbol 'newSymbol' that are nested within the given operation
   /// 'from'. This does not traverse into any nested symbol tables. If there are

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -282,9 +282,9 @@ public:
   std::unique_ptr<TransientScopeState> transientState;
 
   /// Cache recording which uniqued types and attributes are provably free of a
-  /// transitive SymbolRefAttr. Filled on demand by symbol-table verification
-  /// and never invalidated; reads `threadingIsEnabled` live to guard its set.
-  /// See SymbolRefContainmentCache.h.
+  /// transitive SymbolRefAttr. Filled on demand by symbol-table verification;
+  /// cleared when a transient scope ends, since storage interned during the
+  /// scope is freed then.
   SymbolRefContainmentCache symbolRefContainmentCache{threadingIsEnabled};
 
 public:
@@ -785,6 +785,10 @@ void MLIRContext::endTransientScope() {
   ctxImpl.attributeUniquer.endTransientScope();
   ctxImpl.affineUniquer.endTransientScope();
   ctxImpl.distinctAttributeAllocator.endTransientScope();
+
+  // Transiently allocated uniqued storage is freed here and its addresses may
+  // be recycled, so the containment memo must not survive the scope.
+  ctxImpl.symbolRefContainmentCache.clear();
 
   ctxImpl.transientState.reset();
 }

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -11,6 +11,7 @@
 #include "AffineMapDetail.h"
 #include "AttributeDetail.h"
 #include "IntegerSetDetail.h"
+#include "SymbolRefContainmentCache.h"
 #include "TypeDetail.h"
 #include "mlir/IR/Action.h"
 #include "mlir/IR/AffineExpr.h"
@@ -279,6 +280,11 @@ public:
     llvm::DenseMap<StringRef, size_t> baseDialectReferencingStrAttrCounts;
   };
   std::unique_ptr<TransientScopeState> transientState;
+
+  /// Cache recording, per uniqued type and attribute, whether it may
+  /// transitively contain a SymbolRefAttr. Filled lazily by symbol-table
+  /// verification and never invalidated; see SymbolRefContainmentCache.h.
+  SymbolRefContainmentCache symbolRefContainmentCache;
 
 public:
   MLIRContextImpl(bool threadingIsEnabled)
@@ -1267,6 +1273,11 @@ DistinctAttrStorage *
 detail::DistinctAttributeUniquer::allocateStorage(MLIRContext *context,
                                                   Attribute referencedAttr) {
   return context->getImpl().distinctAttributeAllocator.allocate(referencedAttr);
+}
+
+detail::SymbolRefContainmentCache &
+detail::getSymbolRefContainmentCache(MLIRContext *ctx) {
+  return ctx->getImpl().symbolRefContainmentCache;
 }
 
 /// Return empty dictionary.

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -281,10 +281,11 @@ public:
   };
   std::unique_ptr<TransientScopeState> transientState;
 
-  /// Cache recording, per uniqued type and attribute, whether it may
-  /// transitively contain a SymbolRefAttr. Filled lazily by symbol-table
-  /// verification and never invalidated; see SymbolRefContainmentCache.h.
-  SymbolRefContainmentCache symbolRefContainmentCache;
+  /// Cache recording which uniqued types and attributes are provably free of a
+  /// transitive SymbolRefAttr. Filled on demand by symbol-table verification
+  /// and never invalidated; reads `threadingIsEnabled` live to guard its set.
+  /// See SymbolRefContainmentCache.h.
+  SymbolRefContainmentCache symbolRefContainmentCache{threadingIsEnabled};
 
 public:
   MLIRContextImpl(bool threadingIsEnabled)

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// A context-owned cache answering, for a uniqued type or attribute, whether it
-// may transitively contain a SymbolRefAttr. Symbol-table verification consults
-// it to prune its symbol-use walk to the subtrees that can carry a symbol use.
+// A context-owned record of the uniqued types and attributes proven free of any
+// transitive SymbolRefAttr. Symbol-table verification consults it to prune its
+// symbol-use walk to the subtrees that can carry a symbol use.
 //
 // A recorded answer is a pure function of immutable structure --
 // mutable-storage kinds are never read or recorded -- so it never goes stale.
@@ -59,10 +59,10 @@ public:
 
   /// Return whether `type`/`attr` is provably free of any transitive
   /// SymbolRefAttr -- true is safe to prune, false is walked conservatively.
-  bool isSymbolRefFree(Type type) { return !compute(type); }
-  bool isSymbolRefFree(Attribute attr) { return !compute(attr); }
+  bool isSymbolRefFree(Type type) { return !mayContainSymbolRef(type); }
+  bool isSymbolRefFree(Attribute attr) { return !mayContainSymbolRef(attr); }
 
-  /// Drop every recorded fact. The cache is a pure memo of proven-clear
+  /// Drop every recorded fact. The cache is a pure memo of proven-free
   /// objects, so forgetting them all is always correct and only costs a
   /// recomputation on next encounter. The context calls this when a transient
   /// scope ends and its transiently allocated storage is freed, before any
@@ -72,7 +72,7 @@ public:
     std::optional<llvm::sys::SmartScopedWriter<true>> guard;
     if (shouldLock())
       guard.emplace(mutex);
-    clearSet.clear();
+    knownFree.clear();
   }
 
 private:
@@ -84,7 +84,7 @@ private:
   }
 
   /// Return whether `obj` may transitively contain a SymbolRefAttr, recording a
-  /// proven-clear result so it need never recompute. The recursion needs no
+  /// proven-free result so it need never recompute. The recursion needs no
   /// in-progress guard: immutable objects form a DAG (sub-elements are interned
   /// before their parents), so every cycle passes through a mutable kind, where
   /// the descent stops above before reading contents. Once one sub-element
@@ -92,35 +92,35 @@ private:
   /// cannot be interrupted, but the callback is a no-op once `mayContain`
   /// holds.
   template <typename T>
-  bool compute(T obj) {
+  bool mayContainSymbolRef(T obj) {
     const void *key = obj.getAsOpaquePointer();
-    if (isKnownClear(key))
+    if (isKnownFree(key))
       return false;
     bool mayContain = isSelfSymbolRef(obj) ||
                       obj.template hasTrait<StorageUserTrait::IsMutable>();
     if (!mayContain) {
       auto walkSub = [&](auto sub) {
         if (!mayContain && sub)
-          mayContain = compute(sub);
+          mayContain = mayContainSymbolRef(sub);
       };
       obj.walkImmediateSubElements(walkSub, walkSub);
     }
     if (!mayContain)
-      markClear(key);
+      markFree(key);
     return mayContain;
   }
 
-  bool isKnownClear(const void *key) const {
+  bool isKnownFree(const void *key) const {
     std::optional<llvm::sys::SmartScopedReader<true>> guard;
     if (shouldLock())
       guard.emplace(mutex);
-    return clearSet.contains(key);
+    return knownFree.contains(key);
   }
-  void markClear(const void *key) {
+  void markFree(const void *key) {
     std::optional<llvm::sys::SmartScopedWriter<true>> guard;
     if (shouldLock())
       guard.emplace(mutex);
-    clearSet.insert(key);
+    knownFree.insert(key);
   }
 
   /// The set is serialized only while the context runs multithreaded;
@@ -134,11 +134,11 @@ private:
   // write lock the insert and any growth it triggers, and neither is ever held
   // across the recursion.
   mutable llvm::sys::SmartRWMutex<true> mutex;
-  // Only the proven-clear opaque pointers are recorded; a may-contain object --
+  // Only the proven-free opaque pointers are recorded; a may-contain object --
   // including every mutable-storage kind, whose contents are never read -- is
   // left out and recomputed on each encounter, so no fact that could later go
   // stale is ever stored.
-  llvm::DenseSet<const void *> clearSet;
+  llvm::DenseSet<const void *> knownFree;
 };
 
 /// Return the given context's symbol-reference containment cache. Defined in

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -39,12 +39,13 @@ class MLIRContext;
 namespace detail {
 
 /// Per-context cache of the "provably free of a transitive SymbolRefAttr" fact
-/// for uniqued types and attributes, computed on demand, memoizing proven-clear
-/// answers. A false answer is authoritative -- the object references no symbol
-/// -- so a conforming SymbolUserTypeInterface has a vacuous verifySymbolUses
-/// and need never be visited. A true answer is conservative: a mutable-storage
-/// kind, whose sub-elements may change after the query, and anything containing
-/// one, always answers true.
+/// for uniqued types and attributes, computed on demand, memoizing proven-free
+/// answers. A true answer is authoritative -- the object references no symbol,
+/// so a conforming SymbolUserTypeInterface has a vacuous verifySymbolUses and
+/// the caller may prune it unvisited. A false answer is conservative: the
+/// object may contain a reference and the caller walks it, and a
+/// mutable-storage kind, whose sub-elements may change after the query, and
+/// anything containing one, always answers false.
 class SymbolRefContainmentCache {
 public:
   /// `isMultithreaded` is the context's runtime multithreading flag, read live
@@ -56,8 +57,10 @@ public:
   SymbolRefContainmentCache &
   operator=(const SymbolRefContainmentCache &) = delete;
 
-  bool mayContainSymbolRefs(Type type) { return compute(type); }
-  bool mayContainSymbolRefs(Attribute attr) { return compute(attr); }
+  /// Return whether `type`/`attr` is provably free of any transitive
+  /// SymbolRefAttr -- true is safe to prune, false is walked conservatively.
+  bool isSymbolRefFree(Type type) { return !compute(type); }
+  bool isSymbolRefFree(Attribute attr) { return !compute(attr); }
 
   /// Drop every recorded fact. The cache is a pure memo of proven-clear
   /// objects, so forgetting them all is always correct and only costs a

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -6,16 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// A context-owned store recording, per uniqued type and attribute, whether it
-// may transitively contain a SymbolRefAttr. Symbol-table verification consults
-// it to prune the symbol-use walk.
+// A context-owned store recording which uniqued types and attributes are
+// provably free of a transitive SymbolRefAttr. Symbol-table verification
+// consults it to prune the symbol-use walk.
 //
 // The store is filled lazily and never invalidated. Uniqued storage is immortal
-// and immutable for the context's lifetime, so a cached answer can never go
+// and immutable for the context's lifetime, so a recorded answer can never go
 // stale, and a pointer can never be recycled to alias another object within one
-// context. Every entry is write-once: false only for a provably
-// reference-free immutable subtree, true for everything else, including
-// mutable-storage kinds, whose contents the fill never reads.
+// context. Only the "provably reference-free" fact is recorded; a may-contain
+// answer -- including every mutable-storage kind, whose contents the fill never
+// reads -- is left unrecorded and recomputed on each encounter.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,41 +24,34 @@
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Types.h"
-#include "llvm/Support/MathExtras.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/RWMutex.h"
-#include <cstdint>
 #include <optional>
-#include <vector>
 
 namespace mlir {
 class MLIRContext;
 namespace detail {
 
-/// Per-context store of the "may transitively contain a SymbolRefAttr" fact for
-/// uniqued types and attributes. Two tables mirror the context's two uniquers,
-/// so type and attribute opaque pointers never need to be argued disjoint.
+/// Per-context store of the "provably free of a transitive SymbolRefAttr" fact
+/// for uniqued types and attributes. Two sets mirror the context's two
+/// uniquers, so type and attribute opaque pointers never need to be argued
+/// disjoint.
 ///
-/// Each table is a packed open-addressed array of single-word slots. A live
-/// slot holds the uniqued opaque pointer with its answer in bit 0; both storage
-/// families are 8-aligned, so bit 0 is always free to carry the fact (the
-/// static_asserts below stand watch over that). A zero word is an empty slot,
-/// which a live entry can never collide with because a uniqued pointer is never
-/// null.
+/// Each set holds only the opaque pointers of objects proven reference-free.
+/// Membership means "clear" (answer false); non-membership means "not yet
+/// proven clear", which the fill treats as unfilled and may-contain both at
+/// once -- it recomputes containment, and a genuine may-contain object is
+/// recomputed cheaply because the walk early-exits at its first SymbolRefAttr.
+/// A may-contain answer is therefore never stored, so a mutable-storage kind is
+/// conservatively may-contain forever with no special handling.
 ///
-/// Locking discipline: the tables live entirely behind one SmartRWMutex. A
-/// lookup holds the read lock for its whole probe; an insert -- including any
-/// table growth it triggers -- holds the write lock. Readers therefore never
-/// observe a half-grown table and the plain arrays need no per-slot atomics.
-/// The `lock` flag threaded through each operation is the context's runtime
-/// multithreading flag: when it is false the store is touched single-threaded
-/// and no lock is taken, mirroring MLIRContext's ScopedWriterLock.
-///
-/// Probe contract: a lookup probes forward from the mixed home slot until it
-/// meets the key (a hit) or an empty slot (a miss); it is never bounded short
-/// of an empty slot. Growth keeps the load factor at or below one half, so an
-/// empty slot always exists and every probe terminates. Insert places a key at
-/// the first empty slot on its probe, or returns the resident answer if the key
-/// is already present, so a racing duplicate fill is a no-op.
+/// Locking discipline: the sets live entirely behind one SmartRWMutex. A lookup
+/// holds the read lock for its whole probe; an insert -- including any set
+/// growth it triggers -- holds the write lock. Readers therefore never observe
+/// a half-grown set and the plain sets need no per-slot atomics. The `lock`
+/// flag threaded through each operation is the context's runtime multithreading
+/// flag: when it is false the store is touched single-threaded and no lock is
+/// taken, mirroring MLIRContext's ScopedWriterLock.
 class SymbolRefContainmentCache {
 public:
   SymbolRefContainmentCache() = default;
@@ -66,7 +59,9 @@ public:
   SymbolRefContainmentCache &
   operator=(const SymbolRefContainmentCache &) = delete;
 
-  /// Return the cached answer for `type`/`attr`, or nullopt if not yet filled.
+  /// Return false for `type`/`attr` if it is recorded clear, or nullopt if it
+  /// is not yet proven clear (unfilled, treated as may-contain by the caller).
+  /// A true answer is never recorded, so lookup never returns true.
   std::optional<bool> lookup(Type type, bool lock) const {
     return lookupImpl(typeEntries, type.getAsOpaquePointer(), lock);
   }
@@ -74,9 +69,11 @@ public:
     return lookupImpl(attrEntries, attr.getAsOpaquePointer(), lock);
   }
 
-  /// Record `value` for `type`/`attr` if no entry exists yet and return the
-  /// resident answer. A racing duplicate fill computes the same immutable fact,
-  /// so the losing insert is a no-op.
+  /// Record `type`/`attr` as clear when `value` is false and return the answer
+  /// unchanged. A may-contain (`value` true) fact is not stored -- it is
+  /// recomputed cheaply on each encounter -- so insert then returns true
+  /// without touching the set. A racing duplicate clear fill records the same
+  /// membership and is a no-op.
   bool insert(Type type, bool value, bool lock) {
     return insertImpl(typeEntries, type.getAsOpaquePointer(), value, lock);
   }
@@ -85,116 +82,47 @@ public:
   }
 
 private:
-  // Both uniqued-storage families are 8-aligned, so bit 0 of a stored pointer
-  // is free to hold the cached answer.
-  static_assert(
-      alignof(TypeStorage) >= 8,
-      "type storage must be 8-aligned so bit 0 of its pointer is free "
-      "to tag the cached answer");
-  static_assert(
-      alignof(AttributeStorage) >= 8,
-      "attribute storage must be 8-aligned so bit 0 of its pointer is "
-      "free to tag the cached answer");
+  /// One uniquer's clear-object set. It is not self-synchronizing: the
+  /// enclosing cache serializes all access with its SmartRWMutex, so every
+  /// method here runs under the read lock (lookup) or the write lock (insert
+  /// and the growth it may trigger).
+  struct ClearSet {
+    llvm::DenseSet<const void *> clear;
 
-  /// One packed open-addressed table of tagged-pointer facts. It is not
-  /// self-synchronizing: the enclosing cache serializes all access with its
-  /// SmartRWMutex, so every method here runs under the read lock (lookup) or
-  /// the write lock (insert and the growth it may trigger).
-  struct Table {
-    // Power-of-two length, or empty before the first insert. 0 == empty slot;
-    // a live slot is (uniqued pointer | answer bit).
-    std::vector<uintptr_t> slots;
-    size_t count = 0;
-
-    std::optional<bool> lookup(uintptr_t key) const {
-      if (slots.empty())
-        return std::nullopt;
-      unsigned shift = 64u - llvm::Log2_64(slots.size());
-      size_t mask = slots.size() - 1;
-      for (size_t i = home(key, shift);; i = (i + 1) & mask) {
-        uintptr_t word = slots[i];
-        if (word == 0)
-          return std::nullopt;
-        if ((word & ~static_cast<uintptr_t>(1)) == key)
-          return static_cast<bool>(word & 1);
-      }
+    std::optional<bool> lookup(const void *key) const {
+      if (clear.count(key))
+        return false;
+      return std::nullopt;
     }
 
-    bool insert(uintptr_t key, bool value) {
-      // Grow before this insert could push the load past one half, so a lookup
-      // is always guaranteed an empty slot to terminate on.
-      if (slots.empty() || (count + 1) * 2 > slots.size())
-        grow();
-      for (;;) {
-        unsigned shift = 64u - llvm::Log2_64(slots.size());
-        size_t mask = slots.size() - 1;
-        size_t probe = 0;
-        for (size_t i = home(key, shift);; i = (i + 1) & mask) {
-          uintptr_t word = slots[i];
-          if (word == 0) {
-            slots[i] = key | static_cast<uintptr_t>(value);
-            ++count;
-            return value;
-          }
-          if ((word & ~static_cast<uintptr_t>(1)) == key)
-            return static_cast<bool>(word & 1);
-          // A cluster longer than the bound is a sign the mix has degenerated
-          // for this address run; grow to break it up rather than lengthen it.
-          if (++probe > kMaxProbe)
-            break;
-        }
-        grow();
-      }
+    bool insert(const void *key, bool value) {
+      // Only the clear fact is durable; a may-contain answer is left out to be
+      // recomputed cheaply on each encounter. A racing duplicate clear fill
+      // records the same membership and is a no-op.
+      if (!value)
+        clear.insert(key);
+      return value;
     }
-
-  private:
-    // Fibonacci hashing: one multiply by the 64-bit golden-ratio constant, then
-    // take the top log2(capacity) bits. Bump-allocated storage pointers advance
-    // in regular strides, which a bare mask would fold into long clusters; the
-    // multiply spreads those strides across the whole table.
-    static size_t home(uintptr_t key, unsigned shift) {
-      uint64_t mixed = static_cast<uint64_t>(key >> 3) * 0x9E3779B97F4A7C15ULL;
-      return static_cast<size_t>(mixed >> shift);
-    }
-
-    void grow() {
-      size_t newCapacity = slots.empty() ? kInitialCapacity : slots.size() * 2;
-      std::vector<uintptr_t> old = std::move(slots);
-      slots.assign(newCapacity, 0);
-      unsigned shift = 64u - llvm::Log2_64(newCapacity);
-      size_t mask = newCapacity - 1;
-      for (uintptr_t word : old) {
-        if (word == 0)
-          continue;
-        size_t i = home(word & ~static_cast<uintptr_t>(1), shift);
-        while (slots[i] != 0)
-          i = (i + 1) & mask;
-        slots[i] = word;
-      }
-    }
-
-    static constexpr size_t kInitialCapacity = 8;
-    static constexpr size_t kMaxProbe = 16;
   };
 
-  std::optional<bool> lookupImpl(const Table &table, const void *key,
+  std::optional<bool> lookupImpl(const ClearSet &set, const void *key,
                                  bool lock) const {
     std::optional<llvm::sys::SmartScopedReader<true>> guard;
     if (lock)
       guard.emplace(mutex);
-    return table.lookup(reinterpret_cast<uintptr_t>(key));
+    return set.lookup(key);
   }
 
-  bool insertImpl(Table &table, const void *key, bool value, bool lock) {
+  bool insertImpl(ClearSet &set, const void *key, bool value, bool lock) {
     std::optional<llvm::sys::SmartScopedWriter<true>> guard;
     if (lock)
       guard.emplace(mutex);
-    return table.insert(reinterpret_cast<uintptr_t>(key), value);
+    return set.insert(key, value);
   }
 
   mutable llvm::sys::SmartRWMutex<true> mutex;
-  Table typeEntries;
-  Table attrEntries;
+  ClearSet typeEntries;
+  ClearSet attrEntries;
 };
 
 /// Return the given context's symbol-reference containment cache. Defined in

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -24,20 +24,41 @@
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Types.h"
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/RWMutex.h"
+#include <cstdint>
 #include <optional>
+#include <vector>
 
 namespace mlir {
 class MLIRContext;
 namespace detail {
 
 /// Per-context store of the "may transitively contain a SymbolRefAttr" fact for
-/// uniqued types and attributes. Two maps mirror the context's two uniquers, so
-/// type and attribute opaque pointers never need to be argued disjoint. The
-/// `lock` flag threaded through each operation is the context's runtime
+/// uniqued types and attributes. Two tables mirror the context's two uniquers,
+/// so type and attribute opaque pointers never need to be argued disjoint.
+///
+/// Each table is a packed open-addressed array of single-word slots. A live
+/// slot holds the uniqued opaque pointer with its answer in bit 0; both storage
+/// families are 8-aligned, so bit 0 is always free to carry the fact (the
+/// static_asserts below stand watch over that). A zero word is an empty slot,
+/// which a live entry can never collide with because a uniqued pointer is never
+/// null.
+///
+/// Locking discipline: the tables live entirely behind one SmartRWMutex. A
+/// lookup holds the read lock for its whole probe; an insert -- including any
+/// table growth it triggers -- holds the write lock. Readers therefore never
+/// observe a half-grown table and the plain arrays need no per-slot atomics.
+/// The `lock` flag threaded through each operation is the context's runtime
 /// multithreading flag: when it is false the store is touched single-threaded
 /// and no lock is taken, mirroring MLIRContext's ScopedWriterLock.
+///
+/// Probe contract: a lookup probes forward from the mixed home slot until it
+/// meets the key (a hit) or an empty slot (a miss); it is never bounded short
+/// of an empty slot. Growth keeps the load factor at or below one half, so an
+/// empty slot always exists and every probe terminates. Insert places a key at
+/// the first empty slot on its probe, or returns the resident answer if the key
+/// is already present, so a racing duplicate fill is a no-op.
 class SymbolRefContainmentCache {
 public:
   SymbolRefContainmentCache() = default;
@@ -64,29 +85,116 @@ public:
   }
 
 private:
-  using Map = DenseMap<const void *, bool>;
+  // Both uniqued-storage families are 8-aligned, so bit 0 of a stored pointer
+  // is free to hold the cached answer.
+  static_assert(
+      alignof(TypeStorage) >= 8,
+      "type storage must be 8-aligned so bit 0 of its pointer is free "
+      "to tag the cached answer");
+  static_assert(
+      alignof(AttributeStorage) >= 8,
+      "attribute storage must be 8-aligned so bit 0 of its pointer is "
+      "free to tag the cached answer");
 
-  std::optional<bool> lookupImpl(const Map &map, const void *key,
+  /// One packed open-addressed table of tagged-pointer facts. It is not
+  /// self-synchronizing: the enclosing cache serializes all access with its
+  /// SmartRWMutex, so every method here runs under the read lock (lookup) or
+  /// the write lock (insert and the growth it may trigger).
+  struct Table {
+    // Power-of-two length, or empty before the first insert. 0 == empty slot;
+    // a live slot is (uniqued pointer | answer bit).
+    std::vector<uintptr_t> slots;
+    size_t count = 0;
+
+    std::optional<bool> lookup(uintptr_t key) const {
+      if (slots.empty())
+        return std::nullopt;
+      unsigned shift = 64u - llvm::Log2_64(slots.size());
+      size_t mask = slots.size() - 1;
+      for (size_t i = home(key, shift);; i = (i + 1) & mask) {
+        uintptr_t word = slots[i];
+        if (word == 0)
+          return std::nullopt;
+        if ((word & ~static_cast<uintptr_t>(1)) == key)
+          return static_cast<bool>(word & 1);
+      }
+    }
+
+    bool insert(uintptr_t key, bool value) {
+      // Grow before this insert could push the load past one half, so a lookup
+      // is always guaranteed an empty slot to terminate on.
+      if (slots.empty() || (count + 1) * 2 > slots.size())
+        grow();
+      for (;;) {
+        unsigned shift = 64u - llvm::Log2_64(slots.size());
+        size_t mask = slots.size() - 1;
+        size_t probe = 0;
+        for (size_t i = home(key, shift);; i = (i + 1) & mask) {
+          uintptr_t word = slots[i];
+          if (word == 0) {
+            slots[i] = key | static_cast<uintptr_t>(value);
+            ++count;
+            return value;
+          }
+          if ((word & ~static_cast<uintptr_t>(1)) == key)
+            return static_cast<bool>(word & 1);
+          // A cluster longer than the bound is a sign the mix has degenerated
+          // for this address run; grow to break it up rather than lengthen it.
+          if (++probe > kMaxProbe)
+            break;
+        }
+        grow();
+      }
+    }
+
+  private:
+    // Fibonacci hashing: one multiply by the 64-bit golden-ratio constant, then
+    // take the top log2(capacity) bits. Bump-allocated storage pointers advance
+    // in regular strides, which a bare mask would fold into long clusters; the
+    // multiply spreads those strides across the whole table.
+    static size_t home(uintptr_t key, unsigned shift) {
+      uint64_t mixed = static_cast<uint64_t>(key >> 3) * 0x9E3779B97F4A7C15ULL;
+      return static_cast<size_t>(mixed >> shift);
+    }
+
+    void grow() {
+      size_t newCapacity = slots.empty() ? kInitialCapacity : slots.size() * 2;
+      std::vector<uintptr_t> old = std::move(slots);
+      slots.assign(newCapacity, 0);
+      unsigned shift = 64u - llvm::Log2_64(newCapacity);
+      size_t mask = newCapacity - 1;
+      for (uintptr_t word : old) {
+        if (word == 0)
+          continue;
+        size_t i = home(word & ~static_cast<uintptr_t>(1), shift);
+        while (slots[i] != 0)
+          i = (i + 1) & mask;
+        slots[i] = word;
+      }
+    }
+
+    static constexpr size_t kInitialCapacity = 8;
+    static constexpr size_t kMaxProbe = 16;
+  };
+
+  std::optional<bool> lookupImpl(const Table &table, const void *key,
                                  bool lock) const {
     std::optional<llvm::sys::SmartScopedReader<true>> guard;
     if (lock)
       guard.emplace(mutex);
-    auto it = map.find(key);
-    if (it == map.end())
-      return std::nullopt;
-    return it->second;
+    return table.lookup(reinterpret_cast<uintptr_t>(key));
   }
 
-  bool insertImpl(Map &map, const void *key, bool value, bool lock) {
+  bool insertImpl(Table &table, const void *key, bool value, bool lock) {
     std::optional<llvm::sys::SmartScopedWriter<true>> guard;
     if (lock)
       guard.emplace(mutex);
-    return map.try_emplace(key, value).first->second;
+    return table.insert(reinterpret_cast<uintptr_t>(key), value);
   }
 
   mutable llvm::sys::SmartRWMutex<true> mutex;
-  Map typeEntries;
-  Map attrEntries;
+  Table typeEntries;
+  Table attrEntries;
 };
 
 /// Return the given context's symbol-reference containment cache. Defined in

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -10,12 +10,16 @@
 // may transitively contain a SymbolRefAttr. Symbol-table verification consults
 // it to prune its symbol-use walk to the subtrees that can carry a symbol use.
 //
-// Uniqued type and attribute storage is immortal, and immutable in everything
-// the cache reads -- mutable-storage kinds are never read or recorded -- so a
-// recorded answer never goes stale, and two live objects can never share an
-// address. One DenseSet of opaque pointers therefore keys both kinds without
-// arguing them disjoint -- the attribute side already pools two allocators, the
-// uniquer and the DistinctAttr allocator, on that same argument.
+// A recorded answer is a pure function of immutable structure --
+// mutable-storage kinds are never read or recorded -- so it never goes stale.
+// Outside a transient scope, uniqued storage is also immortal, so two live
+// objects can never share an address. A transient scope frees the storage it
+// allocated when it ends; the context clears this cache at that point, before
+// any freed address can be recycled into a different object that would inherit
+// a stale answer. One DenseSet of opaque pointers therefore keys both kinds
+// without arguing them disjoint -- the attribute side already pools two
+// allocators, the uniquer and the DistinctAttr allocator, on that same
+// argument.
 //
 //===----------------------------------------------------------------------===//
 
@@ -54,6 +58,19 @@ public:
 
   bool mayContainSymbolRefs(Type type) { return compute(type); }
   bool mayContainSymbolRefs(Attribute attr) { return compute(attr); }
+
+  /// Drop every recorded fact. The cache is a pure memo of proven-clear
+  /// objects, so forgetting them all is always correct and only costs a
+  /// recomputation on next encounter. The context calls this when a transient
+  /// scope ends and its transiently allocated storage is freed, before any
+  /// address can be recycled into a different object that would inherit a stale
+  /// answer.
+  void clear() {
+    std::optional<llvm::sys::SmartScopedWriter<true>> guard;
+    if (shouldLock())
+      guard.emplace(mutex);
+    clearSet.clear();
+  }
 
 private:
   // A type is never itself a SymbolRefAttr; an attribute is one exactly when
@@ -94,13 +111,13 @@ private:
     std::optional<llvm::sys::SmartScopedReader<true>> guard;
     if (shouldLock())
       guard.emplace(mutex);
-    return clear.contains(key);
+    return clearSet.contains(key);
   }
   void markClear(const void *key) {
     std::optional<llvm::sys::SmartScopedWriter<true>> guard;
     if (shouldLock())
       guard.emplace(mutex);
-    clear.insert(key);
+    clearSet.insert(key);
   }
 
   /// The set is serialized only while the context runs multithreaded;
@@ -118,7 +135,7 @@ private:
   // including every mutable-storage kind, whose contents are never read -- is
   // left out and recomputed on each encounter, so no fact that could later go
   // stale is ever stored.
-  llvm::DenseSet<const void *> clear;
+  llvm::DenseSet<const void *> clearSet;
 };
 
 /// Return the given context's symbol-reference containment cache. Defined in

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -6,16 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// A context-owned store recording which uniqued types and attributes are
-// provably free of a transitive SymbolRefAttr. Symbol-table verification
-// consults it to prune the symbol-use walk.
+// A context-owned cache answering, for a uniqued type or attribute, whether it
+// may transitively contain a SymbolRefAttr. Symbol-table verification consults
+// it to prune its symbol-use walk to the subtrees that can carry a symbol use.
 //
-// The store is filled lazily and never invalidated. Uniqued storage is immortal
-// and immutable for the context's lifetime, so a recorded answer can never go
-// stale, and a pointer can never be recycled to alias another object within one
-// context. Only the "provably reference-free" fact is recorded; a may-contain
-// answer -- including every mutable-storage kind, whose contents the fill never
-// reads -- is left unrecorded and recomputed on each encounter.
+// Uniqued type and attribute storage is immortal, and immutable in everything
+// the cache reads -- mutable-storage kinds are never read or recorded -- so a
+// recorded answer never goes stale, and two live objects can never share an
+// address. One DenseSet of opaque pointers therefore keys both kinds without
+// arguing them disjoint -- the attribute side already pools two allocators, the
+// uniquer and the DistinctAttr allocator, on that same argument.
 //
 //===----------------------------------------------------------------------===//
 
@@ -23,106 +23,102 @@
 #define MLIR_LIB_IR_SYMBOLREFCONTAINMENTCACHE_H
 
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Types.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/RWMutex.h"
+#include "llvm/Support/Threading.h"
 #include <optional>
 
 namespace mlir {
 class MLIRContext;
 namespace detail {
 
-/// Per-context store of the "provably free of a transitive SymbolRefAttr" fact
-/// for uniqued types and attributes. Two sets mirror the context's two
-/// uniquers, so type and attribute opaque pointers never need to be argued
-/// disjoint.
-///
-/// Each set holds only the opaque pointers of objects proven reference-free.
-/// Membership means "clear" (answer false); non-membership means "not yet
-/// proven clear", which the fill treats as unfilled and may-contain both at
-/// once -- it recomputes containment, and a genuine may-contain object is
-/// recomputed cheaply because the walk early-exits at its first SymbolRefAttr.
-/// A may-contain answer is therefore never stored, so a mutable-storage kind is
-/// conservatively may-contain forever with no special handling.
-///
-/// Locking discipline: the sets live entirely behind one SmartRWMutex. A lookup
-/// holds the read lock for its whole probe; an insert -- including any set
-/// growth it triggers -- holds the write lock. Readers therefore never observe
-/// a half-grown set and the plain sets need no per-slot atomics. The `lock`
-/// flag threaded through each operation is the context's runtime multithreading
-/// flag: when it is false the store is touched single-threaded and no lock is
-/// taken, mirroring MLIRContext's ScopedWriterLock.
+/// Per-context cache of the "provably free of a transitive SymbolRefAttr" fact
+/// for uniqued types and attributes, computed on demand, memoizing proven-clear
+/// answers. A false answer is authoritative -- the object references no symbol
+/// -- so a conforming SymbolUserTypeInterface has a vacuous verifySymbolUses
+/// and need never be visited. A true answer is conservative: a mutable-storage
+/// kind, whose sub-elements may change after the query, and anything containing
+/// one, always answers true.
 class SymbolRefContainmentCache {
 public:
-  SymbolRefContainmentCache() = default;
+  /// `isMultithreaded` is the context's runtime multithreading flag, read live
+  /// on every probe to decide whether the set needs its lock; it must outlive
+  /// this cache.
+  explicit SymbolRefContainmentCache(const bool &isMultithreaded)
+      : isMultithreaded(isMultithreaded) {}
   SymbolRefContainmentCache(const SymbolRefContainmentCache &) = delete;
   SymbolRefContainmentCache &
   operator=(const SymbolRefContainmentCache &) = delete;
 
-  /// Return false for `type`/`attr` if it is recorded clear, or nullopt if it
-  /// is not yet proven clear (unfilled, treated as may-contain by the caller).
-  /// A true answer is never recorded, so lookup never returns true.
-  std::optional<bool> lookup(Type type, bool lock) const {
-    return lookupImpl(typeEntries, type.getAsOpaquePointer(), lock);
-  }
-  std::optional<bool> lookup(Attribute attr, bool lock) const {
-    return lookupImpl(attrEntries, attr.getAsOpaquePointer(), lock);
-  }
-
-  /// Record `type`/`attr` as clear when `value` is false and return the answer
-  /// unchanged. A may-contain (`value` true) fact is not stored -- it is
-  /// recomputed cheaply on each encounter -- so insert then returns true
-  /// without touching the set. A racing duplicate clear fill records the same
-  /// membership and is a no-op.
-  bool insert(Type type, bool value, bool lock) {
-    return insertImpl(typeEntries, type.getAsOpaquePointer(), value, lock);
-  }
-  bool insert(Attribute attr, bool value, bool lock) {
-    return insertImpl(attrEntries, attr.getAsOpaquePointer(), value, lock);
-  }
+  bool mayContainSymbolRefs(Type type) { return compute(type); }
+  bool mayContainSymbolRefs(Attribute attr) { return compute(attr); }
 
 private:
-  /// One uniquer's clear-object set. It is not self-synchronizing: the
-  /// enclosing cache serializes all access with its SmartRWMutex, so every
-  /// method here runs under the read lock (lookup) or the write lock (insert
-  /// and the growth it may trigger).
-  struct ClearSet {
-    llvm::DenseSet<const void *> clear;
+  // A type is never itself a SymbolRefAttr; an attribute is one exactly when
+  // isa<SymbolRefAttr> holds (covering FlatSymbolRefAttr).
+  static bool isSelfSymbolRef(Type) { return false; }
+  static bool isSelfSymbolRef(Attribute attr) {
+    return isa<SymbolRefAttr>(attr);
+  }
 
-    std::optional<bool> lookup(const void *key) const {
-      if (clear.count(key))
-        return false;
-      return std::nullopt;
+  /// Return whether `obj` may transitively contain a SymbolRefAttr, recording a
+  /// proven-clear result so it need never recompute. The recursion needs no
+  /// in-progress guard: immutable objects form a DAG (sub-elements are interned
+  /// before their parents), so every cycle passes through a mutable kind, where
+  /// the descent stops above before reading contents. Once one sub-element
+  /// answers may-contain the rest need not be visited: walkImmediateSubElements
+  /// cannot be interrupted, but the callback is a no-op once `mayContain`
+  /// holds.
+  template <typename T>
+  bool compute(T obj) {
+    const void *key = obj.getAsOpaquePointer();
+    if (isKnownClear(key))
+      return false;
+    bool mayContain = isSelfSymbolRef(obj) ||
+                      obj.template hasTrait<StorageUserTrait::IsMutable>();
+    if (!mayContain) {
+      auto walkSub = [&](auto sub) {
+        if (!mayContain && sub)
+          mayContain = compute(sub);
+      };
+      obj.walkImmediateSubElements(walkSub, walkSub);
     }
+    if (!mayContain)
+      markClear(key);
+    return mayContain;
+  }
 
-    bool insert(const void *key, bool value) {
-      // Only the clear fact is durable; a may-contain answer is left out to be
-      // recomputed cheaply on each encounter. A racing duplicate clear fill
-      // records the same membership and is a no-op.
-      if (!value)
-        clear.insert(key);
-      return value;
-    }
-  };
-
-  std::optional<bool> lookupImpl(const ClearSet &set, const void *key,
-                                 bool lock) const {
+  bool isKnownClear(const void *key) const {
     std::optional<llvm::sys::SmartScopedReader<true>> guard;
-    if (lock)
+    if (shouldLock())
       guard.emplace(mutex);
-    return set.lookup(key);
+    return clear.contains(key);
   }
-
-  bool insertImpl(ClearSet &set, const void *key, bool value, bool lock) {
+  void markClear(const void *key) {
     std::optional<llvm::sys::SmartScopedWriter<true>> guard;
-    if (lock)
+    if (shouldLock())
       guard.emplace(mutex);
-    return set.insert(key, value);
+    clear.insert(key);
   }
 
+  /// The set is serialized only while the context runs multithreaded;
+  /// llvm_is_multithreaded() is a compile-time constant folded in here.
+  bool shouldLock() const {
+    return isMultithreaded && llvm::llvm_is_multithreaded();
+  }
+
+  const bool &isMultithreaded;
+  // The set lives behind this lock: a read lock guards the contains probe, a
+  // write lock the insert and any growth it triggers, and neither is ever held
+  // across the recursion.
   mutable llvm::sys::SmartRWMutex<true> mutex;
-  ClearSet typeEntries;
-  ClearSet attrEntries;
+  // Only the proven-clear opaque pointers are recorded; a may-contain object --
+  // including every mutable-storage kind, whose contents are never read -- is
+  // left out and recomputed on each encounter, so no fact that could later go
+  // stale is ever stored.
+  llvm::DenseSet<const void *> clear;
 };
 
 /// Return the given context's symbol-reference containment cache. Defined in

--- a/mlir/lib/IR/SymbolRefContainmentCache.h
+++ b/mlir/lib/IR/SymbolRefContainmentCache.h
@@ -1,0 +1,99 @@
+//===- SymbolRefContainmentCache.h - Symbol-ref containment cache ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A context-owned store recording, per uniqued type and attribute, whether it
+// may transitively contain a SymbolRefAttr. Symbol-table verification consults
+// it to prune the symbol-use walk.
+//
+// The store is filled lazily and never invalidated. Uniqued storage is immortal
+// and immutable for the context's lifetime, so a cached answer can never go
+// stale, and a pointer can never be recycled to alias another object within one
+// context. Every entry is write-once: false only for a provably
+// reference-free immutable subtree, true for everything else, including
+// mutable-storage kinds, whose contents the fill never reads.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_LIB_IR_SYMBOLREFCONTAINMENTCACHE_H
+#define MLIR_LIB_IR_SYMBOLREFCONTAINMENTCACHE_H
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Types.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/RWMutex.h"
+#include <optional>
+
+namespace mlir {
+class MLIRContext;
+namespace detail {
+
+/// Per-context store of the "may transitively contain a SymbolRefAttr" fact for
+/// uniqued types and attributes. Two maps mirror the context's two uniquers, so
+/// type and attribute opaque pointers never need to be argued disjoint. The
+/// `lock` flag threaded through each operation is the context's runtime
+/// multithreading flag: when it is false the store is touched single-threaded
+/// and no lock is taken, mirroring MLIRContext's ScopedWriterLock.
+class SymbolRefContainmentCache {
+public:
+  SymbolRefContainmentCache() = default;
+  SymbolRefContainmentCache(const SymbolRefContainmentCache &) = delete;
+  SymbolRefContainmentCache &
+  operator=(const SymbolRefContainmentCache &) = delete;
+
+  /// Return the cached answer for `type`/`attr`, or nullopt if not yet filled.
+  std::optional<bool> lookup(Type type, bool lock) const {
+    return lookupImpl(typeEntries, type.getAsOpaquePointer(), lock);
+  }
+  std::optional<bool> lookup(Attribute attr, bool lock) const {
+    return lookupImpl(attrEntries, attr.getAsOpaquePointer(), lock);
+  }
+
+  /// Record `value` for `type`/`attr` if no entry exists yet and return the
+  /// resident answer. A racing duplicate fill computes the same immutable fact,
+  /// so the losing insert is a no-op.
+  bool insert(Type type, bool value, bool lock) {
+    return insertImpl(typeEntries, type.getAsOpaquePointer(), value, lock);
+  }
+  bool insert(Attribute attr, bool value, bool lock) {
+    return insertImpl(attrEntries, attr.getAsOpaquePointer(), value, lock);
+  }
+
+private:
+  using Map = DenseMap<const void *, bool>;
+
+  std::optional<bool> lookupImpl(const Map &map, const void *key,
+                                 bool lock) const {
+    std::optional<llvm::sys::SmartScopedReader<true>> guard;
+    if (lock)
+      guard.emplace(mutex);
+    auto it = map.find(key);
+    if (it == map.end())
+      return std::nullopt;
+    return it->second;
+  }
+
+  bool insertImpl(Map &map, const void *key, bool value, bool lock) {
+    std::optional<llvm::sys::SmartScopedWriter<true>> guard;
+    if (lock)
+      guard.emplace(mutex);
+    return map.try_emplace(key, value).first->second;
+  }
+
+  mutable llvm::sys::SmartRWMutex<true> mutex;
+  Map typeEntries;
+  Map attrEntries;
+};
+
+/// Return the given context's symbol-reference containment cache. Defined in
+/// MLIRContext.cpp, where MLIRContextImpl is visible.
+SymbolRefContainmentCache &getSymbolRefContainmentCache(MLIRContext *ctx);
+
+} // namespace detail
+} // namespace mlir
+
+#endif // MLIR_LIB_IR_SYMBOLREFCONTAINMENTCACHE_H

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -476,6 +476,51 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 // SymbolTable Trait Types
 //===----------------------------------------------------------------------===//
 
+/// Verify the symbol uses held by the types owned by `op`: its operand,
+/// result, and block-argument types, and any types nested within its
+/// attributes. `op` is the anchor used for symbol lookups. `verifiedTypes`
+/// records the types already verified within the current symbol table so that
+/// each type, which may be uniqued and shared across many positions or
+/// operations, is verified at most once. Verification fails fast on the first
+/// invalid symbol use.
+static LogicalResult verifyOpTypeSymbolUses(Operation *op,
+                                            SymbolTableCollection &symbolTable,
+                                            SetVector<Type> &verifiedTypes) {
+  // Walk `type` and any nested type parameters reachable from it, verifying
+  // each not-yet-seen type and interrupting on the first failure.
+  auto verify = [&](Type type) {
+    return type.walk<WalkOrder::PreOrder>([&](Type nestedType) {
+      if (!verifiedTypes.insert(nestedType))
+        return WalkResult::advance();
+      if (auto user = dyn_cast<SymbolUserTypeInterface>(nestedType))
+        if (failed(user.verifySymbolUses(op, symbolTable)))
+          return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+  };
+
+  for (Type type : op->getOperandTypes())
+    if (verify(type).wasInterrupted())
+      return failure();
+  for (Type type : op->getResultTypes())
+    if (verify(type).wasInterrupted())
+      return failure();
+  for (Region &region : op->getRegions())
+    for (Block &block : region)
+      for (BlockArgument argument : block.getArguments())
+        if (verify(argument.getType()).wasInterrupted())
+          return failure();
+
+  // Verify types nested within the operation's attributes.
+  WalkResult attrResult =
+      op->getAttrDictionary().walk<WalkOrder::PreOrder>([&](Type type) {
+        if (verify(type).wasInterrupted())
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      });
+  return failure(attrResult.wasInterrupted());
+}
+
 LogicalResult detail::verifySymbolTable(Operation *op) {
   if (op->getNumRegions() != 1)
     return op->emitOpError()
@@ -506,16 +551,27 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
 
   // Verify any nested symbol user operations.
   SymbolTableCollection symbolTable;
+  // walkSymbolTable does not descend into nested symbol tables, so every
+  // operation visited here shares the same nearest symbol table. A uniqued
+  // attribute or type therefore resolves its symbol uses identically
+  // regardless of which operation anchors the lookup, so each is verified at
+  // most once across the whole scope.
+  SetVector<Attribute> verifiedAttrs;
+  SetVector<Type> verifiedTypes;
   auto verifySymbolUserFn = [&](Operation *op) -> std::optional<WalkResult> {
     if (SymbolUserOpInterface user = dyn_cast<SymbolUserOpInterface>(op))
       if (failed(user.verifySymbolUses(symbolTable)))
         return WalkResult::interrupt();
     for (auto &attr : op->getDiscardableAttrs()) {
       if (auto user = dyn_cast<SymbolUserAttrInterface>(attr.getValue())) {
+        if (!verifiedAttrs.insert(attr.getValue()))
+          continue;
         if (failed(user.verifySymbolUses(op, symbolTable)))
           return WalkResult::interrupt();
       }
     }
+    if (failed(verifyOpTypeSymbolUses(op, symbolTable, verifiedTypes)))
+      return WalkResult::interrupt();
     return WalkResult::advance();
   };
 
@@ -1137,3 +1193,4 @@ ParseResult impl::parseOptionalVisibilityKeyword(OpAsmParser &parser,
 /// Include the generated symbol interfaces.
 #include "mlir/IR/SymbolInterfaces.cpp.inc"
 #include "mlir/IR/SymbolInterfacesAttrInterface.cpp.inc"
+#include "mlir/IR/SymbolInterfacesTypeInterface.cpp.inc"

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/SymbolTable.h"
+#include "SymbolRefContainmentCache.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "llvm/ADT/SetVector.h"
@@ -473,6 +474,62 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 }
 
 //===----------------------------------------------------------------------===//
+// SymbolRefAttr containment query
+//===----------------------------------------------------------------------===//
+
+static bool computeMayContainSymbolRefs(Type type);
+static bool computeMayContainSymbolRefs(Attribute attr);
+
+/// Fill (once) and return the "may transitively contain a SymbolRefAttr" fact
+/// for a uniqued type or attribute `obj`, seeded by `selfIsRef` for an object
+/// that is itself a symbol reference. The answer is computed entirely outside
+/// the cache lock -- which is taken only for the write-once insert -- so no
+/// lock is held across the recursion and a racing duplicate fill computes the
+/// same fact idempotently. A mutable-storage kind may gain sub-elements after
+/// this point, so its contents are never read; it and its containers report
+/// may-contain conservatively.
+template <typename T>
+static bool fillMayContainSymbolRefs(T obj, bool selfIsRef) {
+  MLIRContext *ctx = obj.getContext();
+  bool lock = ctx->isMultithreadingEnabled();
+  detail::SymbolRefContainmentCache &cache =
+      detail::getSymbolRefContainmentCache(ctx);
+  if (std::optional<bool> cached = cache.lookup(obj, lock))
+    return *cached;
+
+  bool mayContain =
+      selfIsRef || obj.template hasTrait<detail::StorageUserTrait::IsMutable>();
+  // The recursion needs no in-progress guard: immutable objects form a DAG
+  // (sub-elements are interned before their parents), so every cycle passes
+  // through a mutable kind, where the fill stops above before descending.
+  if (!mayContain)
+    obj.walkImmediateSubElements(
+        [&](Attribute sub) {
+          mayContain |= sub && computeMayContainSymbolRefs(sub);
+        },
+        [&](Type sub) {
+          mayContain |= sub && computeMayContainSymbolRefs(sub);
+        });
+  return cache.insert(obj, mayContain, lock);
+}
+
+// A type is never itself a SymbolRefAttr; an attribute is one exactly when
+// isa<SymbolRefAttr> holds (covering FlatSymbolRefAttr).
+static bool computeMayContainSymbolRefs(Type type) {
+  return fillMayContainSymbolRefs(type, /*selfIsRef=*/false);
+}
+static bool computeMayContainSymbolRefs(Attribute attr) {
+  return fillMayContainSymbolRefs(attr, /*selfIsRef=*/isa<SymbolRefAttr>(attr));
+}
+
+bool SymbolTable::mayContainSymbolRefs(Type type) {
+  return computeMayContainSymbolRefs(type);
+}
+bool SymbolTable::mayContainSymbolRefs(Attribute attr) {
+  return computeMayContainSymbolRefs(attr);
+}
+
+//===----------------------------------------------------------------------===//
 // SymbolTable Trait Types
 //===----------------------------------------------------------------------===//
 
@@ -485,7 +542,18 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 /// Verification fails fast on the first invalid symbol use.
 static LogicalResult verifyOpTypeSymbolUses(Operation *op,
                                             AttrTypeWalker &walker) {
-  auto verify = [&](Type type) { return walker.walk<WalkOrder::PreOrder>(type); };
+  // A root that provably contains no SymbolRefAttr is not worth entering; the
+  // walker's callbacks prune interior subtrees the same way.
+  auto verify = [&](Type type) {
+    if (!SymbolTable::mayContainSymbolRefs(type))
+      return WalkResult::advance();
+    return walker.walk<WalkOrder::PreOrder>(type);
+  };
+  auto verifyAttr = [&](Attribute attr) {
+    if (!attr || !SymbolTable::mayContainSymbolRefs(attr))
+      return WalkResult::advance();
+    return walker.walk<WalkOrder::PreOrder>(attr);
+  };
 
   for (Type type : op->getOperandTypes())
     if (verify(type).wasInterrupted())
@@ -508,15 +576,15 @@ static LogicalResult verifyOpTypeSymbolUses(Operation *op,
   // properties, and the discardable attributes otherwise; the properties-held
   // inherent attributes are appended into a stack-local NamedAttrList via
   // populateInherentAttrs and walked separately -- the same coverage
-  // getAttrDictionary() provides, since it calls the same populateInherentAttrs.
-  if (walker.walk<WalkOrder::PreOrder>(op->getRawDictionaryAttrs())
-          .wasInterrupted())
+  // getAttrDictionary() provides, since it calls the same
+  // populateInherentAttrs.
+  if (verifyAttr(op->getRawDictionaryAttrs()).wasInterrupted())
     return failure();
   if (op->getPropertiesStorageSize()) {
     NamedAttrList inherentAttrs;
     op->getName().populateInherentAttrs(op, inherentAttrs);
     for (const NamedAttribute &namedAttr : inherentAttrs)
-      if (walker.walk<WalkOrder::PreOrder>(namedAttr.getValue()).wasInterrupted())
+      if (verifyAttr(namedAttr.getValue()).wasInterrupted())
         return failure();
   }
   return success();
@@ -570,9 +638,21 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
   Operation *typeSymbolUseAnchor = nullptr;
   AttrTypeWalker typeWalker;
   typeWalker.addWalk([&](Type type) -> WalkResult {
+    // Prune subtrees that provably hold no SymbolRefAttr: a conforming
+    // SymbolUserTypeInterface spells its references as SymbolRefAttr
+    // sub-elements, so such a type has a vacuous verifySymbolUses.
+    if (!SymbolTable::mayContainSymbolRefs(type))
+      return WalkResult::skip();
     if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
       if (failed(user.verifySymbolUses(typeSymbolUseAnchor, symbolTable)))
         return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  typeWalker.addWalk([&](Attribute attr) -> WalkResult {
+    // Prune reference-free attribute subtrees so the walk descends only where a
+    // SymbolRefAttr, and thus a symbol-using type, may live.
+    if (!SymbolTable::mayContainSymbolRefs(attr))
+      return WalkResult::skip();
     return WalkResult::advance();
   });
 

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -477,23 +477,26 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 // SymbolRefAttr containment query
 //===----------------------------------------------------------------------===//
 
-static bool computeMayContainSymbolRefs(Type type);
-static bool computeMayContainSymbolRefs(Attribute attr);
+static bool
+computeMayContainSymbolRefs(Type type, bool lock,
+                            detail::SymbolRefContainmentCache &cache);
+static bool
+computeMayContainSymbolRefs(Attribute attr, bool lock,
+                            detail::SymbolRefContainmentCache &cache);
 
 /// Fill (once) and return the "may transitively contain a SymbolRefAttr" fact
 /// for a uniqued type or attribute `obj`, seeded by `selfIsRef` for an object
-/// that is itself a symbol reference. The answer is computed entirely outside
-/// the cache lock -- which is taken only for the write-once insert -- so no
-/// lock is held across the recursion and a racing duplicate fill computes the
-/// same fact idempotently. A mutable-storage kind may gain sub-elements after
-/// this point, so its contents are never read; it and its containers report
-/// may-contain conservatively.
+/// that is itself a symbol reference. The context's runtime multithreading flag
+/// `lock` and its containment `cache` are resolved once per verification scope
+/// and threaded through the recursion, so no probe re-derives them. The answer
+/// is computed entirely outside the cache lock -- which is taken only for the
+/// write-once insert -- so no lock is held across the recursion and a racing
+/// duplicate fill computes the same fact idempotently. A mutable-storage kind
+/// may gain sub-elements after this point, so its contents are never read; it
+/// and its containers report may-contain conservatively.
 template <typename T>
-static bool fillMayContainSymbolRefs(T obj, bool selfIsRef) {
-  MLIRContext *ctx = obj.getContext();
-  bool lock = ctx->isMultithreadingEnabled();
-  detail::SymbolRefContainmentCache &cache =
-      detail::getSymbolRefContainmentCache(ctx);
+static bool fillMayContainSymbolRefs(T obj, bool selfIsRef, bool lock,
+                                     detail::SymbolRefContainmentCache &cache) {
   if (std::optional<bool> cached = cache.lookup(obj, lock))
     return *cached;
 
@@ -501,32 +504,46 @@ static bool fillMayContainSymbolRefs(T obj, bool selfIsRef) {
       selfIsRef || obj.template hasTrait<detail::StorageUserTrait::IsMutable>();
   // The recursion needs no in-progress guard: immutable objects form a DAG
   // (sub-elements are interned before their parents), so every cycle passes
-  // through a mutable kind, where the fill stops above before descending.
+  // through a mutable kind, where the fill stops above before descending. Once
+  // one sub-element has answered may-contain, the rest need not be visited:
+  // walkImmediateSubElements cannot be interrupted, but the callback is a no-op
+  // once `mayContain` is set.
   if (!mayContain)
     obj.walkImmediateSubElements(
         [&](Attribute sub) {
-          mayContain |= sub && computeMayContainSymbolRefs(sub);
+          if (!mayContain && sub)
+            mayContain = computeMayContainSymbolRefs(sub, lock, cache);
         },
         [&](Type sub) {
-          mayContain |= sub && computeMayContainSymbolRefs(sub);
+          if (!mayContain && sub)
+            mayContain = computeMayContainSymbolRefs(sub, lock, cache);
         });
   return cache.insert(obj, mayContain, lock);
 }
 
 // A type is never itself a SymbolRefAttr; an attribute is one exactly when
 // isa<SymbolRefAttr> holds (covering FlatSymbolRefAttr).
-static bool computeMayContainSymbolRefs(Type type) {
-  return fillMayContainSymbolRefs(type, /*selfIsRef=*/false);
+static bool
+computeMayContainSymbolRefs(Type type, bool lock,
+                            detail::SymbolRefContainmentCache &cache) {
+  return fillMayContainSymbolRefs(type, /*selfIsRef=*/false, lock, cache);
 }
-static bool computeMayContainSymbolRefs(Attribute attr) {
-  return fillMayContainSymbolRefs(attr, /*selfIsRef=*/isa<SymbolRefAttr>(attr));
+static bool
+computeMayContainSymbolRefs(Attribute attr, bool lock,
+                            detail::SymbolRefContainmentCache &cache) {
+  return fillMayContainSymbolRefs(attr, /*selfIsRef=*/isa<SymbolRefAttr>(attr),
+                                  lock, cache);
 }
 
 bool SymbolTable::mayContainSymbolRefs(Type type) {
-  return computeMayContainSymbolRefs(type);
+  MLIRContext *ctx = type.getContext();
+  return computeMayContainSymbolRefs(type, ctx->isMultithreadingEnabled(),
+                                     detail::getSymbolRefContainmentCache(ctx));
 }
 bool SymbolTable::mayContainSymbolRefs(Attribute attr) {
-  return computeMayContainSymbolRefs(attr);
+  MLIRContext *ctx = attr.getContext();
+  return computeMayContainSymbolRefs(attr, ctx->isMultithreadingEnabled(),
+                                     detail::getSymbolRefContainmentCache(ctx));
 }
 
 //===----------------------------------------------------------------------===//
@@ -540,17 +557,22 @@ bool SymbolTable::mayContainSymbolRefs(Attribute attr) {
 /// makes each uniqued type, which may recur across many positions and
 /// operations, verified against the enclosing symbol table at most once.
 /// Verification fails fast on the first invalid symbol use.
-static LogicalResult verifyOpTypeSymbolUses(Operation *op,
-                                            AttrTypeWalker &walker) {
-  // A root that provably contains no SymbolRefAttr is not worth entering; the
-  // walker's callbacks prune interior subtrees the same way.
+static LogicalResult
+verifyOpTypeSymbolUses(Operation *op, AttrTypeWalker &walker, bool lock,
+                       detail::SymbolRefContainmentCache &cache,
+                       NamedAttrList &inherentAttrs) {
+  // Skip a root that provably holds no SymbolRefAttr before entering the walker
+  // at all: the cheap containment probe spares the walker's out-of-line descent
+  // and keeps its per-scope visited memo confined to subtrees that can actually
+  // carry a symbol use, rather than growing it by every distinct clean root.
+  // The walker's callbacks prune interior subtrees on the same fact.
   auto verify = [&](Type type) {
-    if (!SymbolTable::mayContainSymbolRefs(type))
+    if (!computeMayContainSymbolRefs(type, lock, cache))
       return WalkResult::advance();
     return walker.walk<WalkOrder::PreOrder>(type);
   };
   auto verifyAttr = [&](Attribute attr) {
-    if (!attr || !SymbolTable::mayContainSymbolRefs(attr))
+    if (!attr || !computeMayContainSymbolRefs(attr, lock, cache))
       return WalkResult::advance();
     return walker.walk<WalkOrder::PreOrder>(attr);
   };
@@ -574,14 +596,16 @@ static LogicalResult verifyOpTypeSymbolUses(Operation *op,
   // that keeps its inherent attributes in properties. The raw dictionary
   // already covers inherent attributes for operations that do not use
   // properties, and the discardable attributes otherwise; the properties-held
-  // inherent attributes are appended into a stack-local NamedAttrList via
+  // inherent attributes are appended into a scope-reused NamedAttrList via
   // populateInherentAttrs and walked separately -- the same coverage
   // getAttrDictionary() provides, since it calls the same
-  // populateInherentAttrs.
+  // populateInherentAttrs. The list is cleared before each population so its
+  // heap buffer is reused across operations without accumulating their
+  // attributes.
   if (verifyAttr(op->getRawDictionaryAttrs()).wasInterrupted())
     return failure();
   if (op->getPropertiesStorageSize()) {
-    NamedAttrList inherentAttrs;
+    inherentAttrs.clear();
     op->getName().populateInherentAttrs(op, inherentAttrs);
     for (const NamedAttribute &namedAttr : inherentAttrs)
       if (verifyAttr(namedAttr.getValue()).wasInterrupted())
@@ -627,6 +651,16 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
   // most once across the whole scope.
   SetVector<Attribute> verifiedAttrs;
 
+  // Resolve the containment cache, the context's multithreading flag, and (via
+  // the hoisted NamedAttrList) the properties-attribute scratch buffer once for
+  // the whole scope, then thread them through every containment probe and the
+  // fill recursion, rather than re-deriving them per type occurrence.
+  MLIRContext *ctx = op->getContext();
+  bool cacheLock = ctx->isMultithreadingEnabled();
+  detail::SymbolRefContainmentCache &cache =
+      detail::getSymbolRefContainmentCache(ctx);
+  NamedAttrList inherentAttrs;
+
   // A single walker, shared across the whole scope, checks the symbol uses of
   // every SymbolUserTypeInterface type. Its visited memo records each uniqued
   // type and attribute once, so a subtree recurring across operand, result,
@@ -641,7 +675,7 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
     // Prune subtrees that provably hold no SymbolRefAttr: a conforming
     // SymbolUserTypeInterface spells its references as SymbolRefAttr
     // sub-elements, so such a type has a vacuous verifySymbolUses.
-    if (!SymbolTable::mayContainSymbolRefs(type))
+    if (!computeMayContainSymbolRefs(type, cacheLock, cache))
       return WalkResult::skip();
     if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
       if (failed(user.verifySymbolUses(typeSymbolUseAnchor, symbolTable)))
@@ -651,7 +685,7 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
   typeWalker.addWalk([&](Attribute attr) -> WalkResult {
     // Prune reference-free attribute subtrees so the walk descends only where a
     // SymbolRefAttr, and thus a symbol-using type, may live.
-    if (!SymbolTable::mayContainSymbolRefs(attr))
+    if (!computeMayContainSymbolRefs(attr, cacheLock, cache))
       return WalkResult::skip();
     return WalkResult::advance();
   });
@@ -669,7 +703,8 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
       }
     }
     typeSymbolUseAnchor = op;
-    if (failed(verifyOpTypeSymbolUses(op, typeWalker)))
+    if (failed(verifyOpTypeSymbolUses(op, typeWalker, cacheLock, cache,
+                                      inherentAttrs)))
       return WalkResult::interrupt();
     return WalkResult::advance();
   };

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -474,79 +474,6 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 }
 
 //===----------------------------------------------------------------------===//
-// SymbolRefAttr containment query
-//===----------------------------------------------------------------------===//
-
-static bool
-computeMayContainSymbolRefs(Type type, bool lock,
-                            detail::SymbolRefContainmentCache &cache);
-static bool
-computeMayContainSymbolRefs(Attribute attr, bool lock,
-                            detail::SymbolRefContainmentCache &cache);
-
-/// Fill (once) and return the "may transitively contain a SymbolRefAttr" fact
-/// for a uniqued type or attribute `obj`, seeded by `selfIsRef` for an object
-/// that is itself a symbol reference. The context's runtime multithreading flag
-/// `lock` and its containment `cache` are resolved once per verification scope
-/// and threaded through the recursion, so no probe re-derives them. The answer
-/// is computed entirely outside the cache lock -- which is taken only for the
-/// write-once insert -- so no lock is held across the recursion and a racing
-/// duplicate fill computes the same fact idempotently. A mutable-storage kind
-/// may gain sub-elements after this point, so its contents are never read; it
-/// and its containers report may-contain conservatively.
-template <typename T>
-static bool fillMayContainSymbolRefs(T obj, bool selfIsRef, bool lock,
-                                     detail::SymbolRefContainmentCache &cache) {
-  if (std::optional<bool> cached = cache.lookup(obj, lock))
-    return *cached;
-
-  bool mayContain =
-      selfIsRef || obj.template hasTrait<detail::StorageUserTrait::IsMutable>();
-  // The recursion needs no in-progress guard: immutable objects form a DAG
-  // (sub-elements are interned before their parents), so every cycle passes
-  // through a mutable kind, where the fill stops above before descending. Once
-  // one sub-element has answered may-contain, the rest need not be visited:
-  // walkImmediateSubElements cannot be interrupted, but the callback is a no-op
-  // once `mayContain` is set.
-  if (!mayContain)
-    obj.walkImmediateSubElements(
-        [&](Attribute sub) {
-          if (!mayContain && sub)
-            mayContain = computeMayContainSymbolRefs(sub, lock, cache);
-        },
-        [&](Type sub) {
-          if (!mayContain && sub)
-            mayContain = computeMayContainSymbolRefs(sub, lock, cache);
-        });
-  return cache.insert(obj, mayContain, lock);
-}
-
-// A type is never itself a SymbolRefAttr; an attribute is one exactly when
-// isa<SymbolRefAttr> holds (covering FlatSymbolRefAttr).
-static bool
-computeMayContainSymbolRefs(Type type, bool lock,
-                            detail::SymbolRefContainmentCache &cache) {
-  return fillMayContainSymbolRefs(type, /*selfIsRef=*/false, lock, cache);
-}
-static bool
-computeMayContainSymbolRefs(Attribute attr, bool lock,
-                            detail::SymbolRefContainmentCache &cache) {
-  return fillMayContainSymbolRefs(attr, /*selfIsRef=*/isa<SymbolRefAttr>(attr),
-                                  lock, cache);
-}
-
-bool SymbolTable::mayContainSymbolRefs(Type type) {
-  MLIRContext *ctx = type.getContext();
-  return computeMayContainSymbolRefs(type, ctx->isMultithreadingEnabled(),
-                                     detail::getSymbolRefContainmentCache(ctx));
-}
-bool SymbolTable::mayContainSymbolRefs(Attribute attr) {
-  MLIRContext *ctx = attr.getContext();
-  return computeMayContainSymbolRefs(attr, ctx->isMultithreadingEnabled(),
-                                     detail::getSymbolRefContainmentCache(ctx));
-}
-
-//===----------------------------------------------------------------------===//
 // SymbolTable Trait Types
 //===----------------------------------------------------------------------===//
 
@@ -554,23 +481,24 @@ namespace {
 /// Verifies the symbol uses carried by the types an operation owns -- its
 /// operand, result, and block-argument types, and the types nested within its
 /// attributes -- against the enclosing symbol table, failing fast on the first
-/// invalid use. One instance serves a whole verification scope and is invoked
-/// once per operation, holding the per-scope state each verification would
-/// otherwise re-derive: the context's containment cache and multithreading
-/// flag, a NamedAttrList reused as the scratch buffer for properties-held
+/// invalid use. A root is a type or attribute the operation holds directly: its
+/// operand, result, and block-argument types, and its top-level attributes (the
+/// raw stored dictionary and each properties-held inherent attribute); its
+/// sub-elements are everything beneath. One instance serves a whole
+/// verification scope and is invoked once per operation, holding the per-scope
+/// state each verification would otherwise re-derive: the context's containment
+/// cache, a NamedAttrList reused as the scratch buffer for properties-held
 /// attributes, and a single AttrTypeWalker whose visited memo walks each
 /// uniqued type or attribute -- which may recur across many positions and
 /// operations -- at most once per scope.
 class OpTypeSymbolUseVerifier {
 public:
   OpTypeSymbolUseVerifier(MLIRContext *ctx, SymbolTableCollection &symbolTable)
-      : lock(ctx->isMultithreadingEnabled()),
-        cache(detail::getSymbolRefContainmentCache(ctx)) {
+      : cache(detail::getSymbolRefContainmentCache(ctx)) {
     typeWalker.addWalk([this, &symbolTable](Type type) -> WalkResult {
-      // Prune subtrees that provably hold no SymbolRefAttr: a conforming
-      // SymbolUserTypeInterface spells its references as SymbolRefAttr
-      // sub-elements, so such a type has a vacuous verifySymbolUses.
-      if (!computeMayContainSymbolRefs(type, lock, cache))
+      // Prune subtrees that provably hold no SymbolRefAttr; nothing under them
+      // can carry a symbol use.
+      if (!cache.mayContainSymbolRefs(type))
         return WalkResult::skip();
       if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
         if (failed(user.verifySymbolUses(anchor, symbolTable)))
@@ -580,7 +508,7 @@ public:
     typeWalker.addWalk([this](Attribute attr) -> WalkResult {
       // Prune reference-free attribute subtrees so the walk descends only where
       // a SymbolRefAttr, and thus a symbol-using type, may live.
-      if (!computeMayContainSymbolRefs(attr, lock, cache))
+      if (!cache.mayContainSymbolRefs(attr))
         return WalkResult::skip();
       return WalkResult::advance();
     });
@@ -590,64 +518,59 @@ public:
   /// SymbolUserTypeInterface check at `op`.
   LogicalResult verify(Operation *op) {
     anchor = op;
-    // Skip a root that provably holds no SymbolRefAttr before entering the
-    // walker at all: the cheap containment probe spares the walker's
-    // out-of-line descent and keeps its visited memo confined to subtrees that
-    // can actually carry a symbol use, rather than growing it by every distinct
-    // clean root. The walker's callbacks prune interior subtrees on the same
-    // fact.
-    auto verifyType = [&](Type type) {
-      if (!computeMayContainSymbolRefs(type, lock, cache))
-        return WalkResult::advance();
-      return typeWalker.walk<WalkOrder::PreOrder>(type);
-    };
-    auto verifyAttr = [&](Attribute attr) {
-      if (!attr || !computeMayContainSymbolRefs(attr, lock, cache))
-        return WalkResult::advance();
-      return typeWalker.walk<WalkOrder::PreOrder>(attr);
-    };
-
     for (Type type : op->getOperandTypes())
-      if (verifyType(type).wasInterrupted())
+      if (visit(type).wasInterrupted())
         return failure();
     for (Type type : op->getResultTypes())
-      if (verifyType(type).wasInterrupted())
+      if (visit(type).wasInterrupted())
         return failure();
     for (Region &region : op->getRegions())
       for (Block &block : region)
         for (BlockArgument argument : block.getArguments())
-          if (verifyType(argument.getType()).wasInterrupted())
+          if (visit(argument.getType()).wasInterrupted())
             return failure();
 
-    return success(!forEachAttributeRoot(op, verifyAttr).wasInterrupted());
+    return success(!verifyAttributeRoots(op).wasInterrupted());
   }
 
 private:
-  /// Invoke `root` on each attribute subtree an operation can carry a nested
-  /// type within: its raw stored attribute dictionary as one root, then each
-  /// properties-held inherent attribute, stopping early once `root` interrupts.
-  /// This covers exactly what getAttrDictionary() would walk without allocating
-  /// and uniquing a fresh DictionaryAttr per operation -- the raw dictionary
-  /// already holds the inherent attributes of operations that keep none in
-  /// properties and the discardable attributes otherwise, and
-  /// populateInherentAttrs supplies the properties-held remainder into the
-  /// scope-reused list, cleared before each population so its buffer serves
-  /// every operation without accumulating attributes across them.
-  WalkResult forEachAttributeRoot(Operation *op,
-                                  function_ref<WalkResult(Attribute)> root) {
-    if (root(op->getRawDictionaryAttrs()).wasInterrupted())
+  /// Verify one root, probing its containment before entering the walker. A
+  /// clean top-level root is skipped outright -- kept out of the walk and out
+  /// of the walker's visited memo, unlike the clean interior elements the walk
+  /// memoizes as it descends. A may-contain root is walked and reprobed by the
+  /// walker's root callback, so this spares only the clean roots, which
+  /// dominate.
+  template <typename T>
+  WalkResult visit(T root) {
+    if (!cache.mayContainSymbolRefs(root))
+      return WalkResult::advance();
+    return typeWalker.walk<WalkOrder::PreOrder>(root);
+  }
+
+  /// Verify each attribute root an operation can carry a nested type within:
+  /// its raw stored attribute dictionary as one root, then each properties-held
+  /// inherent attribute, stopping early on the first invalid use. This reaches
+  /// everything getAttrDictionary() would without allocating and uniquing a
+  /// fresh DictionaryAttr per operation -- the raw dictionary already holds the
+  /// inherent attributes of operations that keep none in properties and the
+  /// discardable attributes otherwise, and populateInherentAttrs supplies the
+  /// properties-held remainder into the scope-reused list, cleared before each
+  /// population so its buffer serves every operation without accumulating
+  /// attributes across them. An operation's raw dictionary and a NamedAttribute
+  /// value are both non-null by construction, so no root is ever null.
+  WalkResult verifyAttributeRoots(Operation *op) {
+    if (visit(op->getRawDictionaryAttrs()).wasInterrupted())
       return WalkResult::interrupt();
     if (op->getPropertiesStorageSize()) {
       inherentAttrs.clear();
       op->getName().populateInherentAttrs(op, inherentAttrs);
       for (const NamedAttribute &namedAttr : inherentAttrs)
-        if (root(namedAttr.getValue()).wasInterrupted())
+        if (visit(namedAttr.getValue()).wasInterrupted())
           return WalkResult::interrupt();
     }
     return WalkResult::advance();
   }
 
-  bool lock;
   detail::SymbolRefContainmentCache &cache;
   AttrTypeWalker typeWalker;
   NamedAttrList inherentAttrs;

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -496,9 +496,9 @@ public:
   OpTypeSymbolUseVerifier(MLIRContext *ctx, SymbolTableCollection &symbolTable)
       : cache(detail::getSymbolRefContainmentCache(ctx)) {
     typeWalker.addWalk([this, &symbolTable](Type type) -> WalkResult {
-      // Prune subtrees that provably hold no SymbolRefAttr; nothing under them
-      // can carry a symbol use.
-      if (!cache.mayContainSymbolRefs(type))
+      // Prune subtrees the cache proves free of any SymbolRefAttr; nothing
+      // under them can carry a symbol use.
+      if (cache.isSymbolRefFree(type))
         return WalkResult::skip();
       if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
         if (failed(user.verifySymbolUses(anchor, symbolTable)))
@@ -508,7 +508,7 @@ public:
     typeWalker.addWalk([this](Attribute attr) -> WalkResult {
       // Prune reference-free attribute subtrees so the walk descends only where
       // a SymbolRefAttr, and thus a symbol-using type, may live.
-      if (!cache.mayContainSymbolRefs(attr))
+      if (cache.isSymbolRefFree(attr))
         return WalkResult::skip();
       return WalkResult::advance();
     });
@@ -534,15 +534,15 @@ public:
   }
 
 private:
-  /// Verify one root, probing its containment before entering the walker. A
+  /// Verify one root, first asking the cache whether it is symbol-ref-free. A
   /// clean top-level root is skipped outright -- kept out of the walk and out
   /// of the walker's visited memo, unlike the clean interior elements the walk
-  /// memoizes as it descends. A may-contain root is walked and reprobed by the
-  /// walker's root callback, so this spares only the clean roots, which
-  /// dominate.
+  /// memoizes as it descends. A root that may contain one is walked and
+  /// reprobed by the walker's root callback, so this spares only the clean
+  /// roots, which dominate.
   template <typename T>
   WalkResult visit(T root) {
-    if (!cache.mayContainSymbolRefs(root))
+    if (cache.isSymbolRefFree(root))
       return WalkResult::advance();
     return typeWalker.walk<WalkOrder::PreOrder>(root);
   }

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -476,28 +476,16 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 // SymbolTable Trait Types
 //===----------------------------------------------------------------------===//
 
-/// Verify the symbol uses held by the types owned by `op`: its operand,
-/// result, and block-argument types, and any types nested within its
-/// attributes. `op` is the anchor used for symbol lookups. `verifiedTypes`
-/// records the types already verified within the current symbol table so that
-/// each type, which may be uniqued and shared across many positions or
-/// operations, is verified at most once. Verification fails fast on the first
-/// invalid symbol use.
+/// Verify the symbol uses held by the types owned by `op`: its operand, result,
+/// and block-argument types, and any types nested within its attributes.
+/// `walker` carries the SymbolUserTypeInterface check as a type-walk callback,
+/// anchored at the operation currently being verified, and its visited memo
+/// makes each uniqued type, which may recur across many positions and
+/// operations, verified against the enclosing symbol table at most once.
+/// Verification fails fast on the first invalid symbol use.
 static LogicalResult verifyOpTypeSymbolUses(Operation *op,
-                                            SymbolTableCollection &symbolTable,
-                                            SetVector<Type> &verifiedTypes) {
-  // Walk `type` and any nested type parameters reachable from it, verifying
-  // each not-yet-seen type and interrupting on the first failure.
-  auto verify = [&](Type type) {
-    return type.walk<WalkOrder::PreOrder>([&](Type nestedType) {
-      if (!verifiedTypes.insert(nestedType))
-        return WalkResult::advance();
-      if (auto user = dyn_cast<SymbolUserTypeInterface>(nestedType))
-        if (failed(user.verifySymbolUses(op, symbolTable)))
-          return WalkResult::interrupt();
-      return WalkResult::advance();
-    });
-  };
+                                            AttrTypeWalker &walker) {
+  auto verify = [&](Type type) { return walker.walk<WalkOrder::PreOrder>(type); };
 
   for (Type type : op->getOperandTypes())
     if (verify(type).wasInterrupted())
@@ -511,14 +499,13 @@ static LogicalResult verifyOpTypeSymbolUses(Operation *op,
         if (verify(argument.getType()).wasInterrupted())
           return failure();
 
-  // Verify types nested within the operation's attributes.
-  WalkResult attrResult =
-      op->getAttrDictionary().walk<WalkOrder::PreOrder>([&](Type type) {
-        if (verify(type).wasInterrupted())
-          return WalkResult::interrupt();
-        return WalkResult::advance();
-      });
-  return failure(attrResult.wasInterrupted());
+  // Verify types nested within the operation's attributes. Route the attribute
+  // dictionary through the same walker, and thus the same visited memo, as the
+  // type positions above, so a type recurring across positions and attributes
+  // is verified only at its first occurrence.
+  if (walker.walk<WalkOrder::PreOrder>(op->getAttrDictionary()).wasInterrupted())
+    return failure();
+  return success();
 }
 
 LogicalResult detail::verifySymbolTable(Operation *op) {
@@ -557,7 +544,24 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
   // regardless of which operation anchors the lookup, so each is verified at
   // most once across the whole scope.
   SetVector<Attribute> verifiedAttrs;
-  SetVector<Type> verifiedTypes;
+
+  // A single walker, shared across the whole scope, checks the symbol uses of
+  // every SymbolUserTypeInterface type. Its visited memo records each uniqued
+  // type and attribute once, so a subtree recurring across operand, result,
+  // block-argument, and attribute positions and across operations is walked
+  // only at its first occurrence, whose operation supplies the lookup anchor;
+  // a re-encounter returns from the memo without re-descending. Because a first
+  // occurrence descends the whole subtree pre-order and verification fails
+  // fast, skipping the re-descent verifies nothing new.
+  Operation *typeSymbolUseAnchor = nullptr;
+  AttrTypeWalker typeWalker;
+  typeWalker.addWalk([&](Type type) -> WalkResult {
+    if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
+      if (failed(user.verifySymbolUses(typeSymbolUseAnchor, symbolTable)))
+        return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+
   auto verifySymbolUserFn = [&](Operation *op) -> std::optional<WalkResult> {
     if (SymbolUserOpInterface user = dyn_cast<SymbolUserOpInterface>(op))
       if (failed(user.verifySymbolUses(symbolTable)))
@@ -570,7 +574,8 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
           return WalkResult::interrupt();
       }
     }
-    if (failed(verifyOpTypeSymbolUses(op, symbolTable, verifiedTypes)))
+    typeSymbolUseAnchor = op;
+    if (failed(verifyOpTypeSymbolUses(op, typeWalker)))
       return WalkResult::interrupt();
     return WalkResult::advance();
   };

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -499,12 +499,26 @@ static LogicalResult verifyOpTypeSymbolUses(Operation *op,
         if (verify(argument.getType()).wasInterrupted())
           return failure();
 
-  // Verify types nested within the operation's attributes. Route the attribute
-  // dictionary through the same walker, and thus the same visited memo, as the
-  // type positions above, so a type recurring across positions and attributes
-  // is verified only at its first occurrence.
-  if (walker.walk<WalkOrder::PreOrder>(op->getAttrDictionary()).wasInterrupted())
+  // Verify types nested within the operation's attributes, routed through the
+  // same walker (and thus the same visited memo) as the type positions above.
+  // Read the raw stored attribute dictionary rather than getAttrDictionary():
+  // the latter allocates and uniques a fresh DictionaryAttr for every operation
+  // that keeps its inherent attributes in properties. The raw dictionary
+  // already covers inherent attributes for operations that do not use
+  // properties, and the discardable attributes otherwise; the properties-held
+  // inherent attributes are appended into a stack-local NamedAttrList via
+  // populateInherentAttrs and walked separately -- the same coverage
+  // getAttrDictionary() provides, since it calls the same populateInherentAttrs.
+  if (walker.walk<WalkOrder::PreOrder>(op->getRawDictionaryAttrs())
+          .wasInterrupted())
     return failure();
+  if (op->getPropertiesStorageSize()) {
+    NamedAttrList inherentAttrs;
+    op->getName().populateInherentAttrs(op, inherentAttrs);
+    for (const NamedAttribute &namedAttr : inherentAttrs)
+      if (walker.walk<WalkOrder::PreOrder>(namedAttr.getValue()).wasInterrupted())
+        return failure();
+  }
   return success();
 }
 

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -535,10 +535,10 @@ public:
 
 private:
   /// Verify one root, first asking the cache whether it is symbol-ref-free. A
-  /// clean top-level root is skipped outright -- kept out of the walk and out
-  /// of the walker's visited memo, unlike the clean interior elements the walk
+  /// root proven free is skipped outright -- kept out of the walk and out of
+  /// the walker's visited memo, unlike the free interior elements the walk
   /// memoizes as it descends. A root that may contain one is walked and
-  /// reprobed by the walker's root callback, so this spares only the clean
+  /// reprobed by the walker's root callback, so this spares only the free
   /// roots, which dominate.
   template <typename T>
   WalkResult visit(T root) {

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -550,69 +550,112 @@ bool SymbolTable::mayContainSymbolRefs(Attribute attr) {
 // SymbolTable Trait Types
 //===----------------------------------------------------------------------===//
 
-/// Verify the symbol uses held by the types owned by `op`: its operand, result,
-/// and block-argument types, and any types nested within its attributes.
-/// `walker` carries the SymbolUserTypeInterface check as a type-walk callback,
-/// anchored at the operation currently being verified, and its visited memo
-/// makes each uniqued type, which may recur across many positions and
-/// operations, verified against the enclosing symbol table at most once.
-/// Verification fails fast on the first invalid symbol use.
-static LogicalResult
-verifyOpTypeSymbolUses(Operation *op, AttrTypeWalker &walker, bool lock,
-                       detail::SymbolRefContainmentCache &cache,
-                       NamedAttrList &inherentAttrs) {
-  // Skip a root that provably holds no SymbolRefAttr before entering the walker
-  // at all: the cheap containment probe spares the walker's out-of-line descent
-  // and keeps its per-scope visited memo confined to subtrees that can actually
-  // carry a symbol use, rather than growing it by every distinct clean root.
-  // The walker's callbacks prune interior subtrees on the same fact.
-  auto verify = [&](Type type) {
-    if (!computeMayContainSymbolRefs(type, lock, cache))
+namespace {
+/// Verifies the symbol uses carried by the types an operation owns -- its
+/// operand, result, and block-argument types, and the types nested within its
+/// attributes -- against the enclosing symbol table, failing fast on the first
+/// invalid use. One instance serves a whole verification scope and is invoked
+/// once per operation, holding the per-scope state each verification would
+/// otherwise re-derive: the context's containment cache and multithreading
+/// flag, a NamedAttrList reused as the scratch buffer for properties-held
+/// attributes, and a single AttrTypeWalker whose visited memo walks each
+/// uniqued type or attribute -- which may recur across many positions and
+/// operations -- at most once per scope.
+class OpTypeSymbolUseVerifier {
+public:
+  OpTypeSymbolUseVerifier(MLIRContext *ctx, SymbolTableCollection &symbolTable)
+      : lock(ctx->isMultithreadingEnabled()),
+        cache(detail::getSymbolRefContainmentCache(ctx)) {
+    typeWalker.addWalk([this, &symbolTable](Type type) -> WalkResult {
+      // Prune subtrees that provably hold no SymbolRefAttr: a conforming
+      // SymbolUserTypeInterface spells its references as SymbolRefAttr
+      // sub-elements, so such a type has a vacuous verifySymbolUses.
+      if (!computeMayContainSymbolRefs(type, lock, cache))
+        return WalkResult::skip();
+      if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
+        if (failed(user.verifySymbolUses(anchor, symbolTable)))
+          return WalkResult::interrupt();
       return WalkResult::advance();
-    return walker.walk<WalkOrder::PreOrder>(type);
-  };
-  auto verifyAttr = [&](Attribute attr) {
-    if (!attr || !computeMayContainSymbolRefs(attr, lock, cache))
+    });
+    typeWalker.addWalk([this](Attribute attr) -> WalkResult {
+      // Prune reference-free attribute subtrees so the walk descends only where
+      // a SymbolRefAttr, and thus a symbol-using type, may live.
+      if (!computeMayContainSymbolRefs(attr, lock, cache))
+        return WalkResult::skip();
       return WalkResult::advance();
-    return walker.walk<WalkOrder::PreOrder>(attr);
-  };
-
-  for (Type type : op->getOperandTypes())
-    if (verify(type).wasInterrupted())
-      return failure();
-  for (Type type : op->getResultTypes())
-    if (verify(type).wasInterrupted())
-      return failure();
-  for (Region &region : op->getRegions())
-    for (Block &block : region)
-      for (BlockArgument argument : block.getArguments())
-        if (verify(argument.getType()).wasInterrupted())
-          return failure();
-
-  // Verify types nested within the operation's attributes, routed through the
-  // same walker (and thus the same visited memo) as the type positions above.
-  // Read the raw stored attribute dictionary rather than getAttrDictionary():
-  // the latter allocates and uniques a fresh DictionaryAttr for every operation
-  // that keeps its inherent attributes in properties. The raw dictionary
-  // already covers inherent attributes for operations that do not use
-  // properties, and the discardable attributes otherwise; the properties-held
-  // inherent attributes are appended into a scope-reused NamedAttrList via
-  // populateInherentAttrs and walked separately -- the same coverage
-  // getAttrDictionary() provides, since it calls the same
-  // populateInherentAttrs. The list is cleared before each population so its
-  // heap buffer is reused across operations without accumulating their
-  // attributes.
-  if (verifyAttr(op->getRawDictionaryAttrs()).wasInterrupted())
-    return failure();
-  if (op->getPropertiesStorageSize()) {
-    inherentAttrs.clear();
-    op->getName().populateInherentAttrs(op, inherentAttrs);
-    for (const NamedAttribute &namedAttr : inherentAttrs)
-      if (verifyAttr(namedAttr.getValue()).wasInterrupted())
-        return failure();
+    });
   }
-  return success();
-}
+
+  /// Verify the symbol uses carried by `op`'s types, anchoring each
+  /// SymbolUserTypeInterface check at `op`.
+  LogicalResult verify(Operation *op) {
+    anchor = op;
+    // Skip a root that provably holds no SymbolRefAttr before entering the
+    // walker at all: the cheap containment probe spares the walker's
+    // out-of-line descent and keeps its visited memo confined to subtrees that
+    // can actually carry a symbol use, rather than growing it by every distinct
+    // clean root. The walker's callbacks prune interior subtrees on the same
+    // fact.
+    auto verifyType = [&](Type type) {
+      if (!computeMayContainSymbolRefs(type, lock, cache))
+        return WalkResult::advance();
+      return typeWalker.walk<WalkOrder::PreOrder>(type);
+    };
+    auto verifyAttr = [&](Attribute attr) {
+      if (!attr || !computeMayContainSymbolRefs(attr, lock, cache))
+        return WalkResult::advance();
+      return typeWalker.walk<WalkOrder::PreOrder>(attr);
+    };
+
+    for (Type type : op->getOperandTypes())
+      if (verifyType(type).wasInterrupted())
+        return failure();
+    for (Type type : op->getResultTypes())
+      if (verifyType(type).wasInterrupted())
+        return failure();
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        for (BlockArgument argument : block.getArguments())
+          if (verifyType(argument.getType()).wasInterrupted())
+            return failure();
+
+    return success(!forEachAttributeRoot(op, verifyAttr).wasInterrupted());
+  }
+
+private:
+  /// Invoke `root` on each attribute subtree an operation can carry a nested
+  /// type within: its raw stored attribute dictionary as one root, then each
+  /// properties-held inherent attribute, stopping early once `root` interrupts.
+  /// This covers exactly what getAttrDictionary() would walk without allocating
+  /// and uniquing a fresh DictionaryAttr per operation -- the raw dictionary
+  /// already holds the inherent attributes of operations that keep none in
+  /// properties and the discardable attributes otherwise, and
+  /// populateInherentAttrs supplies the properties-held remainder into the
+  /// scope-reused list, cleared before each population so its buffer serves
+  /// every operation without accumulating attributes across them.
+  WalkResult forEachAttributeRoot(Operation *op,
+                                  function_ref<WalkResult(Attribute)> root) {
+    if (root(op->getRawDictionaryAttrs()).wasInterrupted())
+      return WalkResult::interrupt();
+    if (op->getPropertiesStorageSize()) {
+      inherentAttrs.clear();
+      op->getName().populateInherentAttrs(op, inherentAttrs);
+      for (const NamedAttribute &namedAttr : inherentAttrs)
+        if (root(namedAttr.getValue()).wasInterrupted())
+          return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  }
+
+  bool lock;
+  detail::SymbolRefContainmentCache &cache;
+  AttrTypeWalker typeWalker;
+  NamedAttrList inherentAttrs;
+  // The operation currently being verified; the type-walk anchors each
+  // SymbolUserTypeInterface check here.
+  Operation *anchor = nullptr;
+};
+} // namespace
 
 LogicalResult detail::verifySymbolTable(Operation *op) {
   if (op->getNumRegions() != 1)
@@ -642,53 +685,15 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
     }
   }
 
-  // Verify any nested symbol user operations.
+  // Verify any nested symbol user operations. walkSymbolTable does not descend
+  // into nested symbol tables, so every operation visited here shares one
+  // nearest symbol table; a uniqued attribute or type therefore resolves its
+  // symbol uses identically no matter which operation anchors the lookup, so
+  // each need be verified only once across the whole scope. The type verifier's
+  // walk memo and this attribute set both hold that once-per-scope state.
   SymbolTableCollection symbolTable;
-  // walkSymbolTable does not descend into nested symbol tables, so every
-  // operation visited here shares the same nearest symbol table. A uniqued
-  // attribute or type therefore resolves its symbol uses identically
-  // regardless of which operation anchors the lookup, so each is verified at
-  // most once across the whole scope.
   SetVector<Attribute> verifiedAttrs;
-
-  // Resolve the containment cache, the context's multithreading flag, and (via
-  // the hoisted NamedAttrList) the properties-attribute scratch buffer once for
-  // the whole scope, then thread them through every containment probe and the
-  // fill recursion, rather than re-deriving them per type occurrence.
-  MLIRContext *ctx = op->getContext();
-  bool cacheLock = ctx->isMultithreadingEnabled();
-  detail::SymbolRefContainmentCache &cache =
-      detail::getSymbolRefContainmentCache(ctx);
-  NamedAttrList inherentAttrs;
-
-  // A single walker, shared across the whole scope, checks the symbol uses of
-  // every SymbolUserTypeInterface type. Its visited memo records each uniqued
-  // type and attribute once, so a subtree recurring across operand, result,
-  // block-argument, and attribute positions and across operations is walked
-  // only at its first occurrence, whose operation supplies the lookup anchor;
-  // a re-encounter returns from the memo without re-descending. Because a first
-  // occurrence descends the whole subtree pre-order and verification fails
-  // fast, skipping the re-descent verifies nothing new.
-  Operation *typeSymbolUseAnchor = nullptr;
-  AttrTypeWalker typeWalker;
-  typeWalker.addWalk([&](Type type) -> WalkResult {
-    // Prune subtrees that provably hold no SymbolRefAttr: a conforming
-    // SymbolUserTypeInterface spells its references as SymbolRefAttr
-    // sub-elements, so such a type has a vacuous verifySymbolUses.
-    if (!computeMayContainSymbolRefs(type, cacheLock, cache))
-      return WalkResult::skip();
-    if (auto user = dyn_cast<SymbolUserTypeInterface>(type))
-      if (failed(user.verifySymbolUses(typeSymbolUseAnchor, symbolTable)))
-        return WalkResult::interrupt();
-    return WalkResult::advance();
-  });
-  typeWalker.addWalk([&](Attribute attr) -> WalkResult {
-    // Prune reference-free attribute subtrees so the walk descends only where a
-    // SymbolRefAttr, and thus a symbol-using type, may live.
-    if (!computeMayContainSymbolRefs(attr, cacheLock, cache))
-      return WalkResult::skip();
-    return WalkResult::advance();
-  });
+  OpTypeSymbolUseVerifier typeVerifier(op->getContext(), symbolTable);
 
   auto verifySymbolUserFn = [&](Operation *op) -> std::optional<WalkResult> {
     if (SymbolUserOpInterface user = dyn_cast<SymbolUserOpInterface>(op))
@@ -702,9 +707,7 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
           return WalkResult::interrupt();
       }
     }
-    typeSymbolUseAnchor = op;
-    if (failed(verifyOpTypeSymbolUses(op, typeWalker, cacheLock, cache,
-                                      inherentAttrs)))
+    if (failed(typeVerifier.verify(op)))
       return WalkResult::interrupt();
     return WalkResult::advance();
   };

--- a/mlir/test/IR/test-verifiers-symbol-user-type.mlir
+++ b/mlir/test/IR/test-verifiers-symbol-user-type.mlir
@@ -1,0 +1,95 @@
+// RUN: mlir-opt %s -verify-diagnostics -split-input-file
+
+module {
+  func.func private @existing_symbol()
+
+  "test.type_producer"() : () -> !test.symbol_ref<@existing_symbol>
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.type_producer"() : () -> !test.symbol_ref<@non_existent_symbol>
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  %0 = "test.type_producer"() : () -> !test.symbol_ref<@existing_symbol>
+  "test.type_consumer"(%0) : (!test.symbol_ref<@existing_symbol>) -> ()
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  "test.type_producer"() : () -> tuple<!test.symbol_ref<@existing_symbol>>
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.type_producer"() : () -> tuple<!test.symbol_ref<@non_existent_symbol>>
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  func.func private @uses_symbol_type(%arg0: !test.symbol_ref<@existing_symbol>)
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  func.func private @uses_symbol_type(%arg0: !test.symbol_ref<@non_existent_symbol>)
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  "test.one_region_op"() ({
+  ^bb0(%arg0: !test.symbol_ref<@existing_symbol>):
+    "test.valid"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.one_region_op"() ({
+  ^bb0(%arg0: !test.symbol_ref<@non_existent_symbol>):
+    "test.valid"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  "test.typed_attr"() <{
+    type = !test.symbol_ref<@existing_symbol>,
+    attr = 0 : i32
+  }> : () -> ()
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.typed_attr"() <{
+    type = !test.symbol_ref<@non_existent_symbol>,
+    attr = 0 : i32
+  }> : () -> ()
+}

--- a/mlir/test/lib/Dialect/Test/TestTypeDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestTypeDefs.td
@@ -19,6 +19,7 @@ include "TestAttrDefs.td"
 include "TestInterfaces.td"
 include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/DataLayoutInterfaces.td"
 include "mlir/Dialect/Bufferization/IR/BufferizationTypeInterfaces.td"
 
@@ -82,6 +83,14 @@ def CompoundNestedOuterTypeQual : Test_Type<"CompoundNestedOuterQual"> {
     CompoundNestedInnerType:$inner
   );
   let assemblyFormat = "`<` `i`  qualified($inner) `>`";
+}
+
+def TestSymbolUserType : Test_Type<"TestSymbolUser",
+    [DeclareTypeInterfaceMethods<SymbolUserTypeInterface>]> {
+  let mnemonic = "symbol_ref";
+  let summary = "Test type that references a symbol";
+  let parameters = (ins "::mlir::FlatSymbolRefAttr":$symbol);
+  let assemblyFormat = "`<` $symbol `>`";
 }
 
 // An example of how one could implement a standard integer.

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -333,6 +333,19 @@ uint64_t TestTypeWithLayoutType::extractKind(DataLayoutEntryListRef params,
 }
 
 //===----------------------------------------------------------------------===//
+// TestSymbolUserType
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+TestSymbolUserType::verifySymbolUses(Operation *op,
+                                     SymbolTableCollection &symbolTable) const {
+  if (!symbolTable.lookupNearestSymbolFrom<SymbolOpInterface>(op, getSymbol()))
+    return op->emitOpError()
+           << "'" << getSymbol() << "' does not reference a valid symbol";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Dynamic Types
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/lib/Dialect/Test/TestTypes.h
+++ b/mlir/test/lib/Dialect/Test/TestTypes.h
@@ -24,6 +24,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_unittest(MLIRIRTests
   PatternMatchTest.cpp
   RemarkTest.cpp  
   ShapedTypeTest.cpp
+  SymbolReferenceContainmentTest.cpp
   SymbolTableTest.cpp
   TypeTest.cpp
   TypeAttrNamesTest.cpp

--- a/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
+++ b/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Tests for the per-context symbol-reference containment cache, which records
-// which uniqued types and attributes are provably free of a transitive
-// SymbolRefAttr; everything else, including mutable storage, answers true
-// conservatively. Symbol-table verification relies on it to prune the
-// symbol-using types it would otherwise walk. Because a SymbolUserTypeInterface
-// implementation must spell its references as SymbolRefAttr sub-elements, a
-// false answer is a sound reason to skip such a type even after the interface
-// is attached late.
+// Tests for the per-context symbol-reference containment cache, whose
+// isSymbolRefFree query answers true for a uniqued type or attribute proven
+// free of any transitive SymbolRefAttr, and false conservatively otherwise
+// (including mutable storage). Symbol-table verification relies on it to prune
+// the symbol-using types it would otherwise walk. Because a
+// SymbolUserTypeInterface implementation must spell its references as
+// SymbolRefAttr sub-elements, a true (free) answer is a sound reason to skip
+// such a type even after the interface is attached late.
 //
 //===----------------------------------------------------------------------===//
 
@@ -76,15 +76,14 @@ protected:
     return test::TestSymbolRefAttr::get(&context, symbolRef());
   }
 
-  // Query the cache for `obj`. The row index names a failed row without
-  // printing `obj`, which a mutable-storage kind with an unset body cannot
-  // survive.
+  // Query the cache for `obj`; `expected` is whether it is proven symbol-ref-
+  // free. The row index names a failed row without printing `obj`, which a
+  // mutable-storage kind with an unset body cannot survive.
   template <typename T>
   void expect(T obj, bool expected) {
     SCOPED_TRACE("containment row " + std::to_string(++row));
     EXPECT_EQ(
-        detail::getSymbolRefContainmentCache(&context).mayContainSymbolRefs(
-            obj),
+        detail::getSymbolRefContainmentCache(&context).isSymbolRefFree(obj),
         expected);
   }
 
@@ -92,77 +91,78 @@ protected:
   MLIRContext context;
 };
 
-// The containment answer across leaves, self-references, conforming user
+// The symbol-ref-free answer across leaves, self-references, conforming user
 // types/attributes, and every nesting path a symbol reference can hide behind.
 TEST_F(SymbolReferenceContainmentTest, ContainmentTruthTable) {
   Type i32 = IntegerType::get(&context, 32);
 
-  // Leaves hold no reference.
-  expect(i32, false);
-  expect(StringAttr::get(&context, "hi"), false);
-  expect(TypeAttr::get(i32), false);
+  // Leaves hold no reference and are free.
+  expect(i32, true);
+  expect(StringAttr::get(&context, "hi"), true);
+  expect(TypeAttr::get(i32), true);
 
-  // A SymbolRefAttr, flat or nesting further references, is itself a reference.
-  expect(symbolRef(), true);
+  // A SymbolRefAttr, flat or nesting further references, is itself a reference,
+  // so it is not free.
+  expect(symbolRef(), false);
   expect(SymbolRefAttr::get(StringAttr::get(&context, "root"),
                             {FlatSymbolRefAttr::get(&context, "n")}),
-         true);
+         false);
 
-  // A conforming symbol-user type/attribute answers true through its
-  // SymbolRefAttr parameter, not through the interface (which plays no part).
-  expect(symbolUserType(), true);
-  expect(symbolUserAttr(), true);
+  // A conforming symbol-user type/attribute is not free -- it carries a
+  // SymbolRefAttr parameter (the interface plays no part in the answer).
+  expect(symbolUserType(), false);
+  expect(symbolUserAttr(), false);
 
-  // Nesting propagates the reference; ordinary nesting stays clear.
-  expect(TupleType::get(&context, {symbolUserType()}), true);
-  expect(TupleType::get(&context, {i32, i32}), false);
+  // Nesting propagates the reference; ordinary nesting stays free.
+  expect(TupleType::get(&context, {symbolUserType()}), false);
+  expect(TupleType::get(&context, {i32, i32}), true);
 
   // A type reaches a reference through an attribute sub-element -- a plain
   // SymbolRefAttr encoding, or a TypeAttr of a symbol-ref-bearing type.
-  expect(RankedTensorType::get({2}, i32, symbolRef()), true);
-  expect(TypeAttr::get(symbolUserType()), true);
+  expect(RankedTensorType::get({2}, i32, symbolRef()), false);
+  expect(TypeAttr::get(symbolUserType()), false);
   expect(RankedTensorType::get({2}, i32, TypeAttr::get(symbolUserType())),
-         true);
+         false);
 
   // A dictionary summarizes its whole nested tree, whichever way a reference
-  // hides, and stays clear when none does.
+  // hides, and stays free when none does.
   expect(DictionaryAttr::get(
              &context, {NamedAttribute(StringAttr::get(&context, "callee"),
                                        symbolRef())}),
-         true);
+         false);
   expect(DictionaryAttr::get(&context,
                              {NamedAttribute(StringAttr::get(&context, "key"),
                                              TypeAttr::get(symbolUserType()))}),
-         true);
+         false);
   expect(DictionaryAttr::get(&context,
                              {NamedAttribute(StringAttr::get(&context, "key"),
                                              TypeAttr::get(i32))}),
-         false);
+         true);
 
-  // A mutable-storage kind, and any container of one, answers true
+  // A mutable-storage kind, and any container of one, answers not-free
   // conservatively: its sub-elements may change after the query, so its
-  // contents are never read and no later mutation can turn a cached false
+  // contents are never read and no later mutation can turn a cached-free answer
   // stale.
-  expect(test::TestRecursiveType::get(&context, "rec"), true);
+  expect(test::TestRecursiveType::get(&context, "rec"), false);
   expect(
       TupleType::get(&context, {test::TestRecursiveType::get(&context, "c")}),
-      true);
+      false);
 
   // A DistinctAttr is keyed by its own always-allocated storage address, not
-  // the attribute uniquer; two instances answer false independently, and a
+  // the attribute uniquer; two instances answer free independently, and a
   // repeat query is stable across the cold fill and the warm hit.
   DistinctAttr d1 = DistinctAttr::create(UnitAttr::get(&context));
   DistinctAttr d2 = DistinctAttr::create(UnitAttr::get(&context));
   ASSERT_NE(d1, d2);
-  expect(d1, false);
-  expect(d1, false);
-  expect(d2, false);
+  expect(d1, true);
+  expect(d1, true);
+  expect(d2, true);
 }
 
 // Interface membership plays no part in the answer, so late attachment needs no
 // fallback: a type that structurally holds a SymbolRefAttr (a tensor with a
-// symbol-ref encoding) answers true from interning, so verification visits it
-// and the newly-attached verifySymbolUses fires.
+// symbol-ref encoding) is not symbol-ref-free from interning, so verification
+// visits it and the newly-attached verifySymbolUses fires.
 TEST_F(SymbolReferenceContainmentTest, LateInterfaceAttachmentStillVerifies) {
   OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(
       "module { \"foo.op\"() : () -> tensor<4xf32, @sym> }", &context);
@@ -177,9 +177,9 @@ TEST_F(SymbolReferenceContainmentTest, LateInterfaceAttachmentStillVerifies) {
 
 // The contract boundary: a type that references a symbol without spelling it as
 // a SymbolRefAttr (here f32, standing in for a non-conforming symbol-user type)
-// answers false and is therefore skipped -- its verifySymbolUses never fires,
-// so verification succeeds. This is the documented cost of the interface
-// contract.
+// answers symbol-ref-free and is therefore skipped -- its verifySymbolUses
+// never fires, so verification succeeds. This is the documented cost of the
+// interface contract.
 TEST_F(SymbolReferenceContainmentTest, NonConformingSymbolUserTypeIsSkipped) {
   OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(
       "module { \"foo.op\"() : () -> f32 }", &context);
@@ -236,9 +236,9 @@ TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
   std::vector<Type> types = buildTypes(context);
   std::vector<bool> attrTruth, typeTruth;
   for (Attribute a : attrs)
-    attrTruth.push_back(truthCache.mayContainSymbolRefs(a));
+    attrTruth.push_back(truthCache.isSymbolRefFree(a));
   for (Type t : types)
-    typeTruth.push_back(truthCache.mayContainSymbolRefs(t));
+    typeTruth.push_back(truthCache.isSymbolRefFree(t));
 
   MLIRContext raced;
   raced.loadDialect<test::TestDialect>();
@@ -260,9 +260,9 @@ TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
       while (!go.load())
         ;
       for (Attribute a : racedAttrs)
-        attrResults[i].push_back(racedCache.mayContainSymbolRefs(a));
+        attrResults[i].push_back(racedCache.isSymbolRefFree(a));
       for (Type t : racedTypes)
-        typeResults[i].push_back(racedCache.mayContainSymbolRefs(t));
+        typeResults[i].push_back(racedCache.isSymbolRefFree(t));
     });
   while (ready.load() < numThreads)
     ;

--- a/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
+++ b/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Parser/Parser.h"
 #include "gtest/gtest.h"
 
+#include "../../lib/IR/SymbolRefContainmentCache.h"
 #include "../../test/lib/Dialect/Test/TestAttributes.h"
 #include "../../test/lib/Dialect/Test/TestDialect.h"
 #include "../../test/lib/Dialect/Test/TestTypes.h"
@@ -331,6 +332,75 @@ TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
     EXPECT_EQ(attrResults[i], attrTruth) << "thread " << i;
     EXPECT_EQ(typeResults[i], typeTruth) << "thread " << i;
   }
+}
+
+// Growth preserves every earlier fact. The cache's internal table starts
+// minimal and doubles as it fills, so inserting far past the growth trigger
+// forces several rehashes; open addressing must re-home every live slot on each
+// grow. Synthetic 8-aligned pointers in a regular stride stand in for the
+// bump-allocated storage addresses the cache keys on; the keys are opaque and
+// never dereferenced. Because a probe runs to the empty slot, preservation
+// holds for any home function, so this exercises the rehash, not the mix -- the
+// mix instead keeps the table's capacity bounded when storage addresses arrive
+// in a stride, which this test does not measure.
+TEST_F(SymbolReferenceContainmentTest, TableGrowthPreservesEntries) {
+  detail::SymbolRefContainmentCache cache;
+  const int n = 5000; // many doublings past the minimal table
+  std::vector<Type> keys;
+  keys.reserve(n);
+  for (int i = 0; i < n; ++i) {
+    auto *p = reinterpret_cast<const void *>(
+        static_cast<uintptr_t>(0x100000 + i * 8));
+    Type key = Type::getFromOpaquePointer(p);
+    bool value = (i % 3 == 0); // a deterministic mix of true/false facts
+    // The first insert of a key returns the value it records.
+    EXPECT_EQ(cache.insert(key, value, /*lock=*/false), value);
+    keys.push_back(key);
+  }
+  // After all the growth, every earlier fact is still found with its value.
+  for (int i = 0; i < n; ++i) {
+    std::optional<bool> got = cache.lookup(keys[i], /*lock=*/false);
+    ASSERT_TRUE(got.has_value()) << "lost entry " << i;
+    EXPECT_EQ(*got, (i % 3 == 0)) << "entry " << i;
+  }
+  // A key never inserted is a miss, not a stray cluster hit.
+  Type absent = Type::getFromOpaquePointer(
+      reinterpret_cast<const void *>(static_cast<uintptr_t>(0x100000 + n * 8)));
+  EXPECT_FALSE(cache.lookup(absent, /*lock=*/false).has_value());
+}
+
+// A DistinctAttr is keyed by the address of its own storage, which comes from a
+// separate always-allocating allocator rather than the attribute uniquer; the
+// cache must tag and recover that pointer just like a uniqued one. Its
+// 8-alignment, which frees bit 0 for the answer tag, is asserted at compile
+// time beside the table; this exercises the runtime path.
+TEST_F(SymbolReferenceContainmentTest, DistinctAttrIsHandled) {
+  DistinctAttr d1 = DistinctAttr::create(UnitAttr::get(&context));
+  DistinctAttr d2 = DistinctAttr::create(UnitAttr::get(&context));
+  ASSERT_NE(d1, d2); // always-allocating: distinct instances, distinct pointers
+
+  // The separate allocator must still hand back 8-aligned storage, so bit 0 of
+  // the opaque pointer is free for the answer tag.
+  EXPECT_EQ(
+      reinterpret_cast<uintptr_t>(Attribute(d1).getAsOpaquePointer()) & 1u, 0u);
+
+  // Through the public query a DistinctAttr exposes no SymbolRefAttr
+  // sub-element, so it answers false, stably across the cold fill and the warm
+  // cache hit.
+  bool cold = SymbolTable::mayContainSymbolRefs(d1);
+  EXPECT_FALSE(cold);
+  EXPECT_EQ(SymbolTable::mayContainSymbolRefs(d1), cold);
+  EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(d2));
+
+  // Drive the tag round-trip with bit 0 set on a distinct-allocator pointer: a
+  // forced true must survive the insert and be returned by the warm lookup,
+  // while an uninserted distinct pointer stays a miss.
+  detail::SymbolRefContainmentCache cache;
+  EXPECT_TRUE(cache.insert(d1, /*value=*/true, /*lock=*/false));
+  std::optional<bool> warm = cache.lookup(d1, /*lock=*/false);
+  ASSERT_TRUE(warm.has_value());
+  EXPECT_TRUE(*warm);
+  EXPECT_FALSE(cache.lookup(d2, /*lock=*/false).has_value());
 }
 
 } // namespace

--- a/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
+++ b/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
@@ -1,0 +1,336 @@
+//===- SymbolReferenceContainmentTest.cpp - Containment query unit tests --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for SymbolTable::mayContainSymbolRefs, which records per uniqued type
+// or attribute whether it transitively contains a SymbolRefAttr (conservatively
+// true for mutable storage). Symbol-table verification relies on it to prune
+// types and attributes that provably hold no symbol reference. Because a
+// SymbolUserTypeInterface / SymbolUserAttrInterface implementation must spell
+// its references as SymbolRefAttr sub-elements, a false answer is a sound
+// reason to skip an instance even after the interface is attached late.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "gtest/gtest.h"
+
+#include "../../test/lib/Dialect/Test/TestAttributes.h"
+#include "../../test/lib/Dialect/Test/TestDialect.h"
+#include "../../test/lib/Dialect/Test/TestTypes.h"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace mlir;
+
+namespace {
+
+// Symbol-user models whose verification always fails, attached externally to
+// exercise late interface attachment. One targets a type that structurally
+// holds a SymbolRefAttr (a tensor with a symbol-ref encoding); the other
+// targets f32, which holds none.
+struct FailingTensorSymbolUserModel
+    : public SymbolUserTypeInterface::ExternalModel<
+          FailingTensorSymbolUserModel, RankedTensorType> {
+  LogicalResult verifySymbolUses(Type type, Operation *op,
+                                 SymbolTableCollection &symbolTable) const {
+    return op->emitError("tensor rejected by its attached symbol-user model");
+  }
+};
+struct FailingF32SymbolUserModel
+    : public SymbolUserTypeInterface::ExternalModel<FailingF32SymbolUserModel,
+                                                    Float32Type> {
+  LogicalResult verifySymbolUses(Type type, Operation *op,
+                                 SymbolTableCollection &symbolTable) const {
+    return op->emitError("f32 rejected by its attached symbol-user model");
+  }
+};
+
+class SymbolReferenceContainmentTest : public ::testing::Test {
+protected:
+  SymbolReferenceContainmentTest() {
+    context.loadDialect<test::TestDialect>();
+    context.allowUnregisteredDialects();
+  }
+
+  FlatSymbolRefAttr symbolRef() {
+    return FlatSymbolRefAttr::get(&context, "sym");
+  }
+
+  // A conforming type implementing SymbolUserTypeInterface, spelling its
+  // reference as a FlatSymbolRefAttr parameter: !test.symbol_ref<@sym>.
+  test::TestSymbolUserType symbolUserType() {
+    return test::TestSymbolUserType::get(&context, symbolRef());
+  }
+
+  // A conforming attribute implementing SymbolUserAttrInterface, spelling its
+  // reference as a FlatSymbolRefAttr parameter: #test.symbol_ref_attr<@sym>.
+  test::TestSymbolRefAttr symbolUserAttr() {
+    return test::TestSymbolRefAttr::get(&context, symbolRef());
+  }
+
+  MLIRContext context;
+};
+
+// A leaf type holding no symbol reference answers false.
+TEST_F(SymbolReferenceContainmentTest, LeafTypeIsClear) {
+  EXPECT_FALSE(
+      SymbolTable::mayContainSymbolRefs(IntegerType::get(&context, 32)));
+}
+
+// A plain attribute holding no symbol reference answers false.
+TEST_F(SymbolReferenceContainmentTest, LeafAttrIsClear) {
+  EXPECT_FALSE(
+      SymbolTable::mayContainSymbolRefs(StringAttr::get(&context, "hi")));
+  EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(
+      TypeAttr::get(IntegerType::get(&context, 32))));
+}
+
+// A SymbolRefAttr itself answers true.
+TEST_F(SymbolReferenceContainmentTest, FlatSymbolRefAttrIsTrue) {
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(symbolRef()));
+}
+
+// A non-flat SymbolRefAttr, which nests further references, answers true.
+TEST_F(SymbolReferenceContainmentTest, NestedSymbolRefAttrIsTrue) {
+  SymbolRefAttr ref =
+      SymbolRefAttr::get(StringAttr::get(&context, "root"),
+                         {FlatSymbolRefAttr::get(&context, "n")});
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(ref));
+}
+
+// A conforming symbol-user type answers true through its SymbolRefAttr
+// parameter (not through the interface, which plays no part in the answer).
+TEST_F(SymbolReferenceContainmentTest, ConformingSymbolUserTypeIsTrue) {
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(symbolUserType()));
+}
+
+// A conforming symbol-user attribute answers true through its SymbolRefAttr
+// parameter.
+TEST_F(SymbolReferenceContainmentTest, ConformingSymbolUserAttrIsTrue) {
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(symbolUserAttr()));
+}
+
+// A type nesting a symbol-ref-bearing type propagates true.
+TEST_F(SymbolReferenceContainmentTest, TypeNestingSymbolRefBearingType) {
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(
+      TupleType::get(&context, {symbolUserType()})));
+}
+
+// A tuple of ordinary types stays false.
+TEST_F(SymbolReferenceContainmentTest, TypeNestingOrdinaryTypesIsClear) {
+  Type i32 = IntegerType::get(&context, 32);
+  EXPECT_FALSE(
+      SymbolTable::mayContainSymbolRefs(TupleType::get(&context, {i32, i32})));
+}
+
+// A type reaches a SymbolRefAttr two levels deep, through an attribute
+// sub-element (a tensor encoding holding a TypeAttr of a symbol-ref type).
+TEST_F(SymbolReferenceContainmentTest, TypeReachesSymbolRefThroughAttribute) {
+  Attribute encoding = TypeAttr::get(symbolUserType());
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(encoding));
+  RankedTensorType tensor =
+      RankedTensorType::get({2}, IntegerType::get(&context, 32), encoding);
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(tensor));
+}
+
+// A type reaches a plain SymbolRefAttr through an attribute parameter (a tensor
+// encoding).
+TEST_F(SymbolReferenceContainmentTest, TypeWithSymbolRefAttrParameter) {
+  RankedTensorType tensor =
+      RankedTensorType::get({2}, IntegerType::get(&context, 32), symbolRef());
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(tensor));
+}
+
+// A dictionary attribute containing a plain SymbolRefAttr answers true.
+TEST_F(SymbolReferenceContainmentTest, DictionaryAttrContainingSymbolRef) {
+  NamedAttribute named(StringAttr::get(&context, "callee"), symbolRef());
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(
+      DictionaryAttr::get(&context, {named})));
+}
+
+// A dictionary attribute containing a symbol-ref-bearing type inside a TypeAttr
+// answers true; the answer on the dictionary summarizes its whole nested tree.
+TEST_F(SymbolReferenceContainmentTest, DictionaryAttrContainingSymbolRefType) {
+  NamedAttribute named(StringAttr::get(&context, "key"),
+                       TypeAttr::get(symbolUserType()));
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(
+      DictionaryAttr::get(&context, {named})));
+}
+
+// A dictionary attribute with no symbol reference stays false.
+TEST_F(SymbolReferenceContainmentTest, DictionaryAttrIsClear) {
+  NamedAttribute named(StringAttr::get(&context, "key"),
+                       TypeAttr::get(IntegerType::get(&context, 32)));
+  EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(
+      DictionaryAttr::get(&context, {named})));
+}
+
+// A type carrying a mutable component answers true conservatively, since its
+// sub-elements may change after the answer is computed at first query; the
+// fill never reads its contents.
+TEST_F(SymbolReferenceContainmentTest, MutableTypeReportsConservatively) {
+  test::TestRecursiveType recursive =
+      test::TestRecursiveType::get(&context, "rec");
+  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(recursive));
+}
+
+// A container of a mutable-storage kind inherits true, even before the mutable
+// body is populated, so no later mutation can turn a cached false stale.
+TEST_F(SymbolReferenceContainmentTest, ContainerOfMutableTypeIsTrue) {
+  test::TestRecursiveType recursive =
+      test::TestRecursiveType::get(&context, "rec2");
+  EXPECT_TRUE(
+      SymbolTable::mayContainSymbolRefs(TupleType::get(&context, {recursive})));
+}
+
+// Interface membership plays no part in the answer, so late attachment needs no
+// fallback: a type that structurally holds a SymbolRefAttr (a tensor with a
+// symbol-ref encoding) answers true from interning, so verification visits it
+// and the newly-attached verifySymbolUses fires.
+TEST_F(SymbolReferenceContainmentTest, LateInterfaceAttachmentStillVerifies) {
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(
+      "module { \"foo.op\"() : () -> tensor<4xf32, @sym> }", &context);
+  ASSERT_TRUE(module);
+
+  RankedTensorType::attachInterface<FailingTensorSymbolUserModel>(context);
+  ScopedDiagnosticHandler handler(&context,
+                                  [](Diagnostic &) { return success(); });
+  EXPECT_TRUE(failed(verify(*module)));
+}
+
+// The contract boundary: a type that references a symbol without spelling it as
+// a SymbolRefAttr (here f32, standing in for a non-conforming symbol-user type)
+// answers false and is therefore skipped -- its verifySymbolUses never fires,
+// so verification succeeds. This is the documented cost of the interface
+// contract.
+TEST_F(SymbolReferenceContainmentTest, NonConformingSymbolUserTypeIsSkipped) {
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(
+      "module { \"foo.op\"() : () -> f32 }", &context);
+  ASSERT_TRUE(module);
+
+  Float32Type::attachInterface<FailingF32SymbolUserModel>(context);
+  ScopedDiagnosticHandler handler(&context,
+                                  [](Diagnostic &) { return success(); });
+  EXPECT_TRUE(succeeded(verify(*module)));
+}
+
+// Concurrency crux: many threads query the same cold, shared objects at once,
+// exactly as parallel symbol-table verification fills the context cache from
+// several isolated-op workers simultaneously. Every thread must agree with the
+// single-threaded ground truth, and the run must be clean under
+// ThreadSanitizer. Built cold (constructed but never queried before the
+// threads start) so the fills genuinely race.
+TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
+  ASSERT_TRUE(context.isMultithreadingEnabled());
+
+  // A set of shared objects spanning the interesting fill paths and sharing
+  // sub-elements, so concurrent fills overlap on the same interior objects.
+  Type i32 = IntegerType::get(&context, 32);
+  std::vector<Attribute> attrs = {
+      StringAttr::get(&context, "leaf"),
+      symbolRef(),
+      symbolUserAttr(),
+      TypeAttr::get(symbolUserType()),
+      DictionaryAttr::get(
+          &context,
+          {NamedAttribute(StringAttr::get(&context, "callee"), symbolRef())}),
+      DictionaryAttr::get(&context,
+                          {NamedAttribute(StringAttr::get(&context, "plain"),
+                                          TypeAttr::get(i32))}),
+  };
+  std::vector<Type> types = {
+      i32,
+      symbolUserType(),
+      TupleType::get(&context, {i32, symbolUserType()}),
+      TupleType::get(&context, {i32, i32}),
+      RankedTensorType::get({2}, i32, symbolRef()),
+  };
+
+  // Ground truth computed single-threaded (this also warms nothing new for the
+  // threads, since these very objects are what they race to fill).
+  std::vector<bool> attrTruth, typeTruth;
+  for (Attribute a : attrs)
+    attrTruth.push_back(SymbolTable::mayContainSymbolRefs(a));
+  for (Type t : types)
+    typeTruth.push_back(SymbolTable::mayContainSymbolRefs(t));
+
+  // Fresh context so the threads hit a cold cache and genuinely race the fills.
+  MLIRContext raced;
+  raced.loadDialect<test::TestDialect>();
+  raced.allowUnregisteredDialects();
+  ASSERT_TRUE(raced.isMultithreadingEnabled());
+  auto rebuildAttrs = [&](MLIRContext &ctx) {
+    Type ri32 = IntegerType::get(&ctx, 32);
+    FlatSymbolRefAttr rsym = FlatSymbolRefAttr::get(&ctx, "sym");
+    return std::vector<Attribute>{
+        StringAttr::get(&ctx, "leaf"),
+        rsym,
+        test::TestSymbolRefAttr::get(&ctx, rsym),
+        TypeAttr::get(test::TestSymbolUserType::get(&ctx, rsym)),
+        DictionaryAttr::get(
+            &ctx, {NamedAttribute(StringAttr::get(&ctx, "callee"), rsym)}),
+        DictionaryAttr::get(&ctx,
+                            {NamedAttribute(StringAttr::get(&ctx, "plain"),
+                                            TypeAttr::get(ri32))}),
+    };
+  };
+  auto rebuildTypes = [&](MLIRContext &ctx) {
+    Type ri32 = IntegerType::get(&ctx, 32);
+    FlatSymbolRefAttr rsym = FlatSymbolRefAttr::get(&ctx, "sym");
+    test::TestSymbolUserType user = test::TestSymbolUserType::get(&ctx, rsym);
+    return std::vector<Type>{
+        ri32,
+        user,
+        TupleType::get(&ctx, {ri32, user}),
+        TupleType::get(&ctx, {ri32, ri32}),
+        RankedTensorType::get({2}, ri32, rsym),
+    };
+  };
+  std::vector<Attribute> racedAttrs = rebuildAttrs(raced);
+  std::vector<Type> racedTypes = rebuildTypes(raced);
+
+  const int numThreads = 16;
+  std::vector<std::vector<bool>> attrResults(numThreads);
+  std::vector<std::vector<bool>> typeResults(numThreads);
+  std::atomic<int> ready{0};
+  std::atomic<bool> go{false};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < numThreads; ++i)
+    threads.emplace_back([&, i] {
+      ready.fetch_add(1);
+      while (!go.load())
+        ;
+      for (Attribute a : racedAttrs)
+        attrResults[i].push_back(SymbolTable::mayContainSymbolRefs(a));
+      for (Type t : racedTypes)
+        typeResults[i].push_back(SymbolTable::mayContainSymbolRefs(t));
+    });
+  while (ready.load() < numThreads)
+    ;
+  go.store(true);
+  for (std::thread &t : threads)
+    t.join();
+
+  for (int i = 0; i < numThreads; ++i) {
+    ASSERT_EQ(attrResults[i].size(), attrTruth.size());
+    ASSERT_EQ(typeResults[i].size(), typeTruth.size());
+    EXPECT_EQ(attrResults[i], attrTruth) << "thread " << i;
+    EXPECT_EQ(typeResults[i], typeTruth) << "thread " << i;
+  }
+}
+
+} // namespace

--- a/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
+++ b/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
@@ -334,35 +334,42 @@ TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
   }
 }
 
-// Growth preserves every earlier fact. The cache's internal table starts
-// minimal and doubles as it fills, so inserting far past the growth trigger
-// forces several rehashes; open addressing must re-home every live slot on each
-// grow. Synthetic 8-aligned pointers in a regular stride stand in for the
-// bump-allocated storage addresses the cache keys on; the keys are opaque and
-// never dereferenced. Because a probe runs to the empty slot, preservation
-// holds for any home function, so this exercises the rehash, not the mix -- the
-// mix instead keeps the table's capacity bounded when storage addresses arrive
-// in a stride, which this test does not measure.
-TEST_F(SymbolReferenceContainmentTest, TableGrowthPreservesEntries) {
+// Growth preserves every recorded clear fact. The clear-object set starts empty
+// and grows as it fills, so inserting far past its initial capacity forces
+// several rehashes; every live key must survive each grow. Synthetic pointers
+// in a regular stride stand in for the bump-allocated storage addresses the
+// cache keys on; the keys are opaque and never dereferenced. Only clear facts
+// are recorded, so this checks that each survives the rehash and that
+// may-contain facts, which the store never keeps, stay misses.
+TEST_F(SymbolReferenceContainmentTest, SetGrowthPreservesEntries) {
   detail::SymbolRefContainmentCache cache;
-  const int n = 5000; // many doublings past the minimal table
-  std::vector<Type> keys;
-  keys.reserve(n);
+  const int n = 5000; // many doublings past the minimal set
+  std::vector<Type> clearKeys;
+  std::vector<Type> mayContainKeys;
   for (int i = 0; i < n; ++i) {
     auto *p = reinterpret_cast<const void *>(
         static_cast<uintptr_t>(0x100000 + i * 8));
     Type key = Type::getFromOpaquePointer(p);
-    bool value = (i % 3 == 0); // a deterministic mix of true/false facts
-    // The first insert of a key returns the value it records.
-    EXPECT_EQ(cache.insert(key, value, /*lock=*/false), value);
-    keys.push_back(key);
+    if (i % 3 == 0) {
+      // A may-contain fact is never stored: insert returns true but records
+      // nothing, so a later lookup stays a miss and the caller recomputes.
+      EXPECT_TRUE(cache.insert(key, /*value=*/true, /*lock=*/false));
+      mayContainKeys.push_back(key);
+    } else {
+      // A clear fact is recorded and returned unchanged.
+      EXPECT_FALSE(cache.insert(key, /*value=*/false, /*lock=*/false));
+      clearKeys.push_back(key);
+    }
   }
-  // After all the growth, every earlier fact is still found with its value.
-  for (int i = 0; i < n; ++i) {
-    std::optional<bool> got = cache.lookup(keys[i], /*lock=*/false);
-    ASSERT_TRUE(got.has_value()) << "lost entry " << i;
-    EXPECT_EQ(*got, (i % 3 == 0)) << "entry " << i;
+  // After all the growth, every clear fact is still found as false.
+  for (Type key : clearKeys) {
+    std::optional<bool> got = cache.lookup(key, /*lock=*/false);
+    ASSERT_TRUE(got.has_value()) << "lost clear entry";
+    EXPECT_FALSE(*got);
   }
+  // A may-contain fact was never stored, so it stays a miss.
+  for (Type key : mayContainKeys)
+    EXPECT_FALSE(cache.lookup(key, /*lock=*/false).has_value());
   // A key never inserted is a miss, not a stray cluster hit.
   Type absent = Type::getFromOpaquePointer(
       reinterpret_cast<const void *>(static_cast<uintptr_t>(0x100000 + n * 8)));
@@ -371,18 +378,11 @@ TEST_F(SymbolReferenceContainmentTest, TableGrowthPreservesEntries) {
 
 // A DistinctAttr is keyed by the address of its own storage, which comes from a
 // separate always-allocating allocator rather than the attribute uniquer; the
-// cache must tag and recover that pointer just like a uniqued one. Its
-// 8-alignment, which frees bit 0 for the answer tag, is asserted at compile
-// time beside the table; this exercises the runtime path.
+// cache must record and recover that pointer just like a uniqued one.
 TEST_F(SymbolReferenceContainmentTest, DistinctAttrIsHandled) {
   DistinctAttr d1 = DistinctAttr::create(UnitAttr::get(&context));
   DistinctAttr d2 = DistinctAttr::create(UnitAttr::get(&context));
   ASSERT_NE(d1, d2); // always-allocating: distinct instances, distinct pointers
-
-  // The separate allocator must still hand back 8-aligned storage, so bit 0 of
-  // the opaque pointer is free for the answer tag.
-  EXPECT_EQ(
-      reinterpret_cast<uintptr_t>(Attribute(d1).getAsOpaquePointer()) & 1u, 0u);
 
   // Through the public query a DistinctAttr exposes no SymbolRefAttr
   // sub-element, so it answers false, stably across the cold fill and the warm
@@ -392,14 +392,18 @@ TEST_F(SymbolReferenceContainmentTest, DistinctAttrIsHandled) {
   EXPECT_EQ(SymbolTable::mayContainSymbolRefs(d1), cold);
   EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(d2));
 
-  // Drive the tag round-trip with bit 0 set on a distinct-allocator pointer: a
-  // forced true must survive the insert and be returned by the warm lookup,
-  // while an uninserted distinct pointer stays a miss.
+  // A may-contain answer is never recorded: a forced-true insert on a
+  // distinct-allocator pointer returns true but stores nothing, so the warm
+  // lookup stays a miss and the caller recomputes. A clear answer, by contrast,
+  // is recorded and returned false warm, while an uninserted distinct pointer
+  // stays a miss -- the pointer round-trips just like a uniqued one.
   detail::SymbolRefContainmentCache cache;
   EXPECT_TRUE(cache.insert(d1, /*value=*/true, /*lock=*/false));
+  EXPECT_FALSE(cache.lookup(d1, /*lock=*/false).has_value());
+  EXPECT_FALSE(cache.insert(d1, /*value=*/false, /*lock=*/false));
   std::optional<bool> warm = cache.lookup(d1, /*lock=*/false);
   ASSERT_TRUE(warm.has_value());
-  EXPECT_TRUE(*warm);
+  EXPECT_FALSE(*warm);
   EXPECT_FALSE(cache.lookup(d2, /*lock=*/false).has_value());
 }
 

--- a/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
+++ b/mlir/unittests/IR/SymbolReferenceContainmentTest.cpp
@@ -6,13 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Tests for SymbolTable::mayContainSymbolRefs, which records per uniqued type
-// or attribute whether it transitively contains a SymbolRefAttr (conservatively
-// true for mutable storage). Symbol-table verification relies on it to prune
-// types and attributes that provably hold no symbol reference. Because a
-// SymbolUserTypeInterface / SymbolUserAttrInterface implementation must spell
-// its references as SymbolRefAttr sub-elements, a false answer is a sound
-// reason to skip an instance even after the interface is attached late.
+// Tests for the per-context symbol-reference containment cache, which records
+// which uniqued types and attributes are provably free of a transitive
+// SymbolRefAttr; everything else, including mutable storage, answers true
+// conservatively. Symbol-table verification relies on it to prune the
+// symbol-using types it would otherwise walk. Because a SymbolUserTypeInterface
+// implementation must spell its references as SymbolRefAttr sub-elements, a
+// false answer is a sound reason to skip such a type even after the interface
+// is attached late.
 //
 //===----------------------------------------------------------------------===//
 
@@ -32,6 +33,7 @@
 #include "../../test/lib/Dialect/Test/TestTypes.h"
 
 #include <atomic>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -39,24 +41,15 @@ using namespace mlir;
 
 namespace {
 
-// Symbol-user models whose verification always fails, attached externally to
-// exercise late interface attachment. One targets a type that structurally
-// holds a SymbolRefAttr (a tensor with a symbol-ref encoding); the other
-// targets f32, which holds none.
-struct FailingTensorSymbolUserModel
+// A symbol-user model whose verification always fails, attached externally to
+// exercise late interface attachment on an arbitrary concrete type.
+template <typename ConcreteType>
+struct FailingSymbolUserModel
     : public SymbolUserTypeInterface::ExternalModel<
-          FailingTensorSymbolUserModel, RankedTensorType> {
+          FailingSymbolUserModel<ConcreteType>, ConcreteType> {
   LogicalResult verifySymbolUses(Type type, Operation *op,
                                  SymbolTableCollection &symbolTable) const {
-    return op->emitError("tensor rejected by its attached symbol-user model");
-  }
-};
-struct FailingF32SymbolUserModel
-    : public SymbolUserTypeInterface::ExternalModel<FailingF32SymbolUserModel,
-                                                    Float32Type> {
-  LogicalResult verifySymbolUses(Type type, Operation *op,
-                                 SymbolTableCollection &symbolTable) const {
-    return op->emitError("f32 rejected by its attached symbol-user model");
+    return op->emitError("rejected by its attached symbol-user model");
   }
 };
 
@@ -83,119 +76,87 @@ protected:
     return test::TestSymbolRefAttr::get(&context, symbolRef());
   }
 
+  // Query the cache for `obj`. The row index names a failed row without
+  // printing `obj`, which a mutable-storage kind with an unset body cannot
+  // survive.
+  template <typename T>
+  void expect(T obj, bool expected) {
+    SCOPED_TRACE("containment row " + std::to_string(++row));
+    EXPECT_EQ(
+        detail::getSymbolRefContainmentCache(&context).mayContainSymbolRefs(
+            obj),
+        expected);
+  }
+
+  unsigned row = 0;
   MLIRContext context;
 };
 
-// A leaf type holding no symbol reference answers false.
-TEST_F(SymbolReferenceContainmentTest, LeafTypeIsClear) {
-  EXPECT_FALSE(
-      SymbolTable::mayContainSymbolRefs(IntegerType::get(&context, 32)));
-}
-
-// A plain attribute holding no symbol reference answers false.
-TEST_F(SymbolReferenceContainmentTest, LeafAttrIsClear) {
-  EXPECT_FALSE(
-      SymbolTable::mayContainSymbolRefs(StringAttr::get(&context, "hi")));
-  EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(
-      TypeAttr::get(IntegerType::get(&context, 32))));
-}
-
-// A SymbolRefAttr itself answers true.
-TEST_F(SymbolReferenceContainmentTest, FlatSymbolRefAttrIsTrue) {
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(symbolRef()));
-}
-
-// A non-flat SymbolRefAttr, which nests further references, answers true.
-TEST_F(SymbolReferenceContainmentTest, NestedSymbolRefAttrIsTrue) {
-  SymbolRefAttr ref =
-      SymbolRefAttr::get(StringAttr::get(&context, "root"),
-                         {FlatSymbolRefAttr::get(&context, "n")});
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(ref));
-}
-
-// A conforming symbol-user type answers true through its SymbolRefAttr
-// parameter (not through the interface, which plays no part in the answer).
-TEST_F(SymbolReferenceContainmentTest, ConformingSymbolUserTypeIsTrue) {
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(symbolUserType()));
-}
-
-// A conforming symbol-user attribute answers true through its SymbolRefAttr
-// parameter.
-TEST_F(SymbolReferenceContainmentTest, ConformingSymbolUserAttrIsTrue) {
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(symbolUserAttr()));
-}
-
-// A type nesting a symbol-ref-bearing type propagates true.
-TEST_F(SymbolReferenceContainmentTest, TypeNestingSymbolRefBearingType) {
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(
-      TupleType::get(&context, {symbolUserType()})));
-}
-
-// A tuple of ordinary types stays false.
-TEST_F(SymbolReferenceContainmentTest, TypeNestingOrdinaryTypesIsClear) {
+// The containment answer across leaves, self-references, conforming user
+// types/attributes, and every nesting path a symbol reference can hide behind.
+TEST_F(SymbolReferenceContainmentTest, ContainmentTruthTable) {
   Type i32 = IntegerType::get(&context, 32);
-  EXPECT_FALSE(
-      SymbolTable::mayContainSymbolRefs(TupleType::get(&context, {i32, i32})));
-}
 
-// A type reaches a SymbolRefAttr two levels deep, through an attribute
-// sub-element (a tensor encoding holding a TypeAttr of a symbol-ref type).
-TEST_F(SymbolReferenceContainmentTest, TypeReachesSymbolRefThroughAttribute) {
-  Attribute encoding = TypeAttr::get(symbolUserType());
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(encoding));
-  RankedTensorType tensor =
-      RankedTensorType::get({2}, IntegerType::get(&context, 32), encoding);
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(tensor));
-}
+  // Leaves hold no reference.
+  expect(i32, false);
+  expect(StringAttr::get(&context, "hi"), false);
+  expect(TypeAttr::get(i32), false);
 
-// A type reaches a plain SymbolRefAttr through an attribute parameter (a tensor
-// encoding).
-TEST_F(SymbolReferenceContainmentTest, TypeWithSymbolRefAttrParameter) {
-  RankedTensorType tensor =
-      RankedTensorType::get({2}, IntegerType::get(&context, 32), symbolRef());
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(tensor));
-}
+  // A SymbolRefAttr, flat or nesting further references, is itself a reference.
+  expect(symbolRef(), true);
+  expect(SymbolRefAttr::get(StringAttr::get(&context, "root"),
+                            {FlatSymbolRefAttr::get(&context, "n")}),
+         true);
 
-// A dictionary attribute containing a plain SymbolRefAttr answers true.
-TEST_F(SymbolReferenceContainmentTest, DictionaryAttrContainingSymbolRef) {
-  NamedAttribute named(StringAttr::get(&context, "callee"), symbolRef());
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(
-      DictionaryAttr::get(&context, {named})));
-}
+  // A conforming symbol-user type/attribute answers true through its
+  // SymbolRefAttr parameter, not through the interface (which plays no part).
+  expect(symbolUserType(), true);
+  expect(symbolUserAttr(), true);
 
-// A dictionary attribute containing a symbol-ref-bearing type inside a TypeAttr
-// answers true; the answer on the dictionary summarizes its whole nested tree.
-TEST_F(SymbolReferenceContainmentTest, DictionaryAttrContainingSymbolRefType) {
-  NamedAttribute named(StringAttr::get(&context, "key"),
-                       TypeAttr::get(symbolUserType()));
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(
-      DictionaryAttr::get(&context, {named})));
-}
+  // Nesting propagates the reference; ordinary nesting stays clear.
+  expect(TupleType::get(&context, {symbolUserType()}), true);
+  expect(TupleType::get(&context, {i32, i32}), false);
 
-// A dictionary attribute with no symbol reference stays false.
-TEST_F(SymbolReferenceContainmentTest, DictionaryAttrIsClear) {
-  NamedAttribute named(StringAttr::get(&context, "key"),
-                       TypeAttr::get(IntegerType::get(&context, 32)));
-  EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(
-      DictionaryAttr::get(&context, {named})));
-}
+  // A type reaches a reference through an attribute sub-element -- a plain
+  // SymbolRefAttr encoding, or a TypeAttr of a symbol-ref-bearing type.
+  expect(RankedTensorType::get({2}, i32, symbolRef()), true);
+  expect(TypeAttr::get(symbolUserType()), true);
+  expect(RankedTensorType::get({2}, i32, TypeAttr::get(symbolUserType())),
+         true);
 
-// A type carrying a mutable component answers true conservatively, since its
-// sub-elements may change after the answer is computed at first query; the
-// fill never reads its contents.
-TEST_F(SymbolReferenceContainmentTest, MutableTypeReportsConservatively) {
-  test::TestRecursiveType recursive =
-      test::TestRecursiveType::get(&context, "rec");
-  EXPECT_TRUE(SymbolTable::mayContainSymbolRefs(recursive));
-}
+  // A dictionary summarizes its whole nested tree, whichever way a reference
+  // hides, and stays clear when none does.
+  expect(DictionaryAttr::get(
+             &context, {NamedAttribute(StringAttr::get(&context, "callee"),
+                                       symbolRef())}),
+         true);
+  expect(DictionaryAttr::get(&context,
+                             {NamedAttribute(StringAttr::get(&context, "key"),
+                                             TypeAttr::get(symbolUserType()))}),
+         true);
+  expect(DictionaryAttr::get(&context,
+                             {NamedAttribute(StringAttr::get(&context, "key"),
+                                             TypeAttr::get(i32))}),
+         false);
 
-// A container of a mutable-storage kind inherits true, even before the mutable
-// body is populated, so no later mutation can turn a cached false stale.
-TEST_F(SymbolReferenceContainmentTest, ContainerOfMutableTypeIsTrue) {
-  test::TestRecursiveType recursive =
-      test::TestRecursiveType::get(&context, "rec2");
-  EXPECT_TRUE(
-      SymbolTable::mayContainSymbolRefs(TupleType::get(&context, {recursive})));
+  // A mutable-storage kind, and any container of one, answers true
+  // conservatively: its sub-elements may change after the query, so its
+  // contents are never read and no later mutation can turn a cached false
+  // stale.
+  expect(test::TestRecursiveType::get(&context, "rec"), true);
+  expect(
+      TupleType::get(&context, {test::TestRecursiveType::get(&context, "c")}),
+      true);
+
+  // A DistinctAttr is keyed by its own always-allocated storage address, not
+  // the attribute uniquer; two instances answer false independently, and a
+  // repeat query is stable across the cold fill and the warm hit.
+  DistinctAttr d1 = DistinctAttr::create(UnitAttr::get(&context));
+  DistinctAttr d2 = DistinctAttr::create(UnitAttr::get(&context));
+  ASSERT_NE(d1, d2);
+  expect(d1, false);
+  expect(d1, false);
+  expect(d2, false);
 }
 
 // Interface membership plays no part in the answer, so late attachment needs no
@@ -207,7 +168,8 @@ TEST_F(SymbolReferenceContainmentTest, LateInterfaceAttachmentStillVerifies) {
       "module { \"foo.op\"() : () -> tensor<4xf32, @sym> }", &context);
   ASSERT_TRUE(module);
 
-  RankedTensorType::attachInterface<FailingTensorSymbolUserModel>(context);
+  RankedTensorType::attachInterface<FailingSymbolUserModel<RankedTensorType>>(
+      context);
   ScopedDiagnosticHandler handler(&context,
                                   [](Diagnostic &) { return success(); });
   EXPECT_TRUE(failed(verify(*module)));
@@ -223,86 +185,68 @@ TEST_F(SymbolReferenceContainmentTest, NonConformingSymbolUserTypeIsSkipped) {
       "module { \"foo.op\"() : () -> f32 }", &context);
   ASSERT_TRUE(module);
 
-  Float32Type::attachInterface<FailingF32SymbolUserModel>(context);
+  Float32Type::attachInterface<FailingSymbolUserModel<Float32Type>>(context);
   ScopedDiagnosticHandler handler(&context,
                                   [](Diagnostic &) { return success(); });
   EXPECT_TRUE(succeeded(verify(*module)));
+}
+
+// The corpus both the ground-truth and the raced context are filled from,
+// spanning the interesting fill paths and sharing sub-elements so concurrent
+// fills overlap on the same interior objects. Built from one helper so the two
+// contexts stay in lock-step by construction.
+std::vector<Attribute> buildAttrs(MLIRContext &ctx) {
+  Type i32 = IntegerType::get(&ctx, 32);
+  FlatSymbolRefAttr sym = FlatSymbolRefAttr::get(&ctx, "sym");
+  return {
+      StringAttr::get(&ctx, "leaf"),
+      sym,
+      test::TestSymbolRefAttr::get(&ctx, sym),
+      TypeAttr::get(test::TestSymbolUserType::get(&ctx, sym)),
+      DictionaryAttr::get(
+          &ctx, {NamedAttribute(StringAttr::get(&ctx, "callee"), sym)}),
+      DictionaryAttr::get(&ctx, {NamedAttribute(StringAttr::get(&ctx, "plain"),
+                                                TypeAttr::get(i32))}),
+  };
+}
+std::vector<Type> buildTypes(MLIRContext &ctx) {
+  Type i32 = IntegerType::get(&ctx, 32);
+  FlatSymbolRefAttr sym = FlatSymbolRefAttr::get(&ctx, "sym");
+  test::TestSymbolUserType user = test::TestSymbolUserType::get(&ctx, sym);
+  return {
+      i32,
+      user,
+      TupleType::get(&ctx, {i32, user}),
+      TupleType::get(&ctx, {i32, i32}),
+      RankedTensorType::get({2}, i32, sym),
+  };
 }
 
 // Concurrency crux: many threads query the same cold, shared objects at once,
 // exactly as parallel symbol-table verification fills the context cache from
 // several isolated-op workers simultaneously. Every thread must agree with the
 // single-threaded ground truth, and the run must be clean under
-// ThreadSanitizer. Built cold (constructed but never queried before the
-// threads start) so the fills genuinely race.
+// ThreadSanitizer. The raced context is built cold (constructed but never
+// queried before the threads start) so the fills genuinely race.
 TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
   ASSERT_TRUE(context.isMultithreadingEnabled());
 
-  // A set of shared objects spanning the interesting fill paths and sharing
-  // sub-elements, so concurrent fills overlap on the same interior objects.
-  Type i32 = IntegerType::get(&context, 32);
-  std::vector<Attribute> attrs = {
-      StringAttr::get(&context, "leaf"),
-      symbolRef(),
-      symbolUserAttr(),
-      TypeAttr::get(symbolUserType()),
-      DictionaryAttr::get(
-          &context,
-          {NamedAttribute(StringAttr::get(&context, "callee"), symbolRef())}),
-      DictionaryAttr::get(&context,
-                          {NamedAttribute(StringAttr::get(&context, "plain"),
-                                          TypeAttr::get(i32))}),
-  };
-  std::vector<Type> types = {
-      i32,
-      symbolUserType(),
-      TupleType::get(&context, {i32, symbolUserType()}),
-      TupleType::get(&context, {i32, i32}),
-      RankedTensorType::get({2}, i32, symbolRef()),
-  };
-
-  // Ground truth computed single-threaded (this also warms nothing new for the
-  // threads, since these very objects are what they race to fill).
+  auto &truthCache = detail::getSymbolRefContainmentCache(&context);
+  std::vector<Attribute> attrs = buildAttrs(context);
+  std::vector<Type> types = buildTypes(context);
   std::vector<bool> attrTruth, typeTruth;
   for (Attribute a : attrs)
-    attrTruth.push_back(SymbolTable::mayContainSymbolRefs(a));
+    attrTruth.push_back(truthCache.mayContainSymbolRefs(a));
   for (Type t : types)
-    typeTruth.push_back(SymbolTable::mayContainSymbolRefs(t));
+    typeTruth.push_back(truthCache.mayContainSymbolRefs(t));
 
-  // Fresh context so the threads hit a cold cache and genuinely race the fills.
   MLIRContext raced;
   raced.loadDialect<test::TestDialect>();
   raced.allowUnregisteredDialects();
   ASSERT_TRUE(raced.isMultithreadingEnabled());
-  auto rebuildAttrs = [&](MLIRContext &ctx) {
-    Type ri32 = IntegerType::get(&ctx, 32);
-    FlatSymbolRefAttr rsym = FlatSymbolRefAttr::get(&ctx, "sym");
-    return std::vector<Attribute>{
-        StringAttr::get(&ctx, "leaf"),
-        rsym,
-        test::TestSymbolRefAttr::get(&ctx, rsym),
-        TypeAttr::get(test::TestSymbolUserType::get(&ctx, rsym)),
-        DictionaryAttr::get(
-            &ctx, {NamedAttribute(StringAttr::get(&ctx, "callee"), rsym)}),
-        DictionaryAttr::get(&ctx,
-                            {NamedAttribute(StringAttr::get(&ctx, "plain"),
-                                            TypeAttr::get(ri32))}),
-    };
-  };
-  auto rebuildTypes = [&](MLIRContext &ctx) {
-    Type ri32 = IntegerType::get(&ctx, 32);
-    FlatSymbolRefAttr rsym = FlatSymbolRefAttr::get(&ctx, "sym");
-    test::TestSymbolUserType user = test::TestSymbolUserType::get(&ctx, rsym);
-    return std::vector<Type>{
-        ri32,
-        user,
-        TupleType::get(&ctx, {ri32, user}),
-        TupleType::get(&ctx, {ri32, ri32}),
-        RankedTensorType::get({2}, ri32, rsym),
-    };
-  };
-  std::vector<Attribute> racedAttrs = rebuildAttrs(raced);
-  std::vector<Type> racedTypes = rebuildTypes(raced);
+  std::vector<Attribute> racedAttrs = buildAttrs(raced);
+  std::vector<Type> racedTypes = buildTypes(raced);
+  auto &racedCache = detail::getSymbolRefContainmentCache(&raced);
 
   const int numThreads = 16;
   std::vector<std::vector<bool>> attrResults(numThreads);
@@ -316,9 +260,9 @@ TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
       while (!go.load())
         ;
       for (Attribute a : racedAttrs)
-        attrResults[i].push_back(SymbolTable::mayContainSymbolRefs(a));
+        attrResults[i].push_back(racedCache.mayContainSymbolRefs(a));
       for (Type t : racedTypes)
-        typeResults[i].push_back(SymbolTable::mayContainSymbolRefs(t));
+        typeResults[i].push_back(racedCache.mayContainSymbolRefs(t));
     });
   while (ready.load() < numThreads)
     ;
@@ -332,79 +276,6 @@ TEST_F(SymbolReferenceContainmentTest, ConcurrentFillIsRaceFree) {
     EXPECT_EQ(attrResults[i], attrTruth) << "thread " << i;
     EXPECT_EQ(typeResults[i], typeTruth) << "thread " << i;
   }
-}
-
-// Growth preserves every recorded clear fact. The clear-object set starts empty
-// and grows as it fills, so inserting far past its initial capacity forces
-// several rehashes; every live key must survive each grow. Synthetic pointers
-// in a regular stride stand in for the bump-allocated storage addresses the
-// cache keys on; the keys are opaque and never dereferenced. Only clear facts
-// are recorded, so this checks that each survives the rehash and that
-// may-contain facts, which the store never keeps, stay misses.
-TEST_F(SymbolReferenceContainmentTest, SetGrowthPreservesEntries) {
-  detail::SymbolRefContainmentCache cache;
-  const int n = 5000; // many doublings past the minimal set
-  std::vector<Type> clearKeys;
-  std::vector<Type> mayContainKeys;
-  for (int i = 0; i < n; ++i) {
-    auto *p = reinterpret_cast<const void *>(
-        static_cast<uintptr_t>(0x100000 + i * 8));
-    Type key = Type::getFromOpaquePointer(p);
-    if (i % 3 == 0) {
-      // A may-contain fact is never stored: insert returns true but records
-      // nothing, so a later lookup stays a miss and the caller recomputes.
-      EXPECT_TRUE(cache.insert(key, /*value=*/true, /*lock=*/false));
-      mayContainKeys.push_back(key);
-    } else {
-      // A clear fact is recorded and returned unchanged.
-      EXPECT_FALSE(cache.insert(key, /*value=*/false, /*lock=*/false));
-      clearKeys.push_back(key);
-    }
-  }
-  // After all the growth, every clear fact is still found as false.
-  for (Type key : clearKeys) {
-    std::optional<bool> got = cache.lookup(key, /*lock=*/false);
-    ASSERT_TRUE(got.has_value()) << "lost clear entry";
-    EXPECT_FALSE(*got);
-  }
-  // A may-contain fact was never stored, so it stays a miss.
-  for (Type key : mayContainKeys)
-    EXPECT_FALSE(cache.lookup(key, /*lock=*/false).has_value());
-  // A key never inserted is a miss, not a stray cluster hit.
-  Type absent = Type::getFromOpaquePointer(
-      reinterpret_cast<const void *>(static_cast<uintptr_t>(0x100000 + n * 8)));
-  EXPECT_FALSE(cache.lookup(absent, /*lock=*/false).has_value());
-}
-
-// A DistinctAttr is keyed by the address of its own storage, which comes from a
-// separate always-allocating allocator rather than the attribute uniquer; the
-// cache must record and recover that pointer just like a uniqued one.
-TEST_F(SymbolReferenceContainmentTest, DistinctAttrIsHandled) {
-  DistinctAttr d1 = DistinctAttr::create(UnitAttr::get(&context));
-  DistinctAttr d2 = DistinctAttr::create(UnitAttr::get(&context));
-  ASSERT_NE(d1, d2); // always-allocating: distinct instances, distinct pointers
-
-  // Through the public query a DistinctAttr exposes no SymbolRefAttr
-  // sub-element, so it answers false, stably across the cold fill and the warm
-  // cache hit.
-  bool cold = SymbolTable::mayContainSymbolRefs(d1);
-  EXPECT_FALSE(cold);
-  EXPECT_EQ(SymbolTable::mayContainSymbolRefs(d1), cold);
-  EXPECT_FALSE(SymbolTable::mayContainSymbolRefs(d2));
-
-  // A may-contain answer is never recorded: a forced-true insert on a
-  // distinct-allocator pointer returns true but stores nothing, so the warm
-  // lookup stays a miss and the caller recomputes. A clear answer, by contrast,
-  // is recorded and returned false warm, while an uninserted distinct pointer
-  // stays a miss -- the pointer round-trips just like a uniqued one.
-  detail::SymbolRefContainmentCache cache;
-  EXPECT_TRUE(cache.insert(d1, /*value=*/true, /*lock=*/false));
-  EXPECT_FALSE(cache.lookup(d1, /*lock=*/false).has_value());
-  EXPECT_FALSE(cache.insert(d1, /*value=*/false, /*lock=*/false));
-  std::optional<bool> warm = cache.lookup(d1, /*lock=*/false);
-  ASSERT_TRUE(warm.has_value());
-  EXPECT_FALSE(*warm);
-  EXPECT_FALSE(cache.lookup(d2, /*lock=*/false).has_value());
 }
 
 } // namespace

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -95,24 +95,33 @@ filegroup(
 
 exports_files(glob(["include/**/*.td"]))
 
-[
-    gentbl_cc_library(
-        name = name + "IncGen",
-        tbl_outs = {
-            "include/mlir/IR/" + name + ".h.inc": ["-gen-op-interface-decls"],
-            "include/mlir/IR/" + name + ".cpp.inc": ["-gen-op-interface-defs"],
-            "include/mlir/IR/" + name + "AttrInterface.h.inc": ["-gen-attr-interface-decls"],
-            "include/mlir/IR/" + name + "AttrInterface.cpp.inc": ["-gen-attr-interface-defs"],
-        },
-        tblgen = ":mlir-tblgen",
-        td_file = "include/mlir/IR/" + name + ".td",
-        deps = [":OpBaseTdFiles"],
-    )
-    for name in [
-        "RegionKindInterface",
-        "SymbolInterfaces",
-    ]
-]
+gentbl_cc_library(
+    name = "RegionKindInterfaceIncGen",
+    tbl_outs = {
+        "include/mlir/IR/RegionKindInterface.h.inc": ["-gen-op-interface-decls"],
+        "include/mlir/IR/RegionKindInterface.cpp.inc": ["-gen-op-interface-defs"],
+        "include/mlir/IR/RegionKindInterfaceAttrInterface.h.inc": ["-gen-attr-interface-decls"],
+        "include/mlir/IR/RegionKindInterfaceAttrInterface.cpp.inc": ["-gen-attr-interface-defs"],
+    },
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/IR/RegionKindInterface.td",
+    deps = [":OpBaseTdFiles"],
+)
+
+gentbl_cc_library(
+    name = "SymbolInterfacesIncGen",
+    tbl_outs = {
+        "include/mlir/IR/SymbolInterfaces.h.inc": ["-gen-op-interface-decls"],
+        "include/mlir/IR/SymbolInterfaces.cpp.inc": ["-gen-op-interface-defs"],
+        "include/mlir/IR/SymbolInterfacesAttrInterface.h.inc": ["-gen-attr-interface-decls"],
+        "include/mlir/IR/SymbolInterfacesAttrInterface.cpp.inc": ["-gen-attr-interface-defs"],
+        "include/mlir/IR/SymbolInterfacesTypeInterface.h.inc": ["-gen-type-interface-decls"],
+        "include/mlir/IR/SymbolInterfacesTypeInterface.cpp.inc": ["-gen-type-interface-defs"],
+    },
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/IR/SymbolInterfaces.td",
+    deps = [":OpBaseTdFiles"],
+)
 
 gentbl_cc_library(
     name = "OpAsmInterfaceIncGen",

--- a/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
@@ -36,6 +36,7 @@ cc_test(
     srcs = glob([
         "IR/*.cpp",
     ]),
+    features = ["-layering_check"],  # #include "../../lib/IR/SymbolRefContainmentCache.h"
     deps = [
         "//llvm:Core",
         "//llvm:Remarks",


### PR DESCRIPTION
This PR now also relands SymbolUserTypeInterface (#198435), reverted in #217959 pending verification cost mitigation.

Motivation: #198435 made the SymbolTable verifier walk every op's types and full attribute dictionary per pass; @ehein6 measured 14.1s -> 26.1s on a real pipeline with zero participating types (#212160).

On a synthetic reproduction (8000 functions, big dictionaries, 40 passes) this patch takes this pipeline from 8.75s to 1.77s. This PR composes with, and does not subsume, the registration-level skip proposed in #212160.

Whether an attribute or type contains a SymbolRefAttr is a fixed fact of that object, so we can compute it once and consult it to avoid pointless traversal during SymbolTable verification.

This PR keeps that fact in a set inside MLIRContext holding the types and attributes proven to contain no SymbolRefAttr. Membership in the set lets the symbol-use walk prune; everything else is walked and left unrecorded. "Everything else" includes objects with mutable storage, which must be treated conservatively. The set fills lazily as verification encounters objects.

This solution uses the same concurrency discipline as the lazily-grown OperationName map, with one difference forced by the non-reentrant mutex: a fill computes its answer before taking the writer lock, so racing duplicate fills are idempotent. Since #217320's transient scopes free storage interned during the scope and may cause recycled addresses, the cache is cleared when a transient scope ends.

Additionally:
1. One walker with one deduped visited set is hoisted once per SymbolTable scope so that the attributes & types which do get traversed get traversed at most once per symbol table scope, rather than once per operation they appear on.
2. Avoid materializing a DictionaryAttr value when checking an operation's attributes & properties.

One semantic change: the contract on SymbolUserTypeInterface now requires that the symbols an implementation references be spelled as SymbolRefAttr sub-elements. So, a use is a structural fact about a type. An implementation that references symbols in some other encoding (e.g., a string) is treated as referencing no symbols and may no longer have verifySymbolUses invoked. SymbolUserAttrInterface's contract and behavior are unchanged.

Other than tightening the contract on SymbolUserTypeInterface, the set of things verified against each symbol table scope is unchanged. This PR just removes all the pointless traversal.

Assisted-by: Claude Code (Anthropic)