### PR TITLE
[ORC] Remove SymbolInstance class.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -57,26 +57,6 @@ using WaitingOnGraph =
 using ResourceTrackerSP = IntrusiveRefCntPtr<ResourceTracker>;
 using JITDylibSP = IntrusiveRefCntPtr<JITDylib>;
 
-/// A definition of a Symbol within a JITDylib.
-class SymbolInstance {
-public:
-  using LookupAsyncOnCompleteFn =
-      unique_function<void(Expected<ExecutorSymbolDef>)>;
-
-  SymbolInstance(JITDylibSP JD, SymbolStringPtr Name)
-      : JD(std::move(JD)), Name(std::move(Name)) {}
-
-  const JITDylib &getJITDylib() const { return *JD; }
-  const SymbolStringPtr &getName() const { return Name; }
-
-  Expected<ExecutorSymbolDef> lookup() const;
-  LLVM_ABI void lookupAsync(LookupAsyncOnCompleteFn OnComplete) const;
-
-private:
-  JITDylibSP JD;
-  SymbolStringPtr Name;
-};
-
 using ResourceKey = uintptr_t;
 
 /// API to remove / transfer ownership of JIT resources.
@@ -1633,10 +1613,6 @@ private:
   DenseMap<ExecutorAddr, std::shared_ptr<JITDispatchHandlerFunction>>
       JITDispatchHandlers;
 };
-
-inline Expected<ExecutorSymbolDef> SymbolInstance::lookup() const {
-  return JD->getExecutionSession().lookup({JD.get()}, Name);
-}
 
 template <typename Func> Error ResourceTracker::withResourceKeyDo(Func &&F) {
   return getJITDylib().getExecutionSession().runSessionLocked([&]() -> Error {

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -188,27 +188,6 @@ void UnexpectedSymbolDefinitions::log(raw_ostream &OS) const {
      << ": " << Symbols;
 }
 
-void SymbolInstance::lookupAsync(LookupAsyncOnCompleteFn OnComplete) const {
-  JD->getExecutionSession().lookup(
-      LookupKind::Static, {{JD.get(), JITDylibLookupFlags::MatchAllSymbols}},
-      SymbolLookupSet(Name), SymbolState::Ready,
-      [OnComplete = std::move(OnComplete)
-#ifndef NDEBUG
-           ,
-       Name = this->Name // Captured for the assert below only.
-#endif                   // NDEBUG
-  ](Expected<SymbolMap> Result) mutable {
-        if (Result) {
-          assert(Result->size() == 1 && "Unexpected number of results");
-          assert(Result->count(Name) &&
-                 "Result does not contain expected symbol");
-          OnComplete(Result->begin()->second);
-        } else
-          OnComplete(Result.takeError());
-      },
-      NoDependenciesToRegister);
-}
-
 AsynchronousSymbolQuery::AsynchronousSymbolQuery(
     const SymbolLookupSet &Symbols, SymbolState RequiredState,
     SymbolsResolvedCallback NotifyComplete)

--- a/llvm/lib/ExecutionEngine/Orc/LazyReexports.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LazyReexports.cpp
@@ -429,21 +429,23 @@ void LazyReexportsManager::resolve(ResolveSendResultFn SendResult,
   if (L)
     L->onLazyReexportCalled(LandingInfo);
 
-  SymbolInstance LandingSym(LandingInfo.JD, std::move(LandingInfo.BodyName));
-  LandingSym.lookupAsync([this, JD = std::move(LandingInfo.JD),
-                          ReentryName = std::move(LandingInfo.Name),
-                          SendResult = std::move(SendResult)](
-                             Expected<ExecutorSymbolDef> Result) mutable {
-    if (Result) {
-      // FIXME: Make RedirectionManager operations async, then use the async
-      //        APIs here.
-      if (auto Err = RSMgr.redirect(*JD, ReentryName, *Result))
-        SendResult(std::move(Err));
-      else
-        SendResult(std::move(Result));
-    } else
-      SendResult(std::move(Result));
-  });
+  ES.lookup(
+      LookupKind::Static,
+      {{LandingInfo.JD.get(), JITDylibLookupFlags::MatchAllSymbols}},
+      SymbolLookupSet(std::move(LandingInfo.BodyName)), SymbolState::Ready,
+      [this, JD = std::move(LandingInfo.JD),
+       ReentryName = std::move(LandingInfo.Name),
+       SendResult = std::move(SendResult)](Expected<SymbolMap> Result) mutable {
+        if (!Result)
+          return SendResult(Result.takeError());
+
+        assert(Result->size() == 1 && "Unexpected number of results");
+        auto BodySym = Result->begin()->second;
+        if (auto Err = RSMgr.redirect(*JD, ReentryName, BodySym))
+          SendResult(std::move(Err));
+        SendResult(BodySym);
+      },
+      NoDependenciesToRegister);
 }
 
 class SimpleLazyReexportsSpeculator::SpeculateTask : public IdleTask {


### PR DESCRIPTION
This class had only one user, and no tests. Remove it for now and update the single user to call ExecutionSession::lookup directly.