### PR TITLE
[WebAssembly] Fix legalization of v8f16 insertelement

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -257,6 +257,7 @@ WebAssemblyTargetLowering::WebAssemblyTargetLowering(
 
     if (Subtarget->hasFP16()) {
       setOperationAction(ISD::BUILD_VECTOR, MVT::f16, Custom);
+      setOperationAction(ISD::INSERT_VECTOR_ELT, MVT::f16, Custom);
       setOperationAction(ISD::FP_ROUND, MVT::v4f16, Custom);
     }
 
@@ -2511,7 +2512,7 @@ SDValue WebAssemblyTargetLowering::LowerBUILD_VECTOR(SDValue Op,
                                                      SelectionDAG &DAG) const {
   MVT VT = Op.getSimpleValueType();
   if (VT == MVT::v8f16) {
-    // BUILD_VECTOR can't handle FP16 operands since Wasm doesn't have a scaler
+    // BUILD_VECTOR can't handle FP16 operands since Wasm doesn't have a scalar
     // FP16 type, so cast them to I16s.
     MVT IVT = VT.changeVectorElementType(MVT::i16);
     SmallVector<SDValue, 8> NewOps;
@@ -2818,6 +2819,18 @@ SDValue WebAssemblyTargetLowering::LowerSETCC(SDValue Op,
 SDValue
 WebAssemblyTargetLowering::LowerAccessVectorElement(SDValue Op,
                                                     SelectionDAG &DAG) const {
+  if (Op.getOpcode() == ISD::INSERT_VECTOR_ELT &&
+      Op.getValueType() == MVT::v8f16) {
+    // INSERT_VECTOR_ELT can't handle FP16 operands since Wasm doesn't have a
+    // scalar FP16 type, so cast them to I16s.
+    SDLoc DL(Op);
+    SDValue IntVector = DAG.getBitcast(MVT::v8i16, Op.getOperand(0));
+    SDValue IntElement = DAG.getBitcast(MVT::i16, Op.getOperand(1));
+    SDValue Inserted = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, MVT::v8i16,
+                                   IntVector, IntElement, Op.getOperand(2));
+    return DAG.getBitcast(MVT::v8f16, Inserted);
+  }
+
   // Allow constant lane indices, expand variable lane indices
   SDNode *IdxNode = Op.getOperand(Op.getNumOperands() - 1).getNode();
   if (isa<ConstantSDNode>(IdxNode)) {

--- a/llvm/test/CodeGen/WebAssembly/f16-intrinsics.ll
+++ b/llvm/test/CodeGen/WebAssembly/f16-intrinsics.ll
@@ -81,6 +81,14 @@ define <8 x half> @replace_lane_v8f16(<8 x half> %v, float %f) {
   ret <8 x half> %r
 }
 
+; CHECK-LABEL: insert_lane_v8f16:
+; CHECK:       i16x8.replace_lane $push0=, $0, 3, $1
+; CHECK-NEXT:  return $pop0
+define <8 x half> @insert_lane_v8f16(<8 x half> %v, half %x) {
+  %r = insertelement <8 x half> %v, half %x, i32 3
+  ret <8 x half> %r
+}
+
 ; CHECK-LABEL: add_v8f16:
 ; CHECK:       f16x8.add $push0=, $0, $1
 ; CHECK-NEXT:  return $pop0


### PR DESCRIPTION
```
define <8 x half> @insert_v8f16(<8 x half> %v, half %x) {
  %r = insertelement <8 x half> %v, half %x, i32 3
  ret <8 x half> %r
}
```

```
llc \
  -mtriple=wasm32-unknown-unknown \
  -mattr=+simd128,+fp16 \
  -o /dev/null \
  /private/tmp/wasm-v8f16-insert-only.ll
```

Would lead to 
```
Initial selection DAG: %bb.0 'insert_v8f16:'
SelectionDAG has 10 nodes:
    t0: ch,glue = EntryToken
      t2: v8f16 = WebAssemblyISD::ARGUMENT TargetConstant:i32<0>
          t4: i32 = WebAssemblyISD::ARGUMENT TargetConstant:i32<1>
        t5: i16 = truncate t4
      t6: f16 = bitcast t5
    t8: v8f16 = insert_vector_elt t2, t6, Constant:i32<3>
  t9: ch = WebAssemblyISD::RETURN t0, t8

Soft promote half operand 1:
t8: v8f16 = insert_vector_elt t2, t6, Constant:i32<3>

SoftPromoteHalfOperand Op #1:
t8: v8f16 = insert_vector_elt t2, t6, Constant:i32<3>

LLVM ERROR: Do not know how to soft promote this operator's operand!
```

