### PR TITLE
[libsycl] Add missing header include to global_objects.hpp

### DIFF
--- a/libsycl/src/detail/global_objects.hpp
+++ b/libsycl/src/detail/global_objects.hpp
@@ -19,6 +19,7 @@
 #include <sycl/__impl/detail/config.hpp>
 #include <sycl/__impl/exception.hpp>
 
+#include <array>
 #include <map>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Fixes a build error observed on Windows.