### PR TITLE
[sanitizer-common][rtsan] Add rtsan to sanitizer-common suite

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -18,6 +18,7 @@
 
 #include "sanitizer_common/sanitizer_atomic.h"
 #include "sanitizer_common/sanitizer_common.h"
+#include "sanitizer_common/sanitizer_interface_internal.h"
 #include "sanitizer_common/sanitizer_mutex.h"
 #include "sanitizer_common/sanitizer_stackdepot.h"
 
@@ -82,7 +83,9 @@ SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init() {
   SetInitializationState(InitializationState::Initializing);
 
   SanitizerToolName = "RealtimeSanitizer";
+  CacheBinaryName();
   InitializeFlags();
+  __sanitizer_set_report_path(common_flags()->log_path);
 
   InitializePlatformEarly();
 

--- a/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
@@ -30,6 +30,16 @@ void BufferedStackTrace::UnwindImpl(uptr pc, uptr bp, void *context,
 }
 } // namespace __sanitizer
 
+extern "C" {
+SANITIZER_INTERFACE_ATTRIBUTE
+void __sanitizer_print_stack_trace() {
+  GET_CURRENT_PC_BP;
+  UNINITIALIZED BufferedStackTrace stack;
+  stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal);
+  stack.Print();
+}
+} // extern "C"
+
 namespace {
 class Decorator : public SanitizerCommonDecorator {
 public:

--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -869,15 +869,16 @@ INTERCEPTOR(void *, calloc, SIZE_T num, SIZE_T size) {
 }
 
 INTERCEPTOR(void, free, void *ptr) {
-  if (DlsymAlloc::PointerIsMine(ptr))
-    return DlsymAlloc::Free(ptr);
-
   // According to the C and C++ standard, freeing a nullptr is guaranteed to be
   // a no-op (and thus real-time safe). This can be confirmed for looking at
   // __libc_free in the glibc source.
-  if (ptr != nullptr)
-    __rtsan_notify_intercepted_call("free");
+  if (ptr == nullptr)
+    return;
 
+  if (DlsymAlloc::PointerIsMine(ptr))
+    return DlsymAlloc::Free(ptr);
+
+  __rtsan_notify_intercepted_call("free");
   return REAL(free)(ptr);
 }
 

--- a/compiler-rt/test/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/test/sanitizer_common/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SANITIZER_COMMON_TESTSUITES)
 # FIXME(dliew): We should switch to COMPILER_RT_SANITIZERS_TO_BUILD instead of
 # the hard coded `SUPPORTED_TOOLS_INIT` list once we know that the other
 # sanitizers work.
-set(SUPPORTED_TOOLS_INIT asan lsan hwasan msan tsan ubsan)
+set(SUPPORTED_TOOLS_INIT asan lsan hwasan msan tsan ubsan rtsan)
 set(SUPPORTED_TOOLS)
   foreach(SANITIZER_TOOL ${SUPPORTED_TOOLS_INIT})
     string(TOUPPER ${SANITIZER_TOOL} SANITIZER_TOOL_UPPER)

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cpp
@@ -14,12 +14,12 @@
 
 int global;
 
-int main() {
+int main() [[clang::nonblocking]] {
 #if defined(USING_ubsan)
   volatile int *null = 0;
   *null = 0;
 #else
-  volatile int *a = new int[100];
+  volatile int *a = new int[100]; // triggers RTSan report
   delete[] a;
   global = a[0]; // use-after-free: triggers ASan/TSan report.
 #endif

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/malloc_zone.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/malloc_zone.cpp
@@ -20,6 +20,8 @@
 // Currently fails on darwin/lsan
 // XFAIL: darwin && lsan
 
+// UNSUPPORTED: rtsan
+
 #include <malloc/malloc.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/allow_user_segv.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/allow_user_segv.cpp
@@ -21,6 +21,8 @@
 // Flaky errors in debuggerd with "waitpid returned unexpected pid (0)" in logcat.
 // UNSUPPORTED: android && i386-target-arch
 
+// UNSUPPORTED: rtsan
+
 // Note: this test case is unusual because it retrieves the original
 // (ASan-installed) signal handler; thus, it is incompatible with the
 // cloak_sanitizer_signal_handlers runtime option.

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/assert.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/assert.cpp
@@ -5,6 +5,8 @@
 // RUN: %env_tool_opts=handle_abort=0 not --crash %run %t 2>&1 | FileCheck --check-prefix=CHECK0 %s
 // RUN: %env_tool_opts=handle_abort=1 not         %run %t 2>&1 | FileCheck --check-prefix=CHECK1 %s
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <stdio.h>
 #include <sanitizer/asan_interface.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/cloak_sigaction.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/cloak_sigaction.cpp
@@ -17,6 +17,8 @@
 // RUN: %env_tool_opts=handle_segv=2:cloak_sanitizer_signal_handlers=false not %run %t 2>&1 | FileCheck %s --check-prefixes=NONDEFAULT,SANITIZER
 // RUN: %env_tool_opts=handle_segv=2:cloak_sanitizer_signal_handlers=true not %run %t 2>&1 | FileCheck %s --check-prefixes=DEFAULT,SANITIZER
 
+// UNSUPPORTED: rtsan
+
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/cloak_signal.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/cloak_signal.cpp
@@ -1,5 +1,6 @@
 // UNSUPPORTED: android
 // UNSUPPORTED: hwasan
+// UNSUPPORTED: rtsan
 
 // RUN: %clangxx -O0 %s -o %t
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/deepbind.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/deepbind.cpp
@@ -3,6 +3,7 @@
 
 // FIXME: Implement.
 // XFAIL: hwasan
+// UNSUPPORTED: rtsan
 
 #include <dlfcn.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_aarch64.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_aarch64.cpp
@@ -5,6 +5,8 @@
 //
 // REQUIRES: aarch64-target-arch && glibc
 
+// UNSUPPORTED: rtsan
+
 #include <signal.h>
 
 int main() {

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/malloc_usable_size.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/malloc_usable_size.c
@@ -3,6 +3,8 @@
 // Must not be implemented, no other reason to install interceptors.
 // XFAIL: ubsan
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <malloc.h>
 #include <sanitizer/allocator_interface.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/mlock_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/mlock_test.cpp
@@ -7,6 +7,8 @@
 // FIXME: Implement.
 // XFAIL: hwasan
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <sys/mman.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/mprobe.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/mprobe.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx %s -o %t && %run %t 2>&1 | FileCheck %s
 // UNSUPPORTED: android, hwasan, ubsan
+// UNSUPPORTED: rtsan
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/release_to_os_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/release_to_os_test.cpp
@@ -14,6 +14,8 @@
 // Page size is hardcoded below, but test still fails even if not hardcoded.
 // REQUIRES: page-size-4096
 
+// UNSUPPORTED: rtsan
+
 #include <algorithm>
 #include <assert.h>
 #include <fcntl.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/replace_dlopen_main_program_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/replace_dlopen_main_program_test.cpp
@@ -13,6 +13,8 @@
 // Flag has no effect with dynamic runtime
 // UNSUPPORTED: asan-dynamic-runtime
 
+// UNSUPPORTED: rtsan
+
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_line.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_line.cpp
@@ -6,6 +6,8 @@
 // RUN: %env_tool_opts=handle_segv=1:print_stacktrace=1 not %run %t 1 2>&1 | FileCheck --check-prefixes=CHECK1,CHECK %s
 // RUN: %env_tool_opts=handle_segv=1:print_stacktrace=1 not %run %t 2 2>&1 | FileCheck --check-prefixes=CHECK2,CHECK %s
 
+// UNSUPPORTED: rtsan
+
 #include <cstdio>
 #include <cstdlib>
 #include <string>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_name.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_name.c
@@ -9,6 +9,8 @@
 // FIXME: Hwasan misclassify TRAP as tag missmatch.
 // XFAIL: hwasan && !hwasan-aliasing
 
+// UNSUPPORTED: rtsan
+
 #include <signal.h>
 #include <stdlib.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/soft_rss_limit_mb_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/soft_rss_limit_mb_test.cpp
@@ -22,6 +22,8 @@
 // Symbolizer needs to allocated memory when reporting.
 // UNSUPPORTED: internal_symbolizer
 
+// UNSUPPORTED: rtsan
+
 // FIXME: The test fails flakily, see e.g. PRs #170911, #171469, #188441.
 // Flaky on llvm-clang-x86_64-gcc-ubuntu, llvm-clang-x86_64-gcc-ubuntu-no-asserts and https://crbug.com/481656455.
 // UNSUPPORTED: true

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_malloc_hook.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_malloc_hook.c
@@ -9,6 +9,8 @@
 // No allocator and hooks.
 // XFAIL: ubsan
 
+// UNSUPPORTED: rtsan
+
 #ifndef BUILD_SO
 #  include <assert.h>
 #  include <dlfcn.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/unexpected_format_specifier_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/unexpected_format_specifier_test.cpp
@@ -3,6 +3,7 @@
 // UNSUPPORTED: lsan
 // UNSUPPORTED: msan
 // UNSUPPORTED: ubsan
+// UNSUPPORTED: rtsan
 #include <stdio.h>
 int main() {
   int a;

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/dedup_token_length_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/dedup_token_length_test.cpp
@@ -16,6 +16,8 @@
 
 // XFAIL: target={{.*netbsd.*}} && !asan
 
+// UNSUPPORTED: rtsan
+
 volatile int *null = 0;
 
 namespace Xyz {

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/illegal_read_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/illegal_read_test.cpp
@@ -5,6 +5,7 @@
 
 // REQUIRES: stable-runtime
 // XFAIL: target={{(powerpc64|s390x).*}}
+// UNSUPPORTED: rtsan
 
 volatile int *null = 0;
 volatile int a;

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/illegal_write_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/illegal_write_test.cpp
@@ -5,6 +5,7 @@
 
 // REQUIRES: stable-runtime
 // XFAIL: target={{(powerpc64|s390x).*}}
+// UNSUPPORTED: rtsan
 
 volatile int *null = 0;
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/mmap_write_exec.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/mmap_write_exec.cpp
@@ -7,6 +7,8 @@
 // TODO: Fix option on Android, it hangs there for unknown reasons.
 // XFAIL: android
 
+// UNSUPPORTED: rtsan
+
 #if defined(__APPLE__)
 #include <Availability.h>
 #endif

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_memalign-alignment.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_memalign-alignment.cpp
@@ -18,6 +18,7 @@
 // REQUIRES: stable-runtime
 
 // UNSUPPORTED: ubsan
+// UNSUPPORTED: rtsan
 
 #include <assert.h>
 #include <errno.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/print-module-map.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/print-module-map.cpp
@@ -21,6 +21,8 @@
 // FIXME: Implement.
 // XFAIL: lsan, hwasan
 
+// UNSUPPORTED: rtsan
+
 int global;
 
 int main() {

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_death_callback_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_death_callback_test.cpp
@@ -6,6 +6,8 @@
 // FIXME: On Darwin, LSAn detects the leak, but does not invoke the death_callback.
 // XFAIL: darwin && lsan
 
+// UNSUPPORTED: rtsan
+
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_fd_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_fd_test.cpp
@@ -8,6 +8,7 @@
 
 // REQUIRES: stable-runtime
 // UNSUPPORTED: android && asan
+// UNSUPPORTED: rtsan
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/weak_hook_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/weak_hook_test.cpp
@@ -7,6 +7,8 @@
 // FIXME: Implement.
 // XFAIL: hwasan
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <string.h>
 #if defined(_GNU_SOURCE)

--- a/compiler-rt/test/sanitizer_common/TestCases/allocator_interface.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/allocator_interface.cpp
@@ -4,6 +4,8 @@
 // No allocator.
 // UNSUPPORTED: ubsan
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <sanitizer/allocator_interface.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/allocator_returns_null.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/allocator_returns_null.cpp
@@ -38,6 +38,8 @@
 // TODO(alekseyshl): win32 is disabled due to failing errno tests, fix it there.
 // UNSUPPORTED: ubsan, target={{.*windows-msvc.*}}
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/compress_stack_depot.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/compress_stack_depot.cpp
@@ -14,6 +14,8 @@
 // Similar to D114934, something is broken with background thread on THUMB and Asan.
 // XFAIL: target=thumb{{.*}} && asan
 
+// UNSUPPORTED: rtsan
+
 #include <sanitizer/common_interface_defs.h>
 
 #include <memory>

--- a/compiler-rt/test/sanitizer_common/TestCases/get_allocated_begin.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/get_allocated_begin.cpp
@@ -3,6 +3,8 @@
 // Must not be implemented, no other reason to install interceptors.
 // XFAIL: ubsan
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <sanitizer/allocator_interface.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/hard_rss_limit_mb_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/hard_rss_limit_mb_test.cpp
@@ -13,6 +13,7 @@
 // Ubsan does not intercept pthread_create.
 // XFAIL: ubsan
 // UNSUPPORTED: target={{.*(freebsd|solaris).*}}, darwin
+// UNSUPPORTED: rtsan
 
 // THUMB starts background thead only for Asan.
 // XFAIL: target=thumb{{.*}} && !asan

--- a/compiler-rt/test/sanitizer_common/TestCases/malloc_hook.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/malloc_hook.cpp
@@ -6,6 +6,8 @@
 // Must not be implemented, no other reason to install interceptors.
 // XFAIL: ubsan
 
+// UNSUPPORTED: rtsan
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <sanitizer/allocator_interface.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/malloc_hook_get_allocated_size_fast.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/malloc_hook_get_allocated_size_fast.cpp
@@ -6,6 +6,8 @@
 // Must not be implemented, no other reason to install interceptors.
 // XFAIL: ubsan
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <sanitizer/allocator_interface.h>
 #include <stdlib.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/max_allocation_size.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/max_allocation_size.cpp
@@ -46,6 +46,8 @@
 // Symbolizer needs to allocated memory when reporting.
 // UNSUPPORTED: internal_symbolizer
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <errno.h>
 #include <limits>

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_control_flow.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_control_flow.cpp
@@ -6,6 +6,8 @@
 // RUN: %clangxx -O0 -std=c++11 -fsanitize-coverage=control-flow %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s
 
+// UNSUPPORTED: rtsan
+
 #include <cstdint>
 #include <cstdio>
 #if __has_feature(ptrauth_calls)

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_inline8bit_counter.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_inline8bit_counter.cpp
@@ -6,6 +6,8 @@
 // RUN: %clangxx -O0 %s -fsanitize-coverage=inline-8bit-counters,pc-table -o %t
 // RUN: %run %t 2>&1 | FileCheck %s
 
+// UNSUPPORTED: rtsan
+
 #include <stdio.h>
 #include <stdint.h>
 #include <assert.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_inline_bool_flag.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_inline_bool_flag.cpp
@@ -6,6 +6,8 @@
 // RUN: %clangxx -O0 %s -fsanitize-coverage=inline-bool-flag,pc-table -o %t
 // RUN: %run %t 2>&1 | FileCheck %s
 
+// UNSUPPORTED: rtsan
+
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_no_prune.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_no_prune.cpp
@@ -4,6 +4,7 @@
 // UNSUPPORTED: i386-darwin
 // XFAIL: ubsan
 // XFAIL: android && asan
+// UNSUPPORTED: rtsan
 
 // RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=trace-pc,bb,no-prune 2>&1 | grep "call void @__sanitizer_cov_trace_pc" | count 3
 // RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=trace-pc,bb          2>&1 | grep "call void @__sanitizer_cov_trace_pc" | count 2

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_stack_depth.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_stack_depth.cpp
@@ -6,6 +6,8 @@
 // RUN:     %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s --implicit-check-not Assertion{{.*}}failed
 
+// UNSUPPORTED: rtsan
+
 #include <cstdint>
 #include <cstdio>
 #include <cassert>

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard-dso.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard-dso.cpp
@@ -5,6 +5,7 @@
 // UNSUPPORTED: ubsan,target={{(powerpc64|s390x|sparc|thumb).*}}
 // XFAIL: tsan,darwin
 // XFAIL: android && asan
+// UNSUPPORTED: rtsan
 
 // RUN: rm -rf %t_workdir
 // RUN: mkdir -p %t_workdir

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
@@ -7,6 +7,7 @@
 // XFAIL: tsan
 // XFAIL: android && asan
 // XFAIL: darwin-remote
+// UNSUPPORTED: rtsan
 
 // RUN: rm -rf %t_workdir
 // RUN: mkdir -p %t_workdir


### PR DESCRIPTION
Add `rtsan` to the supported sanitizers to run sanitizer-common tests on it.

This review:
* Adds it to the supported list (most tests passed with no modification)
* Fixes a few low-hanging fruit tests
* Disables many of the others that fail on Linux and Darwin, to be implemented later. This was to ensure this review didn't get too much larger.