### PR TITLE
[libc++] Remove unused headers from <cmath>

### DIFF
--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -316,15 +316,11 @@ constexpr long double lerp(long double a, long double b, long double t) noexcept
 #  include <__cxx03/cmath>
 #else
 #  include <__config>
-#  include <__math/hypot.h>
 #  include <__type_traits/enable_if.h>
 #  include <__type_traits/is_arithmetic.h>
-#  include <__type_traits/is_constant_evaluated.h>
 #  include <__type_traits/is_floating_point.h>
 #  include <__type_traits/is_same.h>
 #  include <__type_traits/promote.h>
-#  include <__type_traits/remove_cv.h>
-#  include <limits>
 #  include <version>
 
 #  include <__math/special_functions.h>

--- a/libcxx/test/std/numerics/complex.number/cases.h
+++ b/libcxx/test/std/numerics/complex.number/cases.h
@@ -14,7 +14,9 @@
 #define CASES_H
 
 #include <cassert>
+#include <cmath>
 #include <complex>
+#include <limits>
 #include <type_traits>
 
 #include "test_macros.h"


### PR DESCRIPTION
I believe these headers were relevant when we actually implemented functions in `<cmath>`, but they are not anymore. Note that ::hypot in particular is obtained from <math.h> like all the other math functions.