### PR TITLE
[NFC][analyzer] Remove BlockEdge parameter of processCFGBlockEntrance

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -54,7 +54,7 @@ class CoreEngine {
 
 public:
   using BlocksExhausted =
-      std::vector<std::pair<BlockEdge, const ExplodedNode *>>;
+      std::vector<std::pair<BlockEntrance, const ExplodedNode *>>;
 
   using BlocksAborted =
       std::vector<std::pair<const CFGBlock *, const ExplodedNode *>>;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -388,8 +388,8 @@ public:
                             ExplodedNode *Pred, ExplodedNodeSet &Dst);
 
   /// Called by CoreEngine when processing the entrance of a CFGBlock.
-  void processCFGBlockEntrance(const BlockEdge &L, const BlockEntrance &BE,
-                               NodeBuilder &Builder, ExplodedNode *Pred);
+  void processCFGBlockEntrance(const BlockEntrance &BE, NodeBuilder &Builder,
+                               ExplodedNode *Pred);
 
   void runCheckersForBlockEntrance(const BlockEntrance &Entrance,
                                    ExplodedNode *Pred, ExplodedNodeSet &Dst);

--- a/clang/lib/StaticAnalyzer/Checkers/AnalyzerStatsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/AnalyzerStatsChecker.cpp
@@ -112,8 +112,8 @@ void AnalyzerStatsChecker::checkEndAnalysis(ExplodedGraph &G,
 
   // Emit warning for each block we bailed out on.
   const CoreEngine &CE = Eng.getCoreEngine();
-  for (const BlockEdge &BE : make_first_range(CE.exhausted_blocks())) {
-    const CFGBlock *Exit = BE.getDst();
+  for (const BlockEntrance &BE : make_first_range(CE.exhausted_blocks())) {
+    const CFGBlock *Exit = BE.getBlock();
     if (Exit->empty())
       continue;
     const CFGElement &CE = Exit->front();

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -327,7 +327,7 @@ void CoreEngine::HandleBlockEdge(const BlockEdge &L, ExplodedNode *Pred) {
   BlockEntrance BE(L.getSrc(), L.getDst(), Pred->getStackFrame());
   ExplodedNodeSet DstNodes;
   NodeBuilder Builder(Pred, DstNodes, ExprEng.getBuilderContext());
-  ExprEng.processCFGBlockEntrance(L, BE, Builder, Pred);
+  ExprEng.processCFGBlockEntrance(BE, Builder, Pred);
 
   // Auto-generate a node.
   if (!Builder.hasGeneratedNodes()) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2390,11 +2390,7 @@ bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
 }
 
 /// Block entrance.  (Update counters).
-/// FIXME: `BlockEdge &L` is only used for debug statistics, consider removing
-/// it and using `BlockEntrance &BE` (where `BlockEntrance` is a subtype of
-/// `ProgramPoint`) for statistical purposes.
-void ExprEngine::processCFGBlockEntrance(const BlockEdge &L,
-                                         const BlockEntrance &BE,
+void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                          NodeBuilder &Builder,
                                          ExplodedNode *Pred) {
   // If we reach a loop which has a known bound (and meets
@@ -2472,7 +2468,7 @@ void ExprEngine::processCFGBlockEntrance(const BlockEdge &L,
       NumMaxBlockCountReached++;
 
     // Make sink nodes as exhausted(for stats) only if retry failed.
-    Engine.blocksExhausted.push_back(std::make_pair(L, Sink));
+    Engine.blocksExhausted.push_back(std::make_pair(BE, Sink));
   }
 }
 


### PR DESCRIPTION
As a side effect of my previous refactoring efforts, the method `ExprEngine::processCFGBlockEntrance` had two very similar parameters: a `BlockEdge` and a `BlockEntrance` instance.

These are both subclasses of `ProgramPoint`, stored the same data (the `BlockEntrance` was initialized with data taken from the `BlockEdge` just before the call) and the `BlockEdge` was almost completely unused within `processCFGBlockEntrance`.

The only reason for having the `BlockEdge` was that it was stored in the debug statistic table `blocksExhausted`; so this commit transitions that simple debug code to use `BlockEntrance` instances instead (which is also perfectly sufficient for its goals). This allows the removal of the redundant argument of `processCFGBlockEntrance`.

This prepares the ground for further cleanup in this method.