### PR TITLE
[llvm][macho][test] Fix failing target triple tests

### DIFF
--- a/llvm/test/MC/MachO/target-triple-padding.s
+++ b/llvm/test/MC/MachO/target-triple-padding.s
@@ -1,3 +1,5 @@
+// REQUIRES: aarch64-registered-target
+
 // RUN: split-file %s %t
 
 // RUN: llvm-mc -triple arm64-ios-macabi %t/target-triple-always-has-nul.s -filetype=obj -o - \

--- a/llvm/test/MC/MachO/target-triple.s
+++ b/llvm/test/MC/MachO/target-triple.s
@@ -1,3 +1,5 @@
+// REQUIRES: aarch64-registered-target
+
 // RUN: split-file %s %t
 
 // RUN: llvm-mc -triple arm64-apple-macos %t/target-triple.s | FileCheck %t/target-triple.s

--- a/llvm/test/Object/Inputs/macho-invalid-target-triple-name_offset-toosmall.yaml
+++ b/llvm/test/Object/Inputs/macho-invalid-target-triple-name_offset-toosmall.yaml
@@ -14,5 +14,5 @@ LoadCommands:
   - cmd:             LC_TARGET_TRIPLE
     cmdsize:         16
     triple:          8
-    Content:         'abcd'
+    Content:         'arm64-apple-macos27.0.0'
 ...

--- a/llvm/test/Object/Inputs/macho-invalid-target-triple-name_toobig.yaml
+++ b/llvm/test/Object/Inputs/macho-invalid-target-triple-name_toobig.yaml
@@ -14,5 +14,5 @@ LoadCommands:
   - cmd:             LC_TARGET_TRIPLE
     cmdsize:         16
     triple:          12
-    Content:         'abcd'
+    Content:         'arm64-apple-macos27.0.0'
 ...


### PR DESCRIPTION
`llvm-mc -triple arm64-*` requires aarch64-registered-target.