### PR TITLE
[libc] Add missing type dependencies to sys_types header target

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -877,16 +877,23 @@ add_header_macro(
   sys/types.h
   DEPENDS
     .llvm_libc_common_h
+    .llvm-libc-types.__off_t
+    .llvm-libc-types.__off64_t
+    .llvm-libc-types.__uint64_t
     .llvm-libc-types.blkcnt_t
     .llvm-libc-types.blksize_t
+    .llvm-libc-types.caddr_t
     .llvm-libc-types.clockid_t
     .llvm-libc-types.dev_t
     .llvm-libc-types.gid_t
+    .llvm-libc-types.id_t
+    .llvm-libc-types.ino64_t
     .llvm-libc-types.ino_t
     .llvm-libc-types.key_t
     .llvm-libc-types.loff_t
     .llvm-libc-types.mode_t
     .llvm-libc-types.nlink_t
+    .llvm-libc-types.off64_t
     .llvm-libc-types.off_t
     .llvm-libc-types.pid_t
     .llvm-libc-types.pthread_attr_t
@@ -901,9 +908,17 @@ add_header_macro(
     .llvm-libc-types.suseconds_t
     .llvm-libc-types.time_t
     .llvm-libc-types.u_char
+    .llvm-libc-types.u_int
+    .llvm-libc-types.u_int16_t
     .llvm-libc-types.u_int32_t
+    .llvm-libc-types.u_int8_t
+    .llvm-libc-types.u_long
+    .llvm-libc-types.u_short
     .llvm-libc-types.uid_t
     .llvm-libc-types.uint
+    .llvm-libc-types.ulong
+    .llvm-libc-types.useconds_t
+    .llvm-libc-types.ushort
 )
 
 add_header_macro(


### PR DESCRIPTION
Add missing type dependencies to the sys_types header target in libc/include/CMakeLists.txt for types defined in sys/types.yaml, including __off_t, __off64_t, __uint64_t, off64_t, and BSD/System V types added in commit 39df67d0edef.

Without these DEPENDS entries, CMake and Ninja do not copy the corresponding type headers into the build and install directories, causing missing header includes (e.g. __off64_t.h) when consuming generated <sys/types.h>.

Assisted-by: Automated tooling, human reviewed.