### PR TITLE
[OFFLOAD] Add JIT support for SPIRV backend

### DIFF
--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(PluginCommon OBJECT
 add_dependencies(PluginCommon intrinsics_gen PluginErrcodes OffloadAPI)
 
 # Only enable JIT for those targets that LLVM can support.
-set(supported_jit_targets AMDGPU NVPTX)
+set(supported_jit_targets AMDGPU NVPTX SPIRV)
 if (NOT LLVM_LINK_LLVM_DYLIB)
   foreach(target IN LISTS supported_jit_targets)
     if("${target}" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/offload/plugins-nextgen/common/src/JIT.cpp
+++ b/offload/plugins-nextgen/common/src/JIT.cpp
@@ -135,6 +135,14 @@ JITEngine::JITEngine(Triple::ArchType TA) : TT(Triple::getArchTypeName(TA)) {
     LLVMInitializeAMDGPUAsmPrinter();
   }
 #endif
+#ifdef LIBOMPTARGET_JIT_SPIRV
+  if (TT.isSPIRV()) {
+    LLVMInitializeSPIRVTargetInfo();
+    LLVMInitializeSPIRVTarget();
+    LLVMInitializeSPIRVTargetMC();
+    LLVMInitializeSPIRVAsmPrinter();
+  }
+#endif
 }
 
 void JITEngine::opt(TargetMachine *TM, TargetLibraryInfoImpl *TLII, Module &M,


### PR DESCRIPTION
This PR adds support for SPIRV to plugins JIT. It is required in cases when kernel is supplied in bitcode format for spirv triple.