### PR TITLE
[libc++] Switch XFAIL in xsgetn.buffer.pass.cpp to LLVM 23

### DIFF
--- a/libcxx/test/extensions/libcxx/input.output/file.streams/fstreams/filebuf.members/xsgetn.buffer.pass.cpp
+++ b/libcxx/test/extensions/libcxx/input.output/file.streams/fstreams/filebuf.members/xsgetn.buffer.pass.cpp
@@ -10,7 +10,7 @@
 
 // UNSUPPORTED: no-localization, no-filesystem
 
-// XFAIL: using-built-library-before-llvm-24
+// XFAIL: using-built-library-before-llvm-23
 
 // <fstream>
 


### PR DESCRIPTION
We want to back-port the fix for xsgetn, so the XFAIL needs to be updated to reflect that.
