### PR TITLE
[MC] Add default ctor to SubtargetSubTypeAliasKV for zero-alias targets- #38762

### DIFF
--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -110,6 +110,10 @@ struct SubtargetSubTypeAliasKV {
   uint16_t KeyStrOff;  ///< Relative offset to the alias name.
   uint16_t SubTypeIdx; ///< Index into the SubtargetSubTypeKV array.
 
+  // MSVC STL before VS2022 value-initializes an element of std::array<T, 0>,
+  // which every target defining no processor aliases instantiates.
+  constexpr SubtargetSubTypeAliasKV() : KeyStrOff(0), SubTypeIdx(0) {}
+
   constexpr SubtargetSubTypeAliasKV(uint16_t KeyStrOff, uint16_t SubTypeIdx)
       : KeyStrOff(KeyStrOff), SubTypeIdx(SubTypeIdx) {}
 


### PR DESCRIPTION
Fixes a Windows MSVC 2019-only build break from 02da012 ("TableGen: Use a
compact table for CPU aliases", #211952).

That commit added std::array<SubtargetSubTypeAliasKV, NumAliases> to
SubtargetSubTypeKVStorage. SubtargetSubTypeAliasKV uses relative string
offsets, so it is non-copyable and declares only a two-argument constructor -
no default constructor. In the MSVC 2019 STL, std::array<T, 0> still holds a
real _Ty _Elems[1] and value-initializes it, so it requires T to be
default-constructible. Any target that defines no ProcessorAlias records
instantiates std::array<..., 0> and fails to compile. MSVC 2022 changed this
member to a conditionally-empty type, so only MSVC 2019 is affected.

Fix: add a constexpr default constructor.

Co-Authored-By: Claude Opus 5
Signed-off-by: Munoz Jr, Ramon <ramon.g.munoz.jr@intel.com>