### PR TITLE
AMDGPU/GlobalISel: Switch more FP opcodes to extended LLTs (part 2)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -294,7 +294,6 @@ static LegalityPredicate elementTypeIsLegal(unsigned TypeIdx) {
   };
 }
 
-const LLT I16 = LLT::integer(16);
 constexpr LLT F16 = LLT::float16();
 constexpr LLT BF16 = LLT::bfloat16();
 constexpr LLT F32 = LLT::float32();
@@ -740,6 +739,12 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
                                                      V2S64};
 
   const LLT MinScalarFPTy = ST.has16BitInsts() ? S16 : S32;
+  const LLT MinExtendedFPTy = ST.has16BitInsts() ? F16 : F32;
+  const LLT I1 = LLT::integer(1);
+  const LLT I16 = LLT::integer(16);
+  const LLT I32 = LLT::integer(32);
+  const LLT I64 = LLT::integer(64);
+  const LLT V2I16 = LLT::fixed_vector(2, I16);
 
   getActionDefinitionsBuilder(G_BR).alwaysLegal();
 
@@ -1224,48 +1229,45 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
 
   // TODO: Split s1->s64 during regbankselect for VALU.
   auto &IToFP = getActionDefinitionsBuilder({G_SITOFP, G_UITOFP})
-                    .legalFor({{S32, S32}, {S64, S32}})
-                    .widenScalarFor({{S16, S32}}, changeElementSizeTo(0, S32))
-                    .lowerIf(typeIs(1, S1))
-                    .customFor({{S32, S64}, {S64, S64}});
+                    .legalFor({{F32, I32}, {F64, I32}})
+                    .widenScalarFor({{F16, I32}}, changeElementSizeTo(0, F32))
+                    .lowerIf(typeIs(1, I1))
+                    .customFor({{F32, I64}, {F64, I64}});
   if (ST.has16BitInsts())
-    IToFP.legalFor({{S16, S16}});
-  IToFP.clampScalar(1, S32, S64)
-       .minScalar(0, S32)
-       .scalarize(0)
-       .widenScalarToNextPow2(1);
+    IToFP.legalFor({{F16, I16}});
+  IToFP.clampScalar(1, I32, I64)
+      .minScalar(0, F32)
+      .scalarize(0)
+      .widenScalarToNextPow2(1);
 
   auto &FPToI = getActionDefinitionsBuilder({G_FPTOSI, G_FPTOUI})
-                    .legalFor({{S32, S32}, {S32, S64}})
-                    .customFor({{S64, S32}, {S64, S64}})
-                    .widenScalarFor({{S32, S16}}, changeElementSizeTo(1, S32))
-                    .narrowScalarFor({{S64, S16}}, changeElementSizeTo(0, S32));
+                    .legalFor({{I32, F32}, {I32, F64}})
+                    .customFor({{I64, F32}, {I64, F64}})
+                    .widenScalarFor({{I32, F16}}, changeElementSizeTo(1, F32))
+                    .narrowScalarFor({{I64, F16}}, changeElementSizeTo(0, I32));
   if (ST.has16BitInsts())
-    FPToI.legalFor({{S16, S16}});
+    FPToI.legalFor({{I16, F16}});
   else
-    FPToI.minScalar(1, S32);
+    FPToI.minScalar(1, F32);
 
-  FPToI.minScalar(0, S32)
-       .widenScalarToNextPow2(0, 32)
-       .scalarize(0)
-       .lower();
+  FPToI.minScalar(0, I32).widenScalarToNextPow2(0, 32).scalarize(0).lower();
 
   // clang-format off
   auto &FPToISat = getActionDefinitionsBuilder({G_FPTOSI_SAT, G_FPTOUI_SAT})
-    .legalFor({{S32, S32}, {S32, S64}, {S16, S32}})
-    .legalFor(ST.has16BitInsts(), {{S16, S16}})
-    .legalFor(ST.hasVCvtPkIU16F32(), {{V2S16, V2S32}})
-    .narrowScalarFor({{S64, S16}}, changeElementSizeTo(0, S32));
+    .legalFor({{I32, F32}, {I32, F64}, {I16, F32}})
+    .legalFor(ST.has16BitInsts(), {{I16, F16}})
+    .legalFor(ST.hasVCvtPkIU16F32(), {{V2I16, V2F32}})
+    .narrowScalarFor({{I64, F16}}, changeElementSizeTo(0, I32));
 
   // If available, widen width <16 to i16, intead of i32 so v_cvt_i16/u16_f16 can be used.
   if (ST.has16BitInsts())
-    FPToISat.minScalarIf(typeIs(1, S16), 0, S16);
+    FPToISat.minScalarIf(typeIs(1, F16), 0, I16);
 
   if (ST.hasVCvtPkIU16F32())
-    FPToISat.clampMaxNumElements(0, S16, 2);
+    FPToISat.clampMaxNumElements(0, I16, 2);
 
-  FPToISat.minScalar(1, S32);
-  FPToISat.minScalar(0, S32)
+  FPToISat.minScalar(1, F32);
+  FPToISat.minScalar(0, I32)
        .widenScalarToNextPow2(0, 32)
        .scalarize(0)
        .lower();
@@ -1277,7 +1279,7 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
       .lower();
 
   getActionDefinitionsBuilder(G_INTRINSIC_FPTRUNC_ROUND)
-      .legalFor({S16, S32})
+      .legalFor({F16, F32})
       .scalarize(0)
       .lower();
 
@@ -1364,15 +1366,14 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
   // FIXME: fpow has a selection pattern that should move to custom lowering.
   auto &ExpOps = getActionDefinitionsBuilder(G_FPOW);
   if (ST.has16BitInsts())
-    ExpOps.customFor({{S32}, {S16}});
+    ExpOps.customFor({{F32}, {F16}});
   else
-    ExpOps.customFor({S32});
-  ExpOps.clampScalar(0, MinScalarFPTy, S32)
-        .scalarize(0);
+    ExpOps.customFor({F32});
+  ExpOps.clampScalar(0, MinExtendedFPTy, F32).scalarize(0);
 
   getActionDefinitionsBuilder(G_FPOWI)
-    .clampScalar(0, MinScalarFPTy, S32)
-    .lower();
+      .clampScalar(0, MinExtendedFPTy, F32)
+      .lower();
 
   getActionDefinitionsBuilder(G_FLOG2)
       .legalFor(ST.has16BitInsts(), {S16})

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fpow.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fpow.mir
@@ -5,18 +5,18 @@
 # RUN: llc -mtriple=amdgpu11.00-mesa-mesa3d -mattr=-real-true16 -run-pass=legalizer %s -o - | FileCheck -check-prefixes=GFX9 %s
 
 ---
-name: test_fpow_s32
+name: test_fpow_f32
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpow_s32
+    ; GFX6-LABEL: name: test_fpow_f32
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $vgpr1
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s32), [[C]]
+    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](f32), [[C]]
     ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -26,27 +26,25 @@ body: |
     ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[INT]], [[SELECT1]]
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](s32)
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](f32)
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX6-NEXT: $vgpr0 = COPY [[FMUL1]](s32)
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX6-NEXT: $vgpr0 = COPY [[FMUL1]](f32)
     ;
-    ; GFX9-LABEL: name: test_fpow_s32
+    ; GFX9-LABEL: name: test_fpow_f32
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $vgpr1
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s32), [[C]]
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](f32), [[C]]
     ; GFX9-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX9-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -56,40 +54,38 @@ body: |
     ; GFX9-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[INT]], [[SELECT1]]
-    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](s32)
-    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](f32)
+    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT2]]
-    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX9-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX9-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FMUL1]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = COPY $vgpr1
-    %2:_(s32) = G_FPOW %0, %1
+    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FMUL1]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(f32) = COPY $vgpr1
+    %2:_(f32) = G_FPOW %0, %1
     $vgpr0 = COPY %2
 ...
 
 ---
-name: test_fpow_v2s32
+name: test_fpow_v2f32
 body: |
   bb.0.entry:
     liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
 
-    ; GFX6-LABEL: name: test_fpow_v2s32
+    ; GFX6-LABEL: name: test_fpow_v2f32
     ; GFX6: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    ; GFX6-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX6-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<2 x s32>)
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr2_vgpr3
+    ; GFX6-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX6-NEXT: [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<2 x f32>)
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](s32), [[C]]
+    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](f32), [[C]]
     ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -99,43 +95,41 @@ body: |
     ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[INT]], [[SELECT1]]
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV2]](s32)
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV2]](f32)
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX6-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](s32), [[C]]
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX6-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](f32), [[C]]
     ; GFX6-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C1]], [[C2]]
     ; GFX6-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV1]], [[SELECT4]]
     ; GFX6-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FMUL2]](f32)
     ; GFX6-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB1:%[0-9]+]]:_(f32) = G_FSUB [[INT3]], [[SELECT5]]
-    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV3]](s32)
+    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV3]](f32)
     ; GFX6-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT4]](f32), [[C5]]
-    ; GFX6-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD1:%[0-9]+]]:_(f32) = G_FADD [[INT4]], [[SELECT6]]
-    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
-    ; GFX6-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL3:%[0-9]+]]:_(s32) = G_FMUL [[INT5]], [[SELECT7]]
-    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FMUL1]](s32), [[FMUL3]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
+    ; GFX6-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL3:%[0-9]+]]:_(f32) = G_FMUL [[INT5]], [[SELECT7]]
+    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FMUL1]](f32), [[FMUL3]](f32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; GFX9-LABEL: name: test_fpow_v2s32
+    ; GFX9-LABEL: name: test_fpow_v2f32
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX9-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<2 x s32>)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr2_vgpr3
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX9-NEXT: [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<2 x f32>)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](s32), [[C]]
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](f32), [[C]]
     ; GFX9-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX9-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -145,54 +139,52 @@ body: |
     ; GFX9-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[INT]], [[SELECT1]]
-    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV2]](s32)
-    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV2]](f32)
+    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT2]]
-    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX9-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX9-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](s32), [[C]]
+    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](f32), [[C]]
     ; GFX9-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C1]], [[C2]]
     ; GFX9-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV1]], [[SELECT4]]
     ; GFX9-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FMUL2]](f32)
     ; GFX9-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB1:%[0-9]+]]:_(f32) = G_FSUB [[INT3]], [[SELECT5]]
-    ; GFX9-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV3]](s32)
+    ; GFX9-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV3]](f32)
     ; GFX9-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT4]](f32), [[C5]]
-    ; GFX9-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD1:%[0-9]+]]:_(f32) = G_FADD [[INT4]], [[SELECT6]]
-    ; GFX9-NEXT: [[INT5:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
-    ; GFX9-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL3:%[0-9]+]]:_(s32) = G_FMUL [[INT5]], [[SELECT7]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FMUL1]](s32), [[FMUL3]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    %2:_(<2 x s32>) = G_FPOW %0, %1
+    ; GFX9-NEXT: [[INT5:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
+    ; GFX9-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL3:%[0-9]+]]:_(f32) = G_FMUL [[INT5]], [[SELECT7]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FMUL1]](f32), [[FMUL3]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %1:_(<2 x f32>) = COPY $vgpr2_vgpr3
+    %2:_(<2 x f32>) = G_FPOW %0, %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
 ---
-name: test_fpow_v3s32
+name: test_fpow_v3f32
 body: |
   bb.0.entry:
     liveins: $vgpr0_vgpr1_vgpr2, $vgpr3_vgpr4_vgpr5
 
-    ; GFX6-LABEL: name: test_fpow_v3s32
+    ; GFX6-LABEL: name: test_fpow_v3f32
     ; GFX6: liveins: $vgpr0_vgpr1_vgpr2, $vgpr3_vgpr4_vgpr5
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr3_vgpr4_vgpr5
-    ; GFX6-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX6-NEXT: [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<3 x s32>)
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr3_vgpr4_vgpr5
+    ; GFX6-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX6-NEXT: [[UV3:%[0-9]+]]:_(f32), [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<3 x f32>)
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](s32), [[C]]
+    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](f32), [[C]]
     ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -202,56 +194,54 @@ body: |
     ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[INT]], [[SELECT1]]
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV3]](s32)
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV3]](f32)
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX6-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](s32), [[C]]
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX6-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](f32), [[C]]
     ; GFX6-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C1]], [[C2]]
     ; GFX6-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV1]], [[SELECT4]]
     ; GFX6-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FMUL2]](f32)
     ; GFX6-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB1:%[0-9]+]]:_(f32) = G_FSUB [[INT3]], [[SELECT5]]
-    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV4]](s32)
+    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV4]](f32)
     ; GFX6-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT4]](f32), [[C5]]
-    ; GFX6-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD1:%[0-9]+]]:_(f32) = G_FADD [[INT4]], [[SELECT6]]
-    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
-    ; GFX6-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL3:%[0-9]+]]:_(s32) = G_FMUL [[INT5]], [[SELECT7]]
-    ; GFX6-NEXT: [[FCMP4:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV2]](s32), [[C]]
+    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
+    ; GFX6-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL3:%[0-9]+]]:_(f32) = G_FMUL [[INT5]], [[SELECT7]]
+    ; GFX6-NEXT: [[FCMP4:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV2]](f32), [[C]]
     ; GFX6-NEXT: [[SELECT8:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](s1), [[C1]], [[C2]]
     ; GFX6-NEXT: [[FMUL4:%[0-9]+]]:_(f32) = G_FMUL [[UV2]], [[SELECT8]]
     ; GFX6-NEXT: [[INT6:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FMUL4]](f32)
     ; GFX6-NEXT: [[SELECT9:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB2:%[0-9]+]]:_(f32) = G_FSUB [[INT6]], [[SELECT9]]
-    ; GFX6-NEXT: [[INT7:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB2]](f32), [[UV5]](s32)
+    ; GFX6-NEXT: [[INT7:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB2]](f32), [[UV5]](f32)
     ; GFX6-NEXT: [[FCMP5:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT7]](f32), [[C5]]
-    ; GFX6-NEXT: [[SELECT10:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[SELECT10:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD2:%[0-9]+]]:_(f32) = G_FADD [[INT7]], [[SELECT10]]
-    ; GFX6-NEXT: [[INT8:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD2]](f32)
-    ; GFX6-NEXT: [[SELECT11:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL5:%[0-9]+]]:_(s32) = G_FMUL [[INT8]], [[SELECT11]]
-    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FMUL1]](s32), [[FMUL3]](s32), [[FMUL5]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; GFX6-NEXT: [[INT8:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD2]](f32)
+    ; GFX6-NEXT: [[SELECT11:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL5:%[0-9]+]]:_(f32) = G_FMUL [[INT8]], [[SELECT11]]
+    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FMUL1]](f32), [[FMUL3]](f32), [[FMUL5]](f32)
+    ; GFX6-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; GFX9-LABEL: name: test_fpow_v3s32
+    ; GFX9-LABEL: name: test_fpow_v3f32
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2, $vgpr3_vgpr4_vgpr5
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr3_vgpr4_vgpr5
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX9-NEXT: [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<3 x s32>)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr3_vgpr4_vgpr5
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX9-NEXT: [[UV3:%[0-9]+]]:_(f32), [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<3 x f32>)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](s32), [[C]]
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](f32), [[C]]
     ; GFX9-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX9-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -261,65 +251,63 @@ body: |
     ; GFX9-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[INT]], [[SELECT1]]
-    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV3]](s32)
-    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[UV3]](f32)
+    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT2]]
-    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX9-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX9-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](s32), [[C]]
+    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](f32), [[C]]
     ; GFX9-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C1]], [[C2]]
     ; GFX9-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV1]], [[SELECT4]]
     ; GFX9-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FMUL2]](f32)
     ; GFX9-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB1:%[0-9]+]]:_(f32) = G_FSUB [[INT3]], [[SELECT5]]
-    ; GFX9-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV4]](s32)
+    ; GFX9-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB1]](f32), [[UV4]](f32)
     ; GFX9-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT4]](f32), [[C5]]
-    ; GFX9-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD1:%[0-9]+]]:_(f32) = G_FADD [[INT4]], [[SELECT6]]
-    ; GFX9-NEXT: [[INT5:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
-    ; GFX9-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL3:%[0-9]+]]:_(s32) = G_FMUL [[INT5]], [[SELECT7]]
-    ; GFX9-NEXT: [[FCMP4:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV2]](s32), [[C]]
+    ; GFX9-NEXT: [[INT5:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
+    ; GFX9-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL3:%[0-9]+]]:_(f32) = G_FMUL [[INT5]], [[SELECT7]]
+    ; GFX9-NEXT: [[FCMP4:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV2]](f32), [[C]]
     ; GFX9-NEXT: [[SELECT8:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](s1), [[C1]], [[C2]]
     ; GFX9-NEXT: [[FMUL4:%[0-9]+]]:_(f32) = G_FMUL [[UV2]], [[SELECT8]]
     ; GFX9-NEXT: [[INT6:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FMUL4]](f32)
     ; GFX9-NEXT: [[SELECT9:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB2:%[0-9]+]]:_(f32) = G_FSUB [[INT6]], [[SELECT9]]
-    ; GFX9-NEXT: [[INT7:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB2]](f32), [[UV5]](s32)
+    ; GFX9-NEXT: [[INT7:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB2]](f32), [[UV5]](f32)
     ; GFX9-NEXT: [[FCMP5:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT7]](f32), [[C5]]
-    ; GFX9-NEXT: [[SELECT10:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[SELECT10:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD2:%[0-9]+]]:_(f32) = G_FADD [[INT7]], [[SELECT10]]
-    ; GFX9-NEXT: [[INT8:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD2]](f32)
-    ; GFX9-NEXT: [[SELECT11:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL5:%[0-9]+]]:_(s32) = G_FMUL [[INT8]], [[SELECT11]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FMUL1]](s32), [[FMUL3]](s32), [[FMUL5]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    %1:_(<3 x s32>) = COPY $vgpr3_vgpr4_vgpr5
-    %2:_(<3 x s32>) = G_FPOW %0, %1
+    ; GFX9-NEXT: [[INT8:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD2]](f32)
+    ; GFX9-NEXT: [[SELECT11:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL5:%[0-9]+]]:_(f32) = G_FMUL [[INT8]], [[SELECT11]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FMUL1]](f32), [[FMUL3]](f32), [[FMUL5]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
+    %0:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    %1:_(<3 x f32>) = COPY $vgpr3_vgpr4_vgpr5
+    %2:_(<3 x f32>) = G_FPOW %0, %1
     $vgpr0_vgpr1_vgpr2 = COPY %2
 ...
 
 ---
-name: test_fpow_s32_flags
+name: test_fpow_f32_flags
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpow_s32_flags
+    ; GFX6-LABEL: name: test_fpow_f32_flags
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $vgpr1
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s32), [[C]]
+    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](f32), [[C]]
     ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -329,27 +317,25 @@ body: |
     ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB:%[0-9]+]]:_(f32) = nnan nsz G_FSUB [[INT]], [[SELECT1]]
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](s32)
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](f32)
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan nsz G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = nnan nsz G_FADD [[INT1]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = nnan nsz G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX6-NEXT: $vgpr0 = COPY [[FMUL1]](s32)
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = nnan nsz G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX6-NEXT: $vgpr0 = COPY [[FMUL1]](f32)
     ;
-    ; GFX9-LABEL: name: test_fpow_s32_flags
+    ; GFX9-LABEL: name: test_fpow_f32_flags
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $vgpr1
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s32), [[C]]
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](f32), [[C]]
     ; GFX9-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX9-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -359,253 +345,251 @@ body: |
     ; GFX9-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB:%[0-9]+]]:_(f32) = nnan nsz G_FSUB [[INT]], [[SELECT1]]
-    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](s32)
-    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[COPY1]](f32)
+    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan nsz G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD:%[0-9]+]]:_(f32) = nnan nsz G_FADD [[INT1]], [[SELECT2]]
-    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(s32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX9-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX9-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = nnan nsz G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FMUL1]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = COPY $vgpr1
-    %2:_(s32) = nnan nsz G_FPOW %0, %1
+    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = nnan nsz G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FMUL1]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(f32) = COPY $vgpr1
+    %2:_(f32) = nnan nsz G_FPOW %0, %1
     $vgpr0 = COPY %2
 ...
 
 ---
-name: test_fpow_s16
+name: test_fpow_f16
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpow_s16
+    ; GFX6-LABEL: name: test_fpow_f16
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[COPY1]](s32)
-    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; GFX6-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](s32)
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[FPEXT1]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $vgpr1
+    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX6-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[COPY1]](i32)
+    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; GFX6-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](f32)
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[FPEXT1]](f32)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C]]
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
-    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT1]]
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FMUL]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
-    ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT1]]
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FMUL]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC]](f16)
+    ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_fpow_s16
+    ; GFX9-LABEL: name: test_fpow_f16
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[COPY1]](s32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $vgpr1
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[COPY1]](i32)
     ; GFX9-NEXT: [[FLOG2_:%[0-9]+]]:_(f16) = G_FLOG2 [[TRUNC]]
     ; GFX9-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[FLOG2_]](f16)
-    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](s16)
+    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
     ; GFX9-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FPEXT]](f32), [[FPEXT1]](f32)
     ; GFX9-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
-    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(s16) = G_FEXP2 [[FPTRUNC]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FEXP2_]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = COPY $vgpr1
-    %2:_(s16) = G_TRUNC %0
-    %3:_(s16) = G_TRUNC %1
-    %4:_(s16) = G_FPOW %2, %3
-    %5:_(s32) = G_ANYEXT %4
+    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(f16) = G_FEXP2 [[FPTRUNC]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FEXP2_]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(i32) = COPY $vgpr0
+    %1:_(i32) = COPY $vgpr1
+    %2:_(f16) = G_TRUNC %0
+    %3:_(f16) = G_TRUNC %1
+    %4:_(f16) = G_FPOW %2, %3
+    %5:_(i32) = G_ANYEXT %4
     $vgpr0 = COPY %5
 ...
 
 ---
-name: test_fpow_v2s16
+name: test_fpow_v2f16
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpow_v2s16
+    ; GFX6-LABEL: name: test_fpow_v2f16
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX6-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX6-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX6-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX6-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX6-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX6-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX6-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX6-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX6-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; GFX6-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC2]](s16)
-    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](s32)
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[FPEXT1]](s32)
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; GFX6-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](f16)
+    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](f32)
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[FPEXT1]](f32)
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT1]](f32), [[C1]]
-    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
+    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C2]], [[C3]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[INT1]], [[SELECT]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[C4]], [[C5]]
-    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INT2]], [[SELECT1]]
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FMUL]](s32)
-    ; GFX6-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; GFX6-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC3]](s16)
-    ; GFX6-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT2]](s32)
-    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT3]](f32), [[FPEXT3]](s32)
+    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INT2]], [[SELECT1]]
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FMUL]](f32)
+    ; GFX6-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; GFX6-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](f16)
+    ; GFX6-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT2]](f32)
+    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT3]](f32), [[FPEXT3]](f32)
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[INT4]](f32), [[C1]]
     ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C2]], [[C3]]
     ; GFX6-NEXT: [[FADD1:%[0-9]+]]:_(f32) = G_FADD [[INT4]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
+    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
     ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[C4]], [[C5]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INT5]], [[SELECT3]]
-    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FMUL1]](s32)
-    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INT5]], [[SELECT3]]
+    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FMUL1]](f32)
+    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; GFX6-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; GFX6-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST2]](<2 x s16>)
+    ; GFX6-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST2]](<2 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fpow_v2s16
+    ; GFX9-LABEL: name: test_fpow_v2f16
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
     ; GFX9-NEXT: [[FLOG2_:%[0-9]+]]:_(f16) = G_FLOG2 [[TRUNC]]
     ; GFX9-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[FLOG2_]](f16)
-    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](s16)
+    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](f16)
     ; GFX9-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FPEXT]](f32), [[FPEXT1]](f32)
     ; GFX9-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
-    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(s16) = G_FEXP2 [[FPTRUNC]]
+    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(f16) = G_FEXP2 [[FPTRUNC]]
     ; GFX9-NEXT: [[FLOG2_1:%[0-9]+]]:_(f16) = G_FLOG2 [[TRUNC1]]
     ; GFX9-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[FLOG2_1]](f16)
-    ; GFX9-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](s16)
+    ; GFX9-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](f16)
     ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FPEXT2]](f32), [[FPEXT3]](f32)
     ; GFX9-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT1]](f32)
-    ; GFX9-NEXT: [[FEXP2_1:%[0-9]+]]:_(s16) = G_FEXP2 [[FPTRUNC1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FEXP2_]](s16), [[FEXP2_1]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x s16>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = COPY $vgpr1
-    %2:_(<2 x s16>) = G_FPOW %0, %1
+    ; GFX9-NEXT: [[FEXP2_1:%[0-9]+]]:_(f16) = G_FEXP2 [[FPTRUNC1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FEXP2_]](f16), [[FEXP2_1]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x f16>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = COPY $vgpr1
+    %2:_(<2 x f16>) = G_FPOW %0, %1
     $vgpr0 = COPY %2
 ...
 
 ---
-name: test_fpow_v2s16_flags
+name: test_fpow_v2f16_flags
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpow_v2s16_flags
+    ; GFX6-LABEL: name: test_fpow_v2f16_flags
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX6-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX6-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX6-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX6-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX6-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX6-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX6-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX6-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX6-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = nnan nsz G_FPEXT [[TRUNC]](s16)
-    ; GFX6-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = nnan nsz G_FPEXT [[TRUNC2]](s16)
-    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](s32)
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[FPEXT1]](s32)
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC]](f16)
+    ; GFX6-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC2]](f16)
+    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](f32)
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[FPEXT1]](f32)
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nnan nsz G_FCMP floatpred(olt), [[INT1]](f32), [[C1]]
-    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
+    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP]](s1), [[C2]], [[C3]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = nnan nsz G_FADD [[INT1]], [[SELECT]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP]](s1), [[C4]], [[C5]]
-    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(s32) = nnan nsz G_FMUL [[INT2]], [[SELECT1]]
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = nnan nsz G_FPTRUNC [[FMUL]](s32)
-    ; GFX6-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = nnan nsz G_FPEXT [[TRUNC1]](s16)
-    ; GFX6-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = nnan nsz G_FPEXT [[TRUNC3]](s16)
-    ; GFX6-NEXT: [[INT3:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT2]](s32)
-    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT3]](f32), [[FPEXT3]](s32)
+    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(f32) = nnan nsz G_FMUL [[INT2]], [[SELECT1]]
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = nnan nsz G_FPTRUNC [[FMUL]](f32)
+    ; GFX6-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC1]](f16)
+    ; GFX6-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC3]](f16)
+    ; GFX6-NEXT: [[INT3:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT2]](f32)
+    ; GFX6-NEXT: [[INT4:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT3]](f32), [[FPEXT3]](f32)
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan nsz G_FCMP floatpred(olt), [[INT4]](f32), [[C1]]
     ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C2]], [[C3]]
     ; GFX6-NEXT: [[FADD1:%[0-9]+]]:_(f32) = nnan nsz G_FADD [[INT4]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(s32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
+    ; GFX6-NEXT: [[INT5:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD1]](f32)
     ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan nsz G_SELECT [[FCMP1]](s1), [[C4]], [[C5]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = nnan nsz G_FMUL [[INT5]], [[SELECT3]]
-    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = nnan nsz G_FPTRUNC [[FMUL1]](s32)
-    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = nnan nsz G_FMUL [[INT5]], [[SELECT3]]
+    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = nnan nsz G_FPTRUNC [[FMUL1]](f32)
+    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; GFX6-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; GFX6-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST2]](<2 x s16>)
+    ; GFX6-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST2]](<2 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fpow_v2s16_flags
+    ; GFX9-LABEL: name: test_fpow_v2f16_flags
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
     ; GFX9-NEXT: [[FLOG2_:%[0-9]+]]:_(f16) = nnan nsz G_FLOG2 [[TRUNC]]
     ; GFX9-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[FLOG2_]](f16)
-    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC2]](s16)
+    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC2]](f16)
     ; GFX9-NEXT: [[INT:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FPEXT]](f32), [[FPEXT1]](f32)
     ; GFX9-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
-    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(s16) = nnan nsz G_FEXP2 [[FPTRUNC]]
+    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(f16) = nnan nsz G_FEXP2 [[FPTRUNC]]
     ; GFX9-NEXT: [[FLOG2_1:%[0-9]+]]:_(f16) = nnan nsz G_FLOG2 [[TRUNC1]]
     ; GFX9-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[FLOG2_1]](f16)
-    ; GFX9-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC3]](s16)
+    ; GFX9-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = nnan nsz G_FPEXT [[TRUNC3]](f16)
     ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FPEXT2]](f32), [[FPEXT3]](f32)
     ; GFX9-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT1]](f32)
-    ; GFX9-NEXT: [[FEXP2_1:%[0-9]+]]:_(s16) = nnan nsz G_FEXP2 [[FPTRUNC1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FEXP2_]](s16), [[FEXP2_1]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x s16>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = COPY $vgpr1
-    %2:_(<2 x s16>) = nnan nsz G_FPOW %0, %1
+    ; GFX9-NEXT: [[FEXP2_1:%[0-9]+]]:_(f16) = nnan nsz G_FEXP2 [[FPTRUNC1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FEXP2_]](f16), [[FEXP2_1]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x f16>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = COPY $vgpr1
+    %2:_(<2 x f16>) = nnan nsz G_FPOW %0, %1
     $vgpr0 = COPY %2
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fpowi.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fpowi.mir
@@ -5,74 +5,74 @@
 # RUN: llc -mtriple=amdgpu11.00-mesa-mesa3d -run-pass=legalizer -o - %s | FileCheck -check-prefix=GFX9 %s
 
 ---
-name: test_fpowi_s16_s32_flags
+name: test_fpowi_f16_i32_flags
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpowi_s16_s32_flags
+    ; GFX6-LABEL: name: test_fpowi_f16_i32_flags
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = nnan G_FPEXT [[TRUNC]](s16)
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[COPY1]](s32)
-    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](s32)
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[SITOFP]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $vgpr1
+    ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX6-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = nnan G_FPEXT [[TRUNC]](f16)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[COPY1]](i32)
+    ; GFX6-NEXT: [[INT:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.log), [[FPEXT]](f32)
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[INT]](f32), [[SITOFP]](f32)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(olt), [[INT1]](f32), [[C]]
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = nnan G_FADD [[INT1]], [[SELECT]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C3:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
-    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(s32) = nnan G_FMUL [[INT2]], [[SELECT1]]
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = nnan G_FPTRUNC [[FMUL]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
-    ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; GFX6-NEXT: [[FMUL:%[0-9]+]]:_(f32) = nnan G_FMUL [[INT2]], [[SELECT1]]
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = nnan G_FPTRUNC [[FMUL]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC]](f16)
+    ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_fpowi_s16_s32_flags
+    ; GFX9-LABEL: name: test_fpowi_f16_i32_flags
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[COPY1]](s32)
-    ; GFX9-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[SITOFP]](s32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $vgpr1
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[COPY1]](i32)
+    ; GFX9-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[SITOFP]](f32)
     ; GFX9-NEXT: [[FLOG2_:%[0-9]+]]:_(f16) = nnan G_FLOG2 [[TRUNC]]
     ; GFX9-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = nnan G_FPEXT [[FLOG2_]](f16)
-    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = nnan G_FPEXT [[FPTRUNC]](s16)
+    ; GFX9-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = nnan G_FPEXT [[FPTRUNC]](f16)
     ; GFX9-NEXT: [[INT:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FPEXT]](f32), [[FPEXT1]](f32)
     ; GFX9-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
-    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(s16) = nnan G_FEXP2 [[FPTRUNC1]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FEXP2_]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = COPY $vgpr1
-    %2:_(s16) = G_TRUNC %0
-    %3:_(s16) = nnan G_FPOWI %2, %1
-    %4:_(s32) = G_ANYEXT %3
+    ; GFX9-NEXT: [[FEXP2_:%[0-9]+]]:_(f16) = nnan G_FEXP2 [[FPTRUNC1]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FEXP2_]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(i32) = COPY $vgpr0
+    %1:_(i32) = COPY $vgpr1
+    %2:_(f16) = G_TRUNC %0
+    %3:_(f16) = nnan G_FPOWI %2, %1
+    %4:_(i32) = G_ANYEXT %3
     $vgpr0 = COPY %4
 ...
 
 ---
-name: test_fpowi_s32_s32_flags
+name: test_fpowi_f32_i32_flags
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
 
-    ; GFX6-LABEL: name: test_fpowi_s32_s32_flags
+    ; GFX6-LABEL: name: test_fpowi_f32_i32_flags
     ; GFX6: liveins: $vgpr0, $vgpr1
     ; GFX6-NEXT: {{  $}}
-    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[COPY1]](s32)
+    ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX6-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $vgpr1
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[COPY1]](i32)
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s32), [[C]]
+    ; GFX6-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](f32), [[C]]
     ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX6-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -82,28 +82,26 @@ body: |
     ; GFX6-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX6-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX6-NEXT: [[FSUB:%[0-9]+]]:_(f32) = nnan G_FSUB [[INT]], [[SELECT1]]
-    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[SITOFP]](s32)
-    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX6-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[SITOFP]](f32)
+    ; GFX6-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX6-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX6-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX6-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f32) = nnan G_FADD [[INT1]], [[SELECT2]]
-    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(s32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX6-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX6-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = nnan G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX6-NEXT: $vgpr0 = COPY [[FMUL1]](s32)
+    ; GFX6-NEXT: [[INT2:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX6-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX6-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX6-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = nnan G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX6-NEXT: $vgpr0 = COPY [[FMUL1]](f32)
     ;
-    ; GFX9-LABEL: name: test_fpowi_s32_s32_flags
+    ; GFX9-LABEL: name: test_fpowi_f32_i32_flags
     ; GFX9: liveins: $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
-    ; GFX9-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[COPY1]](s32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $vgpr1
+    ; GFX9-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[COPY1]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x00800000
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s32), [[C]]
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](f32), [[C]]
     ; GFX9-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GFX9-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
     ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP]](s1), [[C1]], [[C2]]
@@ -113,21 +111,19 @@ body: |
     ; GFX9-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
     ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP]](s1), [[C3]], [[C4]]
     ; GFX9-NEXT: [[FSUB:%[0-9]+]]:_(f32) = nnan G_FSUB [[INT]], [[SELECT1]]
-    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[SITOFP]](s32)
-    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.260000e+02
+    ; GFX9-NEXT: [[INT1:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fmul.legacy), [[FSUB]](f32), [[SITOFP]](f32)
+    ; GFX9-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.260000e+02
     ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(olt), [[INT1]](f32), [[C5]]
-    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(s32) = G_FCONSTANT float 6.400000e+01
-    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C6]], [[C7]]
+    ; GFX9-NEXT: [[C6:%[0-9]+]]:_(f32) = G_FCONSTANT float 6.400000e+01
+    ; GFX9-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C6]], [[C4]]
     ; GFX9-NEXT: [[FADD:%[0-9]+]]:_(f32) = nnan G_FADD [[INT1]], [[SELECT2]]
-    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(s32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
-    ; GFX9-NEXT: [[C8:%[0-9]+]]:_(s32) = G_FCONSTANT float f0x1F800000
-    ; GFX9-NEXT: [[C9:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C8]], [[C9]]
-    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = nnan G_FMUL [[INT2]], [[SELECT3]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FMUL1]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = COPY $vgpr1
-    %2:_(s32) = nnan G_FPOWI %0, %1
+    ; GFX9-NEXT: [[INT2:%[0-9]+]]:_(f32) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.exp2), [[FADD]](f32)
+    ; GFX9-NEXT: [[C7:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x1F800000
+    ; GFX9-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = nnan G_SELECT [[FCMP1]](s1), [[C7]], [[C2]]
+    ; GFX9-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = nnan G_FMUL [[INT2]], [[SELECT3]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FMUL1]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(i32) = COPY $vgpr1
+    %2:_(f32) = nnan G_FPOWI %0, %1
     $vgpr0 = COPY %2
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fptosi.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fptosi.mir
@@ -11,17 +11,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_s32_to_s32
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s32_to_s32
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s32) = G_FPTOSI %0
     $vgpr0 = COPY %1
 ...
@@ -35,17 +35,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_s64_to_s32
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f64)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s64_to_s32
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f64)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
-    %0:_(s64) = COPY $vgpr0_vgpr1
+    %0:_(f64) = COPY $vgpr0_vgpr1
     %1:_(s32) = G_FPTOSI %0
     $vgpr0 = COPY %1
 ...
@@ -59,23 +59,23 @@ body: |
     ; SI-LABEL: name: test_fptosi_v2s32_to_v2s32
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](s32)
-    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](f32)
+    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](f32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOSI]](s32), [[FPTOSI1]](s32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
     ;
     ; VI-LABEL: name: test_fptosi_v2s32_to_v2s32
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](s32)
-    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](f32)
+    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](f32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOSI]](s32), [[FPTOSI1]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
     %1:_(<2 x s32>) = G_FPTOSI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -89,23 +89,23 @@ body: |
     ; SI-LABEL: name: test_fptosi_v2s64_to_v2s32
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](s64)
-    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](f64)
+    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](f64)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOSI]](s32), [[FPTOSI1]](s32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
     ;
     ; VI-LABEL: name: test_fptosi_v2s64_to_v2s32
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](s64)
-    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[UV]](f64)
+    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[UV1]](f64)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOSI]](s32), [[FPTOSI1]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
     %1:_(<2 x s32>) = G_FPTOSI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -120,21 +120,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s16_to_s16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s16) = G_FPTOSI [[TRUNC]](s16)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s16) = G_FPTOSI [[TRUNC]](f16)
     ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTOSI]](s16)
     ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s16) = G_FPTOSI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -149,17 +149,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_s32_to_s16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s32_to_s16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s16) = G_FPTOSI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
@@ -174,17 +174,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_s64_to_s16
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f64)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s64_to_s16
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f64)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
-    %0:_(s64) = COPY $vgpr0_vgpr1
+    %0:_(f64) = COPY $vgpr0_vgpr1
     %1:_(s16) = G_FPTOSI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
@@ -199,8 +199,8 @@ body: |
     ; SI-LABEL: name: test_fptosi_s64_s64
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[COPY]](f64)
     ; SI-NEXT: [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BITCAST]](i64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 20
     ; SI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 11
@@ -221,38 +221,38 @@ body: |
     ; SI-NEXT: [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(sgt), [[SUB]](i32), [[C7]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(i64) = G_SELECT [[ICMP]](s1), [[MV]], [[AND1]]
     ; SI-NEXT: [[SELECT1:%[0-9]+]]:_(i64) = G_SELECT [[ICMP1]](s1), [[BITCAST]], [[SELECT]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(s64) = G_BITCAST [[SELECT1]](i64)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(f64) = G_BITCAST [[SELECT1]](i64)
     ; SI-NEXT: [[C8:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; SI-NEXT: [[C9:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[BITCAST1]], [[C8]]
-    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](s64)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[BITCAST1]], [[C8]]
+    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](f64)
     ; SI-NEXT: [[C10:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT1]], [[C10]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](s64), [[FMUL]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](f64), [[FMUL]]
     ; SI-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](s1), [[FMUL]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[SELECT2]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FMUL]], [[FNEG]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FADD]](s64)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FMUL]], [[FNEG]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FADD]](f64)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI]](i32), [[FPTOSI]](i32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[MV1]](s64)
     ;
     ; VI-LABEL: name: test_fptosi_s64_s64
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s64) = G_INTRINSIC_TRUNC [[COPY]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f64) = G_INTRINSIC_TRUNC [[COPY]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FFLOOR]](s64)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FFLOOR]](f64)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI]](i32), [[FPTOSI]](i32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[MV]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
+    %0:_(f64) = COPY $vgpr0_vgpr1
     %1:_(s64) = G_FPTOSI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -331,9 +331,9 @@ body: |
     ; SI-LABEL: name: test_fptosi_v2s64_to_v2s64
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[UV]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[UV]](f64)
     ; SI-NEXT: [[UV2:%[0-9]+]]:_(i32), [[UV3:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BITCAST]](i64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 20
     ; SI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 11
@@ -354,22 +354,22 @@ body: |
     ; SI-NEXT: [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(sgt), [[SUB]](i32), [[C7]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(i64) = G_SELECT [[ICMP]](s1), [[MV]], [[AND1]]
     ; SI-NEXT: [[SELECT1:%[0-9]+]]:_(i64) = G_SELECT [[ICMP1]](s1), [[BITCAST]], [[SELECT]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(s64) = G_BITCAST [[SELECT1]](i64)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(f64) = G_BITCAST [[SELECT1]](i64)
     ; SI-NEXT: [[C8:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; SI-NEXT: [[C9:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[BITCAST1]], [[C8]]
-    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](s64)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[BITCAST1]], [[C8]]
+    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](f64)
     ; SI-NEXT: [[C10:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT1]], [[C10]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](s64), [[FMUL]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](f64), [[FMUL]]
     ; SI-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](s1), [[FMUL]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[SELECT2]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FMUL]], [[FNEG]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FADD]](s64)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FMUL]], [[FNEG]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FADD]](f64)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI]](i32), [[FPTOSI]](i32)
-    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i64) = G_BITCAST [[UV1]](s64)
+    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i64) = G_BITCAST [[UV1]](f64)
     ; SI-NEXT: [[UV4:%[0-9]+]]:_(i32), [[UV5:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BITCAST2]](i64)
     ; SI-NEXT: [[INT2:%[0-9]+]]:_(i32) = G_INTRINSIC intrinsic(@llvm.amdgcn.ubfe), [[UV5]](i32), [[C]](i32), [[C1]](i32)
     ; SI-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[INT2]], [[C2]]
@@ -382,17 +382,17 @@ body: |
     ; SI-NEXT: [[ICMP3:%[0-9]+]]:_(s1) = G_ICMP intpred(sgt), [[SUB1]](i32), [[C7]]
     ; SI-NEXT: [[SELECT3:%[0-9]+]]:_(i64) = G_SELECT [[ICMP2]](s1), [[MV2]], [[AND3]]
     ; SI-NEXT: [[SELECT4:%[0-9]+]]:_(i64) = G_SELECT [[ICMP3]](s1), [[BITCAST2]], [[SELECT3]]
-    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(s64) = G_BITCAST [[SELECT4]](i64)
-    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(s64) = G_FMUL [[BITCAST3]], [[C8]]
-    ; SI-NEXT: [[INT3:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL1]](s64)
+    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(f64) = G_BITCAST [[SELECT4]](i64)
+    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(f64) = G_FMUL [[BITCAST3]], [[C8]]
+    ; SI-NEXT: [[INT3:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL1]](f64)
     ; SI-NEXT: [[FMINNUM_IEEE1:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT3]], [[C10]]
-    ; SI-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL1]](s64), [[FMUL1]]
+    ; SI-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL1]](f64), [[FMUL1]]
     ; SI-NEXT: [[SELECT5:%[0-9]+]]:_(f64) = G_SELECT [[FCMP1]](s1), [[FMUL1]], [[FMINNUM_IEEE1]]
     ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(f64) = G_FNEG [[SELECT5]]
-    ; SI-NEXT: [[FADD1:%[0-9]+]]:_(s64) = G_FADD [[FMUL1]], [[FNEG1]]
-    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(s64) = G_FMA [[FADD1]], [[C9]], [[BITCAST3]]
-    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(i32) = G_FPTOSI [[FADD1]](s64)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s64)
+    ; SI-NEXT: [[FADD1:%[0-9]+]]:_(f64) = G_FADD [[FMUL1]], [[FNEG1]]
+    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(f64) = G_FMA [[FADD1]], [[C9]], [[BITCAST3]]
+    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(i32) = G_FPTOSI [[FADD1]](f64)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f64)
     ; SI-NEXT: [[MV3:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOSI1]](i32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV1]](s64), [[MV3]](s64)
     ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
@@ -400,27 +400,27 @@ body: |
     ; VI-LABEL: name: test_fptosi_v2s64_to_v2s64
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s64) = G_INTRINSIC_TRUNC [[UV]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f64) = G_INTRINSIC_TRUNC [[UV]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FFLOOR]](s64)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(i32) = G_FPTOSI [[FFLOOR]](f64)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI]](i32), [[FPTOSI]](i32)
-    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(s64) = G_INTRINSIC_TRUNC [[UV1]]
-    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(s64) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s64) = G_FFLOOR [[FMUL1]]
-    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(s64) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
-    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(i32) = G_FPTOSI [[FFLOOR1]](s64)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s64)
+    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(f64) = G_INTRINSIC_TRUNC [[UV1]]
+    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(f64) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f64) = G_FFLOOR [[FMUL1]]
+    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(f64) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
+    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(i32) = G_FPTOSI [[FFLOOR1]](f64)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f64)
     ; VI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOSI1]](i32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
     ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
     %1:_(<2 x s64>) = G_FPTOSI %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
@@ -434,19 +434,19 @@ body: |
     ; SI-LABEL: name: test_fptosi_s32_to_s64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](f32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 31
     ; SI-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST]], [[C]](i32)
     ; SI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC]]
     ; SI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; SI-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FABS]], [[C1]]
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FABS]], [[C1]]
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; SI-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR]](i32), [[ASHR]](i32)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; SI-NEXT: [[XOR:%[0-9]+]]:_(i64) = G_XOR [[MV1]], [[MV]]
@@ -459,19 +459,19 @@ body: |
     ; VI-LABEL: name: test_fptosi_s32_to_s64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](f32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 31
     ; VI-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST]], [[C]](i32)
     ; VI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC]]
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; VI-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FABS]], [[C1]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FABS]], [[C1]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR]](i32), [[ASHR]](i32)
     ; VI-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; VI-NEXT: [[XOR:%[0-9]+]]:_(i64) = G_XOR [[MV1]], [[MV]]
@@ -480,7 +480,7 @@ body: |
     ; VI-NEXT: [[USUBE:%[0-9]+]]:_(s32), [[USUBE1:%[0-9]+]]:_(i1) = G_USUBE [[UV1]], [[ASHR]], [[USUBO1]]
     ; VI-NEXT: [[MV2:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[USUBO]](s32), [[USUBE]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[MV2]](s64)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s64) = G_FPTOSI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -494,20 +494,20 @@ body: |
     ; SI-LABEL: name: test_fptosi_v2s32_to_v2s64
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV]]
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV]]
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](f32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 31
     ; SI-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST]], [[C]](i32)
     ; SI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC]]
     ; SI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; SI-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FABS]], [[C1]]
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FABS]], [[C1]]
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; SI-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR]](i32), [[ASHR]](i32)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; SI-NEXT: [[XOR:%[0-9]+]]:_(i64) = G_XOR [[MV1]], [[MV]]
@@ -515,15 +515,15 @@ body: |
     ; SI-NEXT: [[USUBO:%[0-9]+]]:_(s32), [[USUBO1:%[0-9]+]]:_(i1) = G_USUBO [[UV2]], [[ASHR]]
     ; SI-NEXT: [[USUBE:%[0-9]+]]:_(s32), [[USUBE1:%[0-9]+]]:_(i1) = G_USUBE [[UV3]], [[ASHR]], [[USUBO1]]
     ; SI-NEXT: [[MV2:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[USUBO]](s32), [[USUBE]](s32)
-    ; SI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV1]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](s32)
+    ; SI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV1]]
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](f32)
     ; SI-NEXT: [[ASHR1:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST1]], [[C]](i32)
     ; SI-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC1]]
-    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[FABS1]], [[C1]]
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL1]]
-    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR1]], [[C2]], [[FABS1]]
-    ; SI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](s32)
-    ; SI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s32)
+    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[FABS1]], [[C1]]
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL1]]
+    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR1]], [[C2]], [[FABS1]]
+    ; SI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](f32)
+    ; SI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f32)
     ; SI-NEXT: [[MV3:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR1]](i32), [[ASHR1]](i32)
     ; SI-NEXT: [[MV4:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI3]](i32), [[FPTOUI2]](i32)
     ; SI-NEXT: [[XOR1:%[0-9]+]]:_(i64) = G_XOR [[MV4]], [[MV3]]
@@ -537,20 +537,20 @@ body: |
     ; VI-LABEL: name: test_fptosi_v2s32_to_v2s64
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV]]
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV]]
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](f32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 31
     ; VI-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST]], [[C]](i32)
     ; VI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC]]
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; VI-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FABS]], [[C1]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FABS]], [[C1]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR]](i32), [[ASHR]](i32)
     ; VI-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; VI-NEXT: [[XOR:%[0-9]+]]:_(i64) = G_XOR [[MV1]], [[MV]]
@@ -558,15 +558,15 @@ body: |
     ; VI-NEXT: [[USUBO:%[0-9]+]]:_(s32), [[USUBO1:%[0-9]+]]:_(i1) = G_USUBO [[UV2]], [[ASHR]]
     ; VI-NEXT: [[USUBE:%[0-9]+]]:_(s32), [[USUBE1:%[0-9]+]]:_(i1) = G_USUBE [[UV3]], [[ASHR]], [[USUBO1]]
     ; VI-NEXT: [[MV2:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[USUBO]](s32), [[USUBE]](s32)
-    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV1]]
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](s32)
+    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV1]]
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](f32)
     ; VI-NEXT: [[ASHR1:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST1]], [[C]](i32)
     ; VI-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC1]]
-    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[FABS1]], [[C1]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL1]]
-    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR1]], [[C2]], [[FABS1]]
-    ; VI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](s32)
-    ; VI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s32)
+    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[FABS1]], [[C1]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL1]]
+    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR1]], [[C2]], [[FABS1]]
+    ; VI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](f32)
+    ; VI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f32)
     ; VI-NEXT: [[MV3:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR1]](i32), [[ASHR1]](i32)
     ; VI-NEXT: [[MV4:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI3]](i32), [[FPTOUI2]](i32)
     ; VI-NEXT: [[XOR1:%[0-9]+]]:_(i64) = G_XOR [[MV4]], [[MV3]]
@@ -576,7 +576,7 @@ body: |
     ; VI-NEXT: [[MV5:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[USUBO2]](s32), [[USUBE2]](s32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV2]](s64), [[MV5]](s64)
     ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
     %1:_(<2 x s64>) = G_FPTOSI %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
@@ -591,9 +591,9 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[FPTOSI]](s32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[SEXT]](s64)
     ;
@@ -601,13 +601,13 @@ body: |
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[FPTOSI]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[SEXT]](s64)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s64) = G_FPTOSI %1
     $vgpr0_vgpr1 = COPY %2
 ...
@@ -621,17 +621,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_v2s16_to_v2s64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[FPTOSI]](s32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT1]](s32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; SI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT1]](f32)
     ; SI-NEXT: [[SEXT1:%[0-9]+]]:_(s64) = G_SEXT [[FPTOSI1]](s32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[SEXT]](s64), [[SEXT1]](s64)
     ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
@@ -639,21 +639,21 @@ body: |
     ; VI-LABEL: name: test_fptosi_v2s16_to_v2s64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[FPTOSI]](s32)
-    ; VI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT1]](s32)
+    ; VI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; VI-NEXT: [[FPTOSI1:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT1]](f32)
     ; VI-NEXT: [[SEXT1:%[0-9]+]]:_(s64) = G_SEXT [[FPTOSI1]](s32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[SEXT]](s64), [[SEXT1]](s64)
     ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s16>) = COPY $vgpr0
+    %0:_(<2 x f16>) = COPY $vgpr0
     %1:_(<2 x s64>) = G_FPTOSI %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
@@ -667,9 +667,9 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s1) = G_TRUNC [[FPTOSI]](s32)
     ; SI-NEXT: S_ENDPGM 0, implicit [[TRUNC1]](s1)
     ;
@@ -677,13 +677,13 @@ body: |
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s1) = G_TRUNC [[FPTOSI]](s32)
     ; VI-NEXT: S_ENDPGM 0, implicit [[TRUNC1]](s1)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s1)  = G_FPTOSI %1
     S_ENDPGM 0, implicit %2
 ...
@@ -698,21 +698,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s16_to_s15
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s15) = G_FPTOSI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -728,21 +728,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s16_to_s17
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s17) = G_FPTOSI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -757,19 +757,19 @@ body: |
     ; SI-LABEL: name: test_fptosi_s32_to_s33
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](f32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 31
     ; SI-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST]], [[C]](i32)
     ; SI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC]]
     ; SI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; SI-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FABS]], [[C1]]
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FABS]], [[C1]]
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; SI-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR]](i32), [[ASHR]](i32)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; SI-NEXT: [[XOR:%[0-9]+]]:_(i64) = G_XOR [[MV1]], [[MV]]
@@ -782,19 +782,19 @@ body: |
     ; VI-LABEL: name: test_fptosi_s32_to_s33
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](f32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 31
     ; VI-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[BITCAST]], [[C]](i32)
     ; VI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[INTRINSIC_TRUNC]]
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; VI-NEXT: [[C2:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FABS]], [[C1]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FABS]], [[C1]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C2]], [[FABS]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[ASHR]](i32), [[ASHR]](i32)
     ; VI-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; VI-NEXT: [[XOR:%[0-9]+]]:_(i64) = G_XOR [[MV1]], [[MV]]
@@ -803,7 +803,7 @@ body: |
     ; VI-NEXT: [[USUBE:%[0-9]+]]:_(s32), [[USUBE1:%[0-9]+]]:_(i1) = G_USUBE [[UV1]], [[ASHR]], [[USUBO1]]
     ; VI-NEXT: [[MV2:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[USUBO]](s32), [[USUBE]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[MV2]](s64)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s33) = G_FPTOSI %0
     %2:_(s64) = G_ANYEXT %1
     $vgpr0_vgpr1 = COPY %2
@@ -819,21 +819,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s16_to_s7
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s7) = G_FPTOSI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -849,21 +849,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s16_to_s8
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s8) = G_FPTOSI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -879,21 +879,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s16_to_s9
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s9) = G_FPTOSI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -908,17 +908,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_s32_to_s15
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s32_to_s15
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s15) = G_FPTOSI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
@@ -933,17 +933,17 @@ body: |
     ; SI-LABEL: name: test_fptosi_s32_to_s17
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
     ;
     ; VI-LABEL: name: test_fptosi_s32_to_s17
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOSI:%[0-9]+]]:_(s32) = G_FPTOSI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOSI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s17) = G_FPTOSI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fptoui.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fptoui.mir
@@ -11,17 +11,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_s32
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s32_s32
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s32) = G_FPTOUI %0
     $vgpr0 = COPY %1
 ...
@@ -35,17 +35,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_s64
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f64)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s32_s64
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f64)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
-    %0:_(s64) = COPY $vgpr0_vgpr1
+    %0:_(f64) = COPY $vgpr0_vgpr1
     %1:_(s32) = G_FPTOUI %0
     $vgpr0 = COPY %1
 ...
@@ -59,23 +59,23 @@ body: |
     ; SI-LABEL: name: test_fptoui_v2s32_to_v2s32
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](f32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOUI]](s32), [[FPTOUI1]](s32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
     ;
     ; VI-LABEL: name: test_fptoui_v2s32_to_v2s32
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](f32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOUI]](s32), [[FPTOUI1]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
     %1:_(<2 x s32>) = G_FPTOUI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -89,23 +89,23 @@ body: |
     ; SI-LABEL: name: test_fptoui_v2s64_to_v2s32
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](s64)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](f64)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](f64)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOUI]](s32), [[FPTOUI1]](s32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
     ;
     ; VI-LABEL: name: test_fptoui_v2s64_to_v2s32
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](s64)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[UV]](f64)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[UV1]](f64)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FPTOUI]](s32), [[FPTOUI1]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
     %1:_(<2 x s32>) = G_FPTOUI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -120,21 +120,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s16_to_s16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s16) = G_FPTOUI [[TRUNC]](s16)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s16) = G_FPTOUI [[TRUNC]](f16)
     ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTOUI]](s16)
     ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s16) = G_FPTOUI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -149,17 +149,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_to_s16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s32_to_s16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s16) = G_FPTOUI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
@@ -174,17 +174,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_s64_to_s16
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f64)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s64_to_s16
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f64)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
-    %0:_(s64) = COPY $vgpr0_vgpr1
+    %0:_(f64) = COPY $vgpr0_vgpr1
     %1:_(s16) = G_FPTOUI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
@@ -199,8 +199,8 @@ body: |
     ; SI-LABEL: name: test_fptoui_s64_s64
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[COPY]](f64)
     ; SI-NEXT: [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BITCAST]](i64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 20
     ; SI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 11
@@ -221,38 +221,38 @@ body: |
     ; SI-NEXT: [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(sgt), [[SUB]](i32), [[C7]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(i64) = G_SELECT [[ICMP]](s1), [[MV]], [[AND1]]
     ; SI-NEXT: [[SELECT1:%[0-9]+]]:_(i64) = G_SELECT [[ICMP1]](s1), [[BITCAST]], [[SELECT]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(s64) = G_BITCAST [[SELECT1]](i64)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(f64) = G_BITCAST [[SELECT1]](i64)
     ; SI-NEXT: [[C8:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; SI-NEXT: [[C9:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[BITCAST1]], [[C8]]
-    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](s64)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[BITCAST1]], [[C8]]
+    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](f64)
     ; SI-NEXT: [[C10:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT1]], [[C10]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](s64), [[FMUL]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](f64), [[FMUL]]
     ; SI-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](s1), [[FMUL]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[SELECT2]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FMUL]], [[FNEG]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FADD]](s64)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FMUL]], [[FNEG]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FADD]](f64)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[MV1]](s64)
     ;
     ; VI-LABEL: name: test_fptoui_s64_s64
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s64) = G_INTRINSIC_TRUNC [[COPY]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f64) = G_INTRINSIC_TRUNC [[COPY]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s64)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f64)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[MV]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
+    %0:_(f64) = COPY $vgpr0_vgpr1
     %1:_(s64) = G_FPTOUI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -331,9 +331,9 @@ body: |
     ; SI-LABEL: name: test_fptoui_v2s64_to_v2s64
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[UV]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i64) = G_BITCAST [[UV]](f64)
     ; SI-NEXT: [[UV2:%[0-9]+]]:_(i32), [[UV3:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BITCAST]](i64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 20
     ; SI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 11
@@ -354,22 +354,22 @@ body: |
     ; SI-NEXT: [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(sgt), [[SUB]](i32), [[C7]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(i64) = G_SELECT [[ICMP]](s1), [[MV]], [[AND1]]
     ; SI-NEXT: [[SELECT1:%[0-9]+]]:_(i64) = G_SELECT [[ICMP1]](s1), [[BITCAST]], [[SELECT]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(s64) = G_BITCAST [[SELECT1]](i64)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(f64) = G_BITCAST [[SELECT1]](i64)
     ; SI-NEXT: [[C8:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; SI-NEXT: [[C9:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[BITCAST1]], [[C8]]
-    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](s64)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[BITCAST1]], [[C8]]
+    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL]](f64)
     ; SI-NEXT: [[C10:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT1]], [[C10]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](s64), [[FMUL]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL]](f64), [[FMUL]]
     ; SI-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](s1), [[FMUL]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[SELECT2]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FMUL]], [[FNEG]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FADD]](s64)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FMUL]], [[FNEG]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FADD]], [[C9]], [[BITCAST1]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FADD]](f64)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
-    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i64) = G_BITCAST [[UV1]](s64)
+    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i64) = G_BITCAST [[UV1]](f64)
     ; SI-NEXT: [[UV4:%[0-9]+]]:_(i32), [[UV5:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[BITCAST2]](i64)
     ; SI-NEXT: [[INT2:%[0-9]+]]:_(i32) = G_INTRINSIC intrinsic(@llvm.amdgcn.ubfe), [[UV5]](i32), [[C]](i32), [[C1]](i32)
     ; SI-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[INT2]], [[C2]]
@@ -382,17 +382,17 @@ body: |
     ; SI-NEXT: [[ICMP3:%[0-9]+]]:_(s1) = G_ICMP intpred(sgt), [[SUB1]](i32), [[C7]]
     ; SI-NEXT: [[SELECT3:%[0-9]+]]:_(i64) = G_SELECT [[ICMP2]](s1), [[MV2]], [[AND3]]
     ; SI-NEXT: [[SELECT4:%[0-9]+]]:_(i64) = G_SELECT [[ICMP3]](s1), [[BITCAST2]], [[SELECT3]]
-    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(s64) = G_BITCAST [[SELECT4]](i64)
-    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(s64) = G_FMUL [[BITCAST3]], [[C8]]
-    ; SI-NEXT: [[INT3:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL1]](s64)
+    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(f64) = G_BITCAST [[SELECT4]](i64)
+    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(f64) = G_FMUL [[BITCAST3]], [[C8]]
+    ; SI-NEXT: [[INT3:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[FMUL1]](f64)
     ; SI-NEXT: [[FMINNUM_IEEE1:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT3]], [[C10]]
-    ; SI-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL1]](s64), [[FMUL1]]
+    ; SI-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[FMUL1]](f64), [[FMUL1]]
     ; SI-NEXT: [[SELECT5:%[0-9]+]]:_(f64) = G_SELECT [[FCMP1]](s1), [[FMUL1]], [[FMINNUM_IEEE1]]
     ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(f64) = G_FNEG [[SELECT5]]
-    ; SI-NEXT: [[FADD1:%[0-9]+]]:_(s64) = G_FADD [[FMUL1]], [[FNEG1]]
-    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(s64) = G_FMA [[FADD1]], [[C9]], [[BITCAST3]]
-    ; SI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FADD1]](s64)
-    ; SI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s64)
+    ; SI-NEXT: [[FADD1:%[0-9]+]]:_(f64) = G_FADD [[FMUL1]], [[FNEG1]]
+    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(f64) = G_FMA [[FADD1]], [[C9]], [[BITCAST3]]
+    ; SI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FADD1]](f64)
+    ; SI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f64)
     ; SI-NEXT: [[MV3:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI3]](i32), [[FPTOUI2]](i32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV1]](s64), [[MV3]](s64)
     ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
@@ -400,27 +400,27 @@ body: |
     ; VI-LABEL: name: test_fptoui_v2s64_to_v2s64
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s64) = G_INTRINSIC_TRUNC [[UV]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f64) = G_INTRINSIC_TRUNC [[UV]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3DF0000000000000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double f0xC1F0000000000000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s64)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s64)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f64) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f64)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f64)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
-    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(s64) = G_INTRINSIC_TRUNC [[UV1]]
-    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(s64) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s64) = G_FFLOOR [[FMUL1]]
-    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(s64) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
-    ; VI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](s64)
-    ; VI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s64)
+    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(f64) = G_INTRINSIC_TRUNC [[UV1]]
+    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(f64) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f64) = G_FFLOOR [[FMUL1]]
+    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(f64) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
+    ; VI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](f64)
+    ; VI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f64)
     ; VI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI3]](i32), [[FPTOUI2]](i32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
     ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
     %1:_(<2 x s64>) = G_FPTOUI %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
@@ -434,33 +434,33 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_to_s64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
     ; SI-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; SI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; SI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[MV]](s64)
     ;
     ; VI-LABEL: name: test_fptoui_s32_to_s64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[MV]](s64)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s64) = G_FPTOUI %0
     $vgpr0_vgpr1 = COPY %1
 ...
@@ -474,23 +474,23 @@ body: |
     ; SI-LABEL: name: test_fptoui_v2s32_to_v2s64
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV]]
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV]]
     ; SI-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; SI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; SI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
-    ; SI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV1]]
-    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL1]]
-    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
-    ; SI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](s32)
-    ; SI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s32)
+    ; SI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV1]]
+    ; SI-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL1]]
+    ; SI-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
+    ; SI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](f32)
+    ; SI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f32)
     ; SI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI3]](i32), [[FPTOUI2]](i32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
     ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
@@ -498,27 +498,27 @@ body: |
     ; VI-LABEL: name: test_fptoui_v2s32_to_v2s64
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
-    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[UV1]]
-    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL1]]
-    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
-    ; VI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](s32)
-    ; VI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](s32)
+    ; VI-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[UV1]]
+    ; VI-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC1]], [[C]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL1]]
+    ; VI-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR1]], [[C1]], [[INTRINSIC_TRUNC1]]
+    ; VI-NEXT: [[FPTOUI2:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR1]](f32)
+    ; VI-NEXT: [[FPTOUI3:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA1]](f32)
     ; VI-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI3]](i32), [[FPTOUI2]](i32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
     ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
     %1:_(<2 x s64>) = G_FPTOUI %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
@@ -533,9 +533,9 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[FPTOUI]](s32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[ZEXT]](s64)
     ;
@@ -543,13 +543,13 @@ body: |
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[FPTOUI]](s32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[ZEXT]](s64)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s64) = G_FPTOUI %1
     $vgpr0_vgpr1 = COPY %2
 ...
@@ -563,17 +563,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_v2s16_to_v2s64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[FPTOUI]](s32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT1]](s32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT1]](f32)
     ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(s64) = G_ZEXT [[FPTOUI1]](s32)
     ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[ZEXT]](s64), [[ZEXT1]](s64)
     ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
@@ -581,21 +581,21 @@ body: |
     ; VI-LABEL: name: test_fptoui_v2s16_to_v2s64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[FPTOUI]](s32)
-    ; VI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT1]](s32)
+    ; VI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT1]](f32)
     ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(s64) = G_ZEXT [[FPTOUI1]](s32)
     ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[ZEXT]](s64), [[ZEXT1]](s64)
     ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s16>) = COPY $vgpr0
+    %0:_(<2 x f16>) = COPY $vgpr0
     %1:_(<2 x s64>) = G_FPTOUI %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
@@ -640,21 +640,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s16_to_s15
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s15) = G_FPTOUI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -670,21 +670,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s16_to_s17
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s17) = G_FPTOUI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -699,33 +699,33 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_to_s33
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
     ; SI-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; SI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; SI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; SI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; SI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; SI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; SI-NEXT: $vgpr0_vgpr1 = COPY [[MV]](s64)
     ;
     ; VI-LABEL: name: test_fptoui_s32_to_s33
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[COPY]]
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[COPY]]
     ; VI-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x2F800000
     ; VI-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0xCF800000
-    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FMUL]]
-    ; VI-NEXT: [[FMA:%[0-9]+]]:_(s32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](s32)
-    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](s32)
+    ; VI-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[INTRINSIC_TRUNC]], [[C]]
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FMUL]]
+    ; VI-NEXT: [[FMA:%[0-9]+]]:_(f32) = G_FMA [[FFLOOR]], [[C1]], [[INTRINSIC_TRUNC]]
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(i32) = G_FPTOUI [[FFLOOR]](f32)
+    ; VI-NEXT: [[FPTOUI1:%[0-9]+]]:_(i32) = G_FPTOUI [[FMA]](f32)
     ; VI-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[FPTOUI1]](i32), [[FPTOUI]](i32)
     ; VI-NEXT: $vgpr0_vgpr1 = COPY [[MV]](s64)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s33) = G_FPTOUI %0
     %2:_(s64) = G_ANYEXT %1
     $vgpr0_vgpr1 = COPY %2
@@ -741,21 +741,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s16_to_s7
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s7) = G_FPTOUI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -771,21 +771,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s16_to_s8
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s8) = G_FPTOUI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -801,21 +801,21 @@ body: |
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s16_to_s9
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](s32)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](s32)
+    ; VI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[FPEXT]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
+    %1:_(f16) = G_TRUNC %0
     %2:_(s9) = G_FPTOUI %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
@@ -830,17 +830,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_to_s15
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s32_to_s15
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s15) = G_FPTOUI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
@@ -855,17 +855,17 @@ body: |
     ; SI-LABEL: name: test_fptoui_s32_to_s17
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; SI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
     ;
     ; VI-LABEL: name: test_fptoui_s32_to_s17
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FPTOUI:%[0-9]+]]:_(s32) = G_FPTOUI [[COPY]](f32)
     ; VI-NEXT: $vgpr0 = COPY [[FPTOUI]](s32)
-    %0:_(s32) = COPY $vgpr0
+    %0:_(f32) = COPY $vgpr0
     %1:_(s17) = G_FPTOUI %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-sitofp.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-sitofp.mir
@@ -12,17 +12,17 @@ body: |
     ; GFX6: liveins: $vgpr0
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[COPY]](s32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[SITOFP]](s32)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[COPY]](s32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[SITOFP]](f32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s32_to_s32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[COPY]](s32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[SITOFP]](s32)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[COPY]](s32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[SITOFP]](f32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = G_SITOFP %0
+    %1:_(f32) = G_SITOFP %0
     $vgpr0 = COPY %1
 ...
 
@@ -36,17 +36,17 @@ body: |
     ; GFX6: liveins: $vgpr0
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[COPY]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](s64)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[COPY]](s32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](f64)
     ;
     ; GFX8-LABEL: name: test_sitofp_s32_to_s64
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[COPY]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](s64)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[COPY]](s32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](f64)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s64) = G_SITOFP %0
+    %1:_(f64) = G_SITOFP %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
@@ -61,22 +61,22 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
     ; GFX6-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[UV]](s32)
-    ; GFX6-NEXT: [[SITOFP1:%[0-9]+]]:_(s32) = G_SITOFP [[UV1]](s32)
-    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[SITOFP]](s32), [[SITOFP1]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[UV]](s32)
+    ; GFX6-NEXT: [[SITOFP1:%[0-9]+]]:_(f32) = G_SITOFP [[UV1]](s32)
+    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[SITOFP]](f32), [[SITOFP1]](f32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
     ; GFX8-LABEL: name: test_sitofp_v2s32_to_v2s32
     ; GFX8: liveins: $vgpr0_vgpr1
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
     ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[UV]](s32)
-    ; GFX8-NEXT: [[SITOFP1:%[0-9]+]]:_(s32) = G_SITOFP [[UV1]](s32)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[SITOFP]](s32), [[SITOFP1]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[UV]](s32)
+    ; GFX8-NEXT: [[SITOFP1:%[0-9]+]]:_(f32) = G_SITOFP [[UV1]](s32)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[SITOFP]](f32), [[SITOFP1]](f32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = G_SITOFP %0
+    %1:_(<2 x f32>) = G_SITOFP %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
@@ -91,22 +91,22 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
     ; GFX6-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[UV]](s32)
-    ; GFX6-NEXT: [[SITOFP1:%[0-9]+]]:_(s64) = G_SITOFP [[UV1]](s32)
-    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[SITOFP]](s64), [[SITOFP1]](s64)
-    ; GFX6-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[UV]](s32)
+    ; GFX6-NEXT: [[SITOFP1:%[0-9]+]]:_(f64) = G_SITOFP [[UV1]](s32)
+    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[SITOFP]](f64), [[SITOFP1]](f64)
+    ; GFX6-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
     ; GFX8-LABEL: name: test_sitofp_v2s32_to_v2s64
     ; GFX8: liveins: $vgpr0_vgpr1
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
     ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[UV]](s32)
-    ; GFX8-NEXT: [[SITOFP1:%[0-9]+]]:_(s64) = G_SITOFP [[UV1]](s32)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[SITOFP]](s64), [[SITOFP1]](s64)
-    ; GFX8-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[UV]](s32)
+    ; GFX8-NEXT: [[SITOFP1:%[0-9]+]]:_(f64) = G_SITOFP [[UV1]](s32)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[SITOFP]](f64), [[SITOFP1]](f64)
+    ; GFX8-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s64>) = G_SITOFP %0
+    %1:_(<2 x f64>) = G_SITOFP %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
 
@@ -136,8 +136,8 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s64_to_s32
     ; GFX8: liveins: $vgpr0_vgpr1
@@ -159,10 +159,10 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s32) = G_SITOFP %0
+    %1:_(f32) = G_SITOFP %0
     $vgpr0 = COPY %1
 ...
 
@@ -181,8 +181,8 @@ body: |
     ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[UV1]](i32)
     ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[UV]](i32)
     ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = G_FLDEXP [[SITOFP]], [[C]](i32)
-    ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FLDEXP]], [[UITOFP]]
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FLDEXP]], [[UITOFP]]
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     ;
     ; GFX8-LABEL: name: test_sitofp_s64_to_s64
     ; GFX8: liveins: $vgpr0_vgpr1
@@ -193,10 +193,10 @@ body: |
     ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[UV1]](i32)
     ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[UV]](i32)
     ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = G_FLDEXP [[SITOFP]], [[C]](i32)
-    ; GFX8-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FLDEXP]], [[UITOFP]]
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; GFX8-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FLDEXP]], [[UITOFP]]
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = G_SITOFP %0
+    %1:_(f64) = G_SITOFP %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
@@ -211,9 +211,9 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 16
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[SITOFP]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[SITOFP]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s16_to_s16
@@ -221,12 +221,12 @@ body: |
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s16) = G_SITOFP [[TRUNC]](s16)
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SITOFP]](s16)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f16) = G_SITOFP [[TRUNC]](s16)
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SITOFP]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s16) = G_TRUNC %0
-    %2:_(s16) = G_SITOFP %1
+    %2:_(f16) = G_SITOFP %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
 ...
@@ -242,19 +242,19 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 16
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[SITOFP]](s32)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[SITOFP]](f32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s16_to_s32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 16
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[SITOFP]](s32)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[SITOFP]](f32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s16) = G_TRUNC %0
-    %2:_(s32) = G_SITOFP %1
+    %2:_(f32) = G_SITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -269,19 +269,19 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 16
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](s64)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](f64)
     ;
     ; GFX8-LABEL: name: test_sitofp_s16_to_s64
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 16
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](s64)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](f64)
     %0:_(s32) = COPY $vgpr0
     %1:_(s16) = G_TRUNC %0
-    %2:_(s64) = G_SITOFP %1
+    %2:_(f64) = G_SITOFP %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
@@ -296,9 +296,9 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 8
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[SITOFP]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[SITOFP]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s8_to_s16
@@ -306,13 +306,13 @@ body: |
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 8
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[SITOFP]](s32)
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[SITOFP]](f32)
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s8) = G_TRUNC %0
-    %2:_(s16) = G_SITOFP %1
+    %2:_(f16) = G_SITOFP %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
 ...
@@ -328,19 +328,19 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 8
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[SITOFP]](s32)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[SITOFP]](f32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s8_to_s32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 8
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s32) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[SITOFP]](s32)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[SITOFP]](f32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s8) = G_TRUNC %0
-    %2:_(s32) = G_SITOFP %1
+    %2:_(f32) = G_SITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -355,19 +355,19 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 8
-    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](s64)
+    ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](f64)
     ;
     ; GFX8-LABEL: name: test_sitofp_s8_to_s64
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[COPY]], 8
-    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(s64) = G_SITOFP [[SEXT_INREG]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](s64)
+    ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f64) = G_SITOFP [[SEXT_INREG]](s32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SITOFP]](f64)
     %0:_(s32) = COPY $vgpr0
     %1:_(s8) = G_TRUNC %0
-    %2:_(s64) = G_SITOFP %1
+    %2:_(f64) = G_SITOFP %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
@@ -382,10 +382,10 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s16) = G_FCONSTANT half -1.000000e+00
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s16) = G_FCONSTANT half 0.000000e+00
-    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half -1.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s1_to_s16
@@ -393,14 +393,14 @@ body: |
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s16) = G_FCONSTANT half -1.000000e+00
-    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(s16) = G_FCONSTANT half 0.000000e+00
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half -1.000000e+00
+    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s1) = G_TRUNC %0
-    %2:_(s16) = G_SITOFP %1
+    %2:_(f16) = G_SITOFP %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
 ...
@@ -416,23 +416,23 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.000000e+00
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX6-NEXT: $vgpr0 = COPY [[SELECT]](s32)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX6-NEXT: $vgpr0 = COPY [[SELECT]](f32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s1_to_s32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float -1.000000e+00
-    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX8-NEXT: $vgpr0 = COPY [[SELECT]](s32)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float -1.000000e+00
+    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX8-NEXT: $vgpr0 = COPY [[SELECT]](f32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s1) = G_TRUNC %0
-    %2:_(s32) = G_SITOFP %1
+    %2:_(f32) = G_SITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -447,23 +447,23 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s64) = G_FCONSTANT double -1.000000e+00
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s64) = G_FCONSTANT double 0.000000e+00
-    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double -1.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
     ;
     ; GFX8-LABEL: name: test_sitofp_s1_to_s64
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s64) = G_FCONSTANT double -1.000000e+00
-    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(s64) = G_FCONSTANT double 0.000000e+00
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double -1.000000e+00
+    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
     %0:_(s32) = COPY $vgpr0
     %1:_(s1) = G_TRUNC %0
-    %2:_(s64) = G_SITOFP %1
+    %2:_(f64) = G_SITOFP %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
@@ -494,8 +494,8 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s33_to_s32
     ; GFX8: liveins: $vgpr0_vgpr1
@@ -518,11 +518,11 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     %0:_(s64) = COPY $vgpr0_vgpr1
     %1:_(s33) = G_TRUNC %0
-    %2:_(s32) = G_SITOFP %1
+    %2:_(f32) = G_SITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -552,9 +552,9 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_sitofp_s64_to_s16
@@ -577,12 +577,12 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s16) = G_SITOFP %0
+    %1:_(f16) = G_SITOFP %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
 ...
@@ -614,8 +614,8 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV5]], [[UMIN1]]
     ; GFX6-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
     ; GFX6-NEXT: [[UV6:%[0-9]+]]:_(i32), [[UV7:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[UV1]](s64)
     ; GFX6-NEXT: [[XOR1:%[0-9]+]]:_(i32) = G_XOR [[UV6]], [[UV7]]
     ; GFX6-NEXT: [[ASHR1:%[0-9]+]]:_(i32) = G_ASHR [[XOR1]], [[C2]](i32)
@@ -629,15 +629,15 @@ body: |
     ; GFX6-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[UV9]], [[UMIN3]]
     ; GFX6-NEXT: [[SITOFP1:%[0-9]+]]:_(f32) = G_SITOFP [[OR1]](i32)
     ; GFX6-NEXT: [[SUB3:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN2]]
-    ; GFX6-NEXT: [[FLDEXP1:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP1]], [[SUB3]](i32)
-    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP1]](s32)
-    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; GFX6-NEXT: [[FLDEXP1:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP1]], [[SUB3]](i32)
+    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP1]](f32)
+    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; GFX6-NEXT: [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX6-NEXT: [[SHL2:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C3]](i32)
     ; GFX6-NEXT: [[OR2:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL2]]
-    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR2]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x s16>)
+    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR2]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x f16>)
     ;
     ; GFX8-LABEL: name: test_sitofp_v2s64_to_v2s16
     ; GFX8: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
@@ -660,8 +660,8 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV5]], [[UMIN1]]
     ; GFX8-NEXT: [[SITOFP:%[0-9]+]]:_(f32) = G_SITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
-    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP]], [[SUB1]](i32)
+    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
     ; GFX8-NEXT: [[UV6:%[0-9]+]]:_(i32), [[UV7:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[UV1]](s64)
     ; GFX8-NEXT: [[XOR1:%[0-9]+]]:_(i32) = G_XOR [[UV6]], [[UV7]]
     ; GFX8-NEXT: [[ASHR1:%[0-9]+]]:_(i32) = G_ASHR [[XOR1]], [[C2]](i32)
@@ -675,16 +675,16 @@ body: |
     ; GFX8-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[UV9]], [[UMIN3]]
     ; GFX8-NEXT: [[SITOFP1:%[0-9]+]]:_(f32) = G_SITOFP [[OR1]](i32)
     ; GFX8-NEXT: [[SUB3:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN2]]
-    ; GFX8-NEXT: [[FLDEXP1:%[0-9]+]]:_(s32) = G_FLDEXP [[SITOFP1]], [[SUB3]](i32)
-    ; GFX8-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP1]](s32)
-    ; GFX8-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; GFX8-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; GFX8-NEXT: [[FLDEXP1:%[0-9]+]]:_(f32) = G_FLDEXP [[SITOFP1]], [[SUB3]](i32)
+    ; GFX8-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP1]](f32)
+    ; GFX8-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; GFX8-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; GFX8-NEXT: [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX8-NEXT: [[SHL2:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C3]](i32)
     ; GFX8-NEXT: [[OR2:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL2]]
-    ; GFX8-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR2]](i32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x s16>)
+    ; GFX8-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR2]](i32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x f16>)
     %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %1:_(<2 x s16>) = G_SITOFP %0
+    %1:_(<2 x f16>) = G_SITOFP %0
     $vgpr0 = COPY %1
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-uitofp.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-uitofp.mir
@@ -12,17 +12,17 @@ body: |
     ; GFX6: liveins: $vgpr0
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[COPY]](s32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[UITOFP]](s32)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[COPY]](s32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[UITOFP]](f32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s32_to_s32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[COPY]](s32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[UITOFP]](s32)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[COPY]](s32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[UITOFP]](f32)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = G_UITOFP %0
+    %1:_(f32) = G_UITOFP %0
     $vgpr0 = COPY %1
 ...
 
@@ -36,17 +36,17 @@ body: |
     ; GFX6: liveins: $vgpr0
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s64) = G_UITOFP [[COPY]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](s64)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[COPY]](s32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](f64)
     ;
     ; GFX8-LABEL: name: test_uitofp_s32_to_s64
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s64) = G_UITOFP [[COPY]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](s64)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[COPY]](s32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](f64)
     %0:_(s32) = COPY $vgpr0
-    %1:_(s64) = G_UITOFP %0
+    %1:_(f64) = G_UITOFP %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
@@ -61,22 +61,22 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
     ; GFX6-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[UV]](s32)
-    ; GFX6-NEXT: [[UITOFP1:%[0-9]+]]:_(s32) = G_UITOFP [[UV1]](s32)
-    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[UITOFP]](s32), [[UITOFP1]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[UV]](s32)
+    ; GFX6-NEXT: [[UITOFP1:%[0-9]+]]:_(f32) = G_UITOFP [[UV1]](s32)
+    ; GFX6-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[UITOFP]](f32), [[UITOFP1]](f32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
     ; GFX8-LABEL: name: test_uitofp_v2s32_to_v2s32
     ; GFX8: liveins: $vgpr0_vgpr1
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
     ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[UV]](s32)
-    ; GFX8-NEXT: [[UITOFP1:%[0-9]+]]:_(s32) = G_UITOFP [[UV1]](s32)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[UITOFP]](s32), [[UITOFP1]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[UV]](s32)
+    ; GFX8-NEXT: [[UITOFP1:%[0-9]+]]:_(f32) = G_UITOFP [[UV1]](s32)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[UITOFP]](f32), [[UITOFP1]](f32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = G_UITOFP %0
+    %1:_(<2 x f32>) = G_UITOFP %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
@@ -101,8 +101,8 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s64_to_s32
     ; GFX8: liveins: $vgpr0_vgpr1
@@ -119,10 +119,10 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s32) = G_UITOFP %0
+    %1:_(f32) = G_UITOFP %0
     $vgpr0 = COPY %1
 ...
 
@@ -141,8 +141,8 @@ body: |
     ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[UV1]](i32)
     ; GFX6-NEXT: [[UITOFP1:%[0-9]+]]:_(f64) = G_UITOFP [[UV]](i32)
     ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = G_FLDEXP [[UITOFP]], [[C]](i32)
-    ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FLDEXP]], [[UITOFP1]]
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; GFX6-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FLDEXP]], [[UITOFP1]]
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     ;
     ; GFX8-LABEL: name: test_uitofp_s64_to_s64
     ; GFX8: liveins: $vgpr0_vgpr1
@@ -153,10 +153,10 @@ body: |
     ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[UV1]](i32)
     ; GFX8-NEXT: [[UITOFP1:%[0-9]+]]:_(f64) = G_UITOFP [[UV]](i32)
     ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = G_FLDEXP [[UITOFP]], [[C]](i32)
-    ; GFX8-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[FLDEXP]], [[UITOFP1]]
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; GFX8-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[FLDEXP]], [[UITOFP1]]
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = G_UITOFP %0
+    %1:_(f64) = G_UITOFP %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
@@ -172,9 +172,9 @@ body: |
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; GFX6-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[UITOFP]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[UITOFP]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s16_to_s16
@@ -182,12 +182,12 @@ body: |
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s16) = G_UITOFP [[TRUNC]](s16)
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[UITOFP]](s16)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f16) = G_UITOFP [[TRUNC]](s16)
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[UITOFP]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s16) = G_TRUNC %0
-    %2:_(s16) = G_UITOFP %1
+    %2:_(f16) = G_UITOFP %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
 ...
@@ -204,8 +204,8 @@ body: |
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; GFX6-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[UITOFP]](s32)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[UITOFP]](f32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s16_to_s32
     ; GFX8: liveins: $vgpr0
@@ -213,11 +213,11 @@ body: |
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; GFX8-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[UITOFP]](s32)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[UITOFP]](f32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s16) = G_TRUNC %0
-    %2:_(s32) = G_UITOFP %1
+    %2:_(f32) = G_UITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -233,8 +233,8 @@ body: |
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; GFX6-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s64) = G_UITOFP [[AND]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](s64)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[AND]](s32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](f64)
     ;
     ; GFX8-LABEL: name: test_uitofp_s16_to_s64
     ; GFX8: liveins: $vgpr0
@@ -242,11 +242,11 @@ body: |
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; GFX8-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s64) = G_UITOFP [[AND]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](s64)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[AND]](s32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](f64)
     %0:_(s32) = COPY $vgpr0
     %1:_(s16) = G_TRUNC %0
-    %2:_(s64) = G_UITOFP %1
+    %2:_(f64) = G_UITOFP %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
@@ -262,9 +262,9 @@ body: |
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; GFX6-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[UITOFP]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[UITOFP]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s8_to_s16
@@ -273,13 +273,13 @@ body: |
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; GFX8-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[UITOFP]](s32)
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[UITOFP]](f32)
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s8) = G_TRUNC %0
-    %2:_(s16) = G_UITOFP %1
+    %2:_(f16) = G_UITOFP %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
 ...
@@ -296,8 +296,8 @@ body: |
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; GFX6-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[UITOFP]](s32)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[UITOFP]](f32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s8_to_s32
     ; GFX8: liveins: $vgpr0
@@ -305,11 +305,11 @@ body: |
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; GFX8-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s32) = G_UITOFP [[AND]](s32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[UITOFP]](s32)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[AND]](s32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[UITOFP]](f32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s8) = G_TRUNC %0
-    %2:_(s32) = G_UITOFP %1
+    %2:_(f32) = G_UITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -325,8 +325,8 @@ body: |
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; GFX6-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(s64) = G_UITOFP [[AND]](s32)
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](s64)
+    ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[AND]](s32)
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](f64)
     ;
     ; GFX8-LABEL: name: test_uitofp_s8_to_s64
     ; GFX8: liveins: $vgpr0
@@ -334,11 +334,11 @@ body: |
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
     ; GFX8-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C]]
-    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(s64) = G_UITOFP [[AND]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](s64)
+    ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f64) = G_UITOFP [[AND]](s32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[UITOFP]](f64)
     %0:_(s32) = COPY $vgpr0
     %1:_(s8) = G_TRUNC %0
-    %2:_(s64) = G_UITOFP %1
+    %2:_(f64) = G_UITOFP %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
@@ -353,10 +353,10 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s16) = G_FCONSTANT half 1.000000e+00
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s16) = G_FCONSTANT half 0.000000e+00
-    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half 1.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s1_to_s16
@@ -364,14 +364,14 @@ body: |
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s16) = G_FCONSTANT half 1.000000e+00
-    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(s16) = G_FCONSTANT half 0.000000e+00
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half 1.000000e+00
+    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s1) = G_TRUNC %0
-    %2:_(s16) = G_UITOFP %1
+    %2:_(f16) = G_UITOFP %1
     %3:_(s32) = G_ANYEXT %2
     $vgpr0 = COPY %3
 ...
@@ -387,23 +387,23 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX6-NEXT: $vgpr0 = COPY [[SELECT]](s32)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX6-NEXT: $vgpr0 = COPY [[SELECT]](f32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s1_to_s32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float 1.000000e+00
-    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX8-NEXT: $vgpr0 = COPY [[SELECT]](s32)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 1.000000e+00
+    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX8-NEXT: $vgpr0 = COPY [[SELECT]](f32)
     %0:_(s32) = COPY $vgpr0
     %1:_(s1) = G_TRUNC %0
-    %2:_(s32) = G_UITOFP %1
+    %2:_(f32) = G_UITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -418,23 +418,23 @@ body: |
     ; GFX6-NEXT: {{  $}}
     ; GFX6-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX6-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX6-NEXT: [[C:%[0-9]+]]:_(s64) = G_FCONSTANT double 1.000000e+00
-    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(s64) = G_FCONSTANT double 0.000000e+00
-    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
+    ; GFX6-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double 1.000000e+00
+    ; GFX6-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX6-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX6-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
     ;
     ; GFX8-LABEL: name: test_uitofp_s1_to_s64
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
     ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s64) = G_FCONSTANT double 1.000000e+00
-    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(s64) = G_FCONSTANT double 0.000000e+00
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double 1.000000e+00
+    ; GFX8-NEXT: [[C1:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[TRUNC]](s1), [[C]], [[C1]]
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
     %0:_(s32) = COPY $vgpr0
     %1:_(s1) = G_TRUNC %0
-    %2:_(s64) = G_UITOFP %1
+    %2:_(f64) = G_UITOFP %1
     $vgpr0_vgpr1 = COPY %2
 ...
 
@@ -461,8 +461,8 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C1]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s33_to_s32
     ; GFX8: liveins: $vgpr0_vgpr1
@@ -481,11 +481,11 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C1]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](s32)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[FLDEXP]](f32)
     %0:_(s64) = COPY $vgpr0_vgpr1
     %1:_(s33) = G_TRUNC %0
-    %2:_(s32) = G_UITOFP %1
+    %2:_(f32) = G_UITOFP %1
     $vgpr0 = COPY %2
 ...
 
@@ -510,9 +510,9 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
-    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
+    ; GFX6-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX6-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     ;
     ; GFX8-LABEL: name: test_uitofp_s64_to_s16
@@ -530,12 +530,12 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV3]], [[UMIN1]]
     ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](f16)
     ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
     %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s16) = G_UITOFP %0
+    %1:_(f16) = G_UITOFP %0
     %2:_(s32) = G_ANYEXT %1
     $vgpr0 = COPY %2
 ...
@@ -562,8 +562,8 @@ body: |
     ; GFX6-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV5]], [[UMIN1]]
     ; GFX6-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX6-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
+    ; GFX6-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX6-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
     ; GFX6-NEXT: [[UV6:%[0-9]+]]:_(i32), [[UV7:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[UV1]](s64)
     ; GFX6-NEXT: [[AMDGPU_FFBH_U32_1:%[0-9]+]]:_(i32) = G_AMDGPU_FFBH_U32 [[UV7]](i32)
     ; GFX6-NEXT: [[UMIN2:%[0-9]+]]:_(i32) = G_UMIN [[AMDGPU_FFBH_U32_1]], [[C]]
@@ -573,15 +573,15 @@ body: |
     ; GFX6-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[UV9]], [[UMIN3]]
     ; GFX6-NEXT: [[UITOFP1:%[0-9]+]]:_(f32) = G_UITOFP [[OR1]](i32)
     ; GFX6-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN2]]
-    ; GFX6-NEXT: [[FLDEXP1:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP1]], [[SUB1]](i32)
-    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP1]](s32)
-    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; GFX6-NEXT: [[FLDEXP1:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP1]], [[SUB1]](i32)
+    ; GFX6-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP1]](f32)
+    ; GFX6-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; GFX6-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; GFX6-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX6-NEXT: [[SHL2:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C2]](i32)
     ; GFX6-NEXT: [[OR2:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL2]]
-    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR2]](i32)
-    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x s16>)
+    ; GFX6-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR2]](i32)
+    ; GFX6-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x f16>)
     ;
     ; GFX8-LABEL: name: test_sitofp_v2s64_to_v2s16
     ; GFX8: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
@@ -599,8 +599,8 @@ body: |
     ; GFX8-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[UV5]], [[UMIN1]]
     ; GFX8-NEXT: [[UITOFP:%[0-9]+]]:_(f32) = G_UITOFP [[OR]](i32)
     ; GFX8-NEXT: [[SUB:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN]]
-    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
-    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP]](s32)
+    ; GFX8-NEXT: [[FLDEXP:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP]], [[SUB]](i32)
+    ; GFX8-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP]](f32)
     ; GFX8-NEXT: [[UV6:%[0-9]+]]:_(i32), [[UV7:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[UV1]](s64)
     ; GFX8-NEXT: [[AMDGPU_FFBH_U32_1:%[0-9]+]]:_(i32) = G_AMDGPU_FFBH_U32 [[UV7]](i32)
     ; GFX8-NEXT: [[UMIN2:%[0-9]+]]:_(i32) = G_UMIN [[AMDGPU_FFBH_U32_1]], [[C]]
@@ -610,16 +610,16 @@ body: |
     ; GFX8-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[UV9]], [[UMIN3]]
     ; GFX8-NEXT: [[UITOFP1:%[0-9]+]]:_(f32) = G_UITOFP [[OR1]](i32)
     ; GFX8-NEXT: [[SUB1:%[0-9]+]]:_(i32) = G_SUB [[C]], [[UMIN2]]
-    ; GFX8-NEXT: [[FLDEXP1:%[0-9]+]]:_(s32) = G_FLDEXP [[UITOFP1]], [[SUB1]](i32)
-    ; GFX8-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FLDEXP1]](s32)
-    ; GFX8-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; GFX8-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; GFX8-NEXT: [[FLDEXP1:%[0-9]+]]:_(f32) = G_FLDEXP [[UITOFP1]], [[SUB1]](i32)
+    ; GFX8-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FLDEXP1]](f32)
+    ; GFX8-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; GFX8-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; GFX8-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX8-NEXT: [[SHL2:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C2]](i32)
     ; GFX8-NEXT: [[OR2:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL2]]
-    ; GFX8-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR2]](i32)
-    ; GFX8-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x s16>)
+    ; GFX8-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR2]](i32)
+    ; GFX8-NEXT: $vgpr0 = COPY [[BITCAST]](<2 x f16>)
     %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %1:_(<2 x s16>) = G_UITOFP %0
+    %1:_(<2 x f16>) = G_UITOFP %0
     $vgpr0 = COPY %1
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-fptosi-sat.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-fptosi-sat.mir
@@ -11,11 +11,11 @@ body: |
     ; CHECK-LABEL: name: fptosi_sat_s
     ; CHECK: liveins: $sgpr0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:sgpr(s32) = COPY $sgpr0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vgpr(s32) = COPY [[COPY]](s32)
-    ; CHECK-NEXT: [[FPTOSI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOSI_SAT [[COPY1]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:sgpr(f32) = COPY $sgpr0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vgpr(f32) = COPY [[COPY]](f32)
+    ; CHECK-NEXT: [[FPTOSI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOSI_SAT [[COPY1]](f32)
     ; CHECK-NEXT: [[AMDGPU_READANYLANE:%[0-9]+]]:sgpr(s32) = G_AMDGPU_READANYLANE [[FPTOSI_SAT]]
-    %0:_(s32) = COPY $sgpr0
+    %0:_(f32) = COPY $sgpr0
     %1:_(s32) = G_FPTOSI_SAT %0
 ...
 
@@ -29,8 +29,8 @@ body: |
     ; CHECK-LABEL: name: fptosi_sat_v
     ; CHECK: liveins: $vgpr0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(s32) = COPY $vgpr0
-    ; CHECK-NEXT: [[FPTOSI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOSI_SAT [[COPY]](s32)
-    %0:_(s32) = COPY $vgpr0
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(f32) = COPY $vgpr0
+    ; CHECK-NEXT: [[FPTOSI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOSI_SAT [[COPY]](f32)
+    %0:_(f32) = COPY $vgpr0
     %1:_(s32) = G_FPTOSI_SAT %0
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-fptoui-sat.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-fptoui-sat.mir
@@ -11,11 +11,11 @@ body: |
     ; CHECK-LABEL: name: fptoui_sat_s
     ; CHECK: liveins: $sgpr0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:sgpr(s32) = COPY $sgpr0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vgpr(s32) = COPY [[COPY]](s32)
-    ; CHECK-NEXT: [[FPTOUI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOUI_SAT [[COPY1]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:sgpr(f32) = COPY $sgpr0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vgpr(f32) = COPY [[COPY]](f32)
+    ; CHECK-NEXT: [[FPTOUI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOUI_SAT [[COPY1]](f32)
     ; CHECK-NEXT: [[AMDGPU_READANYLANE:%[0-9]+]]:sgpr(s32) = G_AMDGPU_READANYLANE [[FPTOUI_SAT]]
-    %0:_(s32) = COPY $sgpr0
+    %0:_(f32) = COPY $sgpr0
     %1:_(s32) = G_FPTOUI_SAT %0
 ...
 
@@ -29,8 +29,8 @@ body: |
     ; CHECK-LABEL: name: fptoui_sat_v
     ; CHECK: liveins: $vgpr0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(s32) = COPY $vgpr0
-    ; CHECK-NEXT: [[FPTOUI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOUI_SAT [[COPY]](s32)
-    %0:_(s32) = COPY $vgpr0
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(f32) = COPY $vgpr0
+    ; CHECK-NEXT: [[FPTOUI_SAT:%[0-9]+]]:vgpr(s32) = G_FPTOUI_SAT [[COPY]](f32)
+    %0:_(f32) = COPY $vgpr0
     %1:_(s32) = G_FPTOUI_SAT %0
 ...


### PR DESCRIPTION
Migrate G_FPOW, G_FPOWI, G_INTRINSIC_FPTRUNC_ROUND, and FP<->INT conversions opcodes to extended float LLTs.

Also update the relevant MIR tests.