### PR TITLE
[libc][CPP] Fix ASan alloc-dealloc-mismatch in custom operator delete

### DIFF
--- a/libc/src/__support/CPP/new.cpp
+++ b/libc/src/__support/CPP/new.cpp
@@ -8,6 +8,9 @@
 
 #include "new.h"
 #include "hdr/func/free.h"
+#include "src/__support/macros/sanitizer.h"
+
+#ifndef LIBC_HAS_ADDRESS_SANITIZER
 
 void operator delete(void *mem) noexcept { ::free(mem); }
 
@@ -42,3 +45,5 @@ void operator delete[](void *mem, size_t, std::align_val_t) noexcept {
   ::free(mem);
 #endif
 }
+
+#endif // LIBC_HAS_ADDRESS_SANITIZER

--- a/libc/src/__support/CPP/new.h
+++ b/libc/src/__support/CPP/new.h
@@ -53,7 +53,9 @@ LIBC_INLINE void *operator new[](size_t, void *p) { return p; }
 // header file in all libc source files where operator delete is called ensures
 // that only libc call sites use these replacement operator delete functions.
 
-#ifndef LIBC_COMPILER_IS_MSVC
+#include "src/__support/macros/sanitizer.h"
+
+#if !defined(LIBC_COMPILER_IS_MSVC) && !defined(LIBC_HAS_ADDRESS_SANITIZER)
 #define DELETE_NAME(name)                                                      \
   __asm__(LLVM_LIBC_STRINGIFY(LIBC_NAMESPACE) "_" LLVM_LIBC_STRINGIFY(name))
 #else


### PR DESCRIPTION
Bypass custom operator delete redirection in new.h and new.cpp when building with AddressSanitizer (LIBC_HAS_ADDRESS_SANITIZER).

cpp::unique_ptr is the first heap-owning utility in src/__support/CPP/ that executes delete/delete[] expressions. Previously, new.h redirected operator delete via asm-renaming to __llvm_libc_delete (calling free()), which caused ASan to report an alloc-dealloc-mismatch (operator new vs free) when objects allocated via host operator new were deleted by cpp::unique_ptr.

Guarding the custom operator delete implementations under ASan enables ASan deallocation tracking while preserving hermetic libc behavior for non-ASan builds.

Assisted-by: Automated tooling, human reviewed.