### PR TITLE
Module Build Fix: Add NVPTXTargetParser.def as a header

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -430,6 +430,7 @@ module LLVM_Utils {
     textual header "llvm/TargetParser/CSKYTargetParser.def"
     textual header "llvm/TargetParser/X86TargetParser.def"
     textual header "llvm/TargetParser/LoongArchTargetParser.def"
+    textual header "llvm/TargetParser/NVPTXTargetParser.def"
     textual header "llvm/TargetParser/PPCTargetParser.def"
     textual header "llvm/TargetParser/TripleName.def"
     textual header "llvm/TargetParser/XtensaTargetParser.def"


### PR DESCRIPTION
Fixes module build `-DLLVM_ENABLE_MODULES=ON` in https://ci.swift.org/job/llvm.org/job/clang-stage2-Rthinlto/job/main/457 by adding missing header for `NVPTXTargetParser.def`.