### PR TITLE
[libc] Fix path collisions between unit and hermetic tests

### DIFF
--- a/libc/test/src/semaphore/linux/CMakeLists.txt
+++ b/libc/test/src/semaphore/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_semaphore_unittests)
 
-add_libc_unittest(
+add_libc_test(
   semaphore_test
   SUITE
     libc_semaphore_unittests

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -153,7 +153,7 @@ TEST(LlvmLibcSemaphoreTest, ClockWaitUnsupportedClock) {
 // Named semaphore tests.
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenCloseUnlink) {
-  const char *name = "/llvmlibc_test_sem";
+  const char *name = APPEND_LIBC_TEST("/llvmlibc_test_sem");
 
   // clean up any leftover from previous test runs.
   Semaphore::unlink(name);
@@ -172,7 +172,7 @@ TEST(LlvmLibcSemaphoreTest, NamedOpenCloseUnlink) {
 }
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenExisting) {
-  const char *name = "/llvmlibc_test_sem_exist";
+  const char *name = APPEND_LIBC_TEST("/llvmlibc_test_sem_exist");
 
   Semaphore::unlink(name);
 
@@ -196,7 +196,7 @@ TEST(LlvmLibcSemaphoreTest, NamedOpenExisting) {
 }
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenExclFails) {
-  const char *name = "/llvmlibc_test_sem_excl";
+  const char *name = APPEND_LIBC_TEST("/llvmlibc_test_sem_excl");
 
   Semaphore::unlink(name);
 

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -52,7 +52,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   chown_test
   SUITE
     libc_unistd_unittests
@@ -188,7 +188,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   ftruncate_test
   SUITE
     libc_unistd_unittests
@@ -596,7 +596,7 @@ add_libc_unittest(
     libc.src.unistd.geteuid
 )
 
-add_libc_unittest(
+add_libc_test(
   syscall_test
   SUITE
     libc_unistd_unittests

--- a/libc/test/src/unistd/chown_test.cpp
+++ b/libc/test/src/unistd/chown_test.cpp
@@ -25,7 +25,7 @@ TEST_F(LlvmLibcChownTest, ChownSuccess) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   uid_t my_uid = LIBC_NAMESPACE::getuid();
   gid_t my_gid = LIBC_NAMESPACE::getgid();
-  constexpr const char *FILENAME = "chown.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("chown.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   // Create a test file.

--- a/libc/test/src/unistd/syscall_test.cpp
+++ b/libc/test/src/unistd/syscall_test.cpp
@@ -34,7 +34,8 @@ TEST_F(LlvmLibcSyscallTest, TrivialCall) {
 
 TEST_F(LlvmLibcSyscallTest, SymlinkCreateDestroy) {
   constexpr const char LINK_VAL[] = "syscall_readlink_test_value";
-  constexpr const char LINK[] = "testdata/syscall_readlink.test.link";
+  constexpr const char LINK[] =
+      APPEND_LIBC_TEST("testdata/syscall_readlink.test.link");
 
 #ifdef SYS_symlink
   ASSERT_GE(LIBC_NAMESPACE::syscall(SYS_symlink, LINK_VAL, LINK), 0l);
@@ -71,7 +72,8 @@ TEST_F(LlvmLibcSyscallTest, FileReadWrite) {
   constexpr const char HELLO[] = "hello";
   constexpr int HELLO_SIZE = sizeof(HELLO);
 
-  constexpr const char *TEST_FILE = "testdata/syscall_pread_pwrite.test";
+  constexpr const char *TEST_FILE =
+      APPEND_LIBC_TEST("testdata/syscall_pread_pwrite.test");
 
 #ifdef SYS_open
   long fd =
@@ -98,11 +100,13 @@ TEST_F(LlvmLibcSyscallTest, FileReadWrite) {
 
 TEST_F(LlvmLibcSyscallTest, FileLinkCreateDestroy) {
   constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = "syscall_linkat.test";
-  constexpr const char *TEST_FILE_PATH = "testdata/syscall_linkat.test";
-  constexpr const char *TEST_FILE_LINK = "syscall_linkat.test.link";
+  constexpr const char *TEST_FILE = APPEND_LIBC_TEST("syscall_linkat.test");
+  constexpr const char *TEST_FILE_PATH =
+      APPEND_LIBC_TEST("testdata/syscall_linkat.test");
+  constexpr const char *TEST_FILE_LINK =
+      APPEND_LIBC_TEST("syscall_linkat.test.link");
   constexpr const char *TEST_FILE_LINK_PATH =
-      "testdata/syscall_linkat.test.link";
+      APPEND_LIBC_TEST("testdata/syscall_linkat.test.link");
 
   // The test strategy is as follows:
   //   1. Create a normal file

--- a/libc/test/src/unistd/truncate_test.cpp
+++ b/libc/test/src/unistd/truncate_test.cpp
@@ -24,7 +24,7 @@ using LlvmLibcTruncateTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcTruncateTest, CreateAndTruncate) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = "truncate.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("truncate.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   constexpr const char WRITE_DATA[] = "hello, truncate";
   constexpr size_t WRITE_SIZE = sizeof(WRITE_DATA);


### PR DESCRIPTION
Use the APPEND_LIBC_TEST macro to ensure each test gets a unique path to operate on. Enable the affected tests in hermetic mode.