### PR TITLE
[libc++] Add missing includes in the locale headers

### DIFF
--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -29,7 +29,8 @@
 #include <string_view>
 
 #if _LIBCPP_HAS_LOCALIZATION
-#  include <iomanip> // for quoted
+#  include <__locale> // for __narrow_to_utf8 and __widen_from_utf8
+#  include <iomanip>  // for quoted
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -15,6 +15,7 @@
 
 #if _LIBCPP_HAS_LOCALIZATION
 
+#  include <__fwd/ios.h>
 #  include <__locale_dir/locale_base_api.h>
 #  include <__memory/addressof.h>
 #  include <__memory/shared_count.h>
@@ -26,6 +27,7 @@
 #  include <clocale>
 #  include <cstdint>
 #  include <cstdlib>
+#  include <stdexcept>
 #  include <string>
 #  include <text_encoding>
 

--- a/libcxx/include/__locale_dir/num.h
+++ b/libcxx/include/__locale_dir/num.h
@@ -18,6 +18,7 @@
 #include <__config>
 #include <__iterator/istreambuf_iterator.h>
 #include <__iterator/ostreambuf_iterator.h>
+#include <__locale>
 #include <__locale_dir/check_grouping.h>
 #include <__locale_dir/get_c_locale.h>
 #include <__locale_dir/pad_and_output.h>

--- a/libcxx/include/__locale_dir/time.h
+++ b/libcxx/include/__locale_dir/time.h
@@ -11,6 +11,7 @@
 
 #include <__algorithm/copy.h>
 #include <__config>
+#include <__locale>
 #include <__locale_dir/get_c_locale.h>
 #include <__locale_dir/scan_keyword.h>
 #include <ios>

--- a/libcxx/include/__locale_dir/wbuffer_convert.h
+++ b/libcxx/include/__locale_dir/wbuffer_convert.h
@@ -11,6 +11,7 @@
 
 #include <__algorithm/reverse.h>
 #include <__config>
+#include <__locale>
 #include <__string/char_traits.h>
 #include <ios>
 #include <streambuf>

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -320,6 +320,7 @@ typedef basic_stringstream<wchar_t> wstringstream;
 #  if _LIBCPP_HAS_LOCALIZATION
 
 #    include <__fwd/sstream.h>
+#    include <__locale>
 #    include <__ostream/basic_ostream.h>
 #    include <__type_traits/is_convertible.h>
 #    include <__utility/swap.h>


### PR DESCRIPTION
Several headers use entities from `<__locale>` but rely on picking them up transitively, in most cases through `<ios>`. Fix this in preparation for splitting up `<__locale>`.