### PR TITLE
[InstCombine] Rebuild type-changing PHIs in PointerReplacer

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -425,15 +425,30 @@ void PointerReplacer::replace(Instruction *I) {
     // replacement (new value).
     WorkMap[NewI] = NewI;
   } else if (auto *PHI = dyn_cast<PHINode>(I)) {
-    // Create a new PHI by replacing any incoming value that is a user of the
-    // root pointer and has a replacement.
-    Value *V = WorkMap.lookup(PHI->getIncomingValue(0));
-    PHI->mutateType(V ? V->getType() : PHI->getIncomingValue(0)->getType());
-    for (unsigned int I = 0; I < PHI->getNumIncomingValues(); ++I) {
-      Value *V = WorkMap.lookup(PHI->getIncomingValue(I));
-      PHI->setIncomingValue(I, V ? V : PHI->getIncomingValue(I));
+    Value *FirstIncoming = PHI->getIncomingValue(0);
+    Value *V = WorkMap.lookup(FirstIncoming);
+    Type *NewType = V ? V->getType() : FirstIncoming->getType();
+    if (PHI->getType() == NewType) {
+      for (unsigned I = 0; I < PHI->getNumIncomingValues(); ++I) {
+        Value *V = WorkMap.lookup(PHI->getIncomingValue(I));
+        PHI->setIncomingValue(I, V ? V : PHI->getIncomingValue(I));
+      }
+      WorkMap[PHI] = PHI;
+      return;
     }
-    WorkMap[PHI] = PHI;
+
+    auto *NewPHI = PHINode::Create(NewType, PHI->getNumIncomingValues(), "");
+    IC.InsertNewInstWith(NewPHI, PHI->getIterator());
+    NewPHI->takeName(PHI);
+    NewPHI->copyMetadata(*PHI);
+    WorkMap[PHI] = NewPHI;
+    for (unsigned I = 0; I < PHI->getNumIncomingValues(); ++I) {
+      Value *IncomingValue = PHI->getIncomingValue(I);
+      Value *V = WorkMap.lookup(IncomingValue);
+      assert(V && V->getType() == NewType &&
+             "Type-changing PHI incoming value was not replaced");
+      NewPHI->addIncoming(V, PHI->getIncomingBlock(I));
+    }
   } else if (auto *GEP = dyn_cast<GetElementPtrInst>(I)) {
     auto *V = getReplacement(GEP->getPointerOperand());
     assert(V && "Operand not replaced");

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -442,12 +442,12 @@ void PointerReplacer::replace(Instruction *I) {
     NewPHI->takeName(PHI);
     NewPHI->copyMetadata(*PHI);
     WorkMap[PHI] = NewPHI;
-    for (unsigned I = 0; I < PHI->getNumIncomingValues(); ++I) {
-      Value *IncomingValue = PHI->getIncomingValue(I);
+    for (auto [IncomingValue, IncomingBlock] :
+         zip_equal(PHI->incoming_values(), PHI->blocks())) {
       Value *V = WorkMap.lookup(IncomingValue);
       assert(V && V->getType() == NewType &&
              "Type-changing PHI incoming value was not replaced");
-      NewPHI->addIncoming(V, PHI->getIncomingBlock(I));
+      NewPHI->addIncoming(V, IncomingBlock);
     }
   } else if (auto *GEP = dyn_cast<GetElementPtrInst>(I)) {
     auto *V = getReplacement(GEP->getPointerOperand());

--- a/llvm/test/Transforms/InstCombine/ptr-replace-alloca.ll
+++ b/llvm/test/Transforms/InstCombine/ptr-replace-alloca.ll
@@ -38,6 +38,41 @@ sink:
   ret i8 %load
 }
 
+define i8 @phi_addrspace_change(i1 %cond) {
+; CHECK-LABEL: @phi_addrspace_change(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[IF:%.*]], label [[ELSE:%.*]]
+; CHECK:       if:
+; CHECK-NEXT:    br label [[SINK:%.*]]
+; CHECK:       else:
+; CHECK-NEXT:    br label [[SINK]]
+; CHECK:       sink:
+; CHECK-NEXT:    [[PTR:%.*]] = phi ptr [ getelementptr inbounds nuw (i8, ptr @g1, i64 1), [[IF]] ], [ getelementptr inbounds nuw (i8, ptr @g1, i64 2), [[ELSE]] ]
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[PTR]], i64 1
+; CHECK-NEXT:    [[LOAD:%.*]] = load i8, ptr [[GEP]], align 1
+; CHECK-NEXT:    ret i8 [[LOAD]]
+;
+entry:
+  %alloca = alloca [32 x i8], align 4, addrspace(5)
+  call void @llvm.memcpy.p5.p0.i64(ptr addrspace(5) %alloca, ptr @g1, i64 32, i1 false)
+  %base = getelementptr [32 x i8], ptr addrspace(5) %alloca, i32 0, i32 0
+  br i1 %cond, label %if, label %else
+
+if:
+  %val.if = getelementptr i8, ptr addrspace(5) %base, i32 1
+  br label %sink
+
+else:
+  %val.else = getelementptr i8, ptr addrspace(5) %base, i32 2
+  br label %sink
+
+sink:
+  %ptr = phi ptr addrspace(5) [ %val.if, %if ], [ %val.else, %else ]
+  %gep = getelementptr i8, ptr addrspace(5) %ptr, i32 1
+  %load = load i8, ptr addrspace(5) %gep
+  ret i8 %load
+}
+
 define i8 @volatile_load_keep_alloca(i1 %cond) {
 ; CHECK-LABEL: @volatile_load_keep_alloca(
 ; CHECK-NEXT:  entry:
@@ -502,6 +537,7 @@ define i8 @preserve_load_metadata(i64 %idx) {
 !0 = !{!"my-annotation"}
 
 declare void @llvm.memcpy.p1.p0.i64(ptr addrspace(1), ptr, i64, i1)
+declare void @llvm.memcpy.p5.p0.i64(ptr addrspace(5), ptr, i64, i1)
 declare void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 declare void @llvm.memcpy.p0.p1.i64(ptr, ptr addrspace(1), i64, i1)
 declare void @llvm.memcpy.p1.p1.i64(ptr addrspace(1), ptr addrspace(1), i64, i1)


### PR DESCRIPTION
PointerReplacer mutates PHI types when replacing an alloca with a pointer in another address space. Mutating a value type in place can invalidate existing users whose result types or operand constraints were formed from the original pointer type.

For example:
```
%p = phi ptr addrspace(5) [ %a, %bb0 ], [ %b, %bb1 ]
%g = getelementptr i8, ptr addrspace(5) %p, i64 1
```

Changing `%p` to `ptr addrspace(4)` leaves the existing GEP result in `AS5`  while its pointer operand is now in `AS4`. (This is what exposed the bug). This triggered:
    https://github.com/llvm/llvm-project/blob/0bcff14b1740cf32f9e0983726238dcf353c6ac8/llvm/lib/IR/Operator.cpp#L129-L131

Create a new PHI when the replacement changes type so existing users remain attached to the original well-typed graph while PointerReplacer builds their replacements. Preserve in-place operand updates when the PHI type is unchanged.

Assisted-by: Codex