### PR TITLE
[lldb][Windows] Don't cut the loader helper off after 250ms

### DIFF
--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -424,7 +424,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
-      5, process->GetUtilityExpressionTimeout() / 2));
+      std::chrono::microseconds(5),
+      process->GetUtilityExpressionTimeout() / 2));
   options.SetIsForUtilityExpr(true);
 
   ExpressionResults result =
@@ -936,7 +937,8 @@ extern "C" {
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
-      5, process->GetUtilityExpressionTimeout() / 2));
+      std::chrono::microseconds(5),
+      process->GetUtilityExpressionTimeout() / 2));
 
   ExpressionResults result = UserExpression::Evaluate(
       context, options, expression, kLoaderDecls, value);

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -8,6 +8,7 @@
 
 #include "PlatformWindows.h"
 
+#include <chrono>
 #include <cstdio>
 #include <optional>
 #if defined(_WIN32)
@@ -422,6 +423,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   // handle currently.
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
+  options.SetOneThreadTimeout(
+      std::min<std::chrono::microseconds>(5, process->GetUtilityExpressionTimeout() / 2));
   options.SetIsForUtilityExpr(true);
 
   ExpressionResults result =
@@ -932,6 +935,8 @@ extern "C" {
   // handle currently.
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
+  options.SetOneThreadTimeout(
+      std::min<std::chrono::microseconds>(5, process->GetUtilityExpressionTimeout() / 2));
 
   ExpressionResults result = UserExpression::Evaluate(
       context, options, expression, kLoaderDecls, value);

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -424,8 +424,7 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
-      std::chrono::microseconds(5),
-      process->GetUtilityExpressionTimeout() / 2));
+      std::chrono::seconds(5), process->GetUtilityExpressionTimeout() / 2));
   options.SetIsForUtilityExpr(true);
 
   ExpressionResults result =
@@ -937,8 +936,7 @@ extern "C" {
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
-      std::chrono::microseconds(5),
-      process->GetUtilityExpressionTimeout() / 2));
+      std::chrono::seconds(5), process->GetUtilityExpressionTimeout() / 2));
 
   ExpressionResults result = UserExpression::Evaluate(
       context, options, expression, kLoaderDecls, value);

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -423,8 +423,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   // handle currently.
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
-  options.SetOneThreadTimeout(
-      std::min<std::chrono::microseconds>(5, process->GetUtilityExpressionTimeout() / 2));
+  options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
+      5, process->GetUtilityExpressionTimeout() / 2));
   options.SetIsForUtilityExpr(true);
 
   ExpressionResults result =
@@ -935,8 +935,8 @@ extern "C" {
   // handle currently.
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
-  options.SetOneThreadTimeout(
-      std::min<std::chrono::microseconds>(5, process->GetUtilityExpressionTimeout() / 2));
+  options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
+      5, process->GetUtilityExpressionTimeout() / 2));
 
   ExpressionResults result = UserExpression::Evaluate(
       context, options, expression, kLoaderDecls, value);


### PR DESCRIPTION
`LoadLibraryW` runs on the debuggee with a timeout of 250ms (the default). On a loaded machine (in CI), this timeout is reached quite often, causing tests failures.

This patch gives both loader helpers an explicit timeout of 5s (clamped to half the overall timeout so the two stay consistent).