### PR TITLE
[lld] Fix -Wunused-result in e44068cc129912c88dcdeae0d1b5dc5937eb1059

### DIFF
--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -845,8 +845,9 @@ bool ObjcCategoryMerger::parseCatInfoToExtInfo(const InfoInputCategory &catInfo,
     else
       extInfo.baseClassName = classSym->getName().str();
   } else {
-    auto [classSym, classAddend] = tryGetSymbolReferenceAtIsecOffset(
-        catInfo.catBodyIsec, catLayout.klassOffset);
+    [[maybe_unused]] auto [classSym, classAddend] =
+        tryGetSymbolReferenceAtIsecOffset(catInfo.catBodyIsec,
+                                          catLayout.klassOffset);
     assert((extInfo.baseClass == classSym &&
             extInfo.baseClassAddend == classAddend) &&
            "Trying to parse category info into container with different base "


### PR DESCRIPTION
These variables are only used in an assertion, so mark them maybe unused to avoid warnings in release builds.

Fixes https://lab.llvm.org/buildbot/#/builders/228/builds/6605.