### PR TITLE
[mlir] Honor IntrHasSideEffects on IntrNoMem LLVM intrinsics

### DIFF
--- a/mlir/tools/mlir-tblgen/LLVMIRIntrinsicGen.cpp
+++ b/mlir/tools/mlir-tblgen/LLVMIRIntrinsicGen.cpp
@@ -161,11 +161,15 @@ public:
   }
 
   /// Return true if the intrinsic may have side effects, i.e. does not have the
-  /// `IntrNoMem` property.
+  /// `IntrNoMem` property or has the `IntrHasSideEffects` property.
   bool hasSideEffects() const {
     return llvm::none_of(
-        record.getValueAsListOfDefs(fieldTraits),
-        [](const Record *r) { return r->getName() == "IntrNoMem"; });
+               record.getValueAsListOfDefs(fieldTraits),
+               [](const Record *r) { return r->getName() == "IntrNoMem"; }) ||
+           llvm::any_of(record.getValueAsListOfDefs(fieldTraits),
+                        [](const Record *r) {
+                          return r->getName() == "IntrHasSideEffects";
+                        });
   }
 
   /// Return true if the intrinsic is commutative, i.e. has the respective


### PR DESCRIPTION
`[IntrNoMem, IntrHasSideEffects]` is a perfectly valid intrinsic trait combination, and MLIR would CSE/DCE those without checking. This mirrors how LLVM models this, see getEffectiveME in IntrinsicEmitter.cpp

@vsytch