### PR TITLE
[MLIR] Remove redundant dialect dependencies

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Affine/Transforms/Passes.td
@@ -439,7 +439,7 @@ def SimplifyAffineWithBounds : Pass<"affine-simplify-with-bounds"> {
     comparisons, this pass can prove equality of dynamic basis products through
     `ValueBoundsConstraintSet`.
   }];
-  let dependentDialects = ["affine::AffineDialect", "arith::ArithDialect"];
+  let dependentDialects = ["arith::ArithDialect"];
 }
 
 def AffineExpandIndexOps : Pass<"affine-expand-index-ops"> {

--- a/mlir/include/mlir/Dialect/ArmSME/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/ArmSME/Transforms/Passes.td
@@ -180,7 +180,7 @@ def OuterProductFusion
     https://mlir.llvm.org/docs/Dialects/ArmSME/#arm_smesmopa_4way-arm_smesmopa_4wayop
   }];
   let constructor = "mlir::arm_sme::createOuterProductFusionPass()";
-  let dependentDialects = ["func::FuncDialect", "arm_sme::ArmSMEDialect"];
+  let dependentDialects = ["func::FuncDialect"];
 }
 
 def VectorLegalization

--- a/mlir/include/mlir/Dialect/Async/Passes.td
+++ b/mlir/include/mlir/Dialect/Async/Passes.td
@@ -43,14 +43,14 @@ def AsyncParallelForPass : Pass<"async-parallel-for", "ModuleOp"> {
 def AsyncToAsyncRuntimePass : Pass<"async-to-async-runtime", "ModuleOp"> {
   let summary = "Lower all high level async operations (e.g. async.execute) to"
                 "the explicit async.runtime and async.coro operations";
-  let dependentDialects = ["async::AsyncDialect", "func::FuncDialect", "cf::ControlFlowDialect"];
+  let dependentDialects = ["func::FuncDialect", "cf::ControlFlowDialect"];
 }
 
 def AsyncFuncToAsyncRuntimePass
     : Pass<"async-func-to-async-runtime", "ModuleOp"> {
   let summary = "Lower async.func operations to the explicit async.runtime and"
                 "async.coro operations";
-  let dependentDialects = ["async::AsyncDialect", "func::FuncDialect"];
+  let dependentDialects = ["func::FuncDialect"];
 }
 
 def AsyncRuntimeRefCountingPass : Pass<"async-runtime-ref-counting"> {
@@ -65,15 +65,11 @@ def AsyncRuntimeRefCountingPass : Pass<"async-runtime-ref-counting"> {
 
     See: https://llvm.org/docs/Coroutines.html#switched-resume-lowering
   }];
-
-  let dependentDialects = ["async::AsyncDialect"];
 }
 
 def AsyncRuntimeRefCountingOptPass : Pass<"async-runtime-ref-counting-opt"> {
   let summary = "Optimize automatic reference counting operations for the"
                 "Async runtime by removing redundant operations";
-
-  let dependentDialects = ["async::AsyncDialect"];
 }
 
 def AsyncRuntimePolicyBasedRefCountingPass
@@ -103,8 +99,6 @@ def AsyncRuntimePolicyBasedRefCountingPass
     This pass introduces significanly less runtime overhead compared to the
     automatic reference counting.
   }];
-
-  let dependentDialects = ["async::AsyncDialect"];
 }
 
 #endif // MLIR_DIALECT_ASYNC_PASSES

--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
@@ -163,8 +163,7 @@ def BufferDeallocationSimplificationPass
     some memref isn't deallocated twice (double free).
   }];
 
-  let dependentDialects = ["mlir::bufferization::BufferizationDialect",
-                           "mlir::arith::ArithDialect",
+  let dependentDialects = ["mlir::arith::ArithDialect",
                            "mlir::memref::MemRefDialect"];
 }
 

--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
@@ -51,7 +51,6 @@ def WrapFuncInClassPass : Pass<"wrap-emitc-func-in-class", "ModuleOp"> {
     }
     ```
   }];
-  let dependentDialects = ["emitc::EmitCDialect"];
   let options = [
       Option<"funcName", "func-name", "std::string",
       /*default=*/[{"operator()"}],
@@ -96,7 +95,6 @@ def MLGOAddReflectionMapPass : Pass<"mlgo-add-reflection-map", "ModuleOp"> {
     }
     ```
   }];
-  let dependentDialects = ["emitc::EmitCDialect"];
   let options = [
     ListOption<"includedFieldAttrs", "included-field-attrs", "std::string",
       "Attribute keys used to extract field names from a field's "

--- a/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
@@ -14,7 +14,6 @@ include "mlir/Pass/PassBase.td"
 def GpuLaunchSinkIndexComputationsPass
     : Pass<"gpu-launch-sink-index-computations"> {
   let summary = "Sink index computations into gpu.launch body";
-  let dependentDialects = ["mlir::gpu::GPUDialect"];
 }
 
 def GpuKernelOutliningPass : Pass<"gpu-kernel-outlining", "ModuleOp"> {
@@ -66,7 +65,6 @@ def GpuEliminateBarriers
     PPoPP 2023 and implementation in Polygeist.
   }];
   let dependentDialects = [
-    "mlir::gpu::GPUDialect",
     "mlir::memref::MemRefDialect",
     "mlir::scf::SCFDialect"
   ];
@@ -84,7 +82,7 @@ def GpuDecomposeMemrefsPass : Pass<"gpu-decompose-memrefs"> {
     `gpu.launch`.
   }];
   let dependentDialects = [
-    "mlir::gpu::GPUDialect", "mlir::memref::MemRefDialect",
+    "mlir::memref::MemRefDialect",
     "mlir::affine::AffineDialect"
   ];
 }

--- a/mlir/include/mlir/Dialect/Linalg/Passes.td
+++ b/mlir/include/mlir/Dialect/Linalg/Passes.td
@@ -80,7 +80,6 @@ def LinalgMorphOpsPass : Pass<"linalg-morph-ops"> {
 def LinalgGeneralizeNamedOpsPass : Pass<"linalg-generalize-named-ops">,
                                    Deprecated<"Use 'linalg-morph-ops' instead."> {
   let summary = "Convert named ops into generic ops";
-  let dependentDialects = ["linalg::LinalgDialect"];
 }
 
 def LinalgSpecializeGenericOpsPass : Pass<"linalg-specialize-generic-ops">,
@@ -93,7 +92,7 @@ def LinalgSpecializeGenericOpsPass : Pass<"linalg-specialize-generic-ops">,
 
 def SimplifyDepthwiseConvPass: Pass<"simplify-depthwise-conv"> {
   let summary = "Simplify depthwise convolution.";
-  let dependentDialects = ["linalg::LinalgDialect", "tensor::TensorDialect"];
+  let dependentDialects = ["tensor::TensorDialect"];
 }
 
 def ConvertElementwiseToLinalgPass : Pass<"convert-elementwise-to-linalg", ""> {
@@ -112,7 +111,7 @@ def ConvertLinalgToAffineLoopsPass : Pass<"convert-linalg-to-affine-loops"> {
   let summary = "Lower the operations from the linalg dialect into affine "
                 "loops";
   let dependentDialects = [
-    "affine::AffineDialect", "linalg::LinalgDialect", "memref::MemRefDialect"];
+    "affine::AffineDialect", "memref::MemRefDialect"];
 }
 
 def ConvertLinalgToLoopsPass : Pass<"convert-linalg-to-loops"> {
@@ -125,7 +124,6 @@ def ConvertLinalgToLoopsPass : Pass<"convert-linalg-to-loops"> {
     bufferization.
   }];
   let dependentDialects = [
-    "linalg::LinalgDialect",
     "scf::SCFDialect",
     "affine::AffineDialect"
   ];
@@ -137,7 +135,6 @@ def ConvertLinalgToParallelLoopsPass
                 "loops";
   let dependentDialects = [
     "affine::AffineDialect",
-    "linalg::LinalgDialect",
     "memref::MemRefDialect",
     "scf::SCFDialect"
   ];
@@ -151,7 +148,7 @@ def LinalgFoldUnitExtentDimsPass : Pass<"linalg-fold-unit-extent-dims", ""> {
            "Generate rank-reducing slices instead of reassociative reshapes">
   ];
   let dependentDialects = [
-    "linalg::LinalgDialect", "affine::AffineDialect", "memref::MemRefDialect"
+    "affine::AffineDialect", "memref::MemRefDialect"
   ];
 }
 
@@ -215,7 +212,7 @@ def LinalgBlockPackMatmul : Pass<"linalg-block-pack-matmul"> {
       %res = unpack %res_packed : 4D <MBxNBxmbxnb> -> 2D <MxN>
     ```
   }];
-  let dependentDialects = ["linalg::LinalgDialect", "tensor::TensorDialect",
+  let dependentDialects = ["tensor::TensorDialect",
                            "arith::ArithDialect",
                            "vector::VectorDialect"];
   let options = [

--- a/mlir/include/mlir/Dialect/Math/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Math/Transforms/Passes.td
@@ -41,7 +41,7 @@ def MathExtendToSupportedTypes : Pass<"math-extend-to-supported-types"> {
     Option<"targetTypeStr", "target-type", "std::string", "\"f32\"",
       "MLIR type to convert the unsupported source types to">,
   ];
-  let dependentDialects = ["math::MathDialect", "arith::ArithDialect"];
+  let dependentDialects = ["arith::ArithDialect"];
 }
 
 def MathExpandOpsPass : Pass<"math-expand-ops"> {
@@ -69,7 +69,6 @@ def MathSincosFusionPass : Pass<"math-sincos-fusion"> {
   let description = [{
     Fuse sin and cos operations into a sincos operation.
   }];
-  let dependentDialects = ["math::MathDialect"];
 }
 
 #endif // MLIR_DIALECT_MATH_TRANSFORMS_PASSES

--- a/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.td
@@ -35,7 +35,7 @@ def FoldMemRefAliasOpsPass : Pass<"fold-memref-alias-ops"> {
     from/to the original memref.
   }];
   let dependentDialects = [
-      "memref::MemRefDialect", "vector::VectorDialect"
+      "vector::VectorDialect"
   ];
 }
 
@@ -183,7 +183,7 @@ def ResolveRankedShapeTypeResultDimsPass
            "Throw an error when pattern rewriter hits iteration limit">,
   ];
   let dependentDialects = [
-    "memref::MemRefDialect", "tensor::TensorDialect"
+    "tensor::TensorDialect"
   ];
 }
 
@@ -201,7 +201,7 @@ def ResolveShapedTypeResultDimsPass : Pass<"resolve-shaped-type-result-dims"> {
            "Throw an error when pattern rewriter hits iteration limit">,
   ];
   let dependentDialects = [
-    "affine::AffineDialect", "memref::MemRefDialect", "tensor::TensorDialect"
+    "affine::AffineDialect", "tensor::TensorDialect"
   ];
 }
 
@@ -263,7 +263,7 @@ def ReifyResultShapesPass : Pass<"reify-result-shapes"> {
     ```
   }];
   let dependentDialects = [
-    "affine::AffineDialect", "memref::MemRefDialect", "tensor::TensorDialect"
+    "affine::AffineDialect", "tensor::TensorDialect"
   ];
 }
 
@@ -285,7 +285,7 @@ def ExpandStridedMetadataPass : Pass<"expand-strided-metadata"> {
     - `memref.subview`
   }];
   let dependentDialects = [
-      "affine::AffineDialect", "memref::MemRefDialect"
+      "affine::AffineDialect"
   ];
 }
 
@@ -326,7 +326,7 @@ def ExpandReallocPass : Pass<"expand-realloc"> {
                         "Emit deallocation operations for the original MemRef">,
   ];
   let dependentDialects = [
-      "arith::ArithDialect", "scf::SCFDialect", "memref::MemRefDialect"
+      "arith::ArithDialect", "scf::SCFDialect"
   ];
 }
 
@@ -336,7 +336,7 @@ def FlattenMemrefsPass : Pass<"flatten-memref"> {
 
   }];
   let dependentDialects = [
-      "affine::AffineDialect", "arith::ArithDialect", "memref::MemRefDialect"
+      "affine::AffineDialect", "arith::ArithDialect"
   ];
 }
 

--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -68,8 +68,7 @@ def ACCImplicitData : Pass<"acc-implicit-data", "mlir::ModuleOp"> {
        - A copy clause if the compute construct is a kernels construct.
        - A firstprivate clause otherwise (parallel, serial).
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect",
-      "mlir::memref::MemRefDialect",
+  let dependentDialects = ["mlir::memref::MemRefDialect",
       "mlir::arith::ArithDialect"];
   let options = [
     Option<"enableImplicitReductionCopy", "enable-implicit-reduction-copy",
@@ -115,7 +114,6 @@ def ACCImplicitDeclare : Pass<"acc-implicit-declare", "mlir::ModuleOp"> {
     - Hoisting non-constant global references that can use implicit mapping
     - Only processing symbols that are not already valid in device regions
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect"];
 }
 
 def ACCImplicitRoutine : Pass<"acc-implicit-routine", "mlir::ModuleOp"> {
@@ -146,7 +144,6 @@ def ACCImplicitRoutine : Pass<"acc-implicit-routine", "mlir::ModuleOp"> {
        implicit routine operations for function calls within these routines,
        while avoiding infinite recursion through proper tracking.
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect"];
   let options = [ AccDeviceTypeOption ];
 }
 
@@ -156,7 +153,7 @@ def ACCDeclareGPUModuleInsertion : Pass<"acc-declare-gpu-module-insertion", "mli
     Copies globals that have the `acc.declare` attribute into the GPU module so
     that device code can reference them.
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect", "mlir::gpu::GPUDialect"];
+  let dependentDialects = ["mlir::gpu::GPUDialect"];
   let options = [
     Option<"cudaUnified", "cuda-unified", "bool", "false",
            "Emit declaration-only device globals for CUDA unified memory.">
@@ -175,8 +172,7 @@ def ACCLegalizeSerial : Pass<"acc-legalize-serial", "mlir::func::FuncOp"> {
     and vector), this conversion is semantically equivalent while enabling code
     reuse in later compilation stages.
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect",
-      "mlir::arith::ArithDialect"];
+  let dependentDialects = ["mlir::arith::ArithDialect"];
 }
 
 
@@ -208,7 +204,6 @@ def ACCEmitRemarksPrivate
     reports the implicit and explicit `private` and `firstprivate` variables it
     carries.
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect"];
 }
 
 def ACCEmitRemarksData : Pass<"acc-emit-remarks-data", "mlir::func::FuncOp"> {
@@ -252,8 +247,7 @@ def ACCLoopTiling : Pass<"acc-loop-tiling", "mlir::func::FuncOp"> {
     - Collapsed loops with tile counts exceeding collapse count
     - Proper handling of loop attributes (gang, worker, vector)
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect",
-      "mlir::arith::ArithDialect"];
+  let dependentDialects = ["mlir::arith::ArithDialect"];
   let options = [
     Option<"defaultTileSize", "default-tile-size", "int32_t", "32",
            "Default tile size to use for wildcard ('*') tile sizes">
@@ -282,7 +276,6 @@ def ACCSpecializeForDevice : Pass<"acc-specialize-for-device", "mlir::func::Func
     - Runtime ops (erased): acc.init, acc.shutdown, acc.set, acc.wait
                   (folded if known): acc.on_device
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect"];
   let options = [
     ListOption<"theDeviceTypes", "the-device-types", "int64_t",
                "List of integers which represent the device we are specializing for">
@@ -313,8 +306,7 @@ def ACCSpecializeForHost : Pass<"acc-specialize-for-host", "mlir::func::FuncOp">
     - Data entry ops (orphan): replaced with var operand
     - In host fallback mode: all data, compute, and runtime ops are removed
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect",
-      "mlir::scf::SCFDialect"];
+  let dependentDialects = ["mlir::scf::SCFDialect"];
   let options = [
     Option<"enableHostFallback", "enable-host-fallback", "bool", "false",
            "Enable host fallback mode which converts ALL ACC operations, "
@@ -354,8 +346,7 @@ def ACCIfClauseLowering : Pass<"acc-if-clause-lowering", "mlir::func::FuncOp"> {
     - Data exit operations (acc.copyout, acc.delete, etc.) are cloned to device path
     - The host path uses `populateACCHostFallbackPatterns` to convert ACC ops
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect",
-      "mlir::scf::SCFDialect"];
+  let dependentDialects = ["mlir::scf::SCFDialect"];
 }
 
 def OffloadLiveInValueCanonicalization : Pass<"offload-livein-value-canonicalization", "mlir::func::FuncOp"> {
@@ -443,7 +434,7 @@ def ACCRecipeMaterialization : Pass<"acc-recipe-materialization", "mlir::ModuleO
     acc.reduction_combine_region for reductions) and removes unused recipe
     symbols.
   }];
-  let dependentDialects = ["mlir::acc::OpenACCDialect", "mlir::arith::ArithDialect"];
+  let dependentDialects = ["mlir::arith::ArithDialect"];
 }
 
 def OffloadTargetVerifier : Pass<"offload-target-verifier", "mlir::func::FuncOp"> {
@@ -498,7 +489,6 @@ def ACCComputeLowering : Pass<"acc-compute-lowering", "mlir::func::FuncOp"> {
        `acc.compute_region`.
   }];
   let dependentDialects = [
-    "mlir::acc::OpenACCDialect",
     "mlir::arith::ArithDialect",
     "mlir::scf::SCFDialect"
   ];
@@ -522,7 +512,6 @@ def ACCRoutineLowering : Pass<"acc-routine-lowering", "mlir::ModuleOp"> {
     external functions are skipped.
   }];
   let dependentDialects = [
-    "mlir::acc::OpenACCDialect",
     "mlir::func::FuncDialect",
     "mlir::scf::SCFDialect"
   ];
@@ -574,7 +563,6 @@ def ACCCGToGPU : InterfacePass<"acc-cg-to-gpu", "mlir::FunctionOpInterface"> {
     "mlir::arith::ArithDialect",
     "mlir::complex::ComplexDialect",
     "mlir::gpu::GPUDialect",
-    "mlir::acc::OpenACCDialect",
     "mlir::scf::SCFDialect",
     "mlir::NVVM::NVVMDialect",
     "mlir::memref::MemRefDialect"

--- a/mlir/include/mlir/Dialect/OpenMP/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenMP/Transforms/Passes.td
@@ -43,7 +43,6 @@ def MarkDeclareTargetPass : Pass<"omp-mark-declare-target", "ModuleOp"> {
     called from within an explicitly marked declare target function or a target
     region (omp.target).
     }];
-  let dependentDialects = ["mlir::omp::OpenMPDialect"];
 }
 
 def PrepareForOMPOffloadPrivatizationPass : Pass<"omp-offload-privatization-prepare", "ModuleOp"> {

--- a/mlir/include/mlir/Dialect/Quant/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Quant/Transforms/Passes.td
@@ -25,7 +25,6 @@ def LowerQuantOps : Pass<"lower-quant-ops", "func::FuncOp"> {
   let dependentDialects = [
     "arith::ArithDialect",
     "linalg::LinalgDialect",
-    "quant::QuantDialect",
     "shape::ShapeDialect",
     "tensor::TensorDialect"
   ];
@@ -66,7 +65,7 @@ def NormalizeQuantTypes : Pass<"normalize-quant-types", "func::FuncOp"> {
     everything as subchannel type.
 
   }];
-  let dependentDialects = ["func::FuncDialect", "quant::QuantDialect"];
+  let dependentDialects = ["func::FuncDialect"];
 }
 
 def StripFuncQuantTypes : Pass<"strip-func-quant-types"> {
@@ -78,10 +77,7 @@ def StripFuncQuantTypes : Pass<"strip-func-quant-types"> {
     at the head of the function's entry block converting the new integer
     argument into the original quantized value.
   }];
-  let dependentDialects = [
-    "func::FuncDialect",
-    "quant::QuantDialect"
-  ];
+  let dependentDialects = ["func::FuncDialect"];
 }
 
 #endif // MLIR_DIALECT_QUANT_TRANSFORMS_PASSES

--- a/mlir/include/mlir/Dialect/Shard/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Shard/Transforms/Passes.td
@@ -39,9 +39,6 @@ def ShardingPropagation : InterfacePass<"sharding-propagation", "mlir::FunctionO
               "backward-forward traversal.")
             )}]>,
   ];
-  let dependentDialects = [
-    "shard::ShardDialect"
-  ];
 }
 
 def ShardSimplify : Pass<"shard-simplify"> {
@@ -55,10 +52,7 @@ def ShardSimplify : Pass<"shard-simplify"> {
       share the same grid and grid_axes.
     - Folding static grid shapes into constants.
   }];
-  let dependentDialects = [
-    "arith::ArithDialect",
-    "shard::ShardDialect"
-  ];
+  let dependentDialects = ["arith::ArithDialect"];
 }
 
 def Partition : InterfacePass<"shard-partition", "mlir::FunctionOpInterface"> {
@@ -114,9 +108,6 @@ def Partition : InterfacePass<"shard-partition", "mlir::FunctionOpInterface"> {
     }
     ```
   }];
-  let dependentDialects = [
-    "shard::ShardDialect"
-  ];
 }
 
 #endif // MLIR_DIALECT_SHARD_TRANSFORMS_PASSES_TD

--- a/mlir/include/mlir/Dialect/SparseTensor/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/SparseTensor/Transforms/Passes.td
@@ -67,7 +67,6 @@ def SparseReinterpretMap : Pass<"sparse-reinterpret-map", "ModuleOp"> {
   let dependentDialects = [
     "affine::AffineDialect",
     "linalg::LinalgDialect",
-    "sparse_tensor::SparseTensorDialect",
   ];
   let options = [
     Option<"scope", "scope", "mlir::ReinterpretMapScope",
@@ -106,7 +105,6 @@ def PreSparsificationRewrite : Pass<"pre-sparsification-rewrite", "ModuleOp"> {
     "linalg::LinalgDialect",
     "memref::MemRefDialect",
     "scf::SCFDialect",
-    "sparse_tensor::SparseTensorDialect",
   ];
 }
 
@@ -219,7 +217,6 @@ def LowerSparseOpsToForeach : Pass<"lower-sparse-ops-to-foreach", "ModuleOp"> {
     "linalg::LinalgDialect",
     "memref::MemRefDialect",
     "scf::SCFDialect",
-    "sparse_tensor::SparseTensorDialect",
   ];
   let options = [
     Option<"enableRuntimeLibrary", "enable-runtime-library", "bool",

--- a/mlir/include/mlir/Dialect/Tensor/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tensor/Transforms/Passes.td
@@ -22,7 +22,7 @@ def FoldTensorSubsetOpsPass : Pass<"fold-tensor-subset-ops"> {
 
   }];
   let dependentDialects = [
-      "affine::AffineDialect", "tensor::TensorDialect", "vector::VectorDialect"
+      "affine::AffineDialect", "vector::VectorDialect"
   ];
 }
 

--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -39,8 +39,7 @@ def TosaInferShapesPass : Pass<"tosa-infer-shapes", "func::FuncOp"> {
 
   let dependentDialects = [
     "func::FuncDialect",
-    "tensor::TensorDialect",
-    "tosa::TosaDialect",
+    "tensor::TensorDialect"
   ];
 
   let options = [
@@ -214,8 +213,7 @@ def TosaNarrowI64ToI32Pass : Pass<"tosa-narrow-i64-to-i32", "func::FuncOp"> {
   ];
 
   let dependentDialects = [
-    "func::FuncDialect",
-    "tosa::TosaDialect",
+    "func::FuncDialect"
   ];
 }
 
@@ -239,8 +237,7 @@ def TosaNarrowF64ToF32Pass : Pass<"tosa-narrow-f64-to-f32", "func::FuncOp"> {
   ];
 
   let dependentDialects = [
-    "func::FuncDialect",
-    "tosa::TosaDialect",
+    "func::FuncDialect"
   ];
 }
 

--- a/mlir/include/mlir/Dialect/XeGPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/XeGPU/Transforms/Passes.td
@@ -37,8 +37,7 @@ def XeGPUPropagateLayout : Pass<"xegpu-propagate-layout"> {
       Propagate the `sg_layout` and `sg_data` fields of the layout attribute.
       Default values are selected to align with hardware.
   }];
-  let dependentDialects = ["memref::MemRefDialect", "xegpu::XeGPUDialect",
-                           "vector::VectorDialect"];
+  let dependentDialects = ["memref::MemRefDialect", "vector::VectorDialect"];
   let options = [Option<
     "printOnly", "print-analysis-only", "bool",
     /*default=*/"false",
@@ -61,9 +60,9 @@ def XeGPUWgToSgDistribute : Pass<"xegpu-wg-to-sg-distribute"> {
     multiple subgroups based on the sg_layout and sg_data attributes.
   }];
 
-  let dependentDialects = ["memref::MemRefDialect", "xegpu::XeGPUDialect",
-                           "vector::VectorDialect", "arith::ArithDialect",
-                           "gpu::GPUDialect", "index::IndexDialect"];
+  let dependentDialects = ["memref::MemRefDialect", "vector::VectorDialect",
+                           "arith::ArithDialect", "gpu::GPUDialect",
+                           "index::IndexDialect"];
 }
 
 def XeGPUBlocking: Pass<"xegpu-blocking"> {
@@ -75,7 +74,7 @@ def XeGPUBlocking: Pass<"xegpu-blocking"> {
     to a hardware instruction.
   }];
   let dependentDialects = [
-      "memref::MemRefDialect", "xegpu::XeGPUDialect", "vector::VectorDialect",
+      "memref::MemRefDialect", "vector::VectorDialect",
       "index::IndexDialect"];
 }
 
@@ -96,7 +95,7 @@ def XeGPUPeepHoleOptimizer : Pass<"xegpu-optimize-peephole"> {
     - Rewriting transpose B loads into more optimal forms to use HW block
       transpose instructions for better performance.
   }];
-  let dependentDialects = ["memref::MemRefDialect", "xegpu::XeGPUDialect",
+  let dependentDialects = ["memref::MemRefDialect",
                            "vector::VectorDialect"];
 }
 
@@ -105,8 +104,8 @@ def XeGPUSgToLaneDistribute : Pass<"xegpu-sg-to-lane-distribute"> {
   let description = [{
     The pass distributes subgroup level XeGPU ops to lane level XeGPU ops.
   }];
-  let dependentDialects = ["memref::MemRefDialect", "xegpu::XeGPUDialect",
-                           "vector::VectorDialect", "index::IndexDialect"];
+  let dependentDialects = ["memref::MemRefDialect", "vector::VectorDialect",
+                           "index::IndexDialect"];
 }
 
 

--- a/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
@@ -50,9 +50,5 @@ struct FormExpressionsPass
     if (failed(applyPatternsGreedily(rootOp, std::move(patterns))))
       return signalPassFailure();
   }
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<emitc::EmitCDialect>();
-  }
 };
 } // namespace

--- a/mlir/lib/Dialect/Shard/Transforms/Partition.cpp
+++ b/mlir/lib/Dialect/Shard/Transforms/Partition.cpp
@@ -898,11 +898,6 @@ struct Partition : public impl::PartitionBase<Partition> {
       return signalPassFailure();
     }
   }
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    reshardingRegisterDependentDialects(registry);
-    registry.insert<shard::ShardDialect>();
-  }
 };
 
 } // namespace


### PR DESCRIPTION
Conservatively remove redundant self-dependencies from transform passes in Affine, ArmSME, Async, Bufferization, EmitC, GPU, Linalg, Math, OpenACC, OpenMP, Shard, SparseTensor, Tensor, TOSA, Quant, and XeGPU. Each affected pass either matches existing entities from its own dialect or requires values, types, attributes, interfaces, or enclosing operations that already ensure the dialect is loaded.

For `FormExpressionsPass`, the TableGen dependency is kept and the duplicate C++ registration is removed. `Partition`  no longer redundantly inserts `ShardDialect` neither from TableGen or its C++ `getDependentDialects()` override.

## Motivation
A dialect is already loaded when the input IR contains registered operations, types, or attributes from that dialect. Therefore, passes that match such existing IR do not need to list their own dialect in `dependentDialects`.

Keeping these self-dependencies can be misleading: omitting them makes it clearer that the pass expects and matches existing dialect operations, types, attributes, or interfaces in its input, rather than introducing the dialect independently.

This also aligns with the documentation for `getDependentDialects()`, which states that a pass should register dialects for which it will create entities:
> "For example, a pass that converts from Linalg to Affine would register the Affine dialect but does not need to register Linalg."

Assisted-by: ChatGPT (refine PR description).