### PR TITLE
[Sema] Fix crash in __builtin_dump_struct with -Werror -Wformat-pedantic

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -350,6 +350,8 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed a crash when classifying a call to a builtin with dependent arguments,
   such as when the call is used as an `auto` non-type template argument.
+- Fixed a crash in ``__builtin_dump_struct`` when ``-Werror`` promotes
+  format warnings to errors. (#GH211943)
 
 #### Bug Fixes to Attribute Support
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -541,9 +541,9 @@ struct BuiltinDumpStructGenerator {
     S.popCodeSynthesisContext();
     if (!RealCall.isInvalid())
       Actions.push_back(RealCall.get());
-    // Bail out if we've hit any errors, even if we managed to build the
-    // call. We don't want to produce more than one error.
-    return RealCall.isInvalid() || ErrorTracker.hasErrorOccurred();
+    // Bail out if we've hit any unrecoverable errors, even if we managed
+    // to build the call.
+    return RealCall.isInvalid() || ErrorTracker.hasUnrecoverableErrorOccurred();
   }
 
   Expr *getIndentString(unsigned Depth) {

--- a/clang/test/CodeGenCXX/GH211943.cpp
+++ b/clang/test/CodeGenCXX/GH211943.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -Wformat-pedantic -Werror -emit-llvm -o /dev/null -verify %s
+
+int printflike(const char *__restrict__ x, ...) __attribute__((__format__(__printf__, 1, 2)));
+
+struct Foo {
+    int *x;
+};
+
+void test() {
+    __builtin_dump_struct(&(struct Foo){0}, printflike); // expected-error {{taking the address of a temporary object of type 'struct Foo'}} \
+                                                         // expected-error {{format specifies type 'void *' but the argument has type 'int *'}} \
+                                                         // expected-note {{in call to printing function}}
+}


### PR DESCRIPTION
`DiagnosticErrorTrap::hasErrorOccurred()` treats warnings promoted to errors by `-Werror` as real errors, causing `BuiltinDumpStructGenerator` to bail out before building the `PseudoObjectExpr` wrapper. CodeGen then encounters the untransformed `CallExpr` with a placeholder builtin type and hits `llvm_unreachable` in `CodeGenTypes::ConvertType`.
Use `hasUnrecoverableErrorOccurred()` instead, which ignores `-Werror` promoted warnings and only bails on genuine compilation errors.

Fixes #211943