### PR TITLE
[flang] Blank-fill internal list-directed record when no output is emitted

### DIFF
--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -219,9 +219,7 @@ template <Direction DIR>
 void InternalListIoStatementState<DIR>::CompleteOperation() {
   if (!this->completedOperation()) {
     if constexpr (DIR == Direction::Output) {
-      if (unit_.furthestPositionInRecord > 0) {
-        unit_.AdvanceRecord(*this);
-      }
+      unit_.AdvanceRecord(*this);
     }
     IoStatementBase::CompleteOperation();
   }

--- a/flang-rt/unittests/Runtime/NumericalFormatTest.cpp
+++ b/flang-rt/unittests/Runtime/NumericalFormatTest.cpp
@@ -244,6 +244,20 @@ TEST(IOApiTests, ListInputComplexRegressionTest) {
       << "', but got '" << output << "'";
 }
 
+TEST(IOApiTests, InternalListBlankFillNoOutputTest) {
+  static constexpr int bufferSize{10};
+  char buffer[bufferSize];
+  std::memcpy(buffer, "abcdefghij", bufferSize);
+  auto cookie{IONAME(BeginInternalListOutput)(buffer, bufferSize)};
+  auto status{IONAME(EndIoStatement)(cookie)};
+  ASSERT_EQ(status, 0) << "EndIoStatement failed, status "
+                       << static_cast<int>(status);
+  EXPECT_TRUE(
+      CompareFormattedStrings("          ", std::string{buffer, bufferSize}))
+      << "Expected all blanks but got '" << std::string{buffer, bufferSize}
+      << "'";
+}
+
 TEST(IOApiTests, DescriptorOutputTest) {
   static constexpr int bufferSize{10};
   char buffer[bufferSize];


### PR DESCRIPTION
Fixes #205989

Root cause: CompleteOperation() only called AdvanceRecord() when furthestPositionInRecord > 0, so zero-byte writes skipped blank-fill.

Fix: always call AdvanceRecord() for internal list-directed output. Added internal-list-blank-fill-empty-derived.f90 integration test.