### PR TITLE
[LLVM] Disambiguate MVT and SVT comparisons

### DIFF
--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -64,6 +64,10 @@ namespace llvm {
     bool operator>=(const MVT& S) const { return SimpleTy >= S.SimpleTy; }
     bool operator<=(const MVT& S) const { return SimpleTy <= S.SimpleTy; }
 
+    // Support comparison with SimpleValueType.
+    bool operator==(SimpleValueType S) const { return SimpleTy == S; }
+    bool operator!=(SimpleValueType S) const { return SimpleTy != S; }
+
     /// Support for debugging, callable in GDB: VT.dump()
     LLVM_ABI void dump() const;
 


### PR DESCRIPTION
[LLVM] Disambiguate MVT and SVT comparisons

Without this:
```
error: use of overloaded operator '==' is ambiguous (with operand types 'MVT' and 'llvm::MVT::SimpleValueType')
  167 |       if (VT == MVT::Untyped)
      |           ~~ ^  ~~~~~~~~~~~~
llvm/include/llvm/CodeGenTypes/MachineValueType.h:62:10: note: candidate function
   62 |     bool operator==(const MVT& S) const { return SimpleTy == S.SimpleTy; }
      |          ^
llvm/include/llvm/CodeGen/ValueTypes.h:598:15: note: candidate function (with reversed parameter order)
  598 |   inline bool operator==(MVT::SimpleValueType SVT, EVT VT) { return VT == SVT; }
      |               ^
1 error generated.
```

Fixes 52f6c88c2c1b6f0c10b9c8fb09ec35e147c593e3