### PR TITLE
AMDGPU: Remove xnack and sramecc subtarget features

### DIFF
--- a/clang/test/Driver/amdgpu-assembler-xnack-sramecc.s
+++ b/clang/test/Driver/amdgpu-assembler-xnack-sramecc.s
@@ -1,38 +1,33 @@
 // REQUIRES: amdgpu-registered-target
 
 /// Assembling a .s file that has no target ID directive (.amdgcn_target). The
-/// xnack/sramecc mode is a property of the assembly / object, so specifying it
-/// on the command line, either with -mxnack/-msramecc or via the -mcpu target
-/// ID modifiers, is not preserved: the driver no longer forwards these to the
-/// assembler, and the resulting object uses the "any" setting in its e_flags.
-/// To pin a mode, the .s file must contain a .amdgcn_target directive.
+/// xnack/sramecc mode requested on the command line, either with
+/// -mxnack/-msramecc or via the -mcpu target ID modifiers, is forwarded to the
+/// assembler as a target feature and recorded in the object's e_flags.
 
+/// The mode is forwarded to the assembler as a target feature.
 // RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=CC1AS %s
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mxnack -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=CC1AS %s
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-sramecc -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=CC1AS %s
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack+ -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=CC1AS %s
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc- -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=CC1AS %s
+// RUN:   FileCheck -check-prefix=XNACK-OFF %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack- -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=XNACK-OFF %s
+// XNACK-OFF: "-cc1as"
+// XNACK-OFF-SAME: "-target-feature" "-xnack"
 
-/// The assembler is invoked with the plain target-cpu and no xnack/sramecc
-/// target feature.
-// CC1AS: "-cc1as"
-// CC1AS-SAME: "-target-cpu" "gfx906"
-// CC1AS-NOT: "-target-feature"
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -msramecc -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc+ -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
+// SRAMECC-ON: "-cc1as"
+// SRAMECC-ON-SAME: "-target-feature" "+sramecc"
 
-/// End to end: the mode requested on the command line is not reflected in the
-/// object, which keeps the "any" xnack/sramecc e_flags.
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s -o %t.o 2>&1 | \
-// RUN:   FileCheck -check-prefix=UNUSED %s
-// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=ANY %s
-
+/// End to end: the requested mode is reflected in the object's e_flags.
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s -o %t.o
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-XNACK-OFF %s
 // RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack+ -c %s -o %t.o
-// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=ANY %s
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-XNACK-ON %s
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc- -c %s -o %t.o
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-SRAMECC-OFF %s
 
-// UNUSED: warning: argument unused during compilation: '-mno-xnack'
-// ANY: EF_AMDGPU_FEATURE_SRAMECC_ANY_V4 (0x400)
-// ANY: EF_AMDGPU_FEATURE_XNACK_ANY_V4 (0x100)
+// OBJ-XNACK-OFF: EF_AMDGPU_FEATURE_XNACK_OFF_V4 (0x200)
+// OBJ-XNACK-ON: EF_AMDGPU_FEATURE_XNACK_ON_V4 (0x300)
+// OBJ-SRAMECC-OFF: EF_AMDGPU_FEATURE_SRAMECC_OFF_V4 (0x800)

--- a/clang/test/Driver/amdgpu-assembler-xnack-sramecc.s
+++ b/clang/test/Driver/amdgpu-assembler-xnack-sramecc.s
@@ -1,33 +1,38 @@
 // REQUIRES: amdgpu-registered-target
 
 /// Assembling a .s file that has no target ID directive (.amdgcn_target). The
-/// xnack/sramecc mode requested on the command line, either with
-/// -mxnack/-msramecc or via the -mcpu target ID modifiers, is forwarded to the
-/// assembler as a target feature and recorded in the object's e_flags.
+/// xnack/sramecc mode is a property of the assembly / object, so specifying it
+/// on the command line, either with -mxnack/-msramecc or via the -mcpu target
+/// ID modifiers, is not preserved: the driver no longer forwards these to the
+/// assembler, and the resulting object uses the "any" setting in its e_flags.
+/// To pin a mode, the .s file must contain a .amdgcn_target directive.
 
-/// The mode is forwarded to the assembler as a target feature.
 // RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=XNACK-OFF %s
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack- -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=XNACK-OFF %s
-// XNACK-OFF: "-cc1as"
-// XNACK-OFF-SAME: "-target-feature" "-xnack"
+// RUN:   FileCheck -check-prefix=CC1AS %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mxnack -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=CC1AS %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-sramecc -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=CC1AS %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack+ -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=CC1AS %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc- -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=CC1AS %s
 
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -msramecc -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
-// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc+ -c %s 2>&1 | \
-// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
-// SRAMECC-ON: "-cc1as"
-// SRAMECC-ON-SAME: "-target-feature" "+sramecc"
+/// The assembler is invoked with the plain target-cpu and no xnack/sramecc
+/// target feature.
+// CC1AS: "-cc1as"
+// CC1AS-SAME: "-target-cpu" "gfx906"
+// CC1AS-NOT: "-target-feature"
 
-/// End to end: the requested mode is reflected in the object's e_flags.
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s -o %t.o
-// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-XNACK-OFF %s
+/// End to end: the mode requested on the command line is not reflected in the
+/// object, which keeps the "any" xnack/sramecc e_flags.
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s -o %t.o 2>&1 | \
+// RUN:   FileCheck -check-prefix=UNUSED %s
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=ANY %s
+
 // RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack+ -c %s -o %t.o
-// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-XNACK-ON %s
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc- -c %s -o %t.o
-// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-SRAMECC-OFF %s
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=ANY %s
 
-// OBJ-XNACK-OFF: EF_AMDGPU_FEATURE_XNACK_OFF_V4 (0x200)
-// OBJ-XNACK-ON: EF_AMDGPU_FEATURE_XNACK_ON_V4 (0x300)
-// OBJ-SRAMECC-OFF: EF_AMDGPU_FEATURE_SRAMECC_OFF_V4 (0x800)
+// UNUSED: warning: argument unused during compilation: '-mno-xnack'
+// ANY: EF_AMDGPU_FEATURE_SRAMECC_ANY_V4 (0x400)
+// ANY: EF_AMDGPU_FEATURE_XNACK_ANY_V4 (0x100)

--- a/lld/test/ELF/amdgpu-tid.s
+++ b/lld/test/ELF/amdgpu-tid.s
@@ -1,16 +1,18 @@
 # REQUIRES: amdgpu
 
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=-xnack --amdhsa-code-object-version=4 -filetype=obj %s -o %t-xnack-off0.o
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=-xnack --amdhsa-code-object-version=4 -filetype=obj %s -o %t-xnack-off1.o
+# RUN: split-file %s %t
+
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/xnack-off.s -o %t-xnack-off0.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/xnack-off.s -o %t-xnack-off1.o
 # RUN: ld.lld -shared %t-xnack-off0.o %t-xnack-off1.o -o %t-xnack-off2.so
 # RUN: llvm-readobj --file-headers %t-xnack-off2.so | FileCheck --check-prefix=XNACK-OFF %s
 
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=+xnack --amdhsa-code-object-version=4 -filetype=obj %s -o %t-xnack-on0.o
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=+xnack --amdhsa-code-object-version=4 -filetype=obj %s -o %t-xnack-on1.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/xnack-on.s -o %t-xnack-on0.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/xnack-on.s -o %t-xnack-on1.o
 # RUN: ld.lld -shared %t-xnack-on0.o %t-xnack-on1.o -o %t-xnack-on2.so
 # RUN: llvm-readobj --file-headers %t-xnack-on2.so | FileCheck --check-prefix=XNACK-ON %s
 
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %s -o %t-xnack-any.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/empty.s -o %t-xnack-any.o
 # RUN: ld.lld -shared %t-xnack-off0.o %t-xnack-any.o -o %t-xnack-off3.so
 # RUN: llvm-readobj --file-headers %t-xnack-off3.so | FileCheck --check-prefix=XNACK-OFF %s
 # RUN: ld.lld -shared %t-xnack-on0.o %t-xnack-any.o -o %t-xnack-on3.so
@@ -22,17 +24,17 @@
 # XNACK-ON:           EF_AMDGPU_FEATURE_XNACK_ON_V4 (0x300)
 # XNACK-INCOMPATIBLE: incompatible xnack:
 
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=-sramecc --amdhsa-code-object-version=4 -filetype=obj %s -o %t-sramecc-off0.o
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=-sramecc --amdhsa-code-object-version=4 -filetype=obj %s -o %t-sramecc-off1.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/sramecc-off.s -o %t-sramecc-off0.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/sramecc-off.s -o %t-sramecc-off1.o
 # RUN: ld.lld -shared %t-sramecc-off0.o %t-sramecc-off1.o -o %t-sramecc-off2.so
 # RUN: llvm-readobj --file-headers %t-sramecc-off2.so | FileCheck --check-prefix=SRAMECC-OFF %s
 
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=+sramecc --amdhsa-code-object-version=4 -filetype=obj %s -o %t-sramecc-on0.o
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa -mattr=+sramecc --amdhsa-code-object-version=4 -filetype=obj %s -o %t-sramecc-on1.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/sramecc-on.s -o %t-sramecc-on0.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/sramecc-on.s -o %t-sramecc-on1.o
 # RUN: ld.lld -shared %t-sramecc-on0.o %t-sramecc-on1.o -o %t-sramecc-on2.so
 # RUN: llvm-readobj --file-headers %t-sramecc-on2.so | FileCheck --check-prefix=SRAMECC-ON %s
 
-# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %s -o %t-sramecc-any.o
+# RUN: llvm-mc -triple amdgpu9.06-amd-amdhsa --amdhsa-code-object-version=4 -filetype=obj %t/empty.s -o %t-sramecc-any.o
 # RUN: ld.lld -shared %t-sramecc-off0.o %t-sramecc-any.o -o %t-sramecc-off3.so
 # RUN: llvm-readobj --file-headers %t-sramecc-off3.so | FileCheck --check-prefix=SRAMECC-OFF %s
 # RUN: ld.lld -shared %t-sramecc-on0.o %t-sramecc-any.o -o %t-sramecc-on3.so
@@ -44,13 +46,13 @@
 # SRAMECC-ON:           EF_AMDGPU_FEATURE_SRAMECC_ON_V4 (0xC00)
 # SRAMECC-INCOMPATIBLE: incompatible sramecc:
 
-# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=1 -filetype=obj %s -o %t-genericv1_0.o
-# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=1 -filetype=obj %s -o %t-genericv1_1.o
+# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=1 -filetype=obj %t/empty.s -o %t-genericv1_0.o
+# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=1 -filetype=obj %t/empty.s -o %t-genericv1_1.o
 # RUN: ld.lld -shared %t-genericv1_0.o %t-genericv1_1.o -o %t-genericv1_2.so
 # RUN: llvm-readobj --file-headers %t-genericv1_2.so | FileCheck --check-prefix=GENERICV1 %s
 
-# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=2 -filetype=obj %s -o %t-genericv2_0.o
-# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=2 -filetype=obj %s -o %t-genericv2_1.o
+# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=2 -filetype=obj %t/empty.s -o %t-genericv2_0.o
+# RUN: llvm-mc -triple amdgpu9.00-amd-amdhsa --amdhsa-code-object-version=6 --amdgpu-force-generic-version=2 -filetype=obj %t/empty.s -o %t-genericv2_1.o
 # RUN: ld.lld -shared %t-genericv2_0.o %t-genericv2_1.o -o %t-genericv2_2.so
 # RUN: llvm-readobj --file-headers %t-genericv2_2.so | FileCheck --check-prefix=GENERICV2 %s
 
@@ -59,3 +61,17 @@
 # GENERICV1:            EF_AMDGPU_GENERIC_VERSION_V1 (0x1000000)
 # GENERICV2:            EF_AMDGPU_GENERIC_VERSION_V2 (0x2000000)
 # GENERIC-INCOMPATIBLE: incompatible generic version
+
+#--- empty.s
+
+#--- xnack-off.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx906:xnack-"
+
+#--- xnack-on.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx906:xnack+"
+
+#--- sramecc-off.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx906:sramecc-"
+
+#--- sramecc-on.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx906:sramecc+"

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1014,6 +1014,13 @@ consumed by the AMDGPU backend during code generation.
        produce an error. Modules with **any** (absent flag) are compatible
        with any setting.
 
+       XNACK is disabled if ``SH_MEM_CONFIG.ADDRESS_MODE = GPUVM`` on chips
+       that support XNACK. The current default kernel driver setting is XNACK
+       disabled on the graphics ring and XNACK enabled on the compute ring.
+       If XNACK is enabled, the VMEM latency can be worse. If XNACK is
+       disabled, the 2 SGPRs otherwise reserved for the XNACK mask can be used
+       for general purposes.
+
    * - ``amdgpu.sramecc``
      - ``i32``
      - Error

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -293,6 +293,14 @@ public:
   static std::optional<TargetID>
   parseTargetIDString(StringRef TargetIDDirective);
 
+  /// Construct a TargetID for triple \p TT and processor \p CPU, taking the
+  /// xnack/sramecc modes from the subtarget \p FeatureString (a comma-separated
+  /// "+xnack,-sramecc" list). Unspecified modes keep the processor's default.
+  /// The assembler uses this because it has no target directive to carry the
+  /// mode.
+  static TargetID createFromSubtargetFeatures(const Triple &TT, StringRef CPU,
+                                              StringRef FeatureString);
+
   /// Returns true if \p Other denotes the same target as *this, i.e. the same
   /// processor and xnack/sramecc settings on a compatible triple. This is a
   /// semantic equality that looks through spelling differences.

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -360,6 +360,14 @@ public:
   static std::optional<TargetID>
   parseTargetIDString(StringRef TargetIDDirective);
 
+  /// Construct a TargetID for triple \p TT and processor \p CPU, taking the
+  /// xnack/sramecc modes from the subtarget \p FeatureString (a comma-separated
+  /// "+xnack,-sramecc" list). Unspecified modes keep the processor's default.
+  /// The assembler uses this because it has no target directive to carry the
+  /// mode.
+  static TargetID createFromSubtargetFeatures(const Triple &TT, StringRef CPU,
+                                              StringRef FeatureString);
+
   /// Returns true if \p Other denotes the same target as *this, i.e. the same
   /// processor and xnack/sramecc settings on a compatible triple. This is a
   /// semantic equality that looks through spelling differences.

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -233,21 +233,6 @@ defm XNACKOnOffModes : AMDGPUSubtargetFeature<"xnack-on-off-modes",
   InlineIgnore
 >;
 
-// XNACK is disabled if SH_MEM_CONFIG.ADDRESS_MODE = GPUVM on chips that support
-// XNACK. The current default kernel driver setting is:
-// - graphics ring: XNACK disabled
-// - compute ring: XNACK enabled
-//
-// If XNACK is enabled, the VMEM latency can be worse.
-// If XNACK is disabled, the 2 SGPRs can be used for general purposes.
-def FeatureXNACK : SubtargetFeature<"xnack",
-  "EnableXNACK",
-  "true",
-  "Enable XNACK support",
-  [FeatureSupportsXNACK],
-  InlineIgnore
->;
-
 // Whether the hardware supports WGP (work-group processor) execution
 // mode, as opposed to the per-kernel CU-mode selection
 // (FeatureCuMode).
@@ -1172,12 +1157,6 @@ def FeatureSupportsSRAMECC : SubtargetFeature<"sramecc-support",
   "true",
   "Hardware supports SRAMECC",
   [], InlineIgnore
->;
-
-def FeatureSRAMECC : SubtargetFeature<"sramecc",
-  "EnableSRAMECC",
-  "true",
-  "Enable SRAMECC"
 >;
 
 defm NoSdstCMPX : AMDGPUSubtargetFeature<"no-sdst-cmpx",
@@ -2451,7 +2430,7 @@ def FeatureISAVersion12_50_Common : FeatureSet<
    FeatureSetPrioIncWgInst,
    FeatureSWakeupBarrier,
    Feature45BitNumRecordsBufferResource,
-   FeatureXNACK,
+   FeatureSupportsXNACK,
    FeatureClusters,
    FeatureD16Writes32BitVgpr,
    FeatureMcastLoadInsts,
@@ -2559,7 +2538,6 @@ def FeatureISAVersion12_5_Generic: FeatureSet<
   [FeatureAddressableLocalMemorySize327680,
    FeatureSetregVGPRMSBFixup,
    FeatureRequiresCOV6,
-   FeatureSupportsXNACK,
    FeatureGFX125xLowestRateWMMA,
    FeatureTransCoexecutionHazard,
    FeatureWMMACoexecutionHazards,
@@ -3018,7 +2996,7 @@ def HasUnrestrictedSOffset : Predicate<"!Subtarget->hasRestrictedSOffset()">,
 
 def D16PreservesUnusedBits :
   Predicate<"Subtarget->d16PreservesUnusedBits()">,
-  AssemblerPredicate<(all_of FeatureGFX9Insts, (not FeatureSRAMECC))>;
+  AssemblerPredicate<(all_of FeatureGFX9Insts, (not FeatureSupportsSRAMECC))>;
 
 def LDSRequiresM0Init : Predicate<"Subtarget->ldsRequiresM0Init()">;
 def NotLDSRequiresM0Init : Predicate<"!Subtarget->ldsRequiresM0Init()">;

--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -223,21 +223,6 @@ defm XNACKOnOffModes : AMDGPUSubtargetFeature<"xnack-on-off-modes",
   InlineIgnore
 >;
 
-// XNACK is disabled if SH_MEM_CONFIG.ADDRESS_MODE = GPUVM on chips that support
-// XNACK. The current default kernel driver setting is:
-// - graphics ring: XNACK disabled
-// - compute ring: XNACK enabled
-//
-// If XNACK is enabled, the VMEM latency can be worse.
-// If XNACK is disabled, the 2 SGPRs can be used for general purposes.
-def FeatureXNACK : SubtargetFeature<"xnack",
-  "EnableXNACK",
-  "true",
-  "Enable XNACK support",
-  [FeatureSupportsXNACK],
-  InlineIgnore
->;
-
 // Whether the hardware supports WGP (work-group processor) execution
 // mode, as opposed to the per-kernel CU-mode selection
 // (FeatureCuMode).
@@ -1145,12 +1130,6 @@ def FeatureSupportsSRAMECC : SubtargetFeature<"sramecc-support",
   "true",
   "Hardware supports SRAMECC",
   [], InlineIgnore
->;
-
-def FeatureSRAMECC : SubtargetFeature<"sramecc",
-  "EnableSRAMECC",
-  "true",
-  "Enable SRAMECC"
 >;
 
 defm NoSdstCMPX : AMDGPUSubtargetFeature<"no-sdst-cmpx",
@@ -2373,7 +2352,7 @@ def FeatureISAVersion12_50_Common : FeatureSet<
    FeatureSetPrioIncWgInst,
    FeatureSWakeupBarrier,
    Feature45BitNumRecordsBufferResource,
-   FeatureXNACK,
+   FeatureSupportsXNACK,
    FeatureClusters,
    FeatureD16Writes32BitVgpr,
    FeatureMcastLoadInsts,
@@ -2451,7 +2430,6 @@ def FeatureISAVersion12_5_Generic: FeatureSet<
   [FeatureAddressableLocalMemorySize327680,
    FeatureSetregVGPRMSBFixup,
    FeatureRequiresCOV6,
-   FeatureSupportsXNACK,
    FeatureGFX125xLowestRateWMMA,
    FeatureTransCoexecutionHazard,
    FeatureWMMACoexecutionHazards,
@@ -2910,7 +2888,7 @@ def HasUnrestrictedSOffset : Predicate<"!Subtarget->hasRestrictedSOffset()">,
 
 def D16PreservesUnusedBits :
   Predicate<"Subtarget->d16PreservesUnusedBits()">,
-  AssemblerPredicate<(all_of FeatureGFX9Insts, (not FeatureSRAMECC))>;
+  AssemblerPredicate<(all_of FeatureGFX9Insts, (not FeatureSupportsSRAMECC))>;
 
 def LDSRequiresM0Init : Predicate<"Subtarget->ldsRequiresM0Init()">;
 def NotLDSRequiresM0Init : Predicate<"!Subtarget->ldsRequiresM0Init()">;

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetParser.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetParser.td
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: These duplicate real SubtargetFeatures and should be unified
-// (e.g. FEATURE_XNACK mirrors FeatureXNACK).
+// (e.g. R600_FEATURE_FMA mirrors FeatureFMA).
 class AMDGPUArchFeature<string spelling> {
   string Spelling = spelling;
 }

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -6297,8 +6297,7 @@ bool AMDGPUAsmParser::ParseDirectiveAMDHSAKernel() {
         return Error(IDRange.Start, "directive requires gfx8+", IDRange);
       if (!isUInt<1>(Val))
         return OutOfRangeError(ValRange);
-      bool XnackOn = getTargetStreamer().getTargetID()->isXnackOnOrAny() ||
-                     getSTI().hasFeature(AMDGPU::FeatureXNACK);
+      bool XnackOn = getTargetStreamer().getTargetID()->isXnackOnOrAny();
       if (Val != XnackOn) {
         return getParser().Error(
             IDRange.Start,

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -6376,8 +6376,7 @@ bool AMDGPUAsmParser::ParseDirectiveAMDHSAKernel() {
         return Error(IDRange.Start, "directive requires gfx8+", IDRange);
       if (!isUInt<1>(Val))
         return OutOfRangeError(ValRange);
-      bool XnackOn = getTargetStreamer().getTargetID()->isXnackOnOrAny() ||
-                     getSTI().hasFeature(AMDGPU::FeatureXNACK);
+      bool XnackOn = getTargetStreamer().getTargetID()->isXnackOnOrAny();
       if (Val != XnackOn) {
         return getParser().Error(
             IDRange.Start,

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -60,6 +60,7 @@ AMDGPUDisassembler::AMDGPUDisassembler(const MCSubtargetInfo &STI,
       MAI(Ctx.getAsmInfo()),
       HwModeRegClass(STI.getHwMode(MCSubtargetInfo::HwMode_RegInfo)),
       TargetMaxInstBytes(MAI.getMaxInstLength(&STI)),
+      TargetID(AMDGPU::createAMDGPUTargetID(STI, "")),
       CodeObjectVersion(AMDGPU::getDefaultAMDHSACodeObjectVersion()) {
   // ToDo: AMDGPUDisassembler supports only VI ISA.
   if (!STI.hasFeature(AMDGPU::FeatureGCN3Encoding) && !isGFX10Plus())
@@ -103,27 +104,40 @@ void AMDGPUDisassembler::emitTargetIDIfSupported(raw_ostream &OS,
     unsigned SrameccSetting = EFlags & ELF::EF_AMDGPU_FEATURE_SRAMECC_V4;
     switch (SrameccSetting) {
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_UNSUPPORTED_V4:
+      break;
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_ANY_V4:
+      TargetID.setSramEccSetting(AMDGPU::TargetIDSetting::Any);
       break;
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_OFF_V4:
+      TargetID.setSramEccSetting(AMDGPU::TargetIDSetting::Off);
       OS << ":sramecc-";
       break;
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_ON_V4:
+      TargetID.setSramEccSetting(AMDGPU::TargetIDSetting::On);
       OS << ":sramecc+";
       break;
     }
 
+    // Targets that hardwire xnack on (e.g. gfx1250) don't expose it as a
+    // selectable modifier, so don't print it.
+    bool XnackHardwiredOn = TargetID.isXnackSupported() &&
+                            !STI.hasFeature(AMDGPU::FeatureXNACKOnOffModes);
     unsigned XnackSetting = EFlags & ELF::EF_AMDGPU_FEATURE_XNACK_V4;
     switch (XnackSetting) {
     case ELF::EF_AMDGPU_FEATURE_XNACK_UNSUPPORTED_V4:
+      break;
     case ELF::EF_AMDGPU_FEATURE_XNACK_ANY_V4:
+      TargetID.setXnackSetting(AMDGPU::TargetIDSetting::Any);
       break;
     case ELF::EF_AMDGPU_FEATURE_XNACK_OFF_V4:
-      OS << ":xnack-";
+      TargetID.setXnackSetting(AMDGPU::TargetIDSetting::Off);
+      if (!XnackHardwiredOn)
+        OS << ":xnack-";
       break;
     case ELF::EF_AMDGPU_FEATURE_XNACK_ON_V4:
-      OS << ":xnack+";
-      XnackOnFromEFlags = true;
+      TargetID.setXnackSetting(AMDGPU::TargetIDSetting::On);
+      if (!XnackHardwiredOn)
+        OS << ":xnack+";
       break;
     }
   }
@@ -2604,8 +2618,7 @@ Expected<bool> AMDGPUDisassembler::decodeCOMPUTE_PGM_RSRC1(
   // Only print the directive on xnack-supporting targets (matching the
   // asmprinter), unless the binary erronously set xnack on an unsupported
   // target
-  bool ReservedXnackMask =
-      STI.hasFeature(AMDGPU::FeatureXNACK) || XnackOnFromEFlags;
+  bool ReservedXnackMask = TargetID.isXnackOnOrAny();
   if (STI.hasFeature(AMDGPU::FeatureSupportsXNACK) || ReservedXnackMask) {
     KdStream << Indent << ".amdhsa_reserve_xnack_mask " << ReservedXnackMask
              << '\n';

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -60,6 +60,7 @@ AMDGPUDisassembler::AMDGPUDisassembler(const MCSubtargetInfo &STI,
       MAI(Ctx.getAsmInfo()),
       HwModeRegClass(STI.getHwMode(MCSubtargetInfo::HwMode_RegInfo)),
       TargetMaxInstBytes(MAI.getMaxInstLength(&STI)),
+      TargetID(AMDGPU::createAMDGPUTargetID(STI, "")),
       CodeObjectVersion(AMDGPU::getDefaultAMDHSACodeObjectVersion()) {
   // ToDo: AMDGPUDisassembler supports only VI ISA.
   if (!STI.hasFeature(AMDGPU::FeatureGCN3Encoding) && !isGFX10Plus())
@@ -103,27 +104,40 @@ void AMDGPUDisassembler::emitTargetIDIfSupported(raw_ostream &OS,
     unsigned SrameccSetting = EFlags & ELF::EF_AMDGPU_FEATURE_SRAMECC_V4;
     switch (SrameccSetting) {
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_UNSUPPORTED_V4:
+      break;
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_ANY_V4:
+      TargetID.setSramEccSetting(AMDGPU::TargetIDSetting::Any);
       break;
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_OFF_V4:
+      TargetID.setSramEccSetting(AMDGPU::TargetIDSetting::Off);
       OS << ":sramecc-";
       break;
     case ELF::EF_AMDGPU_FEATURE_SRAMECC_ON_V4:
+      TargetID.setSramEccSetting(AMDGPU::TargetIDSetting::On);
       OS << ":sramecc+";
       break;
     }
 
+    // Targets that hardwire xnack on (e.g. gfx1250) don't expose it as a
+    // selectable modifier, so don't print it.
+    bool XnackHardwiredOn = TargetID.isXnackSupported() &&
+                            !STI.hasFeature(AMDGPU::FeatureXNACKOnOffModes);
     unsigned XnackSetting = EFlags & ELF::EF_AMDGPU_FEATURE_XNACK_V4;
     switch (XnackSetting) {
     case ELF::EF_AMDGPU_FEATURE_XNACK_UNSUPPORTED_V4:
+      break;
     case ELF::EF_AMDGPU_FEATURE_XNACK_ANY_V4:
+      TargetID.setXnackSetting(AMDGPU::TargetIDSetting::Any);
       break;
     case ELF::EF_AMDGPU_FEATURE_XNACK_OFF_V4:
-      OS << ":xnack-";
+      TargetID.setXnackSetting(AMDGPU::TargetIDSetting::Off);
+      if (!XnackHardwiredOn)
+        OS << ":xnack-";
       break;
     case ELF::EF_AMDGPU_FEATURE_XNACK_ON_V4:
-      OS << ":xnack+";
-      XnackOnFromEFlags = true;
+      TargetID.setXnackSetting(AMDGPU::TargetIDSetting::On);
+      if (!XnackHardwiredOn)
+        OS << ":xnack+";
       break;
     }
   }
@@ -2576,8 +2590,7 @@ Expected<bool> AMDGPUDisassembler::decodeCOMPUTE_PGM_RSRC1(
   // Only print the directive on xnack-supporting targets (matching the
   // asmprinter), unless the binary erronously set xnack on an unsupported
   // target
-  bool ReservedXnackMask =
-      STI.hasFeature(AMDGPU::FeatureXNACK) || XnackOnFromEFlags;
+  bool ReservedXnackMask = TargetID.isXnackOnOrAny();
   if (STI.hasFeature(AMDGPU::FeatureSupportsXNACK) || ReservedXnackMask) {
     KdStream << Indent << ".amdhsa_reserve_xnack_mask " << ReservedXnackMask
              << '\n';

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -22,6 +22,7 @@
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/Support/DataExtractor.h"
+#include "llvm/TargetParser/AMDGPUTargetParser.h"
 #include <memory>
 
 namespace llvm {
@@ -47,9 +48,7 @@ private:
   mutable uint64_t Literal;
   mutable bool HasLiteral;
   mutable std::optional<bool> EnableWavefrontSize32;
-
-  // If the object's ELF e_flags enable xnack. TODO: Replace with TargetID
-  mutable bool XnackOnFromEFlags = false;
+  mutable AMDGPU::TargetID TargetID;
   unsigned CodeObjectVersion;
   const MCExpr *UCVersionW64Expr;
   const MCExpr *UCVersionW32Expr;

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -349,9 +349,7 @@ public:
     return HasUnalignedScratchAccess && HasUnalignedAccessMode;
   }
 
-  bool isXNACKEnabled() const {
-    return enableXNACK() || TargetID.isXnackOnOrAny();
-  }
+  bool isXNACKEnabled() const { return TargetID.isXnackOnOrAny(); }
 
   bool hasRelaxedBufferOOBMode() const { return BufferOOBRelaxed; }
   bool hasRelaxedTBufferOOBMode() const { return TBufferOOBRelaxed; }

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -344,9 +344,7 @@ public:
     return HasUnalignedScratchAccess && HasUnalignedAccessMode;
   }
 
-  bool isXNACKEnabled() const {
-    return enableXNACK() || TargetID.isXnackOnOrAny();
-  }
+  bool isXNACKEnabled() const { return TargetID.isXnackOnOrAny(); }
 
   bool hasRelaxedBufferOOBMode() const { return BufferOOBRelaxed; }
   bool hasRelaxedTBufferOOBMode() const { return TBufferOOBRelaxed; }

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -566,8 +566,7 @@ void AMDGPUTargetAsmStreamer::EmitAmdhsaKernelDescriptor(
   case AMDGPU::AMDHSA_COV4:
   case AMDGPU::AMDHSA_COV5:
     if (STI.hasFeature(AMDGPU::FeatureSupportsXNACK)) {
-      bool XnackOn = getTargetID()->isXnackOnOrAny() ||
-                     STI.hasFeature(AMDGPU::FeatureXNACK);
+      bool XnackOn = getTargetID()->isXnackOnOrAny();
       OS << "\t\t.amdhsa_reserve_xnack_mask " << XnackOn << '\n';
     }
     break;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -568,8 +568,7 @@ void AMDGPUTargetAsmStreamer::EmitAmdhsaKernelDescriptor(
   case AMDGPU::AMDHSA_COV4:
   case AMDGPU::AMDHSA_COV5:
     if (STI.hasFeature(AMDGPU::FeatureSupportsXNACK)) {
-      bool XnackOn = getTargetID()->isXnackOnOrAny() ||
-                     STI.hasFeature(AMDGPU::FeatureXNACK);
+      bool XnackOn = getTargetID()->isXnackOnOrAny();
       OS << "\t\t.amdhsa_reserve_xnack_mask " << XnackOn << '\n';
     }
     break;

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1086,25 +1086,11 @@ VOPD::InstInfo getVOPDInstInfo(unsigned VOPDOpcode,
 
 TargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
                               StringRef FeatureString) {
-  // xnack/sramecc are derived from capability features alone; the actual mode
-  // comes later from module flags / directives / e_flags. A target supporting
-  // xnack without on/off modes has it hardwired On (gfx1250).
-  bool SupportsXNACK = STI.getFeatureBits().test(FeatureSupportsXNACK);
-  bool XNACKOnOffModes = STI.getFeatureBits().test(FeatureXNACKOnOffModes);
-
-  TargetIDSetting XnackSetting;
-  if (!SupportsXNACK)
-    XnackSetting = TargetIDSetting::Unsupported;
-  else if (XNACKOnOffModes)
-    XnackSetting = TargetIDSetting::Any;
-  else
-    XnackSetting = TargetIDSetting::On;
-
-  return TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
-                  XnackSetting,
-                  STI.getFeatureBits().test(FeatureSupportsSRAMECC)
-                      ? TargetIDSetting::Any
-                      : TargetIDSetting::Unsupported);
+  // In codegen the mode comes from module flags and FeatureString is empty, so
+  // the processor defaults apply. The assembler has no target directive, so it
+  // pins the mode via the +xnack/-xnack/+sramecc/-sramecc feature string.
+  return TargetID::createFromSubtargetFeatures(STI.getTargetTriple(),
+                                               STI.getCPU(), FeatureString);
 }
 
 namespace IsaInfo {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1086,75 +1086,25 @@ VOPD::InstInfo getVOPDInstInfo(unsigned VOPDOpcode,
 
 TargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
                               StringRef FeatureString) {
-  TargetID TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
-                    STI.getFeatureBits().test(FeatureXNACKOnOffModes)
-                        ? TargetIDSetting::Any
-                        : TargetIDSetting::Unsupported,
-                    STI.getFeatureBits().test(FeatureSupportsSRAMECC)
-                        ? TargetIDSetting::Any
-                        : TargetIDSetting::Unsupported);
+  // xnack/sramecc are derived from capability features alone; the actual mode
+  // comes later from module flags / directives / e_flags. A target supporting
+  // xnack without on/off modes has it hardwired On (gfx1250).
+  bool SupportsXNACK = STI.getFeatureBits().test(FeatureSupportsXNACK);
+  bool XNACKOnOffModes = STI.getFeatureBits().test(FeatureXNACKOnOffModes);
 
-  // Check if xnack or sramecc is explicitly enabled or disabled.  In the
-  // absence of the target features we assume we must generate code that can run
-  // in any environment.
-  SubtargetFeatures Features(FeatureString);
-  std::optional<bool> XnackRequested;
-  std::optional<bool> SramEccRequested;
+  TargetIDSetting XnackSetting;
+  if (!SupportsXNACK)
+    XnackSetting = TargetIDSetting::Unsupported;
+  else if (XNACKOnOffModes)
+    XnackSetting = TargetIDSetting::Any;
+  else
+    XnackSetting = TargetIDSetting::On;
 
-  for (const std::string &Feature : Features.getFeatures()) {
-    if (Feature == "+xnack")
-      XnackRequested = true;
-    else if (Feature == "-xnack")
-      XnackRequested = false;
-    else if (Feature == "+sramecc")
-      SramEccRequested = true;
-    else if (Feature == "-sramecc")
-      SramEccRequested = false;
-  }
-
-  // Only allow changing xnack setting if the target supports on/off modes.
-  // Targets without on/off mode support keep their initial setting
-  // (Unsupported).
-
-  bool XnackSupported = STI.getFeatureBits().test(FeatureXNACKOnOffModes);
-  bool SramEccSupported = TargetID.isSramEccSupported();
-
-  if (XnackRequested) {
-    if (XnackSupported) {
-      TargetID.setXnackSetting(*XnackRequested ? TargetIDSetting::On
-                                               : TargetIDSetting::Off);
-    } else {
-      // If a specific xnack setting was requested and this GPU does not support
-      // xnack emit a warning. Setting will remain set to "Unsupported".
-      if (*XnackRequested) {
-        errs() << "warning: xnack 'On' was requested for a processor that does "
-                  "not support it!\n";
-      } else {
-        errs() << "warning: xnack 'Off' was requested for a processor that "
-                  "does not support it!\n";
-      }
-    }
-  }
-
-  if (SramEccRequested) {
-    if (SramEccSupported) {
-      TargetID.setSramEccSetting(*SramEccRequested ? TargetIDSetting::On
-                                                   : TargetIDSetting::Off);
-    } else {
-      // If a specific sramecc setting was requested and this GPU does not
-      // support sramecc emit a warning. Setting will remain set to
-      // "Unsupported".
-      if (*SramEccRequested) {
-        errs() << "warning: sramecc 'On' was requested for a processor that "
-                  "does not support it!\n";
-      } else {
-        errs() << "warning: sramecc 'Off' was requested for a processor that "
-                  "does not support it!\n";
-      }
-    }
-  }
-
-  return TargetID;
+  return TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
+                  XnackSetting,
+                  STI.getFeatureBits().test(FeatureSupportsSRAMECC)
+                      ? TargetIDSetting::Any
+                      : TargetIDSetting::Unsupported);
 }
 
 namespace IsaInfo {
@@ -1364,8 +1314,11 @@ unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
 
 unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
                           bool FlatScrUsed) {
-  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed,
-                          STI.getFeatureBits().test(AMDGPU::FeatureXNACK));
+  // Without a TargetID mode, only hardwired-on xnack (gfx1250) is knowable from
+  // the subtarget, and it reserves SGPRs.
+  bool XNACKUsed = STI.getFeatureBits().test(AMDGPU::FeatureSupportsXNACK) &&
+                   !STI.getFeatureBits().test(AMDGPU::FeatureXNACKOnOffModes);
+  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, XNACKUsed);
 }
 
 static unsigned getGranulatedNumRegisterBlocks(unsigned NumRegs,
@@ -2489,7 +2442,10 @@ unsigned getDynamicVGPRBlockSize(const Function &F) {
 }
 
 bool hasXNACK(const MCSubtargetInfo &STI) {
-  return STI.hasFeature(AMDGPU::FeatureXNACK);
+  // Only hardwired-on xnack (gfx1250) is knowable from the subtarget alone;
+  // toggleable targets take their mode from the TargetID.
+  return STI.hasFeature(AMDGPU::FeatureSupportsXNACK) &&
+         !STI.hasFeature(AMDGPU::FeatureXNACKOnOffModes);
 }
 
 bool hasMIMG_R128(const MCSubtargetInfo &STI) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1300,11 +1300,7 @@ unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
 
 unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
                           bool FlatScrUsed) {
-  // Without a TargetID mode, only hardwired-on xnack (gfx1250) is knowable from
-  // the subtarget, and it reserves SGPRs.
-  bool XNACKUsed = STI.getFeatureBits().test(AMDGPU::FeatureSupportsXNACK) &&
-                   !STI.getFeatureBits().test(AMDGPU::FeatureXNACKOnOffModes);
-  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, XNACKUsed);
+  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, hasXNACK(STI));
 }
 
 static unsigned getGranulatedNumRegisterBlocks(unsigned NumRegs,

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1298,11 +1298,6 @@ unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
   return ExtraSGPRs;
 }
 
-unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
-                          bool FlatScrUsed) {
-  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, hasXNACK(STI));
-}
-
 static unsigned getGranulatedNumRegisterBlocks(unsigned NumRegs,
                                                unsigned Granule) {
   return divideCeil(std::max(1u, NumRegs), Granule);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1284,11 +1284,7 @@ unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
 
 unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
                           bool FlatScrUsed) {
-  // Without a TargetID mode, only hardwired-on xnack (gfx1250) is knowable from
-  // the subtarget, and it reserves SGPRs.
-  bool XNACKUsed = STI.getFeatureBits().test(AMDGPU::FeatureSupportsXNACK) &&
-                   !STI.getFeatureBits().test(AMDGPU::FeatureXNACKOnOffModes);
-  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, XNACKUsed);
+  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, hasXNACK(STI));
 }
 
 static unsigned getGranulatedNumRegisterBlocks(unsigned NumRegs,

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1086,75 +1086,25 @@ VOPD::InstInfo getVOPDInstInfo(unsigned VOPDOpcode,
 
 TargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
                               StringRef FeatureString) {
-  TargetID TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
-                    STI.getFeatureBits().test(FeatureXNACKOnOffModes)
-                        ? TargetIDSetting::Any
-                        : TargetIDSetting::Unsupported,
-                    STI.getFeatureBits().test(FeatureSupportsSRAMECC)
-                        ? TargetIDSetting::Any
-                        : TargetIDSetting::Unsupported);
+  // xnack/sramecc are derived from capability features alone; the actual mode
+  // comes later from module flags / directives / e_flags. A target supporting
+  // xnack without on/off modes has it hardwired On (gfx1250).
+  bool SupportsXNACK = STI.getFeatureBits().test(FeatureSupportsXNACK);
+  bool XNACKOnOffModes = STI.getFeatureBits().test(FeatureXNACKOnOffModes);
 
-  // Check if xnack or sramecc is explicitly enabled or disabled.  In the
-  // absence of the target features we assume we must generate code that can run
-  // in any environment.
-  SubtargetFeatures Features(FeatureString);
-  std::optional<bool> XnackRequested;
-  std::optional<bool> SramEccRequested;
+  TargetIDSetting XnackSetting;
+  if (!SupportsXNACK)
+    XnackSetting = TargetIDSetting::Unsupported;
+  else if (XNACKOnOffModes)
+    XnackSetting = TargetIDSetting::Any;
+  else
+    XnackSetting = TargetIDSetting::On;
 
-  for (const std::string &Feature : Features.getFeatures()) {
-    if (Feature == "+xnack")
-      XnackRequested = true;
-    else if (Feature == "-xnack")
-      XnackRequested = false;
-    else if (Feature == "+sramecc")
-      SramEccRequested = true;
-    else if (Feature == "-sramecc")
-      SramEccRequested = false;
-  }
-
-  // Only allow changing xnack setting if the target supports on/off modes.
-  // Targets without on/off mode support keep their initial setting
-  // (Unsupported).
-
-  bool XnackSupported = STI.getFeatureBits().test(FeatureXNACKOnOffModes);
-  bool SramEccSupported = TargetID.isSramEccSupported();
-
-  if (XnackRequested) {
-    if (XnackSupported) {
-      TargetID.setXnackSetting(*XnackRequested ? TargetIDSetting::On
-                                               : TargetIDSetting::Off);
-    } else {
-      // If a specific xnack setting was requested and this GPU does not support
-      // xnack emit a warning. Setting will remain set to "Unsupported".
-      if (*XnackRequested) {
-        errs() << "warning: xnack 'On' was requested for a processor that does "
-                  "not support it!\n";
-      } else {
-        errs() << "warning: xnack 'Off' was requested for a processor that "
-                  "does not support it!\n";
-      }
-    }
-  }
-
-  if (SramEccRequested) {
-    if (SramEccSupported) {
-      TargetID.setSramEccSetting(*SramEccRequested ? TargetIDSetting::On
-                                                   : TargetIDSetting::Off);
-    } else {
-      // If a specific sramecc setting was requested and this GPU does not
-      // support sramecc emit a warning. Setting will remain set to
-      // "Unsupported".
-      if (*SramEccRequested) {
-        errs() << "warning: sramecc 'On' was requested for a processor that "
-                  "does not support it!\n";
-      } else {
-        errs() << "warning: sramecc 'Off' was requested for a processor that "
-                  "does not support it!\n";
-      }
-    }
-  }
-
-  return TargetID;
+  return TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
+                  XnackSetting,
+                  STI.getFeatureBits().test(FeatureSupportsSRAMECC)
+                      ? TargetIDSetting::Any
+                      : TargetIDSetting::Unsupported);
 }
 
 namespace IsaInfo {
@@ -1348,8 +1298,11 @@ unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
 
 unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
                           bool FlatScrUsed) {
-  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed,
-                          STI.getFeatureBits().test(AMDGPU::FeatureXNACK));
+  // Without a TargetID mode, only hardwired-on xnack (gfx1250) is knowable from
+  // the subtarget, and it reserves SGPRs.
+  bool XNACKUsed = STI.getFeatureBits().test(AMDGPU::FeatureSupportsXNACK) &&
+                   !STI.getFeatureBits().test(AMDGPU::FeatureXNACKOnOffModes);
+  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, XNACKUsed);
 }
 
 static unsigned getGranulatedNumRegisterBlocks(unsigned NumRegs,
@@ -2470,7 +2423,10 @@ unsigned getDynamicVGPRBlockSize(const Function &F) {
 }
 
 bool hasXNACK(const MCSubtargetInfo &STI) {
-  return STI.hasFeature(AMDGPU::FeatureXNACK);
+  // Only hardwired-on xnack (gfx1250) is knowable from the subtarget alone;
+  // toggleable targets take their mode from the TargetID.
+  return STI.hasFeature(AMDGPU::FeatureSupportsXNACK) &&
+         !STI.hasFeature(AMDGPU::FeatureXNACKOnOffModes);
 }
 
 bool hasMIMG_R128(const MCSubtargetInfo &STI) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1282,11 +1282,6 @@ unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
   return ExtraSGPRs;
 }
 
-unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
-                          bool FlatScrUsed) {
-  return getNumExtraSGPRs(STI, VCCUsed, FlatScrUsed, hasXNACK(STI));
-}
-
 static unsigned getGranulatedNumRegisterBlocks(unsigned NumRegs,
                                                unsigned Granule) {
   return divideCeil(std::max(1u, NumRegs), Granule);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -215,12 +215,6 @@ unsigned getMaxNumSGPRs(const MCSubtargetInfo &STI, unsigned WavesPerEU,
 unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
                           bool FlatScrUsed, bool XNACKUsed);
 
-/// \returns Number of extra SGPRs implicitly required by given subtarget \p
-/// STI when the given special registers are used. XNACK is inferred from
-/// \p STI.
-unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
-                          bool FlatScrUsed);
-
 /// \returns Number of SGPR blocks needed for given subtarget \p STI when
 /// \p NumSGPRs are used. \p NumSGPRs should already include any special
 /// register counts.

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -236,12 +236,6 @@ unsigned getMaxNumSGPRs(const MCSubtargetInfo &STI, unsigned WavesPerEU,
 unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
                           bool FlatScrUsed, bool XNACKUsed);
 
-/// \returns Number of extra SGPRs implicitly required by given subtarget \p
-/// STI when the given special registers are used. XNACK is inferred from
-/// \p STI.
-unsigned getNumExtraSGPRs(const MCSubtargetInfo &STI, bool VCCUsed,
-                          bool FlatScrUsed);
-
 /// \returns Number of SGPR blocks needed for given subtarget \p STI when
 /// \p NumSGPRs are used. \p NumSGPRs should already include any special
 /// register counts.

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -598,14 +598,11 @@ static GPUKind getGPUKindFromTargetID(const Triple &TT, StringRef TargetIDStr) {
              : parseArchAMDGCN(CPUName);
 }
 
-// Compute the xnack/sramecc settings for processor \p Arch from the
-// processor+features string \p TargetIDStr
-// (e.g. "gfx90a:xnack+:sramecc-"). Returns false if a modifier names an unknown
-// or repeated feature, names one the processor does not support, or has a
-// malformed sign.
-static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
-                                    TargetIDSetting &XnackSetting,
-                                    TargetIDSetting &SramEccSetting) {
+// Compute the default xnack/sramecc settings for processor \p Arch, before any
+// explicit feature modifiers are applied.
+static void getDefaultTargetIDFeatures(GPUKind Arch,
+                                       TargetIDSetting &XnackSetting,
+                                       TargetIDSetting &SramEccSetting) {
   const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
   // xnack with on/off modes defaults to Any; supported without on/off modes is
   // hardwired On (e.g. gfx1250); unsupported is Unsupported.
@@ -618,6 +615,18 @@ static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
   SramEccSetting = Features.test(FEAT_SRAMECC_SUPPORT)
                        ? TargetIDSetting::Any
                        : TargetIDSetting::Unsupported;
+}
+
+// Compute the xnack/sramecc settings for processor \p Arch from the
+// processor+features string \p TargetIDStr
+// (e.g. "gfx90a:xnack+:sramecc-"). Returns false if a modifier names an unknown
+// or repeated feature, names one the processor does not support, or has a
+// malformed sign.
+static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
+                                    TargetIDSetting &XnackSetting,
+                                    TargetIDSetting &SramEccSetting) {
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
+  getDefaultTargetIDFeatures(Arch, XnackSetting, SramEccSetting);
 
   // The first component is the processor; the rest are feature modifiers of the
   // form "<feature><+|->".
@@ -660,6 +669,33 @@ TargetID::TargetID(const Triple &TT, StringRef TargetIDStr)
   // Derive the feature settings from the string. Validity is not checked here;
   // parseTargetIDString validates untrusted input.
   computeTargetIDFeatures(Arch, TargetIDStr, XnackSetting, SramEccSetting);
+}
+
+TargetID TargetID::createFromSubtargetFeatures(const Triple &TT, StringRef CPU,
+                                               StringRef FeatureString) {
+  GPUKind Arch = parseArchAMDGCN(CPU);
+  TargetIDSetting XnackSetting, SramEccSetting;
+  getDefaultTargetIDFeatures(Arch, XnackSetting, SramEccSetting);
+
+  // Apply the +/-xnack and +/-sramecc modifiers from the feature string, only
+  // for targets that can toggle the corresponding mode.
+  bool XnackToggleable = XnackSetting == TargetIDSetting::Any;
+  bool SramEccToggleable = SramEccSetting != TargetIDSetting::Unsupported;
+  SmallVector<StringRef, 4> Features;
+  FeatureString.split(Features, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef Feature : Features) {
+    TargetIDSetting Sign =
+        getTargetIDSettingFromFeatureString(Feature.take_front());
+    if (Sign == TargetIDSetting::Unsupported)
+      continue;
+    StringRef Name = Feature.drop_front();
+    if (Name == "xnack" && XnackToggleable)
+      XnackSetting = Sign;
+    else if (Name == "sramecc" && SramEccToggleable)
+      SramEccSetting = Sign;
+  }
+
+  return TargetID(Arch, TT, XnackSetting, SramEccSetting);
 }
 
 std::optional<TargetID> TargetID::parse(const Triple &TT,

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -680,7 +680,7 @@ TargetID TargetID::createFromSubtargetFeatures(const Triple &TT, StringRef CPU,
   // Apply the +/-xnack and +/-sramecc modifiers from the feature string, only
   // for targets that can toggle the corresponding mode.
   bool XnackToggleable = XnackSetting == TargetIDSetting::Any;
-  bool SramEccToggleable = SramEccSetting != TargetIDSetting::Unsupported;
+  bool SramEccToggleable = SramEccSetting == TargetIDSetting::Any;
   SmallVector<StringRef, 4> Features;
   FeatureString.split(Features, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
   for (StringRef Feature : Features) {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -607,9 +607,14 @@ static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
                                     TargetIDSetting &XnackSetting,
                                     TargetIDSetting &SramEccSetting) {
   const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
-  XnackSetting = Features.test(FEAT_XNACK_ON_OFF_MODES)
-                     ? TargetIDSetting::Any
-                     : TargetIDSetting::Unsupported;
+  // xnack with on/off modes defaults to Any; supported without on/off modes is
+  // hardwired On (e.g. gfx1250); unsupported is Unsupported.
+  if (!Features.test(FEAT_XNACK_SUPPORT))
+    XnackSetting = TargetIDSetting::Unsupported;
+  else if (Features.test(FEAT_XNACK_ON_OFF_MODES))
+    XnackSetting = TargetIDSetting::Any;
+  else
+    XnackSetting = TargetIDSetting::On;
   SramEccSetting = Features.test(FEAT_SRAMECC_SUPPORT)
                        ? TargetIDSetting::Any
                        : TargetIDSetting::Unsupported;
@@ -625,7 +630,9 @@ static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
     StringRef FeatureString = Split[I];
     if (FeatureString.consume_front("xnack")) {
       TargetIDSetting Sign = getTargetIDSettingFromFeatureString(FeatureString);
-      if (SeenXnack || XnackSetting == TargetIDSetting::Unsupported ||
+      // An xnack modifier is only valid with on/off modes: rejected when xnack
+      // is unsupported or hardwired on (e.g. gfx1250).
+      if (SeenXnack || !Features.test(FEAT_XNACK_ON_OFF_MODES) ||
           Sign == TargetIDSetting::Unsupported)
         Valid = false;
       else
@@ -696,14 +703,27 @@ TargetID::parseTargetIDString(StringRef TargetIDDirective) {
   return parse(Triple(Parts[0], Parts[1], Parts[2], Parts[3]), Parts[4]);
 }
 
+// Returns true if \p Arch hardwires xnack on (supports xnack but has no on/off
+// modes, e.g. gfx1250), so xnack is not a selectable target-id modifier.
+static bool isXnackHardwiredOn(GPUKind Arch) {
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
+  return Features.test(FEAT_XNACK_SUPPORT) &&
+         !Features.test(FEAT_XNACK_ON_OFF_MODES);
+}
+
 // Append the explicit (On/Off) sramecc/xnack feature modifiers in canonical
-// order, e.g. ":sramecc-:xnack+".
+// order, e.g. ":sramecc-:xnack+". Xnack is never emitted for hardwired-on
+// targets.
 static void printFeatureModifiers(raw_ostream &OS, TargetIDSetting SramEcc,
-                                  TargetIDSetting Xnack) {
+                                  TargetIDSetting Xnack,
+                                  bool XnackHardwiredOn) {
   if (SramEcc == TargetIDSetting::Off)
     OS << ":sramecc-";
   else if (SramEcc == TargetIDSetting::On)
     OS << ":sramecc+";
+
+  if (XnackHardwiredOn)
+    return;
 
   if (Xnack == TargetIDSetting::Off)
     OS << ":xnack-";
@@ -715,7 +735,8 @@ void TargetID::print(raw_ostream &StreamRep) const {
   StreamRep << TargetTripleString << '-' << getArchNameAMDGCN(Arch);
 
   if (IsAMDHSA)
-    printFeatureModifiers(StreamRep, getSramEccSetting(), getXnackSetting());
+    printFeatureModifiers(StreamRep, getSramEccSetting(), getXnackSetting(),
+                          isXnackHardwiredOn(Arch));
 }
 
 std::string TargetID::toString() const {
@@ -727,7 +748,8 @@ std::string TargetID::toString() const {
 
 void TargetID::printCanonicalTargetIDString(raw_ostream &OS) const {
   OS << getArchNameAMDGCN(Arch);
-  printFeatureModifiers(OS, getSramEccSetting(), getXnackSetting());
+  printFeatureModifiers(OS, getSramEccSetting(), getXnackSetting(),
+                        isXnackHardwiredOn(Arch));
 }
 
 std::string TargetID::getCanonicalFeatureString() const {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -704,9 +704,14 @@ static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
                                     TargetIDSetting &XnackSetting,
                                     TargetIDSetting &SramEccSetting) {
   const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
-  XnackSetting = Features.test(FEAT_XNACK_ON_OFF_MODES)
-                     ? TargetIDSetting::Any
-                     : TargetIDSetting::Unsupported;
+  // xnack with on/off modes defaults to Any; supported without on/off modes is
+  // hardwired On (e.g. gfx1250); unsupported is Unsupported.
+  if (!Features.test(FEAT_XNACK_SUPPORT))
+    XnackSetting = TargetIDSetting::Unsupported;
+  else if (Features.test(FEAT_XNACK_ON_OFF_MODES))
+    XnackSetting = TargetIDSetting::Any;
+  else
+    XnackSetting = TargetIDSetting::On;
   SramEccSetting = Features.test(FEAT_SRAMECC_SUPPORT)
                        ? TargetIDSetting::Any
                        : TargetIDSetting::Unsupported;
@@ -722,7 +727,9 @@ static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
     StringRef FeatureString = Split[I];
     if (FeatureString.consume_front("xnack")) {
       TargetIDSetting Sign = getTargetIDSettingFromFeatureString(FeatureString);
-      if (SeenXnack || XnackSetting == TargetIDSetting::Unsupported ||
+      // An xnack modifier is only valid with on/off modes: rejected when xnack
+      // is unsupported or hardwired on (e.g. gfx1250).
+      if (SeenXnack || !Features.test(FEAT_XNACK_ON_OFF_MODES) ||
           Sign == TargetIDSetting::Unsupported)
         Valid = false;
       else
@@ -793,14 +800,27 @@ TargetID::parseTargetIDString(StringRef TargetIDDirective) {
   return parse(Triple(Parts[0], Parts[1], Parts[2], Parts[3]), Parts[4]);
 }
 
+// Returns true if \p Arch hardwires xnack on (supports xnack but has no on/off
+// modes, e.g. gfx1250), so xnack is not a selectable target-id modifier.
+static bool isXnackHardwiredOn(GPUKind Arch) {
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
+  return Features.test(FEAT_XNACK_SUPPORT) &&
+         !Features.test(FEAT_XNACK_ON_OFF_MODES);
+}
+
 // Append the explicit (On/Off) sramecc/xnack feature modifiers in canonical
-// order, e.g. ":sramecc-:xnack+".
+// order, e.g. ":sramecc-:xnack+". Xnack is never emitted for hardwired-on
+// targets.
 static void printFeatureModifiers(raw_ostream &OS, TargetIDSetting SramEcc,
-                                  TargetIDSetting Xnack) {
+                                  TargetIDSetting Xnack,
+                                  bool XnackHardwiredOn) {
   if (SramEcc == TargetIDSetting::Off)
     OS << ":sramecc-";
   else if (SramEcc == TargetIDSetting::On)
     OS << ":sramecc+";
+
+  if (XnackHardwiredOn)
+    return;
 
   if (Xnack == TargetIDSetting::Off)
     OS << ":xnack-";
@@ -812,7 +832,8 @@ void TargetID::print(raw_ostream &StreamRep) const {
   StreamRep << TargetTripleString << '-' << getArchNameAMDGCN(Arch);
 
   if (IsAMDHSA)
-    printFeatureModifiers(StreamRep, getSramEccSetting(), getXnackSetting());
+    printFeatureModifiers(StreamRep, getSramEccSetting(), getXnackSetting(),
+                          isXnackHardwiredOn(Arch));
 }
 
 std::string TargetID::toString() const {
@@ -824,7 +845,8 @@ std::string TargetID::toString() const {
 
 void TargetID::printCanonicalTargetIDString(raw_ostream &OS) const {
   OS << getArchNameAMDGCN(Arch);
-  printFeatureModifiers(OS, getSramEccSetting(), getXnackSetting());
+  printFeatureModifiers(OS, getSramEccSetting(), getXnackSetting(),
+                        isXnackHardwiredOn(Arch));
 }
 
 std::string TargetID::getCanonicalFeatureString() const {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -777,7 +777,7 @@ TargetID TargetID::createFromSubtargetFeatures(const Triple &TT, StringRef CPU,
   // Apply the +/-xnack and +/-sramecc modifiers from the feature string, only
   // for targets that can toggle the corresponding mode.
   bool XnackToggleable = XnackSetting == TargetIDSetting::Any;
-  bool SramEccToggleable = SramEccSetting != TargetIDSetting::Unsupported;
+  bool SramEccToggleable = SramEccSetting == TargetIDSetting::Any;
   SmallVector<StringRef, 4> Features;
   FeatureString.split(Features, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
   for (StringRef Feature : Features) {

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -695,14 +695,11 @@ static GPUKind getGPUKindFromTargetID(const Triple &TT, StringRef TargetIDStr) {
              : parseArchAMDGCN(CPUName);
 }
 
-// Compute the xnack/sramecc settings for processor \p Arch from the
-// processor+features string \p TargetIDStr
-// (e.g. "gfx90a:xnack+:sramecc-"). Returns false if a modifier names an unknown
-// or repeated feature, names one the processor does not support, or has a
-// malformed sign.
-static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
-                                    TargetIDSetting &XnackSetting,
-                                    TargetIDSetting &SramEccSetting) {
+// Compute the default xnack/sramecc settings for processor \p Arch, before any
+// explicit feature modifiers are applied.
+static void getDefaultTargetIDFeatures(GPUKind Arch,
+                                       TargetIDSetting &XnackSetting,
+                                       TargetIDSetting &SramEccSetting) {
   const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
   // xnack with on/off modes defaults to Any; supported without on/off modes is
   // hardwired On (e.g. gfx1250); unsupported is Unsupported.
@@ -715,6 +712,18 @@ static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
   SramEccSetting = Features.test(FEAT_SRAMECC_SUPPORT)
                        ? TargetIDSetting::Any
                        : TargetIDSetting::Unsupported;
+}
+
+// Compute the xnack/sramecc settings for processor \p Arch from the
+// processor+features string \p TargetIDStr
+// (e.g. "gfx90a:xnack+:sramecc-"). Returns false if a modifier names an unknown
+// or repeated feature, names one the processor does not support, or has a
+// malformed sign.
+static bool computeTargetIDFeatures(GPUKind Arch, StringRef TargetIDStr,
+                                    TargetIDSetting &XnackSetting,
+                                    TargetIDSetting &SramEccSetting) {
+  const AMDGPUFeatureBitset &Features = getFeatureBitset(Arch);
+  getDefaultTargetIDFeatures(Arch, XnackSetting, SramEccSetting);
 
   // The first component is the processor; the rest are feature modifiers of the
   // form "<feature><+|->".
@@ -757,6 +766,33 @@ TargetID::TargetID(const Triple &TT, StringRef TargetIDStr)
   // Derive the feature settings from the string. Validity is not checked here;
   // parseTargetIDString validates untrusted input.
   computeTargetIDFeatures(Arch, TargetIDStr, XnackSetting, SramEccSetting);
+}
+
+TargetID TargetID::createFromSubtargetFeatures(const Triple &TT, StringRef CPU,
+                                               StringRef FeatureString) {
+  GPUKind Arch = parseArchAMDGCN(CPU);
+  TargetIDSetting XnackSetting, SramEccSetting;
+  getDefaultTargetIDFeatures(Arch, XnackSetting, SramEccSetting);
+
+  // Apply the +/-xnack and +/-sramecc modifiers from the feature string, only
+  // for targets that can toggle the corresponding mode.
+  bool XnackToggleable = XnackSetting == TargetIDSetting::Any;
+  bool SramEccToggleable = SramEccSetting != TargetIDSetting::Unsupported;
+  SmallVector<StringRef, 4> Features;
+  FeatureString.split(Features, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef Feature : Features) {
+    TargetIDSetting Sign =
+        getTargetIDSettingFromFeatureString(Feature.take_front());
+    if (Sign == TargetIDSetting::Unsupported)
+      continue;
+    StringRef Name = Feature.drop_front();
+    if (Name == "xnack" && XnackToggleable)
+      XnackSetting = Sign;
+    else if (Name == "sramecc" && SramEccToggleable)
+      SramEccSetting = Sign;
+  }
+
+  return TargetID(Arch, TT, XnackSetting, SramEccSetting);
 }
 
 std::optional<TargetID> TargetID::parse(const Triple &TT,

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -867,9 +867,10 @@ static void printFeatureModifiers(raw_ostream &OS, TargetIDSetting SramEcc,
 void TargetID::print(raw_ostream &StreamRep) const {
   StreamRep << TargetTripleString << '-' << getArchNameAMDGCN(Arch);
 
-  if (IsAMDHSA)
+  if (IsAMDHSA) {
     printFeatureModifiers(StreamRep, getSramEccSetting(), getXnackSetting(),
                           isXnackHardwiredOn(Arch));
+  }
 }
 
 std::string TargetID::toString() const {

--- a/llvm/test/MC/AMDGPU/amdgcn-target-directive-conflict.s
+++ b/llvm/test/MC/AMDGPU/amdgcn-target-directive-conflict.s
@@ -1,55 +1,69 @@
 // RUN: split-file %s %t
 
 // Test that .amdgcn_target emits separate warnings for conflicting xnack and
-// sramecc settings between the directive and the command line.
+// sramecc settings between two .amdgcn_target directives. The first directive
+// establishes the target id's xnack/sramecc modes; a second directive with
+// different specific modes conflicts.
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+xnack,+sramecc %t/xnack.s 2>&1 | FileCheck --check-prefix=XNACK --implicit-check-not=warning %s
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+xnack,+sramecc %t/sramecc.s 2>&1 | FileCheck --check-prefix=SRAMECC --implicit-check-not=warning %s
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+xnack,+sramecc %t/both.s 2>&1 | FileCheck --check-prefix=BOTH --implicit-check-not=warning %s
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa %t/xnack.s 2>&1 | FileCheck --check-prefix=XNACK --implicit-check-not=warning %s
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa %t/sramecc.s 2>&1 | FileCheck --check-prefix=SRAMECC --implicit-check-not=warning %s
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa %t/both.s 2>&1 | FileCheck --check-prefix=BOTH --implicit-check-not=warning %s
 
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=+xnack,+sramecc %t/xnack-legacy.s 2>&1 | FileCheck --check-prefix=XNACK-LEGACY --implicit-check-not=warning %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=+xnack,+sramecc %t/sramecc-legacy.s 2>&1 | FileCheck --check-prefix=SRAMECC-LEGACY --implicit-check-not=warning %s
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=+xnack,+sramecc %t/both-legacy.s 2>&1 | FileCheck --check-prefix=BOTH-LEGACY --implicit-check-not=warning %s
+// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 %t/xnack-legacy.s 2>&1 | FileCheck --check-prefix=XNACK-LEGACY --implicit-check-not=warning %s
+// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 %t/sramecc-legacy.s 2>&1 | FileCheck --check-prefix=SRAMECC-LEGACY --implicit-check-not=warning %s
+// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 %t/both-legacy.s 2>&1 | FileCheck --check-prefix=BOTH-LEGACY --implicit-check-not=warning %s
 
-// When the directive specifies modes but the command line leaves them
-// unspecified (Any), there is no conflict and no warning is emitted.
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa %t/both.s 2>&1 | FileCheck --check-prefix=NOCONFLICT --implicit-check-not=warning %s
+// When a single directive specifies modes and nothing conflicts, no warning is
+// emitted.
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa %t/noconflict.s 2>&1 | FileCheck --check-prefix=NOCONFLICT --implicit-check-not=warning %s
 
 // The object emission path honors the directive's xnack/sramecc settings in the
-// e_flags even when the command line does not specify them.
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/both.s -o %t/both.o
+// e_flags.
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/noconflict.s -o %t/both.o
 // RUN: llvm-readobj --file-headers %t/both.o | FileCheck --check-prefix=OBJ %s
 
-// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj %t/both-legacy.s -o %t/both-legacy.o
+// RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj %t/noconflict-legacy.s -o %t/both-legacy.o
 // RUN: llvm-readobj --file-headers %t/both-legacy.o | FileCheck --check-prefix=OBJ-LEGACY %s
 
 //--- xnack.s
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack+"
 // XNACK: warning: .amdgcn_target directive has conflicting xnack settings
 .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack-"
 
 //--- sramecc.s
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack+"
 // SRAMECC: warning: .amdgcn_target directive has conflicting sramecc settings
 .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack+"
 
 //--- both.s
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack+"
 // BOTH: warning: .amdgcn_target directive has conflicting xnack settings
 // BOTH: warning: .amdgcn_target directive has conflicting sramecc settings
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack-"
+
+//--- xnack-legacy.s
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack+"
+// XNACK-LEGACY: warning: .amdgcn_target directive has conflicting xnack settings
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack-"
+
+//--- sramecc-legacy.s
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack+"
+// SRAMECC-LEGACY: warning: .amdgcn_target directive has conflicting sramecc settings
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack+"
+
+//--- both-legacy.s
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack+"
+// BOTH-LEGACY: warning: .amdgcn_target directive has conflicting xnack settings
+// BOTH-LEGACY: warning: .amdgcn_target directive has conflicting sramecc settings
+.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack-"
+
+//--- noconflict.s
 // NOCONFLICT: .amdgcn_target "amdgpu9.08-amd-amdhsa-unknown-gfx908:sramecc-:xnack-"
 // OBJ: EF_AMDGPU_FEATURE_SRAMECC_OFF_V4 (0x800)
 // OBJ: EF_AMDGPU_FEATURE_XNACK_OFF_V4 (0x200)
 .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack-"
 
-//--- xnack-legacy.s
-// XNACK-LEGACY: warning: .amdgcn_target directive has conflicting xnack settings
-.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc+:xnack-"
-
-//--- sramecc-legacy.s
-// SRAMECC-LEGACY: warning: .amdgcn_target directive has conflicting sramecc settings
-.amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack+"
-
-//--- both-legacy.s
-// BOTH-LEGACY: warning: .amdgcn_target directive has conflicting xnack settings
-// BOTH-LEGACY: warning: .amdgcn_target directive has conflicting sramecc settings
+//--- noconflict-legacy.s
 // NOCONFLICT-LEGACY: .amdgcn_target "amdgcn-amd-amdhsa-unknown-gfx908:sramecc-:xnack-"
 // OBJ-LEGACY: EF_AMDGPU_FEATURE_SRAMECC_OFF_V4 (0x800)
 // OBJ-LEGACY: EF_AMDGPU_FEATURE_XNACK_OFF_V4 (0x200)

--- a/llvm/test/MC/AMDGPU/amdgcn_target_directive_from_eflags.s
+++ b/llvm/test/MC/AMDGPU/amdgcn_target_directive_from_eflags.s
@@ -1,46 +1,50 @@
 // Test that llvm-objdump emits the .amdgcn_target directive based on e_flags.
+// The xnack/sramecc mode is encoded in the assembly via a .amdgcn_target
+// directive, which sets the object's e_flags; objdump reproduces it.
 
-// RUN: llvm-mc -triple=amdgpu9.00-amd-amdhsa -filetype=obj %s -o %t-gfx900.o
+// RUN: split-file %s %t
+
+// RUN: llvm-mc -triple=amdgpu9.00-amd-amdhsa -filetype=obj %t/plain.s -o %t-gfx900.o
 // RUN: llvm-objdump --disassemble-all %t-gfx900.o | FileCheck --check-prefix=CHECK-GFX900 %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %s -o %t-gfx908.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/plain.s -o %t-gfx908.o
 // RUN: llvm-objdump --disassemble-all %t-gfx908.o | FileCheck --check-prefix=CHECK-GFX908 %s
 
-// RUN: llvm-mc -triple=amdgpu10.10-amd-amdhsa -filetype=obj %s -o %t-gfx1010.o
+// RUN: llvm-mc -triple=amdgpu10.10-amd-amdhsa -filetype=obj %t/plain.s -o %t-gfx1010.o
 // RUN: llvm-objdump --disassemble-all %t-gfx1010.o | FileCheck --check-prefix=CHECK-GFX1010 %s
 
-// RUN: llvm-mc -triple=amdgpu11.00-amd-amdhsa -filetype=obj %s -o %t-gfx1100.o
+// RUN: llvm-mc -triple=amdgpu11.00-amd-amdhsa -filetype=obj %t/plain.s -o %t-gfx1100.o
 // RUN: llvm-objdump --disassemble-all %t-gfx1100.o | FileCheck --check-prefix=CHECK-GFX1100 %s
 
-// RUN: llvm-mc -triple=amdgpu12.00-amd-amdhsa -filetype=obj %s -o %t-gfx1200.o
+// RUN: llvm-mc -triple=amdgpu12.00-amd-amdhsa -filetype=obj %t/plain.s -o %t-gfx1200.o
 // RUN: llvm-objdump --disassemble-all %t-gfx1200.o | FileCheck --check-prefix=CHECK-GFX1200 %s
 
 // Test xnack/sramecc combinations
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %s -o %t-default.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/plain.s -o %t-default.o
 // RUN: llvm-objdump --disassemble-all %t-default.o | FileCheck --check-prefix=CHECK-DEFAULT %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+xnack,+sramecc -filetype=obj %s -o %t-both-on.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/both-on.s -o %t-both-on.o
 // RUN: llvm-objdump --disassemble-all %t-both-on.o | FileCheck --check-prefix=CHECK-BOTH-ON %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=-xnack,-sramecc -filetype=obj %s -o %t-both-off.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/both-off.s -o %t-both-off.o
 // RUN: llvm-objdump --disassemble-all %t-both-off.o | FileCheck --check-prefix=CHECK-BOTH-OFF %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+xnack,-sramecc -filetype=obj %s -o %t-xnack-on.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/xnack-on.s -o %t-xnack-on.o
 // RUN: llvm-objdump --disassemble-all %t-xnack-on.o | FileCheck --check-prefix=CHECK-XNACK-ON %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=-xnack,+sramecc -filetype=obj %s -o %t-sramecc-on.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/sramecc-on.s -o %t-sramecc-on.o
 // RUN: llvm-objdump --disassemble-all %t-sramecc-on.o | FileCheck --check-prefix=CHECK-SRAMECC-ON %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+xnack -filetype=obj %s -o %t-xnack-only.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/xnack-only.s -o %t-xnack-only.o
 // RUN: llvm-objdump --disassemble-all %t-xnack-only.o | FileCheck --check-prefix=CHECK-XNACK-ONLY %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj %s -o %t-xnack-off-only.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/xnack-off-only.s -o %t-xnack-off-only.o
 // RUN: llvm-objdump --disassemble-all %t-xnack-off-only.o | FileCheck --check-prefix=CHECK-XNACK-OFF-ONLY %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=+sramecc -filetype=obj %s -o %t-sramecc-only.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/sramecc-only.s -o %t-sramecc-only.o
 // RUN: llvm-objdump --disassemble-all %t-sramecc-only.o | FileCheck --check-prefix=CHECK-SRAMECC-ONLY %s
 
-// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -mattr=-sramecc -filetype=obj %s -o %t-sramecc-off-only.o
+// RUN: llvm-mc -triple=amdgpu9.08-amd-amdhsa -filetype=obj %t/sramecc-off-only.s -o %t-sramecc-off-only.o
 // RUN: llvm-objdump --disassemble-all %t-sramecc-off-only.o | FileCheck --check-prefix=CHECK-SRAMECC-OFF-ONLY %s
 
 // CHECK-GFX900: .amdgcn_target "amdgpu-amd-amdhsa-unknown-gfx900"
@@ -70,3 +74,29 @@
 // CHECK-SRAMECC-ONLY: .amdgcn_target "amdgpu-amd-amdhsa-unknown-gfx908:sramecc+"
 
 // CHECK-SRAMECC-OFF-ONLY: .amdgcn_target "amdgpu-amd-amdhsa-unknown-gfx908:sramecc-"
+
+//--- plain.s
+
+//--- both-on.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:sramecc+:xnack+"
+
+//--- both-off.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:sramecc-:xnack-"
+
+//--- xnack-on.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:sramecc-:xnack+"
+
+//--- sramecc-on.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:sramecc+:xnack-"
+
+//--- xnack-only.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack+"
+
+//--- xnack-off-only.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
+
+//--- sramecc-only.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:sramecc+"
+
+//--- sramecc-off-only.s
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:sramecc-"

--- a/llvm/test/MC/AMDGPU/hsa-diag-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-diag-v4.s
@@ -1,10 +1,10 @@
-// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu8.10-amd-amdhsa -mattr=+xnack %s -filetype=null 2>&1 | FileCheck %s -DMCPU=gfx810 --check-prefixes=ALL,GCN,GFX8,PREGFX10,NOWGP,AMDHSA
-// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu10.10-amd-amdhsa -mattr=+xnack %s -filetype=null 2>&1 | FileCheck %s --check-prefixes=ALL,GCN,GFX10PLUS,GFX10,AMDHSA
+// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu8.10-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s -DMCPU=gfx810 --check-prefixes=ALL,GCN,GFX8,PREGFX10,NOWGP,AMDHSA
+// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu10.10-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s --check-prefixes=ALL,GCN,GFX10PLUS,GFX10,AMDHSA
 // RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu11.00-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s --check-prefixes=ALL,GCN,GFX10PLUS,GFX11,AMDHSA
 // RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu12.00-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s -DMCPU=gfx1200 --check-prefixes=ALL,GCN,GFX10PLUS,GFX12,AMDHSA
 // RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu11.70-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s --check-prefixes=ALL,GCN,GFX10PLUS,GFX1170,AMDHSA
-// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu8.10-amd- -mattr=+xnack %s -filetype=null 2>&1 | FileCheck %s --check-prefixes=ALL,GCN,NONAMDHSA
-// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu9.0a-amd-amdhsa -mattr=+xnack %s -filetype=null 2>&1 | FileCheck %s -DMCPU=gfx90a --check-prefixes=ALL,GFX90A,PREGFX10,NOWGP,AMDHSA
+// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu8.10-amd- %s -filetype=null 2>&1 | FileCheck %s --check-prefixes=ALL,GCN,NONAMDHSA
+// RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu9.0a-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s -DMCPU=gfx90a --check-prefixes=ALL,GFX90A,PREGFX10,NOWGP,AMDHSA
 // RUN: not llvm-mc --amdhsa-code-object-version=4 -triple=amdgpu12.50-amd-amdhsa %s -filetype=null 2>&1 | FileCheck %s -DMCPU=gfx1250 --check-prefixes=ALL,GCN,GFX10PLUS,GFX1250,NOWGP,AMDHSA
 
 .text

--- a/llvm/test/MC/AMDGPU/hsa-tg-split.s
+++ b/llvm/test/MC/AMDGPU/hsa-tg-split.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa -filetype=obj < %s > %t
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
 // OBJDUMP: Contents of section .rodata

--- a/llvm/test/MC/AMDGPU/hsa-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-v4.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 

--- a/llvm/test/MC/AMDGPU/hsa-v5-uses-dynamic-stack.s
+++ b/llvm/test/MC/AMDGPU/hsa-v5-uses-dynamic-stack.s
@@ -1,10 +1,10 @@
-// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 
-// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa --amdhsa-code-object-version=6 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
-// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa --amdhsa-code-object-version=6 -mattr=+xnack -filetype=obj < %s > %t
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa --amdhsa-code-object-version=6 < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.04-amd-amdhsa --amdhsa-code-object-version=6 -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
 // RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
 

--- a/llvm/test/MC/AMDGPU/user-sgpr-count.s
+++ b/llvm/test/MC/AMDGPU/user-sgpr-count.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa --amdhsa-code-object-version=4 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple=amdgpu9.0a-amd-amdhsa --amdhsa-code-object-version=4 < %s | FileCheck --check-prefix=ASM %s
 
 .amdgcn_target "amdgpu9.0a-amd-amdhsa--gfx90a:xnack+"
 // ASM: .amdgcn_target "amdgpu9.0a-amd-amdhsa-unknown-gfx90a:xnack+"

--- a/llvm/test/MC/AMDGPU/xnack-mask.s
+++ b/llvm/test/MC/AMDGPU/xnack-mask.s
@@ -1,10 +1,10 @@
 // RUN: not llvm-mc -triple=amdgpu6.00 %s -filetype=null 2>&1 | FileCheck -check-prefix=NOSICIVI10 --implicit-check-not=error: %s
 // RUN: not llvm-mc -triple=amdgpu7.01 %s -filetype=null 2>&1 | FileCheck -check-prefix=NOSICIVI10 --implicit-check-not=error: %s
 // RUN: not llvm-mc -triple=amdgpu8.02 %s -filetype=null 2>&1 | FileCheck -check-prefix=NOSICIVI10 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgpu10.10 -mattr=-xnack %s -filetype=null 2>&1 | FileCheck -check-prefix=NOSICIVI10 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgpu10.10 %s -filetype=null 2>&1 | FileCheck -check-prefix=NOSICIVI10 --implicit-check-not=error: %s
 
-// RUN: not llvm-mc -triple=amdgpu8.10 -mattr=+xnack %s -filetype=null 2>&1 | FileCheck -check-prefix=XNACKERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgpu8.10 -mattr=+xnack -show-encoding %s | FileCheck -check-prefix=XNACK %s
+// RUN: not llvm-mc -triple=amdgpu8.10 %s -filetype=null 2>&1 | FileCheck -check-prefix=XNACKERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgpu8.10 -show-encoding %s | FileCheck -check-prefix=XNACK %s
 
 s_mov_b64 xnack_mask, -1
 // NOSICIVI10: :[[@LINE-1]]:{{[0-9]+}}: error: xnack_mask register not available on this GPU

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-cov5.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-cov5.s
@@ -1,16 +1,16 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/5/g' %s \
-; RUN:   | llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
+; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/4/g' %s \
-; RUN:   | llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
+; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV4,CHECK
 
 ;; Make sure we override the default COV in the disassembler on COV6 (there
 ;; currently aren't any differences between 5 and 6, so set the default to 4 so
 ;; we can verify that the default is at least overridden)
 ; RUN: sed 's/CODE_OBJECT_VERSION/6/g' %s \
-; RUN:   | llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
+; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
 ; RUN: llvm-objdump -mllvm --amdhsa-code-object-version=4 --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
 
 ;; Verify that .amdhsa_uses_dynamic_stack is only printed on COV5+.

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-cov5.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-cov5.s
@@ -1,16 +1,16 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/5/g' %s \
-; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
+; RUN:   | llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/4/g' %s \
-; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
+; RUN:   | llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV4,CHECK
 
 ;; Make sure we override the default COV in the disassembler on COV6 (there
 ;; currently aren't any differences between 5 and 6, so set the default to 4 so
 ;; we can verify that the default is at least overridden)
 ; RUN: sed 's/CODE_OBJECT_VERSION/6/g' %s \
-; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
+; RUN:   | llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
 ; RUN: llvm-objdump -mllvm --amdhsa-code-object-version=4 --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
 
 ;; Verify that .amdhsa_uses_dynamic_stack is only printed on COV5+.

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx10.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx10.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj < 1.s > 1.o
-; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1010 < 1.s > 1.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1010 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -51,6 +51,7 @@
 ; CHECK-NEXT: .amdhsa_wavefront_size32 1
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32
@@ -59,10 +60,10 @@
 .end_amdhsa_kernel
 
 ;--- 2.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj < 2.s > 2.o
-; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 2.s > 2.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -107,6 +108,7 @@
 ; CHECK-NEXT: .amdhsa_wavefront_size32 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32
@@ -115,10 +117,10 @@
 .end_amdhsa_kernel
 
 ;--- 3.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj < 3.s > 3.o
-; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 3.s > 3.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -163,6 +165,7 @@
 ; CHECK-NEXT: .amdhsa_wavefront_size32 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32
@@ -171,10 +174,10 @@
 .end_amdhsa_kernel
 
 ;--- 4.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj < 4.s > 4.o
-; RUN: echo '.amdhsa_code_object_version 5' > 4-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 4.s > 4.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 4-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 4.o | tail -n +8 | tee -a 4-disasm.s | FileCheck 4.s
-; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj < 4-disasm.s > 4-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 4-disasm.s > 4-disasm.o
 ; RUN: cmp 4.o 4-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -219,6 +222,7 @@
 ; CHECK-NEXT: .amdhsa_wavefront_size32 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx10.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx10.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1010 < 1.s > 1.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj < 1.s > 1.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1010 < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -60,10 +60,10 @@
 .end_amdhsa_kernel
 
 ;--- 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 2.s > 2.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj < 2.s > 2.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -117,10 +117,10 @@
 .end_amdhsa_kernel
 
 ;--- 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 3.s > 3.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj < 3.s > 3.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -174,10 +174,10 @@
 .end_amdhsa_kernel
 
 ;--- 4.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 4.s > 4.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj < 4.s > 4.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"\n.amdhsa_code_object_version 5\n' > 4-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 4.o | tail -n +8 | tee -a 4-disasm.s | FileCheck 4.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 4-disasm.s > 4-disasm.o
+; RUN: llvm-mc --triple=amdgpu10.10-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj < 4-disasm.s > 4-disasm.o
 ; RUN: cmp 4.o 4-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx90a.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx90a.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -mattr=-xnack -filetype=obj < 1.s > 1.o
-; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 1.s > 1.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -mattr=-xnack -filetype=obj < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -48,6 +48,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 0
@@ -56,10 +57,10 @@
 .end_amdhsa_kernel
 
 ;--- 2.s
-; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -mattr=-xnack -filetype=obj < 2.s > 2.o
-; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 2.s > 2.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -mattr=-xnack -filetype=obj < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -101,6 +102,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32
@@ -109,10 +111,10 @@
 .end_amdhsa_kernel
 
 ;--- 3.s
-; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -mattr=-xnack -filetype=obj < 3.s > 3.o
-; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 3.s > 3.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -mattr=-xnack -filetype=obj < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -156,6 +158,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_kernarg_preload_length  2
 ; CHECK-NEXT: .amdhsa_user_sgpr_kernarg_preload_offset  1
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx90a.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx90a.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 1.s > 1.o
+; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -filetype=obj < 1.s > 1.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -filetype=obj < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -57,10 +57,10 @@
 .end_amdhsa_kernel
 
 ;--- 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 2.s > 2.o
+; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -filetype=obj < 2.s > 2.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -filetype=obj < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -111,10 +111,10 @@
 .end_amdhsa_kernel
 
 ;--- 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 3.s > 3.o
+; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -filetype=obj < 3.s > 3.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx90a:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx90a < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.0a-amd-amdhsa -filetype=obj < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx950.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx950.s
@@ -3,9 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgpu9.50-amd-amdhsa -mattr=-xnack -filetype=obj < 1.s > 1.o
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgpu9.50-amd-amdhsa -mattr=-xnack -filetype=obj < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx950 < 1.s > 1.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx950:xnack-"\n' > 1-disasm.s
+; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx950 < 1-disasm.s > 1-disasm.o
 ; FIxMe: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT:	.amdhsa_group_segment_fixed_size 163840
@@ -44,6 +45,7 @@
 ; CHECK-NEXT:	.amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT:	.amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT:.end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx950:xnack-"
 .amdhsa_kernel kernel
   .amdhsa_group_segment_fixed_size 163840
   .amdhsa_next_free_vgpr 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx950.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx950.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx950 < 1.s > 1.o
+; RUN: llvm-mc --triple=amdgpu9.50-amd-amdhsa -filetype=obj < 1.s > 1.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx950:xnack-"\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx950 < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.50-amd-amdhsa -filetype=obj < 1-disasm.s > 1-disasm.o
 ; FIxMe: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT:	.amdhsa_group_segment_fixed_size 163840

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-sgpr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-sgpr.s
@@ -4,10 +4,10 @@
 
 ;--- 1.s
 ;; Only set next_free_sgpr.
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 1.s > 1.o
-; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1.s > 1.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -47,6 +47,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 0
@@ -58,10 +59,10 @@
 
 ;--- 2.s
 ;; Only set other directives.
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 2.s > 2.o
-; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2.s > 2.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -101,6 +102,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 0
@@ -112,10 +114,10 @@
 
 ;--- 3.s
 ;; Set all affecting directives.
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 3.s > 3.o
-; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3.s > 3.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -155,6 +157,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-sgpr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-sgpr.s
@@ -4,10 +4,10 @@
 
 ;--- 1.s
 ;; Only set next_free_sgpr.
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1.s > 1.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 1.s > 1.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -59,10 +59,10 @@
 
 ;--- 2.s
 ;; Only set other directives.
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2.s > 2.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 2.s > 2.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -114,10 +114,10 @@
 
 ;--- 3.s
 ;; Set all affecting directives.
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3.s > 3.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 3.s > 3.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-vgpr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-vgpr.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 1.s > 1.o
-; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1.s > 1.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -46,6 +46,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 23
@@ -53,10 +54,10 @@
 .end_amdhsa_kernel
 
 ;--- 2.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 2.s > 2.o
-; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2.s > 2.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -96,6 +97,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 14
@@ -103,10 +105,10 @@
 .end_amdhsa_kernel
 
 ;--- 3.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 3.s > 3.o
-; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3.s > 3.o
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -146,6 +148,7 @@
 ; CHECK-NEXT: .amdhsa_user_sgpr_private_segment_size 0
 ; CHECK-NEXT: .amdhsa_uses_dynamic_stack 0
 ; CHECK-NEXT: .end_amdhsa_kernel
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel kernel
   .amdhsa_next_free_vgpr 32

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-vgpr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-vgpr.s
@@ -3,10 +3,10 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
 ;--- 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1.s > 1.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 1.s > 1.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 1-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +8 | tee -a 1-disasm.s | FileCheck 1.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 1-disasm.s > 1-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -54,10 +54,10 @@
 .end_amdhsa_kernel
 
 ;--- 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2.s > 2.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 2.s > 2.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 2-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +8 | tee -a 2-disasm.s | FileCheck 2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 2-disasm.s > 2-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0
@@ -105,10 +105,10 @@
 .end_amdhsa_kernel
 
 ;--- 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3.s > 3.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 3.s > 3.o
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > 3-disasm.s
 ; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +8 | tee -a 3-disasm.s | FileCheck 3.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx908 < 3-disasm.s > 3-disasm.o
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
 ; CHECK-NEXT: .amdhsa_group_segment_fixed_size 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx10.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx10.s
@@ -1,6 +1,6 @@
 ;; Entirely zeroed kernel descriptor (for GFX10).
 
-; RUN: llvm-mc %s --triple=amdgpu10.10-amd-amdhsa -mattr=-xnack -filetype=obj -o %t
+; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -filetype=obj -o %t
 ; RUN: llvm-objdump -s -d -j .text %t | FileCheck --check-prefix=OBJDUMP %s
 
 ;; TODO:
@@ -67,6 +67,7 @@
 ; OBJDUMP-NEXT:         .amdhsa_uses_dynamic_stack 0
 ; OBJDUMP-NEXT: .end_amdhsa_kernel
 
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1010:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel my_kernel
   .amdhsa_group_segment_fixed_size 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx10.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx10.s
@@ -1,6 +1,6 @@
 ;; Entirely zeroed kernel descriptor (for GFX10).
 
-; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -filetype=obj -o %t
+; RUN: llvm-mc %s --triple=amdgpu10.10-amd-amdhsa -filetype=obj -o %t
 ; RUN: llvm-objdump -s -d -j .text %t | FileCheck --check-prefix=OBJDUMP %s
 
 ;; TODO:

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx9.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx9.s
@@ -1,9 +1,9 @@
 ;; Entirely zeroed kernel descriptor (for GFX9).
 
-; RUN: llvm-mc %s --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj -o %t1
-; RUN: echo '.amdhsa_code_object_version 5' > %t2.s
+; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t1
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > %t2.s
 ; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 | tail -n +8 >> %t2.s
-; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj -o %t2 %t2.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t2 %t2.s
 ; RUN: diff %t1 %t2
 
 ; RUN: llvm-objdump -s -j .text %t1 | FileCheck --check-prefix=OBJDUMP %s
@@ -16,6 +16,7 @@
 ;; This file and kd-zeroed-raw.s produce the same output for the kernel
 ;; descriptor - a block of 64 zeroed bytes.
 
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .amdhsa_code_object_version 5
 .amdhsa_kernel my_kernel
   .amdhsa_group_segment_fixed_size 0

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx9.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx9.s
@@ -1,9 +1,9 @@
 ;; Entirely zeroed kernel descriptor (for GFX9).
 
-; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t1
+; RUN: llvm-mc %s --triple=amdgpu9.08-amd-amdhsa -filetype=obj -o %t1
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n.amdhsa_code_object_version 5\n' > %t2.s
 ; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 | tail -n +8 >> %t2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t2 %t2.s
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj -o %t2 %t2.s
 ; RUN: diff %t1 %t2
 
 ; RUN: llvm-objdump -s -j .text %t1 | FileCheck --check-prefix=OBJDUMP %s

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-raw.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-raw.s
@@ -1,6 +1,7 @@
-; RUN: llvm-mc %s --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj -o %t1
-; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 \
-; RUN: | tail -n +8 | llvm-mc --triple=amdgpu9.08-amd-amdhsa -mattr=-xnack -filetype=obj -o %t2
+; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t1
+; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n' > %t2.s
+; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 | tail -n +8 >> %t2.s
+; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t2 %t2.s
 ; RUN: llvm-objdump -s -j .text %t2 | FileCheck --check-prefix=OBJDUMP %s
 
 ;; Not running lit-test over gfx10 (see kd-zeroed-gfx10.s for details).
@@ -18,6 +19,7 @@
 
 ;; The entire object is zeroed out.
 
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"
 .type	my_kernel.kd, @object
 .size my_kernel.kd, 64
 my_kernel.kd:

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-raw.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-raw.s
@@ -1,7 +1,7 @@
-; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t1
+; RUN: llvm-mc %s --triple=amdgpu9.08-amd-amdhsa -filetype=obj -o %t1
 ; RUN: printf '.amdgcn_target "amdgcn-amd-amdhsa--gfx908:xnack-"\n' > %t2.s
 ; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 | tail -n +8 >> %t2.s
-; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -o %t2 %t2.s
+; RUN: llvm-mc --triple=amdgpu9.08-amd-amdhsa -filetype=obj -o %t2 %t2.s
 ; RUN: llvm-objdump -s -j .text %t2 | FileCheck --check-prefix=OBJDUMP %s
 
 ;; Not running lit-test over gfx10 (see kd-zeroed-gfx10.s for details).


### PR DESCRIPTION
Now that these are controlled by module flags, the subtarget
features were just used for assembler and disassembler controls.
Now that the assembler and disassembler can infer these from
the e_flags and target directives, they are no longer necessary.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>