### PR TITLE
[CIR][AArch64] Upstream store (vstrq_p128) NEON builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2467,6 +2467,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
       case NEON::BI__builtin_neon_vst1q_v:
       case NEON::BI__builtin_neon_vst1_lane_v:
       case NEON::BI__builtin_neon_vst1q_lane_v:
+      case NEON::BI__builtin_neon_vstrq_p128:
         // Get the alignment for the argument in addition to the value;
         // we'll use it later.
         ptrOp0 = emitPointerWithAlignment(expr->getArg(0));
@@ -2538,7 +2539,14 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
     return builder.createBitcast(result, convertType(expr->getType()));
   }
   case NEON::BI__builtin_neon_vldrq_p128:
-  case NEON::BI__builtin_neon_vstrq_p128:
+    cgm.errorNYI(expr->getSourceRange(),
+                 std::string("unimplemented AArch64 builtin call: ") +
+                     getContext().BuiltinInfo.getName(builtinID));
+    return mlir::Value{};
+  case NEON::BI__builtin_neon_vstrq_p128: {
+    builder.createStore(loc, ops[1], ptrOp0);
+    return nullptr;
+  }
   case NEON::BI__builtin_neon_vcvts_f32_u32:
   case NEON::BI__builtin_neon_vcvtd_f64_u64:
   case NEON::BI__builtin_neon_vcvts_f32_s32:

--- a/clang/test/CodeGen/AArch64/neon/store.c
+++ b/clang/test/CodeGen/AArch64/neon/store.c
@@ -1484,3 +1484,14 @@ void test_vst1q_u8_x4(uint8_t *a, uint8x16x4_t b) {
 // LLVM: ret void
   vst1q_u8_x4(a, b);
 }
+
+// ALL-LABEL: @test_vstrq_p128(
+void test_vstrq_p128(poly128_t *ptr, poly128_t val) {
+// CIR: cir.cast bitcast {{.*}} : !cir.ptr<!void> -> !cir.ptr<!u128i>
+// CIR: cir.store align(16) {{.*}}, {{.*}} : !u128i, !cir.ptr<!u128i>
+
+// LLVM-SAME: ptr {{.*}} [[PTR:%.*]], i128 {{.*}} [[VAL:%.*]])
+// LLVM: store i128 [[VAL]], ptr [[PTR]], align 16
+// LLVM: ret void
+  vstrq_p128(ptr, val);
+}

--- a/clang/test/CodeGen/AArch64/poly128.c
+++ b/clang/test/CodeGen/AArch64/poly128.c
@@ -14,19 +14,8 @@
 
 #include <arm_neon.h>
 
-// CHECK-LABEL: define {{[^@]+}}@test_vstrq_p128
-// CHECK-SAME: (ptr noundef [[PTR:%.*]], i128 noundef [[VAL:%.*]]) #[[ATTR0:[0-9]+]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    store i128 [[VAL]], ptr [[PTR]], align 16
-// CHECK-NEXT:    ret void
-//
-void test_vstrq_p128(poly128_t * ptr, poly128_t val) {
-  vstrq_p128(ptr, val);
-
-}
-
 // CHECK-LABEL: define {{[^@]+}}@test_vldrq_p128
-// CHECK-SAME: (ptr noundef [[PTR:%.*]]) #[[ATTR0]] {
+// CHECK-SAME: (ptr noundef [[PTR:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = load i128, ptr [[PTR]], align 16
 // CHECK-NEXT:    ret i128 [[TMP0]]


### PR DESCRIPTION
Related to https://github.com/llvm/llvm-project/issues/185382

CIR lowering for store intrinsics (`vstrq_p128`) (https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#store)

Port test from `clang/test/CodeGen/AArch64/poly128.c` to `clang/test/CodeGen/AArch64/neon/store.c`