### PR TITLE
[llvm-calc-occupancy] Fix build after SGPR queries moved to TargetParser

### DIFF
--- a/llvm/tools/llvm-calc-occupancy/llvm-calc-occupancy.cpp
+++ b/llvm/tools/llvm-calc-occupancy/llvm-calc-occupancy.cpp
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
   unsigned AddrLocalMem = AMDGPU::IsaInfo::getAddressableLocalMemorySize(STI);
   unsigned AddrVGPRs =
       AMDGPU::IsaInfo::getAddressableNumVGPRs(STI, DynVGPRBlockSizeEff);
-  unsigned AddrSGPRs = AMDGPU::IsaInfo::getAddressableNumSGPRs(STI);
+  unsigned AddrSGPRs = ST.getAddressableNumSGPRs();
   unsigned MaxWGSize = AMDGPU::IsaInfo::getMaxFlatWorkGroupSize();
 
   // Warn about inputs that exceed the hardware's physical capacity: such a


### PR DESCRIPTION
Urgent buildbot fix for #208727.

That PR was developed before #209848, which moved the SGPR count queries into TargetParser and removed `AMDGPU::IsaInfo::getAddressableNumSGPRs()`, so `llvm-calc-occupancy.cpp` fails to compile on current `main`:

```
llvm-calc-occupancy.cpp:229:41: error: no member named 'getAddressableNumSGPRs' in namespace 'llvm::AMDGPU::IsaInfo'
```

This switches to the equivalent `GCNSubtarget::getAddressableNumSGPRs()`, which forwards to the TargetParser version. All other `IsaInfo::*` calls in the file were checked against the new API and are unaffected.

Verified locally: `ninja llvm-calc-occupancy` builds clean, `llvm/test/tools/llvm-calc-occupancy` passes, and the reported addressable SGPR count is unchanged (102 on gfx90a).