### PR TITLE
[InstCombine]  Simplify `(add (ashr A, N), (ashr B, N))` by factoring out common terms

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -7542,6 +7542,23 @@ OverflowResult llvm::computeOverflowForSignedMul(const Value *LHS,
     if (LHSKnown.isNonNegative() || RHSKnown.isNonNegative())
       return OverflowResult::NeverOverflows;
   }
+
+  // Special case when we're multiplying a power-of-two value. In this case,
+  // we will never overflow as long as the shift amount is less than the number
+  // of sign bits.
+  if (isKnownToBeAPowerOfTwo(RHS, /*OrZero=*/false, SQ)) {
+    KnownBits LHSKnown = computeKnownBits(LHS, SQ);
+    KnownBits RHSKnown = computeKnownBits(RHS, SQ);
+    // If RHS is power of two, the only time it is negative would be
+    // the smallest value. In that case it never overflows only if
+    // LHS is zero or one. If LHS is really zero or one we would have
+    // simplified it somewhere else, therefore this pattern checks only
+    // when RHS is positive.
+    if (RHSKnown.isStrictlyPositive() &&
+        LHSKnown.countMinSignBits() > RHSKnown.countMaxTrailingZeros())
+      return OverflowResult::NeverOverflows;
+  }
+
   return OverflowResult::MayOverflow;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -531,6 +531,13 @@ public:
   /// value, or null if it didn't simplify.
   Value *foldUsingDistributiveLaws(BinaryOperator &I);
 
+  Value *tryFactorization(BinaryOperator &I, const SimplifyQuery &SQ,
+                          Instruction::BinaryOps InnerOpcode, Value *A,
+                          Value *B, Value *C, Value *D);
+
+  bool rightDistributesOverLeft(BinaryOperator &LOp,
+                                Instruction::BinaryOps ROpcode);
+
   /// Tries to simplify add operations using the definition of remainder.
   ///
   /// The definition of remainder is X % C = X - (X / C ) * C. The add

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -711,7 +711,7 @@ bool InstCombinerImpl::rightDistributesOverLeft(
   // If %v0 + %v1 never wraps.
   if ((ROpcode == Instruction::AShr || ROpcode == Instruction::LShr) &&
       match(&LOp,
-            m_BinOp(m_Exact(m_BinOp(ROpcode, m_Value(),
+            m_c_Add(m_Exact(m_BinOp(ROpcode, m_Value(),
                                     m_Value(Z, m_APInt(ShiftAmt)))),
                     m_Exact(m_BinOp(ROpcode, m_Value(), m_Deferred(Z)))))) {
     bool IsSigned = ROpcode == Instruction::AShr;

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -694,17 +694,46 @@ static bool leftDistributesOverRight(Instruction::BinaryOps LOp,
 
 /// Return whether "(X LOp Y) ROp Z" is always equal to
 /// "(X ROp Z) LOp (Y ROp Z)".
-static bool rightDistributesOverLeft(Instruction::BinaryOps LOp,
-                                     Instruction::BinaryOps ROp) {
-  if (Instruction::isCommutative(ROp))
-    return leftDistributesOverRight(ROp, LOp);
+bool InstCombinerImpl::rightDistributesOverLeft(
+    BinaryOperator &LOp, Instruction::BinaryOps ROpcode) {
+  if (Instruction::isCommutative(ROpcode))
+    return leftDistributesOverRight(ROpcode, LOp.getOpcode());
+
+  Value *Z;
+  const APInt *ShiftAmt;
+  // %s0 = ashr exact %v0, N
+  // %s1 = ashr exact %v1, N
+  // %r  = add %s0, %s1
+  // ->
+  // %a = add %v0, %v1
+  // %r = ashr %a, N
+  //
+  // If %v0 + %v1 never wraps.
+  if ((ROpcode == Instruction::AShr || ROpcode == Instruction::LShr) &&
+      match(&LOp,
+            m_BinOp(m_Exact(m_BinOp(ROpcode, m_Value(),
+                                    m_Value(Z, m_APInt(ShiftAmt)))),
+                    m_Exact(m_BinOp(ROpcode, m_Value(), m_Deferred(Z)))))) {
+    bool IsSigned = ROpcode == Instruction::AShr;
+    // Instead of asking directly on whether %v0 + %v1 overflows, we ask
+    // if %r times (1<<N) overflows. Because this works on either cases
+    // where we know a bit more about operands (i.e. %v0, %v1), through
+    // things like llvm.assume, or we know a bit more about the result (i.e.
+    // %r).
+    APInt MulAmt = APInt::getOneBitSet(ShiftAmt->getBitWidth(), 0);
+    MulAmt <<= *ShiftAmt;
+    ConstantInt *MulAmtVal = Builder.getInt(MulAmt);
+    if (computeOverflow(Instruction::Mul, IsSigned, &LOp, MulAmtVal, &LOp) ==
+        OverflowResult::NeverOverflows)
+      return true;
+  }
 
   // (X {&|^} Y) >> Z <--> (X >> Z) {&|^} (Y >> Z) for all shifts.
-  return Instruction::isBitwiseLogicOp(LOp) && Instruction::isShift(ROp);
+  return Instruction::isBitwiseLogicOp(LOp.getOpcode()) &&
+         Instruction::isShift(ROpcode);
 
-  // TODO: It would be nice to handle division, aka "(X + Y)/Z = X/Z + Y/Z",
-  // but this requires knowing that the addition does not overflow and other
-  // such subtleties.
+  // TODO: It would be nice to handle the general division cases, aka "(X + Y)/Z
+  // = X/Z + Y/Z",
 }
 
 /// This function returns identity value for given opcode, which can be used to
@@ -750,10 +779,11 @@ getBinOpsForFactorization(Instruction::BinaryOps TopOpcode, BinaryOperator *Op,
 
 /// This tries to simplify binary operations by factorizing out common terms
 /// (e. g. "(A*B)+(A*C)" -> "A*(B+C)").
-static Value *tryFactorization(BinaryOperator &I, const SimplifyQuery &SQ,
-                               InstCombiner::BuilderTy &Builder,
-                               Instruction::BinaryOps InnerOpcode, Value *A,
-                               Value *B, Value *C, Value *D) {
+Value *InstCombinerImpl::tryFactorization(BinaryOperator &I,
+                                          const SimplifyQuery &SQ,
+                                          Instruction::BinaryOps InnerOpcode,
+                                          Value *A, Value *B, Value *C,
+                                          Value *D) {
   assert(A && B && C && D && "All values must be provided");
 
   Value *V = nullptr;
@@ -785,7 +815,7 @@ static Value *tryFactorization(BinaryOperator &I, const SimplifyQuery &SQ,
   }
 
   // Does "(X op Y) op' Z" always equal "(X op' Z) op (Y op' Z)"?
-  if (!RetVal && rightDistributesOverLeft(TopLevelOpcode, InnerOpcode)) {
+  if (!RetVal && rightDistributesOverLeft(I, InnerOpcode)) {
     // Does the instruction have the form "(A op' B) op (C op' B)" or, in the
     // commutative case, "(A op' B) op (B op' D)"?
     if (B == D || (InnerCommutative && B == C)) {
@@ -1175,23 +1205,21 @@ Value *InstCombinerImpl::tryFactorizationFolds(BinaryOperator &I) {
   // The instruction has the form "(A op' B) op (C op' D)".  Try to factorize
   // a common term.
   if (Op0 && Op1 && LHSOpcode == RHSOpcode)
-    if (Value *V = tryFactorization(I, SQ, Builder, LHSOpcode, A, B, C, D))
+    if (Value *V = tryFactorization(I, SQ, LHSOpcode, A, B, C, D))
       return V;
 
   // The instruction has the form "(A op' B) op (C)".  Try to factorize common
   // term.
   if (Op0)
     if (Value *Ident = getIdentityValue(LHSOpcode, RHS))
-      if (Value *V =
-              tryFactorization(I, SQ, Builder, LHSOpcode, A, B, RHS, Ident))
+      if (Value *V = tryFactorization(I, SQ, LHSOpcode, A, B, RHS, Ident))
         return V;
 
   // The instruction has the form "(B) op (C op' D)".  Try to factorize common
   // term.
   if (Op1)
     if (Value *Ident = getIdentityValue(RHSOpcode, LHS))
-      if (Value *V =
-              tryFactorization(I, SQ, Builder, RHSOpcode, LHS, Ident, C, D))
+      if (Value *V = tryFactorization(I, SQ, RHSOpcode, LHS, Ident, C, D))
         return V;
 
   return nullptr;
@@ -1213,7 +1241,7 @@ Value *InstCombinerImpl::foldUsingDistributiveLaws(BinaryOperator &I) {
     return R;
 
   // Expansion.
-  if (Op0 && rightDistributesOverLeft(Op0->getOpcode(), TopLevelOpcode)) {
+  if (Op0 && rightDistributesOverLeft(*Op0, TopLevelOpcode)) {
     // The instruction has the form "(A op' B) op C".  See if expanding it out
     // to "(A op C) op' (B op C)" results in simplifications.
     Value *A = Op0->getOperand(0), *B = Op0->getOperand(1), *C = RHS;

--- a/llvm/test/Transforms/InstCombine/add-shift.ll
+++ b/llvm/test/Transforms/InstCombine/add-shift.ll
@@ -78,3 +78,79 @@ define <2 x i8> @flip_add_of_shift_neg_vec_fail_multiuse_shift(<2 x i8> %v, <2 x
   %r = add <2 x i8> %x, %sv
   ret <2 x i8> %r
 }
+
+define i64 @factorize_add_of_ashr(i64 %v1, i64 %v2) {
+; CHECK-LABEL: define i64 @factorize_add_of_ashr(
+; CHECK-SAME: i64 [[V1:%.*]], i64 [[V2:%.*]]) {
+; CHECK-NEXT:    [[S01:%.*]] = add i64 [[V1]], [[V2]]
+; CHECK-NEXT:    [[R:%.*]] = ashr i64 [[S01]], 3
+; CHECK-NEXT:    [[A:%.*]] = icmp ult i64 [[R]], 1152921504606846976
+; CHECK-NEXT:    call void @llvm.assume(i1 [[A]])
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %s0 = ashr exact i64 %v1, 3
+  %s1 = ashr exact i64 %v2, 3
+  %r = add i64 %s0, %s1
+  %a = icmp ult i64 %r, 1152921504606846976
+  call void @llvm.assume(i1 %a)
+  ret i64 %r
+}
+
+; llvm.assume on the prospective add's operands rather than
+; on add's result.
+define i64 @factorize_add_of_ashr2(i64 %v1, i64 %v2) {
+; CHECK-LABEL: define i64 @factorize_add_of_ashr2(
+; CHECK-SAME: i64 [[V1:%.*]], i64 [[V2:%.*]]) {
+; CHECK-NEXT:    [[S01:%.*]] = add nuw nsw i64 [[V1]], [[V2]]
+; CHECK-NEXT:    [[R:%.*]] = lshr i64 [[S01]], 3
+; CHECK-NEXT:    [[A0:%.*]] = icmp ult i64 [[V1]], 2147483648
+; CHECK-NEXT:    [[A1:%.*]] = icmp ult i64 [[V2]], 2147483648
+; CHECK-NEXT:    call void @llvm.assume(i1 [[A0]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[A1]])
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %s0 = ashr exact i64 %v1, 3
+  %s1 = ashr exact i64 %v2, 3
+  %r = add i64 %s0, %s1
+  %a0 = icmp ult i64 %v1, 2147483648
+  %a1 = icmp ult i64 %v2, 2147483648
+  call void @llvm.assume(i1 %a0)
+  call void @llvm.assume(i1 %a1)
+  ret i64 %r
+}
+
+define i64 @factorize_add_of_lshr(i64 %v1, i64 %v2) {
+; CHECK-LABEL: define i64 @factorize_add_of_lshr(
+; CHECK-SAME: i64 [[V1:%.*]], i64 [[V2:%.*]]) {
+; CHECK-NEXT:    [[S01:%.*]] = add i64 [[V1]], [[V2]]
+; CHECK-NEXT:    [[R:%.*]] = lshr i64 [[S01]], 3
+; CHECK-NEXT:    [[A:%.*]] = icmp sgt i64 [[S01]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[A]])
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %s0 = lshr exact i64 %v1, 3
+  %s1 = lshr exact i64 %v2, 3
+  %r = add i64 %s0, %s1
+  %a = icmp ult i64 %r, 1152921504606846976
+  call void @llvm.assume(i1 %a)
+  ret i64 %r
+}
+
+; The right shiftings need to be exact
+define i64 @negative_factorize_add_of_ashr(i64 %v1, i64 %v2) {
+; CHECK-LABEL: define i64 @negative_factorize_add_of_ashr(
+; CHECK-SAME: i64 [[V1:%.*]], i64 [[V2:%.*]]) {
+; CHECK-NEXT:    [[S0:%.*]] = ashr i64 [[V1]], 3
+; CHECK-NEXT:    [[S1:%.*]] = ashr i64 [[V2]], 3
+; CHECK-NEXT:    [[R:%.*]] = add nsw i64 [[S0]], [[S1]]
+; CHECK-NEXT:    [[A:%.*]] = icmp ult i64 [[R]], 1152921504606846976
+; CHECK-NEXT:    call void @llvm.assume(i1 [[A]])
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %s0 = ashr i64 %v1, 3
+  %s1 = ashr i64 %v2, 3
+  %r = add i64 %s0, %s1
+  %a = icmp ult i64 %r, 1152921504606846976
+  call void @llvm.assume(i1 %a)
+  ret i64 %r
+}

--- a/llvm/test/Transforms/InstCombine/binop-itofp.ll
+++ b/llvm/test/Transforms/InstCombine/binop-itofp.ll
@@ -659,10 +659,10 @@ define half @test_si_si_i16_mul_fail_overflow(i16 noundef %x_in, i16 noundef %y_
 
 define half @test_si_si_i16_mul_C_fail_overflow(i16 noundef %x_in) {
 ; CHECK-LABEL: @test_si_si_i16_mul_C_fail_overflow(
-; CHECK-NEXT:    [[X:%.*]] = or i16 [[X_IN:%.*]], -129
+; CHECK-NEXT:    [[X1:%.*]] = shl i16 [[X_IN:%.*]], 7
+; CHECK-NEXT:    [[X:%.*]] = or i16 [[X1]], -16512
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i16 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 1.280000e+02
-; CHECK-NEXT:    ret half [[R]]
+; CHECK-NEXT:    ret half [[XF]]
 ;
   %x = or i16 %x_in, -129
   %xf = sitofp i16 %x to half


### PR DESCRIPTION
Stacks on top of #212594 

We can turn
```
%s0 = ashr exact %v0, N
%s1 = ashr exact %v1, N
%r  = add %s0, %s1
```
into
```
%a = add %v0, %v1
%r = ashr %a, N
```
If %v0 + %v1 never wraps. The right shift could either be logical or arithmetic

Alive proofs:
  - https://alive2.llvm.org/ce/z/mRBMwC
  - https://alive2.llvm.org/ce/z/p4n-kA