### PR TITLE
AMDGPU: Migrate assembler tests with content changes to subarch triples

### DIFF
--- a/llvm/test/MC/AMDGPU/amdgcn-target-directive-triple-env.s
+++ b/llvm/test/MC/AMDGPU/amdgcn-target-directive-triple-env.s
@@ -1,17 +1,17 @@
 // RUN: split-file %s %t
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa-llvm -mcpu=gfx802 %t/amdhsa-llvm.s | FileCheck --check-prefix=AMDHSA-LLVM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdpal-llvm -mcpu=gfx802 %t/amdpal-llvm.s | FileCheck --check-prefix=AMDPAL-LLVM %s
-// RUN: not llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx802 %t/amdhsa-llvm.s -filetype=null 2>&1 | FileCheck --check-prefix=AMDHSA-ERR %s
-// RUN: not llvm-mc -triple=amdgcn-amd-amdpal -mcpu=gfx802 %t/amdpal-llvm.s -filetype=null 2>&1 | FileCheck --check-prefix=AMDPAL-ERR %s
+// RUN: llvm-mc -triple=amdgpu8.02-amd-amdhsa-llvm %t/amdhsa-llvm.s | FileCheck --check-prefix=AMDHSA-LLVM %s
+// RUN: llvm-mc -triple=amdgpu8.02-amd-amdpal-llvm %t/amdpal-llvm.s | FileCheck --check-prefix=AMDPAL-LLVM %s
+// RUN: not llvm-mc -triple=amdgpu8.02-amd-amdhsa %t/amdhsa-llvm.s -filetype=null 2>&1 | FileCheck --check-prefix=AMDHSA-ERR %s
+// RUN: not llvm-mc -triple=amdgpu8.02-amd-amdpal %t/amdpal-llvm.s -filetype=null 2>&1 | FileCheck --check-prefix=AMDPAL-ERR %s
 
 // Test that the environment component of the triple is preserved and validated
 
 //--- amdhsa-llvm.s
-// AMDHSA-LLVM: .amdgcn_target "amdgcn-amd-amdhsa-llvm-gfx802"
-// AMDHSA-ERR: error: .amdgcn_target amdgcn-amd-amdhsa-llvm-gfx802 is incompatible with amdgcn-amd-amdhsa-unknown-gfx802
-.amdgcn_target "amdgcn-amd-amdhsa-llvm-gfx802"
+// AMDHSA-LLVM: .amdgcn_target "amdgpu8.02-amd-amdhsa-llvm-gfx802"
+// AMDHSA-ERR: error: .amdgcn_target amdgpu8.02-amd-amdhsa-llvm-gfx802 is incompatible with amdgpu8.02-amd-amdhsa-unknown-gfx802
+.amdgcn_target "amdgpu8.02-amd-amdhsa-llvm-gfx802"
 
 //--- amdpal-llvm.s
-// AMDPAL-LLVM: .amd_amdgpu_isa "amdgcn-amd-amdpal-llvm-gfx802"
-// AMDPAL-ERR: error: .amd_amdgpu_isa amdgcn-amd-amdpal-llvm-gfx802 is incompatible with amdgcn-amd-amdpal-unknown-gfx802
-.amd_amdgpu_isa "amdgcn-amd-amdpal-llvm-gfx802"
+// AMDPAL-LLVM: .amd_amdgpu_isa "amdgpu8.02-amd-amdpal-llvm-gfx802"
+// AMDPAL-ERR: error: .amd_amdgpu_isa amdgpu8.02-amd-amdpal-llvm-gfx802 is incompatible with amdgpu8.02-amd-amdpal-unknown-gfx802
+.amd_amdgpu_isa "amdgpu8.02-amd-amdpal-llvm-gfx802"

--- a/llvm/test/MC/AMDGPU/hsa-exp.s
+++ b/llvm/test/MC/AMDGPU/hsa-exp.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn--amdhsa -mcpu=kaveri -show-encoding %s | FileCheck %s --check-prefix=ASM
-// RUN: llvm-mc -filetype=obj -triple=amdgcn--amdhsa -mcpu=kaveri -show-encoding %s | llvm-readobj --symbols -S --sd - | FileCheck %s --check-prefix=ELF
+// RUN: llvm-mc -triple=amdgpu7.00--amdhsa -show-encoding %s | FileCheck %s --check-prefix=ASM
+// RUN: llvm-mc -filetype=obj -triple=amdgpu7.00--amdhsa -show-encoding %s | llvm-readobj --symbols -S --sd - | FileCheck %s --check-prefix=ELF
 
 // ELF: Section {
 // ELF: Name: .text
@@ -13,11 +13,11 @@
 // ELF: Section: .text
 // ELF: }
 
-.amdgcn_target "amdgcn-unknown-amdhsa--gfx700"
+.amdgcn_target "amdgpu7.00-unknown-amdhsa--gfx700"
 
 .amdhsa_code_object_version 4
 // ASM: .amdhsa_code_object_version 4
-// ASM: .amdgcn_target "amdgcn-unknown-amdhsa-unknown-gfx700"
+// ASM: .amdgcn_target "amdgpu7.00-unknown-amdhsa-unknown-gfx700"
 
 .set my_is_ptr64, 1
 

--- a/llvm/test/MC/AMDGPU/hsa-gfx12-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx12-v4.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1200 < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1200 -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu12.00-amd-amdhsa < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu12.00-amd-amdhsa -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
@@ -48,11 +48,11 @@
 
 .text
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx1200"
+.amdgcn_target "amdgpu12.00-amd-amdhsa--gfx1200"
 
 .amdhsa_code_object_version 4
 // ASM: .amdhsa_code_object_version 4
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx1200"
+// ASM: .amdgcn_target "amdgpu12.00-amd-amdhsa-unknown-gfx1200"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/hsa-gfx1250-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx1250-v4.s
@@ -1,8 +1,8 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 --amdhsa-code-object-version=4 < %s | FileCheck --check-prefixes=ASM,W32 %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 --amdhsa-code-object-version=4 -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu12.50-amd-amdhsa --amdhsa-code-object-version=4 < %s | FileCheck --check-prefixes=ASM,W32 %s
+// RUN: llvm-mc -triple=amdgpu12.50-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
-// RUN: not llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 -mattr=+wavefrontsize64,-wavefrontsize32 --amdhsa-code-object-version=4 < %s -filetype=null 2>&1 | FileCheck --check-prefix=W64-ERR %s
+// RUN: not llvm-mc -triple=amdgpu12.50-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 --amdhsa-code-object-version=4 < %s -filetype=null 2>&1 | FileCheck --check-prefix=W64-ERR %s
 
 // READOBJ: Section Headers
 // READOBJ: .text   PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9]+}} AX {{[0-9]+}} {{[0-9]+}} 256
@@ -64,8 +64,8 @@
 
 .text
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx1250"
+.amdgcn_target "amdgpu12.50-amd-amdhsa--gfx1250"
+// ASM: .amdgcn_target "amdgpu12.50-amd-amdhsa-unknown-gfx1250"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/hsa-gfx1251-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx1251-v4.s
@@ -1,8 +1,8 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1251 --amdhsa-code-object-version=4 < %s | FileCheck --check-prefixes=ASM,W32 %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1251 --amdhsa-code-object-version=4 -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu12.51-amd-amdhsa --amdhsa-code-object-version=4 < %s | FileCheck --check-prefixes=ASM,W32 %s
+// RUN: llvm-mc -triple=amdgpu12.51-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
-// RUN: not llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1251 -mattr=+wavefrontsize64,-wavefrontsize32 --amdhsa-code-object-version=4 < %s -filetype=null 2>&1 | FileCheck --check-prefix=W64-ERR %s
+// RUN: not llvm-mc -triple=amdgpu12.51-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 --amdhsa-code-object-version=4 < %s -filetype=null 2>&1 | FileCheck --check-prefix=W64-ERR %s
 
 // READOBJ: Section Headers
 // READOBJ: .text   PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9]+}} AX {{[0-9]+}} {{[0-9]+}} 256
@@ -64,8 +64,8 @@
 
 .text
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx1251"
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx1251"
+.amdgcn_target "amdgpu12.51-amd-amdhsa--gfx1251"
+// ASM: .amdgcn_target "amdgpu12.51-amd-amdhsa-unknown-gfx1251"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/hsa-gfx13-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx13-v4.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1310 < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1310 -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu13.10-amd-amdhsa < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu13.10-amd-amdhsa -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
@@ -48,11 +48,11 @@
 
 .text
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx1310"
+.amdgcn_target "amdgpu13.10-amd-amdhsa--gfx1310"
 
 .amdhsa_code_object_version 4
 // ASM: .amdhsa_code_object_version 4
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx1310"
+// ASM: .amdgcn_target "amdgpu13.10-amd-amdhsa-unknown-gfx1310"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/hsa-tg-split.s
+++ b/llvm/test/MC/AMDGPU/hsa-tg-split.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
 // OBJDUMP: Contents of section .rodata
@@ -12,7 +12,7 @@
 
 .amdhsa_code_object_version 4
 // ASM: .amdhsa_code_object_version 4
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx90a:xnack+"
+// ASM: .amdgcn_target "amdgpu9.0a-amd-amdhsa-unknown-gfx90a:xnack+"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/hsa-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-v4.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
@@ -46,11 +46,11 @@
 // OBJDUMP-NEXT: 00e0 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 00f0 0000ac00 80000000 00000000 00000000
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx904:xnack+"
+.amdgcn_target "amdgpu9.04-amd-amdhsa--gfx904:xnack+"
 
 .amdhsa_code_object_version 4
 // ASM: .amdhsa_code_object_version 4
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx904:xnack+"
+// ASM: .amdgcn_target "amdgpu9.04-amd-amdhsa-unknown-gfx904:xnack+"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/hsa-v5-uses-dynamic-stack.s
+++ b/llvm/test/MC/AMDGPU/hsa-v5-uses-dynamic-stack.s
@@ -1,10 +1,10 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx904 --amdhsa-code-object-version=6 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx904 --amdhsa-code-object-version=6 -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa --amdhsa-code-object-version=6 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa --amdhsa-code-object-version=6 -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
@@ -51,11 +51,11 @@
 // OBJDUMP-NEXT: 00e0 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 00f0 0000ac00 80000000 00000000 00000000
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx904:xnack+"
+.amdgcn_target "amdgpu9.04-amd-amdhsa--gfx904:xnack+"
 
 .amdhsa_code_object_version 5
 // ASM: .amdhsa_code_object_version 5
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx904:xnack+"
+// ASM: .amdgcn_target "amdgpu9.04-amd-amdhsa-unknown-gfx904:xnack+"
 
 .p2align 8
 .type minimal,@function

--- a/llvm/test/MC/AMDGPU/user-sgpr-count.s
+++ b/llvm/test/MC/AMDGPU/user-sgpr-count.s
@@ -1,7 +1,7 @@
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx90a --amdhsa-code-object-version=4 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa --amdhsa-code-object-version=4 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack+"
-// ASM: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx90a:xnack+"
+.amdgcn_target "amdgpu9.0a-amd-amdhsa--gfx90a:xnack+"
+// ASM: .amdgcn_target "amdgpu9.0a-amd-amdhsa-unknown-gfx90a:xnack+"
 
 
 // ASM-LABEL: .amdhsa_kernel user_sgprs_implied_count


### PR DESCRIPTION
Convert tests which failed after converting the arguments due to content
changes from checking the emitted target id string.