### PR TITLE
[clang][X86] Enable non-global SSP on FreeBSD

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
+++ b/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
@@ -546,7 +546,8 @@ unsigned X86TargetLowering::getAddressSpace() const {
 
 static bool hasStackGuardSlotTLS(const Triple &TargetTriple) {
   return TargetTriple.isOSGlibc() || TargetTriple.isMusl() ||
-         TargetTriple.isOSFuchsia() || TargetTriple.isAndroid();
+         TargetTriple.isOSFuchsia() || TargetTriple.isAndroid() ||
+         TargetTriple.IsOSFreeBSD();
 }
 
 static Constant* SegmentOffset(IRBuilderBase &IRB,


### PR DESCRIPTION
The `tls` flavor of the `-mstack-protector-guard` flag is currently ignored on FreeBSD.
The `-fstack-protector-strong` option will emit global SSP instructions even if `-mstack-protector-guard=tls` is passed which is interfering with ongoing work for implementing per-thread SSP in the FreeBSD kernel. 

Fix this by checking for FreeBSD in `hasStackGuardSlotTLS`.