### PR TITLE
[Support][Driver][LLDB] Guard WIN32_LEAN_AND_MEAN definitions with #ifndef

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -26,14 +26,14 @@
 #include <cstdio>
 
 #ifdef _WIN32
-  #ifndef WIN32_LEAN_AND_MEAN
-  #define WIN32_LEAN_AND_MEAN
-  #endif
-  #define NOGDI
-  #ifndef NOMINMAX
-    #define NOMINMAX
-  #endif
-  #include <windows.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#define NOGDI
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #endif
 
 using namespace clang::driver;

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -26,7 +26,9 @@
 #include <cstdio>
 
 #ifdef _WIN32
+  #ifndef WIN32_LEAN_AND_MEAN
   #define WIN32_LEAN_AND_MEAN
+  #endif
   #define NOGDI
   #ifndef NOMINMAX
     #define NOMINMAX

--- a/lldb/include/lldb/Host/windows/windows.h
+++ b/lldb/include/lldb/Host/windows/windows.h
@@ -12,7 +12,9 @@
 #define NTDDI_VERSION NTDDI_VISTA
 #undef _WIN32_WINNT // undef a previous definition to avoid warning
 #define _WIN32_WINNT _WIN32_WINNT_VISTA
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #define NOGDI
 #undef NOMINMAX // undef a previous definition to avoid warning
 #define NOMINMAX

--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -26,7 +26,9 @@
 
 // Require at least Windows 7 API.
 #define _WIN32_WINNT 0x0601
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif

--- a/llvm/lib/WindowsDriver/MSVCPaths.cpp
+++ b/llvm/lib/WindowsDriver/MSVCPaths.cpp
@@ -27,7 +27,9 @@
 #endif
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #define NOGDI
 #ifndef NOMINMAX
 #define NOMINMAX


### PR DESCRIPTION
Several Windows headers/TUs unconditionally `#define WIN32_LEAN_AND_MEAN`. When a build predefines the macro on the compiler command line (e.g. a toolchain that passes -DWIN32_LEAN_AND_MEAN, which clang treats as `#define WIN32_LEAN_AND_MEAN 1`), the differing token lists trigger -Wmacro-redefined, which becomes a hard error under -Werror.

Guard the definitions with #ifndef, matching the adjacent NOMINMAX handling and the existing pattern in llvm/lib/Support/rpmalloc/rpmalloc.c. The macro is only a presence flag, so keeping an externally-provided definition is correct.

Sites guarded:
  llvm/include/llvm/Support/Windows/WindowsSupport.h
  llvm/lib/WindowsDriver/MSVCPaths.cpp
  clang/lib/Driver/ToolChains/MSVC.cpp
  lldb/include/lldb/Host/windows/windows.h

Meta ran into this internally building lldb on window after a sync with upstream from July commit, so adding guards would allow us to drop a workaround of ignoring the duplicate defines.

Error:
llvm\include\llvm/Support/Windows/WindowsSupport.h(29,9): error: 'WIN32_LEAN_AND_MEAN' macro redefined [-Werror,-Wmacro-redefined]
   29 | #define WIN32_LEAN_AND_MEAN
      |         ^
<command line>(10,9): note: previous definition is here
   10 | #define WIN32_LEAN_AND_MEAN 1
      |         ^
1 error generated.