### PR TITLE
[mlir][affine] Skip sibling fusion for loops with live results

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
@@ -1365,6 +1365,10 @@ public:
     // Returns true if 'sibNode' can be fused with 'dstNode' for input reuse
     // on 'memref'.
     auto canFuseWithSibNode = [&](Node *sibNode, Value memref) {
+      // The sibling loop is erased after fusion, so preserve it if any of its
+      // results still have users.
+      if (!sibNode->op->use_empty())
+        return false;
       // Skip if 'outEdge' is not a read-after-write dependence.
       // TODO: Remove restrict to single load op restriction.
       if (sibNode->getLoadOpCount(memref) != 1)

--- a/mlir/test/Dialect/Affine/loop-fusion-live-results.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-live-results.mlir
@@ -1,0 +1,48 @@
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(affine-loop-tile{tile-size=8},affine-loop-fusion))' | FileCheck %s
+
+// Ensure sibling fusion does not erase a result-producing loop with live uses.
+
+// CHECK-LABEL: func.func @preserve_live_sibling_results
+// CHECK-COUNT-2: = affine.for
+// CHECK: arith.addi
+// CHECK: return
+func.func @preserve_live_sibling_results() -> i64 {
+  %a = memref.alloc() : memref<4xi64>
+  %b = memref.alloc() : memref<4xi64>
+  %c = memref.alloc() : memref<4xi64>
+  %c0 = arith.constant 0 : i64
+  %c3 = arith.constant 3 : i64
+  %c7 = arith.constant 7 : i64
+
+  affine.for %i = 0 to 4 {
+    affine.store %c3, %a[%i] : memref<4xi64>
+  }
+  affine.for %i = 0 to 4 {
+    affine.store %c0, %b[%i] : memref<4xi64>
+    affine.store %c0, %c[%i] : memref<4xi64>
+  }
+  affine.for %i = 0 to 4 {
+    %v = affine.load %a[%i] : memref<4xi64>
+    %p = arith.muli %v, %c3 : i64
+    affine.store %p, %b[%i] : memref<4xi64>
+  }
+  affine.for %i = 0 to 4 {
+    %v = affine.load %b[%i] : memref<4xi64>
+    %q = arith.addi %v, %c7 : i64
+    affine.store %q, %c[%i] : memref<4xi64>
+  }
+
+  %sum0 = affine.for %i = 0 to 4 iter_args(%sum = %c0) -> i64 {
+    %v = affine.load %b[%i] : memref<4xi64>
+    %next = arith.addi %sum, %v : i64
+    affine.yield %next : i64
+  }
+  %sum1 = affine.for %i = 0 to 4 iter_args(%sum = %c0) -> i64 {
+    %v = affine.load %c[%i] : memref<4xi64>
+    %next = arith.addi %sum, %v : i64
+    affine.yield %next : i64
+  }
+
+  %sum = arith.addi %sum0, %sum1 : i64
+  return %sum : i64
+}


### PR DESCRIPTION
## Summary

Skip affine sibling fusion when the sibling loop has live SSA results.

Sibling fusion unconditionally erases the original sibling loop after cloning
its computation into the destination. For result-producing loops, the cloned
computation does not currently provide a replacement for external users of the
original results. Erasing such a loop therefore leaves dangling SSA uses and
can crash verification.

This change conservatively preserves sibling loops whose results still have
users. It also adds a regression test covering tiled reduction loops whose
results are consumed by a later `arith.addi`.

Related issue: #212046

## Testing

- `ninja -C build mlir-opt`
- `build/bin/llvm-lit -v mlir/test/Dialect/Affine/loop-fusion-live-results.mlir mlir/test/Dialect/Affine/loop-fusion-sibling.mlir`

Assisted by: codex
