### PR TITLE
[mlir] Make lit site configs relocatable

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -93,12 +93,28 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  PATHS
+  "LLVM_SOURCE_DIR"
+  "LLVM_BINARY_DIR"
+  "LLVM_TOOLS_DIR"
+  "LLVM_LIBS_DIR"
+  "SHLIBDIR"
+  "LLVM_LIT_TOOLS_DIR"
+  "MLIR_BINARY_DIR"
+  "MLIR_CMAKE_DIR"
+  "MLIR_LIB_DIR"
+  "MLIR_SOURCE_DIR"
+  "MLIR_TOOLS_DIR"
   )
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg.py
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.cfg.py
+  PATHS
+  "LLVM_TOOLS_DIR"
+  "MLIR_BINARY_DIR"
+  "MLIR_SOURCE_DIR"
   )
 
 set(MLIR_TEST_DEPENDS

--- a/mlir/test/Unit/lit.site.cfg.py.in
+++ b/mlir/test/Unit/lit.site.cfg.py.in
@@ -2,9 +2,10 @@
 
 import sys
 
-config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.llvm_tools_dir = lit_config.substitute(path("@LLVM_TOOLS_DIR@"))
 config.llvm_build_mode = lit_config.substitute("@LLVM_BUILD_MODE@")
-config.mlir_obj_root = "@MLIR_BINARY_DIR@"
+config.mlir_obj_root = path("@MLIR_BINARY_DIR@")
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@MLIR_SOURCE_DIR@/test/Unit/lit.cfg.py")
+lit_config.load_config(
+    config, os.path.join(path(r"@MLIR_SOURCE_DIR@"), "test/Unit/lit.cfg.py"))

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -3,9 +3,9 @@
 import sys
 
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
-config.llvm_src_root = path("@LLVM_SOURCE_DIR@")
-config.llvm_tools_dir = lit_config.substitute(path("@LLVM_TOOLS_DIR@"))
-config.lit_tools_dir = path("@LLVM_LIT_TOOLS_DIR@")
+config.llvm_src_root = path(r"@LLVM_SOURCE_DIR@")
+config.llvm_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
+config.lit_tools_dir = path(r"@LLVM_LIT_TOOLS_DIR@")
 config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
 config.llvm_shlib_ext = "@SHLIBEXT@"
 config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))
@@ -25,11 +25,11 @@ config.cmake_build_type = "@CMAKE_BUILD_TYPE@"
 config.llvm_use_linker = "@LLVM_USE_LINKER@"
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.host_arch = "@HOST_ARCH@"
-config.mlir_src_root = path("@MLIR_SOURCE_DIR@")
-config.mlir_obj_root = path("@MLIR_BINARY_DIR@")
-config.mlir_tools_dir = path("@MLIR_TOOLS_DIR@")
-config.mlir_cmake_dir = path("@MLIR_CMAKE_DIR@")
-config.mlir_lib_dir = path("@MLIR_LIB_DIR@")
+config.mlir_src_root = path(r"@MLIR_SOURCE_DIR@")
+config.mlir_obj_root = path(r"@MLIR_BINARY_DIR@")
+config.mlir_tools_dir = path(r"@MLIR_TOOLS_DIR@")
+config.mlir_cmake_dir = path(r"@MLIR_CMAKE_DIR@")
+config.mlir_lib_dir = path(r"@MLIR_LIB_DIR@")
 
 config.build_examples = @LLVM_BUILD_EXAMPLES@
 config.run_nvptx_tests = @LLVM_HAS_NVPTX_TARGET@

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -3,9 +3,9 @@
 import sys
 
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
-config.llvm_src_root = "@LLVM_SOURCE_DIR@"
-config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
-config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.llvm_src_root = path("@LLVM_SOURCE_DIR@")
+config.llvm_tools_dir = lit_config.substitute(path("@LLVM_TOOLS_DIR@"))
+config.lit_tools_dir = path("@LLVM_LIT_TOOLS_DIR@")
 config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
 config.llvm_shlib_ext = "@SHLIBEXT@"
 config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))
@@ -25,11 +25,11 @@ config.cmake_build_type = "@CMAKE_BUILD_TYPE@"
 config.llvm_use_linker = "@LLVM_USE_LINKER@"
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.host_arch = "@HOST_ARCH@"
-config.mlir_src_root = "@MLIR_SOURCE_DIR@"
-config.mlir_obj_root = "@MLIR_BINARY_DIR@"
-config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
-config.mlir_cmake_dir = "@MLIR_CMAKE_DIR@"
-config.mlir_lib_dir = "@MLIR_LIB_DIR@"
+config.mlir_src_root = path("@MLIR_SOURCE_DIR@")
+config.mlir_obj_root = path("@MLIR_BINARY_DIR@")
+config.mlir_tools_dir = path("@MLIR_TOOLS_DIR@")
+config.mlir_cmake_dir = path("@MLIR_CMAKE_DIR@")
+config.mlir_lib_dir = path("@MLIR_LIB_DIR@")
 
 config.build_examples = @LLVM_BUILD_EXAMPLES@
 config.run_nvptx_tests = @LLVM_HAS_NVPTX_TARGET@
@@ -83,4 +83,5 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@MLIR_SOURCE_DIR@/test/lit.cfg.py")
+lit_config.load_config(
+    config, os.path.join(path(r"@MLIR_SOURCE_DIR@"), "test/lit.cfg.py"))


### PR DESCRIPTION
Follow the same pattern as all the other test suites where the PATHS
option to configure_lit_site_cfg and the path() function in the lit site
config are used to make site configs relocatable.
