### PR TITLE
[OpenACC] Do not clean up nohost routines in `ACCRoutineLowering`.

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -510,9 +510,8 @@ def ACCRoutineLowering : Pass<"acc-routine-lowering", "mlir::ModuleOp"> {
     expressed by one acc.par_width derived from the routine's clauses (seq,
     vector, worker, gang). The pass does not use acc.kernel_environment. It
     sets acc.specialized_routine on the new function and updates the
-    acc.routine's func_name to point to it. For nohost routines, all uses of
-    the host symbol are replaced with the device symbol and the host function
-    is erased. Routines with bind(name) and external functions are skipped.
+    acc.routine's func_name to point to it. Routines with bind(name) and
+    external functions are skipped.
   }];
   let dependentDialects = [
     "mlir::acc::OpenACCDialect",

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineLowering.cpp
@@ -30,8 +30,6 @@
 //    the compute_region.
 //
 // 3. Finalization: acc.routine's func_name is updated to the device function.
-//    For nohost routines, all uses of the host symbol are replaced with the
-//    device symbol and the host function is erased.
 //
 //===----------------------------------------------------------------------===//
 
@@ -169,7 +167,7 @@ buildRoutineBody(func::FuncOp deviceFunc, func::FuncOp hostFunc,
   return success();
 }
 
-/// Update acc.routine refs and optionally erase host for nohost routines.
+/// Update acc.routine refs
 static LogicalResult finalizeRoutines(
     SmallVectorImpl<std::tuple<func::FuncOp, func::FuncOp, RoutineOp>>
         &accRoutineInfo,
@@ -177,16 +175,6 @@ static LogicalResult finalizeRoutines(
   for (auto &[hostFunc, deviceFunc, routineOp] : accRoutineInfo) {
     routineOp.setFuncNameAttr(SymbolRefAttr::get(ctx, deviceFunc.getName()));
     routineOp->moveBefore(deviceFunc);
-
-    if (routineOp.getNohost()) {
-      if (failed(SymbolTable::replaceAllSymbolUses(
-              StringAttr::get(ctx, hostFunc.getName()),
-              StringAttr::get(ctx, deviceFunc.getName()), mod))) {
-        routineOp.emitError("cannot replace symbol uses for acc routine");
-        return failure();
-      }
-      hostFunc->erase();
-    }
   }
   return success();
 }

--- a/mlir/test/Dialect/OpenACC/acc-routine-lowering.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-routine-lowering.mlir
@@ -123,3 +123,14 @@ acc.routine @r_b func(@f_a) vector
 func.func @f_a() {
   return
 }
+
+// -----
+
+// Test nohost routine is specialized.
+acc.routine @routine_nohost func(@host_nohost) gang nohost
+// CHECK: func.func @host_nohost()
+// CHECK: acc.routine @routine_nohost func(@
+// CHECK: acc.specialized_routine = #acc.specialized_routine<@routine_nohost, <gang_dim1>, "host_nohost">
+func.func @host_nohost() {
+  return
+}


### PR DESCRIPTION
The design of the ACC routine lowering supports multiple device side specializations of an ACC routine function. Earlier in the pipeline, all calls to the function are expected to refer the original host function and not their device side specialized versions. Once there is enough parallelism context, the calls can be changed to point to the appropriate specialized routine.

The nohost handling in `ACCRoutineLowering` goes against this design. This change removes the special handling of nohost routines and this clean up should be done in later passes.

Assisted-by: Codex