### PR TITLE
[OpenMP][OMPT] Mark dispatch callback as sometimes on registration

### DIFF
--- a/openmp/runtime/src/ompt-event-specific.h
+++ b/openmp/runtime/src/ompt-event-specific.h
@@ -103,7 +103,7 @@
 
 #define ompt_callback_reduction_implemented ompt_event_MAY_ALWAYS_OPTIONAL
 
-#define ompt_callback_dispatch_implemented ompt_event_MAY_ALWAYS_OPTIONAL
+#define ompt_callback_dispatch_implemented ompt_event_MAY_CONVENIENT
 
 #define ompt_callback_error_implemented ompt_event_MAY_ALWAYS_OPTIONAL
 


### PR DESCRIPTION
Recently, multiple issues in the implementation of the `dispatch` callback have been found (e.g., #212784, #207746). In these, the code generation done by Clang and Flang does not provide a sufficient amount of information for the runtime to dispatch the correct amount of flags, or a callback for a given event at all.

These missing and incorrect events do not satisfy OpenMP's requirement for `ompt_set_always` as a registration result, as the runtime does not trace or invoke the correct callback whenever an associated event occurs (OpenMP v5.2, p. 457, l.5-6).
As such, change the registration result for the `dispatch` callback to `ompt_set_sometimes` for now, which is fulfilled. Here, an implementation can dispatch callbacks or trace an implementation-defined subset of associated event occurrences.

Based on the changed registration result, a tool can then decide if they are still interested in recording the information provided by the runtime implementation.