### PR TITLE
[offload][lit] Run check-offload-unit as part of check-all

### DIFF
--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -72,5 +72,4 @@ add_offload_testsuite(check-offload
 
 add_lit_testsuite(check-offload-unit "Running offload unittest suites"
   ${CMAKE_CURRENT_BINARY_DIR}/unit
-  EXCLUDE_FROM_CHECK_ALL
   DEPENDS LLVMOffload OffloadUnitTests)


### PR DESCRIPTION
I tried to do `check-offload` instead but that [caused](https://github.com/llvm/llvm-project/pull/212500) a bloodbath, so just enable `check-offload-unit` as part of `check-all`.