### PR TITLE
[TableGen] Speed up intrinsic lookups with DenseMap (NFC)

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -3354,6 +3354,10 @@ CodeGenDAGPatterns::CodeGenDAGPatterns(const RecordKeeper &R, bool ExpandHwMode)
     : Records(R), Target(R), Intrinsics(R),
       LegalVTS(Target.getLegalValueTypes()),
       LegalPtrVTS(ComputeLegalPtrTypes()) {
+  IntrinsicIDs.reserve(Intrinsics.size());
+  for (auto [ID, Intrinsic] : enumerate(Intrinsics))
+    IntrinsicIDs.try_emplace(Intrinsic.TheDef, ID);
+
   ParseNodeInfo();
   ParseNodeTransforms();
   ParseComplexPatterns();

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -17,6 +17,7 @@
 #include "Basic/CodeGenIntrinsics.h"
 #include "Basic/SDNodeProperties.h"
 #include "CodeGenTarget.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -1101,6 +1102,7 @@ private:
   const RecordKeeper &Records;
   CodeGenTarget Target;
   CodeGenIntrinsicTable Intrinsics;
+  DenseMap<const Record *, unsigned> IntrinsicIDs;
 
   std::map<const Record *, SDNodeInfo, LessRecordByID> SDNodes;
 
@@ -1155,10 +1157,9 @@ public:
   }
 
   const CodeGenIntrinsic &getIntrinsic(const Record *R) const {
-    for (const CodeGenIntrinsic &Intrinsic : Intrinsics)
-      if (Intrinsic.TheDef == R)
-        return Intrinsic;
-    llvm_unreachable("Unknown intrinsic!");
+    auto I = IntrinsicIDs.find(R);
+    assert(I != IntrinsicIDs.end() && "Unknown intrinsic!");
+    return Intrinsics[I->second];
   }
 
   const CodeGenIntrinsic &getIntrinsicInfo(unsigned IID) const {
@@ -1168,10 +1169,9 @@ public:
   }
 
   unsigned getIntrinsicID(const Record *R) const {
-    for (unsigned i = 0, e = Intrinsics.size(); i != e; ++i)
-      if (Intrinsics[i].TheDef == R)
-        return i;
-    llvm_unreachable("Unknown intrinsic!");
+    auto I = IntrinsicIDs.find(R);
+    assert(I != IntrinsicIDs.end() && "Unknown intrinsic!");
+    return I->second;
   }
 
   const DAGDefaultOperand &getDefaultOperand(const Record *R) const {

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -1157,9 +1157,7 @@ public:
   }
 
   const CodeGenIntrinsic &getIntrinsic(const Record *R) const {
-    auto I = IntrinsicIDs.find(R);
-    assert(I != IntrinsicIDs.end() && "Unknown intrinsic!");
-    return Intrinsics[I->second];
+    return Intrinsics[getIntrinsicID(R)];
   }
 
   const CodeGenIntrinsic &getIntrinsicInfo(unsigned IID) const {


### PR DESCRIPTION
Store in DenseMap, avoids linear lookups.
Speeds up NVPTX -gen-dag-isel and -gen-instr-info by 10%.
RISCV shows similar gains.
Neutral or marginally beneficial for other targets.