### PR TITLE
[libc++][test][NFC] Format `test_macros.h`

### DIFF
--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -27,19 +27,19 @@
 #define TEST_CONCAT(X, Y) TEST_CONCAT1(X, Y)
 
 #ifdef __has_feature
-#define TEST_HAS_FEATURE(X) __has_feature(X)
+#  define TEST_HAS_FEATURE(X) __has_feature(X)
 #else
-#define TEST_HAS_FEATURE(X) 0
+#  define TEST_HAS_FEATURE(X) 0
 #endif
 
 #ifndef __has_include
-#define __has_include(...) 0
+#  define __has_include(...) 0
 #endif
 
 #ifdef __has_extension
-#define TEST_HAS_EXTENSION(X) __has_extension(X)
+#  define TEST_HAS_EXTENSION(X) __has_extension(X)
 #else
-#define TEST_HAS_EXTENSION(X) 0
+#  define TEST_HAS_EXTENSION(X) 0
 #endif
 
 // _BitInt(N) is a C23 standard feature and a Clang extension in earlier C and C++.
@@ -52,109 +52,109 @@
 #endif
 
 #ifdef __has_warning
-#define TEST_HAS_WARNING(X) __has_warning(X)
+#  define TEST_HAS_WARNING(X) __has_warning(X)
 #else
-#define TEST_HAS_WARNING(X) 0
+#  define TEST_HAS_WARNING(X) 0
 #endif
 
 #ifdef __has_builtin
-#define TEST_HAS_BUILTIN(X) __has_builtin(X)
+#  define TEST_HAS_BUILTIN(X) __has_builtin(X)
 #else
-#define TEST_HAS_BUILTIN(X) 0
+#  define TEST_HAS_BUILTIN(X) 0
 #endif
 #ifdef __is_identifier
 // '__is_identifier' returns '0' if '__x' is a reserved identifier provided by
 // the compiler and '1' otherwise.
-#define TEST_HAS_BUILTIN_IDENTIFIER(X) !__is_identifier(X)
+#  define TEST_HAS_BUILTIN_IDENTIFIER(X) !__is_identifier(X)
 #else
-#define TEST_HAS_BUILTIN_IDENTIFIER(X) 0
+#  define TEST_HAS_BUILTIN_IDENTIFIER(X) 0
 #endif
 
 #if defined(__EDG__)
-# define TEST_COMPILER_EDG
+#  define TEST_COMPILER_EDG
 #elif defined(__clang__)
-# define TEST_COMPILER_CLANG
-# if defined(__apple_build_version__)
-#  define TEST_COMPILER_APPLE_CLANG
-# endif
+#  define TEST_COMPILER_CLANG
+#  if defined(__apple_build_version__)
+#    define TEST_COMPILER_APPLE_CLANG
+#  endif
 #elif defined(_MSC_VER)
-# define TEST_COMPILER_MSVC
+#  define TEST_COMPILER_MSVC
 #elif defined(__GNUC__)
-# define TEST_COMPILER_GCC
+#  define TEST_COMPILER_GCC
 #endif
 
 #if defined(__apple_build_version__)
 // Given AppleClang XX.Y.Z, TEST_APPLE_CLANG_VER is XXYZ (e.g. AppleClang 14.0.3 => 1403)
-#define TEST_APPLE_CLANG_VER (__apple_build_version__ / 10000)
+#  define TEST_APPLE_CLANG_VER (__apple_build_version__ / 10000)
 #elif defined(__clang_major__)
-#define TEST_CLANG_VER (__clang_major__ * 100) + __clang_minor__
+#  define TEST_CLANG_VER (__clang_major__ * 100) + __clang_minor__
 #elif defined(__GNUC__)
 // Given GCC XX.YY.ZZ, TEST_GCC_VER is XXYYZZ
-#define TEST_GCC_VER ((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__)
+#  define TEST_GCC_VER ((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__)
 #endif
 
 /* Make a nice name for the standard version */
 #ifndef TEST_STD_VER
-#if  __cplusplus <= 199711L
-# define TEST_STD_VER 3
-#elif __cplusplus <= 201103L
-# define TEST_STD_VER 11
-#elif __cplusplus <= 201402L
-# define TEST_STD_VER 14
-#elif __cplusplus <= 201703L
-# define TEST_STD_VER 17
-#elif __cplusplus <= 202002L
-# define TEST_STD_VER 20
-#elif __cplusplus <= 202302L
-# define TEST_STD_VER 23
-#else
-# define TEST_STD_VER 99    // greater than current standard
+#  if __cplusplus <= 199711L
+#    define TEST_STD_VER 3
+#  elif __cplusplus <= 201103L
+#    define TEST_STD_VER 11
+#  elif __cplusplus <= 201402L
+#    define TEST_STD_VER 14
+#  elif __cplusplus <= 201703L
+#    define TEST_STD_VER 17
+#  elif __cplusplus <= 202002L
+#    define TEST_STD_VER 20
+#  elif __cplusplus <= 202302L
+#    define TEST_STD_VER 23
+#  else
+#    define TEST_STD_VER 99 // greater than current standard
 // This is deliberately different than _LIBCPP_STD_VER to discourage matching them up.
-#endif
+#  endif
 #endif
 
 // Attempt to deduce the GLIBC version
 #if (defined(__has_include) && __has_include(<features.h>)) || \
     defined(__linux__)
-#include <features.h>
-#if defined(__GLIBC_PREREQ)
-#define TEST_HAS_GLIBC
-#define TEST_GLIBC_PREREQ(major, minor) __GLIBC_PREREQ(major, minor)
-#endif
+#  include <features.h>
+#  if defined(__GLIBC_PREREQ)
+#    define TEST_HAS_GLIBC
+#    define TEST_GLIBC_PREREQ(major, minor) __GLIBC_PREREQ(major, minor)
+#  endif
 #endif
 
 #if TEST_STD_VER >= 11
-# define TEST_ALIGNOF(...) alignof(__VA_ARGS__)
-# define TEST_ALIGNAS(...) alignas(__VA_ARGS__)
-# define TEST_CONSTEXPR constexpr
-# define TEST_NOEXCEPT noexcept
-# define TEST_NOEXCEPT_FALSE noexcept(false)
-# define TEST_NOEXCEPT_COND(...) noexcept(__VA_ARGS__)
+#  define TEST_ALIGNOF(...) alignof(__VA_ARGS__)
+#  define TEST_ALIGNAS(...) alignas(__VA_ARGS__)
+#  define TEST_CONSTEXPR constexpr
+#  define TEST_NOEXCEPT noexcept
+#  define TEST_NOEXCEPT_FALSE noexcept(false)
+#  define TEST_NOEXCEPT_COND(...) noexcept(__VA_ARGS__)
 #else
-#   if defined(TEST_COMPILER_CLANG)
+#  if defined(TEST_COMPILER_CLANG)
 #    define TEST_ALIGNOF(...) _Alignof(__VA_ARGS__)
-#   else
+#  else
 #    define TEST_ALIGNOF(...) __alignof(__VA_ARGS__)
-#   endif
-# define TEST_ALIGNAS(...) __attribute__((__aligned__(__VA_ARGS__)))
-# define TEST_CONSTEXPR
-# define TEST_NOEXCEPT throw()
-# define TEST_NOEXCEPT_FALSE
-# define TEST_NOEXCEPT_COND(...)
+#  endif
+#  define TEST_ALIGNAS(...) __attribute__((__aligned__(__VA_ARGS__)))
+#  define TEST_CONSTEXPR
+#  define TEST_NOEXCEPT throw()
+#  define TEST_NOEXCEPT_FALSE
+#  define TEST_NOEXCEPT_COND(...)
 #endif
 
 #if TEST_STD_VER >= 11
-# define TEST_THROW_SPEC(...)
+#  define TEST_THROW_SPEC(...)
 #else
-# define TEST_THROW_SPEC(...) throw(__VA_ARGS__)
+#  define TEST_THROW_SPEC(...) throw(__VA_ARGS__)
 #endif
 
 #if defined(__cpp_lib_is_constant_evaluated) && __cpp_lib_is_constant_evaluated >= 201811L
-# define TEST_IS_CONSTANT_EVALUATED std::is_constant_evaluated()
+#  define TEST_IS_CONSTANT_EVALUATED std::is_constant_evaluated()
 #elif TEST_HAS_BUILTIN(__builtin_is_constant_evaluated)
-# define TEST_IS_CONSTANT_EVALUATED __builtin_is_constant_evaluated()
+#  define TEST_IS_CONSTANT_EVALUATED __builtin_is_constant_evaluated()
 #else
-# define TEST_IS_CONSTANT_EVALUATED false
+#  define TEST_IS_CONSTANT_EVALUATED false
 #endif
 
 #if TEST_STD_VER >= 20
@@ -176,21 +176,21 @@
 #endif
 
 #if TEST_STD_VER >= 14
-# define TEST_CONSTEXPR_CXX14 constexpr
+#  define TEST_CONSTEXPR_CXX14 constexpr
 #else
-# define TEST_CONSTEXPR_CXX14
+#  define TEST_CONSTEXPR_CXX14
 #endif
 
 #if TEST_STD_VER >= 17
-# define TEST_CONSTEXPR_CXX17 constexpr
+#  define TEST_CONSTEXPR_CXX17 constexpr
 #else
-# define TEST_CONSTEXPR_CXX17
+#  define TEST_CONSTEXPR_CXX17
 #endif
 
 #if TEST_STD_VER >= 20
-# define TEST_CONSTEXPR_CXX20 constexpr
+#  define TEST_CONSTEXPR_CXX20 constexpr
 #else
-# define TEST_CONSTEXPR_CXX20
+#  define TEST_CONSTEXPR_CXX20
 #endif
 
 #if TEST_STD_VER >= 23
@@ -207,26 +207,24 @@
 
 #define TEST_ALIGNAS_TYPE(...) TEST_ALIGNAS(TEST_ALIGNOF(__VA_ARGS__))
 
-#if !TEST_HAS_FEATURE(cxx_rtti) && !defined(__cpp_rtti) \
-    && !defined(__GXX_RTTI)
-#define TEST_HAS_NO_RTTI
+#if !TEST_HAS_FEATURE(cxx_rtti) && !defined(__cpp_rtti) && !defined(__GXX_RTTI)
+#  define TEST_HAS_NO_RTTI
 #endif
 
 #if !defined(TEST_HAS_NO_RTTI)
-# define RTTI_ASSERT(X) assert(X)
+#  define RTTI_ASSERT(X) assert(X)
 #else
-# define RTTI_ASSERT(X)
+#  define RTTI_ASSERT(X)
 #endif
 
-#if !TEST_HAS_FEATURE(cxx_exceptions) && !defined(__cpp_exceptions) \
-     && !defined(__EXCEPTIONS)
-#define TEST_HAS_NO_EXCEPTIONS
+#if !TEST_HAS_FEATURE(cxx_exceptions) && !defined(__cpp_exceptions) && !defined(__EXCEPTIONS)
+#  define TEST_HAS_NO_EXCEPTIONS
 #endif
 
-#if TEST_HAS_FEATURE(address_sanitizer) || TEST_HAS_FEATURE(hwaddress_sanitizer) || \
+#if TEST_HAS_FEATURE(address_sanitizer) || TEST_HAS_FEATURE(hwaddress_sanitizer) ||                                    \
     TEST_HAS_FEATURE(memory_sanitizer) || TEST_HAS_FEATURE(thread_sanitizer)
-#define TEST_HAS_SANITIZERS
-#define TEST_IS_EXECUTED_IN_A_SLOW_ENVIRONMENT
+#  define TEST_HAS_SANITIZERS
+#  define TEST_IS_EXECUTED_IN_A_SLOW_ENVIRONMENT
 #endif
 
 #ifdef _LIBCPP_USE_FROZEN_CXX03_HEADERS
@@ -248,29 +246,27 @@
 #endif
 
 #if TEST_STD_VER < 11
-#define ASSERT_NOEXCEPT(...)
-#define ASSERT_NOT_NOEXCEPT(...)
+#  define ASSERT_NOEXCEPT(...)
+#  define ASSERT_NOT_NOEXCEPT(...)
 #else
-#define ASSERT_NOEXCEPT(...) \
-    static_assert(noexcept(__VA_ARGS__), "Operation must be noexcept")
+#  define ASSERT_NOEXCEPT(...) static_assert(noexcept(__VA_ARGS__), "Operation must be noexcept")
 
-#define ASSERT_NOT_NOEXCEPT(...) \
-    static_assert(!noexcept(__VA_ARGS__), "Operation must NOT be noexcept")
+#  define ASSERT_NOT_NOEXCEPT(...) static_assert(!noexcept(__VA_ARGS__), "Operation must NOT be noexcept")
 #endif
 
 /* Macros for testing libc++ specific behavior and extensions */
 #if defined(_LIBCPP_VERSION)
-#define LIBCPP_ASSERT(...) assert(__VA_ARGS__)
-#define LIBCPP_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
-#define LIBCPP_ASSERT_NOEXCEPT(...) ASSERT_NOEXCEPT(__VA_ARGS__)
-#define LIBCPP_ASSERT_NOT_NOEXCEPT(...) ASSERT_NOT_NOEXCEPT(__VA_ARGS__)
-#define LIBCPP_ONLY(...) __VA_ARGS__
+#  define LIBCPP_ASSERT(...) assert(__VA_ARGS__)
+#  define LIBCPP_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
+#  define LIBCPP_ASSERT_NOEXCEPT(...) ASSERT_NOEXCEPT(__VA_ARGS__)
+#  define LIBCPP_ASSERT_NOT_NOEXCEPT(...) ASSERT_NOT_NOEXCEPT(__VA_ARGS__)
+#  define LIBCPP_ONLY(...) __VA_ARGS__
 #else
-#define LIBCPP_ASSERT(...) static_assert(true, "")
-#define LIBCPP_STATIC_ASSERT(...) static_assert(true, "")
-#define LIBCPP_ASSERT_NOEXCEPT(...) static_assert(true, "")
-#define LIBCPP_ASSERT_NOT_NOEXCEPT(...) static_assert(true, "")
-#define LIBCPP_ONLY(...) static_assert(true, "")
+#  define LIBCPP_ASSERT(...) static_assert(true, "")
+#  define LIBCPP_STATIC_ASSERT(...) static_assert(true, "")
+#  define LIBCPP_ASSERT_NOEXCEPT(...) static_assert(true, "")
+#  define LIBCPP_ASSERT_NOT_NOEXCEPT(...) static_assert(true, "")
+#  define LIBCPP_ONLY(...) static_assert(true, "")
 #endif
 
 #ifdef _LIBCPP_USE_FROZEN_CXX03_HEADERS
@@ -295,24 +291,27 @@
 
 namespace test_macros_detail {
 template <class T, class U>
-struct is_same { enum { value = 0};} ;
+struct is_same {
+  enum { value = 0 };
+};
 template <class T>
-struct is_same<T, T> { enum {value = 1}; };
+struct is_same<T, T> {
+  enum { value = 1 };
+};
 } // namespace test_macros_detail
 
-#define ASSERT_SAME_TYPE(...) \
-    static_assert((test_macros_detail::is_same<__VA_ARGS__>::value), \
-                 "Types differ unexpectedly")
+#define ASSERT_SAME_TYPE(...)                                                                                          \
+  static_assert((test_macros_detail::is_same<__VA_ARGS__>::value), "Types differ unexpectedly")
 
 #ifndef TEST_HAS_NO_EXCEPTIONS
-#define TEST_THROW(...) throw __VA_ARGS__
+#  define TEST_THROW(...) throw __VA_ARGS__
 #else
-#if defined(__GNUC__)
-#define TEST_THROW(...) __builtin_abort()
-#else
-#include <stdlib.h>
-#define TEST_THROW(...) ::abort()
-#endif
+#  if defined(__GNUC__)
+#    define TEST_THROW(...) __builtin_abort()
+#  else
+#    include <stdlib.h>
+#    define TEST_THROW(...) ::abort()
+#  endif
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -348,7 +347,7 @@ inline Tp& DoNotOptimize(Tp& value) {
   return value;
 }
 #else
-#include <intrin.h>
+#  include <intrin.h>
 template <class Tp>
 inline Tp const& DoNotOptimize(Tp const& value) {
   const volatile void* volatile unused = __builtin_addressof(value);
@@ -359,23 +358,23 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #endif
 
 #if defined(__GNUC__)
-#define TEST_ALWAYS_INLINE __attribute__((always_inline))
-#define TEST_NOINLINE __attribute__((noinline))
+#  define TEST_ALWAYS_INLINE __attribute__((always_inline))
+#  define TEST_NOINLINE __attribute__((noinline))
 #elif defined(_MSC_VER)
-#define TEST_ALWAYS_INLINE __forceinline
-#define TEST_NOINLINE __declspec(noinline)
+#  define TEST_ALWAYS_INLINE __forceinline
+#  define TEST_NOINLINE __declspec(noinline)
 #else
-#define TEST_ALWAYS_INLINE
-#define TEST_NOINLINE
+#  define TEST_ALWAYS_INLINE
+#  define TEST_NOINLINE
 #endif
 
 #ifdef _WIN32
-#define TEST_NOT_WIN32(...) ((void)0)
+#  define TEST_NOT_WIN32(...) ((void)0)
 #else
-#define TEST_NOT_WIN32(...) __VA_ARGS__
+#  define TEST_NOT_WIN32(...) __VA_ARGS__
 #endif
 
-#if defined(TEST_WINDOWS_DLL) ||defined(__MVS__) || defined(_AIX)
+#if defined(TEST_WINDOWS_DLL) || defined(__MVS__) || defined(_AIX)
 // Macros for waiving cases when we can't count allocations done within
 // the library implementation.
 //
@@ -386,15 +385,14 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 //
 // The same goes on IBM zOS.
 // The same goes on AIX.
-#define ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(...) ((void)(__VA_ARGS__))
-#define TEST_SUPPORTS_LIBRARY_INTERNAL_ALLOCATIONS 0
+#  define ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(...) ((void)(__VA_ARGS__))
+#  define TEST_SUPPORTS_LIBRARY_INTERNAL_ALLOCATIONS 0
 #else
-#define ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(...) assert(__VA_ARGS__)
-#define TEST_SUPPORTS_LIBRARY_INTERNAL_ALLOCATIONS 1
+#  define ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(...) assert(__VA_ARGS__)
+#  define TEST_SUPPORTS_LIBRARY_INTERNAL_ALLOCATIONS 1
 #endif
 
-#if (defined(TEST_WINDOWS_DLL) && !defined(_MSC_VER)) ||                      \
-    defined(__MVS__)
+#if (defined(TEST_WINDOWS_DLL) && !defined(_MSC_VER)) || defined(__MVS__)
 // Normally, a replaced e.g. 'operator new' ends up used if the user code
 // does a call to e.g. 'operator new[]'; it's enough to replace the base
 // versions and have it override all of them.
@@ -408,13 +406,13 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 // the end user executable, and these fallbacks work even in DLL configurations.
 // In MinGW configurations when built as a DLL, and on zOS, these fallbacks
 // don't work though.
-#define ASSERT_WITH_OPERATOR_NEW_FALLBACKS(...) ((void)(__VA_ARGS__))
+#  define ASSERT_WITH_OPERATOR_NEW_FALLBACKS(...) ((void)(__VA_ARGS__))
 #else
-#define ASSERT_WITH_OPERATOR_NEW_FALLBACKS(...) assert(__VA_ARGS__)
+#  define ASSERT_WITH_OPERATOR_NEW_FALLBACKS(...) assert(__VA_ARGS__)
 #endif
 
 #ifdef _WIN32
-#define TEST_WIN_NO_FILESYSTEM_PERMS_NONE
+#  define TEST_WIN_NO_FILESYSTEM_PERMS_NONE
 #endif
 
 // Support for carving out parts of the test suite, like removing wide characters, etc.
@@ -500,7 +498,7 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #  define TEST_DIAGNOSTIC_POP _Pragma("warning(pop)")
 #  define TEST_CLANG_DIAGNOSTIC_IGNORED(str)
 #  define TEST_GCC_DIAGNOSTIC_IGNORED(str)
-#  define TEST_MSVC_DIAGNOSTIC_IGNORED(num) _Pragma(TEST_STRINGIZE(warning(disable: num)))
+#  define TEST_MSVC_DIAGNOSTIC_IGNORED(num) _Pragma(TEST_STRINGIZE(warning(disable : num)))
 #else
 #  define TEST_DIAGNOSTIC_PUSH
 #  define TEST_DIAGNOSTIC_POP
@@ -510,11 +508,11 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #endif
 
 #if __has_cpp_attribute(msvc::no_unique_address)
-#define TEST_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#  define TEST_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #elif __has_cpp_attribute(no_unique_address)
-#define TEST_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#  define TEST_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
-#define TEST_NO_UNIQUE_ADDRESS
+#  define TEST_NO_UNIQUE_ADDRESS
 #endif
 
 #ifdef _LIBCPP_SHORT_WCHAR


### PR DESCRIPTION
Avoiding errors about untouched lines from clang-format when modifying conditions in `test_macros.h`.