### PR TITLE
[SCEV] Only try (A+B)/C distribution for nuw adds (NFC)

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -3624,13 +3624,11 @@ const SCEV *ScalarEvolution::getUDivExpr(SCEVUse LHS, SCEVUse RHS) {
         }
       }
 
-      // (A+B)/C --> (A/C + B/C) if safe and A/C and B/C can be folded.
+      // (A+B)/C --> (A/C + B/C) if the add does not unsigned wrap and A/C and
+      // B/C can be folded.
       if (const SCEVAddExpr *A = dyn_cast<SCEVAddExpr>(LHS)) {
-        SmallVector<SCEVUse, 4> Operands;
-        for (const SCEV *Op : A->operands())
-          Operands.push_back(getZeroExtendExpr(Op, ExtTy));
-        if (getZeroExtendExpr(A, ExtTy) == getAddExpr(Operands)) {
-          Operands.clear();
+        if (A->hasNoUnsignedWrap()) {
+          SmallVector<SCEVUse, 4> Operands;
           for (unsigned i = 0, e = A->getNumOperands(); i != e; ++i) {
             const SCEV *Op = getUDivExpr(A->getOperand(i), RHS);
             if (isa<SCEVUDivExpr>(Op) ||


### PR DESCRIPTION
Checking for NUW is cheaper to check and should be equivalent to checking extended expression: https://alive2.llvm.org/ce/z/_VxSSD

Compile-time impact:
 * stage1-O3: -0.09%
 * stage1-ReleaseThinLTO: -0.07%
 * stage1-ReleaseLTO-g: -0.10%
 * stage1-aarch64-O3: -0.10%
 * stage2-O3: -0.09%
 * stage2-clang: -0.23%
 

https://llvm-compile-time-tracker.com/compare.php?from=e432cb12962f1619bc73c50a2dc4d2ad5ac6b44c&to=6e11321bd7308202d7973656dee8dc03ac6a4686&stat=instructions:u