### PR TITLE
[Support] Don't bring PatternMatchHelpers into top-level scope. NFC

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
@@ -17,8 +17,6 @@
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
 #include "llvm/Support/PatternMatchHelpers.h"
 
-using namespace llvm::PatternMatchHelpers;
-
 namespace llvm {
 namespace PatternMatchHelpers {
 template <typename SCEVPtrT> struct match_bind<SCEVUseT<SCEVPtrT>> {
@@ -34,6 +32,8 @@ template <typename SCEVPtrT> struct match_bind<SCEVUseT<SCEVPtrT>> {
 } // namespace PatternMatchHelpers
 
 namespace SCEVPatternMatch {
+
+using namespace llvm::PatternMatchHelpers;
 
 template <typename Pattern> bool match(const SCEV *S, const Pattern &P) {
   return P.match(S);

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -46,10 +46,10 @@
 #include <cstdint>
 #include <utility>
 
-using namespace llvm::PatternMatchHelpers;
-
 namespace llvm {
 namespace PatternMatch {
+
+using namespace llvm::PatternMatchHelpers;
 
 template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
   return P.match(V);

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -20,9 +20,9 @@
 #include "llvm/Support/PatternMatchHelpers.h"
 #include <utility>
 
-using namespace llvm::PatternMatchHelpers;
-
 namespace llvm::VPlanPatternMatch {
+
+using namespace llvm::PatternMatchHelpers;
 
 template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
   return P.match(V);


### PR DESCRIPTION
Otherwise every file that includes any of the PatternMatch.h headers ends up inadvertently bringing it into scope.
