### PR TITLE
clang/AMDGPU: Add missing driver tests for invalid target names

### DIFF
--- a/clang/test/Driver/invalid-target-id.cl
+++ b/clang/test/Driver/invalid-target-id.cl
@@ -2,6 +2,10 @@
 // RUN:   -mcpu=gfx908xnack -nostdlib \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS %s
 
+// RUN: not %clang -target amdgcn-amd-amdhsa \
+// RUN:   -march=gfx908xnack -nostdlib -### \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS %s
+
 // NOPLUS: error: invalid target ID 'gfx908xnack'
 
 // RUN: not %clang -target amdgcn-amd-amdpal \

--- a/clang/test/Driver/openmp-invalid-target-id.c
+++ b/clang/test/Driver/openmp-invalid-target-id.c
@@ -9,6 +9,12 @@
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS-L %s
 
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mcpu=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mcpu=gfx908xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS-L %s
+
 // NOPLUS-L: error: invalid target ID 'gfx908xnack'
 
 // RUN: not %clang -### -target x86_64-linux-gnu -fopenmp=libomp \


### PR DESCRIPTION
Make sure -march and -mcpu both error for nonoffload and for
-Xopenmp-target arguments. Defends against regression I almost
introduced.