### PR TITLE
[analyzer] Add engine support for cleanup function calls

### DIFF
--- a/clang/include/clang/Analysis/CFG.h
+++ b/clang/include/clang/Analysis/CFG.h
@@ -436,19 +436,23 @@ private:
 class CFGCleanupFunction final : public CFGElement {
 public:
   CFGCleanupFunction() = default;
-  CFGCleanupFunction(const VarDecl *VD)
-      : CFGElement(Kind::CleanupFunction, VD) {
-    assert(VD->hasAttr<CleanupAttr>());
-  }
+  CFGCleanupFunction(VarDecl *VD)
+      : CFGElement(Kind::CleanupFunction, createPseudoCallExpr(VD)) {}
 
   const VarDecl *getVarDecl() const {
-    return static_cast<const VarDecl *>(Data1.getPointer());
+    return cast<VarDecl>(
+        cast<DeclRefExpr>(
+            cast<UnaryOperator>(getPseudoCallExpr()->getArg(0))->getSubExpr())
+            ->getDecl());
   }
 
   /// Returns the function to be called when cleaning up the var decl.
   const FunctionDecl *getFunctionDecl() const {
-    const CleanupAttr *A = getVarDecl()->getAttr<CleanupAttr>();
-    return A->getFunctionDecl();
+    return getPseudoCallExpr()->getDirectCallee();
+  }
+
+  const CallExpr *getPseudoCallExpr() const {
+    return static_cast<const CallExpr *>(Data1.getPointer());
   }
 
 private:
@@ -457,6 +461,8 @@ private:
   static bool isKind(const CFGElement E) {
     return E.getKind() == Kind::CleanupFunction;
   }
+
+  static const CallExpr *createPseudoCallExpr(VarDecl *VD);
 };
 
 /// Represents C++ object destructor implicitly generated for automatic object
@@ -1222,7 +1228,7 @@ public:
     Elements.push_back(CFGAutomaticObjDtor(VD, S), C);
   }
 
-  void appendCleanupFunction(const VarDecl *VD, BumpVectorContext &C) {
+  void appendCleanupFunction(VarDecl *VD, BumpVectorContext &C) {
     Elements.push_back(CFGCleanupFunction(VD), C);
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -387,6 +387,8 @@ public:
   void ProcessTemporaryDtor(const CFGTemporaryDtor D,
                             ExplodedNode *Pred, ExplodedNodeSet &Dst);
 
+  void ProcessCleanupFunction(const CFGCleanupFunction D, ExplodedNode *Pred);
+
   /// Called by CoreEngine when processing the entrance of a CFGBlock.
   void processCFGBlockEntrance(const BlockEdge &L, const BlockEntrance &BE,
                                NodeBuilder &Builder, ExplodedNode *Pred);

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -5582,6 +5582,31 @@ CFGImplicitDtor::getDestructorDecl(ASTContext &astContext) const {
   llvm_unreachable("getKind() returned bogus value");
 }
 
+static const CallExpr *CFGCleanupFunction::createPseudoCallExpr(VarDecl *VD) {
+  const ASTContext &Ctx = VD->getASTContext();
+  const CleanupAttr *A = VD->getAttr<CleanupAttr>();
+  const FunctionDecl *FD = A->getFunctionDecl();
+
+  DeclRefExpr *RV = new (&Ctx)
+      DeclRefExpr(Ctx, VD, /*RefersToEnclosingVariableOrCapture=*/false,
+                  VD->getType(), VK_LValue, A->getLocation());
+  UnaryOperator *UO =
+      UnaryOperator::create(Ctx, DR, Ctx->getPointerType(VD->getType()),
+                            UO_AddrOf, VK_LValue, OK_Ordinary, A->getLocation(),
+                            /*CanOverflow=*/false, FPOptionsOverride());
+  DeclRefExpr *RF = new (&Ctx)
+      DeclRefExpr(Ctx, FD, /*RefersToEnclosingVariableOrCapture=*/false,
+                  FD->getType(), VK_LValue, A->getLocation());
+  ImplictCastExpr *IC = ImplicitCastExpr::create(
+      Ctx, Ctx->getPointeeType(FD->getType()), CK_FunctionToPointerDecay, RF,
+      nullptr, VK_LValue, FPOptionsOverride());
+  Expr *Args[1] = {IC};
+  CallExpr *CE = CallExpr::create(Ctx, Args, FD->getReturnType(), VK_RValue,
+                                  A->getLocation(), FPOptionsOverride());
+
+  return CE;
+}
+
 //===----------------------------------------------------------------------===//
 // CFGBlock operations.
 //===----------------------------------------------------------------------===//

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -5582,27 +5582,28 @@ CFGImplicitDtor::getDestructorDecl(ASTContext &astContext) const {
   llvm_unreachable("getKind() returned bogus value");
 }
 
-static const CallExpr *CFGCleanupFunction::createPseudoCallExpr(VarDecl *VD) {
+const CallExpr *CFGCleanupFunction::createPseudoCallExpr(VarDecl *VD) {
   const ASTContext &Ctx = VD->getASTContext();
   const CleanupAttr *A = VD->getAttr<CleanupAttr>();
-  const FunctionDecl *FD = A->getFunctionDecl();
+  FunctionDecl *FD = A->getFunctionDecl();
 
   DeclRefExpr *RV = new (&Ctx)
       DeclRefExpr(Ctx, VD, /*RefersToEnclosingVariableOrCapture=*/false,
                   VD->getType(), VK_LValue, A->getLocation());
-  UnaryOperator *UO =
-      UnaryOperator::create(Ctx, DR, Ctx->getPointerType(VD->getType()),
-                            UO_AddrOf, VK_LValue, OK_Ordinary, A->getLocation(),
-                            /*CanOverflow=*/false, FPOptionsOverride());
+  UnaryOperator *UO = UnaryOperator::Create(
+      Ctx, RV, UO_AddrOf, Ctx.getPointerType(VD->getType()), VK_LValue,
+      OK_Ordinary, A->getLocation(),
+      /*CanOverflow=*/false, FPOptionsOverride());
+  Expr *Args[1] = {UO};
   DeclRefExpr *RF = new (&Ctx)
       DeclRefExpr(Ctx, FD, /*RefersToEnclosingVariableOrCapture=*/false,
                   FD->getType(), VK_LValue, A->getLocation());
-  ImplictCastExpr *IC = ImplicitCastExpr::create(
-      Ctx, Ctx->getPointeeType(FD->getType()), CK_FunctionToPointerDecay, RF,
+  ImplicitCastExpr *IC = ImplicitCastExpr::Create(
+      Ctx, Ctx.getPointerType(FD->getType()), CK_FunctionToPointerDecay, RF,
       nullptr, VK_LValue, FPOptionsOverride());
-  Expr *Args[1] = {IC};
-  CallExpr *CE = CallExpr::create(Ctx, Args, FD->getReturnType(), VK_RValue,
-                                  A->getLocation(), FPOptionsOverride());
+  CallExpr *CE =
+      CallExpr::Create(Ctx, IC, Args, FD->getReturnType(), VK_PRValue,
+                       A->getLocation(), FPOptionsOverride());
 
   return CE;
 }

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -5589,21 +5589,21 @@ const CallExpr *CFGCleanupFunction::createPseudoCallExpr(VarDecl *VD) {
 
   DeclRefExpr *RV = new (&Ctx)
       DeclRefExpr(Ctx, VD, /*RefersToEnclosingVariableOrCapture=*/false,
-                  VD->getType(), VK_LValue, A->getLocation());
+                  VD->getType(), VK_LValue, A->getArgLoc());
   UnaryOperator *UO = UnaryOperator::Create(
       Ctx, RV, UO_AddrOf, Ctx.getPointerType(VD->getType()), VK_LValue,
-      OK_Ordinary, A->getLocation(),
+      OK_Ordinary, A->getArgLoc(),
       /*CanOverflow=*/false, FPOptionsOverride());
   Expr *Args[1] = {UO};
   DeclRefExpr *RF = new (&Ctx)
       DeclRefExpr(Ctx, FD, /*RefersToEnclosingVariableOrCapture=*/false,
-                  FD->getType(), VK_LValue, A->getLocation());
+                  FD->getType(), VK_LValue, A->getArgLoc());
   ImplicitCastExpr *IC = ImplicitCastExpr::Create(
       Ctx, Ctx.getPointerType(FD->getType()), CK_FunctionToPointerDecay, RF,
       nullptr, VK_LValue, FPOptionsOverride());
   CallExpr *CE =
       CallExpr::Create(Ctx, IC, Args, FD->getReturnType(), VK_PRValue,
-                       A->getLocation(), FPOptionsOverride());
+                       A->getArgLoc(), FPOptionsOverride());
 
   return CE;
 }

--- a/clang/lib/Analysis/LiveVariables.cpp
+++ b/clang/lib/Analysis/LiveVariables.cpp
@@ -517,10 +517,16 @@ LiveVariablesImpl::runOnBlock(const CFGBlock *block,
       continue;
     }
 
-    if (!elem.getAs<CFGStmt>())
+    const Stmt *S = nullptr;
+    if (auto StmtElem = elem.getAs<CFGStmt>())
+      S = elem.castAs<CFGStmt>().getStmt();
+    else if (auto CleanupElem = elem.getAs<CFGCleanupFunction>())
+      S = cast<UnaryOperator>(CleanupElem->getPseudoCallExpr()->getArg(0))
+              ->getSubExpr();
+
+    if (!S)
       continue;
 
-    const Stmt *S = elem.castAs<CFGStmt>().getStmt();
     TF.Visit(const_cast<Stmt*>(S));
     stmtsToLiveness[S] = val;
   }

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -526,6 +526,9 @@ static PathDiagnosticLocation getLocationForCaller(const StackFrame *SF,
   case CFGElement::CXXRecordTypedCall:
     return PathDiagnosticLocation(Source.castAs<CFGStmt>().getStmt(), SM,
                                   CallerSF);
+  case CFGElement::CleanupFunction:
+    return PathDiagnosticLocation(
+        Source.castAs<CFGCleanupFunction>().getPseudoCallExpr(), SM, CallerSF);
   case CFGElement::Initializer: {
     const CFGInitializer &Init = Source.castAs<CFGInitializer>();
     return PathDiagnosticLocation(Init.getInitializer()->getInit(), SM,
@@ -561,7 +564,6 @@ static PathDiagnosticLocation getLocationForCaller(const StackFrame *SF,
   }
   case CFGElement::ScopeBegin:
   case CFGElement::ScopeEnd:
-  case CFGElement::CleanupFunction:
     llvm_unreachable("not yet implemented!");
   case CFGElement::LifetimeEnds:
   case CFGElement::FullExprCleanup:

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -609,9 +609,15 @@ void CoreEngine::enqueueStmtNode(ExplodedNode *N,
     return;
   }
 
-  // At this point, we know we're processing a normal statement.
-  CFGStmt CS = (*Block)[Idx].castAs<CFGStmt>();
-  PostStmt Loc(CS.getStmt(), N->getStackFrame());
+  // At this point, we know we're processing a normal statement from a CFGStmt
+  // or the pseudo CallExpr from CFGCleanupFunction.
+  const Stmt *S = nullptr;
+  if (std::optional<CFGStmt> CS = (*Block)[Idx].getAs<CFGStmt>())
+    S = CS->getStmt();
+  else if (std::optional<CFGCleanupFunction> CF =
+               (*Block)[Idx].getAs<CFGCleanupFunction>())
+    S = CF->getPseudoCallExpr();
+  PostStmt Loc(S, N->getStackFrame());
 
   if (Loc == N->getLocation().withTag(nullptr)) {
     // Note: 'N' should be a fresh node because otherwise it shouldn't be

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1613,7 +1613,8 @@ void ExprEngine::ProcessTemporaryDtor(const CFGTemporaryDtor D,
                      /*IsBase=*/false, CleanPred, Dst, CallOpts);
 }
 
-void ExprEngine::ProcessCleanupFunction(const CFGCleanupFunction CF, ExplodedNode *Pred) {
+void ExprEngine::ProcessCleanupFunction(const CFGCleanupFunction CF,
+                                        ExplodedNode *Pred) {
   ProgramStateRef State = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
 
@@ -1623,12 +1624,13 @@ void ExprEngine::ProcessCleanupFunction(const CFGCleanupFunction CF, ExplodedNod
   const VarDecl *VD = CF.getVarDecl();
   SVal VLoc = State->getLValue(VD, SF);
 
-  const CallExpr *CE = nullptr; // CF.getPseudoCallExpr();
-  // assert(CE->getNumArgs() == 1 && "Invalid cleanup function definition!");
-  const Expr *Callee = nullptr; // CE->getCallee();
-  const Expr *VarAddr = nullptr; // CE->getArg(0);
-  State = State->BindExpr(Callee, SF, VF, false);
-  State = State->BindExpr(VarAddr, SF, VLoc, false);
+  const CallExpr *CE = CF.getPseudoCallExpr();
+  const ImplicitCastExpr *Callee = cast<ImplicitCastExpr>(CE->getCallee());
+  const UnaryOperator *VarAddr = cast<UnaryOperator>(CE->getArg(0));
+  State = State->BindExpr(Callee->getSubExpr(), SF, VF);
+  State = State->BindExpr(Callee, SF, VF);
+  State = State->BindExpr(VarAddr->getSubExpr(), SF, VLoc);
+  State = State->BindExpr(VarAddr, SF, VLoc);
 
   // Copied from ExprEngine::VisitCallExpr
   CallEventManager &CEMgr = getStateManager().getCallEventManager();

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -983,7 +983,6 @@ void ExprEngine::processCFGElement(const CFGElement E, ExplodedNode *Pred,
     case CFGElement::CleanupFunction:
       ProcessCleanupFunction(E.castAs<CFGCleanupFunction>(), Pred);
       return;
-    case CFGElement::LifetimeEnds:
     case CFGElement::FullExprCleanup:
     case CFGElement::ScopeBegin:
     case CFGElement::ScopeEnd:
@@ -1625,20 +1624,17 @@ void ExprEngine::ProcessCleanupFunction(const CFGCleanupFunction CF,
   SVal VLoc = State->getLValue(VD, SF);
 
   const CallExpr *CE = CF.getPseudoCallExpr();
-  const ImplicitCastExpr *Callee = cast<ImplicitCastExpr>(CE->getCallee());
-  const UnaryOperator *VarAddr = cast<UnaryOperator>(CE->getArg(0));
-  State = State->BindExpr(Callee->getSubExpr(), SF, VF);
-  State = State->BindExpr(Callee, SF, VF);
-  State = State->BindExpr(VarAddr->getSubExpr(), SF, VLoc);
-  State = State->BindExpr(VarAddr, SF, VLoc);
+  State = State->BindExpr(CE->getCallee(), SF, VF);
+  State = State->BindExpr(CE->getArg(0), SF, VLoc);
 
   // Copied from ExprEngine::VisitCallExpr
   CallEventManager &CEMgr = getStateManager().getCallEventManager();
-  CallEventRef<> CallTemplate = CEMgr.getSimpleCall(CE, State, SF, CF);
+  CallEventRef<> CallTemplate =
+      CEMgr.getSimpleCall(CE, State, SF, getCFGElementRef());
   ExplodedNodeSet Dst;
   evalCall(Dst, Pred, *CallTemplate);
 
-  Engine.enqueueStmtNode(Dst, getCurrBlock(), currStmtIdx);
+  Engine.enqueueStmtNodes(Dst, getCurrBlock(), currStmtIdx);
 }
 
 void ExprEngine::processCleanupTemporaryBranch(const CXXBindTemporaryExpr *BTE,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -981,6 +981,9 @@ void ExprEngine::processCFGElement(const CFGElement E, ExplodedNode *Pred,
                          E.castAs<CFGLifetimeEnds>().getVarDecl(), Pred);
       return;
     case CFGElement::CleanupFunction:
+      ProcessCleanupFunction(E.castAs<CFGCleanupFunction>(), Pred);
+      return;
+    case CFGElement::LifetimeEnds:
     case CFGElement::FullExprCleanup:
     case CFGElement::ScopeBegin:
     case CFGElement::ScopeEnd:
@@ -1608,6 +1611,32 @@ void ExprEngine::ProcessTemporaryDtor(const CFGTemporaryDtor D,
   }
   VisitCXXDestructor(T, MR, BTE,
                      /*IsBase=*/false, CleanPred, Dst, CallOpts);
+}
+
+void ExprEngine::ProcessCleanupFunction(const CFGCleanupFunction CF, ExplodedNode *Pred) {
+  ProgramStateRef State = Pred->getState();
+  const StackFrame *SF = Pred->getStackFrame();
+
+  const FunctionDecl *FD = CF.getFunctionDecl();
+  SVal VF = svalBuilder.getFunctionPointer(FD);
+
+  const VarDecl *VD = CF.getVarDecl();
+  SVal VLoc = State->getLValue(VD, SF);
+
+  const CallExpr *CE = nullptr; // CF.getPseudoCallExpr();
+  // assert(CE->getNumArgs() == 1 && "Invalid cleanup function definition!");
+  const Expr *Callee = nullptr; // CE->getCallee();
+  const Expr *VarAddr = nullptr; // CE->getArg(0);
+  State = State->BindExpr(Callee, SF, VF, false);
+  State = State->BindExpr(VarAddr, SF, VLoc, false);
+
+  // Copied from ExprEngine::VisitCallExpr
+  CallEventManager &CEMgr = getStateManager().getCallEventManager();
+  CallEventRef<> CallTemplate = CEMgr.getSimpleCall(CE, State, SF, CF);
+  ExplodedNodeSet Dst;
+  evalCall(Dst, Pred, *CallTemplate);
+
+  Engine.enqueueStmtNode(Dst, getCurrBlock(), currStmtIdx);
 }
 
 void ExprEngine::processCleanupTemporaryBranch(const CXXBindTemporaryExpr *BTE,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1632,7 +1632,9 @@ void ExprEngine::ProcessCleanupFunction(const CFGCleanupFunction CF,
   CallEventRef<> CallTemplate =
       CEMgr.getSimpleCall(CE, State, SF, getCFGElementRef());
   ExplodedNodeSet Dst;
-  evalCall(Dst, Pred, *CallTemplate);
+  // Create a new node to apply the new state before function call.
+  evalCall(Dst, Engine.makeNode(PreStmt(CE, SF, /*tag=*/nullptr), State, Pred),
+           *CallTemplate);
 
   Engine.enqueueStmtNodes(Dst, getCurrBlock(), currStmtIdx);
 }

--- a/clang/test/Analysis/gcc-cleanup-attr.c
+++ b/clang/test/Analysis/gcc-cleanup-attr.c
@@ -1,0 +1,11 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify %s
+
+void clang_analyzer_dump(int);
+
+void defined_cleanup(int *p) {
+  clang_analyzer_dump(*p); // expected-warning {{42}}
+}
+
+void vardecl_defined() {
+  int x __attribute__((cleanup(defined_cleanup))) = 42;
+}

--- a/clang/test/Analysis/gcc-cleanup-attr.c
+++ b/clang/test/Analysis/gcc-cleanup-attr.c
@@ -1,13 +1,49 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify %s
+// RUN: %clang_analyze_cc1 -verify %s -Wno-int-to-void-pointer-cast \
+// RUN:   -analyzer-checker=core,unix,debug.ExprInspection
 
-void clang_analyzer_dump(int);
+void clang_analyzer_dump(const void *);
 
 void defined_cleanup(int *p) {
-  clang_analyzer_dump(*p); // expected-warning {{42}}
-                           // expected-warning@-1 {{43}}
+  clang_analyzer_dump(p); // expected-warning {{&x}}
+                          // expected-warning@-1 {{&y}}
+  clang_analyzer_dump((const void *)*p); // expected-warning {{42}}
+                                         // expected-warning@-1 {{43}}
 }
 
 void vardecl_defined() {
-  int x __attribute__((cleanup(defined_cleanup))) = 42;
-  int y __attribute__((cleanup(defined_cleanup))) = 43;
+  {
+    int x __attribute__((cleanup(defined_cleanup)));
+    x = 42;
+  }
+  int y __attribute__((cleanup(defined_cleanup)));
+  y = 43;
+}
+
+typedef __typeof(sizeof(int)) size_t;
+void *malloc(size_t);
+void free(void *);
+
+// If cleanup function is not defined, fallback to conservative.
+void declared_cleanup(int **p);
+
+void vardecl_declared() {
+  int *p1 __attribute__((cleanup(declared_cleanup))) = malloc(sizeof(int));
+  int *p2 __attribute__((cleanup(declared_cleanup))) = malloc(sizeof(int));
+  *p1 = 42;
+  *p2 = 43;
+}
+
+void malloc_cleanup(int **p) {
+  clang_analyzer_dump((const void *)**p); // expected-warning {{42}}
+                                          // expected-warning@-1 {{43}}
+  free(*p);
+  clang_analyzer_dump(p); // expected-warning {{&p1}}
+                          // expected-warning@-1 {{&p2}}
+}
+
+void vardecl_malloc() {
+  int *p1 __attribute__((cleanup(malloc_cleanup))) = malloc(sizeof(int));
+  int *p2 __attribute__((cleanup(malloc_cleanup))) = malloc(sizeof(int));
+  *p1 = 42;
+  *p2 = 43;
 }

--- a/clang/test/Analysis/gcc-cleanup-attr.c
+++ b/clang/test/Analysis/gcc-cleanup-attr.c
@@ -4,8 +4,10 @@ void clang_analyzer_dump(int);
 
 void defined_cleanup(int *p) {
   clang_analyzer_dump(*p); // expected-warning {{42}}
+                           // expected-warning@-1 {{43}}
 }
 
 void vardecl_defined() {
   int x __attribute__((cleanup(defined_cleanup))) = 42;
+  int y __attribute__((cleanup(defined_cleanup))) = 43;
 }


### PR DESCRIPTION
Closing #160527 (omitting other redundant issues and Bugzilla reports)

* Modifying the CFGCleanupFunction by creating and storing an off-AST pseudo CallExpr
  For `T var __attribute__((cleanup(freefunc)));`, creating a `freefunc(&var)` CallExpr in CFGCleanupFunction.
* Invoking the cleanup callee via the pseudo CallExpr when handling the CFGCleanupFunction, by following the evalCall procedure.
* Extending the liveness of the annotated variable to keep its assignment until after the cleanup callee invocation.
* Other necessary adjustments in Diagnostics and CoreEngine for the invocation.

Call for comments on improving this. Test execution on Linux kernel, no crash detected. Feel free to add other related reviewers.