### PR TITLE
[lldb-mcp] Add --help and --version

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -128,6 +128,10 @@ if(TARGET lldb-dap)
   add_lldb_test_dependency(lldb-dap)
 endif()
 
+if(TARGET lldb-mcp)
+  add_lldb_test_dependency(lldb-mcp)
+endif()
+
 if(TARGET liblldb)
   add_lldb_test_dependency(liblldb)
 endif()

--- a/lldb/test/Shell/MCP/TestHelp.test
+++ b/lldb/test/Shell/MCP/TestHelp.test
@@ -1,0 +1,7 @@
+# RUN: lldb-mcp --help | FileCheck %s
+# RUN: lldb-mcp -h | FileCheck %s
+# CHECK: OVERVIEW: LLDB MCP
+# CHECK: USAGE: lldb-mcp
+# CHECK: OPTIONS:
+# CHECK: --help
+# CHECK: --version

--- a/lldb/test/Shell/MCP/TestUnknownArgument.test
+++ b/lldb/test/Shell/MCP/TestUnknownArgument.test
@@ -1,0 +1,3 @@
+# RUN: not lldb-mcp --bogus 2>&1 | FileCheck %s
+# CHECK: error: unknown argument '--bogus'
+# CHECK: USAGE: lldb-mcp

--- a/lldb/test/Shell/MCP/TestVersion.test
+++ b/lldb/test/Shell/MCP/TestVersion.test
@@ -1,4 +1,4 @@
 # RUN: lldb-mcp --version | FileCheck %s
 # RUN: lldb-mcp -v | FileCheck %s
-# CHECK: lldb-mcp:
+# CHECK: lldb-mcp{{.*}}:
 # CHECK: liblldb:

--- a/lldb/test/Shell/MCP/TestVersion.test
+++ b/lldb/test/Shell/MCP/TestVersion.test
@@ -1,0 +1,4 @@
+# RUN: lldb-mcp --version | FileCheck %s
+# RUN: lldb-mcp -v | FileCheck %s
+# CHECK: lldb-mcp:
+# CHECK: liblldb:

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -172,6 +172,7 @@ def use_lldb_substitutions(config):
         ),
         "lldb-test",
         "lldb-dap",
+        "lldb-mcp",
         ToolSubst(
             "%build", command="'" + sys.executable + "'", extra_args=build_script_args
         ),

--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -25,9 +25,11 @@
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/WithColor.h"
@@ -117,6 +119,24 @@ llvm::Error connectBackend(lldb_mcp::Multiplexer &multiplexer, MainLoop &loop,
   return llvm::Error::success();
 }
 
+void printHelp(StringRef tool_name) {
+  outs() << "OVERVIEW: LLDB MCP\n\nUSAGE: " << tool_name << " [options]\n";
+  outs() << R"___(
+Multiplexes the Model Context Protocol over stdio across the running LLDB
+instances, and hosts its own debug sessions.
+
+OPTIONS:
+  -h, --help     Display this help message
+  -v, --version  Display the version
+)___";
+}
+
+void printVersion() {
+  outs() << "lldb-mcp: ";
+  cl::PrintVersionMessage();
+  outs() << "liblldb: " << SBDebugger::GetVersionString() << '\n';
+}
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -140,6 +160,21 @@ int main(int argc, char *argv[]) {
   UNUSED_IF_ASSERT_DISABLED(result);
   assert(result);
 #endif
+
+  for (int i = 1; i < argc; ++i) {
+    StringRef arg(argv[i]);
+    if (arg == "-h" || arg == "--help") {
+      printHelp(sys::path::filename(argv[0]));
+      return EXIT_SUCCESS;
+    }
+    if (arg == "-v" || arg == "--version") {
+      printVersion();
+      return EXIT_SUCCESS;
+    }
+    WithColor::error(errs()) << "unknown argument '" << arg << "'\n";
+    printHelp(sys::path::filename(argv[0]));
+    return EXIT_FAILURE;
+  }
 
   // Bring up the debug engine (through the public SB API) so lldb-mcp can host
   // debug sessions in its own process.

--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -131,8 +131,8 @@ OPTIONS:
 )___";
 }
 
-void printVersion() {
-  outs() << "lldb-mcp: ";
+void printVersion(StringRef tool_name) {
+  outs() << tool_name << ": ";
   cl::PrintVersionMessage();
   outs() << "liblldb: " << SBDebugger::GetVersionString() << '\n';
 }
@@ -161,18 +161,19 @@ int main(int argc, char *argv[]) {
   assert(result);
 #endif
 
+  StringRef tool_name = sys::path::filename(argv[0]);
   for (int i = 1; i < argc; ++i) {
     StringRef arg(argv[i]);
     if (arg == "-h" || arg == "--help") {
-      printHelp(sys::path::filename(argv[0]));
+      printHelp(tool_name);
       return EXIT_SUCCESS;
     }
     if (arg == "-v" || arg == "--version") {
-      printVersion();
+      printVersion(tool_name);
       return EXIT_SUCCESS;
     }
     WithColor::error(errs()) << "unknown argument '" << arg << "'\n";
-    printHelp(sys::path::filename(argv[0]));
+    printHelp(tool_name);
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
lldb-mcp accepted no arguments at all, so --help and --version fell through to the protocol loop and blocked reading stdin, and a mistyped flag was silently ignored while the tool waited for MCP traffic. Handle both flags and reject anything else with a usage message.