### PR TITLE
Fix test case failure due to Commit aa50eb69 DwarfDebug: Move emission of types from beginModule() to endModule()

### DIFF
--- a/llvm/test/DebugInfo/Generic/debug-info-qualifiers.ll
+++ b/llvm/test/DebugInfo/Generic/debug-info-qualifiers.ll
@@ -19,9 +19,13 @@
 ; CHECK: DW_TAG_subroutine_type     DW_CHILDREN_yes
 ; CHECK-NEXT: DW_AT_rvalue_reference DW_FORM_flag_present
 
+; The abbrev table (printed before .debug_info on some targets, e.g. XCOFF/AIX)
+; may contain multiple DW_TAG_subprogram entries that would trip the CHECK-NOT
+; below.  Anchor to .debug_info contents: to skip past the abbrev section.
+; CHECK: .debug_info contents:
 ; CHECK: DW_TAG_subprogram
 ; CHECK-NOT: DW_TAG_subprogram
-; CHECK:   DW_AT_name {{.*}} "g")
+; CHECK:   DW_AT_name {{.*}}"g"
 ;
 ; CHECK: DW_TAG_subprogram
 ; CHECK-NOT: DW_TAG_subprogram


### PR DESCRIPTION
Commit `aa50eb69 ("DwarfDebug: Move emission of types from beginModule() to endModule()") ` added new CHECK lines to `debug-info-qualifiers.ll` that broke on XCOFF/AIX in two ways: 
(1) `CHECK-NOT: DW_TAG_subprogram` tripped on abbrev table entries printed before .debug_info, and 
(2) the pattern `{{.*}} "g")` had a space/paren mismatch against the AIX dwarfdump output format

This PR is fixing that by adding `; CHECK: .debug_info contents: ` anchor and changed the pattern to `{{.*}}"g"` in the test file.