### PR TITLE
[AMDGPU] Generalize MFMA VGPR->AGPR opcode mapping (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -77,7 +77,7 @@ public:
         LIS(LIS), LSS(LSS), RegClassInfo(RegClassInfo) {}
 
   bool isRewriteCandidate(const MachineInstr &MI) const {
-    return TII.isMAI(MI) && AMDGPU::getMFMASrcCVDstAGPROp(MI.getOpcode()) != -1;
+    return TII.isMAI(MI) && AMDGPU::getAGPRFormOp(MI.getOpcode()) != -1;
   }
 
   /// Find AV_* registers assigned to AGPRs (or virtual registers which were
@@ -159,7 +159,7 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::recomputeRegClassExceptRewritable(
       // either AGPR or VGPR in src0/src1. We still need to check constraint
       // effects for scale variant, which does not allow AGPR.
       if (isRewriteCandidate(*MI)) {
-        int AGPROp = AMDGPU::getMFMASrcCVDstAGPROp(MI->getOpcode());
+        int AGPROp = AMDGPU::getAGPRFormOp(MI->getOpcode());
         const MCInstrDesc &AGPRDesc = TII.get(AGPROp);
         const TargetRegisterClass *NewRC =
             TII.getRegClass(AGPRDesc, MO.getOperandNo());
@@ -293,8 +293,7 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryReassigningMFMAChain(
   }
 
   for (MachineInstr *RewriteCandidate : RewriteCandidates) {
-    int NewMFMAOp =
-        AMDGPU::getMFMASrcCVDstAGPROp(RewriteCandidate->getOpcode());
+    int NewMFMAOp = AMDGPU::getAGPRFormOp(RewriteCandidate->getOpcode());
     RewriteCandidate->setDesc(TII.get(NewMFMAOp));
     ++NumMFMAsRewrittenToAGPR;
   }

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2359,7 +2359,7 @@ void RewriteMFMAFormStage::resetRewriteCandsToVGPR(
 bool RewriteMFMAFormStage::isRewriteCandidate(MachineInstr *MI) const {
   if (!static_cast<const SIInstrInfo *>(DAG.TII)->isMAI(*MI))
     return false;
-  if (AMDGPU::getMFMASrcCVDstAGPROp(MI->getOpcode()) == -1)
+  if (AMDGPU::getAGPRFormOp(MI->getOpcode()) == -1)
     return false;
   // Reject candidates whose users force an unavoidable bridge copy.
   Register DstReg = MI->getOperand(0).getReg();
@@ -2397,7 +2397,7 @@ bool RewriteMFMAFormStage::initHeuristics(
       if (!isRewriteCandidate(&MI))
         continue;
 
-      int ReplacementOp = AMDGPU::getMFMASrcCVDstAGPROp(MI.getOpcode());
+      int ReplacementOp = AMDGPU::getAGPRFormOp(MI.getOpcode());
       assert(ReplacementOp != -1);
 
       RewriteCands.push_back({&MI, MI.getOpcode()});
@@ -2657,7 +2657,7 @@ bool RewriteMFMAFormStage::rewrite(
   }
 
   for (auto &[MI, OriginalOpcode] : RewriteCands) {
-    int ReplacementOp = AMDGPU::getMFMASrcCVDstAGPROp(MI->getOpcode());
+    int ReplacementOp = AMDGPU::getAGPRFormOp(MI->getOpcode());
     if (ReplacementOp == -1)
       continue;
     MI->setDesc(TII->get(ReplacementOp));

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1894,10 +1894,10 @@ namespace AMDGPU {
   LLVM_READONLY
   int32_t getMFMAEarlyClobberOp(uint32_t Opcode);
 
-  /// \returns Version of an MFMA instruction which uses AGPRs for srcC and
-  /// vdst, given an \p Opcode of an MFMA which uses VGPRs for srcC/vdst.
+  /// \returns Version of an instruction which uses AGPRs for coupled operands
+  /// given an \p Opcode which uses VGPRs for coupled operands.
   LLVM_READONLY
-  int32_t getMFMASrcCVDstAGPROp(uint32_t Opcode);
+  int32_t getAGPRFormOp(uint32_t Opcode);
 
   /// \returns v_cmpx version of a v_cmp instruction.
   LLVM_READONLY

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -3262,6 +3262,11 @@ class Commutable_REV <string revOp, bit isOrig> {
   bit IsOrig = isOrig;
 }
 
+class AGPRFormTable<string Kind, string Name = NAME> {
+  string AGPRFormOp = Name;
+  string AGPRFormKind = Kind;
+}
+
 //===----------------------------------------------------------------------===//
 // Interpolation opcodes
 //===----------------------------------------------------------------------===//
@@ -3512,11 +3517,11 @@ def getMFMAEarlyClobberOp : InstrMapping {
   let ValueCols = [["0"]];
 }
 
-// Map from an mfma using VGPRs to one using AGPRs.
-def getMFMASrcCVDstAGPROp : InstrMapping {
-  let FilterClass = "MFMATable";
-  let RowFields = ["AGPROp"];
-  let ColFields = ["MFMAKind"];
+// Map from an instruction using VGPRs to one using AGPRs.
+def getAGPRFormOp : InstrMapping {
+  let FilterClass = "AGPRFormTable";
+  let RowFields = ["AGPRFormOp"];
+  let ColFields = ["AGPRFormKind"];
   let KeyCol = ["VGPR"];
   let ValueCols = [["AGPR"]];
 }

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -1103,13 +1103,9 @@ def VOPProfileMAI_I32_V4I32_X16_VCD : VOPProfileMAI<VOP_V16I32_V4I32_V4I32_V16I3
 
 
 class MFMATable <bit is_mac, string Kind, string Name,
-                 string AGPROpName = NAME> {
+                 string AGPROpName = NAME> : AGPRFormTable<Kind, AGPROpName> {
   bit IsMac = is_mac;
   string FMAOp = Name;
-  string AGPROp = AGPROpName;
-
-  // Does this MFMA use "AGPR" or "VGPR" for srcC/vdst
-  string MFMAKind = Kind;
 }
 
 class MFMA_F8F6F4_WithSizeTable<int A, int B, Instruction ThisVariant, Instruction F8F8Variant> {


### PR DESCRIPTION
Move the VGPR/AGPR pairing out of MFMATable into a generalized
AGPRFormTable class and rename getMFMASrcCVDstAGPROp to getAGPRFormOp.
MFMATable inherits AGPRFormTable, so the instantiation sites and the
generated table are unchanged.

Other instruction families with paired VGPR/AGPR pseudos, such as DS,
can now be tagged with AGPRFormTable.

Related to #168983
