### PR TITLE
[lldb] Fix flaky test_expr_with_fork_trap by increasing expression timeout

### DIFF
--- a/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
+++ b/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
@@ -53,9 +53,16 @@ class ExprWithForkTestCase(TestBase):
             self, "// break here", lldb.SBFileSpec("main.cpp")
         )
 
-        self.expect_expr(
-            "fork_and_return_trap(42)", result_type="int", result_value="1"
+        # Use a longer timeout because the parent blocks in waitpid() until
+        # the detached child is scheduled by the kernel and hits SIGTRAP.
+        options = lldb.SBExpressionOptions()
+        options.SetTimeoutInMicroSeconds(5000000)  # 5s
+
+        value = thread.GetSelectedFrame().EvaluateExpression(
+            "fork_and_return_trap(42)", options
         )
+        self.assertSuccess(value.GetError())
+        self.assertEqual(value.GetValueAsSigned(), 1)
 
     # --- follow-fork-mode child override during expression evaluation ---
 


### PR DESCRIPTION
The test evaluates an expression that forks a child which returns normally (triggering SIGTRAP from the JIT wrapper trap at _start). The parent blocks in waitpid() until the detached child terminates. With the default 250ms expression timeout, the kernel sometimes doesn't schedule the detached child fast enough, causing waitpid() to still be blocking when the timeout fires and the expression gets interrupted.

Set a 5-second expression timeout to give the kernel ample time to schedule the detached child process.