### PR TITLE
[VE] Fix crash when splitting all-ones v512i1 mask

### DIFF
--- a/llvm/lib/Target/VE/VEInstrPatternsVec.td
+++ b/llvm/lib/Target/VE/VEInstrPatternsVec.td
@@ -130,6 +130,10 @@ def: Mask_Binary<v256i1, xor, "XORM">;
 ///// Packing support /////
 
 // v256i1 <> v512i1
+def : Pat<(v256i1 (vec_unpack_lo (v512i1 true_mask), (i32 srcvalue))),
+          (v256i1 VM0)>;
+def : Pat<(v256i1 (vec_unpack_hi (v512i1 true_mask), (i32 srcvalue))),
+          (v256i1 VM0)>;
 def : Pat<(v256i1 (vec_unpack_lo v512i1:$vm, (i32 srcvalue))),
           (EXTRACT_SUBREG $vm, sub_vm_odd)>;
 def : Pat<(v256i1 (vec_unpack_hi v512i1:$vm, (i32 srcvalue))),

--- a/llvm/test/CodeGen/VE/Packed/vp_mul.ll
+++ b/llvm/test/CodeGen/VE/Packed/vp_mul.ll
@@ -23,3 +23,24 @@ define fastcc <512 x i32> @test_vp_v512i32(<512 x i32> %i0, <512 x i32> %i1, <51
   %r0 = call <512 x i32> @llvm.vp.mul.v512i32(<512 x i32> %i0, <512 x i32> %i1, <512 x i1> %m, i32 %n)
   ret <512 x i32> %r0
 }
+
+define fastcc <512 x i32> @test_vp_v512i32_vmp0(<512 x i32> %i0, <512 x i32> %i1, <512 x i1> %m, i32 %n) {
+; CHECK-LABEL: test_vp_v512i32_vmp0:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    adds.w.sx %s1, 1, %s0
+; CHECK-NEXT:    and %s1, %s1, (32)0
+; CHECK-NEXT:    srl %s1, %s1, 1
+; CHECK-NEXT:    lvl %s1
+; CHECK-NEXT:    vshf %v2, %v1, %v1, 0
+; CHECK-NEXT:    vshf %v3, %v0, %v0, 0
+; CHECK-NEXT:    vmuls.w.sx %v2, %v3, %v2, %vm0
+; CHECK-NEXT:    and %s0, %s0, (32)0
+; CHECK-NEXT:    srl %s0, %s0, 1
+; CHECK-NEXT:    lvl %s0
+; CHECK-NEXT:    vmuls.w.sx %v0, %v0, %v1, %vm0
+; CHECK-NEXT:    lvl %s1
+; CHECK-NEXT:    vshf %v0, %v0, %v2, 13
+; CHECK-NEXT:    b.l.t (, %s10)
+  %r0 = call <512 x i32> @llvm.vp.mul.v512i32(<512 x i32> %i0, <512 x i32> %i1, <512 x i1> splat (i1 true), i32 %n)
+  ret <512 x i32> %r0
+}


### PR DESCRIPTION
The added test case crashes because we try to extract a subreg from vmp0 when selecting vec_unpack_*, but vmp0 has no subregisters, see d46e49838e17800cb72d95db1b23c04bbca610e2

vmp0 is hardwired to all ones, so it gets selected for an all ones mask.

Fix it by adding an explicit pattern for an all ones mask that selects vm0, the v256i1 version of vmp0, instead of creating an invalid subreg extract.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>