### PR TITLE
[GVN]Infer nsz flag on value selects from the function attribute

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -1187,10 +1187,17 @@ Value *AvailableValue::MaterializeAdjustedValue(LoadInst *Load,
     // Introduce a new value select for a load from an eligible pointer select.
     Value *Cond = getSelectCondition();
     assert(V1 && V2 && "both value operands of the select must be present");
-    Res = SelectInst::Create(Cond, V1, V2, "", InsertPt->getIterator());
+    auto *Sel = SelectInst::Create(Cond, V1, V2, "", InsertPt->getIterator());
     // We use the DebugLoc from the original load here, as this instruction
     // materializes the value that would previously have been loaded.
-    cast<SelectInst>(Res)->setDebugLoc(Load->getDebugLoc());
+    Sel->setDebugLoc(Load->getDebugLoc());
+    // Propagate nsz flag from the function attribute to enable min/max folding.
+    if (isa<FPMathOperator>(Sel) &&
+        Load->getFunction()
+            ->getFnAttribute("no-signed-zeros-fp-math")
+            .getValueAsBool())
+      Sel->setHasNoSignedZeros(true);
+    Res = Sel;
   } else {
     llvm_unreachable("Should not materialize value from dead block");
   }

--- a/llvm/test/Transforms/GVN/load-of-pointer-select-available.ll
+++ b/llvm/test/Transforms/GVN/load-of-pointer-select-available.ll
@@ -942,3 +942,47 @@ exit:
   %res = load i32, ptr %min.select, align 4
   ret i32 %res
 }
+
+define float @float_value_select_nsz_fn_attr(ptr %p1, ptr %p2, i1 %c) #0 {
+; CHECK-LABEL: @float_value_select_nsz_fn_attr(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[V1:%.*]] = load float, ptr [[P1:%.*]], align 4
+; CHECK-NEXT:    [[V2:%.*]] = load float, ptr [[P2:%.*]], align 4
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[C:%.*]], ptr [[P1]], ptr [[P2]]
+; CHECK-NEXT:    [[TMP0:%.*]] = select nsz i1 [[C]], float [[V1]], float [[V2]]
+; CHECK-NEXT:    [[R:%.*]] = fadd float [[V1]], [[TMP0]]
+; CHECK-NEXT:    [[R2:%.*]] = fadd float [[R]], [[V2]]
+; CHECK-NEXT:    ret float [[R2]]
+;
+entry:
+  %v1 = load float, ptr %p1, align 4
+  %v2 = load float, ptr %p2, align 4
+  %s = select i1 %c, ptr %p1, ptr %p2
+  %v = load float, ptr %s, align 4
+  %r = fadd float %v1, %v
+  %r2 = fadd float %r, %v2
+  ret float %r2
+}
+
+define float @float_value_select_no_nsz_fn_attr(ptr %p1, ptr %p2, i1 %c) {
+; CHECK-LABEL: @float_value_select_no_nsz_fn_attr(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[V1:%.*]] = load float, ptr [[P1:%.*]], align 4
+; CHECK-NEXT:    [[V2:%.*]] = load float, ptr [[P2:%.*]], align 4
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[C:%.*]], ptr [[P1]], ptr [[P2]]
+; CHECK-NEXT:    [[TMP0:%.*]] = select i1 [[C]], float [[V1]], float [[V2]]
+; CHECK-NEXT:    [[R:%.*]] = fadd float [[V1]], [[TMP0]]
+; CHECK-NEXT:    [[R2:%.*]] = fadd float [[R]], [[V2]]
+; CHECK-NEXT:    ret float [[R2]]
+;
+entry:
+  %v1 = load float, ptr %p1, align 4
+  %v2 = load float, ptr %p2, align 4
+  %s = select i1 %c, ptr %p1, ptr %p2
+  %v = load float, ptr %s, align 4
+  %r = fadd float %v1, %v
+  %r2 = fadd float %r, %v2
+  ret float %r2
+}
+
+attributes #0 = { "no-signed-zeros-fp-math"="true" }


### PR DESCRIPTION
The value select materialized for a load through a pointer select is
created without fast-math flags. After the signed zero handling fix in
matchSelectPattern (#210077), an FP min/max based on such a select no
longer folds (fcsel instead of fminnm on AArch64). Propagate nsz from
the no-signed-zeros-fp-math function attribute to re-enable the fold.
