### PR TITLE
[lldb][Windows] Dump thread stacks before lit's timeout kills a test

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -169,6 +169,10 @@ lldb_python_dir = None
 # Typical values include Debug, Release, RelWithDebInfo and MinSizeRel
 cmake_build_type = None
 
+# The timeout (in seconds) lit is using to run this test, if any. 0 means no
+# timeout was configured.
+timeout = 0
+
 
 def shouldSkipBecauseOfCategories(test_categories):
     if use_categories:

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -504,6 +504,19 @@ def registerFaulthandler():
     if getattr(faulthandler, "register", None):
         faulthandler.register(signal.SIGTERM, chain=True)
 
+    if sys.platform != "win32":
+        return
+
+    # lit kills a hung test with TerminateProcess on Windows, so the SIGTERM
+    # handler above never runs and a timeout is reported with no indication of
+    # where it hung. Dump every thread's stack while the process is still alive.
+    try:
+        secs = float(os.environ.get("LLDB_TEST_STACK_DUMP_SECS", 300))
+    except ValueError:
+        secs = 300
+    if secs > 0:
+        faulthandler.dump_traceback_later(secs, exit=False)
+
 
 def setupSysPath():
     """

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -509,16 +509,11 @@ def registerFaulthandler():
     if sys.platform != "win32":
         return
 
-    # lit kills a hung test with TerminateProcess on Windows, so the SIGTERM
-    # handler above never runs and a timeout is reported with no indication of
-    # where it hung. Dump every thread's stack shortly before lit's own
-    # per-test timeout (--timeout, forwarded from lit's `maxIndividualTestTime`
-    # by lldbtest.py) would kill the process.
+    # Dump every thread's stack shortly before lit's own per-test timeout would
+    # kill the process.
     if configuration.timeout <= 0:
         return
 
-    # Leave some headroom so the dump has time to reach lit's output before
-    # the process is terminated.
     secs = max(1.0, configuration.timeout * 0.9)
     faulthandler.dump_traceback_later(secs, exit=False)
 

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -449,6 +449,8 @@ def parseOptionsAndInitTestdirs():
         configuration.lldb_platform_available_ports = args.lldb_platform_available_ports
     if platform_system == "Darwin" and args.apple_sdk:
         configuration.apple_sdk = args.apple_sdk
+    if args.timeout:
+        configuration.timeout = args.timeout
     if args.test_build_dir:
         configuration.test_build_dir = args.test_build_dir
     if args.lldb_module_cache_dir:
@@ -509,13 +511,16 @@ def registerFaulthandler():
 
     # lit kills a hung test with TerminateProcess on Windows, so the SIGTERM
     # handler above never runs and a timeout is reported with no indication of
-    # where it hung. Dump every thread's stack while the process is still alive.
-    try:
-        secs = float(os.environ.get("LLDB_TEST_STACK_DUMP_SECS", 300))
-    except ValueError:
-        secs = 300
-    if secs > 0:
-        faulthandler.dump_traceback_later(secs, exit=False)
+    # where it hung. Dump every thread's stack shortly before lit's own
+    # per-test timeout (--timeout, forwarded from lit's `maxIndividualTestTime`
+    # by lldbtest.py) would kill the process.
+    if configuration.timeout <= 0:
+        return
+
+    # Leave some headroom so the dump has time to reach lit's output before
+    # the process is terminated.
+    secs = max(1.0, configuration.timeout * 0.9)
+    faulthandler.dump_traceback_later(secs, exit=False)
 
 
 def setupSysPath():

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -249,6 +249,14 @@ def create_parser():
         help="The root build directory for the tests. It will be removed before running.",
     )
     group.add_argument(
+        "--timeout",
+        dest="timeout",
+        metavar="Timeout in seconds",
+        type=float,
+        default=0,
+        help="The timeout lit is using to run this test, if any.",
+    )
+    group.add_argument(
         "--lldb-module-cache-dir",
         dest="lldb_module_cache_dir",
         metavar="The clang module cache directory used by LLDB",

--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -55,6 +55,9 @@ class LLDBTest(TestFormat):
         # python exe as the first parameter of the command.
         cmd = [executable] + self.dotest_cmd + [testPath, "-p", testFile]
 
+        if test.config.maxIndividualTestTime > 0:
+            cmd += ["--timeout", str(test.config.maxIndividualTestTime)]
+
         launcher = getattr(test.config, "lldb_launcher", None)
         if launcher:
             cmd = [launcher] + cmd


### PR DESCRIPTION
On Windows, when a test hits a timeout, we currently don't get a stacktrace. dotest solves this on POSIX: it registers a SIGTERM handler, so a killed test prints its stack. The handler does not run on Windows however because `faulthandler.register` doesn't exist there, and lit terminates the process instead of signalling it (no signals on Windows).

This patch adds `faulthandler.dump_traceback_later()` with a default timeout value of 300s. That's longer than the longest test in CI (~150s) and does not kill the test. It simply dumps the stacktrace at a point where the test is very likely stuck.

# Before

```
TIMEOUT: lldb-api :: types/TestFloatTypesExpr.py (2698 of 2698)
******************** TEST 'lldb-api :: types/TestFloatTypesExpr.py' FAILED ********************
Exit Code: 15
Timeout: Reached timeout of 900 seconds
```

There is no stacktrace.

# After

```
Timeout (0:00:20)!
Thread 0x00012fe8 (most recent call first):
  File ".../types/TestFloatTypesExpr.py", line 22 in test_float_type
  File ".../lldbsuite/test/lldbtest.py", line 2097 in test_method
  File ".../unittest/case.py", line 549 in _callTestMethod
  ...
  File ".../lldbsuite/test/dotest.py", line 1212 in run_suite
```