### PR TITLE
[AMDGPU] Move narrow ballot diagnostic from selection to legalization

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -1729,15 +1729,6 @@ bool AMDGPUInstructionSelector::selectBallot(MachineInstr &I) const {
   const unsigned BallotSize = MRI->getType(DstReg).getSizeInBits();
   const unsigned WaveSize = STI.getWavefrontSize();
 
-  if (BallotSize < WaveSize) {
-    const Function &Fn = MF->getFunction();
-    Fn.getContext().diagnose(DiagnosticInfoUnsupported(
-        Fn, "ballot return type is narrower than the wavefront size", DL));
-    BuildMI(*BB, &I, DL, TII.get(AMDGPU::IMPLICIT_DEF), DstReg);
-    I.eraseFromParent();
-    return true;
-  }
-
   if (BallotSize != WaveSize && (BallotSize != 64 || WaveSize != 32))
     return false;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -8192,6 +8192,18 @@ bool AMDGPULegalizerInfo::legalizeIntrinsic(LegalizerHelper &Helper,
     MI.eraseFromParent();
     return true;
   }
+  case Intrinsic::amdgcn_ballot: {
+    Register Dst = MI.getOperand(0).getReg();
+    if (MRI.getType(Dst).getSizeInBits() < ST.getWavefrontSize()) {
+      Function &Fn = B.getMF().getFunction();
+      Fn.getContext().diagnose(DiagnosticInfoUnsupported(
+          Fn, "ballot return type is narrower than the wavefront size",
+          MI.getDebugLoc()));
+      B.buildUndef(Dst);
+      MI.eraseFromParent();
+    }
+    return true;
+  }
   case Intrinsic::sponentry:
     if (B.getMF().getInfo<SIMachineFunctionInfo>()->isBottomOfStack()) {
       // FIXME: The imported pattern checks for i32 instead of p5; if we fix


### PR DESCRIPTION
To match SDAG handling logic, suggested in https://github.com/llvm/llvm-project/pull/211493