### PR TITLE
Affine fusion recurrence slice

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/LoopAnalysis.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/LoopAnalysis.h
@@ -128,6 +128,15 @@ bool isTilingValid(ArrayRef<AffineForOp> loops);
 /// for aliases.
 bool hasCyclicDependence(AffineForOp root);
 
+/// Returns true if any dependence in the affine nest rooted at `root` is
+/// carried by one of the loops of that nest (`root` inclusive). Such a nest
+/// can't be sliced by selecting an arbitrary subset of its iterations: the
+/// omitted iterations may be needed to produce the values computed by the
+/// retained ones. Dependences carried by loops outer to `root` and
+/// loop-independent dependences aren't relevant. This method doesn't
+/// consider/account for aliases.
+bool hasLoopCarriedDependence(AffineForOp root);
+
 } // namespace affine
 } // namespace mlir
 

--- a/mlir/lib/Dialect/Affine/Analysis/LoopAnalysis.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/LoopAnalysis.cpp
@@ -583,3 +583,29 @@ bool mlir::affine::hasCyclicDependence(AffineForOp root) {
   }
   return graph.hasCycle();
 }
+
+bool mlir::affine::hasLoopCarriedDependence(AffineForOp root) {
+  SmallVector<MemRefAccess> accesses;
+  root->walk([&](Operation *op) {
+    if (isa<AffineReadOpInterface, AffineWriteOpInterface>(op))
+      accesses.emplace_back(op);
+  });
+
+  unsigned rootDepth = getNestingDepth(root);
+  for (const auto &accA : accesses) {
+    for (const auto &accB : accesses) {
+      if (accA.memref != accB.memref)
+        continue;
+      unsigned numCommonLoops =
+          getNumCommonSurroundingLoops(*accA.opInst, *accB.opInst);
+      // Only consider depths corresponding to a loop of the nest rooted at
+      // `root`. Depth `numCommonLoops + 1` is the loop-independent one and is
+      // deliberately excluded: it never prevents iteration-wise slicing.
+      for (unsigned d = rootDepth + 1; d <= numCommonLoops; ++d) {
+        if (!noDependence(checkMemrefAccessDependence(accA, accB, d)))
+          return true;
+      }
+    }
+  }
+  return false;
+}

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -2596,6 +2596,9 @@ static SmallVector<OpFoldResult> AffineForEmptyLoopFolder(AffineForOp forOp) {
       return {};
     if (iterArgIt == iterArgs.end()) {
       // `val` is defined outside of the loop.
+      if(!val.getParentRegion()){
+        return{};
+      }
       assert(forOp.isDefinedOutsideOfLoop(val) &&
              "must be defined outside of the loop");
       hasValDefinedOutsideLoop = true;

--- a/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
@@ -1015,8 +1015,10 @@ public:
         // redundant execution of the source happens (1:1 pointwise dep on the
         // producer-consumer memref access for example). Check this and allow
         // fusion accordingly.
-        if (hasCyclicDependence(srcAffineForOp)) {
-          LDBG() << "Source nest has a cyclic dependence.";
+        bool srcHasLoopCarriedDep = hasCyclicDependence(srcAffineForOp) ||
+                                    hasLoopCarriedDependence(srcAffineForOp);
+        if (srcHasLoopCarriedDep) {
+          LDBG() << "Source nest has a dependence carried by its own loops.";
           // Maximal fusion does not check for compute tolerance threshold; so
           // perform the maximal fusion only when the redundanation computation
           // is zero.
@@ -1067,6 +1069,26 @@ public:
         ComputationSliceState &bestSlice =
             depthSliceUnions[bestDstLoopDepth - 1];
         assert(!bestSlice.isEmpty() && "Missing slice union for depth");
+
+        // A dependence carried by a loop of the source nest additionally
+        // requires the slice to reproduce every source iteration: dropping any
+        // of them would leave the retained iterations reading values that are
+        // never computed. A slice that omits source iterations performs
+        // strictly less computation than the original source nest, which shows
+        // up as a negative additional compute fraction. The redundant
+        // computation side is already handled above.
+        if (srcHasLoopCarriedDep) {
+          int64_t sliceCost;
+          int64_t fusedLoopNestComputeCost;
+          auto fraction = getAdditionalComputeFraction(
+              srcAffineForOp, dstAffineForOp, bestDstLoopDepth,
+              depthSliceUnions, sliceCost, fusedLoopNestComputeCost);
+          if (!fraction || *fraction < 0.0) {
+            LDBG() << "Can't fuse: the slice omits source iterations needed by "
+                   << "a dependence carried by the source nest.";
+            continue;
+          }
+        }
 
         // Determine if 'srcId' can be removed after fusion, taking into
         // account remaining dependences, escaping memrefs and the fusion

--- a/mlir/test/Conversion/FuncToLLVM/func-to-llvm.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-to-llvm.mlir
@@ -583,3 +583,17 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// Regression test: the affine.for empty loop folder used to crash when fold
+// was attempted during dialect conversion, after the old entry block was
+// detached but the loop still yielded one of its arguments. The folder must
+// bail out instead of hitting the isDefinedOutsideOfLoop assertion.
+
+// CHECK-LABEL: @affine_for_fold_detached_block
+// CHECK: affine.for
+func.func @affine_for_fold_detached_block(%arg0: index) -> index {
+  %0 = affine.for %i = 0 to 10 iter_args(%acc = %arg0) -> (index) {
+    affine.yield %arg0 : index
+  }
+  return %0 : index
+}

--- a/mlir/test/Dialect/Affine/loop-fusion-4.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-4.mlir
@@ -884,3 +884,38 @@ func.func @high_trip_count(%arg0: memref<1024x4096xf32>, %arg1: memref<8192x4096
   }
   return %alloc : memref<1024x8192xf32>
 }
+
+// -----
+
+// From https://github.com/llvm/llvm-project/issues/212041
+// The producer computes a recurrence: tmp[i] is computed from tmp[i - 1]. The
+// consumer reads only the even points, so a slice keyed off the producer stores
+// alone would retain only the even producer iterations and drop the odd
+// predecessors they are computed from. Leave the producer nest alone.
+
+// PRODUCER-CONSUMER-MAXIMAL-LABEL: func @producer_recurrence_no_fusion
+// PRODUCER-CONSUMER-LABEL:         func @producer_recurrence_no_fusion
+// ALL-LABEL:                       func @producer_recurrence_no_fusion
+func.func @producer_recurrence_no_fusion(%in: memref<32xf64>, %out: memref<32xf64>) {
+  %tmp = memref.alloc() : memref<32xf64>
+  %seed = arith.constant 2.900000e+01 : f64
+  affine.store %seed, %tmp[0] : memref<32xf64>
+  // PRODUCER-CONSUMER-MAXIMAL: affine.for %{{.*}} = 1 to 16
+  // PRODUCER-CONSUMER:         affine.for %{{.*}} = 1 to 16
+  // ALL:                       affine.for %{{.*}} = 1 to 16
+  affine.for %i = 1 to 16 {
+    %prev = affine.load %tmp[%i - 1] : memref<32xf64>
+    %src = affine.load %in[%i] : memref<32xf64>
+    %v = arith.addf %prev, %src : f64
+    affine.store %v, %tmp[%i] : memref<32xf64>
+  }
+  // PRODUCER-CONSUMER-MAXIMAL: affine.for %{{.*}} = 1 to 8
+  // PRODUCER-CONSUMER:         affine.for %{{.*}} = 1 to 8
+  // ALL:                       affine.for %{{.*}} = 1 to 8
+  affine.for %j = 1 to 8 {
+    %dst = affine.load %tmp[2 * %j] : memref<32xf64>
+    %v = arith.addf %dst, %dst : f64
+    affine.store %v, %out[%j] : memref<32xf64>
+  }
+  return
+}


### PR DESCRIPTION
Producer-consumer affine loop fusion builds the producer slice from the producer stores only. If the producer's own loops carry a dependence, the slice can drop iterations that the kept ones are computed from. The original producer loop is then deleted, so the fused code loads values that nothing stores. Both the input and the output pass the verifier. In the reproducer the producer computes `tmp[i] = tmp[i - 1] + in[i]` and the consumer reads only the even points, so `tmp[1], tmp[3], ..., tmp[13]` are no longer computed.

The old guard was `hasCyclicDependence`, which needs a cycle in the op level dependence graph. Here the only edge is store to load, so the graph is acyclic and the guard never fires. It also only rejected fusion that adds computation,
not fusion that drops it.

The fix adds `hasLoopCarriedDependence`, which reports a dependence at any depth belonging to a loop of the nest without needing a cycle, and rejects a slice whose additional compute fraction is negative once the fusion depth is
chosen. Test added to `mlir/test/Dialect/Affine/loop-fusion-4.mlir`.

Fixes #212041

Assisted by: Claude Opus 5