### PR TITLE
[include-cleaner] Support ObjC interface and protocol declarations in LocateSymbol

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/LocateSymbol.cpp
+++ b/clang-tools-extra/include-cleaner/lib/LocateSymbol.cpp
@@ -7,14 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "AnalysisInternal.h"
+#include "TypesInternal.h"
 #include "clang-include-cleaner/Types.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/Support/Casting.h"
-#include <utility>
+#include "llvm/Support/ErrorHandling.h"
 #include <vector>
 
 namespace clang::include_cleaner {
@@ -26,13 +28,19 @@ template <typename T> Hints completeIfDefinition(T *D) {
 }
 
 Hints declHints(const Decl *D) {
-  // Definition is only needed for classes and templates for completeness.
+  // For C++, definition is only needed for classes and templates for
+  // completeness. For Objective-C, definition is needed for classes and
+  // protocols. TagDecl covers enums and structs.
   if (auto *TD = llvm::dyn_cast<TagDecl>(D))
     return completeIfDefinition(TD);
   else if (auto *CTD = llvm::dyn_cast<ClassTemplateDecl>(D))
     return completeIfDefinition(CTD);
   else if (auto *FTD = llvm::dyn_cast<FunctionTemplateDecl>(D))
     return completeIfDefinition(FTD);
+  else if (auto *OID = llvm::dyn_cast<ObjCInterfaceDecl>(D))
+    return completeIfDefinition(OID);
+  else if (auto *OPD = llvm::dyn_cast<ObjCProtocolDecl>(D))
+    return completeIfDefinition(OPD);
   // Any other declaration is assumed usable.
   return Hints::CompleteSymbol;
 }

--- a/clang-tools-extra/include-cleaner/unittests/LocateSymbolTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/LocateSymbolTest.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Testing/Annotations/Annotations.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <cassert>
 #include <tuple>
 #include <vector>
 
@@ -46,7 +47,12 @@ public:
   LocateExample(llvm::StringRef AnnotatedCode)
       : Target(AnnotatedCode), AST([this] {
           TestInputs Inputs(Target.code());
-          Inputs.ExtraArgs.push_back("-std=c++17");
+          if (Target.code().starts_with("@")) {
+            Inputs.ExtraArgs.push_back("-x");
+            Inputs.ExtraArgs.push_back("objective-c");
+          } else {
+            Inputs.ExtraArgs.push_back("-std=c++17");
+          }
           return Inputs;
         }()) {}
 
@@ -161,9 +167,13 @@ TEST(LocateSymbol, CompleteSymbolHint) {
   {
     // Completeness is only absent in cases that matters.
     const llvm::StringLiteral Cases[] = {
+        "enum ^foo : int; enum ^foo : int {};",
+        "enum class ^foo; enum class ^foo {};",
         "struct ^foo; struct ^foo {};",
         "template <typename> struct ^foo; template <typename> struct ^foo {};",
         "template <typename> void ^foo(); template <typename> void ^foo() {};",
+        "@class ^foo; @interface ^foo @end",
+        "@protocol ^foo; @protocol ^foo @end",
     };
     for (auto &Case : Cases) {
       SCOPED_TRACE(Case);


### PR DESCRIPTION
Treats forward declarations of Objective-C interfaces (ObjCInterfaceDecl) and protocols (ObjCProtocolDecl) as incomplete, allowing the symbol locator to prefer their definitions. 

Also updates the unit tests to support Objective-C and adds test cases for these declarations.

Also update the unit tests for forward declarations of enums and enum classes.