### PR TITLE
release/23.x: [clang][Index][USR] Generate USRs for class-type non-type template arguments (#212356)

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -835,6 +835,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Fixed a case where function effect analysis (`nonblocking` etc.) did not visit a destructor invoked from a `delete` expression. (#GH184460)
 - Clang now defines the GCC-compatible predefined macros `__WCHAR_MIN__`, `__WINT_MIN__`, and `__SIG_ATOMIC_MIN__`. (#GH199678)
 - Fix a crash in addUnsizedArray due assert not verifying we have a Base before doing checks on it. (#GH44212)
+- Fixed USR generation for declarations whose signature mentions a class-type
+  non-type template parameter. (#GH212351)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/UnifiedSymbolResolution/USRGeneration.cpp
+++ b/clang/lib/UnifiedSymbolResolution/USRGeneration.cpp
@@ -193,6 +193,7 @@ public:
   void VisitTemplateArgument(const TemplateArgument &Arg);
 
   void VisitMSGuidDecl(const MSGuidDecl *D);
+  void VisitTemplateParamObjectDecl(const TemplateParamObjectDecl *D);
 
   /// Emit a Decl's name using NamedDecl::printName() and return true if
   ///  the decl had no name.
@@ -1210,6 +1211,15 @@ void USRGenerator::VisitMSGuidDecl(const MSGuidDecl *D) {
   VisitDeclContext(D->getDeclContext());
   Out << "@MG@";
   D->NamedDecl::printName(Out);
+}
+
+void USRGenerator::VisitTemplateParamObjectDecl(
+    const TemplateParamObjectDecl *D) {
+  Out << "@TPO@";
+  VisitType(D->getType());
+  ODRHash Hash{};
+  Hash.AddStructuralValue(D->getValue());
+  Out << Hash.CalculateHash();
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/Index/USR/class-type-tpl-arg.cpp
+++ b/clang/test/Index/USR/class-type-tpl-arg.cpp
@@ -1,0 +1,27 @@
+// RUN: c-index-test core -print-source-symbols -- -std=c++20 %s | FileCheck %s
+
+// Check USRs of template specializations with class-type NTTP values.
+
+struct R {
+  int a;
+};
+
+template <R> struct L {};
+
+// Equal parameter object values must produce equal USRs, and distinct values
+// must produce distinct ones.
+
+// CHECK: | f | c:@F@f#$@S@L>#@TPO@1$@S@R[[#HASH0:]]#
+void f(L<R{0}>);
+
+// CHECK: | g | c:@F@g#$@S@L>#@TPO@1$@S@R[[#HASH0]]#
+void g(L<R{0}>);
+
+// CHECK: | h | c:@F@h#$@S@L>#@TPO@1$@S@R[[#HASH1:]]#
+// CHECK-NOT: | h | c:@F@h#$@S@L>#@TPO@1$@S@R[[#HASH0]]#
+void h(L<R{1}>);
+
+struct S {
+  // CHECK: | set | c:@S@S@F@set#&&$@S@L>#@TPO@1$@S@R[[#HASH0]]#
+  void set(L<R{0}> &&);
+};


### PR DESCRIPTION
Backport 912128312f026605bce4ff11ef8a37d56a1a03f8