### PR TITLE
[WebAssembly] Fix v8i16-to-v8f32 uitofp cost

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetTransformInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetTransformInfo.cpp
@@ -204,7 +204,7 @@ InstructionCost WebAssemblyTTIImpl::getCastInstrCost(
       {ISD::SINT_TO_FP, MVT::v8f32, MVT::v8i8, 10},
       {ISD::UINT_TO_FP, MVT::v8f32, MVT::v8i8, 10},
       {ISD::SINT_TO_FP, MVT::v8f32, MVT::v8i16, 10},
-      {ISD::UINT_TO_FP, MVT::v8f32, MVT::v8i8, 10},
+      {ISD::UINT_TO_FP, MVT::v8f32, MVT::v8i16, 10},
       /// trunc_sat, const, and, 3x narrow
       {ISD::FP_TO_SINT, MVT::v2i8, MVT::v2f32, 6},
       {ISD::FP_TO_UINT, MVT::v2i8, MVT::v2f32, 6},

--- a/llvm/test/Analysis/CostModel/WebAssembly/cast.ll
+++ b/llvm/test/Analysis/CostModel/WebAssembly/cast.ll
@@ -1,0 +1,16 @@
+; RUN: opt -mtriple=wasm32-unknown-unknown -mattr=+simd128 \
+; RUN:   -passes='print<cost-model>' -disable-output < %s 2>&1 | FileCheck %s
+
+define <8 x float> @sitofp_v8i16(<8 x i16> %x) {
+; CHECK-LABEL: function 'sitofp_v8i16'
+; CHECK: estimated cost of 10 for instruction:
+  %result = sitofp <8 x i16> %x to <8 x float>
+  ret <8 x float> %result
+}
+
+define <8 x float> @uitofp_v8i16(<8 x i16> %x) {
+; CHECK-LABEL: function 'uitofp_v8i16'
+; CHECK: estimated cost of 10 for instruction:
+  %result = uitofp <8 x i16> %x to <8 x float>
+  ret <8 x float> %result
+}


### PR DESCRIPTION
I think there was a wrong duplication here. The WebAssembly SIMD conversion cost table accidentally duplicated the
`UINT_TO_FP` entry for `v8i8` to `v8f32`. As a result, the unsigned `v8i16` to `v8f32` conversion missed the target-specific table entry and fell back to the generic cost of 5 instead of the intended cost of 10.

I've added ` llvm/test/Analysis/CostModel/WebAssembly/cast.ll` which I think is good here as it would help test other casting errors in the future too.