### PR TITLE
[CIR] Rewrite a raised std::find over bytes into memchr

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1512,8 +1512,12 @@ def CIR_FuncIdentityAttr : CIR_Attr<"FuncIdentity", "func_identity"> {
     function named `find` in the `std` namespace, so a member function, a
     static member, or an operator can never carry the tag. Inline
     namespaces, such as the versioning namespace of libc++, count as part
-    of `std`. The tag never encodes signatures, and a function that
+    of `std`. The kind never encodes signatures, and a function that
     matches no known entity carries no attribute.
+
+    The `narrow_char_params` parameter is a separate precondition for the
+    byte rewrites and not part of the identity, true when every parameter
+    points to one narrow non volatile character type, char8_t excluded.
 
     Example:
     ```
@@ -1522,11 +1526,12 @@ def CIR_FuncIdentityAttr : CIR_Attr<"FuncIdentity", "func_identity"> {
   }];
 
   let parameters = (ins
-    EnumParameter<CIR_KnownFuncKind>:$kind
+    EnumParameter<CIR_KnownFuncKind>:$kind,
+    DefaultValuedParameter<"bool", "false">:$narrow_char_params
   );
 
   let assemblyFormat = [{
-    `<` $kind `>`
+    `<` $kind (`,` struct($narrow_char_params)^)? `>`
   }];
 
   let canHaveIllegalCXXABIType = 0;

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1512,12 +1512,13 @@ def CIR_FuncIdentityAttr : CIR_Attr<"FuncIdentity", "func_identity"> {
     function named `find` in the `std` namespace, so a member function, a
     static member, or an operator can never carry the tag. Inline
     namespaces, such as the versioning namespace of libc++, count as part
-    of `std`. The kind never encodes signatures, and a function that
-    matches no known entity carries no attribute.
+    of `std`. The `kind` parameter identifies the known standard library
+    entity and never encodes signatures. A function that matches no known
+    entity carries no attribute.
 
     The `narrow_char_params` parameter is a separate precondition for the
     byte rewrites and not part of the identity, true when every parameter
-    points to one narrow non volatile character type, char8_t excluded.
+    points to one narrow non volatile character type, `char8_t` excluded.
 
     Example:
     ```

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -36,6 +36,11 @@ def CIR_Dialect : Dialect {
   let extraClassDeclaration = [{
     static llvm::StringRef getSourceLanguageAttrName() { return "cir.lang"; }
     static llvm::StringRef getTripleAttrName() { return "cir.triple"; }
+    // Width in bits of the size_t the AST uses for this target. It can
+    // disagree with the module data layout, as it does on AArch64 GNUILP32.
+    static llvm::StringRef getSizeTypeWidthAttrName() {
+      return "cir.size_type_width";
+    }
     static llvm::StringRef getOptInfoAttrName() { return "cir.opt_info"; }
     static llvm::StringRef getCalleeAttrName() { return "callee"; }
     static llvm::StringRef getNoThrowAttrName() { return "nothrow"; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -137,6 +137,8 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
         cir::SourceLanguageAttr::get(&mlirContext, *sourceLanguage));
   theModule->setAttr(cir::CIRDialect::getTripleAttrName(),
                      builder.getStringAttr(getTriple().str()));
+  theModule->setAttr(cir::CIRDialect::getSizeTypeWidthAttrName(),
+                     builder.getI32IntegerAttr(sizeTypeSize));
 
   if (cgo.OptimizationLevel > 0 || cgo.OptimizeSize > 0)
     theModule->setAttr(cir::CIRDialect::getOptInfoAttrName(),

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3629,7 +3629,24 @@ void CIRGenModule::setFuncInfoAttr(cir::FuncOp funcOp,
   if (!kind)
     return;
 
-  funcOp.setFuncInfoAttr(cir::FuncIdentityAttr::get(&getMLIRContext(), *kind));
+  clang::QualType firstPointee;
+  bool narrowCharParams =
+      !funcDecl->parameters().empty() &&
+      llvm::all_of(funcDecl->parameters(), [&](const ParmVarDecl *param) {
+        clang::QualType pointee = param->getType()->getPointeeType();
+        if (pointee.isNull() || !pointee->isCharType() ||
+            pointee.isVolatileQualified()) {
+          return false;
+        }
+        clang::QualType canonical =
+            pointee.getCanonicalType().getUnqualifiedType();
+        if (firstPointee.isNull())
+          firstPointee = canonical;
+        return canonical == firstPointee;
+      });
+
+  funcOp.setFuncInfoAttr(
+      cir::FuncIdentityAttr::get(&getMLIRContext(), *kind, narrowCharParams));
 }
 
 static void setWindowsItaniumDLLImport(CIRGenModule &cgm, bool isLocal,

--- a/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
@@ -30,24 +30,6 @@ namespace mlir {
 
 namespace {
 
-// True when the call's no builtin state forbids treating it as `name`. A
-// builtin mark wins over a nobuiltin mark or a nobuiltins list.
-bool isNoBuiltin(CallOp call, llvm::StringRef name) {
-  if (call->hasAttr(cir::CIRDialect::getBuiltinAttrName()))
-    return false;
-  if (call->hasAttr(cir::CIRDialect::getNoBuiltinAttrName()))
-    return true;
-  auto noBuiltins = call->getAttrOfType<mlir::ArrayAttr>(
-      cir::CIRDialect::getNoBuiltinsAttrName());
-  if (!noBuiltins)
-    return false;
-  return noBuiltins.empty() ||
-         llvm::any_of(noBuiltins, [name](mlir::Attribute entry) {
-           auto builtinName = mlir::dyn_cast<mlir::StringAttr>(entry);
-           return builtinName && builtinName.getValue() == name;
-         });
-}
-
 // Raises a direct cir.call to the first candidate in `TargetOps` that matches.
 template <typename... TargetOps> class StdRecognizer {
   template <typename TargetOp, size_t... Indices>

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
+#include "llvm/TargetParser/Triple.h"
 
 using cir::CIRBaseBuilderTy;
 using namespace mlir;
@@ -50,26 +51,92 @@ struct LibOptPass : public impl::LibOptBase<LibOptPass> {
   // Raw libopt option string forwarded by the frontend. This will later control
   // which optimizations the pass enables.
   std::string optimizationOptions;
-
-  /// Tracks current module.
-  ModuleOp theModule;
 };
 } // namespace
 
 mlir::LogicalResult LibOptPass::initializeOptions(
     llvm::StringRef options,
-    llvm::function_ref<mlir::LogicalResult(const llvm::Twine &)> errorHandler) {
-  (void)errorHandler;
+    llvm::function_ref<mlir::LogicalResult(const llvm::Twine &)>) {
   optimizationOptions = options.str();
   // TODO(cir): Parse options to select the active transformations for the
   // pass.
   return mlir::success();
 }
 
+static void xformStdFindIntoMemchr(StdFindOp findOp,
+                                   mlir::SymbolTableCollection &symbolTables) {
+  auto iterTy = mlir::dyn_cast<cir::PointerType>(findOp.getResult().getType());
+  if (!iterTy || iterTy.getAddrSpace())
+    return;
+  auto elemTy = mlir::dyn_cast<cir::IntType>(iterTy.getPointee());
+  if (!elemTy || elemTy.getWidth() != 8)
+    return;
+
+  auto patternPtrTy =
+      mlir::dyn_cast<cir::PointerType>(findOp.getPattern().getType());
+  if (!patternPtrTy || patternPtrTy.getPointee() != elemTy)
+    return;
+
+  // No builtin state rides on both the raised call and the enclosing function.
+  auto enclosing = findOp->getParentOfType<cir::FuncOp>();
+  if (isNoBuiltin(findOp, "memchr") ||
+      (enclosing && noBuiltinsForbid(enclosing, "memchr"))) {
+    return;
+  }
+
+  // An enum or atomic element also lowers to a byte wide integer.
+  auto callee = symbolTables.lookupNearestSymbolFrom<cir::FuncOp>(
+      findOp, findOp.getOriginalFnAttr());
+  auto funcIdentity = mlir::dyn_cast_if_present<cir::FuncIdentityAttr>(
+      callee ? callee.getFuncInfoAttr() : mlir::Attribute());
+  if (!funcIdentity || funcIdentity.getKind() != cir::KnownFuncKind::StdFind ||
+      !funcIdentity.getNarrowCharParams()) {
+    return;
+  }
+
+  // cir.libc.memchr fixes the value and length widths at 32 and 64 bits.
+  // Logical SPIR-V and the PS3 pair 64 bit pointers with a 32 bit size_t.
+  // The GPU targets and BPF ship no C library that could provide the call.
+  // TODO(cir): gate on the target size type and libcall availability.
+  auto module = findOp->getParentOfType<mlir::ModuleOp>();
+  auto tripleAttr = module ? module->getAttrOfType<mlir::StringAttr>(
+                                 cir::CIRDialect::getTripleAttrName())
+                           : nullptr;
+  if (!tripleAttr)
+    return;
+  llvm::Triple triple(tripleAttr.getValue().str());
+  if (!triple.isArch64Bit() || triple.isX32() || triple.isABIN32() ||
+      triple.getEnvironment() == llvm::Triple::GNUILP32 ||
+      triple.isSPIRV() || triple.isAMDGPU() || triple.isNVPTX() ||
+      triple.isBPF() || triple.getOS() == llvm::Triple::Lv2) {
+    return;
+  }
+
+  mlir::Location loc = findOp.getLoc();
+  mlir::Value first = findOp.getFirst();
+  mlir::Value last = findOp.getLast();
+  CIRBaseBuilderTy builder(*findOp.getContext());
+  builder.setInsertionPointAfter(findOp.getOperation());
+
+  // void *memchr(const void *s, int c, size_t n)
+  mlir::Value src = builder.createBitcast(loc, first, builder.getVoidPtrTy());
+  mlir::Value pattern = builder.createIntCast(
+      builder.createLoad(loc, findOp.getPattern()), builder.getSIntNTy(32));
+  mlir::Value len =
+      cir::PtrDiffOp::create(builder, loc, builder.getUIntNTy(64), last, first);
+  mlir::Value res = cir::MemChrOp::create(builder, loc, src, pattern, len);
+  res = builder.createBitcast(loc, res, iterTy);
+
+  mlir::Value result =
+      builder.createSelect(loc, builder.createPtrIsNull(res), last, res);
+  findOp.getResult().replaceAllUsesWith(result);
+  findOp.erase();
+}
+
 void LibOptPass::runOnOperation() {
-  auto *op = getOperation();
-  if (isa<::mlir::ModuleOp>(op))
-    theModule = cast<::mlir::ModuleOp>(op);
+  mlir::SymbolTableCollection symbolTables;
+  getOperation()->walk(
+      [&](StdFindOp findOp) { xformStdFindIntoMemchr(findOp, symbolTables); });
 }
 
 std::unique_ptr<Pass> mlir::createLibOptPass() {

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -106,9 +106,9 @@ static void xformStdFindIntoMemchr(StdFindOp findOp,
     return;
   llvm::Triple triple(tripleAttr.getValue().str());
   if (!triple.isArch64Bit() || triple.isX32() || triple.isABIN32() ||
-      triple.getEnvironment() == llvm::Triple::GNUILP32 ||
-      triple.isSPIRV() || triple.isAMDGPU() || triple.isNVPTX() ||
-      triple.isBPF() || triple.getOS() == llvm::Triple::Lv2) {
+      triple.getEnvironment() == llvm::Triple::GNUILP32 || triple.isSPIRV() ||
+      triple.isAMDGPU() || triple.isNVPTX() || triple.isBPF() ||
+      triple.getOS() == llvm::Triple::Lv2) {
     return;
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -77,12 +77,18 @@ static void rewriteStdFindToMemchr(StdFindOp findOp,
   if (!patternPtrTy || patternPtrTy.getPointee() != elemTy)
     return;
 
-  // No builtin state rides on both the raised call and the enclosing function.
+  // LibOpt runs before LoweringPrepare, so a global initializer is still a
+  // cir.global here. Anything else is not a shape CIRGen produces.
   auto enclosing = findOp->getParentOfType<cir::FuncOp>();
-  if (isNoBuiltin(findOp, "memchr") ||
-      (enclosing && noBuiltinListDisables(enclosing, "memchr"))) {
+  auto enclosingGlobal = findOp->getParentOfType<cir::GlobalOp>();
+  if (!enclosing && !enclosingGlobal)
     return;
-  }
+
+  // No builtin state rides on the raised call and on the enclosing function.
+  // A global initializer has no function to carry the list.
+  if (isNoBuiltin(findOp, "memchr") ||
+      (enclosing && noBuiltinListDisables(enclosing, "memchr")))
+    return;
 
   // An enum or atomic element also lowers to a byte wide integer.
   auto callee = symbolTables.lookupNearestSymbolFrom<cir::FuncOp>(
@@ -94,46 +100,76 @@ static void rewriteStdFindToMemchr(StdFindOp findOp,
     return;
   }
 
-  // cir.libc.memchr fixes the value and length widths at 32 and 64 bits.
-  // TODO(cir): gate on the target size type and libcall availability.
   auto moduleOp = findOp->getParentOfType<mlir::ModuleOp>();
-  auto tripleAttr = moduleOp ? moduleOp->getAttrOfType<mlir::StringAttr>(
-                                   cir::CIRDialect::getTripleAttrName())
-                             : nullptr;
+  if (!moduleOp)
+    return;
+
+  auto tripleAttr = moduleOp->getAttrOfType<mlir::StringAttr>(
+      cir::CIRDialect::getTripleAttrName());
   if (!tripleAttr)
     return;
+
   llvm::Triple triple(tripleAttr.getValue().str());
 
-  // size_t is not 64 bits on the 32 bit archs, the ILP32 on 64 ABIs, and
-  // the PS3, so the length argument would have the wrong width there.
-  bool sizeTypeMismatch = !triple.isArch64Bit() || triple.isX32() ||
-                          triple.isABIN32() ||
-                          triple.getEnvironment() == llvm::Triple::GNUILP32 ||
-                          triple.getOS() == llvm::Triple::Lv2;
+  // cir.libc.memchr currently requires a 64 bit length. Use the AST size_t
+  // width recorded by CIRGen instead of inferring it from target properties.
+  auto sizeWidthAttr = moduleOp->getAttrOfType<mlir::IntegerAttr>(
+      cir::CIRDialect::getSizeTypeWidthAttrName());
+  bool sizeTypeMismatch = !sizeWidthAttr ||
+                          !sizeWidthAttr.getType().isSignlessInteger(32) ||
+                          sizeWidthAttr.getInt() != 64;
 
-  // These targets ship no C library that could provide the new call.
-  bool noCLibrary = triple.isGPU() || triple.isBPF();
+  // The current memchr lowering supplies no target ABI extension attributes, so
+  // restrict the rewrite to targets known not to need them.
+  // TODO(cir): use target-aware ABI and libcall availability information.
+  bool abiSafeTarget =
+      triple.getArch() == llvm::Triple::x86_64 || triple.isAArch64();
 
-  if (sizeTypeMismatch || noCLibrary)
+  // AArch64 GNUILP32 AST types disagree with LLVM's data layout.
+  bool unsupportedABI =
+      triple.isAArch64() && triple.getEnvironment() == llvm::Triple::GNUILP32;
+
+  if (sizeTypeMismatch || !abiSafeTarget || unsupportedABI)
+    return;
+
+  // Lowering resolves memchr in the module symbol table. An existing symbol may
+  // collide with the introduced libcall or carry incompatible semantics.
+  if (symbolTables.lookupSymbolIn(
+          moduleOp, mlir::StringAttr::get(findOp.getContext(), "memchr")))
     return;
 
   mlir::Location loc = findOp.getLoc();
   mlir::Value first = findOp.getFirst();
   mlir::Value last = findOp.getLast();
   CIRBaseBuilderTy builder(*findOp.getContext());
-  builder.setInsertionPointAfter(findOp.getOperation());
+  builder.setInsertionPointAfter(findOp);
 
-  // void *memchr(const void *s, int c, size_t n)
-  mlir::Value src = builder.createBitcast(loc, first, builder.getVoidPtrTy());
-  mlir::Value pattern = builder.createIntCast(
-      builder.createLoad(loc, findOp.getPattern()), builder.getSIntNTy(32));
-  mlir::Value len =
-      cir::PtrDiffOp::create(builder, loc, builder.getUIntNTy(64), last, first);
-  mlir::Value res = cir::MemChrOp::create(builder, loc, src, pattern, len);
-  res = builder.createBitcast(loc, res, iterTy);
-
+  // C requires the pointer argument to be valid even when the length is zero,
+  // and an empty range is allowed to be a pair of null pointers.
+  mlir::Value isEmpty =
+      builder.createCompare(loc, cir::CmpOpKind::eq, first, last);
   mlir::Value result =
-      builder.createSelect(loc, builder.createPtrIsNull(res), last, res);
+      cir::TernaryOp::create(
+          builder, loc, isEmpty,
+          [&](mlir::OpBuilder &, mlir::Location) {
+            builder.createYield(loc, last);
+          },
+          [&](mlir::OpBuilder &, mlir::Location) {
+            mlir::Value src =
+                builder.createBitcast(loc, first, builder.getVoidPtrTy());
+            mlir::Value pattern = builder.createIntCast(
+                builder.createLoad(loc, findOp.getPattern()),
+                builder.getSIntNTy(32));
+            mlir::Value len = cir::PtrDiffOp::create(
+                builder, loc, builder.getUIntNTy(64), last, first);
+            mlir::Value res =
+                cir::MemChrOp::create(builder, loc, src, pattern, len);
+            res = builder.createBitcast(loc, res, iterTy);
+            builder.createYield(
+                loc, builder.createSelect(loc, builder.createPtrIsNull(res),
+                                          last, res));
+          })
+          .getResult();
   findOp.getResult().replaceAllUsesWith(result);
   findOp.erase();
 }

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -63,7 +63,7 @@ mlir::LogicalResult LibOptPass::initializeOptions(
   return mlir::success();
 }
 
-static void xformStdFindIntoMemchr(StdFindOp findOp,
+static void rewriteStdFindToMemchr(StdFindOp findOp,
                                    mlir::SymbolTableCollection &symbolTables) {
   auto iterTy = mlir::dyn_cast<cir::PointerType>(findOp.getResult().getType());
   if (!iterTy || iterTy.getAddrSpace())
@@ -80,7 +80,7 @@ static void xformStdFindIntoMemchr(StdFindOp findOp,
   // No builtin state rides on both the raised call and the enclosing function.
   auto enclosing = findOp->getParentOfType<cir::FuncOp>();
   if (isNoBuiltin(findOp, "memchr") ||
-      (enclosing && noBuiltinsForbid(enclosing, "memchr"))) {
+      (enclosing && noBuiltinListDisables(enclosing, "memchr"))) {
     return;
   }
 
@@ -95,22 +95,27 @@ static void xformStdFindIntoMemchr(StdFindOp findOp,
   }
 
   // cir.libc.memchr fixes the value and length widths at 32 and 64 bits.
-  // Logical SPIR-V and the PS3 pair 64 bit pointers with a 32 bit size_t.
-  // The GPU targets and BPF ship no C library that could provide the call.
   // TODO(cir): gate on the target size type and libcall availability.
-  auto module = findOp->getParentOfType<mlir::ModuleOp>();
-  auto tripleAttr = module ? module->getAttrOfType<mlir::StringAttr>(
-                                 cir::CIRDialect::getTripleAttrName())
-                           : nullptr;
+  auto moduleOp = findOp->getParentOfType<mlir::ModuleOp>();
+  auto tripleAttr = moduleOp ? moduleOp->getAttrOfType<mlir::StringAttr>(
+                                   cir::CIRDialect::getTripleAttrName())
+                             : nullptr;
   if (!tripleAttr)
     return;
   llvm::Triple triple(tripleAttr.getValue().str());
-  if (!triple.isArch64Bit() || triple.isX32() || triple.isABIN32() ||
-      triple.getEnvironment() == llvm::Triple::GNUILP32 || triple.isSPIRV() ||
-      triple.isAMDGPU() || triple.isNVPTX() || triple.isBPF() ||
-      triple.getOS() == llvm::Triple::Lv2) {
+
+  // size_t is not 64 bits on the 32 bit archs, the ILP32 on 64 ABIs, and
+  // the PS3, so the length argument would have the wrong width there.
+  bool sizeTypeMismatch = !triple.isArch64Bit() || triple.isX32() ||
+                          triple.isABIN32() ||
+                          triple.getEnvironment() == llvm::Triple::GNUILP32 ||
+                          triple.getOS() == llvm::Triple::Lv2;
+
+  // These targets ship no C library that could provide the new call.
+  bool noCLibrary = triple.isGPU() || triple.isBPF();
+
+  if (sizeTypeMismatch || noCLibrary)
     return;
-  }
 
   mlir::Location loc = findOp.getLoc();
   mlir::Value first = findOp.getFirst();
@@ -136,7 +141,7 @@ static void xformStdFindIntoMemchr(StdFindOp findOp,
 void LibOptPass::runOnOperation() {
   mlir::SymbolTableCollection symbolTables;
   getOperation()->walk(
-      [&](StdFindOp findOp) { xformStdFindIntoMemchr(findOp, symbolTables); });
+      [&](StdFindOp findOp) { rewriteStdFindToMemchr(findOp, symbolTables); });
 }
 
 std::unique_ptr<Pass> mlir::createLibOptPass() {

--- a/clang/lib/CIR/Dialect/Transforms/PassDetail.h
+++ b/clang/lib/CIR/Dialect/Transforms/PassDetail.h
@@ -9,13 +9,37 @@
 #ifndef CIR_DIALECT_TRANSFORMS_PASSDETAIL_H
 #define CIR_DIALECT_TRANSFORMS_PASSDETAIL_H
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Pass/Pass.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "llvm/ABI/TargetInfo.h"
 
 namespace cir {
-class CIRDialect;
+
+// A nobuiltin mark or list forbids `name`, and an empty list forbids all.
+inline bool noBuiltinsForbid(mlir::Operation *op, llvm::StringRef name) {
+  if (op->hasAttr(cir::CIRDialect::getNoBuiltinAttrName()))
+    return true;
+  auto noBuiltins = op->getAttrOfType<mlir::ArrayAttr>(
+      cir::CIRDialect::getNoBuiltinsAttrName());
+  if (!noBuiltins)
+    return false;
+  return noBuiltins.empty() ||
+         llvm::any_of(noBuiltins, [name](mlir::Attribute entry) {
+           auto builtinName = mlir::dyn_cast<mlir::StringAttr>(entry);
+           return builtinName && builtinName.getValue() == name;
+         });
+}
+
+// The call form, where a builtin mark wins over the nobuiltin state.
+inline bool isNoBuiltin(mlir::Operation *op, llvm::StringRef name) {
+  if (op->hasAttr(cir::CIRDialect::getBuiltinAttrName()))
+    return false;
+  return noBuiltinsForbid(op, name);
+}
+
 } // namespace cir
 
 namespace mlir {

--- a/clang/lib/CIR/Dialect/Transforms/PassDetail.h
+++ b/clang/lib/CIR/Dialect/Transforms/PassDetail.h
@@ -18,10 +18,10 @@
 
 namespace cir {
 
-// A nobuiltin mark or list forbids `name`, and an empty list forbids all.
-inline bool noBuiltinsForbid(mlir::Operation *op, llvm::StringRef name) {
-  if (op->hasAttr(cir::CIRDialect::getNoBuiltinAttrName()))
-    return true;
+// Reads only the `nobuiltins` list attribute, where an empty list disables
+// every builtin. The `nobuiltin` unit mark is a different attribute, on a
+// function it describes calls to the function itself, not its body.
+inline bool noBuiltinListDisables(mlir::Operation *op, llvm::StringRef name) {
   auto noBuiltins = op->getAttrOfType<mlir::ArrayAttr>(
       cir::CIRDialect::getNoBuiltinsAttrName());
   if (!noBuiltins)
@@ -33,11 +33,14 @@ inline bool noBuiltinsForbid(mlir::Operation *op, llvm::StringRef name) {
          });
 }
 
-// The call form, where a builtin mark wins over the nobuiltin state.
+// This is the form for calls, where a `builtin` mark wins, a `nobuiltin`
+// mark disables every builtin, and otherwise the `nobuiltins` list decides.
 inline bool isNoBuiltin(mlir::Operation *op, llvm::StringRef name) {
   if (op->hasAttr(cir::CIRDialect::getBuiltinAttrName()))
     return false;
-  return noBuiltinsForbid(op, name);
+  if (op->hasAttr(cir::CIRDialect::getNoBuiltinAttrName()))
+    return true;
+  return noBuiltinListDisables(op, name);
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/PassDetail.h
+++ b/clang/lib/CIR/Dialect/Transforms/PassDetail.h
@@ -18,14 +18,18 @@
 
 namespace cir {
 
-// Reads only the `nobuiltins` list attribute, where an empty list disables
-// every builtin. The `nobuiltin` unit mark is a different attribute, on a
-// function it describes calls to the function itself, not its body.
+// Check the `nobuiltins` list. On a function, this list controls builtin
+// calls in its body; the singular `nobuiltin` mark describes calls to the
+// function and is intentionally not read here.
 inline bool noBuiltinListDisables(mlir::Operation *op, llvm::StringRef name) {
+  // Read the `nobuiltins` list of builtin names disabled on this operation.
   auto noBuiltins = op->getAttrOfType<mlir::ArrayAttr>(
       cir::CIRDialect::getNoBuiltinsAttrName());
+  // No list means the list adds no restriction.
   if (!noBuiltins)
     return false;
+  // An empty list disables every builtin, and a named list disables only
+  // the builtins it contains.
   return noBuiltins.empty() ||
          llvm::any_of(noBuiltins, [name](mlir::Attribute entry) {
            auto builtinName = mlir::dyn_cast<mlir::StringAttr>(entry);
@@ -33,13 +37,15 @@ inline bool noBuiltinListDisables(mlir::Operation *op, llvm::StringRef name) {
          });
 }
 
-// This is the form for calls, where a `builtin` mark wins, a `nobuiltin`
-// mark disables every builtin, and otherwise the `nobuiltins` list decides.
+// Check all no builtin state attached to a call.
 inline bool isNoBuiltin(mlir::Operation *op, llvm::StringRef name) {
+  // `builtin` wins over both `nobuiltin` and `nobuiltins` on this call.
   if (op->hasAttr(cir::CIRDialect::getBuiltinAttrName()))
     return false;
+  // The singular `nobuiltin` mark blocks builtin handling for this call.
   if (op->hasAttr(cir::CIRDialect::getNoBuiltinAttrName()))
     return true;
+  // Otherwise check the `nobuiltins` list for this name.
   return noBuiltinListDisables(op, name);
 }
 

--- a/clang/test/CIR/CodeGen/func-identity-attr-char8.cpp
+++ b/clang/test/CIR/CodeGen/func-identity-attr-char8.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir
+
+namespace std {
+inline namespace __1 {
+template <class Iter, class T> Iter find(Iter first, Iter last, const T &value);
+}
+}
+
+char8_t *char8_call(char8_t *first, char8_t *last, const char8_t &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPDuDuEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>

--- a/clang/test/CIR/CodeGen/func-identity-attr-char8.cpp
+++ b/clang/test/CIR/CodeGen/func-identity-attr-char8.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck %s --input-file=%t.cir
+// RUN: FileCheck %s --input-file=%t.cir --implicit-check-not=narrow_char_params
 
 namespace std {
 inline namespace __1 {
@@ -11,3 +11,18 @@ char8_t *char8_call(char8_t *first, char8_t *last, const char8_t &value) {
   return std::find(first, last, value);
 }
 // CHECK: cir.func{{.*}} @_ZNSt3__14findIPDuDuEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>
+
+wchar_t *wchar_call(wchar_t *first, wchar_t *last, const wchar_t &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPwwEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>
+
+char16_t *char16_call(char16_t *first, char16_t *last, const char16_t &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPDsDsEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>
+
+char32_t *char32_call(char32_t *first, char32_t *last, const char32_t &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPDiDiEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>

--- a/clang/test/CIR/CodeGen/func-identity-attr.cpp
+++ b/clang/test/CIR/CodeGen/func-identity-attr.cpp
@@ -5,6 +5,7 @@
 namespace std {
 inline namespace __1 {
 int *find(int *first, int *last, int value);
+template <class Iter, class T> Iter find(Iter first, Iter last, const T &value);
 }
 struct container {
   int *find(int value);
@@ -33,7 +34,23 @@ void other_calls(S &s, std::container &c, int *first, int *last) {
   other::find(first, last, 42);
   s();
 }
+char *narrow_call(char *first, char *last, const char &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPccEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+
+char *mixed_call(char *first, char *last, const signed char &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPcaEET_S2_S2_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>
+
+volatile char *volatile_call(volatile char *first, volatile char *last,
+                             const char &value) {
+  return std::find(first, last, value);
+}
+// CHECK: cir.func{{.*}} @_ZNSt3__14findIPVccEET_S3_S3_RKT0_{{.*}} func_info<#cir.func_identity<"std::find">>
+
 // Members, static members, operators, and functions outside std match no
-// entity, so the free std find above stays the only tagged function.
-// TAG-COUNT-1: #cir.func_identity
+// entity, so the tagged functions above stay the only tagged functions.
+// TAG-COUNT-4: #cir.func_identity
 // TAG-NOT: #cir.func_identity

--- a/clang/test/CIR/CodeGen/size-type-width-attr.c
+++ b/clang/test/CIR/CodeGen/size-type-width-attr.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.lp64.cir
+// RUN: FileCheck --check-prefix=LP64 --input-file=%t.lp64.cir %s
+// RUN: %clang_cc1 -triple i686-unknown-linux-gnu -fclangir -emit-cir %s -o %t.ilp32.cir
+// RUN: FileCheck --check-prefix=ILP32 --input-file=%t.ilp32.cir %s
+
+// LP64: module{{.*}} attributes {{{.*}}cir.size_type_width = 64 : i32{{.*}}}
+// ILP32: module{{.*}} attributes {{{.*}}cir.size_type_width = 32 : i32{{.*}}}
+
+void f(void) {}

--- a/clang/test/CIR/IR/func-identity-attr.cir
+++ b/clang/test/CIR/IR/func-identity-attr.cir
@@ -5,4 +5,7 @@ module {
 cir.func private @_ZSt4findv() func_info<#cir.func_identity<"std::find">>
 // CHECK: cir.func private @_ZSt4findv() func_info<#cir.func_identity<"std::find">>
 
+cir.func private @_ZSt4findc() func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+// CHECK: cir.func private @_ZSt4findc() func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+
 }

--- a/clang/test/CIR/Transforms/lib-opt-find.cir
+++ b/clang/test/CIR/Transforms/lib-opt-find.cir
@@ -1,0 +1,98 @@
+// RUN: cir-opt --cir-lib-opt -split-input-file %s -o - | FileCheck %s
+
+!u8i = !cir.int<u, 8>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_2(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find">>
+
+  cir.func @transforms(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @transforms
+// CHECK-NOT: cir.std.find
+// CHECK: %[[LEN:.*]] = cir.ptr_diff
+// CHECK: cir.libc.memchr(%{{.*}}, %{{.*}}, %[[LEN]])
+// CHECK: cir.select
+
+  cir.func @keeps_without_narrow(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_2) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_without_narrow
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+
+  cir.func @keeps_no_builtin(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i> {nobuiltins = ["memchr"]}
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_no_builtin
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+
+  cir.func @keeps_enclosing_no_builtin(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> attributes {nobuiltins = ["memchr"]} {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_enclosing_no_builtin
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+
+  cir.func builtin @keeps_builtin_marked_function(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> attributes {nobuiltins = ["memchr"]} {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_builtin_marked_function
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+
+module {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+
+  cir.func @keeps_without_triple(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_without_triple
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+
+module attributes {cir.triple = "mips64-unknown-linux-gnuabin32"} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+
+  cir.func @keeps_on_n32(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_on_n32
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+
+module attributes {cir.triple = "powerpc64-scei-lv2"} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+
+  cir.func @keeps_on_ps3(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_on_ps3
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}

--- a/clang/test/CIR/Transforms/lib-opt-find.cir
+++ b/clang/test/CIR/Transforms/lib-opt-find.cir
@@ -32,6 +32,14 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 // CHECK: cir.std.find
 // CHECK-NOT: cir.libc.memchr
 
+  cir.func @keeps_no_builtin_marked_call(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i> {nobuiltin}
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_no_builtin_marked_call
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+
   cir.func @keeps_enclosing_no_builtin(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> attributes {nobuiltins = ["memchr"]} {
     %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
     cir.return %0 : !cir.ptr<!u8i>
@@ -47,6 +55,14 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 // CHECK-LABEL: @keeps_builtin_marked_function
 // CHECK: cir.std.find
 // CHECK-NOT: cir.libc.memchr
+
+  cir.func @transforms_in_no_builtin_marked_function(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> attributes {nobuiltin} {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @transforms_in_no_builtin_marked_function
+// CHECK-NOT: cir.std.find
+// CHECK: cir.libc.memchr
 }
 
 // -----

--- a/clang/test/CIR/Transforms/lib-opt-find.cir
+++ b/clang/test/CIR/Transforms/lib-opt-find.cir
@@ -2,7 +2,7 @@
 
 !u8i = !cir.int<u, 8>
 
-module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.size_type_width = 64 : i32} {
   cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
   cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_2(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find">>
 
@@ -10,11 +10,28 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
     %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
     cir.return %0 : !cir.ptr<!u8i>
   }
-// CHECK-LABEL: @transforms
+// CHECK-LABEL: cir.func @transforms
+// CHECK-SAME: (%[[FIRST:.*]]: !cir.ptr<!u8i>, %[[LAST:.*]]: !cir.ptr<!u8i>, %[[VALUE:.*]]: !cir.ptr<!u8i>)
 // CHECK-NOT: cir.std.find
-// CHECK: %[[LEN:.*]] = cir.ptr_diff
-// CHECK: cir.libc.memchr(%{{.*}}, %{{.*}}, %[[LEN]])
-// CHECK: cir.select
+// CHECK-NOT: cir.load
+// CHECK-NOT: cir.ptr_diff
+// CHECK-NOT: cir.libc.memchr
+// CHECK: %[[EMPTY:.*]] = cir.cmp eq %[[FIRST]], %[[LAST]] : !cir.ptr<!u8i>
+// CHECK: %[[RESULT:.*]] = cir.ternary(%[[EMPTY]], true {
+// CHECK-NEXT: cir.yield %[[LAST]] : !cir.ptr<!u8i>
+// CHECK-NEXT: }, false {
+// CHECK: %[[SRC:.*]] = cir.cast bitcast %[[FIRST]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
+// CHECK: %[[BYTE:.*]] = cir.load %[[VALUE]] : !cir.ptr<!u8i>, !u8i
+// CHECK: %[[PATTERN:.*]] = cir.cast integral %[[BYTE]] : !u8i -> !s32i
+// CHECK: %[[LEN:.*]] = cir.ptr_diff %[[LAST]], %[[FIRST]] : !cir.ptr<!u8i> -> !u64i
+// CHECK: %[[PTR:.*]] = cir.libc.memchr(%[[SRC]], %[[PATTERN]], %[[LEN]])
+// CHECK: %[[RES:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!void> -> !cir.ptr<!u8i>
+// CHECK: %[[NULL:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!u8i>
+// CHECK: %[[MISS:.*]] = cir.cmp eq %[[RES]], %[[NULL]] : !cir.ptr<!u8i>
+// CHECK: %[[SELECT:.*]] = cir.select if %[[MISS]] then %[[LAST]] else %[[RES]]
+// CHECK-NEXT: cir.yield %[[SELECT]] : !cir.ptr<!u8i>
+// CHECK-NEXT: }) : (!cir.bool) -> !cir.ptr<!u8i>
+// CHECK: cir.return %[[RESULT]] : !cir.ptr<!u8i>
 
   cir.func @keeps_without_narrow(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
     %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_2) -> !cir.ptr<!u8i>
@@ -69,7 +86,7 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 
 !u8i = !cir.int<u, 8>
 
-module {
+module attributes {cir.size_type_width = 64 : i32} {
   cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
 
   cir.func @keeps_without_triple(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
@@ -85,14 +102,14 @@ module {
 
 !u8i = !cir.int<u, 8>
 
-module attributes {cir.triple = "mips64-unknown-linux-gnuabin32"} {
+module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
 
-  cir.func @keeps_on_n32(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+  cir.func @keeps_without_size_width(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
     %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
     cir.return %0 : !cir.ptr<!u8i>
   }
-// CHECK-LABEL: @keeps_on_n32
+// CHECK-LABEL: @keeps_without_size_width
 // CHECK: cir.std.find
 // CHECK-NOT: cir.libc.memchr
 }
@@ -101,14 +118,92 @@ module attributes {cir.triple = "mips64-unknown-linux-gnuabin32"} {
 
 !u8i = !cir.int<u, 8>
 
-module attributes {cir.triple = "powerpc64-scei-lv2"} {
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.size_type_width = 32 : i32} {
   cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
 
-  cir.func @keeps_on_ps3(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+  cir.func @keeps_on_32_bit_width(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
     %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
     cir.return %0 : !cir.ptr<!u8i>
   }
-// CHECK-LABEL: @keeps_on_ps3
+// CHECK-LABEL: @keeps_on_32_bit_width
 // CHECK: cir.std.find
 // CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.size_type_width = 64 : si32} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+
+  cir.func @keeps_on_signed_width(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_on_signed_width
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+!s32i = !cir.int<s, 32>
+!u64i = !cir.int<u, 64>
+!voidptr = !cir.ptr<!cir.void>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.size_type_width = 64 : i32} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+  cir.func private @memchr(!voidptr, !s32i, !u64i) -> !voidptr
+
+  cir.func @keeps_with_memchr_function(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_with_memchr_function
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+!s32i = !cir.int<s, 32>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.size_type_width = 64 : i32} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+  cir.global external @memchr = #cir.int<0> : !s32i
+
+  cir.func @keeps_with_memchr_global(%arg0: !cir.ptr<!u8i>, %arg1: !cir.ptr<!u8i>, %arg2: !cir.ptr<!u8i>) -> !cir.ptr<!u8i> {
+    %0 = cir.std.find(%arg0 : !cir.ptr<!u8i>, %arg1 : !cir.ptr<!u8i>, %arg2 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    cir.return %0 : !cir.ptr<!u8i>
+  }
+// CHECK-LABEL: @keeps_with_memchr_global
+// CHECK: cir.std.find
+// CHECK-NOT: cir.libc.memchr
+}
+
+// -----
+
+!u8i = !cir.int<u, 8>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.size_type_width = 64 : i32} {
+  cir.func private @_ZSt4findIPhhET_S1_S1_RKT0_(!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !cir.ptr<!u8i> func_info<#cir.func_identity<"std::find", narrow_char_params = true>>
+  cir.global external @buf = #cir.zero : !cir.array<!u8i x 8>
+  cir.global external @val = #cir.int<99> : !u8i
+
+  cir.global external @g = ctor : !cir.ptr<!u8i> {
+    %0 = cir.get_global @buf : !cir.ptr<!cir.array<!u8i x 8>>
+    %1 = cir.cast array_to_ptrdecay %0 : !cir.ptr<!cir.array<!u8i x 8>> -> !cir.ptr<!u8i>
+    %2 = cir.const #cir.int<8> : !cir.int<s, 64>
+    %3 = cir.ptr_stride %1, %2 : (!cir.ptr<!u8i>, !cir.int<s, 64>) -> !cir.ptr<!u8i>
+    %4 = cir.get_global @val : !cir.ptr<!u8i>
+    %5 = cir.std.find(%1 : !cir.ptr<!u8i>, %3 : !cir.ptr<!u8i>, %4 : !cir.ptr<!u8i>, @_ZSt4findIPhhET_S1_S1_RKT0_) -> !cir.ptr<!u8i>
+    %6 = cir.get_global @g : !cir.ptr<!cir.ptr<!u8i>>
+    cir.store %5, %6 : !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>
+  }
+// CHECK-LABEL: cir.global external @g = ctor
+// CHECK-NOT: cir.std.find
+// CHECK: cir.libc.memchr
 }

--- a/clang/test/CIR/Transforms/lib-opt-find.cpp
+++ b/clang/test/CIR/Transforms/lib-opt-find.cpp
@@ -1,0 +1,168 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir
+// RUN: %clang_cc1 -std=c++17 -triple i686-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.ilp32.cir
+// RUN: FileCheck %s --input-file=%t.ilp32.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnux32 -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.x32.cir
+// RUN: FileCheck %s --input-file=%t.x32.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple aarch64-unknown-linux-gnu_ilp32 -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.a64ilp32.cir
+// RUN: FileCheck %s --input-file=%t.a64ilp32.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple spirv-unknown-vulkan-compute -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.spirv.cir
+// RUN: FileCheck %s --input-file=%t.spirv.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple amdgcn-amd-amdhsa -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.amdgcn.cir
+// RUN: FileCheck %s --input-file=%t.amdgcn.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple nvptx64-nvidia-cuda -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nvptx.cir
+// RUN: FileCheck %s --input-file=%t.nvptx.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple bpfel -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.bpf.cir
+// RUN: FileCheck %s --input-file=%t.bpf.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -ffreestanding -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.free.cir
+// RUN: FileCheck %s --input-file=%t.free.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fno-builtin-memchr -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nomemchr.cir
+// RUN: FileCheck %s --input-file=%t.nomemchr.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fno-builtin-strlen -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nostrlen.cir
+// RUN: FileCheck %s --input-file=%t.nostrlen.cir
+// NOXFORM: cir.call @_ZSt4findIPhhET_S1_S1_RKT0_
+// NOXFORM: cir.call @_ZSt4findIPccET_S1_S1_RKT0_
+// NOXFORM: cir.call @_ZSt4findIPaaET_S1_S1_RKT0_
+
+namespace std {
+template <class Iter, class T> Iter find(Iter, Iter, const T &);
+}
+
+unsigned char *test_byte_find(unsigned char *first, unsigned char *last,
+                              const unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z14test_byte_findPhS_RKh
+// CHECK: %[[FIRST:.*]] = cir.load align(8) %{{.*}} : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK: %[[LAST:.*]] = cir.load align(8) %{{.*}} : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK: %[[VALUEPTR:.*]] = cir.load %{{.*}} : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK-NOT: cir.call
+// CHECK: %[[SRC:.*]] = cir.cast bitcast %[[FIRST]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
+// CHECK: %[[BYTE:.*]] = cir.load %[[VALUEPTR]] : !cir.ptr<!u8i>, !u8i
+// CHECK: %[[PATTERN:.*]] = cir.cast integral %[[BYTE]] : !u8i -> !s32i
+// CHECK: %[[LEN:.*]] = cir.ptr_diff %[[LAST]], %[[FIRST]] : !cir.ptr<!u8i> -> !u64i
+// CHECK: %[[PTR:.*]] = cir.libc.memchr(%[[SRC]], %[[PATTERN]], %[[LEN]])
+// CHECK: %[[RES:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!void> -> !cir.ptr<!u8i>
+// CHECK: %[[NULL:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!u8i>
+// CHECK: %[[MISS:.*]] = cir.cmp eq %[[RES]], %[[NULL]]
+// CHECK: cir.select if %[[MISS]] then %[[LAST]] else %[[RES]]
+
+char *test_char_find(char *first, char *last, const char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z14test_char_findPcS_RKc
+// CHECK-NOT: cir.call
+// CHECK: cir.cast integral %{{.*}} : !s8i -> !s32i
+// CHECK: %[[CLEN:.*]] = cir.ptr_diff %{{.*}}, %{{.*}} : !cir.ptr<!s8i> -> !u64i
+// CHECK: %[[CPTR:.*]] = cir.libc.memchr(%{{.*}}, %{{.*}}, %[[CLEN]])
+// CHECK: %[[CRES:.*]] = cir.cast bitcast %[[CPTR]] : !cir.ptr<!void> -> !cir.ptr<!s8i>
+// CHECK: %[[CMISS:.*]] = cir.cmp eq %[[CRES]], %{{.*}}
+// CHECK: cir.select if %[[CMISS]] then %{{.*}} else %[[CRES]]
+
+signed char *test_signed_char_find(signed char *first, signed char *last,
+                                   const signed char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z21test_signed_char_find
+// CHECK-NOT: cir.call
+// CHECK: cir.cast integral %{{.*}} : !s8i -> !s32i
+// CHECK: %[[SLEN:.*]] = cir.ptr_diff %{{.*}}, %{{.*}} : !cir.ptr<!s8i> -> !u64i
+// CHECK: %[[SPTR:.*]] = cir.libc.memchr(%{{.*}}, %{{.*}}, %[[SLEN]])
+// CHECK: %[[SRES:.*]] = cir.cast bitcast %[[SPTR]] : !cir.ptr<!void> -> !cir.ptr<!s8i>
+// CHECK: %[[SMISS:.*]] = cir.cmp eq %[[SRES]], %{{.*}}
+// CHECK: cir.select if %[[SMISS]] then %{{.*}} else %[[SRES]]
+
+int *test_int_find(int *first, int *last, const int &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z13test_int_findPiS_RKi
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+char *test_sign_mismatch(char *first, char *last, const unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z18test_sign_mismatchPcS_RKh
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+char *test_char_flavors(char *first, char *last, const signed char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z17test_char_flavorsPcS_RKa
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+volatile unsigned char *test_volatile_find(volatile unsigned char *first,
+                                           volatile unsigned char *last,
+                                           const unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z18test_volatile_findPVhS0_RKh
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+unsigned char *test_volatile_value(unsigned char *first, unsigned char *last,
+                                   const volatile unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z19test_volatile_valuePhS_RVKh
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+__attribute__((no_builtin("memchr")))
+unsigned char *test_fn_no_builtin(unsigned char *first, unsigned char *last,
+                                  const unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z18test_fn_no_builtinPhS_RKh
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+enum class Tri : unsigned char { A, B, C };
+bool operator==(Tri, Tri);
+Tri *test_enum_find(Tri *first, Tri *last, const Tri &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z14test_enum_findP3TriS0_RKS_
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+typedef _Atomic(unsigned char) AByte;
+AByte *test_atomic_find(AByte *first, AByte *last,
+                        const unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z16test_atomic_find
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+struct Byte {
+  unsigned char b;
+  bool operator==(const Byte &) const;
+};
+Byte *test_record_find(Byte *first, Byte *last, const Byte &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z16test_record_findP4ByteS0_RKS_
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find
+
+typedef __attribute__((address_space(1))) unsigned char ASByte;
+ASByte *test_addr_space_find(ASByte *first, ASByte *last,
+                             const unsigned char &value) {
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z20test_addr_space_findPU3AS1hS0_RKh
+// CHECK: cir.call @_ZSt4find{{.*}}(
+// CHECK-NOT: cir.libc.memchr
+// CHECK-NOT: cir.std.find

--- a/clang/test/CIR/Transforms/lib-opt-find.cpp
+++ b/clang/test/CIR/Transforms/lib-opt-find.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir
+// RUN: %clang_cc1 -std=c++17 -triple aarch64-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.a64.cir
+// RUN: FileCheck %s --input-file=%t.a64.cir
 // RUN: %clang_cc1 -std=c++17 -triple i686-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.ilp32.cir
 // RUN: FileCheck %s --input-file=%t.ilp32.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnux32 -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.x32.cir
@@ -16,15 +18,38 @@
 // RUN: FileCheck %s --input-file=%t.bpf.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple spir64-unknown-unknown -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.spir64.cir
 // RUN: FileCheck %s --input-file=%t.spir64.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple powerpc64le-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.ppc64le.cir
+// RUN: FileCheck %s --input-file=%t.ppc64le.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple s390x-unknown-linux-gnu -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.s390x.cir
+// RUN: FileCheck %s --input-file=%t.s390x.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -ffreestanding -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.free.cir
 // RUN: FileCheck %s --input-file=%t.free.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fno-builtin-memchr -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nomemchr.cir
 // RUN: FileCheck %s --input-file=%t.nomemchr.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fno-builtin-strlen -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nostrlen.cir
 // RUN: FileCheck %s --input-file=%t.nostrlen.cir
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -DMEMCHR_NORETURN -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.noreturn.cir
+// RUN: FileCheck %s --input-file=%t.noreturn.cir --check-prefixes=NOXFORM,NORETURN --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -DMEMCHR_NONNULL -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nonnull.cir
+// RUN: FileCheck %s --input-file=%t.nonnull.cir --check-prefixes=NOXFORM,NONNULL --implicit-check-not=cir.libc.memchr
+// NORETURN: cir.func private @memchr({{.*}}) -> !cir.ptr<!void> {{.*}}noreturn
+// NONNULL: cir.func private @memchr({{.*}}) -> (!cir.ptr<!void> {llvm.nonnull})
 // NOXFORM: cir.call @_ZSt4findIPhhET_S1_S1_RKT0_
 // NOXFORM: cir.call @_ZSt4findIPccET_S1_S1_RKT0_
 // NOXFORM: cir.call @_ZSt4findIPaaET_S1_S1_RKT0_
+// NOXFORM: cir.call @_ZSt4findIPaaET_S1_S1_RKT0_
+
+#ifdef MEMCHR_NORETURN
+extern "C" __attribute__((noreturn)) void *memchr(const void *, int,
+                                                  unsigned long);
+#endif
+#ifdef MEMCHR_NONNULL
+extern "C" __attribute__((returns_nonnull)) void *memchr(const void *, int,
+                                                         unsigned long);
+#endif
+#if defined(MEMCHR_NORETURN) || defined(MEMCHR_NONNULL)
+const void *force_memchr(const void *p) { return memchr(p, 'x', 4); }
+#endif
 
 namespace std {
 template <class Iter, class T> Iter find(Iter, Iter, const T &);
@@ -35,10 +60,20 @@ unsigned char *test_byte_find(unsigned char *first, unsigned char *last,
   return std::find(first, last, value);
 }
 // CHECK-LABEL: @_Z14test_byte_findPhS_RKh
-// CHECK: %[[FIRST:.*]] = cir.load align(8) %{{.*}} : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-// CHECK: %[[LAST:.*]] = cir.load align(8) %{{.*}} : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-// CHECK: %[[VALUEPTR:.*]] = cir.load %{{.*}} : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK: %[[FIRSTSLOT:.*]] = cir.alloca "first" align(8) init : !cir.ptr<!cir.ptr<!u8i>>
+// CHECK: %[[LASTSLOT:.*]] = cir.alloca "last" align(8) init : !cir.ptr<!cir.ptr<!u8i>>
+// CHECK: %[[VALUESLOT:.*]] = cir.alloca "value" align(8) init const : !cir.ptr<!cir.ptr<!u8i>>
+// CHECK: %[[FIRST:.*]] = cir.load align(8) %[[FIRSTSLOT]] : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK: %[[LAST:.*]] = cir.load align(8) %[[LASTSLOT]] : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK: %[[VALUEPTR:.*]] = cir.load %[[VALUESLOT]] : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
 // CHECK-NOT: cir.call
+// CHECK-NOT: cir.load %[[VALUEPTR]]
+// CHECK-NOT: cir.ptr_diff
+// CHECK-NOT: cir.libc.memchr
+// CHECK: %[[EMPTY:.*]] = cir.cmp eq %[[FIRST]], %[[LAST]] : !cir.ptr<!u8i>
+// CHECK: cir.ternary(%[[EMPTY]], true {
+// CHECK-NEXT: cir.yield %[[LAST]] : !cir.ptr<!u8i>
+// CHECK-NEXT: }, false {
 // CHECK: %[[SRC:.*]] = cir.cast bitcast %[[FIRST]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
 // CHECK: %[[BYTE:.*]] = cir.load %[[VALUEPTR]] : !cir.ptr<!u8i>, !u8i
 // CHECK: %[[PATTERN:.*]] = cir.cast integral %[[BYTE]] : !u8i -> !s32i
@@ -47,7 +82,9 @@ unsigned char *test_byte_find(unsigned char *first, unsigned char *last,
 // CHECK: %[[RES:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!void> -> !cir.ptr<!u8i>
 // CHECK: %[[NULL:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!u8i>
 // CHECK: %[[MISS:.*]] = cir.cmp eq %[[RES]], %[[NULL]]
-// CHECK: cir.select if %[[MISS]] then %[[LAST]] else %[[RES]]
+// CHECK: %[[SELECT:.*]] = cir.select if %[[MISS]] then %[[LAST]] else %[[RES]]
+// CHECK-NEXT: cir.yield %[[SELECT]] : !cir.ptr<!u8i>
+// CHECK-NEXT: }) : (!cir.bool) -> !cir.ptr<!u8i>
 
 char *test_char_find(char *first, char *last, const char &value) {
   return std::find(first, last, value);
@@ -60,6 +97,19 @@ char *test_char_find(char *first, char *last, const char &value) {
 // CHECK: %[[CRES:.*]] = cir.cast bitcast %[[CPTR]] : !cir.ptr<!void> -> !cir.ptr<!s8i>
 // CHECK: %[[CMISS:.*]] = cir.cmp eq %[[CRES]], %{{.*}}
 // CHECK: cir.select if %[[CMISS]] then %{{.*}} else %[[CRES]]
+
+signed char *test_high_bit_find(signed char *first, signed char *last) {
+  signed char value = -128;
+  return std::find(first, last, value);
+}
+// CHECK-LABEL: @_Z18test_high_bit_findPaS_
+// CHECK: %[[SLOT:.*]] = cir.alloca "value" align(1) init : !cir.ptr<!s8i>
+// CHECK: %[[HIGH:.*]] = cir.const #cir.int<-128> : !s8i
+// CHECK: cir.store align(1) %[[HIGH]], %[[SLOT]] : !s8i, !cir.ptr<!s8i>
+// CHECK-NOT: cir.call
+// CHECK: %[[HBYTE:.*]] = cir.load %[[SLOT]] : !cir.ptr<!s8i>, !s8i
+// CHECK: %[[HPATTERN:.*]] = cir.cast integral %[[HBYTE]] : !s8i -> !s32i
+// CHECK: cir.libc.memchr(%{{.*}}, %[[HPATTERN]], %{{.*}})
 
 signed char *test_signed_char_find(signed char *first, signed char *last,
                                    const signed char &value) {

--- a/clang/test/CIR/Transforms/lib-opt-find.cpp
+++ b/clang/test/CIR/Transforms/lib-opt-find.cpp
@@ -14,6 +14,8 @@
 // RUN: FileCheck %s --input-file=%t.nvptx.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple bpfel -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.bpf.cir
 // RUN: FileCheck %s --input-file=%t.bpf.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
+// RUN: %clang_cc1 -std=c++17 -triple spir64-unknown-unknown -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.spir64.cir
+// RUN: FileCheck %s --input-file=%t.spir64.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -ffreestanding -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.free.cir
 // RUN: FileCheck %s --input-file=%t.free.cir --check-prefix=NOXFORM --implicit-check-not=cir.libc.memchr
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fno-builtin-memchr -fclangir -O1 -clangir-enable-idiom-recognizer -clangir-lib-opt -emit-cir %s -o %t.nomemchr.cir

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -87,6 +87,10 @@ int main(int argc, char **argv) {
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createLibOptPass();
+  });
+
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createCallConvLoweringPass();
   });
 


### PR DESCRIPTION
This patch adds the first transformation to the LibOpt pass, following the ClangIR incubator. A raised `std::find` over a byte range becomes a call to `memchr`. A null result is mapped back to the final iterator through `cir.select`.

The rewrite requires the range elements and searched value to use the same narrow character type. Enums may use custom equality, while atomic and volatile elements require special accesses. Mixed character types can also compare differently when plain char is unsigned. CIR types do not preserve all of these distinctions, so CIRGen records the required fact through `narrow_char_params` on the function identity attribute. LibOpt reads this fact from the original callee.

The rewrite introduces `memchr`, so it respects the no builtin state recorded on both the raised operation and the enclosing function. It also declines when the module already holds a symbol named `memchr`, because the introduced call binds to that symbol. Targets where `size_t` is not 64 bits keep the original call, using the width CIRGen now records on the module as `cir.size_type_width` rather than the triple.

The target check is an allow list, because the current `memchr` lowering supplies no ABI extension attributes. AArch64 GNUILP32 is excluded because its AST types disagree with the data layout. An empty range yields the final iterator without forming the call. Ranges outside the default address space are not rewritten. The pass is registered with `cir-opt`. Tests cover successful rewrites and rejected cases from both frontend generated and parsed CIR.

Aided by Claude Opus 4.8