### PR TITLE
[lldb/docs] Document the remaining scripted-extension plugin categories

### DIFF
--- a/lldb/docs/CMakeLists.txt
+++ b/lldb/docs/CMakeLists.txt
@@ -34,6 +34,7 @@ if (LLDB_ENABLE_PYTHON AND SPHINX_FOUND)
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_hook.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_stackframe_recognizer.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_command.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
+      COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/parsed_cmd.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_string_summary.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_synthetic_children.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMENT "Copying lldb.py to pretend its a Python package.")

--- a/lldb/docs/python_extensions.md
+++ b/lldb/docs/python_extensions.md
@@ -16,12 +16,66 @@ This page describes some of these scripting extensions:
     :skip: ScriptedThread
 ```
 
+## Parsed Command Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.parsed_cmd
+
+.. automodsumm:: lldb.plugins.parsed_cmd
+    :classes-only:
+    :toctree: python_api
+```
+
+## Scripted Breakpoint Resolver Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.scripted_breakpoint
+
+.. automodsumm:: lldb.plugins.scripted_breakpoint
+    :classes-only:
+    :toctree: python_api
+    :skip: ABCMeta
+```
+
+## Scripted Command Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.scripted_command
+
+.. automodsumm:: lldb.plugins.scripted_command
+    :classes-only:
+    :toctree: python_api
+    :skip: ABCMeta
+```
+
 ## Scripted Frame Provider Plugins
 
 ```{eval-rst}
 .. automodule:: lldb.plugins.scripted_frame_provider
 
 .. automodsumm:: lldb.plugins.scripted_frame_provider
+    :classes-only:
+    :toctree: python_api
+    :skip: ABCMeta
+```
+
+## Scripted Hook Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.scripted_hook
+
+.. automodsumm:: lldb.plugins.scripted_hook
+    :classes-only:
+    :toctree: python_api
+    :skip: ABCMeta
+```
+
+## Scripted Platform Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.scripted_platform
+
+.. automodsumm:: lldb.plugins.scripted_platform
     :classes-only:
     :toctree: python_api
     :skip: ABCMeta
@@ -38,12 +92,34 @@ This page describes some of these scripting extensions:
     :skip: ABCMeta
 ```
 
-## Scripted Platform Plugins
+## Scripted Stack Frame Recognizer Plugins
 
 ```{eval-rst}
-.. automodule:: lldb.plugins.scripted_platform
+.. automodule:: lldb.plugins.scripted_stackframe_recognizer
 
-.. automodsumm:: lldb.plugins.scripted_platform
+.. automodsumm:: lldb.plugins.scripted_stackframe_recognizer
+    :classes-only:
+    :toctree: python_api
+    :skip: ABCMeta
+```
+
+## Scripted String Summary Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.scripted_string_summary
+
+.. automodsumm:: lldb.plugins.scripted_string_summary
+    :classes-only:
+    :toctree: python_api
+    :skip: ABCMeta
+```
+
+## Scripted Synthetic Children Plugins
+
+```{eval-rst}
+.. automodule:: lldb.plugins.scripted_synthetic_children
+
+.. automodsumm:: lldb.plugins.scripted_synthetic_children
     :classes-only:
     :toctree: python_api
     :skip: ABCMeta


### PR DESCRIPTION
`python_extensions.md` only covered the first five plugin categories.

This commit adds the missing sections for every plugin category added since: `ScriptedBreakpointResolver`, `ScriptedHook`, `ScriptedStackFrameRecognizer`, `ScriptedCommand`, `ParsedCommand`, `ScriptedStringSummary`, and `ScriptedSyntheticChildren`.