### PR TITLE
[clang][AST] Remove ASTContext parameter from getFlexibleArrayInitChars

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -1737,7 +1737,7 @@ public:
   /// necessary to store those elements. Otherwise, returns zero.
   ///
   /// This can only be called for declarations where hasInit() is true.
-  CharUnits getFlexibleArrayInitChars(const ASTContext &Ctx) const;
+  CharUnits getFlexibleArrayInitChars() const;
 
   /// Apply a deduced address space, if one isn't already set.
   void assignAddressSpace(const ASTContext &Ctxt, LangAS AS);

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2837,7 +2837,7 @@ bool VarDecl::hasFlexibleArrayInit(const ASTContext &Ctx) const {
   return !InitTy->isZeroSize();
 }
 
-CharUnits VarDecl::getFlexibleArrayInitChars(const ASTContext &Ctx) const {
+CharUnits VarDecl::getFlexibleArrayInitChars() const {
   assert(hasInit() && "Expect initializer to check for flexible array init");
   auto *RD = getType()->getAsRecordDecl();
   if (!RD || !RD->hasFlexibleArrayMember())
@@ -2845,6 +2845,8 @@ CharUnits VarDecl::getFlexibleArrayInitChars(const ASTContext &Ctx) const {
   auto *List = dyn_cast<InitListExpr>(getInit()->IgnoreParens());
   if (!List || List->getNumInits() == 0)
     return CharUnits::Zero();
+
+  const ASTContext &Ctx = getASTContext();
   const Expr *FlexibleInit = List->getInit(List->getNumInits() - 1);
   auto InitTy = Ctx.getAsConstantArrayType(FlexibleInit->getType());
   if (!InitTy)

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -16684,7 +16684,7 @@ static void addFlexibleArrayMemberInitSize(EvalInfo &Info, const QualType &T,
     if (const auto *V = LV.getLValueBase().dyn_cast<const ValueDecl *>())
       if (const auto *VD = dyn_cast<VarDecl>(V))
         if (VD->hasInit())
-          Size += VD->getFlexibleArrayInitChars(Info.Ctx);
+          Size += VD->getFlexibleArrayInitChars();
 }
 
 /// Helper for tryEvaluateBuiltinObjectSize -- Given an LValue, this will

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -384,7 +384,7 @@ CodeGenFunction::AddInitializerToStaticVarDecl(const VarDecl &D,
 
 #ifndef NDEBUG
   CharUnits VarSize = CGM.getContext().getTypeSizeInChars(D.getType()) +
-                      D.getFlexibleArrayInitChars(getContext());
+                      D.getFlexibleArrayInitChars();
   CharUnits CstSize = CharUnits::fromQuantity(
       CGM.getDataLayout().getTypeAllocSize(Init->getType()));
   assert(VarSize == CstSize && "Emitted constant has unexpected size");

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6479,7 +6479,7 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
 
 #ifndef NDEBUG
       CharUnits VarSize = getContext().getTypeSizeInChars(ASTTy) +
-                          InitDecl->getFlexibleArrayInitChars(getContext());
+                          InitDecl->getFlexibleArrayInitChars();
       CharUnits CstSize = CharUnits::fromQuantity(
           getDataLayout().getTypeAllocSize(Init->getType()));
       assert(VarSize == CstSize && "Emitted constant has unexpected size");


### PR DESCRIPTION
Decls already have a reference to the ASTContext, so no need to pass another one.