### PR TITLE
clang/AMDGPU: Forward xnack/sramecc mode to the assembler

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -661,7 +661,8 @@ void amdgpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                                      const llvm::Triple &Triple,
                                      const llvm::opt::ArgList &Args,
-                                     std::vector<StringRef> &Features) {
+                                     std::vector<StringRef> &Features,
+                                     bool ForAS) {
   if (Args.hasFlag(options::OPT_mwavefrontsize64,
                    options::OPT_mno_wavefrontsize64, false))
     Features.push_back("+wavefrontsize64");
@@ -669,6 +670,22 @@ void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
   if (Args.hasFlag(options::OPT_mamdgpu_precise_memory_op,
                    options::OPT_mno_amdgpu_precise_memory_op, false))
     Features.push_back("+precise-memory");
+
+  // When assembling, the xnack/sramecc mode cannot come from a module flag
+  // (there is no module), so forward it to the assembler as a feature.
+  if (ForAS) {
+    if (Arg *A = Args.getLastArg(options::OPT_mxnack, options::OPT_mno_xnack)) {
+      Features.push_back(
+          A->getOption().matches(options::OPT_mxnack) ? "+xnack" : "-xnack");
+    }
+
+    if (Arg *A =
+            Args.getLastArg(options::OPT_msramecc, options::OPT_mno_sramecc)) {
+      Features.push_back(A->getOption().matches(options::OPT_msramecc)
+                             ? "+sramecc"
+                             : "-sramecc");
+    }
+  }
 
   handleTargetFeaturesGroup(D, Triple, Args, Features,
                             options::OPT_m_amdgpu_Features_Group);

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -39,7 +39,8 @@ public:
 
 void getAMDGPUTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                              const llvm::opt::ArgList &Args,
-                             std::vector<StringRef> &Features);
+                             std::vector<StringRef> &Features,
+                             bool ForAS = false);
 
 void addFullLTOPartitionOption(const Driver &D, const llvm::opt::ArgList &Args,
                                llvm::opt::ArgStringList &CmdArgs);

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -906,7 +906,7 @@ void tools::getTargetFeatures(const Driver &D, const llvm::Triple &Triple,
     break;
   case llvm::Triple::amdgpu:
   case llvm::Triple::r600:
-    amdgpu::getAMDGPUTargetFeatures(D, Triple, Args, Features);
+    amdgpu::getAMDGPUTargetFeatures(D, Triple, Args, Features, ForAS);
     break;
   case llvm::Triple::nvptx:
   case llvm::Triple::nvptx64:

--- a/clang/test/Driver/amdgpu-assembler-xnack-sramecc.s
+++ b/clang/test/Driver/amdgpu-assembler-xnack-sramecc.s
@@ -1,0 +1,33 @@
+// REQUIRES: amdgpu-registered-target
+
+/// Assembling a .s file that has no target ID directive (.amdgcn_target). The
+/// xnack/sramecc mode requested on the command line, either with
+/// -mxnack/-msramecc or via the -mcpu target ID modifiers, is forwarded to the
+/// assembler as a target feature and recorded in the object's e_flags.
+
+/// The mode is forwarded to the assembler as a target feature.
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=XNACK-OFF %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack- -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=XNACK-OFF %s
+// XNACK-OFF: "-cc1as"
+// XNACK-OFF-SAME: "-target-feature" "-xnack"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -msramecc -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc+ -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
+// SRAMECC-ON: "-cc1as"
+// SRAMECC-ON-SAME: "-target-feature" "+sramecc"
+
+/// End to end: the requested mode is reflected in the object's e_flags.
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906 -mno-xnack -c %s -o %t.o
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-XNACK-OFF %s
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906:xnack+ -c %s -o %t.o
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-XNACK-ON %s
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx906:sramecc- -c %s -o %t.o
+// RUN: llvm-readobj --file-headers %t.o | FileCheck -check-prefix=OBJ-SRAMECC-OFF %s
+
+// OBJ-XNACK-OFF: EF_AMDGPU_FEATURE_XNACK_OFF_V4 (0x200)
+// OBJ-XNACK-ON: EF_AMDGPU_FEATURE_XNACK_ON_V4 (0x300)
+// OBJ-SRAMECC-OFF: EF_AMDGPU_FEATURE_SRAMECC_OFF_V4 (0x800)


### PR DESCRIPTION
When assembling a .s file with no target ID directive, the requested
xnack/sramecc mode has no module flag to carry it. Forward the mode
requested via -mxnack/-msramecc (or the -mcpu target ID modifiers) to the
assembler as a target feature so it is recorded in the object's e_flags.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>