### PR TITLE
[test] Migrate AArch64 thunk tests to the default thunk order

### DIFF
--- a/lld/test/ELF/aarch64-thunk-align.s
+++ b/lld/test/ELF/aarch64-thunk-align.s
@@ -1,6 +1,6 @@
 // REQUIRES: aarch64
 // RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t
-// RUN: ld.lld -z nosort-thunks --image-base=0x12000 -Ttext=0x12000 -defsym long=0x10000000 -defsym short=0x8012004 -defsym short2=0x8012008 -defsym short3=0x801200c %t -o %t.exe
+// RUN: ld.lld --image-base=0x12000 -Ttext=0x12000 -defsym long=0x10000000 -defsym short=0x8012004 -defsym short2=0x8012008 -defsym short3=0x801200c %t -o %t.exe
 // RUN: llvm-objdump -d --no-show-raw-insn %t.exe | FileCheck %s
 
 /// The AArch64AbsLongThunk requires 8-byte alignment just in case unaligned
@@ -18,25 +18,24 @@ _start:
  nop
 
 // CHECK-LABEL: <_start>:
-// CHECK-NEXT: 12000: b       0x12018 <__AArch64AbsLongThunk_short>
-// CHECK-NEXT:        b       0x1201c <__AArch64AbsLongThunk_short2>
-// CHECK-NEXT:        b       0x12020 <__AArch64AbsLongThunk_short3>
-// CHECK-NEXT:        b       0x12028 <__AArch64AbsLongThunk_long>
+// CHECK-NEXT: 12000: b       0x12030 <__AArch64AbsLongThunk_short>
+// CHECK-NEXT:        b       0x1202c <__AArch64AbsLongThunk_short2>
+// CHECK-NEXT:        b       0x12028 <__AArch64AbsLongThunk_short3>
+// CHECK-NEXT:        b       0x12018 <__AArch64AbsLongThunk_long>
 // CHECK-NEXT:        nop
 // CHECK-NEXT:        udf     #0x0
 // CHECK-EMPTY:
-// CHECK-LABEL: <__AArch64AbsLongThunk_short>:
-// CHECK-NEXT: 12018: b       0x8012004 <__AArch64AbsLongThunk_long+0x7ffffdc>
-// CHECK-EMPY:
-// CHECK-LABEL: <__AArch64AbsLongThunk_short2>:
-// CHECK-NEXT: 1201c: b       0x8012008 <__AArch64AbsLongThunk_long+0x7ffffe0>
-// CHECK-EMPTY:
-// CHECK-LABEL: <__AArch64AbsLongThunk_short3>:
-// CHECK-NEXT: 12020: b       0x801200c <__AArch64AbsLongThunk_long+0x7ffffe4>
-// CHECK-NEXT:        udf     #0x0
-// CHECK-EMPTY:
 // CHECK-LABEL: <__AArch64AbsLongThunk_long>:
-// CHECK-NEXT: 12028: ldr     x16, 0x12030 <__AArch64AbsLongThunk_long+0x8>
+// CHECK-NEXT: 12018: ldr     x16, 0x12020 <__AArch64AbsLongThunk_long+0x8>
 // CHECK-NEXT:        br      x16
 // CHECK-NEXT: 00 00 00 10   .word   0x10000000
 // CHECK-NEXT: 00 00 00 00   .word   0x00000000
+// CHECK-EMPTY:
+// CHECK-LABEL: <__AArch64AbsLongThunk_short3>:
+// CHECK-NEXT: 12028: b       0x801200c <__AArch64AbsLongThunk_short+0x7ffffdc>
+// CHECK-EMPTY:
+// CHECK-LABEL: <__AArch64AbsLongThunk_short2>:
+// CHECK-NEXT: 1202c: b       0x8012008 <__AArch64AbsLongThunk_short+0x7ffffd8>
+// CHECK-EMPTY:
+// CHECK-LABEL: <__AArch64AbsLongThunk_short>:
+// CHECK-NEXT: 12030: b       0x8012004 <__AArch64AbsLongThunk_short+0x7ffffd4>

--- a/lld/test/ELF/aarch64-thunk-bti-execute-only.s
+++ b/lld/test/ELF/aarch64-thunk-bti-execute-only.s
@@ -1,7 +1,7 @@
 // REQUIRES: aarch64
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -filetype=obj -triple=aarch64 asm -o a.o
-// RUN: ld.lld -z nosort-thunks --script=lds a.o -o exe --defsym absolute=0xf0000000
+// RUN: ld.lld --script=lds a.o -o exe --defsym absolute=0xf0000000
 // RUN: llvm-objdump -d --no-show-raw-insn exe | FileCheck %s
 
 //--- asm
@@ -38,20 +38,20 @@ fn1:
   ret
 
 // CHECK-LABEL: <_start>:
-// CHECK-NEXT:  18001000: bl      0x1800100c <__AArch64AbsXOLongThunk_>
-// CHECK-NEXT:            b       0x1800100c <__AArch64AbsXOLongThunk_>
-// CHECK-NEXT:            bl      0x18001020 <__AArch64AbsXOLongThunk_absolute>
+// CHECK-NEXT:  18001000: bl      0x18001020 <__AArch64AbsXOLongThunk_>
+// CHECK-NEXT:            b       0x18001020 <__AArch64AbsXOLongThunk_>
+// CHECK-NEXT:            bl      0x1800100c <__AArch64AbsXOLongThunk_absolute>
 
-// CHECK-LABEL: <__AArch64AbsXOLongThunk_>:
+// CHECK-LABEL: <__AArch64AbsXOLongThunk_absolute>:
 // CHECK-NEXT:  1800100c: mov     x16, #0x0
-// CHECK-NEXT:            movk    x16, #0x3000, lsl #16
+// CHECK-NEXT:            movk    x16, #0xf000, lsl #16
 // CHECK-NEXT:            movk    x16, #0x0, lsl #32
 // CHECK-NEXT:            movk    x16, #0x0, lsl #48
 // CHECK-NEXT:            br      x16
 
-// CHECK-LABEL: <__AArch64AbsXOLongThunk_absolute>:
+// CHECK-LABEL: <__AArch64AbsXOLongThunk_>:
 // CHECK-NEXT:  18001020: mov     x16, #0x0
-// CHECK-NEXT:            movk    x16, #0xf000, lsl #16
+// CHECK-NEXT:            movk    x16, #0x3000, lsl #16
 // CHECK-NEXT:            movk    x16, #0x0, lsl #32
 // CHECK-NEXT:            movk    x16, #0x0, lsl #48
 // CHECK-NEXT:            br      x16

--- a/lld/test/ELF/aarch64-thunk-bti-multipass.s
+++ b/lld/test/ELF/aarch64-thunk-bti-multipass.s
@@ -1,7 +1,7 @@
 // REQUIRES: aarch64
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -filetype=obj -triple=aarch64 asm -o a.o
-// RUN: ld.lld -z nosort-thunks --script=lds a.o -o out
+// RUN: ld.lld --script=lds a.o -o out
 // RUN: llvm-objdump -d --no-show-raw-insn out | FileCheck %s
 
 /// Test that a thunk that at creation time does not need to use a BTI
@@ -39,19 +39,19 @@ _start:
 /// and will need a long branch thunk, which in turn needs a BTI landing pad.
 
 // CHECK-LABEL: <_start>:
-// CHECK-NEXT: 10001000: bl  0x10002008 <__AArch64AbsLongThunk_fn1>
-// CHECK-NEXT:           bl  0x10002018 <__AArch64AbsLongThunk_fn2>
-
-// CHECK-LABEL: <__AArch64AbsLongThunk_fn1>:
-// CHECK-NEXT: 10002008: ldr     x16, 0x10002010 <__AArch64AbsLongThunk_fn1+0x8>
-// CHECK-NEXT:           br      x16
-// CHECK-NEXT:           00 30 00 18    .word   0x18003000
-// CHECK-NEXT:           00 00 00 00    .word   0x00000000
+// CHECK-NEXT: 10001000: bl  0x10002018 <__AArch64AbsLongThunk_fn1>
+// CHECK-NEXT:           bl  0x10002008 <__AArch64AbsLongThunk_fn2>
 
 // CHECK-LABEL: <__AArch64AbsLongThunk_fn2>:
-// CHECK-NEXT: 10002018: ldr     x16, 0x10002020 <__AArch64AbsLongThunk_fn2+0x8>
+// CHECK-NEXT: 10002008: ldr     x16, 0x10002010 <__AArch64AbsLongThunk_fn2+0x8>
 // CHECK-NEXT:           br      x16
 // CHECK-NEXT:           04 40 00 18    .word   0x18004004
+// CHECK-NEXT:           00 00 00 00    .word   0x00000000
+
+// CHECK-LABEL: <__AArch64AbsLongThunk_fn1>:
+// CHECK-NEXT: 10002018: ldr     x16, 0x10002020 <__AArch64AbsLongThunk_fn1+0x8>
+// CHECK-NEXT:           br      x16
+// CHECK-NEXT:           00 30 00 18    .word   0x18003000
 // CHECK-NEXT:           00 00 00 00    .word   0x00000000
 
 .section .text.1, "ax", %progbits

--- a/lld/test/ELF/aarch64-thunk-bti.s
+++ b/lld/test/ELF/aarch64-thunk-bti.s
@@ -1,12 +1,12 @@
 // REQUIRES: aarch64
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -filetype=obj -triple=aarch64 asm -o a.o
-// RUN: ld.lld -z nosort-thunks --shared --script=lds a.o -o out.so --defsym absolute=0xf0000000
+// RUN: ld.lld --shared --script=lds a.o -o out.so --defsym absolute=0xf0000000
 // RUN: llvm-objdump -d --no-show-raw-insn out.so | FileCheck %s
 // RUN: llvm-objdump -d --no-show-raw-insn out.so | FileCheck %s --check-prefix=CHECK-PADS
 // RUN: llvm-mc -filetype=obj -triple=aarch64 shared -o shared.o
-// RUN: ld.lld -z nosort-thunks --shared -o shared.so shared.o
-// RUN: ld.lld -z nosort-thunks shared.so --script=lds a.o -o exe --defsym absolute=0xf0000000
+// RUN: ld.lld --shared -o shared.so shared.o
+// RUN: ld.lld shared.so --script=lds a.o -o exe --defsym absolute=0xf0000000
 // RUN: llvm-objdump -d --no-show-raw-insn exe | FileCheck %s --check-prefix=CHECK-EXE
 // RUN: llvm-objdump -d --no-show-raw-insn exe | FileCheck %s --check-prefix=CHECK-PADS
 
@@ -57,91 +57,108 @@ _start:
  .balign 8
  .space 0x1000
 
-// CHECK-PADS-LABEL: <_start>:
-// CHECK-PADS-NEXT: 10001000: bl      0x10002040
-// CHECK-PADS-NEXT:           bl      0x10002044
-// CHECK-PADS-NEXT:           bl      0x10002048
-// CHECK-PADS-NEXT:           bl      0x1000204c
-// CHECK-PADS-NEXT:           bl      0x10002050
-// CHECK-PADS-NEXT:           bl      0x10002054
-// CHECK-PADS-NEXT:           b       0x10002054
-// CHECK-PADS-NEXT:           bl      0x10002058
-// CHECK-PADS-NEXT:           b       0x10002058
-// CHECK-PADS-NEXT:           bl      0x1000205c
-// CHECK-PADS-NEXT:           b       0x1000205c
-// CHECK-PADS-NEXT:           bl      0x10002060
-// CHECK-PADS-NEXT:           b       0x10002060
-// CHECK-PADS-NEXT:           bl      0x10002064
-// CHECK-PADS-NEXT:           bl      0x10002068
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002040: b       0x18001000 <bti_c_target>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002044: b       0x18001008 <bti_j_target>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002048: b       0x18001010 <bti_jc_target>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 1000204c: b       0x18001018 <paciasp_target>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002050: b       0x18001020 <pacibsp_target>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002054: b       0x18001038 <fn2>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002058:       b       0x18001034 <fn1>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 1000205c:       b       0x18001040 <fn3>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_>:
-// CHECK-NEXT: 10002060:       b       0x18001050 <fn4>
-
-// CHECK-LABEL: <__AArch64ADRPThunk_via_plt>:
-// CHECK-NEXT: 10002064:       b       0x18001080 <via_plt@plt>
+// CHECK-LABEL: <_start>:
+// CHECK-NEXT: 10001000: bl      0x10002068 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002064 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002060 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x1000205c <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002058 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002050 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           b       0x10002050 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002054 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           b       0x10002054 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x1000204c <__AArch64ADRPThunk_>
+// CHECK-NEXT:           b       0x1000204c <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002048 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           b       0x10002048 <__AArch64ADRPThunk_>
+// CHECK-NEXT:           bl      0x10002044 <__AArch64ADRPThunk_via_plt>
+// CHECK-NEXT:           bl      0x10002040 <__AArch64ADRPThunk_absolute>
 
 // CHECK-LABEL: <__AArch64ADRPThunk_absolute>:
-// CHECK-NEXT: 10002068:       b       0x18001098 <absolute@plt>
+// CHECK-NEXT: 10002040: b       0x18001098 <absolute@plt>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002040: b       0x18001000 <bti_c_target>
+// CHECK-LABEL: <__AArch64ADRPThunk_via_plt>:
+// CHECK-NEXT: 10002044: b       0x18001080 <via_plt@plt>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002044: b       0x18001008 <bti_j_target>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002048: b       0x18001050 <fn4>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002048: b       0x18001010 <bti_jc_target>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 1000204c: b       0x18001040 <fn3>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 1000204c: b       0x18001018 <paciasp_target>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002050: b       0x18001038 <fn2>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002050: b       0x18001020 <pacibsp_target>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002054: b       0x18001034 <fn1>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002054: b       0x18001038 <fn2>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002058: b       0x18001020 <pacibsp_target>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002058: b       0x18001034 <fn1>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 1000205c: b       0x18001018 <paciasp_target>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 1000205c: b       0x18001040 <fn3>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002060: b       0x18001010 <bti_jc_target>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
-// CHECK-EXE-NEXT: 10002060: b       0x18001050 <fn4>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002064: b       0x18001008 <bti_j_target>
 
-// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_via_plt>:
-// CHECK-EXE-NEXT: 10002064: b       0x18001080 <via_plt@plt>
+// CHECK-LABEL: <__AArch64ADRPThunk_>:
+// CHECK-NEXT: 10002068: b       0x18001000 <bti_c_target>
+
+// CHECK-EXE-LABEL: <_start>:
+// CHECK-EXE-NEXT: 10001000: bl      0x10002074 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002070 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x1000206c <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002068 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002064 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x1000205c <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           b       0x1000205c <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002060 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           b       0x10002060 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002058 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           b       0x10002058 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002054 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           b       0x10002054 <__AArch64AbsLongThunk_>
+// CHECK-EXE-NEXT:           bl      0x10002050 <__AArch64AbsLongThunk_via_plt>
+// CHECK-EXE-NEXT:           bl      0x10002040 <__AArch64AbsLongThunk_absolute>
 
 // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_absolute>:
-// CHECK-EXE-NEXT: 10002068:   ldr     x16, 0x10002070 <__AArch64AbsLongThunk_absolute+0x8>
+// CHECK-EXE-NEXT: 10002040:   ldr     x16, 0x10002048 <__AArch64AbsLongThunk_absolute+0x8>
 // CHECK-EXE-NEXT:             br      x16
 // CHECK-EXE-NEXT: 00 00 00 f0 .word   0xf0000000
 // CHECK-EXE-NEXT: 00 00 00 00 .word   0x00000000
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_via_plt>:
+// CHECK-EXE-NEXT: 10002050: b       0x18001080 <via_plt@plt>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002054: b       0x18001050 <fn4>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002058: b       0x18001040 <fn3>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 1000205c: b       0x18001038 <fn2>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002060: b       0x18001034 <fn1>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002064: b       0x18001020 <pacibsp_target>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002068: b       0x18001018 <paciasp_target>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 1000206c: b       0x18001010 <bti_jc_target>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002070: b       0x18001008 <bti_j_target>
+
+// CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+// CHECK-EXE-NEXT: 10002074: b       0x18001000 <bti_c_target>
 
 .section .text.1, "ax", %progbits
 /// These indirect branch targets already have a BTI compatible landing pad,

--- a/lld/test/ELF/aarch64-thunk-script.s
+++ b/lld/test/ELF/aarch64-thunk-script.s
@@ -1,7 +1,7 @@
 // REQUIRES: aarch64
 // RUN: split-file %s %t
 // RUN: llvm-mc -filetype=obj -triple=aarch64 %t/asm -o %t.o
-// RUN: ld.lld -z nosort-thunks --script %t/lds %t.o -o %t/out
+// RUN: ld.lld --script %t/lds %t.o -o %t/out
 // RUN: llvm-objdump -d --no-show-raw-insn --print-imm-hex %t/out | FileCheck %s
 // RUN: llvm-nm --no-sort --special-syms %t/out | FileCheck --check-prefix=NM %s
 
@@ -29,13 +29,13 @@ high_target:
 // CHECK: Disassembly of section .text_low:
 // CHECK-EMPTY:
 // CHECK-NEXT: <_start>:
-// CHECK-NEXT:     2000:       bl      0x200c <__AArch64AbsLongThunk_high_target>
-// CHECK-NEXT:     2004:       bl      0x2010 <__AArch64AbsLongThunk_>
+// CHECK-NEXT:     2000:       bl      0x2010 <__AArch64AbsLongThunk_high_target>
+// CHECK-NEXT:     2004:       bl      0x200c <__AArch64AbsLongThunk_>
 // CHECK-NEXT:                 ret
-// CHECK: <__AArch64AbsLongThunk_high_target>:
-// CHECK-NEXT:     200c:       b       0x8002000 <high_target>
 // CHECK: <__AArch64AbsLongThunk_>:
-// CHECK-NEXT:     2010:       b       0x8002004 <high_target+0x4>
+// CHECK-NEXT:     200c:       b       0x8002004 <high_target+0x4>
+// CHECK: <__AArch64AbsLongThunk_high_target>:
+// CHECK-NEXT:     2010:       b       0x8002000 <high_target>
 // CHECK: Disassembly of section .text_high:
 // CHECK-EMPTY:
 // CHECK-NEXT: <high_target>:


### PR DESCRIPTION
Drop -z nosort-thunks (added by #211721 to keep creation order) and
update expectations to the default order: forward thunks sorted by
descending destination.
