### PR TITLE
[libc++] Clean up headers that relied on `<optional>`'s transitive includes

### DIFF
--- a/libcxx/include/__algorithm/ranges_fold.h
+++ b/libcxx/include/__algorithm/ranges_fold.h
@@ -31,6 +31,7 @@
 #include <__type_traits/decay.h>
 #include <__type_traits/invoke.h>
 #include <__utility/forward.h>
+#include <__utility/in_place.h>
 #include <__utility/move.h>
 #include <optional>
 

--- a/libcxx/include/__node_handle
+++ b/libcxx/include/__node_handle
@@ -63,7 +63,9 @@ public:
 #include <__memory/allocator_traits.h>
 #include <__memory/pointer_traits.h>
 #include <__type_traits/is_specialization.h>
+#include <__type_traits/remove_const.h>
 #include <__utility/exchange.h>
+#include <__utility/move.h>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__pstl/cpu_algos/transform_reduce.h
+++ b/libcxx/include/__pstl/cpu_algos/transform_reduce.h
@@ -17,6 +17,8 @@
 #include <__pstl/backend_fwd.h>
 #include <__pstl/cpu_algos/cpu_traits.h>
 #include <__type_traits/desugars_to.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/invoke.h>
 #include <__type_traits/is_arithmetic.h>
 #include <__type_traits/is_execution_policy.h>
 #include <__utility/move.h>

--- a/libcxx/include/__ranges/join_view.h
+++ b/libcxx/include/__ranges/join_view.h
@@ -31,10 +31,14 @@
 #include <__ranges/range_adaptor.h>
 #include <__ranges/view_interface.h>
 #include <__type_traits/common_type.h>
+#include <__type_traits/conditional.h>
+#include <__type_traits/is_reference.h>
 #include <__type_traits/maybe_const.h>
+#include <__type_traits/remove_cvref.h>
 #include <__utility/as_lvalue.h>
 #include <__utility/empty.h>
 #include <__utility/forward.h>
+#include <__utility/move.h>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__ranges/movable_box.h
+++ b/libcxx/include/__ranges/movable_box.h
@@ -16,7 +16,11 @@
 #include <__config>
 #include <__memory/addressof.h>
 #include <__memory/construct_at.h>
+#include <__type_traits/is_constructible.h>
 #include <__type_traits/is_nothrow_constructible.h>
+#include <__type_traits/is_object.h>
+#include <__utility/forward.h>
+#include <__utility/in_place.h>
 #include <__utility/move.h>
 #include <optional>
 

--- a/libcxx/include/__ranges/non_propagating_cache.h
+++ b/libcxx/include/__ranges/non_propagating_cache.h
@@ -14,6 +14,7 @@
 #include <__iterator/concepts.h>        // indirectly_readable
 #include <__iterator/iterator_traits.h> // iter_reference_t
 #include <__memory/addressof.h>
+#include <__type_traits/is_object.h>
 #include <__utility/forward.h>
 #include <optional>
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -268,21 +268,7 @@ namespace std {
 #  include <__optional/optional.h>
 #  include <__optional/optional_ref.h>
 #  include <__optional/swap.h>
-
-// TODO: Some headers rely on these transitive includes
-#  include <__cstddef/size_t.h>
-#  include <__type_traits/conditional.h>
-#  include <__type_traits/enable_if.h>
-#  include <__type_traits/invoke.h>
-#  include <__type_traits/is_constructible.h>
-#  include <__type_traits/is_object.h>
-#  include <__type_traits/is_reference.h>
-#  include <__type_traits/remove_const.h>
-#  include <__type_traits/remove_cvref.h>
-#  include <__utility/declval.h>
-#  include <__utility/forward.h>
 #  include <__utility/in_place.h>
-#  include <__utility/move.h>
 
 #  include <initializer_list>
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -268,7 +268,6 @@ namespace std {
 #  include <__optional/optional.h>
 #  include <__optional/optional_ref.h>
 #  include <__optional/swap.h>
-#  include <__utility/in_place.h>
 
 #  include <initializer_list>
 

--- a/libcxx/test/libcxx/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 #include "test_allocator.h"
 #include "test_macros.h"

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.move.wrap/types.h
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.move.wrap/types.h
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <concepts>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/concepts/concepts.object/regular.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.object/regular.compile.pass.cpp
@@ -22,6 +22,7 @@
 #include <stdexcept>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "type_classification/moveconstructible.h"

--- a/libcxx/test/std/input.output/filesystems/class.path/path.nonmember/path.io.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.path/path.nonmember/path.io.pass.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <cassert>
 #include <iostream>
+#include <utility>
 
 #include "count_new.h"
 #include "make_string.h"

--- a/libcxx/test/std/thread/thread.stoptoken/stopsource/cons.copy.pass.cpp
+++ b/libcxx/test/std/thread/thread.stoptoken/stopsource/cons.copy.pass.cpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <stop_token>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 #include <cassert>
 #include <memory>
+#include <utility>
 
 #include "test_macros.h"
 #include "archetypes.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/const_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/const_optional_U.pass.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <type_traits>
 #include <cassert>
+#include <utility>
 
 #include "test_macros.h"
 #include "archetypes.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 #include "../optional_helper_types.h"
 #include "test_macros.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 #include "archetypes.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
@@ -15,6 +15,7 @@
 
 #include <cassert>
 #include <optional>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/explicit_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/explicit_optional_U.pass.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/in_place_t.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/in_place_t.pass.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "test_macros.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/move.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/move.pass.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 #include "archetypes.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/rvalue_T.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/rvalue_T.pass.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 #include "test_macros.h"
 #include "archetypes.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.observe/value_or.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.observe/value_or.pass.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <type_traits>
 #include <cassert>
+#include <utility>
 
 #include "test_macros.h"
 

--- a/libcxx/test/std/utilities/optional/optional.syn/optional_in_place_t.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.syn/optional_in_place_t.verify.cpp
@@ -14,6 +14,7 @@
 // (possibly cv-qualified) in_place_t is ill-formed.
 
 #include <optional>
+#include <utility>
 
 #include "test_macros.h"
 


### PR DESCRIPTION
- Clear out the headers in optional that were left in to not break other headers, and fix them also.
- Also fix tests
