### PR TITLE
[Hexagon] Fix reg class for C2_cmoveit/cmoveif cext lowering

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
@@ -971,8 +971,10 @@ unsigned HCE::getDirectRegReplacement(unsigned ExtOpc) const {
     case Hexagon::A4_combineri:     return TargetOpcode::REG_SEQUENCE;
     case Hexagon::A4_rcmpeqi:       return Hexagon::A4_rcmpeq;
     case Hexagon::A4_rcmpneqi:      return Hexagon::A4_rcmpneq;
-    case Hexagon::C2_cmoveif:       return Hexagon::A2_tfrpf;
-    case Hexagon::C2_cmoveit:       return Hexagon::A2_tfrpt;
+    case Hexagon::C2_cmoveif:
+      return Hexagon::A2_tfrf;
+    case Hexagon::C2_cmoveit:
+      return Hexagon::A2_tfrt;
     case Hexagon::C2_cmpeqi:        return Hexagon::C2_cmpeq;
     case Hexagon::C2_cmpgti:        return Hexagon::C2_cmpgt;
     case Hexagon::C2_cmpgtui:       return Hexagon::C2_cmpgtu;

--- a/llvm/test/CodeGen/Hexagon/cext-cmovei-32bit.mir
+++ b/llvm/test/CodeGen/Hexagon/cext-cmovei-32bit.mir
@@ -1,0 +1,45 @@
+# RUN: llc -mtriple=hexagon -mcpu=hexagonv73 -run-pass=hexagon-cext-opt \
+# RUN:     -hexagon-cext-threshold=1 -verify-machineinstrs %s -o - \
+# RUN:   | FileCheck %s
+
+## C2_cmoveit / C2_cmoveif are 32-bit predicated immediate moves into
+## IntRegs. When the constant-extender pass hoists the extended immediate
+## into a register, the replacement opcode must be the 32-bit predicated
+## transfer A2_tfrt / A2_tfrf, not the 64-bit DoubleRegs form
+## A2_tfrpt / A2_tfrpf, which fails the machine verifier.
+##
+## -hexagon-cext-threshold=1 makes the pass replace even a single extended
+## use, so a minimal function is enough to exercise the lowering.
+
+---
+name: test_cmoveit
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_cmoveit
+    ; CHECK: [[IMM:%[0-9]+]]:intregs = A2_tfrsi 65535
+    ; CHECK: %{{[0-9]+}}:intregs = A2_tfrt %{{[0-9]+}}, [[IMM]]
+    ; CHECK-NOT: A2_tfrpt
+    %0:intregs = COPY $r0
+    %1:predregs = S2_tstbit_i %0, 0
+    %2:intregs = C2_cmoveit %1, 65535
+    $r0 = COPY %2
+    PS_jmpret $r31, implicit-def $pc, implicit $r0
+...
+---
+name: test_cmoveif
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_cmoveif
+    ; CHECK: [[IMM:%[0-9]+]]:intregs = A2_tfrsi 65535
+    ; CHECK: %{{[0-9]+}}:intregs = A2_tfrf %{{[0-9]+}}, [[IMM]]
+    ; CHECK-NOT: A2_tfrpf
+    %0:intregs = COPY $r0
+    %1:predregs = S2_tstbit_i %0, 0
+    %2:intregs = C2_cmoveif %1, 65535
+    $r0 = COPY %2
+    PS_jmpret $r31, implicit-def $pc, implicit $r0
+...


### PR DESCRIPTION
HexagonConstExtenders::getDirectRegReplacement mapped C2_cmoveit and C2_cmoveif (32-bit predicated immediate moves into IntRegs) to A2_tfrpt / A2_tfrpf - the 64-bit DoubleRegs predicated transfers. When the const-extender pass found a shared extended immediate profitable to hoist into a register, it rewrote

    %d:intregs = C2_cmoveit %p:predregs, #imm

into

    %d:intregs = A2_tfrpt %p:predregs, %hoisted:intregs   (BAD)

producing a paired-register transfer with IntRegs operands and tripping the machine verifier:

    Bad machine code: Illegal virtual register for instruction
    Expected a DoubleRegs register, but got a IntRegs register

The bug was latent in default codegen because HexagonGenMux re-collapsed the predicated transfer pair back into mux/muxii before the extender pass could see C2_cmoveit/if. This patch maps both opcodes to the matching 32-bit forms A2_tfrt / A2_tfrf.

Because of that, the test runs hexagon-cext-opt directly, with -hexagon-cext-threshold=1 so that a single extended use is replaced.