### PR TITLE
[clang][deps] Update each module's in-process timestamp only once

### DIFF
--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -130,8 +130,16 @@ public:
     // Note: This essentially replaces FS contention with mutex contention.
     auto &Timestamp = getOrCreateEntry(Filename).Timestamp;
 
+    // Multiple threads can ask to refresh the same timestamp, since each
+    // snapshots it before reading the module file (ModuleManager::addModule()).
+    // Only the first store matters: the timestamp is exclusively compared
+    // against the build session timestamp, which precedes all of them.
+    time_t Expected = 0;
+    time_t Now = llvm::sys::toTimeT(std::chrono::system_clock::now());
+    if (!Timestamp.compare_exchange_strong(Expected, Now))
+      return;
+
     Logger.log() << "timestamp_write: " << Filename;
-    Timestamp.store(llvm::sys::toTimeT(std::chrono::system_clock::now()));
   }
 
   void maybePrune(StringRef Path, time_t PruneInterval,

--- a/clang/unittests/DependencyScanning/InProcessModuleCacheTest.cpp
+++ b/clang/unittests/DependencyScanning/InProcessModuleCacheTest.cpp
@@ -74,3 +74,23 @@ TEST(InProcessModuleCache, ReadReadInvalidation) {
   EXPECT_EQ(Buf1->getBuffer().begin(), Buf2->getBuffer().begin());
   EXPECT_EQ(Buf1->getBuffer().end(), Buf2->getBuffer().end());
 }
+
+TEST(InProcessModuleCache, TimestampUpdatedOnce) {
+  ModuleCacheEntries Entries;
+  AtomicLineLogger Logger;
+  std::shared_ptr<ModuleCache> ModCache =
+      makeInProcessModuleCache(Entries, Logger);
+
+  StringRef Path = "M.pcm";
+  ASSERT_EQ(ModCache->getModuleTimestamp(Path), 0);
+
+  ModCache->updateModuleTimestamp(Path);
+  EXPECT_NE(ModCache->getModuleTimestamp(Path), 0);
+
+  // Every thread that read the module file asks to update its timestamp, no
+  // matter which one built it. Only the first update takes effect.
+  auto &Timestamp = Entries.Map[Path]->Timestamp;
+  Timestamp.store(42);
+  ModCache->updateModuleTimestamp(Path);
+  EXPECT_EQ(Timestamp.load(), 42);
+}


### PR DESCRIPTION
A drive-by fix for a real failure encountered in CI, diagnosed by GPT and then fixed by Claude Opus.

The in-process module cache records when a module file was last validated so that -fmodules-validate-once-per-build-session can skip revalidating it for the rest of the scan. Several threads can end up recording it for the same module: each snapshots the timestamp in ModuleManager::addModule() before reading the module file, so every thread that looked at the module while it was still unbuilt asks to refresh the timestamp once it manages to read it, no matter which thread built it.

That is easy to hit, because a thread that observed the module as missing does not have to wait for the writer to release the module's lock: as soon as the winner has called write(), the pending readers can read the module out of the in-process cache and go on to refresh a timestamp the winner is about to refresh too.

Only the first update can matter. The timestamp is exclusively compared against the build session timestamp, which is fixed when the owning DependencyScanningService is created, so every store during its lifetime is indistinguishable from the first one. Make the update a compare-exchange from zero, so the redundant stores (and the duplicate timestamp_write log entries they produce) are dropped.

This also makes the timestamp_write count in
ClangScanDeps/logging-two-threads.c deterministic. It was intermittently failing with 3 writes for 2 modules in CI, e.g. in llvm/llvm-project#211885