### PR TITLE
[lit] Switch tests to using path function

### DIFF
--- a/llvm/utils/lit/CMakeLists.txt
+++ b/llvm/utils/lit/CMakeLists.txt
@@ -4,6 +4,11 @@
 configure_lit_site_cfg(
   "${CMAKE_CURRENT_SOURCE_DIR}/tests/lit.site.cfg.in"
   "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg"
+  PATHS
+  "LLVM_SOURCE_DIR"
+  "LLVM_BINARY_DIR"
+  "LLVM_TOOLS_DIR"
+  "LLVM_LIT_TOOLS_DIR"
   )
 
 # Lit's test suite creates output files next to the sources which makes the

--- a/llvm/utils/lit/tests/lit.site.cfg.in
+++ b/llvm/utils/lit/tests/lit.site.cfg.in
@@ -2,13 +2,14 @@
 
 import sys
 
-config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
-config.llvm_src_root = "@LLVM_SOURCE_DIR@"
-config.llvm_obj_root = "@LLVM_BINARY_DIR@"
-config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.lit_tools_dir = path("@LLVM_LIT_TOOLS_DIR@")
+config.llvm_src_root = path("@LLVM_SOURCE_DIR@")
+config.llvm_obj_root = path("@LLVM_BINARY_DIR@")
+config.llvm_tools_dir = lit_config.substitute(path("@LLVM_TOOLS_DIR@"))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@LLVM_BINARY_DIR@/utils/lit/tests/lit.cfg")
+lit_config.load_config(
+    config, os.path.join(path(r"@LLVM_BINARY_DIR@"), "utils/lit/tests/lit.cfg"))

--- a/llvm/utils/lit/tests/lit.site.cfg.in
+++ b/llvm/utils/lit/tests/lit.site.cfg.in
@@ -2,10 +2,10 @@
 
 import sys
 
-config.lit_tools_dir = path("@LLVM_LIT_TOOLS_DIR@")
-config.llvm_src_root = path("@LLVM_SOURCE_DIR@")
-config.llvm_obj_root = path("@LLVM_BINARY_DIR@")
-config.llvm_tools_dir = lit_config.substitute(path("@LLVM_TOOLS_DIR@"))
+config.lit_tools_dir = path(r"@LLVM_LIT_TOOLS_DIR@")
+config.llvm_src_root = path(r"@LLVM_SOURCE_DIR@")
+config.llvm_obj_root = path(r"@LLVM_BINARY_DIR@")
+config.llvm_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
All the other test suites use the PATHS option to configure_lit_site_cfg
and the path() function in lit.site.cfg to make the site configs
relocatable. Apply the same pattern to lit's own suite as well.
