### PR TITLE
[clangd][HLSL] Fix register attribute source range for hover inside arguments

### DIFF
--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5412,6 +5412,25 @@ TEST(Hover, HLSLInvalidVectorSwizzleNoCrash) {
   EXPECT_FALSE(H);
 }
 
+TEST(Hover, HLSLRegisterAttributeRange) {
+  Annotations T(R"hlsl(
+    Texture2D tex : [[^register]]([[^t1]]);
+  )hlsl");
+
+  TestTU TU = TestTU::withCode(T.code());
+  configureHLSL(TU);
+
+  auto AST = TU.build();
+
+  for (const auto &P : T.points()) {
+    auto H = getHover(AST, P, format::getLLVMStyle(), nullptr);
+
+    ASSERT_TRUE(H);
+    EXPECT_EQ(H->Name, "register");
+    EXPECT_FALSE(H->Documentation.empty());
+  }
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang/lib/Parse/ParseHLSL.cpp
+++ b/clang/lib/Parse/ParseHLSL.cpp
@@ -185,6 +185,7 @@ void Parser::ParseHLSLAnnotations(ParsedAttributes &Attrs,
   if (EndLoc)
     *EndLoc = Tok.getLocation();
 
+  SourceLocation AttrEndLoc = Loc;
   ArgsVector ArgExprs;
   switch (AttrKind) {
   case ParsedAttr::AT_HLSLResourceBinding: {
@@ -227,6 +228,7 @@ void Parser::ParseHLSLAnnotations(ParsedAttributes &Attrs,
         fixSeparateAttrArgAndNumber(SpaceStr, SpaceLoc, Tok, ArgExprs, *this,
                                     Actions.Context, PP);
     }
+    AttrEndLoc = Tok.getLocation(); // location of the closing ')'
     if (ExpectAndConsume(tok::r_paren, diag::err_expected)) {
       SkipUntil(tok::r_paren, StopAtSemi); // skip through )
       return;
@@ -337,6 +339,7 @@ void Parser::ParseHLSLAnnotations(ParsedAttributes &Attrs,
     break;
   }
 
-  Attrs.addNew(II, Loc, AttributeScopeInfo(), ArgExprs.data(), ArgExprs.size(),
+  Attrs.addNew(II, SourceRange(Loc, AttrEndLoc), AttributeScopeInfo(),
+               ArgExprs.data(), ArgExprs.size(),
                ParsedAttr::Form::HLSLAnnotation());
 }

--- a/clang/test/AST/HLSL/resource_binding_attr.hlsl
+++ b/clang/test/AST/HLSL/resource_binding_attr.hlsl
@@ -98,6 +98,13 @@ StructuredBuffer<float> SB[10];
 [[vk::binding(2)]]
 StructuredBuffer<float> SB2[10];
 
+// Regression test: the register attribute's SourceRange should span the
+// full `register(...)` construct (not just the `register` keyword), so
+// that clangd hover works when the cursor is inside the argument list.
+// CHECK: VarDecl {{.*}} rangeTest 'RWBuffer<float>':'hlsl::RWBuffer<float>'
+// CHECK: HLSLResourceBindingAttr {{.*}} "u7" "space0"
+RWBuffer<float> rangeTest : register(u7);
+
 // $Globals should have implicit binding attribute added by SemaHLSL
 // CHECK: HLSLBufferDecl {{.*}} implicit cbuffer $Globals
 // CHECK: HLSLResourceBindingAttr {{.*}} Implicit "" "0"


### PR DESCRIPTION
Hovering on the slot identifier inside `register(t1)` (e.g. on `t1`) previously produced no tooltip, only hovering on the `register` keyword itself worked.

`HLSLResourceBindingAttr`'s `SourceRange` was zero-width: both the start and end pointed to the start of the `register` keyword. `ParseHLSLAnnotations` called `Attrs.addNew` with a single `SourceLocation` instead of a full `SourceRange`. Since clangd's `SelectionTree` only matches when the cursor falls inside an attribute's range, a zero-width range never matched positions inside the argument.

Capture the closing `)` location before it's consumed in the `AT_HLSLResourceBinding` case, and pass a full `SourceRange` (from the attribute start to the closing paren) to `addNew`.

Fixes #212749 