### PR TITLE
[lldb] Only preload a Module's symbols once

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -1122,6 +1122,7 @@ protected:
   std::atomic<bool> m_did_load_objfile{false};
   std::atomic<bool> m_did_load_symfile{false};
   std::atomic<bool> m_did_set_uuid{false};
+  std::atomic<bool> m_did_preload_symbols{false};
   mutable bool m_file_has_changed : 1,
       m_first_file_changed_log : 1; /// See if the module was modified after it
                                     /// was initially opened.

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1336,6 +1336,9 @@ void Module::FindSymbolsMatchingRegExAndType(
 }
 
 void Module::PreloadSymbols() {
+  if (m_did_preload_symbols.exchange(true))
+    return;
+
   LockedPtr<SymbolFile> sym_file = GetSymbolFileLocked();
   if (!sym_file)
     return;
@@ -1409,6 +1412,7 @@ void Module::SetSymbolFileFileSpec(const FileSpec &file) {
   m_symfile_spec = file;
   m_symfile_up.reset();
   m_did_load_symfile = false;
+  m_did_preload_symbols = false;
 }
 
 bool Module::IsExecutable() {


### PR DESCRIPTION
Creating several targets for the same file concurrently could deadlock.

Targets share Module objects. Therefore, each concurrent `SBDebugger::CreateTarget()` call creates a `PreloadSymbols()` task for the *same* Module. The thread pool running those tasks can pick up a duplicate preload task for the same Module. The mutex used by the Module is recursive, so the thread starts the task again, enters the same `std::call_once` and deadlocks.

Preloading only needs to happen once: it does work taht a later lookup would do anyway. If it's already in progress, skip it. This deduplicate the task that causes the deadlock.

At desk, this fixes a timeout in `api/multiple-targets/TestMultipleTargets.py`, roughly 1/40 runs. To reproduce the issue, I shrunk the thread pool to 2 threads, which makes it always timeout.