### PR TITLE
[AArch64] NFC: simplify isCopyInstrImpl expression

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -11360,7 +11360,7 @@ AArch64InstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
        MI.getOperand(1).getReg() == AArch64::WZR &&
        MI.getOperand(3).getImm() == 0x0) ||
       (MI.getOpcode() == AArch64::ORRWrr &&
-       MI.getOperand(1).getReg() == AArch64::WZR))
+       MI.getOperand(1).getReg() == AArch64::WZR)) {
     // Check that the w->w move is not a zero-extending w->x mov.
     if ((MI.getOperand(0).getReg().isPhysical() &&
          MI.findRegisterDefOperandIdx(
@@ -11369,6 +11369,7 @@ AArch64InstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
         (MI.getOperand(0).getReg().isVirtual() &&
          !MI.getOperand(0).getSubReg()))
       return DestSourcePair{MI.getOperand(0), MI.getOperand(2)};
+  }
 
   if (MI.getOpcode() == AArch64::ORRXrs &&
       MI.getOperand(1).getReg() == AArch64::XZR &&

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -11356,18 +11356,19 @@ AArch64InstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
 
   // AArch64::ORRWrs and AArch64::ORRXrs with WZR/XZR reg
   // and zero immediate operands used as an alias for mov instruction.
-  if (((MI.getOpcode() == AArch64::ORRWrs &&
-        MI.getOperand(1).getReg() == AArch64::WZR &&
-        MI.getOperand(3).getImm() == 0x0) ||
-       (MI.getOpcode() == AArch64::ORRWrr &&
-        MI.getOperand(1).getReg() == AArch64::WZR)) &&
-      // Check that the w->w move is not a zero-extending w->x mov.
-      (!MI.getOperand(0).getReg().isVirtual() ||
-       MI.getOperand(0).getSubReg() == 0) &&
-      (!MI.getOperand(0).getReg().isPhysical() ||
-       MI.findRegisterDefOperandIdx(getXRegFromWReg(MI.getOperand(0).getReg()),
-                                    /*TRI=*/nullptr) == -1))
-    return DestSourcePair{MI.getOperand(0), MI.getOperand(2)};
+  if ((MI.getOpcode() == AArch64::ORRWrs &&
+       MI.getOperand(1).getReg() == AArch64::WZR &&
+       MI.getOperand(3).getImm() == 0x0) ||
+      (MI.getOpcode() == AArch64::ORRWrr &&
+       MI.getOperand(1).getReg() == AArch64::WZR))
+    // Check that the w->w move is not a zero-extending w->x mov.
+    if ((MI.getOperand(0).getReg().isPhysical() &&
+         MI.findRegisterDefOperandIdx(
+             getXRegFromWReg(MI.getOperand(0).getReg()),
+             /*TRI=*/nullptr) == -1) ||
+        (MI.getOperand(0).getReg().isVirtual() &&
+         !MI.getOperand(0).getSubReg()))
+      return DestSourcePair{MI.getOperand(0), MI.getOperand(2)};
 
   if (MI.getOpcode() == AArch64::ORRXrs &&
       MI.getOperand(1).getReg() == AArch64::XZR &&


### PR DESCRIPTION
To something more intuitive by applying the following logic:
* `!isVirtual()` -> `isPhysical()`
* `!isPhysical()` -> `isVirtual()`
* `(a || b) && (!a || c)` -> `(!a && b) || (a && c)`