### PR TITLE
[libc++] Remove __constexpr_isinf

### DIFF
--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -70,15 +70,15 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 // isinf
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-[[__nodiscard__]] constexpr _LIBCPP_HIDE_FROM_ABI bool __isinf(_A1) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool __isinf(_A1) _NOEXCEPT {
   return false;
 }
 
-[[__nodiscard__]] inline constexpr _LIBCPP_HIDE_FROM_ABI bool __isinf(float __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool __isinf(float __x) _NOEXCEPT {
   return __builtin_isinf(__x);
 }
 
-[[__nodiscard__]] inline constexpr _LIBCPP_HIDE_FROM_ABI
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
 #ifdef _LIBCPP_PREFERRED_OVERLOAD
 _LIBCPP_PREFERRED_OVERLOAD
 #endif
@@ -86,7 +86,7 @@ _LIBCPP_PREFERRED_OVERLOAD
   return __builtin_isinf(__x);
 }
 
-[[__nodiscard__]] inline constexpr _LIBCPP_HIDE_FROM_ABI bool __isinf(long double __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool __isinf(long double __x) _NOEXCEPT {
   return __builtin_isinf(__x);
 }
 

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -70,25 +70,29 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 // isinf
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isinf(_A1) _NOEXCEPT {
+[[__nodiscard__]] constexpr _LIBCPP_HIDE_FROM_ABI bool __isinf(_A1) _NOEXCEPT {
   return false;
 }
 
-[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isinf(float __x) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _LIBCPP_HIDE_FROM_ABI bool __isinf(float __x) _NOEXCEPT {
   return __builtin_isinf(__x);
 }
 
-[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI
+[[__nodiscard__]] inline constexpr _LIBCPP_HIDE_FROM_ABI
 #ifdef _LIBCPP_PREFERRED_OVERLOAD
 _LIBCPP_PREFERRED_OVERLOAD
 #endif
-    bool
-    isinf(double __x) _NOEXCEPT {
+    bool __isinf(double __x) _NOEXCEPT {
   return __builtin_isinf(__x);
 }
 
-[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isinf(long double __x) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _LIBCPP_HIDE_FROM_ABI bool __isinf(long double __x) _NOEXCEPT {
   return __builtin_isinf(__x);
+}
+
+template <class _Tp>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isinf(_Tp __x) _NOEXCEPT {
+  return __math::__isinf(__x);
 }
 
 // isnan
@@ -106,8 +110,7 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 #ifdef _LIBCPP_PREFERRED_OVERLOAD
 _LIBCPP_PREFERRED_OVERLOAD
 #endif
-    bool
-    isnan(double __x) _NOEXCEPT {
+    bool isnan(double __x) _NOEXCEPT {
   return __builtin_isnan(__x);
 }
 

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -557,20 +557,6 @@ using ::scalbnl _LIBCPP_USING_IF_EXISTS;
 using ::tgammal _LIBCPP_USING_IF_EXISTS;
 using ::truncl _LIBCPP_USING_IF_EXISTS;
 
-template <class _A1, __enable_if_t<is_floating_point<_A1>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool __constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT {
-#  if __has_builtin(__builtin_isinf)
-  return __builtin_isinf(__lcpp_x);
-#  else
-  return isinf(__lcpp_x);
-#  endif
-}
-
-template <class _A1, __enable_if_t<!is_floating_point<_A1>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool __constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT {
-  return std::isinf(__lcpp_x);
-}
-
 #  if _LIBCPP_STD_VER >= 20
 template <typename _Fp>
 _LIBCPP_HIDE_FROM_ABI constexpr _Fp __lerp(_Fp __a, _Fp __b, _Fp __t) noexcept {

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -317,10 +317,8 @@ constexpr long double lerp(long double a, long double b, long double t) noexcept
 #else
 #  include <__config>
 #  include <__math/hypot.h>
-#  include <__type_traits/enable_if.h>
 #  include <__type_traits/is_arithmetic.h>
 #  include <__type_traits/is_constant_evaluated.h>
-#  include <__type_traits/is_floating_point.h>
 #  include <__type_traits/is_same.h>
 #  include <__type_traits/promote.h>
 #  include <__type_traits/remove_cv.h>

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -263,6 +263,7 @@ template<class T> complex<T> tanh (const complex<T>&);
 #  include <__cstddef/size_t.h>
 #  include <__fwd/complex.h>
 #  include <__fwd/tuple.h>
+#  include <__math/traits.h>
 #  include <__tuple/tuple_element.h>
 #  include <__tuple/tuple_size.h>
 #  include <__type_traits/conditional.h>
@@ -972,9 +973,9 @@ template <class _Tp, __enable_if_t<is_same<_Tp, float>::value, int> = 0>
 
 template <class _Tp>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Tp norm(const complex<_Tp>& __c) {
-  if (std::__constexpr_isinf(__c.real()))
+  if (__math::__isinf(__c.real()))
     return std::abs(__c.real());
-  if (std::__constexpr_isinf(__c.imag()))
+  if (__math::__isinf(__c.imag()))
     return std::abs(__c.imag());
   return __c.real() * __c.real() + __c.imag() * __c.imag();
 }


### PR DESCRIPTION
Instead of reimplementing __constexpr_isinf, reuse what we already have in <__math/traits.h>. The gymnastics to create an internal __isinf is simply to avoid making the public std::isinf constexpr before C++23.