### PR TITLE
[libc++][test] Disable test coverage for `_BitInt` for non-libc++ implementations

### DIFF
--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -45,8 +45,9 @@
 // _BitInt(N) is a C23 standard feature and a Clang extension in earlier C and C++.
 // __BITINT_MAXWIDTH__ is the portable probe: defined by every compiler that accepts _BitInt.
 // Note __has_extension(bit_int) is unusable because it is not recognized by Clang and produces 0.
-// Currently, MSVC STL has no plan to support _BitInt(N). So we should not enable test coverage for it.
-#if defined(__BITINT_MAXWIDTH__) && !defined(_MSVC_STL_VERSION)
+// Currently, library support for _BitInt(N) is an extension explicitly supported by libc++,
+// and test coverage is disabled for other implementations.
+#if defined(__BITINT_MAXWIDTH__) && defined(_LIBCPP_VERSION)
 #  define TEST_HAS_BITINT 1
 #else
 #  define TEST_HAS_BITINT 0

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -45,7 +45,8 @@
 // _BitInt(N) is a C23 standard feature and a Clang extension in earlier C and C++.
 // __BITINT_MAXWIDTH__ is the portable probe: defined by every compiler that accepts _BitInt.
 // Note __has_extension(bit_int) is unusable because it is not recognized by Clang and produces 0.
-#ifdef __BITINT_MAXWIDTH__
+// Currently, MSVC STL has no plan to support _BitInt(N). So we should not enable test coverage for it.
+#if defined(__BITINT_MAXWIDTH__) && !defined(_MSVC_STL_VERSION)
 #  define TEST_HAS_BITINT 1
 #else
 #  define TEST_HAS_BITINT 0


### PR DESCRIPTION
Currently, library support for `_BitInt(N)` is an extension explicitly supported by libc++. However, when using Clang with other standard library implementations, `TEST_HAS_BITINT` is currently `1` as the condition only detects compiler support of `_BitInt`.

This patch disables `_BitInt` coverage for other implementations for now.