### PR TITLE
[clangd] Respect background index priority

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -211,6 +211,15 @@ ClangdServer::Options::operator TUScheduler::Options() const {
   return Opts;
 }
 
+ClangdServer::Options::operator BackgroundIndex::Options() const {
+  BackgroundIndex::Options Opts;
+  Opts.ThreadPoolSize = std::max(AsyncThreadsCount, 1u);
+  Opts.IndexingPriority = BackgroundIndexPriority;
+  Opts.ContextProvider = ContextProvider;
+  Opts.SupportContainedRefs = EnableOutgoingCalls;
+  return Opts;
+}
+
 ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
                            const ThreadsafeFS &TFS, const Options &Opts,
                            Callbacks *Callbacks)
@@ -253,14 +262,11 @@ ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
   if (Opts.StaticIndex)
     AddIndex(Opts.StaticIndex);
   if (Opts.BackgroundIndex) {
-    BackgroundIndex::Options BGOpts;
-    BGOpts.ThreadPoolSize = std::max(Opts.AsyncThreadsCount, 1u);
+    BackgroundIndex::Options BGOpts(Opts);
     BGOpts.OnProgress = [Callbacks](BackgroundQueue::Stats S) {
       if (Callbacks)
         Callbacks->onBackgroundIndexProgress(S);
     };
-    BGOpts.ContextProvider = Opts.ContextProvider;
-    BGOpts.SupportContainedRefs = Opts.EnableOutgoingCalls;
     BackgroundIdx = std::make_unique<BackgroundIndex>(
         TFS, CDB,
         BackgroundIndexStorage::createDiskBackedStorageFactory(

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -203,6 +203,7 @@ public:
     bool PublishInactiveRegions = false;
 
     explicit operator TUScheduler::Options() const;
+    explicit operator BackgroundIndex::Options() const;
   };
   // Sensible default options for use in tests.
   // Features like indexing must be enabled if desired.

--- a/clang-tools-extra/clangd/unittests/ClangdTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdTests.cpp
@@ -1361,6 +1361,16 @@ $inactive4[[  int inactiveInt3;]]
                   Source.range("inactive3"), Source.range("inactive4"))));
 }
 
+TEST(ClangdServer, BackgroundIndexPriorityPropagatesToIndexingThreads) {
+  auto Opts = ClangdServer::optsForTest();
+  for (auto Priority :
+       {llvm::ThreadPriority::Background, llvm::ThreadPriority::Low,
+        llvm::ThreadPriority::Default}) {
+    Opts.BackgroundIndexPriority = Priority;
+    EXPECT_EQ(BackgroundIndex::Options(Opts).IndexingPriority, Priority);
+  }
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang


### PR DESCRIPTION
The --background-index-priority CLI option was not wired correctly, leading to it being always 'low' even when otherwise specified.

This code was written by Claude Opus 5. I wrote the description myself and read the code.