### PR TITLE
[compiler-rt] [docs] Clean up explanation of `__fixunsdfdi`

### DIFF
--- a/compiler-rt/www/index.html
+++ b/compiler-rt/www/index.html
@@ -22,7 +22,7 @@
     <p><b>builtins</b> - a simple library that provides an implementation
     of the low-level target-specific hooks required by code generation and
     other runtime components.  For example, when compiling for a 32-bit target,
-    converting a double to a 64-bit unsigned integer is compiling into a runtime
+    converting a double to a 64-bit unsigned integer is compiled into a runtime
     call to the "__fixunsdfdi" function.  The builtins library provides
     optimized implementations of this and other low-level routines, either in
     target-independent C form, or as a heavily-optimized assembly.</p>

--- a/compiler-rt/www/index.html
+++ b/compiler-rt/www/index.html
@@ -22,7 +22,7 @@
     <p><b>builtins</b> - a simple library that provides an implementation
     of the low-level target-specific hooks required by code generation and
     other runtime components.  For example, when compiling for a 32-bit target,
-    converting a double to a 64-bit unsigned integer is compiled into a runtime
+    converting a double to a 64-bit unsigned integer results in a runtime
     call to the "__fixunsdfdi" function.  The builtins library provides
     optimized implementations of this and other low-level routines, either in
     target-independent C form, or as a heavily-optimized assembly.</p>


### PR DESCRIPTION
Replace "is compiling into" with "results in"