### PR TITLE
[X86] Push VZEXT_MOVL through scalar FADD and CMOV in combineTargetShuffle

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -43242,6 +43242,40 @@ static SDValue combineTargetShuffle(SDValue N, const SDLoc &DL,
       }
     }
 
+    // Fold (vzext_movl (scalar_to_vector (cmov A, B))) ->
+    //      (cmov (push_vzext A), (push_vzext B))
+    // and push vzext_movl through scalar conversions and selected scalar
+    // operations to expose target conversion idioms (like vcvtsi2ss with
+    // V_SET0).
+    if (N0.getOpcode() == ISD::SCALAR_TO_VECTOR && N0.hasOneUse() &&
+        (N0.getOperand(0).getOpcode() == ISD::FADD ||
+         N0.getOperand(0).getOpcode() == X86ISD::CMOV)) {
+      auto PushVzext = [&](auto &Self, SDValue S, unsigned Depth) -> SDValue {
+        if (Depth >= SelectionDAG::MaxRecursionDepth)
+          return SDValue();
+        if (S.getOpcode() == ISD::SINT_TO_FP ||
+            S.getOpcode() == ISD::UINT_TO_FP)
+          return DAG.getNode(X86ISD::VZEXT_MOVL, DL, VT,
+                             DAG.getNode(ISD::SCALAR_TO_VECTOR, DL, VT, S));
+        if (S.getOpcode() == ISD::FADD && S.hasOneUse()) {
+          SDValue A = Self(Self, S.getOperand(0), Depth + 1);
+          SDValue B = Self(Self, S.getOperand(1), Depth + 1);
+          if (A && B)
+            return DAG.getNode(ISD::FADD, DL, VT, A, B, S->getFlags());
+        }
+        if (S.getOpcode() == X86ISD::CMOV && S.hasOneUse()) {
+          SDValue A = Self(Self, S.getOperand(0), Depth + 1);
+          SDValue B = Self(Self, S.getOperand(1), Depth + 1);
+          if (A && B)
+            return DAG.getNode(X86ISD::CMOV, DL, VT, A, B, S.getOperand(2),
+                               S.getOperand(3));
+        }
+        return SDValue();
+      };
+      if (SDValue Res = PushVzext(PushVzext, N0.getOperand(0), 0))
+        return Res;
+    }
+
     // Fold (v4i32 (vzext_movl (v2i64 bitcast (scalar_to_vector (i64 X)))))
     // ---> (v4i32 (vzext_movl (scalar_to_vector (i32 (trunc X))))).
     if (VT == MVT::v4i32 && N0.getOpcode() == ISD::BITCAST && N0.hasOneUse()) {

--- a/llvm/test/CodeGen/X86/vector-uint-to-fp-zero.ll
+++ b/llvm/test/CodeGen/X86/vector-uint-to-fp-zero.ll
@@ -40,58 +40,52 @@ define <4 x float> @test_v4f32_u64(i64 %x) {
 ; AVX-LABEL: test_v4f32_u64:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    testq %rdi, %rdi
+; AVX-NEXT:    vxorps %xmm0, %xmm0, %xmm0
 ; AVX-NEXT:    js .LBB1_1
 ; AVX-NEXT:  # %bb.2:
-; AVX-NEXT:    vcvtsi2ss %rdi, %xmm15, %xmm0
-; AVX-NEXT:    jmp .LBB1_3
+; AVX-NEXT:    vcvtsi2ss %rdi, %xmm0, %xmm0
+; AVX-NEXT:    retq
 ; AVX-NEXT:  .LBB1_1:
 ; AVX-NEXT:    movq %rdi, %rax
 ; AVX-NEXT:    shrq %rax
 ; AVX-NEXT:    andl $1, %edi
 ; AVX-NEXT:    orq %rax, %rdi
-; AVX-NEXT:    vcvtsi2ss %rdi, %xmm15, %xmm0
-; AVX-NEXT:    vaddss %xmm0, %xmm0, %xmm0
-; AVX-NEXT:  .LBB1_3:
-; AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
-; AVX-NEXT:    vmovss {{.*#+}} xmm0 = xmm0[0],xmm1[1,2,3]
+; AVX-NEXT:    vcvtsi2ss %rdi, %xmm0, %xmm0
+; AVX-NEXT:    vaddps %xmm0, %xmm0, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; SSE-LABEL: test_v4f32_u64:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    testq %rdi, %rdi
+; SSE-NEXT:    xorps %xmm0, %xmm0
 ; SSE-NEXT:    js .LBB1_1
 ; SSE-NEXT:  # %bb.2:
-; SSE-NEXT:    cvtsi2ss %rdi, %xmm1
-; SSE-NEXT:    jmp .LBB1_3
+; SSE-NEXT:    cvtsi2ss %rdi, %xmm0
+; SSE-NEXT:    retq
 ; SSE-NEXT:  .LBB1_1:
 ; SSE-NEXT:    movq %rdi, %rax
 ; SSE-NEXT:    shrq %rax
 ; SSE-NEXT:    andl $1, %edi
 ; SSE-NEXT:    orq %rax, %rdi
-; SSE-NEXT:    cvtsi2ss %rdi, %xmm1
-; SSE-NEXT:    addss %xmm1, %xmm1
-; SSE-NEXT:  .LBB1_3:
-; SSE-NEXT:    xorps %xmm0, %xmm0
-; SSE-NEXT:    movss {{.*#+}} xmm0 = xmm1[0],xmm0[1,2,3]
+; SSE-NEXT:    cvtsi2ss %rdi, %xmm0
+; SSE-NEXT:    addps %xmm0, %xmm0
 ; SSE-NEXT:    retq
 ;
 ; SSE41-LABEL: test_v4f32_u64:
 ; SSE41:       # %bb.0:
 ; SSE41-NEXT:    testq %rdi, %rdi
+; SSE41-NEXT:    xorps %xmm0, %xmm0
 ; SSE41-NEXT:    js .LBB1_1
 ; SSE41-NEXT:  # %bb.2:
-; SSE41-NEXT:    cvtsi2ss %rdi, %xmm1
-; SSE41-NEXT:    jmp .LBB1_3
+; SSE41-NEXT:    cvtsi2ss %rdi, %xmm0
+; SSE41-NEXT:    retq
 ; SSE41-NEXT:  .LBB1_1:
 ; SSE41-NEXT:    movq %rdi, %rax
 ; SSE41-NEXT:    shrq %rax
 ; SSE41-NEXT:    andl $1, %edi
 ; SSE41-NEXT:    orq %rax, %rdi
-; SSE41-NEXT:    cvtsi2ss %rdi, %xmm1
-; SSE41-NEXT:    addss %xmm1, %xmm1
-; SSE41-NEXT:  .LBB1_3:
-; SSE41-NEXT:    xorps %xmm0, %xmm0
-; SSE41-NEXT:    movss {{.*#+}} xmm0 = xmm1[0],xmm0[1,2,3]
+; SSE41-NEXT:    cvtsi2ss %rdi, %xmm0
+; SSE41-NEXT:    addps %xmm0, %xmm0
 ; SSE41-NEXT:    retq
 ;
 ; AVX512-LABEL: test_v4f32_u64:


### PR DESCRIPTION
This patch extends combineTargetShuffle for X86ISD::VZEXT_MOVL to recursively push VZEXT_MOVL through scalar ISD::FADD and X86ISD::CMOV nodes down to scalar integer-to-float conversion leaves (ISD::SINT_TO_FP / ISD::UINT_TO_FP)