### PR TITLE
[Clang] [OpenMP] Add missing WrongDirective guards in ParseOpenMPClause

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3584,8 +3584,9 @@ OMPClause *Parser::ParseOpenMPClause(OpenMPDirectiveKind DKind,
       ErrorFound = true;
     }
     SourceLocation Loc = ConsumeToken();
-    Clause = Actions.OpenMP().ActOnOpenMPNullaryAssumptionClause(
-        CKind, Loc, Tok.getLocation());
+    if (!WrongDirective)
+      Clause = Actions.OpenMP().ActOnOpenMPNullaryAssumptionClause(
+          CKind, Loc, Tok.getLocation());
     break;
   }
   case OMPC_ompx_attribute:


### PR DESCRIPTION
Protect ActOnOpenMPNullaryAssumptionClause (no_openmp etc.) and ActOnOpenMPDirectivePresenceClause (absent/contains) with a check for WrongDirective, similar to other clauses. This avoids unnecessary parsing and Act calls when the clause is not allowed on the current directive.

Fixes #212780