### PR TITLE
[offload][lit] Disable failing olCreateProgram test on AMD

### DIFF
--- a/offload/unittests/OffloadAPI/program/olCreateProgram.cpp
+++ b/offload/unittests/OffloadAPI/program/olCreateProgram.cpp
@@ -28,6 +28,7 @@ TEST_P(olCreateProgramTest, Success) {
 }
 
 TEST_P(olCreateProgramTest, JITSuccess) {
+  SKIP_KNOWN_FAILURE(AMDGPU{"problem finding lld"});
 
   std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
   ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo_jit", Device, DeviceBin));


### PR DESCRIPTION
Fails with an error about not being able to find `lld`. AMD team is investigating, but disable the test in the meantime.

Context: https://github.com/llvm/llvm-project/pull/212860