### PR TITLE
[libclang] Add clang_Type_getDependentSizeExpr

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -3734,6 +3734,14 @@ CINDEX_LINKAGE CXType clang_Type_getModifiedType(CXType T);
  */
 CINDEX_LINKAGE CXType clang_Type_getValueType(CXType CT);
 
+
+/**
+ *  Gets the expression associated with this dependent sized array
+ *
+ *  If a non-dependent type is passed in, an invalid cursor is returned.
+ */
+CINDEX_LINKAGE CXCursor clang_Type_getDependentSizeExpr(CXType CT);
+
 /**
  * Return the offset of the field represented by the Cursor.
  *

--- a/clang/tools/libclang/CXType.cpp
+++ b/clang/tools/libclang/CXType.cpp
@@ -912,6 +912,32 @@ long long clang_getNumElements(CXType CT) {
   return result;
 }
 
+CXCursor clang_Type_getDependentSizeExpr(CXType CT) {
+  QualType T = GetQualType(CT);
+  const Type *TP = T.getTypePtrOrNull();
+
+  if (!TP)
+    return cxcursor::MakeCXCursorInvalid(CXCursor_NoDeclFound);
+
+  const Expr* E = nullptr;
+
+  switch (TP->getTypeClass()) {
+  case Type::DependentSizedArray:
+    E = cast<DependentSizedArrayType> (TP)->getSizeExpr();
+    break;
+  case Type::DependentSizedExtVector:
+    E = cast<DependentSizedExtVectorType> (TP)->getSizeExpr();
+    break;
+  default:
+    break;
+  }
+
+  if (!E) 
+    return cxcursor::MakeCXCursorInvalid(CXCursor_NoDeclFound);
+  
+  return cxcursor::MakeCXCursor(E, nullptr, GetTU(CT));
+}
+
 CXType clang_getArrayElementType(CXType CT) {
   QualType ET = QualType();
   QualType T = GetQualType(CT);

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -461,6 +461,7 @@ LLVM_23 {
   global:
     clang_ModuleCache_prune;
     clang_ModuleCache_pruneWithCallback;
+    clang_Type_getDependentSizeExpr;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol


### PR DESCRIPTION
clang_Type_getDependentSizeExpr gets the expression related to a dependent sized type (array / extvector). This would clean up traversing declarations of (possibly nested) array types for users of libclang.