### PR TITLE
[flang][OpenMP] Reject standalone block-associated variants

### DIFF
--- a/flang/lib/Semantics/check-omp-variant.cpp
+++ b/flang/lib/Semantics/check-omp-variant.cpp
@@ -716,8 +716,10 @@ void OmpStructureChecker::Enter(const parser::OmpDirectiveSpecification &x) {
   llvm::omp::Directive dirId{x.DirId()};
   bool checkDefaultNoneInAssociatedLoop{
       GetDirectiveNest(MetadirectiveNest) != 0};
+  bool isDelimited{false};
   if (const parser::OpenMPConstruct *meta{GetCurrentConstruct()}) {
     if (parser::Unwrap<parser::OmpDelimitedMetadirectiveDirective>(meta->u)) {
+      isDelimited = true;
       checkDefaultNoneInAssociatedLoop = false;
       unsigned version{context_.langOptions().OpenMPVersion};
       switch (llvm::omp::getDirectiveAssociation(dirId)) {
@@ -733,6 +735,19 @@ void OmpStructureChecker::Enter(const parser::OmpDirectiveSpecification &x) {
                   llvm::omp::Directive::OMPD_metadirective, version));
         }
       }
+    }
+  }
+  if (!isDelimited && checkDefaultNoneInAssociatedLoop) {
+    OmpVariantMatchContext matchContext{context_};
+    if (currentWhenSelector_ &&
+        MayVariantBeSelected(currentWhenSelector_, context_, matchContext) &&
+        llvm::omp::getDirectiveAssociation(dirId) ==
+            llvm::omp::Association::Block) {
+      unsigned version{context_.langOptions().OpenMPVersion};
+      context_.Say(x.DirName().source,
+          "A standalone %s cannot contain a block-associated directive"_err_en_US,
+          parser::omp::GetUpperName(
+              llvm::omp::Directive::OMPD_metadirective, version));
     }
   }
 

--- a/flang/lib/Semantics/check-omp-variant.cpp
+++ b/flang/lib/Semantics/check-omp-variant.cpp
@@ -738,16 +738,16 @@ void OmpStructureChecker::Enter(const parser::OmpDirectiveSpecification &x) {
     }
   }
   if (!isDelimited && checkDefaultNoneInAssociatedLoop) {
-    OmpVariantMatchContext matchContext{context_};
-    if (currentWhenSelector_ &&
-        MayVariantBeSelected(currentWhenSelector_, context_, matchContext) &&
-        llvm::omp::getDirectiveAssociation(dirId) ==
-            llvm::omp::Association::Block) {
-      unsigned version{context_.langOptions().OpenMPVersion};
-      context_.Say(x.DirName().source,
-          "A standalone %s cannot contain a block-associated directive"_err_en_US,
-          parser::omp::GetUpperName(
-              llvm::omp::Directive::OMPD_metadirective, version));
+    if (llvm::omp::getDirectiveAssociation(dirId) ==
+        llvm::omp::Association::Block) {
+      OmpVariantMatchContext matchContext{context_};
+      if (MayVariantBeSelected(currentWhenSelector_, context_, matchContext)) {
+        unsigned version{context_.langOptions().OpenMPVersion};
+        context_.Say(x.DirName().source,
+            "A standalone %s cannot contain a block-associated directive"_err_en_US,
+            parser::omp::GetUpperName(
+                llvm::omp::Directive::OMPD_metadirective, version));
+      }
     }
   }
 

--- a/flang/test/Parser/OpenMP/metadirective-dirspec.f90
+++ b/flang/test/Parser/OpenMP/metadirective-dirspec.f90
@@ -31,13 +31,16 @@ end
 
 subroutine f01(x)
   integer :: x
-  !$omp metadirective when(user={condition(.true.)}: &
+  ! condition(.false.) prevents block-associated variant from being
+  ! selected so the semantic check does not fire, while still testing
+  ! directive-specification parsing with an argument and ResolveCriticalName.
+  !$omp metadirective when(user={condition(.false.)}: &
   !$omp & critical(x))
 end
 
 !UNPARSE: SUBROUTINE f01 (x)
 !UNPARSE:  INTEGER x
-!UNPARSE: !$OMP METADIRECTIVE WHEN(USER={CONDITION(.true._4)}: CRITICAL(x))
+!UNPARSE: !$OMP METADIRECTIVE WHEN(USER={CONDITION(.false._4)}: CRITICAL(x))
 !UNPARSE: END SUBROUTINE
 
 !PARSE-TREE: DeclarationConstruct -> SpecificationConstruct -> OpenMPDeclarativeConstruct -> OmpMetadirectiveDirective
@@ -47,9 +50,9 @@ end
 !PARSE-TREE: | | | OmpTraitSelector
 !PARSE-TREE: | | | | OmpTraitSelectorName -> Value = Condition
 !PARSE-TREE: | | | | Properties
-!PARSE-TREE: | | | | | OmpTraitProperty -> Scalar -> Expr = '.true._4'
+!PARSE-TREE: | | | | | OmpTraitProperty -> Scalar -> Expr = '.false._4'
 !PARSE-TREE: | | | | | | LiteralConstant -> LogicalLiteralConstant
-!PARSE-TREE: | | | | | | | bool = 'true'
+!PARSE-TREE: | | | | | | | bool = 'false'
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = critical
 !PARSE-TREE: | | | OmpArgumentList -> OmpArgument -> OmpObject -> Designator -> DataRef -> Name = 'x'

--- a/flang/test/Semantics/OpenMP/metadirective-common.f90
+++ b/flang/test/Semantics/OpenMP/metadirective-common.f90
@@ -45,3 +45,12 @@ subroutine f05
 !ERROR: 'context-selector' modifier is required
   !$omp & when(nothing)
 end
+
+! A standalone metadirective cannot contain a block-associated directive
+subroutine f06(x)
+  integer :: x
+  !$omp metadirective &
+!ERROR: A standalone METADIRECTIVE cannot contain a block-associated directive
+  !$omp & when(implementation={vendor(llvm)}: parallel num_threads(4)) otherwise(nothing)
+  x = 1
+end

--- a/flang/test/Semantics/OpenMP/metadirective-common.f90
+++ b/flang/test/Semantics/OpenMP/metadirective-common.f90
@@ -54,3 +54,13 @@ subroutine f06(x)
   !$omp & when(implementation={vendor(llvm)}: parallel num_threads(4)) otherwise(nothing)
   x = 1
 end
+
+! The fallback (otherwise/default) variant is also checked
+subroutine f07(x)
+  integer :: x
+  !$omp metadirective &
+  !$omp & when(implementation={vendor(llvm)}: nothing) &
+!ERROR: A standalone METADIRECTIVE cannot contain a block-associated directive
+  !$omp & otherwise(parallel num_threads(4))
+  x = 1
+end

--- a/flang/test/Semantics/OpenMP/metadirective-loop-nest.f90
+++ b/flang/test/Semantics/OpenMP/metadirective-loop-nest.f90
@@ -177,7 +177,7 @@ module no_loop_before_another_metadirective
   implicit none
   !ERROR: This construct should contain a DO-loop or a loop-nest-generating construct
   !$omp metadirective when(implementation={vendor(llvm)}: do) default(nothing)
-  !$omp metadirective when(implementation={vendor(llvm)}: parallel) default(nothing)
+  !$omp metadirective when(implementation={vendor(llvm)}: nothing) default(nothing)
 end module
 
 ! A loop in the enclosing subprogram cannot satisfy a variant from an


### PR DESCRIPTION
standalone OpenMP metadirectives are `Association::none`, so they must not select a block-associated directive variant such as `parallel`.

this adds a semantic check in `check-omp-variant.cpp` to diagnose this case when the selected variant is actually selectable on the current target and a regression test in `flang/test/Semantics/OpenMP/metadirective-common.f90` for the issue reproducer.

closes #212635