### PR TITLE
[ORC] Drop ExecutorProcessControl::JITDispatchInfo.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -102,13 +102,6 @@ public:
     TaskDispatcher &D;
   };
 
-  /// Contains the address of the dispatch function and context that the ORC
-  /// runtime can use to call functions in the JIT.
-  struct JITDispatchInfo {
-    ExecutorAddr JITDispatchFunction;
-    ExecutorAddr JITDispatchContext;
-  };
-
   ExecutorProcessControl(std::shared_ptr<SymbolStringPool> SSP,
                          std::unique_ptr<TaskDispatcher> D)
       : SSP(std::move(SSP)), D(std::move(D)) {}
@@ -135,9 +128,6 @@ public:
 
   /// Get the page size for the target process.
   unsigned getPageSize() const { return PageSize; }
-
-  /// Get the JIT dispatch function and context address for the executor.
-  const JITDispatchInfo &getJITDispatchInfo() const { return JDI; }
 
   /// Create a default JITLinkMemoryManager for the target process.
   virtual Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>
@@ -312,7 +302,6 @@ protected:
   ExecutionSession *ES = nullptr;
   Triple TargetTriple;
   unsigned PageSize = 0;
-  JITDispatchInfo JDI;
   StringMap<std::vector<char>> BootstrapMap;
   StringMap<ExecutorAddr> BootstrapSymbols;
 };

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -65,6 +65,9 @@ LLVM_ABI extern const char *RunAsMainWrapperName;
 LLVM_ABI extern const char *RunAsVoidFunctionWrapperName;
 LLVM_ABI extern const char *RunAsIntFunctionWrapperName;
 
+LLVM_ABI extern const char *DispatchName;
+LLVM_ABI extern const char *DispatchCtxName;
+
 /// Symbol names for memory management implementation.
 /// FIXME: We should find a better home for this struct.
 struct SimpleExecutorMemoryManagerSymbolNames {

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -65,8 +65,8 @@ LLVM_ABI extern const char *RunAsMainWrapperName;
 LLVM_ABI extern const char *RunAsVoidFunctionWrapperName;
 LLVM_ABI extern const char *RunAsIntFunctionWrapperName;
 
-LLVM_ABI extern const char *DispatchName;
-LLVM_ABI extern const char *DispatchCtxName;
+LLVM_ABI extern const char *const DispatchName;
+LLVM_ABI extern const char *const DispatchCtxName;
 
 /// Symbol names for memory management implementation.
 /// FIXME: We should find a better home for this struct.

--- a/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/ObjectFileInterface.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
 #include "llvm/Object/COFF.h"
 
@@ -165,8 +166,6 @@ COFFPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
                                        ES.getTargetTriple().str(),
                                    inconvertibleErrorCode());
 
-  auto &EPC = ES.getExecutorProcessControl();
-
   auto GeneratorArchive =
       object::Archive::create(OrcRuntimeArchiveBuffer->getMemBufferRef());
   if (!GeneratorArchive)
@@ -193,19 +192,17 @@ COFFPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
   if (auto Err = PlatformJD.define(symbolAliases(std::move(*RuntimeAliases))))
     return std::move(Err);
 
-  auto &HostFuncJD = ES.createBareJITDylib("$<PlatformRuntimeHostFuncJD>");
-
-  // Add JIT-dispatch function support symbols.
-  if (auto Err = HostFuncJD.define(
-          absoluteSymbols({{ES.intern("__orc_rt_jit_dispatch"),
-                            {EPC.getJITDispatchInfo().JITDispatchFunction,
-                             JITSymbolFlags::Exported}},
-                           {ES.intern("__orc_rt_jit_dispatch_ctx"),
-                            {EPC.getJITDispatchInfo().JITDispatchContext,
-                             JITSymbolFlags::Exported}}})))
-    return std::move(Err);
-
-  PlatformJD.addToLinkOrder(HostFuncJD);
+  {
+    // Add JIT dispatch reexports from bootstrap JITDylib.
+    auto Exports = buildSimpleReexportsAliasMap(
+        ES.getBootstrapJITDylib(),
+        {{ES.intern(rt::DispatchName), ES.intern(rt::DispatchCtxName)}});
+    if (!Exports)
+      return Exports.takeError();
+    if (auto Err =
+            PlatformJD.define(reexports(ES.getBootstrapJITDylib(), *Exports)))
+      return Err;
+  }
 
   // Create the instance.
   Error Err = Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/ELFNixPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ELFNixPlatform.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/Debug.h"
 #include <optional>
 
@@ -218,8 +219,6 @@ ELFNixPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer,
                                        ES.getTargetTriple().str(),
                                    inconvertibleErrorCode());
 
-  auto &EPC = ES.getExecutorProcessControl();
-
   // Create default aliases if the caller didn't supply any.
   if (!RuntimeAliases) {
     auto StandardRuntimeAliases = standardPlatformAliases(ES, PlatformJD);
@@ -232,15 +231,17 @@ ELFNixPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer,
   if (auto Err = PlatformJD.define(symbolAliases(std::move(*RuntimeAliases))))
     return std::move(Err);
 
-  // Add JIT-dispatch function support symbols.
-  if (auto Err = PlatformJD.define(
-          absoluteSymbols({{ES.intern("__orc_rt_jit_dispatch"),
-                            {EPC.getJITDispatchInfo().JITDispatchFunction,
-                             JITSymbolFlags::Exported}},
-                           {ES.intern("__orc_rt_jit_dispatch_ctx"),
-                            {EPC.getJITDispatchInfo().JITDispatchContext,
-                             JITSymbolFlags::Exported}}})))
-    return std::move(Err);
+  {
+    // Add JIT dispatch reexports from bootstrap JITDylib.
+    auto Exports = buildSimpleReexportsAliasMap(
+        ES.getBootstrapJITDylib(),
+        {{ES.intern(rt::DispatchName), ES.intern(rt::DispatchCtxName)}});
+    if (!Exports)
+      return Exports.takeError();
+    if (auto Err =
+            PlatformJD.define(reexports(ES.getBootstrapJITDylib(), *Exports)))
+      return Err;
+  }
 
   // Create the instance.
   Error Err = Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/MachOBuilder.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/Debug.h"
 #include <optional>
 
@@ -292,8 +293,6 @@ MachOPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
                                        ES.getTargetTriple().str(),
                                    inconvertibleErrorCode());
 
-  auto &EPC = ES.getExecutorProcessControl();
-
   // Create default aliases if the caller didn't supply any.
   if (!RuntimeAliases)
     RuntimeAliases = standardPlatformAliases(ES);
@@ -302,15 +301,17 @@ MachOPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
   if (auto Err = PlatformJD.define(symbolAliases(std::move(*RuntimeAliases))))
     return std::move(Err);
 
-  // Add JIT-dispatch function support symbols.
-  if (auto Err = PlatformJD.define(
-          absoluteSymbols({{ES.intern("___orc_rt_jit_dispatch"),
-                            {EPC.getJITDispatchInfo().JITDispatchFunction,
-                             JITSymbolFlags::Exported}},
-                           {ES.intern("___orc_rt_jit_dispatch_ctx"),
-                            {EPC.getJITDispatchInfo().JITDispatchContext,
-                             JITSymbolFlags::Exported}}})))
-    return std::move(Err);
+  {
+    // Add JIT dispatch reexports from bootstrap JITDylib.
+    if (auto Err = PlatformJD.define(reexports(
+            ES.getBootstrapJITDylib(),
+            {{ES.intern("___orc_rt_jit_dispatch"),
+              {ES.intern(rt::DispatchName),
+               JITSymbolFlags::Exported | JITSymbolFlags::Callable}},
+             {ES.intern("___orc_rt_jit_dispatch_ctx"),
+              {ES.intern(rt::DispatchCtxName), JITSymbolFlags::Exported}}})))
+      return Err;
+  }
 
   // Create the instance.
   Error Err = Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -1,5 +1,7 @@
 #include "llvm/ExecutionEngine/Orc/ReOptimizeLayer.h"
+#include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
 using namespace llvm;
 using namespace orc;
@@ -93,17 +95,19 @@ Error ReOptimizeLayer::addOrcRTLiteSupport(JITDylib &PlatformJD,
   BasicBlock *Entry = BasicBlock::Create(*Ctx, "entry", ReOptimizeFn);
   Builder.SetInsertPoint(Entry);
 
-  // Create absolute address constants
-  auto &JDI = PlatformJD.getExecutionSession()
-                  .getExecutorProcessControl()
-                  .getJITDispatchInfo();
+  ExecutorAddr JITDispatchSym, JITDispatchCtxSym;
+  if (auto Err = lookupAndRecordAddrs(
+          ES, LookupKind::Static,
+          makeJITDylibSearchOrder(&ES.getBootstrapJITDylib()),
+          {{ES.intern(rt::DispatchName), &JITDispatchSym},
+           {ES.intern(rt::DispatchCtxName), &JITDispatchCtxSym}}))
+    return Err;
 
   Type *IntPtrTy = DL.getIntPtrType(*Ctx);
   Constant *JITDispatchPtr = ConstantExpr::getIntToPtr(
-      ConstantInt::get(IntPtrTy, JDI.JITDispatchFunction.getValue()),
-      VoidPtrTy);
+      ConstantInt::get(IntPtrTy, JITDispatchSym.getValue()), VoidPtrTy);
   Constant *JITDispatchCtxPtr = ConstantExpr::getIntToPtr(
-      ConstantInt::get(IntPtrTy, JDI.JITDispatchContext.getValue()), VoidPtrTy);
+      ConstantInt::get(IntPtrTy, JITDispatchCtxSym.getValue()), VoidPtrTy);
   Constant *HelperFnAddr = ConstantExpr::getIntToPtr(
       ConstantInt::get(IntPtrTy, reinterpret_cast<uintptr_t>(
                                      &orc_rt_lite_reoptimize_helper)),

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/ExecutionEngine/Orc/InProcessMemoryAccess.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -41,10 +42,12 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
 
   this->TargetTriple = std::move(TargetTriple);
   this->PageSize = PageSize;
-  this->JDI = {ExecutorAddr::fromPtr(jitDispatchViaWrapperFunctionManager),
-               ExecutorAddr::fromPtr(this)};
 
   addDefaultBootstrapValuesForHostProcess(BootstrapMap, BootstrapSymbols);
+
+  BootstrapSymbols[rt::DispatchName] =
+      ExecutorAddr::fromPtr(jitDispatchViaWrapperFunctionManager);
+  BootstrapSymbols[rt::DispatchCtxName] = ExecutorAddr::fromPtr(this);
 
 #ifdef __APPLE__
   // FIXME: Don't add an UnwindInfoManager by default -- it's redundant when

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -83,6 +83,9 @@ const char *RunAsVoidFunctionWrapperName =
 const char *RunAsIntFunctionWrapperName =
     "__llvm_orc_bootstrap_run_as_int_function_wrapper";
 
+const char *DispatchName = "__orc_rt_jit_dispatch";
+const char *DispatchCtxName = "__orc_rt_jit_dispatch_ctx";
+
 const SimpleExecutorMemoryManagerSymbolNames
     orc_rt_SimpleNativeMemoryMapSPSSymbols = {
         "orc_rt_ci_SimpleNativeMemoryMap_Instance",

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -83,8 +83,8 @@ const char *RunAsVoidFunctionWrapperName =
 const char *RunAsIntFunctionWrapperName =
     "__llvm_orc_bootstrap_run_as_int_function_wrapper";
 
-const char *DispatchName = "__orc_rt_jit_dispatch";
-const char *DispatchCtxName = "__orc_rt_jit_dispatch_ctx";
+const char *const DispatchName = "__orc_rt_jit_dispatch";
+const char *const DispatchCtxName = "__orc_rt_jit_dispatch_ctx";
 
 const SimpleExecutorMemoryManagerSymbolNames
     orc_rt_SimpleNativeMemoryMapSPSSymbols = {

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -339,10 +339,12 @@ Error SimpleRemoteEPC::setup() {
   BootstrapMap = std::move(EI->BootstrapMap);
   BootstrapSymbols = std::move(EI->BootstrapSymbols);
 
+  BootstrapSymbols[rt::DispatchName] = BootstrapSymbols[DispatchFnName];
+  BootstrapSymbols[rt::DispatchCtxName] =
+      BootstrapSymbols[ExecutorSessionObjectName];
+
   if (auto Err = getBootstrapSymbols(
-          {{JDI.JITDispatchContext, ExecutorSessionObjectName},
-           {JDI.JITDispatchFunction, DispatchFnName},
-           {RunAsMainAddr, rt::RunAsMainWrapperName},
+          {{RunAsMainAddr, rt::RunAsMainWrapperName},
            {RunAsVoidFunctionAddr, rt::RunAsVoidFunctionWrapperName},
            {RunAsIntFunctionAddr, rt::RunAsIntFunctionWrapperName}}))
     return Err;


### PR DESCRIPTION
The JIT-dispatch mechanism lets JIT'd code call handlers in an ORC ExecutionSession, via the "__orc_rt_jit_dispatch" and "__orc_rt_jit_dispatch_ctx" symbols. Until now ExecutorProcessControl carried the addresses backing those symbols in a dedicated JITDispatchInfo struct, which every EPC had to populate and each Platform read back to define the symbols.

That detour couples ExecutorProcessControl to the shape of the dispatch mechanism -- two symbols with fixed names -- and forces every EPC to provide the addresses whether or not a given JIT setup uses dispatch.

Represent the two addresses as ordinary bootstrap symbols instead. EPCs that support dispatch add __orc_rt_jit_dispatch(_ctx) to their bootstrap symbols; Platforms reexport them from the bootstrap JITDylib rather than reading JITDispatchInfo. EPCs that don't use dispatch provide nothing, and ExecutorProcessControl no longer references the mechanism at all.