### PR TITLE
[Docs] don't stylize syntax errors in code blocks

### DIFF
--- a/llvm/docs/_static/custom.css
+++ b/llvm/docs/_static/custom.css
@@ -49,6 +49,14 @@ body {
   overflow-wrap: break-word;
 }
 
+/* Pygments emits Error tokens that the theme's style renders as
+   red-bordered boxes. Render them like ordinary code text instead. */
+.highlight .err {
+    border: none;
+    background-color: transparent;
+    color: inherit;
+}
+
 /* Printing support. */
 @media print {
     pre {


### PR DESCRIPTION
When a code block in the documentation contains (almost) pseudocode, the Pygments parser flags errors and renders them with red-bordered boxes. This is unnecessarily ugly. We can see examples of this in the LangRef with LLVM code blocks.

Instead set the style to just render them as plain text. This is still recognizable as incorrect syntax, but does not distract the reader from the actual example.

Assisted-by: Claude Opus 4.8