### PR TITLE
[Driver] Enable --build-id by default (ENABLE_LINKER_BUILD_ID=ON)

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -275,7 +275,7 @@ if(CLANG_USE_XCSELECT)
   endif()
 endif()
 
-set(ENABLE_LINKER_BUILD_ID OFF CACHE BOOL "pass --build-id to ld")
+set(ENABLE_LINKER_BUILD_ID ON CACHE BOOL "pass --build-id to ld")
 
 set(ENABLE_X86_RELAX_RELOCATIONS ON CACHE BOOL
     "enable x86 relax relocations by default")

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -146,6 +146,12 @@ features cannot lower the translation-unit ABI level;
 
 ### Non-comprehensive list of changes in this release
 
+- Clang now passes `--build-id` to the linker by default on the Linux,
+  GNU/Hurd, Managarm, and OHOS toolchains, matching the configuration used by
+  most Linux distributions and by distribution GCC (`--enable-linker-build-id`).
+  The `ENABLE_LINKER_BUILD_ID` CMake option now defaults to `ON`; set it to
+  `OFF` to restore the previous behavior.
+
 ### New Compiler Flags
 
 - New option `-fdefined-pointer-subtraction` added to preserve stable semantics


### PR DESCRIPTION
Flip the ENABLE_LINKER_BUILD_ID CMake option to default ON, so Clang passes --build-id to the linker by default on the Linux, GNU/Hurd, Managarm, and OHOS toolchains. Set ENABLE_LINKER_BUILD_ID=OFF to restore the previous behavior.

This reverses the default established in 2016 by
https://github.com/llvm/llvm-project/commit/5ed89d4a010633b18af151c3e1a195f8cb8882ea

The concern then was that build-is is "fairly expensive" in the edit/build lifecycle; however that seems to be larely moot today, as lld defaults to a fast build-id and overhead is negligible.

In practice, every major Linux distribution already turns this on, so the default OFF is mainly a surprise for anyone who builds from source themselves.

 - Fedora:            -DENABLE_LINKER_BUILD_ID:BOOL=ON  ([llvm.spec](https://src.fedoraproject.org/rpms/llvm/blob/rawhide/f/llvm.spec#_321))
 - CentOS Stream/RHEL: -DENABLE_LINKER_BUILD_ID:BOOL=ON (llvm.spec)
 - Debian/Ubuntu:     -DENABLE_LINKER_BUILD_ID=ON (debian/rules)

build-id is relied on by debuginfod, RPM/dpkg debuginfo extraction, core-dump symbolization, and profilers.

Assisted-by: Claude