### PR TITLE
[VPlan] Eta-reduce fn in pullOutPermutations (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -1131,8 +1131,7 @@ void vputils::detail::pullOutPermutationsImpl(
         continue;
 
       // At least one of the ops must be a permutation.
-      if (none_of(Def->operands(),
-                  [&MatchPerm](VPValue *Op) { return MatchPerm(Op); }))
+      if (none_of(Def->operands(), MatchPerm))
         continue;
 
       // All operands must be a single-use permutation or a live in (splat).


### PR DESCRIPTION
fun x => f x can be eta-reduced to just f.