### PR TITLE
[docs] de-highlight code snippet errors in dark mode

### DIFF
--- a/llvm/docs/_static/custom.css
+++ b/llvm/docs/_static/custom.css
@@ -51,6 +51,7 @@ body {
 
 /* Pygments emits Error tokens that the theme's style renders as
    red-bordered boxes. Render them like ordinary code text instead. */
+body[data-theme="dark"] .highlight .err,
 .highlight .err {
     border: none;
     background-color: transparent;


### PR DESCRIPTION
Apply https://github.com/llvm/llvm-project/pull/212698 to dark mode as well as light mode.