### PR TITLE
[MLIR][LLVM] Reject distinct generic metadata on import

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -181,6 +181,8 @@ static Attribute convertMetadataToAttrImpl(
     return MDFuncAttr::get(ctx, FlatSymbolRefAttr::get(ctx, fn->getName()));
   }
   if (auto *node = dyn_cast<llvm::MDNode>(md)) {
+    if (node->isDistinct())
+      return {};
     if (Attribute cached = attrMap.lookup(node))
       return cached;
     // If `node` is already on the current search path, this is a back-edge into
@@ -206,8 +208,9 @@ static Attribute convertMetadataToAttrImpl(
 
 /// Converts the metadata node `md` to the matching LLVM dialect metadata
 /// attribute. Returns a null attribute for shapes that the dialect's
-/// metadata-attribute hierarchy does not currently model, including cyclic
-/// metadata graphs that the immutable metadata attributes cannot express.
+/// metadata-attribute hierarchy does not currently model, including distinct
+/// nodes and cyclic metadata graphs that the immutable metadata attributes
+/// cannot express.
 static Attribute convertMetadataToAttr(MLIRContext *ctx,
                                        const llvm::Metadata *md) {
   SmallPtrSet<const llvm::Metadata *, 8> path;

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -181,6 +181,7 @@ static Attribute convertMetadataToAttrImpl(
     return MDFuncAttr::get(ctx, FlatSymbolRefAttr::get(ctx, fn->getName()));
   }
   if (auto *node = dyn_cast<llvm::MDNode>(md)) {
+    // Metadata attributes cannot preserve distinctness, so bail out.
     if (node->isDistinct())
       return {};
     if (Attribute cached = attrMap.lookup(node))

--- a/mlir/test/Target/LLVMIR/Import/import-failure.ll
+++ b/mlir/test/Target/LLVMIR/Import/import-failure.ll
@@ -459,6 +459,31 @@ bb1:
 
 ; // -----
 
+; CHECK: error: unsupported metadata: !{{[0-9]+}} = distinct !{!"sp"}
+declare i32 @llvm.read_register.i32(metadata)
+
+define i32 @distinct_metadata_as_value() {
+  %r = call i32 @llvm.read_register.i32(metadata !0)
+  ret i32 %r
+}
+
+!0 = distinct !{!"sp"}
+
+; // -----
+
+; CHECK: error: unsupported metadata: !{{[0-9]+}} = !{!{{[0-9]+}}}
+declare i32 @llvm.read_register.i32(metadata)
+
+define i32 @nested_distinct_metadata_as_value() {
+  %r = call i32 @llvm.read_register.i32(metadata !0)
+  ret i32 %r
+}
+
+!0 = !{!1}
+!1 = distinct !{!"sp"}
+
+; // -----
+
 ; CHECK: error: unsupported metadata: !{{[0-9]+}} = distinct !{!{{[0-9]+}}}
 declare i32 @llvm.read_register.i32(metadata)
 


### PR DESCRIPTION
Reject distinct nodes when converting generic LLVM metadata into LLVM dialect attributes because `MDNodeAttr` cannot preserve node identity. Apply the policy recursively so top-level and nested nodes use the existing unsupported-metadata failure path while finite acyclic uniqued nodes remain importable.