### PR TITLE
[analyzer] Require x86 target for Analysis/string-search-modeling.c

### DIFF
--- a/clang/test/Analysis/string-search-modeling.c
+++ b/clang/test/Analysis/string-search-modeling.c
@@ -12,6 +12,8 @@
 // RUN:   -analyzer-checker=debug.ExprInspection \
 // RUN:   -analyzer-config eagerly-assume=false
 
+// REQUIRES: x86-registered-target
+
 typedef __SIZE_TYPE__ size_t;
 void *malloc(size_t size);
 void free(void *p);


### PR DESCRIPTION
This is a fixup to #212124.
The Solaris/sparcv9 build bot failure was reported in: https://github.com/llvm/llvm-project/pull/212124#issuecomment-5130635364

Build bot failure:
https://lab.llvm.org/buildbot/#/builders/13/builds/14261

```
# RUN: at line 3
/opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/bin/clang -cc1 -internal-isystem /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/lib/clang/24/include -nostdsysteminc -analyze -setup-static-analyzer -std=c17 -verify /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c    -analyzer-checker=core,unix    -analyzer-checker=debug.ExprInspection    -analyzer-config eagerly-assume=false
# executed command: /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/bin/clang -cc1 -internal-isystem /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/lib/clang/24/include -nostdsysteminc -analyze -setup-static-analyzer -std=c17 -verify /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c -analyzer-checker=core,unix -analyzer-checker=debug.ExprInspection -analyzer-config eagerly-assume=false
# RUN: at line 10
/opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/bin/clang -cc1 -internal-isystem /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/lib/clang/24/include -nostdsysteminc -analyze -setup-static-analyzer -triple x86_64-scei-ps4 -std=c17 -verify /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c    -analyzer-checker=core,unix    -analyzer-checker=debug.ExprInspection    -analyzer-config eagerly-assume=false
# executed command: /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/bin/clang -cc1 -internal-isystem /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/lib/clang/24/include -nostdsysteminc -analyze -setup-static-analyzer -triple x86_64-scei-ps4 -std=c17 -verify /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c -analyzer-checker=core,unix -analyzer-checker=debug.ExprInspection -analyzer-config eagerly-assume=false
# .---command stderr------------
# | error: 'expected-warning' diagnostics expected but not seen:
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 528: TRUE
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 539: TRUE
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 551: TRUE
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 565: TRUE
# | error: 'expected-warning' diagnostics seen but not expected:
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 528: FALSE [debug.ExprInspection]
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 539: FALSE [debug.ExprInspection]
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 551: FALSE [debug.ExprInspection]
# |   File /opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/llvm/clang/test/Analysis/string-search-modeling.c Line 565: FALSE [debug.ExprInspection]
# | 8 errors generated.
# `-----------------------------
# error: command failed with exit status: 1
```