### PR TITLE
[MC][ELF] Deduce SHT_LLVM_CALL_GRAPH type for .llvm.callgraph sections

### DIFF
--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -601,6 +601,8 @@ EndStmt:
       Type = ELF::SHT_FINI_ARRAY;
     else if (hasPrefix(SectionName, ".preinit_array"))
       Type = ELF::SHT_PREINIT_ARRAY;
+    else if (hasPrefix(SectionName, ".llvm.callgraph"))
+      Type = ELF::SHT_LLVM_CALL_GRAPH;
   } else {
     if (TypeName == "init_array")
       Type = ELF::SHT_INIT_ARRAY;

--- a/llvm/test/MC/ELF/callgraph-section-group.s
+++ b/llvm/test/MC/ELF/callgraph-section-group.s
@@ -1,0 +1,28 @@
+# RUN: llvm-mc -triple x86_64-unknown-linux -filetype=obj %s -o %t
+# RUN: llvm-readelf -S %t | FileCheck %s
+
+# Tests that .llvm.callgraph section is deduced as SHT_LLVM_CALL_GRAPH
+# for both ungrouped sections and grouped sections inheriting group via "?".
+
+.section .text, "ax", %progbits
+  bar:
+  ret
+
+.pushsection .llvm.callgraph, "?"
+  .byte 0, 0
+  .dc.a bar
+  .quad 0
+.popsection
+
+.section .text.foo, "axG", %progbits, foo
+  foo:
+  ret
+
+.pushsection .llvm.callgraph, "?"
+  .byte 0, 0
+  .dc.a foo
+  .quad 0
+.popsection
+
+# CHECK: .llvm.callgraph LLVM_CALL_GRAPH {{.*}}
+# CHECK: .llvm.callgraph LLVM_CALL_GRAPH {{.*}} G


### PR DESCRIPTION
Deduce ELF section type SHT_LLVM_CALL_GRAPH for .llvm.callgraph sections
when section type is omitted (such as when using .pushsection with "?").
