### PR TITLE
[lldb][elf-core] Populate memory region names from NT_FILE

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -6,9 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
 #include <cstdlib>
 
 #include <memory>
+#include <vector>
 
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
@@ -132,15 +134,19 @@ lldb::addr_t ProcessElfCore::AddAddressRangeFromLoadSegment(
       m_core_aranges.Append(range_entry);
     }
   }
-  // Keep a separate map of permissions that isn't coalesced so all ranges
-  // are maintained.
+  // Keep mapped regions separate from m_core_aranges and uncoalesced so each
+  // PT_LOAD's permissions are preserved.
   const uint32_t permissions =
       ((header.p_flags & llvm::ELF::PF_R) ? lldb::ePermissionsReadable : 0u) |
       ((header.p_flags & llvm::ELF::PF_W) ? lldb::ePermissionsWritable : 0u) |
       ((header.p_flags & llvm::ELF::PF_X) ? lldb::ePermissionsExecutable : 0u);
 
-  m_core_range_infos.Append(
-      VMRangeToPermissions::Entry(addr, header.p_memsz, permissions));
+  MemoryRegionInfo region_info;
+  region_info.GetRange() = MemoryRegionInfo::RangeType(addr, header.p_memsz);
+  region_info.SetLLDBPermissions(permissions);
+  region_info.SetMapped(eLazyBoolYes);
+  region_info.SetMemoryTagged(eLazyBoolNo);
+  m_core_range_infos.insert(std::move(region_info));
 
   return addr;
 }
@@ -224,9 +230,10 @@ Status ProcessElfCore::DoLoadCore() {
 
   if (!ranges_are_sorted) {
     m_core_aranges.Sort();
-    m_core_range_infos.Sort();
     m_core_tag_ranges.Sort();
   }
+
+  FinalizeMemoryRegionInfos();
 
   // Ensure we found at least one thread that was stopped on a signal.
   bool siginfo_signal_found = false;
@@ -314,6 +321,70 @@ void ProcessElfCore::UpdateBuildIdForNTFileEntries() {
                 entry.path.c_str());
     }
   }
+}
+
+void ProcessElfCore::FinalizeMemoryRegionInfos() {
+  std::set<MemoryRegionInfo, std::less<>> finalized_regions;
+  // Add NT_FILE paths as names to PT_LOAD regions with matching start
+  // addresses, preserving the PT_LOAD ranges and permissions.
+  for (MemoryRegionInfo region_info : m_core_range_infos) {
+    const lldb::addr_t range_base = region_info.GetRange().GetRangeBase();
+    const lldb::addr_t range_end = region_info.GetRange().GetRangeEnd();
+
+    auto file_entry =
+        std::find_if(m_nt_file_entries.begin(), m_nt_file_entries.end(),
+                     [range_base](const NT_FILE_Entry &entry) {
+                       return entry.start == range_base;
+                     });
+    if (file_entry != m_nt_file_entries.end() && !file_entry->path.empty())
+      region_info.SetName(file_entry->path.c_str());
+
+    const VMRangeToFileOffset::Entry *tag_entry =
+        m_core_tag_ranges.FindEntryStartsAt(range_base);
+    if (tag_entry && tag_entry->GetRangeEnd() == range_end)
+      region_info.SetMemoryTagged(eLazyBoolYes);
+
+    finalized_regions.insert(std::move(region_info));
+  }
+
+  // Create mapped regions with unknown permissions for portions of NT_FILE
+  // entries not covered by any PT_LOAD region.
+  for (const NT_FILE_Entry &file_entry : m_nt_file_entries) {
+    if (file_entry.start >= file_entry.end)
+      continue;
+
+    lldb::addr_t cursor = file_entry.start;
+    std::vector<MemoryRegionInfo::RangeType> uncovered_ranges;
+    for (const MemoryRegionInfo &region_info : finalized_regions) {
+      const lldb::addr_t range_base = region_info.GetRange().GetRangeBase();
+      const lldb::addr_t range_end = region_info.GetRange().GetRangeEnd();
+
+      if (range_end <= cursor)
+        continue;
+      if (range_base >= file_entry.end)
+        break;
+
+      if (cursor < range_base)
+        uncovered_ranges.emplace_back(cursor, range_base - cursor);
+
+      cursor = std::max(cursor, range_end);
+      if (cursor >= file_entry.end)
+        break;
+    }
+
+    if (cursor < file_entry.end)
+      uncovered_ranges.emplace_back(cursor, file_entry.end - cursor);
+
+    for (const MemoryRegionInfo::RangeType &range : uncovered_ranges) {
+      MemoryRegionInfo region_info;
+      region_info.GetRange() = range;
+      region_info.SetMapped(eLazyBoolYes);
+      if (!file_entry.path.empty())
+        region_info.SetName(file_entry.path.c_str());
+      finalized_regions.insert(std::move(region_info));
+    }
+  }
+  m_core_range_infos = std::move(finalized_regions);
 }
 
 /// Correctly create a FileSpec from a path found in a core file.
@@ -466,46 +537,23 @@ size_t ProcessElfCore::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
 Status ProcessElfCore::DoGetMemoryRegionInfo(lldb::addr_t load_addr,
                                              MemoryRegionInfo &region_info) {
   region_info.Clear();
-  const VMRangeToPermissions::Entry *permission_entry =
-      m_core_range_infos.FindEntryThatContainsOrFollows(load_addr);
-  if (permission_entry) {
-    if (permission_entry->Contains(load_addr)) {
-      region_info.GetRange().SetRangeBase(permission_entry->GetRangeBase());
-      region_info.GetRange().SetRangeEnd(permission_entry->GetRangeEnd());
-      const Flags permissions(permission_entry->data);
-      region_info.SetReadable(permissions.Test(lldb::ePermissionsReadable)
-                                  ? eLazyBoolYes
-                                  : eLazyBoolNo);
-      region_info.SetWritable(permissions.Test(lldb::ePermissionsWritable)
-                                  ? eLazyBoolYes
-                                  : eLazyBoolNo);
-      region_info.SetExecutable(permissions.Test(lldb::ePermissionsExecutable)
-                                    ? eLazyBoolYes
-                                    : eLazyBoolNo);
-      region_info.SetMapped(eLazyBoolYes);
-
-      // A region is memory tagged if there is a memory tag segment that covers
-      // the exact same range.
-      region_info.SetMemoryTagged(eLazyBoolNo);
-      const VMRangeToFileOffset::Entry *tag_entry =
-          m_core_tag_ranges.FindEntryStartsAt(permission_entry->GetRangeBase());
-      if (tag_entry &&
-          tag_entry->GetRangeEnd() == permission_entry->GetRangeEnd())
-        region_info.SetMemoryTagged(eLazyBoolYes);
-    } else if (load_addr < permission_entry->GetRangeBase()) {
-      region_info.GetRange().SetRangeBase(load_addr);
-      region_info.GetRange().SetRangeEnd(permission_entry->GetRangeBase());
-      region_info.SetReadable(eLazyBoolNo);
-      region_info.SetWritable(eLazyBoolNo);
-      region_info.SetExecutable(eLazyBoolNo);
-      region_info.SetMapped(eLazyBoolNo);
-      region_info.SetMemoryTagged(eLazyBoolNo);
-    }
+  auto following = m_core_range_infos.upper_bound(load_addr);
+  // PT_LOAD ranges can overlap, so the immediate predecessor is not
+  // necessarily the range containing load_addr.
+  auto range_entry = std::find_if(m_core_range_infos.begin(), following,
+                                  [load_addr](const auto &entry) {
+                                    return entry.GetRange().Contains(load_addr);
+                                  });
+  if (range_entry != following) {
+    region_info = *range_entry;
     return Status();
   }
 
   region_info.GetRange().SetRangeBase(load_addr);
-  region_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
+  region_info.GetRange().SetRangeEnd(
+      following == m_core_range_infos.end()
+          ? LLDB_INVALID_ADDRESS
+          : following->GetRange().GetRangeBase());
   region_info.SetReadable(eLazyBoolNo);
   region_info.SetWritable(eLazyBoolNo);
   region_info.SetExecutable(eLazyBoolNo);

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
@@ -16,10 +16,13 @@
 #ifndef LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_PROCESSELFCORE_H
 #define LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_PROCESSELFCORE_H
 
+#include <functional>
 #include <list>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
+#include "lldb/Target/MemoryRegionInfo.h"
 #include "lldb/Target/PostMortemProcess.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/Status.h"
@@ -124,8 +127,6 @@ private:
   typedef lldb_private::Range<lldb::addr_t, lldb::addr_t> FileRange;
   typedef lldb_private::RangeDataVector<lldb::addr_t, lldb::addr_t, FileRange>
       VMRangeToFileOffset;
-  typedef lldb_private::RangeDataVector<lldb::addr_t, lldb::addr_t, uint32_t>
-      VMRangeToPermissions;
 
   lldb::ModuleSP m_core_module_sp;
   std::string m_dyld_plugin_name;
@@ -142,8 +143,8 @@ private:
   // Address ranges found in the core
   VMRangeToFileOffset m_core_aranges;
 
-  // Permissions for all ranges
-  VMRangeToPermissions m_core_range_infos;
+  // Information for all mapped ranges, ordered by address.
+  std::set<lldb_private::MemoryRegionInfo, std::less<>> m_core_range_infos;
 
   // Memory tag ranges found in the core
   VMRangeToFileOffset m_core_tag_ranges;
@@ -169,6 +170,9 @@ private:
 
   // Populate gnu uuid for each NT_FILE entry
   void UpdateBuildIdForNTFileEntries();
+
+  // Complete memory region information after all program headers are parsed.
+  void FinalizeMemoryRegionInfos();
 
   bool FindModuleUUID(lldb_private::ModuleSpec &spec) override;
 

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -1439,6 +1439,75 @@ class LinuxCoreTestCase(TestBase):
 
     @skipIfLLVMTargetMissing("X86")
     @skipIfWindows
+    def test_memory_region_name_from_nt_file(self):
+        yaml_path = self.getSourcePath("elf-NT_FILE-memory-region.yaml")
+        core_path = self.getBuildArtifact("elf-NT_FILE-memory-region.core")
+        self.yaml2obj(yaml_path, core_path)
+        target = self.dbg.CreateTarget(None)
+        process = target.LoadCore(core_path)
+        self.assertTrue(process.IsValid())
+
+        region = lldb.SBMemoryRegionInfo()
+        self.assertSuccess(process.GetMemoryRegionInfo(0x400000, region))
+        self.assertEqual(region.GetRegionBase(), 0x400000)
+        self.assertEqual(region.GetRegionEnd(), 0x401000)
+        self.assertTrue(region.IsMapped())
+        self.assertTrue(region.IsReadable())
+        self.assertFalse(region.IsWritable())
+        self.assertTrue(region.IsExecutable())
+        self.assertEqual(region.GetName(), "/tmp/kernel.hsaco")
+
+        interior_region = lldb.SBMemoryRegionInfo()
+        self.assertSuccess(process.GetMemoryRegionInfo(0x401000, interior_region))
+        self.assertEqual(interior_region.GetRegionBase(), 0x401000)
+        self.assertEqual(interior_region.GetRegionEnd(), 0x402000)
+        self.assertTrue(interior_region.IsMapped())
+        self.assertTrue(interior_region.IsReadable())
+        self.assertFalse(interior_region.IsWritable())
+        self.assertFalse(interior_region.IsExecutable())
+        self.assertIsNone(interior_region.GetName())
+
+        nt_file_region = lldb.SBMemoryRegionInfo()
+        self.assertSuccess(process.GetMemoryRegionInfo(0x402000, nt_file_region))
+        self.assertEqual(nt_file_region.GetRegionBase(), 0x402000)
+        self.assertEqual(nt_file_region.GetRegionEnd(), 0x403000)
+        self.assertTrue(nt_file_region.IsMapped())
+        # SB's boolean permission accessors report unknown as false.
+        self.assertFalse(nt_file_region.IsReadable())
+        self.assertFalse(nt_file_region.IsWritable())
+        self.assertFalse(nt_file_region.IsExecutable())
+        self.assertEqual(nt_file_region.GetName(), "/tmp/kernel.hsaco")
+
+        self.expect(
+            "memory region 0x402000",
+            substrs=["???", "/tmp/kernel.hsaco"],
+        )
+
+        regions = process.GetMemoryRegions()
+        self.assertEqual(regions.GetSize(), 3)
+        listed_region = lldb.SBMemoryRegionInfo()
+        self.assertTrue(
+            regions.GetMemoryRegionContainingAddress(0x400000, listed_region)
+        )
+        self.assertEqual(listed_region, region)
+        self.assertTrue(
+            regions.GetMemoryRegionContainingAddress(0x401000, listed_region)
+        )
+        self.assertEqual(listed_region, interior_region)
+        self.assertTrue(regions.GetMemoryRegionAtIndex(2, listed_region))
+        self.assertEqual(listed_region, nt_file_region)
+
+        following_region = lldb.SBMemoryRegionInfo()
+        self.assertSuccess(process.GetMemoryRegionInfo(0x403000, following_region))
+        self.assertEqual(following_region.GetRegionBase(), 0x403000)
+        self.assertEqual(following_region.GetRegionEnd(), lldb.LLDB_INVALID_ADDRESS)
+        self.assertFalse(following_region.IsMapped())
+        self.assertIsNone(following_region.GetName())
+
+        self.dbg.DeleteTarget(target)
+
+    @skipIfLLVMTargetMissing("X86")
+    @skipIfWindows
     def test_exe_name_extraction_nt_file(self):
         # This core file has:
         # - NT_FILE entry for the executable with path '/path/nt_file_foo

--- a/lldb/test/API/functionalities/postmortem/elf-core/elf-NT_FILE-memory-region.yaml
+++ b/lldb/test/API/functionalities/postmortem/elf-core/elf-NT_FILE-memory-region.yaml
@@ -1,0 +1,30 @@
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_CORE
+  Machine: EM_X86_64
+  OSABI:   ELFOSABI_LINUX
+ProgramHeaders:
+  - Type:     PT_LOAD
+    Flags:    [ PF_R, PF_X ]
+    VAddr:    0x400000
+    Align:    0x1000
+    FileSize: 0
+    MemSize:  0x1000
+  - Type:     PT_LOAD
+    Flags:    [ PF_R ]
+    VAddr:    0x401000
+    Align:    0x1000
+    FileSize: 0
+    MemSize:  0x1000
+  - Type:     PT_NOTE
+    FirstSec: .note
+    LastSec:  .note
+Sections:
+  - Name: .note
+    Type: SHT_NOTE
+    Notes:
+      - Name: CORE
+        Type: NT_FILE
+        Desc: 020000000000000000100000000000000000400000000000001040000000000000000000000000000020400000000000003040000000000002000000000000002f746d702f6b65726e656c2e687361636f002f746d702f6b65726e656c2e687361636f00


### PR DESCRIPTION
## Summary

`ProcessElfCore` already parses `NT_FILE`, but its cached `PT_LOAD` memory-region entries did not retain their backing filenames.

- cache a complete `MemoryRegionInfo` for each `PT_LOAD` instead of rebuilding one from a custom permissions/name record on every query
- associate an `NT_FILE` pathname when the `PT_LOAD` and `NT_FILE` starts match; their ends may differ, while a `PT_LOAD` beginning inside an `NT_FILE` range remains unnamed
- finalize names and memory-tag state after all program headers are parsed, making the result independent of `PT_LOAD` and `PT_NOTE` ordering
- preserve regions with `p_filesz == 0` and return the cached region directly from `DoGetMemoryRegionInfo`
- add API coverage for the same-start/different-end case, an interior unnamed region, and an unnamed NT_FILE-only tail

## Testing

- Clean LLVM 24/LLDB build completed successfully.
- `check-lldb-api-functionalities-postmortem-elf-core` (4/4 passed)
- `ProcessElfCoreTests` (3/3 passed)
- `check-lldb-api-linux-aarch64-mte_core_file` (1/1 passed)
- Real IPNext core compatibility smoke test using an assertion-disabled Release build:

```
(lldb) memory region 0x7fc4f25fd000
[0x00007fc4f25fd000-0x00007fc4f2600000) r-- /tmp/aot_inductor_loaded_modelaCZzUI/ckq4hskzrtwkbxruge7ofytm2zmahqgcizkszojgcp3eepdubxc2.hsaco
```

The focused API fixture exercises the mismatched-end and interior-start policies; the production core verifies compatibility with a large zero-file-size HSACO mapping.
