### PR TITLE
[SPARC] Accept named register aliases

### DIFF
--- a/llvm/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.cpp
@@ -1204,16 +1204,43 @@ SparcTargetLowering::LowerCall_32(TargetLowering::CallLoweringInfo &CLI,
 // this table could be generated automatically from RegInfo.
 Register SparcTargetLowering::getRegisterByName(const char* RegName, LLT VT,
                                                 const MachineFunction &MF) const {
-  Register Reg = StringSwitch<Register>(RegName)
-    .Case("i0", SP::I0).Case("i1", SP::I1).Case("i2", SP::I2).Case("i3", SP::I3)
-    .Case("i4", SP::I4).Case("i5", SP::I5).Case("i6", SP::I6).Case("i7", SP::I7)
-    .Case("o0", SP::O0).Case("o1", SP::O1).Case("o2", SP::O2).Case("o3", SP::O3)
-    .Case("o4", SP::O4).Case("o5", SP::O5).Case("o6", SP::O6).Case("o7", SP::O7)
-    .Case("l0", SP::L0).Case("l1", SP::L1).Case("l2", SP::L2).Case("l3", SP::L3)
-    .Case("l4", SP::L4).Case("l5", SP::L5).Case("l6", SP::L6).Case("l7", SP::L7)
-    .Case("g0", SP::G0).Case("g1", SP::G1).Case("g2", SP::G2).Case("g3", SP::G3)
-    .Case("g4", SP::G4).Case("g5", SP::G5).Case("g6", SP::G6).Case("g7", SP::G7)
-    .Default(0);
+  StringRef Name(RegName);
+  Name.consume_front("%");
+
+  Register Reg = StringSwitch<Register>(Name)
+                     .Cases({"r24", "i0"}, SP::I0)
+                     .Cases({"r25", "i1"}, SP::I1)
+                     .Cases({"r26", "i2"}, SP::I2)
+                     .Cases({"r27", "i3"}, SP::I3)
+                     .Cases({"r28", "i4"}, SP::I4)
+                     .Cases({"r29", "i5"}, SP::I5)
+                     .Cases({"r30", "i6", "fp"}, SP::I6)
+                     .Cases({"r31", "i7"}, SP::I7)
+                     .Cases({"r8", "o0"}, SP::O0)
+                     .Cases({"r9", "o1"}, SP::O1)
+                     .Cases({"r10", "o2"}, SP::O2)
+                     .Cases({"r11", "o3"}, SP::O3)
+                     .Cases({"r12", "o4"}, SP::O4)
+                     .Cases({"r13", "o5"}, SP::O5)
+                     .Cases({"r14", "o6", "sp"}, SP::O6)
+                     .Cases({"r15", "o7"}, SP::O7)
+                     .Cases({"r16", "l0"}, SP::L0)
+                     .Cases({"r17", "l1"}, SP::L1)
+                     .Cases({"r18", "l2"}, SP::L2)
+                     .Cases({"r19", "l3"}, SP::L3)
+                     .Cases({"r20", "l4"}, SP::L4)
+                     .Cases({"r21", "l5"}, SP::L5)
+                     .Cases({"r22", "l6"}, SP::L6)
+                     .Cases({"r23", "l7"}, SP::L7)
+                     .Cases({"r0", "g0"}, SP::G0)
+                     .Cases({"r1", "g1"}, SP::G1)
+                     .Cases({"r2", "g2"}, SP::G2)
+                     .Cases({"r3", "g3"}, SP::G3)
+                     .Cases({"r4", "g4"}, SP::G4)
+                     .Cases({"r5", "g5"}, SP::G5)
+                     .Cases({"r6", "g6"}, SP::G6)
+                     .Cases({"r7", "g7"}, SP::G7)
+                     .Default(0);
 
   // If we're directly referencing register names
   // (e.g in GCC C extension `register int r asm("g1");`),

--- a/llvm/test/CodeGen/SPARC/reserved-regs-named.ll
+++ b/llvm/test/CodeGen/SPARC/reserved-regs-named.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -mtriple=sparc64-linux-gnu -mattr=+reserve-l0 -o - %s | FileCheck %s --check-prefixes=CHECK-RESERVED-L0
+; RUN: llc -mtriple=sparc64-linux-gnu -mattr=+reserve-l0 -stop-after=finalize-isel -o - %s | FileCheck %s --check-prefix=NAMES
 
 ;; Ensure explicit register references are catched as well.
 
@@ -11,3 +12,96 @@ entry:
 
 declare void @llvm.write_register.i32(metadata, i32)
 !0 = !{!"l0"}
+
+; NAMES-LABEL: name: {{ *}}read_percent_sp
+; NAMES: {{%[0-9]+}}:i64regs = COPY $o6
+define i64 @read_percent_sp() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !1)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_sp
+; NAMES: {{%[0-9]+}}:i64regs = COPY $o6
+define i64 @read_sp() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !2)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_percent_r14
+; NAMES: {{%[0-9]+}}:i64regs = COPY $o6
+define i64 @read_percent_r14() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !3)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_percent_fp
+; NAMES: {{%[0-9]+}}:i64regs = COPY $i6
+define i64 @read_percent_fp() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !4)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_fp
+; NAMES: {{%[0-9]+}}:i64regs = COPY $i6
+define i64 @read_fp() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !5)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_r30
+; NAMES: {{%[0-9]+}}:i64regs = COPY $i6
+define i64 @read_r30() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !6)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_percent_g6
+; NAMES: {{%[0-9]+}}:i64regs = COPY $g6
+define i64 @read_percent_g6() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !7)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_r0
+; NAMES: {{%[0-9]+}}:i64regs = COPY $g0
+define i64 @read_r0() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !8)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_r16
+; NAMES: {{%[0-9]+}}:i64regs = COPY $l0
+define i64 @read_r16() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !9)
+  ret i64 %value
+}
+
+; NAMES-LABEL: name: {{ *}}read_r31
+; NAMES: {{%[0-9]+}}:i64regs = COPY $i7
+define i64 @read_r31() {
+entry:
+  %value = call i64 @llvm.read_register.i64(metadata !10)
+  ret i64 %value
+}
+
+declare i64 @llvm.read_register.i64(metadata)
+
+!1 = !{!"%sp"}
+!2 = !{!"sp"}
+!3 = !{!"%r14"}
+!4 = !{!"%fp"}
+!5 = !{!"fp"}
+!6 = !{!"r30"}
+!7 = !{!"%g6"}
+!8 = !{!"r0"}
+!9 = !{!"r16"}
+!10 = !{!"r31"}


### PR DESCRIPTION
Handle r0-r31, sp, fp and the optional '%' prefix in llvm.read_register and llvm.write_register.