### PR TITLE
[libc] Fix aligned_alloc used in hermetic tests.

### DIFF
--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -73,6 +73,9 @@ int atexit(void (*func)(void)) { return LIBC_NAMESPACE::atexit(func); }
 void *aligned_alloc(size_t align, size_t s) {
   if (align & (align - 1)) // Must be power of 2
     return nullptr;
+  uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
+  uintptr_t aligned_ptr_val = ((ptr_val + align - 1) / align) * align;
+  ptr = reinterpret_cast<uint8_t *>(aligned_ptr_val);
   s = ((s + align - 1) / align) * align;
   void *mem = ptr;
   ptr += s;

--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -76,7 +76,6 @@ void *aligned_alloc(size_t align, size_t s) {
   uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
   uintptr_t aligned_ptr_val = ((ptr_val + align - 1) / align) * align;
   ptr = reinterpret_cast<uint8_t *>(aligned_ptr_val);
-  s = ((s + align - 1) / align) * align;
   void *mem = ptr;
   ptr += s;
   return static_cast<uint64_t>(ptr - memory) >= MEMORY_SIZE ? nullptr : mem;


### PR DESCRIPTION
Make sure to use provided alignment both for the pointer to the returned memory chunk and the size.

This fixes occasional segfaults in `hsearch` tests after ce62aab97e58c52e6bb0972c49d6fd1aaa6a08a0, since
hash-table bitmask implementation uses SSE2 intrinsics with 16-byte alignment.