### PR TITLE
[RISCV] Fix incorrect lowering of VECTOR_INTERLEAVE on fixed vectors

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13835,29 +13835,12 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
   if (VecVT.getVectorElementType() == MVT::i1)
     return widenVectorOpsToi8(Op, DL, DAG);
 
-  // Convert to scalable vectors first.
-  if (VecVT.isFixedLengthVector()) {
-    MVT ContainerVT = getContainerForFixedLengthVector(VecVT);
-    SmallVector<SDValue, 8> Ops(Factor);
-    for (unsigned i = 0U; i < Factor; ++i)
-      Ops[i] = convertToScalableVector(ContainerVT, Op.getOperand(i), DAG,
-                                       Subtarget);
-
-    SmallVector<EVT, 8> VTs(Factor, ContainerVT);
-    SDValue NewInterleave = DAG.getNode(ISD::VECTOR_INTERLEAVE, DL, VTs, Ops);
-
-    SmallVector<SDValue, 8> Res(Factor);
-    for (unsigned i = 0U; i < Factor; ++i)
-      Res[i] = convertFromScalableVector(VecVT, NewInterleave.getValue(i), DAG,
-                                         Subtarget);
-    return DAG.getMergeValues(Res, DL);
-  }
-
-  MVT XLenVT = Subtarget.getXLenVT();
-  auto [Mask, VL] = getDefaultScalableVLOps(VecVT, DL, DAG, Subtarget);
+  MVT ContainerVecVT = VecVT;
+  if (VecVT.isFixedLengthVector())
+    ContainerVecVT = getContainerForFixedLengthVector(VecVT);
 
   // If the VT is larger than LMUL=8, we need to split and reassemble.
-  if ((VecVT.getSizeInBits().getKnownMinValue() * Factor) >
+  if ((ContainerVecVT.getSizeInBits().getKnownMinValue() * Factor) >
       (8 * RISCV::RVVBitsPerBlock)) {
     SmallVector<SDValue, 8> Ops(Factor * 2);
     for (unsigned i = 0; i != Factor; ++i) {
@@ -13885,6 +13868,9 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
     return DAG.getMergeValues(Concats, DL);
   }
 
+  MVT XLenVT = Subtarget.getXLenVT();
+  auto [Mask, VL] = getDefaultVLOps(VecVT, ContainerVecVT, DL, DAG, Subtarget);
+
   SDValue Interleaved;
 
   // Spill to the stack using a segment store for simplicity.
@@ -13908,25 +13894,45 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
         Intrinsic::riscv_vsseg6_mask, Intrinsic::riscv_vsseg7_mask,
         Intrinsic::riscv_vsseg8_mask,
     };
+    static const Intrinsic::ID FixedIntrIds[] = {
+        Intrinsic::riscv_seg2_store_mask, Intrinsic::riscv_seg3_store_mask,
+        Intrinsic::riscv_seg4_store_mask, Intrinsic::riscv_seg5_store_mask,
+        Intrinsic::riscv_seg6_store_mask, Intrinsic::riscv_seg7_store_mask,
+        Intrinsic::riscv_seg8_store_mask,
+    };
 
-    unsigned Sz =
-        Factor * VecVT.getVectorMinNumElements() * VecVT.getScalarSizeInBits();
-    EVT VecTupTy = MVT::getRISCVVectorTupleVT(Sz, Factor);
+    SmallVector<SDValue> Ops;
+    if (VecVT.isFixedLengthVector()) {
+      Ops = {DAG.getEntryNode(),
+             DAG.getTargetConstant(FixedIntrIds[Factor - 2], DL, XLenVT)};
+      for (unsigned i = 0U; i < Factor; ++i)
+        Ops.push_back(Op.getOperand(i));
 
-    SDValue StoredVal = DAG.getUNDEF(VecTupTy);
-    for (unsigned i = 0; i < Factor; i++)
-      StoredVal =
-          DAG.getNode(RISCVISD::TUPLE_INSERT, DL, VecTupTy, StoredVal,
-                      Op.getOperand(i), DAG.getTargetConstant(i, DL, MVT::i32));
+      // We cannot use Mask (or getAllOnesMask) here as it is a scalable vector
+      // mask.
+      SDValue FixedAllOnesMask = DAG.getSplat(getMaskTypeFor(VecVT), DL,
+                                              DAG.getConstant(1, DL, XLenVT));
+      Ops.append({StackPtr, FixedAllOnesMask, VL});
+    } else {
+      unsigned Sz = Factor * VecVT.getVectorMinNumElements() *
+                    VecVT.getScalarSizeInBits();
+      EVT VecTupTy = MVT::getRISCVVectorTupleVT(Sz, Factor);
 
-    SDValue Ops[] = {DAG.getEntryNode(),
-                     DAG.getTargetConstant(IntrIds[Factor - 2], DL, XLenVT),
-                     StoredVal,
-                     StackPtr,
-                     Mask,
-                     VL,
-                     DAG.getTargetConstant(Log2_64(VecVT.getScalarSizeInBits()),
-                                           DL, XLenVT)};
+      SDValue StoredVal = DAG.getUNDEF(VecTupTy);
+      for (unsigned i = 0; i < Factor; i++)
+        StoredVal = DAG.getNode(RISCVISD::TUPLE_INSERT, DL, VecTupTy, StoredVal,
+                                Op.getOperand(i),
+                                DAG.getTargetConstant(i, DL, MVT::i32));
+
+      Ops = {DAG.getEntryNode(),
+             DAG.getTargetConstant(IntrIds[Factor - 2], DL, XLenVT),
+             StoredVal,
+             StackPtr,
+             Mask,
+             VL,
+             DAG.getTargetConstant(Log2_64(VecVT.getScalarSizeInBits()), DL,
+                                   XLenVT)};
+    }
 
     SDValue Chain = DAG.getMemIntrinsicNode(
         ISD::INTRINSIC_VOID, DL, DAG.getVTList(MVT::Other), Ops,
@@ -13945,6 +13951,10 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
 
     return DAG.getMergeValues(Loads, DL);
   }
+
+  assert(!VecVT.isFixedLengthVector() &&
+         "Fixed factor=2 vector interleave should already lower to "
+         "SHUFFLE_VECTOR");
 
   if (Subtarget.hasStdExtZvzip() && !Op.getOperand(0).isUndef() &&
       !Op.getOperand(1).isUndef()) {

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13880,6 +13880,10 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
                          VecVT.getVectorElementCount() * Factor);
 
     // Allocate a stack slot.
+    // Note that in the case where VecVT is fixed vector, even we later
+    // create a container for each (fixed vector) operand, we still allocate
+    // the stack with fixed vector size, rather than container size, as
+    // fixed vector size is already sufficient.
     Align Alignment = DAG.getReducedAlign(VecVT, /*UseABI=*/false);
     SDValue StackPtr =
         DAG.CreateStackTemporary(MemVT.getStoreSize(), Alignment);
@@ -13894,45 +13898,28 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
         Intrinsic::riscv_vsseg6_mask, Intrinsic::riscv_vsseg7_mask,
         Intrinsic::riscv_vsseg8_mask,
     };
-    static const Intrinsic::ID FixedIntrIds[] = {
-        Intrinsic::riscv_seg2_store_mask, Intrinsic::riscv_seg3_store_mask,
-        Intrinsic::riscv_seg4_store_mask, Intrinsic::riscv_seg5_store_mask,
-        Intrinsic::riscv_seg6_store_mask, Intrinsic::riscv_seg7_store_mask,
-        Intrinsic::riscv_seg8_store_mask,
-    };
 
-    SmallVector<SDValue> Ops;
-    if (VecVT.isFixedLengthVector()) {
-      Ops = {DAG.getEntryNode(),
-             DAG.getTargetConstant(FixedIntrIds[Factor - 2], DL, XLenVT)};
-      for (unsigned i = 0U; i < Factor; ++i)
-        Ops.push_back(Op.getOperand(i));
+    unsigned Sz = Factor * ContainerVecVT.getVectorMinNumElements() *
+                  ContainerVecVT.getScalarSizeInBits();
+    EVT VecTupTy = MVT::getRISCVVectorTupleVT(Sz, Factor);
 
-      // We cannot use Mask (or getAllOnesMask) here as it is a scalable vector
-      // mask.
-      SDValue FixedAllOnesMask = DAG.getSplat(getMaskTypeFor(VecVT), DL,
-                                              DAG.getConstant(1, DL, XLenVT));
-      Ops.append({StackPtr, FixedAllOnesMask, VL});
-    } else {
-      unsigned Sz = Factor * VecVT.getVectorMinNumElements() *
-                    VecVT.getScalarSizeInBits();
-      EVT VecTupTy = MVT::getRISCVVectorTupleVT(Sz, Factor);
-
-      SDValue StoredVal = DAG.getUNDEF(VecTupTy);
-      for (unsigned i = 0; i < Factor; i++)
-        StoredVal = DAG.getNode(RISCVISD::TUPLE_INSERT, DL, VecTupTy, StoredVal,
-                                Op.getOperand(i),
-                                DAG.getTargetConstant(i, DL, MVT::i32));
-
-      Ops = {DAG.getEntryNode(),
-             DAG.getTargetConstant(IntrIds[Factor - 2], DL, XLenVT),
-             StoredVal,
-             StackPtr,
-             Mask,
-             VL,
-             DAG.getTargetConstant(Log2_64(VecVT.getScalarSizeInBits()), DL,
-                                   XLenVT)};
+    SDValue StoredVal = DAG.getUNDEF(VecTupTy);
+    for (unsigned i = 0; i < Factor; i++) {
+      SDValue OpVal = Op.getOperand(i);
+      if (VecVT.isFixedLengthVector())
+        OpVal = convertToScalableVector(ContainerVecVT, OpVal, DAG, Subtarget);
+      StoredVal = DAG.getNode(RISCVISD::TUPLE_INSERT, DL, VecTupTy, StoredVal,
+                              OpVal, DAG.getTargetConstant(i, DL, MVT::i32));
     }
+
+    SDValue Ops[] = {DAG.getEntryNode(),
+                     DAG.getTargetConstant(IntrIds[Factor - 2], DL, XLenVT),
+                     StoredVal,
+                     StackPtr,
+                     Mask,
+                     VL,
+                     DAG.getTargetConstant(Log2_64(VecVT.getScalarSizeInBits()),
+                                           DL, XLenVT)};
 
     SDValue Chain = DAG.getMemIntrinsicNode(
         ISD::INTRINSIC_VOID, DL, DAG.getVTList(MVT::Other), Ops,

--- a/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
@@ -171,83 +171,59 @@ define <4 x i64> @vector_interleave_v4i64_v2i64(<2 x i64> %a, <2 x i64> %b) {
 define <6 x i32> @vector_interleave3_v6i32_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) nounwind {
 ; CHECK-LABEL: vector_interleave3_v6i32_v2i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; CHECK-NEXT:    vsseg3e32.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 1
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle32.v v9, (a2)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle32.v v9, (a1)
 ; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    add a1, a2, a1
-; CHECK-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; CHECK-NEXT:    vle32.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 24
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vle32.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave3_v6i32_v2i32:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 8
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVBB-NEXT:    vsseg3e32.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 1
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle32.v v9, (a2)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle32.v v9, (a1)
 ; ZVBB-NEXT:    vle32.v v8, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    add a1, a2, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVBB-NEXT:    vle32.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 24
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVBB-NEXT:    vle32.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave3_v6i32_v2i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 8
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vsseg3e32.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 1
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle32.v v9, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle32.v v9, (a1)
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    add a1, a2, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 24
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <6 x i32> @llvm.vector.interleave3.v6i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c)
 	   ret <6 x i32> %res
@@ -256,95 +232,71 @@ define <6 x i32> @vector_interleave3_v6i32_v2i32(<2 x i32> %a, <2 x i32> %b, <2 
 define <8 x i32> @vector_interleave4_v8i32_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c, <2 x i32> %d) nounwind {
 ; CHECK-LABEL: vector_interleave4_v8i32_v2i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; CHECK-NEXT:    vsseg4e32.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 1
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    add a1, a3, a1
+; CHECK-NEXT:    addi a1, sp, 24
 ; CHECK-NEXT:    vle32.v v9, (a1)
-; CHECK-NEXT:    vle32.v v10, (a2)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vle32.v v10, (a1)
 ; CHECK-NEXT:    vle32.v v8, (a0)
+; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 2
-; CHECK-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; CHECK-NEXT:    vle32.v v10, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vle32.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave4_v8i32_v2i32:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    mv a0, sp
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVBB-NEXT:    vsseg4e32.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 1
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    add a1, a3, a1
+; ZVBB-NEXT:    addi a1, sp, 24
 ; ZVBB-NEXT:    vle32.v v9, (a1)
-; ZVBB-NEXT:    vle32.v v10, (a2)
+; ZVBB-NEXT:    addi a1, sp, 8
+; ZVBB-NEXT:    vle32.v v10, (a1)
 ; ZVBB-NEXT:    vle32.v v8, (a0)
+; ZVBB-NEXT:    addi a0, sp, 16
 ; ZVBB-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVBB-NEXT:    vle32.v v10, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVBB-NEXT:    vle32.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave4_v8i32_v2i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vsseg4e32.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 1
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    add a1, a3, a1
+; ZVZIP-NEXT:    addi a1, sp, 24
 ; ZVZIP-NEXT:    vle32.v v9, (a1)
-; ZVZIP-NEXT:    vle32.v v10, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 8
+; ZVZIP-NEXT:    vle32.v v10, (a1)
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 16
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v10, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x i32> @llvm.vector.interleave4.v8i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c, <2 x i32> %d)
 	   ret <8 x i32> %res
@@ -353,104 +305,80 @@ define <8 x i32> @vector_interleave4_v8i32_v2i32(<2 x i32> %a, <2 x i32> %b, <2 
 define <10 x i16> @vector_interleave5_v10i16_v2i16(<2 x i16> %a, <2 x i16> %b, <2 x i16> %c, <2 x i16> %d, <2 x i16> %e) nounwind {
 ; CHECK-LABEL: vector_interleave5_v10i16_v2i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg5e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle16.v v9, (a2)
-; CHECK-NEXT:    add a2, a2, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v10, (a3)
-; CHECK-NEXT:    vle16.v v11, (a2)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vle16.v v11, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v11, v10, 2
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    add a1, a3, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 28
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave5_v10i16_v2i16:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 12
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg5e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle16.v v9, (a2)
-; ZVBB-NEXT:    add a2, a2, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v10, (a3)
-; ZVBB-NEXT:    vle16.v v11, (a2)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 24
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 20
+; ZVBB-NEXT:    vle16.v v11, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v11, v10, 2
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v11, 4
-; ZVBB-NEXT:    add a1, a3, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 28
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave5_v10i16_v2i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 12
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg5e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle16.v v9, (a2)
-; ZVZIP-NEXT:    add a2, a2, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v10, (a3)
-; ZVZIP-NEXT:    vle16.v v11, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 24
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 20
+; ZVZIP-NEXT:    vle16.v v11, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v11, v10, 2
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v11, 4
-; ZVZIP-NEXT:    add a1, a3, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 28
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <10 x i16> @llvm.vector.interleave5.v10i16(<2 x i16> %a, <2 x i16> %b, <2 x i16> %c, <2 x i16> %d, <2 x i16> %e)
 	   ret <10 x i16> %res
@@ -459,119 +387,95 @@ define <10 x i16> @vector_interleave5_v10i16_v2i16(<2 x i16> %a, <2 x i16> %b, <
 define <12 x i16> @vector_interleave6_v12i16_v2i16(<2 x i16> %a, <2 x i16> %b, <2 x i16> %c, <2 x i16> %d, <2 x i16> %e, <2 x i16> %f) nounwind {
 ; CHECK-LABEL: vector_interleave6_v12i16_v2i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg6e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle16.v v9, (a2)
-; CHECK-NEXT:    add a2, a2, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v10, (a3)
-; CHECK-NEXT:    vle16.v v11, (a2)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle16.v v11, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
-; CHECK-NEXT:    add a3, a3, a1
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v11, v10, 2
-; CHECK-NEXT:    add a1, a3, a1
+; CHECK-NEXT:    addi a0, sp, 28
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
+; CHECK-NEXT:    addi a0, sp, 24
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave6_v12i16_v2i16:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 8
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg6e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle16.v v9, (a2)
-; ZVBB-NEXT:    add a2, a2, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v10, (a3)
-; ZVBB-NEXT:    vle16.v v11, (a2)
+; ZVBB-NEXT:    addi a1, sp, 12
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 20
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle16.v v11, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
-; ZVBB-NEXT:    add a3, a3, a1
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v11, v10, 2
-; ZVBB-NEXT:    add a1, a3, a1
+; ZVBB-NEXT:    addi a0, sp, 28
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
+; ZVBB-NEXT:    addi a0, sp, 24
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v11, 4
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave6_v12i16_v2i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 8
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg6e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle16.v v9, (a2)
-; ZVZIP-NEXT:    add a2, a2, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v10, (a3)
-; ZVZIP-NEXT:    vle16.v v11, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 12
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 20
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle16.v v11, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
-; ZVZIP-NEXT:    add a3, a3, a1
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v11, v10, 2
-; ZVZIP-NEXT:    add a1, a3, a1
+; ZVZIP-NEXT:    addi a0, sp, 28
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 24
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v11, 4
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <12 x i16> @llvm.vector.interleave6.v12i16(<2 x i16> %a, <2 x i16> %b, <2 x i16> %c, <2 x i16> %d, <2 x i16> %e, <2 x i16> %f)
 	   ret <12 x i16> %res
@@ -581,126 +485,108 @@ define <14 x i8> @vector_interleave7_v14i8_v2i8(<2 x i8> %a, <2 x i8> %b, <2 x i
 ; CHECK-LABEL: vector_interleave7_v14i8_v2i8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; CHECK-NEXT:    addi a0, sp, 2
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vsseg7e8.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 3
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle8.v v9, (a3)
-; CHECK-NEXT:    add a3, a3, a1
-; CHECK-NEXT:    vle8.v v10, (a2)
-; CHECK-NEXT:    add a2, a3, a1
-; CHECK-NEXT:    add a4, a2, a1
-; CHECK-NEXT:    vle8.v v11, (a4)
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vle8.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vle8.v v10, (a1)
 ; CHECK-NEXT:    vle8.v v8, (a0)
-; CHECK-NEXT:    vle8.v v12, (a2)
+; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vle8.v v11, (a0)
+; CHECK-NEXT:    addi a0, sp, 10
+; CHECK-NEXT:    vle8.v v12, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 2
-; CHECK-NEXT:    add a1, a4, a1
-; CHECK-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; CHECK-NEXT:    vle8.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 14
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vle8.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v12, v11, 2
+; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 4
-; CHECK-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; CHECK-NEXT:    vle8.v v9, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vle8.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v12, v10, 4
 ; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 6
 ; CHECK-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v12, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave7_v14i8_v2i8:
 ; ZVBB:       # %bb.0:
 ; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; ZVBB-NEXT:    addi a0, sp, 2
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; ZVBB-NEXT:    vsseg7e8.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 3
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle8.v v9, (a3)
-; ZVBB-NEXT:    add a3, a3, a1
-; ZVBB-NEXT:    vle8.v v10, (a2)
-; ZVBB-NEXT:    add a2, a3, a1
-; ZVBB-NEXT:    add a4, a2, a1
-; ZVBB-NEXT:    vle8.v v11, (a4)
+; ZVBB-NEXT:    addi a1, sp, 6
+; ZVBB-NEXT:    vle8.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 4
+; ZVBB-NEXT:    vle8.v v10, (a1)
 ; ZVBB-NEXT:    vle8.v v8, (a0)
-; ZVBB-NEXT:    vle8.v v12, (a2)
+; ZVBB-NEXT:    addi a0, sp, 12
+; ZVBB-NEXT:    vle8.v v11, (a0)
+; ZVBB-NEXT:    addi a0, sp, 10
+; ZVBB-NEXT:    vle8.v v12, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 2
-; ZVBB-NEXT:    add a1, a4, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVBB-NEXT:    vle8.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 14
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVBB-NEXT:    vle8.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v12, v11, 2
+; ZVBB-NEXT:    addi a0, sp, 8
 ; ZVBB-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 4
-; ZVBB-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVBB-NEXT:    vle8.v v9, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVBB-NEXT:    vle8.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v12, v10, 4
 ; ZVBB-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 6
 ; ZVBB-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v12, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    add sp, sp, a0
 ; ZVBB-NEXT:    addi sp, sp, 16
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave7_v14i8_v2i8:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; ZVZIP-NEXT:    addi a0, sp, 2
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; ZVZIP-NEXT:    vsseg7e8.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 3
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle8.v v9, (a3)
-; ZVZIP-NEXT:    add a3, a3, a1
-; ZVZIP-NEXT:    vle8.v v10, (a2)
-; ZVZIP-NEXT:    add a2, a3, a1
-; ZVZIP-NEXT:    add a4, a2, a1
-; ZVZIP-NEXT:    vle8.v v11, (a4)
+; ZVZIP-NEXT:    addi a1, sp, 6
+; ZVZIP-NEXT:    vle8.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 4
+; ZVZIP-NEXT:    vle8.v v10, (a1)
 ; ZVZIP-NEXT:    vle8.v v8, (a0)
-; ZVZIP-NEXT:    vle8.v v12, (a2)
+; ZVZIP-NEXT:    addi a0, sp, 12
+; ZVZIP-NEXT:    vle8.v v11, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 10
+; ZVZIP-NEXT:    vle8.v v12, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
-; ZVZIP-NEXT:    add a1, a4, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vle8.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 14
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVZIP-NEXT:    vle8.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v12, v11, 2
+; ZVZIP-NEXT:    addi a0, sp, 8
 ; ZVZIP-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 4
-; ZVZIP-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vle8.v v9, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVZIP-NEXT:    vle8.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v12, v10, 4
 ; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 6
 ; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    add sp, sp, a0
 ; ZVZIP-NEXT:    addi sp, sp, 16
 ; ZVZIP-NEXT:    ret
 	   %res = call <14 x i8> @llvm.vector.interleave7.v14i8(<2 x i8> %a, <2 x i8> %b, <2 x i8> %c, <2 x i8> %d, <2 x i8> %e, <2 x i8> %f, <2 x i8> %g)
@@ -711,135 +597,117 @@ define <16 x i8> @vector_interleave8_v16i8_v2i8(<2 x i8> %a, <2 x i8> %b, <2 x i
 ; CHECK-LABEL: vector_interleave8_v16i8_v2i8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vsseg8e8.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 3
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    add a4, a3, a1
-; CHECK-NEXT:    add a5, a4, a1
-; CHECK-NEXT:    add a6, a5, a1
-; CHECK-NEXT:    vle8.v v9, (a6)
-; CHECK-NEXT:    vle8.v v10, (a5)
-; CHECK-NEXT:    add a6, a6, a1
-; CHECK-NEXT:    vle8.v v11, (a6)
-; CHECK-NEXT:    vle8.v v12, (a2)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vle8.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vle8.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vle8.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    vle8.v v12, (a1)
 ; CHECK-NEXT:    vle8.v v8, (a0)
+; CHECK-NEXT:    addi a0, sp, 4
 ; CHECK-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; CHECK-NEXT:    vle8.v v9, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vle8.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v12, 2
-; CHECK-NEXT:    add a1, a6, a1
-; CHECK-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; CHECK-NEXT:    vle8.v v12, (a1)
+; CHECK-NEXT:    addi a0, sp, 14
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vle8.v v12, (a0)
 ; CHECK-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v10, v11, 4
 ; CHECK-NEXT:    vslideup.vi v8, v9, 4
-; CHECK-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; CHECK-NEXT:    vle8.v v9, (a4)
+; CHECK-NEXT:    addi a0, sp, 6
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vle8.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v12, 6
 ; CHECK-NEXT:    vslideup.vi v8, v9, 6
 ; CHECK-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave8_v16i8_v2i8:
 ; ZVBB:       # %bb.0:
 ; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; ZVBB-NEXT:    mv a0, sp
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; ZVBB-NEXT:    vsseg8e8.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 3
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    add a4, a3, a1
-; ZVBB-NEXT:    add a5, a4, a1
-; ZVBB-NEXT:    add a6, a5, a1
-; ZVBB-NEXT:    vle8.v v9, (a6)
-; ZVBB-NEXT:    vle8.v v10, (a5)
-; ZVBB-NEXT:    add a6, a6, a1
-; ZVBB-NEXT:    vle8.v v11, (a6)
-; ZVBB-NEXT:    vle8.v v12, (a2)
+; ZVBB-NEXT:    addi a1, sp, 10
+; ZVBB-NEXT:    vle8.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 8
+; ZVBB-NEXT:    vle8.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 12
+; ZVBB-NEXT:    vle8.v v11, (a1)
+; ZVBB-NEXT:    addi a1, sp, 2
+; ZVBB-NEXT:    vle8.v v12, (a1)
 ; ZVBB-NEXT:    vle8.v v8, (a0)
+; ZVBB-NEXT:    addi a0, sp, 4
 ; ZVBB-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVBB-NEXT:    vle8.v v9, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVBB-NEXT:    vle8.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v12, 2
-; ZVBB-NEXT:    add a1, a6, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVBB-NEXT:    vle8.v v12, (a1)
+; ZVBB-NEXT:    addi a0, sp, 14
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVBB-NEXT:    vle8.v v12, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v11, 4
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 4
-; ZVBB-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVBB-NEXT:    vle8.v v9, (a4)
+; ZVBB-NEXT:    addi a0, sp, 6
+; ZVBB-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVBB-NEXT:    vle8.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v12, 6
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 6
 ; ZVBB-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    add sp, sp, a0
 ; ZVBB-NEXT:    addi sp, sp, 16
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave8_v16i8_v2i8:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; ZVZIP-NEXT:    vsseg8e8.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 3
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    add a4, a3, a1
-; ZVZIP-NEXT:    add a5, a4, a1
-; ZVZIP-NEXT:    add a6, a5, a1
-; ZVZIP-NEXT:    vle8.v v9, (a6)
-; ZVZIP-NEXT:    vle8.v v10, (a5)
-; ZVZIP-NEXT:    add a6, a6, a1
-; ZVZIP-NEXT:    vle8.v v11, (a6)
-; ZVZIP-NEXT:    vle8.v v12, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 10
+; ZVZIP-NEXT:    vle8.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 8
+; ZVZIP-NEXT:    vle8.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 12
+; ZVZIP-NEXT:    vle8.v v11, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 2
+; ZVZIP-NEXT:    vle8.v v12, (a1)
 ; ZVZIP-NEXT:    vle8.v v8, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 4
 ; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vle8.v v9, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVZIP-NEXT:    vle8.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 2
-; ZVZIP-NEXT:    add a1, a6, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vle8.v v12, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 14
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVZIP-NEXT:    vle8.v v12, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v11, 4
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 4
-; ZVZIP-NEXT:    vsetvli a0, zero, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vle8.v v9, (a4)
+; ZVZIP-NEXT:    addi a0, sp, 6
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; ZVZIP-NEXT:    vle8.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v12, 6
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 6
 ; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    add sp, sp, a0
 ; ZVZIP-NEXT:    addi sp, sp, 16
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x i8> @llvm.vector.interleave8.v16i8(<2 x i8> %a, <2 x i8> %b, <2 x i8> %c, <2 x i8> %d, <2 x i8> %e, <2 x i8> %f, <2 x i8> %g, <2 x i8> %h)
@@ -1128,83 +996,59 @@ define <4 x double> @vector_interleave_v4f64_v2f64(<2 x double> %a, <2 x double>
 define <6 x float> @vector_interleave3_v6f32_v2f32(<2 x float> %a, <2 x float> %b, <2 x float> %c) nounwind {
 ; CHECK-LABEL: vector_interleave3_v6f32_v2f32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; CHECK-NEXT:    vsseg3e32.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 1
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle32.v v9, (a2)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle32.v v9, (a1)
 ; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    add a1, a2, a1
-; CHECK-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; CHECK-NEXT:    vle32.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 24
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vle32.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave3_v6f32_v2f32:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 8
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVBB-NEXT:    vsseg3e32.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 1
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle32.v v9, (a2)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle32.v v9, (a1)
 ; ZVBB-NEXT:    vle32.v v8, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    add a1, a2, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVBB-NEXT:    vle32.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 24
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVBB-NEXT:    vle32.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave3_v6f32_v2f32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 8
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vsseg3e32.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 1
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle32.v v9, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle32.v v9, (a1)
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    add a1, a2, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 24
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <6 x float> @llvm.vector.interleave3.v6f32(<2 x float> %a, <2 x float> %b, <2 x float> %c)
 	   ret <6 x float> %res
@@ -1213,95 +1057,71 @@ define <6 x float> @vector_interleave3_v6f32_v2f32(<2 x float> %a, <2 x float> %
 define <8 x float> @vector_interleave4_v8f32_v2f32(<2 x float> %a, <2 x float> %b, <2 x float> %c, <2 x float> %d) nounwind {
 ; CHECK-LABEL: vector_interleave4_v8f32_v2f32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; CHECK-NEXT:    vsseg4e32.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 1
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    add a1, a3, a1
+; CHECK-NEXT:    addi a1, sp, 24
 ; CHECK-NEXT:    vle32.v v9, (a1)
-; CHECK-NEXT:    vle32.v v10, (a2)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vle32.v v10, (a1)
 ; CHECK-NEXT:    vle32.v v8, (a0)
+; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 2
-; CHECK-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; CHECK-NEXT:    vle32.v v10, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vle32.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave4_v8f32_v2f32:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    mv a0, sp
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVBB-NEXT:    vsseg4e32.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 1
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    add a1, a3, a1
+; ZVBB-NEXT:    addi a1, sp, 24
 ; ZVBB-NEXT:    vle32.v v9, (a1)
-; ZVBB-NEXT:    vle32.v v10, (a2)
+; ZVBB-NEXT:    addi a1, sp, 8
+; ZVBB-NEXT:    vle32.v v10, (a1)
 ; ZVBB-NEXT:    vle32.v v8, (a0)
+; ZVBB-NEXT:    addi a0, sp, 16
 ; ZVBB-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVBB-NEXT:    vle32.v v10, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVBB-NEXT:    vle32.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave4_v8f32_v2f32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vsseg4e32.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 1
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    add a1, a3, a1
+; ZVZIP-NEXT:    addi a1, sp, 24
 ; ZVZIP-NEXT:    vle32.v v9, (a1)
-; ZVZIP-NEXT:    vle32.v v10, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 8
+; ZVZIP-NEXT:    vle32.v v10, (a1)
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 16
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v10, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x float> @llvm.vector.interleave4.v8f32(<2 x float> %a, <2 x float> %b, <2 x float> %c, <2 x float> %d)
 	   ret <8 x float> %res
@@ -1310,104 +1130,80 @@ define <8 x float> @vector_interleave4_v8f32_v2f32(<2 x float> %a, <2 x float> %
 define <10 x half> @vector_interleave5_v10f16_v2f16(<2 x half> %a, <2 x half> %b, <2 x half> %c, <2 x half> %d, <2 x half> %e) nounwind {
 ; CHECK-LABEL: vector_interleave5_v10f16_v2f16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg5e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle16.v v9, (a2)
-; CHECK-NEXT:    add a2, a2, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v10, (a3)
-; CHECK-NEXT:    vle16.v v11, (a2)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vle16.v v11, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v11, v10, 2
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    add a1, a3, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 28
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave5_v10f16_v2f16:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 12
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg5e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle16.v v9, (a2)
-; ZVBB-NEXT:    add a2, a2, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v10, (a3)
-; ZVBB-NEXT:    vle16.v v11, (a2)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 24
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 20
+; ZVBB-NEXT:    vle16.v v11, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v11, v10, 2
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v11, 4
-; ZVBB-NEXT:    add a1, a3, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 28
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave5_v10f16_v2f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 12
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg5e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle16.v v9, (a2)
-; ZVZIP-NEXT:    add a2, a2, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v10, (a3)
-; ZVZIP-NEXT:    vle16.v v11, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 24
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 20
+; ZVZIP-NEXT:    vle16.v v11, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v11, v10, 2
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v11, 4
-; ZVZIP-NEXT:    add a1, a3, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 28
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <10 x half> @llvm.vector.interleave5.v10f16(<2 x half> %a, <2 x half> %b, <2 x half> %c, <2 x half> %d, <2 x half> %e)
 	   ret <10 x half> %res
@@ -1416,104 +1212,80 @@ define <10 x half> @vector_interleave5_v10f16_v2f16(<2 x half> %a, <2 x half> %b
 define <10 x bfloat> @vector_interleave5_v10bf16_v2bf16(<2 x bfloat> %a, <2 x bfloat> %b, <2 x bfloat> %c, <2 x bfloat> %d, <2 x bfloat> %e) nounwind {
 ; CHECK-LABEL: vector_interleave5_v10bf16_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg5e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle16.v v9, (a2)
-; CHECK-NEXT:    add a2, a2, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v10, (a3)
-; CHECK-NEXT:    vle16.v v11, (a2)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vle16.v v11, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v11, v10, 2
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    add a1, a3, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 28
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave5_v10bf16_v2bf16:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 12
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg5e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle16.v v9, (a2)
-; ZVBB-NEXT:    add a2, a2, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v10, (a3)
-; ZVBB-NEXT:    vle16.v v11, (a2)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 24
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 20
+; ZVBB-NEXT:    vle16.v v11, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v11, v10, 2
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v11, 4
-; ZVBB-NEXT:    add a1, a3, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 28
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave5_v10bf16_v2bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 12
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg5e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle16.v v9, (a2)
-; ZVZIP-NEXT:    add a2, a2, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v10, (a3)
-; ZVZIP-NEXT:    vle16.v v11, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 24
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 20
+; ZVZIP-NEXT:    vle16.v v11, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v11, v10, 2
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v11, 4
-; ZVZIP-NEXT:    add a1, a3, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 28
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <10 x bfloat> @llvm.vector.interleave5.v10bf16(<2 x bfloat> %a, <2 x bfloat> %b, <2 x bfloat> %c, <2 x bfloat> %d, <2 x bfloat> %e)
 	   ret <10 x bfloat> %res
@@ -1522,119 +1294,95 @@ define <10 x bfloat> @vector_interleave5_v10bf16_v2bf16(<2 x bfloat> %a, <2 x bf
 define <12 x half> @vector_interleave6_v12f16_v2f16(<2 x half> %a, <2 x half> %b, <2 x half> %c, <2 x half> %d, <2 x half> %e, <2 x half> %f) nounwind {
 ; CHECK-LABEL: vector_interleave6_v12f16_v2f16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg6e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle16.v v9, (a2)
-; CHECK-NEXT:    add a2, a2, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v10, (a3)
-; CHECK-NEXT:    vle16.v v11, (a2)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle16.v v11, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
-; CHECK-NEXT:    add a3, a3, a1
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v11, v10, 2
-; CHECK-NEXT:    add a1, a3, a1
+; CHECK-NEXT:    addi a0, sp, 28
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
+; CHECK-NEXT:    addi a0, sp, 24
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave6_v12f16_v2f16:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 8
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg6e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle16.v v9, (a2)
-; ZVBB-NEXT:    add a2, a2, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v10, (a3)
-; ZVBB-NEXT:    vle16.v v11, (a2)
+; ZVBB-NEXT:    addi a1, sp, 12
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 20
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle16.v v11, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
-; ZVBB-NEXT:    add a3, a3, a1
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v11, v10, 2
-; ZVBB-NEXT:    add a1, a3, a1
+; ZVBB-NEXT:    addi a0, sp, 28
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
+; ZVBB-NEXT:    addi a0, sp, 24
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v11, 4
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave6_v12f16_v2f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 8
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg6e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle16.v v9, (a2)
-; ZVZIP-NEXT:    add a2, a2, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v10, (a3)
-; ZVZIP-NEXT:    vle16.v v11, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 12
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 20
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle16.v v11, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
-; ZVZIP-NEXT:    add a3, a3, a1
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v11, v10, 2
-; ZVZIP-NEXT:    add a1, a3, a1
+; ZVZIP-NEXT:    addi a0, sp, 28
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 24
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v11, 4
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <12 x half> @llvm.vector.interleave6.v12f16(<2 x half> %a, <2 x half> %b, <2 x half> %c, <2 x half> %d, <2 x half> %e, <2 x half> %f)
 	   ret <12 x half> %res
@@ -1643,119 +1391,95 @@ define <12 x half> @vector_interleave6_v12f16_v2f16(<2 x half> %a, <2 x half> %b
 define <12 x bfloat> @vector_interleave6_v12bf16_v2bf16(<2 x bfloat> %a, <2 x bfloat> %b, <2 x bfloat> %c, <2 x bfloat> %d, <2 x bfloat> %e, <2 x bfloat> %f) nounwind {
 ; CHECK-LABEL: vector_interleave6_v12bf16_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg6e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vle16.v v9, (a2)
-; CHECK-NEXT:    add a2, a2, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v10, (a3)
-; CHECK-NEXT:    vle16.v v11, (a2)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vle16.v v11, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
-; CHECK-NEXT:    add a3, a3, a1
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v11, v10, 2
-; CHECK-NEXT:    add a1, a3, a1
+; CHECK-NEXT:    addi a0, sp, 28
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
+; CHECK-NEXT:    addi a0, sp, 24
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a3)
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 2
 ; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave6_v12bf16_v2bf16:
 ; ZVBB:       # %bb.0:
-; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi sp, sp, -32
+; ZVBB-NEXT:    addi a0, sp, 8
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg6e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    vle16.v v9, (a2)
-; ZVBB-NEXT:    add a2, a2, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v10, (a3)
-; ZVBB-NEXT:    vle16.v v11, (a2)
+; ZVBB-NEXT:    addi a1, sp, 12
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 20
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 16
+; ZVBB-NEXT:    vle16.v v11, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
-; ZVBB-NEXT:    add a3, a3, a1
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v11, v10, 2
-; ZVBB-NEXT:    add a1, a3, a1
+; ZVBB-NEXT:    addi a0, sp, 28
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
+; ZVBB-NEXT:    addi a0, sp, 24
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v11, 4
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a3)
+; ZVBB-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 2
 ; ZVBB-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 8
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
-; ZVBB-NEXT:    addi sp, sp, 16
+; ZVBB-NEXT:    addi sp, sp, 32
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave6_v12bf16_v2bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi sp, sp, -32
+; ZVZIP-NEXT:    addi a0, sp, 8
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg6e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    vle16.v v9, (a2)
-; ZVZIP-NEXT:    add a2, a2, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v10, (a3)
-; ZVZIP-NEXT:    vle16.v v11, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 12
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 20
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 16
+; ZVZIP-NEXT:    vle16.v v11, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
-; ZVZIP-NEXT:    add a3, a3, a1
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v11, v10, 2
-; ZVZIP-NEXT:    add a1, a3, a1
+; ZVZIP-NEXT:    addi a0, sp, 28
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 24
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v11, 4
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 2
 ; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 8
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
-; ZVZIP-NEXT:    addi sp, sp, 16
+; ZVZIP-NEXT:    addi sp, sp, 32
 ; ZVZIP-NEXT:    ret
 	   %res = call <12 x bfloat> @llvm.vector.interleave6.v12bf16(<2 x bfloat> %a, <2 x bfloat> %b, <2 x bfloat> %c, <2 x bfloat> %d, <2 x bfloat> %e, <2 x bfloat> %f)
 	   ret <12 x bfloat> %res
@@ -1765,132 +1489,108 @@ define <7 x half> @vector_interleave7_v7f16_v1f16(<1 x half> %a, <1 x half> %b, 
 ; CHECK-LABEL: vector_interleave7_v7f16_v1f16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi a0, sp, 2
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg7e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v9, (a3)
-; CHECK-NEXT:    add a3, a3, a1
-; CHECK-NEXT:    vle16.v v10, (a2)
-; CHECK-NEXT:    add a2, a3, a1
-; CHECK-NEXT:    add a4, a2, a1
-; CHECK-NEXT:    vle16.v v11, (a4)
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vle16.v v10, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
-; CHECK-NEXT:    vle16.v v12, (a2)
+; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vle16.v v11, (a0)
+; CHECK-NEXT:    addi a0, sp, 10
+; CHECK-NEXT:    vle16.v v12, (a0)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 1
-; CHECK-NEXT:    add a1, a4, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 14
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v12, v11, 1
+; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a3)
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v12, v10, 2
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 3
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v12, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave7_v7f16_v1f16:
 ; ZVBB:       # %bb.0:
 ; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi a0, sp, 2
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg7e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v9, (a3)
-; ZVBB-NEXT:    add a3, a3, a1
-; ZVBB-NEXT:    vle16.v v10, (a2)
-; ZVBB-NEXT:    add a2, a3, a1
-; ZVBB-NEXT:    add a4, a2, a1
-; ZVBB-NEXT:    vle16.v v11, (a4)
+; ZVBB-NEXT:    addi a1, sp, 6
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 4
+; ZVBB-NEXT:    vle16.v v10, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
-; ZVBB-NEXT:    vle16.v v12, (a2)
+; ZVBB-NEXT:    addi a0, sp, 12
+; ZVBB-NEXT:    vle16.v v11, (a0)
+; ZVBB-NEXT:    addi a0, sp, 10
+; ZVBB-NEXT:    vle16.v v12, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 1
-; ZVBB-NEXT:    add a1, a4, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 14
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v12, v11, 1
+; ZVBB-NEXT:    addi a0, sp, 8
 ; ZVBB-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a3)
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v12, v10, 2
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 3
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v12, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
 ; ZVBB-NEXT:    addi sp, sp, 16
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave7_v7f16_v1f16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi a0, sp, 2
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg7e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v9, (a3)
-; ZVZIP-NEXT:    add a3, a3, a1
-; ZVZIP-NEXT:    vle16.v v10, (a2)
-; ZVZIP-NEXT:    add a2, a3, a1
-; ZVZIP-NEXT:    add a4, a2, a1
-; ZVZIP-NEXT:    vle16.v v11, (a4)
+; ZVZIP-NEXT:    addi a1, sp, 6
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 4
+; ZVZIP-NEXT:    vle16.v v10, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
-; ZVZIP-NEXT:    vle16.v v12, (a2)
+; ZVZIP-NEXT:    addi a0, sp, 12
+; ZVZIP-NEXT:    vle16.v v11, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 10
+; ZVZIP-NEXT:    vle16.v v12, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 1
-; ZVZIP-NEXT:    add a1, a4, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 14
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v12, v11, 1
+; ZVZIP-NEXT:    addi a0, sp, 8
 ; ZVZIP-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v12, v10, 2
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 3
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
 ; ZVZIP-NEXT:    addi sp, sp, 16
 ; ZVZIP-NEXT:    ret
 	   %res = call <7 x half> @llvm.vector.interleave7.v7f16(<1 x half> %a, <1 x half> %b, <1 x half> %c, <1 x half> %d, <1 x half> %e, <1 x half> %f, <1 x half> %g)
@@ -1901,132 +1601,108 @@ define <7 x bfloat> @vector_interleave7_v7bf16_v1bf16(<1 x bfloat> %a, <1 x bflo
 ; CHECK-LABEL: vector_interleave7_v7bf16_v1bf16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    addi a0, sp, 2
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg7e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vle16.v v9, (a3)
-; CHECK-NEXT:    add a3, a3, a1
-; CHECK-NEXT:    vle16.v v10, (a2)
-; CHECK-NEXT:    add a2, a3, a1
-; CHECK-NEXT:    add a4, a2, a1
-; CHECK-NEXT:    vle16.v v11, (a4)
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vle16.v v10, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
-; CHECK-NEXT:    vle16.v v12, (a2)
+; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vle16.v v11, (a0)
+; CHECK-NEXT:    addi a0, sp, 10
+; CHECK-NEXT:    vle16.v v12, (a0)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 1
-; CHECK-NEXT:    add a1, a4, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a0, sp, 14
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v10, (a0)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v12, v11, 1
+; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a3)
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v12, v10, 2
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v9, 3
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v12, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave7_v7bf16_v1bf16:
 ; ZVBB:       # %bb.0:
 ; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    addi a0, sp, 2
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg7e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    vle16.v v9, (a3)
-; ZVBB-NEXT:    add a3, a3, a1
-; ZVBB-NEXT:    vle16.v v10, (a2)
-; ZVBB-NEXT:    add a2, a3, a1
-; ZVBB-NEXT:    add a4, a2, a1
-; ZVBB-NEXT:    vle16.v v11, (a4)
+; ZVBB-NEXT:    addi a1, sp, 6
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 4
+; ZVBB-NEXT:    vle16.v v10, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
-; ZVBB-NEXT:    vle16.v v12, (a2)
+; ZVBB-NEXT:    addi a0, sp, 12
+; ZVBB-NEXT:    vle16.v v11, (a0)
+; ZVBB-NEXT:    addi a0, sp, 10
+; ZVBB-NEXT:    vle16.v v12, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 1
-; ZVBB-NEXT:    add a1, a4, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a0, sp, 14
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v10, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v12, v11, 1
+; ZVBB-NEXT:    addi a0, sp, 8
 ; ZVBB-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a3)
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v12, v10, 2
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 3
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v12, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
 ; ZVBB-NEXT:    addi sp, sp, 16
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave7_v7bf16_v1bf16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    addi a0, sp, 2
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg7e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    vle16.v v9, (a3)
-; ZVZIP-NEXT:    add a3, a3, a1
-; ZVZIP-NEXT:    vle16.v v10, (a2)
-; ZVZIP-NEXT:    add a2, a3, a1
-; ZVZIP-NEXT:    add a4, a2, a1
-; ZVZIP-NEXT:    vle16.v v11, (a4)
+; ZVZIP-NEXT:    addi a1, sp, 6
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 4
+; ZVZIP-NEXT:    vle16.v v10, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
-; ZVZIP-NEXT:    vle16.v v12, (a2)
+; ZVZIP-NEXT:    addi a0, sp, 12
+; ZVZIP-NEXT:    vle16.v v11, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 10
+; ZVZIP-NEXT:    vle16.v v12, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 1
-; ZVZIP-NEXT:    add a1, a4, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 14
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v10, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v12, v11, 1
+; ZVZIP-NEXT:    addi a0, sp, 8
 ; ZVZIP-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v12, v10, 2
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 3
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
 ; ZVZIP-NEXT:    addi sp, sp, 16
 ; ZVZIP-NEXT:    ret
 	   %res = call <7 x bfloat> @llvm.vector.interleave7.v7bf16(<1 x bfloat> %a, <1 x bfloat> %b, <1 x bfloat> %c, <1 x bfloat> %d, <1 x bfloat> %e, <1 x bfloat> %f, <1 x bfloat> %g)
@@ -2037,141 +1713,117 @@ define <8 x half> @vector_interleave8_v8f16_v1f16(<1 x half> %a, <1 x half> %b, 
 ; CHECK-LABEL: vector_interleave8_v8f16_v1f16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg8e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    add a4, a3, a1
-; CHECK-NEXT:    add a5, a4, a1
-; CHECK-NEXT:    add a6, a5, a1
-; CHECK-NEXT:    vle16.v v9, (a6)
-; CHECK-NEXT:    vle16.v v10, (a5)
-; CHECK-NEXT:    add a6, a6, a1
-; CHECK-NEXT:    vle16.v v11, (a6)
-; CHECK-NEXT:    vle16.v v12, (a2)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vle16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    vle16.v v12, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
+; CHECK-NEXT:    addi a0, sp, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a3)
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v12, 1
-; CHECK-NEXT:    add a1, a6, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v12, (a1)
+; CHECK-NEXT:    addi a0, sp, 14
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v12, (a0)
 ; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v10, v11, 2
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a4)
+; CHECK-NEXT:    addi a0, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v12, 3
 ; CHECK-NEXT:    vslideup.vi v8, v9, 3
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave8_v8f16_v1f16:
 ; ZVBB:       # %bb.0:
 ; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    mv a0, sp
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg8e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    add a4, a3, a1
-; ZVBB-NEXT:    add a5, a4, a1
-; ZVBB-NEXT:    add a6, a5, a1
-; ZVBB-NEXT:    vle16.v v9, (a6)
-; ZVBB-NEXT:    vle16.v v10, (a5)
-; ZVBB-NEXT:    add a6, a6, a1
-; ZVBB-NEXT:    vle16.v v11, (a6)
-; ZVBB-NEXT:    vle16.v v12, (a2)
+; ZVBB-NEXT:    addi a1, sp, 10
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 8
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 12
+; ZVBB-NEXT:    vle16.v v11, (a1)
+; ZVBB-NEXT:    addi a1, sp, 2
+; ZVBB-NEXT:    vle16.v v12, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
+; ZVBB-NEXT:    addi a0, sp, 4
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a3)
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v12, 1
-; ZVBB-NEXT:    add a1, a6, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v12, (a1)
+; ZVBB-NEXT:    addi a0, sp, 14
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v12, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v11, 2
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a4)
+; ZVBB-NEXT:    addi a0, sp, 6
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v12, 3
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 3
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
 ; ZVBB-NEXT:    addi sp, sp, 16
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave8_v8f16_v1f16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg8e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    add a4, a3, a1
-; ZVZIP-NEXT:    add a5, a4, a1
-; ZVZIP-NEXT:    add a6, a5, a1
-; ZVZIP-NEXT:    vle16.v v9, (a6)
-; ZVZIP-NEXT:    vle16.v v10, (a5)
-; ZVZIP-NEXT:    add a6, a6, a1
-; ZVZIP-NEXT:    vle16.v v11, (a6)
-; ZVZIP-NEXT:    vle16.v v12, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 10
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 8
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 12
+; ZVZIP-NEXT:    vle16.v v11, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 2
+; ZVZIP-NEXT:    vle16.v v12, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 4
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 1
-; ZVZIP-NEXT:    add a1, a6, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v12, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 14
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v12, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v11, 2
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a4)
+; ZVZIP-NEXT:    addi a0, sp, 6
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v12, 3
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 3
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
 ; ZVZIP-NEXT:    addi sp, sp, 16
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x half> @llvm.vector.interleave8.v8f16(<1 x half> %a, <1 x half> %b, <1 x half> %c, <1 x half> %d, <1 x half> %e, <1 x half> %f, <1 x half> %g, <1 x half> %h)
@@ -2182,141 +1834,117 @@ define <8 x bfloat> @vector_interleave8_v8bf16_v1bf16(<1 x bfloat> %a, <1 x bflo
 ; CHECK-LABEL: vector_interleave8_v8bf16_v1bf16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vsseg8e16.v v8, (a0)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    srli a1, a1, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    add a4, a3, a1
-; CHECK-NEXT:    add a5, a4, a1
-; CHECK-NEXT:    add a6, a5, a1
-; CHECK-NEXT:    vle16.v v9, (a6)
-; CHECK-NEXT:    vle16.v v10, (a5)
-; CHECK-NEXT:    add a6, a6, a1
-; CHECK-NEXT:    vle16.v v11, (a6)
-; CHECK-NEXT:    vle16.v v12, (a2)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vle16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vle16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vle16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    vle16.v v12, (a1)
 ; CHECK-NEXT:    vle16.v v8, (a0)
+; CHECK-NEXT:    addi a0, sp, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v10, v9, 1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a3)
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v8, v12, 1
-; CHECK-NEXT:    add a1, a6, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v12, (a1)
+; CHECK-NEXT:    addi a0, sp, 14
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v12, (a0)
 ; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; CHECK-NEXT:    vslideup.vi v10, v11, 2
 ; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; CHECK-NEXT:    vle16.v v9, (a4)
+; CHECK-NEXT:    addi a0, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vle16.v v9, (a0)
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vslideup.vi v10, v12, 3
 ; CHECK-NEXT:    vslideup.vi v8, v9, 3
 ; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 ;
 ; ZVBB-LABEL: vector_interleave8_v8bf16_v1bf16:
 ; ZVBB:       # %bb.0:
 ; ZVBB-NEXT:    addi sp, sp, -16
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    sub sp, sp, a0
-; ZVBB-NEXT:    addi a0, sp, 16
-; ZVBB-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVBB-NEXT:    mv a0, sp
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVBB-NEXT:    vsseg8e16.v v8, (a0)
-; ZVBB-NEXT:    csrr a1, vlenb
-; ZVBB-NEXT:    srli a1, a1, 2
-; ZVBB-NEXT:    add a2, a0, a1
-; ZVBB-NEXT:    add a3, a2, a1
-; ZVBB-NEXT:    add a4, a3, a1
-; ZVBB-NEXT:    add a5, a4, a1
-; ZVBB-NEXT:    add a6, a5, a1
-; ZVBB-NEXT:    vle16.v v9, (a6)
-; ZVBB-NEXT:    vle16.v v10, (a5)
-; ZVBB-NEXT:    add a6, a6, a1
-; ZVBB-NEXT:    vle16.v v11, (a6)
-; ZVBB-NEXT:    vle16.v v12, (a2)
+; ZVBB-NEXT:    addi a1, sp, 10
+; ZVBB-NEXT:    vle16.v v9, (a1)
+; ZVBB-NEXT:    addi a1, sp, 8
+; ZVBB-NEXT:    vle16.v v10, (a1)
+; ZVBB-NEXT:    addi a1, sp, 12
+; ZVBB-NEXT:    vle16.v v11, (a1)
+; ZVBB-NEXT:    addi a1, sp, 2
+; ZVBB-NEXT:    vle16.v v12, (a1)
 ; ZVBB-NEXT:    vle16.v v8, (a0)
+; ZVBB-NEXT:    addi a0, sp, 4
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v9, 1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a3)
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v12, 1
-; ZVBB-NEXT:    add a1, a6, a1
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v12, (a1)
+; ZVBB-NEXT:    addi a0, sp, 14
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v12, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v11, 2
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 2
-; ZVBB-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVBB-NEXT:    vle16.v v9, (a4)
+; ZVBB-NEXT:    addi a0, sp, 6
+; ZVBB-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVBB-NEXT:    vle16.v v9, (a0)
 ; ZVBB-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v10, v12, 3
 ; ZVBB-NEXT:    vslideup.vi v8, v9, 3
 ; ZVBB-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVBB-NEXT:    vslideup.vi v8, v10, 4
-; ZVBB-NEXT:    csrr a0, vlenb
-; ZVBB-NEXT:    slli a0, a0, 1
-; ZVBB-NEXT:    add sp, sp, a0
 ; ZVBB-NEXT:    addi sp, sp, 16
 ; ZVBB-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_interleave8_v8bf16_v1bf16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    addi sp, sp, -16
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    sub sp, sp, a0
-; ZVZIP-NEXT:    addi a0, sp, 16
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vsseg8e16.v v8, (a0)
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    srli a1, a1, 2
-; ZVZIP-NEXT:    add a2, a0, a1
-; ZVZIP-NEXT:    add a3, a2, a1
-; ZVZIP-NEXT:    add a4, a3, a1
-; ZVZIP-NEXT:    add a5, a4, a1
-; ZVZIP-NEXT:    add a6, a5, a1
-; ZVZIP-NEXT:    vle16.v v9, (a6)
-; ZVZIP-NEXT:    vle16.v v10, (a5)
-; ZVZIP-NEXT:    add a6, a6, a1
-; ZVZIP-NEXT:    vle16.v v11, (a6)
-; ZVZIP-NEXT:    vle16.v v12, (a2)
+; ZVZIP-NEXT:    addi a1, sp, 10
+; ZVZIP-NEXT:    vle16.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 8
+; ZVZIP-NEXT:    vle16.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 12
+; ZVZIP-NEXT:    vle16.v v11, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 2
+; ZVZIP-NEXT:    vle16.v v12, (a1)
 ; ZVZIP-NEXT:    vle16.v v8, (a0)
+; ZVZIP-NEXT:    addi a0, sp, 4
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v9, 1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a3)
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 1
-; ZVZIP-NEXT:    add a1, a6, a1
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v12, (a1)
+; ZVZIP-NEXT:    addi a0, sp, 14
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v12, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v11, 2
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 2
-; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vle16.v v9, (a4)
+; ZVZIP-NEXT:    addi a0, sp, 6
+; ZVZIP-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; ZVZIP-NEXT:    vle16.v v9, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v10, v12, 3
 ; ZVZIP-NEXT:    vslideup.vi v8, v9, 3
 ; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 4
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    slli a0, a0, 1
-; ZVZIP-NEXT:    add sp, sp, a0
 ; ZVZIP-NEXT:    addi sp, sp, 16
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x bfloat> @llvm.vector.interleave8.v8bf16(<1 x bfloat> %a, <1 x bfloat> %b, <1 x bfloat> %c, <1 x bfloat> %d, <1 x bfloat> %e, <1 x bfloat> %f, <1 x bfloat> %g, <1 x bfloat> %h)


### PR DESCRIPTION
This is the sibling patch of #207254, as it turns out VECTOR_INTERLEAVE has the same problem on fixed vectors as well.

Instead of converting individual operands into scalable vectors, this patch puts each of the operands directly onto stack using the fixed vector version of segmented store intrinsics, before loading them back.