### PR TITLE
[ADT] Remove deprecated llvm::make_scope_exit

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -1119,13 +1119,13 @@ bool HostInfoMacOSX::IsBundleCodeSignTrusted(const FileSpec &bundle_path) {
       path.size(), /*isDirectory=*/true);
   if (!url)
     return false;
-  auto url_cleanup = llvm::make_scope_exit([&]() { CFRelease(url); });
+  auto url_cleanup = llvm::scope_exit([&]() { CFRelease(url); });
 
   SecStaticCodeRef static_code = nullptr;
   if (SecStaticCodeCreateWithPath(url, kSecCSDefaultFlags, &static_code) !=
       errSecSuccess)
     return false;
-  auto code_cleanup = llvm::make_scope_exit([&]() { CFRelease(static_code); });
+  auto code_cleanup = llvm::scope_exit([&]() { CFRelease(static_code); });
 
   // Check that the signature chains to a trusted root CA.
   SecRequirementRef requirement = nullptr;
@@ -1133,7 +1133,7 @@ bool HostInfoMacOSX::IsBundleCodeSignTrusted(const FileSpec &bundle_path) {
                                      kSecCSDefaultFlags,
                                      &requirement) != errSecSuccess)
     return false;
-  auto req_cleanup = llvm::make_scope_exit([&]() { CFRelease(requirement); });
+  auto req_cleanup = llvm::scope_exit([&]() { CFRelease(requirement); });
 
   return SecStaticCodeCheckValidity(static_code, kSecCSDefaultFlags,
                                     requirement) == errSecSuccess;

--- a/lldb/source/Host/windows/DomainSocketWindows.cpp
+++ b/lldb/source/Host/windows/DomainSocketWindows.cpp
@@ -31,7 +31,7 @@ llvm::Expected<DomainSocket::Pair> DomainSocketWindows::CreatePair() {
   llvm::SmallString<128> path;
   llvm::sys::fs::createUniquePath(model, path, /*MakeAbsolute=*/false);
   auto remove_file =
-      llvm::make_scope_exit([&] { llvm::sys::fs::remove(path); });
+      llvm::scope_exit([&] { llvm::sys::fs::remove(path); });
 
   auto listen_socket =
       std::make_unique<DomainSocketWindows>(/*should_close=*/true);

--- a/lldb/source/Host/windows/DomainSocketWindows.cpp
+++ b/lldb/source/Host/windows/DomainSocketWindows.cpp
@@ -30,8 +30,7 @@ llvm::Expected<DomainSocket::Pair> DomainSocketWindows::CreatePair() {
   llvm::sys::path::append(model, "lldb-domain-socketpair-%%%%%%%%.sock");
   llvm::SmallString<128> path;
   llvm::sys::fs::createUniquePath(model, path, /*MakeAbsolute=*/false);
-  auto remove_file =
-      llvm::scope_exit([&] { llvm::sys::fs::remove(path); });
+  auto remove_file = llvm::scope_exit([&] { llvm::sys::fs::remove(path); });
 
   auto listen_socket =
       std::make_unique<DomainSocketWindows>(/*should_close=*/true);

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
@@ -308,7 +308,7 @@ Status NativeRegisterContextWindows_arm64::GPRRead(const uint32_t reg,
 Status
 NativeRegisterContextWindows_arm64::GPRWrite(const uint32_t reg,
                                              const RegisterValue &reg_value) {
-  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+  auto cleanup = llvm::scope_exit([&]() { m_context = nullptr; });
 
   PCONTEXT context = nullptr;
   DataBufferHeap context_buffer;
@@ -533,7 +533,7 @@ Status NativeRegisterContextWindows_arm64::FPRRead(const uint32_t reg,
 Status
 NativeRegisterContextWindows_arm64::FPRWrite(const uint32_t reg,
                                              const RegisterValue &reg_value) {
-  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+  auto cleanup = llvm::scope_exit([&]() { m_context = nullptr; });
 
   PCONTEXT context = nullptr;
   DataBufferHeap context_buffer;
@@ -743,7 +743,7 @@ Status NativeRegisterContextWindows_arm64::ReadAllRegisterValues(
 
 Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
     const lldb::DataBufferSP &data_sp) {
-  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+  auto cleanup = llvm::scope_exit([&]() { m_context = nullptr; });
 
   Log *log = GetLog(WindowsLog::Registers);
   Status error;
@@ -796,7 +796,7 @@ llvm::Error NativeRegisterContextWindows_arm64::ReadHardwareDebugInfo() {
 
 llvm::Error
 NativeRegisterContextWindows_arm64::WriteHardwareDebugRegs(DREGType hwbType) {
-  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+  auto cleanup = llvm::scope_exit([&]() { m_context = nullptr; });
 
   PCONTEXT context = nullptr;
   DataBufferHeap context_buffer;

--- a/llvm/include/llvm/ADT/ScopeExit.h
+++ b/llvm/include/llvm/ADT/ScopeExit.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file defines the make_scope_exit function, which executes user-defined
+/// This file defines the scope_exit class, which executes user-defined
 /// cleanup logic at scope exit.
 ///
 //===----------------------------------------------------------------------===//
@@ -15,7 +15,6 @@
 #ifndef LLVM_ADT_SCOPEEXIT_H
 #define LLVM_ADT_SCOPEEXIT_H
 
-#include "llvm/Support/Compiler.h"
 #include <utility>
 
 namespace llvm {
@@ -45,19 +44,6 @@ public:
 };
 
 template <typename Callable> scope_exit(Callable) -> scope_exit<Callable>;
-
-// Keeps the callable object that is passed in, and execute it at the
-// destruction of the returned object (usually at the scope exit where the
-// returned object is kept).
-//
-// Interface is specified by p0052r2.
-template <typename Callable>
-[[nodiscard]]
-LLVM_DEPRECATED("Prefer calling the constructor of llvm::scope_exit directly.",
-                "scope_exit") auto make_scope_exit(Callable &&F) {
-  // TODO(LLVM 24): Remove this function.
-  return scope_exit(std::forward<Callable>(F));
-}
 
 } // end namespace llvm
 


### PR DESCRIPTION
Update remaining call sites in lldb to construct llvm::scope_exit directly, per the deprecation notice.