### PR TITLE
[include-cleaner] Ensure receiver headers are kept when accessing ObjC properties

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -417,11 +417,11 @@ public:
   }
 
   bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
-    auto startLoc = E->getSelectorStartLoc();
+    auto StartLoc = E->getSelectorStartLoc();
     // Identify the selector and the method declaration
     if (auto *Method = E->getMethodDecl()) {
       // Report the method as a used symbol
-      report(startLoc, Method);
+      report(StartLoc, Method);
     }
 
     // If it's a class message, report the interface/class as used
@@ -429,19 +429,15 @@ public:
       if (auto *Interface = E->getReceiverInterface()) {
         report(E->getReceiverRange().getBegin(), Interface);
       }
-    } else {
-      if (auto *Interface = E->getReceiverInterface()) {
-        report(startLoc, Interface, RefType::Implicit);
-      }
-      QualType Type = E->getReceiverType();
-      if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
-        for (auto *Proto : ObjCPtr->quals()) {
-          report(startLoc, Proto, RefType::Implicit);
-        }
-      } else if (const auto *ObjCType = Type->getAs<ObjCObjectType>()) {
-        for (auto *Proto : ObjCType->quals()) {
-          report(startLoc, Proto, RefType::Implicit);
-        }
+      return true;
+    }
+    if (auto *Interface = E->getReceiverInterface()) {
+      report(StartLoc, Interface, RefType::Implicit);
+    }
+    QualType Type = E->getReceiverType();
+    if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
+      for (auto *Proto : ObjCPtr->quals()) {
+        report(StartLoc, Proto, RefType::Implicit);
       }
     }
     return true;
@@ -494,18 +490,6 @@ public:
       if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
         if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
           report(E->getLocation(), Interface, RefType::Implicit);
-        }
-        for (auto *Proto : ObjCPtr->quals()) {
-          report(E->getLocation(), Proto, RefType::Implicit);
-        }
-      } else if (const auto *ObjCType = Type->getAs<ObjCObjectType>()) {
-        // This is for handling `super.foo` property references.
-        if (auto *Interface = ObjCType->getInterface()) {
-          report(E->getLocation(), Interface, RefType::Implicit);
-        }
-        // The foo declaration could be in a protocol on super.
-        for (auto *Proto : ObjCType->quals()) {
-          report(E->getLocation(), Proto, RefType::Implicit);
         }
       }
     }

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -469,30 +469,6 @@ public:
       if (auto *Setter = E->getImplicitPropertySetter())
         report(E->getLocation(), Setter);
     }
-
-    // Report the receiver to ensure its declaring header is kept.
-    if (E->isObjectReceiver()) {
-      QualType Type = E->getBase()->IgnoreImpCasts()->getType();
-      if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
-        if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
-          report(E->getLocation(), Interface, RefType::Implicit);
-        }
-        for (auto *Proto : ObjCPtr->quals()) {
-          report(E->getLocation(), Proto, RefType::Implicit);
-        }
-      }
-    } else if (E->isClassReceiver()) {
-      if (auto *Interface = E->getClassReceiver()) {
-        report(E->getLocation(), Interface, RefType::Implicit);
-      }
-    } else if (E->isSuperReceiver()) {
-      QualType Type = E->getSuperReceiverType();
-      if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
-        if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
-          report(E->getLocation(), Interface, RefType::Implicit);
-        }
-      }
-    }
     return true;
   }
 

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -193,7 +193,7 @@ public:
   }
 
   bool VisitCXXConstructExpr(CXXConstructExpr *E) {
-    // Always treat consturctor calls as implicit. We'll have an explicit
+    // Always treat constructor calls as implicit. We'll have an explicit
     // reference for the constructor calls that mention the type-name (through
     // TypeLocs). This reference only matters for cases where there's no
     // explicit syntax at all or there're only braces.
@@ -416,11 +416,12 @@ public:
     return true;
   }
 
-  bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
+bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
+    auto startLoc = E->getSelectorStartLoc();
     // Identify the selector and the method declaration
     if (auto *Method = E->getMethodDecl()) {
       // Report the method as a used symbol
-      report(E->getSelectorStartLoc(), Method);
+      report(startLoc, Method);
     }
 
     // If it's a class message, report the interface/class as used
@@ -428,9 +429,24 @@ public:
       if (auto *Interface = E->getReceiverInterface()) {
         report(E->getReceiverRange().getBegin(), Interface);
       }
+    } else {
+      if (auto *Interface = E->getReceiverInterface()) {
+        report(startLoc, Interface, RefType::Implicit);
+      }
+      QualType Type = E->getReceiverType();
+      if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
+        for (auto *Proto : ObjCPtr->quals()) {
+          report(startLoc, Proto, RefType::Implicit);
+        }
+      } else if (const auto *ObjCType = Type->getAs<ObjCObjectType>()) {
+        for (auto *Proto : ObjCType->quals()) {
+          report(startLoc, Proto, RefType::Implicit);
+        }
+      }
     }
     return true;
   }
+
 
   bool VisitObjCPropertyDecl(clang::ObjCPropertyDecl *PD) {
     reportType(PD->getLocation(), PD);
@@ -460,15 +476,14 @@ public:
     }
 
     // Report the receiver to ensure its declaring header is kept.
-    if (E->isObjectReceiver()) {
+   if (E->isObjectReceiver()) {
       QualType Type = E->getBase()->IgnoreImpCasts()->getType();
       if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
         if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
           report(E->getLocation(), Interface, RefType::Implicit);
         }
-        for (const auto *Proto : ObjCPtr->quals()) {
-          report(E->getLocation(), const_cast<ObjCProtocolDecl *>(Proto),
-                 RefType::Implicit);
+        for (auto *Proto : ObjCPtr->quals()) {
+          report(E->getLocation(), Proto, RefType::Implicit);
         }
       }
     } else if (E->isClassReceiver()) {
@@ -481,9 +496,17 @@ public:
         if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
           report(E->getLocation(), Interface, RefType::Implicit);
         }
-        for (const auto *Proto : ObjCPtr->quals()) {
-          report(E->getLocation(), const_cast<ObjCProtocolDecl *>(Proto),
-                 RefType::Implicit);
+        for (auto *Proto : ObjCPtr->quals()) {
+          report(E->getLocation(), Proto, RefType::Implicit);
+        }
+      } else if (const auto *ObjCType = Type->getAs<ObjCObjectType>()) {
+        // This is for handling `super.foo` property references.
+        if (auto *Interface = ObjCType->getInterface()) {
+          report(E->getLocation(), Interface, RefType::Implicit);
+        }
+        // The foo declaration could be in a protocol on super.
+        for (auto *Proto : ObjCType->quals()) {
+          report(E->getLocation(), Proto, RefType::Implicit);
         }
       }
     }

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -416,7 +416,7 @@ public:
     return true;
   }
 
-bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
+  bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
     auto startLoc = E->getSelectorStartLoc();
     // Identify the selector and the method declaration
     if (auto *Method = E->getMethodDecl()) {
@@ -447,7 +447,6 @@ bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
     return true;
   }
 
-
   bool VisitObjCPropertyDecl(clang::ObjCPropertyDecl *PD) {
     reportType(PD->getLocation(), PD);
     return true;
@@ -476,7 +475,7 @@ bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
     }
 
     // Report the receiver to ensure its declaring header is kept.
-   if (E->isObjectReceiver()) {
+    if (E->isObjectReceiver()) {
       QualType Type = E->getBase()->IgnoreImpCasts()->getType();
       if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
         if (auto *Interface = ObjCPtr->getInterfaceDecl()) {

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -458,6 +458,35 @@ public:
       if (auto *Setter = E->getImplicitPropertySetter())
         report(E->getLocation(), Setter);
     }
+
+    // Report the receiver to ensure its declaring header is kept.
+    if (E->isObjectReceiver()) {
+      QualType Type = E->getBase()->IgnoreImpCasts()->getType();
+      if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
+        if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
+          report(E->getLocation(), Interface, RefType::Implicit);
+        }
+        for (const auto *Proto : ObjCPtr->quals()) {
+          report(E->getLocation(), const_cast<ObjCProtocolDecl *>(Proto),
+                 RefType::Implicit);
+        }
+      }
+    } else if (E->isClassReceiver()) {
+      if (auto *Interface = E->getClassReceiver()) {
+        report(E->getLocation(), Interface, RefType::Implicit);
+      }
+    } else if (E->isSuperReceiver()) {
+      QualType Type = E->getSuperReceiverType();
+      if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
+        if (auto *Interface = ObjCPtr->getInterfaceDecl()) {
+          report(E->getLocation(), Interface, RefType::Implicit);
+        }
+        for (const auto *Proto : ObjCPtr->quals()) {
+          report(E->getLocation(), const_cast<ObjCProtocolDecl *>(Proto),
+                 RefType::Implicit);
+        }
+      }
+    }
     return true;
   }
 

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -605,13 +605,45 @@ TEST(WalkAST, ObjCImplementationDeclDependsOnInterface) {
 
 TEST(WalkAST, ObjCMessageExprSelectorLoc) {
   testWalk(R"objc(
-    @interface MyClass
+    @interface $implicit^MyClass
     $explicit^- (void)doSomething;
     @end
   )objc",
            R"objc(
     void test(MyClass *obj) {
       [obj ^doSomething];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCMessageExprSelectorLocProtocol) {
+  testWalk(R"objc(
+    @protocol $implicit^MyProtocol
+    $explicit^- (void)doSomething;
+    @end
+  )objc",
+           R"objc(
+    void test(id<MyProtocol> obj) {
+      [obj ^doSomething];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCMessageExprSelectorMessageChaining) {
+  testWalk(R"objc(
+    @interface $implicit^MyClass
+    $explicit^- (void)doSomething;
+    @end
+    @interface WrapperClass
+    - (MyClass *)myClass;
+    @end
+  )objc",
+           R"objc(
+    void test(WrapperClass *obj) {
+      // Weird space avoids Annotations thinking this is a range.
+      [ [obj myClass] ^doSomething];
     }
   )objc",
            {"-x", "objective-c"});
@@ -687,6 +719,62 @@ TEST(WalkAST, ObjCPropertyRefExprExplicitSetter) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCPropertyRefExprDesugaredSetter) {
+  testWalk(R"objc(
+    @interface $implicit^MyClass
+    @property(nonatomic) int $explicit^foo;
+    @end
+  )objc",
+           R"objc(
+    void test(MyClass *obj) {
+      [obj ^setFoo:42];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprDesugaredGetter) {
+  testWalk(R"objc(
+    @interface $implicit^MyClass
+    @property(nonatomic) int $explicit^foo;
+    @end
+  )objc",
+           R"objc(
+    void test(MyClass *obj) {
+      [obj ^foo];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprDesugaredClassSetter) {
+  testWalk(R"objc(
+    @interface MyClass
+    @property(class) int $explicit^foo;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      [MyClass ^setFoo:42];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprDesugaredClassGetter) {
+  testWalk(R"objc(
+    @interface MyClass
+    @property(class) int $explicit^foo;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      [MyClass ^foo];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
 TEST(WalkAST, ObjCPropertyRefExprProtocol) {
   testWalk(R"objc(
     @protocol $implicit^MyProtocol
@@ -726,6 +814,44 @@ TEST(WalkAST, ObjCPropertyRefExprSuperReceiver) {
            R"objc(
     @implementation MyClass
     - (void)testSummary {
+      int x = super.^foo;
+    }
+    @end
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprClassSuperReceiver) {
+  testWalk(R"objc(
+    @interface $implicit^ParentClass
+    @property(class, nonatomic) int $explicit^foo;
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    + (void)testSummary {
+      int x = super.^foo;
+    }
+    @end
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprClassSuperProtocolReceiver) {
+  testWalk(R"objc(
+    @protocol MyProtocol
+    @property(class) int $explicit^foo;
+    @end
+    @interface $implicit^ParentClass <MyProtocol>
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    + (void)testSummary {
       int x = super.^foo;
     }
     @end

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -633,7 +633,7 @@ TEST(WalkAST, ObjCMessageExprClassReceiver) {
 
 TEST(WalkAST, ObjCPropertyRefExprExplicit) {
   testWalk(R"objc(
-    @interface MyClass
+    @interface $implicit^MyClass
     @property(nonatomic) int $explicit^foo;
     @end
   )objc",
@@ -647,7 +647,7 @@ TEST(WalkAST, ObjCPropertyRefExprExplicit) {
 
 TEST(WalkAST, ObjCPropertyRefExprImplicitGetter) {
   testWalk(R"objc(
-    @interface MyClass
+    @interface $implicit^MyClass
     $explicit^- (int)foo;
     @end
   )objc",
@@ -661,7 +661,7 @@ TEST(WalkAST, ObjCPropertyRefExprImplicitGetter) {
 
 TEST(WalkAST, ObjCPropertyRefExprImplicitSetter) {
   testWalk(R"objc(
-    @interface MyClass
+    @interface $implicit^MyClass
     $explicit^- (void)setFoo:(int)val;
     @end
   )objc",
@@ -675,7 +675,7 @@ TEST(WalkAST, ObjCPropertyRefExprImplicitSetter) {
 
 TEST(WalkAST, ObjCPropertyRefExprExplicitSetter) {
   testWalk(R"objc(
-    @interface MyClass
+    @interface $implicit^MyClass
     @property(nonatomic) int $explicit^foo;
     @end
   )objc",
@@ -689,7 +689,7 @@ TEST(WalkAST, ObjCPropertyRefExprExplicitSetter) {
 
 TEST(WalkAST, ObjCPropertyRefExprProtocol) {
   testWalk(R"objc(
-    @protocol MyProtocol
+    @protocol $implicit^MyProtocol
     @property(nonatomic) int $explicit^foo;
     @end
   )objc",
@@ -697,6 +697,38 @@ TEST(WalkAST, ObjCPropertyRefExprProtocol) {
     void test(id<MyProtocol> obj) {
       int x = obj.^foo;
     }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprClassReceiver) {
+  testWalk(R"objc(
+    @interface $implicit^MyClass
+    @property(class, nonatomic) int $explicit^foo;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      int x = MyClass.^foo;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprSuperReceiver) {
+  testWalk(R"objc(
+    @interface $implicit^ParentClass
+    @property(nonatomic) int $explicit^foo;
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    - (void)testSummary {
+      int x = super.^foo;
+    }
+    @end
   )objc",
            {"-x", "objective-c"});
 }

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -631,6 +631,38 @@ TEST(WalkAST, ObjCMessageExprSelectorLocProtocol) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCMessageExprSelectorLocNestedProtocol) {
+  testWalk(R"objc(
+    @protocol FirstProtocol
+        $explicit^- (void)doSomething;
+    @end
+    @protocol $implicit^SecondProtocol <FirstProtocol>
+    @end
+  )objc",
+           R"objc(
+    void test(id<SecondProtocol> obj) {
+      [obj ^doSomething];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCMessageExprSelectorLocMultipleProtocol) {
+  testWalk(R"objc(
+    @protocol $implicit^FirstProtocol
+    @end
+    @protocol $implicit^SecondProtocol
+      $explicit^- (void)doSomething;
+    @end
+  )objc",
+           R"objc(
+    void test(id<FirstProtocol, SecondProtocol> obj) {
+      [obj ^doSomething];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
 TEST(WalkAST, ObjCMessageExprSelectorMessageChaining) {
   testWalk(R"objc(
     @interface $implicit^MyClass
@@ -789,6 +821,38 @@ TEST(WalkAST, ObjCPropertyRefExprProtocol) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCPropertyRefExprNestedProtocol) {
+  testWalk(R"objc(
+    @protocol FirstProtocol
+    @property(nonatomic) int $explicit^foo;
+    @end
+    @protocol $implicit^SecondProtocol <FirstProtocol>
+    @end
+  )objc",
+           R"objc(
+    void test(id<SecondProtocol> obj) {
+      int x = obj.^foo;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprMultipleProtocol) {
+  testWalk(R"objc(
+    @protocol $implicit^FirstProtocol
+    @end
+    @protocol $implicit^SecondProtocol
+    @property(nonatomic) int $explicit^foo;
+    @end
+  )objc",
+           R"objc(
+    void test(id<FirstProtocol, SecondProtocol> obj) {
+      int x = obj.^foo;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
 TEST(WalkAST, ObjCPropertyRefExprClassReceiver) {
   testWalk(R"objc(
     @interface $implicit^MyClass
@@ -839,6 +903,24 @@ TEST(WalkAST, ObjCPropertyRefExprClassSuperReceiver) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCPropertyRefExprClassSuperSetter) {
+  testWalk(R"objc(
+    @interface $implicit^ParentClass
+    @property(class, nonatomic) int $explicit^foo;
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    + (void)testSummary {
+      super.^foo = 1;
+    }
+    @end
+  )objc",
+           {"-x", "objective-c"});
+}
+
 TEST(WalkAST, ObjCPropertyRefExprClassSuperProtocolReceiver) {
   testWalk(R"objc(
     @protocol MyProtocol
@@ -852,6 +934,50 @@ TEST(WalkAST, ObjCPropertyRefExprClassSuperProtocolReceiver) {
            R"objc(
     @implementation MyClass
     + (void)testSummary {
+      int x = super.^foo;
+    }
+    @end
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprSuperMultipleProtocolReceiver) {
+  testWalk(R"objc(
+    @protocol FirstProtocol
+    @end
+    @protocol SecondProtocol
+    @property(nonatomic) int $explicit^foo;
+    @end
+    @interface $implicit^ParentClass <FirstProtocol, SecondProtocol>
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    - (void)testSummary {
+      int x = super.^foo;
+    }
+    @end
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprSuperNestedProtocolReceiver) {
+  testWalk(R"objc(
+    @protocol FirstProtocol
+    @property(nonatomic) int $explicit^foo;
+    @end
+    @protocol SecondProtocol <FirstProtocol>
+    @end
+    @interface $implicit^ParentClass <SecondProtocol>
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    - (void)testSummary {
       int x = super.^foo;
     }
     @end

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -855,13 +855,27 @@ TEST(WalkAST, ObjCPropertyRefExprMultipleProtocol) {
 
 TEST(WalkAST, ObjCPropertyRefExprClassReceiver) {
   testWalk(R"objc(
-    @interface $implicit^MyClass
+    @interface MyClass
     @property(class, nonatomic) int $explicit^foo;
     @end
   )objc",
            R"objc(
     void test() {
       int x = MyClass.^foo;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprClassReceiverInterface) {
+  testWalk(R"objc(
+    @interface $explicit^MyClass
+    @property(class, nonatomic) int foo;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      int x = ^MyClass.foo;
     }
   )objc",
            {"-x", "objective-c"});


### PR DESCRIPTION
When accessing Objective-C properties via dot-notation (e.g., obj.foo), include-cleaner was previously only recording the usage of the property itself or its underlying getter/setter methods. This could lead to cases where the header declaring the receiver's type (Interface or Protocol) was incorrectly flagged as unused if no other standard methods were invoked on it.