### PR TITLE
Revert "[github] Move BOLT reviewers to team (#211422)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 # See https://llvm.org/docs/DeveloperPolicy.html#maintainers as well as the
 # Maintainers.md files in the the respective subproject directories.
 
-/bolt/ @llvm/reviewers-bolt
 /libc/ @llvm/reviewers-libc
 /libcxx/ @llvm/reviewers-libcxx
 /libcxxabi/ @llvm/reviewers-libcxxabi
@@ -177,6 +176,9 @@
 
 # MLIR IRDL-related
 /mlir/**/*IRDL* @moxinilian
+
+# BOLT
+/bolt/ @aaupov @maksfb @rafaelauler @ayermolo @yota9 @paschalis-mpeis @yozhu @yavtuk
 
 # Bazel build system.
 /utils/bazel/ @rupprecht @keith @aaronmondal @googlewalt


### PR DESCRIPTION
We haven't really being tagged in new PRs anymore, so it looks like this is not working.

Revert for now until we can fix this, so we don't miss PRs.

This reverts commit 04f124f6151e8c8410e28aba28dc38e590e34c58.