### PR TITLE
[LLDB] Remove Xcode sdk guessing from Makefile.rules (NFC)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -209,15 +209,6 @@ class Builder:
             "CXX=%s" % cxx,
         ] + utils
 
-    def getSDKRootSpec(self):
-        """
-        Helper function to return the key-value string to specify the SDK root
-        used for the make system.
-        """
-        if configuration.sdkroot:
-            return ["SDKROOT={}".format(configuration.sdkroot)]
-        return []
-
     def getModuleCacheSpec(self):
         """
         Helper function to return the key-value string to specify the clang
@@ -302,7 +293,6 @@ class Builder:
             self.getTripleSpec(),
             self.getToolchainSpec(compiler),
             self.getExtraMakeArgs(),
-            self.getSDKRootSpec(),
             self.getModuleCacheSpec(),
             self.getLibCxxArgs(),
             self.getLLDBObjRoot(),

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -326,15 +326,15 @@ def parseOptionsAndInitTestdirs():
     if args.out_of_tree_debugserver:
         lldbtest_config.out_of_tree_debugserver = args.out_of_tree_debugserver
 
-    # Set SDKROOT if we are using an Apple SDK
     if args.sysroot:
         configuration.sdkroot = args.sysroot
-    elif platform_system == "Darwin" and args.apple_sdk:
+    elif platform_system == "Darwin":
+        sdk = args.apple_sdk if args.apple_sdk else "macosx"
         configuration.sdkroot = seven.get_command_output(
-            'xcrun --sdk "%s" --show-sdk-path 2> /dev/null' % (args.apple_sdk)
+            'xcrun --sdk "%s" --show-sdk-path 2> /dev/null' % (sdk)
         )
         if not configuration.sdkroot:
-            logging.error("No SDK found with the name %s; aborting...", args.apple_sdk)
+            logging.error('xcrun found no SDK for "%s"', sdk)
             sys.exit(-1)
 
     if args.triple:

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1674,8 +1674,11 @@ class Base(unittest.TestCase):
 
     def runBuildCommand(self, command):
         self.trace(shlex.join(command))
+        env = dict(os.environ)
+        if configuration.sdkroot:
+            env["SDKROOT"] = configuration.sdkroot
         try:
-            output = check_output(command, stderr=STDOUT, errors="replace")
+            output = check_output(command, stderr=STDOUT, errors="replace", env=env)
         except CalledProcessError as cpe:
             raise build_exception.BuildError(cpe)
         self.trace(output)

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -174,8 +174,7 @@ endif
 
 ifeq "$(OS)" "Darwin"
     ifeq "$(SDKROOT)" ""
-	# We haven't otherwise set the SDKROOT, so set it now to macosx
-	SDKROOT := $(shell xcrun --sdk macosx --show-sdk-path)
+        $(error SDKROOT must be set on Darwin)
     endif
     SYSROOT_FLAGS := -isysroot "$(SDKROOT)"
     GCC_TOOLCHAIN_FLAGS :=


### PR DESCRIPTION
This cleanup patch pushes the auto-detection of the `macosx` SDK from Makefile.rules up into `dotest.py` and unifies it with the existing SDK handling for other Apple platforms.

Assisted-by: claude