### PR TITLE
[lldb][Windows] Expose each thread's TEB address as extended thread info

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
@@ -44,6 +44,46 @@ void TargetThreadWindows::RefreshStateAfterStop() {
 
 void TargetThreadWindows::WillResume(lldb::StateType resume_state) {}
 
+StructuredData::ObjectSP TargetThreadWindows::FetchThreadExtendedInfo() {
+  struct ThreadBasicInformation {
+    LONG ExitStatus;
+    PVOID TebBaseAddress;
+    struct {
+      HANDLE UniqueProcess;
+      HANDLE UniqueThread;
+    } ClientId;
+    ULONG_PTR AffinityMask;
+    LONG Priority;
+    LONG BasePriority;
+  };
+  using NtQueryInformationThreadFn =
+      LONG(WINAPI *)(HANDLE ThreadHandle, ULONG ThreadInformationClass,
+                     PVOID ThreadInformation, ULONG ThreadInformationLength,
+                     PULONG ReturnLength);
+
+  static LazyImport<NtQueryInformationThreadFn> s_query_information_thread{
+      L"Kernel32.dll", "NtQueryInformationThread"};
+  if (!s_query_information_thread)
+    return StructuredData::ObjectSP();
+  auto NtQueryInformationThread = *s_query_information_thread;
+
+  HANDLE handle = m_host_thread.GetNativeThread().GetSystemHandle();
+  if (!handle || handle == INVALID_HANDLE_VALUE)
+    return StructuredData::ObjectSP();
+
+  ThreadBasicInformation info = {};
+  // ThreadInformationClass 0 is ThreadBasicInformation.
+  if (NtQueryInformationThread(handle, 0, &info, sizeof(info), nullptr) < 0)
+    return StructuredData::ObjectSP();
+  if (!info.TebBaseAddress)
+    return StructuredData::ObjectSP();
+
+  auto dict = std::make_shared<StructuredData::Dictionary>();
+  dict->AddIntegerItem("teb_address",
+                       reinterpret_cast<uint64_t>(info.TebBaseAddress));
+  return dict;
+}
+
 void TargetThreadWindows::DidStop() {}
 
 RegisterContextSP TargetThreadWindows::GetRegisterContext() {

--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.h
@@ -34,6 +34,10 @@ public:
   bool CalculateStopInfo() override;
   const char *GetName() override;
 
+  /// Exposes this thread's TEB address under the "teb_address" key, so that
+  /// language runtimes can resolve thread-local storage.
+  lldb_private::StructuredData::ObjectSP FetchThreadExtendedInfo() override;
+
   Status DoResume();
 
   HostThread GetHostThread() const { return m_host_thread; }


### PR DESCRIPTION
A Windows thread's local storage is accessed through its Thread Environment Block ([TEB](https://learn.microsoft.com/en-us/windows/win32/api/winternl/ns-winternl-teb)), but nothing in the target exposes that address, so a language runtime cannot resolve a variable local to the thread in the debuggee.

This patch publishes the thread's TEB from `TargetThreadWindows::FetchThreadExtendedInfo` under the "teb_address" key.

This is required for:
- https://github.com/swiftlang/llvm-project/pull/13597