### PR TITLE
[MLIR][Arith] Fix BitcastOp fold crashing on unhandled constant attributes

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -2284,9 +2284,7 @@ OpFoldResult arith::BitcastOp::fold(FoldAdaptor adaptor) {
   if (auto resFloatType = dyn_cast<FloatType>(resType))
     return FloatAttr::get(resType,
                           APFloat(resFloatType.getFloatSemantics(), bits));
-  if (auto resIntType = dyn_cast<IntegerType>(resType))
-    return IntegerAttr::get(resType, bits);
-  return {};
+  return IntegerAttr::get(resType, bits);
 }
 
 void arith::BitcastOp::getCanonicalizationPatterns(RewritePatternSet &patterns,

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -2270,16 +2270,23 @@ OpFoldResult arith::BitcastOp::fold(FoldAdaptor adaptor) {
     return ub::PoisonAttr::get(getContext());
 
   /// Bitcast integer or float to integer or float.
-  APInt bits = llvm::isa<FloatAttr>(operand)
-                   ? llvm::cast<FloatAttr>(operand).getValue().bitcastToAPInt()
-                   : llvm::cast<IntegerAttr>(operand).getValue();
+  APInt bits;
+  if (auto floatAttr = dyn_cast<FloatAttr>(operand))
+    bits = floatAttr.getValue().bitcastToAPInt();
+  else if (auto intAttr = dyn_cast<IntegerAttr>(operand))
+    bits = intAttr.getValue();
+  else
+    return {};
+
   assert(resType.getIntOrFloatBitWidth() == bits.getBitWidth() &&
          "trying to fold on broken IR: operands have incompatible types");
 
   if (auto resFloatType = dyn_cast<FloatType>(resType))
     return FloatAttr::get(resType,
                           APFloat(resFloatType.getFloatSemantics(), bits));
-  return IntegerAttr::get(resType, bits);
+  if (auto resIntType = dyn_cast<IntegerType>(resType))
+    return IntegerAttr::get(resType, bits);
+  return {};
 }
 
 void arith::BitcastOp::getCanonicalizationPatterns(RewritePatternSet &patterns,

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -2276,7 +2276,6 @@ OpFoldResult arith::BitcastOp::fold(FoldAdaptor adaptor) {
   APInt bits = llvm::isa<FloatAttr>(operand)
                    ? llvm::cast<FloatAttr>(operand).getValue().bitcastToAPInt()
                    : llvm::cast<IntegerAttr>(operand).getValue();
-
   assert(resType.getIntOrFloatBitWidth() == bits.getBitWidth() &&
          "trying to fold on broken IR: operands have incompatible types");
 

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -2273,11 +2273,9 @@ OpFoldResult arith::BitcastOp::fold(FoldAdaptor adaptor) {
   if (!llvm::isa<FloatAttr, IntegerAttr>(operand))
     return {};
 
-  const APInt bits = [&]() {
-    if (auto floatAttr = dyn_cast<FloatAttr>(operand))
-      return floatAttr.getValue().bitcastToAPInt();
-    return cast<IntegerAttr>(operand).getValue();
-  }();
+  APInt bits = llvm::isa<FloatAttr>(operand)
+                   ? llvm::cast<FloatAttr>(operand).getValue().bitcastToAPInt()
+                   : llvm::cast<IntegerAttr>(operand).getValue();
 
   assert(resType.getIntOrFloatBitWidth() == bits.getBitWidth() &&
          "trying to fold on broken IR: operands have incompatible types");

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -2270,13 +2270,14 @@ OpFoldResult arith::BitcastOp::fold(FoldAdaptor adaptor) {
     return ub::PoisonAttr::get(getContext());
 
   /// Bitcast integer or float to integer or float.
-  APInt bits;
-  if (auto floatAttr = dyn_cast<FloatAttr>(operand))
-    bits = floatAttr.getValue().bitcastToAPInt();
-  else if (auto intAttr = dyn_cast<IntegerAttr>(operand))
-    bits = intAttr.getValue();
-  else
+  if (!llvm::isa<FloatAttr, IntegerAttr>(operand))
     return {};
+
+  const APInt bits = [&]() {
+    if (auto floatAttr = dyn_cast<FloatAttr>(operand))
+      return floatAttr.getValue().bitcastToAPInt();
+    return cast<IntegerAttr>(operand).getValue();
+  }();
 
   assert(resType.getIntOrFloatBitWidth() == bits.getBitWidth() &&
          "trying to fold on broken IR: operands have incompatible types");

--- a/mlir/test/Dialect/Arith/canonicalize.mlir
+++ b/mlir/test/Dialect/Arith/canonicalize.mlir
@@ -2651,6 +2651,18 @@ func.func @bitcastChain(%arg: i16) -> f16 {
 
 // -----
 
+// CHECK-LABEL: func @bitcastForeignConstantAttr
+func.func @bitcastForeignConstantAttr() -> f64 {
+  // CHECK: %[[UNDEF:.*]] = llvm.mlir.undef : i64
+  // CHECK: %[[CAST:.*]] = arith.bitcast %[[UNDEF]] : i64 to f64
+  // CHECK: return %[[CAST]] : f64
+  %0 = llvm.mlir.undef : i64
+  %1 = arith.bitcast %0 : i64 to f64
+  return %1 : f64
+}
+
+// -----
+
 // CHECK-LABEL: test_maxsi
 // CHECK-DAG: %[[C0:.+]] = arith.constant 42
 // CHECK-DAG: %[[MAX_INT_CST:.+]] = arith.constant 127

--- a/mlir/test/Transforms/sccp.mlir
+++ b/mlir/test/Transforms/sccp.mlir
@@ -335,3 +335,19 @@ func.func @fold_to_non_operand_value(%x: i64, %cond: i1) -> i64 {
   %cast2 = builtin.unrealized_conversion_cast %cast1 : index to i64
   return %cast2 : i64
 }
+
+// -----
+
+// SCCP propagates the constant attribute produced by llvm.mlir.undef's fold
+// (an LLVM::UndefAttr) into arith.bitcast's fold, which must gracefully bail
+// instead of asserting.
+
+// CHECK-LABEL: func @bitcast_of_foreign_constant_attr
+func.func @bitcast_of_foreign_constant_attr() -> f64 {
+  // CHECK: %[[UNDEF:.*]] = llvm.mlir.undef : i64
+  // CHECK: %[[CAST:.*]] = arith.bitcast %[[UNDEF]] : i64 to f64
+  // CHECK: return %[[CAST]] : f64
+  %0 = llvm.mlir.undef : i64
+  %1 = arith.bitcast %0 : i64 to f64
+  return %1 : f64
+}

--- a/mlir/test/Transforms/sccp.mlir
+++ b/mlir/test/Transforms/sccp.mlir
@@ -335,19 +335,3 @@ func.func @fold_to_non_operand_value(%x: i64, %cond: i1) -> i64 {
   %cast2 = builtin.unrealized_conversion_cast %cast1 : index to i64
   return %cast2 : i64
 }
-
-// -----
-
-// SCCP propagates the constant attribute produced by llvm.mlir.undef's fold
-// (an LLVM::UndefAttr) into arith.bitcast's fold, which must gracefully bail
-// instead of asserting.
-
-// CHECK-LABEL: func @bitcast_of_foreign_constant_attr
-func.func @bitcast_of_foreign_constant_attr() -> f64 {
-  // CHECK: %[[UNDEF:.*]] = llvm.mlir.undef : i64
-  // CHECK: %[[CAST:.*]] = arith.bitcast %[[UNDEF]] : i64 to f64
-  // CHECK: return %[[CAST]] : f64
-  %0 = llvm.mlir.undef : i64
-  %1 = arith.bitcast %0 : i64 to f64
-  return %1 : f64
-}


### PR DESCRIPTION
`BitcastOp::fold` assumed any non-poison scalar operand attribute is a `FloatAttr` or `IntegerAttr` and hard-casted it. 
Constant attributes from other dialects, e.g. the `LLVM::UndefAttr` produced by `llvm.mlir.undef`'s fold, hit the cast assertion.
This crashed SCCP on IR where `llvm.mlir.undef` feeds `arith.bitcast`.
Bail out on attributes and result types the fold does not handle.