### PR TITLE
[Darwin][tests] Partially restore some of the change in #212329

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -678,13 +678,24 @@ if(CMAKE_HOST_APPLE AND APPLE)
       find_program(CMAKE_XCRUN NAMES xcrun)
     endif()
 
-    # Check for ld on apple platform. LD64 is the legacy name.
+    # First, check if there's ld-classic, which is ld64 in newer SDKs.
     if(CMAKE_XCRUN)
-      execute_process(COMMAND ${CMAKE_XCRUN} -find ld
+      execute_process(COMMAND ${CMAKE_XCRUN} -find ld-classic
         OUTPUT_VARIABLE LD64_EXECUTABLE
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()
-      find_program(LD64_EXECUTABLE NAMES ld DOC "The apple static linker")
+      find_program(LD64_EXECUTABLE NAMES ld-classic DOC "The ld64 linker")
+    endif()
+
+    # Otherwise look for ld directly.
+    if(NOT LD64_EXECUTABLE)
+        if(CMAKE_XCRUN)
+          execute_process(COMMAND ${CMAKE_XCRUN} -find ld
+            OUTPUT_VARIABLE LD64_EXECUTABLE
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        else()
+          find_program(LD64_EXECUTABLE NAMES ld DOC "The ld64 linker")
+        endif()
     endif()
   endif()
 


### PR DESCRIPTION
Restore the fallback path for ld-classic in #212329 to fix some of the
failing CI jobs due to some Xcode releases doesn't have the new linker
that supports `-save-temps` flag. Restore the logic so that `ld-classic`
is preferred over `ld` but no longer requires ld64/ld-classic.

In legacy releases only has ld64, ld64 is used. In latest releases where
ld64 is removed, new linker is feature completed and fully compatible
with ld64. During the transition period where ld64 is shipped as
ld-classic, prefer ld64 since new linker might not be feature complete.

rdar://183454376
