### PR TITLE
[IR] Remove deprecated typed-pointer creation APIs

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -762,25 +762,9 @@ public:
   PointerType(const PointerType &) = delete;
   PointerType &operator=(const PointerType &) = delete;
 
-  /// This constructs a pointer to an object of the specified type in a numbered
-  /// address space.
-  [[deprecated("PointerType::get with pointee type is pending removal. Use "
-               "Context overload.")]]
-  LLVM_ABI static PointerType *get(Type *ElementType, unsigned AddressSpace);
   /// This constructs an opaque pointer to an object in a numbered address
   /// space.
   LLVM_ABI static PointerType *get(LLVMContext &C, unsigned AddressSpace);
-
-  /// This constructs a pointer to an object of the specified type in the
-  /// default address space (address space zero).
-  [[deprecated("PointerType::getUnqual with pointee type is pending removal. "
-               "Use Context overload.")]]
-  static PointerType *getUnqual(Type *ElementType) {
-    assert(ElementType && "Can't get a pointer to <null> type!");
-    assert(isValidElementType(ElementType) &&
-           "Invalid type for pointer element!");
-    return PointerType::getUnqual(ElementType->getContext());
-  }
 
   /// This constructs an opaque pointer to an object in the
   /// default address space (address space zero).

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -520,12 +520,6 @@ public:
   LLVM_ABI static Type *getWasm_ExternrefTy(LLVMContext &C);
   LLVM_ABI static Type *getWasm_FuncrefTy(LLVMContext &C);
 
-  /// Return a pointer to the current type. This is equivalent to
-  /// PointerType::get(Ctx, AddrSpace).
-  /// TODO: Remove this after opaque pointer transition is complete.
-  LLVM_ABI LLVM_DEPRECATED("Use PointerType::get instead", "PointerType::get")
-      PointerType *getPointerTo(unsigned AddrSpace = 0) const;
-
 private:
   /// Derived types like structures and arrays are sized iff all of the members
   /// of the type are sized as well. Since asking for their size is relatively

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -908,14 +908,6 @@ ScalableVectorType *ScalableVectorType::get(Type *ElementType,
 //                         PointerType Implementation
 //===----------------------------------------------------------------------===//
 
-PointerType *PointerType::get(Type *EltTy, unsigned AddressSpace) {
-  assert(EltTy && "Can't get a pointer to <null> type!");
-  assert(isValidElementType(EltTy) && "Invalid type for pointer element!");
-
-  // Automatically convert typed pointers to opaque pointers.
-  return get(EltTy->getContext(), AddressSpace);
-}
-
 PointerType *PointerType::get(LLVMContext &C, unsigned AddressSpace) {
   LLVMContextImpl *CImpl = C.pImpl;
 
@@ -931,10 +923,6 @@ PointerType *PointerType::get(LLVMContext &C, unsigned AddressSpace) {
 PointerType::PointerType(LLVMContext &C, unsigned AddrSpace)
     : Type(C, PointerTyID) {
   setSubclassData(AddrSpace);
-}
-
-PointerType *Type::getPointerTo(unsigned AddrSpace) const {
-  return PointerType::get(getContext(), AddrSpace);
 }
 
 bool PointerType::isValidElementType(Type *ElemTy) {


### PR DESCRIPTION
Removes `PointerType::get(Type*, unsigned)`, `PointerType::getUnqual(Type*)`, and `Type::getPointerTo(unsigned)`, the last typed-pointer-creation leftovers from the opaque pointers migration. All three have been marked deprecated for a while and have no remaining in-tree callers; every caller already uses the LLVMContext-taking overloads.