### PR TITLE
[Hexagon] Forward target features to the external assembler

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -14,6 +14,7 @@
 #include "clang/Driver/MultilibBuilder.h"
 #include "clang/Driver/SanitizerArgs.h"
 #include "clang/Options/Options.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -228,11 +229,16 @@ void hexagon::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fsyntax-only");
   }
 
-  if (Arg *A = Args.getLastArg(options::OPT_mhexagon_hvx_ieee_fp,
-                               options::OPT_mno_hexagon_hvx_ieee_fp)) {
-    if (A->getOption().matches(options::OPT_mhexagon_hvx_ieee_fp))
-      CmdArgs.push_back("-mhvx-ieee-fp");
-  }
+  // Forward the target features (e.g. HVX, HVX length, HVX qfloat/ieee-fp) to
+  // the external assembler so that its behavior matches the integrated
+  // assembler. getHexagonTargetFeatures() computes the same feature list that
+  // the compiler and integrated assembler use, and llvm-mc consumes it via
+  // -mattr=.
+  std::vector<StringRef> Features;
+  hexagon::getHexagonTargetFeatures(D, HTC.getTriple(), Args, Features);
+  if (!Features.empty())
+    CmdArgs.push_back(
+        Args.MakeArgString("-mattr=" + llvm::join(Features, ",")));
 
   if (auto G = toolchains::HexagonToolChain::getSmallDataThreshold(Args)) {
     CmdArgs.push_back(Args.MakeArgString("-gpsize=" + Twine(*G)));

--- a/clang/test/Driver/hexagon-external-as-features.c
+++ b/clang/test/Driver/hexagon-external-as-features.c
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------------
+// Tests that target features are forwarded to the external assembler
+// (llvm-mc) via -mattr= when -fno-integrated-as is used, so that the
+// external assembler path is on par with the integrated assembler.
+// -----------------------------------------------------------------------------
+
+// Baseline: no HVX means no HVX features in -mattr=.
+// RUN: %clang -### -c %s --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -mcpu=hexagonv79 2>&1 | FileCheck -check-prefix=CHECK-NOHVX %s
+// CHECK-NOHVX: llvm-mc
+// CHECK-NOHVX-SAME: "-mcpu=hexagonv79"
+// CHECK-NOHVX-NOT: "+hvx
+
+// -mhvx enables HVX for the external assembler.
+// RUN: %clang -### -c %s --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -mcpu=hexagonv79 -mhvx 2>&1 | FileCheck -check-prefix=CHECK-HVX %s
+// CHECK-HVX: llvm-mc
+// CHECK-HVX-SAME: "-mcpu=hexagonv79"
+// CHECK-HVX-SAME: "-mattr={{[^"]*}}+hvxv79
+
+// -mhvx= selects an explicit HVX version.
+// RUN: %clang -### -c %s --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -mcpu=hexagonv79 -mhvx=v68 2>&1 | FileCheck -check-prefix=CHECK-HVXV68 %s
+// CHECK-HVXV68: llvm-mc
+// CHECK-HVXV68-SAME: "-mattr={{[^"]*}}+hvxv68
+
+// -mhvx-length= is forwarded.
+// RUN: %clang -### -c %s --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -mcpu=hexagonv79 -mhvx -mhvx-length=128b 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-HVXLEN %s
+// CHECK-HVXLEN: llvm-mc
+// CHECK-HVXLEN-SAME: "-mattr={{[^"]*}}+hvx-length128b
+
+// -mhvx-qfloat is forwarded.
+// RUN: %clang -### -c %s --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -mcpu=hexagonv79 -mhvx -mhvx-qfloat 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-HVXQFLOAT %s
+// CHECK-HVXQFLOAT: llvm-mc
+// CHECK-HVXQFLOAT-SAME: "-mattr={{[^"]*}}+hvx-qfloat
+
+// -mhvx-ieee-fp is forwarded (previously the only HVX flag handled here).
+// RUN: %clang -### -c %s --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -mcpu=hexagonv73 -mhvx -mhvx-ieee-fp 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-HVXIEEE %s
+// CHECK-HVXIEEE: llvm-mc
+// CHECK-HVXIEEE-SAME: "-mattr={{[^"]*}}+hvx-ieee-fp


### PR DESCRIPTION
The external assembler path (-fno-integrated-as, which invokes llvm-mc) only forwarded -mcpu and -mhvx-ieee-fp, so target features such as HVX, HVX length, HVX qfloat, and long-calls never reached the assembler. As a result, HVX-using code that compiled fine with the integrated assembler failed to assemble with the external one.

Compute the features with hexagon::getHexagonTargetFeatures(); the same helper used by the compiler and integrated assembler and forward them to llvm-mc via -mattr=, bringing the external assembler path to parity so behavior is consistent regardless of which assembler is selected.

Fixes #212471 