### PR TITLE
[libc++][test][NFC] remove old UNSUPPORTED clang from clear_padding.pass.cpp

### DIFF
--- a/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
+++ b/libcxx/test/libcxx/atomics/clear_padding.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: gcc
 
 // Older versions of Clang don't support __builtin_clear_padding
-// UNSUPPORTED: clang-19, clang-20, clang-21, clang-22, apple-clang-17, apple-clang-21
+// UNSUPPORTED: clang-21, clang-22, apple-clang-21
 
 // Older Clang doesn't handle __builtin_clear_padding correctly on Windows
 // (see https://github.com/llvm/llvm-project/issues/209787)


### PR DESCRIPTION
Follow up PR for comment
https://github.com/llvm/llvm-project/pull/211258/changes#r3663614103

I think I must have made an oversight while resolving a merge conflict
