### PR TITLE
[InstCombine] Don't fold integer-float bitcasts in store type combining

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -1306,6 +1306,13 @@ static bool combineStoreToValueType(InstCombinerImpl &IC, StoreInst &SI) {
     // x86_amx type happy.
     if (V->getType()->isX86_AMXTy())
       return false;
+    // Don't fold integer↔float bitcasts. Backends may canonicalize NaN
+    // values on floating-point loads/stores (e.g., x87) which would
+    // corrupt NaN payload bits stored through an integer type.
+    // See llvm/llvm-project#44497.
+    if (V->getType()->isFPOrFPVectorTy() !=
+        BC->getType()->isFPOrFPVectorTy())
+      return false;
     if (!SI.isAtomic() || isSupportedAtomicType(V->getType())) {
       combineStoreToNewValue(IC, SI, V);
       return true;

--- a/llvm/test/Transforms/InstCombine/bitcast-phi-uselistorder.ll
+++ b/llvm/test/Transforms/InstCombine/bitcast-phi-uselistorder.ll
@@ -11,9 +11,10 @@ define double @test(i1 %c, ptr %p) {
 ; CHECK-NEXT:    [[LOAD1:%.*]] = load double, ptr @Q, align 8
 ; CHECK-NEXT:    br label [[END]]
 ; CHECK:       end:
-; CHECK-NEXT:    [[TMP0:%.*]] = phi double [ 0.000000e+00, [[ENTRY:%.*]] ], [ [[LOAD1]], [[IF]] ]
-; CHECK-NEXT:    store double [[TMP0]], ptr [[P:%.*]], align 8
-; CHECK-NEXT:    ret double [[TMP0]]
+; CHECK-NEXT:    [[CAST:%.*]] = phi double [ 0.000000e+00, [[ENTRY:%.*]] ], [ [[LOAD1]], [[IF]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = bitcast double [[CAST]] to i64
+; CHECK-NEXT:    store i64 [[TMP0]], ptr [[P:%.*]], align 8
+; CHECK-NEXT:    ret double [[CAST]]
 ;
 entry:
   br i1 %c, label %if, label %end


### PR DESCRIPTION
combineStoreToValueType folds "store i64 (bitcast double ...)" into "store double ..." to remove the bitcast. On targets where floating-point loads/stores canonicalize NaN payload bits (e.g., x87 without SSE), this changes the stored bit pattern for NaN values, breaking NaN boxing data and Rust transmute guarantees.

Fixes #44497

**Change**
In combineStoreToValueType, when the bitcast crosses the integer\--floating-point boundary, keep the original integer store + bitcast sequence. Integer stores are bit-preserving on all targets.

  if (V->getType()->isFPOrFPVectorTy() != BC->getType()->isFPOrFPVectorTy())
        return false;

**Testing**
- Updated bitcast-phi-uselistorder.ll to expect store i64 + bitcast.
- All 1800+ InstCombine test files process without errors.
