### PR TITLE
[CIR] Implement fenv lowering to constrained intrinsic calls

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -73,8 +73,20 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 //
 // If you want fully customized LLVM IR lowering logic, simply exclude the
 // `llvmOp` field from your CIR operation definition.
+//
+// The `constrainedLLVMIntrinsic` field enables a specialized variant of this
+// generated lowering for floating-point operations that carry an optional
+// `fenv` attribute. When it is set and the operation has an `fenv` attribute
+// the operation is lowering to a call to the corresponding constrained fp
+// intrinsic. If `constrainedLLVMIntrinsic` is set `llvmOp` must be set as well.
+//
+// `constrainedLLVMIntrinsicHasRoundingMode` indicates whether the constrained
+// intrinsic takes a rounding-mode metadata argument in addition to the
+// exception-behavior metadata argument.
 class LLVMLoweringInfo {
   string llvmOp = "";
+  string constrainedLLVMIntrinsic = "";
+  bit constrainedLLVMIntrinsicHasRoundingMode = true;
 }
 
 class LoweringBuilders<dag p> {
@@ -2861,6 +2873,8 @@ class CIR_FPBinaryOp<string mnemonic, list<Trait> traits = []>
                    !listconcat(CIR_FenvOpTraits, traits),
                    CIR_DynamicMemoryEffects> {
   let arguments = !con(commonArgs, (ins OptionalAttr<CIR_FenvAttr>:$fenv));
+
+  let constrainedLLVMIntrinsic = mnemonic;
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$lhs, "mlir::Value":$rhs), [{
@@ -7040,6 +7054,8 @@ def CIR_PtrDiffOp : CIR_Op<"ptr_diff", [Pure, SameTypeOperands]> {
 // Floating Point Ops
 //===----------------------------------------------------------------------===//
 
+// The optional `fenv` attribute describes constraints on the floating-point
+// handling of the operation.
 class CIR_UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
     : CIR_Op<mnemonic,
              !listconcat([SameOperandsAndResultType], CIR_FenvOpTraits)>
@@ -7057,6 +7073,7 @@ class CIR_UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
   ];
 
   let llvmOp = llvmOpName;
+  let constrainedLLVMIntrinsic = mnemonic;
 }
 
 def CIR_SqrtOp : CIR_UnaryFPToFPBuiltinOp<"sqrt", "SqrtOp"> {
@@ -7118,6 +7135,8 @@ def CIR_CeilOp : CIR_UnaryFPToFPBuiltinOp<"ceil", "FCeilOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_CosOp : CIR_UnaryFPToFPBuiltinOp<"cos", "CosOp"> {
@@ -7230,6 +7249,8 @@ def CIR_RoundOp : CIR_UnaryFPToFPBuiltinOp<"round", "RoundOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_RoundEvenOp : CIR_UnaryFPToFPBuiltinOp<"roundeven", "RoundEvenOp"> {
@@ -7240,6 +7261,8 @@ def CIR_RoundEvenOp : CIR_UnaryFPToFPBuiltinOp<"roundeven", "RoundEvenOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_SinOp : CIR_UnaryFPToFPBuiltinOp<"sin", "SinOp"> {
@@ -7290,6 +7313,8 @@ def CIR_TruncOp : CIR_UnaryFPToFPBuiltinOp<"trunc", "FTruncOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_FAbsOp : CIR_UnaryFPToFPBuiltinOp<"fabs", "FAbsOp"> {
@@ -7300,6 +7325,10 @@ def CIR_FAbsOp : CIR_UnaryFPToFPBuiltinOp<"fabs", "FAbsOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  // fabs is exact and does not raise exceptions, so it is always lowered to
+  // the plain llvm.fabs intrinsic.
+  let constrainedLLVMIntrinsic = "";
 }
 
 def CIR_AbsOp : CIR_Op<"abs", [Pure, SameOperandsAndResultType]> {
@@ -7346,6 +7375,8 @@ def CIR_FloorOp : CIR_UnaryFPToFPBuiltinOp<"floor", "FFloorOp"> {
     %y = cir.floor %x : !cir.double
     ```
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 class CIR_UnaryFPToIntBuiltinOp<string mnemonic, string llvmOpName>
@@ -7371,6 +7402,7 @@ class CIR_UnaryFPToIntBuiltinOp<string mnemonic, string llvmOpName>
   ];
 
   let llvmOp = llvmOpName;
+  let constrainedLLVMIntrinsic = mnemonic;
 }
 
 def CIR_LroundOp : CIR_UnaryFPToIntBuiltinOp<"lround", "LroundOp"> {
@@ -7379,6 +7411,8 @@ def CIR_LroundOp : CIR_UnaryFPToIntBuiltinOp<"lround", "LroundOp"> {
     `cir.lround` rounds a floating-point value to the nearest integer value,
     rounding halfway cases away from zero, and returns the result as a `long`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_LlroundOp : CIR_UnaryFPToIntBuiltinOp<"llround", "LlroundOp"> {
@@ -7388,6 +7422,8 @@ def CIR_LlroundOp : CIR_UnaryFPToIntBuiltinOp<"llround", "LlroundOp"> {
     rounding halfway cases away from zero, and returns the result as a
     `long long`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_LrintOp : CIR_UnaryFPToIntBuiltinOp<"lrint", "LrintOp"> {
@@ -7441,6 +7477,9 @@ def CIR_CopysignOp : CIR_BinaryFPToFPBuiltinOp<"copysign", "CopySignOp"> {
     `cir.copysign` returns a value with the magnitude of the first operand
     and the sign of the second operand.
   }];
+
+  // copysign is exact and does not raise exceptions, so it is always lowered
+  // to the plain llvm.copysign intrinsic.
 }
 
 def CIR_FMaxNumOp : CIR_BinaryFPToFPBuiltinOp<"fmaxnum", "MaxNumOp"> {
@@ -7459,6 +7498,9 @@ def CIR_FMaximumOp : CIR_BinaryFPToFPBuiltinOp<"fmaximum", "MaximumOp"> {
     `cir.fmaximum` returns the larger of its two operands according to
     IEEE 754-2019 semantics. If either operand is NaN, NaN is returned.
   }];
+
+  let constrainedLLVMIntrinsic = "maximum";
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_FMinNumOp : CIR_BinaryFPToFPBuiltinOp<"fminnum", "MinNumOp"> {
@@ -7477,6 +7519,9 @@ def CIR_FMinimumOp : CIR_BinaryFPToFPBuiltinOp<"fminimum", "MinimumOp"> {
     `cir.fminimum` returns the smaller of its two operands according to
     IEEE 754-2019 semantics. If either operand is NaN, NaN is returned.
   }];
+
+  let constrainedLLVMIntrinsic = "minimum";
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_FModOp : CIR_BinaryFPToFPBuiltinOp<"fmod", "FRemOp"> {
@@ -7485,6 +7530,9 @@ def CIR_FModOp : CIR_BinaryFPToFPBuiltinOp<"fmod", "FRemOp"> {
     `cir.fmod` computes the floating-point remainder of dividing the first
     operand by the second operand.
   }];
+
+  // fmod maps to the constrained frem intrinsic.
+  let constrainedLLVMIntrinsic = "frem";
 }
 
 def CIR_PowOp : CIR_BinaryFPToFPBuiltinOp<"pow", "PowOp"> {
@@ -7493,6 +7541,8 @@ def CIR_PowOp : CIR_BinaryFPToFPBuiltinOp<"pow", "PowOp"> {
     `cir.pow` computes the first operand raised to the power of the second
     operand.
   }];
+
+  let constrainedLLVMIntrinsic = "pow";
 }
 
 def CIR_ATan2Op : CIR_BinaryFPToFPBuiltinOp<"atan2", "ATan2Op"> {
@@ -7501,6 +7551,8 @@ def CIR_ATan2Op : CIR_BinaryFPToFPBuiltinOp<"atan2", "ATan2Op"> {
     `cir.atan2` computes the arc tangent of the first operand divided by the
     second operand, using the signs of both to determine the quadrant.
   }];
+
+  let constrainedLLVMIntrinsic = "atan2";
 }
 
 def CIR_FrexpOp : CIR_Op<"frexp", [Pure]> {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -460,25 +460,105 @@ void convertSideEffectForCall(mlir::Operation *callOp, bool isNothrow,
 static mlir::LLVM::CallIntrinsicOp
 createCallLLVMIntrinsicOp(mlir::ConversionPatternRewriter &rewriter,
                           mlir::Location loc, const llvm::Twine &intrinsicName,
-                          mlir::Type resultTy, mlir::ValueRange operands) {
+                          mlir::Type resultTy, mlir::ValueRange operands,
+                          mlir::LLVM::FastmathFlags fastmathFlags = {}) {
   auto intrinsicNameAttr =
       mlir::StringAttr::get(rewriter.getContext(), intrinsicName);
-  // CallIntrinsicOp has distinct void / single-result create overloads.
+  auto fmfAttr =
+      mlir::LLVM::FastmathFlagsAttr::get(rewriter.getContext(), fastmathFlags);
+  // CallIntrinsicOp has distinct void / result create overloads. The FMF
+  // builders take a TypeRange for results.
   if (resultTy)
-    return mlir::LLVM::CallIntrinsicOp::create(rewriter, loc, resultTy,
-                                               intrinsicNameAttr, operands);
+    return mlir::LLVM::CallIntrinsicOp::create(
+        rewriter, loc, mlir::TypeRange{resultTy}, intrinsicNameAttr, operands,
+        fmfAttr);
   return mlir::LLVM::CallIntrinsicOp::create(rewriter, loc, intrinsicNameAttr,
-                                             operands);
+                                             operands, fmfAttr);
 }
 
 static mlir::LLVM::CallIntrinsicOp replaceOpWithCallLLVMIntrinsicOp(
     mlir::ConversionPatternRewriter &rewriter, mlir::Operation *op,
     const llvm::Twine &intrinsicName, mlir::Type resultTy,
-    mlir::ValueRange operands) {
+    mlir::ValueRange operands, mlir::LLVM::FastmathFlags fastmathFlags = {}) {
   mlir::LLVM::CallIntrinsicOp callIntrinOp = createCallLLVMIntrinsicOp(
-      rewriter, op->getLoc(), intrinsicName, resultTy, operands);
+      rewriter, op->getLoc(), intrinsicName, resultTy, operands, fastmathFlags);
   rewriter.replaceOp(op, callIntrinOp.getOperation());
   return callIntrinOp;
+}
+
+static llvm::StringRef getConstrainedRoundingMetadata(cir::FenvAttr fenv) {
+  std::optional<cir::FPDynamicRoundingMode> rounding =
+      fenv.getDynamicRoundingMode();
+  if (!rounding)
+    return "round.tonearest";
+  switch (*rounding) {
+  case cir::FPDynamicRoundingMode::ToNearest:
+    return "round.tonearest";
+  case cir::FPDynamicRoundingMode::Downward:
+    return "round.downward";
+  case cir::FPDynamicRoundingMode::Upward:
+    return "round.upward";
+  case cir::FPDynamicRoundingMode::UpwardZero:
+    return "round.towardzero";
+  case cir::FPDynamicRoundingMode::ToNearestAway:
+    return "round.tonearestaway";
+  case cir::FPDynamicRoundingMode::Unknown:
+    return "round.dynamic";
+  }
+  llvm_unreachable("unknown FP dynamic rounding mode");
+}
+
+static llvm::StringRef getConstrainedExceptMetadata(cir::FenvAttr fenv) {
+  mlir::BoolAttr strictExcept = fenv.getStrictExcept();
+  if (!strictExcept)
+    return "fpexcept.ignore";
+  return strictExcept.getValue() ? "fpexcept.strict" : "fpexcept.maytrap";
+}
+
+static mlir::Value
+createFenvMetadataValue(mlir::ConversionPatternRewriter &rewriter,
+                        mlir::Location loc, llvm::StringRef str) {
+  auto mdString = mlir::LLVM::MDStringAttr::get(
+      rewriter.getContext(), mlir::StringAttr::get(rewriter.getContext(), str));
+  return mlir::LLVM::MetadataAsValueOp::create(rewriter, loc, mdString);
+}
+
+mlir::LogicalResult lowerToConstrainedFPIntrinsic(
+    mlir::Operation *op, mlir::ValueRange operands, cir::FenvAttr fenv,
+    mlir::Type llvmResTy, mlir::ConversionPatternRewriter &rewriter,
+    llvm::StringRef constrainedMnemonic, bool hasRoundingMode,
+    mlir::LLVM::FastmathFlags fastmathFlags) {
+  mlir::Location loc = op->getLoc();
+  llvm::SmallVector<mlir::Value> callOperands(operands.begin(), operands.end());
+  if (hasRoundingMode)
+    callOperands.push_back(createFenvMetadataValue(
+        rewriter, loc, getConstrainedRoundingMetadata(fenv)));
+  callOperands.push_back(createFenvMetadataValue(
+      rewriter, loc, getConstrainedExceptMetadata(fenv)));
+
+  replaceOpWithCallLLVMIntrinsicOp(
+      rewriter, op, "llvm.experimental.constrained." + constrainedMnemonic,
+      llvmResTy, callOperands, fastmathFlags);
+  return mlir::success();
+}
+
+template <typename LLVMOp>
+mlir::LogicalResult lowerConstrainableFPOp(
+    mlir::Operation *op, mlir::ValueRange operands, cir::FenvAttr fenv,
+    const mlir::TypeConverter &typeConverter,
+    mlir::ConversionPatternRewriter &rewriter,
+    llvm::StringRef constrainedMnemonic, bool hasRoundingMode) {
+  mlir::Type llvmResTy = typeConverter.convertType(op->getResultTypes()[0]);
+  if (!llvmResTy)
+    return op->emitError("expected LLVM result type for floating-point op");
+
+  if (!fenv) {
+    rewriter.replaceOpWithNewOp<LLVMOp>(op, llvmResTy, operands);
+    return mlir::success();
+  }
+
+  return lowerToConstrainedFPIntrinsic(op, operands, fenv, llvmResTy, rewriter,
+                                       constrainedMnemonic, hasRoundingMode);
 }
 
 mlir::LogicalResult CIRToLLVMLLVMIntrinsicCallOpLowering::matchAndRewrite(
@@ -1473,7 +1553,15 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
       return mlir::cast<cir::FPTypeInterface>(ty).getWidth();
     };
 
-    if (getFloatWidth(srcTy) > getFloatWidth(dstTy))
+    bool isTrunc = getFloatWidth(srcTy) > getFloatWidth(dstTy);
+    if (cir::FenvAttr fenv = castOp.getFenvAttr()) {
+      // fptrunc takes rounding mode + exception behavior; fpext takes only
+      // exception behavior.
+      return lowerToConstrainedFPIntrinsic(
+          castOp, llvmSrcVal, fenv, llvmDstTy, rewriter,
+          isTrunc ? "fptrunc" : "fpext", /*hasRoundingMode=*/isTrunc);
+    }
+    if (isTrunc)
       rewriter.replaceOpWithNewOp<mlir::LLVM::FPTruncOp>(castOp, llvmDstTy,
                                                          llvmSrcVal);
     else
@@ -1543,8 +1631,15 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     mlir::Type dstTy = castOp.getType();
     mlir::Value llvmSrcVal = adaptor.getSrc();
     mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
-    if (mlir::cast<cir::IntType>(elementTypeIfVector(castOp.getSrc().getType()))
-            .isSigned())
+    bool isSigned =
+        mlir::cast<cir::IntType>(elementTypeIfVector(castOp.getSrc().getType()))
+            .isSigned();
+    if (cir::FenvAttr fenv = castOp.getFenvAttr()) {
+      return lowerToConstrainedFPIntrinsic(
+          castOp, llvmSrcVal, fenv, llvmDstTy, rewriter,
+          isSigned ? "sitofp" : "uitofp", /*hasRoundingMode=*/true);
+    }
+    if (isSigned)
       rewriter.replaceOpWithNewOp<mlir::LLVM::SIToFPOp>(castOp, llvmDstTy,
                                                         llvmSrcVal);
     else
@@ -1556,8 +1651,15 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     mlir::Type dstTy = castOp.getType();
     mlir::Value llvmSrcVal = adaptor.getSrc();
     mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
-    if (mlir::cast<cir::IntType>(elementTypeIfVector(castOp.getType()))
-            .isSigned())
+    bool isSigned =
+        mlir::cast<cir::IntType>(elementTypeIfVector(castOp.getType()))
+            .isSigned();
+    if (cir::FenvAttr fenv = castOp.getFenvAttr()) {
+      return lowerToConstrainedFPIntrinsic(
+          castOp, llvmSrcVal, fenv, llvmDstTy, rewriter,
+          isSigned ? "fptosi" : "fptoui", /*hasRoundingMode=*/false);
+    }
+    if (isSigned)
       rewriter.replaceOpWithNewOp<mlir::LLVM::FPToSIOp>(castOp, llvmDstTy,
                                                         llvmSrcVal);
     else
@@ -1824,6 +1926,10 @@ mlir::LogicalResult CIRToLLVMFMaxNumOpLowering::matchAndRewrite(
     cir::FMaxNumOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Type resTy = typeConverter->convertType(op.getType());
+  if (cir::FenvAttr fenv = op.getFenvAttr())
+    return lowerToConstrainedFPIntrinsic(
+        op, adaptor.getOperands(), fenv, resTy, rewriter, "maxnum",
+        /*hasRoundingMode=*/false, mlir::LLVM::FastmathFlags::nsz);
   rewriter.replaceOpWithNewOp<mlir::LLVM::MaxNumOp>(
       op, resTy, adaptor.getLhs(), adaptor.getRhs(),
       mlir::LLVM::FastmathFlags::nsz);
@@ -1834,6 +1940,10 @@ mlir::LogicalResult CIRToLLVMFMinNumOpLowering::matchAndRewrite(
     cir::FMinNumOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Type resTy = typeConverter->convertType(op.getType());
+  if (cir::FenvAttr fenv = op.getFenvAttr())
+    return lowerToConstrainedFPIntrinsic(
+        op, adaptor.getOperands(), fenv, resTy, rewriter, "minnum",
+        /*hasRoundingMode=*/false, mlir::LLVM::FastmathFlags::nsz);
   rewriter.replaceOpWithNewOp<mlir::LLVM::MinNumOp>(
       op, resTy, adaptor.getLhs(), adaptor.getRhs(),
       mlir::LLVM::FastmathFlags::nsz);
@@ -3160,6 +3270,65 @@ convertCmpKindToFCmpPredicate(cir::CmpOpKind kind) {
   llvm_unreachable("Unknown CmpOpKind");
 }
 
+static llvm::StringRef
+convertCmpKindToConstrainedFCmpPredicate(cir::CmpOpKind kind) {
+  using CIR = cir::CmpOpKind;
+  switch (kind) {
+  case CIR::eq:
+    return "oeq";
+  case CIR::ne:
+    return "une";
+  case CIR::lt:
+    return "olt";
+  case CIR::le:
+    return "ole";
+  case CIR::gt:
+    return "ogt";
+  case CIR::ge:
+    return "oge";
+  case CIR::one:
+    return "one";
+  case CIR::uno:
+    return "uno";
+  }
+  llvm_unreachable("Unknown CmpOpKind");
+}
+
+static bool isSignalingConstrainedFCmp(cir::CmpOpKind kind) {
+  using CIR = cir::CmpOpKind;
+  switch (kind) {
+  case CIR::lt:
+  case CIR::le:
+  case CIR::gt:
+  case CIR::ge:
+    return true;
+  case CIR::eq:
+  case CIR::ne:
+  case CIR::one:
+  case CIR::uno:
+    return false;
+  }
+  llvm_unreachable("Unknown CmpOpKind");
+}
+
+static mlir::LLVM::CallIntrinsicOp
+createConstrainedFCmpCall(mlir::ConversionPatternRewriter &rewriter,
+                          mlir::Location loc, mlir::Value lhs, mlir::Value rhs,
+                          cir::CmpOpKind kind, cir::FenvAttr fenv,
+                          mlir::Type llvmResTy) {
+  llvm::SmallVector<mlir::Value, 4> callOperands = {
+      lhs, rhs,
+      createFenvMetadataValue(rewriter, loc,
+                              convertCmpKindToConstrainedFCmpPredicate(kind)),
+      createFenvMetadataValue(rewriter, loc,
+                              getConstrainedExceptMetadata(fenv))};
+  llvm::StringRef intrinsicName = isSignalingConstrainedFCmp(kind)
+                                      ? "llvm.experimental.constrained.fcmps"
+                                      : "llvm.experimental.constrained.fcmp";
+  return createCallLLVMIntrinsicOp(rewriter, loc, intrinsicName, llvmResTy,
+                                   callOperands);
+}
+
 mlir::LogicalResult CIRToLLVMCmpOpLowering::matchAndRewrite(
     cir::CmpOp cmpOp, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -3188,6 +3357,14 @@ mlir::LogicalResult CIRToLLVMCmpOpLowering::matchAndRewrite(
   }
 
   if (mlir::isa<cir::FPTypeInterface>(type)) {
+    mlir::Type llvmResTy = getTypeConverter()->convertType(cmpOp.getType());
+    if (cir::FenvAttr fenv = cmpOp.getFenvAttr()) {
+      mlir::LLVM::CallIntrinsicOp call = createConstrainedFCmpCall(
+          rewriter, cmpOp.getLoc(), adaptor.getLhs(), adaptor.getRhs(),
+          cmpOp.getKind(), fenv, llvmResTy);
+      rewriter.replaceOp(cmpOp, call.getResult(0));
+      return mlir::success();
+    }
     mlir::LLVM::FCmpPredicate kind =
         convertCmpKindToFCmpPredicate(cmpOp.getKind());
     rewriter.replaceOpWithNewOp<mlir::LLVM::FCmpOp>(
@@ -4507,9 +4684,19 @@ mlir::LogicalResult CIRToLLVMVecCmpOpLowering::matchAndRewrite(
         convertCmpKindToICmpPredicate(op.getKind(), intType.isSigned()),
         adaptor.getLhs(), adaptor.getRhs());
   } else if (mlir::isa<cir::FPTypeInterface>(elementType)) {
-    bitResult = mlir::LLVM::FCmpOp::create(
-        rewriter, op.getLoc(), convertCmpKindToFCmpPredicate(op.getKind()),
-        adaptor.getLhs(), adaptor.getRhs());
+    if (cir::FenvAttr fenv = op.getFenvAttr()) {
+      auto i1VecTy = mlir::VectorType::get(
+          mlir::cast<cir::VectorType>(op.getLhs().getType()).getSize(),
+          rewriter.getI1Type());
+      bitResult = createConstrainedFCmpCall(rewriter, op.getLoc(),
+                                            adaptor.getLhs(), adaptor.getRhs(),
+                                            op.getKind(), fenv, i1VecTy)
+                      .getResult(0);
+    } else {
+      bitResult = mlir::LLVM::FCmpOp::create(
+          rewriter, op.getLoc(), convertCmpKindToFCmpPredicate(op.getKind()),
+          adaptor.getLhs(), adaptor.getRhs());
+    }
   } else {
     return op.emitError() << "unsupported type for VecCmpOp: " << elementType;
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -81,6 +81,19 @@ private:
   int32_t blockTagOpIndex;
 };
 
+mlir::LogicalResult lowerToConstrainedFPIntrinsic(
+    mlir::Operation *op, mlir::ValueRange operands, cir::FenvAttr fenv,
+    mlir::Type llvmResTy, mlir::ConversionPatternRewriter &rewriter,
+    llvm::StringRef constrainedMnemonic, bool hasRoundingMode,
+    mlir::LLVM::FastmathFlags fastmathFlags = {});
+
+template <typename LLVMOp>
+mlir::LogicalResult lowerConstrainableFPOp(
+    mlir::Operation *op, mlir::ValueRange operands, cir::FenvAttr fenv,
+    const mlir::TypeConverter &typeConverter,
+    mlir::ConversionPatternRewriter &rewriter,
+    llvm::StringRef constrainedMnemonic, bool hasRoundingMode);
+
 #define GET_LLVM_LOWERING_PATTERNS
 #include "clang/CIR/Dialect/IR/CIRLowering.inc"
 #undef GET_LLVM_LOWERING_PATTERNS

--- a/clang/test/CIR/Lowering/fenv.cir
+++ b/clang/test/CIR/Lowering/fenv.cir
@@ -1,0 +1,222 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module {
+  // CHECK-LABEL: llvm.func @fadd_variants
+  cir.func @fadd_variants(%a: !cir.float, %b: !cir.float) {
+    // CHECK: %[[RM:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %[[RM]], %[[EB]]) : (f32, f32, !llvm.metadata, !llvm.metadata) -> f32
+    %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+
+    // CHECK: llvm.fadd %{{.*}}, %{{.*}} : f32
+    %1 = cir.fadd %a, %b : !cir.float
+
+    // CHECK: %[[RM2:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: %[[EB2:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.ignore">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %[[RM2]], %[[EB2]]) : (f32, f32, !llvm.metadata, !llvm.metadata) -> f32
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<>}
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @rounding_modes
+  cir.func @rounding_modes(%a: !cir.float, %b: !cir.float) {
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.downward">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %1 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = downward>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.upward">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = upward>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.towardzero">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %3 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearestaway">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %4 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearestaway>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.dynamic">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %5 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = unknown>}
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @exception_behaviors
+  cir.func @exception_behaviors(%a: !cir.float, %b: !cir.float) {
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.maytrap">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %1 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<strict_except = false>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.ignore">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @all_binops
+  cir.func @all_binops(%a: !cir.double, %b: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %0 = cir.fadd %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fsub"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %1 = cir.fsub %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fmul"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %2 = cir.fmul %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fdiv"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %3 = cir.fdiv %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.frem"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %4 = cir.frem %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @vector_binop
+  cir.func @vector_binop(%a: !cir.vector<4 x !cir.float>,
+                         %b: !cir.vector<4 x !cir.float>) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (vector<4xf32>, vector<4xf32>, !llvm.metadata, !llvm.metadata) -> vector<4xf32>
+    %0 = cir.fadd %a, %b : !cir.vector<4 x !cir.float> {fenv = #cir.fenv<strict_except = true>}
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @unary_fp_builtins
+  cir.func @unary_fp_builtins(%a: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.cos"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, !llvm.metadata, !llvm.metadata) -> f64
+    %0 = cir.cos %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.sqrt"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, !llvm.metadata, !llvm.metadata) -> f64
+    %1 = cir.sqrt %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.ceil"(%{{.*}}, %[[EB]]) : (f64, !llvm.metadata) -> f64
+    %2 = cir.ceil %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.intr.fabs(%{{.*}}) : (f64) -> f64
+    %3 = cir.fabs %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.intr.cos(%{{.*}}) : (f64) -> f64
+    %4 = cir.cos %a : !cir.double
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @binary_fp_builtins
+  cir.func @binary_fp_builtins(%a: !cir.double, %b: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.pow"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %0 = cir.pow %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.atan2"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %1 = cir.atan2 %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.frem"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %2 = cir.fmod %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.maximum"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata) -> f64
+    %3 = cir.fmaximum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.minimum"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata) -> f64
+    %4 = cir.fminimum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.intr.copysign(%{{.*}}, %{{.*}}) : (f64, f64) -> f64
+    %5 = cir.copysign %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @minmax_num
+  cir.func @minmax_num(%a: !cir.double, %b: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.maxnum"(%{{.*}}, %{{.*}}, %{{.*}}) {fastmathFlags = #llvm.fastmath<nsz>} : (f64, f64, !llvm.metadata) -> f64
+    %0 = cir.fmaxnum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.minnum"(%{{.*}}, %{{.*}}, %{{.*}}) {fastmathFlags = #llvm.fastmath<nsz>} : (f64, f64, !llvm.metadata) -> f64
+    %1 = cir.fminnum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.intr.maxnum(%{{.*}}, %{{.*}}) {fastmathFlags = #llvm.fastmath<nsz>} : (f64, f64) -> f64
+    %2 = cir.fmaxnum %a, %b : !cir.double
+    // CHECK: llvm.intr.minnum(%{{.*}}, %{{.*}}) {fastmathFlags = #llvm.fastmath<nsz>} : (f64, f64) -> f64
+    %3 = cir.fminnum %a, %b : !cir.double
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @fp_casts
+  cir.func @fp_casts(%a: !cir.float, %b: !cir.double, %i: !s32i) {
+    // CHECK: %[[RM:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fptrunc"(%{{.*}}, %[[RM]], %[[EB]]) : (f64, !llvm.metadata, !llvm.metadata) -> f32
+    %0 = cir.cast floating %b : !cir.double -> !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[EB2:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fpext"(%{{.*}}, %[[EB2]]) : (f32, !llvm.metadata) -> f64
+    %1 = cir.cast floating %a : !cir.float -> !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.sitofp"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !llvm.metadata, !llvm.metadata) -> f32
+    %2 = cir.cast int_to_float %i : !s32i -> !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fptosi"(%{{.*}}, %{{.*}}) : (f32, !llvm.metadata) -> i32
+    %3 = cir.cast float_to_int %a : !cir.float -> !s32i {fenv = #cir.fenv<strict_except = true>}
+    // Without fenv the plain LLVM cast ops are used.
+    // CHECK: llvm.fptrunc %{{.*}} : f64 to f32
+    %4 = cir.cast floating %b : !cir.double -> !cir.float
+    // CHECK: llvm.fpext %{{.*}} : f32 to f64
+    %5 = cir.cast floating %a : !cir.float -> !cir.double
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @fp_cmp
+  cir.func @fp_cmp(%a: !cir.float, %b: !cir.float) {
+    // CHECK: %[[PRED:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"olt">
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmps"(%{{.*}}, %{{.*}}, %[[PRED]], %[[EB]]) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %0 = cir.cmp lt %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_LE:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"ole">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmps"(%{{.*}}, %{{.*}}, %[[PRED_LE]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %1 = cir.cmp le %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_GT:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"ogt">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmps"(%{{.*}}, %{{.*}}, %[[PRED_GT]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %2 = cir.cmp gt %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_GE:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"oge">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmps"(%{{.*}}, %{{.*}}, %[[PRED_GE]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %3 = cir.cmp ge %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_EQ:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"oeq">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmp"(%{{.*}}, %{{.*}}, %[[PRED_EQ]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %4 = cir.cmp eq %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_NE:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"une">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmp"(%{{.*}}, %{{.*}}, %[[PRED_NE]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %5 = cir.cmp ne %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_ONE:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"one">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmp"(%{{.*}}, %{{.*}}, %[[PRED_ONE]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %6 = cir.cmp one %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[PRED_UNO:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"uno">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fcmp"(%{{.*}}, %{{.*}}, %[[PRED_UNO]], %{{.*}}) : (f32, f32, !llvm.metadata, !llvm.metadata) -> i1
+    %7 = cir.cmp uno %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.fcmp "olt" %{{.*}}, %{{.*}} : f32
+    %8 = cir.cmp lt %a, %b : !cir.float
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @fp_vec_cmp
+  cir.func @fp_vec_cmp(%a: !cir.vector<4 x !cir.float>,
+                       %b: !cir.vector<4 x !cir.float>) {
+    // CHECK: %[[PRED:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"ogt">
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: %[[CMP:.*]] = llvm.call_intrinsic "llvm.experimental.constrained.fcmps"(%{{.*}}, %{{.*}}, %[[PRED]], %[[EB]]) : (vector<4xf32>, vector<4xf32>, !llvm.metadata, !llvm.metadata) -> vector<4xi1>
+    // CHECK: llvm.sext %[[CMP]] : vector<4xi1> to vector<4xi32>
+    %0 = cir.vec.cmp(gt, %a, %b) : !cir.vector<4 x !cir.float>, !cir.vector<4 x !s32i> {
+      fenv = #cir.fenv<strict_except = true>
+    }
+    // CHECK: %[[PRED_EQ:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"oeq">
+    // CHECK: %[[CMP_EQ:.*]] = llvm.call_intrinsic "llvm.experimental.constrained.fcmp"(%{{.*}}, %{{.*}}, %[[PRED_EQ]], %{{.*}}) : (vector<4xf32>, vector<4xf32>, !llvm.metadata, !llvm.metadata) -> vector<4xi1>
+    // CHECK: llvm.sext %[[CMP_EQ]] : vector<4xi1> to vector<4xi32>
+    %1 = cir.vec.cmp(eq, %a, %b) : !cir.vector<4 x !cir.float>, !cir.vector<4 x !s32i> {
+      fenv = #cir.fenv<strict_except = true>
+    }
+    // CHECK: llvm.fcmp "olt" %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: llvm.sext %{{.*}} : vector<4xi1> to vector<4xi32>
+    %2 = cir.vec.cmp(lt, %a, %b) : !cir.vector<4 x !cir.float>, !cir.vector<4 x !s32i>
+    cir.return
+  }
+
+  // CHECK-LABEL: llvm.func @unary_fp_to_int_builtins
+  cir.func @unary_fp_to_int_builtins(%a: !cir.double) {
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.lround"(%{{.*}}, %[[EB]]) : (f64, !llvm.metadata) -> i64
+    %0 = cir.lround %a : !cir.double -> !s64i {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.llround"(%{{.*}}, %{{.*}}) : (f64, !llvm.metadata) -> i64
+    %1 = cir.llround %a : !cir.double -> !s64i {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: %[[RM:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: %[[EB2:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.lrint"(%{{.*}}, %[[RM]], %[[EB2]]) : (f64, !llvm.metadata, !llvm.metadata) -> i64
+    %2 = cir.lrint %a : !cir.double -> !s64i {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.llrint"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, !llvm.metadata, !llvm.metadata) -> i64
+    %3 = cir.llrint %a : !cir.double -> !s64i {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.intr.lround(%{{.*}}) : (f64) -> i64
+    %4 = cir.lround %a : !cir.double -> !s64i
+    cir.return
+  }
+}

--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -134,11 +134,11 @@ void GenerateABILoweringPattern(llvm::StringRef OpName,
   CXXABILoweringPatterns.push_back(std::move(CodeBuffer));
 }
 
-void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
-                                 llvm::StringRef PatternName, bool IsRecursive,
-                                 llvm::StringRef ExtraDecl,
-                                 const Record *CustomCtorRec,
-                                 llvm::StringRef LLVMOp, bool HasZeroResult) {
+void GenerateLLVMLoweringPattern(
+    llvm::StringRef OpName, llvm::StringRef PatternName, bool IsRecursive,
+    llvm::StringRef ExtraDecl, const Record *CustomCtorRec,
+    llvm::StringRef LLVMOp, llvm::StringRef ConstrainedLLVMIntrinsic,
+    bool ConstrainedHasRoundingMode, bool HasZeroResult) {
   std::optional<CustomLoweringCtor> CustomCtor =
       parseCustomLoweringCtor(CustomCtorRec);
   std::string CodeBuffer;
@@ -182,7 +182,25 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
 
   Code << "  }\n\n";
 
-  if (!LLVMOp.empty()) {
+  if (!ConstrainedLLVMIntrinsic.empty()) {
+    // Generate a matchAndRewrite body for a floating-point operation that
+    // carries an optional `fenv` attribute. The shared `lowerConstrainableFPOp`
+    // helper lowers to the plain `llvmOp` when no `fenv` attribute is present
+    // and to a call to the constrained floating-point intrinsic when one is.
+    assert(!LLVMOp.empty() && "constrainedLLVMIntrinsic requires llvmOp");
+    Code
+        << "  mlir::LogicalResult matchAndRewrite(cir::" << OpName
+        << " op, OpAdaptor adaptor, mlir::ConversionPatternRewriter &rewriter) "
+           "const override {\n";
+    Code << "    return lowerConstrainableFPOp<mlir::LLVM::" << LLVMOp
+         << ">(\n";
+    Code << "        op, adaptor.getOperands(), op.getFenvAttr(),\n";
+    Code << "        *getTypeConverter(), rewriter, \""
+         << ConstrainedLLVMIntrinsic << "\",\n";
+    Code << "        /*hasRoundingMode=*/"
+         << (ConstrainedHasRoundingMode ? "true" : "false") << ");\n";
+    Code << "  }\n";
+  } else if (!LLVMOp.empty()) {
     // Generate the matchAndRewrite body automatically.
     Code
         << "  mlir::LogicalResult matchAndRewrite(cir::" << OpName
@@ -234,6 +252,10 @@ void Generate(const Record *OpRecord) {
         OpRecord->getValueAsString("extraLLVMLoweringPatternDecl");
 
     llvm::StringRef LLVMOp = OpRecord->getValueAsString("llvmOp");
+    llvm::StringRef ConstrainedLLVMIntrinsic =
+        OpRecord->getValueAsString("constrainedLLVMIntrinsic");
+    bool ConstrainedHasRoundingMode =
+        OpRecord->getValueAsBit("constrainedLLVMIntrinsicHasRoundingMode");
 
     if (!LLVMOp.empty() && CustomCtor)
       PrintFatalError(OpRecord->getLoc(),
@@ -241,10 +263,17 @@ void Generate(const Record *OpRecord) {
                           "' has both llvmOp and a custom lowering "
                           "constructor, which is not supported");
 
+    if (!ConstrainedLLVMIntrinsic.empty() && LLVMOp.empty())
+      PrintFatalError(OpRecord->getLoc(),
+                      "op '" + OpName +
+                          "' has constrainedLLVMIntrinsic set but no llvmOp, "
+                          "which is not supported");
+
     const DagInit *ResultsDag = OpRecord->getValueAsDag("results");
     bool IsZeroResult = ResultsDag->getNumArgs() == 0;
     GenerateLLVMLoweringPattern(OpName, PatternName, IsRecursive, ExtraDecl,
-                                CustomCtor, LLVMOp, IsZeroResult);
+                                CustomCtor, LLVMOp, ConstrainedLLVMIntrinsic,
+                                ConstrainedHasRoundingMode, IsZeroResult);
     // Only automatically register patterns that use the default constructor.
     // Patterns with a custom constructor must be manually registered by the
     // lowering pass.


### PR DESCRIPTION
This change adds support for lowering floating-point operations with the fenv attribute set to a call to the corresponding constrained intrinsic when the operation is lowered to the LLVM dialect.

Generation of operations with the Fenv attribute set will be implemented in a later change. This only adds support for lowering.

Assisted-by: Cursor / claude-opus-4.8