### PR TITLE
[VPlan] Remove redundant x && (y && x) -> x && y combine

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -199,6 +199,11 @@ inline bind_const_int m_ConstantInt(uint64_t &C) { return C; }
 /// Match a VPValue, capturing it if we match.
 inline match_bind<VPValue> m_VPValue(VPValue *&V) { return V; }
 
+/// Match against the nested pattern, and capture the value if we match.
+template <typename Op_t> inline auto m_VPValue(VPValue *&V, const Op_t &Op) {
+  return m_CombineAnd(Op, m_VPValue(V));
+}
+
 /// Match a VPIRValue.
 inline match_bind<VPIRValue> m_VPIRValue(VPIRValue *&V) { return V; }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1193,8 +1193,9 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
 
   // x && (x && y) -> x && y
   if (match(Def, m_c_LogicalAnd(m_VPValue(X),
-                                m_c_LogicalAnd(m_Deferred(X), m_VPValue())))) {
-    Def->replaceAllUsesWith(Def->getOperand(Def->getOperand(1) == X ? 0 : 1));
+                                m_VPValue(Z, m_c_LogicalAnd(m_Deferred(X),
+                                                            m_VPValue()))))) {
+    Def->replaceAllUsesWith(Z);
     return true;
   }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1194,7 +1194,7 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
   // x && (x && y) -> x && y
   if (match(Def, m_c_LogicalAnd(m_VPValue(X),
                                 m_c_LogicalAnd(m_Deferred(X), m_VPValue())))) {
-    Def->replaceAllUsesWith(Def->getOperand(1));
+    Def->replaceAllUsesWith(Def->getOperand(Def->getOperand(1) == X ? 0 : 1));
     return true;
   }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1192,16 +1192,9 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
   }
 
   // x && (x && y) -> x && y
-  if (match(Def, m_LogicalAnd(m_VPValue(X),
-                              m_LogicalAnd(m_Deferred(X), m_VPValue())))) {
+  if (match(Def, m_c_LogicalAnd(m_VPValue(X),
+                                m_c_LogicalAnd(m_Deferred(X), m_VPValue())))) {
     Def->replaceAllUsesWith(Def->getOperand(1));
-    return true;
-  }
-
-  // x && (y && x) -> x && y
-  if (match(Def, m_LogicalAnd(m_VPValue(X),
-                              m_LogicalAnd(m_VPValue(Y), m_Deferred(X))))) {
-    Def->replaceAllUsesWith(Builder.createLogicalAnd(X, Y));
     return true;
   }
 


### PR DESCRIPTION
It can be subsumed by making the combine above commutative. In theory this isn't NFC as it changes the order, in practice it doesn't make a difference.
