### PR TITLE
[Hexagon] Set the offset of the memory operand for brev intrinsic

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -1990,15 +1990,43 @@ static Value *returnEdge(const PHINode *PN, Value *IntrBaseVal) {
 // Bit-reverse Load Intrinsic: Figure out the underlying object the base
 // pointer points to, for the bit-reverse load intrinsic. Setting this to
 // memoperand might help alias analysis to figure out the dependencies.
-static Value *getUnderLyingObjectForBrevLdIntr(Value *V) {
+// A bit-reverse load accesses the base pointer with its low 16 bits reversed,
+// and post-increments the base pointer by the modifier value. For a chain of
+// bit-reverse loads, the offset that a load accesses relative to the
+// underlying object is the bit-reverse of the sum of the modifiers of the
+// preceding loads in the chain. Offset is set to that value, and HasOffset is
+// set to true, when the sum is known, that is when all of those modifiers are
+// constants and the sum fits in 16 unsigned bits. Otherwise HasOffset is set
+// to false and Offset is left unchanged.
+static Value *getUnderLyingObjectForBrevLdIntr(Value *V, int &Offset,
+                                               bool &HasOffset) {
   Value *IntrBaseVal = V;
   Value *BaseVal;
+  int64_t Sum = 0;
+  HasOffset = true;
   // Loop over till we return the same Value, implies we either figure out
   // the object or we hit a PHI
   do {
     BaseVal = V;
     V = getBrevLdObject(V);
+    // Identify if this is part of a chain of bit-reverse loads, and accumulate
+    // the modifier of the preceding load in the chain.
+    if (HasOffset && BaseVal != V && isa<IntrinsicInst>(V) &&
+        isBrevLdIntrinsic(V)) {
+      Value *Modifier = cast<IntrinsicInst>(V)->getOperand(1);
+      if (auto *CN = dyn_cast<ConstantInt>(Modifier))
+        Sum += CN->getSExtValue();
+      else
+        HasOffset = false;
+    }
   } while (BaseVal != V);
+
+  // Only the low 16 bits of the base pointer take part in the bit-reverse. A
+  // sum that does not fit in them would also change the remaining bits.
+  if (HasOffset && Sum >= 0 && isUInt<16>(Sum))
+    Offset = APInt(16, Sum).reverseBits().getZExtValue();
+  else
+    HasOffset = false;
 
   // Identify the object from PHINode.
   if (const PHINode *PN = dyn_cast<PHINode>(V))
@@ -2031,10 +2059,16 @@ void HexagonTargetLowering::getTgtMemIntrinsic(
     Type *ElTy = I.getCalledFunction()->getReturnType()->getStructElementType(0);
     Info.memVT = MVT::getVT(ElTy);
     llvm::Value *BasePtrVal = I.getOperand(0);
-    Info.ptrVal = getUnderLyingObjectForBrevLdIntr(BasePtrVal);
-    // The offset value comes through Modifier register. For now, assume the
-    // offset is 0.
+    // The offset value comes through the Modifier register. Determine the
+    // offset that is going to be accessed relative to the underlying object.
+    // If it cannot be determined, leave the pointer information out of the
+    // memory operand, so that alias analysis stays conservative.
+    bool HasOffset = false;
     Info.offset = 0;
+    Value *UnderlyingObj =
+        getUnderLyingObjectForBrevLdIntr(BasePtrVal, Info.offset, HasOffset);
+    if (HasOffset)
+      Info.ptrVal = UnderlyingObj;
     Info.align = DL.getABITypeAlign(Info.memVT.getTypeForEVT(Cont));
     Info.flags = MachineMemOperand::MOLoad;
     Infos.push_back(Info);

--- a/llvm/test/CodeGen/Hexagon/bitrev-chain-offset.ll
+++ b/llvm/test/CodeGen/Hexagon/bitrev-chain-offset.ll
@@ -1,0 +1,79 @@
+; RUN: llc -mtriple=hexagon -stop-after=hexagon-isel -o - %s | FileCheck %s
+
+; A bit-reverse load accesses the base pointer with its low 16 bits reversed,
+; and post-increments the base pointer by the modifier value. For a chain of
+; bit-reverse loads the offset accessed by a load is therefore the bit-reverse
+; of the sum of the modifiers of the preceding loads in the chain. Check that
+; the offset of the memory operand is set accordingly, so that alias analysis
+; does not break the dependence between an aliasing store and the loads.
+
+@buf = global [256 x i8] zeroinitializer, align 65536
+
+; CHECK-LABEL: name: {{.*}}brev_chain
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf + 128)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf + 64)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf + 192)
+define i8 @brev_chain() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 256)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %p1 = extractvalue { i32, ptr } %v1, 1
+  %v2 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p1, i32 256)
+  %p2 = extractvalue { i32, ptr } %v2, 1
+  %v3 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p2, i32 256)
+  %r = extractvalue { i32, ptr } %v3, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; The offset of the second load is not known, because the modifier of the
+; first load is not a constant.
+
+; CHECK-LABEL: name: {{.*}}brev_unknown_mod
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_unknown_mod(i32 %m) {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 %m)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; Only the low 16 bits of the base pointer take part in the bit-reverse, so
+; the offset of the second load is not known if the sum of the modifiers does
+; not fit in 16 unsigned bits.
+
+; CHECK-LABEL: name: {{.*}}brev_wide_mod
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_wide_mod() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 65536)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; A negative modifier makes the offset of the second load unknown as well.
+
+; CHECK-LABEL: name: {{.*}}brev_negative_mod
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_negative_mod() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 -256)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+declare { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr, i32)


### PR DESCRIPTION
If the offset is constant and can be reasoned about, set the offset in the machine memory operand of the intrinsic. This will help the alias analysis not to break the dependences between an aliased store and the intrinsic.

A bit-reverse load, memXX(Rx++Mu:brev), accesses the address formed by reversing the low 16 bits of Rx and then post-increments Rx by the modifier Mu, so the address a load in a chain accesses is the base pointer of the chain plus the bit-reverse of the sum of the modifiers of the preceding loads. The offset was previously left at 0 for every load of such a chain, which claims they all access the first bytes of the underlying object; alias analysis then concluded that a store elsewhere in the object did not alias the loads and the machine scheduler moved the store across them, so the loads read stale data.

When the offset cannot be computed, because a modifier is not a constant or the sum does not fit in the 16 bits that take part in the bit-reverse, no pointer information is attached to the memory operand at all, so that alias analysis stays conservative.