### PR TITLE
workflows/release-binaries: Move environment declaration to upload job

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -53,9 +53,6 @@ permissions:
 jobs:
   prepare:
     name: Prepare to build binaries
-    environment:
-      deployment: false
-      name: ${{ case( github.event_name == 'pull_request', null, 'release') }}
     runs-on: ${{ inputs.runs-on }}
     if: github.repository_owner == 'llvm'
     outputs:
@@ -82,14 +79,6 @@ jobs:
       uses: ./.github/workflows/validate-release-version
       with:
         release-version: ${{ inputs.release-version }}
-
-    - name: Check Permissions
-      if: github.event_name != 'pull_request'
-      uses: ./.github/workflows/require-team-membership
-      with:
-        team-slug: llvm-release-managers
-        LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
-        LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
     # The name of the Windows binaries uses the version from source, so we need
     # to fetch it here.
@@ -368,6 +357,9 @@ jobs:
 
   upload-release-binaries:
     name: "Upload Release Binaries"
+    environment:
+      deployment: false
+      name: release
     needs:
       - prepare
       - build-release-package


### PR DESCRIPTION
This is the only job that actually needs to use the environment secrets, so the environment must be declared.  We were using secrets in the prepare job to do a permissions check, but this is unnecessary, because that job does not do anything that is security sensitive.

Only the upload job needs to have these permission checks and these are already included in the upload-release-artifact composite action.