### PR TITLE
ARM: Read float ABI from the "float-abi" module flag

### DIFF
--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -698,8 +698,13 @@ void ARMAsmPrinter::emitAttributes() {
   }
   const ARMBaseTargetMachine &ATM =
       static_cast<const ARMBaseTargetMachine &>(TM);
+  // The float ABI comes from the "float-abi" module flag if present, otherwise
+  // from the legacy -float-abi target option.
+  FloatABI::ABIType FloatABI = MMI->getModule()->getFloatABI();
+  if (FloatABI == FloatABI::Default)
+    FloatABI = ATM.Options.FloatABIType;
   const ARMSubtarget STI(TT, std::string(CPU), ArchFS, ATM,
-                         ATM.isLittleEndian(), ATM.Options.FloatABIType);
+                         ATM.isLittleEndian(), FloatABI);
 
   // Emit build attributes for the available hardware.
   ATS.emitTargetAttributes(STI);

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -37,6 +37,7 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -237,7 +238,15 @@ ARMBaseTargetMachine::getSubtargetImpl(const Function &F) const {
   if (DM != DenormalMode::getIEEE())
     Key += "denormal-fp-math=" + DM.str();
 
-  FloatABI::ABIType FloatABI = this->Options.FloatABIType;
+  // The float ABI comes from the "float-abi" module flag if present, otherwise
+  // from the legacy -float-abi target option (which the constructor seeded from
+  // the target triple).
+  FloatABI::ABIType FloatABI = F.getParent()->getFloatABI();
+  if (FloatABI == FloatABI::Default) {
+    FloatABI = Options.FloatABIType;
+    assert(FloatABI != FloatABI::Default &&
+           "expected TargetMachine constructor to overwrite default float abi");
+  }
 
   // It is legal to have FloatABI::Hard with +soft-float for targets with SIMD
   // registers, but no floating-point hardware (mve+nofp)

--- a/llvm/test/CodeGen/ARM/float-abi-module-flag.ll
+++ b/llvm/test/CodeGen/ARM/float-abi-module-flag.ll
@@ -1,0 +1,43 @@
+; The "float-abi" module flag selects the floating-point calling convention.
+; RUN: split-file %s %t
+
+; Hard float ABI module flag: FP argument returned in a VFP register (s0).
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 < %t/hard.ll | FileCheck %s --check-prefix=HARD
+
+; Soft float ABI module flag: FP argument returned in a GPR (r0).
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 < %t/soft.ll | FileCheck %s --check-prefix=SOFT
+
+; No module flag: the -float-abi command-line option still applies.
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=hard < %t/none.ll | FileCheck %s --check-prefix=HARD
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=soft < %t/none.ll | FileCheck %s --check-prefix=SOFT
+
+; The module flag overrides the target-default soft ABI even without -float-abi.
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 < %t/none.ll | FileCheck %s --check-prefix=SOFT
+
+; An explicit module flag takes precedence over a conflicting -float-abi option.
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=soft < %t/hard.ll | FileCheck %s --check-prefix=HARD
+; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=hard < %t/soft.ll | FileCheck %s --check-prefix=SOFT
+
+;--- hard.ll
+define float @f(float %x) {
+  %r = fadd float %x, %x
+  ret float %r
+}
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"float-abi", !"hard"}
+; HARD: vadd.f32 s0,
+
+;--- soft.ll
+define float @f(float %x) {
+  %r = fadd float %x, %x
+  ret float %r
+}
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"float-abi", !"soft"}
+; SOFT: vmov {{s[0-9]+}}, r0
+
+;--- none.ll
+define float @f(float %x) {
+  %r = fadd float %x, %x
+  ret float %r
+}

--- a/llvm/test/CodeGen/ARM/float-abi-module-flag.ll
+++ b/llvm/test/CodeGen/ARM/float-abi-module-flag.ll
@@ -11,7 +11,7 @@
 ; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=hard < %t/none.ll | FileCheck %s --check-prefix=HARD
 ; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=soft < %t/none.ll | FileCheck %s --check-prefix=SOFT
 
-; The module flag overrides the target-default soft ABI even without -float-abi.
+; The triple default applies with no module flag.
 ; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 < %t/none.ll | FileCheck %s --check-prefix=SOFT
 
 ; An explicit module flag takes precedence over a conflicting -float-abi option.


### PR DESCRIPTION
Use the value from the module flag if present, otherwise
fall back on the legacy TargetOptions field until that is
removed.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>