### PR TITLE
[tsan] Fix buildgo.sh on FreeBSD/NetBSD

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2490,7 +2490,7 @@ static void DumpSingleReg(ucontext_t *ctx, int RegNum) {
 #      if SANITIZER_LINUX
          ctx->uc_mcontext.gregs[RegNum]
 #      elif SANITIZER_NETBSD
-         ctx->uc_mcontext.__gregs[RegNum]
+         (unsigned long long)ctx->uc_mcontext.__gregs[RegNum]
 #      endif
   );
 #    elif defined(__i386__)

--- a/compiler-rt/lib/tsan/go/buildgo.sh
+++ b/compiler-rt/lib/tsan/go/buildgo.sh
@@ -128,7 +128,7 @@ elif [ "$GOOS" = "freebsd" ]; then
 	# We removed this dependency for Go runtime for other OSes,
 	# and we should remove it for FreeBSD as well, but there is no pressing need.
 	DEPENDS_ON_LIBC=1
-	OSCFLAGS="-fno-strict-aliasing -fPIC -Werror"
+	OSCFLAGS="-fno-strict-aliasing -fPIC -Werror -Wno-unused-template"
 	ARCHCFLAGS="-m64"
 	OSLDFLAGS="-lpthread -fPIC -fpie"
 	SRCS="
@@ -149,7 +149,7 @@ elif [ "$GOOS" = "netbsd" ]; then
 	# We removed this dependency for Go runtime for other OSes,
 	# and we should remove it for NetBSD as well, but there is no pressing need.
 	DEPENDS_ON_LIBC=1
-	OSCFLAGS="-fno-strict-aliasing -fPIC -Werror"
+	OSCFLAGS="-fno-strict-aliasing -fPIC -Werror -Wno-unused-template"
 	ARCHCFLAGS="-m64"
 	OSLDFLAGS="-lpthread -fPIC -fpie"
 	SRCS="

--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -27,6 +27,18 @@
 #include "tsan_platform.h"
 #include "tsan_rtl.h"
 
+#if SANITIZER_NETBSD
+#  // for __lwp_gettcb_fast() / __lwp_getprivate_fast()
+#  define _RTLD_SOURCE
+#  include <sys/types.h>
+#  include <machine/mcontext.h>
+#  undef _RTLD_SOURCE
+#  include <sys/param.h>
+#  if __NetBSD_Version__ >= 1099001200
+#    include <machine/lwp_private.h>
+#  endif
+#endif
+
 #include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>


### PR DESCRIPTION
This patch fixes the remaining compile errors when running `ninja check-all` on FreeBSD and NetBSD:

- `sanitizer_linux.cpp` doesn't compile on NetBSD, so this patch adds a cast:
  ```
  sanitizer_common/sanitizer_linux.cpp:2492:10: error: format specifies type 'unsigned long long' but the argument has type '__greg_t' (aka 'unsigned long') [-Werror,-Wformat] 
   ```

- `tsan_interface_atomic.cpp` doesn't compile on both FreeBSD and NetBSD, so this patch disables the warning:
  ```
  tsan_interface_atomic.cpp:353:12: error: unused function template 'NoTsanAtomic' [-Werror,-Wunused-template]
  tsan_interface_atomic.cpp:358:12: error: unused function template 'Atomic' [-Werror,-Wunused-template]
  tsan_interface_atomic.cpp:389:12: error: unused function template 'NoTsanAtomic' [-Werror,-Wunused-template] 
  tsan_interface_atomic.cpp:394:12: error: unused function template 'Atomic' [-Werror,-Wunused-template]
  tsan_interface_atomic.cpp:401:12: error: unused function template 'NoTsanAtomic' [-Werror,-Wunused-template]
  tsan_interface_atomic.cpp:406:12: error: unused function template 'Atomic' [-Werror,-Wunused-template]
  ```

- `sanitizer_linux_libcdep.cpp` doesn't compile on NetBSD:
  ``` 
  sanitizer_linux_libcdep.cpp:527:27: error: use of undeclared identifier '__lwp_getprivate_fast'; did you mean '_lwp_getprivate'?
  ```
  This is the same issue already handled in `tsan_platform_linux.cpp`: to expose the `__lwp_getprivate_fast` definition in `<machine/mcontext.h>`, `_RTLD_SOURCE` needs to be defined before `<machine/mcontext.h>` is included (indirectly from `<signal.h>` in this case).  It also needs to include `<sys/types.h>` to get a definition of the `__aligned` macro.

Tested on `amd64-pc-freebsd15.1` and `amd64-pc-netbsd10.1`.