### PR TITLE
[MIRParser] Reject a one-element fixed-length vector type

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -2110,8 +2110,11 @@ static bool verifyScalarSize(uint64_t Size) {
   return Size != 0 && isUInt<16>(Size);
 }
 
-static bool verifyVectorElementCount(uint64_t NumElts) {
-  return NumElts != 0 && isUInt<16>(NumElts);
+static bool verifyVectorElementCount(uint64_t NumElts, bool HasVScale) {
+  // A fixed-length vector needs at least two elements: LLT::vector rejects a
+  // one-element ElementCount, and producers map such a type to the element
+  // type itself through LLT::scalarOrVector.
+  return NumElts != 0 && (HasVScale || NumElts != 1) && isUInt<16>(NumElts);
 }
 
 static bool verifyAddrSpace(uint64_t AddrSpace) {
@@ -2198,7 +2201,7 @@ bool MIParser::parseLowLevelType(StringRef::iterator Loc, LLT &Ty) {
   if (Token.isNot(MIToken::IntegerLiteral))
     return GetError();
   uint64_t NumElements = Token.integerValue().getZExtValue();
-  if (!verifyVectorElementCount(NumElements))
+  if (!verifyVectorElementCount(NumElements, HasVScale))
     return error("invalid number of vector elements");
 
   lex();

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1965,8 +1965,11 @@ static bool verifyScalarSize(uint64_t Size) {
   return Size != 0 && isUInt<16>(Size);
 }
 
-static bool verifyVectorElementCount(uint64_t NumElts) {
-  return NumElts != 0 && isUInt<16>(NumElts);
+static bool verifyVectorElementCount(uint64_t NumElts, bool HasVScale) {
+  // A fixed-length vector needs at least two elements: LLT::vector rejects a
+  // one-element ElementCount, and producers map such a type to the element
+  // type itself through LLT::scalarOrVector.
+  return NumElts != 0 && (HasVScale || NumElts != 1) && isUInt<16>(NumElts);
 }
 
 static bool verifyAddrSpace(uint64_t AddrSpace) {
@@ -2053,7 +2056,7 @@ bool MIParser::parseLowLevelType(StringRef::iterator Loc, LLT &Ty) {
   if (Token.isNot(MIToken::IntegerLiteral))
     return GetError();
   uint64_t NumElements = Token.integerValue().getZExtValue();
-  if (!verifyVectorElementCount(NumElements))
+  if (!verifyVectorElementCount(NumElements, HasVScale))
     return error("invalid number of vector elements");
 
   lex();

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1966,9 +1966,7 @@ static bool verifyScalarSize(uint64_t Size) {
 }
 
 static bool verifyVectorElementCount(uint64_t NumElts, bool HasVScale) {
-  // A fixed-length vector needs at least two elements: LLT::vector rejects a
-  // one-element ElementCount, and producers map such a type to the element
-  // type itself through LLT::scalarOrVector.
+  // A fixed-length vector needs at least two elements.
   return NumElts != 0 && (HasVScale || NumElts != 1) && isUInt<16>(NumElts);
 }
 

--- a/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid11.mir
+++ b/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid11.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -mtriple=aarch64-- -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# When a fixed-length low-level type vector has 1 element
+---
+name: test_vector_1_element
+body: |
+  bb.0:
+    liveins: $x0
+    ; CHECK: [[@LINE+1]]:11: invalid number of vector elements
+    %0:_(<1 x s64>) = G_IMPLICIT_DEF
+...

--- a/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid11.mir
+++ b/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid11.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=aarch64-- -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=aarch64-- -run-pass=none -filetype=null %s 2>&1 | FileCheck %s
 # When a fixed-length low-level type vector has 1 element
 ---
 name: test_vector_1_element


### PR DESCRIPTION
MIParser accepts `<1 x sN>` and then asserts while building the LLT, so llc
aborts during parsing instead of reporting a parse error:

```
Assertion `!EC.isScalar() && "invalid number of vector elements"' failed.
```

LLT has no one-element fixed-length vector. `getLLTForType`, `getLLTForMVT` and
`LLT::changeElementCount` all map a one-element `ElementCount` to the element
type through `LLT::scalarOrVector`, nothing calls `LLT::fixed_vector(1, ...)`,
and no in-tree .mir test uses the syntax. `verifyVectorElementCount` already
rejects 0 and anything above 2^16, so 1 was the remaining hole; it now gets the
same diagnostic instead of aborting the parser.

Scalable vectors are unaffected: `<vscale x 1 x sN>` is a valid type and stays
legal through the `HasVScale` check.

AI assistance: drafted with AI help; reviewed and validated by me.
