### PR TITLE
[lldb] Fix crash on creating string error

### DIFF
--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2159,6 +2159,8 @@ lldb::SBInstructionList SBTarget::ReadInstructions(lldb::SBAddress base_addr,
       if (llvm::Expected<DisassemblerSP> disassembler =
               target_sp->ReadInstructions(*addr_ptr, count, flavor_string)) {
         sb_instructions.SetDisassembler(*disassembler);
+      } else {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::API), disassembler.takeError(), "{0}");
       }
     }
   }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3120,11 +3120,11 @@ Target::ReadInstructions(const Address &start_addr, uint32_t count,
                  force_live_memory, &load_addr);
 
   if (error.Fail()) {
-    if (error.AsCString(/*default_error_str=*/nullptr))
-      return error.takeError();
-    return llvm::createStringErrorV(
-        "Target::ReadInstructions failed to read memory at {:x}",
-        start_addr.GetLoadAddress(this));
+    return llvm::joinErrors(
+        llvm::createStringErrorV(
+            "Target::ReadInstructions failed to read memory at {:x}: ",
+            start_addr.GetLoadAddress(this)),
+        error.takeError());
   }
 
   const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3119,11 +3119,13 @@ Target::ReadInstructions(const Address &start_addr, uint32_t count,
       ReadMemory(start_addr, data.GetBytes(), data.GetByteSize(), error,
                  force_live_memory, &load_addr);
 
-  if (error.Fail())
+  if (error.Fail()) {
+    if (error.AsCString(/*default_error_str=*/nullptr))
+      return error.takeError();
     return llvm::createStringErrorV(
-        error.AsCString(
-            "Target::ReadInstructions failed to read memory at {:x}"),
+        "Target::ReadInstructions failed to read memory at {:x}",
         start_addr.GetLoadAddress(this));
+  }
 
   const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;
   if (!flavor_string || flavor_string[0] == '\0') {


### PR DESCRIPTION
It crashes because the `default` error string may not be a format string compared to the `fallback` error string