### PR TITLE
[AArch64] Relax SDep requirement for AppleSMECompute clustering     

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp
@@ -674,12 +674,23 @@ static bool shouldScheduleAdjacent(const TargetInstrInfo &TII,
                                    const MachineInstr *FirstMI,
                                    const MachineInstr &SecondMI,
                                    const SDep *Dep) {
-  if (isNonDataDep(Dep))
-    return false;
   const AArch64Subtarget &ST = static_cast<const AArch64Subtarget&>(TSI);
+  const TargetRegisterInfo *TRI = TSI.getRegisterInfo();
 
   // All checking functions assume that the 1st instr is a wildcard if it is
   // unspecified.
+
+  // FuseAppleSMECompute does not require a specific dependency kind
+  if (ST.hasFuseAppleSMECompute() &&
+      isAppleSMEComputePair(FirstMI, SecondMI, TII, TRI)) {
+    ++NumFusedAppleSMECompute;
+    return true;
+  }
+
+  // All the other fusions require RAW dependency
+  if (isNonDataDep(Dep))
+    return false;
+
   if (ST.hasCmpBccFusion() || ST.hasArithmeticBccFusion()) {
     bool CmpOnly = !ST.hasArithmeticBccFusion();
     if (isArithmeticBccPair(FirstMI, SecondMI, CmpOnly)) {
@@ -730,12 +741,6 @@ static bool shouldScheduleAdjacent(const TargetInstrInfo &TII,
   if (ST.hasFuseAddSub2RegAndConstOne() &&
       isAddSub2RegAndConstOnePair(FirstMI, SecondMI)) {
     ++NumFusedAddSub2RegAndConstOne;
-    return true;
-  }
-  const TargetRegisterInfo *TRI = TSI.getRegisterInfo();
-  if (ST.hasFuseAppleSMECompute() &&
-      isAppleSMEComputePair(FirstMI, SecondMI, TII, TRI)) {
-    ++NumFusedAppleSMECompute;
     return true;
   }
   if (ST.hasFuseFMinFMax() && isFMinFMaxPair(FirstMI, SecondMI)) {

--- a/llvm/test/CodeGen/AArch64/misched-fusion-apple-sme-compute.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-apple-sme-compute.mir
@@ -179,3 +179,23 @@ body:             |
     $za = FMLA_VG2_M2ZZ_S $za, $w8, 0, $z0_z1, $z2
     RET undef $lr
 ...
+
+## SME fusion doesnt require RAW dependency. This is a representative test case for Z write
+
+# CHECK-LABEL: fuse_non_raw
+# CHECK: SU({{[0-9]+}}): $z0 = ADD_ZZZ_S $z1, $z2
+# CHECK: Successors:
+# FUSE: SU({{[0-9]+}}): Ord  Latency={{[0-9]+}} Cluster
+# NOFUSE-NOT: SU({{[0-9]+}}): Ord  Latency={{[0-9]+}} Cluster
+# CHECK: SU({{[0-9]+}}): $z0 = ADD_ZZZ_S $z3, $z4
+---
+name:            fuse_non_raw
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $z1, $z2, $z3, $z4, $w2
+    $z0 = ADD_ZZZ_S $z1, $z2
+    $w3 = ORRWri $w2, 4096
+    $z0 = ADD_ZZZ_S $z3, $z4
+    RET undef $lr
+...


### PR DESCRIPTION
Do not require RAW dependency for FuseAppleSMECompute.