### PR TITLE
[llvm-profdata] Reject merging single-byte-coverage with count profiles

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -434,6 +434,7 @@ enum class instrprof_error {
   zlib_unavailable,
   raw_profile_version_mismatch,
   counter_value_too_large,
+  coverage_count_mismatch,
 };
 
 /// An ordered list of functions identified by their NameRef found in

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -186,7 +186,9 @@ public:
     if (static_cast<bool>(
             (ProfileKind & InstrProfKind::FrontendInstrumentation) ^
             (Other & InstrProfKind::FrontendInstrumentation))) {
-      return make_error<InstrProfError>(instrprof_error::unsupported_version);
+      return make_error<InstrProfError>(
+          instrprof_error::unsupported_version,
+          "cannot merge IR generated profile with Clang generated profile");
     }
     if (testIncompatible(InstrProfKind::FunctionEntryOnly,
                          InstrProfKind::FunctionEntryInstrumentation) ||

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -196,6 +196,11 @@ public:
           instrprof_error::unsupported_version,
           "cannot merge FunctionEntryOnly profiles and BB profiles together");
     }
+    if (static_cast<bool>((ProfileKind & InstrProfKind::SingleByteCoverage) ^
+                          (Other & InstrProfKind::SingleByteCoverage))) {
+      return make_error<InstrProfError>(
+          instrprof_error::coverage_count_mismatch);
+    }
 
     // Now we update the profile type with the bits that are set.
     ProfileKind |= Other;

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -167,6 +167,10 @@ static std::string getInstrProfErrString(instrprof_error Err,
   case instrprof_error::counter_value_too_large:
     OS << "excessively large counter value suggests corrupted profile data";
     break;
+  case instrprof_error::coverage_count_mismatch:
+    OS << "cannot merge single-byte-coverage profiles with count "
+          "(non-coverage) profiles";
+    break;
   }
 
   // If optional error message is not empty, append it to the message.

--- a/llvm/test/tools/llvm-profdata/merge-incompatible.test
+++ b/llvm/test/tools/llvm-profdata/merge-incompatible.test
@@ -2,7 +2,7 @@ RUN: export LSAN_OPTIONS=detect_leaks=0
 RUN: rm -rf %t && split-file %s %t
 
 RUN: not llvm-profdata merge %p/Inputs/fe-basic.proftext %p/Inputs/ir-basic.proftext -o /dev/null 2>&1 | FileCheck %s
-CHECK: ir-basic.proftext: Merge IR generated profile with Clang generated profile.
+CHECK: ir-basic.proftext: unsupported instrumentation profile format version: cannot merge IR generated profile with Clang generated profile
 
 // We get a slightly different error message when using multiple threads because
 // we do not know which files have incompatible kinds.

--- a/llvm/test/tools/llvm-profdata/merge-incompatible.test
+++ b/llvm/test/tools/llvm-profdata/merge-incompatible.test
@@ -1,4 +1,6 @@
 RUN: export LSAN_OPTIONS=detect_leaks=0
+RUN: rm -rf %t && split-file %s %t
+
 RUN: not llvm-profdata merge %p/Inputs/fe-basic.proftext %p/Inputs/ir-basic.proftext -o /dev/null 2>&1 | FileCheck %s
 CHECK: ir-basic.proftext: Merge IR generated profile with Clang generated profile.
 
@@ -6,3 +8,19 @@ CHECK: ir-basic.proftext: Merge IR generated profile with Clang generated profil
 // we do not know which files have incompatible kinds.
 RUN: not llvm-profdata merge %p/Inputs/fe-basic.proftext %p/Inputs/ir-basic.proftext --num-threads=2 -o /dev/null 2>&1 | FileCheck %s --check-prefix=THREADS
 THREADS: unsupported instrumentation profile format version
+
+// Single-byte-coverage profiles cannot be merged with count profiles, in either
+// order, because the merged profile would be marked as coverage-only.
+RUN: not llvm-profdata merge %p/Inputs/ir-basic.proftext %t/coverage.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=COVERAGE
+RUN: not llvm-profdata merge %t/coverage.proftext %p/Inputs/ir-basic.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=COVERAGE
+RUN: not llvm-profdata merge %p/Inputs/ir-basic.proftext %t/coverage.proftext --num-threads=2 -o /dev/null 2>&1 | FileCheck %s --check-prefix=COVERAGE
+COVERAGE: cannot merge single-byte-coverage profiles with count (non-coverage) profiles
+
+//--- coverage.proftext
+:ir
+:single_byte_coverage
+foo2
+29667547796
+2
+1
+1

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -812,7 +812,12 @@ loadInput(const WeightedFile &Input, SymbolRemapper *Remapper,
 
   auto Reader = std::move(ReaderOrErr.get());
   if (Error E = WC->Writer.mergeProfileKind(Reader->getProfileKind())) {
-    consumeError(std::move(E));
+    auto [ErrorCode, Msg] = InstrProfError::take(std::move(E));
+    if (ErrorCode == instrprof_error::coverage_count_mismatch) {
+      WC->Errors.emplace_back(make_error<InstrProfError>(ErrorCode, Msg),
+                              Filename);
+      return;
+    }
     WC->Errors.emplace_back(
         make_error<StringError>(
             "Merge IR generated profile with Clang generated profile.",

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -812,17 +812,7 @@ loadInput(const WeightedFile &Input, SymbolRemapper *Remapper,
 
   auto Reader = std::move(ReaderOrErr.get());
   if (Error E = WC->Writer.mergeProfileKind(Reader->getProfileKind())) {
-    auto [ErrorCode, Msg] = InstrProfError::take(std::move(E));
-    if (ErrorCode == instrprof_error::coverage_count_mismatch) {
-      WC->Errors.emplace_back(make_error<InstrProfError>(ErrorCode, Msg),
-                              Filename);
-      return;
-    }
-    WC->Errors.emplace_back(
-        make_error<StringError>(
-            "Merge IR generated profile with Clang generated profile.",
-            std::error_code()),
-        Filename);
+    WC->Errors.emplace_back(std::move(E), Filename);
     return;
   }
 


### PR DESCRIPTION
llvm-profdata merge previously silently merged single-byte-coverage profiles with count profiles. We should reject this, because SingleByteCoverage will always be set to true in the merged profile, and mess up the PGO pipeline.

mergeProfileKind now errors with cannot merge single-byte-coverage profiles with count (non-coverage) profiles when exactly one side has InstrProfKind::SingleByteCoverage set.

Note: Used AI to generate the code