### PR TITLE
[RISCV][MC] Improve FPR Error Messages

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -38,7 +38,7 @@ def GPRPairAsFPR : AsmOperandClass {
   let ParserMethod = "parseGPRPairAsFPR64";
   let PredicateMethod = "isGPRPairAsFPR64";
   let RenderMethod = "addRegOperands";
-  let DiagnosticString = "register must be an even-numbered GPR when used as FPR";
+  let DiagnosticString = "register must be an even-numbered GPR when used as an FP operand";
 }
 
 def GPRF64AsFPR : AsmOperandClass {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -38,6 +38,7 @@ def GPRPairAsFPR : AsmOperandClass {
   let ParserMethod = "parseGPRPairAsFPR64";
   let PredicateMethod = "isGPRPairAsFPR64";
   let RenderMethod = "addRegOperands";
+  let DiagnosticString = "register must be an even-numbered GPR when used as FPR";
 }
 
 def GPRF64AsFPR : AsmOperandClass {
@@ -45,6 +46,7 @@ def GPRF64AsFPR : AsmOperandClass {
   let PredicateMethod = "isGPRAsFPR";
   let ParserMethod = "parseGPRAsFPR64";
   let RenderMethod = "addRegOperands";
+  let DiagnosticString = "register must be a GPR when used as FPR";
 }
 
 def FPR64INX : RegisterOperand<GPR> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -46,7 +46,7 @@ def GPRF64AsFPR : AsmOperandClass {
   let PredicateMethod = "isGPRAsFPR";
   let ParserMethod = "parseGPRAsFPR64";
   let RenderMethod = "addRegOperands";
-  let DiagnosticString = "register must be a GPR when used as FPR";
+  let DiagnosticString = "register must be a GPR when used as an FP operand";
 }
 
 def FPR64INX : RegisterOperand<GPR> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
@@ -115,6 +115,7 @@ def GPRAsFPR32 : AsmOperandClass {
   let Name = "GPRAsFPR32";
   let ParserMethod = "parseGPRAsFPR";
   let RenderMethod = "addRegOperands";
+  let DiagnosticString = "register must be a GPR when used as FPR";
 }
 
 def FPR32INX : RegisterOperand<GPRF32> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
@@ -115,7 +115,7 @@ def GPRAsFPR32 : AsmOperandClass {
   let Name = "GPRAsFPR32";
   let ParserMethod = "parseGPRAsFPR";
   let RenderMethod = "addRegOperands";
-  let DiagnosticString = "register must be a GPR when used as FPR";
+  let DiagnosticString = "register must be a GPR when used as an FP operand";
 }
 
 def FPR32INX : RegisterOperand<GPRF32> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
@@ -46,7 +46,7 @@ def GPRAsFPR16 : AsmOperandClass {
   let Name = "GPRAsFPR16";
   let ParserMethod = "parseGPRAsFPR";
   let RenderMethod = "addRegOperands";
-  let DiagnosticString = "register must be a GPR when used as FPR";
+  let DiagnosticString = "register must be a GPR when used as an FP operand";
 }
 
 def FPR16INX : RegisterOperand<GPRF16> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
@@ -46,6 +46,7 @@ def GPRAsFPR16 : AsmOperandClass {
   let Name = "GPRAsFPR16";
   let ParserMethod = "parseGPRAsFPR";
   let RenderMethod = "addRegOperands";
+  let DiagnosticString = "register must be a GPR when used as FPR";
 }
 
 def FPR16INX : RegisterOperand<GPRF16> {

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -546,21 +546,43 @@ class FPRCRegisterClass<list<ValueType> regTypes, int align, string regSuffix>
 // meaning caller-save regs are listed before callee-save.
 // We start by allocating argument registers in reverse order since they are
 // compressible.
-def FPR16 : FPRRegisterClass<[f16, bf16], 16, "H">;
+def FPR16 : FPRRegisterClass<[f16, bf16], 16, "H"> {
+  let DiagnosticType   = "InvalidRegClassFPR16";
+  let DiagnosticString = "register must be a FPR";
+}
 
-def FPR16C : FPRCRegisterClass<[f16, bf16], 16, "H">;
+def FPR16C : FPRCRegisterClass<[f16, bf16], 16, "H"> {
+  let DiagnosticType   = "InvalidRegClassFPR16C";
+  let DiagnosticString = "register must be a FPR from f8 to f15 (fs0-fs1, fa0-fa5)";
+}
 
-def FPR32 : FPRRegisterClass<[f32], 32, "F">;
+def FPR32 : FPRRegisterClass<[f32], 32, "F"> {
+  let DiagnosticType   = "InvalidRegClassFPR32";
+  let DiagnosticString = "register must be a FPR";
+}
 
-def FPR32C : FPRCRegisterClass<[f32], 32, "F">;
+def FPR32C : FPRCRegisterClass<[f32], 32, "F"> {
+  let DiagnosticType   = "InvalidRegClassFPR32C";
+  let DiagnosticString = "register must be a FPR from f8 to f15 (fs0-fs1, fa0-fa5)";
+}
+
 
 // The order of registers represents the preferred allocation sequence,
 // meaning caller-save regs are listed before callee-save.
-def FPR64 : FPRRegisterClass<[f64], 64, "D">;
+def FPR64 : FPRRegisterClass<[f64], 64, "D"> {
+  let DiagnosticType   = "InvalidRegClassFPR64";
+  let DiagnosticString = "register must be a FPR";
+}
 
-def FPR64C : FPRCRegisterClass<[f64], 64, "D">;
+def FPR64C : FPRCRegisterClass<[f64], 64, "D"> {
+  let DiagnosticType   = "InvalidRegClassFPR64C";
+  let DiagnosticString = "register must be a FPR from f8 to f15 (fs0-fs1, fa0-fa5)";
+}
 
-def FPR128 : FPRRegisterClass<[f128], 128, "Q">;
+def FPR128 : FPRRegisterClass<[f128], 128, "Q"> {
+  let DiagnosticType   = "InvalidRegClassFPR128";
+  let DiagnosticString = "register must be a FPR";
+}
 
 //===----------------------------------------------------------------------===//
 // GPR Classes for "H/F/D in X"
@@ -1016,7 +1038,10 @@ let RegAltNameIndices = [ABIRegAltName] in
 
 // The order of registers represents the preferred allocation sequence,
 // meaning caller-save regs are listed before callee-save.
-def FPR256 : FPRRegisterClass<[v8i32, v8f32], 256, "Q2">;
+def FPR256 : FPRRegisterClass<[v8i32, v8f32], 256, "Q2"> {
+  let DiagnosticType   = "InvalidRegClassFPR256";
+  let DiagnosticString = "register must be a FPR";
+}
 
 // Mask registers m0 to m7
 foreach Index = 0-7 in

--- a/llvm/test/MC/RISCV/rv32d-invalid.s
+++ b/llvm/test/MC/RISCV/rv32d-invalid.s
@@ -10,12 +10,15 @@ fld ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 fsd ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
-fld ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fld ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fld ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
-fsgnjn.d fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fsgnjn.d fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
 
 # Integer registers where FP regs are expected
-fadd.d a2, a1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+fadd.d a2, a1, a0 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:8: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-3]]:8: note: register must be an even-numbered GPR when used as FPR
 
 # FP registers where integer regs are expected
 fcvt.wu.d ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32d-invalid.s
+++ b/llvm/test/MC/RISCV/rv32d-invalid.s
@@ -17,7 +17,7 @@ fsgnjn.d fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
 # Integer registers where FP regs are expected
 fadd.d a2, a1, a0 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:8: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as an FP operand
 # CHECK: :[[@LINE-3]]:8: note: register must be an even-numbered GPR when used as an FP operand
 
 # FP registers where integer regs are expected

--- a/llvm/test/MC/RISCV/rv32d-invalid.s
+++ b/llvm/test/MC/RISCV/rv32d-invalid.s
@@ -18,7 +18,7 @@ fsgnjn.d fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
 fadd.d a2, a1, a0 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:8: note: register must be a FPR
 # CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as FPR
-# CHECK: :[[@LINE-3]]:8: note: register must be an even-numbered GPR when used as FPR
+# CHECK: :[[@LINE-3]]:8: note: register must be an even-numbered GPR when used as an FP operand
 
 # FP registers where integer regs are expected
 fcvt.wu.d ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32dc-invalid.s
+++ b/llvm/test/MC/RISCV/rv32dc-invalid.s
@@ -1,7 +1,7 @@
 # RUN: not llvm-mc -triple=riscv32 -mattr=+c,+d < %s 2>&1 | FileCheck %s
 
 ## FPRC
-c.fld  ft3, 8(a5) # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+c.fld  ft3, 8(a5) # CHECK: :[[@LINE]]:8: error: register must be a FPR
 
 ## uimm9_lsb000
 c.fldsp  fs1, 512(sp) # CHECK: :[[@LINE]]:15: error: immediate must be a multiple of 8 bytes in the range [0, 504]

--- a/llvm/test/MC/RISCV/rv32f-invalid.s
+++ b/llvm/test/MC/RISCV/rv32f-invalid.s
@@ -10,18 +10,18 @@ flw ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 fsw ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
-flw ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+flw ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 flw ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
-fsgnjn.s fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fsgnjn.s fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
 
 # Integer registers where FP regs are expected
 fmv.x.w fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fmv.w.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.w.x a8, ft2 # CHECK: :[[@LINE]]:9: error: register must be a FPR
 
 # Rounding mode when a register is expected
-fmadd.s f10, f11, f12, ree # CHECK: :[[@LINE]]:24: error: invalid operand for instruction
+fmadd.s f10, f11, f12, ree # CHECK: :[[@LINE]]:24: error: register must be a FPR
 
 # Invalid rounding modes
 fmadd.s f10, f11, f12, f13, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32fc-invalid.s
+++ b/llvm/test/MC/RISCV/rv32fc-invalid.s
@@ -1,7 +1,7 @@
 # RUN: not llvm-mc -triple=riscv32 -mattr=+c,+f < %s 2>&1 | FileCheck %s
 
 ## FPRC
-c.flw  ft3, 8(a5) # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+c.flw  ft3, 8(a5) # CHECK: :[[@LINE]]:8: error: register must be a FPR
 
 ## uimm8_lsb00
 c.flwsp  fs1, 256(sp) # CHECK: :[[@LINE]]:15: error: immediate must be a multiple of 4 bytes in the range [0, 252]

--- a/llvm/test/MC/RISCV/rv32q-invalid.s
+++ b/llvm/test/MC/RISCV/rv32q-invalid.s
@@ -10,12 +10,12 @@ flq ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 fsq ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
-flq ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+flq ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 flq ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
-fsgnjn.q fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fsgnjn.q fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
 
 # Integer registers where FP regs are expected
-fadd.q a2, a1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+fadd.q a2, a1, a0 # CHECK: :[[@LINE]]:8: error: register must be a FPR
 
 # FP registers where integer regs are expected
 fcvt.wu.q ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32zdinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zdinx-invalid.s
@@ -12,11 +12,11 @@ fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.w s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # Invalid register names
-fadd.d a100, a2, a4 # CHECK: :[[@LINE]]:8: error: register must be an even-numbered GPR when used as FPR
-fsgnjn.d a100, a2, a4 # CHECK: :[[@LINE]]:10: error: register must be an even-numbered GPR when used as FPR
+fadd.d a100, a2, a4 # CHECK: :[[@LINE]]:8: error: register must be an even-numbered GPR when used as an FP operand
+fsgnjn.d a100, a2, a4 # CHECK: :[[@LINE]]:10: error: register must be an even-numbered GPR when used as an FP operand
 
 # Rounding mode when a register is expected
-fmadd.d x10, x12, x14, ree # CHECK: :[[@LINE]]:24: error: register must be an even-numbered GPR when used as FPR
+fmadd.d x10, x12, x14, ree # CHECK: :[[@LINE]]:24: error: register must be an even-numbered GPR when used as an FP operand
 
 # Invalid rounding modes
 fmadd.d x10, x12, x14, x16, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32zdinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zdinx-invalid.s
@@ -8,15 +8,15 @@ flw fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following
 fadd.d fa0, fa1, fa2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
 
 # Invalid instructions
-fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.w s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # Invalid register names
-fadd.d a100, a2, a4 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-fsgnjn.d a100, a2, a4 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fadd.d a100, a2, a4 # CHECK: :[[@LINE]]:8: error: register must be an even-numbered GPR when used as FPR
+fsgnjn.d a100, a2, a4 # CHECK: :[[@LINE]]:10: error: register must be an even-numbered GPR when used as FPR
 
 # Rounding mode when a register is expected
-fmadd.d x10, x12, x14, ree # CHECK: :[[@LINE]]:24: error: invalid operand for instruction
+fmadd.d x10, x12, x14, ree # CHECK: :[[@LINE]]:24: error: register must be an even-numbered GPR when used as FPR
 
 # Invalid rounding modes
 fmadd.d x10, x12, x14, x16, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32zfh-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zfh-invalid.s
@@ -32,7 +32,7 @@ fnmsub.h f18, f19, f20, f21, 0b111 # CHECK: :[[@LINE]]:30: error: operand must b
 # Integer registers where FP regs are expected
 fadd.h a2, a1, a0 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:8: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as an FP operand
 
 # FP registers where integer regs are expected
 fcvt.wu.h ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32zfh-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zfh-invalid.s
@@ -11,18 +11,18 @@ flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 fsw ft2, a1, 100 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
-flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 flh ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
-fsgnjn.h fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fsgnjn.h fa100, fa2, fa3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
 
 # Integer registers where FP regs are expected
 fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: register must be a FPR
 
 # Rounding mode when a register is expected
-fmadd.h f10, f11, f12, ree # CHECK: :[[@LINE]]:24: error: invalid operand for instruction
+fmadd.h f10, f11, f12, ree # CHECK: :[[@LINE]]:24: error: register must be a FPR
 
 # Invalid rounding modes
 fmadd.h f10, f11, f12, f13, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic
@@ -30,7 +30,9 @@ fmsub.h f14, f15, f16, f17, 0 # CHECK: :[[@LINE]]:29: error: operand must be a v
 fnmsub.h f18, f19, f20, f21, 0b111 # CHECK: :[[@LINE]]:30: error: operand must be a valid floating point rounding mode mnemonic
 
 # Integer registers where FP regs are expected
-fadd.h a2, a1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+fadd.h a2, a1, a0 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:8: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:8: note: register must be a GPR when used as FPR
 
 # FP registers where integer regs are expected
 fcvt.wu.h ft2, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR

--- a/llvm/test/MC/RISCV/rv32zfinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zfinx-invalid.s
@@ -10,11 +10,11 @@ fmv.x.w s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fadd.d t1, t3, t5 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zdinx' (Double in Integer){{$}}
 
 # Invalid register names
-fadd.s a100, a2, a3 # CHECK: :[[@LINE]]:8: error: register must be a GPR when used as FPR
-fsgnjn.s a100, a2, a3 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as FPR
+fadd.s a100, a2, a3 # CHECK: :[[@LINE]]:8: error: register must be a GPR when used as an FP operand
+fsgnjn.s a100, a2, a3 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as an FP operand
 
 # Rounding mode when a register is expected
-fmadd.s x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: register must be a GPR when used as FPR
+fmadd.s x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: register must be a GPR when used as an FP operand
 
 # Invalid rounding modes
 fmadd.s x10, x11, x12, x13, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32zfinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zfinx-invalid.s
@@ -5,16 +5,16 @@ flw fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following
 fadd.s fa0, fa1, fa2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'F' (Single-Precision Floating-Point){{$}}
 
 # Invalid instructions
-fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.w s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fadd.d t1, t3, t5 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zdinx' (Double in Integer){{$}}
 
 # Invalid register names
-fadd.s a100, a2, a3 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-fsgnjn.s a100, a2, a3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fadd.s a100, a2, a3 # CHECK: :[[@LINE]]:8: error: register must be a GPR when used as FPR
+fsgnjn.s a100, a2, a3 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as FPR
 
 # Rounding mode when a register is expected
-fmadd.s x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: invalid operand for instruction
+fmadd.s x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: register must be a GPR when used as FPR
 
 # Invalid rounding modes
 fmadd.s x10, x11, x12, x13, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32zhinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zhinx-invalid.s
@@ -5,15 +5,15 @@ flw fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following
 fadd.h fa0, fa1, fa2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zfh' (Half-Precision Floating-Point){{$}}
 
 # Invalid instructions
-fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.h s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # Invalid register names
-fadd.h a100, a2, a3 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-fsgnjn.h a100, a2, a3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fadd.h a100, a2, a3 # CHECK: :[[@LINE]]:8: error: register must be a GPR when used as FPR
+fsgnjn.h a100, a2, a3 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as FPR
 
 # Rounding mode when a register is expected
-fmadd.h x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: invalid operand for instruction
+fmadd.h x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: register must be a GPR when used as FPR
 
 # Invalid rounding modes
 fmadd.h x10, x11, x12, x13, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32zhinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zhinx-invalid.s
@@ -9,11 +9,11 @@ fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.h s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # Invalid register names
-fadd.h a100, a2, a3 # CHECK: :[[@LINE]]:8: error: register must be a GPR when used as FPR
-fsgnjn.h a100, a2, a3 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as FPR
+fadd.h a100, a2, a3 # CHECK: :[[@LINE]]:8: error: register must be a GPR when used as an FP operand
+fsgnjn.h a100, a2, a3 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as an FP operand
 
 # Rounding mode when a register is expected
-fmadd.h x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: register must be a GPR when used as FPR
+fmadd.h x10, x11, x12, ree # CHECK: :[[@LINE]]:24: error: register must be a GPR when used as an FP operand
 
 # Invalid rounding modes
 fmadd.h x10, x11, x12, x13, ree # CHECK: :[[@LINE]]:29: error: operand must be a valid floating point rounding mode mnemonic

--- a/llvm/test/MC/RISCV/rv32zhinxmin-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zhinxmin-invalid.s
@@ -5,11 +5,11 @@ flw fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following
 fcvt.h.s fa0, fa1 # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zfh' (Half-Precision Floating-Point) or 'Zfhmin' (Half-Precision Floating-Point Minimal){{$}}
 
 # Invalid instructions
-fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.h s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # Invalid register names
-fcvt.h.s a100, a1 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fcvt.h.s a100, a1 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as FPR
 
 # Valid in Zhinx
 fmadd.h x10, x11, x12, x13, dyn # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zhinx' (Half Float in Integer){{$}}

--- a/llvm/test/MC/RISCV/rv32zhinxmin-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zhinxmin-invalid.s
@@ -9,7 +9,7 @@ fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.h s0, s1 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # Invalid register names
-fcvt.h.s a100, a1 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as FPR
+fcvt.h.s a100, a1 # CHECK: :[[@LINE]]:10: error: register must be a GPR when used as an FP operand
 
 # Valid in Zhinx
 fmadd.h x10, x11, x12, x13, dyn # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zhinx' (Half Float in Integer){{$}}

--- a/llvm/test/MC/RISCV/rv64d-invalid.s
+++ b/llvm/test/MC/RISCV/rv64d-invalid.s
@@ -8,10 +8,10 @@ fmv.x.d ft2, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 # FP registers where integer regs are expected
 fcvt.d.l a3, ft3 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:10: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as an FP operand
 
 fcvt.d.lu a4, ft4 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:11: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as an FP operand
 
 fmv.d.x a5, ft5 # CHECK: :[[@LINE]]:9: error: register must be a FPR

--- a/llvm/test/MC/RISCV/rv64d-invalid.s
+++ b/llvm/test/MC/RISCV/rv64d-invalid.s
@@ -6,6 +6,12 @@ fcvt.lu.d ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 fmv.x.d ft2, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fcvt.d.l a3, ft3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.d.lu a4, ft4 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-fmv.d.x a5, ft5 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fcvt.d.l a3, ft3 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:10: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as FPR
+
+fcvt.d.lu a4, ft4 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:11: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as FPR
+
+fmv.d.x a5, ft5 # CHECK: :[[@LINE]]:9: error: register must be a FPR

--- a/llvm/test/MC/RISCV/rv64f-invalid.s
+++ b/llvm/test/MC/RISCV/rv64f-invalid.s
@@ -7,8 +7,8 @@ fcvt.lu.s ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 # FP registers where integer regs are expected
 fcvt.s.l a2, ft2 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:10: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as an FP operand
 
 fcvt.s.lu a3, ft3 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:11: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as an FP operand

--- a/llvm/test/MC/RISCV/rv64f-invalid.s
+++ b/llvm/test/MC/RISCV/rv64f-invalid.s
@@ -5,5 +5,10 @@ fcvt.l.s ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
 fcvt.lu.s ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fcvt.s.l a2, ft2 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.s.lu a3, ft3 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.s.l a2, ft2 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:10: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as FPR
+
+fcvt.s.lu a3, ft3 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:11: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as FPR

--- a/llvm/test/MC/RISCV/rv64q-invalid.s
+++ b/llvm/test/MC/RISCV/rv64q-invalid.s
@@ -5,5 +5,5 @@ fcvt.l.q ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
 fcvt.lu.q ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fcvt.q.l a3, ft3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.q.lu a4, ft4 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.q.l a3, ft3 # CHECK: :[[@LINE]]:10: error: register must be a FPR
+fcvt.q.lu a4, ft4 # CHECK: :[[@LINE]]:11: error: register must be a FPR

--- a/llvm/test/MC/RISCV/rv64xtheadfmemidx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64xtheadfmemidx-invalid.s
@@ -2,8 +2,8 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+d -mattr=+xtheadfmemidx < %s 2>&1 | FileCheck %s
 
 th.flrd fa0, a1, a2, 5     # CHECK: :[[@LINE]]:22: error: immediate must be an integer in the range [0, 3]
-th.flrd a0, a1, a2, 3      # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-th.flrw 0(fa0), a1, a2, 0  # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+th.flrd a0, a1, a2, 3      # CHECK: :[[@LINE]]:9: error: register must be a FPR
+th.flrw 0(fa0), a1, a2, 0  # CHECK: :[[@LINE]]:9: error: register must be a FPR
 th.flrw fa0, 4(a1), a2, 3  # CHECK: :[[@LINE]]:14: error: register must be a GPR
 th.fsrd fa0, a1, -1(a2), 0 # CHECK: :[[@LINE]]:18: error: register must be a GPR
 th.fsrd fa0, a1, a2, -3    # CHECK: :[[@LINE]]:22: error: immediate must be an integer in the range [0, 3]

--- a/llvm/test/MC/RISCV/rv64zdinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zdinx-invalid.s
@@ -5,7 +5,7 @@ fld fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following
 ld a0, -2049(a1) # CHECK: :[[@LINE]]:8: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 # Invalid instructions
-fsd a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsd a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 sd fa4, 64(sp) # CHECK: :[[@LINE]]:4: error: register must be a GPR
 fmv.x.d t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.d.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction

--- a/llvm/test/MC/RISCV/rv64zfh-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zfh-invalid.s
@@ -11,5 +11,9 @@ fcvt.l.h ft0, a0 # CHECK: :[[@LINE]]:10: error: register must be a GPR
 fcvt.lu.h ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fcvt.h.l a2, ft2 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-fcvt.h.lu a3, ft3 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fcvt.h.l a2, ft2 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:10: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as FPR
+fcvt.h.lu a3, ft3 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-1]]:11: note: register must be a FPR
+# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as FPR

--- a/llvm/test/MC/RISCV/rv64zfh-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zfh-invalid.s
@@ -13,7 +13,7 @@ fcvt.lu.h ft1, a1 # CHECK: :[[@LINE]]:11: error: register must be a GPR
 # FP registers where integer regs are expected
 fcvt.h.l a2, ft2 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:10: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:10: note: register must be a GPR when used as an FP operand
 fcvt.h.lu a3, ft3 # CHECK: :[[@LINE]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-1]]:11: note: register must be a FPR
-# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as FPR
+# CHECK: :[[@LINE-2]]:11: note: register must be a GPR when used as an FP operand

--- a/llvm/test/MC/RISCV/rv64zfinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zfinx-invalid.s
@@ -4,7 +4,7 @@
 flw fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'F' (Single-Precision Floating-Point){{$}}
 
 # Invalid instructions
-fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsw a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.w t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.w.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 

--- a/llvm/test/MC/RISCV/rv64zhinx-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zhinx-invalid.s
@@ -4,7 +4,7 @@
 flh fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zfh' (Half-Precision Floating-Point) or 'Zfhmin' (Half-Precision Floating-Point Minimal) or 'Zfbfmin' (Scalar BF16 Converts){{$}}
 
 # Invalid instructions
-fsh a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsh a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.h t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.h.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 

--- a/llvm/test/MC/RISCV/rv64zhinxmin-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zhinxmin-invalid.s
@@ -4,10 +4,10 @@
 flh fa4, 12(sp) # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zfh' (Half-Precision Floating-Point) or 'Zfhmin' (Half-Precision Floating-Point Minimal) or 'Zfbfmin' (Scalar BF16 Converts){{$}}
 
 # Invalid instructions
-fsh a5, 12(sp) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+fsh a5, 12(sp) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 fmv.x.h t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.h.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # FP registers where integer regs are expected
-fcvt.d.h a0, fa2 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+fcvt.d.h a0, fa2 # CHECK: :[[@LINE]]:10: error: register must be an even-numbered GPR when used as FPR
 fcvt.h.d a0, fa2 # CHECK: :[[@LINE]]:1: error: invalid instruction

--- a/llvm/test/MC/RISCV/rv64zhinxmin-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zhinxmin-invalid.s
@@ -9,5 +9,5 @@ fmv.x.h t2, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 fmv.h.x a5, t5 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 # FP registers where integer regs are expected
-fcvt.d.h a0, fa2 # CHECK: :[[@LINE]]:10: error: register must be an even-numbered GPR when used as FPR
+fcvt.d.h a0, fa2 # CHECK: :[[@LINE]]:10: error: register must be an even-numbered GPR when used as an FP operand
 fcvt.h.d a0, fa2 # CHECK: :[[@LINE]]:1: error: invalid instruction

--- a/llvm/test/MC/RISCV/rvzfbfmin-invalid.s
+++ b/llvm/test/MC/RISCV/rvzfbfmin-invalid.s
@@ -12,14 +12,14 @@ fsh ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %
 flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
-flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 flh ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
 
 # Integer registers where FP regs are expected
 fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: register must be a FPR
 
 # Attempting to use fcvt instructions from zfhmin
 fcvt.s.h fa0, ft0 # CHECK: [[@LINE]]:1: error: instruction requires the following: 'Zfh' (Half-Precision Floating-Point) or 'Zfhmin' (Half-Precision Floating-Point Minimal)

--- a/llvm/test/MC/RISCV/rvzfhmin-invalid.s
+++ b/llvm/test/MC/RISCV/rvzfhmin-invalid.s
@@ -12,14 +12,14 @@ fsh ft2, 2048(a1) # CHECK: :[[@LINE]]:10: error: operand must be a symbol with %
 flh ft1, a0, -200 # CHECK: :[[@LINE]]:14: error: register must be a GPR
 
 # Invalid register names
-flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: invalid operand for instruction
+flh ft15, 100(a0) # CHECK: :[[@LINE]]:5: error: register must be a FPR
 flh ft1, 100(a10) # CHECK: :[[@LINE]]:14: error: expected register
 
 # Integer registers where FP regs are expected
 fmv.x.h fs7, a2 # CHECK: :[[@LINE]]:9: error: register must be a GPR
 
 # FP registers where integer regs are expected
-fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+fmv.h.x a8, ft2 # CHECK: :[[@LINE]]:9: error: register must be a FPR
 
 # Zfh instructions
 fmadd.h f10, f11, f12, f13, dyn # CHECK: :[[@LINE]]:1: error: instruction requires the following: 'Zfh' (Half-Precision Floating-Point){{$}}


### PR DESCRIPTION
For the usual FPR RegClasses (FPR16, FPR32, FPR64, FPR128, FPR256)
For the compressed FPR RegClasses (FPR16C, FPR32C, FPR64C) which are 
limited to f8 to f15.
For GPR-as-FPR classes used by Zfinx/Zdinx extensions 
(GPRAsFPR16, GPRAsFPR32, GPRF64AsFPR, GPRPairAsFPR).