### PR TITLE
[clangd][HLSL] Add hover support for vector swizzle and matrix element access

### DIFF
--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -960,11 +960,13 @@ std::optional<HoverInfo> getHoverContents(const SelectionTree::Node *N,
   std::optional<HoverInfo> HI;
 
   if (const auto *VecExpr = dyn_cast<ExtVectorElementExpr>(E)) {
+    HI.emplace();
     HI->Name = VecExpr->getAccessor().getName().str();
     HI->Type = printType(VecExpr->getType(), AST.getASTContext(), PP);
     return HI;
   }
   if (const auto *MatExpr = dyn_cast<MatrixElementExpr>(E)) {
+    HI.emplace();
     HI->Name = MatExpr->getAccessor().getName().str();
     HI->Type = printType(MatExpr->getType(), AST.getASTContext(), PP);
     return HI;

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -959,6 +959,17 @@ std::optional<HoverInfo> getHoverContents(const SelectionTree::Node *N,
                                           const SymbolIndex *Index) {
   std::optional<HoverInfo> HI;
 
+  if (const auto *VecExpr = dyn_cast<ExtVectorElementExpr>(E)) {
+    HI->Name = VecExpr->getAccessor().getName().str();
+    HI->Type = printType(VecExpr->getType(), AST.getASTContext(), PP);
+    return HI;
+  }
+  if (const auto *MatExpr = dyn_cast<MatrixElementExpr>(E)) {
+    HI->Name = MatExpr->getAccessor().getName().str();
+    HI->Type = printType(MatExpr->getType(), AST.getASTContext(), PP);
+    return HI;
+  }
+
   if (const StringLiteral *SL = dyn_cast<StringLiteral>(E)) {
     // Print the type and the size for string literals
     HI = getStringLiteralContents(SL, PP);

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5311,6 +5311,107 @@ TEST(Hover, FunctionParameters) {
   }
 }
 
+static void configureHLSL(TestTU &TU, bool EnableMatrix = false) {
+  TU.Filename = "TestTU.hlsl";
+  TU.ExtraArgs.push_back("-x");
+  TU.ExtraArgs.push_back("hlsl");
+  if (EnableMatrix)
+    TU.ExtraArgs.push_back("-fenable-matrix");
+  TU.ExtraArgs.push_back("--target=dxil-pc-shadermodel6.3-library");
+}
+
+TEST(Hover, HLSLVectorAndMatrixSwizzle) {
+  struct {
+    const char *const Code;
+    const std::function<void(HoverInfo &)> ExpectedBuilder;
+  } Cases[] = {
+      {
+          R"hlsl(
+            typedef float float3 __attribute__((ext_vector_type(3)));
+            void main() {
+              float3 v;
+              float3 s = v.^[[xyz]];
+            }
+          )hlsl",
+          [](HoverInfo &HI) {
+            HI.Name = "xyz";
+            HI.Type = "float3";
+          }},
+      {
+          R"hlsl(
+            typedef float float3 __attribute__((ext_vector_type(3)));
+            typedef float float2 __attribute__((ext_vector_type(2)));
+            void main() {
+              float3 v;
+              float2 s = v.^[[xy]];
+            }
+          )hlsl",
+          [](HoverInfo &HI) {
+            HI.Name = "xy";
+            HI.Type = "float2";
+          }},
+      {
+          R"hlsl(
+            typedef float float4x4 __attribute__((matrix_type(4, 4)));
+            void main() {
+              float4x4 m;
+              float e = m.^[[_m00]];
+            }
+          )hlsl",
+          [](HoverInfo &HI) {
+            HI.Name = "_m00";
+            HI.Type = "float";
+          }},
+  };
+
+  for (const auto &Case : Cases) {
+    SCOPED_TRACE(Case.Code);
+    Annotations T(Case.Code);
+    TestTU TU = TestTU::withCode(T.code());
+    configureHLSL(TU, /*EnableMatrix=*/true);
+    auto AST = TU.build();
+    auto H = getHover(AST, T.point(), format::getLLVMStyle(), nullptr);
+    ASSERT_TRUE(H);
+    HoverInfo Expected;
+    Expected.SymRange = T.range();
+    Case.ExpectedBuilder(Expected);
+    SCOPED_TRACE(H->present(MarkupKind::PlainText));
+    EXPECT_EQ(H->Name, Expected.Name);
+    EXPECT_EQ(H->Type, Expected.Type);
+    EXPECT_EQ(H->SymRange, Expected.SymRange);
+  }
+}
+
+TEST(Hover, HLSLInvalidMatrixSwizzleNoCrash) {
+  Annotations T(R"hlsl(
+    typedef float float2x2 __attribute__((matrix_type(2, 2)));
+    void main() {
+      float2x2 m;
+      float bad = m.^[[_m22]]; // out of bounds for a 2x2 matrix /*error-ok*/
+    }
+  )hlsl");
+  TestTU TU = TestTU::withCode(T.code());
+  configureHLSL(TU, /*EnableMatrix=*/true);
+  auto AST = TU.build();
+  auto H = getHover(AST, T.point(), format::getLLVMStyle(), nullptr);
+  EXPECT_FALSE(H);
+}
+
+TEST(Hover, HLSLInvalidVectorSwizzleNoCrash) {
+  Annotations T(R"hlsl(
+    typedef float float3 __attribute__((ext_vector_type(3)));
+    void main() {
+      float3 v;
+      float bad = v.^[[w]]; // 'w' is not a valid component for a 3-component vector /*error-ok*/
+    }
+  )hlsl");
+  TestTU TU = TestTU::withCode(T.code());
+  configureHLSL(TU);
+  auto AST = TU.build();
+  auto H = getHover(AST, T.point(), format::getLLVMStyle(), nullptr);
+  EXPECT_FALSE(H);
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang


### PR DESCRIPTION
Hovering over a vector swizzle expression (e.g. `.xyz`) or a matrix element access (e.g. `._m00`) previously produced no hover information, since ExtVectorElementExpr and MatrixElementExpr were not handled in getHoverContents(const Expr *E).

This patch adds support for these expressions within `getHoverContents` by extracting the accessor name and resolved type for both node kinds.

Fixes #212612 