### PR TITLE
[mlir][SPIR-V] Lower arith.convertf operation

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -1069,6 +1069,55 @@ struct TypeCastingOpPattern final : public OpConversionPattern<Op> {
 };
 
 //===----------------------------------------------------------------------===//
+// ConvertFOp
+//===----------------------------------------------------------------------===//
+
+/// Converts arith.convertf (same-bitwidth FP cast, e.g. f16 <-> bf16) to
+/// SPIR-V. spirv.FConvert requires differing component widths, so widen to
+/// f32 first and then narrow to the destination type.
+struct ConvertFOpPattern final : public OpConversionPattern<arith::ConvertFOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(arith::ConvertFOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type dstType = getTypeConverter()->convertType(op.getType());
+    if (!dstType)
+      return getTypeConversionFailure(rewriter, op);
+
+    if (dstType == adaptor.getIn().getType()) {
+      rewriter.replaceOp(op, adaptor.getIn());
+      return success();
+    }
+
+    Location loc = op.getLoc();
+    Type f32Type = Float32Type::get(rewriter.getContext());
+    if (auto vecType = dyn_cast<VectorType>(dstType))
+      f32Type = VectorType::get(vecType.getShape(), f32Type);
+
+    Value widened =
+        spirv::FConvertOp::create(rewriter, loc, f32Type, adaptor.getIn());
+
+    std::optional<spirv::FPRoundingMode> rm = std::nullopt;
+    if (arith::RoundingModeAttr roundingMode = op.getRoundingmodeAttr()) {
+      if (!(rm = convertArithRoundingModeToSPIRV(roundingMode.getValue())))
+        return rewriter.notifyMatchFailure(
+            op->getLoc(),
+            llvm::formatv("unsupported rounding mode '{0}'", roundingMode));
+    }
+
+    auto narrowed =
+        rewriter.replaceOpWithNewOp<spirv::FConvertOp>(op, dstType, widened);
+    if (rm) {
+      narrowed->setAttr(
+          getDecorationString(spirv::Decoration::FPRoundingMode),
+          spirv::FPRoundingModeAttr::get(rewriter.getContext(), *rm));
+    }
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // CmpIOp
 //===----------------------------------------------------------------------===//
 
@@ -1500,6 +1549,7 @@ void mlir::arith::populateArithToSPIRVPatterns(
     TypeCastingOpPattern<arith::ExtFOp, spirv::FConvertOp>,
     TruncIPattern, TruncII1Pattern,
     TypeCastingOpPattern<arith::TruncFOp, spirv::FConvertOp>,
+    ConvertFOpPattern,
     IntToFPPattern<arith::UIToFPOp, spirv::ConvertUToFOp, false>,
     BoolToValuePattern<arith::UIToFPOp>,
     IntToFPPattern<arith::SIToFPOp, spirv::ConvertSToFOp, true>,

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -1158,6 +1158,47 @@ func.func @fptosi2(%arg0 : f16) -> i16 {
 
 // -----
 
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [Float16, BFloat16TypeKHR], [SPV_KHR_bfloat16]>, #spirv.resource_limits<>>
+} {
+
+// CHECK-LABEL: @convertf_f16_to_bf16
+func.func @convertf_f16_to_bf16(%arg0 : f16) -> bf16 {
+  // CHECK: %[[WIDE:.+]] = spirv.FConvert %{{.*}} : f16 to f32
+  // CHECK: spirv.FConvert %[[WIDE]] : f32 to bf16
+  %0 = arith.convertf %arg0 : f16 to bf16
+  return %0 : bf16
+}
+
+// CHECK-LABEL: @convertf_bf16_to_f16
+func.func @convertf_bf16_to_f16(%arg0 : bf16) -> f16 {
+  // CHECK: %[[WIDE:.+]] = spirv.FConvert %{{.*}} : bf16 to f32
+  // CHECK: spirv.FConvert %[[WIDE]] : f32 to f16
+  %0 = arith.convertf %arg0 : bf16 to f16
+  return %0 : f16
+}
+
+// CHECK-LABEL: @convertf_vector_f16_to_bf16
+func.func @convertf_vector_f16_to_bf16(%arg0 : vector<4xf16>) -> vector<4xbf16> {
+  // CHECK: %[[WIDE:.+]] = spirv.FConvert %{{.*}} : vector<4xf16> to vector<4xf32>
+  // CHECK: spirv.FConvert %[[WIDE]] : vector<4xf32> to vector<4xbf16>
+  %0 = arith.convertf %arg0 : vector<4xf16> to vector<4xbf16>
+  return %0 : vector<4xbf16>
+}
+
+// CHECK-LABEL: @convertf_rounding_mode
+func.func @convertf_rounding_mode(%arg0 : f16) -> bf16 {
+  // CHECK: %[[WIDE:.+]] = spirv.FConvert %{{.*}} : f16 to f32
+  // CHECK: spirv.FConvert %[[WIDE]] {fp_rounding_mode = #spirv.fp_rounding_mode<RTE>} : f32 to bf16
+  %0 = arith.convertf %arg0 to_nearest_even : f16 to bf16
+  return %0 : bf16
+}
+
+} // end module
+
+// -----
+
 // Checks that cast types will be adjusted when missing special capabilities for
 // certain non-32-bit scalar types.
 module attributes {


### PR DESCRIPTION
Lower arith.convertf (same-bitwidth casts like f16<->bf16) to spirv.FConvert