### PR TITLE
[mlir][complex] Fix signed zero miscompile with complex.add fold

### DIFF
--- a/mlir/lib/Dialect/Complex/IR/ComplexOps.cpp
+++ b/mlir/lib/Dialect/Complex/IR/ComplexOps.cpp
@@ -261,11 +261,11 @@ OpFoldResult AddOp::fold(FoldAdaptor adaptor) {
     if (getLhs() == sub.getRhs())
       return sub.getLhs();
 
-  // complex.add(a, complex.constant<0.0, 0.0>) -> a
+  // complex.add(a, complex.constant<-0.0, -0.0>) -> a
   if (auto constantOp = getRhs().getDefiningOp<ConstantOp>()) {
     auto arrayAttr = constantOp.getValue();
-    if (llvm::cast<FloatAttr>(arrayAttr[0]).getValue().isZero() &&
-        llvm::cast<FloatAttr>(arrayAttr[1]).getValue().isZero()) {
+    if (llvm::cast<FloatAttr>(arrayAttr[0]).getValue().isNegZero() &&
+        llvm::cast<FloatAttr>(arrayAttr[1]).getValue().isNegZero()) {
       return getLhs();
     }
   }

--- a/mlir/test/Dialect/Complex/canonicalize.mlir
+++ b/mlir/test/Dialect/Complex/canonicalize.mlir
@@ -125,11 +125,11 @@ func.func @complex_conj_conj() -> complex<f32> {
   return %conj2 : complex<f32>
 }
 
-// CHECK-LABEL: func @complex_add_zero
-func.func @complex_add_zero() -> complex<f32> {
-  %complex1 = complex.constant [1.0 : f32, 0.0 : f32] : complex<f32>
-  %complex2 = complex.constant [0.0 : f32, 0.0 : f32] : complex<f32>
-  // CHECK: %[[CPLX:.*]] = complex.constant [1.000000e+00 : f32, 0.000000e+00 : f32] : complex<f32>
+// CHECK-LABEL: func @complex_add_neg_zero
+func.func @complex_add_neg_zero() -> complex<f32> {
+  %complex1 = complex.constant [1.0 : f32, -0.0 : f32] : complex<f32>
+  %complex2 = complex.constant [-0.0 : f32, -0.0 : f32] : complex<f32>
+  // CHECK: %[[CPLX:.*]] = complex.constant [1.000000e+00 : f32, -0.000000e+00 : f32] : complex<f32>
   // CHECK-NEXT: return %[[CPLX]] : complex<f32>
   %add = complex.add %complex1, %complex2 : complex<f32>
   return %add : complex<f32>


### PR DESCRIPTION
The pattern `a + complex.constant<0.0, 0.0>` currently gets folded to `a`. This is incorrect when e.g. `a=(-0.0, 1.0)` since as per the IEEE spec and what's done in the arith dialect `0.0 + (-0.0) = 0.0 != (-0.0)`.

This PR changes the pattern to `a + complex<-0.0, -0.0> -> a` and updates the associated test.