### PR TITLE
[clang][Driver] Fix libc++ include path on OpenBSD

### DIFF
--- a/clang/lib/Driver/ToolChains/OpenBSD.cpp
+++ b/clang/lib/Driver/ToolChains/OpenBSD.cpp
@@ -349,12 +349,6 @@ void OpenBSD::AddClangSystemIncludeArgs(
                           concat(D.SysRoot, "/usr/include"));
 }
 
-void OpenBSD::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                                    llvm::opt::ArgStringList &CC1Args) const {
-  addSystemInclude(DriverArgs, CC1Args,
-                   concat(getDriver().SysRoot, "/usr/include/c++/v1"));
-}
-
 void OpenBSD::AddCXXStdlibLibArgs(const ArgList &Args,
                                   ArgStringList &CmdArgs) const {
   bool Profiling = Args.hasArg(options::OPT_pg);

--- a/clang/lib/Driver/ToolChains/OpenBSD.h
+++ b/clang/lib/Driver/ToolChains/OpenBSD.h
@@ -73,9 +73,6 @@ public:
   void
   AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &CC1Args) const override;
-
-  void addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                             llvm::opt::ArgStringList &CC1Args) const override;
   void AddCXXStdlibLibArgs(const llvm::opt::ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs) const override;
 

--- a/clang/test/Driver/openbsd.cpp
+++ b/clang/test/Driver/openbsd.cpp
@@ -28,7 +28,8 @@
 // RUN:   | FileCheck --check-prefix=CHECK-LIBCXX-SYSROOT %s
 // CHECK-LIBCXX-SYSROOT: "-cc1"
 // CHECK-LIBCXX-SYSROOT-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
-// CHECK-LIBCXX-SYSROOT-SAME: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
+// CHECK-LIBCXX-SYSROOT-SAME: "-internal-isystem" "{{.*}}/bin/../include/c++/v1"
+// CHECK-LIBCXX-SYSROOT-NOT:  "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
 
 // Test include paths when the sysroot path ends with `/`.
 // RUN: %clangxx %s -### -fsyntax-only 2>&1 \
@@ -38,4 +39,5 @@
 // RUN:   | FileCheck --check-prefix=CHECK-LIBCXX-SYSROOT-SLASH %s
 // CHECK-LIBCXX-SYSROOT-SLASH: "-cc1"
 // CHECK-LIBCXX-SYSROOT-SLASH-SAME: "-isysroot" "[[SYSROOT:[^"]+/]]"
-// CHECK-LIBCXX-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr/include/c++/v1"
+// CHECK-LIBCXX-SYSROOT-SLASH-SAME: "-internal-isystem" "{{.*}}/bin/../include/c++/v1"
+// CHECK-LIBCXX-SYSROOT-SLASH-NOT:  "-internal-isystem" "[[SYSROOT]]usr/include/c++/v1"


### PR DESCRIPTION
`clang++` defaults to `-stdlib=libc++` on OpenBSD. When building with both
`clang` and `libcxx` included, the freshly built `clang++` uses the system
version of the `libc++` headers. However, this is from the bundled `libc++`
22.1.8, thus inconsistent with the `libc++` being built.

OpenBSD has its own version of addLibCxxIncludePaths which just includes
`/usr/include/c++/v1`.

This patch removes OpenBSD::addLibCxxIncludePaths in favour of the generic
version in `Gnu.cpp`.