### PR TITLE
[clang] Avoid folding __builtin_nan with non-char strings

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -20395,6 +20395,8 @@ static bool TryEvaluateBuiltinNaN(const ASTContext &Context,
                                   llvm::APFloat &Result) {
   const StringLiteral *S = dyn_cast<StringLiteral>(Arg->IgnoreParenCasts());
   if (!S) return false;
+  if (S->getCharByteWidth() != 1)
+    return false;
 
   const llvm::fltSemantics &Sem = Context.getFloatTypeSemantics(ResultTy);
 

--- a/clang/test/Sema/constant-builtins-2.c
+++ b/clang/test/Sema/constant-builtins-2.c
@@ -23,6 +23,10 @@ long double  g8  = __builtin_nanl("");
 __float128   g8_2 = __builtin_nanf128("");
 #endif
 
+// expected-error@+2 {{incompatible pointer types passing}}
+// expected-error@+1 {{initializer element is not a compile-time constant}}
+char         g8_3 = __builtin_nanf(L"");
+
 // GCC constant folds these too (via native strtol):
 //double       g6_1  = __builtin_nan("1");
 //float        g7_1  = __builtin_nanf("1");


### PR DESCRIPTION
Fixes #205306.

`__builtin_nan*` constant evaluation parses the payload with
`StringLiteral::getString()`, which assumes a 1-byte string literal.

For invalid calls such as `__builtin_nanf(L"")`, Sema already diagnoses the
argument type mismatch, but constant evaluation could still try to fold the
builtin and assert when reading the wide string literal.

This change skips folding for non-1-byte string literals, preserving diagnostics
without crashing.

Tested with:
- `build\bin\clang.exe -cc1 -fsyntax-only -verify clang\test\Sema\constant-builtins-2.c`