### PR TITLE
CSKY: Avoid constructing a temporary CSKYSubtarget in AsmPrinter

### DIFF
--- a/llvm/lib/Target/CSKY/CSKYAsmPrinter.cpp
+++ b/llvm/lib/Target/CSKY/CSKYAsmPrinter.cpp
@@ -249,15 +249,7 @@ void CSKYAsmPrinter::emitAttributes() {
   CSKYTargetStreamer &CTS =
       static_cast<CSKYTargetStreamer &>(*OutStreamer->getTargetStreamer());
 
-  const Triple &TT = TM.getTargetTriple();
-  StringRef CPU = TM.getTargetCPU();
-  StringRef FS = TM.getTargetFeatureString();
-  const CSKYTargetMachine &CTM = static_cast<const CSKYTargetMachine &>(TM);
-  /* TuneCPU doesn't impact emission of ELF attributes, ELF attributes only
-     care about arch related features, so we can set TuneCPU as CPU.  */
-  const CSKYSubtarget STI(TT, CPU, /*TuneCPU=*/CPU, FS, CTM);
-
-  CTS.emitTargetAttributes(STI);
+  CTS.emitTargetAttributes(TM.getMCSubtargetInfo());
 }
 
 bool CSKYAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,


### PR DESCRIPTION
This was reconstructing a subtarget equivalent to the global
subtarget instead of just using the available one.