### PR TITLE
[PAC][clang][test] Fix incorrect usage of `-NOT` suffix for FileCheck

### DIFF
--- a/clang/test/Driver/aarch64-ptrauth.c
+++ b/clang/test/Driver/aarch64-ptrauth.c
@@ -1,8 +1,8 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang -### -c --target=aarch64 %s 2>&1 | FileCheck %s --check-prefix NONE
-// NONE:     "-cc1"
-// NONE-NOT: "-fptrauth-
+// RUN: %clang -### -c --target=aarch64 %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix NONE --implicit-check-not='"-fptrauth-'
+// NONE: "-cc1"
 
 //// -fptauth-* driver flags on Linux are only supported with pauthtest ABI.
 // RUN: %clang -### -c --target=aarch64-linux -mabi=pauthtest \
@@ -55,24 +55,26 @@
 // ALL-DARWIN: "-cc1"{{.*}} "-fptrauth-intrinsics" "-fptrauth-calls" "-fptrauth-returns" "-fptrauth-auth-traps" "-fptrauth-vtable-pointer-address-discrimination" "-fptrauth-vtable-pointer-type-discrimination" "-fptrauth-type-info-vtable-pointer-discrimination" "-fptrauth-indirect-gotos"{{.*}} "-faarch64-jump-table-hardening"
 
 // RUN: %clang -### -c --target=aarch64-linux -mabi=pauthtest %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI1
-// RUN: %clang -### -c --target=aarch64-linux-pauthtest %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI1
+// RUN: %clang -### -c --target=aarch64-linux-pauthtest %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=PAUTHABI1 --implicit-check-not='"-fptrauth-function-pointer-type-discrimination"'
 // PAUTHABI1:      "-cc1"{{.*}} "-triple" "aarch64-unknown-linux-pauthtest"
 // PAUTHABI1-SAME: "-fptrauth-intrinsics" "-fptrauth-calls" "-fptrauth-returns" "-fptrauth-auth-traps" "-fptrauth-vtable-pointer-address-discrimination" "-fptrauth-vtable-pointer-type-discrimination" "-fptrauth-type-info-vtable-pointer-discrimination" "-fptrauth-indirect-gotos" "-fptrauth-init-fini" "-fptrauth-init-fini-address-discrimination" "-faarch64-jump-table-hardening"
 // PAUTHABI1-SAME: "-target-abi" "pauthtest"
-// PAUTHABI1-NOT: "-fptrauth-function-pointer-type-discrimination"
 
 // RUN: %clang -### -c --target=aarch64-linux -mabi=pauthtest -fno-ptrauth-intrinsics \
 // RUN:   -fno-ptrauth-calls -fno-ptrauth-returns -fno-ptrauth-auth-traps \
 // RUN:   -fno-ptrauth-vtable-pointer-address-discrimination -fno-ptrauth-vtable-pointer-type-discrimination \
 // RUN:   -fno-ptrauth-type-info-vtable-pointer-discrimination -fno-ptrauth-indirect-gotos \
 // RUN:   -fno-ptrauth-init-fini -fno-ptrauth-init-fini-address-discrimination \
-// RUN:   -fno-aarch64-jump-table-hardening %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI2
+// RUN:   -fno-aarch64-jump-table-hardening %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=PAUTHABI2 --implicit-check-not='"-fptrauth-' --implicit-check-not='"-faarch64-jump-table-hardening"'
 // RUN: %clang -### -c --target=aarch64-linux-pauthtest -fno-ptrauth-intrinsics \
 // RUN:   -fno-ptrauth-calls -fno-ptrauth-returns -fno-ptrauth-auth-traps \
 // RUN:   -fno-ptrauth-vtable-pointer-address-discrimination -fno-ptrauth-vtable-pointer-type-discrimination \
 // RUN:   -fno-ptrauth-type-info-vtable-pointer-discrimination -fno-ptrauth-indirect-gotos \
 // RUN:   -fno-ptrauth-init-fini -fno-ptrauth-init-fini-address-discrimination \
-// RUN:   -fno-aarch64-jump-table-hardening %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI2
+// RUN:   -fno-aarch64-jump-table-hardening %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=PAUTHABI2 --implicit-check-not='"-fptrauth-' --implicit-check-not='"-faarch64-jump-table-hardening"'
 
 //// Non-linux OS: pauthtest ABI has no effect in terms of passing ptrauth cc1 flags.
 //// An error about unsupported ABI will be emitted later in pipeline (see ERR3 below)
@@ -80,15 +82,12 @@
 
 // PAUTHABI2:      "-cc1"
 // PAUTHABI2-SAME: "-target-abi" "pauthtest"
-// PAUTHABI2-NOT:  "-fptrauth-
-// PAUTHABI2-NOT: "-faarch64-jump-table-hardening"
 
 //// Non-linux OS: pauthtest environment does not correspond to pauthtest ABI; aapcs is the default.
-// RUN: %clang -### -c --target=aarch64-pauthtest %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI3
+// RUN: %clang -### -c --target=aarch64-pauthtest %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=PAUTHABI3 --implicit-check-not='"-fptrauth-' --implicit-check-not='"-faarch64-jump-table-hardening"'
 // PAUTHABI3:      "-cc1"
 // PAUTHABI3-SAME: "-target-abi" "aapcs"
-// PAUTHABI3-NOT:  "-fptrauth-
-// PAUTHABI3-NOT: "-faarch64-jump-table-hardening"
 
 //// Non-pauthtest ABI.
 // RUN: not %clang -### -c --target=aarch64-linux -fptrauth-intrinsics -fptrauth-calls -fptrauth-returns -fptrauth-auth-traps \

--- a/clang/test/Driver/aarch64-ptrauth.c
+++ b/clang/test/Driver/aarch64-ptrauth.c
@@ -54,7 +54,8 @@
 // RUN:   %s 2>&1 | FileCheck %s --check-prefix=ALL-DARWIN
 // ALL-DARWIN: "-cc1"{{.*}} "-fptrauth-intrinsics" "-fptrauth-calls" "-fptrauth-returns" "-fptrauth-auth-traps" "-fptrauth-vtable-pointer-address-discrimination" "-fptrauth-vtable-pointer-type-discrimination" "-fptrauth-type-info-vtable-pointer-discrimination" "-fptrauth-indirect-gotos"{{.*}} "-faarch64-jump-table-hardening"
 
-// RUN: %clang -### -c --target=aarch64-linux -mabi=pauthtest %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI1
+// RUN: %clang -### -c --target=aarch64-linux -mabi=pauthtest %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=PAUTHABI1 --implicit-check-not='"-fptrauth-function-pointer-type-discrimination"'
 // RUN: %clang -### -c --target=aarch64-linux-pauthtest %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=PAUTHABI1 --implicit-check-not='"-fptrauth-function-pointer-type-discrimination"'
 // PAUTHABI1:      "-cc1"{{.*}} "-triple" "aarch64-unknown-linux-pauthtest"
@@ -78,7 +79,8 @@
 
 //// Non-linux OS: pauthtest ABI has no effect in terms of passing ptrauth cc1 flags.
 //// An error about unsupported ABI will be emitted later in pipeline (see ERR3 below)
-// RUN: %clang -### -c --target=aarch64 -mabi=pauthtest %s 2>&1 | FileCheck %s --check-prefix=PAUTHABI2
+// RUN: %clang -### -c --target=aarch64 -mabi=pauthtest %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=PAUTHABI2 --implicit-check-not='"-fptrauth-' --implicit-check-not='"-faarch64-jump-table-hardening"'
 
 // PAUTHABI2:      "-cc1"
 // PAUTHABI2-SAME: "-target-abi" "pauthtest"


### PR DESCRIPTION
Previously, `-NOT` checks were not doing what was intended: checking that given strings are not present within the same line where other patterns are confirmed present by other checks. `-NOT` semantics is checking pattern absense in between other checks, not total absense.

This patch makes use of `--implicit-check-not` instead for this purpose.