### PR TITLE
[SPIR-V] Fix OpGroupAsyncCopy null event substitution

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -3127,6 +3127,26 @@ static bool generateAsyncCopy(const SPIRV::IncomingCall *Call,
     Register TypeReg = GR->getSPIRVTypeID(NewType ? NewType : Call->ReturnType);
     unsigned NumArgs = Call->Arguments.size();
     Register EventReg = Call->Arguments[NumArgs - 1];
+    SPIRVTypeInst EventType = GR->getSPIRVTypeForVReg(EventReg);
+    if (!EventType || EventType->getOpcode() != SPIRV::OpTypeEvent) {
+      MachineRegisterInfo *MRI = MIRBuilder.getMRI();
+      Register ConstReg = EventReg;
+      MachineInstr *Def = getDefInstrMaybeConstant(ConstReg, MRI);
+      if (Def->getOpcode() == TargetOpcode::G_CONSTANT &&
+          Def->getOperand(1).getCImm()->isZero()) {
+        // Only substitute a null Event for the "ptr null" idiom, not for a
+        // real event value that just is not typed as OpTypeEvent yet.
+        SPIRVTypeInst EventTy = NewType ? NewType
+                                        : GR->getOrCreateSPIRVTypeByName(
+                                              "spirv.Event", MIRBuilder, true);
+        Register EventTyReg = GR->getSPIRVTypeID(EventTy);
+        Register NullEventReg = createVirtualRegister(EventTy, GR, MIRBuilder);
+        MIRBuilder.buildInstr(SPIRV::OpConstantNull)
+            .addDef(NullEventReg)
+            .addUse(EventTyReg);
+        EventReg = NullEventReg;
+      }
+    }
     bool Res = MIRBuilder.buildInstr(Opcode)
                    .addDef(Call->ReturnRegister)
                    .addUse(TypeReg)

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy.ll
@@ -1,8 +1,9 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; TODO: enable spirv-val: OpGroupAsyncCopy event arg needs OpTypeEvent, not OpTypePointer
-; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-SPIRV-DAG: %[[#]] = OpGroupAsyncCopy %[[#]] %[[#Scope:]]
+; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
+; CHECK-SPIRV-DAG: %[[#NullEvent:]] = OpConstantNull %[[#EventTy]]
+; CHECK-SPIRV-DAG: %[[#]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope:]] %[[#]] %[[#]] %[[#]] %[[#]] %[[#NullEvent]]
 ; CHECK-SPIRV-DAG: %[[#Scope]] = OpConstant %[[#]]
 
 %opencl.event_t = type opaque


### PR DESCRIPTION
Only replace the event operand with OpConstantNull when it is actually a null constant

This complies with spirv-val expectations