### PR TITLE
[mlir][acc] Add pass to emit remarks for openacc data mapping

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -211,6 +211,14 @@ def ACCEmitRemarksPrivate
   let dependentDialects = ["mlir::acc::OpenACCDialect"];
 }
 
+def ACCEmitRemarksData : Pass<"acc-emit-remarks-data", "mlir::func::FuncOp"> {
+  let summary = "Emit OpenACC data-mapping remarks";
+  let description = [{
+    This pass emits remarks describing the data clauses associated
+    with OpenACC data constructs and unstructured data directives.
+  }];
+}
+
 def ACCLoopTiling : Pass<"acc-loop-tiling", "mlir::func::FuncOp"> {
   let summary = "Tile OpenACC loops with tile clauses";
   let description = [{

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksData.cpp
@@ -1,0 +1,267 @@
+//===- ACCEmitRemarksData.cpp - Emit OpenACC data-mapping remarks --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass emits optimization remarks describing OpenACC data-mapping clauses
+// associated with structured and unstructured data constructs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenACC/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir {
+namespace acc {
+#define GEN_PASS_DEF_ACCEMITREMARKSDATA
+#include "mlir/Dialect/OpenACC/Transforms/Passes.h.inc"
+} // namespace acc
+} // namespace mlir
+
+#define DEBUG_TYPE "acc-emit-remarks-data"
+
+using namespace mlir;
+
+namespace {
+
+static bool isStructuredDeclareEnter(acc::DeclareEnterOp op) {
+  return !op.getToken().getUsers().empty();
+}
+
+static StringRef getDataClauseRemarkPrefix(Operation *dataClauseOp) {
+  std::optional<acc::DataClause> clause = acc::getDataClause(dataClauseOp);
+  if (!clause)
+    return {};
+
+  switch (*clause) {
+  case acc::DataClause::acc_copyin:
+    return "copyin(";
+  case acc::DataClause::acc_copyin_readonly:
+    return "copyin(readonly:";
+  case acc::DataClause::acc_copy:
+    return "copy(";
+  case acc::DataClause::acc_copyout:
+    return "copyout(";
+  case acc::DataClause::acc_copyout_zero:
+    return "copyout(zero:";
+  case acc::DataClause::acc_present:
+    return "present(";
+  case acc::DataClause::acc_create:
+    return "create(";
+  case acc::DataClause::acc_create_zero:
+    return "create(zero:";
+  case acc::DataClause::acc_delete:
+    return "delete(";
+  case acc::DataClause::acc_attach:
+    return "attach(";
+  case acc::DataClause::acc_detach:
+    return "detach(";
+  case acc::DataClause::acc_no_create:
+    return "no_create(";
+  case acc::DataClause::acc_private:
+    return "private(";
+  case acc::DataClause::acc_firstprivate:
+    return "firstprivate(";
+  case acc::DataClause::acc_deviceptr:
+    return "deviceptr(";
+  case acc::DataClause::acc_update_host:
+    return "update_host(";
+  case acc::DataClause::acc_update_self:
+    return "update_self(";
+  case acc::DataClause::acc_update_device:
+    return "update_device(";
+  case acc::DataClause::acc_use_device:
+    return "use_device(";
+  case acc::DataClause::acc_reduction:
+    return isa<acc::CopyinOp>(dataClauseOp) ? "copy(" : "reduction(";
+  case acc::DataClause::acc_declare_device_resident:
+    return "device_resident(";
+  case acc::DataClause::acc_declare_link:
+    return "link(";
+  case acc::DataClause::acc_cache:
+    return "cache(";
+  case acc::DataClause::acc_cache_readonly:
+    return "cache(readonly:";
+  case acc::DataClause::acc_getdeviceptr:
+    return "";
+  }
+  llvm_unreachable("Unhandled data clause");
+}
+
+static bool shouldReport(Operation *op, acc::OpenACCSupport &accSupport,
+                         std::string &varName) {
+  if (!isa_and_nonnull<ACC_DATA_CLAUSE_OPS>(op))
+    return false;
+  if (getDataClauseRemarkPrefix(op).empty())
+    return false;
+  if (op->getNumResults() == 0)
+    return false;
+  varName = accSupport.getVariableName(op->getResult(0));
+  // Not useful to report if the variable name is empty.
+  return !varName.empty();
+}
+
+static bool reportOnSameLine(Operation *lhs, Operation *rhs) {
+  return acc::getDataClause(lhs) == acc::getDataClause(rhs) &&
+         acc::getImplicitFlag(lhs) == acc::getImplicitFlag(rhs);
+}
+
+static bool reportIfNotPresent(Operation *op) {
+  switch (acc::getDataClause(op).value()) {
+  case acc::DataClause::acc_copyin:
+  case acc::DataClause::acc_copyin_readonly:
+  case acc::DataClause::acc_copyout:
+  case acc::DataClause::acc_copyout_zero:
+  case acc::DataClause::acc_copy:
+  case acc::DataClause::acc_create:
+  case acc::DataClause::acc_create_zero:
+  case acc::DataClause::acc_no_create:
+    return true;
+  case acc::DataClause::acc_present:
+  case acc::DataClause::acc_delete:
+  case acc::DataClause::acc_attach:
+  case acc::DataClause::acc_detach:
+  case acc::DataClause::acc_private:
+  case acc::DataClause::acc_firstprivate:
+  case acc::DataClause::acc_deviceptr:
+  case acc::DataClause::acc_getdeviceptr:
+  case acc::DataClause::acc_update_host:
+  case acc::DataClause::acc_update_self:
+  case acc::DataClause::acc_update_device:
+  case acc::DataClause::acc_use_device:
+  case acc::DataClause::acc_declare_device_resident:
+  case acc::DataClause::acc_declare_link:
+  case acc::DataClause::acc_cache:
+  case acc::DataClause::acc_cache_readonly:
+    return false;
+  case acc::DataClause::acc_reduction:
+    return isa<acc::CopyinOp>(op);
+  }
+  llvm_unreachable("Unhandled data clause");
+}
+
+static void emitDataMappingRemarks(ValueRange mappingOperands,
+                                   StringRef directivePrefix,
+                                   acc::OpenACCSupport &accSupport) {
+  if (mappingOperands.empty())
+    return;
+
+  // Collect reportable ops with their variable names once so sorting and
+  // remark formatting do not recompute them.
+  struct MappingInfo {
+    Operation *op;
+    std::string varName;
+  };
+  SmallVector<MappingInfo, 8> mappingOps;
+  mappingOps.reserve(mappingOperands.size());
+  for (Value operand : mappingOperands) {
+    Operation *defOp = operand.getDefiningOp();
+    std::string varName;
+    if (!shouldReport(defOp, accSupport, varName))
+      continue;
+    mappingOps.push_back({defOp, std::move(varName)});
+  }
+  if (mappingOps.empty())
+    return;
+
+  llvm::sort(mappingOps, [](const MappingInfo &lhs, const MappingInfo &rhs) {
+    acc::DataClause lhsClause = acc::getDataClause(lhs.op).value();
+    acc::DataClause rhsClause = acc::getDataClause(rhs.op).value();
+    if (lhsClause == rhsClause) {
+      bool lhsImplicit = acc::getImplicitFlag(lhs.op);
+      bool rhsImplicit = acc::getImplicitFlag(rhs.op);
+      if (lhsImplicit == rhsImplicit)
+        return lhs.varName < rhs.varName;
+      return lhsImplicit < rhsImplicit;
+    }
+    return lhsClause < rhsClause;
+  });
+
+  for (auto *it = mappingOps.begin(); it != mappingOps.end(); ++it) {
+    Operation *op = it->op;
+
+    SmallVector<MappingInfo *, 4> groupedOps = {it};
+    while (std::next(it) != mappingOps.end() &&
+           reportOnSameLine(op, std::next(it)->op)) {
+      ++it;
+      groupedOps.push_back(it);
+    }
+
+    // Anchor the remark on the data-clause op so its source location is used.
+    accSupport.emitRemark(
+        op,
+        [&]() {
+          std::string message = "Generating ";
+          message += directivePrefix.str();
+          if (op->getAttr(acc::getFromDefaultClauseAttrName()))
+            message += "default ";
+          else if (acc::getImplicitFlag(op))
+            message += "implicit ";
+          message += getDataClauseRemarkPrefix(op).str();
+          message += groupedOps.front()->varName;
+          for (MappingInfo *grouped : llvm::drop_begin(groupedOps)) {
+            message += ", ";
+            message += grouped->varName;
+          }
+          message += ")";
+          if (reportIfNotPresent(op))
+            message += " [if not already present]";
+          return message;
+        },
+        DEBUG_TYPE);
+  }
+}
+
+class ACCEmitRemarksData
+    : public acc::impl::ACCEmitRemarksDataBase<ACCEmitRemarksData> {
+public:
+  using ACCEmitRemarksDataBase<ACCEmitRemarksData>::ACCEmitRemarksDataBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+
+    auto cachedAnalysis = getCachedParentAnalysis<acc::OpenACCSupport>();
+    acc::OpenACCSupport &accSupport = cachedAnalysis
+                                          ? cachedAnalysis->get()
+                                          : getAnalysis<acc::OpenACCSupport>();
+
+    // Remark emission policy:
+    // - update / enter (structured or unstructured): report
+    // - exit: only unstructured (structured exit was covered at enter)
+    // - declare: only structured declare enter; unstructured declare
+    //   registration does not emit mapping remarks.
+    func.walk([&](Operation *op) {
+      TypeSwitch<Operation *>(op)
+          .Case<acc::DataOp, acc::KernelEnvironmentOp>([&](auto dataOp) {
+            emitDataMappingRemarks(dataOp.getDataClauseOperands(), "",
+                                   accSupport);
+          })
+          .Case<acc::EnterDataOp>([&](acc::EnterDataOp enterOp) {
+            emitDataMappingRemarks(enterOp.getDataClauseOperands(),
+                                   "enter data ", accSupport);
+          })
+          .Case<acc::ExitDataOp>([&](acc::ExitDataOp exitOp) {
+            emitDataMappingRemarks(exitOp.getDataClauseOperands(), "exit data ",
+                                   accSupport);
+          })
+          .Case<acc::UpdateOp>([&](acc::UpdateOp updateOp) {
+            emitDataMappingRemarks(updateOp.getDataClauseOperands(), "",
+                                   accSupport);
+          })
+          .Case<acc::DeclareEnterOp>([&](acc::DeclareEnterOp declareEnterOp) {
+            if (isStructuredDeclareEnter(declareEnterOp))
+              emitDataMappingRemarks(declareEnterOp.getDataClauseOperands(), "",
+                                     accSupport);
+          });
+    });
+  }
+};
+
+} // namespace

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCEmitRemarksData.cpp
@@ -1,4 +1,4 @@
-//===- ACCEmitRemarksData.cpp - Emit OpenACC data-mapping remarks --------===//
+//===- ACCEmitRemarksData.cpp - Emit OpenACC data-mapping remarks ---------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIROpenACCTransforms
   ACCDeclareGPUModuleInsertion.cpp
   ACCEmitRemarksLoop.cpp
   ACCEmitRemarksPrivate.cpp
+  ACCEmitRemarksData.cpp
   ACCIfClauseLowering.cpp
   ACCImplicitData.cpp
   ACCRecipeMaterialization.cpp

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-data.mlir
@@ -1,0 +1,323 @@
+// RUN: mlir-opt %s -acc-emit-remarks-data --remarks-filter="(open)?acc.*" 2>&1 | FileCheck %s
+
+// Remarks are emitted in function order, and within a data construct they are
+// ordered by data clause, then by implicitness, then by variable name.
+// SSA names describe the clause; the `name` attribute is the source identifier
+// that appears in the remark (short Fortran-style names, unique per function).
+
+acc.private.recipe @privatization_memref_f32 : memref<f32> init {
+^bb0(%arg0: memref<f32>):
+  %0 = memref.alloca() : memref<f32>
+  acc.yield %0 : memref<f32>
+}
+
+acc.firstprivate.recipe @firstprivatization_memref_f32 : memref<f32> init {
+^bb0(%arg0: memref<f32>):
+  %0 = memref.alloca() : memref<f32>
+  acc.yield %0 : memref<f32>
+} copy {
+^bb0(%arg0: memref<f32>, %arg1: memref<f32>):
+  %0 = memref.load %arg0[] : memref<f32>
+  memref.store %0, %arg1[] : memref<f32>
+  acc.terminator
+}
+
+acc.reduction.recipe @reduction_add_memref_f32 : memref<f32>
+    reduction_operator <add> init {
+^bb0(%arg0: memref<f32>):
+  %cst = arith.constant 0.0 : f32
+  %0 = memref.alloca() : memref<f32>
+  memref.store %cst, %0[] : memref<f32>
+  acc.yield %0 : memref<f32>
+} combiner {
+^bb0(%arg0: memref<f32>, %arg1: memref<f32>):
+  %0 = memref.load %arg0[] : memref<f32>
+  %1 = memref.load %arg1[] : memref<f32>
+  %2 = arith.addf %0, %1 : f32
+  memref.store %2, %arg0[] : memref<f32>
+  acc.yield %arg0 : memref<f32>
+}
+
+func.func @structured_data(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>,
+    %arg3: memref<f32>, %arg4: memref<f32>, %arg5: memref<f32>,
+    %arg6: memref<f32>, %arg7: memref<f32>, %arg8: memref<f32>,
+    %arg9: memref<f32>, %arg10: memref<f32>, %arg11: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyin(a) [if not already present]"
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyin(readonly:b) [if not already present]"
+  %copyin_readonly = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copy(c) [if not already present]"
+  %copy = acc.copyin varPtr(%arg2 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_copy>, name = "c"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyout(d) [if not already present]"
+  %copyout = acc.create varPtr(%arg3 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_copyout>, name = "d"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyout(zero:e) [if not already present]"
+  %copyout_zero = acc.create varPtr(%arg4 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_copyout_zero>, name = "e"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating present(f)"
+  %present = acc.present varPtr(%arg5 : memref<f32>) -> memref<f32>
+      {name = "f"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating create(g) [if not already present]"
+  %create = acc.create varPtr(%arg6 : memref<f32>) -> memref<f32>
+      {name = "g"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating create(zero:h) [if not already present]"
+  %create_zero = acc.create varPtr(%arg7 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_create_zero>, name = "h"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating attach(i)"
+  %attach = acc.attach varPtr(%arg8 : memref<f32>) -> memref<f32>
+      {name = "i"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating no_create(j) [if not already present]"
+  %no_create = acc.nocreate varPtr(%arg9 : memref<f32>) -> memref<f32>
+      {name = "j"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating deviceptr(k)"
+  %deviceptr = acc.deviceptr varPtr(%arg10 : memref<f32>) -> memref<f32>
+      {name = "k"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copy(l) [if not already present]"
+  %reduction_copy = acc.copyin varPtr(%arg11 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_reduction>, name = "l"}
+  acc.data dataOperands(%copyin, %copyin_readonly, %copy, %copyout,
+      %copyout_zero, %present, %create, %create_zero, %attach, %no_create,
+      %deviceptr, %reduction_copy : memref<f32>, memref<f32>, memref<f32>,
+      memref<f32>, memref<f32>, memref<f32>, memref<f32>, memref<f32>,
+      memref<f32>, memref<f32>, memref<f32>, memref<f32>) {
+    acc.terminator
+  }
+  return
+}
+
+// Each data construct in a function is reported independently.
+func.func @multiple_data_constructs(%arg0: memref<f32>, %arg1: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=multiple_data_constructs | Remark="Generating copyin(a) [if not already present]"
+  %copyin0 = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  acc.data dataOperands(%copyin0 : memref<f32>) {
+    acc.terminator
+  }
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=multiple_data_constructs | Remark="Generating copyin(b) [if not already present]"
+  %copyin1 = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {name = "b"}
+  acc.data dataOperands(%copyin1 : memref<f32>) {
+    acc.terminator
+  }
+  return
+}
+
+// A kernel environment holds the data clauses of an outlined compute construct
+// and thus accepts any kind of data clause operation.
+func.func @kernel_environment(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>,
+    %arg3: memref<f32>, %arg4: memref<f32>, %arg5: memref<f32>,
+    %arg6: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating copyin(a) [if not already present]"
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating private(b)"
+  %private = acc.private varPtr(%arg1 : memref<f32>)
+      recipe(@privatization_memref_f32) -> memref<f32> {name = "b"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating firstprivate(c)"
+  %firstprivate = acc.firstprivate varPtr(%arg2 : memref<f32>)
+      recipe(@firstprivatization_memref_f32) -> memref<f32> {name = "c"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating use_device(d)"
+  %use_device = acc.use_device varPtr(%arg3 : memref<f32>) -> memref<f32>
+      {name = "d"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating reduction(e)"
+  %reduction = acc.reduction varPtr(%arg4 : memref<f32>)
+      recipe(@reduction_add_memref_f32) -> memref<f32> {name = "e"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating cache(f)"
+  %cache = acc.cache varPtr(%arg5 : memref<f32>) -> memref<f32>
+      {name = "f"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating cache(readonly:g)"
+  %cache_readonly = acc.cache varPtr(%arg6 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_cache_readonly>, name = "g"}
+  acc.kernel_environment dataOperands(%copyin, %private, %firstprivate,
+      %use_device, %reduction, %cache, %cache_readonly : memref<f32>,
+      memref<f32>, memref<f32>, memref<f32>, memref<f32>, memref<f32>,
+      memref<f32>) {
+    acc.compute_region {
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}
+
+// A declare enter whose token is used is structured and is reported.
+func.func @structured_declare(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_declare | Remark="Generating create(a) [if not already present]"
+  %create = acc.create varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_declare | Remark="Generating device_resident(b)"
+  %device_resident = acc.declare_device_resident varPtr(%arg1 : memref<f32>)
+      -> memref<f32> {name = "b"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_declare | Remark="Generating link(c)"
+  %link = acc.declare_link varPtr(%arg2 : memref<f32>) -> memref<f32>
+      {name = "c"}
+  %token = acc.declare_enter dataOperands(%create, %device_resident, %link
+      : memref<f32>, memref<f32>, memref<f32>)
+  acc.declare_exit token(%token) dataOperands(%create : memref<f32>)
+  acc.delete accPtr(%create : memref<f32>)
+      {dataClause = #acc<data_clause acc_create>}
+  return
+}
+
+// Unstructured directives get a directive name in the remark.
+func.func @enter_data(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=enter_data | Remark="Generating enter data copyin(a) [if not already present]"
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=enter_data | Remark="Generating enter data create(b) [if not already present]"
+  %create = acc.create varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {name = "b"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=enter_data | Remark="Generating enter data attach(c)"
+  %attach = acc.attach varPtr(%arg2 : memref<f32>) -> memref<f32>
+      {name = "c"}
+  acc.enter_data dataOperands(%copyin, %create, %attach
+      : memref<f32>, memref<f32>, memref<f32>)
+  return
+}
+
+func.func @exit_data(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=exit_data | Remark="Generating exit data copyout(a) [if not already present]"
+  %copyout = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_copyout>, name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=exit_data | Remark="Generating exit data delete(b)"
+  %delete = acc.getdeviceptr varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_delete>, name = "b"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=exit_data | Remark="Generating exit data detach(c)"
+  %detach = acc.getdeviceptr varPtr(%arg2 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_detach>, name = "c"}
+  acc.exit_data dataOperands(%copyout, %delete, %detach
+      : memref<f32>, memref<f32>, memref<f32>)
+  acc.copyout accPtr(%copyout : memref<f32>) to varPtr(%arg0 : memref<f32>)
+  acc.delete accPtr(%delete : memref<f32>)
+  acc.detach accPtr(%detach : memref<f32>)
+  return
+}
+
+// An update directive does not get a directive name in the remark.
+func.func @update(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=update | Remark="Generating update_host(a)"
+  %update_host = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_update_host>, name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=update | Remark="Generating update_self(b)"
+  %update_self = acc.getdeviceptr varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_update_self>, name = "b"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=update | Remark="Generating update_device(c)"
+  %update_device = acc.update_device varPtr(%arg2 : memref<f32>) -> memref<f32>
+      {name = "c"}
+  acc.update dataOperands(%update_host, %update_self, %update_device
+      : memref<f32>, memref<f32>, memref<f32>)
+  acc.update_host accPtr(%update_host : memref<f32>)
+      to varPtr(%arg0 : memref<f32>)
+  acc.update_host accPtr(%update_self : memref<f32>)
+      to varPtr(%arg1 : memref<f32>)
+      {dataClause = #acc<data_clause acc_update_self>}
+  return
+}
+
+// Clauses added by the compiler are marked as implicit, and clauses that come
+// from a default clause are marked as default.
+func.func @implicit_and_default(%arg0: memref<f32>, %arg1: memref<f32>) {
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=implicit_and_default | Remark="Generating default copyin(a) [if not already present]"
+  %from_default = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {acc.from_default, name = "a"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=implicit_and_default | Remark="Generating implicit present(b)"
+  %implicit = acc.present varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {implicit = true, name = "b"}
+  acc.data dataOperands(%from_default, %implicit : memref<f32>, memref<f32>) {
+    acc.terminator
+  }
+  return
+}
+
+// Variables of the same clause and implicitness are reported together, sorted
+// by name. Explicit clauses are reported before implicit ones. The grouped
+// remark is anchored on the first op after sorting (x).
+func.func @grouping_and_sorting(
+    %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>,
+    %arg3: memref<f32>, %arg4: memref<f32>) {
+  %copyin_z = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "z"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=grouping_and_sorting | Remark="Generating copyin(x, y, z) [if not already present]"
+  %copyin_x = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
+      {name = "x"}
+  %copyin_y = acc.copyin varPtr(%arg2 : memref<f32>) -> memref<f32>
+      {name = "y"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=grouping_and_sorting | Remark="Generating implicit copyin(i) [if not already present]"
+  %copyin_i = acc.copyin varPtr(%arg3 : memref<f32>) -> memref<f32>
+      {implicit = true, name = "i"}
+  // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=grouping_and_sorting | Remark="Generating present(p)"
+  %present = acc.present varPtr(%arg4 : memref<f32>) -> memref<f32>
+      {name = "p"}
+  acc.data dataOperands(%copyin_z, %copyin_x, %copyin_y, %copyin_i, %present
+      : memref<f32>, memref<f32>, memref<f32>, memref<f32>, memref<f32>) {
+    acc.terminator
+  }
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Everything below this point must not produce any remark. Since remarks are
+// emitted in order, the check below also catches remarks emitted for any of
+// the functions that follow.
+//===----------------------------------------------------------------------===//
+
+// CHECK-NOT: Remark=
+
+// The synthetic getdeviceptr clause and clauses without a variable name are
+// not reported.
+func.func @not_reportable_clauses(%arg0: memref<f32>, %arg1: memref<f32>) {
+  %synthetic = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "synthetic"}
+  %unnamed = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
+  acc.data dataOperands(%synthetic, %unnamed : memref<f32>, memref<f32>) {
+    acc.terminator
+  }
+  return
+}
+
+// A data construct without data clauses is not reported.
+func.func @default_only_data() {
+  acc.data {
+    acc.terminator
+  } attributes {defaultAttr = #acc<defaultvalue none>}
+  return
+}
+
+// A declare enter whose token is unused registers the variables for the whole
+// program instead of a region, and is not reported.
+func.func @unstructured_declare(%arg0: memref<f32>) {
+  %create = acc.create varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  acc.declare_enter dataOperands(%create : memref<f32>)
+  return
+}
+
+// A declare exit is never reported - for a structured declare the variables
+// are reported at the declare enter, and an unstructured declare exit only
+// unregisters variables.
+func.func @declare_exit(%arg0: memref<f32>) {
+  %delete = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {dataClause = #acc<data_clause acc_delete>, name = "a"}
+  acc.declare_exit dataOperands(%delete : memref<f32>)
+  acc.delete accPtr(%delete : memref<f32>)
+  return
+}
+
+// Data clauses on a compute construct are not reported by this pass - they are
+// reported once they are outlined into a kernel environment.
+func.func @compute_construct(%arg0: memref<f32>) {
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
+      {name = "a"}
+  acc.parallel dataOperands(%copyin : memref<f32>) {
+    acc.yield
+  }
+  return
+}


### PR DESCRIPTION
This pass emits MLIR remarks for all OpenACC data mapping actions. Intended to be used when all the data actions are committed (typically right before codegen to call runtime).