### PR TITLE
[lldb][Windows] Check for EOF before the ctrl-c retry in GetLine

### DIFF
--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -395,13 +395,13 @@ bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
     while (!got_line) {
       char *r = fgets(buffer, sizeof(buffer), in);
       if (r == nullptr) {
-#ifdef _WIN32
         if (feof(in)) {
           got_line = SplitLineEOF(m_line_buffer);
           break;
         }
         if (ferror(in) && errno == EINTR)
           continue;
+#ifdef _WIN32
         // ReadFile on Windows is supposed to set ERROR_OPERATION_ABORTED
         // according to the docs on MSDN. However, this has evidently been a
         // known bug since Windows 8. Therefore, we can't detect if a signal

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -394,8 +394,8 @@ bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
   if (!got_line && in) {
     while (!got_line) {
       char *r = fgets(buffer, sizeof(buffer), in);
-#ifdef _WIN32
       if (r == nullptr) {
+#ifdef _WIN32
         if (feof(in)) {
           got_line = SplitLineEOF(m_line_buffer);
           break;

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -395,23 +395,24 @@ bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
     while (!got_line) {
       char *r = fgets(buffer, sizeof(buffer), in);
 #ifdef _WIN32
-      // ReadFile on Windows is supposed to set ERROR_OPERATION_ABORTED
-      // according to the docs on MSDN. However, this has evidently been a
-      // known bug since Windows 8. Therefore, we can't detect if a signal
-      // interrupted in the fgets. So pressing ctrl-c causes the repl to end
-      // and the process to exit. A temporary workaround is just to attempt to
-      // fgets twice until this bug is fixed.
-      if (r == nullptr)
-        r = fgets(buffer, sizeof(buffer), in);
-      // this is the equivalent of EINTR for Windows
-      if (r == nullptr && GetLastError() == ERROR_OPERATION_ABORTED)
-        continue;
-#endif
       if (r == nullptr) {
+        if (feof(in)) {
+          got_line = SplitLineEOF(m_line_buffer);
+          break;
+        }
         if (ferror(in) && errno == EINTR)
           continue;
-        if (feof(in))
-          got_line = SplitLineEOF(m_line_buffer);
+        // ReadFile on Windows is supposed to set ERROR_OPERATION_ABORTED
+        // according to the docs on MSDN. However, this has evidently been a
+        // known bug since Windows 8. Therefore, we can't detect if a signal
+        // interrupted in the fgets. So pressing ctrl-c causes the repl to end
+        // and the process to exit. A temporary workaround is just to attempt
+        // to fgets twice until this bug is fixed.
+        if (GetLastError() == ERROR_OPERATION_ABORTED) {
+          clearerr(in);
+          continue;
+        }
+#endif
         break;
       }
       m_line_buffer += buffer;


### PR DESCRIPTION
On Windows `lldb --repl` can hang forever instead of exiting at EOF.

`IOHandlerEditline::GetLine` checks `GetLastError() == ERROR_OPERATION_ABORTED` and does a `continue` before checking `feof`.
However `fgets` is a CRT function and does not set the Win32 last error value, so the `GetLastError` read is not the expected error. When it happens to be `ERROR_OPERATION_ABORTED` (995) the loop never reaches the EOF check.

This reorders the checks so EOF wins unconditionally, and adds `clearerr` before the ctrl-c retry (a real interrupt leaves the error flag set, which would fail the next `fgets`). ctrl-c handling is otherwise unchanged.

rdar://183335061