### PR TITLE
[flang][openacc] Allow blank around ':' in generated clause parser with keyword

### DIFF
--- a/flang/test/Parser/acc-unparse.f90
+++ b/flang/test/Parser/acc-unparse.f90
@@ -22,7 +22,7 @@ end program
 subroutine acc_loop()
   integer :: i, j
   real :: a(10)
-  integer :: gangNum, gangDim, gangStatic
+  integer :: gangNum, gangDim, gangStatic, workerNum
 
 !CHECK-LABEL: SUBROUTINE acc_loop
 
@@ -113,6 +113,18 @@ subroutine acc_loop()
     a(i) = i
   end do
 ! CHECK: !$ACC LOOP GANG(NUM:gangnum)
+
+  !$acc loop worker(num : workerNum)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP WORKER(workernum)
+
+  !$acc loop vector(length : 128)
+  do i = 1, 10
+    a(i) = i
+  end do
+! CHECK: !$ACC LOOP VECTOR(128_4)
 
 end subroutine
 

--- a/flang/test/Semantics/OpenACC/acc-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-loop.f90
@@ -129,7 +129,7 @@ program openacc_loop_validity
   !$acc end parallel
 
   !$acc parallel
-  !$acc loop worker(num: worker_size)
+  !$acc loop worker(num : worker_size)
   do i = 1, N
     a(i) = 3.14d0
   end do

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -1249,7 +1249,7 @@ static void generateFlangClausesParser(const DirectiveLanguage &DirLang,
       OS << "nonemptyList(";
 
     if (!C.getPrefix().empty())
-      OS << "\"" << C.getPrefix() << ":\" >> ";
+      OS << "\"" << C.getPrefix() << " :\" >> ";
 
     // The common Flang parser are used directly. Their name is identical to
     // the Flang class with first letter as lowercase. If the Flang class is


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/210446 to also allow the space in the parser generated by TableGen. 