### PR TITLE
[libclc] Produce subnormal results for exp/exp2 on FP32

### DIFF
--- a/libclc/clc/lib/generic/math/clc_exp.cl
+++ b/libclc/clc/lib/generic/math/clc_exp.cl
@@ -11,9 +11,11 @@
 #include "clc/internal/clc.h"
 #include "clc/math/clc_exp_helper.h"
 #include "clc/math/clc_fma.h"
+#include "clc/math/clc_ldexp.h"
 #include "clc/math/clc_mad.h"
 #include "clc/math/math.h"
 #include "clc/relational/clc_isnan.h"
+#include "clc/shared/clc_clamp.h"
 
 #define __CLC_BODY "clc_exp.inc"
 #include "clc/math/gentype.inc"

--- a/libclc/clc/lib/generic/math/clc_exp.inc
+++ b/libclc/clc/lib/generic/math/clc_exp.inc
@@ -37,15 +37,23 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_exp(__CLC_GENTYPE x) {
 
   __CLC_GENTYPE y = 1.0f - (((-lo) - MATH_DIVIDE(t * v, 2.0f - v)) - hi);
 
-  // Scale by 2^p
-  __CLC_GENTYPE r = __CLC_AS_GENTYPE(__CLC_AS_INTN(y) + (p << 23));
+  // Scale by 2^p. Use ldexp so results in the subnormal range are represented
+  // exactly rather than being flushed to zero (an integer as_int(y) + (p << 23)
+  // scaling cannot encode subnormals). On flush-to-zero devices the hardware
+  // collapses the subnormal result to zero, matching the previous behavior.
+  // Clamp the exponent fed to ldexp: for extreme |x| the float->int reduction
+  // above is out of range, and an ill-formed exponent would make ldexp return
+  // NaN. Any such input over/underflows and is saturated to inf/zero by the
+  // ulim/llim selects below, so the clamp never affects a representable result.
+  __CLC_GENTYPE r = __clc_ldexp(y, __clc_clamp(p, (__CLC_INTN)-151, (__CLC_INTN)129));
 
   // ln(largest_normal) = 88.72283905206835305366
   const __CLC_GENTYPE ulim = 0x1.62e430p+6f;
-  // ln(smallest_normal) = -87.33654475055310898657
-  const __CLC_GENTYPE llim = -0x1.5d589ep+6f;
+  // ln(smallest_subnormal) = ln(2^-149) = -103.27892990343184. Below this the
+  // result genuinely underflows to zero.
+  const __CLC_GENTYPE llim = -0x1.9d1dap+6f;
 
-  r = x < llim ? 0.0f : r;
+  r = x < llim ? (__CLC_GENTYPE)0.0f : r;
   r = x < ulim ? r : __CLC_AS_GENTYPE((__CLC_UINTN)0x7f800000);
   return __clc_isnan(x) ? x : r;
 }

--- a/libclc/clc/lib/generic/math/clc_exp2.cl
+++ b/libclc/clc/lib/generic/math/clc_exp2.cl
@@ -11,10 +11,12 @@
 #include "clc/internal/clc.h"
 #include "clc/math/clc_exp_helper.h"
 #include "clc/math/clc_fma.h"
+#include "clc/math/clc_ldexp.h"
 #include "clc/math/clc_mad.h"
 #include "clc/math/clc_rint.h"
 #include "clc/math/math.h"
 #include "clc/relational/clc_isnan.h"
+#include "clc/shared/clc_clamp.h"
 
 #define __CLC_BODY "clc_exp2.inc"
 #include "clc/math/gentype.inc"

--- a/libclc/clc/lib/generic/math/clc_exp2.inc
+++ b/libclc/clc/lib/generic/math/clc_exp2.inc
@@ -36,13 +36,21 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_exp2(__CLC_GENTYPE x) {
 
   __CLC_GENTYPE y = 1.0f - (((-lo) - MATH_DIVIDE(t * v, 2.0f - v)) - hi);
 
-  // Scale by 2^p
-  __CLC_GENTYPE r = __CLC_AS_FLOATN(__CLC_AS_INTN(y) + (p << 23));
+  // Scale by 2^p. Use ldexp so results in the subnormal range are represented
+  // exactly rather than being flushed to zero (an integer as_int(y) + (p << 23)
+  // scaling cannot encode subnormals). On flush-to-zero devices the hardware
+  // collapses the subnormal result to zero, matching the previous behavior.
+  // Clamp the exponent fed to ldexp: for extreme |x| the float->int reduction
+  // above is out of range, and an ill-formed exponent would make ldexp return
+  // NaN. Any such input over/underflows and is saturated to inf/zero by the
+  // ulim/llim selects below, so the clamp never affects a representable result.
+  __CLC_GENTYPE r = __clc_ldexp(y, __clc_clamp(p, (__CLC_INTN)-151, (__CLC_INTN)129));
 
   const __CLC_GENTYPE ulim = 128.0f;
-  const __CLC_GENTYPE llim = -126.0f;
+  // Smallest subnormal is 2^-149; below this the result underflows to zero.
+  const __CLC_GENTYPE llim = -149.0f;
 
-  r = x < llim ? 0.0f : r;
+  r = x < llim ? (__CLC_GENTYPE)0.0f : r;
   r = x < ulim ? r : __CLC_AS_FLOATN((__CLC_UINTN)0x7f800000);
   return __clc_isnan(x) ? x : r;
 }


### PR DESCRIPTION
The FP32 __clc_exp/__clc_exp2 implementations scale the reduced result by 2^p using integer bit manipulation (as_int(y) + (p << 23)). That representation cannot encode a subnormal, so inputs whose result falls below the smallest normal were unconditionally flushed to zero via "x < llim ? 0.0f". On devices that report CL_FP_DENORM this loses the correct subnormal result (e.g. erfc(), which is built on exp(), failed CTS math_brute_force with the reference subnormal vs a returned 0).

Recompute the subnormal range with __clc_ldexp, which does produce subnormals, gated on __clc_fp32_subnormals_supported() so flush-to-zero targets keep the previous fast path. The ldexp path is restricted to [subnorm_llim, llim); inputs below subnorm_llim (including -inf and large-magnitude negatives) still flush to zero, since their reduced exponent argument would be ill-formed for ldexp.