### PR TITLE
[SPIR-V] Fix OpDecorate insertion point for non-PHI defs in decorateUsesAsNonUniform

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -6452,7 +6452,8 @@ void SPIRVInstructionSelector::decorateUsesAsNonUniform(
 
     if (!IsDecorated) {
       MachineBasicBlock &MBB = *DefMI->getParent();
-      MachineInstr &InsertPt = DefMI->isPHI() ? *MBB.getFirstNonPHI() : *DefMI;
+      MachineInstr &InsertPt =
+          DefMI->isPHI() ? *MBB.getFirstNonPHI() : *DefMI->getNextNode();
       buildOpDecorate(CurrentReg, InsertPt, TII,
                       SPIRV::Decoration::NonUniformEXT, {});
     }

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/NonUniformIdx/RWBufferNonUniformIdxLoop.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/NonUniformIdx/RWBufferNonUniformIdxLoop.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3-compute %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3-compute -verify-machineinstrs %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
 ; A non-uniform index carried across a loop through a phi creates an SSA cycle


### PR DESCRIPTION
Inserting before the defining instruction placed the decoration ahead of its own operand, breaking dominance for the loop-carried case

Fix machine code errors from https://github.com/llvm/llvm-project/pull/208224#issuecomment-5095074660