### PR TITLE
[Hexagon] Avoid predicating debug instructions

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
@@ -987,6 +987,11 @@ bool HexagonExpandCondsets::predicate(MachineInstr &TfrI, bool Cond,
   }
 
   for (MachineInstr &MI : llvm::make_range(std::next(DefIt), TfrIt)) {
+    // Debug instructions do not generate any code, so their operands should
+    // not be taken into account when checking whether the transformation is
+    // possible.
+    if (MI.isDebugInstr())
+      continue;
     // If this instruction is predicated on the same register, it could
     // potentially be ignored.
     // By default assume that the instruction executes on the same condition

--- a/llvm/test/CodeGen/Hexagon/dont-predicate-debug.mir
+++ b/llvm/test/CodeGen/Hexagon/dont-predicate-debug.mir
@@ -1,0 +1,59 @@
+# RUN: llc -mtriple=hexagon -run-pass expand-condsets -o - %s | FileCheck %s
+
+## Check that HexagonExpandCondsets ignores debug instructions when it looks
+## for registers defined and used between the definition of the source register
+## and the conditional transfer. A DBG_VALUE in that range must not prevent the
+## A2_asrh feeding the C2_mux from being predicated.
+
+# CHECK-LABEL: name: fred
+# CHECK-NOT: A2_asrh
+# CHECK: DBG_VALUE
+# CHECK: A2_tfrt
+# CHECK-NEXT: A4_pasrhf
+
+--- |
+  define void @fred() !dbg !5 {
+    ret void
+  }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!2, !3}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+  !1 = !DIFile(filename: "t.c", directory: "/")
+  !2 = !{i32 2, !"Debug Info Version", i32 3}
+  !3 = !{i32 7, !"Dwarf Version", i32 4}
+  !4 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  !5 = distinct !DISubprogram(name: "fred", scope: !1, file: !1, line: 1, type: !6, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0)
+  !6 = !DISubroutineType(types: !7)
+  !7 = !{null}
+  !8 = !DILocalVariable(name: "a", scope: !5, file: !1, line: 2, type: !4)
+  !9 = !DILocation(line: 2, column: 1, scope: !5)
+...
+---
+name: fred
+tracksRegLiveness: true
+isSSA: false
+registers:
+  - { id: 0, class: intregs }
+  - { id: 1, class: intregs }
+  - { id: 2, class: predregs }
+  - { id: 3, class: intregs }
+  - { id: 4, class: intregs }
+liveins:
+  - { reg: '$r0', virtual-reg: '%0' }
+  - { reg: '$r1', virtual-reg: '%1' }
+  - { reg: '$p0', virtual-reg: '%2' }
+body: |
+  bb.0:
+    liveins: $r0, $r1, $p0
+
+    %0 = COPY $r0
+    %1 = COPY $r1
+    %2 = COPY $p0
+    %3 = A2_asrh %1
+    DBG_VALUE $noreg, $noreg, !8, !DIExpression(), debug-location !9
+    %4 = C2_mux %2, %0, %3
+    $r0 = COPY %4
+    J2_jumpr $r31, implicit $r0, implicit-def $pc
+...


### PR DESCRIPTION
The change is made in HexagonExpandCondsets::(predicate) function. The debug instructions are not predicable as they cannot be separated into conditional branches. So while predicating instructions in a machine basic block if we encounter any debug instructions we need to skip these instructions and continue with other instructions.

The scan that collects the registers defined and used between the definition of the source register and the conditional transfer bailed out as soon as it saw a non-virtual register operand, which a DBG_VALUE can have. The transfer was then left as an unconditional A2_asrh plus an A2_tfrf instead of being folded into a single predicated A4_pasrhf, so again the generated code differed depending on whether debug info was enabled.