### PR TITLE
[clang] perf_helper.py ignore clang warning/note when parsing cc1 command 

### DIFF
--- a/clang/utils/perf-training/perf-helper.py
+++ b/clang/utils/perf-training/perf-helper.py
@@ -276,6 +276,9 @@ def get_cc1_command_for_args(cmd, env):
             or ln.startswith(" (in-process)")
             or ln.startswith("Configuration file:")
             or ln.startswith("Build config:")
+            or ln.startswith("clang: warning:")
+            or ln.startswith("clang: note:")
+            or ln.startswith("clang: remark:")
             or " version " in ln
         ):
             continue


### PR DESCRIPTION
Parsing cc1 command fails in `perf_helper` when `clang: note:` or `clang: warning:` due to driver warnings. As an example, harmless macOS sdk mismatch and `-Wunused-command-line-argument`.