### PR TITLE
[TTI] Add getPointerInfos/getPointerInfo query for target address spaces

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -235,9 +235,7 @@ public:
   const SmallVectorImpl<const Value *> &getArgs() const { return Arguments; }
   const SmallVectorImpl<Type *> &getArgTypes() const { return ParamTys; }
 
-  bool isTypeBasedOnly() const {
-    return Arguments.empty();
-  }
+  bool isTypeBasedOnly() const { return Arguments.empty(); }
 
   bool skipScalarizationCost() const { return ScalarizationCost.isValid(); }
 };
@@ -1286,9 +1284,9 @@ public:
     SK_PermuteSingleSrc, ///< Shuffle elements of single source vector with any
                          ///< shuffle mask.
     SK_Splice            ///< Concatenates elements from the first input vector
-                         ///< with elements of the second input vector. Returning
-                         ///< a vector of the same type as the input vectors.
-                         ///< Index indicates start offset in first input vector.
+              ///< with elements of the second input vector. Returning
+              ///< a vector of the same type as the input vectors.
+              ///< Index indicates start offset in first input vector.
   };
 
   /// Additional information about an operand's possible values.
@@ -1314,21 +1312,16 @@ public:
     OperandValueProperties Properties = OP_None;
 
     bool isConstant() const {
-      return Kind == OK_UniformConstantValue || Kind == OK_NonUniformConstantValue;
+      return Kind == OK_UniformConstantValue ||
+             Kind == OK_NonUniformConstantValue;
     }
     bool isUniform() const {
       return Kind == OK_UniformConstantValue || Kind == OK_UniformValue;
     }
-    bool isPowerOf2() const {
-      return Properties == OP_PowerOf2;
-    }
-    bool isNegatedPowerOf2() const {
-      return Properties == OP_NegatedPowerOf2;
-    }
+    bool isPowerOf2() const { return Properties == OP_PowerOf2; }
+    bool isNegatedPowerOf2() const { return Properties == OP_NegatedPowerOf2; }
 
-    OperandValueInfo getNoProps() const {
-      return {Kind, OP_None};
-    }
+    OperandValueInfo getNoProps() const { return {Kind, OP_None}; }
 
     OperandValueInfo mergeWith(const OperandValueInfo OpInfoY) {
       OperandValueKind MergeKind = OK_AnyValue;

--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -547,6 +547,26 @@ public:
   /// Return false if a \p AS0 address cannot possibly alias a \p AS1 address.
   LLVM_ABI bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const;
 
+  /// Describes a single address space exposed by the target.
+  struct PointerInfo {
+    /// The address space number, in the target's own numbering.
+    unsigned AddrSpace = 0;
+    /// The target's name for this address space, e.g. "global". Empty if the
+    /// target does not name it.
+    StringRef Name;
+  };
+
+  /// Returns every address space the target gives a meaning to, sorted by
+  /// address space number.
+  ///
+  /// \returns an empty list for targets that do not describe their address
+  /// spaces.
+  LLVM_ABI SmallVector<PointerInfo, 8> getPointerInfos() const;
+
+  /// Returns the description of address space \p AS, or std::nullopt if the
+  /// target does not describe it.
+  LLVM_ABI std::optional<PointerInfo> getPointerInfo(unsigned AS) const;
+
   /// Returns the address space ID for a target's 'flat' address space. Note
   /// this is not necessarily the same as addrspace(0), which LLVM sometimes
   /// refers to as the generic address space. The flat address space is a

--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -235,7 +235,9 @@ public:
   const SmallVectorImpl<const Value *> &getArgs() const { return Arguments; }
   const SmallVectorImpl<Type *> &getArgTypes() const { return ParamTys; }
 
-  bool isTypeBasedOnly() const { return Arguments.empty(); }
+  bool isTypeBasedOnly() const {
+    return Arguments.empty();
+  }
 
   bool skipScalarizationCost() const { return ScalarizationCost.isValid(); }
 };
@@ -1271,9 +1273,9 @@ public:
     SK_PermuteSingleSrc, ///< Shuffle elements of single source vector with any
                          ///< shuffle mask.
     SK_Splice            ///< Concatenates elements from the first input vector
-              ///< with elements of the second input vector. Returning
-              ///< a vector of the same type as the input vectors.
-              ///< Index indicates start offset in first input vector.
+                         ///< with elements of the second input vector. Returning
+                         ///< a vector of the same type as the input vectors.
+                         ///< Index indicates start offset in first input vector.
   };
 
   /// Additional information about an operand's possible values.
@@ -1299,16 +1301,21 @@ public:
     OperandValueProperties Properties = OP_None;
 
     bool isConstant() const {
-      return Kind == OK_UniformConstantValue ||
-             Kind == OK_NonUniformConstantValue;
+      return Kind == OK_UniformConstantValue || Kind == OK_NonUniformConstantValue;
     }
     bool isUniform() const {
       return Kind == OK_UniformConstantValue || Kind == OK_UniformValue;
     }
-    bool isPowerOf2() const { return Properties == OP_PowerOf2; }
-    bool isNegatedPowerOf2() const { return Properties == OP_NegatedPowerOf2; }
+    bool isPowerOf2() const {
+      return Properties == OP_PowerOf2;
+    }
+    bool isNegatedPowerOf2() const {
+      return Properties == OP_NegatedPowerOf2;
+    }
 
-    OperandValueInfo getNoProps() const { return {Kind, OP_None}; }
+    OperandValueInfo getNoProps() const {
+      return {Kind, OP_None};
+    }
 
     OperandValueInfo mergeWith(const OperandValueInfo OpInfoY) {
       OperandValueKind MergeKind = OK_AnyValue;

--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -545,25 +545,12 @@ public:
   /// Return false if a \p AS0 address cannot possibly alias a \p AS1 address.
   LLVM_ABI bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const;
 
-  /// Describes a single address space exposed by the target.
-  struct PointerInfo {
-    /// The address space number, in the target's own numbering.
-    unsigned AddrSpace = 0;
-    /// The target's name for this address space, e.g. "global". Empty if the
-    /// target does not name it.
-    StringRef Name;
-  };
-
   /// Returns every address space the target gives a meaning to, sorted by
-  /// address space number.
+  /// address space number and free of duplicates.
   ///
   /// \returns an empty list for targets that do not describe their address
   /// spaces.
-  LLVM_ABI SmallVector<PointerInfo, 8> getPointerInfos() const;
-
-  /// Returns the description of address space \p AS, or std::nullopt if the
-  /// target does not describe it.
-  LLVM_ABI std::optional<PointerInfo> getPointerInfo(unsigned AS) const;
+  LLVM_ABI SmallVector<unsigned, 8> getAddressSpaces() const;
 
   /// Returns the address space ID for a target's 'flat' address space. Note
   /// this is not necessarily the same as addrspace(0), which LLVM sometimes

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -144,6 +144,23 @@ public:
     return true;
   }
 
+  virtual SmallVector<TTI::PointerInfo, 8> getPointerInfos() const {
+    return {};
+  }
+
+  virtual std::optional<TTI::PointerInfo> getPointerInfo(unsigned AS) const {
+    // Targets only need to override getPointerInfos(); this searches the list
+    // they report, which is sorted by address space number.
+    SmallVector<TTI::PointerInfo, 8> Infos = getPointerInfos();
+    const auto *I = lower_bound(Infos, AS, [](const TTI::PointerInfo &PI,
+                                              unsigned AS) {
+      return PI.AddrSpace < AS;
+    });
+    if (I == Infos.end() || I->AddrSpace != AS)
+      return std::nullopt;
+    return *I;
+  }
+
   virtual unsigned getFlatAddressSpace() const { return -1; }
 
   virtual bool collectFlatAddressOperands(SmallVectorImpl<int> &OpIndexes,

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -152,10 +152,10 @@ public:
     // Targets only need to override getPointerInfos(); this searches the list
     // they report, which is sorted by address space number.
     SmallVector<TTI::PointerInfo, 8> Infos = getPointerInfos();
-    const auto *I = lower_bound(Infos, AS, [](const TTI::PointerInfo &PI,
-                                              unsigned AS) {
-      return PI.AddrSpace < AS;
-    });
+    const auto *I =
+        lower_bound(Infos, AS, [](const TTI::PointerInfo &PI, unsigned AS) {
+          return PI.AddrSpace < AS;
+        });
     if (I == Infos.end() || I->AddrSpace != AS)
       return std::nullopt;
     return *I;

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -144,22 +144,7 @@ public:
     return true;
   }
 
-  virtual SmallVector<TTI::PointerInfo, 8> getPointerInfos() const {
-    return {};
-  }
-
-  virtual std::optional<TTI::PointerInfo> getPointerInfo(unsigned AS) const {
-    // Targets only need to override getPointerInfos(); this searches the list
-    // they report, which is sorted by address space number.
-    SmallVector<TTI::PointerInfo, 8> Infos = getPointerInfos();
-    const auto *I =
-        lower_bound(Infos, AS, [](const TTI::PointerInfo &PI, unsigned AS) {
-          return PI.AddrSpace < AS;
-        });
-    if (I == Infos.end() || I->AddrSpace != AS)
-      return std::nullopt;
-    return *I;
-  }
+  virtual SmallVector<unsigned, 8> getAddressSpaces() const { return {}; }
 
   virtual unsigned getFlatAddressSpace() const { return -1; }
 

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -733,12 +733,11 @@ bool TargetTransformInfo::isFPVectorizationPotentiallyUnsafe() const {
   return TTIImpl->isFPVectorizationPotentiallyUnsafe();
 }
 
-bool
-TargetTransformInfo::allowsMisalignedMemoryAccesses(LLVMContext &Context,
-                                                    unsigned BitWidth,
-                                                    unsigned AddressSpace,
-                                                    Align Alignment,
-                                                    unsigned *Fast) const {
+bool TargetTransformInfo::allowsMisalignedMemoryAccesses(LLVMContext &Context,
+                                                         unsigned BitWidth,
+                                                         unsigned AddressSpace,
+                                                         Align Alignment,
+                                                         unsigned *Fast) const {
   return TTIImpl->allowsMisalignedMemoryAccesses(Context, BitWidth,
                                                  AddressSpace, Alignment, Fast);
 }

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -312,6 +312,16 @@ bool llvm::TargetTransformInfo::addrspacesMayAlias(unsigned FromAS,
   return TTIImpl->addrspacesMayAlias(FromAS, ToAS);
 }
 
+SmallVector<TargetTransformInfo::PointerInfo, 8>
+TargetTransformInfo::getPointerInfos() const {
+  return TTIImpl->getPointerInfos();
+}
+
+std::optional<TargetTransformInfo::PointerInfo>
+TargetTransformInfo::getPointerInfo(unsigned AS) const {
+  return TTIImpl->getPointerInfo(AS);
+}
+
 unsigned TargetTransformInfo::getFlatAddressSpace() const {
   return TTIImpl->getFlatAddressSpace();
 }

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -732,11 +732,12 @@ bool TargetTransformInfo::isFPVectorizationPotentiallyUnsafe() const {
   return TTIImpl->isFPVectorizationPotentiallyUnsafe();
 }
 
-bool TargetTransformInfo::allowsMisalignedMemoryAccesses(LLVMContext &Context,
-                                                         unsigned BitWidth,
-                                                         unsigned AddressSpace,
-                                                         Align Alignment,
-                                                         unsigned *Fast) const {
+bool
+TargetTransformInfo::allowsMisalignedMemoryAccesses(LLVMContext &Context,
+                                                    unsigned BitWidth,
+                                                    unsigned AddressSpace,
+                                                    Align Alignment,
+                                                    unsigned *Fast) const {
   return TTIImpl->allowsMisalignedMemoryAccesses(Context, BitWidth,
                                                  AddressSpace, Alignment, Fast);
 }

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/CFG.h"
 #include "llvm/Analysis/LoopIterator.h"
@@ -21,6 +22,7 @@
 #include "llvm/IR/Operator.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/CommandLine.h"
+#include <functional>
 #include <optional>
 #include <utility>
 
@@ -312,14 +314,11 @@ bool llvm::TargetTransformInfo::addrspacesMayAlias(unsigned FromAS,
   return TTIImpl->addrspacesMayAlias(FromAS, ToAS);
 }
 
-SmallVector<TargetTransformInfo::PointerInfo, 8>
-TargetTransformInfo::getPointerInfos() const {
-  return TTIImpl->getPointerInfos();
-}
-
-std::optional<TargetTransformInfo::PointerInfo>
-TargetTransformInfo::getPointerInfo(unsigned AS) const {
-  return TTIImpl->getPointerInfo(AS);
+SmallVector<unsigned, 8> TargetTransformInfo::getAddressSpaces() const {
+  SmallVector<unsigned, 8> AddrSpaces = TTIImpl->getAddressSpaces();
+  assert(is_sorted(AddrSpaces, std::less_equal<>()) &&
+         "target reported address spaces out of order or duplicated");
+  return AddrSpaces;
 }
 
 unsigned TargetTransformInfo::getFlatAddressSpace() const {

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -1265,6 +1265,15 @@ bool GCNTTIImpl::isAlwaysUniform(const Value *V) const {
   return false;
 }
 
+SmallVector<unsigned, 8> GCNTTIImpl::getAddressSpaces() const {
+  // TODO: Add the address spaces 10-16 to the list when they are used.
+  using namespace AMDGPUAS;
+  return {FLAT_ADDRESS,           GLOBAL_ADDRESS,     REGION_ADDRESS,
+          LOCAL_ADDRESS,          CONSTANT_ADDRESS,   PRIVATE_ADDRESS,
+          CONSTANT_ADDRESS_32BIT, BUFFER_FAT_POINTER, BUFFER_RESOURCE,
+          BUFFER_STRIDED_POINTER, STREAMOUT_REGISTER};
+}
+
 bool GCNTTIImpl::collectFlatAddressOperands(SmallVectorImpl<int> &OpIndexes,
                                             Intrinsic::ID IID) const {
   switch (IID) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
@@ -201,6 +201,8 @@ public:
     return AMDGPU::addrspacesMayAlias(AS0, AS1);
   }
 
+  SmallVector<unsigned, 8> getAddressSpaces() const override;
+
   unsigned getFlatAddressSpace() const override {
     // Don't bother running InferAddressSpaces pass on graphics shaders which
     // don't use flat addressing.

--- a/llvm/unittests/Analysis/CMakeLists.txt
+++ b/llvm/unittests/Analysis/CMakeLists.txt
@@ -53,6 +53,7 @@ set(ANALYSIS_TEST_SOURCES
   ScalarEvolutionTest.cpp
   SparsePropagation.cpp
   TargetLibraryInfoTest.cpp
+  TargetTransformInfoTest.cpp
   TensorSpecTest.cpp
   TBAATest.cpp
   UnrollAnalyzerTest.cpp

--- a/llvm/unittests/Analysis/TargetTransformInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetTransformInfoTest.cpp
@@ -19,7 +19,8 @@ namespace {
 // A target that describes some of its address spaces, but not all of them.
 class FakeTTIImpl : public TargetTransformInfoImplBase {
 public:
-  explicit FakeTTIImpl(const DataLayout &DL) : TargetTransformInfoImplBase(DL) {}
+  explicit FakeTTIImpl(const DataLayout &DL)
+      : TargetTransformInfoImplBase(DL) {}
 
   SmallVector<TTI::PointerInfo, 8> getPointerInfos() const override {
     return {TTI::PointerInfo{1, "global"}, TTI::PointerInfo{3, "local"},

--- a/llvm/unittests/Analysis/TargetTransformInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetTransformInfoTest.cpp
@@ -1,0 +1,72 @@
+//===- TargetTransformInfoTest.cpp - TargetTransformInfo unit tests -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Analysis/TargetTransformInfoImpl.h"
+#include "llvm/IR/DataLayout.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+// A target that describes some of its address spaces, but not all of them.
+class FakeTTIImpl : public TargetTransformInfoImplBase {
+public:
+  explicit FakeTTIImpl(const DataLayout &DL) : TargetTransformInfoImplBase(DL) {}
+
+  SmallVector<TTI::PointerInfo, 8> getPointerInfos() const override {
+    return {TTI::PointerInfo{1, "global"}, TTI::PointerInfo{3, "local"},
+            TTI::PointerInfo{7, "private"}};
+  }
+};
+
+TargetTransformInfo makeFakeTTI(const DataLayout &DL) {
+  return TargetTransformInfo(std::make_unique<const FakeTTIImpl>(DL));
+}
+
+TEST(TargetTransformInfoTest, PointerInfosDefaultsToEmpty) {
+  DataLayout DL("p1:32:32-p2:64:64");
+  TargetTransformInfo TTI(DL);
+
+  EXPECT_THAT(TTI.getPointerInfos(), ::testing::IsEmpty());
+}
+
+TEST(TargetTransformInfoTest, PointerInfoDefaultsToNullopt) {
+  DataLayout DL("p1:32:32");
+  TargetTransformInfo TTI(DL);
+
+  EXPECT_FALSE(TTI.getPointerInfo(0).has_value());
+}
+
+TEST(TargetTransformInfoTest, PointerInfoFindsDescribedAddrSpace) {
+  DataLayout DL("");
+  TargetTransformInfo TTI = makeFakeTTI(DL);
+
+  std::optional<TTI::PointerInfo> PI = TTI.getPointerInfo(3);
+  ASSERT_TRUE(PI.has_value());
+  EXPECT_EQ(PI->AddrSpace, 3u);
+  EXPECT_EQ(PI->Name, "local");
+}
+
+TEST(TargetTransformInfoTest, PointerInfoFindsEveryReportedAddrSpace) {
+  DataLayout DL("p1:32:32");
+  TargetTransformInfo TTI = makeFakeTTI(DL);
+
+  for (const TTI::PointerInfo &Reported : TTI.getPointerInfos()) {
+    std::optional<TTI::PointerInfo> PI = TTI.getPointerInfo(Reported.AddrSpace);
+    ASSERT_TRUE(PI.has_value()) << "address space " << Reported.AddrSpace;
+    EXPECT_EQ(PI->AddrSpace, Reported.AddrSpace);
+    EXPECT_EQ(PI->Name, Reported.Name);
+  }
+
+  EXPECT_FALSE(TTI.getPointerInfo(999).has_value());
+}
+
+} // end anonymous namespace

--- a/llvm/unittests/Analysis/TargetTransformInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetTransformInfoTest.cpp
@@ -15,59 +15,52 @@
 using namespace llvm;
 
 namespace {
-
-// A target that describes some of its address spaces, but not all of them.
 class FakeTTIImpl : public TargetTransformInfoImplBase {
 public:
-  explicit FakeTTIImpl(const DataLayout &DL)
-      : TargetTransformInfoImplBase(DL) {}
+  FakeTTIImpl(const DataLayout &DL, SmallVector<unsigned, 8> AddrSpaces)
+      : TargetTransformInfoImplBase(DL), AddrSpaces(std::move(AddrSpaces)) {}
 
-  SmallVector<TTI::PointerInfo, 8> getPointerInfos() const override {
-    return {TTI::PointerInfo{1, "global"}, TTI::PointerInfo{3, "local"},
-            TTI::PointerInfo{7, "private"}};
+  SmallVector<unsigned, 8> getAddressSpaces() const override {
+    return AddrSpaces;
   }
+
+private:
+  SmallVector<unsigned, 8> AddrSpaces;
 };
 
-TargetTransformInfo makeFakeTTI(const DataLayout &DL) {
-  return TargetTransformInfo(std::make_unique<const FakeTTIImpl>(DL));
+TargetTransformInfo makeFakeTTI(const DataLayout &DL,
+                                SmallVector<unsigned, 8> AddrSpaces) {
+  return TargetTransformInfo(
+      std::make_unique<const FakeTTIImpl>(DL, std::move(AddrSpaces)));
 }
 
-TEST(TargetTransformInfoTest, PointerInfosDefaultsToEmpty) {
+TEST(TargetTransformInfoTest, AddressSpacesDefaultsToEmpty) {
   DataLayout DL("p1:32:32-p2:64:64");
   TargetTransformInfo TTI(DL);
 
-  EXPECT_THAT(TTI.getPointerInfos(), ::testing::IsEmpty());
+  EXPECT_THAT(TTI.getAddressSpaces(), ::testing::IsEmpty());
 }
 
-TEST(TargetTransformInfoTest, PointerInfoDefaultsToNullopt) {
+TEST(TargetTransformInfoTest, AddressSpacesReportsDescribedAddrSpaces) {
   DataLayout DL("p1:32:32");
-  TargetTransformInfo TTI(DL);
+  TargetTransformInfo TTI = makeFakeTTI(DL, {1, 3, 7});
 
-  EXPECT_FALSE(TTI.getPointerInfo(0).has_value());
+  EXPECT_THAT(TTI.getAddressSpaces(), ::testing::ElementsAre(1u, 3u, 7u));
 }
 
-TEST(TargetTransformInfoTest, PointerInfoFindsDescribedAddrSpace) {
+#if GTEST_HAS_DEATH_TEST
+#ifndef NDEBUG
+TEST(TargetTransformInfoTest, AddressSpacesOutOfOrderOrDuplicatedIsRejected) {
   DataLayout DL("");
-  TargetTransformInfo TTI = makeFakeTTI(DL);
+  TargetTransformInfo TTI = makeFakeTTI(DL, {3, 1, 7});
 
-  std::optional<TTI::PointerInfo> PI = TTI.getPointerInfo(3);
-  ASSERT_TRUE(PI.has_value());
-  EXPECT_EQ(PI->AddrSpace, 3u);
-  EXPECT_EQ(PI->Name, "local");
+  EXPECT_DEATH(TTI.getAddressSpaces(), "out of order or duplicated");
+
+  TTI = makeFakeTTI(DL, {1, 3, 3});
+
+  EXPECT_DEATH(TTI.getAddressSpaces(), "out of order or duplicated");
 }
-
-TEST(TargetTransformInfoTest, PointerInfoFindsEveryReportedAddrSpace) {
-  DataLayout DL("p1:32:32");
-  TargetTransformInfo TTI = makeFakeTTI(DL);
-
-  for (const TTI::PointerInfo &Reported : TTI.getPointerInfos()) {
-    std::optional<TTI::PointerInfo> PI = TTI.getPointerInfo(Reported.AddrSpace);
-    ASSERT_TRUE(PI.has_value()) << "address space " << Reported.AddrSpace;
-    EXPECT_EQ(PI->AddrSpace, Reported.AddrSpace);
-    EXPECT_EQ(PI->Name, Reported.Name);
-  }
-
-  EXPECT_FALSE(TTI.getPointerInfo(999).has_value());
-}
+#endif // NDEBUG
+#endif // GTEST_HAS_DEATH_TEST
 
 } // end anonymous namespace

--- a/llvm/unittests/Target/AMDGPU/AddressSpacesTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/AddressSpacesTest.cpp
@@ -1,0 +1,52 @@
+//===- AddressSpacesTest.cpp - TTI address space enumeration test ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests that AMDGPU reports the address spaces it gives a meaning to, as
+// listed in the AMDGPU Address Spaces table in AMDGPUUsage.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUUnitTests.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+TEST_F(AMDGPUTestBase, ReportsDocumentedAddressSpaces) {
+  StringRef ModuleString = R"(
+  define amdgpu_kernel void @test() {
+    ret void
+  }
+  )";
+  LLVMContext Context;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(ModuleString, Err, Context);
+  ASSERT_TRUE(M) << Err.getMessage();
+
+  Function *F = M->getFunction("test");
+  ASSERT_TRUE(F);
+
+  auto TM =
+      createAMDGPUTargetMachine(Triple("amdgcn-amd-amdhsa"), "gfx900", "");
+  ASSERT_TRUE(TM);
+  TargetTransformInfo TTI = TM->getTargetTransformInfo(*F);
+
+  using namespace AMDGPUAS;
+  EXPECT_THAT(TTI.getAddressSpaces(),
+              ::testing::ElementsAre(
+                  FLAT_ADDRESS, GLOBAL_ADDRESS, REGION_ADDRESS, LOCAL_ADDRESS,
+                  CONSTANT_ADDRESS, PRIVATE_ADDRESS, CONSTANT_ADDRESS_32BIT,
+                  BUFFER_FAT_POINTER, BUFFER_RESOURCE, BUFFER_STRIDED_POINTER,
+                  STREAMOUT_REGISTER));
+}

--- a/llvm/unittests/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/unittests/Target/AMDGPU/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_target_unittest(AMDGPUTests
+  AddressSpacesTest.cpp
   AMDGPUMCExprTest.cpp
   AMDGPUUnitTests.cpp
   CSETest.cpp


### PR DESCRIPTION
Adds a ~~PointerInfo struct describing an address space's number and target-given name, plus~~ TTI query methods to enumerate all address spaces a target describes or look up a single one. Includes a unit test for the new queries.

---

There's currently no way of enumerating all the address spaces that a backend uses. Here's a naive way to do that in a simple form. I've encountered a need for it while trying to teach ir2vec what an address space is. Seems like a natural place for it, and it could have other use (e.g. early verification). There's probably a way to augment it with the rest of the addrspace apis in TTI with a smarter data structure, so that they are not a pile of unrelated entry points. No backend hooks yet, but the only thing needed is an override for `getPointerInfos`.