### PR TITLE
[LTO] Handle GlobalIFunc in LTOModule::parseSymbols

### DIFF
--- a/llvm/lib/LTO/LTOModule.cpp
+++ b/llvm/lib/LTO/LTOModule.cpp
@@ -611,7 +611,7 @@ void LTOModule::parseSymbols() {
       continue;
     }
 
-    if (getTargetTriple().isOSBinFormatXCOFF() && isa<GlobalIFunc>(GV)) {
+    if (isa<GlobalIFunc>(GV)) {
       addDefinedFunctionSymbol(Sym);
       continue;
     }

--- a/llvm/test/LTO/X86/ifunc.ll
+++ b/llvm/test/LTO/X86/ifunc.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-as < %s >%t1
+; RUN: llvm-lto -o %t2 %t1
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@f2 = dso_local alias void (), void ()* @f
+@f = dso_local ifunc void (), bitcast (i8* ()* @f_ifunc to void ()*)
+
+define internal i8* @f_ifunc() {
+entry:
+  ret i8* bitcast (void ()* @f_impl to i8*)
+}
+
+define internal void @f_impl() {
+entry:
+  ret void
+}


### PR DESCRIPTION
Avoids the assert immediately below.

Fixes #45694

rdar://182744700