### PR TITLE
[clang][CodeGen] Drop debug location on the if-then exit branch

### DIFF
--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -975,7 +975,11 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S) {
     RunCleanupsScope ThenScope(*this);
     EmitStmt(S.getThen());
   }
-  EmitBranch(ContBlock);
+  {
+    // There is no need to emit line number for an unconditional branch.
+    auto NL = ApplyDebugLocation::CreateEmpty(*this);
+    EmitBranch(ContBlock);
+  }
 
   // Emit the 'else' code if present.
   if (Else) {

--- a/clang/test/DebugInfo/Generic/if-then-exit-branch.c
+++ b/clang/test/DebugInfo/Generic/if-then-exit-branch.c
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm -debug-info-kind=line-tables-only %s -o - | FileCheck %s
+
+// The unconditional branch from the 'then' (and 'else') block to the
+// continuation block is not a statement, so it must not carry a debug
+// location.
+
+int g;
+
+// CHECK-LABEL: define {{.*}}@no_else(
+// CHECK:       if.then:
+// CHECK:         store i32 1, ptr @g{{.*}}, !dbg
+// CHECK-NEXT:    br label %if.end{{$}}
+void no_else(int a) {
+  if (a) {
+    g = 1;
+  }
+  g = 2;
+}
+
+// CHECK-LABEL: define {{.*}}@with_else(
+// CHECK:       if.then:
+// CHECK:         store i32 1, ptr @g{{.*}}, !dbg
+// CHECK-NEXT:    br label %if.end{{$}}
+// CHECK:       if.else:
+// CHECK:         store i32 2, ptr @g{{.*}}, !dbg
+// CHECK-NEXT:    br label %if.end{{$}}
+void with_else(int a) {
+  if (a) {
+    g = 1;
+  } else {
+    g = 2;
+  }
+  g = 3;
+}


### PR DESCRIPTION
In EmitIfStmt, the branch from the 'then' block to the continuation block inherited the debug location of the block's closing brace, adding a spurious is_stmt line-table entry on the '}'. Guard it with ApplyDebugLocation::CreateEmpty, as the 'else' branch already is.