### PR TITLE
[TableGen] Use DenseMap in getValueType instead of StringSwitch

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -18,7 +18,7 @@
 #include "CodeGenRegisters.h"
 #include "CodeGenSchedule.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -43,12 +43,13 @@ static cl::opt<unsigned>
 /// Returns the MVT that the specified TableGen
 /// record corresponds to.
 MVT llvm::getValueType(const Record *Rec) {
-  return StringSwitch<MVT>(Rec->getValueAsString("LLVMName"))
+  static const StringMap<MVT> ValueTypes = {
 #define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)      \
-  .Case(#Ty, MVT::Ty)
+  {#Ty, MVT::Ty},
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
-      .Case("INVALID_SIMPLE_VALUE_TYPE", MVT::INVALID_SIMPLE_VALUE_TYPE);
+      {"INVALID_SIMPLE_VALUE_TYPE", MVT::INVALID_SIMPLE_VALUE_TYPE}};
+  return ValueTypes.lookup(Rec->getValueAsString("LLVMName"));
 }
 
 StringRef llvm::getEnumName(MVT T) {

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -17,8 +17,8 @@
 #include "CodeGenInstruction.h"
 #include "CodeGenRegisters.h"
 #include "CodeGenSchedule.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -43,7 +43,7 @@ static cl::opt<unsigned>
 /// Returns the MVT that the specified TableGen
 /// record corresponds to.
 MVT llvm::getValueType(const Record *Rec) {
-  static const StringMap<MVT> ValueTypes = {
+  static const DenseMap<StringRef, MVT> ValueTypes = {
 #define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)      \
   {#Ty, MVT::Ty},
 #include "llvm/CodeGen/GenVT.inc"


### PR DESCRIPTION
StringSwitch is linear.
getValueType gets called often, identified by callgrind to be responsible for 11% of the executed instructions for NVPTX -gen-dag-isel. 

With DenseMap or StringMap, NVPTX and RISCV -gen-dag-isel runs 20% and 15% faster respectively. 

Modest 2-6% improvement for others.