### PR TITLE
[Hexagon] Clang throws "Assertion `Inc.size() <= 2' failed"

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonEarlyIfConv.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonEarlyIfConv.cpp
@@ -62,6 +62,7 @@
 #include "HexagonInstrInfo.h"
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
@@ -433,6 +434,19 @@ bool HexagonEarlyIfConversion::isValid(const FlowPattern &FP) const {
       Register DefR = MI.getOperand(0).getReg();
       if (isPredicate(DefR))
         return false;
+      // The conversion assumes that each of the split, true and false blocks
+      // contributes at most one value to a PHI in the join block. A PHI can
+      // legitimately have several operands for the same incoming block, in
+      // which case a single MUX cannot represent it. Do not convert such
+      // patterns.
+      SmallPtrSet<const MachineBasicBlock *, 4> SeenB;
+      for (unsigned i = 1, e = MI.getNumOperands(); i != e; i += 2) {
+        const MachineBasicBlock *BB = MI.getOperand(i + 1).getMBB();
+        if (BB != FP.SplitB && BB != FP.TrueB && BB != FP.FalseB)
+          continue;
+        if (!SeenB.insert(BB).second)
+          return false;
+      }
     }
   }
   return true;

--- a/llvm/test/CodeGen/Hexagon/early-if-duplicate.mir
+++ b/llvm/test/CodeGen/Hexagon/early-if-duplicate.mir
@@ -1,0 +1,32 @@
+# RUN: llc -mtriple=hexagon -run-pass hexagon-early-if -o - %s | FileCheck %s
+
+# A PHI in the join block can have more than one operand for the same
+# incoming block. Such a pattern cannot be if-converted, because a single
+# MUX cannot represent the PHI. Check that the pass leaves it alone. With
+# assertions enabled the conversion used to fail an assertion in
+# computePhiCost, and without them it dropped one of the duplicated values.
+
+# CHECK-LABEL: name: foo
+# CHECK-NOT: C2_mux
+# CHECK: PHI %2, %bb.0, %2, %bb.0, %3, %bb.1
+
+---
+name: foo
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0
+    %0:intregs = COPY $r0
+    %1:predregs = C2_cmpeqi %0, 0
+    %2:intregs = A2_tfrsi 123
+    J2_jumpt %1, %bb.2, implicit-def dead $pc
+    J2_jump %bb.1, implicit-def dead $pc
+
+  bb.1:
+    %3:intregs = A2_tfrsi 321
+
+  bb.2:
+    %4:intregs = PHI %2, %bb.0, %2, %bb.0, %3, %bb.1
+    $r0 = COPY %4
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...


### PR DESCRIPTION
Adding a check in EarlyIfConv.cpp to consider whether one of SplitB, TrueB, or FalseB appears in multiple operands to a phi in JoinB. If one does, we do not consider it valid for if conversion.

A PHI may legitimately have more than one operand for the same incoming block, and a single MUX cannot represent it. Without assertions enabled the pattern was converted anyway and updatePhiNodes() silently kept only one of the duplicated values, so the test checks that the flow pattern is left unconverted rather than checking for the assertion.