### PR TITLE
[offload][lit] Run check-offload as part of check-all

### DIFF
--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -65,7 +65,6 @@ add_offload_testsuite(check-offload
   "Running offload tests"
   ${LIBOMPTARGET_LIT_TESTSUITES}
   ${CMAKE_CURRENT_BINARY_DIR}/unit
-  EXCLUDE_FROM_CHECK_ALL
   DEPENDS ${OFFLOAD_TOOLS} omptarget ${OMP_DEPEND} ${LIBOMPTARGET_TESTED_PLUGINS}
           LLVMOffload OffloadUnitTests
   ARGS ${LIBOMPTARGET_LIT_ARG_LIST})


### PR DESCRIPTION
It's unclear why these were excluded from `check-all`, but we made all tests pass on Level Zero and our local testing shows they pass on AMD and NVIDIA too, so enable it by default.

Context: https://github.com/llvm/llvm-project/pull/211633