### PR TITLE
[test] Migrate Arm thunk tests to the default thunk order

### DIFF
--- a/lld/test/ELF/arm-bl-v4t.s
+++ b/lld/test/ELF/arm-bl-v4t.s
@@ -1,23 +1,23 @@
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv4t-none-linux-gnueabi %t/a.s -o %t/a.o
-// RUN: ld.lld -z nosort-thunks %t/a.o --script %t/far.lds -o %t/a-far
+// RUN: ld.lld %t/a.o --script %t/far.lds -o %t/a-far
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4t-none-linux-gnueabi %t/a-far | FileCheck %s --check-prefixes=FAR
-// RUN: ld.lld -z nosort-thunks %t/a.o --script %t/near.lds -o %t/a-near
+// RUN: ld.lld %t/a.o --script %t/near.lds -o %t/a-near
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4t-none-linux-gnueabi %t/a-near | FileCheck %s --check-prefixes=NEAR
-// RUN: ld.lld -z nosort-thunks %t/a.o -pie --script %t/far.lds -o %t/a-far-pie
+// RUN: ld.lld %t/a.o -pie --script %t/far.lds -o %t/a-far-pie
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4t-none-linux-gnueabi %t/a-far-pie | FileCheck %s --check-prefixes=FAR-PIE
-// RUN: ld.lld -z nosort-thunks %t/a.o -pie --script %t/near.lds -o %t/a-near-pie
+// RUN: ld.lld %t/a.o -pie --script %t/near.lds -o %t/a-near-pie
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4t-none-linux-gnueabi %t/a-near-pie | FileCheck %s --check-prefixes=NEAR
 
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv4teb-none-linux-gnueabi %t/a.s -o %t/a.o
-// RUN: ld.lld -z nosort-thunks %t/a.o --script %t/far.lds -o %t/a-far
+// RUN: ld.lld %t/a.o --script %t/far.lds -o %t/a-far
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4teb-none-linux-gnueabi %t/a-far | FileCheck %s --check-prefixes=FAR-EB
-// RUN: ld.lld -z nosort-thunks %t/a.o --script %t/near.lds -o %t/a-near
+// RUN: ld.lld %t/a.o --script %t/near.lds -o %t/a-near
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4teb-none-linux-gnueabi %t/a-near | FileCheck %s --check-prefixes=NEAR
-// RUN: ld.lld -z nosort-thunks %t/a.o -pie --script %t/far.lds -o %t/a-far-pie
+// RUN: ld.lld %t/a.o -pie --script %t/far.lds -o %t/a-far-pie
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4teb-none-linux-gnueabi %t/a-far-pie | FileCheck %s --check-prefixes=FAR-EB-PIE
-// RUN: ld.lld -z nosort-thunks %t/a.o -pie --script %t/near.lds -o %t/a-near-pie
+// RUN: ld.lld %t/a.o -pie --script %t/near.lds -o %t/a-near-pie
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv4teb-none-linux-gnueabi %t/a-near-pie | FileCheck %s --check-prefixes=NEAR
 
 /// On Armv4T there is no blx instruction so long branch/exchange looks slightly
@@ -46,88 +46,88 @@ thumb_start:
   bx lr
 
 // FAR-LABEL: <_start>:
-// FAR-NEXT:   1000000:      	bl	0x1000010 <__ARMv5LongLdrPcThunk_target> @ imm = #8
+// FAR-NEXT:   1000000:      	bl	0x1000020 <__ARMv5LongLdrPcThunk_target> @ imm = #24
 // FAR-NEXT:                	bx	lr
 // FAR-EMPTY:
 // FAR-LABEL: <thumb_start>:
-// FAR-NEXT:   1000008:      	bl	0x1000018 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #12
+// FAR-NEXT:   1000008:      	bl	0x1000010 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #4
 // FAR-NEXT:                	bx	lr
 // FAR-NEXT:                	bmi	0xffffba                @ imm = #-88
 // FAR-EMPTY:
-// FAR-NEXT:  <__ARMv5LongLdrPcThunk_target>:
-// FAR-NEXT:   1000010:      	ldr	pc, [pc, #-4]           @ 0x1000014 <__ARMv5LongLdrPcThunk_target+0x4>
-// FAR-NEXT:   1000014: 00 00 00 06  	.word	0x06000000
-// FAR-EMPTY:
 // FAR-NEXT:  <__Thumbv4ABSLongThunk_thumb_target>:
-// FAR-NEXT:   1000018:      	bx	pc
-// FAR-NEXT:                	b	0x1000018 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #-6
-// FAR-NEXT:   100001c:      	ldr	r12, [pc]               @ 0x1000024 <__Thumbv4ABSLongThunk_thumb_target+0xc>
+// FAR-NEXT:   1000010:      	bx	pc
+// FAR-NEXT:                	b	0x1000010 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #-6
+// FAR-NEXT:   1000014:      	ldr	r12, [pc]               @ 0x100001c <__Thumbv4ABSLongThunk_thumb_target+0xc>
 // FAR-NEXT:                	bx	r12
-// FAR-NEXT:   1000024: 05 00 00 06  	.word	0x06000005
+// FAR-NEXT:   100001c: 05 00 00 06  	.word	0x06000005
+// FAR-EMPTY:
+// FAR-NEXT:  <__ARMv5LongLdrPcThunk_target>:
+// FAR-NEXT:   1000020:      	ldr	pc, [pc, #-4]           @ 0x1000024 <__ARMv5LongLdrPcThunk_target+0x4>
+// FAR-NEXT:   1000024: 00 00 00 06  	.word	0x06000000
 
 // FAR-EB-LABEL: <_start>:
-// FAR-EB-NEXT:   1000000:      	bl	0x1000010 <__ARMv5LongLdrPcThunk_target> @ imm = #8
+// FAR-EB-NEXT:   1000000:      	bl	0x1000020 <__ARMv5LongLdrPcThunk_target> @ imm = #24
 // FAR-EB-NEXT:                	bx	lr
 // FAR-EB-EMPTY:
 // FAR-EB-LABEL: <thumb_start>:
-// FAR-EB-NEXT:   1000008:      	bl	0x1000018 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #12
+// FAR-EB-NEXT:   1000008:      	bl	0x1000010 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #4
 // FAR-EB-NEXT:                	bx	lr
 // FAR-EB-NEXT:                	bmi	0xffffba                @ imm = #-88
 // FAR-EB-EMPTY:
-// FAR-EB-NEXT:  <__ARMv5LongLdrPcThunk_target>:
-// FAR-EB-NEXT:   1000010:      	ldr	pc, [pc, #-4]           @ 0x1000014 <__ARMv5LongLdrPcThunk_target+0x4>
-// FAR-EB-NEXT:   1000014: 06 00 00 00  	.word	0x06000000
-// FAR-EB-EMPTY:
 // FAR-EB-NEXT:  <__Thumbv4ABSLongThunk_thumb_target>:
-// FAR-EB-NEXT:   1000018:      	bx	pc
-// FAR-EB-NEXT:                	b	0x1000018 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #-6
-// FAR-EB-NEXT:   100001c:      	ldr	r12, [pc]               @ 0x1000024 <__Thumbv4ABSLongThunk_thumb_target+0xc>
+// FAR-EB-NEXT:   1000010:      	bx	pc
+// FAR-EB-NEXT:                	b	0x1000010 <__Thumbv4ABSLongThunk_thumb_target> @ imm = #-6
+// FAR-EB-NEXT:   1000014:      	ldr	r12, [pc]               @ 0x100001c <__Thumbv4ABSLongThunk_thumb_target+0xc>
 // FAR-EB-NEXT:                	bx	r12
-// FAR-EB-NEXT:   1000024: 06 00 00 05  	.word	0x06000005
+// FAR-EB-NEXT:   100001c: 06 00 00 05  	.word	0x06000005
+// FAR-EB-EMPTY:
+// FAR-EB-NEXT:  <__ARMv5LongLdrPcThunk_target>:
+// FAR-EB-NEXT:   1000020:      	ldr	pc, [pc, #-4]           @ 0x1000024 <__ARMv5LongLdrPcThunk_target+0x4>
+// FAR-EB-NEXT:   1000024: 06 00 00 00  	.word	0x06000000
 
 // FAR-PIE-LABEL: <_start>:
-// FAR-PIE-NEXT:   1000000:      	bl	0x1000010 <__ARMv4PILongThunk_target> @ imm = #8
+// FAR-PIE-NEXT:   1000000:      	bl	0x1000024 <__ARMv4PILongThunk_target> @ imm = #28
 // FAR-PIE-NEXT:                	bx	lr
 // FAR-PIE-EMPTY:
 // FAR-PIE-NEXT:  <thumb_start>:
-// FAR-PIE-NEXT:   1000008:      	bl	0x100001c <__Thumbv4PILongThunk_thumb_target> @ imm = #16
+// FAR-PIE-NEXT:   1000008:      	bl	0x1000010 <__Thumbv4PILongThunk_thumb_target> @ imm = #4
 // FAR-PIE-NEXT:                	bx	lr
 // FAR-PIE-NEXT:                	bmi	0xffffba                @ imm = #-88
 // FAR-PIE-EMPTY:
-// FAR-PIE-NEXT:  <__ARMv4PILongThunk_target>:
-// FAR-PIE-NEXT:   1000010:      	ldr	r12, [pc]               @ 0x1000018 <__ARMv4PILongThunk_target+0x8>
-// FAR-PIE-NEXT:                	add	pc, pc, r12
-// FAR-PIE-NEXT:   1000018: e4 ff ff 04  	.word	0x04ffffe4
-// FAR-PIE-EMPTY:
 // FAR-PIE-NEXT:  <__Thumbv4PILongThunk_thumb_target>:
-// FAR-PIE-NEXT:   100001c:      	bx	pc
-// FAR-PIE-NEXT:                	b	0x100001c <__Thumbv4PILongThunk_thumb_target> @ imm = #-6
-// FAR-PIE-NEXT:   1000020:      	ldr	r12, [pc, #4]           @ 0x100002c <__Thumbv4PILongThunk_thumb_target+0x10>
+// FAR-PIE-NEXT:   1000010:      	bx	pc
+// FAR-PIE-NEXT:                	b	0x1000010 <__Thumbv4PILongThunk_thumb_target> @ imm = #-6
+// FAR-PIE-NEXT:   1000014:      	ldr	r12, [pc, #4]           @ 0x1000020 <__Thumbv4PILongThunk_thumb_target+0x10>
 // FAR-PIE-NEXT:                	add	r12, pc, r12
 // FAR-PIE-NEXT:                	bx	r12
-// FAR-PIE-NEXT:   100002c: d9 ff ff 04  	.word	0x04ffffd9
+// FAR-PIE-NEXT:   1000020: e5 ff ff 04  	.word	0x04ffffe5
+// FAR-PIE-EMPTY:
+// FAR-PIE-NEXT:  <__ARMv4PILongThunk_target>:
+// FAR-PIE-NEXT:   1000024:      	ldr	r12, [pc]               @ 0x100002c <__ARMv4PILongThunk_target+0x8>
+// FAR-PIE-NEXT:                	add	pc, pc, r12
+// FAR-PIE-NEXT:   100002c: d0 ff ff 04  	.word	0x04ffffd0
 
 // FAR-EB-PIE-LABEL: <_start>:
-// FAR-EB-PIE-NEXT:   1000000:      	bl	0x1000010 <__ARMv4PILongThunk_target> @ imm = #8
+// FAR-EB-PIE-NEXT:   1000000:      	bl	0x1000024 <__ARMv4PILongThunk_target> @ imm = #28
 // FAR-EB-PIE-NEXT:                	bx	lr
 // FAR-EB-PIE-EMPTY:
 // FAR-EB-PIE-NEXT:  <thumb_start>:
-// FAR-EB-PIE-NEXT:   1000008:      	bl	0x100001c <__Thumbv4PILongThunk_thumb_target> @ imm = #16
+// FAR-EB-PIE-NEXT:   1000008:      	bl	0x1000010 <__Thumbv4PILongThunk_thumb_target> @ imm = #4
 // FAR-EB-PIE-NEXT:                	bx	lr
 // FAR-EB-PIE-NEXT:                	bmi	0xffffba                @ imm = #-88
 // FAR-EB-PIE-EMPTY:
-// FAR-EB-PIE-NEXT:  <__ARMv4PILongThunk_target>:
-// FAR-EB-PIE-NEXT:   1000010:      	ldr	r12, [pc]               @ 0x1000018 <__ARMv4PILongThunk_target+0x8>
-// FAR-EB-PIE-NEXT:                	add	pc, pc, r12
-// FAR-EB-PIE-NEXT:   1000018: 04 ff ff e4  	.word	0x04ffffe4
-// FAR-EB-PIE-EMPTY:
 // FAR-EB-PIE-NEXT:  <__Thumbv4PILongThunk_thumb_target>:
-// FAR-EB-PIE-NEXT:   100001c:      	bx	pc
-// FAR-EB-PIE-NEXT:                	b	0x100001c <__Thumbv4PILongThunk_thumb_target> @ imm = #-6
-// FAR-EB-PIE-NEXT:   1000020:      	ldr	r12, [pc, #4]           @ 0x100002c <__Thumbv4PILongThunk_thumb_target+0x10>
+// FAR-EB-PIE-NEXT:   1000010:      	bx	pc
+// FAR-EB-PIE-NEXT:                	b	0x1000010 <__Thumbv4PILongThunk_thumb_target> @ imm = #-6
+// FAR-EB-PIE-NEXT:   1000014:      	ldr	r12, [pc, #4]           @ 0x1000020 <__Thumbv4PILongThunk_thumb_target+0x10>
 // FAR-EB-PIE-NEXT:                	add	r12, pc, r12
 // FAR-EB-PIE-NEXT:                	bx	r12
-// FAR-EB-PIE-NEXT:   100002c: 04 ff ff d9  	.word	0x04ffffd9
+// FAR-EB-PIE-NEXT:   1000020: 04 ff ff e5  	.word	0x04ffffe5
+// FAR-EB-PIE-EMPTY:
+// FAR-EB-PIE-NEXT:  <__ARMv4PILongThunk_target>:
+// FAR-EB-PIE-NEXT:   1000024:      	ldr	r12, [pc]               @ 0x100002c <__ARMv4PILongThunk_target+0x8>
+// FAR-EB-PIE-NEXT:                	add	pc, pc, r12
+// FAR-EB-PIE-NEXT:   100002c: 04 ff ff d0  	.word	0x04ffffd0
 
 // NEAR-LABEL: <_start>:
 // NEAR-NEXT:  1000000:      	bl	0x1000010 <target> @ imm = #8

--- a/lld/test/ELF/arm-branch-rangethunk.s
+++ b/lld/test/ELF/arm-branch-rangethunk.s
@@ -1,10 +1,10 @@
 // REQUIRES: arm
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %s -o %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %S/Inputs/far-arm-abs.s -o %tfar
-// RUN: ld.lld -z nosort-thunks  %t %tfar -o %t2
+// RUN: ld.lld  %t %tfar -o %t2
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv7a-none-linux-gnueabi %t2 | FileCheck --check-prefix=SHORT %s
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %S/Inputs/far-long-arm-abs.s -o %tfarlong
-// RUN: ld.lld -z nosort-thunks  %t %tfarlong -o %t3
+// RUN: ld.lld  %t %tfarlong -o %t3
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv7a-none-linux-gnueabi %t3 | FileCheck --check-prefix=LONG %s
  .syntax unified
  .section .text, "ax",%progbits
@@ -19,32 +19,30 @@ _start:
  beq too_far3
 
 // SHORT: 00030000 <_start>:
-// SHORT-NEXT:    30000: bl      0x3000c <__ARMv7ABSLongThunk_too_far1>
+// SHORT-NEXT:    30000: bl      0x30014 <__ARMv7ABSLongThunk_too_far1>
 // SHORT-NEXT:    30004: b       0x30010 <__ARMv7ABSLongThunk_too_far2>
-// SHORT-NEXT:    30008: beq     0x30014 <__ARMv7ABSLongThunk_too_far3>
-// SHORT:      0003000c <__ARMv7ABSLongThunk_too_far1>:
-/// 0x2030008 = too_far1
-// SHORT-NEXT:    3000c: b       0x2030008
+// SHORT-NEXT:    30008: beq     0x3000c <__ARMv7ABSLongThunk_too_far3>
+// SHORT:      0003000c <__ARMv7ABSLongThunk_too_far3>:
+/// 0x2030010 = too_far3
+// SHORT-NEXT:    3000c: b       0x2030010
 // SHORT:      00030010 <__ARMv7ABSLongThunk_too_far2>:
 /// 0x203000c = too_far2
 // SHORT-NEXT:    30010: b       0x203000c
-// SHORT:      00030014 <__ARMv7ABSLongThunk_too_far3>:
-/// 0x2030010 = too_far3
-// SHORT-NEXT:    30014: b       0x2030010
+// SHORT:      00030014 <__ARMv7ABSLongThunk_too_far1>:
+/// 0x2030008 = too_far1
+// SHORT-NEXT:    30014: b       0x2030008
 
 // LONG:      00030000 <_start>:
-// LONG-NEXT:    30000: bl      0x3000c <__ARMv7ABSLongThunk_too_far1>
+// LONG-NEXT:    30000: bl      0x30024 <__ARMv7ABSLongThunk_too_far1>
 // LONG-NEXT:    30004: b       0x30018 <__ARMv7ABSLongThunk_too_far2>
-// LONG-NEXT:    30008: beq     0x30024 <__ARMv7ABSLongThunk_too_far3>
-// LONG:      0003000c <__ARMv7ABSLongThunk_too_far1>:
-// LONG-NEXT:    3000c: movw    r12, #20
+// LONG-NEXT:    30008: beq     0x3000c <__ARMv7ABSLongThunk_too_far3>
+// LONG:      0003000c <__ARMv7ABSLongThunk_too_far3>:
+// LONG-NEXT:    3000c: movw    r12, #44
 // LONG-NEXT:    30010: movt    r12, #515
 // LONG-NEXT:    30014: bx      r12
 // LONG:      00030018 <__ARMv7ABSLongThunk_too_far2>:
 // LONG-NEXT:    30018: movw    r12, #32
 // LONG-NEXT:    3001c: movt    r12, #515
 // LONG-NEXT:    30020: bx      r12
-// LONG:      00030024 <__ARMv7ABSLongThunk_too_far3>:
-// LONG-NEXT:    30024: movw    r12, #44
-// LONG-NEXT:    30028: movt    r12, #515
-// LONG-NEXT:    3002c: bx      r12
+// LONG:      00030024 <__ARMv7ABSLongThunk_too_far1>:
+// LONG-NEXT:    30024: b       0x2030014

--- a/lld/test/ELF/arm-force-pi-thunk.s
+++ b/lld/test/ELF/arm-force-pi-thunk.s
@@ -1,7 +1,7 @@
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi a.s -o a.o
-// RUN: ld.lld -z nosort-thunks --pic-veneer --no-rosegment --script a.lds a.o -o exe
+// RUN: ld.lld --pic-veneer --no-rosegment --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
 
 // Test that we can force generation of position independent thunks even when
@@ -40,22 +40,22 @@ low_target2:
 // CHECK-NEXT: <_start>:
 // CHECK-NEXT:       94:        4770    bx      lr
 // CHECK: <low_target>:
-// CHECK-NEXT:       96:        f000 f803       bl      0xa0 <__ThumbV7PILongThunk_high_target>
-// CHECK-NEXT:       9a:        f000 f807       bl      0xac <__ThumbV7PILongThunk_high_target2>
+// CHECK-NEXT:       96:        f000 f809       bl      0xac <__ThumbV7PILongThunk_high_target>
+// CHECK-NEXT:       9a:        f000 f801       bl      0xa0 <__ThumbV7PILongThunk_high_target2>
 // CHECK-NEXT:       9e:        d4d4 
-// CHECK: <__ThumbV7PILongThunk_high_target>:
-// CHECK-NEXT:       a0:        f64f 7c55       movw    r12, #65365
+// CHECK: <__ThumbV7PILongThunk_high_target2>:
+// CHECK-NEXT:       a0:        f64f 7c75       movw    r12, #65397
 // CHECK-NEXT:       a4:        f2c0 1cff       movt    r12, #511
 // CHECK-NEXT:       a8:        44fc    add     r12, pc
 // CHECK-NEXT:       aa:        4760    bx      r12
-// CHECK: <__ThumbV7PILongThunk_high_target2>:
-// CHECK-NEXT:       ac:        f64f 7c69       movw    r12, #65385
+// CHECK: <__ThumbV7PILongThunk_high_target>:
+// CHECK-NEXT:       ac:        f64f 7c49       movw    r12, #65353
 // CHECK-NEXT:       b0:        f2c0 1cff       movt    r12, #511
 // CHECK-NEXT:       b4:        44fc    add     r12, pc
 // CHECK-NEXT:       b6:        4760    bx      r12
 // CHECK: <low_target2>:
-// CHECK-NEXT:       b8:        f7ff fff2       bl      0xa0 <__ThumbV7PILongThunk_high_target>
-// CHECK-NEXT:       bc:        f7ff fff6       bl      0xac <__ThumbV7PILongThunk_high_target2>
+// CHECK-NEXT:       b8:        f7ff fff8       bl      0xac <__ThumbV7PILongThunk_high_target>
+// CHECK-NEXT:       bc:        f7ff fff0       bl      0xa0 <__ThumbV7PILongThunk_high_target2>
 
 
  .section .text_high, "ax", %progbits

--- a/lld/test/ELF/arm-thumb-condbranch-thunk.s
+++ b/lld/test/ELF/arm-thumb-condbranch-thunk.s
@@ -1,6 +1,6 @@
 // REQUIRES: arm
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t.o
-// RUN: ld.lld -z nosort-thunks %t.o -o %t
+// RUN: ld.lld %t.o -o %t
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
 // RUN: llvm-objdump -d %t --print-imm-hex --start-address=0x80000 --stop-address=0x80010 | FileCheck --check-prefix=CHECK1 %s
@@ -38,11 +38,11 @@ _start:
 // CHECK1-EMPTY:
 // CHECK1-NEXT: <tfunc00>:
 // CHECK1-NEXT:    80000:       4770    bx      lr
-// CHECK1-NEXT:    80002:       f37f d7ff       bl      0x1000004 <__Thumbv7ABSLongThunk_tfunc33>
-// CHECK1: <__Thumbv7ABSLongThunk_tfunc05>:
-// CHECK1-NEXT:    80008:       f27f bffa       b.w     0x300000 <tfunc05>
+// CHECK1-NEXT:    80002:       f380 d001       bl      0x1000008 <__Thumbv7ABSLongThunk_tfunc33>
 // CHECK1: <__Thumbv7ABSLongThunk_tfunc00>:
-// CHECK1-NEXT:    8000c:       f7ff bff8       b.w     0x80000 <tfunc00>
+// CHECK1-NEXT:    80008:       f7ff bffa       b.w     0x80000 <tfunc00>
+// CHECK1: <__Thumbv7ABSLongThunk_tfunc05>:
+// CHECK1-NEXT:    8000c:       f27f bff8       b.w     0x300000 <tfunc05>
  FUNCTION 01
 // tfunc02 is within range of tfunc02
  beq.w tfunc02
@@ -52,14 +52,14 @@ _start:
 // CHECK2:  <tfunc01>:
 // CHECK2-NEXT:   100000:       4770    bx      lr
 // CHECK2-NEXT:   100002:       f03f a7fd       beq.w   0x180000 <tfunc02>
-// CHECK2-NEXT:   100006:       f47f a7ff       bne.w   0x80008 <__Thumbv7ABSLongThunk_tfunc05>
+// CHECK2-NEXT:   100006:       f440 8801       bne.w   0x8000c <__Thumbv7ABSLongThunk_tfunc05>
  FUNCTION 02
 // We can reach the Thunk Section created for bne.w tfunc05
  bne.w tfunc05
  beq.w tfunc00
 // CHECK3:        180000:       4770    bx      lr
-// CHECK3-NEXT:   180002:       f440 8001       bne.w   0x80008 <__Thumbv7ABSLongThunk_tfunc05>
-// CHECK3-NEXT:   180006:       f400 8001       beq.w   0x8000c <__Thumbv7ABSLongThunk_tfunc00>
+// CHECK3-NEXT:   180002:       f440 8003       bne.w   0x8000c <__Thumbv7ABSLongThunk_tfunc05>
+// CHECK3-NEXT:   180006:       f400 8003       beq.w   0x80010 <__Thumbv7ABSLongThunk_tfunc00>
  FUNCTION 03
  FUNCTION 04
  FUNCTION 05
@@ -96,14 +96,14 @@ _start:
  FUNCTION 29
  FUNCTION 30
  FUNCTION 31
-// CHECK6:  <__Thumbv7ABSLongThunk_tfunc33>:
-// CHECK6-NEXT:  1000004:       f0ff bffc       b.w     0x1100000 <tfunc33>
-// CHECK6: <__Thumbv7ABSLongThunk_tfunc00>:
-// CHECK6-NEXT:  1000008:       f47f 97fa       b.w     0x80000 <tfunc00>
+// CHECK6:  <__Thumbv7ABSLongThunk_tfunc00>:
+// CHECK6-NEXT:  1000004:       f47f 97fc       b.w     0x80000 <tfunc00>
+// CHECK6: <__Thumbv7ABSLongThunk_tfunc33>:
+// CHECK6-NEXT:  1000008:       f0ff bffa       b.w     0x1100000 <tfunc33>
  FUNCTION 32
  FUNCTION 33
  // We should be able to reach an existing ThunkSection.
  b.w tfunc00
 // CHECK7: <tfunc33>:
 // CHECK7-NEXT:  1100000:       4770            bx      lr
-// CHECK7-NEXT:  1100002:       f700 b801       b.w     0x1000008 <__Thumbv7ABSLongThunk_tfunc00>
+// CHECK7-NEXT:  1100002:       f6ff bfff       b.w     0x1000004 <__Thumbv7ABSLongThunk_tfunc00>

--- a/lld/test/ELF/arm-thumb-interwork-shared.s
+++ b/lld/test/ELF/arm-thumb-interwork-shared.s
@@ -1,6 +1,6 @@
 // REQUIRES: arm
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t
-// RUN: ld.lld -z nosort-thunks %t --shared -o %t.so
+// RUN: ld.lld %t --shared -o %t.so
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t.so | FileCheck %s
  .syntax unified
  .global sym1
@@ -19,17 +19,17 @@ sym1:
 // CHECK: Disassembly of section .text:
 // CHECK-EMPTY:
 // CHECK-NEXT: <sym1>:
-// CHECK-NEXT:    101e0: b.w 0x101f0 <__ThumbV7PILongThunk_elsewhere>
-// CHECK-NEXT:           b.w 0x101fc <__ThumbV7PILongThunk_weakref>
+// CHECK-NEXT:    101e0: b.w 0x101fc <__ThumbV7PILongThunk_elsewhere>
+// CHECK-NEXT:           b.w 0x101f0 <__ThumbV7PILongThunk_weakref>
 // CHECK-NEXT:           blx 0x10230
 // CHECK-NEXT:           blx 0x10240
-// CHECK: <__ThumbV7PILongThunk_elsewhere>:
-// CHECK-NEXT:     101f0: movw    r12, #52
+// CHECK: <__ThumbV7PILongThunk_weakref>:
+// CHECK-NEXT:     101f0: movw    r12, #68
 // CHECK-NEXT:           movt    r12, #0
 // CHECK-NEXT:           add     r12, pc
 // CHECK-NEXT:           bx      r12
-// CHECK: <__ThumbV7PILongThunk_weakref>:
-// CHECK-NEXT:     101fc: movw    r12, #56
+// CHECK: <__ThumbV7PILongThunk_elsewhere>:
+// CHECK-NEXT:     101fc: movw    r12, #40
 // CHECK-NEXT:           movt    r12, #0
 // CHECK-NEXT:           add     r12, pc
 // CHECK-NEXT:           bx      r12

--- a/lld/test/ELF/arm-thumb-interwork-thunk.s
+++ b/lld/test/ELF/arm-thumb-interwork-thunk.s
@@ -10,13 +10,13 @@
 // RUN:       .R_ARM_JUMP24_callee_2 : { *(.R_ARM_JUMP24_callee_high) } \
 // RUN:       .R_ARM_THM_JUMP_callee_2 : { *(.R_ARM_THM_JUMP_callee_high) } \
 // RUN:       .got.plt 0x18b4 : {  }  } " > %t.script
-// RUN: ld.lld -z nosort-thunks --script %t.script %t -o %t2
+// RUN: ld.lld --script %t.script %t -o %t2
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t2 | FileCheck --check-prefix=CHECK-THUMB --check-prefix=CHECK-ABS-THUMB %s
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv7a-none-linux-gnueabi %t2 | FileCheck --check-prefix=CHECK-ARM --check-prefix=CHECK-ARM-ABS-ARM %s
-// RUN: ld.lld -z nosort-thunks --script %t.script %t -pie -o %t3
+// RUN: ld.lld --script %t.script %t -pie -o %t3
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t3 | FileCheck --check-prefix=CHECK-THUMB --check-prefix=CHECK-PI-THUMB %s
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv7a-none-linux-gnueabi %t3 | FileCheck --check-prefix=CHECK-ARM --check-prefix=CHECK-PI-ARM %s
-// RUN: ld.lld -z nosort-thunks --script %t.script %t --shared -o %t4
+// RUN: ld.lld --script %t.script %t --shared -o %t4
 // RUN: llvm-readobj -S -r %t4 | FileCheck -check-prefix=CHECK-DSO-REL %s
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --triple=armv7a-none-linux-gnueabi %t4 | FileCheck -check-prefix=CHECK-ARM-PLT %s
 /// Test ARM Thumb Interworking
@@ -84,8 +84,8 @@ arm_caller:
 // CHECK-ARM-ABS-ARM-NEXT: 1304: blx     0x1000 <thumb_callee1>
 // CHECK-ARM-ABS-ARM-NEXT: 1308: b       0x1328 <__ARMv7ABSLongThunk_thumb_callee1>
 // CHECK-ARM-ABS-ARM-NEXT: 130c: b       0x1328 <__ARMv7ABSLongThunk_thumb_callee1>
-// CHECK-ARM-ABS-ARM-NEXT: 1310: b       0x1334 <__ARMv7ABSLongThunk_thumb_callee2>
-// CHECK-ARM-ABS-ARM-NEXT: 1314: b       0x1340 <__ARMv7ABSLongThunk_thumb_callee3>
+// CHECK-ARM-ABS-ARM-NEXT: 1310: b       0x1340 <__ARMv7ABSLongThunk_thumb_callee2>
+// CHECK-ARM-ABS-ARM-NEXT: 1314: b       0x1334 <__ARMv7ABSLongThunk_thumb_callee3>
 // CHECK-ARM-ABS-ARM-NEXT: 1318: b       0x1100 <arm_callee1>
 // CHECK-ARM-ABS-ARM-NEXT: 131c: beq     0x1600 <arm_callee2>
 // CHECK-ARM-ABS-ARM-NEXT: 1320: bne     0x1604 <arm_callee3>
@@ -95,14 +95,14 @@ arm_caller:
 // CHECK-ARM-ABS-ARM-NEXT: 1328: movw    r12, #4097
 // CHECK-ARM-ABS-ARM-NEXT: 132c: movt    r12, #0
 // CHECK-ARM-ABS-ARM-NEXT: 1330: bx      r12
-// 0x1501 = thumb_callee2
-// CHECK-ARM-ABS-ARM:      <__ARMv7ABSLongThunk_thumb_callee2>:
-// CHECK-ARM-ABS-ARM-NEXT: 1334: movw    r12, #5377
-// CHECK-ARM-ABS-ARM-NEXT: 1338: movt    r12, #0
-// CHECK-ARM-ABS-ARM-NEXT: 133c: bx      r12
 // 0x1503 = thumb_callee3
 // CHECK-ARM-ABS-ARM:      <__ARMv7ABSLongThunk_thumb_callee3>:
-// CHECK-ARM-ABS-ARM-NEXT: 1340: movw    r12, #5379
+// CHECK-ARM-ABS-ARM-NEXT: 1334: movw    r12, #5379
+// CHECK-ARM-ABS-ARM-NEXT: 1338: movt    r12, #0
+// CHECK-ARM-ABS-ARM-NEXT: 133c: bx      r12
+// 0x1501 = thumb_callee2
+// CHECK-ARM-ABS-ARM:      <__ARMv7ABSLongThunk_thumb_callee2>:
+// CHECK-ARM-ABS-ARM-NEXT: 1340: movw    r12, #5377
 // CHECK-ARM-ABS-ARM-NEXT: 1344: movt    r12, #0
 // CHECK-ARM-ABS-ARM-NEXT: 1348: bx      r12
 
@@ -113,8 +113,8 @@ arm_caller:
 // CHECK-PI-ARM-NEXT: 1304: blx     0x1000 <thumb_callee1>
 // CHECK-PI-ARM-NEXT: 1308: b       0x1328 <__ARMV7PILongThunk_thumb_callee1>
 // CHECK-PI-ARM-NEXT: 130c: b       0x1328 <__ARMV7PILongThunk_thumb_callee1>
-// CHECK-PI-ARM-NEXT: 1310: b       0x1338 <__ARMV7PILongThunk_thumb_callee2>
-// CHECK-PI-ARM-NEXT: 1314: b       0x1348 <__ARMV7PILongThunk_thumb_callee3>
+// CHECK-PI-ARM-NEXT: 1310: b       0x1348 <__ARMV7PILongThunk_thumb_callee2>
+// CHECK-PI-ARM-NEXT: 1314: b       0x1338 <__ARMV7PILongThunk_thumb_callee3>
 // CHECK-PI-ARM-NEXT: 1318: b       0x1100 <arm_callee1>
 // CHECK-PI-ARM-NEXT: 131c: beq     0x1600 <arm_callee2>
 // CHECK-PI-ARM-NEXT: 1320: bne     0x1604 <arm_callee3>
@@ -124,13 +124,13 @@ arm_caller:
 // CHECK-PI-ARM-NEXT: 132c: movt    r12, #65535
 // CHECK-PI-ARM-NEXT: 1330: add     r12, r12, pc
 // CHECK-PI-ARM-NEXT: 1334: bx      r12
-// CHECK-PI-ARM: <__ARMV7PILongThunk_thumb_callee2>:
-// CHECK-PI-ARM-NEXT: 1338: movw    r12, #441
+// CHECK-PI-ARM: <__ARMV7PILongThunk_thumb_callee3>:
+// CHECK-PI-ARM-NEXT: 1338: movw    r12, #443
 // CHECK-PI-ARM-NEXT: 133c: movt    r12, #0
 // CHECK-PI-ARM-NEXT: 1340: add     r12, r12, pc
 // CHECK-PI-ARM-NEXT: 1344: bx      r12
-// CHECK-PI-ARM: <__ARMV7PILongThunk_thumb_callee3>:
-// CHECK-PI-ARM-NEXT: 1348: movw    r12, #427
+// CHECK-PI-ARM: <__ARMV7PILongThunk_thumb_callee2>:
+// CHECK-PI-ARM-NEXT: 1348: movw    r12, #425
 // CHECK-PI-ARM-NEXT: 134c: movt    r12, #0
 // CHECK-PI-ARM-NEXT: 1350: add     r12, r12, pc
 // CHECK-PI-ARM-NEXT: 1354: bx      r12
@@ -178,21 +178,21 @@ thumb_caller:
 // CHECK-ABS-THUMB-NEXT: 1400: blx     0x1100 <arm_callee1>
 // CHECK-ABS-THUMB-NEXT: 1404: blx     0x1100 <arm_callee1>
 // CHECK-ABS-THUMB-NEXT: 1408: b.w     0x1420 <__Thumbv7ABSLongThunk_arm_callee1>
-// CHECK-ABS-THUMB-NEXT: 140c: b.w     0x142a <__Thumbv7ABSLongThunk_arm_callee2>
-// CHECK-ABS-THUMB-NEXT: 1410: b.w     0x1434 <__Thumbv7ABSLongThunk_arm_callee3>
+// CHECK-ABS-THUMB-NEXT: 140c: b.w     0x1434 <__Thumbv7ABSLongThunk_arm_callee2>
+// CHECK-ABS-THUMB-NEXT: 1410: b.w     0x142a <__Thumbv7ABSLongThunk_arm_callee3>
 // CHECK-ABS-THUMB-NEXT: 1414: beq.w   0x1420 <__Thumbv7ABSLongThunk_arm_callee1>
-// CHECK-ABS-THUMB-NEXT: 1418: beq.w   0x142a <__Thumbv7ABSLongThunk_arm_callee2>
-// CHECK-ABS-THUMB-NEXT: 141c: bne.w   0x1434 <__Thumbv7ABSLongThunk_arm_callee3>
+// CHECK-ABS-THUMB-NEXT: 1418: beq.w   0x1434 <__Thumbv7ABSLongThunk_arm_callee2>
+// CHECK-ABS-THUMB-NEXT: 141c: bne.w   0x142a <__Thumbv7ABSLongThunk_arm_callee3>
 // CHECK-ABS-THUMB: <__Thumbv7ABSLongThunk_arm_callee1>:
 // CHECK-ABS-THUMB-NEXT: 1420: movw    r12, #4352
 // CHECK-ABS-THUMB-NEXT: 1424: movt    r12, #0
 // CHECK-ABS-THUMB-NEXT: 1428: bx      r12
-// CHECK-ABS-THUMB: <__Thumbv7ABSLongThunk_arm_callee2>:
-// CHECK-ABS-THUMB-NEXT: 142a: movw    r12, #5632
+// CHECK-ABS-THUMB: <__Thumbv7ABSLongThunk_arm_callee3>:
+// CHECK-ABS-THUMB-NEXT: 142a: movw    r12, #5636
 // CHECK-ABS-THUMB-NEXT: 142e: movt    r12, #0
 // CHECK-ABS-THUMB-NEXT: 1432: bx      r12
-// CHECK-ABS-THUMB: <__Thumbv7ABSLongThunk_arm_callee3>:
-// CHECK-ABS-THUMB-NEXT: 1434: movw    r12, #5636
+// CHECK-ABS-THUMB: <__Thumbv7ABSLongThunk_arm_callee2>:
+// CHECK-ABS-THUMB-NEXT: 1434: movw    r12, #5632
 // CHECK-ABS-THUMB-NEXT: 1438: movt    r12, #0
 // CHECK-ABS-THUMB-NEXT: 143c: bx      r12
 
@@ -202,23 +202,23 @@ thumb_caller:
 // CHECK-PI-THUMB-NEXT: 1400: blx     0x1100 <arm_callee1>
 // CHECK-PI-THUMB-NEXT: 1404: blx     0x1100 <arm_callee1>
 // CHECK-PI-THUMB-NEXT: 1408: b.w     0x1420 <__ThumbV7PILongThunk_arm_callee1>
-// CHECK-PI-THUMB-NEXT: 140c: b.w     0x142c <__ThumbV7PILongThunk_arm_callee2>
-// CHECK-PI-THUMB-NEXT: 1410: b.w     0x1438 <__ThumbV7PILongThunk_arm_callee3>
+// CHECK-PI-THUMB-NEXT: 140c: b.w     0x1438 <__ThumbV7PILongThunk_arm_callee2>
+// CHECK-PI-THUMB-NEXT: 1410: b.w     0x142c <__ThumbV7PILongThunk_arm_callee3>
 // CHECK-PI-THUMB-NEXT: 1414: beq.w   0x1420 <__ThumbV7PILongThunk_arm_callee1>
-// CHECK-PI-THUMB-NEXT: 1418: beq.w   0x142c <__ThumbV7PILongThunk_arm_callee2>
-// CHECK-PI-THUMB-NEXT: 141c: bne.w   0x1438 <__ThumbV7PILongThunk_arm_callee3>
+// CHECK-PI-THUMB-NEXT: 1418: beq.w   0x1438 <__ThumbV7PILongThunk_arm_callee2>
+// CHECK-PI-THUMB-NEXT: 141c: bne.w   0x142c <__ThumbV7PILongThunk_arm_callee3>
 // CHECK-PI-THUMB: <__ThumbV7PILongThunk_arm_callee1>:
 // CHECK-PI-THUMB-NEXT: 1420: movw    r12, #64724
 // CHECK-PI-THUMB-NEXT: 1424: movt    r12, #65535
 // CHECK-PI-THUMB-NEXT: 1428: add     r12, pc
 // CHECK-PI-THUMB-NEXT: 142a: bx      r12
-// CHECK-PI-THUMB: <__ThumbV7PILongThunk_arm_callee2>:
-// CHECK-PI-THUMB-NEXT: 142c: movw    r12, #456
+// CHECK-PI-THUMB: <__ThumbV7PILongThunk_arm_callee3>:
+// CHECK-PI-THUMB-NEXT: 142c: movw    r12, #460
 // CHECK-PI-THUMB-NEXT: 1430: movt    r12, #0
 // CHECK-PI-THUMB-NEXT: 1434: add     r12, pc
 // CHECK-PI-THUMB-NEXT: 1436: bx      r12
-// CHECK-PI-THUMB: <__ThumbV7PILongThunk_arm_callee3>:
-// CHECK-PI-THUMB-NEXT: 1438: movw    r12, #448
+// CHECK-PI-THUMB: <__ThumbV7PILongThunk_arm_callee2>:
+// CHECK-PI-THUMB-NEXT: 1438: movw    r12, #444
 // CHECK-PI-THUMB-NEXT: 143c: movt    r12, #0
 // CHECK-PI-THUMB-NEXT: 1440: add     r12, pc
 // CHECK-PI-THUMB-NEXT: 1442: bx      r12
@@ -231,12 +231,12 @@ thumb_caller:
 // CHECK-ARM-PLT-NEXT: <thumb_caller>:
 // CHECK-ARM-PLT-NEXT: 1400: blx     0x1640
 // CHECK-ARM-PLT-NEXT: 1404: blx     0x1640
-// CHECK-ARM-PLT-NEXT: 1408: b.w     0x1420 <__ThumbV7PILongThunk_arm_callee1>
+// CHECK-ARM-PLT-NEXT: 1408: b.w     0x1438 <__ThumbV7PILongThunk_arm_callee1>
 // CHECK-ARM-PLT-NEXT: 140c: b.w     0x142c <__ThumbV7PILongThunk_arm_callee2>
-// CHECK-ARM-PLT-NEXT: 1410: b.w     0x1438 <__ThumbV7PILongThunk_arm_callee3>
-// CHECK-ARM-PLT-NEXT: 1414: beq.w   0x1420 <__ThumbV7PILongThunk_arm_callee1>
+// CHECK-ARM-PLT-NEXT: 1410: b.w     0x1420 <__ThumbV7PILongThunk_arm_callee3>
+// CHECK-ARM-PLT-NEXT: 1414: beq.w   0x1438 <__ThumbV7PILongThunk_arm_callee1>
 // CHECK-ARM-PLT-NEXT: 1418: beq.w   0x142c <__ThumbV7PILongThunk_arm_callee2>
-// CHECK-ARM-PLT-NEXT: 141c: bne.w   0x1438 <__ThumbV7PILongThunk_arm_callee3>
+// CHECK-ARM-PLT-NEXT: 141c: bne.w   0x1420 <__ThumbV7PILongThunk_arm_callee3>
 
 /// Target Sections for thunks at a higher address than the callers.
 .section .R_ARM_JUMP24_callee_high, "ax", %progbits

--- a/lld/test/ELF/arm-thumb-mix-range-thunk-os.s
+++ b/lld/test/ELF/arm-thumb-mix-range-thunk-os.s
@@ -1,6 +1,6 @@
 // REQUIRES: arm
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %s -o %t
-// RUN: ld.lld -z nosort-thunks %t -o %t2
+// RUN: ld.lld %t -o %t2
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x100000 --stop-address=0x10001c --triple=armv7a-linux-gnueabihf | FileCheck --check-prefix=CHECK1 %s
@@ -64,8 +64,8 @@ _start:
 // CHECK1:  <afunc00>:
 // CHECK1-NEXT:   100000:       e12fff1e        bx      lr
 // CHECK1-NEXT:   100004:       fa7bfffd        blx     0x2000000 <tfunc31>
-// CHECK1-NEXT:   100008:       ea3bfffd        b       0x1000004 <__ARMv7ABSLongThunk_tfunc31>
-// CHECK1-NEXT:   10000c:       0a3bfffc        beq     0x1000004 <__ARMv7ABSLongThunk_tfunc31>
+// CHECK1-NEXT:   100008:       ea3c0000        b       0x1000010 <__ARMv7ABSLongThunk_tfunc31>
+// CHECK1-NEXT:   10000c:       0a3bffff        beq     0x1000010 <__ARMv7ABSLongThunk_tfunc31>
 // CHECK1-NEXT:   100010:       eb7ffffa        bl      0x2100000 <afunc32>
 // CHECK1-NEXT:   100014:       ea7ffff9        b       0x2100000 <afunc32>
 // CHECK1-NEXT:   100018:       1a7ffff8        bne     0x2100000 <afunc32>
@@ -77,7 +77,7 @@ _start:
 // CHECK2: <tfunc01>:
 // CHECK2-NEXT:   200000:       4770    bx      lr
 // CHECK2-NEXT:   200002:       f0ff c7fe       blx     0xf00000 <afunc14>
-// CHECK2-NEXT:   200006:       f200 9003       b.w     0x1000010 <__Thumbv7ABSLongThunk_afunc14>
+// CHECK2-NEXT:   200006:       f1ff 97fd       b.w     0x1000004 <__Thumbv7ABSLongThunk_afunc14>
 
  ARMFUNCTION 02
  THUMBFUNCTION 03
@@ -92,14 +92,14 @@ _start:
  ARMFUNCTION 12
  THUMBFUNCTION 13
  ARMFUNCTION 14
-// CHECK3:   <__ARMv7ABSLongThunk_tfunc31>:
-// CHECK3-NEXT:  1000004:       e300c001        movw    r12, #1
-// CHECK3-NEXT:  1000008:       e340c200        movt    r12, #512
-// CHECK3-NEXT:  100000c:       e12fff1c        bx      r12
-// CHECK4: <__Thumbv7ABSLongThunk_afunc14>:
-// CHECK4-NEXT:  1000010:       f240 0c00       movw    r12, #0
-// CHECK4-NEXT:  1000014:       f2c0 0cf0       movt    r12, #240
-// CHECK4-NEXT:  1000018:       4760    bx      r12
+// CHECK3: <__Thumbv7ABSLongThunk_afunc14>:
+// CHECK3-NEXT:  1000004:       f240 0c00       movw    r12, #0
+// CHECK3-NEXT:  1000008:       f2c0 0cf0       movt    r12, #240
+// CHECK3-NEXT:  100000c:       4760    bx      r12
+// CHECK4:   <__ARMv7ABSLongThunk_tfunc31>:
+// CHECK4-NEXT:  1000010:       e300c001        movw    r12, #1
+// CHECK4-NEXT:  1000014:       e340c200        movt    r12, #512
+// CHECK4-NEXT:  1000018:       e12fff1c        bx      r12
  THUMBFUNCTION 15
  ARMFUNCTION 16
  THUMBFUNCTION 17

--- a/lld/test/ELF/arm-thumb-plt-range-thunk-os.s
+++ b/lld/test/ELF/arm-thumb-plt-range-thunk-os.s
@@ -1,7 +1,7 @@
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi a.s -o a.o
-// RUN: ld.lld -z nosort-thunks a.o --shared --icf=all -o a.so --script=a.lds --print-map --print-icf-sections
+// RUN: ld.lld a.o --shared --icf=all -o a.so --script=a.lds --print-map --print-icf-sections
 // RUN: llvm-objdump --no-show-raw-insn --no-print-imm-hex -d a.so | FileCheck %s
 // RUN: rm a.so
 
@@ -44,18 +44,18 @@ preemptible:
 bx lr
 
 // CHECK-LABEL: <sym1>:
-// CHECK-NEXT: 2000000: bl 0x2000018 <__ThumbV7PILongThunk_elsewhere>
+// CHECK-NEXT: 2000000: bl 0x2000030 <__ThumbV7PILongThunk_elsewhere>
 // CHECK-NEXT:          bl 0x2000024 <__ThumbV7PILongThunk_preemptible>
 // CHECK-NEXT:          bx lr
 
 // CHECK-LABEL: <preemptible>:
-// CHECK-NEXT: 200000a: bl 0x2000030 <__ThumbV7PILongThunk_far_preemptible>
+// CHECK-NEXT: 200000a: bl 0x2000018 <__ThumbV7PILongThunk_far_preemptible>
 // CHECK-NEXT:          bl 0x200003c <__ThumbV7PILongThunk_far_nonpreemptible>
 // CHECK-NEXT:          bl 0x200003c <__ThumbV7PILongThunk_far_nonpreemptible>
 // CHECK-NEXT:          bx lr
 
-// CHECK-LABEL: <__ThumbV7PILongThunk_elsewhere>:
-// CHECK-NEXT: 2000018: movw    r12, #12
+// CHECK-LABEL: <__ThumbV7PILongThunk_far_preemptible>:
+// CHECK-NEXT: 2000018: movw    r12, #44
 // CHECK-NEXT:          movt    r12, #512
 // CHECK-NEXT:          add     r12, pc
 // CHECK-NEXT:          bx      r12
@@ -66,9 +66,9 @@ bx lr
 // CHECK-NEXT:          add     r12, pc
 // CHECK-NEXT:          bx      r12
 
-// CHECK-LABEL: <__ThumbV7PILongThunk_far_preemptible>:
-// CHECK-NEXT: 2000030: movw    r12, #20
-// CHECK-NEXT:          movt    r12, #512
+// CHECK-LABEL: <__ThumbV7PILongThunk_elsewhere>:
+// CHECK-NEXT: 2000030: movw    r12, #65524
+// CHECK-NEXT:          movt    r12, #511
 // CHECK-NEXT:          add     r12, pc
 // CHECK-NEXT:          bx      r12
 

--- a/lld/test/ELF/arm-thumb-range-thunk-os-no-ext.s
+++ b/lld/test/ELF/arm-thumb-range-thunk-os-no-ext.s
@@ -1,6 +1,6 @@
 // REQUIRES: arm
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv4t-none-linux-gnueabi %s -o %t.o
-// RUN: ld.lld -z nosort-thunks %t.o -o %t2
+// RUN: ld.lld %t.o -o %t2
 /// The output file is large, most of it zeroes. We dissassemble only the
 /// parts we need to speed up the test and avoid a large output file.
 // RUN: llvm-objdump --no-show-raw-insn -d %t2 --start-address=0x100000 --stop-address=0x10000c | FileCheck --check-prefix=CHECK1 %s
@@ -46,7 +46,7 @@ _start:
 // CHECK1-LABEL: <_start>:
 // CHECK1-NEXT:   100000:       bl      0x200000 <tfunc00>      @ imm = #0xffffc
 // CHECK1-NEXT:                 bl      0x500000 <tfunc03>      @ imm = #0x3ffff8
-// CHECK1-NEXT:                 bl      0x400008 <__Thumbv4ABSLongThunk_tfunc04> @ imm = #0x2ffffc
+// CHECK1-NEXT:                 bl      0x400018 <__Thumbv4ABSLongThunk_tfunc04> @ imm = #0x30000c
 
 FUNCTION 00
 // CHECK2-LABEL: <tfunc00>:
@@ -61,22 +61,22 @@ FUNCTION 02
   /// The thunks should not generate a v7-style short thunk.
 // CHECK4-LABEL: <tfunc02>:
 // CHECK4-NEXT:   400000:       bx      lr
-// CHECK4-NEXT:                 bl      0x400018 <__Thumbv4ABSLongThunk_tfunc07> @ imm = #0x12
+// CHECK4-NEXT:                 bl      0x400008 <__Thumbv4ABSLongThunk_tfunc07> @ imm = #0x2
 // CHECK4-NEXT:                 bmi     0x3fffb2 <tfunc01+0xfffb2> @ imm = #-0x58
 // CHECK4-EMPTY:
-// CHECK4-NEXT:  <__Thumbv4ABSLongThunk_tfunc04>:
-// CHECK4-NEXT:   400008:      	bx      pc
-// CHECK4-NEXT:                 b       0x400008 <__Thumbv4ABSLongThunk_tfunc04> @ imm = #-0x6
-// CHECK4-NEXT:  40000c:        ldr	    r12, [pc]               @ 0x400014 <__Thumbv4ABSLongThunk_tfunc04+0xc>
-// CHECK4-NEXT:                 bx	    r12
-// CHECK4-NEXT:   400014: 01 00 60 00  	.word	0x00600001
-// CHECK4-EMPTY:
 // CHECK4-NEXT:  <__Thumbv4ABSLongThunk_tfunc07>:
+// CHECK4-NEXT:   400008:      	bx      pc
+// CHECK4-NEXT:                 b       0x400008 <__Thumbv4ABSLongThunk_tfunc07> @ imm = #-0x6
+// CHECK4-NEXT:  40000c:        ldr	    r12, [pc]               @ 0x400014 <__Thumbv4ABSLongThunk_tfunc07+0xc>
+// CHECK4-NEXT:                 bx	    r12
+// CHECK4-NEXT:   400014: 01 00 90 00  	.word	0x00900001
+// CHECK4-EMPTY:
+// CHECK4-NEXT:  <__Thumbv4ABSLongThunk_tfunc04>:
 // CHECK4-NEXT:   400018:      	bx	    pc
-// CHECK4-NEXT:             	b	    0x400018 <__Thumbv4ABSLongThunk_tfunc07> @ imm = #-0x6
-// CHECK4-NEXT:   40001c:      	ldr	r12, [pc]                   @ 0x400024 <__Thumbv4ABSLongThunk_tfunc07+0xc>
+// CHECK4-NEXT:             	b	    0x400018 <__Thumbv4ABSLongThunk_tfunc04> @ imm = #-0x6
+// CHECK4-NEXT:   40001c:      	ldr	r12, [pc]                   @ 0x400024 <__Thumbv4ABSLongThunk_tfunc04+0xc>
 // CHECK4-NEXT:             	bx	r12
-// CHECK4-NEXT:   400024: 01 00 90 00  	.word	0x00900001
+// CHECK4-NEXT:   400024: 01 00 60 00  	.word	0x00600001
 
 FUNCTION 03
 FUNCTION 04

--- a/lld/test/ELF/arm-thumb-range-thunk-os.s
+++ b/lld/test/ELF/arm-thumb-range-thunk-os.s
@@ -1,6 +1,6 @@
 // REQUIRES: arm
 // RUN: llvm-mc  -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t
-// RUN: ld.lld -z nosort-thunks %t -o %t2
+// RUN: ld.lld %t -o %t2
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x100000 --stop-address=0x10000c | FileCheck --check-prefix=CHECK1 %s
@@ -48,7 +48,7 @@ _start:
 // CHECK1-NEXT: <_start>:
 // CHECK1-NEXT:   100000:       f0ff fffe       bl      0x200000 <tfunc00>
 // CHECK1-NEXT:   100004:       f3ff d7fc       bl      0x1100000 <tfunc15>
-// CHECK1-NEXT:   100008:       f2ff d7fc       bl      0x1000004 <__Thumbv7ABSLongThunk_tfunc16>
+// CHECK1-NEXT:   100008:       f300 d00a       bl      0x1000020 <__Thumbv7ABSLongThunk_tfunc16>
 
  FUNCTION 00
 // CHECK2:  <tfunc00>:
@@ -62,7 +62,7 @@ _start:
         b.w tfunc28
 // CHECK4: <tfunc02>:
 // CHECK4-NEXT:   400000:       4770    bx      lr
-// CHECK4-NEXT:   400002:       f000 9001       b.w     0x1000008 <__Thumbv7ABSLongThunk_tfunc28>
+// CHECK4-NEXT:   400002:       f000 900b       b.w     0x100001c <__Thumbv7ABSLongThunk_tfunc28>
  FUNCTION 03
  FUNCTION 04
  FUNCTION 05
@@ -76,20 +76,20 @@ _start:
  FUNCTION 13
  FUNCTION 14
 // Expect precreated ThunkSection here
-// CHECK5: <__Thumbv7ABSLongThunk_tfunc16>:
-// CHECK5-NEXT:  1000004:       f1ff bffc       b.w     0x1200000 <tfunc16>
-// CHECK5: <__Thumbv7ABSLongThunk_tfunc28>:
-// CHECK5-NEXT:  1000008:       f1ff 97fa       b.w     0x1e00000 <tfunc28>
-// CHECK5: <__Thumbv7ABSLongThunk_tfunc32>:
-// CHECK5-NEXT:  100000c:       f240 0c01       movw    r12, #1
-// CHECK5-NEXT:  1000010:       f2c0 2c20       movt    r12, #544
-// CHECK5-NEXT:  1000014:       4760    bx      r12
-// CHECK5: <__Thumbv7ABSLongThunk_tfunc33>:
-// CHECK5-NEXT:  1000016:       f240 0c01       movw    r12, #1
-// CHECK5-NEXT:  100001a:       f2c0 2c30       movt    r12, #560
-// CHECK5-NEXT:  100001e:       4760    bx      r12
 // CHECK5: <__Thumbv7ABSLongThunk_tfunc02>:
-// CHECK5-NEXT:  1000020:       f7ff 97ee       b.w     0x400000 <tfunc02>
+// CHECK5-NEXT:  1000004:       f7ff 97fc       b.w     0x400000 <tfunc02>
+// CHECK5: <__Thumbv7ABSLongThunk_tfunc33>:
+// CHECK5-NEXT:  1000008:       f240 0c01       movw    r12, #1
+// CHECK5-NEXT:  100000c:       f2c0 2c30       movt    r12, #560
+// CHECK5-NEXT:  1000010:       4760    bx      r12
+// CHECK5: <__Thumbv7ABSLongThunk_tfunc32>:
+// CHECK5-NEXT:  1000012:       f240 0c01       movw    r12, #1
+// CHECK5-NEXT:  1000016:       f2c0 2c20       movt    r12, #544
+// CHECK5-NEXT:  100001a:       4760    bx      r12
+// CHECK5: <__Thumbv7ABSLongThunk_tfunc28>:
+// CHECK5-NEXT:  100001c:       f1ff 97f0       b.w     0x1e00000 <tfunc28>
+// CHECK5: <__Thumbv7ABSLongThunk_tfunc16>:
+// CHECK5-NEXT:  1000020:       f1ff bfee       b.w     0x1200000 <tfunc16>
  FUNCTION 15
 // tfunc00 and tfunc01 are < 16Mb away, expect no range extension thunks
  bl tfunc00
@@ -102,8 +102,8 @@ _start:
 // CHECK6-NEXT:  1100000:       4770    bx      lr
 // CHECK6-NEXT:  1100002:       f4ff d7fd       bl      0x200000 <tfunc00>
 // CHECK6-NEXT:  1100006:       f5ff d7fb       bl      0x300000 <tfunc01>
-// CHECK6-NEXT:  110000a:       f6ff ffff       bl      0x100000c <__Thumbv7ABSLongThunk_tfunc32>
-// CHECK6-NEXT:  110000e:       f700 f802       bl      0x1000016 <__Thumbv7ABSLongThunk_tfunc33>
+// CHECK6-NEXT:  110000a:       f700 f802       bl      0x1000012 <__Thumbv7ABSLongThunk_tfunc32>
+// CHECK6-NEXT:  110000e:       f6ff fffb       bl      0x1000008 <__Thumbv7ABSLongThunk_tfunc33>
  FUNCTION 16
  FUNCTION 17
  FUNCTION 18
@@ -126,7 +126,7 @@ _start:
 // section
 // CHECK8:  <tfunc28>:
 // CHECK8-NEXT:  1e00000:       4770    bx      lr
-// CHECK8-NEXT:  1e00002:       f600 900d       b.w     0x1000020 <__Thumbv7ABSLongThunk_tfunc02>
+// CHECK8-NEXT:  1e00002:       f5ff 97ff       b.w     0x1000004 <__Thumbv7ABSLongThunk_tfunc02>
 
  b.w tfunc02
  FUNCTION 29

--- a/lld/test/ELF/arm-thunk-arm-thumb-reuse.s
+++ b/lld/test/ELF/arm-thunk-arm-thumb-reuse.s
@@ -1,13 +1,13 @@
 // REQUIRES: arm
 // RUN: split-file %s %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %t/test.s -o %t.o
-// RUN: ld.lld -z nosort-thunks --script %t/script %t.o -o %t2
+// RUN: ld.lld --script %t/script %t.o -o %t2
 // RUN: llvm-objdump --no-print-imm-hex --no-show-raw-insn -d %t2 | FileCheck %s
 
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7aeb-none-linux-gnueabi -mcpu=cortex-a8 %t/test.s -o %t.o
-// RUN: ld.lld -z nosort-thunks --script %t/script %t.o -o %t2
+// RUN: ld.lld --script %t/script %t.o -o %t2
 // RUN: llvm-objdump --no-print-imm-hex --no-show-raw-insn -d %t2 | FileCheck %s
-// RUN: ld.lld -z nosort-thunks --be8 --script %t/script %t.o -o %t2
+// RUN: ld.lld --be8 --script %t/script %t.o -o %t2
 // RUN: llvm-objdump --no-print-imm-hex --no-show-raw-insn -d %t2 | FileCheck %s
 
 /// Test that we can reuse thunks between Arm and Thumb callers
@@ -35,16 +35,16 @@ _start:
  bl far2
 
 // CHECK:   00010000 <_start>:
-// CHECK-NEXT: 10000: bl      0x10010 <__ARMv7ABSLongThunk_far>
-// CHECK-NEXT: 10004: blx     0x10010 <__ARMv7ABSLongThunk_far>
-// CHECK-NEXT: 10008: bl      0x1001c <__Thumbv7ABSLongThunk_far2>
-// CHECK-NEXT: 1000c: blx     0x1001c <__Thumbv7ABSLongThunk_far2>
-// CHECK:   00010010 <__ARMv7ABSLongThunk_far>:
-// CHECK-NEXT: 10010: movw    r12, #0
+// CHECK-NEXT: 10000: bl      0x1001c <__ARMv7ABSLongThunk_far>
+// CHECK-NEXT: 10004: blx     0x1001c <__ARMv7ABSLongThunk_far>
+// CHECK-NEXT: 10008: bl      0x10010 <__Thumbv7ABSLongThunk_far2>
+// CHECK-NEXT: 1000c: blx     0x10010 <__Thumbv7ABSLongThunk_far2>
+// CHECK:   00010010 <__Thumbv7ABSLongThunk_far2>:
+// CHECK-NEXT: 10010: movw    r12, #4
 // CHECK-NEXT: 10014: movt    r12, #4096
 // CHECK-NEXT: 10018: bx      r12
-// CHECK:   0001001c <__Thumbv7ABSLongThunk_far2>:
-// CHECK-NEXT: 1001c: movw    r12, #4
+// CHECK:   0001001c <__ARMv7ABSLongThunk_far>:
+// CHECK-NEXT: 1001c: movw    r12, #0
 // CHECK-NEXT: 10020: movt    r12, #4096
 // CHECK-NEXT: 10024: bx      r12
 

--- a/lld/test/ELF/arm-thunk-linkerscript-dotexpr.s
+++ b/lld/test/ELF/arm-thunk-linkerscript-dotexpr.s
@@ -1,15 +1,15 @@
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi a.s -o a.o
-// RUN: ld.lld -z nosort-thunks --no-rosegment --script a.lds a.o -o exe
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
 
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7aeb-none-linux-gnueabi -mcpu=cortex-a8 a.s -o a.o
-// RUN: ld.lld -z nosort-thunks --no-rosegment --script a.lds a.o -o exe
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
-// RUN: ld.lld -z nosort-thunks --be8 --no-rosegment --script a.lds a.o -o exe
+// RUN: ld.lld --be8 --no-rosegment --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
 // RUN: rm a.o exe
@@ -53,19 +53,19 @@ low_target2:
 // CHECK1-NEXT: <_start>:
 // CHECK1-NEXT:       94:       4770    bx      lr
 // CHECK1: <low_target>:
-// CHECK1-NEXT:       96:       f000 f803       bl      0xa0 <__Thumbv7ABSLongThunk_high_target>
-// CHECK1-NEXT:       9a:       f000 f806       bl      0xaa <__Thumbv7ABSLongThunk_high_target2>
-// CHECK1: <__Thumbv7ABSLongThunk_high_target>:
-// CHECK1-NEXT:       a0:       f240 0cbd       movw    r12, #189
+// CHECK1-NEXT:       96:       f000 f808       bl      0xaa <__Thumbv7ABSLongThunk_high_target>
+// CHECK1-NEXT:       9a:       f000 f801       bl      0xa0 <__Thumbv7ABSLongThunk_high_target2>
+// CHECK1: <__Thumbv7ABSLongThunk_high_target2>:
+// CHECK1-NEXT:       a0:       f240 0cd9       movw    r12, #217
 // CHECK1-NEXT:       a4:       f2c0 2c00       movt    r12, #512
 // CHECK1-NEXT:       a8:       4760    bx      r12
-// CHECK1: <__Thumbv7ABSLongThunk_high_target2>:
-// CHECK1-NEXT:       aa:       f240 0cd9       movw    r12, #217
+// CHECK1: <__Thumbv7ABSLongThunk_high_target>:
+// CHECK1-NEXT:       aa:       f240 0cbd       movw    r12, #189
 // CHECK1-NEXT:       ae:       f2c0 2c00       movt    r12, #512
 // CHECK1-NEXT:       b2:       4760    bx      r12
 // CHECK1: <low_target2>:
-// CHECK1-NEXT:       b4:       f7ff fff4       bl      0xa0 <__Thumbv7ABSLongThunk_high_target>
-// CHECK1-NEXT:       b8:       f7ff fff7       bl      0xaa <__Thumbv7ABSLongThunk_high_target2>
+// CHECK1-NEXT:       b4:       f7ff fff9       bl      0xaa <__Thumbv7ABSLongThunk_high_target>
+// CHECK1-NEXT:       b8:       f7ff fff2       bl      0xa0 <__Thumbv7ABSLongThunk_high_target2>
 
  .section .text_high, "ax", %progbits
  .thumb

--- a/lld/test/ELF/arm-thunk-linkerscript-orphan.s
+++ b/lld/test/ELF/arm-thunk-linkerscript-orphan.s
@@ -1,7 +1,7 @@
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi a.s -o a.o
-// RUN: ld.lld -z nosort-thunks --script a.lds a.o -o exe
+// RUN: ld.lld --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
 
 //--- a.lds
@@ -29,14 +29,14 @@ low_target:
 // CHECK-NEXT: <_start>:
 // CHECK-NEXT:   100000:        4770    bx      lr
 // CHECK: <low_target>:
-// CHECK-NEXT:   100002:        f000 f803       bl      0x10000c <__Thumbv7ABSLongThunk_high_target>
-// CHECK-NEXT:   100006:        f000 f806       bl      0x100016 <__Thumbv7ABSLongThunk_orphan_target>
-// CHECK: <__Thumbv7ABSLongThunk_high_target>:
-// CHECK-NEXT:   10000c:        f240 0c01       movw    r12, #1
+// CHECK-NEXT:   100002:        f000 f808       bl      0x100016 <__Thumbv7ABSLongThunk_high_target>
+// CHECK-NEXT:   100006:        f000 f801       bl      0x10000c <__Thumbv7ABSLongThunk_orphan_target>
+// CHECK: <__Thumbv7ABSLongThunk_orphan_target>:
+// CHECK-NEXT:   10000c:        f240 0c15       movw    r12, #21
 // CHECK-NEXT:   100010:        f2c0 2c00       movt    r12, #512
 // CHECK-NEXT:   100014:        4760    bx      r12
-// CHECK: <__Thumbv7ABSLongThunk_orphan_target>:
-// CHECK-NEXT:   100016:        f240 0c15       movw    r12, #21
+// CHECK: <__Thumbv7ABSLongThunk_high_target>:
+// CHECK-NEXT:   100016:        f240 0c01       movw    r12, #1
 // CHECK-NEXT:   10001a:        f2c0 2c00       movt    r12, #512
 // CHECK-NEXT:   10001e:        4760    bx      r12
   .section .text_high, "ax", %progbits

--- a/lld/test/ELF/arm-thunk-linkerscript.s
+++ b/lld/test/ELF/arm-thunk-linkerscript.s
@@ -1,12 +1,12 @@
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi a.s -o a.o
-// RUN: ld.lld -z nosort-thunks --no-rosegment --script a.lds a.o -o exe
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7aeb-none-linux-gnueabi -mcpu=cortex-a8 a.s -o a.o
-// RUN: ld.lld -z nosort-thunks --no-rosegment --script a.lds a.o -o exe
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
 // RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
-// RUN: ld.lld -z nosort-thunks --be8 --no-rosegment --script a.lds a.o -o %t2
+// RUN: ld.lld --be8 --no-rosegment --script a.lds a.o -o %t2
 // RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
 
 //--- a.lds
@@ -43,19 +43,19 @@ low_target2:
 // CHECK-NEXT: <_start>:
 // CHECK-NEXT:       94:        4770    bx      lr
 // CHECK: <low_target>:
-// CHECK-NEXT:       96:        f000 f803       bl      0xa0 <__Thumbv7ABSLongThunk_high_target>
-// CHECK-NEXT:       9a:        f000 f806       bl      0xaa <__Thumbv7ABSLongThunk_high_target2>
-// CHECK: <__Thumbv7ABSLongThunk_high_target>:
-// CHECK-NEXT:       a0:        f240 0c01       movw    r12, #1
+// CHECK-NEXT:       96:        f000 f808       bl      0xaa <__Thumbv7ABSLongThunk_high_target>
+// CHECK-NEXT:       9a:        f000 f801       bl      0xa0 <__Thumbv7ABSLongThunk_high_target2>
+// CHECK: <__Thumbv7ABSLongThunk_high_target2>:
+// CHECK-NEXT:       a0:        f240 0c1d       movw    r12, #29
 // CHECK-NEXT:       a4:        f2c0 2c00       movt    r12, #512
 // CHECK-NEXT:       a8:        4760    bx      r12
-// CHECK: <__Thumbv7ABSLongThunk_high_target2>:
-// CHECK-NEXT:       aa:        f240 0c1d       movw    r12, #29
+// CHECK: <__Thumbv7ABSLongThunk_high_target>:
+// CHECK-NEXT:       aa:        f240 0c01       movw    r12, #1
 // CHECK-NEXT:       ae:        f2c0 2c00       movt    r12, #512
 // CHECK-NEXT:       b2:        4760    bx      r12
 // CHECK: <low_target2>:
-// CHECK-NEXT:       b4:        f7ff fff4       bl      0xa0 <__Thumbv7ABSLongThunk_high_target>
-// CHECK-NEXT:       b8:        f7ff fff7       bl      0xaa <__Thumbv7ABSLongThunk_high_target2>
+// CHECK-NEXT:       b4:        f7ff fff9       bl      0xaa <__Thumbv7ABSLongThunk_high_target>
+// CHECK-NEXT:       b8:        f7ff fff2       bl      0xa0 <__Thumbv7ABSLongThunk_high_target2>
 
  .section .text_high, "ax", %progbits
  .thumb

--- a/lld/test/ELF/arm-thunk-re-add.s
+++ b/lld/test/ELF/arm-thunk-re-add.s
@@ -1,6 +1,6 @@
 // REQUIRES: arm
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t
-// RUN: ld.lld -z nosort-thunks %t --shared -o %t.so
+// RUN: ld.lld %t --shared -o %t.so
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1000004 --stop-address=0x100001c | FileCheck --check-prefix=CHECK1 %s
@@ -65,13 +65,13 @@ tfunc\suff\():
  FUNCTION 30
  FUNCTION 31
 /// Precreated Thunk Pool goes here
-// CHECK1: <__ThumbV7PILongThunk_imported>:
-// CHECK1-NEXT:  1000004:       f240 0c30       movw    r12, #48
+// CHECK1: <__ThumbV7PILongThunk_imported2>:
+// CHECK1-NEXT:  1000004:       f240 0c40       movw    r12, #64
 // CHECK1-NEXT:  1000008:       f2c0 0c10       movt    r12, #16
 // CHECK1-NEXT:  100000c:       44fc    add     r12, pc
 // CHECK1-NEXT:  100000e:       4760    bx      r12
-// CHECK1: <__ThumbV7PILongThunk_imported2>:
-// CHECK1-NEXT:  1000010:       f240 0c34       movw    r12, #52
+// CHECK1: <__ThumbV7PILongThunk_imported>:
+// CHECK1-NEXT:  1000010:       f240 0c24       movw    r12, #36
 // CHECK1-NEXT:  1000014:       f2c0 0c10       movt    r12, #16
 // CHECK1-NEXT:  1000018:       44fc    add     r12, pc
 // CHECK1-NEXT:  100001a:       4760    bx      r12
@@ -86,17 +86,17 @@ tfunc\suff\():
  .type callers, %function
 callers:
  b.w imported
- beq.w imported
+ beq.w imported2
  b.w imported2
-// CHECK2: <__ThumbV7PILongThunk_imported>:
-// CHECK2-NEXT:  1100008:       f240 0c2c       movw    r12, #44
+// CHECK2: <__ThumbV7PILongThunk_imported2>:
+// CHECK2-NEXT:  1100008:       f240 0c3c       movw    r12, #60
 // CHECK2-NEXT:  110000c:       f2c0 0c00       movt    r12, #0
 // CHECK2-NEXT:  1100010:       44fc    add     r12, pc
 // CHECK2-NEXT:  1100012:       4760    bx      r12
 // CHECK2: <callers>:
-// CHECK2-NEXT:  1100014:       f6ff bff6       b.w     0x1000004 <__ThumbV7PILongThunk_imported>
-// CHECK2-NEXT:  1100018:       f43f aff6       beq.w   0x1100008 <__ThumbV7PILongThunk_imported>
-// CHECK2-NEXT:  110001c:       f6ff bff8       b.w     0x1000010 <__ThumbV7PILongThunk_imported2>
+// CHECK2-NEXT:  1100014:       f6ff bffc       b.w     0x1000010 <__ThumbV7PILongThunk_imported>
+// CHECK2-NEXT:  1100018:       f43f aff6       beq.w   0x1100008 <__ThumbV7PILongThunk_imported2>
+// CHECK2-NEXT:  110001c:       f6ff bff2       b.w     0x1000004 <__ThumbV7PILongThunk_imported2>
 
 // CHECK3: Disassembly of section .plt:
 // CHECK3-EMPTY:
@@ -123,14 +123,14 @@ callers:
 // CHECK3-NEXT:  110005c:       d4 d4 d4 d4     .word   0xd4d4d4d4
 
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7aeb-none-linux-gnueabi -mcpu=cortex-a8 %s -o %t
-// RUN: ld.lld -z nosort-thunks %t --shared -o %t.so
+// RUN: ld.lld %t --shared -o %t.so
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1000004 --stop-address=0x100001c | FileCheck --check-prefix=CHECK1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1100008 --stop-address=0x1100022 | FileCheck --check-prefix=CHECK2 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1100020 --stop-address=0x1100064 --triple=armv7aeb-linux-gnueabihf | FileCheck --check-prefix=CHECK3 %s
 
-// RUN: ld.lld -z nosort-thunks --be8 %t --shared -o %t.so
+// RUN: ld.lld --be8 %t --shared -o %t.so
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1000004 --stop-address=0x100001c | FileCheck --check-prefix=CHECK1 %s


### PR DESCRIPTION
Drop -z nosort-thunks (added by #211721 to keep creation order) and
update expectations to the default order: forward thunks sorted by
descending destination. Backward-only thunk sections keep creation
order and are unchanged.

In arm-thunk-re-add.s, retarget beq.w to imported2: sorting places
imported's pool thunk just within conditional-branch range, so
beq.w imported would reuse it instead of re-adding a thunk.
