### PR TITLE
AMDGPU: Remove dead FEATURE_FP64/FEATURE_LDEXP from ArchFeatureKind

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -50,10 +50,7 @@ class LLVM_LIBRARY_VISIBILITY AMDGPUTargetInfo final : public TargetInfo {
   llvm::StringMap<bool> OffloadArchFeatures;
   std::string TargetID;
 
-  bool hasFP64() const {
-    return getTriple().isAMDGCN() ||
-           !!(GPUFeatures & llvm::AMDGPU::FEATURE_FP64);
-  }
+  bool hasFP64() const { return getTriple().isAMDGCN(); }
 
   /// Has fast fma f32
   bool hasFastFMAF() const {
@@ -72,10 +69,7 @@ class LLVM_LIBRARY_VISIBILITY AMDGPUTargetInfo final : public TargetInfo {
     return !!(GPUFeatures & llvm::AMDGPU::FEATURE_FAST_DENORMAL_F32);
   }
 
-  bool hasLDEXPF() const {
-    return getTriple().isAMDGCN() ||
-           !!(GPUFeatures & llvm::AMDGPU::FEATURE_LDEXP);
-  }
+  bool hasLDEXPF() const { return getTriple().isAMDGCN(); }
 
   static bool isR600(const llvm::Triple &TT) {
     return TT.getArch() == llvm::Triple::r600;

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -61,32 +61,30 @@ struct IsaVersion {
 enum ArchFeatureKind : uint32_t {
   FEATURE_NONE = 0,
 
-  // These features only exist for r600, and are implied true for amdgcn.
-  FEATURE_FMA = 1 << 1,
-  FEATURE_LDEXP = 1 << 2,
-  FEATURE_FP64 = 1 << 3,
+  // This feature only exists for r600, and is implied true for amdgcn.
+  FEATURE_FMA = 1 << 0,
 
   // Common features.
-  FEATURE_FAST_FMA_F32 = 1 << 4,
-  FEATURE_FAST_DENORMAL_F32 = 1 << 5,
+  FEATURE_FAST_FMA_F32 = 1 << 1,
+  FEATURE_FAST_DENORMAL_F32 = 1 << 2,
 
   // Wavefront 32 is available.
-  FEATURE_WAVE32 = 1 << 6,
+  FEATURE_WAVE32 = 1 << 3,
 
   // Xnack is available.
-  FEATURE_XNACK = 1 << 7,
+  FEATURE_XNACK = 1 << 4,
 
   // Sram-ecc is available.
-  FEATURE_SRAMECC = 1 << 8,
+  FEATURE_SRAMECC = 1 << 5,
 
   // WGP mode is supported.
-  FEATURE_WGP = 1 << 9,
+  FEATURE_WGP = 1 << 6,
 
   // Xnack on/off modes are supported.
-  FEATURE_XNACK_ON_OFF_MODES = 1 << 10,
+  FEATURE_XNACK_ON_OFF_MODES = 1 << 7,
 
   // VI SGPR initialization bug requiring a fixed SGPR allocation size.
-  FEATURE_SGPR_INIT_BUG = 1 << 11
+  FEATURE_SGPR_INIT_BUG = 1 << 8
 };
 
 enum FeatureError : uint32_t {


### PR DESCRIPTION
No GPU ever sets these bits, and clang's hasFP64()/hasLDEXPF() short-circuit
on isAMDGCN() before testing them, so the bits are never observed.

Co-authored-by: Claude (Claude-Opus-4.8)