### PR TITLE
[test] Migrate Hexagon/PowerPC thunk tests to the default thunk order

### DIFF
--- a/lld/test/ELF/hexagon-thunk-range-b22rel.s
+++ b/lld/test/ELF/hexagon-thunk-range-b22rel.s
@@ -1,7 +1,7 @@
 # REQUIRES: hexagon
 # RUN: rm -rf %t && split-file %s %t && cd %t
 # RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf main.s -o main.o
-# RUN: ld.lld -z nosort-thunks main.o -o test
+# RUN: ld.lld main.o -o test
 # RUN: llvm-objdump -d --no-show-raw-insn test | FileCheck %s
 
 ## Test thunk range scenarios for Hexagon R_HEX_B22_PCREL relocations.
@@ -66,13 +66,13 @@ target_beyond_range_min:
   jumpr r31
 
 ## Verify thunk generation for targets beyond B22_PCREL range
-# CHECK:       <__hexagon_thunk_target_within_range_min_from_.text.thunk>:
-# CHECK-NEXT:    200b4: { immext(#0x900000)
-# CHECK-NEXT:             jump 0x9200cc <target_within_range_min> }
-
 # CHECK:       <__hexagon_thunk_target_beyond_range_min_from_.text.thunk>:
-# CHECK-NEXT:    200bc: { immext(#0x1100000)
+# CHECK-NEXT:    200b4: { immext(#0x1100000)
 # CHECK-NEXT:             jump 0x11200c8 <target_beyond_range_min> }
+
+# CHECK:       <__hexagon_thunk_target_within_range_min_from_.text.thunk>:
+# CHECK-NEXT:    200bc: { immext(#0x900000)
+# CHECK-NEXT:             jump 0x9200cc <target_within_range_min> }
 
 # CHECK:       <__hexagon_thunk_target_multiple_calls_from_.text.thunk>:
 # CHECK-NEXT:    200c4: { immext(#0x8fffc0)
@@ -82,8 +82,8 @@ target_beyond_range_min:
 # CHECK:       <_start>:
 # CHECK-NEXT:    200cc: { call 0x8200ac <target_within_range_max> }
 # CHECK-NEXT:           { call 0x8200b8 <target_beyond_range> }
-# CHECK-NEXT:           { call 0x200b4 <__hexagon_thunk_target_within_range_min_from_.text.thunk> }
-# CHECK-NEXT:           { call 0x200bc <__hexagon_thunk_target_beyond_range_min_from_.text.thunk> }
+# CHECK-NEXT:           { call 0x200bc <__hexagon_thunk_target_within_range_min_from_.text.thunk> }
+# CHECK-NEXT:           { call 0x200b4 <__hexagon_thunk_target_beyond_range_min_from_.text.thunk> }
 # CHECK-NEXT:           { call 0x200c4 <__hexagon_thunk_target_multiple_calls_from_.text.thunk> }
 # CHECK-NEXT:           { call 0x200c4 <__hexagon_thunk_target_multiple_calls_from_.text.thunk> }
 # CHECK-NEXT:           { call 0x200ec <target_close> }

--- a/lld/test/ELF/ppc32-call-stub-nopic.s
+++ b/lld/test/ELF/ppc32-call-stub-nopic.s
@@ -1,10 +1,10 @@
 # REQUIRES: ppc
 # RUN: llvm-mc -filetype=obj -triple=powerpc %s -o %t.o
 # RUN: echo '.globl f, g, h; f: g: h:' | llvm-mc -filetype=obj -triple=powerpc - -o %t1.o
-# RUN: ld.lld -z nosort-thunks -shared %t1.o -soname t1.so -o %t1.so
+# RUN: ld.lld -shared %t1.o -soname t1.so -o %t1.so
 
 ## Check we can create PLT entries for -fno-PIE executable.
-# RUN: ld.lld -z nosort-thunks %t.o %t1.so -o %t
+# RUN: ld.lld %t.o %t1.so -o %t
 # RUN: llvm-readobj -r -d %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-readelf -S %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-readelf -x .plt %t | FileCheck --check-prefix=HEX %s
@@ -20,24 +20,24 @@
 
 ## .got2+0x8000-0x10004 = 0x30000+0x8000-0x10004 = 65536*2+32764
 # CHECK-LABEL: <_start>:
-# CHECK-NEXT:    bl 0x100101d0
-# CHECK-NEXT:    bl 0x100101d0
 # CHECK-NEXT:    bl 0x100101e0
 # CHECK-NEXT:    bl 0x100101e0
+# CHECK-NEXT:    bl 0x100101d0
+# CHECK-NEXT:    bl 0x100101d0
 # CHECK-EMPTY:
 
 ## -fno-PIC call stubs of f and g.
 ## .plt[0] = 0x100302c4 = 65536*4099+708
 ## .plt[1] = 0x100302c8 = 65536*4099+712
-# CHECK-NEXT:  <00000000.plt_call32.f>:
-# CHECK-NEXT:    lis 11, 4099
-# CHECK-NEXT:    lwz 11, 708(11)
-# CHECK-NEXT:    mtctr 11
-# CHECK-NEXT:    bctr
-# CHECK-EMPTY:
 # CHECK-NEXT:  <00000000.plt_call32.g>:
 # CHECK-NEXT:    lis 11, 4099
 # CHECK-NEXT:    lwz 11, 712(11)
+# CHECK-NEXT:    mtctr 11
+# CHECK-NEXT:    bctr
+# CHECK-EMPTY:
+# CHECK-NEXT:  <00000000.plt_call32.f>:
+# CHECK-NEXT:    lis 11, 4099
+# CHECK-NEXT:    lwz 11, 708(11)
 # CHECK-NEXT:    mtctr 11
 # CHECK-NEXT:    bctr
 # CHECK-EMPTY:

--- a/lld/test/ELF/ppc32-call-stub-pic.s
+++ b/lld/test/ELF/ppc32-call-stub-pic.s
@@ -1,11 +1,11 @@
 # REQUIRES: ppc
 # RUN: llvm-mc -filetype=obj -triple=powerpc %s -o %t.o
 # RUN: echo '.globl f, g, h; f: g: h:' | llvm-mc -filetype=obj -triple=powerpc - -o %t1.o
-# RUN: ld.lld -z nosort-thunks -shared %t1.o -soname t1.so -o %t1.so
+# RUN: ld.lld -shared %t1.o -soname t1.so -o %t1.so
 # RUN: echo 'bl f+0x8000@plt' | llvm-mc -filetype=obj -triple=powerpc - -o %t2.o
 
 ## Check we can create PLT entries for -fPIE or -fpie executable.
-# RUN: ld.lld -z nosort-thunks -pie %t.o %t1.so %t2.o -o %t
+# RUN: ld.lld -pie %t.o %t1.so %t2.o -o %t
 # RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-readobj -d %t | FileCheck --check-prefix=DYN %s
 # RUN: llvm-readelf -S %t | FileCheck --check-prefix=SEC %s
@@ -13,7 +13,7 @@
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefixes=CHECK,PIE %s
 
 ## Check we can create PLT entries for -fPIC or -fpic DSO.
-# RUN: ld.lld -z nosort-thunks -shared %t.o %t1.so %t2.o -o %t
+# RUN: ld.lld -shared %t.o %t1.so %t2.o -o %t
 # RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefixes=CHECK,SHARED %s
 
@@ -41,53 +41,39 @@
 # PIE-NEXT:           bl 0x10244
 # PIE-NEXT:           bl 0x10244
 ## Two bl 00008000.got2.plt_pic32.g
-# PIE-NEXT:           bl 0x10254
-# PIE-NEXT:           bl 0x10254
+# PIE-NEXT:           bl 0x10284
+# PIE-NEXT:           bl 0x10284
 ## Two bl 00008000.got2.plt_pic32.h
-# PIE-NEXT:           bl 0x10264
-# PIE-NEXT:           bl 0x10264
+# PIE-NEXT:           bl 0x10274
+# PIE-NEXT:           bl 0x10274
 # PIE-NEXT:           addis 30, 30, {{.*}}
 # PIE-NEXT:           addi 30, 30, {{.*}}
-## bl 00008000.plt_pic32.f
-# PIE-NEXT:           bl 0x10274
-## bl 00008000.plt_pic32.f
-# PIE-NEXT:           bl 0x10284
+## bl 00000000.plt_pic32.f
+# PIE-NEXT:           bl 0x10254
+## bl 00008000.got2.plt_pic32.f
+# PIE-NEXT:           bl 0x10264
 # SHARED-NEXT:        bcl 20, 31, 0x10230
 # SHARED-NEXT: 10230: mflr 30
 # SHARED-NEXT:        addis 30, 30, 3
 # SHARED-NEXT:        addi 30, 30, -32420
 # SHARED-NEXT:        bl 0x10264
 # SHARED-NEXT:        bl 0x10264
-# SHARED-NEXT:        bl 0x10274
-# SHARED-NEXT:        bl 0x10274
-# SHARED-NEXT:        bl 0x10284
-# SHARED-NEXT:        bl 0x10284
+# SHARED-NEXT:        bl 0x102a4
+# SHARED-NEXT:        bl 0x102a4
+# SHARED-NEXT:        bl 0x10294
+# SHARED-NEXT:        bl 0x10294
 # SHARED-NEXT:        addis 30, 30, {{.*}}
 # SHARED-NEXT:        addi 30, 30, {{.*}}
-# SHARED-NEXT:        bl 0x10294
-# SHARED-NEXT:        bl 0x102a4
+# SHARED-NEXT:        bl 0x10274
+# SHARED-NEXT:        bl 0x10284
 # CHECK-EMPTY:
 
-## -fPIC call stubs of f and g.
+## -fPIC call stub of f.
 # CHECK-NEXT:  <00008000.got2.plt_pic32.f>:
 # CHECK-NEXT:    lwz 11, 32760(30)
 # CHECK-NEXT:    mtctr 11
 # CHECK-NEXT:    bctr
 # CHECK-NEXT:    nop
-# CHECK-EMPTY:
-# CHECK-NEXT:  <00008000.got2.plt_pic32.g>:
-# CHECK-NEXT:    lwz 11, 32764(30)
-# CHECK-NEXT:    mtctr 11
-# CHECK-NEXT:    bctr
-# CHECK-NEXT:    nop
-# CHECK-EMPTY:
-
-## The -fPIC call stub of h needs two instructions addis+lwz to represent the offset 65536*1-32768.
-# CHECK-NEXT:  <00008000.got2.plt_pic32.h>:
-# CHECK-NEXT:    addis 11, 30, 1
-# CHECK-NEXT:    lwz 11, -32768(11)
-# CHECK-NEXT:    mtctr 11
-# CHECK-NEXT:    bctr
 # CHECK-EMPTY:
 
 ## -fpic call stub of f.
@@ -102,6 +88,27 @@
 ## .got2 may have different addresses in different object files,
 ## so the call stub cannot be shared.
 # CHECK-NEXT:  <00008000.got2.plt_pic32.f>:
+# CHECK-NEXT:    lwz 11, 32760(30)
+# CHECK-NEXT:    mtctr 11
+# CHECK-NEXT:    bctr
+# CHECK-NEXT:    nop
+# CHECK-EMPTY:
+
+## The -fPIC call stub of h needs two instructions addis+lwz to represent the offset 65536*1-32768.
+# CHECK-NEXT:  <00008000.got2.plt_pic32.h>:
+# CHECK-NEXT:    addis 11, 30, 1
+# CHECK-NEXT:    lwz 11, -32768(11)
+# CHECK-NEXT:    mtctr 11
+# CHECK-NEXT:    bctr
+# CHECK-EMPTY:
+
+## -fPIC call stub of g.
+# CHECK-NEXT:  <00008000.got2.plt_pic32.g>:
+# CHECK-NEXT:    lwz 11, 32764(30)
+# CHECK-NEXT:    mtctr 11
+# CHECK-NEXT:    bctr
+# CHECK-NEXT:    nop
+# CHECK-EMPTY:
 
 ## In Secure PLT ABI, .plt stores function pointers to first instructions of .glink
 # HEX: 0x00040374 00010294 00010298 0001029c

--- a/lld/test/ELF/ppc32-long-thunk.s
+++ b/lld/test/ELF/ppc32-long-thunk.s
@@ -5,12 +5,12 @@
 # RUN:       }' > %t.script
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc %s -o %t.o
-# RUN: ld.lld -z nosort-thunks -T %t.script %t.o -o %t
+# RUN: ld.lld -T %t.script %t.o -o %t
 # RUN: llvm-readelf -r %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefixes=CHECK,PD %s
 # RUN: llvm-nm --no-sort %t | FileCheck --check-prefix=NM %s
 
-# RUN: ld.lld -z nosort-thunks -T %t.script -pie %t.o -o %t
+# RUN: ld.lld -T %t.script -pie %t.o -o %t
 # RUN: llvm-readelf -r %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefixes=CHECK,PI %s
 # RUN: llvm-nm --no-sort %t | FileCheck --check-prefix=NM %s
@@ -18,45 +18,47 @@
 # SEC: There are no relocations in this file.
 
 # CHECK:      <_start>:
-# CHECK-NEXT:     2000: bl 0x2018
-# CHECK-NEXT:           bl 0x2018
-# CHECK-NEXT:           bl 0x2018
-# CHECK-NEXT:           bl 0x2002008
+# PD-NEXT:        2000: bl 0x2028
 # PD-NEXT:              bl 0x2028
+# PD-NEXT:              bl 0x2028
+# PI-NEXT:        2000: bl 0x2038
 # PI-NEXT:              bl 0x2038
-
-## high = 0x02002008 = 65536*512+8200
-# PD:         <__LongThunk_high>:
-# PD-NEXT:        2018: lis 12, 512
-# PD-NEXT:              addi 12, 12, 8200
-# PD-NEXT:              mtctr 12
-# PD-NEXT:              bctr
+# PI-NEXT:              bl 0x2038
+# CHECK-NEXT:           bl 0x2002008
+# CHECK-NEXT:           bl 0x2018
 
 ## .text_high+16 = 0x02002010 = 65536*512+8208
 # PD:         <__LongThunk_>:
-# PD-NEXT:        2028: lis 12, 512
+# PD-NEXT:        2018: lis 12, 512
 # PD-NEXT:              addi 12, 12, 8208
 # PD-NEXT:              mtctr 12
 # PD-NEXT:              bctr
 
-## high-0x2028 = 0x02002008-0x2020 = 65536*512-24
-# PI:         <__LongThunk_high>:
+## high = 0x02002008 = 65536*512+8200
+# PD:         <__LongThunk_high>:
+# PD-NEXT:        2028: lis 12, 512
+# PD-NEXT:              addi 12, 12, 8200
+# PD-NEXT:              mtctr 12
+# PD-NEXT:              bctr
+
+## .text_high+16-0x2020 = 0x02002010-0x2020 = 65536*512-16
+# PI:         <__LongThunk_>:
 # PI-NEXT:        2018: mflr 0
 # PI-NEXT:              bcl 20, 31, 0x2020
 # PI-NEXT:        2020: mflr 12
 # PI-NEXT:              addis 12, 12, 512
-# PI-NEXT:              addi 12, 12, -24
+# PI-NEXT:              addi 12, 12, -16
 # PI-NEXT:              mtlr 0
 # PI-NEXT:              mtctr 12
 # PI-NEXT:              bctr
 
-## .text_high+16-0x2048 = 0x02002010-0x2048 = 65536*512-48
-# PI:         <__LongThunk_>:
+## high-0x2040 = 0x02002008-0x2040 = 65536*512-56
+# PI:         <__LongThunk_high>:
 # PI-NEXT:        2038: mflr 0
 # PI-NEXT:              bcl 20, 31, 0x2040
 # PI-NEXT:        2040: mflr 12
 # PI-NEXT:              addis 12, 12, 512
-# PI-NEXT:              addi 12, 12, -48
+# PI-NEXT:              addi 12, 12, -56
 # PI-NEXT:              mtlr 0
 # PI-NEXT:              mtctr 12
 # PI-NEXT:              bctr

--- a/lld/test/ELF/ppc64-call-reach.s
+++ b/lld/test/ELF/ppc64-call-reach.s
@@ -1,37 +1,37 @@
 # REQUIRES: ppc
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc64le-unknown-linux %s -o %t.o
-# RUN: ld.lld -z nosort-thunks --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
+# RUN: ld.lld --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
-# RUN: ld.lld -z nosort-thunks --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
+# RUN: ld.lld --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
-# RUN: ld.lld -z nosort-thunks --defsym callee=0xE010014 --defsym tail_callee=0xE010024 \
+# RUN: ld.lld --defsym callee=0xE010014 --defsym tail_callee=0xE010024 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefix=NEGOFFSET  %s
-# RUN: ld.lld -z nosort-thunks --defsym callee=0x12010018 --defsym tail_callee=0x12010028 \
+# RUN: ld.lld --defsym callee=0x12010018 --defsym tail_callee=0x12010028 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefix=THUNK %s
 # RUN: llvm-readelf --sections %t | FileCheck --check-prefix=BRANCHLT %s
-# RUN: not ld.lld -z nosort-thunks --defsym callee=0x1001002D --defsym tail_callee=0x1001002F \
+# RUN: not ld.lld --defsym callee=0x1001002D --defsym tail_callee=0x1001002F \
 # RUN:   -z separate-code %t.o -o %t 2>&1 | FileCheck --check-prefix=MISSALIGNED %s
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc64-unknown-linux %s -o %t.o
-# RUN: ld.lld -z nosort-thunks --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
+# RUN: ld.lld --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
-# RUN: ld.lld -z nosort-thunks --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
+# RUN: ld.lld --defsym callee=0x12010010 --defsym tail_callee=0x12010020 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
-# RUN: ld.lld -z nosort-thunks --defsym callee=0xE010014 --defsym tail_callee=0xE010024 \
+# RUN: ld.lld --defsym callee=0xE010014 --defsym tail_callee=0xE010024 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefix=NEGOFFSET  %s
-# RUN: ld.lld -z nosort-thunks --defsym callee=0x12010018 --defsym tail_callee=0x12010028 \
+# RUN: ld.lld --defsym callee=0x12010018 --defsym tail_callee=0x12010028 \
 # RUN:   -z separate-code %t.o -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck --check-prefix=THUNK %s
 # RUN: llvm-readelf --sections %t | FileCheck --check-prefix=BRANCHLT %s
-# RUN: not ld.lld -z nosort-thunks --defsym callee=0x1001002D --defsym tail_callee=0x1001002F \
+# RUN: not ld.lld --defsym callee=0x1001002D --defsym tail_callee=0x1001002F \
 # RUN:   -z separate-code %t.o -o %t 2>&1 | FileCheck --check-prefix=MISSALIGNED %s
 
 # MISSALIGNED: ld.lld: error: {{.*}}.o:(.text+0x14): improper alignment for relocation R_PPC64_REL24: 0x19 is not aligned to 4 bytes
@@ -66,20 +66,20 @@ test:
 # NEGOFFSET:  10010024:       b  0xe010024
 
 # THUNK-LABEL: <test>:
-# THUNK: 10010014:       bl 0x10010030
-# THUNK: 10010024:       b 0x10010050
+# THUNK: 10010014:       bl 0x10010050
+# THUNK: 10010024:       b 0x10010030
 
 # .branch_lt[0]
-# THUNK-LABEL: <__long_branch_callee>:
+# THUNK-LABEL: <__long_branch_tail_callee>:
 # THUNK-NEXT: 10010030:       addis 12, 2, 1
-# THUNK-NEXT:                 ld 12, -32760(12)
+# THUNK-NEXT:                 ld 12, -32752(12)
 # THUNK-NEXT:                 mtctr 12
 # THUNK-NEXT:                 bctr
 
 # .branch_lt[1]
-# THUNK-LABEL: <__long_branch_tail_callee>:
+# THUNK-LABEL: <__long_branch_callee>:
 # THUNK-NEXT: 10010050:       addis 12, 2, 1
-# THUNK-NEXT:                 ld 12, -32752(12)
+# THUNK-NEXT:                 ld 12, -32760(12)
 # THUNK-NEXT:                 mtctr 12
 # THUNK-NEXT:                 bctr
 

--- a/lld/test/ELF/ppc64-ifunc.s
+++ b/lld/test/ELF/ppc64-ifunc.s
@@ -1,7 +1,7 @@
 # REQUIRES: ppc
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc64le-unknown-linux %s -o %t.o
-# RUN: ld.lld -z nosort-thunks %t.o -o %t
+# RUN: ld.lld %t.o -o %t
 # RUN: llvm-readelf -s %t | FileCheck --check-prefix=SYM %s
 # RUN: llvm-readelf -S %t | FileCheck --check-prefix=SECTIONS %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
@@ -9,7 +9,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc64-unknown-linux %s -o %t.o
 ## IRELATIVE relocs relocating NOBITS .plt do not cause --check-dynamic-relocations errors.
-# RUN: ld.lld -z nosort-thunks %t.o -o %t --apply-dynamic-relocs --check-dynamic-relocations
+# RUN: ld.lld %t.o -o %t --apply-dynamic-relocs --check-dynamic-relocations
 # RUN: llvm-readelf -s %t | FileCheck --check-prefix=SYM %s
 # RUN: llvm-readelf -S %t | FileCheck --check-prefix=SECTIONS %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
@@ -28,28 +28,28 @@
 # CHECK: <_start>:
 # CHECK-NEXT:                 addis 2, 12, 2
 # CHECK-NEXT:                 addi 2, 2, -32636
-# CHECK-NEXT: 1001021c:       bl 0x10010240
+# CHECK-NEXT: 1001021c:       bl 0x10010254
 # CHECK-NEXT:                 ld 2, 24(1)
-# CHECK-NEXT: 10010224:       bl 0x10010254
+# CHECK-NEXT: 10010224:       bl 0x10010240
 # CHECK-NEXT:                 ld 2, 24(1)
 # CHECK-NEXT:                 addis 3, 2, -2
 # CHECK-NEXT:                 addi 3, 3, 32720
 # CHECK-NEXT:                 addis 3, 2, -2
 # CHECK-NEXT:                 addi 3, 3, 32752
 
-# .plt[1] - .TOC. = 0x100302a0+8 - 0x10028298 = (1<<16) - 32752
-# CHECK: <__plt_ifunc2>:
-# CHECK-NEXT:     std 2, 24(1)
-# CHECK-NEXT:     addis 12, 2, 1
-# CHECK-NEXT:     ld 12, -32752(12)
-# CHECK-NEXT:     mtctr 12
-# CHECK-NEXT:     bctr
-
 # .plt[2] - .TOC. = 0x100302a0+16 - 0x10028298 = (1<<16) - 32744
 # CHECK: <__plt_ifunc3>:
 # CHECK-NEXT:     std 2, 24(1)
 # CHECK-NEXT:     addis 12, 2, 1
 # CHECK-NEXT:     ld 12, -32744(12)
+# CHECK-NEXT:     mtctr 12
+# CHECK-NEXT:     bctr
+
+# .plt[1] - .TOC. = 0x100302a0+8 - 0x10028298 = (1<<16) - 32752
+# CHECK: <__plt_ifunc2>:
+# CHECK-NEXT:     std 2, 24(1)
+# CHECK-NEXT:     addis 12, 2, 1
+# CHECK-NEXT:     ld 12, -32752(12)
 # CHECK-NEXT:     mtctr 12
 # CHECK-NEXT:     bctr
 # CHECK-EMPTY:

--- a/lld/test/ELF/ppc64-long-branch-pi.s
+++ b/lld/test/ELF/ppc64-long-branch-pi.s
@@ -4,13 +4,13 @@
 # RUN:       .text_low 0x2000: { *(.text_low) } \
 # RUN:       .text_high 0x2002000 : { *(.text_high) } \
 # RUN:       }' > %t.script
-# RUN: ld.lld -z nosort-thunks -pie -T %t.script %t.o -o %t
+# RUN: ld.lld -pie -T %t.script %t.o -o %t
 # RUN: llvm-readelf -S %t | FileCheck --check-prefix=SEC-PIE %s
 # RUN: llvm-readobj -r %t | FileCheck --check-prefix=RELOC %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
 
 ## RELATIVE relocs relocating NOBITS .branch_lt do not cause --check-dynamic-relocations errors.
-# RUN: ld.lld -z nosort-thunks -shared -T %t.script %t.o -o %t.so --apply-dynamic-relocs --check-dynamic-relocations
+# RUN: ld.lld -shared -T %t.script %t.o -o %t.so --apply-dynamic-relocs --check-dynamic-relocations
 # RUN: llvm-readelf -S %t.so | FileCheck --check-prefix=SEC-SHARED %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t.so | FileCheck %s
 
@@ -32,15 +32,15 @@
 # RELOC-NEXT: }
 
 # CHECK:      <_start>:
-# CHECK-NEXT:     2000:       bl 0x2010
+# CHECK-NEXT:     2000:       bl 0x2050
 # CHECK-NEXT:                 bl 0x2002000
 # CHECK-NEXT:                 bl 0x2030
-# CHECK-NEXT:                 bl 0x2050
+# CHECK-NEXT:                 bl 0x2010
 
-## &.branch_lt[0] - .TOC. = .branch_lt - (.got+0x8000) = -32744
+## &.branch_lt[2] - .TOC. = .branch_lt - (.got+0x8000) = -32728
 # CHECK:      <__long_branch_>:
 # CHECK-NEXT:     2010:       addis 12, 2, 0
-# CHECK-NEXT:                 ld 12, -32744(12)
+# CHECK-NEXT:                 ld 12, -32728(12)
 # CHECK-NEXT:                 mtctr 12
 # CHECK-NEXT:                 bctr
 
@@ -51,10 +51,10 @@
 # CHECK-NEXT:                 mtctr 12
 # CHECK-NEXT:                 bctr
 
-## &.branch_lt[2] - .TOC. = .branch_lt - (.got+0x8000) = -32728
+## &.branch_lt[0] - .TOC. = .branch_lt - (.got+0x8000) = -32744
 # CHECK:      <__long_branch_>:
 # CHECK-NEXT:     2050:       addis 12, 2, 0
-# CHECK-NEXT:                 ld 12, -32728(12)
+# CHECK-NEXT:                 ld 12, -32744(12)
 # CHECK-NEXT:                 mtctr 12
 # CHECK-NEXT:                 bctr
 

--- a/lld/test/ELF/ppc64-long-branch-rel14.s
+++ b/lld/test/ELF/ppc64-long-branch-rel14.s
@@ -5,28 +5,28 @@
 # RUN:       }' > %t.lds
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc64 %s -o %t.o
-# RUN: ld.lld -z nosort-thunks -T %t.lds %t.o -o %t
+# RUN: ld.lld -T %t.lds %t.o -o %t
 # RUN: llvm-readelf -r %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
 
 # RUN: llvm-mc -filetype=obj -triple=powerpc64le %s -o %t.o
-# RUN: ld.lld -z nosort-thunks -pie -T %t.lds %t.o -o %t
+# RUN: ld.lld -pie -T %t.lds %t.o -o %t
 # RUN: llvm-readelf -r %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
 
 # SEC: There are no relocations in this file.
 
 # CHECK-LABEL: <_start>:
-# CHECK-NEXT:  2000: bt 2, 0x2020
-# CHECK-NEXT:        bt+ 2, 0x2020
+# CHECK-NEXT:  2000: bt 2, 0x2040
+# CHECK-NEXT:        bt+ 2, 0x2040
 # CHECK-NEXT:        bf 2, 0xa004
-# CHECK-NEXT:        bt 2, 0x2040
+# CHECK-NEXT:        bt 2, 0x2020
 # CHECK-NEXT:        blr
 # CHECK-NEXT:        trap
 # CHECK-NEXT:        trap
 # CHECK-NEXT:        trap
 # CHECK-EMPTY:
-# CHECK-NEXT: <__long_branch_high>:
+# CHECK-NEXT: <__long_branch_>:
 # CHECK-NEXT:  2020: addis 12, 2, 0
 # CHECK-NEXT:        ld 12, {{.*}}(12)
 # CHECK-NEXT:        mtctr 12
@@ -34,7 +34,7 @@
 # CHECK-NEXT:        ...
 # CHECK-EMPTY:
 
-# CHECK-NEXT: <__long_branch_>:
+# CHECK-NEXT: <__long_branch_high>:
 # CHECK-NEXT:  2040: addis 12, 2, 0
 # CHECK-NEXT:        ld 12, {{.*}}(12)
 # CHECK-NEXT:        mtctr 12

--- a/lld/test/ELF/ppc64-long-branch.s
+++ b/lld/test/ELF/ppc64-long-branch.s
@@ -5,14 +5,14 @@
 # RUN:       }' > %t.script
 
 # RUN: llvm-mc -filetype=obj -triple=ppc64le %s -o %t.o
-# RUN: ld.lld -z nosort-thunks -T %t.script %t.o -o %t
+# RUN: ld.lld -T %t.script %t.o -o %t
 # RUN: llvm-readelf -S -r %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-readelf -x .branch_lt %t | FileCheck --check-prefix=BRANCH-LE %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
 # RUN: llvm-nm --no-sort %t | FileCheck --check-prefix=NM %s
 
 # RUN: llvm-mc -filetype=obj -triple=ppc64 %s -o %t.o
-# RUN: ld.lld -z nosort-thunks -T %t.script %t.o -o %t
+# RUN: ld.lld -T %t.script %t.o -o %t
 # RUN: llvm-readelf -S -r %t | FileCheck --check-prefix=SEC %s
 # RUN: llvm-readelf -x .branch_lt %t | FileCheck --check-prefix=BRANCH-BE %s
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
@@ -31,22 +31,22 @@
 # BRANCH-BE-NEXT: 0x02002058 00000000 00002008
 
 # CHECK:      <_start>:
-# CHECK-NEXT:     2000:       bl 0x2020
-# CHECK-NEXT:                 bl 0x2020
-# CHECK-NEXT:                 bl 0x2020
+# CHECK-NEXT:     2000:       bl 0x2040
+# CHECK-NEXT:                 bl 0x2040
+# CHECK-NEXT:                 bl 0x2040
 # CHECK-NEXT:                 bl 0x2002008
-
-## &.branch_lt[0] - .TOC. = .branch_lt - (.got+0x8000) = -32760
-# CHECK:      <__long_branch_high>:
-# CHECK-NEXT:     2020:       addis 12, 2, 0
-# CHECK-NEXT:                 ld 12, -32760(12)
-# CHECK-NEXT:                 mtctr 12
-# CHECK-NEXT:                 bctr
 
 ## &.branch_lt[1] - .TOC. = .branch_lt - (.got+0x8000) = -32752
 # CHECK:      <__long_branch_>:
-# CHECK-NEXT:     2040:       addis 12, 2, 0
+# CHECK-NEXT:     2020:       addis 12, 2, 0
 # CHECK-NEXT:                 ld 12, -32752(12)
+# CHECK-NEXT:                 mtctr 12
+# CHECK-NEXT:                 bctr
+
+## &.branch_lt[0] - .TOC. = .branch_lt - (.got+0x8000) = -32760
+# CHECK:      <__long_branch_high>:
+# CHECK-NEXT:     2040:       addis 12, 2, 0
+# CHECK-NEXT:                 ld 12, -32760(12)
 # CHECK-NEXT:                 mtctr 12
 # CHECK-NEXT:                 bctr
 


### PR DESCRIPTION
Drop -z nosort-thunks (added by #211721 to keep creation order) and
update expectations to the default order: forward thunks sorted by
descending destination.