### PR TITLE
[libc] Modernize and extend dirent.h header.

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -47,6 +47,11 @@ add_header_macro(
     .llvm-libc-types.ino_t
     .llvm-libc-types.DIR
     .llvm-libc-types.struct_dirent
+    .llvm-libc-types.struct_posix_dent
+    .llvm-libc-types.reclen_t
+    .llvm-libc-types.size_t
+    .llvm-libc-types.ssize_t
+    .llvm-libc-macros.dirent_macros
 )
 
 add_header_macro(

--- a/libc/include/dirent.yaml
+++ b/libc/include/dirent.yaml
@@ -1,10 +1,31 @@
 header: dirent.h
 standards:
   - posix
+macros:
+  - macro_name: DT_UNKNOWN
+    macro_header: dirent-macros.h
+  - macro_name: DT_FIFO
+    macro_header: dirent-macros.h
+  - macro_name: DT_CHR
+    macro_header: dirent-macros.h
+  - macro_name: DT_DIR
+    macro_header: dirent-macros.h
+  - macro_name: DT_BLK
+    macro_header: dirent-macros.h
+  - macro_name: DT_REG
+    macro_header: dirent-macros.h
+  - macro_name: DT_LNK
+    macro_header: dirent-macros.h
+  - macro_name: DT_SOCK
+    macro_header: dirent-macros.h
 types:
   - type_name: struct_dirent
+  - type_name: struct_posix_dent
   - type_name: DIR
   - type_name: ino_t
+  - type_name: reclen_t
+  - type_name: size_t
+  - type_name: ssize_t
 functions:
   - name: alphasort
     standards:

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -73,6 +73,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  dirent_macros
+  HDR
+    dirent-macros.h
+)
+
+add_macro_header(
   fcntl_macros
   HDR
     fcntl-macros.h

--- a/libc/include/llvm-libc-macros/dirent-macros.h
+++ b/libc/include/llvm-libc-macros/dirent-macros.h
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from dirent.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_DIRENT_MACROS_H
+#define LLVM_LIBC_MACROS_DIRENT_MACROS_H
+
+#ifdef __linux__
+#include "linux/dirent-macros.h"
+#endif
+
+#endif // LLVM_LIBC_MACROS_DIRENT_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/linux/CMakeLists.txt
@@ -5,6 +5,12 @@ add_header(
 )
 
 add_header(
+  dirent_macros
+  HDR
+    dirent-macros.h
+)
+
+add_header(
   fcntl_macros
   HDR
     fcntl-macros.h

--- a/libc/include/llvm-libc-macros/linux/dirent-macros.h
+++ b/libc/include/llvm-libc-macros/linux/dirent-macros.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from dirent.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_LINUX_DIRENT_MACROS_H
+#define LLVM_LIBC_MACROS_LINUX_DIRENT_MACROS_H
+
+#define DT_UNKNOWN 0
+#define DT_FIFO 1
+#define DT_CHR 2
+#define DT_DIR 4
+#define DT_BLK 6
+#define DT_REG 8
+#define DT_LNK 10
+#define DT_SOCK 12
+
+#endif // LLVM_LIBC_MACROS_LINUX_DIRENT_MACROS_H

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -11,6 +11,7 @@ add_header(
     .size_t
     libc.include.llvm-libc-macros.annex_k_macros
 )
+add_header(reclen_t HDR reclen_t.h)
 add_header(ssize_t HDR ssize_t.h)
 add_header(__atfork_callback_t HDR __atfork_callback_t.h)
 add_header(__search_compare_t HDR __search_compare_t.h)
@@ -122,7 +123,8 @@ add_header(time_t HDR time_t_64.h DEST_HDR time_t.h)
 add_header(sighandler_t HDR sighandler_t.h)
 add_header(stack_t HDR stack_t.h DEPENDS .size_t)
 add_header(suseconds_t HDR suseconds_t.h)
-add_header(struct_dirent HDR struct_dirent.h DEPENDS .ino_t .off_t)
+add_header(struct_dirent HDR struct_dirent.h DEPENDS .ino_t .off_t .reclen_t)
+add_header(struct_posix_dent HDR struct_posix_dent.h DEPENDS .ino_t .off_t .reclen_t)
 add_header(struct_dl_phdr_info HDR struct_dl_phdr_info.h DEPENDS .size_t libc.include.llvm-libc-macros.link_macros)
 add_header(dl_info HDR Dl_info.h)
 add_header(struct_f_owner_ex HDR struct_f_owner_ex.h DEPENDS .pid_t)

--- a/libc/include/llvm-libc-types/reclen_t.h
+++ b/libc/include/llvm-libc-types/reclen_t.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of reclen_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_RECLEN_T_H
+#define LLVM_LIBC_TYPES_RECLEN_T_H
+
+typedef unsigned short reclen_t;
+
+#endif // LLVM_LIBC_TYPES_RECLEN_T_H

--- a/libc/include/llvm-libc-types/struct_dirent.h
+++ b/libc/include/llvm-libc-types/struct_dirent.h
@@ -11,12 +11,13 @@
 
 #include "ino_t.h"
 #include "off_t.h"
+#include "reclen_t.h"
 
 struct dirent {
   ino_t d_ino;
 #ifdef __linux__
   off_t d_off;
-  unsigned short d_reclen;
+  reclen_t d_reclen;
 #endif
   unsigned char d_type;
   // The user code should use strlen to determine actual the size of d_name.

--- a/libc/include/llvm-libc-types/struct_posix_dent.h
+++ b/libc/include/llvm-libc-types/struct_posix_dent.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of struct posix_dent.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_POSIX_DENT_H
+#define LLVM_LIBC_TYPES_STRUCT_POSIX_DENT_H
+
+#include "ino_t.h"
+#include "off_t.h"
+#include "reclen_t.h"
+
+struct posix_dent {
+  ino_t d_ino;
+#ifdef __linux__
+  off_t d_off;
+#endif
+  reclen_t d_reclen;
+  unsigned char d_type;
+  // The user code should use strlen to determine the actual size of d_name.
+  // Likewise, it is incorrect and prohibited by the POSIX standard to determine
+  // the size of struct posix_dent type using sizeof. The size should be got
+  // using a different method, for example, from the d_reclen field.
+  char d_name[1];
+};
+
+#endif // LLVM_LIBC_TYPES_STRUCT_POSIX_DENT_H

--- a/libc/test/src/dirent/dirent_test.cpp
+++ b/libc/test/src/dirent/dirent_test.cpp
@@ -34,14 +34,22 @@ TEST_F(LlvmLibcDirentTest, SimpleOpenAndRead) {
     struct ::dirent *d = LIBC_NAMESPACE::readdir(dir);
     if (d == nullptr)
       break;
-    if (string_view(&d->d_name[0]) == "file1.txt")
+    if (string_view(&d->d_name[0]) == "file1.txt") {
       file1 = d;
-    if (string_view(&d->d_name[0]) == "file2.txt")
+      EXPECT_EQ(d->d_type, static_cast<decltype(d->d_type)>(DT_REG));
+    }
+    if (string_view(&d->d_name[0]) == "file2.txt") {
       file2 = d;
-    if (string_view(&d->d_name[0]) == "dir1")
+      EXPECT_EQ(d->d_type, static_cast<decltype(d->d_type)>(DT_REG));
+    }
+    if (string_view(&d->d_name[0]) == "dir1") {
       dir1 = d;
-    if (string_view(&d->d_name[0]) == "dir2")
+      EXPECT_EQ(d->d_type, static_cast<decltype(d->d_type)>(DT_DIR));
+    }
+    if (string_view(&d->d_name[0]) == "dir2") {
       dir2 = d;
+      EXPECT_EQ(d->d_type, static_cast<decltype(d->d_type)>(DT_DIR));
+    }
   }
 
   // Verify that we don't break out of the above loop in error.


### PR DESCRIPTION
Extend the `<dirent.h>` header with macro and types specified in recent POSIX.1-2024:
* Add `posix_dent` structure, which has more fields than `dirent`, that are actually used in practice. This struct would be identical to `dirent` that we have on Linux
* Add `reclen_t` type for `d_reclen` field.
* Add macro `DT_BLK` and friends

Also, extend the tests to verify the values of `d_type` field, now that we have the proper macro defined.

Assisted by: Gemini, human-verified
