### PR TITLE
[VPlan] Make simplifyRecipe more like InstCombine

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1127,8 +1127,9 @@ static void removeRedundantExpandSCEVRecipes(VPlan &Plan) {
 }
 
 /// Try to simplify logical and bitwise recipes in \p Def.
-static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
-                                  bool CanCreateNewRecipe) {
+static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
+                                      VPBuilder &Builder,
+                                      bool CanCreateNewRecipe) {
   VPlan *Plan = Def->getParent()->getPlan();
 
   // Simplify (X && Y) | (X && !Y) -> X.
@@ -1138,53 +1139,36 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
   VPValue *X, *Y, *Z;
   if (match(Def,
             m_c_BinaryOr(m_LogicalAnd(m_VPValue(X), m_VPValue(Y)),
-                         m_LogicalAnd(m_Deferred(X), m_Not(m_Deferred(Y)))))) {
-    Def->replaceAllUsesWith(X);
-    Def->eraseFromParent();
-    return true;
-  }
+                         m_LogicalAnd(m_Deferred(X), m_Not(m_Deferred(Y))))))
+    return X;
 
   // x | AllOnes -> AllOnes
-  if (match(Def, m_c_BinaryOr(m_VPValue(X), m_AllOnes()))) {
-    Def->replaceAllUsesWith(Plan->getAllOnesValue(Def->getScalarType()));
-    return true;
-  }
+  if (match(Def, m_c_BinaryOr(m_VPValue(X), m_AllOnes())))
+    return Plan->getAllOnesValue(Def->getScalarType());
 
   // x | 0 -> x
-  if (match(Def, m_c_BinaryOr(m_VPValue(X), m_ZeroInt()))) {
-    Def->replaceAllUsesWith(X);
-    return true;
-  }
+  if (match(Def, m_c_BinaryOr(m_VPValue(X), m_ZeroInt())))
+    return X;
 
   // x | !x -> AllOnes
-  if (match(Def, m_c_BinaryOr(m_VPValue(X), m_Not(m_Deferred(X))))) {
-    Def->replaceAllUsesWith(Plan->getAllOnesValue(Def->getScalarType()));
-    return true;
-  }
+  if (match(Def, m_c_BinaryOr(m_VPValue(X), m_Not(m_Deferred(X)))))
+    return Plan->getAllOnesValue(Def->getScalarType());
 
   // x & 0 -> 0
-  if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_ZeroInt()))) {
-    Def->replaceAllUsesWith(Plan->getZero(Def->getScalarType()));
-    return true;
-  }
+  if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_ZeroInt())))
+    return Plan->getZero(Def->getScalarType());
 
   // x & AllOnes -> x
-  if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_AllOnes()))) {
-    Def->replaceAllUsesWith(X);
-    return true;
-  }
+  if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_AllOnes())))
+    return X;
 
   // x && false -> false
-  if (match(Def, m_c_LogicalAnd(m_VPValue(X), m_False()))) {
-    Def->replaceAllUsesWith(Plan->getFalse());
-    return true;
-  }
+  if (match(Def, m_c_LogicalAnd(m_VPValue(X), m_False())))
+    return Plan->getFalse();
 
   // x && true -> x
-  if (match(Def, m_c_LogicalAnd(m_VPValue(X), m_True()))) {
-    Def->replaceAllUsesWith(X);
-    return true;
-  }
+  if (match(Def, m_c_LogicalAnd(m_VPValue(X), m_True())))
+    return X;
 
   // (x && y) | (x && z) -> x && (y | z)
   if (CanCreateNewRecipe &&
@@ -1193,51 +1177,38 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
       // Simplify only if one of the operands has one use to avoid creating an
       // extra recipe.
       (!Def->getOperand(0)->hasMoreThanOneUniqueUser() ||
-       !Def->getOperand(1)->hasMoreThanOneUniqueUser())) {
-    Def->replaceAllUsesWith(
-        Builder.createLogicalAnd(X, Builder.createOr(Y, Z)));
-    return true;
-  }
+       !Def->getOperand(1)->hasMoreThanOneUniqueUser()))
+    return Builder.createLogicalAnd(X, Builder.createOr(Y, Z));
 
   // x && (x && y) -> x && y
   if (match(Def, m_LogicalAnd(m_VPValue(X),
-                              m_LogicalAnd(m_Deferred(X), m_VPValue())))) {
-    Def->replaceAllUsesWith(Def->getOperand(1));
-    return true;
-  }
+                              m_LogicalAnd(m_Deferred(X), m_VPValue()))))
+    return Def->getOperand(1);
 
   // x && (y && x) -> x && y
   if (match(Def, m_LogicalAnd(m_VPValue(X),
-                              m_LogicalAnd(m_VPValue(Y), m_Deferred(X))))) {
-    Def->replaceAllUsesWith(Builder.createLogicalAnd(X, Y));
-    return true;
-  }
+                              m_LogicalAnd(m_VPValue(Y), m_Deferred(X)))))
+    return Builder.createLogicalAnd(X, Y);
 
   // x && !x -> 0
-  if (match(Def, m_LogicalAnd(m_VPValue(X), m_Not(m_Deferred(X))))) {
-    Def->replaceAllUsesWith(Plan->getFalse());
-    return true;
-  }
+  if (match(Def, m_LogicalAnd(m_VPValue(X), m_Not(m_Deferred(X)))))
+    return Plan->getFalse();
 
-  if (match(Def, m_Select(m_VPValue(), m_VPValue(X), m_Deferred(X)))) {
-    Def->replaceAllUsesWith(X);
-    return true;
-  }
+  if (match(Def, m_Select(m_VPValue(), m_VPValue(X), m_Deferred(X))))
+    return X;
 
   // select c, false, true -> not c
   VPValue *C;
   if (CanCreateNewRecipe &&
-      match(Def, m_Select(m_VPValue(C), m_False(), m_True()))) {
-    Def->replaceAllUsesWith(Builder.createNot(C));
-    return true;
-  }
+      match(Def, m_Select(m_VPValue(C), m_False(), m_True())))
+    return Builder.createNot(C);
 
   // select !c, x, y -> select c, y, x
   if (match(Def, m_Select(m_Not(m_VPValue(C)), m_VPValue(X), m_VPValue(Y)))) {
     Def->setOperand(0, C);
     Def->setOperand(1, Y);
     Def->setOperand(2, X);
-    return true;
+    return Def;
   }
 
   // select x, (i1 y | z), y -> y | (x && z)
@@ -1245,11 +1216,8 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
       match(Def, m_Select(m_VPValue(X),
                           m_OneUse(m_c_BinaryOr(m_VPValue(Y), m_VPValue(Z))),
                           m_Deferred(Y))) &&
-      Y->getScalarType()->isIntegerTy(1)) {
-    Def->replaceAllUsesWith(
-        Builder.createOr(Y, Builder.createLogicalAnd(X, Z)));
-    return true;
-  }
+      Y->getScalarType()->isIntegerTy(1))
+    return Builder.createOr(Y, Builder.createLogicalAnd(X, Z));
 
   // select %M0, (select %M1, %X, %Y), %Y -> select (%M0 && %M1), %X, %Y
   VPValue *Mask0, *Mask1;
@@ -1258,31 +1226,30 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
             m_SelectLike(m_VPValue(Mask0),
                          m_OneUse(m_SelectLike(m_VPValue(Mask1), m_VPValue(X),
                                                m_VPValue(Y))),
-                         m_Deferred(Y)))) {
-    auto *Select = Builder.createSelect(Builder.createLogicalAnd(Mask0, Mask1),
-                                        X, Y, Def->getDebugLoc());
-    Def->replaceAllUsesWith(Select);
-    return true;
-  }
+                         m_Deferred(Y))))
+    return Builder.createSelect(Builder.createLogicalAnd(Mask0, Mask1), X, Y,
+                                Def->getDebugLoc());
 
-  return false;
+  return nullptr;
 }
 
-/// Try to simplify VPSingleDefRecipe \p Def.
-static void simplifyRecipe(VPSingleDefRecipe *Def) {
+/// Try to simplify VPSingleDefRecipe \p Def. Returns a new recipe if it should
+/// be replaced, or the existing recipe if it was modified. Returns nullptr if
+/// nothing was simplified.
+static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
   VPlan *Plan = Def->getParent()->getPlan();
 
   // Simplification of live-in IR values for SingleDef recipes using
   // InstSimplifyFolder.
   const DataLayout &DL = Plan->getDataLayout();
   if (VPValue *V = vputils::tryToFoldLiveIns(*Def, Def->operands(), DL))
-    return Def->replaceAllUsesWith(V);
+    return V;
 
   // Fold PredPHI LiveIn -> LiveIn.
   if (auto *PredPHI = dyn_cast<VPPredInstPHIRecipe>(Def)) {
     VPValue *Op = PredPHI->getOperand(0);
     if (isa<VPIRValue>(Op))
-      PredPHI->replaceAllUsesWith(Op);
+      return Op;
   }
 
   // Drop the mask of a predicated store masked by the header mask (which is
@@ -1298,9 +1265,7 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
         RepR->isSingleScalar(), /*Mask=*/nullptr, *RepR, *RepR,
         RepR->getDebugLoc());
     Unmasked->insertBefore(RepR);
-    RepR->replaceAllUsesWith(Unmasked);
-    RepR->eraseFromParent();
-    return;
+    return Unmasked;
   }
 
   VPBuilder Builder(Def);
@@ -1325,7 +1290,7 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
     } else {
       // Don't replace a non-widened cast recipe with a widened cast.
       if (!isa<VPWidenCastRecipe>(Def))
-        return;
+        return nullptr;
       if (ATy->getScalarSizeInBits() < TruncTy->getScalarSizeInBits()) {
 
         unsigned ExtOpcode = match(Z, m_SExt(m_VPValue())) ? Instruction::SExt
@@ -1344,25 +1309,25 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
     }
   }
 
-  if (simplifyLogicalRecipe(Def, Builder, CanCreateNewRecipe))
-    return;
+  if (VPValue *V = simplifyLogicalRecipe(Def, Builder, CanCreateNewRecipe))
+    return V;
 
   VPValue *X, *Y;
   if (match(Def, m_c_Add(m_VPValue(A), m_ZeroInt())))
-    return Def->replaceAllUsesWith(A);
+    return A;
 
   if (match(Def, m_c_Mul(m_VPValue(A), m_One())))
-    return Def->replaceAllUsesWith(A);
+    return A;
 
   if (match(Def, m_c_Mul(m_VPValue(A), m_ZeroInt())))
-    return Def->replaceAllUsesWith(Plan->getZero(Def->getScalarType()));
+    return Plan->getZero(Def->getScalarType());
 
   if (CanCreateNewRecipe && match(Def, m_c_Mul(m_VPValue(A), m_AllOnes()))) {
     // Preserve nsw from the Mul on the new Sub.
     VPIRFlags::WrapFlagsTy NW = {
         false, cast<VPRecipeWithIRFlags>(Def)->hasNoSignedWrap()};
-    return Def->replaceAllUsesWith(Builder.createSub(
-        Plan->getZero(A->getScalarType()), A, Def->getDebugLoc(), "", NW));
+    return Builder.createSub(Plan->getZero(A->getScalarType()), A,
+                             Def->getDebugLoc(), "", NW);
   }
 
   if (CanCreateNewRecipe &&
@@ -1373,16 +1338,14 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
     VPIRFlags::WrapFlagsTy NW = {
         false, cast<VPRecipeWithIRFlags>(Def)->hasNoSignedWrap() &&
                    cast<VPRecipeWithIRFlags>(Z)->hasNoSignedWrap()};
-    return Def->replaceAllUsesWith(
-        Builder.createSub(X, Y, Def->getDebugLoc(), "", NW));
+    return Builder.createSub(X, Y, Def->getDebugLoc(), "", NW);
   }
 
   const APInt *APC;
   if (CanCreateNewRecipe && match(Def, m_URem(m_VPValue(X), m_APInt(APC))) &&
-      APC->isPowerOf2()) {
-    return Def->replaceAllUsesWith(Builder.createAnd(
-        X, Plan->getConstantInt(*APC - 1), Def->getDebugLoc()));
-  }
+      APC->isPowerOf2())
+    return Builder.createAnd(X, Plan->getConstantInt(*APC - 1),
+                             Def->getDebugLoc());
 
   if (CanCreateNewRecipe && match(Def, m_c_Mul(m_VPValue(A), m_APInt(APC))) &&
       APC->isPowerOf2()) {
@@ -1391,22 +1354,22 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
     VPIRFlags::WrapFlagsTy NW(MulR->hasNoUnsignedWrap(),
                               MulR->hasNoSignedWrap() &&
                                   ShiftAmt != APC->getBitWidth() - 1);
-    return Def->replaceAllUsesWith(Builder.createNaryOp(
+    return Builder.createNaryOp(
         Instruction::Shl,
         {A, Plan->getConstantInt(APC->getBitWidth(), ShiftAmt)}, NW,
-        Def->getDebugLoc()));
+        Def->getDebugLoc());
   }
 
   if (CanCreateNewRecipe && match(Def, m_UDiv(m_VPValue(A), m_APInt(APC))) &&
       APC->isPowerOf2())
-    return Def->replaceAllUsesWith(Builder.createNaryOp(
+    return Builder.createNaryOp(
         Instruction::LShr,
         {A, Plan->getConstantInt(APC->getBitWidth(), APC->exactLogBase2())},
-        *cast<VPRecipeWithIRFlags>(Def), Def->getDebugLoc()));
+        *cast<VPRecipeWithIRFlags>(Def), Def->getDebugLoc());
 
   if (match(Def, m_Not(m_VPValue(A)))) {
     if (match(A, m_Not(m_VPValue(A))))
-      return Def->replaceAllUsesWith(A);
+      return A;
 
     // Try to fold Not into compares by adjusting the predicate in-place.
     CmpPredicate Pred;
@@ -1435,6 +1398,7 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
           Cmp->setDebugLoc(Def->getDebugLoc());
       }
     }
+    return Def;
   }
 
   // Fold any-of (fcmp uno %A, %A), (fcmp uno %B, %B), ... ->
@@ -1462,7 +1426,7 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
 
     if (NewOps.size() < Def->getNumOperands()) {
       VPValue *NewAnyOf = Builder.createNaryOp(VPInstruction::AnyOf, NewOps);
-      return Def->replaceAllUsesWith(NewAnyOf);
+      return NewAnyOf;
     }
   }
 
@@ -1470,28 +1434,25 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
   // This is useful for fmax/fmin without fast-math flags, where we need to
   // check if any operand is NaN.
   if (CanCreateNewRecipe &&
-      match(Def, m_BinaryOr(m_SpecificCmp(CmpInst::FCMP_UNO, m_VPValue(X),
-                                          m_Deferred(X)),
-                            m_SpecificCmp(CmpInst::FCMP_UNO, m_VPValue(Y),
-                                          m_Deferred(Y))))) {
-    VPValue *NewCmp = Builder.createFCmp(CmpInst::FCMP_UNO, X, Y);
-    return Def->replaceAllUsesWith(NewCmp);
-  }
+      match(Def,
+            m_BinaryOr(
+                m_SpecificCmp(CmpInst::FCMP_UNO, m_VPValue(X), m_Deferred(X)),
+                m_SpecificCmp(CmpInst::FCMP_UNO, m_VPValue(Y), m_Deferred(Y)))))
+    return Builder.createFCmp(CmpInst::FCMP_UNO, X, Y);
 
   // Remove redundant DerviedIVs, that is 0 + A * 1 -> A and 0 + 0 * x -> 0.
   if ((match(Def, m_DerivedIV(m_ZeroInt(), m_VPValue(A), m_One())) ||
        match(Def, m_DerivedIV(m_ZeroInt(), m_VPValue(A, m_ZeroInt()),
                               m_VPValue()))) &&
       A->getScalarType() == Def->getScalarType())
-    return Def->replaceAllUsesWith(A);
+    return A;
 
   if (match(Def, m_VPInstruction<VPInstruction::WideIVStep>(m_VPValue(X),
                                                             m_One()))) {
     Type *WideStepTy = Def->getScalarType();
     if (X->getScalarType() != WideStepTy)
       X = Builder.createWidenCast(Instruction::Trunc, X, WideStepTy);
-    Def->replaceAllUsesWith(X);
-    return;
+    return X;
   }
 
   // For i1 vp.merges produced by AnyOf reductions:
@@ -1502,53 +1463,45 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
       Def->getScalarType()->isIntegerTy(1)) {
     Def->setOperand(1, Plan->getTrue());
     Def->setOperand(0, Y);
-    return;
+    return Def;
   }
 
   // Simplify MaskedCond with no block mask to its single operand.
   if (match(Def, m_VPInstruction<VPInstruction::MaskedCond>()) &&
       !cast<VPInstruction>(Def)->isMasked())
-    return Def->replaceAllUsesWith(Def->getOperand(0));
+    return Def->getOperand(0);
 
   // Look through ExtractLastLane.
   if (match(Def, m_ExtractLastLane(m_VPValue(A)))) {
     if (match(A, m_BuildVector())) {
       auto *BuildVector = cast<VPInstruction>(A);
-      Def->replaceAllUsesWith(
-          BuildVector->getOperand(BuildVector->getNumOperands() - 1));
-      return;
+      return BuildVector->getOperand(BuildVector->getNumOperands() - 1);
     }
 
     if (match(A, m_Broadcast(m_VPValue(X))))
-      return Def->replaceAllUsesWith(X);
+      return X;
 
     if (isa<VPInstruction, VPReplicateRecipe>(A) && vputils::isSingleScalar(A))
-      return Def->replaceAllUsesWith(A);
+      return A;
 
     if (Plan->hasScalarVFOnly())
-      return Def->replaceAllUsesWith(A);
+      return A;
   }
 
   // Look through ExtractPenultimateElement (BuildVector ....).
   if (match(Def, m_ExtractPenultimateElement(m_BuildVector()))) {
     auto *BuildVector = cast<VPInstruction>(Def->getOperand(0));
-    Def->replaceAllUsesWith(
-        BuildVector->getOperand(BuildVector->getNumOperands() - 2));
-    return;
+    return BuildVector->getOperand(BuildVector->getNumOperands() - 2);
   }
 
   uint64_t Idx;
   if (match(Def, m_ExtractElement(m_BuildVector(), m_ConstantInt(Idx)))) {
     auto *BuildVector = cast<VPInstruction>(Def->getOperand(0));
-    Def->replaceAllUsesWith(BuildVector->getOperand(Idx));
-    return;
+    return BuildVector->getOperand(Idx);
   }
 
-  if (match(Def, m_BuildVector()) && all_equal(Def->operands())) {
-    Def->replaceAllUsesWith(
-        Builder.createNaryOp(VPInstruction::Broadcast, Def->getOperand(0)));
-    return;
-  }
+  if (match(Def, m_BuildVector()) && all_equal(Def->operands()))
+    return Builder.createNaryOp(VPInstruction::Broadcast, Def->getOperand(0));
 
   // Replace uses of a BuildVector by users that only use its first lane with
   // its first operand directly.
@@ -1556,6 +1509,7 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
     Def->replaceUsesWithIf(Def->getOperand(0), [Def](VPUser &U, unsigned) {
       return U.usesFirstLaneOnly(Def);
     });
+    return Def;
   }
 
   // Look through broadcast of single-scalar when used as select conditions; in
@@ -1565,34 +1519,35 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
     assert(vputils::isSingleScalar(Z) &&
            "broadcast operand must be single-scalar");
     Def->setOperand(0, Z);
-    return;
+    return Def;
   }
 
-  if (match(Def, m_Broadcast(m_VPValue(X))))
-    return Def->replaceUsesWithIf(
+  if (match(Def, m_Broadcast(m_VPValue(X)))) {
+    Def->replaceUsesWithIf(
         X, [Def](const VPUser &U, unsigned) { return U.usesScalars(Def); });
+    return Def;
+  }
 
   if (isa<VPPhi, VPWidenPHIRecipe, VPHeaderPHIRecipe>(Def)) {
     if (Def->getNumOperands() == 1) {
-      Def->replaceAllUsesWith(Def->getOperand(0));
-      return;
+      return Def->getOperand(0);
     }
     if (auto *Phi = dyn_cast<VPFirstOrderRecurrencePHIRecipe>(Def)) {
       if (all_equal(Phi->incoming_values()))
-        Phi->replaceAllUsesWith(Phi->getOperand(0));
+        return Phi->getOperand(0);
     }
-    return;
+    return nullptr;
   }
 
   VPIRValue *IRV;
   if (Def->getNumOperands() == 1 &&
       match(Def, m_ComputeReductionResult(m_VPIRValue(IRV))))
-    return Def->replaceAllUsesWith(IRV);
+    return IRV;
 
   // Some simplifications can only be applied after unrolling. Perform them
   // below.
   if (!Plan->isUnrolled())
-    return;
+    return nullptr;
 
   // After unrolling, extract-lane may be used to extract values from multiple
   // scalar sources. Only simplify when extracting from a single scalar source.
@@ -1600,19 +1555,18 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
   if (match(Def, m_ExtractLane(m_VPValue(LaneToExtract), m_VPValue(A)))) {
     // Simplify extract-lane(%lane_num, %scalar_val) -> %scalar_val.
     if (vputils::isSingleScalar(A))
-      return Def->replaceAllUsesWith(A);
+      return A;
 
     // Replace extract-lane(0, canonical-WIDEN-INDUCTION) with the region's
     // scalar canonical IV.
     VPWidenIntOrFpInductionRecipe *WidenIV;
     if (match(LaneToExtract, m_ZeroInt()) &&
         match(A, m_CanonicalWidenIV(WidenIV)))
-      return Def->replaceAllUsesWith(WidenIV->getRegion()->getCanonicalIV());
+      return WidenIV->getRegion()->getCanonicalIV();
 
     // Simplify extract-lane with single source to extract-element.
-    Def->replaceAllUsesWith(Builder.createNaryOp(
-        Instruction::ExtractElement, {A, LaneToExtract}, Def->getDebugLoc()));
-    return;
+    return Builder.createNaryOp(Instruction::ExtractElement, {A, LaneToExtract},
+                                Def->getDebugLoc());
   }
 
   // Look for cycles where Def is of the form:
@@ -1636,7 +1590,7 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
         if (Inc)
           Inc->replaceAllUsesWith(Phi);
         Phi->setOperand(0, Y);
-        return;
+        return Def;
       }
     }
   }
@@ -1645,16 +1599,14 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
   // just the pointer operand.
   if (auto *VPR = dyn_cast<VPVectorPointerRecipe>(Def))
     if (!VPR->getVFxPart() || match(VPR->getVFxPart(), m_ZeroInt()))
-      return VPR->replaceAllUsesWith(VPR->getOperand(0));
+      return VPR->getOperand(0);
 
   // VPScalarIVSteps after unrolling can be replaced by their start value, if
   // the start index is zero and only the first lane 0 is demanded.
-  if (auto *Steps = dyn_cast<VPScalarIVStepsRecipe>(Def)) {
-    if (!Steps->getStartIndex() && vputils::onlyFirstLaneUsed(Steps)) {
-      Steps->replaceAllUsesWith(Steps->getOperand(0));
-      return;
-    }
-  }
+  if (auto *Steps = dyn_cast<VPScalarIVStepsRecipe>(Def))
+    if (!Steps->getStartIndex() && vputils::onlyFirstLaneUsed(Steps))
+      return Steps->getOperand(0);
+
   // Simplify redundant ReductionStartVector recipes after unrolling.
   VPValue *StartV;
   if (match(Def, m_VPInstruction<VPInstruction::ReductionStartVector>(
@@ -1663,11 +1615,13 @@ static void simplifyRecipe(VPSingleDefRecipe *Def) {
       auto *PhiR = dyn_cast<VPReductionPHIRecipe>(&U);
       return PhiR && PhiR->isInLoop();
     });
-    return;
+    return Def;
   }
 
   if (Plan->getConcreteUF() == 1 && match(Def, m_ExtractLastPart(m_VPValue(A))))
-    return Def->replaceAllUsesWith(A);
+    return A;
+
+  return nullptr;
 }
 
 void VPlanTransforms::simplifyRecipes(VPlan &Plan) {
@@ -1676,7 +1630,16 @@ void VPlanTransforms::simplifyRecipes(VPlan &Plan) {
   for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(RPOT)) {
     for (VPRecipeBase &R : make_early_inc_range(*VPBB))
       if (auto *Def = dyn_cast<VPSingleDefRecipe>(&R))
-        simplifyRecipe(Def);
+        if (VPValue *New = simplifyRecipe(Def)) {
+          if (New != Def) {
+            // Replace the recipe with a new one.
+            Def->replaceAllUsesWith(New);
+            Def->eraseFromParent();
+          } else if (vputils::isDeadRecipe(R)) {
+            // Recipe was modified - it may be dead now.
+            Def->eraseFromParent();
+          }
+        }
   }
 }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1286,7 +1286,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
     Type *TruncTy = Def->getScalarType();
     Type *ATy = A->getScalarType();
     if (TruncTy == ATy) {
-      Def->replaceAllUsesWith(A);
+      return A;
     } else {
       // Don't replace a non-widened cast recipe with a widened cast.
       if (!isa<VPWidenCastRecipe>(Def))
@@ -1301,10 +1301,10 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
           // UnderlyingExt has distinct return type, used to retain legacy cost.
           Ext->setUnderlyingValue(UnderlyingExt);
         }
-        Def->replaceAllUsesWith(Ext);
+        return Ext;
       } else if (ATy->getScalarSizeInBits() > TruncTy->getScalarSizeInBits()) {
         auto *Trunc = Builder.createWidenCast(Instruction::Trunc, A, TruncTy);
-        Def->replaceAllUsesWith(Trunc);
+        return Trunc;
       }
     }
   }
@@ -1396,9 +1396,9 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
         // to preserve the location.
         if (!Cmp->getDebugLoc() && Def->getDebugLoc())
           Cmp->setDebugLoc(Def->getDebugLoc());
+        return Def;
       }
     }
-    return Def;
   }
 
   // Fold any-of (fcmp uno %A, %A), (fcmp uno %B, %B), ... ->

--- a/llvm/test/Transforms/LoopVectorize/VPlan/constant-fold.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/constant-fold.ll
@@ -25,14 +25,11 @@ define void @f1() {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  bb2:
 ; CHECK-NEXT:    EMIT-SCALAR ir<%c.1.0> = phi [ ir<0>, vector.ph ], [ ir<%_tmp9>, bb2 ]
-; CHECK-NEXT:    EMIT-SCALAR ir<%_tmp1> = zext ir<0> to i64
-; CHECK-NEXT:    EMIT ir<%_tmp2> = getelementptr ir<@a>, ir<0>, ir<0>
 ; CHECK-NEXT:    EMIT-SCALAR ir<%_tmp6> = sext ir<%c.1.0> to i64
 ; CHECK-NEXT:    EMIT ir<%_tmp7> = getelementptr ir<@b>, ir<0>, ir<%_tmp6>
 ; CHECK-NEXT:    EMIT store ir<@a>, ir<%_tmp7>
 ; CHECK-NEXT:    EMIT ir<%_tmp9> = add nsw ir<%c.1.0>, ir<1>
 ; CHECK-NEXT:    EMIT ir<%_tmp11> = icmp sge ir<%_tmp9>, ir<2>
-; CHECK-NEXT:    EMIT vp<[[VP1:%[0-9]+]]> = not ir<%_tmp11>
 ; CHECK-NEXT:    EMIT branch-on-cond ir<%_tmp11>
 ; CHECK-NEXT:  Successor(s): middle.block, bb2
 ;
@@ -75,8 +72,6 @@ define void @redundant_or_1(ptr %dst, i1 %c.0, i1 %c.1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  then.1:
 ; CHECK-NEXT:    EMIT ir<%cmp> = icmp eq ir<%iv>, ir<2>
-; CHECK-NEXT:    EMIT ir<%or> = or ir<%cmp>, ir<true>
-; CHECK-NEXT:    EMIT ir<%cond> = select ir<true>, ir<%c.1>, ir<false>
 ; CHECK-NEXT:    EMIT branch-on-cond ir<%c.1>
 ; CHECK-NEXT:  Successor(s): then.2, loop.latch
 ; CHECK-EMPTY:
@@ -137,8 +132,6 @@ define void @redundant_or_2(ptr %dst, i1 %c.0, i1 %c.1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  then.1:
 ; CHECK-NEXT:    EMIT ir<%cmp> = icmp eq ir<%iv>, ir<2>
-; CHECK-NEXT:    EMIT ir<%or> = or ir<true>, ir<%cmp>
-; CHECK-NEXT:    EMIT ir<%cond> = select ir<true>, ir<%c.1>, ir<false>
 ; CHECK-NEXT:    EMIT branch-on-cond ir<%c.1>
 ; CHECK-NEXT:  Successor(s): then.2, loop.latch
 ; CHECK-EMPTY:
@@ -199,7 +192,6 @@ define void @redundant_and_1(ptr %dst, i1 %c.0, i1 %c.1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  then.1:
 ; CHECK-NEXT:    EMIT ir<%cmp> = icmp eq ir<%iv>, ir<2>
-; CHECK-NEXT:    EMIT ir<%or> = or ir<%cmp>, ir<false>
 ; CHECK-NEXT:    EMIT ir<%cond> = select ir<%cmp>, ir<%c.1>, ir<false>
 ; CHECK-NEXT:    EMIT branch-on-cond ir<%cond>
 ; CHECK-NEXT:  Successor(s): then.2, loop.latch
@@ -262,8 +254,6 @@ define void @redundant_and_2(ptr %dst, i1 %c.0, i1 %c.1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  then.1:
 ; CHECK-NEXT:    EMIT ir<%cmp> = icmp eq ir<%iv>, ir<2>
-; CHECK-NEXT:    EMIT ir<%or> = and ir<false>, ir<%cmp>
-; CHECK-NEXT:    EMIT ir<%cond> = select ir<false>, ir<%c.1>, ir<false>
 ; CHECK-NEXT:    EMIT branch-on-cond ir<false>
 ; CHECK-NEXT:  Successor(s): then.2, loop.latch
 ; CHECK-EMPTY:
@@ -325,7 +315,6 @@ define void @fold_replicating_umax_equal_live_ins(ptr noalias %dst, ptr %cond, i
 ; CHECK-NEXT:  Successor(s): then, latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  then:
-; CHECK-NEXT:    EMIT ir<%m> = call ir<%x>, ir<%x>, ir<@llvm.umax.i32>
 ; CHECK-NEXT:    EMIT ir<%gep> = getelementptr ir<%dst>, ir<%iv>
 ; CHECK-NEXT:    EMIT store ir<%x>, ir<%gep>
 ; CHECK-NEXT:  Successor(s): latch

--- a/llvm/test/Transforms/LoopVectorize/X86/funclet.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/funclet.ll
@@ -80,19 +80,16 @@ define void @constant_foldable() #0 personality ptr @__CxxFrameHandler3 {
 ; CHECK-NEXT:    [[TMP0:%.*]] = catchswitch within none [label %[[CATCH:.*]]] unwind to caller
 ; CHECK:       [[CATCH]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = catchpad within [[TMP0]] [ptr null, i32 64, ptr null]
-; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
-; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[TMP2:%.*]] = call <16 x double> @llvm.floor.v16f64(<16 x double> splat (double 1.000000e+00)) [ "funclet"(token [[TMP1]]) ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 16
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, %[[CATCH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[CALL:%.*]] = call double @floor(double 1.000000e+00) #[[ATTR1:[0-9]+]] [ "funclet"(token [[TMP1]]) ]
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw nsw i32 [[IV]], 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[INDEX_NEXT]], 1024
-; CHECK-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP3:![0-9]+]]
-; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    br label %[[EXIT:.*]]
+; CHECK-NEXT:    br i1 [[TMP3]], label %[[EXIT:.*]], label %[[VECTOR_BODY]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    store double 1.000000e+00, ptr @sink, align 8
+; CHECK-NEXT:    [[CALL_LCSSA:%.*]] = phi double [ [[CALL]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    store double [[CALL_LCSSA]], ptr @sink, align 8
 ; CHECK-NEXT:    catchret from [[TMP1]] to label %[[TRY_CONT:.*]]
 ; CHECK:       [[TRY_CONT]]:
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
Most combines in simplifyRecipe RAUW a value, but not all of them erase the old recipe.
Unify them and bring it in line with InstCombine by having it return a VPValue, which simplifyRecipes can then call RAUW with, and automatically erase the old recipe.

Similarly to InstCombine, combines that modify a recipe should return the same recipe.
