### PR TITLE
[flang] Reject MODULE prefix in abstract interface body

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5632,7 +5632,7 @@ bool SubprogramVisitor::BeginSubprogram(const parser::Name &name,
   }
   if (hasModulePrefix && inInterfaceBlock() && isAbstract()) { // C1547
     Say(name,
-        "'%s' has MODULE prefix, which is not allowed in an ABSTRACT interface body"_err_en_US);
+        "'%s' may not have a MODULE prefix in an ABSTRACT interface body"_err_en_US);
     isValid = false;
   }
   Symbol *moduleInterface{nullptr};

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5630,6 +5630,11 @@ bool SubprogramVisitor::BeginSubprogram(const parser::Name &name,
     // other semantic checks run before we print the errors
     isValid = false;
   }
+  if (hasModulePrefix && inInterfaceBlock() && isAbstract()) { // C1547
+    Say(name,
+        "'%s' has MODULE prefix, which is not allowed in an ABSTRACT interface body"_err_en_US);
+    isValid = false;
+  }
   Symbol *moduleInterface{nullptr};
   if (isValid && hasModulePrefix && !inInterfaceBlock()) {
     moduleInterface = FindSeparateModuleProcedureInterface(name);

--- a/flang/test/Semantics/resolve36.f90
+++ b/flang/test/Semantics/resolve36.f90
@@ -98,11 +98,26 @@ real module function c1547()
   func = 0.0
 end function
 
-module mod_test
+module m5
 abstract interface
-  !ERROR: 'f1' has MODULE prefix, which is not allowed in an ABSTRACT interface body
+  !ERROR: 'f1' may not have a MODULE prefix in an ABSTRACT interface body
   pure integer module function f1(i)
     integer, intent(in) :: i
   end function
+  !ERROR: 's1' may not have a MODULE prefix in an ABSTRACT interface body
+  module subroutine s1(i)
+    integer, intent(in) :: i
+  end subroutine
 end interface
 end module
+
+module m6
+end module
+submodule(m6) s6
+abstract interface
+  !ERROR: 'f2' may not have a MODULE prefix in an ABSTRACT interface body
+  module function f2()
+    integer :: f2
+  end function
+end interface
+end submodule

--- a/flang/test/Semantics/resolve36.f90
+++ b/flang/test/Semantics/resolve36.f90
@@ -97,3 +97,12 @@ end
 real module function c1547()
   func = 0.0
 end function
+
+module mod_test
+abstract interface
+  !ERROR: 'f1' has MODULE prefix, which is not allowed in an ABSTRACT interface body
+  pure integer module function f1(i)
+    integer, intent(in) :: i
+  end function
+end interface
+end module


### PR DESCRIPTION
Flang failed to diagnose an invalid MODULE prefix on a function or subroutine declared inside an ABSTRACT INTERFACE block. C1547 (R1526, J3/18-007r1) requires that MODULE appear only in a module subprogram or a nonabstract interface body declared in a module or submodule. 

Flang accepted such code with no diagnostic. The root cause is that BeginSubprogram() in resolve-names.cpp enforced only the module/submodule scope part of C1547 and never checked whether the interface body was abstract. For abstract interfaces, the code took the isAbstract() path and silently skipped the MODULE prefix instead of reporting an error. 

This patch adds a C1547 check to reject MODULE in this particular case. A semantics test is added in resolve36.f90

Fixes #208200