### PR TITLE
[lldb] Fix trace test assertions after error-message style change

### DIFF
--- a/lldb/test/API/commands/trace/TestTraceDumpInfo.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpInfo.py
@@ -34,7 +34,7 @@ class TestTraceDumpInfo(TraceIntelPTTestCaseBase):
 
         self.expect(
             "thread trace dump info",
-            substrs=["error: Process is not being traced"],
+            substrs=["error: process is not being traced"],
             error=True,
         )
 

--- a/lldb/test/API/commands/trace/TestTraceDumpInstructions.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpInstructions.py
@@ -32,7 +32,7 @@ class TestTraceDumpInstructions(TraceIntelPTTestCaseBase):
 
         self.expect(
             "thread trace dump instructions",
-            substrs=["error: Process is not being traced"],
+            substrs=["error: process is not being traced"],
             error=True,
         )
 

--- a/lldb/test/API/commands/trace/TestTraceExport.py
+++ b/lldb/test/API/commands/trace/TestTraceExport.py
@@ -38,7 +38,7 @@ class TestTraceExport(TraceIntelPTTestCaseBase):
 
         self.expect(
             f"thread trace export ctf --file {ctf_test_file}",
-            substrs=["error: Process is not being traced"],
+            substrs=["error: process is not being traced"],
             error=True,
         )
 

--- a/lldb/test/API/commands/trace/TestTraceSave.py
+++ b/lldb/test/API/commands/trace/TestTraceSave.py
@@ -40,7 +40,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
         self.expect("run")
 
         self.expect(
-            "trace save", substrs=["error: Process is not being traced"], error=True
+            "trace save", substrs=["error: process is not being traced"], error=True
         )
 
     @skipIfNoIntelPT

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -220,7 +220,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
         self.expect(
             "thread trace stop",
             error=True,
-            substrs=["error: Process is not being traced"],
+            substrs=["error: process is not being traced"],
         )
 
         # the help command should be the intel-pt one now


### PR DESCRIPTION
Commit 820f4402745d ([lldb] Correct style of error messages, #156774) changed the "process is not being traced" error emitted by CommandObject::CheckRequirements from "Process is not being traced." to "process is not being traced" (lowercase, no trailing period), but did not update the trace API tests that assert on that string.

These tests only run when the intel-pt plugin is enabled and the host has Intel PT support (TraceIntelPTTestCaseBase.setUp skips otherwise), so they are skipped on most buildbots and the stale assertions went unnoticed. Update all five affected tests to match the new message.