### PR TITLE
DAG: Skip poison elements in BUILD_VECTOR computeKnownBits

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -3452,6 +3452,9 @@ KnownBits SelectionDAG::computeKnownBits(SDValue Op, const APInt &DemandedElts,
         continue;
 
       SDValue SrcOp = Op.getOperand(i);
+      if (SrcOp.getOpcode() == ISD::POISON)
+        continue;
+
       Known2 = computeKnownBits(SrcOp, Depth + 1);
 
       // BUILD_VECTOR can implicitly truncate sources, we must handle this.
@@ -3468,6 +3471,10 @@ KnownBits SelectionDAG::computeKnownBits(SDValue Op, const APInt &DemandedElts,
       if (Known.isUnknown())
         break;
     }
+
+    // If every demanded element was poison, we know nothing.
+    if (Known.hasConflict())
+      Known.resetAll();
     break;
   case ISD::VECTOR_COMPRESS: {
     SDValue Vec = Op.getOperand(0);

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3437,7 +3437,9 @@ bool TargetLowering::SimplifyDemandedVectorElts(
             continue;
           for (unsigned SrcElt = 0; SrcElt != NumSrcElts; ++SrcElt) {
             unsigned Elt = Scale * SrcElt + SubElt;
-            if (DemandedElts[Elt])
+            // A wholly-undef source lane is reported as undef below; don't also
+            // flag it as zero, keeping the undef and zero sets disjoint.
+            if (DemandedElts[Elt] && !SrcUndef[SrcElt])
               KnownZero.setBit(Elt);
           }
         }
@@ -4004,6 +4006,7 @@ bool TargetLowering::SimplifyDemandedVectorElts(
     break;
   }
   }
+
   assert((KnownUndef & KnownZero) == 0 && "Elements flagged as undef AND zero");
 
   // Constant fold all undef cases.

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.96bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.96bit.ll
@@ -11307,13 +11307,14 @@ define <12 x i8> @bitcast_v6i16_to_v12i8(<6 x i16> %a, i32 %b) #0 {
 ; GFX9-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; GFX9-NEXT:    s_cbranch_execz .LBB46_4
 ; GFX9-NEXT:  ; %bb.3: ; %cmp.true
-; GFX9-NEXT:    v_pk_add_u16 v8, v8, 3 op_sel_hi:[1,0]
 ; GFX9-NEXT:    v_pk_add_u16 v14, v14, 3 op_sel_hi:[1,0]
 ; GFX9-NEXT:    v_pk_add_u16 v13, v13, 3 op_sel_hi:[1,0]
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
-; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
+; GFX9-NEXT:    v_pk_add_u16 v9, v0, 3 op_sel_hi:[1,0]
+; GFX9-NEXT:    v_pk_add_u16 v8, v8, 3 op_sel_hi:[1,0]
 ; GFX9-NEXT:    v_lshrrev_b64 v[11:12], 24, v[8:9]
+; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
+; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 24, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 8, v14
@@ -11358,16 +11359,18 @@ define <12 x i8> @bitcast_v6i16_to_v12i8(<6 x i16> %a, i32 %b) #0 {
 ; GFX11-TRUE16-NEXT:    s_and_not1_saveexec_b32 s0, s0
 ; GFX11-TRUE16-NEXT:    s_cbranch_execz .LBB46_4
 ; GFX11-TRUE16-NEXT:  ; %bb.3: ; %cmp.true
-; GFX11-TRUE16-NEXT:    v_pk_add_u16 v8, v8, 3 op_sel_hi:[1,0]
 ; GFX11-TRUE16-NEXT:    v_pk_add_u16 v12, v12, 3 op_sel_hi:[1,0]
+; GFX11-TRUE16-NEXT:    v_pk_add_u16 v9, v0, 3 op_sel_hi:[1,0]
+; GFX11-TRUE16-NEXT:    v_pk_add_u16 v8, v8, 3 op_sel_hi:[1,0]
 ; GFX11-TRUE16-NEXT:    v_pk_add_u16 v11, v11, 3 op_sel_hi:[1,0]
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
-; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[11:12]
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v12
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v12
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[13:14], 24, v[8:9]
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[11:12]
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v12
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v11
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v11
@@ -11411,16 +11414,18 @@ define <12 x i8> @bitcast_v6i16_to_v12i8(<6 x i16> %a, i32 %b) #0 {
 ; GFX11-FAKE16-NEXT:    s_and_not1_saveexec_b32 s0, s0
 ; GFX11-FAKE16-NEXT:    s_cbranch_execz .LBB46_4
 ; GFX11-FAKE16-NEXT:  ; %bb.3: ; %cmp.true
-; GFX11-FAKE16-NEXT:    v_pk_add_u16 v8, v8, 3 op_sel_hi:[1,0]
 ; GFX11-FAKE16-NEXT:    v_pk_add_u16 v14, v14, 3 op_sel_hi:[1,0]
+; GFX11-FAKE16-NEXT:    v_pk_add_u16 v9, v0, 3 op_sel_hi:[1,0]
+; GFX11-FAKE16-NEXT:    v_pk_add_u16 v8, v8, 3 op_sel_hi:[1,0]
 ; GFX11-FAKE16-NEXT:    v_pk_add_u16 v13, v13, 3 op_sel_hi:[1,0]
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
-; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[11:12], 24, v[8:9]
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v13
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v13
@@ -11637,13 +11642,14 @@ define inreg <12 x i8> @bitcast_v6i16_to_v12i8_scalar(<6 x i16> inreg %a, i32 in
 ; GFX9-NEXT:    s_cmp_lg_u32 s5, 1
 ; GFX9-NEXT:    s_cbranch_scc1 .LBB47_5
 ; GFX9-NEXT:  ; %bb.4: ; %cmp.true
-; GFX9-NEXT:    v_pk_add_u16 v8, s18, 3 op_sel_hi:[1,0]
 ; GFX9-NEXT:    v_pk_add_u16 v14, s17, 3 op_sel_hi:[1,0]
 ; GFX9-NEXT:    v_pk_add_u16 v13, s16, 3 op_sel_hi:[1,0]
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
-; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
+; GFX9-NEXT:    v_pk_add_u16 v9, s4, 3 op_sel_hi:[1,0]
+; GFX9-NEXT:    v_pk_add_u16 v8, s18, 3 op_sel_hi:[1,0]
 ; GFX9-NEXT:    v_lshrrev_b64 v[11:12], 24, v[8:9]
+; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
+; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 24, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 8, v14
@@ -11703,16 +11709,18 @@ define inreg <12 x i8> @bitcast_v6i16_to_v12i8_scalar(<6 x i16> inreg %a, i32 in
 ; GFX11-NEXT:    s_cmp_lg_u32 s5, 1
 ; GFX11-NEXT:    s_cbranch_scc1 .LBB47_5
 ; GFX11-NEXT:  ; %bb.4: ; %cmp.true
-; GFX11-NEXT:    v_pk_add_u16 v8, s2, 3 op_sel_hi:[1,0]
 ; GFX11-NEXT:    v_pk_add_u16 v14, s1, 3 op_sel_hi:[1,0]
+; GFX11-NEXT:    v_pk_add_u16 v9, s0, 3 op_sel_hi:[1,0]
+; GFX11-NEXT:    v_pk_add_u16 v8, s2, 3 op_sel_hi:[1,0]
 ; GFX11-NEXT:    v_pk_add_u16 v13, s0, 3 op_sel_hi:[1,0]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
-; GFX11-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 24, v14
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v14
 ; GFX11-NEXT:    v_lshrrev_b64 v[11:12], 24, v[8:9]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_lshrrev_b64 v[3:4], 24, v[13:14]
+; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 8, v8
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 8, v14
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v13
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v13

--- a/llvm/test/CodeGen/AMDGPU/llvm.is.fpclass.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.is.fpclass.bf16.ll
@@ -1094,7 +1094,7 @@ define <3 x i1> @isnan_v3bf16(<3 x bfloat> %x) nounwind {
 ; GFX9CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9CHECK-NEXT:    v_and_b32_e32 v3, 0x7fff7fff, v0
 ; GFX9CHECK-NEXT:    s_movk_i32 s4, 0x7f80
-; GFX9CHECK-NEXT:    v_and_b32_e32 v1, 0x7fff, v1
+; GFX9CHECK-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v1
 ; GFX9CHECK-NEXT:    v_cmp_lt_i16_e32 vcc, s4, v3
 ; GFX9CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX9CHECK-NEXT:    v_cmp_lt_i16_e32 vcc, s4, v1
@@ -1108,7 +1108,7 @@ define <3 x i1> @isnan_v3bf16(<3 x bfloat> %x) nounwind {
 ; GFX10CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10CHECK-NEXT:    v_and_b32_e32 v2, 0x7fff7fff, v0
 ; GFX10CHECK-NEXT:    v_mov_b32_e32 v3, 0x7f80
-; GFX10CHECK-NEXT:    v_and_b32_e32 v4, 0x7fff, v1
+; GFX10CHECK-NEXT:    v_and_b32_e32 v4, 0x7fff7fff, v1
 ; GFX10CHECK-NEXT:    v_cmp_lt_i16_e32 vcc_lo, 0x7f80, v2
 ; GFX10CHECK-NEXT:    v_cmp_gt_i16_sdwa s4, v2, v3 src0_sel:WORD_1 src1_sel:DWORD
 ; GFX10CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
@@ -1121,7 +1121,7 @@ define <3 x i1> @isnan_v3bf16(<3 x bfloat> %x) nounwind {
 ; GFX11SELDAG-TRUE16:       ; %bb.0:
 ; GFX11SELDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11SELDAG-TRUE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
-; GFX11SELDAG-TRUE16-NEXT:    v_and_b32_e32 v3, 0x7fff, v1
+; GFX11SELDAG-TRUE16-NEXT:    v_and_b32_e32 v3, 0x7fff7fff, v1
 ; GFX11SELDAG-TRUE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX11SELDAG-TRUE16-NEXT:    v_cmp_lt_i16_e32 vcc_lo, 0x7f80, v0.l
 ; GFX11SELDAG-TRUE16-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
@@ -1135,7 +1135,7 @@ define <3 x i1> @isnan_v3bf16(<3 x bfloat> %x) nounwind {
 ; GFX11SELDAG-FAKE16:       ; %bb.0:
 ; GFX11SELDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11SELDAG-FAKE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
-; GFX11SELDAG-FAKE16-NEXT:    v_and_b32_e32 v3, 0x7fff, v1
+; GFX11SELDAG-FAKE16-NEXT:    v_and_b32_e32 v3, 0x7fff7fff, v1
 ; GFX11SELDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX11SELDAG-FAKE16-NEXT:    v_cmp_lt_i16_e32 vcc_lo, 0x7f80, v0
 ; GFX11SELDAG-FAKE16-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo

--- a/llvm/test/CodeGen/X86/avx512-trunc.ll
+++ b/llvm/test/CodeGen/X86/avx512-trunc.ll
@@ -1393,7 +1393,8 @@ define void @test_truncus_v4i16_v4i8(ptr %dst, ptr %src) {
 ; SKX-LABEL: test_truncus_v4i16_v4i8:
 ; SKX:       ## %bb.0:
 ; SKX-NEXT:    vmovq {{.*#+}} xmm0 = mem[0],zero
-; SKX-NEXT:    vpmovuswb %xmm0, %xmm0
+; SKX-NEXT:    vpminuw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; SKX-NEXT:    vpmovwb %xmm0, %xmm0
 ; SKX-NEXT:    vmovd %xmm0, (%rdi)
 ; SKX-NEXT:    retq
   %1 = load <4 x i16>, ptr %src

--- a/llvm/test/CodeGen/X86/build-vector-known-bits-poison.ll
+++ b/llvm/test/CodeGen/X86/build-vector-known-bits-poison.ll
@@ -10,19 +10,11 @@ define <4 x i8> @poison_build_vector_known_bits(<4 x i32> %v) {
 ; CHECK-NEXT:    pcmpgtd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; CHECK-NEXT:    packssdw %xmm0, %xmm0
 ; CHECK-NEXT:    packsswb %xmm0, %xmm0
-; CHECK-NEXT:    psllw $5, %xmm0
-; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
-; CHECK-NEXT:    paddb %xmm0, %xmm0
-; CHECK-NEXT:    paddb %xmm0, %xmm0
+; CHECK-NEXT:    psllw $7, %xmm0
 ; CHECK-NEXT:    pxor %xmm1, %xmm1
 ; CHECK-NEXT:    pcmpgtb %xmm0, %xmm1
-; CHECK-NEXT:    movdqa {{.*#+}} xmm0 = [11,11,11,11,u,u,u,u,u,u,u,u,u,u,u,u]
-; CHECK-NEXT:    movdqa %xmm0, %xmm2
-; CHECK-NEXT:    paddb %xmm0, %xmm2
-; CHECK-NEXT:    pand %xmm1, %xmm2
-; CHECK-NEXT:    pandn %xmm0, %xmm1
-; CHECK-NEXT:    por %xmm2, %xmm1
-; CHECK-NEXT:    por %xmm0, %xmm1
+; CHECK-NEXT:    por {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
 ; CHECK-NEXT:    movdqa %xmm1, %xmm0
 ; CHECK-NEXT:    retq
   %icmp = icmp ugt <4 x i32> %v, splat (i32 -9)

--- a/llvm/test/CodeGen/X86/fpclamptosat_vec.ll
+++ b/llvm/test/CodeGen/X86/fpclamptosat_vec.ll
@@ -1104,14 +1104,14 @@ define <2 x i16> @utest_f64i16(<2 x double> %x) nounwind {
 ; AVX2-NEXT:    vorpd %xmm0, %xmm1, %xmm0
 ; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [65535,65535,65535,65535]
 ; AVX2-NEXT:    vpminud %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm0[0,2,2,3,4,5,6,7]
+; AVX2-NEXT:    vpackusdw %xmm0, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: utest_f64i16:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vcvttpd2udq %xmm0, %xmm0
 ; AVX512-NEXT:    vpminud {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm0, %xmm0
-; AVX512-NEXT:    vpmovdw %xmm0, %xmm0
+; AVX512-NEXT:    vpackusdw %xmm0, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
 entry:
   %conv = fptoui <2 x double> %x to <2 x i32>
@@ -3711,14 +3711,14 @@ define <2 x i16> @utest_f64i16_mm(<2 x double> %x) nounwind {
 ; AVX2-NEXT:    vorpd %xmm0, %xmm1, %xmm0
 ; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [65535,65535,65535,65535]
 ; AVX2-NEXT:    vpminud %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm0[0,2,2,3,4,5,6,7]
+; AVX2-NEXT:    vpackusdw %xmm0, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: utest_f64i16_mm:
 ; AVX512:       # %bb.0: # %entry
 ; AVX512-NEXT:    vcvttpd2udq %xmm0, %xmm0
 ; AVX512-NEXT:    vpminud {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm0, %xmm0
-; AVX512-NEXT:    vpmovdw %xmm0, %xmm0
+; AVX512-NEXT:    vpackusdw %xmm0, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
 entry:
   %conv = fptoui <2 x double> %x to <2 x i32>

--- a/llvm/test/CodeGen/X86/ifma-combine-vpmadd52.ll
+++ b/llvm/test/CodeGen/X86/ifma-combine-vpmadd52.ll
@@ -493,30 +493,31 @@ define <3 x i64> @test_v3i64(<3 x i64> %x, <3 x i64> %y, <3 x i64> %z) {
 ; AVXIFMA:       # %bb.0:
 ; AVXIFMA-NEXT:    vpbroadcastq {{.*#+}} ymm1 = [67108863,67108863,67108863,67108863]
 ; AVXIFMA-NEXT:    vpand %ymm1, %ymm0, %ymm0
-; AVXIFMA-NEXT:    vpmuludq %ymm0, %ymm0, %ymm0
-; AVXIFMA-NEXT:    vpaddq %ymm2, %ymm0, %ymm0
+; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm2
+; AVXIFMA-NEXT:    vmovdqa %ymm2, %ymm0
 ; AVXIFMA-NEXT:    retq
 ;
 ; AVX512-NOVL-LABEL: test_v3i64:
 ; AVX512-NOVL:       # %bb.0:
+; AVX512-NOVL-NEXT:    # kill: def $ymm2 killed $ymm2 def $zmm2
 ; AVX512-NOVL-NEXT:    vpbroadcastq {{.*#+}} ymm1 = [67108863,67108863,67108863,67108863]
 ; AVX512-NOVL-NEXT:    vpand %ymm1, %ymm0, %ymm0
-; AVX512-NOVL-NEXT:    vpmuludq %ymm0, %ymm0, %ymm0
-; AVX512-NOVL-NEXT:    vpaddq %ymm2, %ymm0, %ymm0
+; AVX512-NOVL-NEXT:    vpmadd52luq %zmm2, %zmm0, %zmm0
+; AVX512-NOVL-NEXT:    # kill: def $ymm0 killed $ymm0 killed $zmm0
 ; AVX512-NOVL-NEXT:    retq
 ;
 ; AVX512VL-LABEL: test_v3i64:
 ; AVX512VL:       # %bb.0:
 ; AVX512VL-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpmuludq %ymm0, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpaddq %ymm2, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpmadd52luq %ymm0, %ymm0, %ymm2
+; AVX512VL-NEXT:    vmovdqa %ymm2, %ymm0
 ; AVX512VL-NEXT:    retq
 ;
 ; AVX512-NOIFMA-LABEL: test_v3i64:
 ; AVX512-NOIFMA:       # %bb.0:
 ; AVX512-NOIFMA-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %ymm0, %ymm0
-; AVX512-NOIFMA-NEXT:    vpmuludq %ymm0, %ymm0, %ymm0
-; AVX512-NOIFMA-NEXT:    vpaddq %ymm2, %ymm0, %ymm0
+; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm2
+; AVX512-NOIFMA-NEXT:    vmovdqa %ymm2, %ymm0
 ; AVX512-NOIFMA-NEXT:    retq
   %x_masked = and <3 x i64> %x, splat (i64 67108863)
   %y_masked = and <3 x i64> %x, splat (i64 67108863)
@@ -536,34 +537,36 @@ define <5 x i64> @test_v5i64(<5 x i64> %x, <5 x i64> %y, <5 x i64> %z) {
 ; AVXIFMA-NEXT:    vmovq %rsi, %xmm2
 ; AVXIFMA-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
 ; AVXIFMA-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
-; AVXIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm1
-; AVXIFMA-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [67108863,67108863,67108863,67108863]
-; AVXIFMA-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVXIFMA-NEXT:    vmovq {{.*#+}} xmm1 = mem[0],zero
+; AVXIFMA-NEXT:    vmovq %r9, %xmm2
+; AVXIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm3
+; AVXIFMA-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [67108863,67108863,67108863,67108863]
+; AVXIFMA-NEXT:    vpand %ymm4, %ymm0, %ymm0
 ; AVXIFMA-NEXT:    movl $67108863, %ecx # imm = 0x3FFFFFF
-; AVXIFMA-NEXT:    vmovq %rcx, %xmm2
-; AVXIFMA-NEXT:    vmovq %r9, %xmm3
-; AVXIFMA-NEXT:    vpand %xmm2, %xmm3, %xmm2
-; AVXIFMA-NEXT:    vpmuludq %xmm2, %xmm2, %xmm2
-; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm1
-; AVXIFMA-NEXT:    vmovq %xmm2, %rcx
-; AVXIFMA-NEXT:    addq {{[0-9]+}}(%rsp), %rcx
-; AVXIFMA-NEXT:    movq %rcx, 32(%rdi)
-; AVXIFMA-NEXT:    vmovdqa %ymm1, (%rdi)
+; AVXIFMA-NEXT:    vmovq %rcx, %xmm4
+; AVXIFMA-NEXT:    vpand %xmm4, %xmm2, %xmm2
+; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm3
+; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm2, %ymm2, %ymm1
+; AVXIFMA-NEXT:    vmovq %xmm1, 32(%rdi)
+; AVXIFMA-NEXT:    vmovdqa %ymm3, (%rdi)
 ; AVXIFMA-NEXT:    vzeroupper
 ; AVXIFMA-NEXT:    retq
 ;
 ; AVX512-LABEL: test_v5i64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NEXT:    vpmuludq %zmm0, %zmm0, %zmm0
-; AVX512-NEXT:    vpaddq %zmm2, %zmm0, %zmm0
+; AVX512-NEXT:    vpmadd52luq %zmm0, %zmm0, %zmm2
+; AVX512-NEXT:    vmovdqa64 %zmm2, %zmm0
 ; AVX512-NEXT:    retq
 ;
 ; AVX512-NOIFMA-LABEL: test_v5i64:
 ; AVX512-NOIFMA:       # %bb.0:
 ; AVX512-NOIFMA-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NOIFMA-NEXT:    vpmuludq %zmm0, %zmm0, %zmm0
-; AVX512-NOIFMA-NEXT:    vpaddq %zmm2, %zmm0, %zmm0
+; AVX512-NOIFMA-NEXT:    vextracti64x4 $1, %zmm2, %ymm1
+; AVX512-NOIFMA-NEXT:    vextracti64x4 $1, %zmm0, %ymm3
+; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm3, %ymm3, %ymm1
+; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm2
+; AVX512-NOIFMA-NEXT:    vinserti64x4 $1, %ymm1, %zmm2, %zmm0
 ; AVX512-NOIFMA-NEXT:    retq
   %x_masked = and <5 x i64> %x, splat (i64 67108863)
   %y_masked = and <5 x i64> %x, splat (i64 67108863)
@@ -601,15 +604,18 @@ define <6 x i64> @test_v6i64(<6 x i64> %x, <6 x i64> %y, <6 x i64> %z) {
 ; AVX512-LABEL: test_v6i64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NEXT:    vpmuludq %zmm0, %zmm0, %zmm0
-; AVX512-NEXT:    vpaddq %zmm2, %zmm0, %zmm0
+; AVX512-NEXT:    vpmadd52luq %zmm0, %zmm0, %zmm2
+; AVX512-NEXT:    vmovdqa64 %zmm2, %zmm0
 ; AVX512-NEXT:    retq
 ;
 ; AVX512-NOIFMA-LABEL: test_v6i64:
 ; AVX512-NOIFMA:       # %bb.0:
 ; AVX512-NOIFMA-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NOIFMA-NEXT:    vpmuludq %zmm0, %zmm0, %zmm0
-; AVX512-NOIFMA-NEXT:    vpaddq %zmm2, %zmm0, %zmm0
+; AVX512-NOIFMA-NEXT:    vextracti64x4 $1, %zmm2, %ymm1
+; AVX512-NOIFMA-NEXT:    vextracti64x4 $1, %zmm0, %ymm3
+; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm3, %ymm3, %ymm1
+; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm2
+; AVX512-NOIFMA-NEXT:    vinserti64x4 $1, %ymm1, %zmm2, %zmm0
 ; AVX512-NOIFMA-NEXT:    retq
   %x_masked = and <6 x i64> %x, splat (i64 67108863)
   %y_masked = and <6 x i64> %x, splat (i64 67108863)
@@ -629,27 +635,26 @@ define <9 x i64> @test_v9i64(<9 x i64> %x, <9 x i64> %y, <9 x i64> %z) {
 ; AVXIFMA-NEXT:    vmovq %rsi, %xmm2
 ; AVXIFMA-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
 ; AVXIFMA-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
-; AVXIFMA-NEXT:    vmovq %r9, %xmm1
-; AVXIFMA-NEXT:    vmovq {{.*#+}} xmm2 = mem[0],zero
-; AVXIFMA-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm2[0]
-; AVXIFMA-NEXT:    vinserti128 $1, {{[0-9]+}}(%rsp), %ymm1, %ymm1
-; AVXIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm2
+; AVXIFMA-NEXT:    vmovq {{.*#+}} xmm1 = mem[0],zero
+; AVXIFMA-NEXT:    vmovq %r9, %xmm2
+; AVXIFMA-NEXT:    vmovq {{.*#+}} xmm3 = mem[0],zero
+; AVXIFMA-NEXT:    vpunpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm3[0]
+; AVXIFMA-NEXT:    vinserti128 $1, {{[0-9]+}}(%rsp), %ymm2, %ymm2
 ; AVXIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm3
-; AVXIFMA-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [67108863,67108863,67108863,67108863]
-; AVXIFMA-NEXT:    vpand %ymm4, %ymm0, %ymm0
-; AVXIFMA-NEXT:    vpand %ymm4, %ymm1, %ymm1
-; AVXIFMA-NEXT:    movl $67108863, %ecx # imm = 0x3FFFFFF
-; AVXIFMA-NEXT:    vmovq %rcx, %xmm4
+; AVXIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm4
 ; AVXIFMA-NEXT:    vmovq {{.*#+}} xmm5 = mem[0],zero
-; AVXIFMA-NEXT:    vpand %xmm4, %xmm5, %xmm4
-; AVXIFMA-NEXT:    vpmuludq %xmm4, %xmm4, %xmm4
-; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm3
-; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm1, %ymm1, %ymm2
-; AVXIFMA-NEXT:    vmovq %xmm4, %rcx
-; AVXIFMA-NEXT:    addq {{[0-9]+}}(%rsp), %rcx
-; AVXIFMA-NEXT:    movq %rcx, 64(%rdi)
-; AVXIFMA-NEXT:    vmovdqa %ymm2, 32(%rdi)
-; AVXIFMA-NEXT:    vmovdqa %ymm3, (%rdi)
+; AVXIFMA-NEXT:    vpbroadcastq {{.*#+}} ymm6 = [67108863,67108863,67108863,67108863]
+; AVXIFMA-NEXT:    vpand %ymm6, %ymm0, %ymm0
+; AVXIFMA-NEXT:    vpand %ymm6, %ymm2, %ymm2
+; AVXIFMA-NEXT:    movl $67108863, %ecx # imm = 0x3FFFFFF
+; AVXIFMA-NEXT:    vmovq %rcx, %xmm6
+; AVXIFMA-NEXT:    vpand %xmm6, %xmm5, %xmm5
+; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm4
+; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm5, %ymm5, %ymm1
+; AVXIFMA-NEXT:    {vex} vpmadd52luq %ymm2, %ymm2, %ymm3
+; AVXIFMA-NEXT:    vmovq %xmm1, 64(%rdi)
+; AVXIFMA-NEXT:    vmovdqa %ymm3, 32(%rdi)
+; AVXIFMA-NEXT:    vmovdqa %ymm4, (%rdi)
 ; AVXIFMA-NEXT:    vzeroupper
 ; AVXIFMA-NEXT:    retq
 ;
@@ -668,18 +673,17 @@ define <9 x i64> @test_v9i64(<9 x i64> %x, <9 x i64> %y, <9 x i64> %z) {
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm2[0]
 ; AVX512-NEXT:    vinserti128 $1, {{[0-9]+}}(%rsp), %ymm1, %ymm1
 ; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512-NEXT:    vmovdqu64 {{[0-9]+}}(%rsp), %zmm1
+; AVX512-NEXT:    vmovq {{.*#+}} xmm1 = mem[0],zero
+; AVX512-NEXT:    vmovdqu64 {{[0-9]+}}(%rsp), %zmm2
+; AVX512-NEXT:    vmovq {{.*#+}} xmm3 = mem[0],zero
 ; AVX512-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
 ; AVX512-NEXT:    movl $67108863, %ecx # imm = 0x3FFFFFF
-; AVX512-NEXT:    vmovq %rcx, %xmm2
-; AVX512-NEXT:    vmovq {{.*#+}} xmm3 = mem[0],zero
-; AVX512-NEXT:    vpand %xmm2, %xmm3, %xmm2
-; AVX512-NEXT:    vpmuludq %xmm2, %xmm2, %xmm2
-; AVX512-NEXT:    vpmadd52luq %zmm0, %zmm0, %zmm1
-; AVX512-NEXT:    vmovq %xmm2, %rcx
-; AVX512-NEXT:    addq {{[0-9]+}}(%rsp), %rcx
-; AVX512-NEXT:    movq %rcx, 64(%rdi)
-; AVX512-NEXT:    vmovdqa64 %zmm1, (%rdi)
+; AVX512-NEXT:    vmovq %rcx, %xmm4
+; AVX512-NEXT:    vpand %xmm4, %xmm3, %xmm3
+; AVX512-NEXT:    vpmadd52luq %zmm0, %zmm0, %zmm2
+; AVX512-NEXT:    vpmadd52luq %zmm3, %zmm3, %zmm1
+; AVX512-NEXT:    vmovq %xmm1, 64(%rdi)
+; AVX512-NEXT:    vmovdqa64 %zmm2, (%rdi)
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
 ;
@@ -698,21 +702,20 @@ define <9 x i64> @test_v9i64(<9 x i64> %x, <9 x i64> %y, <9 x i64> %z) {
 ; AVX512-NOIFMA-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm2[0]
 ; AVX512-NOIFMA-NEXT:    vinserti128 $1, {{[0-9]+}}(%rsp), %ymm1, %ymm1
 ; AVX512-NOIFMA-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-NOIFMA-NEXT:    vmovq {{.*#+}} xmm1 = mem[0],zero
 ; AVX512-NOIFMA-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
 ; AVX512-NOIFMA-NEXT:    movl $67108863, %ecx # imm = 0x3FFFFFF
-; AVX512-NOIFMA-NEXT:    vmovq %rcx, %xmm1
-; AVX512-NOIFMA-NEXT:    vmovq {{.*#+}} xmm2 = mem[0],zero
-; AVX512-NOIFMA-NEXT:    vpand %xmm1, %xmm2, %xmm1
-; AVX512-NOIFMA-NEXT:    vpmuludq %xmm1, %xmm1, %xmm1
+; AVX512-NOIFMA-NEXT:    vmovq %rcx, %xmm2
+; AVX512-NOIFMA-NEXT:    vpand %xmm2, %xmm1, %xmm1
 ; AVX512-NOIFMA-NEXT:    vextracti64x4 $1, %zmm0, %ymm2
 ; AVX512-NOIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm3
 ; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm2, %ymm2, %ymm3
 ; AVX512-NOIFMA-NEXT:    vmovdqu {{[0-9]+}}(%rsp), %ymm2
 ; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm0, %ymm0, %ymm2
 ; AVX512-NOIFMA-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm0
-; AVX512-NOIFMA-NEXT:    vmovq %xmm1, %rcx
-; AVX512-NOIFMA-NEXT:    addq {{[0-9]+}}(%rsp), %rcx
-; AVX512-NOIFMA-NEXT:    movq %rcx, 64(%rdi)
+; AVX512-NOIFMA-NEXT:    vmovq {{.*#+}} xmm2 = mem[0],zero
+; AVX512-NOIFMA-NEXT:    {vex} vpmadd52luq %ymm1, %ymm1, %ymm2
+; AVX512-NOIFMA-NEXT:    vmovq %xmm2, 64(%rdi)
 ; AVX512-NOIFMA-NEXT:    vmovdqa64 %zmm0, (%rdi)
 ; AVX512-NOIFMA-NEXT:    vzeroupper
 ; AVX512-NOIFMA-NEXT:    retq

--- a/llvm/test/CodeGen/X86/kmov.ll
+++ b/llvm/test/CodeGen/X86/kmov.ll
@@ -12,10 +12,10 @@ define <2 x i1> @i8_mask_extract2(i8 %mask) {
 ; X64-KNL-LABEL: i8_mask_extract2:
 ; X64-KNL:       # %bb.0:
 ; X64-KNL-NEXT:    vmovd %edi, %xmm0
-; X64-KNL-NEXT:    vpbroadcastw {{.*#+}} xmm1 = [1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2]
 ; X64-KNL-NEXT:    vpbroadcastb %xmm0, %xmm0
-; X64-KNL-NEXT:    vpand %xmm1, %xmm0, %xmm0
-; X64-KNL-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; X64-KNL-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-KNL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; X64-KNL-NEXT:    vpcmpgtb %xmm1, %xmm0, %xmm0
 ; X64-KNL-NEXT:    vpmovzxbq {{.*#+}} xmm0 = xmm0[0],zero,zero,zero,zero,zero,zero,zero,xmm0[1],zero,zero,zero,zero,zero,zero,zero
 ; X64-KNL-NEXT:    retq
   %.splatinsert = insertelement <2 x i8> poison, i8 %mask, i64 0
@@ -60,9 +60,9 @@ define <4 x i1> @i8_mask_extract_4(i8 %mask) {
 ; X64-KNL:       # %bb.0:
 ; X64-KNL-NEXT:    vmovd %edi, %xmm0
 ; X64-KNL-NEXT:    vpbroadcastb %xmm0, %xmm0
-; X64-KNL-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [1,2,4,8,1,2,4,8,1,2,4,8,1,2,4,8]
-; X64-KNL-NEXT:    vpand %xmm1, %xmm0, %xmm0
-; X64-KNL-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; X64-KNL-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-KNL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; X64-KNL-NEXT:    vpcmpgtb %xmm1, %xmm0, %xmm0
 ; X64-KNL-NEXT:    vpmovzxbd {{.*#+}} xmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero
 ; X64-KNL-NEXT:    retq
   %.splatinsert = insertelement <4 x i8> poison, i8 %mask, i64 0
@@ -205,9 +205,9 @@ define <4 x i1> @i16_mask_extract_4(i16 %mask) {
 ; X64-KNL:       # %bb.0:
 ; X64-KNL-NEXT:    vmovd %edi, %xmm0
 ; X64-KNL-NEXT:    vpbroadcastw %xmm0, %xmm0
-; X64-KNL-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [1,2,4,8,1,2,4,8]
-; X64-KNL-NEXT:    vpand %xmm1, %xmm0, %xmm0
-; X64-KNL-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
+; X64-KNL-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-KNL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; X64-KNL-NEXT:    vpcmpgtw %xmm1, %xmm0, %xmm0
 ; X64-KNL-NEXT:    vpmovzxwd {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
 ; X64-KNL-NEXT:    retq
   %.splatinsert = insertelement <4 x i16> poison, i16 %mask, i64 0

--- a/llvm/test/CodeGen/X86/pr120906.ll
+++ b/llvm/test/CodeGen/X86/pr120906.ll
@@ -5,26 +5,16 @@ define i32 @PR120906(ptr %p) {
 ; CHECK-LABEL: PR120906:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    movl $564341309, (%rdi) # imm = 0x21A32A3D
-; CHECK-NEXT:    pxor %xmm0, %xmm0
+; CHECK-NEXT:    movdqa {{.*#+}} xmm0 = [11,11,11,11,u,u,u,u,u,u,u,u,u,u,u,u]
+; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; CHECK-NEXT:    pxor %xmm1, %xmm1
-; CHECK-NEXT:    paddb %xmm1, %xmm1
-; CHECK-NEXT:    paddb %xmm1, %xmm1
-; CHECK-NEXT:    pxor %xmm2, %xmm2
-; CHECK-NEXT:    pcmpgtb %xmm1, %xmm2
-; CHECK-NEXT:    movdqa {{.*#+}} xmm1 = [11,11,11,11,u,u,u,u,u,u,u,u,u,u,u,u]
-; CHECK-NEXT:    movdqa %xmm1, %xmm3
-; CHECK-NEXT:    paddb %xmm1, %xmm3
-; CHECK-NEXT:    pand %xmm2, %xmm3
-; CHECK-NEXT:    pandn %xmm1, %xmm2
-; CHECK-NEXT:    por %xmm1, %xmm2
-; CHECK-NEXT:    por %xmm3, %xmm2
-; CHECK-NEXT:    punpcklbw {{.*#+}} xmm2 = xmm2[0],xmm0[0],xmm2[1],xmm0[1],xmm2[2],xmm0[2],xmm2[3],xmm0[3],xmm2[4],xmm0[4],xmm2[5],xmm0[5],xmm2[6],xmm0[6],xmm2[7],xmm0[7]
-; CHECK-NEXT:    punpcklwd {{.*#+}} xmm2 = xmm2[0],xmm0[0],xmm2[1],xmm0[1],xmm2[2],xmm0[2],xmm2[3],xmm0[3]
-; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[2,3,2,3]
-; CHECK-NEXT:    por %xmm2, %xmm0
-; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
+; CHECK-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
+; CHECK-NEXT:    punpcklwd {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3]
+; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; CHECK-NEXT:    por %xmm0, %xmm1
-; CHECK-NEXT:    movd %xmm1, %eax
+; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
+; CHECK-NEXT:    por %xmm1, %xmm0
+; CHECK-NEXT:    movd %xmm0, %eax
 ; CHECK-NEXT:    retq
   store i32 564341309, ptr %p, align 4
   %load = load i32, ptr %p, align 4

--- a/llvm/test/CodeGen/X86/shrink_vmul.ll
+++ b/llvm/test/CodeGen/X86/shrink_vmul.ll
@@ -1864,7 +1864,7 @@ define void @mul_2xi16_varconst3(ptr nocapture readonly %a, i64 %index) {
 ; X86-SSE-NEXT:    movl c, %edx
 ; X86-SSE-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
 ; X86-SSE-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[1,1,1,1,4,5,6,7]
-; X86-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0 # [65536,65536,u,u]
+; X86-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0 # [65536,65536,65536,65536]
 ; X86-SSE-NEXT:    psllq $32, %xmm0
 ; X86-SSE-NEXT:    movq %xmm0, (%edx,%eax,4)
 ; X86-SSE-NEXT:    retl
@@ -1885,7 +1885,7 @@ define void @mul_2xi16_varconst3(ptr nocapture readonly %a, i64 %index) {
 ; X64-SSE-NEXT:    movq c(%rip), %rax
 ; X64-SSE-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
 ; X64-SSE-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[1,1,1,1,4,5,6,7]
-; X64-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0 # [65536,65536,u,u]
+; X64-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0 # [65536,65536,65536,65536]
 ; X64-SSE-NEXT:    psllq $32, %xmm0
 ; X64-SSE-NEXT:    movq %xmm0, (%rax,%rsi,4)
 ; X64-SSE-NEXT:    retq
@@ -1923,7 +1923,7 @@ define void @mul_2xi16_varconst4(ptr nocapture readonly %a, i64 %index) {
 ; X86-SSE-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
 ; X86-SSE-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,0,0,0]
 ; X86-SSE-NEXT:    psrad $16, %xmm0
-; X86-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0 # [32768,32768,u,u]
+; X86-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0 # [32768,32768,32768,32768]
 ; X86-SSE-NEXT:    psllq $32, %xmm0
 ; X86-SSE-NEXT:    movq %xmm0, (%edx,%eax,4)
 ; X86-SSE-NEXT:    retl
@@ -1945,7 +1945,7 @@ define void @mul_2xi16_varconst4(ptr nocapture readonly %a, i64 %index) {
 ; X64-SSE-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
 ; X64-SSE-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,0,0,0]
 ; X64-SSE-NEXT:    psrad $16, %xmm0
-; X64-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0 # [32768,32768,u,u]
+; X64-SSE-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0 # [32768,32768,32768,32768]
 ; X64-SSE-NEXT:    psllq $32, %xmm0
 ; X64-SSE-NEXT:    movq %xmm0, (%rax,%rsi,4)
 ; X64-SSE-NEXT:    retq

--- a/llvm/test/CodeGen/X86/srem-vector-lkk.ll
+++ b/llvm/test/CodeGen/X86/srem-vector-lkk.ll
@@ -9,35 +9,34 @@
 define <4 x i16> @fold_srem_vec_1(<4 x i16> %x) {
 ; SSE2-LABEL: fold_srem_vec_1:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movq {{.*#+}} xmm2 = [1,0,0,65535,0,0,0,0]
-; SSE2-NEXT:    pmullw %xmm0, %xmm2
-; SSE2-NEXT:    movq {{.*#+}} xmm1 = [44151,48623,2675,32081,0,0,0,0]
-; SSE2-NEXT:    pmulhw %xmm0, %xmm1
+; SSE2-NEXT:    movq {{.*#+}} xmm2 = [44151,48623,2675,32081,0,0,0,0]
+; SSE2-NEXT:    pmulhw %xmm0, %xmm2
+; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [65535,65535,65535,0,65535,65535,65535,65535]
+; SSE2-NEXT:    movdqa %xmm2, %xmm4
+; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    movq {{.*#+}} xmm1 = [1,0,0,65535,0,0,0,0]
+; SSE2-NEXT:    pmullw %xmm0, %xmm1
 ; SSE2-NEXT:    paddw %xmm2, %xmm1
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [65535,65535,65535,0,65535,65535,65535,65535]
-; SSE2-NEXT:    movdqa %xmm1, %xmm3
-; SSE2-NEXT:    pand %xmm2, %xmm3
+; SSE2-NEXT:    movdqa %xmm1, %xmm5
+; SSE2-NEXT:    psraw $8, %xmm5
+; SSE2-NEXT:    pandn %xmm5, %xmm3
+; SSE2-NEXT:    por %xmm4, %xmm3
 ; SSE2-NEXT:    movdqa %xmm1, %xmm4
-; SSE2-NEXT:    psraw $8, %xmm4
-; SSE2-NEXT:    pandn %xmm4, %xmm2
-; SSE2-NEXT:    por %xmm3, %xmm2
-; SSE2-NEXT:    movdqa %xmm1, %xmm3
-; SSE2-NEXT:    psraw $4, %xmm3
-; SSE2-NEXT:    movss {{.*#+}} xmm2 = xmm3[0],xmm2[1,2,3]
-; SSE2-NEXT:    movaps %xmm2, %xmm3
-; SSE2-NEXT:    psraw $1, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [65535,0,65535,0,65535,65535,65535,65535]
-; SSE2-NEXT:    psraw $2, %xmm2
-; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [0,65535,0,65535,65535,65535,65535,65535]
-; SSE2-NEXT:    movdqa %xmm1, %xmm6
+; SSE2-NEXT:    psraw $4, %xmm4
+; SSE2-NEXT:    movss {{.*#+}} xmm3 = xmm4[0],xmm3[1,2,3]
+; SSE2-NEXT:    movaps %xmm3, %xmm4
+; SSE2-NEXT:    psraw $1, %xmm4
+; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [65535,0,65535,0,65535,65535,65535,65535]
+; SSE2-NEXT:    psraw $2, %xmm3
+; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [0,65535,0,65535,65535,65535,65535,65535]
+; SSE2-NEXT:    pand %xmm6, %xmm2
+; SSE2-NEXT:    pandn %xmm3, %xmm6
+; SSE2-NEXT:    por %xmm2, %xmm6
 ; SSE2-NEXT:    pand %xmm5, %xmm6
-; SSE2-NEXT:    pandn %xmm2, %xmm5
+; SSE2-NEXT:    pandn %xmm4, %xmm5
 ; SSE2-NEXT:    por %xmm6, %xmm5
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pandn %xmm3, %xmm4
-; SSE2-NEXT:    por %xmm5, %xmm4
 ; SSE2-NEXT:    psrlw $15, %xmm1
-; SSE2-NEXT:    paddw %xmm4, %xmm1
+; SSE2-NEXT:    paddw %xmm5, %xmm1
 ; SSE2-NEXT:    pmullw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1 # [95,65412,98,64533,u,u,u,u]
 ; SSE2-NEXT:    psubw %xmm1, %xmm0
 ; SSE2-NEXT:    retq
@@ -263,29 +262,29 @@ define <4 x i16> @dont_fold_srem_power_of_two(<4 x i16> %x) {
 define <4 x i16> @dont_fold_srem_one(<4 x i16> %x) {
 ; SSE2-LABEL: dont_fold_srem_one:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movq {{.*#+}} xmm1 = [65535,0,65535,0,0,0,0,0]
-; SSE2-NEXT:    pand %xmm0, %xmm1
-; SSE2-NEXT:    movq {{.*#+}} xmm2 = [0,12827,45591,12375,0,0,0,0]
-; SSE2-NEXT:    pmulhw %xmm0, %xmm2
-; SSE2-NEXT:    paddw %xmm2, %xmm1
+; SSE2-NEXT:    movq {{.*#+}} xmm2 = [65535,0,65535,0,0,0,0,0]
+; SSE2-NEXT:    pand %xmm0, %xmm2
 ; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [65535,0,0,65535,65535,65535,65535,65535]
-; SSE2-NEXT:    movdqa %xmm1, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    movq {{.*#+}} xmm4 = [0,12827,45591,12375,0,0,0,0]
+; SSE2-NEXT:    pmulhw %xmm0, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm1
+; SSE2-NEXT:    paddw %xmm2, %xmm1
+; SSE2-NEXT:    pand %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm1, %xmm5
 ; SSE2-NEXT:    psraw $4, %xmm5
 ; SSE2-NEXT:    pandn %xmm5, %xmm3
-; SSE2-NEXT:    por %xmm4, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [65535,0,65535,0,65535,65535,65535,65535]
-; SSE2-NEXT:    pand %xmm4, %xmm3
-; SSE2-NEXT:    movdqa %xmm2, %xmm5
+; SSE2-NEXT:    por %xmm2, %xmm3
+; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [65535,0,65535,0,65535,65535,65535,65535]
+; SSE2-NEXT:    pand %xmm2, %xmm3
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
 ; SSE2-NEXT:    psraw $10, %xmm5
-; SSE2-NEXT:    pandn %xmm5, %xmm4
-; SSE2-NEXT:    por %xmm3, %xmm4
+; SSE2-NEXT:    pandn %xmm5, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [65535,0,65535,65535,65535,65535,65535,65535]
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    psraw $7, %xmm2
-; SSE2-NEXT:    pandn %xmm2, %xmm3
-; SSE2-NEXT:    por %xmm4, %xmm3
+; SSE2-NEXT:    pand %xmm3, %xmm2
+; SSE2-NEXT:    psraw $7, %xmm4
+; SSE2-NEXT:    pandn %xmm4, %xmm3
+; SSE2-NEXT:    por %xmm2, %xmm3
 ; SSE2-NEXT:    psrlw $15, %xmm1
 ; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
 ; SSE2-NEXT:    paddw %xmm3, %xmm1

--- a/llvm/test/CodeGen/X86/vector-mulfix-legalize.ll
+++ b/llvm/test/CodeGen/X86/vector-mulfix-legalize.ll
@@ -75,14 +75,8 @@ define <4 x i16> @umulfixsat(<4 x i16> %a) {
 ; CHECK-NEXT:    pmullw %xmm1, %xmm2
 ; CHECK-NEXT:    psrlw $15, %xmm2
 ; CHECK-NEXT:    pmulhuw %xmm1, %xmm0
-; CHECK-NEXT:    movdqa {{.*#+}} xmm1 = [32768,32768,32768,32768,32768,32768,32768,32768]
-; CHECK-NEXT:    psubusw %xmm0, %xmm1
-; CHECK-NEXT:    movdqa %xmm0, %xmm3
-; CHECK-NEXT:    paddw %xmm3, %xmm3
-; CHECK-NEXT:    por %xmm2, %xmm3
-; CHECK-NEXT:    pxor %xmm0, %xmm0
-; CHECK-NEXT:    pcmpeqw %xmm1, %xmm0
-; CHECK-NEXT:    por %xmm3, %xmm0
+; CHECK-NEXT:    paddw %xmm0, %xmm0
+; CHECK-NEXT:    por %xmm2, %xmm0
 ; CHECK-NEXT:    retq
   %t = call <4 x i16> @llvm.umul.fix.sat.v4i16(<4 x i16> <i16 1, i16 2, i16 3, i16 4>, <4 x i16> %a, i32 15)
   ret <4 x i16> %t


### PR DESCRIPTION
This defends against regressions in future patches. Copies the logic
from the IR version of computeKnownBits's handling of ConstantVector.
I'm not sure why the IR version doesn't directly return a value for poison,
but this follows suit.

Co-authored-by: Claude (Claude-Opus-4.8)