### PR TITLE
[Bazel] Fix Host target's exported headers to include windows

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -648,6 +648,10 @@ cc_library(
             "include/lldb/Host/linux/*.h",
             "include/lldb/Host/posix/*.h",
         ]),
+        "@platforms//os:windows": glob(
+            ["include/lldb/Host/windows/*.h"],
+            exclude = ["include/lldb/Host/windows/ConPTYUtils.h"],
+        ),
     }) + select({
         ":libedit_enabled": ["include/lldb/Host/Editline.h"],
         "//conditions:default": [],


### PR DESCRIPTION
When PR# 201283 added windows os select to the build of the Host target, it missed the exported headers since the CI checks run only linux and mac (and I hadn't gotten to this in my slow slog of windows bazel lldb support).  I found when translating to BUCK and running into this compilation error on windows for buck2 built lldb.  
Still cannot build and claude tells me the exclude is necessary to avoid a duplicate.

claude assisted with bazel rule creation