### PR TITLE
[ORC] Fix buildSimpleReexportsAliasMap signature.

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -499,8 +499,8 @@ ReExportsMaterializationUnit::extractFlags(const SymbolAliasMap &Aliases) {
   return MaterializationUnit::Interface(std::move(SymbolFlags), nullptr);
 }
 
-Expected<SymbolAliasMap> buildSimpleReexportsAliasMap(JITDylib &SourceJD,
-                                                      SymbolNameSet Symbols) {
+Expected<SymbolAliasMap>
+buildSimpleReexportsAliasMap(JITDylib &SourceJD, const SymbolNameSet &Symbols) {
   SymbolLookupSet LookupSet(Symbols);
   auto Flags = SourceJD.getExecutionSession().lookupFlags(
       LookupKind::Static, {{&SourceJD, JITDylibLookupFlags::MatchAllSymbols}},


### PR DESCRIPTION
The header declared a `const SymbolNameSet&` argument, but the implementation took a `SymbolNameSet` by value. Update the implementation to also take a `const SymbolNameSet&`.

No testcase. The corrected implementation will be used in an upcoming commit.