### PR TITLE
[TableGen] don't print redundant diagnostic when parser sees Error token at end of file.

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -4778,6 +4778,9 @@ bool TGParser::ParseFile() {
   if (Lex.getCode() == tgtok::Eof)
     return false;
 
+  if (Lex.getCode() == tgtok::Error)
+    return true;
+
   return TokError("Unexpected token at top level");
 }
 

--- a/llvm/test/TableGen/eof-after-endif.td
+++ b/llvm/test/TableGen/eof-after-endif.td
@@ -5,6 +5,6 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
 // CHECK: :[[@LINE+4]]:7: error: reached EOF without matching #endif
 // CHECK: :[[@LINE+2]]:8: error: the latest preprocessor control is here
-// CHECK: :[[@LINE+2]]:7: error: Unexpected token at top level
+// CHECK-NOT: error:
 #ifdef FOO
 #endif


### PR DESCRIPTION
Fixes #151476. 

Currently TableGen parser emits `error: Unexpected token at top level` when it sees `tgtok::Error` token after failing to parse the object list, even though that token's corresponding diagnostics were already emitted during lexing.  This change makes `ParseFile` return true when it sees `tgtok::Error` at end of file, thereby avoiding the redundant diagnostic.