### PR TITLE
[scudo] Fix GCC build after 212604

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -194,7 +194,7 @@ private:
   };
   static_assert(sizeof(RegionInfo) % SCUDO_CACHE_LINE_SIZE == 0, "");
 
-  template <bool ConditionVariableEnabled = false>
+  template <bool ConditionVariableEnabled = false, typename Dummy = void>
   class SCOPED_CAPABILITY ScopedFLLockBase {
   public:
     ScopedFLLockBase(HybridMutex &M, UNUSED RegionInfo *Region) ACQUIRE(M)
@@ -210,7 +210,8 @@ private:
     void operator=(const ScopedFLLockBase &) = delete;
   };
 
-  template <> class SCOPED_CAPABILITY ScopedFLLockBase<true> {
+  template <typename Dummy>
+  class SCOPED_CAPABILITY ScopedFLLockBase<true, Dummy> {
   public:
     ScopedFLLockBase(HybridMutex &M, RegionInfo *Region) ACQUIRE(M)
         : Mutex(M), Region(Region) {


### PR DESCRIPTION
Change #212604 introduced an issue when building with gcc where it
complains there are "too few template-parameter-lists" (see log:
https://lab.llvm.org/buildbot/#/builders/131/builds/51269/steps/6/logs/stdio )
This PR fixes the build.

Assisted-by: Automated tooling, human reviewed.
