### PR TITLE
[lldb] Include `Debugger.h` in `ScriptedCommandPythonInterface.cpp` (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedCommandPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedCommandPythonInterface.cpp
@@ -9,6 +9,7 @@
 #include "../lldb-python.h"
 
 #include "lldb/API/SBCommandReturnObject.h"
+#include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Target/ExecutionContext.h"


### PR DESCRIPTION
Commit c35bdc99a36b passes a `lldb::DebuggerSP` to the `ScriptedPythonInterface` base template, whose `Transform` overload is constrained on `std::is_base_of_v` and so needs `Debugger` to be complete. This patch includes `lldb/Core/Debugger.h` since the translation unit only saw the forward declaration.