### PR TITLE
[NVPTX] Emulate 16-bit floating point atomicrmw when generating PTX

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -7506,16 +7506,12 @@ NVPTXTargetLowering::shouldExpandAtomicRMWInIR(const AtomicRMWInst *AI) const {
         return AtomicExpansionKind::None;
     }
 
-    if (Ty->isHalfTy() && (!FTZ || AllowFTZAtomics) &&
-        STI.getSmVersion() >= 70 && STI.getPTXVersion() >= 63)
-      return AtomicExpansionKind::None;
-
-    if (Ty->isBFloatTy() && STI.getSmVersion() >= 90 &&
-        STI.getPTXVersion() >= 78)
-      return AtomicExpansionKind::None;
-
     if (Ty->isDoubleTy() && STI.hasAtomAddF64())
       return AtomicExpansionKind::None;
+
+    // F16 and BF16 operations are to be lowered to a CAS loop. The denormal
+    // mode of the floating point add in the loop is determined by the
+    // function's FTZ behavior.
   }
 
   // PTX's only atomic fp op is `add`; all other ops expand to a CAS loop.

--- a/llvm/test/CodeGen/NVPTX/atomicrmw-sm70.ll
+++ b/llvm/test/CodeGen/NVPTX/atomicrmw-sm70.ll
@@ -2497,26 +2497,78 @@ define double @fmaximum_acq_rel_double_global_cta(ptr addrspace(1) %addr, double
 define half @fadd_acq_rel_half_global_cta(ptr addrspace(1) %addr, half %val) {
 ; SM70-NOFTZ-DISALLOW-LABEL: fadd_acq_rel_half_global_cta(
 ; SM70-NOFTZ-DISALLOW:       {
-; SM70-NOFTZ-DISALLOW-NEXT:    .reg .b16 %rs<3>;
-; SM70-NOFTZ-DISALLOW-NEXT:    .reg .b64 %rd<2>;
+; SM70-NOFTZ-DISALLOW-NEXT:    .reg .pred %p<2>;
+; SM70-NOFTZ-DISALLOW-NEXT:    .reg .b16 %rs<4>;
+; SM70-NOFTZ-DISALLOW-NEXT:    .reg .b32 %r<15>;
+; SM70-NOFTZ-DISALLOW-NEXT:    .reg .b64 %rd<3>;
 ; SM70-NOFTZ-DISALLOW-EMPTY:
 ; SM70-NOFTZ-DISALLOW-NEXT:  // %bb.0:
-; SM70-NOFTZ-DISALLOW-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_half_global_cta_param_0];
 ; SM70-NOFTZ-DISALLOW-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_half_global_cta_param_1];
-; SM70-NOFTZ-DISALLOW-NEXT:    atom.acq_rel.cta.global.add.noftz.f16 %rs2, [%rd1], %rs1;
-; SM70-NOFTZ-DISALLOW-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM70-NOFTZ-DISALLOW-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_half_global_cta_param_0];
+; SM70-NOFTZ-DISALLOW-NEXT:    fence.acq_rel.cta;
+; SM70-NOFTZ-DISALLOW-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM70-NOFTZ-DISALLOW-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM70-NOFTZ-DISALLOW-NEXT:    and.b32 %r5, %r4, 3;
+; SM70-NOFTZ-DISALLOW-NEXT:    shl.b32 %r1, %r5, 3;
+; SM70-NOFTZ-DISALLOW-NEXT:    mov.b32 %r6, 65535;
+; SM70-NOFTZ-DISALLOW-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM70-NOFTZ-DISALLOW-NEXT:    not.b32 %r2, %r7;
+; SM70-NOFTZ-DISALLOW-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM70-NOFTZ-DISALLOW-NEXT:  $L__BB72_1: // %atomicrmw.start
+; SM70-NOFTZ-DISALLOW-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM70-NOFTZ-DISALLOW-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM70-NOFTZ-DISALLOW-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM70-NOFTZ-DISALLOW-NEXT:    add.rn.f16 %rs3, %rs2, %rs1;
+; SM70-NOFTZ-DISALLOW-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM70-NOFTZ-DISALLOW-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM70-NOFTZ-DISALLOW-NEXT:    and.b32 %r11, %r14, %r2;
+; SM70-NOFTZ-DISALLOW-NEXT:    or.b32 %r12, %r11, %r10;
+; SM70-NOFTZ-DISALLOW-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM70-NOFTZ-DISALLOW-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM70-NOFTZ-DISALLOW-NEXT:    mov.b32 %r14, %r3;
+; SM70-NOFTZ-DISALLOW-NEXT:    @%p1 bra $L__BB72_1;
+; SM70-NOFTZ-DISALLOW-NEXT:  // %bb.2: // %atomicrmw.end
+; SM70-NOFTZ-DISALLOW-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM70-NOFTZ-DISALLOW-NEXT:    fence.acq_rel.cta;
+; SM70-NOFTZ-DISALLOW-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM70-NOFTZ-DISALLOW-NEXT:    ret;
 ;
 ; SM70-NOFTZ-ALLOW-LABEL: fadd_acq_rel_half_global_cta(
 ; SM70-NOFTZ-ALLOW:       {
-; SM70-NOFTZ-ALLOW-NEXT:    .reg .b16 %rs<3>;
-; SM70-NOFTZ-ALLOW-NEXT:    .reg .b64 %rd<2>;
+; SM70-NOFTZ-ALLOW-NEXT:    .reg .pred %p<2>;
+; SM70-NOFTZ-ALLOW-NEXT:    .reg .b16 %rs<4>;
+; SM70-NOFTZ-ALLOW-NEXT:    .reg .b32 %r<15>;
+; SM70-NOFTZ-ALLOW-NEXT:    .reg .b64 %rd<3>;
 ; SM70-NOFTZ-ALLOW-EMPTY:
 ; SM70-NOFTZ-ALLOW-NEXT:  // %bb.0:
-; SM70-NOFTZ-ALLOW-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_half_global_cta_param_0];
 ; SM70-NOFTZ-ALLOW-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_half_global_cta_param_1];
-; SM70-NOFTZ-ALLOW-NEXT:    atom.acq_rel.cta.global.add.noftz.f16 %rs2, [%rd1], %rs1;
-; SM70-NOFTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM70-NOFTZ-ALLOW-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_half_global_cta_param_0];
+; SM70-NOFTZ-ALLOW-NEXT:    fence.acq_rel.cta;
+; SM70-NOFTZ-ALLOW-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM70-NOFTZ-ALLOW-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM70-NOFTZ-ALLOW-NEXT:    and.b32 %r5, %r4, 3;
+; SM70-NOFTZ-ALLOW-NEXT:    shl.b32 %r1, %r5, 3;
+; SM70-NOFTZ-ALLOW-NEXT:    mov.b32 %r6, 65535;
+; SM70-NOFTZ-ALLOW-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM70-NOFTZ-ALLOW-NEXT:    not.b32 %r2, %r7;
+; SM70-NOFTZ-ALLOW-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM70-NOFTZ-ALLOW-NEXT:  $L__BB72_1: // %atomicrmw.start
+; SM70-NOFTZ-ALLOW-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM70-NOFTZ-ALLOW-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM70-NOFTZ-ALLOW-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM70-NOFTZ-ALLOW-NEXT:    add.rn.f16 %rs3, %rs2, %rs1;
+; SM70-NOFTZ-ALLOW-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM70-NOFTZ-ALLOW-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM70-NOFTZ-ALLOW-NEXT:    and.b32 %r11, %r14, %r2;
+; SM70-NOFTZ-ALLOW-NEXT:    or.b32 %r12, %r11, %r10;
+; SM70-NOFTZ-ALLOW-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM70-NOFTZ-ALLOW-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM70-NOFTZ-ALLOW-NEXT:    mov.b32 %r14, %r3;
+; SM70-NOFTZ-ALLOW-NEXT:    @%p1 bra $L__BB72_1;
+; SM70-NOFTZ-ALLOW-NEXT:  // %bb.2: // %atomicrmw.end
+; SM70-NOFTZ-ALLOW-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM70-NOFTZ-ALLOW-NEXT:    fence.acq_rel.cta;
+; SM70-NOFTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM70-NOFTZ-ALLOW-NEXT:    ret;
 ;
 ; SM70-FTZ-DISALLOW-LABEL: fadd_acq_rel_half_global_cta(
@@ -2559,14 +2611,40 @@ define half @fadd_acq_rel_half_global_cta(ptr addrspace(1) %addr, half %val) {
 ;
 ; SM70-FTZ-ALLOW-LABEL: fadd_acq_rel_half_global_cta(
 ; SM70-FTZ-ALLOW:       {
-; SM70-FTZ-ALLOW-NEXT:    .reg .b16 %rs<3>;
-; SM70-FTZ-ALLOW-NEXT:    .reg .b64 %rd<2>;
+; SM70-FTZ-ALLOW-NEXT:    .reg .pred %p<2>;
+; SM70-FTZ-ALLOW-NEXT:    .reg .b16 %rs<4>;
+; SM70-FTZ-ALLOW-NEXT:    .reg .b32 %r<15>;
+; SM70-FTZ-ALLOW-NEXT:    .reg .b64 %rd<3>;
 ; SM70-FTZ-ALLOW-EMPTY:
 ; SM70-FTZ-ALLOW-NEXT:  // %bb.0:
-; SM70-FTZ-ALLOW-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_half_global_cta_param_0];
 ; SM70-FTZ-ALLOW-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_half_global_cta_param_1];
-; SM70-FTZ-ALLOW-NEXT:    atom.acq_rel.cta.global.add.noftz.f16 %rs2, [%rd1], %rs1;
-; SM70-FTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM70-FTZ-ALLOW-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_half_global_cta_param_0];
+; SM70-FTZ-ALLOW-NEXT:    fence.acq_rel.cta;
+; SM70-FTZ-ALLOW-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM70-FTZ-ALLOW-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM70-FTZ-ALLOW-NEXT:    and.b32 %r5, %r4, 3;
+; SM70-FTZ-ALLOW-NEXT:    shl.b32 %r1, %r5, 3;
+; SM70-FTZ-ALLOW-NEXT:    mov.b32 %r6, 65535;
+; SM70-FTZ-ALLOW-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM70-FTZ-ALLOW-NEXT:    not.b32 %r2, %r7;
+; SM70-FTZ-ALLOW-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM70-FTZ-ALLOW-NEXT:  $L__BB72_1: // %atomicrmw.start
+; SM70-FTZ-ALLOW-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM70-FTZ-ALLOW-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM70-FTZ-ALLOW-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM70-FTZ-ALLOW-NEXT:    add.rn.ftz.f16 %rs3, %rs2, %rs1;
+; SM70-FTZ-ALLOW-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM70-FTZ-ALLOW-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM70-FTZ-ALLOW-NEXT:    and.b32 %r11, %r14, %r2;
+; SM70-FTZ-ALLOW-NEXT:    or.b32 %r12, %r11, %r10;
+; SM70-FTZ-ALLOW-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM70-FTZ-ALLOW-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM70-FTZ-ALLOW-NEXT:    mov.b32 %r14, %r3;
+; SM70-FTZ-ALLOW-NEXT:    @%p1 bra $L__BB72_1;
+; SM70-FTZ-ALLOW-NEXT:  // %bb.2: // %atomicrmw.end
+; SM70-FTZ-ALLOW-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM70-FTZ-ALLOW-NEXT:    fence.acq_rel.cta;
+; SM70-FTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM70-FTZ-ALLOW-NEXT:    ret;
         %retval = atomicrmw fadd ptr  addrspace(1) %addr, half %val syncscope("block") acq_rel
         ret half %retval

--- a/llvm/test/CodeGen/NVPTX/atomicrmw-sm90.ll
+++ b/llvm/test/CodeGen/NVPTX/atomicrmw-sm90.ll
@@ -2449,26 +2449,78 @@ define double @fmaximum_acq_rel_double_global_cta(ptr addrspace(1) %addr, double
 define half @fadd_acq_rel_half_global_cta(ptr addrspace(1) %addr, half %val) {
 ; SM90-NOFTZ-DISALLOW-LABEL: fadd_acq_rel_half_global_cta(
 ; SM90-NOFTZ-DISALLOW:       {
-; SM90-NOFTZ-DISALLOW-NEXT:    .reg .b16 %rs<3>;
-; SM90-NOFTZ-DISALLOW-NEXT:    .reg .b64 %rd<2>;
+; SM90-NOFTZ-DISALLOW-NEXT:    .reg .pred %p<2>;
+; SM90-NOFTZ-DISALLOW-NEXT:    .reg .b16 %rs<4>;
+; SM90-NOFTZ-DISALLOW-NEXT:    .reg .b32 %r<15>;
+; SM90-NOFTZ-DISALLOW-NEXT:    .reg .b64 %rd<3>;
 ; SM90-NOFTZ-DISALLOW-EMPTY:
 ; SM90-NOFTZ-DISALLOW-NEXT:  // %bb.0:
-; SM90-NOFTZ-DISALLOW-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_half_global_cta_param_0];
 ; SM90-NOFTZ-DISALLOW-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_half_global_cta_param_1];
-; SM90-NOFTZ-DISALLOW-NEXT:    atom.acq_rel.cta.global.add.noftz.f16 %rs2, [%rd1], %rs1;
-; SM90-NOFTZ-DISALLOW-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM90-NOFTZ-DISALLOW-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_half_global_cta_param_0];
+; SM90-NOFTZ-DISALLOW-NEXT:    fence.release.cta;
+; SM90-NOFTZ-DISALLOW-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM90-NOFTZ-DISALLOW-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM90-NOFTZ-DISALLOW-NEXT:    and.b32 %r5, %r4, 3;
+; SM90-NOFTZ-DISALLOW-NEXT:    shl.b32 %r1, %r5, 3;
+; SM90-NOFTZ-DISALLOW-NEXT:    mov.b32 %r6, 65535;
+; SM90-NOFTZ-DISALLOW-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM90-NOFTZ-DISALLOW-NEXT:    not.b32 %r2, %r7;
+; SM90-NOFTZ-DISALLOW-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM90-NOFTZ-DISALLOW-NEXT:  $L__BB72_1: // %atomicrmw.start
+; SM90-NOFTZ-DISALLOW-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM90-NOFTZ-DISALLOW-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM90-NOFTZ-DISALLOW-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM90-NOFTZ-DISALLOW-NEXT:    add.rn.f16 %rs3, %rs2, %rs1;
+; SM90-NOFTZ-DISALLOW-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM90-NOFTZ-DISALLOW-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM90-NOFTZ-DISALLOW-NEXT:    and.b32 %r11, %r14, %r2;
+; SM90-NOFTZ-DISALLOW-NEXT:    or.b32 %r12, %r11, %r10;
+; SM90-NOFTZ-DISALLOW-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM90-NOFTZ-DISALLOW-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM90-NOFTZ-DISALLOW-NEXT:    mov.b32 %r14, %r3;
+; SM90-NOFTZ-DISALLOW-NEXT:    @%p1 bra $L__BB72_1;
+; SM90-NOFTZ-DISALLOW-NEXT:  // %bb.2: // %atomicrmw.end
+; SM90-NOFTZ-DISALLOW-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM90-NOFTZ-DISALLOW-NEXT:    fence.acquire.cta;
+; SM90-NOFTZ-DISALLOW-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM90-NOFTZ-DISALLOW-NEXT:    ret;
 ;
 ; SM90-NOFTZ-ALLOW-LABEL: fadd_acq_rel_half_global_cta(
 ; SM90-NOFTZ-ALLOW:       {
-; SM90-NOFTZ-ALLOW-NEXT:    .reg .b16 %rs<3>;
-; SM90-NOFTZ-ALLOW-NEXT:    .reg .b64 %rd<2>;
+; SM90-NOFTZ-ALLOW-NEXT:    .reg .pred %p<2>;
+; SM90-NOFTZ-ALLOW-NEXT:    .reg .b16 %rs<4>;
+; SM90-NOFTZ-ALLOW-NEXT:    .reg .b32 %r<15>;
+; SM90-NOFTZ-ALLOW-NEXT:    .reg .b64 %rd<3>;
 ; SM90-NOFTZ-ALLOW-EMPTY:
 ; SM90-NOFTZ-ALLOW-NEXT:  // %bb.0:
-; SM90-NOFTZ-ALLOW-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_half_global_cta_param_0];
 ; SM90-NOFTZ-ALLOW-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_half_global_cta_param_1];
-; SM90-NOFTZ-ALLOW-NEXT:    atom.acq_rel.cta.global.add.noftz.f16 %rs2, [%rd1], %rs1;
-; SM90-NOFTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM90-NOFTZ-ALLOW-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_half_global_cta_param_0];
+; SM90-NOFTZ-ALLOW-NEXT:    fence.release.cta;
+; SM90-NOFTZ-ALLOW-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM90-NOFTZ-ALLOW-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM90-NOFTZ-ALLOW-NEXT:    and.b32 %r5, %r4, 3;
+; SM90-NOFTZ-ALLOW-NEXT:    shl.b32 %r1, %r5, 3;
+; SM90-NOFTZ-ALLOW-NEXT:    mov.b32 %r6, 65535;
+; SM90-NOFTZ-ALLOW-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM90-NOFTZ-ALLOW-NEXT:    not.b32 %r2, %r7;
+; SM90-NOFTZ-ALLOW-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM90-NOFTZ-ALLOW-NEXT:  $L__BB72_1: // %atomicrmw.start
+; SM90-NOFTZ-ALLOW-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM90-NOFTZ-ALLOW-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM90-NOFTZ-ALLOW-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM90-NOFTZ-ALLOW-NEXT:    add.rn.f16 %rs3, %rs2, %rs1;
+; SM90-NOFTZ-ALLOW-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM90-NOFTZ-ALLOW-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM90-NOFTZ-ALLOW-NEXT:    and.b32 %r11, %r14, %r2;
+; SM90-NOFTZ-ALLOW-NEXT:    or.b32 %r12, %r11, %r10;
+; SM90-NOFTZ-ALLOW-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM90-NOFTZ-ALLOW-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM90-NOFTZ-ALLOW-NEXT:    mov.b32 %r14, %r3;
+; SM90-NOFTZ-ALLOW-NEXT:    @%p1 bra $L__BB72_1;
+; SM90-NOFTZ-ALLOW-NEXT:  // %bb.2: // %atomicrmw.end
+; SM90-NOFTZ-ALLOW-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM90-NOFTZ-ALLOW-NEXT:    fence.acquire.cta;
+; SM90-NOFTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM90-NOFTZ-ALLOW-NEXT:    ret;
 ;
 ; SM90-FTZ-DISALLOW-LABEL: fadd_acq_rel_half_global_cta(
@@ -2511,14 +2563,40 @@ define half @fadd_acq_rel_half_global_cta(ptr addrspace(1) %addr, half %val) {
 ;
 ; SM90-FTZ-ALLOW-LABEL: fadd_acq_rel_half_global_cta(
 ; SM90-FTZ-ALLOW:       {
-; SM90-FTZ-ALLOW-NEXT:    .reg .b16 %rs<3>;
-; SM90-FTZ-ALLOW-NEXT:    .reg .b64 %rd<2>;
+; SM90-FTZ-ALLOW-NEXT:    .reg .pred %p<2>;
+; SM90-FTZ-ALLOW-NEXT:    .reg .b16 %rs<4>;
+; SM90-FTZ-ALLOW-NEXT:    .reg .b32 %r<15>;
+; SM90-FTZ-ALLOW-NEXT:    .reg .b64 %rd<3>;
 ; SM90-FTZ-ALLOW-EMPTY:
 ; SM90-FTZ-ALLOW-NEXT:  // %bb.0:
-; SM90-FTZ-ALLOW-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_half_global_cta_param_0];
 ; SM90-FTZ-ALLOW-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_half_global_cta_param_1];
-; SM90-FTZ-ALLOW-NEXT:    atom.acq_rel.cta.global.add.noftz.f16 %rs2, [%rd1], %rs1;
-; SM90-FTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM90-FTZ-ALLOW-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_half_global_cta_param_0];
+; SM90-FTZ-ALLOW-NEXT:    fence.release.cta;
+; SM90-FTZ-ALLOW-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM90-FTZ-ALLOW-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM90-FTZ-ALLOW-NEXT:    and.b32 %r5, %r4, 3;
+; SM90-FTZ-ALLOW-NEXT:    shl.b32 %r1, %r5, 3;
+; SM90-FTZ-ALLOW-NEXT:    mov.b32 %r6, 65535;
+; SM90-FTZ-ALLOW-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM90-FTZ-ALLOW-NEXT:    not.b32 %r2, %r7;
+; SM90-FTZ-ALLOW-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM90-FTZ-ALLOW-NEXT:  $L__BB72_1: // %atomicrmw.start
+; SM90-FTZ-ALLOW-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM90-FTZ-ALLOW-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM90-FTZ-ALLOW-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM90-FTZ-ALLOW-NEXT:    add.rn.ftz.f16 %rs3, %rs2, %rs1;
+; SM90-FTZ-ALLOW-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM90-FTZ-ALLOW-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM90-FTZ-ALLOW-NEXT:    and.b32 %r11, %r14, %r2;
+; SM90-FTZ-ALLOW-NEXT:    or.b32 %r12, %r11, %r10;
+; SM90-FTZ-ALLOW-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM90-FTZ-ALLOW-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM90-FTZ-ALLOW-NEXT:    mov.b32 %r14, %r3;
+; SM90-FTZ-ALLOW-NEXT:    @%p1 bra $L__BB72_1;
+; SM90-FTZ-ALLOW-NEXT:  // %bb.2: // %atomicrmw.end
+; SM90-FTZ-ALLOW-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM90-FTZ-ALLOW-NEXT:    fence.acquire.cta;
+; SM90-FTZ-ALLOW-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM90-FTZ-ALLOW-NEXT:    ret;
         %retval = atomicrmw fadd ptr  addrspace(1) %addr, half %val syncscope("block") acq_rel
         ret half %retval
@@ -3307,14 +3385,40 @@ define half @fmaximum_acq_rel_half_global_cta(ptr addrspace(1) %addr, half %val)
 define bfloat @fadd_acq_rel_bfloat_global_cta(ptr addrspace(1) %addr, bfloat %val) {
 ; SM90-LABEL: fadd_acq_rel_bfloat_global_cta(
 ; SM90:       {
-; SM90-NEXT:    .reg .b16 %rs<3>;
-; SM90-NEXT:    .reg .b64 %rd<2>;
+; SM90-NEXT:    .reg .pred %p<2>;
+; SM90-NEXT:    .reg .b16 %rs<4>;
+; SM90-NEXT:    .reg .b32 %r<15>;
+; SM90-NEXT:    .reg .b64 %rd<3>;
 ; SM90-EMPTY:
 ; SM90-NEXT:  // %bb.0:
-; SM90-NEXT:    ld.param.b64 %rd1, [fadd_acq_rel_bfloat_global_cta_param_0];
 ; SM90-NEXT:    ld.param.b16 %rs1, [fadd_acq_rel_bfloat_global_cta_param_1];
-; SM90-NEXT:    atom.acq_rel.cta.global.add.noftz.bf16 %rs2, [%rd1], %rs1;
-; SM90-NEXT:    st.param.b16 [func_retval0], %rs2;
+; SM90-NEXT:    ld.param.b64 %rd2, [fadd_acq_rel_bfloat_global_cta_param_0];
+; SM90-NEXT:    fence.release.cta;
+; SM90-NEXT:    and.b64 %rd1, %rd2, -4;
+; SM90-NEXT:    cvt.u32.u64 %r4, %rd2;
+; SM90-NEXT:    and.b32 %r5, %r4, 3;
+; SM90-NEXT:    shl.b32 %r1, %r5, 3;
+; SM90-NEXT:    mov.b32 %r6, 65535;
+; SM90-NEXT:    shl.b32 %r7, %r6, %r1;
+; SM90-NEXT:    not.b32 %r2, %r7;
+; SM90-NEXT:    ld.relaxed.cta.global.b32 %r14, [%rd1];
+; SM90-NEXT:  $L__BB78_1: // %atomicrmw.start
+; SM90-NEXT:    // =>This Inner Loop Header: Depth=1
+; SM90-NEXT:    shr.u32 %r8, %r14, %r1;
+; SM90-NEXT:    cvt.u16.u32 %rs2, %r8;
+; SM90-NEXT:    add.rn.bf16 %rs3, %rs2, %rs1;
+; SM90-NEXT:    cvt.u32.u16 %r9, %rs3;
+; SM90-NEXT:    shl.b32 %r10, %r9, %r1;
+; SM90-NEXT:    and.b32 %r11, %r14, %r2;
+; SM90-NEXT:    or.b32 %r12, %r11, %r10;
+; SM90-NEXT:    atom.relaxed.cta.global.cas.b32 %r3, [%rd1], %r14, %r12;
+; SM90-NEXT:    setp.ne.b32 %p1, %r3, %r14;
+; SM90-NEXT:    mov.b32 %r14, %r3;
+; SM90-NEXT:    @%p1 bra $L__BB78_1;
+; SM90-NEXT:  // %bb.2: // %atomicrmw.end
+; SM90-NEXT:    shr.u32 %r13, %r3, %r1;
+; SM90-NEXT:    fence.acquire.cta;
+; SM90-NEXT:    st.param.b16 [func_retval0], %r13;
 ; SM90-NEXT:    ret;
         %retval = atomicrmw fadd ptr  addrspace(1) %addr, bfloat %val syncscope("block") acq_rel
         ret bfloat %retval

--- a/llvm/test/CodeGen/NVPTX/distributed-shared-cluster.ll
+++ b/llvm/test/CodeGen/NVPTX/distributed-shared-cluster.ll
@@ -58,22 +58,60 @@ entry:
 define void @test_distributed_shared_cluster_float_atomic(ptr addrspace(7) %dsmem_ptr) local_unnamed_addr {
 ; CHECK-LABEL: test_distributed_shared_cluster_float_atomic(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .b16 %rs<5>;
-; CHECK-NEXT:    .reg .b32 %r<2>;
-; CHECK-NEXT:    .reg .b64 %rd<3>;
+; CHECK-NEXT:    .reg .pred %p<3>;
+; CHECK-NEXT:    .reg .b16 %rs<7>;
+; CHECK-NEXT:    .reg .b32 %r<22>;
+; CHECK-NEXT:    .reg .b64 %rd<4>;
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    ld.param.b64 %rd1, [test_distributed_shared_cluster_float_atomic_param_0];
+; CHECK-NEXT:    ld.param.b64 %rd2, [test_distributed_shared_cluster_float_atomic_param_0];
 ; CHECK-NEXT:    fence.sc.sys;
-; CHECK-NEXT:    mov.b16 %rs1, 0x3C00;
-; CHECK-NEXT:    atom.acquire.sys.shared::cluster.add.noftz.f16 %rs2, [%rd1], %rs1;
+; CHECK-NEXT:    and.b64 %rd1, %rd2, -4;
+; CHECK-NEXT:    cvt.u32.u64 %r5, %rd2;
+; CHECK-NEXT:    and.b32 %r6, %r5, 3;
+; CHECK-NEXT:    shl.b32 %r1, %r6, 3;
+; CHECK-NEXT:    mov.b32 %r7, 65535;
+; CHECK-NEXT:    shl.b32 %r8, %r7, %r1;
+; CHECK-NEXT:    not.b32 %r2, %r8;
+; CHECK-NEXT:    ld.relaxed.sys.shared::cluster.b32 %r20, [%rd1];
+; CHECK-NEXT:  $L__BB1_1: // %atomicrmw.start10
+; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    shr.u32 %r9, %r20, %r1;
+; CHECK-NEXT:    cvt.u16.u32 %rs1, %r9;
+; CHECK-NEXT:    mov.b16 %rs2, 0x3C00;
+; CHECK-NEXT:    add.rn.f16 %rs3, %rs1, %rs2;
+; CHECK-NEXT:    cvt.u32.u16 %r10, %rs3;
+; CHECK-NEXT:    shl.b32 %r11, %r10, %r1;
+; CHECK-NEXT:    and.b32 %r12, %r20, %r2;
+; CHECK-NEXT:    or.b32 %r13, %r12, %r11;
+; CHECK-NEXT:    atom.relaxed.sys.shared::cluster.cas.b32 %r3, [%rd1], %r20, %r13;
+; CHECK-NEXT:    setp.ne.b32 %p1, %r3, %r20;
+; CHECK-NEXT:    mov.b32 %r20, %r3;
+; CHECK-NEXT:    @%p1 bra $L__BB1_1;
+; CHECK-NEXT:  // %bb.2: // %atomicrmw.end9
+; CHECK-NEXT:    fence.acq_rel.sys;
 ; CHECK-NEXT:    fence.sc.sys;
-; CHECK-NEXT:    mov.b16 %rs3, 0x3F80;
-; CHECK-NEXT:    atom.acquire.sys.shared::cluster.add.noftz.bf16 %rs4, [%rd1], %rs3;
+; CHECK-NEXT:    ld.relaxed.sys.shared::cluster.b32 %r21, [%rd1];
+; CHECK-NEXT:  $L__BB1_3: // %atomicrmw.start
+; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    shr.u32 %r14, %r21, %r1;
+; CHECK-NEXT:    cvt.u16.u32 %rs4, %r14;
+; CHECK-NEXT:    mov.b16 %rs5, 0x3F80;
+; CHECK-NEXT:    add.rn.bf16 %rs6, %rs4, %rs5;
+; CHECK-NEXT:    cvt.u32.u16 %r15, %rs6;
+; CHECK-NEXT:    shl.b32 %r16, %r15, %r1;
+; CHECK-NEXT:    and.b32 %r17, %r21, %r2;
+; CHECK-NEXT:    or.b32 %r18, %r17, %r16;
+; CHECK-NEXT:    atom.relaxed.sys.shared::cluster.cas.b32 %r4, [%rd1], %r21, %r18;
+; CHECK-NEXT:    setp.ne.b32 %p2, %r4, %r21;
+; CHECK-NEXT:    mov.b32 %r21, %r4;
+; CHECK-NEXT:    @%p2 bra $L__BB1_3;
+; CHECK-NEXT:  // %bb.4: // %atomicrmw.end
+; CHECK-NEXT:    fence.acq_rel.sys;
 ; CHECK-NEXT:    fence.sc.sys;
-; CHECK-NEXT:    atom.acquire.sys.shared::cluster.add.f32 %r1, [%rd1], 0f3F800000;
+; CHECK-NEXT:    atom.acquire.sys.shared::cluster.add.f32 %r19, [%rd2], 0f3F800000;
 ; CHECK-NEXT:    fence.sc.sys;
-; CHECK-NEXT:    atom.acquire.sys.shared::cluster.add.f64 %rd2, [%rd1], 0d3FF0000000000000;
+; CHECK-NEXT:    atom.acquire.sys.shared::cluster.add.f64 %rd3, [%rd2], 0d3FF0000000000000;
 ; CHECK-NEXT:    ret;
 entry:
   ; Floating point atomic operations


### PR DESCRIPTION
For 16-bit floating point atomicrmw operations, the SASS codegen has an emulation loop. Post https://github.com/llvm/llvm-project/pull/120220, for all other 16-bit atomicrmw operations, we generate emulation loops in PTX. Do the same for fp.

The denormal mode of the floating point op in the emulation loop is automatically decided by the function's denormal mode.