### PR TITLE
[libc++][NFC] Clean up atomic_support.h

### DIFF
--- a/libcxx/src/include/atomic_support.h
+++ b/libcxx/src/include/atomic_support.h
@@ -10,30 +10,10 @@
 #define ATOMIC_SUPPORT_H
 
 #include <__config>
-#include <memory> // for __libcpp_relaxed_load
-
-#if defined(__clang__) && __has_builtin(__atomic_load_n) && __has_builtin(__atomic_store_n) &&                         \
-    __has_builtin(__atomic_add_fetch) && __has_builtin(__atomic_exchange_n) &&                                         \
-    __has_builtin(__atomic_compare_exchange_n) && defined(__ATOMIC_RELAXED) && defined(__ATOMIC_CONSUME) &&            \
-    defined(__ATOMIC_ACQUIRE) && defined(__ATOMIC_RELEASE) && defined(__ATOMIC_ACQ_REL) && defined(__ATOMIC_SEQ_CST)
-#  define _LIBCPP_HAS_ATOMIC_BUILTINS
-#elif defined(_LIBCPP_COMPILER_GCC)
-#  define _LIBCPP_HAS_ATOMIC_BUILTINS
-#endif
-
-#if !defined(_LIBCPP_HAS_ATOMIC_BUILTINS) && _LIBCPP_HAS_THREADS
-#  if defined(_LIBCPP_WARNING)
-_LIBCPP_WARNING("Building libc++ without __atomic builtins is unsupported")
-#  else
-#    warning Building libc++ without __atomic builtins is unsupported
-#  endif
-#endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-namespace {
-
-#if defined(_LIBCPP_HAS_ATOMIC_BUILTINS) && _LIBCPP_HAS_THREADS
+#if _LIBCPP_HAS_THREADS
 
 enum __libcpp_atomic_order {
   _AO_Relaxed = __ATOMIC_RELAXED,
@@ -124,8 +104,6 @@ __libcpp_atomic_compare_exchange(_ValueType* __val, _ValueType* __expected, _Val
 }
 
 #endif // _LIBCPP_HAS_THREADS
-
-} // namespace
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
We don't support any compilers which don't have the atomic builtins, so we don't need to check whether they exist. There is also no need for an anonymous namespace, since all the functions are inline.
