### PR TITLE
Fix classof implementation for QuantizedType

### DIFF
--- a/mlir/lib/Dialect/Quant/IR/QuantTypes.cpp
+++ b/mlir/lib/Dialect/Quant/IR/QuantTypes.cpp
@@ -41,7 +41,9 @@ unsigned QuantizedType::getFlags() const {
 }
 
 bool QuantizedType::classof(Type type) {
-  return llvm::isa<QuantDialect>(type.getDialect());
+  return llvm::isa<AnyQuantizedType, UniformQuantizedType,
+                   UniformQuantizedPerAxisType, UniformQuantizedSubChannelType,
+                   CalibratedQuantizedType>(type);
 }
 
 LogicalResult


### PR DESCRIPTION
This PR aims to fix the misleading implementation of `classof` which accepted as a `QuantizedType` every type registered under the `QuantDialect.` 

The now updated implementation makes the checks more restrictive, allowing only direct subtypes of `QuantizedType` to be recognized as a `QuantizedType,` therefore preventing `QuantileType` and other types that are registered under `QuantDialect` to be seen as a subtype of `QuantizedType` and wrongfully use its methods which might lead to potential crashes.