### PR TITLE
[PoC][ASan] Add options to limit sanitized address range

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -380,6 +380,15 @@ static cl::opt<uint64_t>
                     cl::desc("offset of asan shadow mapping [EXPERIMENTAL]"),
                     cl::Hidden, cl::init(0));
 
+static cl::opt<uint64_t> ClMappingMin(
+    "asan-mapping-min",
+    cl::desc("Do not do shadow memory checks for pointers below this address"),
+    cl::Hidden, cl::init(0));
+static cl::opt<uint64_t> ClMappingMax(
+    "asan-mapping-max",
+    cl::desc("Do not do shadow memory checks for pointers above this address"),
+    cl::Hidden, cl::init(0));
+
 // Optimization flags. Not user visible, used mostly for testing
 // and benchmarking the tool.
 
@@ -486,6 +495,8 @@ namespace {
 struct ShadowMapping {
   int Scale;
   uint64_t Offset;
+  std::optional<uint64_t> Min;
+  std::optional<uint64_t> Max;
   bool OrShadowOffset;
   bool InGlobal;
 };
@@ -611,6 +622,14 @@ static ShadowMapping getShadowMapping(const Triple &TargetTriple, int LongSize,
 
   if (ClMappingOffset.getNumOccurrences() > 0) {
     Mapping.Offset = ClMappingOffset;
+  }
+
+  if (ClMappingMin.getNumOccurrences() > 0) {
+    Mapping.Min = ClMappingMin;
+  }
+
+  if (ClMappingMax.getNumOccurrences() > 0) {
+    Mapping.Max = ClMappingMax;
   }
 
   // OR-ing shadow offset if more efficient (at least on x86) if the offset
@@ -865,6 +884,8 @@ struct AddressSanitizer {
                                        Value *SizeArgument);
   Instruction *genAMDGPUReportBlock(IRBuilder<> &IRB, Value *Cond,
                                     bool Recover);
+  Instruction *instrumentRangeLimitedAddress(Instruction *InsertBefore,
+                                             Value *Addr);
   void instrumentUnusualSizeOrAlignment(Instruction *I,
                                         Instruction *InsertBefore, Value *Addr,
                                         TypeSize TypeStoreSize, bool IsWrite,
@@ -1965,6 +1986,32 @@ Instruction *AddressSanitizer::genAMDGPUReportBlock(IRBuilder<> &IRB,
       Inserter.insertFunction(kAMDGPUUnreachableName, IRB.getVoidTy()), {});
 }
 
+Instruction *
+AddressSanitizer::instrumentRangeLimitedAddress(Instruction *InsertBefore,
+                                                Value *Addr) {
+  if (Mapping.Min) {
+    // Insert a cmp+br to skip sanitising low addresses, such as ROM.
+    IRBuilder<> IRB(InsertBefore);
+    Value *AddrInt = IRB.CreatePtrToAddr(Addr);
+    Value *Cmp = IRB.CreateICmpUGE(
+        AddrInt, ConstantInt::get(AddrInt->getType(), *Mapping.Min));
+    Value *SkipLanding = SplitBlockAndInsertIfThen(Cmp, InsertBefore, false);
+    InsertBefore = cast<Instruction>(SkipLanding);
+  }
+
+  if (Mapping.Max) {
+    // Insert a cmp+br to skip sanitising high addresses, such as device memory.
+    IRBuilder<> IRB(InsertBefore);
+    Value *AddrInt = IRB.CreatePtrToAddr(Addr);
+    Value *Cmp = IRB.CreateICmpULT(
+        AddrInt, ConstantInt::get(AddrInt->getType(), *Mapping.Max));
+    Value *SkipLanding = SplitBlockAndInsertIfThen(Cmp, InsertBefore, false);
+    InsertBefore = cast<Instruction>(SkipLanding);
+  }
+
+  return InsertBefore;
+}
+
 void AddressSanitizer::instrumentAddress(Instruction *OrigIns,
                                          Instruction *InsertBefore, Value *Addr,
                                          MaybeAlign Alignment,
@@ -1978,6 +2025,8 @@ void AddressSanitizer::instrumentAddress(Instruction *OrigIns,
     if (!InsertBefore)
       return;
   }
+
+  InsertBefore = instrumentRangeLimitedAddress(InsertBefore, Addr);
 
   InstrumentationIRBuilder IRB(InsertBefore);
   size_t AccessSizeIndex = TypeStoreSizeToSizeIndex(TypeStoreSize);

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -384,6 +384,7 @@ static cl::opt<uint64_t> ClMappingMin(
     "asan-mapping-min",
     cl::desc("Omit shadow memory checks for pointers below this address"),
     cl::Hidden, cl::init(0));
+
 static cl::opt<uint64_t> ClMappingMax(
     "asan-mapping-max",
     cl::desc("Omit shadow memory checks for pointers above this address"),
@@ -1990,7 +1991,7 @@ Instruction *
 AddressSanitizer::instrumentRangeLimitedAddress(Instruction *InsertBefore,
                                                 Value *Addr) {
   if (Mapping.Min) {
-    // Insert a cmp+br to skip sanitising low addresses, such as ROM.
+    // Insert a cmp+br to skip sanitizing low addresses, such as ROM.
     IRBuilder<> IRB(InsertBefore);
     Value *AddrInt = IRB.CreatePtrToAddr(Addr);
     Value *Cmp = IRB.CreateICmpUGE(
@@ -2003,7 +2004,7 @@ AddressSanitizer::instrumentRangeLimitedAddress(Instruction *InsertBefore,
     // Insert a cmp+br to skip sanitising high addresses, such as device memory.
     IRBuilder<> IRB(InsertBefore);
     Value *AddrInt = IRB.CreatePtrToAddr(Addr);
-    Value *Cmp = IRB.CreateICmpULT(
+    Value *Cmp = IRB.CreateICmpULE(
         AddrInt, ConstantInt::get(AddrInt->getType(), *Mapping.Max));
     Value *SkipLanding = SplitBlockAndInsertIfThen(Cmp, InsertBefore, false);
     InsertBefore = cast<Instruction>(SkipLanding);

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -382,11 +382,11 @@ static cl::opt<uint64_t>
 
 static cl::opt<uint64_t> ClMappingMin(
     "asan-mapping-min",
-    cl::desc("Do not do shadow memory checks for pointers below this address"),
+    cl::desc("Omit shadow memory checks for pointers below this address"),
     cl::Hidden, cl::init(0));
 static cl::opt<uint64_t> ClMappingMax(
     "asan-mapping-max",
-    cl::desc("Do not do shadow memory checks for pointers above this address"),
+    cl::desc("Omit shadow memory checks for pointers above this address"),
     cl::Hidden, cl::init(0));
 
 // Optimization flags. Not user visible, used mostly for testing

--- a/llvm/test/Instrumentation/AddressSanitizer/range-limit.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/range-limit.ll
@@ -1,0 +1,111 @@
+; Test that the min (-asan-mapping-min) and max (-asan-mapping-max) command-line options work as expected
+;
+; RUN: opt < %s -passes=asan -asan-mapping-min 0x1000 -S | FileCheck --check-prefix=CHECK-MIN %s
+; RUN: opt < %s -passes=asan -asan-mapping-max 0x2000 -S | FileCheck --check-prefix=CHECK-MAX %s
+; RUN: opt < %s -passes=asan -asan-mapping-min 0x1000 -asan-mapping-max 0x2000 -S | FileCheck --check-prefix=CHECK-BOTH %s
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @read(ptr %a) sanitize_address {
+entry:
+  %tmp1 = load i32, ptr %a, align 4
+  ret i32 %tmp1
+}
+
+define void @write(ptr %a, i32 %v) sanitize_address {
+entry:
+  store i32 %v, ptr %a, align 4
+  ret void
+}
+
+define i32 @no_sanitize(ptr %a) {
+entry:
+  %tmp1 = load i32, ptr %a, align 4
+  ret i32 %tmp1
+}
+
+; CHECK-MIN-LABEL: @read
+; CHECK-MIN: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-MIN: [[CMP:%[0-9]+]] = icmp uge i64 [[ADDR]], 4096
+; CHECK-MIN: br i1 [[CMP]], label %[[BEFORE_ASAN:[0-9]+]], label %[[AFTER_ASAN:[0-9]+]]
+; CHECK-MIN: [[BEFORE_ASAN]]:
+; CHECK-MIN: call void @__asan_report_load4
+; CHECK-MIN: [[AFTER_ASAN]]:
+; CHECK-MIN: %tmp1 = load i32, ptr %a, align 4
+
+; CHECK-MIN-LABEL: @write
+; CHECK-MIN: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-MIN: [[CMP:%[0-9]+]] = icmp uge i64 [[ADDR]], 4096
+; CHECK-MIN: br i1 [[CMP]], label %[[BEFORE_ASAN:[0-9]+]], label %[[AFTER_ASAN:[0-9]+]]
+; CHECK-MIN: [[BEFORE_ASAN]]:
+; CHECK-MIN: call void @__asan_report_store4
+; CHECK-MIN: [[AFTER_ASAN]]:
+; CHECK-MIN: store i32 %v, ptr %a, align 4
+
+; CHECK-MIN-LABEL: @no_sanitize
+; CHECK-MIN-NOT: icmp uge i64
+; CHECK-MIN-NOT: __asan_report
+; CHECK-MIN: %tmp1 = load i32, ptr %a, align 4
+; CHECK-MIN: ret i32 %tmp1
+
+
+; CHECK-MAX-LABEL: @read
+; CHECK-MAX: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-MAX: [[CMP:%[0-9]+]] = icmp ult i64 [[ADDR]], 8192
+; CHECK-MAX: br i1 [[CMP]], label %[[BEFORE_ASAN:[0-9]+]], label %[[AFTER_ASAN:[0-9]+]]
+; CHECK-MAX: [[BEFORE_ASAN]]:
+; CHECK-MAX: call void @__asan_report_load4
+; CHECK-MAX: [[AFTER_ASAN]]:
+; CHECK-MAX: %tmp1 = load i32, ptr %a, align 4
+
+; CHECK-MAX-LABEL: @write
+; CHECK-MAX: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-MAX: [[CMP:%[0-9]+]] = icmp ult i64 [[ADDR]], 8192
+; CHECK-MAX: br i1 [[CMP]], label %[[BEFORE_ASAN:[0-9]+]], label %[[AFTER_ASAN:[0-9]+]]
+; CHECK-MAX: [[BEFORE_ASAN]]:
+; CHECK-MAX: call void @__asan_report_store4
+; CHECK-MAX: [[AFTER_ASAN]]:
+; CHECK-MAX: store i32 %v, ptr %a, align 4
+
+; CHECK-MAX-LABEL: @no_sanitize
+; CHECK-MAX-NOT: icmp ult i64
+; CHECK-MAX-NOT: __asan_report
+; CHECK-MAX: %tmp1 = load i32, ptr %a, align 4
+; CHECK-MAX: ret i32 %tmp1
+
+
+; CHECK-BOTH-LABEL: @read
+; CHECK-BOTH: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-BOTH: [[CMP_MIN:%[0-9]+]] = icmp uge i64 [[ADDR]], 4096
+; CHECK-BOTH: br i1 [[CMP_MIN]], label %[[MIN_THEN:[0-9]+]], label %[[EXIT:[0-9]+]]
+; CHECK-BOTH: [[MIN_THEN]]:
+; CHECK-BOTH: [[ADDR2:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-BOTH: [[CMP_MAX:%[0-9]+]] = icmp ult i64 [[ADDR2]], 8192
+; CHECK-BOTH: br i1 [[CMP_MAX]], label %[[MAX_THEN:[0-9]+]], label %[[MIN_EXIT:[0-9]+]]
+; CHECK-BOTH: [[MAX_THEN]]:
+; CHECK-BOTH: call void @__asan_report_load4
+; CHECK-BOTH: [[MIN_EXIT]]:
+; CHECK-BOTH: br label %[[EXIT]]
+; CHECK-BOTH: [[EXIT]]:
+; CHECK-BOTH: %tmp1 = load i32, ptr %a, align 4
+
+; CHECK-BOTH-LABEL: @write
+; CHECK-BOTH: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-BOTH: [[CMP_MIN:%[0-9]+]] = icmp uge i64 [[ADDR]], 4096
+; CHECK-BOTH: br i1 [[CMP_MIN]], label %[[MIN_THEN:[0-9]+]], label %[[EXIT:[0-9]+]]
+; CHECK-BOTH: [[MIN_THEN]]:
+; CHECK-BOTH: [[ADDR2:%[0-9]+]] = ptrtoaddr ptr %a to i64
+; CHECK-BOTH: [[CMP_MAX:%[0-9]+]] = icmp ult i64 [[ADDR2]], 8192
+; CHECK-BOTH: br i1 [[CMP_MAX]], label %[[MAX_THEN:[0-9]+]], label %[[MIN_EXIT:[0-9]+]]
+; CHECK-BOTH: [[MAX_THEN]]:
+; CHECK-BOTH: call void @__asan_report_store4
+; CHECK-BOTH: [[MIN_EXIT]]:
+; CHECK-BOTH: br label %[[EXIT]]
+; CHECK-BOTH: [[EXIT]]:
+; CHECK-BOTH: store i32 %v, ptr %a, align 4
+
+; CHECK-BOTH-LABEL: @no_sanitize
+; CHECK-BOTH-NOT: icmp uge i64
+; CHECK-BOTH-NOT: icmp ult i64
+; CHECK-BOTH-NOT: __asan_report
+; CHECK-BOTH: %tmp1 = load i32, ptr %a, align 4
+; CHECK-BOTH: ret i32 %tmp1

--- a/llvm/test/Instrumentation/AddressSanitizer/range-limit.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/range-limit.ll
@@ -50,7 +50,7 @@ entry:
 
 ; CHECK-MAX-LABEL: @read
 ; CHECK-MAX: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
-; CHECK-MAX: [[CMP:%[0-9]+]] = icmp ult i64 [[ADDR]], 8192
+; CHECK-MAX: [[CMP:%[0-9]+]] = icmp ule i64 [[ADDR]], 8192
 ; CHECK-MAX: br i1 [[CMP]], label %[[BEFORE_ASAN:[0-9]+]], label %[[AFTER_ASAN:[0-9]+]]
 ; CHECK-MAX: [[BEFORE_ASAN]]:
 ; CHECK-MAX: call void @__asan_report_load4
@@ -59,7 +59,7 @@ entry:
 
 ; CHECK-MAX-LABEL: @write
 ; CHECK-MAX: [[ADDR:%[0-9]+]] = ptrtoaddr ptr %a to i64
-; CHECK-MAX: [[CMP:%[0-9]+]] = icmp ult i64 [[ADDR]], 8192
+; CHECK-MAX: [[CMP:%[0-9]+]] = icmp ule i64 [[ADDR]], 8192
 ; CHECK-MAX: br i1 [[CMP]], label %[[BEFORE_ASAN:[0-9]+]], label %[[AFTER_ASAN:[0-9]+]]
 ; CHECK-MAX: [[BEFORE_ASAN]]:
 ; CHECK-MAX: call void @__asan_report_store4
@@ -67,7 +67,7 @@ entry:
 ; CHECK-MAX: store i32 %v, ptr %a, align 4
 
 ; CHECK-MAX-LABEL: @no_sanitize
-; CHECK-MAX-NOT: icmp ult i64
+; CHECK-MAX-NOT: icmp ule i64
 ; CHECK-MAX-NOT: __asan_report
 ; CHECK-MAX: %tmp1 = load i32, ptr %a, align 4
 ; CHECK-MAX: ret i32 %tmp1
@@ -79,7 +79,7 @@ entry:
 ; CHECK-BOTH: br i1 [[CMP_MIN]], label %[[MIN_THEN:[0-9]+]], label %[[EXIT:[0-9]+]]
 ; CHECK-BOTH: [[MIN_THEN]]:
 ; CHECK-BOTH: [[ADDR2:%[0-9]+]] = ptrtoaddr ptr %a to i64
-; CHECK-BOTH: [[CMP_MAX:%[0-9]+]] = icmp ult i64 [[ADDR2]], 8192
+; CHECK-BOTH: [[CMP_MAX:%[0-9]+]] = icmp ule i64 [[ADDR2]], 8192
 ; CHECK-BOTH: br i1 [[CMP_MAX]], label %[[MAX_THEN:[0-9]+]], label %[[MIN_EXIT:[0-9]+]]
 ; CHECK-BOTH: [[MAX_THEN]]:
 ; CHECK-BOTH: call void @__asan_report_load4
@@ -94,7 +94,7 @@ entry:
 ; CHECK-BOTH: br i1 [[CMP_MIN]], label %[[MIN_THEN:[0-9]+]], label %[[EXIT:[0-9]+]]
 ; CHECK-BOTH: [[MIN_THEN]]:
 ; CHECK-BOTH: [[ADDR2:%[0-9]+]] = ptrtoaddr ptr %a to i64
-; CHECK-BOTH: [[CMP_MAX:%[0-9]+]] = icmp ult i64 [[ADDR2]], 8192
+; CHECK-BOTH: [[CMP_MAX:%[0-9]+]] = icmp ule i64 [[ADDR2]], 8192
 ; CHECK-BOTH: br i1 [[CMP_MAX]], label %[[MAX_THEN:[0-9]+]], label %[[MIN_EXIT:[0-9]+]]
 ; CHECK-BOTH: [[MAX_THEN]]:
 ; CHECK-BOTH: call void @__asan_report_store4
@@ -105,7 +105,7 @@ entry:
 
 ; CHECK-BOTH-LABEL: @no_sanitize
 ; CHECK-BOTH-NOT: icmp uge i64
-; CHECK-BOTH-NOT: icmp ult i64
+; CHECK-BOTH-NOT: icmp ule i64
 ; CHECK-BOTH-NOT: __asan_report
 ; CHECK-BOTH: %tmp1 = load i32, ptr %a, align 4
 ; CHECK-BOTH: ret i32 %tmp1


### PR DESCRIPTION
Introduce `-asan-mapping-min` and `-asan-mapping-max` options to bypass shadow memory checks for pointers outside the specified range. This is useful for bare-metal targets where we want to avoid sanitising certain memory regions like ROM or device memory or dedicated IO area.

The change was initially at @ostannard's demo of the Baremetal asan. I am following it up and added some cleanup and changes:

- Since the address range check does not escape the pointer, I switched to `ptrtoaddr` instruction for a better semantic. 
- The feature itself is not restricted to baremetal, so I renamed the function to `instrumentRangeLimitedAddress`.

Co-authored-by: Oliver Stannard <oliver.stannard@arm.com>
Assisted-by: Gemini based automation tools (human-in-the-loop)