### PR TITLE
[libc++] Fix dangling reference in the associative container benchmarks

### DIFF
--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -493,9 +493,9 @@ void associative_container_benchmarks(std::string container) {
       st.ResumeTiming();
     }
   };
-  bench("insert(iterator, iterator) (all new keys, end)", [&](auto& state) { insert_iter_iter_bench(true, state); });
+  bench("insert(iterator, iterator) (all new keys, end)", [=](auto& state) { insert_iter_iter_bench(true, state); });
   bench("insert(iterator, iterator) (all new keys, middle)",
-        [&](auto& state) { insert_iter_iter_bench(false, state); });
+        [=](auto& state) { insert_iter_iter_bench(false, state); });
 
   bench("insert(iterator, iterator) (half new keys)", [=](auto& st) {
     const std::size_t size = st.range(0);


### PR DESCRIPTION
Two insert benchmarks were registered with lambdas capturing insert_iter_iter_bench by reference, unlike every other registration in this file, which captures by value.

RegisterBenchmark() stores the lambda by value and only invokes it from RunSpecifiedBenchmarks(), which happens long after associative_container_benchmarks() has returned, creating a dangling reference.