### PR TITLE
[libc++] Fix incorrect paper statuses

### DIFF
--- a/libcxx/docs/Status/Cxx17Papers.csv
+++ b/libcxx/docs/Status/Cxx17Papers.csv
@@ -42,7 +42,7 @@
 "`P0077R2 <https://wg21.link/P0077R2>`__","``is_callable``\ , the missing INVOKE related trait","2016-02 (Jacksonville)","|Complete|","3.9","`#103638 <https://github.com/llvm/llvm-project/issues/103638>`__",""
 "","","","","","",""
 "`P0032R3 <https://wg21.link/P0032R3>`__","Homogeneous interface for variant, any and optional","2016-06 (Oulu)","|Complete|","4","`#103639 <https://github.com/llvm/llvm-project/issues/103639>`__",""
-"`P0040R3 <https://wg21.link/P0040R3>`__","Extending memory management tools","2016-06 (Oulu)","|Complete|","4","`#103640 <https://github.com/llvm/llvm-project/issues/103640>`__",""
+"`P0040R3 <https://wg21.link/P0040R3>`__","Extending memory management tools","2016-06 (Oulu)","|Partial|","","`#103640 <https://github.com/llvm/llvm-project/issues/103640>`__","The serial overloads have been available since v4, but the ``ExecutionPolicy`` overloads have not been implemented."
 "`P0063R3 <https://wg21.link/P0063R3>`__","C++17 should refer to C11 instead of C99","2016-06 (Oulu)","|Complete|","7","`#103642 <https://github.com/llvm/llvm-project/issues/103642>`__",""
 "`P0067R3 <https://wg21.link/P0067R3>`__","Elementary string conversions","2016-06 (Oulu)","|Nothing To Do|","n/a","`#103643 <https://github.com/llvm/llvm-project/issues/103643>`__","Resolved by `P0067R5 <https://wg21.link/P0067R5>`__"
 "`P0083R3 <https://wg21.link/P0083R3>`__","Splicing Maps and Sets","2016-06 (Oulu)","|Complete|","8","`#103645 <https://github.com/llvm/llvm-project/issues/103645>`__",""

--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -39,7 +39,7 @@
 "`P0722R3 <https://wg21.link/P0722R3>`__","Efficient sized delete for variable sized classes","2018-06 (Rapperswil)","|Complete|","9","`#104092 <https://github.com/llvm/llvm-project/issues/104092>`__",""
 "`P0758R1 <https://wg21.link/P0758R1>`__","Implicit conversion traits and utility functions","2018-06 (Rapperswil)","|Complete|","","`#104093 <https://github.com/llvm/llvm-project/issues/104093>`__",""
 "`P0759R1 <https://wg21.link/P0759R1>`__","fpos Requirements","2018-06 (Rapperswil)","|Complete|","11","`#104094 <https://github.com/llvm/llvm-project/issues/104094>`__",""
-"`P0769R2 <https://wg21.link/P0769R2>`__","Add shift to <algorithm>","2018-06 (Rapperswil)","|Complete|","12","`#104095 <https://github.com/llvm/llvm-project/issues/104095>`__",""
+"`P0769R2 <https://wg21.link/P0769R2>`__","Add shift to <algorithm>","2018-06 (Rapperswil)","|Partial|","","`#104095 <https://github.com/llvm/llvm-project/issues/104095>`__","The serial overloads have been available since v12, but the ``ExecutionPolicy`` overloads have not been implemented."
 "`P0788R3 <https://wg21.link/P0788R3>`__","Standard Library Specification in a Concepts and Contracts World","2018-06 (Rapperswil)","|Nothing To Do|","n/a","`#104096 <https://github.com/llvm/llvm-project/issues/104096>`__","Pulled at the 2019-07 meeting in Cologne"
 "`P0879R0 <https://wg21.link/P0879R0>`__","Constexpr for swap and swap related functions Also resolves LWG issue 2800.","2018-06 (Rapperswil)","|Complete|","13","`#104097 <https://github.com/llvm/llvm-project/issues/104097>`__",""
 "`P0887R1 <https://wg21.link/P0887R1>`__","The identity metafunction","2018-06 (Rapperswil)","|Complete|","8","`#104099 <https://github.com/llvm/llvm-project/issues/104099>`__",""


### PR DESCRIPTION
These two papers also added parallel algorithm overloads, which were never implemented but the papers were still marked as implemented. Mark the papers as Partial instead.

CF #103640 and #104095