### PR TITLE
[ProfileData] Preserve cross-image targets in concatenated raw profiles

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -448,8 +448,12 @@ public:
 
 private:
   Error createSymtab(InstrProfSymtab &Symtab);
+  Expected<const RawInstrProf::Header *>
+  getNextHeader(const char *CurrentPos) const;
+  Expected<const char *> getNextHeaderPosForCurrentHeader() const;
   Error readNextHeader(const char *CurrentPos);
-  Error readHeader(const RawInstrProf::Header &Header);
+  Error readHeader(const RawInstrProf::Header &Header,
+                   InstrProfSymtab *SymtabToPopulate, bool RecordBinaryIds);
 
   template <class IntT> IntT swap(IntT Int) const {
     return ShouldSwapBytes ? llvm::byteswap(Int) : Int;

--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -514,21 +514,46 @@ Error RawInstrProfReader<IntPtrT>::readHeader() {
     return error(instrprof_error::bad_magic);
   if (DataBuffer->getBufferSize() < sizeof(RawInstrProf::Header))
     return error(instrprof_error::bad_header);
-  auto *Header = reinterpret_cast<const RawInstrProf::Header *>(
+  auto *FirstHeader = reinterpret_cast<const RawInstrProf::Header *>(
       DataBuffer->getBufferStart());
-  ShouldSwapBytes = Header->Magic != RawInstrProf::getMagic<IntPtrT>();
-  return readHeader(*Header);
+  ShouldSwapBytes = FirstHeader->Magic != RawInstrProf::getMagic<IntPtrT>();
+
+  BinaryIds.clear();
+  Symtab = std::make_unique<InstrProfSymtab>();
+
+  // A value-profile target recorded by one image can name a function or
+  // vtable in a later concatenated raw profile. Build the address-to-name
+  // mappings for the entire buffer before deserializing the first record.
+  const RawInstrProf::Header *Header = FirstHeader;
+  while (Header) {
+    if (Error E = readHeader(*Header, Symtab.get(), true))
+      return E;
+
+    Expected<const char *> NextPos = getNextHeaderPosForCurrentHeader();
+    if (Error E = NextPos.takeError())
+      return error(std::move(E));
+
+    Expected<const RawInstrProf::Header *> NextHeader = getNextHeader(*NextPos);
+    if (Error E = NextHeader.takeError())
+      return error(std::move(E));
+    Header = *NextHeader;
+  }
+
+  // Restore the first header's iteration state without adding its mappings or
+  // binary IDs a second time.
+  return readHeader(*FirstHeader, nullptr, false);
 }
 
 template <class IntPtrT>
-Error RawInstrProfReader<IntPtrT>::readNextHeader(const char *CurrentPos) {
+Expected<const RawInstrProf::Header *>
+RawInstrProfReader<IntPtrT>::getNextHeader(const char *CurrentPos) const {
   const char *End = DataBuffer->getBufferEnd();
   // Skip zero padding between profiles.
   while (CurrentPos != End && *CurrentPos == 0)
     ++CurrentPos;
   // If there's nothing left, we're done.
   if (CurrentPos == End)
-    return make_error<InstrProfError>(instrprof_error::eof);
+    return nullptr;
   // If there isn't enough space for another header, this is probably just
   // garbage at the end of the file.
   if (CurrentPos + sizeof(RawInstrProf::Header) > End)
@@ -543,9 +568,48 @@ Error RawInstrProfReader<IntPtrT>::readNextHeader(const char *CurrentPos) {
   if (Magic != swap(RawInstrProf::getMagic<IntPtrT>()))
     return make_error<InstrProfError>(instrprof_error::bad_magic);
 
-  // There's another profile to read, so we need to process the header.
-  auto *Header = reinterpret_cast<const RawInstrProf::Header *>(CurrentPos);
-  return readHeader(*Header);
+  return reinterpret_cast<const RawInstrProf::Header *>(CurrentPos);
+}
+
+template <class IntPtrT>
+Expected<const char *>
+RawInstrProfReader<IntPtrT>::getNextHeaderPosForCurrentHeader() const {
+  const uint8_t *CurrentPos = ValueDataStart;
+  const uint8_t *BufferEnd =
+      reinterpret_cast<const uint8_t *>(DataBuffer->getBufferEnd());
+  for (const RawInstrProf::ProfileData<IntPtrT> *I = Data; I != DataEnd; ++I) {
+    uint32_t NumValueKinds = 0;
+    for (uint32_t K = 0; K < IPVK_Last + 1; ++K)
+      NumValueKinds += I->NumValueSites[K] != 0;
+    if (!NumValueKinds)
+      continue;
+
+    if (BufferEnd - CurrentPos < static_cast<ptrdiff_t>(sizeof(ValueProfData)))
+      return make_error<InstrProfError>(instrprof_error::truncated);
+
+    uint32_t TotalSize =
+        support::endian::read32(CurrentPos, getDataEndianness());
+    if (TotalSize < sizeof(ValueProfData) || TotalSize % sizeof(uint64_t) != 0)
+      return make_error<InstrProfError>(
+          instrprof_error::malformed,
+          "invalid total size for value profile data");
+    if (TotalSize > static_cast<uint64_t>(BufferEnd - CurrentPos))
+      return make_error<InstrProfError>(instrprof_error::too_large);
+    CurrentPos += TotalSize;
+  }
+  return reinterpret_cast<const char *>(CurrentPos);
+}
+
+template <class IntPtrT>
+Error RawInstrProfReader<IntPtrT>::readNextHeader(const char *CurrentPos) {
+  Expected<const RawInstrProf::Header *> Header = getNextHeader(CurrentPos);
+  if (Error E = Header.takeError())
+    return E;
+  if (!*Header)
+    return make_error<InstrProfError>(instrprof_error::eof);
+
+  // The full-buffer symtab and binary ID list were built by readHeader().
+  return readHeader(**Header, nullptr, false);
 }
 
 template <class IntPtrT>
@@ -579,7 +643,8 @@ Error RawInstrProfReader<IntPtrT>::createSymtab(InstrProfSymtab &Symtab) {
 
 template <class IntPtrT>
 Error RawInstrProfReader<IntPtrT>::readHeader(
-    const RawInstrProf::Header &Header) {
+    const RawInstrProf::Header &Header, InstrProfSymtab *SymtabToPopulate,
+    bool RecordBinaryIds) {
   Version = swap(Header.Version);
   if (GET_VERSION(Version) != RawInstrProf::Version)
     return error(instrprof_error::raw_profile_version_mismatch,
@@ -599,7 +664,7 @@ Error RawInstrProfReader<IntPtrT>::readHeader(
   if (BinaryIdSize % sizeof(uint64_t) || BinaryIdEnd > BufferEnd)
     return error(instrprof_error::bad_header);
   ArrayRef<uint8_t> BinaryIdsBuffer(BinaryIdStart, BinaryIdSize);
-  if (!BinaryIdsBuffer.empty()) {
+  if (RecordBinaryIds && !BinaryIdsBuffer.empty()) {
     if (Error Err = readBinaryIdsInternal(*DataBuffer, BinaryIdsBuffer,
                                           BinaryIds, getDataEndianness()))
       return Err;
@@ -705,11 +770,9 @@ Error RawInstrProfReader<IntPtrT>::readHeader(
   UniformCountersEnd = UniformCountersStart + UniformCountersSectionSize;
   ValueDataStart = reinterpret_cast<const uint8_t *>(Start + ValueDataOffset);
 
-  std::unique_ptr<InstrProfSymtab> NewSymtab = std::make_unique<InstrProfSymtab>();
-  if (Error E = createSymtab(*NewSymtab))
-    return E;
-
-  Symtab = std::move(NewSymtab);
+  if (SymtabToPopulate)
+    if (Error E = createSymtab(*SymtabToPopulate))
+      return E;
   return success();
 }
 

--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -521,9 +521,9 @@ Error RawInstrProfReader<IntPtrT>::readHeader() {
   BinaryIds.clear();
   Symtab = std::make_unique<InstrProfSymtab>();
 
-  // A value-profile target recorded by one image can name a function or
-  // vtable in a later concatenated raw profile. Build the address-to-name
-  // mappings for the entire buffer before deserializing the first record.
+  // A value-profile target recorded by one image can name a function in a
+  // later concatenated raw profile. Build the address-to-name mappings for the
+  // entire buffer before deserializing the first record.
   const RawInstrProf::Header *Header = FirstHeader;
   while (Header) {
     if (Error E = readHeader(*Header, Symtab.get(), true))

--- a/llvm/test/tools/llvm-profdata/Inputs/raw-two-profiles-use.ll
+++ b/llvm/test/tools/llvm-profdata/Inputs/raw-two-profiles-use.ll
@@ -1,0 +1,11 @@
+@fp = external global ptr
+
+; Keep bar as a declaration to model a target defined by a shared library.
+declare i32 @bar(i32)
+
+define i32 @foo(i32 %x) {
+entry:
+  %target = load ptr, ptr @fp
+  %result = call i32 %target(i32 %x)
+  ret i32 %result
+}

--- a/llvm/test/tools/llvm-profdata/raw-two-profiles.test
+++ b/llvm/test/tools/llvm-profdata/raw-two-profiles.test
@@ -29,13 +29,18 @@ RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\4\0\1\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\0\20\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\1\0\0\0\1\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\023\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\3\0foo\0\0\0' >> %t-foo.profraw
+RUN: printf '\050\0\0\0\1\0\0\0' >> %t-foo.profraw
+RUN: printf '\0\0\0\0\1\0\0\0' >> %t-foo.profraw
+RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\0\40\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\7\0\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\201rforpl\377' > %t-bar.profraw
 RUN: printf '\13\0\0\0\0\0\0\0' >> %t-bar.profraw
@@ -62,7 +67,7 @@ RUN: printf '\02\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\6\0\1\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\0\40\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
@@ -72,14 +77,17 @@ RUN: printf '\101\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\3\0bar\0\0\0' >> %t-bar.profraw
 
 RUN: cat %t-foo.profraw %t-bar.profraw > %t-pad.profraw
-RUN: llvm-profdata show %t-pad.profraw -all-functions -counts | FileCheck %s
+RUN: llvm-profdata show %t-pad.profraw -all-functions -counts -ic-targets | FileCheck %s
 
 CHECK: Counters:
 CHECK:   foo:
 CHECK:     Hash: 0x0000000000000001
 CHECK:     Counters: 1
 CHECK:     Function count: 19
+CHECK:     Indirect Call Site Count: 1
 CHECK:     Block counts: []
+CHECK:     Indirect Target Results:
+CHECK:         [  0, bar,          7 ]
 CHECK:   bar:
 CHECK:     Hash: 0x0000000000000002
 CHECK:     Counters: 2

--- a/llvm/test/tools/llvm-profdata/raw-two-profiles.test
+++ b/llvm/test/tools/llvm-profdata/raw-two-profiles.test
@@ -22,7 +22,7 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\4\0\2\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\2\0\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\254\275\030\333\114\302\370\134' >> %t-foo.profraw
 RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
@@ -32,15 +32,19 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\20\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\1\0\0\0\1\0\0\0' >> %t-foo.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\023\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\3\0foo\0\0\0' >> %t-foo.profraw
-RUN: printf '\050\0\0\0\1\0\0\0' >> %t-foo.profraw
+RUN: printf '\110\0\0\0\2\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\1\0\0\0' >> %t-foo.profraw
 RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\40\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\7\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\2\0\0\0\1\0\0\0' >> %t-foo.profraw
+RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\10\60\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\11\0\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\201rforpl\377' > %t-bar.profraw
 RUN: printf '\13\0\0\0\0\0\0\0' >> %t-bar.profraw
@@ -58,9 +62,9 @@ RUN: printf '\10\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\6\0\1\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\6\0\2\0\0\0' >> %t-bar.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\1\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\10\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\2\0\0\0\0\0\0\0' >> %t-bar.profraw
 
 RUN: printf '\067\265\035\031\112\165\023\344' >> %t-bar.profraw
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t-bar.profraw
@@ -75,9 +79,16 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\067\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\101\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\3\0bar\0\0\0' >> %t-bar.profraw
+RUN: printf '\320\115\170\140\375\107\0\250' >> %t-bar.profraw
+RUN: printf '\0\60\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\20\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\6\0_ZTV1A' >> %t-bar.profraw
 
 RUN: cat %t-foo.profraw %t-bar.profraw > %t-pad.profraw
-RUN: llvm-profdata show %t-pad.profraw -all-functions -counts -ic-targets | FileCheck %s
+RUN: llvm-profdata show %t-pad.profraw -all-functions -counts -ic-targets -show-vtables | FileCheck %s
+RUN: cp %t-pad.profraw %t-bad-value-size.profraw
+RUN: printf '\1\0\0\0' | dd of=%t-bad-value-size.profraw bs=1 seek=240 conv=notrunc 2>/dev/null
+RUN: not llvm-profdata show %t-bad-value-size.profraw 2>&1 | FileCheck %s --check-prefix=BAD-VALUE-SIZE
 
 CHECK: Counters:
 CHECK:   foo:
@@ -85,9 +96,12 @@ CHECK:     Hash: 0x0000000000000001
 CHECK:     Counters: 1
 CHECK:     Function count: 19
 CHECK:     Indirect Call Site Count: 1
+CHECK:     Number of instrumented vtables: 1
 CHECK:     Block counts: []
 CHECK:     Indirect Target Results:
 CHECK:         [  0, bar,          7 ]
+CHECK:     VTable Results:
+CHECK:         [  0, _ZTV1A,          9 ]
 CHECK:   bar:
 CHECK:     Hash: 0x0000000000000002
 CHECK:     Counters: 2
@@ -97,3 +111,5 @@ CHECK: Functions shown: 2
 CHECK: Total functions: 2
 CHECK: Maximum function count: 55
 CHECK: Maximum internal block count: 65
+
+BAD-VALUE-SIZE: malformed instrumentation profile data: invalid total size for value profile data

--- a/llvm/test/tools/llvm-profdata/raw-two-profiles.test
+++ b/llvm/test/tools/llvm-profdata/raw-two-profiles.test
@@ -5,7 +5,7 @@
 // TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t-foo.profraw
-RUN: printf '\13\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\13\0\0\0\0\0\0\1' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
@@ -22,32 +22,28 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\4\0\2\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\2\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\254\275\030\333\114\302\370\134' >> %t-foo.profraw
-RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\377\377\377\177\201\134\137\2' >> %t-foo.profraw
 RUN: printf '\0\0\4\0\1\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\20\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\1\0\0\0\1\0\0\0' >> %t-foo.profraw
-RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw
 
-RUN: printf '\023\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\350\3\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\3\0foo\0\0\0' >> %t-foo.profraw
-RUN: printf '\110\0\0\0\2\0\0\0' >> %t-foo.profraw
+RUN: printf '\050\0\0\0\1\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\1\0\0\0' >> %t-foo.profraw
 RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\40\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\7\0\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\2\0\0\0\1\0\0\0' >> %t-foo.profraw
-RUN: printf '\1\0\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\10\60\0\0\0\0\0\0' >> %t-foo.profraw
-RUN: printf '\11\0\0\0\0\0\0\0' >> %t-foo.profraw
+RUN: printf '\350\3\0\0\0\0\0\0' >> %t-foo.profraw
 
 RUN: printf '\201rforpl\377' > %t-bar.profraw
-RUN: printf '\13\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\13\0\0\0\0\0\0\1' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\1\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
@@ -62,9 +58,9 @@ RUN: printf '\10\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\6\0\1\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\0\0\6\0\2\0\0\0' >> %t-bar.profraw
-RUN: printf '\1\0\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\10\0\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\2\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
+RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 
 RUN: printf '\067\265\035\031\112\165\023\344' >> %t-bar.profraw
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t-bar.profraw
@@ -79,37 +75,49 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\067\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\101\0\0\0\0\0\0\0' >> %t-bar.profraw
 RUN: printf '\3\0bar\0\0\0' >> %t-bar.profraw
-RUN: printf '\320\115\170\140\375\107\0\250' >> %t-bar.profraw
-RUN: printf '\0\60\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\20\0\0\0\0\0\0\0' >> %t-bar.profraw
-RUN: printf '\6\0_ZTV1A' >> %t-bar.profraw
 
 RUN: cat %t-foo.profraw %t-bar.profraw > %t-pad.profraw
-RUN: llvm-profdata show %t-pad.profraw -all-functions -counts -ic-targets -show-vtables | FileCheck %s
+RUN: llvm-profdata show %t-pad.profraw -all-functions -counts -ic-targets | FileCheck %s
+RUN: llvm-profdata merge %t-pad.profraw -o %t.profdata
+// The target remains an external declaration in the profile-use module. ICP
+// rejects it by default, but its explicit declaration-promotion mode can emit
+// a guarded direct call without combining the linkage units.
+RUN: opt %S/Inputs/raw-two-profiles-use.ll -passes='pgo-instr-use,pgo-icall-prom' -pgo-test-profile-file=%t.profdata -icp-allow-decls=false -S | FileCheck %s --check-prefix=NO-ICP
+RUN: opt %S/Inputs/raw-two-profiles-use.ll -passes='pgo-instr-use,pgo-icall-prom' -pgo-test-profile-file=%t.profdata -icp-allow-decls=true -S | FileCheck %s --check-prefix=ICP
 RUN: cp %t-pad.profraw %t-bad-value-size.profraw
 RUN: printf '\1\0\0\0' | dd of=%t-bad-value-size.profraw bs=1 seek=240 conv=notrunc 2>/dev/null
 RUN: not llvm-profdata show %t-bad-value-size.profraw 2>&1 | FileCheck %s --check-prefix=BAD-VALUE-SIZE
 
 CHECK: Counters:
 CHECK:   foo:
-CHECK:     Hash: 0x0000000000000001
+CHECK:     Hash: 0x025f5c817fffffff
 CHECK:     Counters: 1
-CHECK:     Function count: 19
 CHECK:     Indirect Call Site Count: 1
-CHECK:     Number of instrumented vtables: 1
-CHECK:     Block counts: []
+CHECK:     Block counts: [1000]
 CHECK:     Indirect Target Results:
-CHECK:         [  0, bar,          7 ]
-CHECK:     VTable Results:
-CHECK:         [  0, _ZTV1A,          9 ]
+CHECK:         [  0, bar,       1000 ]
 CHECK:   bar:
 CHECK:     Hash: 0x0000000000000002
 CHECK:     Counters: 2
-CHECK:     Function count: 55
-CHECK:     Block counts: [65]
+CHECK:     Block counts: [55, 65]
 CHECK: Functions shown: 2
 CHECK: Total functions: 2
-CHECK: Maximum function count: 55
+CHECK: Maximum function count: 1000
 CHECK: Maximum internal block count: 65
 
 BAD-VALUE-SIZE: malformed instrumentation profile data: invalid total size for value profile data
+
+NO-ICP-LABEL: define i32 @foo
+NO-ICP: %[[TARGET:.*]] = load ptr, ptr @fp
+NO-ICP-NOT: icmp eq ptr %[[TARGET]], @bar
+NO-ICP: call i32 %[[TARGET]](i32 %x)
+
+ICP: declare i32 @bar(i32)
+ICP-LABEL: define i32 @foo
+ICP: %[[TARGET:.*]] = load ptr, ptr @fp
+ICP: %[[MATCH:.*]] = icmp eq ptr %[[TARGET]], @bar
+ICP: br i1 %[[MATCH]], label %if.true.direct_targ, label %if.false.orig_indirect
+ICP: if.true.direct_targ:
+ICP: call i32 @bar(i32 %x)
+ICP: if.false.orig_indirect:
+ICP: call i32 %[[TARGET]](i32 %x)


### PR DESCRIPTION
## Summary

- Build one raw-profile symbol table from every concatenated header before deserializing value records.
- Preserve an indirect-call target whose address belongs to another image in the same raw profile buffer.
- Cover a concrete profile-use workflow in which ICP is explicitly allowed to promote an external declaration while the dynamic-link boundary remains unchanged.

## Problem

An instrumented process can write one `.profraw` buffer containing concatenated profiles from multiple images. `RawInstrProfReader` currently creates or replaces the symbol table as each header is entered. Records from image A are deserialized before header B is entered, so an indirect-call target whose address belongs to B cannot be translated into B's name hash. When header B is entered, mappings from A are replaced as well. The cross-image target becomes external/zero and is lost during merge even though its address/name mapping is present later in the same buffer.

Using `%m` is not equivalent: it gives the executable and instrumented shared libraries separate files, so each input resolves its value-profile addresses independently before the input records are merged. A target owned by another image remains unresolved there as well.

## Profile-use workflow

This is not intended to make default ICP or WPD operate across a dynamic-link boundary. Default ICP rejects a target for which only a declaration is available, and WPD does not combine separate linkage units.

LLVM does, however, provide the explicit `-icp-allow-decls=true` mode. With the same dynamic-link structure in the instrumentation and optimized builds, the caller's IR can contain an external declaration for a function defined by a shared library. Once the profile preserves that function's name hash, ICP can emit a guarded direct call to the declaration without importing its definition or statically linking the library.

This change supplies the missing raw-profile resolution needed by that existing mode; it does not change ICP's default.

## Fix

Pre-scan the concatenated headers, accumulating address/name mappings into one symbol table. The scan advances through value data using validated `TotalSize` fields, restores the first header's iteration state, and then preserves normal record iteration for valid profiles. Binary IDs are collected once.

Malformed data in a later concatenated profile may now be diagnosed during the initial pre-scan rather than after records from earlier profiles have been returned.

No raw profile format change is required.

## Scope

This change covers concatenated raw profiles that carry inline profile data/name mappings. The existing limitation around externally correlating one raw-profile buffer containing multiple build IDs is unchanged. It does not claim cross-DSO WPD support or alter default ICP behavior.

## Testing

- The first raw-profile header owns `foo` and records a hot indirect-call target at `0x2000`; the later header alone maps `0x2000` to `bar`.
- `llvm-profdata show` must recover `bar`, and `llvm-profdata merge` must preserve it in an indexed IR profile.
- The profile-use module defines `foo` but only declares `bar`:
  - default declaration handling leaves the call indirect;
  - `-icp-allow-decls=true` emits a guarded direct call to `bar` while `bar` remains a declaration.
- A malformed value-profile `TotalSize` is rejected during the pre-scan.
- The exact raw-reader, merge, default-ICP negative, declaration-ICP positive, and malformed-size commands passed locally with LLVM 24 tools and the patched `InstrProfReader` object.
