### PR TITLE
XFAIL a test that is being flakey on the bots while we're investigating the failure

### DIFF
--- a/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
+++ b/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
@@ -45,7 +45,7 @@ class ExprWithForkTestCase(TestBase):
         )
 
     @skipIfWindows
-    @expectedFailureAll(bugnumber="github.com/llvm/llvm-project/issues/212556")
+    @expectedFlakeyLinux((bugnumber="github.com/llvm/llvm-project/issues/212556")
     @add_test_categories(["fork"])
     def test_expr_with_fork_trap(self):
         """Test that expression evaluation handles a child process that triggers a SIGTRAP."""

--- a/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
+++ b/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
@@ -45,6 +45,7 @@ class ExprWithForkTestCase(TestBase):
         )
 
     @skipIfWindows
+    @expectedFailureAll(bugnumber="github.com/llvm/llvm-project/issues/212556")
     @add_test_categories(["fork"])
     def test_expr_with_fork_trap(self):
         """Test that expression evaluation handles a child process that triggers a SIGTRAP."""


### PR DESCRIPTION
This test seems to have been failing intermittently for a while on the Ubuntu bots, but is failing more consistently now.

See:

https://github.com/llvm/llvm-project/issues/212556