### PR TITLE
[lldb] Handle scripted Python call exceptions

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -220,17 +220,9 @@ public:
       std::tuple<Args...> original_args = std::forward_as_tuple(args...);
       auto transformed_args = TransformArgs(original_args);
 
-      std::string error_string;
       llvm::Expected<PythonCallable::ArgInfo> arg_info = init.GetArgInfo();
       if (!arg_info) {
-        llvm::handleAllErrors(
-            arg_info.takeError(),
-            [&](PythonException &E) { error_string.append(E.ReadBacktrace()); },
-            [&](const llvm::ErrorInfoBase &E) {
-              error_string.append(E.message());
-            });
-        return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                       error_string);
+        return ConvertPythonError(arg_info.takeError());
       }
 
       llvm::Expected<PythonObject> expected_return_object =
@@ -264,20 +256,20 @@ public:
         std::apply(
             [&init, &expected_return_object](auto &&...args) {
               llvm::consumeError(expected_return_object.takeError());
-              expected_return_object = init(args...);
+              expected_return_object = init.Call(args...);
             },
             std::tuple_cat(transformed_args, std::make_tuple(dict)));
       } else {
         std::apply(
             [&init, &expected_return_object](auto &&...args) {
               llvm::consumeError(expected_return_object.takeError());
-              expected_return_object = init(args...);
+              expected_return_object = init.Call(args...);
             },
             transformed_args);
       }
 
       if (!expected_return_object)
-        return expected_return_object.takeError();
+        return ConvertPythonError(expected_return_object.takeError());
       result = expected_return_object.get();
     }
 
@@ -454,12 +446,12 @@ public:
     std::apply(
         [&method, &expected_return_object](auto &&...args) {
           llvm::consumeError(expected_return_object.takeError());
-          expected_return_object = method(args...);
+          expected_return_object = method.Call(args...);
         },
         transformed_args);
 
     if (llvm::Error e = expected_return_object.takeError()) {
-      error = Status::FromError(std::move(e));
+      error = Status::FromError(ConvertPythonError(std::move(e)));
       return ErrorWithMessage<T>(
           caller_signature, "python static method could not be called", error);
     }
@@ -478,6 +470,18 @@ public:
   }
 
 protected:
+  static llvm::Error ConvertPythonError(llvm::Error error) {
+    if (!error)
+      return llvm::Error::success();
+
+    std::string message;
+    llvm::handleAllErrors(
+        std::move(error),
+        [&](python::PythonException &E) { message.append(E.ReadBacktrace()); },
+        [&](const llvm::ErrorInfoBase &E) { message.append(E.message()); });
+    return llvm::createStringError(llvm::inconvertibleErrorCode(), message);
+  }
+
   template <typename T = StructuredData::ObjectSP>
   T ExtractValueFromPythonObject(python::PythonObject &p, Status &error) {
     return p.CreateStructuredObject();

--- a/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/TestFrameProviderRegisterCommandStatus.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/TestFrameProviderRegisterCommandStatus.py
@@ -37,3 +37,22 @@ class TestFrameProviderRegisterCommandStatus(TestBase):
             "target frame-provider register -C frame_provider.MinimalProvider",
             substrs=["successfully registered scripted frame provider"],
         )
+
+    def test_static_method_exception_does_not_escape(self):
+        target = self.dbg.CreateTarget(None)
+        self.assertTrue(target.IsValid())
+
+        provider_path = os.path.join(self.getSourceDir(), "frame_provider.py")
+        self.runCmd("command script import " + provider_path)
+        self.runCmd(
+            "target frame-provider register "
+            "-C frame_provider.FailingDescriptionProvider"
+        )
+
+        result = lldb.SBCommandReturnObject()
+        self.dbg.GetCommandInterpreter().HandleCommand(
+            "target frame-provider list", result
+        )
+
+        self.assertTrue(result.Succeeded(), result.GetError())
+        self.assertIn("FailingDescriptionProvider", result.GetOutput())

--- a/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/frame_provider.py
@@ -14,3 +14,9 @@ class MinimalProvider(ScriptedFrameProvider):
 
     def get_frame_at_index(self, index):
         return None
+
+
+class FailingDescriptionProvider(MinimalProvider):
+    @staticmethod
+    def get_description():
+        raise ValueError("scripted frame provider description failed")

--- a/lldb/test/API/functionalities/step_scripted/Steps.py
+++ b/lldb/test/API/functionalities/step_scripted/Steps.py
@@ -37,6 +37,11 @@ class StepOut(StepWithChild):
         return self.thread_plan.QueueThreadPlanForStepOut(0)
 
 
+class FailingConstructor:
+    def __init__(self, thread_plan, args_data):
+        raise ValueError("scripted plan construction failed")
+
+
 class StepScripted(StepWithChild):
     def __init__(self, thread_plan, dict):
         StepWithChild.__init__(self, thread_plan)

--- a/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
+++ b/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
@@ -28,6 +28,23 @@ class StepScriptedTestCase(TestBase):
         self.build()
         self.step_out_with_scripted_plan("Steps.StepScripted")
 
+    def test_constructor_error_preserves_traceback(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", self.main_source_file
+        )
+
+        result = lldb.SBCommandReturnObject()
+        self.dbg.GetCommandInterpreter().HandleCommand(
+            "thread step-scripted -C Steps.FailingConstructor", result
+        )
+
+        self.assertFalse(result.Succeeded())
+        self.assertIn("Traceback (most recent call last)", result.GetError())
+        self.assertIn(
+            "ValueError: scripted plan construction failed", result.GetError()
+        )
+
     def step_out_with_scripted_plan(self, name):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "Set a breakpoint here", self.main_source_file


### PR DESCRIPTION
`ScriptedPythonInterface` invoked plugin constructors and static methods through the `PythonCallable` call operator. When either raised, LLDB returned to Python with `PyErr` still set, causing binding callers such as `SBCommandInterpreter.HandleCommand` to raise `SystemError`.

This change uses the error-returning `Call` API for both paths and converts `PythonException` into a traceback-bearing LLVM error while the interpreter lock is held.

This change also adds API tests for a throwing scripted thread-plan constructor and frame-provider static method, verifying `HandleCommand` returns normally and the constructor failure retains its original `ValueError` traceback.