### PR TITLE
[lldb] Convert generic register names in a case insensitive way

### DIFF
--- a/lldb/source/Utility/Args.cpp
+++ b/lldb/source/Utility/Args.cpp
@@ -441,7 +441,7 @@ lldb::Encoding Args::StringToEncoding(llvm::StringRef s,
 uint32_t Args::StringToGenericRegister(llvm::StringRef s) {
   if (s.empty())
     return LLDB_INVALID_REGNUM;
-  uint32_t result = llvm::StringSwitch<uint32_t>(s)
+  uint32_t result = llvm::StringSwitch<uint32_t>(s.lower())
                         .Case("pc", LLDB_REGNUM_GENERIC_PC)
                         .Case("sp", LLDB_REGNUM_GENERIC_SP)
                         .Case("fp", LLDB_REGNUM_GENERIC_FP)

--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -716,3 +716,32 @@ class RegisterCommandsTestCase(TestBase):
         self.expect("register read pc", substrs=[err_msg], error=True)
         self.expect("register write pc 0", substrs=[err_msg], error=True)
         self.expect("register info pc", substrs=[err_msg], error=True)
+
+    def test_case_insensitivity(self):
+        """
+        Register names, their aliases and any generic names like "sp" and "ra"
+        should be looked up case insensitively.
+        """
+
+        def setup():
+            self.build()
+            self.common_setup()
+
+        expected = "0x1122334455667788"
+
+        if self.getArchitecture() in ["amd64", "x86_64"]:
+            setup()
+            self.runCmd(f"register write rsp {expected}")
+            # This checks a primary name (rsp) and a generic name (sp)
+            # (and no registers have an alias).
+            for name in ["rsp", "RSP", "sp", "SP"]:
+                self.expect(f"register read {name}", substrs=[expected])
+        elif self.isAArch64():
+            setup()
+            self.runCmd(f"register write x30 {expected}")
+            # This checks a primary name (lr), an alias (x30), and
+            # a generic name (ra).
+            for name in ["x30", "X30", "lr", "LR", "ra", "RA"]:
+                self.expect(f"register read {name}", substrs=[expected])
+        else:
+            self.skipTest("Unsupported architecture.")


### PR DESCRIPTION
Part of #212778.

There are 3 types of register name:
* The primary name, displayed by default.
* An optional alias, for example AArch64 "lr" is also "x30".
* Generic convenience names like "sp", "ra" and so on.

The first two types are handled case insensitively, but generic names were not. For example:
(lldb) register read RA
error: Invalid register name 'RA'
(lldb) register read ra
  lr = 0x0000fffff7e27400

In this change I've fixed that.

This does close a workaround for #212778, where you could get to the actual x86_64 "sp" by using "sP". However, this is only known to work on Linux, and other architectures are negatively impacted by the bug so I'm fixing it.