### PR TITLE
[AMDGPU] Support loop unrolled asyncmark

### DIFF
--- a/clang/include/clang/Basic/BuiltinsAMDGPU.td
+++ b/clang/include/clang/Basic/BuiltinsAMDGPU.td
@@ -331,7 +331,7 @@ def __builtin_amdgcn_av_store_b128
 
 // Mirrors GCNSubtarget::hasAsyncMark()
 def __builtin_amdgcn_asyncmark : AMDGPUBuiltin<"void()", [], "vmem-to-lds-load-insts|asynccnt">;
-def __builtin_amdgcn_wait_asyncmark : AMDGPUBuiltin<"void(_Constant unsigned short)", [], "vmem-to-lds-load-insts|asynccnt">;
+def __builtin_amdgcn_wait_asyncmark : AMDGPUBuiltin<"void(unsigned short)", [], "vmem-to-lds-load-insts|asynccnt">;
 
 //===----------------------------------------------------------------------===//
 // Ballot builtins.

--- a/clang/test/CodeGenOpenCL/builtins-amdgcn-asyncmark.cl
+++ b/clang/test/CodeGenOpenCL/builtins-amdgcn-asyncmark.cl
@@ -15,3 +15,17 @@ void test_invocation() {
   __builtin_amdgcn_asyncmark();
   __builtin_amdgcn_wait_asyncmark(0);
 }
+
+// The argument is no longer required to be an integer constant expression in
+// the frontend; it must only fold to a constant by instruction selection.
+// CHECK-LABEL: @test_non_ice(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[N_ADDR:%.*]] = alloca i16, align 2, addrspace(5)
+// CHECK-NEXT:    store i16 [[N:%.*]], ptr addrspace(5) [[N_ADDR]], align 2
+// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr addrspace(5) [[N_ADDR]], align 2
+// CHECK-NEXT:    call void @llvm.amdgcn.wait.asyncmark(i16 [[TMP0]])
+// CHECK-NEXT:    ret void
+//
+void test_non_ice(unsigned short n) {
+  __builtin_amdgcn_wait_asyncmark(n);
+}

--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -2880,9 +2880,10 @@ def int_amdgcn_asyncmark : ClangBuiltin<"__builtin_amdgcn_asyncmark">,
   Intrinsic<[], [], [IntrNoMem, IntrHasSideEffects]>;
 
 // Waits until the Nth previous marker is completed, if it exists.
+// N must fold to a constant by instruction selection.
 def int_amdgcn_wait_asyncmark :
     ClangBuiltin<"__builtin_amdgcn_wait_asyncmark">,
-    Intrinsic<[], [llvm_i16_ty], [ImmArg<ArgIndex<0>>, IntrNoMem, IntrHasSideEffects]>;
+    Intrinsic<[], [llvm_i16_ty], [IntrNoMem, IntrHasSideEffects]>;
 
 //===----------------------------------------------------------------------===//
 // GFX10 Intrinsics

--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -1729,7 +1729,7 @@ def ASYNCMARK : SPseudoInstSI<(outs), (ins),
    let isMeta = 1;
 }
 def WAIT_ASYNCMARK : SOPP_Pseudo <"", (ins s16imm:$simm16), "$simm16",
-    [(int_amdgcn_wait_asyncmark timm:$simm16)]> {
+    [(int_amdgcn_wait_asyncmark imm:$simm16)]> {
     let maybeAtomic = 0;
     let Size = 0;
     let isMeta = 1;

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-non-constant-err.ll
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-non-constant-err.ll
@@ -1,0 +1,18 @@
+; RUN: not llc -global-isel=0 -mtriple=amdgpu12.50 -filetype=null %s 2>&1 | FileCheck %s
+; RUN: not llc -global-isel=1 -mtriple=amdgpu12.50 -filetype=null %s 2>&1 | FileCheck %s -check-prefix=CHECK-GISEL
+
+; The wait_asyncmark operand indexes compiler-tracked async mark state, so it
+; must fold to a constant by instruction selection.
+
+; CHECK: LLVM ERROR: Cannot select: intrinsic %llvm.amdgcn.wait.asyncmark
+; CHECK-GISEL: LLVM ERROR: cannot select: G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.amdgcn.wait.asyncmark), %10:sgpr(i16) (in function: non_constant_wait)
+
+define amdgpu_kernel void @non_constant_wait(i16 %n) {
+entry:
+  call void @llvm.amdgcn.asyncmark()
+  call void @llvm.amdgcn.wait.asyncmark(i16 %n)
+  ret void
+}
+
+declare void @llvm.amdgcn.asyncmark()
+declare void @llvm.amdgcn.wait.asyncmark(i16)

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-unrolled-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-unrolled-loop.ll
@@ -1,0 +1,25 @@
+; RUN: opt -O2 -S %s | llc -global-isel=0 -mtriple=amdgpu12.50 -o - | FileCheck %s
+; RUN: opt -O2 -S %s | llc -global-isel=1 -mtriple=amdgpu12.50 -o - | FileCheck %s
+
+; CHECK: ; wait_asyncmark(2)
+; CHECK: ; wait_asyncmark(1)
+
+define amdgpu_kernel void @unrolled_loop() {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i16 [ 0, %entry ], [ %inc, %loop ]
+  call void @llvm.amdgcn.asyncmark()
+  %n = sub i16 2, %i
+  call void @llvm.amdgcn.wait.asyncmark(i16 %n)
+  %inc = add i16 %i, 1
+  %cmp = icmp ult i16 %inc, 2
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+declare void @llvm.amdgcn.asyncmark()
+declare void @llvm.amdgcn.wait.asyncmark(i16)


### PR DESCRIPTION
```
unroll_full for (u32_t i = 1; i <= CONSTANT; ++i) {
        __builtin_amdgcn_wait_asyncmark(CONSTANT - i);
       // some other stuff
}
```
Often we'll want to do something like this, where it's very time consuming to rewrite the source and manually unroll.