### PR TITLE
[include-cleaner] Record #import directives

### DIFF
--- a/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Types.h
+++ b/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Types.h
@@ -24,6 +24,7 @@
 
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Tooling/Inclusions/HeaderIncludes.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -32,9 +33,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
-#include <memory>
 #include <string>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -151,6 +150,8 @@ struct Include {
   SourceLocation HashLocation;         // of hash in #include <vector>
   unsigned Line = 0;                   // 1-based line number for #include
   bool Angled = false;                 // True if spelled with <angle> quotes.
+  tooling::IncludeDirective Directive =
+      tooling::IncludeDirective::Include; // Directive type
   std::string quote() const;           // e.g. <vector>
 };
 llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Include &);

--- a/clang-tools-extra/include-cleaner/lib/Record.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Record.cpp
@@ -18,30 +18,27 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
+#include "clang/Basic/TokenKinds.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/DirectoryLookup.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/Inclusions/HeaderAnalysis.h"
+#include "clang/Tooling/Inclusions/HeaderIncludes.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem/UniqueID.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/StringSaver.h"
-#include <algorithm>
 #include <assert.h>
 #include <memory>
 #include <optional>
-#include <set>
 #include <utility>
 #include <vector>
 
@@ -79,6 +76,15 @@ public:
     I.Line = SM.getSpellingLineNumber(Hash);
     I.Spelled = SpelledFilename;
     I.Angled = IsAngled;
+    llvm::StringRef DirectiveName;
+    if (IncludeTok.is(tok::raw_identifier)) {
+      DirectiveName = IncludeTok.getRawIdentifier();
+    } else if (IncludeTok.getIdentifierInfo()) {
+      DirectiveName = IncludeTok.getIdentifierInfo()->getName();
+    }
+    if (DirectiveName == "import") {
+      I.Directive = clang::tooling::IncludeDirective::Import;
+    }
     Recorded.Includes.add(I);
   }
 

--- a/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
@@ -20,6 +20,7 @@
 #include "clang/Serialization/PCHContainerOperations.h"
 #include "clang/Testing/CommandLineArgs.h"
 #include "clang/Testing/TestAST.h"
+#include "clang/Tooling/Inclusions/HeaderIncludes.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -135,7 +136,7 @@ TEST_F(RecordASTTest, ImplicitTemplates) {
   }
   )cpp";
   Inputs.Code = R"cpp(
-  #include "dispatch.h"  
+  #include "dispatch.h"
   struct MyGetter {
     template <class T> static int get() { return T::value; }
   };
@@ -202,6 +203,46 @@ TEST_F(RecordPPTest, CapturesIncludes) {
                 AST.sourceManager().getMainFileID(), MainFile.point("M")));
   EXPECT_EQ(M.Resolved, std::nullopt);
   EXPECT_TRUE(M.Angled);
+}
+
+TEST_F(RecordPPTest, CapturesImports) {
+  llvm::Annotations MainFile(R"objc(
+    $H^#import "./header.h"
+    $M^#import <missing.h>
+  )objc");
+  Inputs.Code = MainFile.code();
+  Inputs.ExtraFiles["header.h"] = "";
+  Inputs.ErrorOK = true; // missing header
+  Inputs.ExtraArgs.push_back("-x");
+  Inputs.ExtraArgs.push_back("objective-c");
+  auto AST = build();
+
+  auto Includes = Recorded.Includes.all();
+  ASSERT_EQ(Includes.size(), 2u);
+  EXPECT_THAT(Includes[0], spelled("./header.h"));
+  EXPECT_EQ(Includes[0].Directive, clang::tooling::IncludeDirective::Import);
+  EXPECT_THAT(Includes[1], spelled("missing.h"));
+  EXPECT_EQ(Includes[1].Directive, clang::tooling::IncludeDirective::Import);
+}
+
+TEST_F(RecordPPTest, CapturesMixedDirectives) {
+  llvm::Annotations MainFile(R"objc(
+    $H^#import "./header.h"
+    $I^#include "./header2.h"
+  )objc");
+  Inputs.Code = MainFile.code();
+  Inputs.ExtraFiles["header.h"] = "";
+  Inputs.ExtraFiles["header2.h"] = "";
+  Inputs.ExtraArgs.push_back("-x");
+  Inputs.ExtraArgs.push_back("objective-c");
+  auto AST = build();
+
+  auto Includes = Recorded.Includes.all();
+  ASSERT_EQ(Includes.size(), 2u);
+  EXPECT_THAT(Includes[0], spelled("./header.h"));
+  EXPECT_EQ(Includes[0].Directive, clang::tooling::IncludeDirective::Import);
+  EXPECT_THAT(Includes[1], spelled("./header2.h"));
+  EXPECT_EQ(Includes[1].Directive, clang::tooling::IncludeDirective::Include);
 }
 
 TEST_F(RecordPPTest, CapturesMacroRefs) {


### PR DESCRIPTION
Detect #import directives during preprocessing and record them with the IncludeDirective::Import type. This ensures Objective-C imports are correctly classified and tracked by the tool.

Also clean up some includes.