### PR TITLE
clang: Use proper error for unified shared memory openmp error

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -455,6 +455,8 @@ def warn_omp_gpu_unsupported_clause: Warning<
 def warn_omp_gpu_unsupported_modifier_for_clause: Warning<
   "modifier '%0' is currently not supported on a GPU for the '%1' clause; modifier ignored">,
   InGroup<OpenMPClauses>;
+def err_omp_unified_shared_memory_unsupported : Error<
+  "target architecture '%0' does not support unified addressing">;
 
 // Static Analyzer Core
 def err_unknown_analyzer_checker_or_package : Error<

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -2267,11 +2267,9 @@ void CGOpenMPRuntimeGPU::processRequiresDirective(const OMPRequiresDecl *D) {
       !llvm::NVPTX::supportsUnifiedAddressing(llvm::NVPTX::parseArch(CPU))) {
     for (const OMPClause *Clause : D->clauselists()) {
       if (Clause->getClauseKind() == OMPC_unified_shared_memory) {
-        SmallString<256> Buffer;
-        llvm::raw_svector_ostream Out(Buffer);
-        Out << "Target architecture " << CPU
-            << " does not support unified addressing";
-        CGM.Error(Clause->getBeginLoc(), Out.str());
+        CGM.getDiags().Report(Clause->getBeginLoc(),
+                              diag::err_omp_unified_shared_memory_unsupported)
+            << CPU;
         return;
       }
     }

--- a/clang/test/OpenMP/requires_codegen.cpp
+++ b/clang/test/OpenMP/requires_codegen.cpp
@@ -21,5 +21,5 @@
 #endif
 
 #ifdef REGION_DEVICE
-#pragma omp requires unified_shared_memory // expected-error-re {{Target architecture sm_{{20|21|30|32|35|37|50|52|53|60|61|62}} does not support unified addressing}}
+#pragma omp requires unified_shared_memory // expected-error-re {{target architecture 'sm_{{20|21|30|32|35|37|50|52|53|60|61|62}}' does not support unified addressing}}
 #endif


### PR DESCRIPTION
Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>