### PR TITLE
[flang][cuda] Back automatic arrays with managed memory under -gpu=managed

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10645,14 +10645,17 @@ void ResolveNamesVisitor::FinishSpecificationPart(
     }
 
     if (auto *object{symbol.detailsIf<ObjectEntityDetails>()}) {
-      if ((IsAllocatable(symbol) || IsPointer(symbol)) &&
+      // Automatic arrays would otherwise be host allocations the device cannot
+      // reach, needing a copy around every compute region that uses them.
+      const bool isAutomaticArray{IsAutomatic(symbol) && object->IsArray()};
+      if ((IsAllocatable(symbol) || IsPointer(symbol) || isAutomaticArray) &&
           !object->cudaDataAttr()) {
-        // Implicitly treat allocatable/pointer arrays as managed when feature
-        // is enabled. This is done after all explicit CUDA attributes have
-        // been processed. Only applies when CUDA Fortran is enabled; otherwise
-        // -gpu=mem:managed on a non-CUDA-Fortran translation unit (e.g. pure
-        // OpenACC) would incorrectly route every allocatable through the CUDA
-        // Fortran managed descriptor pipeline.
+        // Implicitly treat allocatable/pointer arrays and automatic arrays as
+        // managed when feature is enabled. This is done after all explicit
+        // CUDA attributes have been processed. Only applies when CUDA Fortran
+        // is enabled; otherwise -gpu=mem:managed on a non-CUDA-Fortran
+        // translation unit (e.g. pure OpenACC) would incorrectly route every
+        // allocatable through the CUDA Fortran managed descriptor pipeline.
         if (context().languageFeatures().IsEnabled(
                 common::LanguageFeature::CudaManaged) &&
             context().languageFeatures().IsEnabled(

--- a/flang/test/Lower/CUDA/cuda-gpu-managed-automatic-array.cuf
+++ b/flang/test/Lower/CUDA/cuda-gpu-managed-automatic-array.cuf
@@ -1,0 +1,29 @@
+! RUN: bbc -emit-hlfir -fcuda -gpu=managed %s -o - | FileCheck %s --check-prefix=MANAGED
+! RUN: bbc -emit-hlfir -fcuda -gpu=unified %s -o - | FileCheck %s --check-prefix=STACK
+! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s --check-prefix=STACK
+
+! Check that -gpu=managed implicitly treats automatic arrays as managed
+
+subroutine test_automatic_array(n)
+  integer :: n
+  real :: a(n)
+  call use_it(a)
+end subroutine
+
+! MANAGED-LABEL: func.func @_QPtest_automatic_array(
+! MANAGED: cuf.alloc !fir.array<?xf32>, %{{.*}} {bindc_name = "a", data_attr = #cuf.cuda<managed>, uniq_name = "_QFtest_automatic_arrayEa"}
+! MANAGED: cuf.free %{{.*}} : !fir.ref<!fir.array<?xf32>> {data_attr = #cuf.cuda<managed>}
+
+! STACK-LABEL: func.func @_QPtest_automatic_array(
+! STACK: fir.alloca !fir.array<?xf32>, %{{.*}} {bindc_name = "a", uniq_name = "_QFtest_automatic_arrayEa"}
+
+! Automatic but not an array
+
+subroutine test_automatic_char(n)
+  integer :: n
+  character(len=n) :: c
+  call use_char(c)
+end subroutine
+
+! MANAGED-LABEL: func.func @_QPtest_automatic_char(
+! MANAGED: fir.alloca !fir.char<1,?>{{.*}} {bindc_name = "c", uniq_name = "_QFtest_automatic_charEc"}


### PR DESCRIPTION
Under `-gpu=managed`, a local automatic array (local array with a non-constant bound) was allocated on the ordinary host heap. The device cannot reach that storage, so the array needs to be copied to and from the device around every compute region that uses it, which hurts performance badly for a large array whose leading dimension is only partly used.

This PR extends the existing implicit-managed rule, which covered allocatables and pointers, to also cover automatic arrays. They take the same path allocatables use: `cuf.alloc`/`cuf.free` with `data_attr = #cuf.cuda<managed>`.
The change is for arrays only, so automatic character scalars are unaffected; explicit attributes are still preserved, and the existing `CudaManaged && CUDA` guard leaves every other configuration such as `-gpu=unified` unchanged.

Note that `-fstack-arrays` no longer applies to automatic arrays under `-gpu=managed` with this change, since they are now allocated at lowering rather than as a `fir.alloca` to be relocated later. Honoring it would reintroduce the copying.