### PR TITLE
[OpenMP] Fix ambiguous namespace lookup with delayed template parsing

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
@@ -398,7 +398,7 @@ ConstructDecompositionT<C, H>::addClauseSymsToMap(U &&item,
 // anything and return false, otherwise return true.
 template <typename C, typename H>
 bool ConstructDecompositionT<C, H>::applyToUnique(const ClauseTy *input) {
-  auto unique = detail::find_unique(leafs, [=](const auto &leaf) {
+  auto unique = ::detail::find_unique(leafs, [=](const auto &leaf) {
     return llvm::omp::isAllowedClauseForDirective(leaf.id, input->id, version);
   });
 


### PR DESCRIPTION
Running `check-llvm` on Windows fails while compiling LLVMFrontendTests
with the following error:

  error: reference to 'detail' is ambiguous

Clang enables delayed template parsing by default when targeting the
MSVC ABI on Windows. When ConstructDecompositionT is instantiated after
a using-directive for `llvm::omp`, both `::detail` and `llvm::omp::detail` are
visible, making `detail::find_unique` ambiguous.

Explicitly qualify find_unique with the global namespace. This fixes
check-llvm on Windows and other environments using
-fdelayed-template-parsing, without changing behavior.