### PR TITLE
AMDGPU: Add missing flat-global-insts to gfx13 frontend feature map

### DIFF
--- a/clang/test/CodeGenOpenCL/builtins-amdgcn-global-load-store.cl
+++ b/clang/test/CodeGenOpenCL/builtins-amdgcn-global-load-store.cl
@@ -5,6 +5,7 @@
 // RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgpu11.00-unknown-unknown -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgpu12.00-unknown-unknown -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgpu12.50-unknown-unknown -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgpu13.10-unknown-unknown -emit-llvm -o - %s | FileCheck %s
 
 typedef __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int v4u32;
 typedef v4u32 __global *global_ptr_to_v4u32;

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -500,6 +500,7 @@ static void fillAMDGCNFeatureMap(StringRef GPU, const Triple &T,
     Features["gfx12-insts"] = true;
     Features["gfx1250-insts"] = true;
     Features["gfx13-insts"] = true;
+    Features["flat-global-insts"] = true;
     Features["bitop3-insts"] = true;
     Features["prng-inst"] = true;
     Features["tanh-insts"] = true;

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.av.load.b128.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.av.load.b128.ll
@@ -5,12 +5,14 @@
 ; RUN: llc -global-isel=0 -mtriple=amdgpu10.12 < %s | FileCheck -check-prefix=GFX1012-SDAG %s
 ; RUN: llc -global-isel=0 -mtriple=amdgpu11.00 < %s | FileCheck -check-prefix=GFX1100-SDAG %s
 ; RUN: llc -global-isel=0 -mtriple=amdgpu12.50 < %s | FileCheck -check-prefix=GFX1250-SDAG %s
+; RUN: llc -global-isel=0 -mtriple=amdgpu13.10 < %s | FileCheck -check-prefix=GFX1310-SDAG %s
 
 ; RUN: llc -global-isel=1 -mtriple=amdgpu9.06  < %s | FileCheck -check-prefix=GFX906-ISEL  %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu9.42  < %s | FileCheck -check-prefix=GFX942-ISEL  %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu10.12 < %s | FileCheck -check-prefix=GFX1012-ISEL %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu11.00 < %s | FileCheck -check-prefix=GFX1100-ISEL %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu12.50 < %s | FileCheck -check-prefix=GFX1250-ISEL %s
+; RUN: llc -global-isel=1 -mtriple=amdgpu13.10 < %s | FileCheck -check-prefix=GFX1310-ISEL %s
 
 ;;==============================================================================
 ;; A few basic test cases
@@ -54,6 +56,17 @@ define <4 x i32> @av_global_load_b128_0_00(ptr addrspace(1) %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_0_00:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_0_00:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -89,6 +102,17 @@ define <4 x i32> @av_global_load_b128_0_00(ptr addrspace(1) %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_0_00:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !0)
   ret <4 x i32> %data
@@ -132,6 +156,17 @@ define <4 x i32> @av_global_load_b128_0_01(ptr addrspace(1) %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_0_01:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_0_01:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -167,6 +202,17 @@ define <4 x i32> @av_global_load_b128_0_01(ptr addrspace(1) %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_0_01:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !1)
   ret <4 x i32> %data
@@ -210,6 +256,17 @@ define <4 x i32> @av_global_load_b128_0_10(ptr addrspace(1) %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_0_10:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_0_10:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -245,6 +302,17 @@ define <4 x i32> @av_global_load_b128_0_10(ptr addrspace(1) %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_0_10:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !2)
   ret <4 x i32> %data
@@ -288,6 +356,17 @@ define <4 x i32> @av_global_load_b128_0_11(ptr addrspace(1) %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_0_11:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_0_11:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -323,6 +402,17 @@ define <4 x i32> @av_global_load_b128_0_11(ptr addrspace(1) %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_0_11:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !3)
   ret <4 x i32> %data
@@ -371,6 +461,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_00(ptr addrspace(1) inreg %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_saddr_0_00:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_saddr_0_00:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -411,6 +513,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_00(ptr addrspace(1) inreg %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_saddr_0_00:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !0)
   ret <4 x i32> %data
@@ -459,6 +573,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_01(ptr addrspace(1) inreg %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_saddr_0_01:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_saddr_0_01:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -499,6 +625,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_01(ptr addrspace(1) inreg %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_saddr_0_01:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !1)
   ret <4 x i32> %data
@@ -547,6 +685,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_02(ptr addrspace(1) inreg %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_saddr_0_02:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_saddr_0_02:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -587,6 +737,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_02(ptr addrspace(1) inreg %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_saddr_0_02:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !2)
   ret <4 x i32> %data
@@ -635,6 +797,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_03(ptr addrspace(1) inreg %addr) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_load_b128_saddr_0_03:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_load_b128_saddr_0_03:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -675,6 +849,18 @@ define <4 x i32> @av_global_load_b128_saddr_0_03(ptr addrspace(1) inreg %addr) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_load_b128_saddr_0_03:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %data = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %addr, metadata !3)
   ret <4 x i32> %data
@@ -725,6 +911,17 @@ define <4 x float> @global_load_i8_offset_0(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -760,6 +957,17 @@ define <4 x float> @global_load_i8_offset_0(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %sbase, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
   ret <4 x float> %cast.load
@@ -805,6 +1013,17 @@ define <4 x float> @global_load_i8_offset_4095(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_4095:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_4095:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -842,6 +1061,17 @@ define <4 x float> @global_load_i8_offset_4095(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_4095:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4095
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -896,6 +1126,17 @@ define <4 x float> @global_load_i8_offset_4096(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_4096:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -941,6 +1182,17 @@ define <4 x float> @global_load_i8_offset_4096(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4096
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -995,6 +1247,17 @@ define <4 x float> @global_load_i8_offset_4097(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_4097:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4097 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_4097:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1040,6 +1303,17 @@ define <4 x float> @global_load_i8_offset_4097(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4097 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_4097:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4097 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4097
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1086,6 +1360,17 @@ define <4 x float> @global_load_i8_offset_neg4096(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4096
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg4096:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1123,6 +1408,17 @@ define <4 x float> @global_load_i8_offset_neg4096(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4096
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4096
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4096
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1177,6 +1473,17 @@ define <4 x float> @global_load_i8_offset_neg4097(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg4097:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4097 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg4097:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1222,6 +1529,17 @@ define <4 x float> @global_load_i8_offset_neg4097(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4097
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg4097:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4097 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4097
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1276,6 +1594,17 @@ define <4 x float> @global_load_i8_offset_neg4098(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg4098:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4098 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg4098:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1321,6 +1650,17 @@ define <4 x float> @global_load_i8_offset_neg4098(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4098 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg4098:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4098 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4098
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1367,6 +1707,17 @@ define <4 x float> @global_load_i8_offset_2048(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2048 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1404,6 +1755,17 @@ define <4 x float> @global_load_i8_offset_2048(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2048 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2048 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 2048
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1450,6 +1812,17 @@ define <4 x float> @global_load_i8_offset_2049(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_2049:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2049
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_2049:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1487,6 +1860,17 @@ define <4 x float> @global_load_i8_offset_2049(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2049
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_2049:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2049
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 2049
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1533,6 +1917,17 @@ define <4 x float> @global_load_i8_offset_2050(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_2050:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2050 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_2050:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1570,6 +1965,17 @@ define <4 x float> @global_load_i8_offset_2050(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2050
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_2050:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2050 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 2050
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1614,6 +2020,17 @@ define <4 x float> @global_load_i8_offset_neg2048(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2048 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1649,6 +2066,17 @@ define <4 x float> @global_load_i8_offset_neg2048(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2048 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2048 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -2048
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1695,6 +2123,17 @@ define <4 x float> @global_load_i8_offset_neg2049(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg2049:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2049 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg2049:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1732,6 +2171,17 @@ define <4 x float> @global_load_i8_offset_neg2049(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2049 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg2049:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2049 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -2049
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1778,6 +2228,17 @@ define <4 x float> @global_load_i8_offset_neg2050(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg2050:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2050
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg2050:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1815,6 +2276,17 @@ define <4 x float> @global_load_i8_offset_neg2050(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2050
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg2050:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2050
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -2050
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1869,6 +2341,17 @@ define <4 x float> @global_load_i8_offset_0x7FFFFF(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0x7FFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0x7FFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1914,6 +2397,17 @@ define <4 x float> @global_load_i8_offset_0x7FFFFF(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0x7FFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 8388607
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -1968,6 +2462,17 @@ define <4 x float> @global_load_i8_offset_0xFFFFFF(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0xFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388608 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0xFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2013,6 +2518,17 @@ define <4 x float> @global_load_i8_offset_0xFFFFFF(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388608 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0xFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388608 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -8388608
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2070,6 +2586,20 @@ define <4 x float> @global_load_i8_offset_0xFFFFFFFF(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0xFFFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, 0xff800000, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0xFFFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2118,6 +2648,20 @@ define <4 x float> @global_load_i8_offset_0xFFFFFFFF(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0xFFFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, -1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294967295
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2167,6 +2711,18 @@ define <4 x float> @global_load_i8_offset_0x100000000(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0x100000000:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_nc_u32_e32 v1, 1, v1
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0x100000000:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2215,6 +2771,20 @@ define <4 x float> @global_load_i8_offset_0x100000000(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0x100000000:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294967296
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2272,6 +2842,20 @@ define <4 x float> @global_load_i8_offset_0x100000001(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0x100000001:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, 0, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:1 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0x100000001:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2320,6 +2904,20 @@ define <4 x float> @global_load_i8_offset_0x100000001(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0x100000001:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294967297
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2377,6 +2975,20 @@ define <4 x float> @global_load_i8_offset_0x100000FFF(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0x100000FFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, 0, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0x100000FFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2425,6 +3037,20 @@ define <4 x float> @global_load_i8_offset_0x100000FFF(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0x100000FFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, 0xfff, v0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294971391
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2482,6 +3108,20 @@ define <4 x float> @global_load_i8_offset_0x100001000(ptr addrspace(1) %sbase) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_0x100001000:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, 0, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_0x100001000:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2530,6 +3170,20 @@ define <4 x float> @global_load_i8_offset_0x100001000(ptr addrspace(1) %sbase) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_0x100001000:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, 0x1000, v0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294971392
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2587,6 +3241,20 @@ define <4 x float> @global_load_i8_offset_neg0xFFFFFFFF(ptr addrspace(1) %sbase)
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg0xFFFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, 0x800000, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, -1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388607
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg0xFFFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2635,6 +3303,20 @@ define <4 x float> @global_load_i8_offset_neg0xFFFFFFFF(ptr addrspace(1) %sbase)
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg0xFFFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, -1, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4294967295
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2684,6 +3366,18 @@ define <4 x float> @global_load_i8_offset_neg0x100000000(ptr addrspace(1) %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg0x100000000:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_nc_u32_e32 v1, -1, v1
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg0x100000000:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2732,6 +3426,20 @@ define <4 x float> @global_load_i8_offset_neg0x100000000(ptr addrspace(1) %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg0x100000000:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, -1, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4294967296
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2789,6 +3497,20 @@ define <4 x float> @global_load_i8_offset_neg0x100000001(ptr addrspace(1) %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_neg0x100000001:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, 0, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, -1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-1 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_neg0x100000001:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2837,6 +3559,20 @@ define <4 x float> @global_load_i8_offset_neg0x100000001(ptr addrspace(1) %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_neg0x100000001:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, -1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, -2, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4294967297
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -2897,6 +3633,20 @@ define <4 x float> @global_load_i8_zext_vgpr(ptr addrspace(1) %sbase, i32 %voffs
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2945,6 +3695,20 @@ define <4 x float> @global_load_i8_zext_vgpr(ptr addrspace(1) %sbase, i32 %voffs
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
@@ -3004,6 +3768,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_4095(ptr addrspace(1) %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_4095:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_4095:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3054,6 +3832,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_4095(ptr addrspace(1) %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_4095:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 4095
@@ -3122,6 +3914,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_4096(ptr addrspace(1) %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_4096:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3180,6 +3986,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_4096(ptr addrspace(1) %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 4096
@@ -3240,6 +4060,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg4096(ptr addrspace(1) %sb
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_neg4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4096 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg4096:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3290,6 +4124,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg4096(ptr addrspace(1) %sb
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4096 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4096 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -4096
@@ -3358,6 +4206,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg4097(ptr addrspace(1) %sb
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_neg4097:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4097 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg4097:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3416,6 +4278,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg4097(ptr addrspace(1) %sb
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4097 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg4097:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-4097 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -4097
@@ -3474,6 +4350,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_2047(ptr addrspace(1) %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_2047:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2047
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_2047:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3522,6 +4412,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_2047(ptr addrspace(1) %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2047
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_2047:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2047
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 2047
@@ -3582,6 +4486,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_2048(ptr addrspace(1) %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2048 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3632,6 +4550,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_2048(ptr addrspace(1) %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2048
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:2048 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 2048
@@ -3690,6 +4622,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg2048(ptr addrspace(1) %sb
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_neg2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2048 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3738,6 +4684,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg2048(ptr addrspace(1) %sb
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2048 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2048 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -2048
@@ -3798,6 +4758,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg2049(ptr addrspace(1) %sb
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_neg2049:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2049 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg2049:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3848,6 +4822,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_neg2049(ptr addrspace(1) %sb
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2049 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_neg2049:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-2049 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -2049
@@ -3916,6 +4904,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_0x7FFFFF(ptr addrspace(1) %s
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_0x7FFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_0x7FFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -3974,6 +4976,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_0x7FFFFF(ptr addrspace(1) %s
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_0x7FFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 8388607
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep1, metadata !0)
@@ -4041,6 +5057,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_0xFFFFFF(ptr addrspace(1) %s
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_0xFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388608 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_0xFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4099,6 +5129,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_0xFFFFFF(ptr addrspace(1) %s
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388608
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_0xFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388608 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -8388608
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep1, metadata !1)
@@ -4159,6 +5203,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_4095_gep_order(ptr addrspace
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_offset_4095_gep_order:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_offset_4095_gep_order:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4209,6 +5267,20 @@ define <4 x float> @global_load_i8_zext_vgpr_offset_4095_gep_order(ptr addrspace
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_offset_4095_gep_order:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4095
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 %zext.offset
@@ -4267,6 +5339,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint(ptr addrspace(1) %sbase, i
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_ptrtoint:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4315,6 +5401,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint(ptr addrspace(1) %sbase, i
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %sbase.as.int, %zext.offset
@@ -4374,6 +5474,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint_commute_add(ptr addrspace(
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v2, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4422,6 +5536,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint_commute_add(ptr addrspace(
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -4481,6 +5609,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0(pt
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v2, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4529,6 +5671,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0(pt
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -4589,6 +5745,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1(pt
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4637,6 +5807,20 @@ define <4 x float> @global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1(pt
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add.immoffset = add i64 %sbase.as.int, 128
@@ -4701,6 +5885,20 @@ define <4 x float> @global_load_i8_zext_uniform_offset(ptr addrspace(1) %sbase, 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_uniform_offset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_uniform_offset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4749,6 +5947,20 @@ define <4 x float> @global_load_i8_zext_uniform_offset(ptr addrspace(1) %sbase, 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_uniform_offset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
@@ -4806,6 +6018,20 @@ define <4 x float> @global_load_i8_zext_uniform_offset_immoffset(ptr addrspace(1
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_uniform_offset_immoffset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-24
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_uniform_offset_immoffset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4854,6 +6080,20 @@ define <4 x float> @global_load_i8_zext_uniform_offset_immoffset(ptr addrspace(1
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-24
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_uniform_offset_immoffset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-24
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -24
@@ -4912,6 +6152,20 @@ define <4 x float> @global_load_i8_zext_sgpr_ptrtoint_commute_add(ptr addrspace(
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_sgpr_ptrtoint_commute_add:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v2, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_sgpr_ptrtoint_commute_add:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4960,6 +6214,20 @@ define <4 x float> @global_load_i8_zext_sgpr_ptrtoint_commute_add(ptr addrspace(
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_sgpr_ptrtoint_commute_add:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -5019,6 +6287,20 @@ define <4 x float> @global_load_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0(pt
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v2, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5067,6 +6349,20 @@ define <4 x float> @global_load_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0(pt
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -5127,6 +6423,20 @@ define <4 x float> @global_load_i8_vgpr64_sgpr32(ptr addrspace(1) %vbase, i32 %s
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_vgpr64_sgpr32:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_vgpr64_sgpr32:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5175,6 +6485,20 @@ define <4 x float> @global_load_i8_vgpr64_sgpr32(ptr addrspace(1) %vbase, i32 %s
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_vgpr64_sgpr32:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %vbase, i64 %zext.offset
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
@@ -5234,6 +6558,20 @@ define <4 x float> @global_load_i8_vgpr64_sgpr32_offset_4095(ptr addrspace(1) %v
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_vgpr64_sgpr32_offset_4095:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_vgpr64_sgpr32_offset_4095:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5284,6 +6622,20 @@ define <4 x float> @global_load_i8_vgpr64_sgpr32_offset_4095(ptr addrspace(1) %v
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_vgpr64_sgpr32_offset_4095:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %vbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 4095
@@ -5364,6 +6716,25 @@ define <4 x float> @global_load_f32_natural_addressing(ptr addrspace(1) %sbase, 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_natural_addressing:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v3, 0
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_lshlrev_b64_e32 v[2:3], 2, v[2:3]
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_natural_addressing:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5429,6 +6800,25 @@ define <4 x float> @global_load_f32_natural_addressing(ptr addrspace(1) %sbase, 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_natural_addressing:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_lshlrev_b64_e32 v[2:3], 2, v[2:3]
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -5498,6 +6888,22 @@ define <4 x float> @global_load_f32_natural_addressing_immoffset(ptr addrspace(1
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_natural_addressing_immoffset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_natural_addressing_immoffset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5556,6 +6962,22 @@ define <4 x float> @global_load_f32_natural_addressing_immoffset(ptr addrspace(1
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_natural_addressing_immoffset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:128 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -5630,6 +7052,23 @@ define <4 x float> @global_load_f32_zext_vgpr_range(ptr addrspace(1) %sbase, ptr
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_zext_vgpr_range:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_lshlrev_b32_e32 v2, 2, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_zext_vgpr_range:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5694,6 +7133,23 @@ define <4 x float> @global_load_f32_zext_vgpr_range(ptr addrspace(1) %sbase, ptr
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_zext_vgpr_range:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 2, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr, !range !4, !noundef !{}
   %zext.offset = zext i32 %voffset to i64
   %gep = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -5767,6 +7223,23 @@ define <4 x float> @global_load_f32_zext_vgpr_range_imm_offset(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_zext_vgpr_range_imm_offset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_lshlrev_b32_e32 v2, 2, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:400
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_zext_vgpr_range_imm_offset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5831,6 +7304,23 @@ define <4 x float> @global_load_f32_zext_vgpr_range_imm_offset(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:400
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_zext_vgpr_range_imm_offset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 2, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:400
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr, !range !4, !noundef !{}
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -5908,6 +7398,25 @@ define <4 x float> @global_load_f32_zext_vgpr_range_too_large(ptr addrspace(1) %
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_zext_vgpr_range_too_large:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v3, 0
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_lshlrev_b64_e32 v[2:3], 2, v[2:3]
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_zext_vgpr_range_too_large:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -5973,6 +7482,25 @@ define <4 x float> @global_load_f32_zext_vgpr_range_too_large(ptr addrspace(1) %
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_zext_vgpr_range_too_large:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_lshlrev_b64_e32 v[2:3], 2, v[2:3]
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr, !range !5, !noundef !{}
   %zext.offset = zext i32 %voffset to i64
   %gep = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -6032,6 +7560,18 @@ define <4 x float> @global_load_i8_offset_or_i64_imm_offset_16(ptr addrspace(6) 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_or_i64_imm_offset_16:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_bitop2_b32 v1, 16, v1 bitop3:0x54
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[1:2], off scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_or_i64_imm_offset_16:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -6076,6 +7616,18 @@ define <4 x float> @global_load_i8_offset_or_i64_imm_offset_16(ptr addrspace(6) 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[2:3], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_or_i64_imm_offset_16:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_bitop2_b32 v1, 16, v1 bitop3:0x54
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[1:2], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.idx = zext i32 %idx to i64
   %or = or i64 %zext.idx, 16
   %addr = inttoptr i64 %or to ptr addrspace(1)
@@ -6132,6 +7684,19 @@ define <4 x float> @global_load_i8_offset_or_i64_imm_offset_4160(ptr addrspace(6
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_i8_offset_or_i64_imm_offset_4160:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v2, 0
+; GFX1310-SDAG-NEXT:    v_or_b32_e32 v1, 0x1040, v1
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[1:2], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_i8_offset_or_i64_imm_offset_4160:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -6177,6 +7742,19 @@ define <4 x float> @global_load_i8_offset_or_i64_imm_offset_4160(ptr addrspace(6
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[2:3], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_i8_offset_or_i64_imm_offset_4160:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v2, 0
+; GFX1310-ISEL-NEXT:    v_or_b32_e32 v1, 0x1040, v1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[1:2], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.idx = zext i32 %idx to i64
   %or = or i64 %zext.idx, 4160
   %addr = inttoptr i64 %or to ptr addrspace(1)
@@ -6282,6 +7860,31 @@ define <4 x float> @global_addr_64bit_lsr_iv(ptr addrspace(1) %arg) {
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_addr_64bit_lsr_iv:
+; GFX1310-SDAG:       ; %bb.0: ; %bb
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    s_mov_b32 s0, -1
+; GFX1310-SDAG-NEXT:  .LBB60_1: ; %bb3
+; GFX1310-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_add_co_i32 s0, s0, 1
+; GFX1310-SDAG-NEXT:    s_cmp_eq_u32 s0, 0xff
+; GFX1310-SDAG-NEXT:    s_cbranch_scc0 .LBB60_1
+; GFX1310-SDAG-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-SDAG-NEXT:    s_mov_b32 s1, 0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_lshl_b64 s[0:1], s[0:1], 2
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, s1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_addr_64bit_lsr_iv:
 ; GFX906-ISEL:       ; %bb.0: ; %bb
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -6386,6 +7989,32 @@ define <4 x float> @global_addr_64bit_lsr_iv(ptr addrspace(1) %arg) {
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_addr_64bit_lsr_iv:
+; GFX1310-ISEL:       ; %bb.0: ; %bb
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_mov_b32 s0, -1
+; GFX1310-ISEL-NEXT:  .LBB60_1: ; %bb3
+; GFX1310-ISEL-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_add_co_i32 s0, s0, 1
+; GFX1310-ISEL-NEXT:    s_cmp_eq_u32 s0, 0xff
+; GFX1310-ISEL-NEXT:    s_cbranch_scc0 .LBB60_1
+; GFX1310-ISEL-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-ISEL-NEXT:    s_mov_b32 s1, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_lshl_b64 s[0:1], s[0:1], 2
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 bb:
   br label %bb3
 
@@ -6500,6 +8129,31 @@ define <4 x float> @global_addr_64bit_lsr_iv_multiload(ptr addrspace(1) %arg, pt
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_addr_64bit_lsr_iv_multiload:
+; GFX1310-SDAG:       ; %bb.0: ; %bb
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    s_mov_b32 s0, -1
+; GFX1310-SDAG-NEXT:  .LBB61_1: ; %bb5
+; GFX1310-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_add_co_i32 s0, s0, 1
+; GFX1310-SDAG-NEXT:    s_cmp_eq_u32 s0, 0xff
+; GFX1310-SDAG-NEXT:    s_cbranch_scc0 .LBB61_1
+; GFX1310-SDAG-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-SDAG-NEXT:    s_mov_b32 s1, 0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_lshl_b64 s[0:1], s[0:1], 2
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, s1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_addr_64bit_lsr_iv_multiload:
 ; GFX906-ISEL:       ; %bb.0: ; %bb
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -6604,6 +8258,32 @@ define <4 x float> @global_addr_64bit_lsr_iv_multiload(ptr addrspace(1) %arg, pt
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_addr_64bit_lsr_iv_multiload:
+; GFX1310-ISEL:       ; %bb.0: ; %bb
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_mov_b32 s0, -1
+; GFX1310-ISEL-NEXT:  .LBB61_1: ; %bb5
+; GFX1310-ISEL-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_add_co_i32 s0, s0, 1
+; GFX1310-ISEL-NEXT:    s_cmp_eq_u32 s0, 0xff
+; GFX1310-ISEL-NEXT:    s_cbranch_scc0 .LBB61_1
+; GFX1310-ISEL-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-ISEL-NEXT:    s_mov_b32 s1, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_lshl_b64 s[0:1], s[0:1], 2
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 bb:
   br label %bb5
 
@@ -6681,6 +8361,18 @@ define <4 x float> @global_load_saddr_i8_offset_0(ptr addrspace(1) inreg %sbase)
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0:
 ; GFX906-ISEL:       ; %bb.0:
@@ -6761,6 +8453,25 @@ define <4 x float> @global_load_saddr_i8_offset_0(ptr addrspace(1) inreg %sbase)
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %sbase, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
   ret <4 x float> %cast.load
@@ -6808,6 +8519,18 @@ define <4 x float> @global_load_saddr_i8_offset_4095(ptr addrspace(1) inreg %sba
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_4095:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_4095:
 ; GFX906-ISEL:       ; %bb.0:
@@ -6888,6 +8611,25 @@ define <4 x float> @global_load_saddr_i8_offset_4095(ptr addrspace(1) inreg %sba
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_4095:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4095
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -6936,6 +8678,18 @@ define <4 x float> @global_load_saddr_i8_offset_4096(ptr addrspace(1) inreg %sba
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4096
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4096 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_4096:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7016,6 +8770,25 @@ define <4 x float> @global_load_saddr_i8_offset_4096(ptr addrspace(1) inreg %sba
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4096 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4096
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7064,6 +8837,18 @@ define <4 x float> @global_load_saddr_i8_offset_4097(ptr addrspace(1) inreg %sba
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4097 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_4097:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4097 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_4097:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7144,6 +8929,25 @@ define <4 x float> @global_load_saddr_i8_offset_4097(ptr addrspace(1) inreg %sba
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_4097:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4097 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4097
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7193,6 +8997,18 @@ define <4 x float> @global_load_saddr_i8_offset_neg4096(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4096 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4096 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg4096:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7276,6 +9092,25 @@ define <4 x float> @global_load_saddr_i8_offset_neg4096(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4096 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4096
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7331,6 +9166,18 @@ define <4 x float> @global_load_saddr_i8_offset_neg4097(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4097
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg4097:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4097
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg4097:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7421,6 +9268,25 @@ define <4 x float> @global_load_saddr_i8_offset_neg4097(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg4097:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4097
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4097
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7476,6 +9342,18 @@ define <4 x float> @global_load_saddr_i8_offset_neg4098(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4098
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg4098:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4098 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg4098:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7566,6 +9444,25 @@ define <4 x float> @global_load_saddr_i8_offset_neg4098(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg4098:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4098 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4098
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7614,6 +9511,18 @@ define <4 x float> @global_load_saddr_i8_offset_2048(ptr addrspace(1) inreg %sba
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2048 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2048 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_2048:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7694,6 +9603,25 @@ define <4 x float> @global_load_saddr_i8_offset_2048(ptr addrspace(1) inreg %sba
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2048 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 2048
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7742,6 +9670,18 @@ define <4 x float> @global_load_saddr_i8_offset_2049(ptr addrspace(1) inreg %sba
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2049 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_2049:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2049 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_2049:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7822,6 +9762,25 @@ define <4 x float> @global_load_saddr_i8_offset_2049(ptr addrspace(1) inreg %sba
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_2049:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2049 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 2049
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7870,6 +9829,18 @@ define <4 x float> @global_load_saddr_i8_offset_2050(ptr addrspace(1) inreg %sba
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2050
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_2050:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2050
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_2050:
 ; GFX906-ISEL:       ; %bb.0:
@@ -7950,6 +9921,25 @@ define <4 x float> @global_load_saddr_i8_offset_2050(ptr addrspace(1) inreg %sba
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_2050:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2050
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 2050
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -7998,6 +9988,18 @@ define <4 x float> @global_load_saddr_i8_offset_neg2048(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2048
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2048 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg2048:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8078,6 +10080,25 @@ define <4 x float> @global_load_saddr_i8_offset_neg2048(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2048 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -2048
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8127,6 +10148,18 @@ define <4 x float> @global_load_saddr_i8_offset_neg2049(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2049 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg2049:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2049 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg2049:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8210,6 +10243,25 @@ define <4 x float> @global_load_saddr_i8_offset_neg2049(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg2049:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2049 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -2049
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8259,6 +10311,18 @@ define <4 x float> @global_load_saddr_i8_offset_neg2050(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2050 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg2050:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2050 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg2050:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8342,6 +10406,25 @@ define <4 x float> @global_load_saddr_i8_offset_neg2050(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg2050:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2050 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -2050
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8390,6 +10473,18 @@ define <4 x float> @global_load_saddr_i8_offset_0x7FFFFF(ptr addrspace(1) inreg 
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:8388607
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0x7FFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:8388607
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0x7FFFFF:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8470,6 +10565,25 @@ define <4 x float> @global_load_saddr_i8_offset_0x7FFFFF(ptr addrspace(1) inreg 
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0x7FFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:8388607
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 8388607
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8525,6 +10639,18 @@ define <4 x float> @global_load_saddr_i8_offset_0xFFFFFF(ptr addrspace(1) inreg 
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-8388608
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0xFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-8388608 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0xFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8615,6 +10741,25 @@ define <4 x float> @global_load_saddr_i8_offset_0xFFFFFF(ptr addrspace(1) inreg 
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0xFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-8388608 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -8388608
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8665,6 +10810,20 @@ define <4 x float> @global_load_saddr_i8_offset_0xFFFFFFFF(ptr addrspace(1) inre
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0xFFFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, s0, 0xff800000, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, s1, s0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:8388607 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0xFFFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8748,6 +10907,28 @@ define <4 x float> @global_load_saddr_i8_offset_0xFFFFFFFF(ptr addrspace(1) inre
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0xFFFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, -1
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294967295
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8801,6 +10982,19 @@ define <4 x float> @global_load_saddr_i8_offset_0x100000000(ptr addrspace(1) inr
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0x100000000:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    s_add_co_i32 s1, s1, 1
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0x100000000:
 ; GFX906-ISEL:       ; %bb.0:
@@ -8895,6 +11089,28 @@ define <4 x float> @global_load_saddr_i8_offset_0x100000000(ptr addrspace(1) inr
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0x100000000:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, 0
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, 1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294967296
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -8953,6 +11169,20 @@ define <4 x float> @global_load_saddr_i8_offset_0x100000001(ptr addrspace(1) inr
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:1
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0x100000001:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, s0, 0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, s1, s0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:1
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0x100000001:
 ; GFX906-ISEL:       ; %bb.0:
@@ -9047,6 +11277,28 @@ define <4 x float> @global_load_saddr_i8_offset_0x100000001(ptr addrspace(1) inr
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0x100000001:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, 1
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, 1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294967297
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -9104,6 +11356,20 @@ define <4 x float> @global_load_saddr_i8_offset_0x100000FFF(ptr addrspace(1) inr
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0x100000FFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, s0, 0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, s1, s0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0x100000FFF:
 ; GFX906-ISEL:       ; %bb.0:
@@ -9197,6 +11463,28 @@ define <4 x float> @global_load_saddr_i8_offset_0x100000FFF(ptr addrspace(1) inr
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0x100000FFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, 0xfff
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, 1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294971391
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -9254,6 +11542,20 @@ define <4 x float> @global_load_saddr_i8_offset_0x100001000(ptr addrspace(1) inr
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_0x100001000:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, s0, 0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 1, s1, s0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4096 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_0x100001000:
 ; GFX906-ISEL:       ; %bb.0:
@@ -9347,6 +11649,28 @@ define <4 x float> @global_load_saddr_i8_offset_0x100001000(ptr addrspace(1) inr
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_0x100001000:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, 0x1000
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, 1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4294971392
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -9407,6 +11731,20 @@ define <4 x float> @global_load_saddr_i8_offset_neg0xFFFFFFFF(ptr addrspace(1) i
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388607 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg0xFFFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, s0, 0x800000, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, -1, s1, s0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-8388607 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg0xFFFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
@@ -9501,6 +11839,28 @@ define <4 x float> @global_load_saddr_i8_offset_neg0xFFFFFFFF(ptr addrspace(1) i
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg0xFFFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, 1
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, -1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4294967295
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !3)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -9554,6 +11914,19 @@ define <4 x float> @global_load_saddr_i8_offset_neg0x100000000(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg0x100000000:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    s_add_co_i32 s1, s1, -1
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg0x100000000:
 ; GFX906-ISEL:       ; %bb.0:
@@ -9648,6 +12021,28 @@ define <4 x float> @global_load_saddr_i8_offset_neg0x100000000(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg0x100000000:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, 0
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, -1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4294967296
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !0)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -9706,6 +12101,20 @@ define <4 x float> @global_load_saddr_i8_offset_neg0x100000001(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-1
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_neg0x100000001:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, s0, 0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, -1, s1, s0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:-1 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_neg0x100000001:
 ; GFX906-ISEL:       ; %bb.0:
@@ -9800,6 +12209,28 @@ define <4 x float> @global_load_saddr_i8_offset_neg0x100000001(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_neg0x100000001:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, -1
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, -2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 -4294967297
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !1)
   %cast.load = bitcast <4 x i32> %load to <4 x float>
@@ -9848,6 +12279,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr(ptr addrspace(1) inreg %sbase
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -9883,6 +12325,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr(ptr addrspace(1) inreg %sbase
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
@@ -9932,6 +12385,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_4095(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_4095:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_4095:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -9973,6 +12437,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_4095(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_4095:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 4095
@@ -10039,6 +12514,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_4096(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4096
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_4096:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10100,6 +12586,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_4096(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4096
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4096
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 4096
@@ -10150,6 +12647,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg4096(ptr addrspace(
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg4096:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4096 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg4096:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10191,6 +12699,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg4096(ptr addrspace(
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4096
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg4096:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4096 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -4096
@@ -10257,6 +12776,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg4097(ptr addrspace(
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg4097:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4097 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg4097:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10318,6 +12848,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg4097(ptr addrspace(
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4097 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg4097:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-4097 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -4097
@@ -10364,6 +12905,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_2047(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_2047:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2047 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_2047:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10399,6 +12951,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_2047(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2047 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_2047:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2047 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 2047
@@ -10449,6 +13012,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_2048(ptr addrspace(1) 
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2048
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10490,6 +13064,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_2048(ptr addrspace(1) 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2048
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:2048
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 2048
@@ -10536,6 +13121,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg2048(ptr addrspace(
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2048 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10571,6 +13167,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg2048(ptr addrspace(
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2048
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2048 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -2048
@@ -10621,6 +13228,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg2049(ptr addrspace(
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg2049:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2049 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg2049:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10662,6 +13280,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_neg2049(ptr addrspace(
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2049 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_neg2049:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-2049 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -2049
@@ -10728,6 +13357,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_0x7FFFFF(ptr addrspace
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_0x7FFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:8388607 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_0x7FFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10789,6 +13429,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_0x7FFFFF(ptr addrspace
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:8388607 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_0x7FFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:8388607 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 8388607
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep1, metadata !3)
@@ -10854,6 +13505,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_0xFFFFFF(ptr addrspace
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_0xFFFFFF:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-8388608
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_0xFFFFFF:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -10915,6 +13577,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_0xFFFFFF(ptr addrspace
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-8388608
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_0xFFFFFF:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-8388608
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -8388608
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep1, metadata !0)
@@ -10965,6 +13638,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_4095_gep_order(ptr add
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_offset_4095_gep_order:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_4095_gep_order:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -11006,6 +13690,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_offset_4095_gep_order(ptr add
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_offset_4095_gep_order:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:4095 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 4095
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 %zext.offset
@@ -11052,6 +13747,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint(ptr addrspace(1) inr
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -11087,6 +13793,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint(ptr addrspace(1) inr
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %sbase.as.int, %zext.offset
@@ -11134,6 +13851,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add(ptr addr
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -11169,6 +13897,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add(ptr addr
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -11216,6 +13955,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offs
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -11251,6 +14001,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offs
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -11299,6 +14060,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offs
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -11334,6 +14106,17 @@ define <4 x float> @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offs
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_offset1:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add.immoffset = add i64 %sbase.as.int, 128
@@ -11390,6 +14173,18 @@ define <4 x float> @global_load_saddr_i8_zext_uniform_offset(ptr addrspace(1) in
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_uniform_offset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_uniform_offset:
 ; GFX906-ISEL:       ; %bb.0:
@@ -11470,6 +14265,25 @@ define <4 x float> @global_load_saddr_i8_zext_uniform_offset(ptr addrspace(1) in
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_uniform_offset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
@@ -11519,6 +14333,18 @@ define <4 x float> @global_load_saddr_i8_zext_uniform_offset_immoffset(ptr addrs
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-24 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_uniform_offset_immoffset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-24 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_uniform_offset_immoffset:
 ; GFX906-ISEL:       ; %bb.0:
@@ -11599,6 +14425,25 @@ define <4 x float> @global_load_saddr_i8_zext_uniform_offset_immoffset(ptr addrs
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_uniform_offset_immoffset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:-24 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -24
@@ -11649,6 +14494,18 @@ define <4 x float> @global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add(ptr addr
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add:
 ; GFX906-ISEL:       ; %bb.0:
@@ -11729,6 +14586,25 @@ define <4 x float> @global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add(ptr addr
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -11780,6 +14656,18 @@ define <4 x float> @global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add_imm_offs
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0:
 ; GFX906-ISEL:       ; %bb.0:
@@ -11860,6 +14748,25 @@ define <4 x float> @global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add_imm_offs
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_zext_sgpr_ptrtoint_commute_add_imm_offset0:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %sbase.as.int = ptrtoint ptr addrspace(1) %sbase to i64
   %add = add i64 %zext.offset, %sbase.as.int
@@ -11919,6 +14826,20 @@ define <4 x float> @global_load_saddr_i8_vgpr64_sgpr32(ptr addrspace(1) %vbase, 
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_vgpr64_sgpr32:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_vgpr64_sgpr32:
 ; GFX906-ISEL:       ; %bb.0:
@@ -11982,6 +14903,23 @@ define <4 x float> @global_load_saddr_i8_vgpr64_sgpr32(ptr addrspace(1) %vbase, 
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_vgpr64_sgpr32:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_mov_b32 s1, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, s1
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %vbase, i64 %zext.offset
   %load = call <4 x i32> @llvm.amdgcn.av.load.b128.p1(ptr addrspace(1) %gep0, metadata !2)
@@ -12040,6 +14978,20 @@ define <4 x float> @global_load_saddr_i8_vgpr64_sgpr32_offset_4095(ptr addrspace
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_vgpr64_sgpr32_offset_4095:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, s0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_vgpr64_sgpr32_offset_4095:
 ; GFX906-ISEL:       ; %bb.0:
@@ -12105,6 +15057,23 @@ define <4 x float> @global_load_saddr_i8_vgpr64_sgpr32_offset_4095(ptr addrspace
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_vgpr64_sgpr32_offset_4095:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_mov_b32 s1, 0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, s1
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v3, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off offset:4095 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %soffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %vbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 4095
@@ -12188,6 +15157,25 @@ define <4 x float> @global_load_saddr_f32_natural_addressing(ptr addrspace(1) in
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_f32_natural_addressing:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_lshlrev_b64_e32 v[0:1], 2, v[0:1]
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, s0, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, s1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_f32_natural_addressing:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12258,6 +15246,26 @@ define <4 x float> @global_load_saddr_f32_natural_addressing(ptr addrspace(1) in
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_f32_natural_addressing:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v3, s1
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_lshlrev_b64_e32 v[0:1], 2, v[0:1]
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v2, v0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v3, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -12314,6 +15322,19 @@ define <4 x float> @global_load_saddr_f32_natural_addressing_immoffset(ptr addrs
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_f32_natural_addressing_immoffset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_f32_natural_addressing_immoffset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12359,6 +15380,19 @@ define <4 x float> @global_load_saddr_f32_natural_addressing_immoffset(ptr addrs
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_f32_natural_addressing_immoffset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:128 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -12422,6 +15456,20 @@ define <4 x float> @global_load_f32_saddr_zext_vgpr_range(ptr addrspace(1) inreg
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_saddr_zext_vgpr_range:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_saddr_zext_vgpr_range:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12473,6 +15521,20 @@ define <4 x float> @global_load_f32_saddr_zext_vgpr_range(ptr addrspace(1) inreg
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_saddr_zext_vgpr_range:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr, !range !4, !noundef !{}
   %zext.offset = zext i32 %voffset to i64
   %gep = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -12535,6 +15597,20 @@ define <4 x float> @global_load_f32_saddr_zext_vgpr_range_imm_offset(ptr addrspa
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_saddr_zext_vgpr_range_imm_offset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:400 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_saddr_zext_vgpr_range_imm_offset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12586,6 +15662,20 @@ define <4 x float> @global_load_f32_saddr_zext_vgpr_range_imm_offset(ptr addrspa
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:400 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_saddr_zext_vgpr_range_imm_offset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] offset:400 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr, !range !4, !noundef !{}
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -12666,6 +15756,25 @@ define <4 x float> @global_load_f32_saddr_zext_vgpr_range_too_large(ptr addrspac
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_f32_saddr_zext_vgpr_range_too_large:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_lshlrev_b64_e32 v[0:1], 2, v[0:1]
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, s0, v0
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, s1, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_f32_saddr_zext_vgpr_range_too_large:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12736,6 +15845,26 @@ define <4 x float> @global_load_f32_saddr_zext_vgpr_range_too_large(ptr addrspac
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_f32_saddr_zext_vgpr_range_too_large:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v3, s1
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v2, s0
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_lshlrev_b64_e32 v[0:1], 2, v[0:1]
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v2, v0
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, v3, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr, !range !5, !noundef !{}
   %zext.offset = zext i32 %voffset to i64
   %gep = getelementptr inbounds float, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -12795,6 +15924,18 @@ define <4 x float> @global_load_saddr_i8_offset_or_i64_imm_offset_16(ptr addrspa
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_or_i64_imm_offset_16:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_bitop2_b32 v0, 16, v0 bitop3:0x54
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_or_i64_imm_offset_16:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12839,6 +15980,18 @@ define <4 x float> @global_load_saddr_i8_offset_or_i64_imm_offset_16(ptr addrspa
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_or_i64_imm_offset_16:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_bitop2_b32 v0, 16, v0 bitop3:0x54
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.idx = zext i32 %idx to i64
   %or = or i64 %zext.idx, 16
   %addr = inttoptr i64 %or to ptr addrspace(1)
@@ -12895,6 +16048,19 @@ define <4 x float> @global_load_saddr_i8_offset_or_i64_imm_offset_4160(ptr addrs
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_load_saddr_i8_offset_or_i64_imm_offset_4160:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1310-SDAG-NEXT:    v_or_b32_e32 v0, 0x1040, v0
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_load_saddr_i8_offset_or_i64_imm_offset_4160:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -12940,6 +16106,19 @@ define <4 x float> @global_load_saddr_i8_offset_or_i64_imm_offset_4160(ptr addrs
 ; GFX1250-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_load_saddr_i8_offset_or_i64_imm_offset_4160:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1310-ISEL-NEXT:    v_or_b32_e32 v0, 0x1040, v0
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v[0:1], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.idx = zext i32 %idx to i64
   %or = or i64 %zext.idx, 4160
   %addr = inttoptr i64 %or to ptr addrspace(1)
@@ -13050,6 +16229,30 @@ define <4 x float> @global_saddr_64bit_lsr_iv(ptr addrspace(1) inreg %arg) {
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_saddr_64bit_lsr_iv:
+; GFX1310-SDAG:       ; %bb.0: ; %bb
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    s_mov_b32 s2, -1
+; GFX1310-SDAG-NEXT:  .LBB114_1: ; %bb3
+; GFX1310-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_add_co_i32 s2, s2, 1
+; GFX1310-SDAG-NEXT:    s_cmp_eq_u32 s2, 0xff
+; GFX1310-SDAG-NEXT:    s_cbranch_scc0 .LBB114_1
+; GFX1310-SDAG-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-SDAG-NEXT:    s_mov_b32 s3, 0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    s_lshl_b64 s[2:3], s[2:3], 2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_add_nc_u64 s[0:1], s[0:1], s[2:3]
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_saddr_64bit_lsr_iv:
 ; GFX906-ISEL:       ; %bb.0: ; %bb
@@ -13189,6 +16392,38 @@ define <4 x float> @global_saddr_64bit_lsr_iv(ptr addrspace(1) inreg %arg) {
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_saddr_64bit_lsr_iv:
+; GFX1310-ISEL:       ; %bb.0: ; %bb
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_mov_b32 s2, -1
+; GFX1310-ISEL-NEXT:  .LBB114_1: ; %bb3
+; GFX1310-ISEL-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_add_co_i32 s2, s2, 1
+; GFX1310-ISEL-NEXT:    s_cmp_eq_u32 s2, 0xff
+; GFX1310-ISEL-NEXT:    s_cbranch_scc0 .LBB114_1
+; GFX1310-ISEL-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-ISEL-NEXT:    s_mov_b32 s3, 0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    s_lshl_b64 s[2:3], s[2:3], 2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, s2
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, s3
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1] scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 bb:
   br label %bb3
 
@@ -13308,6 +16543,30 @@ define <4 x float> @global_saddr_64bit_lsr_iv_multiload(ptr addrspace(1) inreg %
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-SDAG-LABEL: global_saddr_64bit_lsr_iv_multiload:
+; GFX1310-SDAG:       ; %bb.0: ; %bb
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    s_mov_b32 s2, -1
+; GFX1310-SDAG-NEXT:  .LBB115_1: ; %bb5
+; GFX1310-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_add_co_i32 s2, s2, 1
+; GFX1310-SDAG-NEXT:    s_cmp_eq_u32 s2, 0xff
+; GFX1310-SDAG-NEXT:    s_cbranch_scc0 .LBB115_1
+; GFX1310-SDAG-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-SDAG-NEXT:    s_mov_b32 s3, 0
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    s_lshl_b64 s[2:3], s[2:3], 2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-SDAG-NEXT:    s_add_nc_u64 s[0:1], s[0:1], s[2:3]
+; GFX1310-SDAG-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GFX906-ISEL-LABEL: global_saddr_64bit_lsr_iv_multiload:
 ; GFX906-ISEL:       ; %bb.0: ; %bb
@@ -13447,6 +16706,38 @@ define <4 x float> @global_saddr_64bit_lsr_iv_multiload(ptr addrspace(1) inreg %
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_saddr_64bit_lsr_iv_multiload:
+; GFX1310-ISEL:       ; %bb.0: ; %bb
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    s_mov_b32 s2, -1
+; GFX1310-ISEL-NEXT:  .LBB115_1: ; %bb5
+; GFX1310-ISEL-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_add_co_i32 s2, s2, 1
+; GFX1310-ISEL-NEXT:    s_cmp_eq_u32 s2, 0xff
+; GFX1310-ISEL-NEXT:    s_cbranch_scc0 .LBB115_1
+; GFX1310-ISEL-NEXT:  ; %bb.2: ; %bb2
+; GFX1310-ISEL-NEXT:    s_mov_b32 s3, 0
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    s_lshl_b64 s[2:3], s[2:3], 2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1310-ISEL-NEXT:    s_add_co_u32 s0, s0, s2
+; GFX1310-ISEL-NEXT:    s_add_co_ci_u32 s1, s1, s3
+; GFX1310-ISEL-NEXT:    global_load_b128 v[0:3], v0, s[0:1]
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 bb:
   br label %bb5
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.av.store.b128.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.av.store.b128.ll
@@ -5,12 +5,14 @@
 ; RUN: llc -global-isel=0 -mtriple=amdgpu10.12 < %s | FileCheck -check-prefix=GFX1012-SDAG %s
 ; RUN: llc -global-isel=0 -mtriple=amdgpu11.00 < %s | FileCheck -check-prefix=GFX1100-SDAG %s
 ; RUN: llc -global-isel=0 -mtriple=amdgpu12.50 < %s | FileCheck -check-prefix=GFX1250-SDAG %s
+; RUN: llc -global-isel=0 -mtriple=amdgpu13.10 < %s | FileCheck -check-prefix=GFX1310-SDAG %s
 
 ; RUN: llc -global-isel=1 -mtriple=amdgpu9.06  < %s | FileCheck -check-prefix=GFX906-ISEL  %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu9.42  < %s | FileCheck -check-prefix=GFX942-ISEL  %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu10.12 < %s | FileCheck -check-prefix=GFX1012-ISEL %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu11.00 < %s | FileCheck -check-prefix=GFX1100-ISEL %s
 ; RUN: llc -global-isel=1 -mtriple=amdgpu12.50 < %s | FileCheck -check-prefix=GFX1250-ISEL %s
+; RUN: llc -global-isel=1 -mtriple=amdgpu13.10 < %s | FileCheck -check-prefix=GFX1310-ISEL %s
 
 ;;==============================================================================
 ;; A few basic test cases
@@ -51,6 +53,16 @@ define void @av_global_store_b128_0_00(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_store_b128_0_00:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_store_b128_0_00:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -83,6 +95,16 @@ define void @av_global_store_b128_0_00(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_store_b128_0_00:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   call void @llvm.amdgcn.av.store.b128.p1(ptr addrspace(1) %addr, <4 x i32> %data, metadata !0)
   ret void
@@ -123,6 +145,16 @@ define void @av_global_store_b128_0_01(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_store_b128_0_01:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_store_b128_0_01:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -155,6 +187,16 @@ define void @av_global_store_b128_0_01(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_store_b128_0_01:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   call void @llvm.amdgcn.av.store.b128.p1(ptr addrspace(1) %addr, <4 x i32> %data, metadata !1)
   ret void
@@ -195,6 +237,16 @@ define void @av_global_store_b128_0_10(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_store_b128_0_10:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_store_b128_0_10:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -227,6 +279,16 @@ define void @av_global_store_b128_0_10(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_store_b128_0_10:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   call void @llvm.amdgcn.av.store.b128.p1(ptr addrspace(1) %addr, <4 x i32> %data, metadata !2)
   ret void
@@ -267,6 +329,16 @@ define void @av_global_store_b128_0_11(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: av_global_store_b128_0_11:
+; GFX1310-SDAG:       ; %bb.0: ; %entry
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: av_global_store_b128_0_11:
 ; GFX906-ISEL:       ; %bb.0: ; %entry
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -299,6 +371,16 @@ define void @av_global_store_b128_0_11(ptr addrspace(1) %addr, <4 x i32> %data) 
 ; GFX1250-ISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: av_global_store_b128_0_11:
+; GFX1310-ISEL:       ; %bb.0: ; %entry
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[2:5], off scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   call void @llvm.amdgcn.av.store.b128.p1(ptr addrspace(1) %addr, <4 x i32> %data, metadata !3)
   ret void
@@ -366,6 +448,21 @@ define void @global_store_i8_zext_vgpr(ptr addrspace(1) %sbase, ptr addrspace(1)
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_i8_zext_vgpr:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_i8_zext_vgpr:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -422,6 +519,21 @@ define void @global_store_i8_zext_vgpr(ptr addrspace(1) %sbase, ptr addrspace(1)
 ; GFX1250-ISEL-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_i8_zext_vgpr:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[4:7], off
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -482,6 +594,19 @@ define void @global_store_v4i32_zext_vgpr_offset_neg128(ptr addrspace(1) %sbase,
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:-128
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_v4i32_zext_vgpr_offset_neg128:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[3:6], off offset:-128 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_v4i32_zext_vgpr_offset_neg128:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -531,6 +656,19 @@ define void @global_store_v4i32_zext_vgpr_offset_neg128(ptr addrspace(1) %sbase,
 ; GFX1250-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[8:11], off offset:-128
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_v4i32_zext_vgpr_offset_neg128:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[3:6], off offset:-128 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -128
@@ -596,6 +734,21 @@ define void @global_store_i8_zext_vgpr_offset_2047(ptr addrspace(1) %sbase, ptr 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:2047 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_i8_zext_vgpr_offset_2047:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:2047 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_i8_zext_vgpr_offset_2047:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -652,6 +805,21 @@ define void @global_store_i8_zext_vgpr_offset_2047(ptr addrspace(1) %sbase, ptr 
 ; GFX1250-ISEL-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:2047 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_i8_zext_vgpr_offset_2047:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:2047 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -718,6 +886,21 @@ define void @global_store_i8_zext_vgpr_offset_neg2048(ptr addrspace(1) %sbase, p
 ; GFX1250-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:-2048 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_i8_zext_vgpr_offset_neg2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-SDAG-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-SDAG-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:-2048 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_i8_zext_vgpr_offset_neg2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -774,6 +957,21 @@ define void @global_store_i8_zext_vgpr_offset_neg2048(ptr addrspace(1) %sbase, p
 ; GFX1250-ISEL-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:-2048 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_i8_zext_vgpr_offset_neg2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v2, v[2:3], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
+; GFX1310-ISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1310-ISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX1310-ISEL-NEXT:    global_store_b128 v[0:1], v[4:7], off offset:-2048 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -832,6 +1030,18 @@ define void @global_store_saddr_i8_zext_vgpr(ptr addrspace(1) inreg %sbase, ptr 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1]
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_saddr_i8_zext_vgpr:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1]
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_saddr_i8_zext_vgpr:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -875,6 +1085,18 @@ define void @global_store_saddr_i8_zext_vgpr(ptr addrspace(1) inreg %sbase, ptr 
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v0, v[2:5], s[0:1]
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_saddr_i8_zext_vgpr:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v0, v[2:5], s[0:1]
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -923,6 +1145,16 @@ define void @global_store_saddr_v4i32_zext_vgpr_offset_neg128(ptr addrspace(1) i
 ; GFX1250-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:-128
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_saddr_v4i32_zext_vgpr_offset_neg128:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v0, v[1:4], s[0:1] offset:-128 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_saddr_v4i32_zext_vgpr_offset_neg128:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -961,6 +1193,16 @@ define void @global_store_saddr_v4i32_zext_vgpr_offset_neg128(ptr addrspace(1) i
 ; GFX1250-ISEL-NEXT:    v_dual_mov_b32 v8, v3 :: v_dual_mov_b32 v9, v4
 ; GFX1250-ISEL-NEXT:    global_store_b128 v0, v[6:9], s[0:1] offset:-128
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_saddr_v4i32_zext_vgpr_offset_neg128:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v0, v[1:4], s[0:1] offset:-128 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
   %gep1 = getelementptr inbounds i8, ptr addrspace(1) %gep0, i64 -128
@@ -1014,6 +1256,18 @@ define void @global_store_saddr_i8_zext_vgpr_offset_2047(ptr addrspace(1) inreg 
 ; GFX1250-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:2047 scope:SCOPE_DEV
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_saddr_i8_zext_vgpr_offset_2047:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:2047 scope:SCOPE_DEV
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_saddr_i8_zext_vgpr_offset_2047:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1057,6 +1311,18 @@ define void @global_store_saddr_i8_zext_vgpr_offset_2047(ptr addrspace(1) inreg 
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:2047 scope:SCOPE_DEV
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_saddr_i8_zext_vgpr_offset_2047:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:2047 scope:SCOPE_DEV
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -1111,6 +1377,18 @@ define void @global_store_saddr_i8_zext_vgpr_offset_neg2048(ptr addrspace(1) inr
 ; GFX1250-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:-2048 scope:SCOPE_SYS
 ; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
+; GFX1310-SDAG-LABEL: global_store_saddr_i8_zext_vgpr_offset_neg2048:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_expcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-SDAG-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-SDAG-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:-2048 scope:SCOPE_SYS
+; GFX1310-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+;
 ; GFX906-ISEL-LABEL: global_store_saddr_i8_zext_vgpr_offset_neg2048:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -1154,6 +1432,18 @@ define void @global_store_saddr_i8_zext_vgpr_offset_neg2048(ptr addrspace(1) inr
 ; GFX1250-ISEL-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-ISEL-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:-2048 scope:SCOPE_SYS
 ; GFX1250-ISEL-NEXT:    s_set_pc_i64 s[30:31]
+;
+; GFX1310-ISEL-LABEL: global_store_saddr_i8_zext_vgpr_offset_neg2048:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    global_load_b32 v0, v[0:1], off
+; GFX1310-ISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1310-ISEL-NEXT:    global_store_b128 v0, v[2:5], s[0:1] offset:-2048 scope:SCOPE_SYS
+; GFX1310-ISEL-NEXT:    s_set_pc_i64 s[30:31]
   %voffset = load i32, ptr addrspace(1) %voffset.ptr
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -1258,6 +1548,23 @@ define amdgpu_kernel void @global_store_saddr_uniform_ptr_in_vgprs(i32 %voffset,
 ; GFX1250-SDAG-NEXT:    global_store_b128 v6, v[0:3], s[0:1]
 ; GFX1250-SDAG-NEXT:    s_endpgm
 ;
+; GFX1310-SDAG-LABEL: global_store_saddr_uniform_ptr_in_vgprs:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    s_clause 0x1
+; GFX1310-SDAG-NEXT:    s_load_b32 s6, s[4:5], 0x24 nv
+; GFX1310-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
+; GFX1310-SDAG-NEXT:    ds_load_b64 v[4:5], v0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v0, s0
+; GFX1310-SDAG-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v3, s3
+; GFX1310-SDAG-NEXT:    s_wait_dscnt 0x0
+; GFX1310-SDAG-NEXT:    v_readfirstlane_b32 s0, v4
+; GFX1310-SDAG-NEXT:    v_readfirstlane_b32 s1, v5
+; GFX1310-SDAG-NEXT:    global_store_b128 v6, v[0:3], s[0:1]
+; GFX1310-SDAG-NEXT:    s_endpgm
+;
 ; GFX906-ISEL-LABEL: global_store_saddr_uniform_ptr_in_vgprs:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    v_mov_b32_e32 v0, 0
@@ -1344,6 +1651,23 @@ define amdgpu_kernel void @global_store_saddr_uniform_ptr_in_vgprs(i32 %voffset,
 ; GFX1250-ISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1250-ISEL-NEXT:    global_store_b128 v4, v[0:3], s[0:1]
 ; GFX1250-ISEL-NEXT:    s_endpgm
+;
+; GFX1310-ISEL-LABEL: global_store_saddr_uniform_ptr_in_vgprs:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    s_clause 0x1
+; GFX1310-ISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
+; GFX1310-ISEL-NEXT:    s_load_b32 s4, s[4:5], 0x24 nv
+; GFX1310-ISEL-NEXT:    ds_load_b64 v[4:5], v0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_wait_dscnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v4
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v5
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v4, s4
+; GFX1310-ISEL-NEXT:    global_store_b128 v4, v[0:3], s[0:1]
+; GFX1310-ISEL-NEXT:    s_endpgm
   %sbase = load ptr addrspace(1), ptr addrspace(3) @ptr.in.lds
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset
@@ -1441,6 +1765,23 @@ define amdgpu_kernel void @global_store_saddr_uniform_ptr_in_vgprs_immoffset(i32
 ; GFX1250-SDAG-NEXT:    global_store_b128 v6, v[0:3], s[0:1] offset:-120
 ; GFX1250-SDAG-NEXT:    s_endpgm
 ;
+; GFX1310-SDAG-LABEL: global_store_saddr_uniform_ptr_in_vgprs_immoffset:
+; GFX1310-SDAG:       ; %bb.0:
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-SDAG-NEXT:    s_clause 0x1
+; GFX1310-SDAG-NEXT:    s_load_b32 s6, s[4:5], 0x24 nv
+; GFX1310-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
+; GFX1310-SDAG-NEXT:    ds_load_b64 v[4:5], v0
+; GFX1310-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-SDAG-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v0, s0
+; GFX1310-SDAG-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX1310-SDAG-NEXT:    v_mov_b32_e32 v3, s3
+; GFX1310-SDAG-NEXT:    s_wait_dscnt 0x0
+; GFX1310-SDAG-NEXT:    v_readfirstlane_b32 s0, v4
+; GFX1310-SDAG-NEXT:    v_readfirstlane_b32 s1, v5
+; GFX1310-SDAG-NEXT:    global_store_b128 v6, v[0:3], s[0:1] offset:-120 scope:SCOPE_SE
+; GFX1310-SDAG-NEXT:    s_endpgm
+;
 ; GFX906-ISEL-LABEL: global_store_saddr_uniform_ptr_in_vgprs_immoffset:
 ; GFX906-ISEL:       ; %bb.0:
 ; GFX906-ISEL-NEXT:    v_mov_b32_e32 v0, 0
@@ -1527,6 +1868,23 @@ define amdgpu_kernel void @global_store_saddr_uniform_ptr_in_vgprs_immoffset(i32
 ; GFX1250-ISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1250-ISEL-NEXT:    global_store_b128 v4, v[0:3], s[0:1] offset:-120
 ; GFX1250-ISEL-NEXT:    s_endpgm
+;
+; GFX1310-ISEL-LABEL: global_store_saddr_uniform_ptr_in_vgprs_immoffset:
+; GFX1310-ISEL:       ; %bb.0:
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1310-ISEL-NEXT:    s_clause 0x1
+; GFX1310-ISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
+; GFX1310-ISEL-NEXT:    s_load_b32 s4, s[4:5], 0x24 nv
+; GFX1310-ISEL-NEXT:    ds_load_b64 v[4:5], v0
+; GFX1310-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX1310-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX1310-ISEL-NEXT:    s_wait_dscnt 0x0
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s0, v4
+; GFX1310-ISEL-NEXT:    v_readfirstlane_b32 s1, v5
+; GFX1310-ISEL-NEXT:    v_mov_b32_e32 v4, s4
+; GFX1310-ISEL-NEXT:    global_store_b128 v4, v[0:3], s[0:1] offset:-120 scope:SCOPE_SE
+; GFX1310-ISEL-NEXT:    s_endpgm
   %sbase = load ptr addrspace(1), ptr addrspace(3) @ptr.in.lds
   %zext.offset = zext i32 %voffset to i64
   %gep0 = getelementptr inbounds i8, ptr addrspace(1) %sbase, i64 %zext.offset


### PR DESCRIPTION
fillAMDGCNFeatureMap omitted flat-global-insts for gfx1310/gfx13-generic,
so clang wrongly rejected __builtin_amdgcn_av_load_b128 /
__builtin_amdgcn_av_store_b128 on those targets even though the backend
enables the feature. Add it to the gfx13 case.

Co-authored-by: Claude (Claude-Opus-4.8)