### PR TITLE
[PoC][ASan] Allow address sanitizer to preserve topbits of sanitized pointer

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -475,6 +475,10 @@ STATISTIC(NumOptimizedAccessesToGlobalVar,
           "Number of optimized accesses to global vars");
 STATISTIC(NumOptimizedAccessesToStackVar,
           "Number of optimized accesses to stack vars");
+static cl::opt<unsigned> ClAsanPreserveTopBits(
+    "asan-preserve-topbits",
+    cl::desc("Number of address top bits to preserve during shadow mapping"),
+    cl::Hidden, cl::init(0));
 
 namespace {
 
@@ -488,6 +492,7 @@ struct ShadowMapping {
   uint64_t Offset;
   bool OrShadowOffset;
   bool InGlobal;
+  unsigned PreserveTopBits;
 };
 
 } // end anonymous namespace
@@ -623,6 +628,7 @@ static ShadowMapping getShadowMapping(const Triple &TargetTriple, int LongSize,
                            !(Mapping.Offset & (Mapping.Offset - 1)) &&
                            Mapping.Offset != kDynamicShadowSentinel;
   Mapping.InGlobal = ClWithIfunc && IsAndroid && IsArmOrThumb;
+  Mapping.PreserveTopBits = ClAsanPreserveTopBits;
 
   return Mapping;
 }
@@ -1431,19 +1437,41 @@ Value *AddressSanitizer::memToShadow(Value *Shadow, IRBuilder<> &IRB) {
     Shadow = IRB.CreateAnd(Shadow,
                            ConstantInt::get(IntptrTy, ~(uint64_t(0x0f) << 56)));
   }
-  // Shadow >> scale
-  Shadow = IRB.CreateLShr(Shadow, Mapping.Scale);
-  if (Mapping.Offset == 0) return Shadow;
-  // (Shadow >> scale) | offset
+  // PtrMask to ensure bit operations stay in platform address range
+  uint64_t PtrMask = IntptrTy->getIntegerBitWidth() == 64
+                         ? ~0ULL
+                         : ((1ULL << IntptrTy->getIntegerBitWidth()) - 1);
+
   Value *ShadowBase;
   if (LocalDynamicShadow)
     ShadowBase = LocalDynamicShadow;
   else
-    ShadowBase = ConstantInt::get(IntptrTy, Mapping.Offset);
+    ShadowBase = ConstantInt::get(IntptrTy, Mapping.Offset & PtrMask);
+
+  if (Mapping.PreserveTopBits > 0) {
+    unsigned BitWidth = IntptrTy->getIntegerBitWidth();
+    uint64_t PreservedMask = 0;
+    if (Mapping.PreserveTopBits < BitWidth)
+      PreservedMask = (~0ULL << (BitWidth - Mapping.PreserveTopBits)) & PtrMask;
+    uint64_t OffsetMask = ~PreservedMask & PtrMask;
+
+    Value *TopBits =
+        IRB.CreateAnd(Shadow, ConstantInt::get(IntptrTy, PreservedMask));
+    Value *BottomBits =
+        IRB.CreateAnd(Shadow, ConstantInt::get(IntptrTy, OffsetMask));
+    BottomBits = IRB.CreateLShr(BottomBits, Mapping.Scale);
+    Shadow = IRB.CreateOr(TopBits, BottomBits);
+    return IRB.CreateAdd(Shadow, ShadowBase);
+  }
+
+  // Shadow >> scale
+  Shadow = IRB.CreateLShr(Shadow, Mapping.Scale);
+  if (Mapping.Offset == 0)
+    return Shadow;
+  // (Shadow >> scale) | offset
   if (Mapping.OrShadowOffset)
     return IRB.CreateOr(Shadow, ShadowBase);
-  else
-    return IRB.CreateAdd(Shadow, ShadowBase);
+  return IRB.CreateAdd(Shadow, ShadowBase);
 }
 
 // Instrument memset/memmove/memcpy

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -476,7 +476,7 @@ STATISTIC(NumOptimizedAccessesToGlobalVar,
 STATISTIC(NumOptimizedAccessesToStackVar,
           "Number of optimized accesses to stack vars");
 static cl::opt<unsigned> ClAsanPreserveTopBits(
-    "asan-preserve-topbits",
+    "asan-preserve-top-bits",
     cl::desc("Number of address top bits to preserve during shadow mapping"),
     cl::Hidden, cl::init(0));
 

--- a/llvm/test/Instrumentation/AddressSanitizer/address-preserve-top-bits.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/address-preserve-top-bits.ll
@@ -1,5 +1,5 @@
-; RUN: opt < %s -passes=asan -asan-preserve-topbits=4 -S -mtriple=x86_64-unknown-linux-gnu | FileCheck %s --check-prefixes=CHECK,CHECK-64
-; RUN: opt < %s -passes=asan -asan-preserve-topbits=4 -S -mtriple=arm-none-eabi | FileCheck %s --check-prefixes=CHECK,CHECK-32
+; RUN: opt < %s -passes=asan -asan-preserve-top-bits=4 -S -mtriple=x86_64-unknown-linux-gnu | FileCheck %s --check-prefixes=CHECK,CHECK-64
+; RUN: opt < %s -passes=asan -asan-preserve-top-bits=4 -S -mtriple=arm-none-eabi | FileCheck %s --check-prefixes=CHECK,CHECK-32
 
 define void @test(ptr %p) sanitize_address {
 ; CHECK-LABEL: define void @test(

--- a/llvm/test/Instrumentation/AddressSanitizer/address-preserve-topbits.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/address-preserve-topbits.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -passes=asan -asan-preserve-topbits=4 -S -mtriple=x86_64-unknown-linux-gnu | FileCheck %s --check-prefixes=CHECK,CHECK-64
+; RUN: opt < %s -passes=asan -asan-preserve-topbits=4 -S -mtriple=arm-none-eabi | FileCheck %s --check-prefixes=CHECK,CHECK-32
+
+define void @test(ptr %p) sanitize_address {
+; CHECK-LABEL: define void @test(
+; CHECK-SAME: ptr [[P:%.*]])
+entry:
+; CHECK-NEXT: entry:
+; CHECK-64-NEXT:   [[ADDR:%[0-9]+]] = ptrtoint ptr [[P]] to i64
+; CHECK-64-NEXT:   [[TOP:%[0-9]+]] = and i64 [[ADDR]], -1152921504606846976
+; CHECK-64-NEXT:   [[BOTTOM:%[0-9]+]] = and i64 [[ADDR]], 1152921504606846975
+; CHECK-64-NEXT:   [[BOTTOM_SHR:%[0-9]+]] = lshr i64 [[BOTTOM]], 3
+; CHECK-64-NEXT:   [[SHADOW:%[0-9]+]] = or i64 [[TOP]], [[BOTTOM_SHR]]
+; CHECK-64-NEXT:   [[SHADOW_ADDR:%[0-9]+]] = add i64 [[SHADOW]], 2147450880
+
+; CHECK-32-NEXT:   [[ADDR:%[0-9]+]] = ptrtoint ptr [[P]] to i32
+; CHECK-32-NEXT:   [[TOP:%[0-9]+]] = and i32 [[ADDR]], -268435456
+; CHECK-32-NEXT:   [[BOTTOM:%[0-9]+]] = and i32 [[ADDR]], 268435455
+; CHECK-32-NEXT:   [[BOTTOM_SHR:%[0-9]+]] = lshr i32 [[BOTTOM]], 3
+; CHECK-32-NEXT:   [[SHADOW:%[0-9]+]] = or i32 [[TOP]], [[BOTTOM_SHR]]
+; CHECK-32-NEXT:   [[SHADOW_ADDR:%[0-9]+]] = add i32 [[SHADOW]], 536870912
+
+; CHECK-NEXT:   [[SHADOW_PTR:%[0-9]+]] = inttoptr {{i(64|32)}} [[SHADOW_ADDR]] to ptr
+; CHECK-NEXT:   [[SHADOW_BYTE:%[0-9]+]] = load i8, ptr [[SHADOW_PTR]], align 1
+; CHECK-NEXT:   [[IS_POISONED:%[0-9]+]] = icmp ne i8 [[SHADOW_BYTE]], 0
+; CHECK-NEXT:   br i1 [[IS_POISONED]], label %[[L_REPORT:[0-9]+]], label %[[L_STORE:[0-9]+]]
+
+  store i32 0, ptr %p, align 4
+  ret void
+}


### PR DESCRIPTION
Some baremetal environments use top bits to represent the zone of memory mapping; asan should preserve the top bits and maps the shadow to corresponding region. This may also apply to architectures that allow user to apply arbitrary pointer tagging at topbits; which should be preserved or at least ruled out when computing shadow address.

Assisted-by: Gemini based automation tools (human-in-the-loop)