### PR TITLE
[SimplifyCFG] Handle degenerate conditional branch

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -9036,9 +9036,11 @@ static bool removeUndefIntroducingPredecessor(BasicBlock *BB,
             DTU->applyUpdates({{DominatorTree::Delete, Predecessor, BB}});
           return true;
         } else if (CondBrInst *BI = dyn_cast<CondBrInst>(T)) {
-          bool IsUncondBr = BI->getSuccessor(0) == BI->getSuccessor(1);
           BB->removePredecessor(Predecessor);
-          if (IsUncondBr) {
+          // Handle degenerate conditional branches.
+          if (BI->getSuccessor(0) == BI->getSuccessor(1)) {
+            // The only difference from the UncondBrInst path above is that it
+            // has two edges in CFG.
             BB->removePredecessor(Predecessor);
             // Turn unconditional branches into unreachables.
             Builder.CreateUnreachable();

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -9036,19 +9036,26 @@ static bool removeUndefIntroducingPredecessor(BasicBlock *BB,
             DTU->applyUpdates({{DominatorTree::Delete, Predecessor, BB}});
           return true;
         } else if (CondBrInst *BI = dyn_cast<CondBrInst>(T)) {
+          bool IsUncondBr = BI->getSuccessor(0) == BI->getSuccessor(1);
           BB->removePredecessor(Predecessor);
-          // Preserve guarding condition in assume, because it might not be
-          // inferrable from any dominating condition.
-          Value *Cond = BI->getCondition();
-          CallInst *Assumption;
-          if (BI->getSuccessor(0) == BB)
-            Assumption = Builder.CreateAssumption(Builder.CreateNot(Cond));
-          else
-            Assumption = Builder.CreateAssumption(Cond);
-          if (AC)
-            AC->registerAssumption(cast<AssumeInst>(Assumption));
-          Builder.CreateBr(BI->getSuccessor(0) == BB ? BI->getSuccessor(1)
-                                                     : BI->getSuccessor(0));
+          if (IsUncondBr) {
+            BB->removePredecessor(Predecessor);
+            // Turn unconditional branches into unreachables.
+            Builder.CreateUnreachable();
+          } else {
+            // Preserve guarding condition in assume, because it might not be
+            // inferrable from any dominating condition.
+            Value *Cond = BI->getCondition();
+            CallInst *Assumption;
+            if (BI->getSuccessor(0) == BB)
+              Assumption = Builder.CreateAssumption(Builder.CreateNot(Cond));
+            else
+              Assumption = Builder.CreateAssumption(Cond);
+            if (AC)
+              AC->registerAssumption(cast<AssumeInst>(Assumption));
+            Builder.CreateBr(BI->getSuccessor(0) == BB ? BI->getSuccessor(1)
+                                                       : BI->getSuccessor(0));
+          }
           BI->eraseFromParent();
           if (DTU)
             DTU->applyUpdates({{DominatorTree::Delete, Predecessor, BB}});

--- a/llvm/test/Transforms/SimplifyCFG/UnreachableEliminate.ll
+++ b/llvm/test/Transforms/SimplifyCFG/UnreachableEliminate.ll
@@ -1228,6 +1228,23 @@ bb:
   ret void
 }
 
+define void @both_unreachable(i1 %cond) {
+; CHECK-LABEL: @both_unreachable(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    unreachable
+;
+entry:
+  br i1 %cond, label %then, label %exit
+
+then:
+  br label %exit
+
+exit:
+  %phi = phi i1 [ false, %entry ], [ false, %then ]
+  tail call void @llvm.assume(i1 %phi)
+  ret void
+}
+
 attributes #0 = { null_pointer_is_valid }
 ;.
 ; CHECK: attributes #[[ATTR0:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }


### PR DESCRIPTION
IR before entering the function:
```
define void @func(i1 %cond) {
entry:
  br i1 %cond, label %exit, label %exit

exit:                                             ; preds = %entry, %entry
  %phi = phi i1 [ false, %entry ], [ false, %entry ]
  tail call void @llvm.assume(i1 %phi)
  ret void
}
```
The original code only removes one edge. There is still an edge from entry to exit, triggering the `Deleted edge still exists in the CFG` assertion.

Closes https://github.com/llvm/llvm-project/issues/212542
