### PR TITLE
[lldb][Windows] Add missing release notes

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -517,6 +517,13 @@ Makes programs 10x faster by doing Special New Thing.
   from the command-line and in the output window when using lldb-dap.
 * LLDB now uses `lldb-server.exe` to launch and manage the program being debugged,
   instead of running it within LLDB's own process. To revert to the previous behavior, set the environment variable `LLDB_USE_LLDB_SERVER=0`.
+* Support for PDB symbol servers has been added. By default, no symbol servers are used.
+  You can control this either through the [`_NT_SYMBOL_PATH`](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/symbol-path)
+  environment variable or by setting `plugin.symbol-locator.symstore.urls`
+  (see [`plugin.symbol-locator.symstore`](https://lldb.llvm.org/use/settings.html#symstore) for more info).
+* LLDB no longer depends on the Python private API on Windows. Users are now free to
+  use any Python version they want, as long as it is 3.8 or later and LLDB can find it
+  (i.e. it is on their `PATH`).
 
 
 ### Changes to BOLT


### PR DESCRIPTION
Closes #212541. The two PRs https://github.com/llvm/llvm-project/pull/209469 and https://github.com/llvm/llvm-project/pull/209456 failed to cherry-pick.