### PR TITLE
[CodeGen] Remove deprecated createTargetMachineForTriple overload

### DIFF
--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -219,13 +219,6 @@ LLVM_ABI Expected<std::unique_ptr<TargetMachine>> createTargetMachineForTriple(
     const Triple &TargetTriple,
     CodeGenOptLevel OptLevel = CodeGenOptLevel::Default);
 
-// TODO: Remove after llvm 23 branches
-LLVM_DEPRECATED("Use the Triple overload instead",
-                "createTargetMachineForTriple")
-LLVM_ABI Expected<std::unique_ptr<TargetMachine>> createTargetMachineForTriple(
-    StringRef TargetTriple,
-    CodeGenOptLevel OptLevel = CodeGenOptLevel::Default);
-
 /// Conditionally enables the collection of LLVM statistics during the tool run,
 /// based on the value of the flag. Must be called before the tool run to
 /// actually collect data.

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -800,12 +800,6 @@ codegen::createTargetMachineForTriple(const Triple &TargetTriple,
   return std::unique_ptr<TargetMachine>(Target);
 }
 
-Expected<std::unique_ptr<TargetMachine>>
-codegen::createTargetMachineForTriple(StringRef TargetTriple,
-                                      CodeGenOptLevel OptLevel) {
-  return createTargetMachineForTriple(Triple(TargetTriple), OptLevel);
-}
-
 void codegen::MaybeEnableStatistics() {
   if (getSaveStats() == SaveStatsMode::None)
     return;


### PR DESCRIPTION
This overload was deprecated in favor of the Triple overload and marked for removal after llvm 23 branched. All in-tree callers already use the Triple overload.