### PR TITLE
[LLVM] Fix VisualStudio detection

### DIFF
--- a/llvm/lib/WindowsDriver/MSVCPaths.cpp
+++ b/llvm/lib/WindowsDriver/MSVCPaths.cpp
@@ -675,6 +675,12 @@ bool llvm::findVCToolChainViaSetupConfig(
   ISetupInstancePtr NewestInstance;
   std::optional<uint64_t> NewestVersionNum;
   do {
+    bstr_t NameString;
+    HR = Instance->GetInstallationName(NameString.GetAddress());
+    if (FAILED(HR))
+      continue;
+    if (std::wstring_view(NameString).find(L"VisualStudio") != 0)
+      continue;
     bstr_t VersionString;
     uint64_t VersionNum;
     HR = Instance->GetInstallationVersion(VersionString.GetAddress());

--- a/llvm/lib/WindowsDriver/MSVCPaths.cpp
+++ b/llvm/lib/WindowsDriver/MSVCPaths.cpp
@@ -677,9 +677,11 @@ bool llvm::findVCToolChainViaSetupConfig(
   do {
     bstr_t NameString;
     HR = Instance->GetInstallationName(NameString.GetAddress());
-    if (FAILED(HR))
+    // Expect that VS products provide an Installation name.
+    if (FAILED(HR) || static_cast<const wchar_t*>(NameString) == nullptr)
       continue;
-    if (std::wstring_view(NameString).find(L"VisualStudio") != 0)
+    // Ignore non-VS products registered with the VS Installer (e.g. SQL Server Management Studio), which have no VC toolchain.
+    if (std::wstring_view(NameString).rfind(L"VisualStudio", 0) == 0)
       continue;
     bstr_t VersionString;
     uint64_t VersionNum;


### PR DESCRIPTION
When packages like SSMS are installed, llvm::findVCToolChainViaSetupConfig will incorrectly assume it is a VS Installation and bail as it wont find `Microsoft.VCToolsVersion.default.txt`, so it will fallback to legacy VS search and ignore VS2019/22/26.

Simplest solution is to check against the InstallationName for "VisualStudio"