### PR TITLE
[libc++][NFC] Make size_t -> int conversions explicit in a few PSTL tests

### DIFF
--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl.adjacent_find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl.adjacent_find.pass.cpp
@@ -101,7 +101,7 @@ struct Test {
           return; // skip the first element to avoid out-of-bounds access
         a[i] = a[i - 1];
         assert(std::adjacent_find(policy, Iter(std::begin(a)), Iter(std::end(a))) == Iter(std::begin(a) + i - 1));
-        a[i] = i;
+        a[i] = static_cast<int>(i);
       });
     }
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl.adjacent_find_pred.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl.adjacent_find_pred.pass.cpp
@@ -109,7 +109,7 @@ struct Test {
         a[i] = a[i - 1] + 42;
         assert(std::adjacent_find(policy, Iter(std::begin(a)), Iter(std::end(a)), Pred{}) ==
                Iter(std::begin(a) + i - 1));
-        a[i] = i;
+        a[i] = static_cast<int>(i);
       });
     }
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp
@@ -101,7 +101,7 @@ struct Test {
         assert(std::find_first_of(
                    policy, Iter1(std::begin(a)), Iter1(std::end(a)), Iter2(std::begin(b)), Iter2(std::end(b))) ==
                Iter1(std::begin(a) + i));
-        a[i] = i;
+        a[i] = static_cast<int>(i);
       });
     }
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp
@@ -122,7 +122,7 @@ struct Test {
             std::find_first_of(
                 policy, Iter1(std::begin(a)), Iter1(std::end(a)), Iter2(std::begin(b)), Iter2(std::end(b)), Pred{}) ==
             Iter1(std::begin(a) + i));
-        a[i] = i;
+        a[i] = static_cast<int>(i);
       });
     }
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp
@@ -151,7 +151,7 @@ struct Test {
             std::mismatch(
                 policy, Iter1(std::begin(lhs)), Iter1(std::end(lhs)), Iter2(std::begin(rhs)), Iter2(std::end(rhs))) ==
             std::make_pair(Iter1(std::begin(lhs) + i), Iter2(std::begin(rhs) + i)));
-        lhs[i] = i;
+        lhs[i] = static_cast<int>(i);
       });
       assert(std::mismatch(policy, Iter1(std::begin(lhs)), Iter1(std::end(lhs)), Iter2(std::begin(rhs))) ==
              std::make_pair(Iter1(std::end(lhs)), Iter2(std::end(rhs))));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp
@@ -183,7 +183,7 @@ struct Test {
                              Iter2(std::begin(rhs)),
                              Iter2(std::end(rhs)),
                              Pred{}) == std::make_pair(Iter1(std::begin(lhs) + i), Iter2(std::begin(rhs) + i)));
-        lhs[i] = i;
+        lhs[i] = static_cast<int>(i);
       });
       assert(std::mismatch(policy, Iter1(std::begin(lhs)), Iter1(std::end(lhs)), Iter2(std::begin(rhs)), Pred{}) ==
              std::make_pair(Iter1(std::end(lhs)), Iter2(std::end(rhs))));


### PR DESCRIPTION
The implicit truncating conversions that were introduced in some PSTL tests are causing warnings on MSVC. This PR fixes that.

See https://github.com/llvm/llvm-project/pull/212366#discussion_r3679252259 for more details.