### PR TITLE
workflows/release-sources: Pass release-version to upload-release-artifacts

### DIFF
--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Upload Artifacts
         uses: ./.github/workflows/upload-release-artifact
         with:
+          release-version: ${{ inputs.release-version }}
           artifact-id: ${{ needs.release-sources.outputs.artifact-id }}
           attestation-name: ${{ needs.inputs.outputs.ref }}-sources-attestation
           digest: ${{ needs.release-sources.outputs.digest }}


### PR DESCRIPTION
This was omitted from a8ccd42ab23af6848929a638cd6b099953c7e491.