### PR TITLE
[llvm-nm][GOFF] Display archive attributes in GOFF archives through --print-armap

### DIFF
--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -349,9 +349,9 @@ public:
     LLVM_ABI Symbol getNext() const;
     LLVM_ABI bool isECSymbol() const;
     /// Archive attribute bit masks for K_ZOS archive symbol table entries.
-    static constexpr uint32_t ZOSAttrWSA       = 0x1;
-    static constexpr uint32_t ZOSAttrXPLink    = 0x2;
-    static constexpr uint32_t ZOSAttr64Bit     = 0x4;
+    static constexpr uint32_t ZOSAttrWSA = 0x1;
+    static constexpr uint32_t ZOSAttrXPLink = 0x2;
+    static constexpr uint32_t ZOSAttr64Bit = 0x4;
     static constexpr uint32_t ZOSKnownAttrMask =
         ZOSAttrWSA | ZOSAttrXPLink | ZOSAttr64Bit;
     /// For K_ZOS archives, returns the 32-bit attribute word stored alongside

--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -348,6 +348,11 @@ public:
     LLVM_ABI Expected<Child> getMember() const;
     LLVM_ABI Symbol getNext() const;
     LLVM_ABI bool isECSymbol() const;
+    /// For K_ZOS archives, returns the 32-bit attribute word stored alongside
+    /// the symbol-table entry. The currently defined low bits are:
+    /// bit 2 = 64-bit, bit 1 = XPLink, and bit 0 = WSA.
+    /// Returns 0 for non-z/OS archives.
+    LLVM_ABI uint32_t getZOSAttributes() const;
   };
 
   class symbol_iterator {

--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -348,10 +348,15 @@ public:
     LLVM_ABI Expected<Child> getMember() const;
     LLVM_ABI Symbol getNext() const;
     LLVM_ABI bool isECSymbol() const;
+    /// Archive attribute bit masks for K_ZOS archive symbol table entries.
+    static constexpr uint32_t ZOSAttrWSA       = 0x1;
+    static constexpr uint32_t ZOSAttrXPLink    = 0x2;
+    static constexpr uint32_t ZOSAttr64Bit     = 0x4;
+    static constexpr uint32_t ZOSKnownAttrMask =
+        ZOSAttrWSA | ZOSAttrXPLink | ZOSAttr64Bit;
     /// For K_ZOS archives, returns the 32-bit attribute word stored alongside
-    /// the symbol-table entry. The currently defined low bits are:
-    /// bit 2 = 64-bit, bit 1 = XPLink, and bit 0 = WSA.
-    /// Returns 0 for non-z/OS archives.
+    /// the symbol-table entry. The low bits are described by the ZOSAttr*
+    /// constants above. Returns 0 for non-z/OS archives.
     LLVM_ABI uint32_t getZOSAttributes() const;
   };
 

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -1143,6 +1143,9 @@ bool Archive::Symbol::isECSymbol() const {
 uint32_t Archive::Symbol::getZOSAttributes() const {
   if (Parent->kind() != K_ZOS)
     return 0;
+  if (SymbolIndex >= Parent->getNumberOfSymbols())
+    return 0;
+
   // The z/OS symbol table layout is:
   //   NumSyms * { uint32_t member_offset, uint32_t attrs }  (big-endian)
   const char *Buf = Parent->getSymbolTable().begin();

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -1140,6 +1140,15 @@ bool Archive::Symbol::isECSymbol() const {
          SymbolIndex < SymbolCount + Parent->getNumberOfECSymbols();
 }
 
+uint32_t Archive::Symbol::getZOSAttributes() const {
+  if (Parent->kind() != K_ZOS)
+    return 0;
+  // The z/OS symbol table layout is:
+  //   NumSyms * { uint32_t member_offset, uint32_t attrs }  (big-endian)
+  const char *Buf = Parent->getSymbolTable().begin();
+  return read32be(Buf + sizeof(uint32_t) + SymbolIndex * 8 + sizeof(uint32_t));
+}
+
 StringRef Archive::Symbol::getName() const {
   if (isECSymbol())
     return Parent->ECSymbolTable.begin() + StringIndex;

--- a/llvm/test/tools/llvm-nm/zos-armap.test
+++ b/llvm/test/tools/llvm-nm/zos-armap.test
@@ -1,10 +1,12 @@
-## Test that llvm-nm --print-armap prints both the standard archive map and
-## the z/OS-specific attribute map for GOFF archives.
+## Test that llvm-nm --print-armap prints the archive map for GOFF archives,
+## including inline z/OS attribute flags on each symbol line.
 ##
-## All 8 combinations of the 3 attribute bits are exercised in this test:
+## All 8 combinations of the 3 known attribute bits are exercised, plus two
+## symbols with unknown bits set to cover the '?' flag:
 ##   bit 2 (0x4): 64-bit  (AMODE == ESD_AMODE_64)
 ##   bit 1 (0x2): XPLink  (LinkageType == ESD_LT_XPLink)
 ##   bit 0 (0x1): WSA     (parent ED namespace == ESD_NS_Parts)
+##   bit 3+      : unknown, printed as '?'
 ##
 ## The archive is generated directly using generate_zos_archive.py.
 
@@ -20,7 +22,9 @@
 # RUN:   --symtab "sym100:0:4"           \
 # RUN:   --symtab "sym101:0:5"           \
 # RUN:   --symtab "sym110:0:6"           \
-# RUN:   --symtab "sym111:0:7"
+# RUN:   --symtab "sym111:0:7"           \
+# RUN:   --symtab "symunk:0:8"           \
+# RUN:   --symtab "symall:0:15"
 
 # RUN: llvm-nm --print-armap %t.dir/test.a | FileCheck %s
 
@@ -34,3 +38,5 @@
 # CHECK-NEXT: sym101 in test.o (flags: 0x00000005 [64-bit + WSA])
 # CHECK-NEXT: sym110 in test.o (flags: 0x00000006 [64-bit + XPLink])
 # CHECK-NEXT: sym111 in test.o (flags: 0x00000007 [64-bit + XPLink + WSA])
+# CHECK-NEXT: symunk in test.o (flags: 0x00000008 [?])
+# CHECK-NEXT: symall in test.o (flags: 0x0000000f [64-bit + XPLink + WSA + ?])

--- a/llvm/test/tools/llvm-nm/zos-armap.test
+++ b/llvm/test/tools/llvm-nm/zos-armap.test
@@ -24,28 +24,13 @@
 
 # RUN: llvm-nm --print-armap %t.dir/test.a | FileCheck %s
 
-## Check the standard archive map with the usual "name in member" format.
+## For z/OS archives, each symbol line includes (flags: <hex> [description]).
 # CHECK:      Archive map
-# CHECK-NEXT: sym000 in test.o
-# CHECK-NEXT: sym001 in test.o
-# CHECK-NEXT: sym010 in test.o
-# CHECK-NEXT: sym011 in test.o
-# CHECK-NEXT: sym100 in test.o
-# CHECK-NEXT: sym101 in test.o
-# CHECK-NEXT: sym110 in test.o
-# CHECK-NEXT: sym111 in test.o
-
-## Check the z/OS attribute map follows with header and separator line.
-# CHECK:      Archive map (z/OS attributes)
-# CHECK-NEXT: Name{{.*}}Member{{.*}}Attributes{{.*}}Attribute Description
-# CHECK-NEXT: ---
-
-## All 8 bit combinations: raw hex and decoded description.
-# CHECK: sym000{{[ ]+}}test.o{{[ ]+}}0x00000000{{[ ]+}}[none]
-# CHECK: sym001{{[ ]+}}test.o{{[ ]+}}0x00000001{{[ ]+}}[WSA]
-# CHECK: sym010{{[ ]+}}test.o{{[ ]+}}0x00000002{{[ ]+}}[XPLink]
-# CHECK: sym011{{[ ]+}}test.o{{[ ]+}}0x00000003{{[ ]+}}[XPLink + WSA]
-# CHECK: sym100{{[ ]+}}test.o{{[ ]+}}0x00000004{{[ ]+}}[64-bit]
-# CHECK: sym101{{[ ]+}}test.o{{[ ]+}}0x00000005{{[ ]+}}[64-bit + WSA]
-# CHECK: sym110{{[ ]+}}test.o{{[ ]+}}0x00000006{{[ ]+}}[64-bit + XPLink]
-# CHECK: sym111{{[ ]+}}test.o{{[ ]+}}0x00000007{{[ ]+}}[64-bit + XPLink + WSA]
+# CHECK-NEXT: sym000 in test.o (flags: 0x00000000 [none])
+# CHECK-NEXT: sym001 in test.o (flags: 0x00000001 [WSA])
+# CHECK-NEXT: sym010 in test.o (flags: 0x00000002 [XPLink])
+# CHECK-NEXT: sym011 in test.o (flags: 0x00000003 [XPLink + WSA])
+# CHECK-NEXT: sym100 in test.o (flags: 0x00000004 [64-bit])
+# CHECK-NEXT: sym101 in test.o (flags: 0x00000005 [64-bit + WSA])
+# CHECK-NEXT: sym110 in test.o (flags: 0x00000006 [64-bit + XPLink])
+# CHECK-NEXT: sym111 in test.o (flags: 0x00000007 [64-bit + XPLink + WSA])

--- a/llvm/test/tools/llvm-nm/zos-armap.test
+++ b/llvm/test/tools/llvm-nm/zos-armap.test
@@ -1,0 +1,51 @@
+## Test that llvm-nm --print-armap prints both the standard archive map and
+## the z/OS-specific attribute map for GOFF archives.
+##
+## All 8 combinations of the 3 attribute bits are exercised in this test:
+##   bit 2 (0x4): 64-bit  (AMODE == ESD_AMODE_64)
+##   bit 1 (0x2): XPLink  (LinkageType == ESD_LT_XPLink)
+##   bit 0 (0x1): WSA     (parent ED namespace == ESD_NS_Parts)
+##
+## The archive is generated directly using generate_zos_archive.py.
+
+# RUN: rm -rf %t.dir && mkdir -p %t.dir
+
+# RUN: %python %S/../../Object/Inputs/generate_zos_archive.py \
+# RUN:   --output %t.dir/test.a          \
+# RUN:   --member "test.o:hex:abcdabcd"  \
+# RUN:   --symtab "sym000:0:0"           \
+# RUN:   --symtab "sym001:0:1"           \
+# RUN:   --symtab "sym010:0:2"           \
+# RUN:   --symtab "sym011:0:3"           \
+# RUN:   --symtab "sym100:0:4"           \
+# RUN:   --symtab "sym101:0:5"           \
+# RUN:   --symtab "sym110:0:6"           \
+# RUN:   --symtab "sym111:0:7"
+
+# RUN: llvm-nm --print-armap %t.dir/test.a | FileCheck %s
+
+## Check the standard archive map with the usual "name in member" format.
+# CHECK:      Archive map
+# CHECK-NEXT: sym000 in test.o
+# CHECK-NEXT: sym001 in test.o
+# CHECK-NEXT: sym010 in test.o
+# CHECK-NEXT: sym011 in test.o
+# CHECK-NEXT: sym100 in test.o
+# CHECK-NEXT: sym101 in test.o
+# CHECK-NEXT: sym110 in test.o
+# CHECK-NEXT: sym111 in test.o
+
+## Check the z/OS attribute map follows with header and separator line.
+# CHECK:      Archive map (z/OS attributes)
+# CHECK-NEXT: Name{{.*}}Member{{.*}}Attributes{{.*}}Attribute Description
+# CHECK-NEXT: ---
+
+## All 8 bit combinations: raw hex and decoded description.
+# CHECK: sym000{{[ ]+}}test.o{{[ ]+}}0x00000000{{[ ]+}}[none]
+# CHECK: sym001{{[ ]+}}test.o{{[ ]+}}0x00000001{{[ ]+}}[WSA]
+# CHECK: sym010{{[ ]+}}test.o{{[ ]+}}0x00000002{{[ ]+}}[XPLink]
+# CHECK: sym011{{[ ]+}}test.o{{[ ]+}}0x00000003{{[ ]+}}[XPLink + WSA]
+# CHECK: sym100{{[ ]+}}test.o{{[ ]+}}0x00000004{{[ ]+}}[64-bit]
+# CHECK: sym101{{[ ]+}}test.o{{[ ]+}}0x00000005{{[ ]+}}[64-bit + WSA]
+# CHECK: sym110{{[ ]+}}test.o{{[ ]+}}0x00000006{{[ ]+}}[64-bit + XPLink]
+# CHECK: sym111{{[ ]+}}test.o{{[ ]+}}0x00000007{{[ ]+}}[64-bit + XPLink + WSA]

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2069,10 +2069,10 @@ static void printArchiveMap(iterator_range<Archive::symbol_iterator> &map,
 /// human-readable string, e.g. "[64-bit + XPLink]".
 /// Any bits above the known 3-bit mask produce a trailing "?" flag.
 static std::string decodeZOSAttributes(uint32_t Attrs) {
-  bool Unknown = (Attrs & ~0x7u) != 0;
-  bool Is64Bit = (Attrs & 0x4) != 0;
-  bool IsXPLink = (Attrs & 0x2) != 0;
-  bool IsWSA    = (Attrs & 0x1) != 0;
+  bool Unknown = (Attrs & ~Archive::Symbol::ZOSKnownAttrMask) != 0;
+  bool Is64Bit = (Attrs & Archive::Symbol::ZOSAttr64Bit) != 0;
+  bool IsXPLink = (Attrs & Archive::Symbol::ZOSAttrXPLink) != 0;
+  bool IsWSA    = (Attrs & Archive::Symbol::ZOSAttrWSA) != 0;
 
   std::string Result = "[";
   bool NeedPlus = false;
@@ -2108,7 +2108,9 @@ static void printZOSArchiveMap(iterator_range<Archive::symbol_iterator> &Map,
          << left_justify("Member", MemberW) << " "
          << left_justify("Attributes", AttrsW) << " "
          << "Attribute Description\n";
-  outs() << std::string(NameW + 1 + MemberW + 1 + AttrsW + 1 + 21, '-') << "\n";
+  constexpr unsigned AttrDescW = sizeof("Attribute Description") - 1;
+  outs() << std::string(NameW + 1 + MemberW + 1 + AttrsW + 1 + AttrDescW, '-')
+         << "\n";
 
   for (auto I : Map) {
     Expected<Archive::Child> C = I.getMember();

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2084,7 +2084,8 @@ static void printArchiveMap(iterator_range<Archive::symbol_iterator> &Map,
       error(FileNameOrErr.takeError(), Filename);
       break;
     }
-    outs() << I.getName() << " in " << FileNameOrErr.get();
+    StringRef SymName = I.getName();
+    outs() << SymName << " in " << FileNameOrErr.get();
     if (PrintZOSAttrs) {
       uint32_t Attrs = I.getZOSAttributes();
       std::string AttrsStr;

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2045,26 +2045,6 @@ static bool checkMachOAndArchFlags(SymbolicFile *O, StringRef Filename) {
   return true;
 }
 
-static void printArchiveMap(iterator_range<Archive::symbol_iterator> &map,
-                            StringRef Filename) {
-  for (auto I : map) {
-    Expected<Archive::Child> C = I.getMember();
-    if (!C) {
-      error(C.takeError(), Filename);
-      break;
-    }
-    Expected<StringRef> FileNameOrErr = C->getName();
-    if (!FileNameOrErr) {
-      error(FileNameOrErr.takeError(), Filename);
-      break;
-    }
-    StringRef SymName = I.getName();
-    outs() << SymName << " in " << FileNameOrErr.get() << "\n";
-  }
-
-  outs() << "\n";
-}
-
 /// Decode the low 3 bits of a z/OS archive symbol attribute word into a
 /// human-readable string, e.g. "[64-bit + XPLink]".
 /// Any bits above the known 3-bit mask produce a trailing "?" flag.
@@ -2091,27 +2071,8 @@ static std::string decodeZOSAttributes(uint32_t Attrs) {
   return Result;
 }
 
-/// Print the z/OS-specific archive map with archive symbol attributes.
-///
-/// Columns:
-///   Name                   - symbol name
-///   Member                 - archive member filename
-///   Attributes             - raw attribute word (hex)
-///   Attribute Description  - decoded bit flags of the archive attributes
-static void printZOSArchiveMap(iterator_range<Archive::symbol_iterator> &Map,
-                               StringRef Filename) {
-  constexpr unsigned NameW   = 20;
-  constexpr unsigned MemberW = 22;
-  constexpr unsigned AttrsW  = 12;
-
-  outs() << left_justify("Name", NameW) << " "
-         << left_justify("Member", MemberW) << " "
-         << left_justify("Attributes", AttrsW) << " "
-         << "Attribute Description\n";
-  constexpr unsigned AttrDescW = sizeof("Attribute Description") - 1;
-  outs() << std::string(NameW + 1 + MemberW + 1 + AttrsW + 1 + AttrDescW, '-')
-         << "\n";
-
+static void printArchiveMap(iterator_range<Archive::symbol_iterator> &Map,
+                            StringRef Filename, bool PrintZOSAttrs = false) {
   for (auto I : Map) {
     Expected<Archive::Child> C = I.getMember();
     if (!C) {
@@ -2123,14 +2084,17 @@ static void printZOSArchiveMap(iterator_range<Archive::symbol_iterator> &Map,
       error(FileNameOrErr.takeError(), Filename);
       break;
     }
-    uint32_t Attrs = I.getZOSAttributes();
-    std::string AttrsStr;
-    llvm::raw_string_ostream(AttrsStr) << format("0x%08x", Attrs);
-    outs() << left_justify(I.getName(), NameW) << " "
-           << left_justify(FileNameOrErr.get(), MemberW) << " "
-           << left_justify(AttrsStr, AttrsW) << " "
-           << decodeZOSAttributes(Attrs) << "\n";
+    outs() << I.getName() << " in " << FileNameOrErr.get();
+    if (PrintZOSAttrs) {
+      uint32_t Attrs = I.getZOSAttributes();
+      std::string AttrsStr;
+      llvm::raw_string_ostream(AttrsStr) << format("0x%08x", Attrs);
+      outs() << " (flags: " << AttrsStr << " " << decodeZOSAttributes(Attrs)
+             << ")";
+    }
+    outs() << "\n";
   }
+
   outs() << "\n";
 }
 
@@ -2138,13 +2102,7 @@ static void dumpArchiveMap(Archive *A, StringRef Filename) {
   auto Map = A->symbols();
   if (!Map.empty()) {
     outs() << "Archive map\n";
-    printArchiveMap(Map, Filename);
-    // For z/OS archives, also print the extended map showing per-symbol
-    // attributes (64-bit, XPLink, WSA) stored in the __.SYMDEF symbol table.
-    if (A->kind() == Archive::K_ZOS) {
-      outs() << "Archive map (z/OS attributes)\n";
-      printZOSArchiveMap(Map, Filename);
-    }
+    printArchiveMap(Map, Filename, A->kind() == Archive::K_ZOS);
   }
 
   auto ECMap = A->ec_symbols();

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2065,11 +2065,84 @@ static void printArchiveMap(iterator_range<Archive::symbol_iterator> &map,
   outs() << "\n";
 }
 
+/// Decode the low 3 bits of a z/OS archive symbol attribute word into a
+/// human-readable string, e.g. "[64-bit + XPLink]".
+/// Any bits above the known 3-bit mask produce a trailing "?" flag.
+static std::string decodeZOSAttributes(uint32_t Attrs) {
+  bool Unknown = (Attrs & ~0x7u) != 0;
+  bool Is64Bit = (Attrs & 0x4) != 0;
+  bool IsXPLink = (Attrs & 0x2) != 0;
+  bool IsWSA    = (Attrs & 0x1) != 0;
+
+  std::string Result = "[";
+  bool NeedPlus = false;
+  auto append = [&](const char *S) {
+    if (NeedPlus)
+      Result += " + ";
+    Result += S;
+    NeedPlus = true;
+  };
+  if (Is64Bit)  append("64-bit");
+  if (IsXPLink) append("XPLink");
+  if (IsWSA)    append("WSA");
+  if (Unknown)  append("?");
+  if (!NeedPlus) append("none");
+  Result += "]";
+  return Result;
+}
+
+/// Print the z/OS-specific archive map with archive symbol attributes.
+///
+/// Columns:
+///   Name                   - symbol name
+///   Member                 - archive member filename
+///   Attributes             - raw attribute word (hex)
+///   Attribute Description  - decoded bit flags of the archive attributes
+static void printZOSArchiveMap(iterator_range<Archive::symbol_iterator> &Map,
+                               StringRef Filename) {
+  constexpr unsigned NameW   = 20;
+  constexpr unsigned MemberW = 22;
+  constexpr unsigned AttrsW  = 12;
+
+  outs() << left_justify("Name", NameW) << " "
+         << left_justify("Member", MemberW) << " "
+         << left_justify("Attributes", AttrsW) << " "
+         << "Attribute Description\n";
+  outs() << std::string(NameW + 1 + MemberW + 1 + AttrsW + 1 + 21, '-') << "\n";
+
+  for (auto I : Map) {
+    Expected<Archive::Child> C = I.getMember();
+    if (!C) {
+      error(C.takeError(), Filename);
+      break;
+    }
+    Expected<StringRef> FileNameOrErr = C->getName();
+    if (!FileNameOrErr) {
+      error(FileNameOrErr.takeError(), Filename);
+      break;
+    }
+    uint32_t Attrs = I.getZOSAttributes();
+    std::string AttrsStr;
+    llvm::raw_string_ostream(AttrsStr) << format("0x%08x", Attrs);
+    outs() << left_justify(I.getName(), NameW) << " "
+           << left_justify(FileNameOrErr.get(), MemberW) << " "
+           << left_justify(AttrsStr, AttrsW) << " "
+           << decodeZOSAttributes(Attrs) << "\n";
+  }
+  outs() << "\n";
+}
+
 static void dumpArchiveMap(Archive *A, StringRef Filename) {
   auto Map = A->symbols();
   if (!Map.empty()) {
     outs() << "Archive map\n";
     printArchiveMap(Map, Filename);
+    // For z/OS archives, also print the extended map showing per-symbol
+    // attributes (64-bit, XPLink, WSA) stored in the __.SYMDEF symbol table.
+    if (A->kind() == Archive::K_ZOS) {
+      outs() << "Archive map (z/OS attributes)\n";
+      printZOSArchiveMap(Map, Filename);
+    }
   }
 
   auto ECMap = A->ec_symbols();

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2052,7 +2052,7 @@ static std::string decodeZOSAttributes(uint32_t Attrs) {
   bool Unknown = (Attrs & ~Archive::Symbol::ZOSKnownAttrMask) != 0;
   bool Is64Bit = (Attrs & Archive::Symbol::ZOSAttr64Bit) != 0;
   bool IsXPLink = (Attrs & Archive::Symbol::ZOSAttrXPLink) != 0;
-  bool IsWSA    = (Attrs & Archive::Symbol::ZOSAttrWSA) != 0;
+  bool IsWSA = (Attrs & Archive::Symbol::ZOSAttrWSA) != 0;
 
   std::string Result = "[";
   bool NeedPlus = false;
@@ -2062,11 +2062,16 @@ static std::string decodeZOSAttributes(uint32_t Attrs) {
     Result += S;
     NeedPlus = true;
   };
-  if (Is64Bit)  append("64-bit");
-  if (IsXPLink) append("XPLink");
-  if (IsWSA)    append("WSA");
-  if (Unknown)  append("?");
-  if (!NeedPlus) append("none");
+  if (Is64Bit)
+    append("64-bit");
+  if (IsXPLink)
+    append("XPLink");
+  if (IsWSA)
+    append("WSA");
+  if (Unknown)
+    append("?");
+  if (!NeedPlus)
+    append("none");
   Result += "]";
   return Result;
 }


### PR DESCRIPTION
GOFF archive symbol table entries contain an attribute word in addition
to the archive member offset. The low three bits describe whether the symbol is
64-bit, uses XPLink, or belongs to the WSA namespace (which was briefly mentioned
in e2c8fa09872cfacba7f73599dcf8557971ebe865).

This patch extends `llvm-nm --print-armap` to print the attribute value (in hex) and
its decoded description beside a symbol and its corresponding member when processing
a GOFF archive. This will functionality will be used to help validate full support for writing
GOFF archives in a subsequent llvm-ar patch.

The output for non-z/OS archives is unchanged.