### PR TITLE
[libc++] Clean up headers that relied on `<optional>`'s transitive includes 

### DIFF
--- a/libcxx/include/__algorithm/ranges_fold.h
+++ b/libcxx/include/__algorithm/ranges_fold.h
@@ -31,6 +31,7 @@
 #include <__type_traits/decay.h>
 #include <__type_traits/invoke.h>
 #include <__utility/forward.h>
+#include <__utility/in_place.h>
 #include <__utility/move.h>
 #include <optional>
 

--- a/libcxx/include/__node_handle
+++ b/libcxx/include/__node_handle
@@ -63,7 +63,9 @@ public:
 #include <__memory/allocator_traits.h>
 #include <__memory/pointer_traits.h>
 #include <__type_traits/is_specialization.h>
+#include <__type_traits/remove_const.h>
 #include <__utility/exchange.h>
+#include <__utility/move.h>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__pstl/cpu_algos/transform_reduce.h
+++ b/libcxx/include/__pstl/cpu_algos/transform_reduce.h
@@ -17,6 +17,8 @@
 #include <__pstl/backend_fwd.h>
 #include <__pstl/cpu_algos/cpu_traits.h>
 #include <__type_traits/desugars_to.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/invoke.h>
 #include <__type_traits/is_arithmetic.h>
 #include <__type_traits/is_execution_policy.h>
 #include <__utility/move.h>

--- a/libcxx/include/__ranges/join_view.h
+++ b/libcxx/include/__ranges/join_view.h
@@ -31,10 +31,14 @@
 #include <__ranges/range_adaptor.h>
 #include <__ranges/view_interface.h>
 #include <__type_traits/common_type.h>
+#include <__type_traits/conditional.h>
+#include <__type_traits/is_reference.h>
 #include <__type_traits/maybe_const.h>
+#include <__type_traits/remove_cvref.h>
 #include <__utility/as_lvalue.h>
 #include <__utility/empty.h>
 #include <__utility/forward.h>
+#include <__utility/move.h>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__ranges/movable_box.h
+++ b/libcxx/include/__ranges/movable_box.h
@@ -16,7 +16,11 @@
 #include <__config>
 #include <__memory/addressof.h>
 #include <__memory/construct_at.h>
+#include <__type_traits/is_constructible.h>
 #include <__type_traits/is_nothrow_constructible.h>
+#include <__type_traits/is_object.h>
+#include <__utility/forward.h>
+#include <__utility/in_place.h>
 #include <__utility/move.h>
 #include <optional>
 

--- a/libcxx/include/__ranges/non_propagating_cache.h
+++ b/libcxx/include/__ranges/non_propagating_cache.h
@@ -14,6 +14,7 @@
 #include <__iterator/concepts.h>        // indirectly_readable
 #include <__iterator/iterator_traits.h> // iter_reference_t
 #include <__memory/addressof.h>
+#include <__type_traits/is_object.h>
 #include <__utility/forward.h>
 #include <optional>
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -269,21 +269,6 @@ namespace std {
 #  include <__optional/optional_ref.h>
 #  include <__optional/swap.h>
 
-// TODO: Some headers rely on these transitive includes
-#  include <__cstddef/size_t.h>
-#  include <__type_traits/conditional.h>
-#  include <__type_traits/enable_if.h>
-#  include <__type_traits/invoke.h>
-#  include <__type_traits/is_constructible.h>
-#  include <__type_traits/is_object.h>
-#  include <__type_traits/is_reference.h>
-#  include <__type_traits/remove_const.h>
-#  include <__type_traits/remove_cvref.h>
-#  include <__utility/declval.h>
-#  include <__utility/forward.h>
-#  include <__utility/in_place.h>
-#  include <__utility/move.h>
-
 #  include <initializer_list>
 
 // standard-mandated includes


### PR DESCRIPTION
- Follow up to #206644
- Clear out the headers in `optional` that were left in to not break other headers, and fix them also.