### PR TITLE
[lldb][test] Fix TestMinidumpSizeOfImage.py with glibc >= 2.41

### DIFF
--- a/lldb/test/API/functionalities/process_save_core_minidump_size_of_image/TestMinidumpSizeOfImage.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump_size_of_image/TestMinidumpSizeOfImage.py
@@ -24,7 +24,7 @@ class MinidumpSizeOfImageTestCase(TestBase):
         with open(lds, "w") as f:
             f.write(
                 "PHDRS { ro PT_LOAD FLAGS(5); rw PT_LOAD FLAGS(6);"
-                " dyn PT_DYNAMIC FLAGS(6); }\n"
+                " dyn PT_DYNAMIC FLAGS(6); stack PT_GNU_STACK FLAGS(6); }\n"
                 "SECTIONS {\n"
                 "  . = SIZEOF_HEADERS;\n"
                 "  .hash : { *(.hash) } :ro\n"


### PR DESCRIPTION
Test added by #188363.

In glibc 2.41:
> * dlopen and dlmopen no longer make the stack executable if a shared
>   library requires it, either implicitly because of a missing GNU_STACK
>   ELF header (and default ABI permission having the executable bit set)
>   or explicitly because of the executable bit in GNU_STACK, and the
>   stack is not already executable.  Instead, loading such objects will
>   fail.

https://lists.gnu.org/archive/html/info-gnu/2025-01/msg00014.html

The test program used for this test provides all the PHDRS itself, but did not include a PT_GNU_STACK entry.

So the loader would assume it wanted exectuable stack. The main program was not using an executable stack and so the loader refused to change that, so loading the object fails.

dlopen failed: lldb-test-build/functionalities/process_save_core_minidump_size_of_image/TestMinidumpSizeOfImage/libtestlib.so: cannot enable executable stack as shared object requires: Invalid argument

To fix this provide a PT_GNU_STACK with value 6 aka read and write but not execute.