### PR TITLE
[clang] Don't warn on stack_protector_ignore in system macros

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -317,7 +317,8 @@ def warn_stack_clash_protection_inline_asm : Warning<
 
 def warn_stack_protection_ignore_attribute : Warning<
   "'stack_protector_ignore' attribute ignored due to "
-  "'-fstack-protector-all' option">, InGroup<IgnoredAttributes>;
+  "'-fstack-protector-all' option">, InGroup<IgnoredAttributes>,
+  SuppressInSystemMacro;
 
 def warn_slh_does_not_support_asm_goto : Warning<
   "speculative load hardening does not protect functions with asm goto">,

--- a/llvm/test/CodeGen/AArch64/stack-protector-metadata.ll
+++ b/llvm/test/CodeGen/AArch64/stack-protector-metadata.ll
@@ -37,6 +37,83 @@ entry:
   ret void
 }
 
+; sspreq protects every function unconditionally, so the metadata is ignored
+; there and test3 still gets a guard despite carrying it.
+
+; CHECK-LABEL: test3:
+; CHECK: ___stack_chk_guard
+
+; Function Attrs: noinline nounwind optnone
+define void @test3(ptr noundef %msg) #4 {
+entry:
+  %msg.addr = alloca ptr, align 8
+  %a = alloca [1000 x i8], align 1, !stack-protector !2
+  store ptr %msg, ptr %msg.addr, align 8
+  %arraydecay = getelementptr inbounds [1000 x i8], ptr %a, i64 0, i64 0
+  %0 = load ptr, ptr %msg.addr, align 8
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %0) #3
+  %arraydecay1 = getelementptr inbounds [1000 x i8], ptr %a, i64 0, i64 0
+  %call2 = call i32 (ptr, ...) @printf(ptr noundef @.str, ptr noundef %arraydecay1)
+  ret void
+}
+
+; Control for test3: same function without the metadata, also protected.
+
+; CHECK-LABEL: test4:
+; CHECK: ___stack_chk_guard
+
+; Function Attrs: noinline nounwind optnone
+define void @test4(ptr noundef %msg) #4 {
+entry:
+  %msg.addr = alloca ptr, align 8
+  %b = alloca [1000 x i8], align 1
+  store ptr %msg, ptr %msg.addr, align 8
+  %arraydecay = getelementptr inbounds [1000 x i8], ptr %b, i64 0, i64 0
+  %0 = load ptr, ptr %msg.addr, align 8
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %0) #3
+  %arraydecay1 = getelementptr inbounds [1000 x i8], ptr %b, i64 0, i64 0
+  %call2 = call i32 (ptr, ...) @printf(ptr noundef @.str, ptr noundef %arraydecay1)
+  ret void
+}
+
+; sspstrong honors the metadata, like ssp.
+
+; CHECK-LABEL: test5:
+; CHECK-NOT: ___stack_chk_guard
+
+; Function Attrs: noinline nounwind optnone
+define void @test5(ptr noundef %msg) #5 {
+entry:
+  %msg.addr = alloca ptr, align 8
+  %a = alloca [1000 x i8], align 1, !stack-protector !2
+  store ptr %msg, ptr %msg.addr, align 8
+  %arraydecay = getelementptr inbounds [1000 x i8], ptr %a, i64 0, i64 0
+  %0 = load ptr, ptr %msg.addr, align 8
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %0) #3
+  %arraydecay1 = getelementptr inbounds [1000 x i8], ptr %a, i64 0, i64 0
+  %call2 = call i32 (ptr, ...) @printf(ptr noundef @.str, ptr noundef %arraydecay1)
+  ret void
+}
+
+; Control for test5: same function without the metadata, protected.
+
+; CHECK-LABEL: test6:
+; CHECK: ___stack_chk_guard
+
+; Function Attrs: noinline nounwind optnone
+define void @test6(ptr noundef %msg) #5 {
+entry:
+  %msg.addr = alloca ptr, align 8
+  %b = alloca [1000 x i8], align 1
+  store ptr %msg, ptr %msg.addr, align 8
+  %arraydecay = getelementptr inbounds [1000 x i8], ptr %b, i64 0, i64 0
+  %0 = load ptr, ptr %msg.addr, align 8
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %0) #3
+  %arraydecay1 = getelementptr inbounds [1000 x i8], ptr %b, i64 0, i64 0
+  %call2 = call i32 (ptr, ...) @printf(ptr noundef @.str, ptr noundef %arraydecay1)
+  ret void
+}
+
 ; Function Attrs: nounwind
 declare ptr @strcpy(ptr noundef, ptr noundef) #1
 
@@ -46,6 +123,8 @@ attributes #0 = { noinline nounwind optnone "no-trapping-math"="true" "stack-pro
 attributes #1 = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #2 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #3 = { nounwind }
+attributes #4 = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" sspreq }
+attributes #5 = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" sspstrong }
 
 !llvm.module.flags = !{!0}
 !llvm.ident = !{!1}


### PR DESCRIPTION
Under -fstack-protector-all, stack_protector_ignore on a local is inert. The warning is therefore accurate, and it stays useful in user code -- an opt-out that silently does nothing is worth knowing about.

The warning is not actionable when the attribute comes from a system header macro and so this change disables it in system macros. Behavior is otherwise unchanged. The attribute was already being ignored, so suppressing the diagnostic hides nothing.

Also extend stack-protector-metadata.ll to cover the remaining protection levels: test3/test4 for sspreq, where the opt-out metadata is ignored, and test5/test6 for sspstrong, where it is honored. Only ssp was covered before.

rdar://173529401