### PR TITLE
[llvm-profdata] Reject merging single-byte-coverage with count profiles

### DIFF
--- a/llvm/test/tools/llvm-profdata/Inputs/ir-single-byte-coverage.proftext
+++ b/llvm/test/tools/llvm-profdata/Inputs/ir-single-byte-coverage.proftext
@@ -1,0 +1,7 @@
+:ir
+:single_byte_coverage
+foo2
+29667547796
+2
+1
+1

--- a/llvm/test/tools/llvm-profdata/merge-incompatible.test
+++ b/llvm/test/tools/llvm-profdata/merge-incompatible.test
@@ -6,3 +6,10 @@ CHECK: ir-basic.proftext: Merge IR generated profile with Clang generated profil
 // we do not know which files have incompatible kinds.
 RUN: not llvm-profdata merge %p/Inputs/fe-basic.proftext %p/Inputs/ir-basic.proftext --num-threads=2 -o /dev/null 2>&1 | FileCheck %s --check-prefix=THREADS
 THREADS: unsupported instrumentation profile format version
+
+// Single-byte-coverage profiles cannot be merged with count profiles, in either
+// order, because the merged profile would be marked as coverage-only.
+RUN: not llvm-profdata merge %p/Inputs/ir-basic.proftext %p/Inputs/ir-single-byte-coverage.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=COVERAGE
+RUN: not llvm-profdata merge %p/Inputs/ir-single-byte-coverage.proftext %p/Inputs/ir-basic.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=COVERAGE
+RUN: not llvm-profdata merge %p/Inputs/ir-basic.proftext %p/Inputs/ir-single-byte-coverage.proftext --num-threads=2 -o /dev/null 2>&1 | FileCheck %s --check-prefix=COVERAGE
+COVERAGE: cannot merge single-byte-coverage profiles with count (non-coverage) profiles


### PR DESCRIPTION
`llvm-profdata merge` previously silently merged single-byte-coverage profiles with count profiles. We should reject this, because `SingleByteCoverage` will always be set to true in the merged profile, and mess up the PGO pipeline.

`mergeProfileKind` now errors with `cannot merge single-byte-coverage profiles with count (non-coverage) profiles` when exactly one side has `InstrProfKind::SingleByteCoverage` set.

Note: Used AI to generate the code