### PR TITLE
clang: Emit "float-abi" module flag

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1380,6 +1380,21 @@ void CodeGenModule::Release() {
     getModule().addModuleFlag(llvm::Module::Error, "wchar_size",
                               static_cast<uint32_t>(WCharWidth));
 
+  // Record the floating-point ABI as a module flag when it differs from the
+  // target default. softfp collapses to soft.
+  llvm::FloatABI::ABIType FloatABI =
+      llvm::StringSwitch<llvm::FloatABI::ABIType>(CodeGenOpts.FloatABI)
+          .Cases({"soft", "softfp"}, llvm::FloatABI::Soft)
+          .Case("hard", llvm::FloatABI::Hard)
+          .Default(llvm::FloatABI::Default);
+  if (FloatABI != llvm::FloatABI::Default &&
+      FloatABI != getTriple().getDefaultFloatABI()) {
+    getModule().addModuleFlag(
+        llvm::Module::Error, "float-abi",
+        llvm::MDString::get(getLLVMContext(),
+                            llvm::FloatABI::getABITypeName(FloatABI)));
+  }
+
   if (getTriple().isOSzOS()) {
     getModule().addModuleFlag(llvm::Module::Warning,
                               "zos_product_major_version",

--- a/clang/test/CodeGen/arm-float-abi-flag.c
+++ b/clang/test/CodeGen/arm-float-abi-flag.c
@@ -1,0 +1,32 @@
+// Check that clang emits the "float-abi" module flag only when the resolved
+// floating-point ABI differs from the target default.
+
+// Default (soft) ABI on a soft-default triple: no flag.
+// RUN: %clang_cc1 -triple arm-none-none-eabi -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=NONE
+
+// Explicit hard on a soft-default triple: flag emitted.
+// RUN: %clang_cc1 -triple arm-none-none-eabi -mfloat-abi hard -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=HARD
+
+// Explicit soft on a soft-default triple: matches default, no flag.
+// RUN: %clang_cc1 -triple arm-none-none-eabi -mfloat-abi soft -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=NONE
+
+// Default (hard) ABI on a hard-default triple: no flag.
+// RUN: %clang_cc1 -triple arm-none-none-eabihf -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=NONE
+
+// Explicit soft on a hard-default triple: flag emitted.
+// RUN: %clang_cc1 -triple arm-none-none-eabihf -mfloat-abi soft -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=SOFT
+
+// softfp collapses to soft: on a hard-default triple, flag emitted as soft.
+// RUN: %clang_cc1 -triple arm-none-none-eabihf -mfloat-abi softfp -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=SOFT
+
+void f(void) {}
+
+// NONE-NOT: !"float-abi"
+// HARD: !{i32 1, !"float-abi", !"hard"}
+// SOFT: !{i32 1, !"float-abi", !"soft"}


### PR DESCRIPTION
Emit the new module flag if it differs from the triple's
default.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>