### PR TITLE
[Docs] Fix typos in Garbage Collection docs

### DIFF
--- a/llvm/docs/GarbageCollection.md
+++ b/llvm/docs/GarbageCollection.md
@@ -222,7 +222,7 @@ work is focused on `gc.statepoint`.
 {doc}`This page <Statepoints>` contains detailed documentation for
 `gc.statepoint`.
 
-#### Using `llvm.gcwrite`
+#### Using `llvm.gcroot`
 
 ```llvm
   void @llvm.gcroot(i8** %ptrloc, i8* %metadata)

--- a/llvm/docs/Statepoints.rst
+++ b/llvm/docs/Statepoints.rst
@@ -692,8 +692,8 @@ This pass would produce the following IR:
 In this case, we've added an (unconditional) entry safepoint poll.  Note that
 despite appearances, the entry poll is not necessarily redundant.  We'd have to
 know that ``foo`` and ``test`` were not mutually recursive for the poll to be
-redundant.  In practice, you'd probably want to your poll definition to contain
-a conditional branch of some form.
+redundant.  In practice, you'd probably want your poll definition to contain a
+conditional branch of some form.
 
 At the moment, PlaceSafepoints can insert safepoint polls at method entry and
 loop backedges locations.  Extending this to work with return polls would be
@@ -735,7 +735,7 @@ Mixing References and Raw Pointers
 
 Support for languages which allow unmanaged pointers to garbage collected
 objects (i.e. pass a pointer to an object to a C routine) in the abstract
-machine model.  At the moment, the best idea on how to approach this
+machine model is lacking.  At the moment, the best idea on how to approach this
 involves an intrinsic or opaque function which hides the connection between
 the reference value and the raw pointer.  The problem is that having a
 ptrtoint or inttoptr cast (which is common for such use cases) breaks the

--- a/llvm/docs/Statepoints.rst
+++ b/llvm/docs/Statepoints.rst
@@ -782,11 +782,11 @@ detail.
 Bugs and Enhancements
 =====================
 
-Currently known bugs and enhancements under consideration can be
-tracked by performing a `bugzilla search
-<https://bugs.llvm.org/buglist.cgi?cmdtype=runnamed&namedcmd=Statepoint%20Bugs&list_id=64342>`_
-for [Statepoint] in the summary field. When filing new bugs, please
-use this tag so that interested parties see the newly filed bug.  As
-with most LLVM features, design discussions take place on the `Discourse forums <https://discourse.llvm.org>`_ and patches
-should be sent to `llvm-commits
-<http://lists.llvm.org/mailman/listinfo/llvm-commits>`_ for review.
+Currently known bugs and enhancements under consideration can be tracked by
+performing a `GitHub issue search
+<https://github.com/llvm/llvm-project/issues>`_ for [Statepoint] in the summary
+field. When filing new bugs, please use this tag so that interested parties see
+the newly filed bug.  As with most LLVM features, design discussions take place
+on the `Discourse forums <https://discourse.llvm.org>`_ and patches should be
+submitted as `GitHub PR <http://github.com/llvm/llvm-project/pulls>`_ for
+review.

--- a/llvm/docs/Statepoints.rst
+++ b/llvm/docs/Statepoints.rst
@@ -434,7 +434,7 @@ This special section is encoded per the
 The general expectation is that a JIT compiler will parse and discard this
 format; it is not particularly memory efficient.  If you need an alternate
 format (e.g. for an ahead of time compiler), see discussion under
-:ref: `open work items <OpenWork>` below.
+:ref:`open work items <OpenWork>` below.
 
 Each statepoint generates the following Locations:
 


### PR DESCRIPTION
I was reading through LLVM documentation on Garbage Collection and found several errors.