### PR TITLE
[llvm][lldb] Support GNU-compressed DWARF in Mach-O and COFF

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Target/ThreadList.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/DataBuffer.h"
+#include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -46,6 +47,7 @@
 #include "lldb/Host/SafeMachO.h"
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/Object/Decompressor.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -1011,6 +1013,58 @@ bool ObjectFileMachO::ParseHeader(DataExtractorSP &extractor_sp,
   return false;
 }
 
+size_t ObjectFileMachO::ReadSectionData(Section *section,
+                                        lldb::offset_t section_offset,
+                                        void *dst, size_t dst_len) {
+  if (section->GetObjectFile() != this)
+    return section->GetObjectFile()->ReadSectionData(section, section_offset,
+                                                     dst, dst_len);
+
+  if (!section->GetName().starts_with("__zdebug_"))
+    return ObjectFile::ReadSectionData(section, section_offset, dst, dst_len);
+
+  DataExtractor data;
+  ReadSectionData(section, data);
+  return data.CopyData(section_offset, dst_len, dst);
+}
+
+size_t ObjectFileMachO::ReadSectionData(Section *section,
+                                        DataExtractor &section_data) {
+  if (section->GetObjectFile() != this)
+    return section->GetObjectFile()->ReadSectionData(section, section_data);
+
+  size_t result = ObjectFile::ReadSectionData(section, section_data);
+  if (result == 0 || !section->GetName().starts_with("__zdebug_"))
+    return result;
+
+  auto decompressor = llvm::object::Decompressor::create(
+      section->GetName(),
+      {reinterpret_cast<const char *>(section_data.GetDataStart()),
+       size_t(section_data.GetByteSize())},
+      GetByteOrder() == eByteOrderLittle, GetAddressByteSize() == 8);
+  if (!decompressor) {
+    GetModule()->ReportWarning(
+        "unable to initialize decompressor for section '{0}': {1}",
+        section->GetName(), llvm::toString(decompressor.takeError()).c_str());
+    section_data.Clear();
+    return 0;
+  }
+
+  auto buffer_sp =
+      std::make_shared<DataBufferHeap>(decompressor->getDecompressedSize(), 0);
+  if (auto error = decompressor->decompress(
+          {buffer_sp->GetBytes(), size_t(buffer_sp->GetByteSize())})) {
+    GetModule()->ReportWarning("decompression of section '{0}' failed: {1}",
+                               section->GetName(),
+                               llvm::toString(std::move(error)).c_str());
+    section_data.Clear();
+    return 0;
+  }
+
+  section_data.SetData(buffer_sp);
+  return buffer_sp->GetByteSize();
+}
+
 bool ObjectFileMachO::ParseHeader() {
   ModuleSP module_sp(GetModule());
   if (!module_sp)
@@ -1464,7 +1518,8 @@ static lldb::SectionType GetSectionType(uint32_t flags,
     return eSectionTypeDWARFDebugStrOffsetsDwo;
 
   llvm::StringRef stripped_name = section_name.GetStringRef();
-  if (stripped_name.consume_front("__debug_"))
+  if (stripped_name.consume_front("__debug_") ||
+      stripped_name.consume_front("__zdebug_"))
     return ObjectFile::GetDWARFSectionTypeFromName(stripped_name);
 
   if (section_name == g_sect_name_dwarf_apple_names)

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -102,6 +102,13 @@ public:
 
   void CreateSections(lldb_private::SectionList &unified_section_list) override;
 
+  size_t ReadSectionData(lldb_private::Section *section,
+                         lldb::offset_t section_offset, void *dst,
+                         size_t dst_len) override;
+
+  size_t ReadSectionData(lldb_private::Section *section,
+                         lldb_private::DataExtractor &section_data) override;
+
   void Dump(lldb_private::Stream *s) override;
 
   lldb_private::ArchSpec GetArchitecture() override;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -33,6 +33,7 @@
 
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/Object/COFFImportFile.h"
+#include "llvm/Object/Decompressor.h"
 #include "llvm/Support/CRC.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatAdapters.h"
@@ -958,6 +959,58 @@ bool ObjectFilePECOFF::IsStripped() {
   return false;
 }
 
+size_t ObjectFilePECOFF::ReadSectionData(Section *section,
+                                         lldb::offset_t section_offset,
+                                         void *dst, size_t dst_len) {
+  if (section->GetObjectFile() != this)
+    return section->GetObjectFile()->ReadSectionData(section, section_offset,
+                                                     dst, dst_len);
+
+  if (!section->GetName().starts_with(".zdebug_"))
+    return ObjectFile::ReadSectionData(section, section_offset, dst, dst_len);
+
+  DataExtractor data;
+  ReadSectionData(section, data);
+  return data.CopyData(section_offset, dst_len, dst);
+}
+
+size_t ObjectFilePECOFF::ReadSectionData(Section *section,
+                                         DataExtractor &section_data) {
+  if (section->GetObjectFile() != this)
+    return section->GetObjectFile()->ReadSectionData(section, section_data);
+
+  size_t result = ObjectFile::ReadSectionData(section, section_data);
+  if (result == 0 || !section->GetName().starts_with(".zdebug_"))
+    return result;
+
+  auto decompressor = llvm::object::Decompressor::create(
+      section->GetName(),
+      {reinterpret_cast<const char *>(section_data.GetDataStart()),
+       size_t(section_data.GetByteSize())},
+      GetByteOrder() == eByteOrderLittle, GetAddressByteSize() == 8);
+  if (!decompressor) {
+    GetModule()->ReportWarning(
+        "unable to initialize decompressor for section '{0}': {1}",
+        section->GetName(), llvm::toString(decompressor.takeError()).c_str());
+    section_data.Clear();
+    return 0;
+  }
+
+  auto buffer_sp =
+      std::make_shared<DataBufferHeap>(decompressor->getDecompressedSize(), 0);
+  if (auto error = decompressor->decompress(
+          {buffer_sp->GetBytes(), size_t(buffer_sp->GetByteSize())})) {
+    GetModule()->ReportWarning("decompression of section '{0}' failed: {1}",
+                               section->GetName(),
+                               llvm::toString(std::move(error)).c_str());
+    section_data.Clear();
+    return 0;
+  }
+
+  section_data.SetData(buffer_sp);
+  return buffer_sp->GetByteSize();
+}
+
 SectionType ObjectFilePECOFF::GetSectionType(llvm::StringRef sect_name,
                                              const section_header_t &sect) {
   ConstString const_sect_name(sect_name);
@@ -990,7 +1043,7 @@ SectionType ObjectFilePECOFF::GetSectionType(llvm::StringRef sect_name,
       return eSectionTypeData;
   }
 
-  if (sect_name.consume_front(".debug_"))
+  if (sect_name.consume_front(".debug_") || sect_name.consume_front(".zdebug_"))
     return GetDWARFSectionTypeFromName(sect_name);
 
   SectionType section_type =

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -118,6 +118,13 @@ public:
 
   void CreateSections(lldb_private::SectionList &unified_section_list) override;
 
+  size_t ReadSectionData(lldb_private::Section *section,
+                         lldb::offset_t section_offset, void *dst,
+                         size_t dst_len) override;
+
+  size_t ReadSectionData(lldb_private::Section *section,
+                         lldb_private::DataExtractor &section_data) override;
+
   void Dump(lldb_private::Stream *s) override;
 
   lldb_private::ArchSpec GetArchitecture() override;

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -19,6 +19,7 @@
 #include "lldb/Symbol/Symtab.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/lldb-defines.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -36,6 +37,72 @@ class ObjectFileMachOTest : public ::testing::Test {
   SubsystemRAII<FileSystem, HostInfo, ObjectFileMachO> subsystems;
 };
 } // namespace
+
+#if LLVM_ENABLE_ZLIB
+TEST_F(ObjectFileMachOTest, GNUCompressedSection) {
+  const char *yamldata = R"(
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      152
+  flags:           0x00000000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __DWARF
+    vmaddr:          0
+    vmsize:          23
+    fileoff:         184
+    filesize:        23
+    maxprot:         7
+    initprot:        3
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __zdebug_line
+        segname:         __DWARF
+        addr:            0
+        size:            23
+        offset:          184
+        align:           0
+        reloff:          0
+        nreloc:          0
+        flags:           0x02000000
+        reserved1:       0
+        reserved2:       0
+        reserved3:       0
+        content:         5A4C49420000000000000003789C4B4C4A0600024D0127
+...
+)";
+
+  llvm::Expected<TestFile> file = TestFile::fromYaml(yamldata);
+  ASSERT_THAT_EXPECTED(file, llvm::Succeeded());
+  lldb::ModuleSP module = std::make_shared<Module>(file->moduleSpec());
+  ObjectFile *object = module->GetObjectFile();
+  ASSERT_TRUE(llvm::isa<ObjectFileMachO>(object));
+
+  SectionSP line = object->GetSectionList()->FindSectionByType(
+      eSectionTypeDWARFDebugLine, true);
+  ASSERT_TRUE(line);
+  EXPECT_EQ(line->GetName(), ConstString("__zdebug_line"));
+
+  lldb_private::DataExtractor data;
+  EXPECT_EQ(line->GetSectionData(data), 3u);
+  ASSERT_EQ(data.GetByteSize(), 3u);
+  EXPECT_EQ(
+      llvm::StringRef(reinterpret_cast<const char *>(data.GetDataStart()), 3),
+      "abc");
+
+  char tail[2];
+  EXPECT_EQ(object->ReadSectionData(line.get(), 1, tail, sizeof(tail)), 2u);
+  EXPECT_EQ(llvm::StringRef(tail, sizeof(tail)), "bc");
+}
+#endif
 
 #if defined(__APPLE__)
 TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {

--- a/lldb/unittests/ObjectFile/PECOFF/CMakeLists.txt
+++ b/lldb/unittests/ObjectFile/PECOFF/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lldb_unittest(ObjectFilePECOFFTests
+  TestCompressedSection.cpp
   TestPECallFrameInfo.cpp
   TestSectionSize.cpp
 

--- a/lldb/unittests/ObjectFile/PECOFF/TestCompressedSection.cpp
+++ b/lldb/unittests/ObjectFile/PECOFF/TestCompressedSection.cpp
@@ -1,0 +1,63 @@
+//===-- TestCompressedSection.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Core/Section.h"
+#include "lldb/Utility/DataExtractor.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+#if LLVM_ENABLE_ZLIB
+TEST(ObjectFilePECOFFTest, GNUCompressedSection) {
+  SubsystemRAII<FileSystem, ObjectFilePECOFF> subsystems;
+  llvm::Expected<TestFile> file = TestFile::fromYaml(R"(
+--- !COFF
+OptionalHeader:
+  SectionAlignment: 4096
+  FileAlignment:   512
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_EXECUTABLE_IMAGE, IMAGE_FILE_LARGE_ADDRESS_AWARE ]
+sections:
+  - Name:            .zdebug_line
+    VirtualSize:     23
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    SectionData:     5A4C49420000000000000003789C4B4C4A0600024D0127
+symbols:         []
+...
+)");
+  ASSERT_THAT_EXPECTED(file, llvm::Succeeded());
+
+  ModuleSP module = std::make_shared<Module>(file->moduleSpec());
+  ObjectFile *object = module->GetObjectFile();
+  ASSERT_TRUE(llvm::isa<ObjectFilePECOFF>(object));
+
+  SectionSP line = object->GetSectionList()->FindSectionByType(
+      eSectionTypeDWARFDebugLine, true);
+  ASSERT_TRUE(line);
+  EXPECT_EQ(line->GetName(), ConstString(".zdebug_line"));
+
+  DataExtractor data;
+  EXPECT_EQ(line->GetSectionData(data), 3u);
+  ASSERT_EQ(data.GetByteSize(), 3u);
+  EXPECT_EQ(
+      llvm::StringRef(reinterpret_cast<const char *>(data.GetDataStart()), 3),
+      "abc");
+
+  char tail[2];
+  EXPECT_EQ(object->ReadSectionData(line.get(), 1, tail, sizeof(tail)), 2u);
+  EXPECT_EQ(llvm::StringRef(tail, sizeof(tail)), "bc");
+}
+#endif

--- a/llvm/include/llvm/Object/Decompressor.h
+++ b/llvm/include/llvm/Object/Decompressor.h
@@ -45,6 +45,7 @@ public:
 private:
   Decompressor(StringRef Data);
 
+  Error consumeCompressedGNUHeader();
   Error consumeCompressedHeader(bool Is64Bit, bool IsLittleEndian);
 
   StringRef SectionData;

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -2100,7 +2100,7 @@ class DWARFObjInMemory final : public DWARFObject {
 
   /// If Sec is compressed section, decompresses and updates its contents
   /// provided by Data. Otherwise leaves it unchanged.
-  Error maybeDecompress(const object::SectionRef &Sec, StringRef Name,
+  Error maybeDecompress(const object::SectionRef &Sec, StringRef &Name,
                         StringRef &Data) {
     if (!Sec.isCompressed())
       return Error::success();
@@ -2116,6 +2116,10 @@ class DWARFObjInMemory final : public DWARFObject {
 
     UncompressedSections.push_back(std::move(Out));
     Data = UncompressedSections.back();
+
+    StringRef NormalizedName = Name.ltrim("._");
+    if (NormalizedName.starts_with("zdebug_"))
+      Name = NormalizedName.drop_front();
 
     return Error::success();
   }

--- a/llvm/lib/Object/COFFObjectFile.cpp
+++ b/llvm/lib/Object/COFFObjectFile.cpp
@@ -304,7 +304,12 @@ uint64_t COFFObjectFile::getSectionAlignment(DataRefImpl Ref) const {
 }
 
 bool COFFObjectFile::isSectionCompressed(DataRefImpl Sec) const {
-  return false;
+  Expected<StringRef> NameOrErr = getSectionName(Sec);
+  if (!NameOrErr) {
+    consumeError(NameOrErr.takeError());
+    return false;
+  }
+  return NameOrErr->ltrim("._").starts_with("zdebug_");
 }
 
 bool COFFObjectFile::isSectionText(DataRefImpl Ref) const {

--- a/llvm/lib/Object/Decompressor.cpp
+++ b/llvm/lib/Object/Decompressor.cpp
@@ -21,13 +21,30 @@ using namespace object;
 Expected<Decompressor> Decompressor::create(StringRef Name, StringRef Data,
                                             bool IsLE, bool Is64Bit) {
   Decompressor D(Data);
-  if (Error Err = D.consumeCompressedHeader(Is64Bit, IsLE))
+  const bool IsGNUStyle = Name.ltrim("._").starts_with("zdebug_");
+  if (Error Err = IsGNUStyle ? D.consumeCompressedGNUHeader()
+                             : D.consumeCompressedHeader(Is64Bit, IsLE))
     return std::move(Err);
   return D;
 }
 
 Decompressor::Decompressor(StringRef Data)
     : SectionData(Data), DecompressedSize(0) {}
+
+Error Decompressor::consumeCompressedGNUHeader() {
+  if (!SectionData.starts_with("ZLIB"))
+    return createError("corrupted compressed section header");
+  if (const char *Reason =
+          llvm::compression::getReasonIfUnsupported(compression::Format::Zlib))
+    return createError(Reason);
+  if (SectionData.size() < 12)
+    return createError("corrupted uncompressed section size");
+
+  CompressionType = DebugCompressionType::Zlib;
+  DecompressedSize = read64be(SectionData.data() + 4);
+  SectionData = SectionData.substr(12);
+  return Error::success();
+}
 
 Error Decompressor::consumeCompressedHeader(bool Is64Bit, bool IsLittleEndian) {
   using namespace ELF;

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2057,7 +2057,12 @@ Expected<SectionRef> MachOObjectFile::getSection(StringRef SectionName) const {
 }
 
 bool MachOObjectFile::isSectionCompressed(DataRefImpl Sec) const {
-  return false;
+  Expected<StringRef> NameOrErr = getSectionName(Sec);
+  if (!NameOrErr) {
+    consumeError(NameOrErr.takeError());
+    return false;
+  }
+  return NameOrErr->ltrim("._").starts_with("zdebug_");
 }
 
 bool MachOObjectFile::isSectionText(DataRefImpl Sec) const {

--- a/llvm/test/DebugInfo/COFF/gnu-compressed-sections.yaml
+++ b/llvm/test/DebugInfo/COFF/gnu-compressed-sections.yaml
@@ -1,0 +1,35 @@
+# REQUIRES: zlib
+# RUN: yaml2obj %s -o %t \
+# RUN:   -DINFO=5A4C4942000000000000000C789CE3606060606100010E0600009C0015
+# RUN: llvm-dwarfdump --debug-info %t | FileCheck %s
+# RUN: yaml2obj %s -o %t.invalid \
+# RUN:   -DINFO=4241442100000000000000000000000000000000000000000000000000
+# RUN: not llvm-dwarfdump --debug-info %t.invalid 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=ERR
+
+# CHECK: .debug_info contents:
+# CHECK: Compile Unit: length = 0x00000008
+# CHECK-SAME: version = 0x0004
+# CHECK-SAME: addr_size = 0x08
+
+# ERR: error: failed to decompress
+# ERR-SAME: corrupted compressed section header
+
+--- !COFF
+OptionalHeader:
+  SectionAlignment: 4096
+  FileAlignment:   512
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_EXECUTABLE_IMAGE, IMAGE_FILE_LARGE_ADDRESS_AWARE ]
+sections:
+  - Name:            .zdebug_info
+    VirtualSize:     29
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    SectionData:     '[[INFO]]'
+  - Name:            .zdebug_abbrev
+    VirtualSize:     21
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    SectionData:     5A4C49420000000000000001789C63000000010001
+symbols:         []
+...

--- a/llvm/test/DebugInfo/MachO/gnu-compressed-sections.yaml
+++ b/llvm/test/DebugInfo/MachO/gnu-compressed-sections.yaml
@@ -1,0 +1,67 @@
+# REQUIRES: zlib
+# RUN: yaml2obj %s -o %t \
+# RUN:   -DINFO=5A4C4942000000000000000C789CE3606060606100010E0600009C0015
+# RUN: llvm-dwarfdump --debug-info %t | FileCheck %s
+# RUN: yaml2obj %s -o %t.invalid \
+# RUN:   -DINFO=4241442100000000000000000000000000000000000000000000000000
+# RUN: not llvm-dwarfdump --debug-info %t.invalid 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=ERR
+
+# CHECK: .debug_info contents:
+# CHECK: Compile Unit: length = 0x00000008
+# CHECK-SAME: version = 0x0004
+# CHECK-SAME: addr_size = 0x08
+
+# ERR: error: failed to decompress
+# ERR-SAME: corrupted compressed section header
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      232
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         232
+    segname:         __DWARF
+    vmaddr:          0
+    vmsize:          50
+    fileoff:         264
+    filesize:        50
+    maxprot:         7
+    initprot:        3
+    nsects:          2
+    flags:           0
+    Sections:
+      - sectname:        __zdebug_info
+        segname:         __DWARF
+        addr:            0
+        size:            29
+        offset:          264
+        align:           0
+        reloff:          0
+        nreloc:          0
+        flags:           0x02000000
+        reserved1:       0
+        reserved2:       0
+        reserved3:       0
+        content:         '[[INFO]]'
+      - sectname:        __zdebug_abbrev
+        segname:         __DWARF
+        addr:            29
+        size:            21
+        offset:          293
+        align:           0
+        reloff:          0
+        nreloc:          0
+        flags:           0x02000000
+        reserved1:       0
+        reserved2:       0
+        reserved3:       0
+        content:         5A4C49420000000000000001789C63000000010001
+...


### PR DESCRIPTION
## Summary

Go's Darwin and Windows linkers emit DWARF in `__zdebug_*` Mach-O sections and
`.zdebug_*` COFF sections. They use the GNU compression header (`ZLIB`
followed by a big-endian 64-bit uncompressed size), while the shared
decompressor currently parses only the ELF compression header.

This change:

- decodes the GNU header when a compressed section has a normalized
  `zdebug_*` name, without re-enabling legacy `.zdebug_*` detection for ELF;
- recognizes and normalizes compressed DWARF section names in Mach-O and COFF;
- makes LLDB decompress full and partial reads from both object formats.

## Testing

- macOS: `ObjectFileMachOTests` 30/30 and `ObjectFilePECOFFTests` 5/5
- Linux arm64: `ObjectFileMachOTests` 28/28 and
  `ObjectFilePECOFFTests` 5/5
- Mach-O lit test passed on both platforms, including the corrupt-header case
- COFF valid and corrupt inputs passed manually on both platforms (the
  native-only Linux build does not advertise the X86 target required by the
  COFF lit directory)
- real Go 1.26.5 Darwin executable with six default `__zdebug_*` sections:
  `llvm-dwarfdump` reads the Go compile units and LLDB resolves a source
  breakpoint
- real Go 1.26.5 Windows executable with default `.zdebug_*` sections: LLDB
  resolves the Go compile unit and a source breakpoint

## AI assistance

OpenAI Codex assisted with investigation, implementation, and test
orchestration. I reviewed and understand all code and text in this contribution
and am responsible for it.
