### PR TITLE
[lldb-mcp] Run managed debug sessions synchronously

### DIFF
--- a/lldb/source/Plugins/Protocol/MCP/Tool.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.cpp
@@ -183,6 +183,10 @@ DebuggerCreateTool::Call(const lldb_protocol::mcp::ToolArguments &) {
   debugger_sp->SetOutputFile(out);
   debugger_sp->SetErrorFile(out);
 
+  // A debugger driven over MCP has no event loop to service asynchronous
+  // stops, so a resume must not return before the process has stopped.
+  debugger_sp->SetAsyncExecution(false);
+
   return createTextResult(to_uri(debugger_sp));
 }
 


### PR DESCRIPTION
A debugger created for an MCP session has no event loop to service asynchronous stops, so a resume returned before the process stopped and every subsequent command failed against a still-running process. That made breakpoint debugging unusable: `run` reported only the launch, and `bt` that followed it errored out. Create these debuggers in synchronous mode, as lldb-dap does.