### PR TITLE
[LoopInfo] Take no dominator tree in verify(). NFC

### DIFF
--- a/llvm/include/llvm/Support/GenericLoopInfo.h
+++ b/llvm/include/llvm/Support/GenericLoopInfo.h
@@ -857,7 +857,7 @@ public:
   // Debugging
   void print(raw_ostream &OS) const;
 
-  void verify(const DominatorTreeBase<BlockT, false> &DomTree) const;
+  void verify() const;
 
   /// Destroy a loop that has been removed from the `LoopInfo` nest.
   ///

--- a/llvm/include/llvm/Support/GenericLoopInfoImpl.h
+++ b/llvm/include/llvm/Support/GenericLoopInfoImpl.h
@@ -889,8 +889,7 @@ static void compareLoops(const LoopT *L, const LoopT *OtherL,
 #endif
 
 template <class BlockT, class LoopT>
-void LoopInfoBase<BlockT, LoopT>::verify(
-    const DomTreeBase<BlockT> &DomTree) const {
+void LoopInfoBase<BlockT, LoopT>::verify() const {
   DenseSet<const LoopT *> Loops;
   for (iterator I = begin(), E = end(); I != E; ++I) {
     assert((*I)->isOutermost() && "Top-level loop has a parent!");
@@ -928,7 +927,7 @@ void LoopInfoBase<BlockT, LoopT>::verify(
 
   // Recompute LoopInfo to verify loops structure.
   LoopInfoBase<BlockT, LoopT> OtherLI;
-  OtherLI.analyze(DomTree);
+  OtherLI.analyze(ParentPtr);
 
   // Build a map we can use to move from our LI to the computed one. This
   // allows us to ignore the particular order in any layer of the loop forest

--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -1271,10 +1271,8 @@ void LoopInfoWrapperPass::verifyAnalysis() const {
   // -verify-loop-info option can enable this. In order to perform some
   // checking by default, LoopPass has been taught to call verifyLoop manually
   // during loop pass sequences.
-  if (VerifyLoopInfo) {
-    auto &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
-    LI.verify(DT);
-  }
+  if (VerifyLoopInfo)
+    LI.verify();
 }
 
 void LoopInfoWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
@@ -1289,8 +1287,7 @@ void LoopInfoWrapperPass::print(raw_ostream &OS, const Module *) const {
 PreservedAnalyses LoopVerifierPass::run(Function &F,
                                         FunctionAnalysisManager &AM) {
   LoopInfo &LI = AM.getResult<LoopAnalysis>(F);
-  auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
-  LI.verify(DT);
+  LI.verify();
   return PreservedAnalyses::all();
 }
 

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -659,7 +659,7 @@ bool CodeGenPrepare::_run(Function &F) {
            "Incorrect DominatorTree updates in CGP");
 
   if (VerifyLoopInfo)
-    LI->verify(getDT());
+    LI->verify();
 #endif
 
   // If we are optimzing huge function, we need to consider the build time.
@@ -723,7 +723,7 @@ bool CodeGenPrepare::_run(Function &F) {
              "Incorrect DominatorTree updates in CGP");
 
     if (VerifyLoopInfo)
-      LI->verify(getDT());
+      LI->verify();
 #endif
 
     // Really free removed instructions during promotion.

--- a/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
@@ -1534,7 +1534,7 @@ bool DFAJumpThreading::run(Function &F) {
   }
 
 #ifdef NDEBUG
-  LI->verify(DTU->getDomTree());
+  LI->verify();
 #endif
 
   SmallPtrSet<const Value *, 32> EphValues;

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1065,7 +1065,7 @@ bool llvm::hoistRegion(DomTreeNode *N, AAResults *AA, LoopInfo *LI,
   if (Changed) {
     assert(DT->verify(DominatorTree::VerificationLevel::Fast) &&
            "Dominator tree verification failed");
-    LI->verify(*DT);
+    LI->verify();
   }
 #endif
 

--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -367,7 +367,7 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
   // Update dominator tree.
   DT.changeImmediateDominator(PostLoopPreHeader, L.getExitingBlock());
 #ifndef NDEBUG
-  LI.verify(DT);
+  LI.verify();
 #endif
   // Update phi nodes in header of post-loop.
   bool isExitingLatch = L.getExitingBlock() == L.getLoopLatch();
@@ -492,7 +492,7 @@ PreservedAnalyses LoopBoundSplitPass::run(Loop &L, LoopAnalysisManager &AM,
     return PreservedAnalyses::all();
 
   assert(AR.DT.verify(DominatorTree::VerificationLevel::Fast));
-  AR.LI.verify(AR.DT);
+  AR.LI.verify();
 
   return getLoopPassPreservedAnalyses();
 }

--- a/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
@@ -845,7 +845,7 @@ public:
     LLVM_DEBUG(Partitions.printBlocks(dbgs()));
 
     if (LDistVerify) {
-      LI->verify(*DT);
+      LI->verify();
       assert(DT->verify(DominatorTree::VerificationLevel::Fast));
     }
 

--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -542,7 +542,7 @@ public:
 #ifndef NDEBUG
     assert(DT.verify());
     assert(PDT.verify());
-    LI.verify(DT);
+    LI.verify();
     SE.verify();
 #endif
 
@@ -1460,7 +1460,7 @@ private:
     assert(!verifyFunction(*FC0.Header->getParent(), &errs()));
     assert(DT.verify(DominatorTree::VerificationLevel::Fast));
     assert(PDT.verify());
-    LI.verify(DT);
+    LI.verify();
     SE.verify();
 #endif
 

--- a/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
@@ -303,7 +303,7 @@ PreservedAnalyses FunctionToLoopPassAdaptor::run(Function &F,
     if (VerifyDomInfo)
       LAR.DT.verify();
     if (VerifyLoopInfo)
-      LAR.LI.verify(LAR.DT);
+      LAR.LI.verify();
     if (VerifySCEV)
       LAR.SE.verify();
     if (LAR.MSSA && VerifyMemorySSA)

--- a/llvm/lib/Transforms/Scalar/LoopSimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopSimplifyCFG.cpp
@@ -654,7 +654,7 @@ public:
            "DT broken after transform!");
 #endif
     assert(DT.isReachableFromEntry(Header));
-    LI.verify(DT);
+    LI.verify();
 #endif
 
     return true;

--- a/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
+++ b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
@@ -2695,7 +2695,7 @@ static void unswitchNontrivialInvariants(
 #ifdef EXPENSIVE_CHECKS
   // Verify the entire loop structure to catch any incorrect updates before we
   // progress in the pass pipeline.
-  LI.verify(DT);
+  LI.verify();
 #endif
 
   // Now that we've unswitched something, make callbacks to report the changes.
@@ -2867,7 +2867,7 @@ static CondBrInst *turnGuardIntoBranch(IntrinsicInst *GI, Loop &L,
   }
 
   if (VerifyLoopInfo)
-    LI.verify(DT);
+    LI.verify();
   ++NumGuards;
   return CheckBI;
 }
@@ -3239,7 +3239,7 @@ injectPendingInvariantConditions(NonTrivialUnswitchCandidate Candidate, Loop &L,
 
 #ifndef NDEBUG
   DT.verify();
-  LI.verify(DT);
+  LI.verify();
   if (MSSAU && VerifyMemorySSA)
     MSSAU->getMemorySSA()->verifyMemorySSA();
 #endif

--- a/llvm/lib/Transforms/Utils/FixIrreducible.cpp
+++ b/llvm/lib/Transforms/Utils/FixIrreducible.cpp
@@ -436,9 +436,8 @@ static bool FixIrreducibleImpl(Function &F, CycleInfo &CI, DominatorTree &DT,
 
 #if defined(EXPENSIVE_CHECKS)
   CI.verify();
-  if (LI) {
-    LI->verify(DT);
-  }
+  if (LI)
+    LI->verify();
 #endif // EXPENSIVE_CHECKS
 
   return true;

--- a/llvm/lib/Transforms/Utils/LoopUnroll.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnroll.cpp
@@ -1627,7 +1627,7 @@ llvm::UnrollLoop(Loop *L, UnrollLoopOptions ULO, LoopInfo *LI,
 
   // LoopInfo should not be valid, confirm that.
   if (UnrollVerifyLoopInfo)
-    LI->verify(*DT);
+    LI->verify();
 
   // After complete unrolling most of the blocks should be contained in OuterL.
   // However, some of them might happen to be out of OuterL (e.g. if they

--- a/llvm/lib/Transforms/Utils/LoopUnrollAndJam.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnrollAndJam.cpp
@@ -611,7 +611,7 @@ llvm::UnrollAndJamLoop(Loop *L, unsigned Count, unsigned TripCount,
                                : SubLoop->getParentLoop()
                          : SubLoop;
   assert(DT->verify());
-  LI->verify(*DT);
+  LI->verify();
   assert(OutestLoop->isRecursivelyLCSSAForm(*DT, *LI));
   if (!CompletelyUnroll)
     assert(L->isLoopSimplifyForm());

--- a/llvm/lib/Transforms/Utils/LoopUnrollRuntime.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnrollRuntime.cpp
@@ -1077,7 +1077,7 @@ bool llvm::UnrollRuntimeLoopRemainder(
 #if defined(EXPENSIVE_CHECKS) && !defined(NDEBUG)
   if (DT) {
     assert(DT->verify(DominatorTree::VerificationLevel::Full));
-    LI->verify(*DT);
+    LI->verify();
   }
 #endif
 

--- a/llvm/lib/Transforms/Utils/UnifyLoopExits.cpp
+++ b/llvm/lib/Transforms/Utils/UnifyLoopExits.cpp
@@ -275,7 +275,7 @@ static bool unifyLoopExits(DominatorTree &DT, LoopInfo &LI, Loop *L) {
   }
 
 #if defined(EXPENSIVE_CHECKS)
-  LI.verify(DT);
+  LI.verify();
 #endif // EXPENSIVE_CHECKS
 
   return true;

--- a/llvm/unittests/Transforms/Utils/BasicBlockUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Utils/BasicBlockUtilsTest.cpp
@@ -374,7 +374,7 @@ exit:
   LoopInfo LI(DT);
 
   EXPECT_TRUE(DT.verify());
-  LI.verify(DT);
+  LI.verify();
   auto *LoopBB = getBasicBlockByName(*F, "loop");
   DomTreeUpdater DTU(DT, DomTreeUpdater::UpdateStrategy::Eager);
   auto *New = splitBlockBefore(LoopBB, LoopBB->getFirstInsertionPt(), &DTU, &LI,
@@ -382,7 +382,7 @@ exit:
                                LoopBB->getName() + ".split");
 
   EXPECT_TRUE(DT.verify());
-  LI.verify(DT);
+  LI.verify();
   EXPECT_EQ(LI.getLoopFor(New)->getHeader(), New);
 }
 
@@ -489,12 +489,12 @@ exit:
   LoopInfo LI(DT);
 
   EXPECT_TRUE(DT.verify());
-  LI.verify(DT);
+  LI.verify();
   SplitBlockPredecessors(getBasicBlockByName(*F, "catch_dest"),
                          {getBasicBlockByName(*F, "loop")}, "", &DT, &LI);
 
   EXPECT_TRUE(DT.verify());
-  LI.verify(DT);
+  LI.verify();
   EXPECT_EQ(LI.getLoopFor(getBasicBlockByName(*F, "catch_dest")), nullptr);
 }
 
@@ -539,12 +539,12 @@ exit:
   LoopInfo LI(DT);
 
   EXPECT_TRUE(DT.verify());
-  LI.verify(DT);
+  LI.verify();
   SplitBlockPredecessors(getBasicBlockByName(*F, "catch_dest"),
                          {getBasicBlockByName(*F, "loop")}, "", &DT, &LI);
 
   EXPECT_TRUE(DT.verify());
-  LI.verify(DT);
+  LI.verify();
   EXPECT_EQ(LI.getLoopFor(getBasicBlockByName(*F, "catch_dest")),
             LI.getLoopFor(getBasicBlockByName(*F, "superloop")));
 }

--- a/llvm/unittests/Transforms/Utils/LoopUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LoopUtilsTest.cpp
@@ -81,7 +81,7 @@ TEST(LoopUtils, DeleteDeadLoopNest) {
 
         assert(DT.verify(DominatorTree::VerificationLevel::Fast) &&
                "Expecting valid dominator tree");
-        LI.verify(DT);
+        LI.verify();
         assert(LI.begin() == LI.end() &&
                "Expecting no loops left in function F");
         SE.verify();


### PR DESCRIPTION
Similar to the recent change that makes analyze() lazy in building
DomTree.
