### PR TITLE
[GitHub] Fix authentication for release workflow git push

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -539,7 +539,7 @@ class ReleaseWorkflow:
 
     @property
     def push_url(self) -> str:
-        return "https://{}@github.com/{}".format(
+        return "https://x-access-token:{}@github.com/{}".format(
             self.branch_repo_token, self.branch_repo_name
         )
 


### PR DESCRIPTION
Update the push URL format to use GitHub's required authentication format with the 'x-access-token' prefix. GitHub now requires:
  https://x-access-token:{token}@github.com/{repo}

instead of the deprecated format:
  https://{token}@github.com/{repo}

Without this change, the release workflow fails when attempting to push branches with the error:
  fatal: could not read Password for 'https://***@github.com':
  No such device or address

This occurs because Git attempts to prompt for credentials in the non-interactive GitHub Actions environment when the token format is not recognized.

Fixes the /cherry-pick command in the issue-release-workflow.

Signed-off-by: nshanmug <nshanmug@qti.qualcomm.com>