### PR TITLE
[VPlan] Prepare replaceSymbolicStrides to handle plain CFG (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2656,14 +2656,18 @@ void VPlanTransforms::replaceSymbolicStrides(
     const VPDominatorTree &VPDT) {
   // Replace VPValues for known constant strides guaranteed by predicated scalar
   // evolution that are guaranteed to be guarded by the runtime checks; that is,
-  // blocks dominated by the vector preheader.
+  // blocks dominated by the vector header.
   assert(!Plan.getVectorLoopRegion() &&
          "expected to run before loop regions are created");
-  VPBlockBase *Preheader = Plan.getEntry()->getSuccessors()[1];
-  auto CanUseVersionedStride = [&VPDT, Preheader](VPUser &U, unsigned) {
+  const auto &[Header, _] = VPBlockUtils::getPlainCFGHeaderAndLatch(Plan);
+  auto CanUseVersionedStride = [&VPDT, Header = Header, &Plan](VPUser &U,
+                                                               unsigned Idx) {
     auto *R = cast<VPRecipeBase>(&U);
-    VPBlockBase *Parent = R->getParent();
-    return VPDT.dominates(Preheader, Parent);
+    // Skip phis if the loop if loop is not yet guarded.
+    if (isa<VPPhiAccessors>(R) &&
+        Header == Plan.getEntry()->getSingleSuccessor())
+      return false;
+    return VPDT.dominates(Header, R->getParent());
   };
   ValueToSCEVMapTy RewriteMap;
   for (const SCEV *Stride : StridesMap.values()) {

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -673,8 +673,12 @@ bool VPBlockUtils::isLatch(const VPBlockBase *VPB,
 
 std::pair<VPBasicBlock *, VPBasicBlock *>
 VPBlockUtils::getPlainCFGHeaderAndLatch(const VPlan &Plan) {
-  auto *Header = cast<VPBasicBlock>(
-      Plan.getEntry()->getSuccessors()[1]->getSingleSuccessor());
+  VPBasicBlock *Header = cast<VPBasicBlock>(
+      Plan.getEntry()->getNumSuccessors() == 1
+          ? Plan.getEntry()->getSingleSuccessor()
+          : Plan.getEntry()->getSuccessors()[1]->getSingleSuccessor());
+  assert(Header->getNumPredecessors() == 2 &&
+         "Header must have exactly 2  predecessors");
   auto *Latch = cast<VPBasicBlock>(Header->getPredecessors()[1]);
   return {Header, Latch};
 }


### PR DESCRIPTION
Update replaceSymbolicStrides to use general getPlainCFGHeaderAndLatch helper to make it more robust w.r.t. to pipeline changes.

Also tighten check for phis to skip replacement if loop executes unconditionally.