### PR TITLE
[libc++] Don't rely on a transitively included BYTE_ORDER in ctype_base

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -12,6 +12,7 @@
 
 #include <__config>
 #include <__configuration/availability.h>
+#include <__configuration/platform.h>
 
 #if _LIBCPP_HAS_LOCALIZATION
 
@@ -345,7 +346,7 @@ public:
   static const mask xdigit = _ISxdigit;
   static const mask blank  = _ISblank;
   _LIBCPP_DIAGNOSTIC_POP
-#    if defined(__mips__) || (BYTE_ORDER == BIG_ENDIAN)
+#    if defined(__mips__) || defined(_LIBCPP_BIG_ENDIAN)
   static const mask __regex_word = static_cast<mask>(_ISbit(15));
 #    else
   static const mask __regex_word = 0x80;


### PR DESCRIPTION
Use libc++'s own _LIBCPP_BIG_ENDIAN macro instead of BYTE_ORDER, which was relied upon from a transitive <endian.h> include on Glibc.