### PR TITLE
[Build] Fix llvm-calc-occupancy link errors when using LLVM_LINK_LLVM_DYLIB.

### DIFF
--- a/llvm/tools/llvm-calc-occupancy/CMakeLists.txt
+++ b/llvm/tools/llvm-calc-occupancy/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_tool(llvm-calc-occupancy
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   llvm-calc-occupancy.cpp
 
   DEPENDS


### PR DESCRIPTION
I don't know if this is the correct fix but I've not been able to build since https://github.com/llvm/llvm-project/pull/208727 landed and other tools have this in their cmake config.