### PR TITLE
[CodeGen] Fix PeepholeOpt ext reuse for earlier same-block uses

### DIFF
--- a/llvm/lib/CodeGen/PeepholeOptimizer.cpp
+++ b/llvm/lib/CodeGen/PeepholeOptimizer.cpp
@@ -67,6 +67,7 @@
 
 #include "llvm/CodeGen/PeepholeOptimizer.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -858,8 +859,15 @@ bool PeepholeOptimizer::optimizeExtInstr(
 
     MachineBasicBlock *UseMBB = UseMI->getParent();
     if (UseMBB == &MBB) {
-      // Local uses that come after the extension.
-      if (!LocalMIs.count(UseMI))
+      // Only rewrite local uses that come after the extension. LocalMIs tracks
+      // instructions already visited during the forward scan, but other
+      // peephole rewrites (e.g. foldLoadInto) can insert new instructions
+      // earlier in this block. Membership in LocalMIs is therefore not a
+      // reliable same-block dominance check; walk forward from MI instead.
+      MachineBasicBlock::iterator It = MI.getIterator();
+      ++It;
+      if (llvm::any_of(llvm::make_range(It, MBB.end()),
+                       [UseMI](const MachineInstr &I) { return &I == UseMI; }))
         Uses.push_back(&UseMO);
     } else if (ReachedBBs.count(UseMBB)) {
       // Non-local uses where the result of the extension is used. Always

--- a/llvm/test/CodeGen/X86/pr212497-peephole-ext-reuse.ll
+++ b/llvm/test/CodeGen/X86/pr212497-peephole-ext-reuse.ll
@@ -1,0 +1,51 @@
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu -O1 -verify-machineinstrs -o /dev/null
+
+; Regression test for https://github.com/llvm/llvm-project/issues/212497
+;
+; PeepholeOpt's optimizeExtInstr must not reuse the result of a zero-extend for
+; a same-block use that occurs *before* the extend. Doing so previously inserted
+; `%x = COPY %ext.sub_8bit` ahead of `%ext = MOVZX ...`, which failed machine
+; verification ("Virtual register defs don't dominate all uses").
+
+@a = dso_local global i32 0, align 4
+@b = dso_local local_unnamed_addr global i32 0, align 4
+@c = dso_local local_unnamed_addr global i8 0, align 1
+@d = dso_local local_unnamed_addr global i32 0, align 4
+@e = dso_local local_unnamed_addr global i32 0, align 4
+
+declare void @f(i32 noundef)
+
+define dso_local noundef i32 @main() local_unnamed_addr {
+  %1 = load i32, ptr @b, align 4
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %19, label %3
+
+3:
+  %4 = load i32, ptr @d, align 4
+  %5 = icmp eq i32 %4, 0
+  %6 = zext i1 %5 to i32
+  store i32 %6, ptr @e, align 4
+  store i32 %6, ptr @b, align 4
+  %7 = load i8, ptr @c, align 1
+  %8 = zext i1 %5 to i8
+  %9 = icmp eq i8 %7, %8
+  %10 = select i1 %9, i32 2, i32 0
+  br i1 %9, label %14, label %11
+
+11:
+  %12 = load volatile i32, ptr @a, align 4
+  %13 = icmp ne i32 %12, 0
+  br label %14
+
+14:
+  %15 = phi i1 [ true, %3 ], [ %13, %11 ]
+  %16 = zext i1 %15 to i32
+  store i32 %16, ptr @b, align 4
+  tail call void @f(i32 noundef %10)
+  %17 = load i32, ptr @b, align 4
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %19, label %3
+
+19:
+  ret i32 0
+}


### PR DESCRIPTION

- Fix `PeepholeOptimizer::optimizeExtInstr` so same-block source uses are rewritten only when they appear after the extension instruction.
- Stop treating `LocalMIs` membership as a dominance check; other peephole rewrites can insert instructions earlier in the block.
- Add an X86 regression test for the #212497 verifier failure.

Fixes #212497
