### PR TITLE
[libc++][test] Suppress warning on bitwise shift with `bool` operands in `std::byte` tests for MSVC

### DIFF
--- a/libcxx/test/std/language.support/support.types/byteops/lshift.assign.pass.cpp
+++ b/libcxx/test/std/language.support/support.types/byteops/lshift.assign.pass.cpp
@@ -12,6 +12,9 @@
 //   constexpr byte& operator<<=(byte& b, IntType shift) noexcept;
 // Constraints: is_integral_v<IntType> is true.
 
+// MSVC warning C4804: '<<': unsafe use of type 'bool' in operation
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4804
+
 #include <cassert>
 #include <cstddef>
 #include <type_traits>

--- a/libcxx/test/std/language.support/support.types/byteops/lshift.pass.cpp
+++ b/libcxx/test/std/language.support/support.types/byteops/lshift.pass.cpp
@@ -12,6 +12,9 @@
 //   constexpr byte operator<<(byte b, IntType shift) noexcept;
 // Constraints: is_integral_v<IntType> is true.
 
+// MSVC warning C4804: '<<': unsafe use of type 'bool' in operation
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4804
+
 #include <cassert>
 #include <cstddef>
 #include <type_traits>

--- a/libcxx/test/std/language.support/support.types/byteops/rshift.assign.pass.cpp
+++ b/libcxx/test/std/language.support/support.types/byteops/rshift.assign.pass.cpp
@@ -12,6 +12,9 @@
 //   constexpr byte& operator>>=(byte& b, IntType shift) noexcept;
 // Constraints: is_integral_v<IntType> is true.
 
+// MSVC warning C4804: '>>': unsafe use of type 'bool' in operation
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4804
+
 #include <cassert>
 #include <cstddef>
 #include <type_traits>

--- a/libcxx/test/std/language.support/support.types/byteops/rshift.pass.cpp
+++ b/libcxx/test/std/language.support/support.types/byteops/rshift.pass.cpp
@@ -12,6 +12,9 @@
 //   constexpr byte operator>>(byte b, IntType shift) noexcept;
 // Constraints: is_integral_v<IntType> is true.
 
+// MSVC warning C4804: '>>': unsafe use of type 'bool' in operation
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4804
+
 #include <cassert>
 #include <cstddef>
 #include <type_traits>


### PR DESCRIPTION
It was intentional in https://llvm.org/PR204116 that tests for `operator<<`, `operator<<=`, `operator>>`, `operator>>=` used `bool` operands, because `bool` is an integral type and thus satisfies the constraints of these operators.

However, MSVC considers `bool` is unsafe as an operand of bitwise shift operators and emits warning C4804. So this patch suppresses the warning for MSVC.