### PR TITLE
[AMDGPU][NFC] Document flat-to-global promotion assumption in AMDGPUP…

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteKernelArguments.cpp
@@ -110,6 +110,12 @@ bool AMDGPUPromoteKernelArguments::promotePointer(Value *Ptr) {
   if (PT->getAddressSpace() != AMDGPUAS::FLAT_ADDRESS)
     return Changed;
 
+  // The promotion is valid because in the HSA offload model the host populates
+  // kernarg slots at dispatch time and can only supply global-aperture
+  // addresses. Any flat pointer reachable from a kernel argument can therefore
+  // be assumed to be in the global aperture. This also mirrors the assumption
+  // in getAssumedAddrSpace (AMDGPUTargetMachine.cpp) which independently
+  // promotes flat kernel arguments to global via InferAddressSpaces.
   IRBuilder<> B(LI ? &*std::next(cast<Instruction>(Ptr)->getIterator())
                    : ArgCastInsertPt);
 


### PR DESCRIPTION
…romoteKernelArguments

AMDGPUPromoteKernelArguments promotes flat pointer kernel arguments to global by inserting a round-trip addrspacecast (flat -> global -> flat) as a hint to InferAddressSpaces. Add a comment explaining why this is valid: in the HSA offload model, the host populates kernarg slots at dispatch time and can only supply global-aperture addresses, so any flat pointer reachable from a kernel argument can be assumed to be in the global aperture. This mirrors the same assumption made by getAssumedAddrSpace in AMDGPUTargetMachine.cpp, which independently promotes flat kernel arguments to global via InferAddressSpaces.