### PR TITLE
[ORC] Generalize RTBridge callers over signature types.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Calls.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Calls.h
@@ -26,42 +26,63 @@
 #include <cstdint>
 #include <future>
 #include <string>
+#include <type_traits>
 
 namespace llvm::orc::rt {
 
-/// Interface for running a main-like function (int(int argc, char *argv[])) in
-/// the executor.
+template <typename FnT> class Caller;
+
+/// Runtime-agnostic interface for invoking an executor-side operation with the
+/// signature RetT(ArgTs...).
 ///
-/// Given the address of the function to run and an argument vector, invokes the
-/// function in the executor and returns its integer result. Calls can be made
-/// asynchronously (delivering the result to an OnComplete continuation) or
-/// synchronously (blocking until the result is available). Concrete
-/// implementations (e.g. rt::sps::MainCaller) determine how the call reaches
-/// the executor.
-class MainCaller {
+/// The operation is identified by an ExecutorAddr (the address of the
+/// executor-side function to invoke) and takes ArgTs... as arguments. Two call
+/// operators are provided: an asynchronous form that delivers the result to an
+/// OnComplete continuation, and a synchronous form that blocks until the result
+/// is available.
+///
+/// A Caller abstracts over how the operation is dispatched to the executor.
+/// Concrete implementations (e.g. rt::sps::Caller) supply the dispatch
+/// mechanism.
+template <typename RetT, typename... ArgTs> class Caller<RetT(ArgTs...)> {
 public:
-  virtual ~MainCaller();
+  using FnType = RetT(ArgTs...);
 
-  /// Asynchronously run the main-like function at MainFnAddr with the given
+  /// The result type produced by the executor-side function itself.
+  using CalleeRetT = RetT;
+
+  /// The result type delivered to callers: Expected<RetT>, or Error when RetT
+  /// is void, so that dispatch failures can be reported alongside the result.
+  using ErrorRetT =
+      std::conditional_t<std::is_void_v<RetT>, Error, Expected<RetT>>;
+
+  virtual ~Caller() = default;
+
+  /// Asynchronously invoke the executor-side function at FnAddr with the given
   /// Args, delivering its result (or an error) to OnComplete.
-  virtual void operator()(unique_function<void(Expected<int64_t>)> OnComplete,
-                          ExecutorAddr MainFnAddr,
-                          ArrayRef<std::string> Args) = 0;
+  virtual void operator()(unique_function<void(ErrorRetT)> OnComplete,
+                          ExecutorAddr FnAddr, ArgTs... Args) = 0;
 
-  /// Run the main-like function at MainFnAddr with the given Args, blocking
+  /// Invoke the executor-side function at FnAddr with the given Args, blocking
   /// until its result (or an error) is available.
-  Expected<int64_t> operator()(ExecutorAddr MainFnAddr,
-                               ArrayRef<std::string> Args) {
-    std::promise<MSVCPExpected<int64_t>> P;
+  ErrorRetT operator()(ExecutorAddr FnAddr, ArgTs &&...Args) {
+    using PromiseValT = std::conditional_t<std::is_void_v<RetT>, MSVCPError,
+                                           MSVCPExpected<RetT>>;
+    std::promise<PromiseValT> P;
     auto F = P.get_future();
     this->operator()(
-        [P = std::move(P)](Expected<int64_t> R) mutable {
-          P.set_value(std::move(R));
-        },
-        MainFnAddr, Args);
+        [P = std::move(P)](ErrorRetT R) mutable { P.set_value(std::move(R)); },
+        FnAddr, std::forward<ArgTs>(Args)...);
     return F.get();
   }
 };
+
+/// Runtime-agnostic interface for running a main-like function
+/// (int(int argc, char *argv[])) in the executor.
+///
+/// The function to run is given by its ExecutorAddr, its arguments as an
+/// argument vector, and its int64_t result is returned.
+class MainCaller : public Caller<int64_t(ArrayRef<std::string>)> {};
 
 } // namespace llvm::orc::rt
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/Calls.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/Calls.h
@@ -6,7 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// SPS-based wrappers for calling functions.
+// SPS-based implementations of the RTBridge caller interfaces.
+//
+// These implement the rt::Caller interfaces by invoking executor-side wrapper
+// functions in the runtime's controller interface, using Simple Packed
+// Serialization to encode arguments and decode results.
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,53 +23,85 @@
 
 namespace llvm::orc::rt::sps {
 
-/// Calls the executor-side "call-main" wrapper, which runs a program's main
-/// function with the given arguments and returns its result.
-class MainCaller : public rt::MainCaller {
-public:
-  /// Name of the controller interface wrapper function.
-  static constexpr const char *CIName = "orc_rt_ci_sps_call_main";
+/// Implements the rt::Caller interface BaseT by calling an executor-side SPS
+/// wrapper function, using SPSSigT to encode the arguments and decode the
+/// result.
+///
+/// The wrapper is a controller-interface (CI) entry point named CIName: a
+/// wrapper function (byte blob in, byte blob out) that the runtime exposes to
+/// the controller. SPSSigT is the Simple Packed Serialization signature used to
+/// encode the argument blob and decode the result blob; it must be compatible
+/// with BaseT's FnType. CIName must have static storage duration (e.g. an
+/// inline constexpr char[]).
+///
+/// The FnType parameter is deduced from BaseT and should not be supplied
+/// explicitly; the primary template is left undefined so that only the
+/// RetT(ArgTs...) specialization can be instantiated.
+template <typename BaseT, typename SPSSigT, const char *CINameV,
+          typename FnType = typename BaseT::FnType>
+class Caller;
 
-  static void callAsync(unique_function<void(Expected<int64_t>)> OnComplete,
-                        ExecutionSession &ES, ExecutorAddr CallMainFnAddr,
-                        ExecutorAddr MainFnAddr, ArrayRef<std::string> Args) {
+template <typename BaseT, typename SPSSigT, const char *CINameV, typename RetT,
+          typename... ArgTs>
+class Caller<BaseT, SPSSigT, CINameV, RetT(ArgTs...)> : public BaseT {
+  using CalleeRetT = typename BaseT::CalleeRetT;
+  using ErrorRetT = typename BaseT::ErrorRetT;
+
+public:
+  /// Name of the controller-interface wrapper this caller targets.
+  static constexpr const char *CIName = CINameV;
+
+  Caller(ExecutionSession &ES, ExecutorAddr CallerFnAddr)
+      : ES(ES), CallerFnAddr(CallerFnAddr) {}
+
+  /// Look the wrapper up in the executor's bootstrap JITDylib and build a
+  /// caller for it.
+  static Expected<Caller> Create(ExecutionSession &ES,
+                                 const char *Name = CIName) {
+    if (auto CallerSym = ES.lookup({&ES.getBootstrapJITDylib()}, Name))
+      return Caller(ES, CallerSym->getAddress());
+    else
+      return CallerSym.takeError();
+  }
+
+  /// Asynchronously call the SPS wrapper at CallerFnAddr to invoke the
+  /// executor-side function at FnAddr with the given Args, delivering the
+  /// result (or an error) to OnComplete. Serialization failures are reported
+  /// through OnComplete's error channel.
+  static void callAsync(unique_function<void(ErrorRetT)> OnComplete,
+                        ExecutionSession &ES, ExecutorAddr CallerFnAddr,
+                        ExecutorAddr FnAddr, const ArgTs &...Args) {
     using namespace llvm::orc::shared;
-    ES.callSPSWrapperAsync<int64_t(SPSExecutorAddr, SPSSequence<SPSString>)>(
-        CallMainFnAddr,
+    ES.callSPSWrapperAsync<SPSSigT>(
+        CallerFnAddr,
         [OnComplete = std::move(OnComplete)](Error SerErr,
-                                             int64_t Result) mutable {
+                                             CalleeRetT Result) mutable {
           if (SerErr)
             return OnComplete(std::move(SerErr));
           else
-            return OnComplete(Result);
+            return OnComplete(std::move(Result));
         },
-        MainFnAddr, Args);
+        FnAddr, Args...);
   }
 
-  MainCaller(ExecutionSession &ES, ExecutorAddr CallMainFnAddr)
-      : ES(ES), CallMainFnAddr(CallMainFnAddr) {}
-
-  /// Look up the call-main wrapper in the executor's bootstrap JITDylib and
-  /// build a MainCaller for it.
-  static Expected<MainCaller> Create(ExecutionSession &ES) {
-    if (auto CallMainSym = ES.lookup({&ES.getBootstrapJITDylib()}, CIName))
-      return MainCaller(ES, CallMainSym->getAddress());
-    else
-      return CallMainSym.takeError();
+  void operator()(unique_function<void(ErrorRetT)> OnComplete,
+                  ExecutorAddr FnAddr, ArgTs... Args) override {
+    callAsync(std::move(OnComplete), ES, CallerFnAddr, FnAddr, Args...);
   }
 
-  void operator()(unique_function<void(Expected<int64_t>)> OnComplete,
-                  ExecutorAddr MainFnAddr,
-                  ArrayRef<std::string> Args) override {
-    callAsync(std::move(OnComplete), ES, CallMainFnAddr, MainFnAddr, Args);
-  }
-
-  using rt::MainCaller::operator();
+  using BaseT::operator();
 
 private:
   ExecutionSession &ES;
-  ExecutorAddr CallMainFnAddr;
+  ExecutorAddr CallerFnAddr;
 };
+
+using CallMainSPSSig = int64_t(shared::SPSExecutorAddr,
+                               shared::SPSSequence<shared::SPSString>);
+inline constexpr char CallMainCIName[] = "orc_rt_ci_sps_call_main";
+/// SPS caller for rt::MainCaller: runs a main-like function
+/// (int(int argc, char *argv[])) in the executor.
+using MainCaller = Caller<rt::MainCaller, CallMainSPSSig, CallMainCIName>;
 
 } // namespace llvm::orc::rt::sps
 

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -14,8 +14,6 @@ namespace llvm {
 namespace orc {
 namespace rt {
 
-MainCaller::~MainCaller() = default;
-
 const char *SimpleExecutorDylibManagerInstanceName =
     "__llvm_orc_SimpleExecutorDylibManager_Instance";
 const char *SimpleExecutorDylibManagerOpenWrapperName =


### PR DESCRIPTION
Recast the RTBridge callers as templates parameterized on the call signature, so future executor accessors can be added as thin declarations rather than hand-written classes.

rt::Caller<RetT(ArgTs...)> is the runtime-agnostic caller interface for a given signature, providing the asynchronous and synchronous call operators and the associated result types. rt::MainCaller is now an alias for rt::Caller<int64_t(ArrayRef<std::string>)>.

rt::sps::Caller<BaseT, SPSSigT, CIName> implements any such interface by invoking an executor-side SPS wrapper in the runtime's controller interface, deducing the argument and result types from BaseT. A concrete caller is a typedef supplying the interface, its SPS signature, and the CI entry-point name; see rt::sps::MainCaller.

MainCaller's observable behavior is unchanged (the existing SPSCallersTest still passes). The out-of-line destructor anchor in OrcRTBridge.cpp is dropped, as the templated base now provides an inline defaulted destructor.