### PR TITLE
[analyzer][NFC] Match the parameters order of getEndPath and finalizeVisitor with VisitNode

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
@@ -75,8 +75,8 @@ public:
 
   /// Last function called on the visitor, no further calls to VisitNode
   /// would follow.
-  virtual void finalizeVisitor(BugReporterContext &BRC,
-                               const ExplodedNode *EndPathNode,
+  virtual void finalizeVisitor(const ExplodedNode *EndPathNode,
+                               BugReporterContext &BRC,
                                PathSensitiveBugReport &BR);
 
   /// Provide custom definition for the final diagnostic piece on the
@@ -84,8 +84,8 @@ public:
   ///
   /// NOTE that this function can be implemented on at most one used visitor,
   /// and otherwise it crahes at runtime.
-  virtual PathDiagnosticPieceRef getEndPath(BugReporterContext &BRC,
-                                            const ExplodedNode *N,
+  virtual PathDiagnosticPieceRef getEndPath(const ExplodedNode *N,
+                                            BugReporterContext &BRC,
                                             PathSensitiveBugReport &BR);
 
   virtual void Profile(llvm::FoldingSetNodeID &ID) const = 0;
@@ -541,7 +541,7 @@ public:
     return nullptr;
   }
 
-  void finalizeVisitor(BugReporterContext &BRC, const ExplodedNode *N,
+  void finalizeVisitor(const ExplodedNode *N, BugReporterContext &BRC,
                        PathSensitiveBugReport &BR) override;
 };
 

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/Z3CrosscheckVisitor.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/Z3CrosscheckVisitor.h
@@ -37,7 +37,7 @@ public:
                                    BugReporterContext &BRC,
                                    PathSensitiveBugReport &BR) override;
 
-  void finalizeVisitor(BugReporterContext &BRC, const ExplodedNode *EndPathNode,
+  void finalizeVisitor(const ExplodedNode *EndPathNode, BugReporterContext &BRC,
                        PathSensitiveBugReport &BR) override;
 
 private:

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -1074,8 +1074,8 @@ public:
                                    BugReporterContext &BRC,
                                    PathSensitiveBugReport &BR) override;
 
-  PathDiagnosticPieceRef getEndPath(BugReporterContext &BRC,
-                                    const ExplodedNode *EndPathNode,
+  PathDiagnosticPieceRef getEndPath(const ExplodedNode *EndPathNode,
+                                    BugReporterContext &BRC,
                                     PathSensitiveBugReport &BR) override {
     if (!IsLeak)
       return nullptr;

--- a/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
@@ -277,8 +277,8 @@ public:
                                    BugReporterContext &BRC,
                                    PathSensitiveBugReport &BR) override;
 
-  PathDiagnosticPieceRef getEndPath(BugReporterContext &BRC,
-                                    const ExplodedNode *N,
+  PathDiagnosticPieceRef getEndPath(const ExplodedNode *N,
+                                    BugReporterContext &BRC,
                                     PathSensitiveBugReport &BR) override;
 };
 
@@ -288,8 +288,8 @@ public:
       : RefCountReportVisitor(Sym, /*IsReleaseUnowned=*/false),
         LastBinding(LastBinding) {}
 
-  PathDiagnosticPieceRef getEndPath(BugReporterContext &BRC,
-                                    const ExplodedNode *N,
+  PathDiagnosticPieceRef getEndPath(const ExplodedNode *N,
+                                    BugReporterContext &BRC,
                                     PathSensitiveBugReport &BR) override;
 
 private:
@@ -691,16 +691,16 @@ static AllocationInfo GetAllocationSite(ProgramStateManager &StateMgr,
 }
 
 PathDiagnosticPieceRef
-RefCountReportVisitor::getEndPath(BugReporterContext &BRC,
-                                  const ExplodedNode *EndN,
+RefCountReportVisitor::getEndPath(const ExplodedNode *EndN,
+                                  BugReporterContext &BRC,
                                   PathSensitiveBugReport &BR) {
   BR.markInteresting(Sym);
   return BugReporterVisitor::getDefaultEndPath(BRC, EndN, BR);
 }
 
 PathDiagnosticPieceRef
-RefLeakReportVisitor::getEndPath(BugReporterContext &BRC,
-                                 const ExplodedNode *EndN,
+RefLeakReportVisitor::getEndPath(const ExplodedNode *EndN,
+                                 BugReporterContext &BRC,
                                  PathSensitiveBugReport &BR) {
 
   // Tell the BugReporterContext to report cases when the tracked symbol is

--- a/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
@@ -96,8 +96,8 @@ private:
       ID.AddPointer(&X);
       ID.AddPointer(Reg);
     }
-    PathDiagnosticPieceRef getEndPath(BugReporterContext &BRC,
-                                      const ExplodedNode *EndPathNode,
+    PathDiagnosticPieceRef getEndPath(const ExplodedNode *EndPathNode,
+                                      BugReporterContext &BRC,
                                       PathSensitiveBugReport &BR) override {
       if (!IsLeak)
         return nullptr;

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2850,9 +2850,9 @@ generateVisitorsDiagnostics(PathSensitiveBugReport *R,
     if (!Pred) {
       PathDiagnosticPieceRef LastPiece;
       for (auto &V : visitors) {
-        V->finalizeVisitor(BRC, ErrorNode, *R);
+        V->finalizeVisitor(ErrorNode, BRC, *R);
 
-        if (auto Piece = V->getEndPath(BRC, ErrorNode, *R)) {
+        if (auto Piece = V->getEndPath(ErrorNode, BRC, *R)) {
           assert(!LastPiece &&
                  "There can only be one final piece in a diagnostic.");
           assert(Piece->getKind() == PathDiagnosticPiece::Kind::Event &&

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -346,14 +346,14 @@ static bool wasRegionOfInterestModifiedAt(const SubRegion *RegionOfInterest,
 // Implementation of BugReporterVisitor.
 //===----------------------------------------------------------------------===//
 
-PathDiagnosticPieceRef BugReporterVisitor::getEndPath(BugReporterContext &,
-                                                      const ExplodedNode *,
-                                                      PathSensitiveBugReport &) {
+PathDiagnosticPieceRef
+BugReporterVisitor::getEndPath(const ExplodedNode *, BugReporterContext &,
+                               PathSensitiveBugReport &) {
   return nullptr;
 }
 
-void BugReporterVisitor::finalizeVisitor(BugReporterContext &,
-                                         const ExplodedNode *,
+void BugReporterVisitor::finalizeVisitor(const ExplodedNode *,
+                                         BugReporterContext &,
                                          PathSensitiveBugReport &) {}
 
 PathDiagnosticPieceRef
@@ -1115,7 +1115,7 @@ public:
     llvm_unreachable("Invalid visit mode!");
   }
 
-  void finalizeVisitor(BugReporterContext &, const ExplodedNode *,
+  void finalizeVisitor(const ExplodedNode *, BugReporterContext &,
                        PathSensitiveBugReport &BR) override {
     if (EnableNullFPSuppression && ShouldInvalidate)
       BR.markInvalid(ReturnVisitor::getTag(), CalleeSF);
@@ -3252,7 +3252,7 @@ bool ConditionBRVisitor::isPieceMessageGeneric(
 //===----------------------------------------------------------------------===//
 
 void LikelyFalsePositiveSuppressionBRVisitor::finalizeVisitor(
-    BugReporterContext &BRC, const ExplodedNode *N,
+    const ExplodedNode *N, BugReporterContext &BRC,
     PathSensitiveBugReport &BR) {
   // Here we suppress false positives coming from system headers. This list is
   // based on known issues.

--- a/clang/lib/StaticAnalyzer/Core/Z3CrosscheckVisitor.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Z3CrosscheckVisitor.cpp
@@ -54,8 +54,8 @@ Z3CrosscheckVisitor::Z3CrosscheckVisitor(Z3CrosscheckVisitor::Z3Result &Result,
     : Constraints(ConstraintMap::Factory().getEmptyMap()), Result(Result),
       Opts(Opts) {}
 
-void Z3CrosscheckVisitor::finalizeVisitor(BugReporterContext &BRC,
-                                          const ExplodedNode *EndPathNode,
+void Z3CrosscheckVisitor::finalizeVisitor(const ExplodedNode *EndPathNode,
+                                          BugReporterContext &BRC,
                                           PathSensitiveBugReport &BR) {
   // Collect new constraints
   addConstraints(EndPathNode, /*OverwriteConstraintsOnExistingSyms=*/true);


### PR DESCRIPTION
Currently the ordering of the parameters in `getEndPath` and `finalizeVisitor` functions does not match the declaration of the `VisitNode` function. This PR resolves it by reordering the parameters among these functions to be consistent.