### PR TITLE
[Hexagon] Fix MachineMemOperand for brev load ; set the offset of the memory operand

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -2041,15 +2041,43 @@ static Value *returnEdge(const PHINode *PN, Value *IntrBaseVal) {
 // Bit-reverse Load Intrinsic: Figure out the underlying object the base
 // pointer points to, for the bit-reverse load intrinsic. Setting this to
 // memoperand might help alias analysis to figure out the dependencies.
-static Value *getUnderLyingObjectForBrevLdIntr(Value *V) {
+// A bit-reverse load accesses the base pointer with its low 16 bits reversed,
+// and post-increments the base pointer by the modifier value. For a chain of
+// bit-reverse loads, the offset that a load accesses relative to the
+// underlying object is the bit-reverse of the sum of the modifiers of the
+// preceding loads in the chain. Offset is set to that value, and HasOffset is
+// set to true, when the sum is known, that is when all of those modifiers are
+// constants and the sum fits in 16 unsigned bits. Otherwise HasOffset is set
+// to false and Offset is left unchanged.
+static Value *getUnderLyingObjectForBrevLdIntr(Value *V, int &Offset,
+                                               bool &HasOffset) {
   Value *IntrBaseVal = V;
   Value *BaseVal;
+  int64_t Sum = 0;
+  HasOffset = true;
   // Loop over till we return the same Value, implies we either figure out
   // the object or we hit a PHI
   do {
     BaseVal = V;
     V = getBrevLdObject(V);
+    // Identify if this is part of a chain of bit-reverse loads, and accumulate
+    // the modifier of the preceding load in the chain.
+    if (HasOffset && BaseVal != V && isa<IntrinsicInst>(V) &&
+        isBrevLdIntrinsic(V)) {
+      Value *Modifier = cast<IntrinsicInst>(V)->getOperand(1);
+      if (auto *CN = dyn_cast<ConstantInt>(Modifier))
+        Sum += CN->getSExtValue();
+      else
+        HasOffset = false;
+    }
   } while (BaseVal != V);
+
+  // Only the low 16 bits of the base pointer take part in the bit-reverse. A
+  // sum that does not fit in them would also change the remaining bits.
+  if (HasOffset && Sum >= 0 && isUInt<16>(Sum))
+    Offset = APInt(16, Sum).reverseBits().getZExtValue();
+  else
+    HasOffset = false;
 
   // Identify the object from PHINode.
   if (const PHINode *PN = dyn_cast<PHINode>(V))
@@ -2082,10 +2110,16 @@ void HexagonTargetLowering::getTgtMemIntrinsic(
     Type *ElTy = I.getCalledFunction()->getReturnType()->getStructElementType(0);
     Info.memVT = MVT::getVT(ElTy);
     llvm::Value *BasePtrVal = I.getOperand(0);
-    Info.ptrVal = getUnderLyingObjectForBrevLdIntr(BasePtrVal);
-    // The offset value comes through Modifier register. For now, assume the
-    // offset is 0.
+    // The offset value comes through the Modifier register. Determine the
+    // offset that is going to be accessed relative to the underlying object.
+    // If it cannot be determined, leave the pointer information out of the
+    // memory operand, so that alias analysis stays conservative.
+    bool HasOffset = false;
     Info.offset = 0;
+    Value *UnderlyingObj =
+        getUnderLyingObjectForBrevLdIntr(BasePtrVal, Info.offset, HasOffset);
+    if (HasOffset)
+      Info.ptrVal = UnderlyingObj;
     Info.align = DL.getABITypeAlign(Info.memVT.getTypeForEVT(Cont));
     Info.flags = MachineMemOperand::MOLoad;
     Infos.push_back(Info);

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -2118,6 +2118,14 @@ void HexagonTargetLowering::getTgtMemIntrinsic(
     Info.offset = 0;
     Value *UnderlyingObj =
         getUnderLyingObjectForBrevLdIntr(BasePtrVal, Info.offset, HasOffset);
+    // The underlying object is unknown if the base pointer could not be traced
+    // back to a pointer value. Also, unless the object is aligned to 64K, the
+    // low 16 bits of the base pointer are not known, and reversing them can
+    // produce an address anywhere in the surrounding 64K region, possibly
+    // outside of the object.
+    if (!UnderlyingObj->getType()->isPointerTy() ||
+        UnderlyingObj->getPointerAlignment(DL) < Align(65536))
+      HasOffset = false;
     if (HasOffset)
       Info.ptrVal = UnderlyingObj;
     Info.align = DL.getABITypeAlign(Info.memVT.getTypeForEVT(Cont));

--- a/llvm/test/CodeGen/Hexagon/bitrev-alias-offset.ll
+++ b/llvm/test/CodeGen/Hexagon/bitrev-alias-offset.ll
@@ -1,0 +1,50 @@
+; RUN: llc -mtriple=hexagon -stop-after=hexagon-isel -o - %s | FileCheck %s
+
+; A bit-reverse load accesses the base pointer with its low 16 bits reversed,
+; so the accessed address is only known to stay inside the underlying object
+; when that object is aligned to 64K. Check that no pointer information is
+; attached to the memory operand otherwise, so that alias analysis stays
+; conservative and an aliasing store is not moved across the loads.
+
+@aligned64k = global [256 x i8] zeroinitializer, align 65536
+@aligned256 = global [256 x i8] zeroinitializer, align 256
+
+; CHECK-LABEL: name: {{.*}}brev_aligned64k
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @aligned64k)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @aligned64k + 128)
+define i8 @brev_aligned64k() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @aligned64k, i32 256)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; CHECK-LABEL: name: {{.*}}brev_aligned256
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_aligned256() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @aligned256, i32 256)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; The alignment of an incoming pointer is not known.
+
+; CHECK-LABEL: name: {{.*}}brev_unknown_align
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_unknown_align(ptr %p) {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p, i32 256)
+  %r = extractvalue { i32, ptr } %v0, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+declare { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr, i32)

--- a/llvm/test/CodeGen/Hexagon/bitrev-chain-offset.ll
+++ b/llvm/test/CodeGen/Hexagon/bitrev-chain-offset.ll
@@ -1,0 +1,79 @@
+; RUN: llc -mtriple=hexagon -stop-after=hexagon-isel -o - %s | FileCheck %s
+
+; A bit-reverse load accesses the base pointer with its low 16 bits reversed,
+; and post-increments the base pointer by the modifier value. For a chain of
+; bit-reverse loads the offset accessed by a load is therefore the bit-reverse
+; of the sum of the modifiers of the preceding loads in the chain. Check that
+; the offset of the memory operand is set accordingly, so that alias analysis
+; does not break the dependence between an aliasing store and the loads.
+
+@buf = global [256 x i8] zeroinitializer, align 65536
+
+; CHECK-LABEL: name: {{.*}}brev_chain
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf + 128)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf + 64)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf + 192)
+define i8 @brev_chain() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 256)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %p1 = extractvalue { i32, ptr } %v1, 1
+  %v2 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p1, i32 256)
+  %p2 = extractvalue { i32, ptr } %v2, 1
+  %v3 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p2, i32 256)
+  %r = extractvalue { i32, ptr } %v3, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; The offset of the second load is not known, because the modifier of the
+; first load is not a constant.
+
+; CHECK-LABEL: name: {{.*}}brev_unknown_mod
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_unknown_mod(i32 %m) {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 %m)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; Only the low 16 bits of the base pointer take part in the bit-reverse, so
+; the offset of the second load is not known if the sum of the modifiers does
+; not fit in 16 unsigned bits.
+
+; CHECK-LABEL: name: {{.*}}brev_wide_mod
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_wide_mod() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 65536)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+; A negative modifier makes the offset of the second load unknown as well.
+
+; CHECK-LABEL: name: {{.*}}brev_negative_mod
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32) from @buf)
+; CHECK: L2_loadrb_pbr{{.*}}:: (load (s32))
+define i8 @brev_negative_mod() {
+entry:
+  %v0 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr @buf, i32 -256)
+  %p0 = extractvalue { i32, ptr } %v0, 1
+  %v1 = tail call { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr %p0, i32 256)
+  %r = extractvalue { i32, ptr } %v1, 0
+  %t = trunc i32 %r to i8
+  ret i8 %t
+}
+
+declare { i32, ptr } @llvm.hexagon.L2.loadrb.pbr(ptr, i32)


### PR DESCRIPTION
`getTgtMemIntrinsic` describes the access of the bit-reverse load intrinsics (`llvm.hexagon.L2.loadr*.pbr`) by attaching the underlying object of the base pointer to the machine memory operand, for alias analysis.

Such a load post-increments its base pointer by the modifier, and accesses the address formed by reversing the low 16 bits of that pointer:

    memXX(Rx++Mu:brev)        EA = Rx.h : bitrev(Rx.l)

So a load in a chain of them accesses the base pointer of the chain, plus the bit-reverse of the sum of the modifiers of the loads before it.

The offset was always zero, so every load of a chain claimed to access the first bytes of the object. Alias analysis concluded a store elsewhere in the object could not alias the loads, the scheduler sank it below them, and the loads read stale data.

The object was described even when it could not be. Only the low 16 bits take part in the reversal, so the access stays inside the object only when those bits are zero, that is when the object is 64K aligned. Otherwise the reversed bits can name an address anywhere in the surrounding 64K region, possibly outside the object, and no offset computation can make that sound.

Compute the offset, and otherwise say nothing. Pointer information is attached only when the underlying object is a pointer aligned to 64K, and every modifier in the chain is a constant whose running sum is non-negative and fits in 16
unsigned bits.