### PR TITLE
[libc++] Add static_assert diagnostics for LWG3133 named requirements

### DIFF
--- a/libcxx/docs/Status/Cxx20Issues.csv
+++ b/libcxx/docs/Status/Cxx20Issues.csv
@@ -136,7 +136,7 @@
 "`LWG3101 <https://wg21.link/LWG3101>`__","``span``\ 's ``Container``\  constructors need another constraint","2019-02 (Kona)","|Complete|","","`#103837 <https://github.com/llvm/llvm-project/issues/103837>`__",""
 "`LWG3112 <https://wg21.link/LWG3112>`__","``system_error``\  and ``filesystem_error``\  constructors taking a ``string``\  may not be able to meet their postconditions","2019-02 (Kona)","|Nothing To Do|","","`#100253 <https://github.com/llvm/llvm-project/issues/100253>`__",""
 "`LWG3119 <https://wg21.link/LWG3119>`__","Program-definedness of closure types","2019-02 (Kona)","|Nothing To Do|","","`#103838 <https://github.com/llvm/llvm-project/issues/103838>`__",""
-"`LWG3133 <https://wg21.link/LWG3133>`__","Modernizing numeric type requirements","2019-02 (Kona)","","","`#100254 <https://github.com/llvm/llvm-project/issues/100254>`__",""
+"`LWG3133 <https://wg21.link/LWG3133>`__","Modernizing numeric type requirements","2019-02 (Kona)","|Complete|","24","`#100254 <https://github.com/llvm/llvm-project/issues/100254>`__",""
 "`LWG3144 <https://wg21.link/LWG3144>`__","``span``\  does not have a ``const_pointer``\  typedef","2019-02 (Kona)","|Complete|","","`#103839 <https://github.com/llvm/llvm-project/issues/103839>`__",""
 "`LWG3173 <https://wg21.link/LWG3173>`__","Enable CTAD for ``ref-view``\ ","2019-02 (Kona)","|Complete|","15","`#103840 <https://github.com/llvm/llvm-project/issues/103840>`__",""
 "`LWG3179 <https://wg21.link/LWG3179>`__","``subrange``\  should always model ``Range``\ ","2019-02 (Kona)","|Nothing To Do|","","`#103842 <https://github.com/llvm/llvm-project/issues/103842>`__",""

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -266,6 +266,11 @@ template<class T> complex<T> tanh (const complex<T>&);
 #  include <__tuple/tuple_element.h>
 #  include <__tuple/tuple_size.h>
 #  include <__type_traits/conditional.h>
+#  include <__type_traits/is_assignable.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_destructible.h>
+#  include <__type_traits/is_object.h>
+#  include <__type_traits/is_unqualified.h>
 #  include <__utility/move.h>
 #  include <cmath>
 #  include <version>
@@ -306,6 +311,13 @@ template <class _Tp>
 class complex {
 public:
   typedef _Tp value_type;
+
+  static_assert(is_object<_Tp>::value && __is_unqualified_v<_Tp> && is_default_constructible<_Tp>::value &&
+                    is_copy_constructible<_Tp>::value && is_copy_assignable<_Tp>::value &&
+                    is_destructible<_Tp>::value,
+                "std::complex<T> requires T to be a cv-unqualified object type that satisfies the "
+                "Cpp17DefaultConstructible, Cpp17CopyConstructible, Cpp17CopyAssignable, and "
+                "Cpp17Destructible requirements");
 
 private:
   value_type __re_;

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -361,6 +361,11 @@ template <class T> unspecified2 end(const valarray<T>& v);
 #  include <__memory/allocator.h>
 #  include <__memory/uninitialized_algorithms.h>
 #  include <__type_traits/decay.h>
+#  include <__type_traits/is_assignable.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_destructible.h>
+#  include <__type_traits/is_object.h>
+#  include <__type_traits/is_unqualified.h>
 #  include <__type_traits/remove_reference.h>
 #  include <__utility/exception_guard.h>
 #  include <__utility/move.h>
@@ -785,6 +790,13 @@ template <class _Tp>
 class valarray {
 public:
   typedef _Tp value_type;
+
+  static_assert(is_object<_Tp>::value && __is_unqualified_v<_Tp> && is_default_constructible<_Tp>::value &&
+                    is_copy_constructible<_Tp>::value && is_copy_assignable<_Tp>::value &&
+                    is_destructible<_Tp>::value,
+                "std::valarray<T> requires T to be a cv-unqualified object type that satisfies the "
+                "Cpp17DefaultConstructible, Cpp17CopyConstructible, Cpp17CopyAssignable, and "
+                "Cpp17Destructible requirements");
   typedef _Tp __result_type;
 
 private:

--- a/libcxx/test/std/numerics/complex.number/complex/complex_requires_cv_unqualified_object.verify.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex/complex_requires_cv_unqualified_object.verify.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
+// <complex>
+
+// template<class T>
+// class complex
+//
+// T shall be a cv-unqualified object type (LWG3133)
+
+#include <complex>
+
+struct NotDefaultConstructible {
+  NotDefaultConstructible() = delete;
+};
+
+struct NotCopyConstructible {
+  NotCopyConstructible()                            = default;
+  NotCopyConstructible(const NotCopyConstructible&) = delete;
+};
+
+struct NotCopyAssignable {
+  NotCopyAssignable()                                    = default;
+  NotCopyAssignable(const NotCopyAssignable&)            = default;
+  NotCopyAssignable& operator=(const NotCopyAssignable&) = delete;
+};
+
+struct NotDestructible {
+  NotDestructible()                                  = default;
+  NotDestructible(const NotDestructible&)            = default;
+  NotDestructible& operator=(const NotDestructible&) = default;
+
+private:
+  ~NotDestructible() = default;
+};
+
+void test() {
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<const double>);
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<volatile int>);
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<const volatile float>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<NotDefaultConstructible>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<NotCopyConstructible>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<NotCopyAssignable>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::complex<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::complex<NotDestructible>);
+}

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/access.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/access.pass.cpp
@@ -15,6 +15,7 @@
 #include <valarray>
 #include <cassert>
 
+#include "operator_hijacker.h"
 #include "test_macros.h"
 
 int main(int, char**)
@@ -30,6 +31,11 @@ int main(int, char**)
             v[i] = i;
             assert(v[i] == static_cast<int>(i));
         }
+    }
+    {
+      std::valarray<operator_hijacker> v(1);
+      operator_hijacker& r = v[0];
+      (void)r;
     }
 
   return 0;

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/const_access.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/const_access.pass.cpp
@@ -15,6 +15,7 @@
 #include <valarray>
 #include <cassert>
 
+#include "operator_hijacker.h"
 #include "test_macros.h"
 
 int main(int, char**)
@@ -28,6 +29,11 @@ int main(int, char**)
         {
             assert(v[i] == a[i]);
         }
+    }
+    {
+      const std::valarray<operator_hijacker> v(1);
+      const operator_hijacker& r = v[0];
+      (void)r;
     }
 
   return 0;

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray_requires_cv_unqualified_object.verify.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray_requires_cv_unqualified_object.verify.cpp
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
+// <valarray>
+
+// template<class T>
+// class valarray
+//
+// T shall be a cv-unqualified object type that satisfies the Cpp17DefaultConstructible,
+// Cpp17CopyConstructible, Cpp17CopyAssignable, and Cpp17Destructible requirements (LWG3133)
+
+#include <valarray>
+
+struct NotDefaultConstructible {
+  NotDefaultConstructible() = delete;
+};
+
+struct NotCopyConstructible {
+  NotCopyConstructible()                            = default;
+  NotCopyConstructible(const NotCopyConstructible&) = delete;
+};
+
+struct NotCopyAssignable {
+  NotCopyAssignable()                                    = default;
+  NotCopyAssignable(const NotCopyAssignable&)            = default;
+  NotCopyAssignable& operator=(const NotCopyAssignable&) = delete;
+};
+
+struct NotDestructible {
+  NotDestructible()                                  = default;
+  NotDestructible(const NotDestructible&)            = default;
+  NotDestructible& operator=(const NotDestructible&) = default;
+
+private:
+  ~NotDestructible() = default;
+};
+
+void test() {
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::valarray<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::valarray<const int>);
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::valarray<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::valarray<volatile int>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::valarray<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::valarray<NotDefaultConstructible>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::valarray<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::valarray<NotCopyConstructible>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::valarray<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::valarray<NotCopyAssignable>);
+
+  // expected-error-re@*:* {{static assertion failed{{.*}}std::valarray<T> requires T to be a cv-unqualified object type}}
+  (void)sizeof(std::valarray<NotDestructible>);
+}


### PR DESCRIPTION
Add a static_assert to both std::complex<T> and std::valarray<T> requiring that T be a cv-unqualified object type that satisfies the Cpp17DefaultConstructible, Cpp17CopyConstructible, Cpp17CopyAssignable, and Cpp17Destructible named requirements, per the revised wording in [numeric.requirements]. This mirrors the existing pattern already used by std::optional<T>.

The individual traits are combined using _And instead of a raw && chain, and the non-_v (class-style) trait forms are used throughout so that the assertion is well-formed even when <complex>/<valarray> are included in C++03/11/14 mode.

Test coverage:
- A .verify.cpp for complex<T> and one for valarray<T>, each covering six failure modes: cv-qualified types, and one type violating each of the four named requirements individually.
- operator_hijacker-based tests added to valarray's access.pass.cpp and const_access.pass.cpp, confirming operator[] does not rely on a user-overloadable operator&.

Fixes #100254