### PR TITLE
workflows/release-documentation: Rework workflow to make it testable

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -372,20 +372,8 @@ jobs:
       attestations: write # For artifact attestations
 
     steps:
-      - name: Checkout Release Scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/workflows/require-team-membership
-            .github/workflows/upload-release-artifact
-            .github/workflows/validate-release-version
-            llvm/utils/release/github-upload-release.py
-            llvm/utils/git/requirements.txt
-          sparse-checkout-cone-mode: false
-
       - name: Upload Artifacts
-        uses: ./.github/workflows/upload-release-artifact
+        uses: $/.github/workflows/upload-release-artifact
         with:
           release-version: ${{ needs.prepare.outputs.release-version }}
           artifact-id: ${{ needs.build-release-package.outputs.artifact-id }}

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -116,6 +116,7 @@ jobs:
       - id: man-page-artifact-upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: man-pages
           path: |
             ${{ steps.build.outputs.man-page-tarball-name }}
 

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -158,7 +158,8 @@ jobs:
           INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
           cd www-releases
-          ls -ltr www-releases/$INPUT_RELEASE_VERSION/*
+          ls -ltr *
+          ls -ltr $INPUT_RELEASE_VERSION/*
           git checkout -b $INPUTS_RELEASE_VERSION
           git add $INPUTS_RELEASE_VERSION
           git config user.email "llvmbot@llvm.org"

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           ./llvm/utils/release/build-docs.sh \
             $(test -n "$INPUTS_RELEASE_VERSION" && echo -release $INPUTS_RELEASE_VERSION || echo -srcdir llvm) -no-doxygen
-          echo "man-page-tarball-name=$(basename $(find . -iname 'llvm_man_pages-*'))" >> "$GITHUB_OUTPUT"
+          echo "man-page-tarball-name=$(basename $(find . -iname 'llvm_man_pages-*.tar.xz'))" >> "$GITHUB_OUTPUT"
 
 
       - name: Generate sha256 digest for man page tarball
@@ -151,15 +151,20 @@ jobs:
           path: www-releases
           persist-credentials: false
 
+      - name: Download Release Notes Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        id: download-artifact
+        with:
+          name: ${{ github.workspace }}/www-releases/${{ inputs.release-version }}
+
       - name: Upload Release Notes
         env:
           PUSH_TOKEN: ${{ secrets.LLVMBOT_WWW_RELEASES_PUSH }}
           GH_TOKEN: ${{ secrets.WWW_RELEASES_TOKEN }}
           INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
-          mkdir -p www-releases/$INPUTS_RELEASE_VERSION
-          mv ./docs-build/html-export/* www-releases/$INPUTS_RELEASE_VERSION
           cd www-releases
+          ls -ltr www-releases/$INPUT_RELEASE_VERSION/*
           git checkout -b $INPUTS_RELEASE_VERSION
           git add $INPUTS_RELEASE_VERSION
           git config user.email "llvmbot@llvm.org"

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -199,16 +199,9 @@ jobs:
       attestations: write # For artifact attestations
 
     steps:
-     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-       with:
-         persist-credentials: false
-         sparse-checkout: |
-           .github/workflows/upload-release-artifact
-         sparse-checkout-cone-mode: false
-
      - name: Upload Man Page Artifacts
        id: man-page-artifact-upload
-       uses: ./.github/workflows/upload-release-artifact
+       uses: $/.github/workflows/upload-release-artifact
        with:
          release-version: ${{ needs.release-documentation.outputs.man-page-release-version }}
          artifact-id: ${{ needs.release-documentation.outputs.man-page-artifact-id }}

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           ./llvm/utils/release/build-docs.sh \
             $(test -n "$INPUTS_RELEASE_VERSION" && echo -release $INPUTS_RELEASE_VERSION || echo -srcdir llvm) -no-doxygen
-          echo "man-page-tarball-name=$(find . -iname 'llvm_man_pages-*')" >> "$GITHUB_OUTPUT"
+          echo "man-page-tarball-name=$(basename $(find . -iname 'llvm_man_pages-*'))" >> "$GITHUB_OUTPUT"
 
 
       - name: Generate sha256 digest for man page tarball

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -67,16 +67,16 @@ jobs:
       man-page-digest: ${{ steps.man-page-digest.outputs.man-page-digest }}
       man-page-artifact-id: ${{ steps.man-page-artifact-upload.outputs.artifact-id }}
     steps:
+      - name: Checkout LLVM
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Validate Input
         if: inputs.release-version
         uses: ./.github/workflows/validate-release-version
         with:
           release-version: ${{ inputs.release-version }}
-
-      - name: Checkout LLVM
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
 
       - name: Setup Python env
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -130,15 +130,8 @@ jobs:
   upload-release-notes:
     name: "Upload Release Notes"
     runs-on: ubuntu-24.04
-    environment:
-      deployment: false
-      name: release
     needs:
       - release-documentation
-    if: >-
-      github.event_name != 'pull_request' &&
-      inputs.upload &&
-      !contains(inputs.release-version, 'rc')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -55,7 +55,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.release-version || github.event.pull_request.number }}
-  cancel-in-progress: True
+  cancel-in-progress: true
 
 jobs:
   release-documentation:
@@ -102,7 +102,7 @@ jobs:
           INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
           ./llvm/utils/release/build-docs.sh \
-            $(test -n "$INPUTS_RELEASE_VERSION" && echo -release $INPUTS_RELEASE_VERSION || echo -srcdir llvm) -no-doxygen
+            $(test -n "$INPUTS_RELEASE_VERSION" && echo -release "$INPUTS_RELEASE_VERSION" || echo -srcdir llvm) -no-doxygen
           echo "man-page-tarball-name=$(basename $(find . -iname 'llvm_man_pages-*.tar.xz'))" >> "$GITHUB_OUTPUT"
 
 

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -61,8 +61,6 @@ jobs:
   release-documentation:
     name: Build and Upload Release Documentation and Man Pages
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     outputs:
       man-page-digest: ${{ steps.man-page-digest.outputs.man-page-digest }}
       man-page-artifact-id: ${{ steps.man-page-artifact-upload.outputs.artifact-id }}

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -61,6 +61,9 @@ jobs:
   release-documentation:
     name: Build and Upload Release Documentation and Man Pages
     runs-on: ubuntu-24.04
+    if: >-
+      github.repository_owner == 'llvm' &&
+      github.event.action != 'closed'
     outputs:
       man-page-digest: ${{ steps.man-page-digest.outputs.man-page-digest }}
       man-page-artifact-id: ${{ steps.man-page-artifact-upload.outputs.artifact-id }}

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -158,8 +158,6 @@ jobs:
           INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
           cd www-releases
-          ls -ltr *
-          ls -ltr $INPUT_RELEASE_VERSION/*
           git checkout -b $INPUTS_RELEASE_VERSION
           git add $INPUTS_RELEASE_VERSION
           git config user.email "llvmbot@llvm.org"

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -112,7 +112,7 @@ jobs:
         env:
           TARBALL_NAME: ${{ steps.build.outputs.man-page-tarball-name }}
         run: |
-            echo "man-page-digest=$(cat "$TARBALL_NAME" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+            echo "man-page-digest=$(cat "$TARBALL_NAME" | sha256sum | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - id: man-page-artifact-upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -38,6 +38,24 @@ on:
       LLVM_TOKEN_GENERATOR_PRIVATE_KEY:
         description: "Private key for our GitHub App we use for generating access tokens."
         required: true
+  # Run on pull_requests for testing purposes.
+  pull_request:
+    paths:
+      - '.github/workflows/release-documentation.yml'
+      - 'llvm/utils/release/build-docs.sh'
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # When a PR is closed, we still start this workflow, but then skip
+      # all the jobs, which makes it effectively a no-op.  The reason to
+      # do this is that it allows us to take advantage of concurrency groups
+      # to cancel in progress CI jobs whenever the PR is closed.
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.release-version || github.event.pull_request.number }}
+  cancel-in-progress: True
 
 jobs:
   # This job checks permissions and validates inputs to prevent potential
@@ -47,9 +65,6 @@ jobs:
   release-man-pages-validate-input:
     name: Release Man Pages Validate Input
     runs-on: ubuntu-24.04
-    environment:
-      name: release
-      deployment: false
     permissions:
       contents: read
     steps:
@@ -58,13 +73,6 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/workflows/
-
-      - name: Check Permissions
-        uses: ./.github/workflows/require-team-membership
-        with:
-          team-slug: llvm-release-managers
-          LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
-          LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
       - name: Validate Input
         uses: ./.github/workflows/validate-release-version
@@ -84,8 +92,6 @@ jobs:
       man-page-tarball-name: ${{ steps.vars.outputs.man-page-tarball-name }}
       man-page-upload: ${{ steps.vars.outputs.man-page-upload }}
       man-page-attestation-name: ${{ steps.vars.outputs.man-page-attestation-name }}
-    env:
-      upload: ${{ inputs.upload && !contains(inputs.release-version, 'rc') }}
     steps:
       - name: Collect Variables
         id: vars
@@ -155,8 +161,23 @@ jobs:
           name: release-notes
           path: docs-build/html-export/
 
+
+  upload-release-notes:
+    name: "Upload Release Notes"
+    runs-on: ubuntu-24.04
+    environment:
+      deployment: false
+      name: release
+    needs:
+      - release-documentation
+    if: >-
+      github.event_name != 'pull_request' &&
+      inputs.upload &&
+      !contains(inputs.release-version, 'rc')
+    permissions:
+      contents: read
+    steps:
       - name: Clone www-releases
-        if: env.upload
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.repository_owner }}/www-releases
@@ -166,7 +187,6 @@ jobs:
           persist-credentials: false
 
       - name: Upload Release Notes
-        if: env.upload
         env:
           PUSH_TOKEN: ${{ secrets.LLVMBOT_WWW_RELEASES_PUSH }}
           GH_TOKEN: ${{ secrets.WWW_RELEASES_TOKEN }}

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -130,8 +130,15 @@ jobs:
   upload-release-notes:
     name: "Upload Release Notes"
     runs-on: ubuntu-24.04
+    environment:
+      deployment: false
+      name: release
     needs:
       - release-documentation
+    if: >-
+      github.event_name != 'pull_request' &&
+      inputs.upload &&
+      !contains(inputs.release-version, 'rc')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -148,7 +148,8 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: download-artifact
         with:
-          name: ${{ github.workspace }}/www-releases/${{ inputs.release-version }}
+          name: release-notes
+          path: ${{ github.workspace }}/www-releases/${{ inputs.release-version }}
 
       - name: Upload Release Notes
         env:

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -58,41 +58,25 @@ concurrency:
   cancel-in-progress: True
 
 jobs:
-  # This job checks permissions and validates inputs to prevent potential
-  # malicious actions.  Since the release-documentation job has contents: write
-  # permissions we need to be extra careful about who can run the job and what
-  # inputs can be provided.
-  release-man-pages-validate-input:
-    name: Release Man Pages Validate Input
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/workflows/
-
-      - name: Validate Input
-        uses: ./.github/workflows/validate-release-version
-        with:
-          release-version: ${{ inputs.release-version }}
-
   release-documentation:
     name: Build and Upload Release Documentation and Man Pages
     runs-on: ubuntu-24.04
-    needs:
-      - release-man-pages-validate-input
+    permissions:
+      contents: read
     outputs:
       man-page-digest: ${{ steps.man-page-digest.outputs.man-page-digest }}
       man-page-artifact-id: ${{ steps.man-page-artifact-upload.outputs.artifact-id }}
 
       man-page-release-version: ${{ steps.vars.outputs.man-page-release-version }}
-      man-page-tarball-name: ${{ steps.vars.outputs.man-page-tarball-name }}
       man-page-upload: ${{ steps.vars.outputs.man-page-upload }}
       man-page-attestation-name: ${{ steps.vars.outputs.man-page-attestation-name }}
     steps:
+      - name: Validate Input
+        if: inputs.release-version
+        uses: ./.github/workflows/validate-release-version
+        with:
+          release-version: ${{ inputs.release-version }}
+
       - name: Collect Variables
         id: vars
         env:
@@ -102,7 +86,6 @@ jobs:
         run: |
           {
             echo "man-page-release-version=$INPUTS_RELEASE_VERSION"
-            echo "man-page-tarball-name=llvm_man_pages-$INPUTS_RELEASE_VERSION.tar.xz"
             echo "man-page-ref=llvmorg-$INPUTS_RELEASE_VERSION"
             echo "man-page-upload=$UPLOAD_MAN_PAGES"
             echo "man-page-attestation-name=$RUNNER_OS-$RUNNER_ARCH-release-man-page-attestation"
@@ -112,11 +95,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-
-      - name: Validate Input
-        uses: ./.github/workflows/validate-release-version
-        with:
-          release-version: ${{ inputs.release-version }}
 
       - name: Setup Python env
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -135,17 +113,21 @@ jobs:
           pip3 install --require-hashes --user -r ./llvm/docs/requirements.txt
 
       - name: Build Documentation
+        id: build
         env:
           GITHUB_TOKEN: ${{ github.token }}
           INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
-          ./llvm/utils/release/build-docs.sh -release "$INPUTS_RELEASE_VERSION" -no-doxygen
+          ./llvm/utils/release/build-docs.sh \
+            $(test -n "$INPUTS_RELEASE_VERSION" && echo -release $INPUTS_RELEASE_VERSION || echo -srcdir llvm) -no-doxygen
+          echo "man-page-tarball-name=$(find . -iname 'llvm_man_pages-*')" >> "$GITHUB_OUTPUT"
+
 
       - name: Generate sha256 digest for man page tarball
         id: man-page-digest
         shell: bash
         env:
-          TARBALL_NAME: ${{ steps.vars.outputs.man-page-tarball-name }}
+          TARBALL_NAME: ${{ steps.build.outputs.man-page-tarball-name }}
         run: |
             echo "man-page-digest=$(cat "$TARBALL_NAME" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
@@ -153,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: |
-            ${{ steps.vars.outputs.man-page-tarball-name }}
+            ${{ steps.build.outputs.man-page-tarball-name }}
 
       - name: Create Release Notes Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -54,7 +54,7 @@ on:
       - closed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.release-version || github.event.pull_request.number }}
+  group: release-documentation-${{ inputs.release-version || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -66,30 +66,12 @@ jobs:
     outputs:
       man-page-digest: ${{ steps.man-page-digest.outputs.man-page-digest }}
       man-page-artifact-id: ${{ steps.man-page-artifact-upload.outputs.artifact-id }}
-
-      man-page-release-version: ${{ steps.vars.outputs.man-page-release-version }}
-      man-page-upload: ${{ steps.vars.outputs.man-page-upload }}
-      man-page-attestation-name: ${{ steps.vars.outputs.man-page-attestation-name }}
     steps:
       - name: Validate Input
         if: inputs.release-version
         uses: ./.github/workflows/validate-release-version
         with:
           release-version: ${{ inputs.release-version }}
-
-      - name: Collect Variables
-        id: vars
-        env:
-          INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
-          UPLOAD_MAN_PAGES: ${{ inputs.upload }}
-        shell: bash
-        run: |
-          {
-            echo "man-page-release-version=$INPUTS_RELEASE_VERSION"
-            echo "man-page-ref=llvmorg-$INPUTS_RELEASE_VERSION"
-            echo "man-page-upload=$UPLOAD_MAN_PAGES"
-            echo "man-page-attestation-name=$RUNNER_OS-$RUNNER_ARCH-release-man-page-attestation"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout LLVM
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -205,10 +187,10 @@ jobs:
        id: man-page-artifact-upload
        uses: $/.github/workflows/upload-release-artifact
        with:
-         release-version: ${{ needs.release-documentation.outputs.man-page-release-version }}
+         release-version: ${{ inputs.release-version }}
          artifact-id: ${{ needs.release-documentation.outputs.man-page-artifact-id }}
-         attestation-name: ${{ needs.release-documentation.outputs.man-page-attestation-name }}
+         attestation-name: ${{ runner.os }}-${{ runner.arch }}-release-man-page-attestation
          digest: ${{ needs.release-documentation.outputs.man-page-digest }}
-         upload: ${{ needs.release-documentation.outputs.man-page-upload }}
+         upload: ${{ inputs.upload }}
          LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
          LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}

--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -130,18 +130,8 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Checkout Release Scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/
-            llvm/utils/release/github-upload-release.py
-            llvm/utils/git/requirements.txt
-          sparse-checkout-cone-mode: false
-
       - name: Upload Artifacts
-        uses: ./.github/workflows/upload-release-artifact
+        uses: $/.github/workflows/upload-release-artifact
         with:
           release-version: ${{ inputs.release-version }}
           artifact-id: ${{ needs.release-sources.outputs.artifact-id }}

--- a/.github/workflows/upload-release-artifact/action.yml
+++ b/.github/workflows/upload-release-artifact/action.yml
@@ -41,6 +41,23 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check Permissions
+      uses: $/.github/workflows/require-team-membership
+      with:
+        team-slug: llvm-release-managers
+        LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+        LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+
+    # Checkout the files used by this action.
+     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+       with:
+         persist-credentials: false
+         path: upload-release-artifact
+         sparse-checkout: |
+            llvm/utils/release/github-upload-release.py
+            llvm/utils/git/requirements.txt
+         sparse-checkout-cone-mode: false
+
     - name: Validate Input
       uses: $/.github/workflows/validate-release-version
       with:
@@ -99,14 +116,7 @@ runs:
       if: inputs.upload == 'true'
       shell: bash
       run: |
-        pip install --require-hashes -r ./llvm/utils/git/requirements.txt
-
-    - name: Check Permissions
-      uses: $/.github/workflows/require-team-membership
-      with:
-        team-slug: llvm-release-managers
-        LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
-        LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+        pip install --require-hashes -r ./upload-release-artifact/llvm/utils/git/requirements.txt
 
     - name: Upload Release
       shell: bash
@@ -115,7 +125,7 @@ runs:
         INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         DOWNLOAD_PATH: ${{ steps.download-artifact.outputs.download-path }}
       run: |
-        ./llvm/utils/release/github-upload-release.py \
+        ./upload-release-artifact/llvm/utils/release/github-upload-release.py \
         --token ${{ github.token }} \
         --release "$INPUTS_RELEASE_VERSION" \
         upload \

--- a/.github/workflows/upload-release-artifact/action.yml
+++ b/.github/workflows/upload-release-artifact/action.yml
@@ -42,7 +42,7 @@ runs:
   using: "composite"
   steps:
     - name: Validate Input
-      uses: ./.github/workflows/validate-release-version
+      uses: $/.github/workflows/validate-release-version
       with:
         release-version: ${{ inputs.release-version }}
 
@@ -102,7 +102,7 @@ runs:
         pip install --require-hashes -r ./llvm/utils/git/requirements.txt
 
     - name: Check Permissions
-      uses: ./.github/workflows/require-team-membership
+      uses: $/.github/workflows/require-team-membership
       with:
         team-slug: llvm-release-managers
         LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -149,22 +149,14 @@ export CXX=clang++
 
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \
+               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \
                -DCMAKE_BUILD_TYPE=Release \
                -DLLVM_BUILD_DOCS=ON \
                $sphinx_flag \
                $doxygen_flag \
                $man_page_flag
 
-ninja -C $builddir $sphinx_targets $doxygen_targets $man_page_targets
-
-cmake -G Ninja $srcdir/../runtimes -B $builddir/runtimes-doc \
-               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \
-               -DLLVM_ENABLE_SPHINX=ON \
-               -DLLVM_BUILD_DOCS=ON \
-               -DSPHINX_WARNINGS_AS_ERRORS=OFF
-
-ninja -C $builddir/runtimes-doc \
-               docs-libcxx-html
+ninja -C $builddir $sphinx_targets $doxygen_targets $man_page_targets docs-libcxx-html
 
 if [ "${no_man_page}" != "yes" ]; then
   output="llvm_man_pages-${release}"
@@ -196,5 +188,5 @@ done
 # Keep the documentation for the runtimes under /projects/ to avoid breaking existing links.
 for d in libcxx/docs/; do
   mkdir -p $html_dir/projects/$d
-  mv $builddir/runtimes-doc/$d/html/* $html_dir/projects/$d/
+  mv $builddir/$d/html/* $html_dir/projects/$d/
 done

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -128,7 +128,7 @@ if [ "${no_man_pages}" != "yes" ]; then
   install_prefix=${builddir}/install
   man_page_flag=" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_WARNINGS_AS_ERRORS=OFF -DSPHINX_OUTPUT_MAN:BOOL=ON -DCMAKE_INSTALL_PREFIX=${install_prefix}"
   extra_man_page_projects=";lldb;mlir;bolt"
-  extra_man_page_runtimes=";compiler-rt;openmp;"
+  extra_man_page_runtimes=";compiler-rt;openmp"
 else
   echo "Man pages: disabled"
 fi

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -147,7 +147,6 @@ fi
 export CC=clang
 export CXX=clang++
 
-set -ex
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \
                -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -147,6 +147,7 @@ fi
 export CC=clang
 export CXX=clang++
 
+set -ex
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \
                -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -150,7 +150,7 @@ export CXX=clang++
 set -ex
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \
-               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \
+               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind${extra_man_page_runtimes}" \
                -DCMAKE_BUILD_TYPE=Release \
                -DLLVM_BUILD_DOCS=ON \
                $sphinx_flag \

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -20,7 +20,7 @@
 #   * pip install --user -r ./llvm/docs/requirements.txt
 #===------------------------------------------------------------------------===#
 
-set -e
+set -ex
 
 builddir=docs-build
 srcdir=$(readlink -f $(dirname "$(readlink -f "$0")")/../..)

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -20,7 +20,7 @@
 #   * pip install --user -r ./llvm/docs/requirements.txt
 #===------------------------------------------------------------------------===#
 
-set -ex
+set -e
 
 builddir=docs-build
 srcdir=$(readlink -f $(dirname "$(readlink -f "$0")")/../..)
@@ -140,12 +140,6 @@ if [ "$no_doxygen" != "yes" ]; then
 else
    echo "Doxygen: disabled"
 fi
-
-# This is just to ensure we're using the right compiler
-# When running this locally, the script otherwise might
-# prefer GCC.
-#export CC=clang
-#export CXX=clang++
 
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -149,14 +149,22 @@ export CXX=clang++
 
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \
-               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \
                -DCMAKE_BUILD_TYPE=Release \
                -DLLVM_BUILD_DOCS=ON \
                $sphinx_flag \
                $doxygen_flag \
                $man_page_flag
 
-ninja -C $builddir $sphinx_targets $doxygen_targets $man_page_targets docs-libcxx-html
+ninja -C $builddir $sphinx_targets $doxygen_targets $man_page_targets
+
+cmake -G Ninja $srcdir/../runtimes -B $builddir/runtimes-doc \
+               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \
+               -DLLVM_ENABLE_SPHINX=ON \
+               -DLLVM_BUILD_DOCS=ON \
+               -DSPHINX_WARNINGS_AS_ERRORS=OFF
+
+ninja -C $builddir/runtimes-doc \
+               docs-libcxx-html
 
 if [ "${no_man_page}" != "yes" ]; then
   output="llvm_man_pages-${release}"
@@ -188,5 +196,5 @@ done
 # Keep the documentation for the runtimes under /projects/ to avoid breaking existing links.
 for d in libcxx/docs/; do
   mkdir -p $html_dir/projects/$d
-  mv $builddir/$d/html/* $html_dir/projects/$d/
+  mv $builddir/runtimes-doc/$d/html/* $html_dir/projects/$d/
 done

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -150,7 +150,7 @@ export CXX=clang++
 set -ex
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \
-               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind${extra_man_page_runtimes}" \
+               -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;${extra_man_page_runtimes}" \
                -DCMAKE_BUILD_TYPE=Release \
                -DLLVM_BUILD_DOCS=ON \
                $sphinx_flag \

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -144,8 +144,8 @@ fi
 # This is just to ensure we're using the right compiler
 # When running this locally, the script otherwise might
 # prefer GCC.
-export CC=clang
-export CXX=clang++
+#export CC=clang
+#export CXX=clang++
 
 cmake -G Ninja $srcdir -B $builddir \
                -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;polly;flang${extra_man_page_projects}" \

--- a/llvm/utils/release/build-docs.sh
+++ b/llvm/utils/release/build-docs.sh
@@ -128,7 +128,7 @@ if [ "${no_man_pages}" != "yes" ]; then
   install_prefix=${builddir}/install
   man_page_flag=" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_WARNINGS_AS_ERRORS=OFF -DSPHINX_OUTPUT_MAN:BOOL=ON -DCMAKE_INSTALL_PREFIX=${install_prefix}"
   extra_man_page_projects=";lldb;mlir;bolt"
-  extra_man_page_runtimes=";compiler-rt;openmp"
+  extra_man_page_runtimes=";compiler-rt;openmp;"
 else
   echo "Man pages: disabled"
 fi


### PR DESCRIPTION
This includes several separate changes for the workflow, which were necessary to get the testing to pass:

* Merged release-man-pages-validate-input into the release-documentation job.
* Split the release note uploading into a separate job.
* Moved the environment declaration to the 
* Stopped forcing clang as the compiler in build-docs.sh script.  This was causing the runtimes build to fail, because the default Ubuntu debian packages for clang where not providing all the necessary CMake files.  It seems that when you use clang as the compiler, the runtimes try to use the cmake files installed along with it.