### PR TITLE
Speed up std::visit() compile times by another 42%

### DIFF
--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1613,21 +1613,21 @@ _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) visit(_Visitor&& __visitor, _Vs&&
             std::forward<_Visitor>(__visitor), __variant::__get_alt<_I>(std::forward<_Vs>(__vs)...).__value);          \
       }                                                                                                                \
       [[__fallthrough__]]
-    switch ((..., __vs.__variant_type::index())) {
-      // Use __LINE__ to avoid hardcoding numbers that might become stale
-      enum : size_t { _I0 = __LINE__ + 1 };           // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      static_assert(__LINE__ - _I0 == _LIBCPP_VARIANT_DISPATCH_COUNT, "index count mismatch");
+    // Use __LINE__ to avoid hardcoding numbers that might become stale
+    constexpr size_t __i0 = __LINE__ + 2;              // New line required
+    switch ((..., __vs.__variant_type::index())) {     // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      static_assert(__LINE__ - __i0 == _LIBCPP_VARIANT_DISPATCH_COUNT, "index count mismatch");
     default:
       std::__throw_bad_variant_access("std::visit: variant is valueless");
     }
@@ -1664,21 +1664,21 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Rp visit(_Visitor&& __visitor, _Vs&&... __vs) {
           }                                                                                                            \
         }                                                                                                              \
         [[__fallthrough__]]
-    switch ((..., __vs.__variant_type::index())) {
-      // Use __LINE__ to avoid hardcoding numbers that might become stale
-      enum : size_t { _I0 = __LINE__ + 1 };           // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - _I0); // New line required
-      static_assert(__LINE__ - _I0 == _LIBCPP_VARIANT_DISPATCH_COUNT, "index count mismatch");
+    // Use __LINE__ to avoid hardcoding numbers that might become stale
+    constexpr size_t __i0 = __LINE__ + 2;              // New line required
+    switch ((..., __vs.__variant_type::index())) {     // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      _LIBCPP_VARIANT_DISPATCH_INDEX(__LINE__ - __i0); // New line required
+      static_assert(__LINE__ - __i0 == _LIBCPP_VARIANT_DISPATCH_COUNT, "index count mismatch");
     default:
       std::__throw_bad_variant_access("std::visit: variant is valueless");
     }


### PR DESCRIPTION
This avoids defining an `enum`, which appears to be expensive for Clang.

Edit: This recovers the original 8x improvement in #164196. Turns out the `enum` was actually not in the [first revision](https://github.com/llvm/llvm-project/commit/6cfb3c0b9a5b404a2337a978a0de57df8bde8286), but I later added it and didn't realize that [lowered it to 4x](https://github.com/llvm/llvm-project/pull/164196#issuecomment-3589875625), so this 2x gets back the original improvement.