### PR TITLE
[NVPTX] Limit mixed FP folds to single-use extensions

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
+++ b/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
@@ -1759,13 +1759,13 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
   }
 }
 
-// Pattern for llvm.fma.f32 intrinsic when there is no FTZ flag
+// Pattern for llvm.fma.f32 with single-use extensions and no FTZ flag
 let Predicates = [hasSM<100>, hasPTX<86>, doNoF32FTZ] in {
-  def : Pat<(f32 (fma (f32 (fpextend f16:$a)),
-                      (f32 (fpextend f16:$b)), f32:$c)),
+  def : Pat<(f32 (fma (f32 (OneUse1<fpextend> f16:$a)),
+                      (f32 (OneUse1<fpextend> f16:$b)), f32:$c)),
             (INT_NVVM_MIXED_FMA_rn_f32_f16 B16:$a, B16:$b, B32:$c)>;
-  def : Pat<(f32 (fma (f32 (fpextend bf16:$a)), 
-                      (f32 (fpextend bf16:$b)), f32:$c)),
+  def : Pat<(f32 (fma (f32 (OneUse1<fpextend> bf16:$a)),
+                      (f32 (OneUse1<fpextend> bf16:$b)), f32:$c)),
             (INT_NVVM_MIXED_FMA_rn_f32_bf16 B16:$a, B16:$b, B32:$c)>;
 }
 
@@ -1921,11 +1921,11 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
   }
 }
 
-// Pattern for fadd when there is no FTZ flag
+// Pattern for fadd with a single-use extension and no FTZ flag
 let Predicates = [hasSM<100>, hasPTX<86>, doNoF32FTZ] in {
-  def : Pat<(f32 (fadd (f32 (fpextend f16:$a)), f32:$b)),
+  def : Pat<(f32 (fadd (f32 (OneUse1<fpextend> f16:$a)), f32:$b)),
             (INT_NVVM_MIXED_ADD_rn_f32_f16 B16:$a, B32:$b)>;
-  def : Pat<(f32 (fadd (f32 (fpextend bf16:$a)), f32:$b)),
+  def : Pat<(f32 (fadd (f32 (OneUse1<fpextend> bf16:$a)), f32:$b)),
             (INT_NVVM_MIXED_ADD_rn_f32_bf16 B16:$a, B32:$b)>;
 }
 
@@ -1981,11 +1981,11 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
   }
 }
 
-// Pattern for fsub when there is no FTZ flag
+// Pattern for fsub with a single-use extension and no FTZ flag
 let Predicates = [hasSM<100>, hasPTX<86>, doNoF32FTZ] in {
-  def : Pat<(f32 (fsub (f32 (fpextend f16:$a)), f32:$b)),
+  def : Pat<(f32 (fsub (f32 (OneUse1<fpextend> f16:$a)), f32:$b)),
             (INT_NVVM_MIXED_SUB_rn_f32_f16 B16:$a, B32:$b)>;
-  def : Pat<(f32 (fsub (f32 (fpextend bf16:$a)), f32:$b)),
+  def : Pat<(f32 (fsub (f32 (OneUse1<fpextend> bf16:$a)), f32:$b)),
             (INT_NVVM_MIXED_SUB_rn_f32_bf16 B16:$a, B32:$b)>;
 }
 

--- a/llvm/test/CodeGen/NVPTX/mixed-precision-fp.ll
+++ b/llvm/test/CodeGen/NVPTX/mixed-precision-fp.ll
@@ -441,3 +441,163 @@ define float @test_fma_f32_bf16_2(bfloat %a, bfloat %b, float %c) {
 
   ret float %r2
 }
+
+; MULTI-USE EXTENSIONS
+
+define float @test_add_sub_f32_f16_multiuse(half %a, float %b) {
+; CHECK-NOF32FTZ-LABEL: test_add_sub_f32_f16_multiuse(
+; CHECK-NOF32FTZ:       {
+; CHECK-NOF32FTZ-NEXT:    .reg .b16 %rs<2>;
+; CHECK-NOF32FTZ-NEXT:    .reg .b32 %r<6>;
+; CHECK-NOF32FTZ-EMPTY:
+; CHECK-NOF32FTZ-NEXT:  // %bb.0:
+; CHECK-NOF32FTZ-NEXT:    ld.param.b16 %rs1, [test_add_sub_f32_f16_multiuse_param_0];
+; CHECK-NOF32FTZ-NEXT:    cvt.f32.f16 %r1, %rs1;
+; CHECK-NOF32FTZ-NEXT:    ld.param.b32 %r2, [test_add_sub_f32_f16_multiuse_param_1];
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r3, %r1, %r2;
+; CHECK-NOF32FTZ-NEXT:    sub.rn.f32 %r4, %r1, %r2;
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r5, %r3, %r4;
+; CHECK-NOF32FTZ-NEXT:    st.param.b32 [func_retval0], %r5;
+; CHECK-NOF32FTZ-NEXT:    ret;
+;
+; CHECK-F32FTZ-LABEL: test_add_sub_f32_f16_multiuse(
+; CHECK-F32FTZ:       {
+; CHECK-F32FTZ-NEXT:    .reg .b16 %rs<2>;
+; CHECK-F32FTZ-NEXT:    .reg .b32 %r<6>;
+; CHECK-F32FTZ-EMPTY:
+; CHECK-F32FTZ-NEXT:  // %bb.0:
+; CHECK-F32FTZ-NEXT:    ld.param.b16 %rs1, [test_add_sub_f32_f16_multiuse_param_0];
+; CHECK-F32FTZ-NEXT:    cvt.ftz.f32.f16 %r1, %rs1;
+; CHECK-F32FTZ-NEXT:    ld.param.b32 %r2, [test_add_sub_f32_f16_multiuse_param_1];
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r3, %r1, %r2;
+; CHECK-F32FTZ-NEXT:    sub.rn.ftz.f32 %r4, %r1, %r2;
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r5, %r3, %r4;
+; CHECK-F32FTZ-NEXT:    st.param.b32 [func_retval0], %r5;
+; CHECK-F32FTZ-NEXT:    ret;
+  %ext = fpext half %a to float
+  %add = fadd float %ext, %b
+  %sub = fsub float %ext, %b
+  %result = fadd float %add, %sub
+  ret float %result
+}
+
+define float @test_add_sub_f32_bf16_multiuse(bfloat %a, float %b) {
+; CHECK-NOF32FTZ-LABEL: test_add_sub_f32_bf16_multiuse(
+; CHECK-NOF32FTZ:       {
+; CHECK-NOF32FTZ-NEXT:    .reg .b16 %rs<2>;
+; CHECK-NOF32FTZ-NEXT:    .reg .b32 %r<6>;
+; CHECK-NOF32FTZ-EMPTY:
+; CHECK-NOF32FTZ-NEXT:  // %bb.0:
+; CHECK-NOF32FTZ-NEXT:    ld.param.b16 %rs1, [test_add_sub_f32_bf16_multiuse_param_0];
+; CHECK-NOF32FTZ-NEXT:    cvt.f32.bf16 %r1, %rs1;
+; CHECK-NOF32FTZ-NEXT:    ld.param.b32 %r2, [test_add_sub_f32_bf16_multiuse_param_1];
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r3, %r1, %r2;
+; CHECK-NOF32FTZ-NEXT:    sub.rn.f32 %r4, %r1, %r2;
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r5, %r3, %r4;
+; CHECK-NOF32FTZ-NEXT:    st.param.b32 [func_retval0], %r5;
+; CHECK-NOF32FTZ-NEXT:    ret;
+;
+; CHECK-F32FTZ-LABEL: test_add_sub_f32_bf16_multiuse(
+; CHECK-F32FTZ:       {
+; CHECK-F32FTZ-NEXT:    .reg .b16 %rs<2>;
+; CHECK-F32FTZ-NEXT:    .reg .b32 %r<6>;
+; CHECK-F32FTZ-EMPTY:
+; CHECK-F32FTZ-NEXT:  // %bb.0:
+; CHECK-F32FTZ-NEXT:    ld.param.b16 %rs1, [test_add_sub_f32_bf16_multiuse_param_0];
+; CHECK-F32FTZ-NEXT:    cvt.ftz.f32.bf16 %r1, %rs1;
+; CHECK-F32FTZ-NEXT:    ld.param.b32 %r2, [test_add_sub_f32_bf16_multiuse_param_1];
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r3, %r1, %r2;
+; CHECK-F32FTZ-NEXT:    sub.rn.ftz.f32 %r4, %r1, %r2;
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r5, %r3, %r4;
+; CHECK-F32FTZ-NEXT:    st.param.b32 [func_retval0], %r5;
+; CHECK-F32FTZ-NEXT:    ret;
+  %ext = fpext bfloat %a to float
+  %add = fadd float %ext, %b
+  %sub = fsub float %ext, %b
+  %result = fadd float %add, %sub
+  ret float %result
+}
+
+define float @test_fma_f32_f16_multiuse(half %a, half %b, float %c) {
+; CHECK-NOF32FTZ-LABEL: test_fma_f32_f16_multiuse(
+; CHECK-NOF32FTZ:       {
+; CHECK-NOF32FTZ-NEXT:    .reg .b16 %rs<3>;
+; CHECK-NOF32FTZ-NEXT:    .reg .b32 %r<7>;
+; CHECK-NOF32FTZ-EMPTY:
+; CHECK-NOF32FTZ-NEXT:  // %bb.0:
+; CHECK-NOF32FTZ-NEXT:    ld.param.b16 %rs1, [test_fma_f32_f16_multiuse_param_0];
+; CHECK-NOF32FTZ-NEXT:    cvt.f32.f16 %r1, %rs1;
+; CHECK-NOF32FTZ-NEXT:    ld.param.b16 %rs2, [test_fma_f32_f16_multiuse_param_1];
+; CHECK-NOF32FTZ-NEXT:    cvt.f32.f16 %r2, %rs2;
+; CHECK-NOF32FTZ-NEXT:    ld.param.b32 %r3, [test_fma_f32_f16_multiuse_param_2];
+; CHECK-NOF32FTZ-NEXT:    fma.rn.f32 %r4, %r1, %r2, %r3;
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r5, %r1, %r2;
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r6, %r4, %r5;
+; CHECK-NOF32FTZ-NEXT:    st.param.b32 [func_retval0], %r6;
+; CHECK-NOF32FTZ-NEXT:    ret;
+;
+; CHECK-F32FTZ-LABEL: test_fma_f32_f16_multiuse(
+; CHECK-F32FTZ:       {
+; CHECK-F32FTZ-NEXT:    .reg .b16 %rs<3>;
+; CHECK-F32FTZ-NEXT:    .reg .b32 %r<7>;
+; CHECK-F32FTZ-EMPTY:
+; CHECK-F32FTZ-NEXT:  // %bb.0:
+; CHECK-F32FTZ-NEXT:    ld.param.b16 %rs1, [test_fma_f32_f16_multiuse_param_0];
+; CHECK-F32FTZ-NEXT:    cvt.ftz.f32.f16 %r1, %rs1;
+; CHECK-F32FTZ-NEXT:    ld.param.b16 %rs2, [test_fma_f32_f16_multiuse_param_1];
+; CHECK-F32FTZ-NEXT:    cvt.ftz.f32.f16 %r2, %rs2;
+; CHECK-F32FTZ-NEXT:    ld.param.b32 %r3, [test_fma_f32_f16_multiuse_param_2];
+; CHECK-F32FTZ-NEXT:    fma.rn.ftz.f32 %r4, %r1, %r2, %r3;
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r5, %r1, %r2;
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r6, %r4, %r5;
+; CHECK-F32FTZ-NEXT:    st.param.b32 [func_retval0], %r6;
+; CHECK-F32FTZ-NEXT:    ret;
+  %exta = fpext half %a to float
+  %extb = fpext half %b to float
+  %fma = call float @llvm.fma.f32(float %exta, float %extb, float %c)
+  %add = fadd float %exta, %extb
+  %result = fadd float %fma, %add
+  ret float %result
+}
+
+define float @test_fma_f32_bf16_multiuse(bfloat %a, bfloat %b, float %c) {
+; CHECK-NOF32FTZ-LABEL: test_fma_f32_bf16_multiuse(
+; CHECK-NOF32FTZ:       {
+; CHECK-NOF32FTZ-NEXT:    .reg .b16 %rs<3>;
+; CHECK-NOF32FTZ-NEXT:    .reg .b32 %r<7>;
+; CHECK-NOF32FTZ-EMPTY:
+; CHECK-NOF32FTZ-NEXT:  // %bb.0:
+; CHECK-NOF32FTZ-NEXT:    ld.param.b16 %rs1, [test_fma_f32_bf16_multiuse_param_0];
+; CHECK-NOF32FTZ-NEXT:    cvt.f32.bf16 %r1, %rs1;
+; CHECK-NOF32FTZ-NEXT:    ld.param.b16 %rs2, [test_fma_f32_bf16_multiuse_param_1];
+; CHECK-NOF32FTZ-NEXT:    cvt.f32.bf16 %r2, %rs2;
+; CHECK-NOF32FTZ-NEXT:    ld.param.b32 %r3, [test_fma_f32_bf16_multiuse_param_2];
+; CHECK-NOF32FTZ-NEXT:    fma.rn.f32 %r4, %r1, %r2, %r3;
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r5, %r1, %r2;
+; CHECK-NOF32FTZ-NEXT:    add.rn.f32 %r6, %r4, %r5;
+; CHECK-NOF32FTZ-NEXT:    st.param.b32 [func_retval0], %r6;
+; CHECK-NOF32FTZ-NEXT:    ret;
+;
+; CHECK-F32FTZ-LABEL: test_fma_f32_bf16_multiuse(
+; CHECK-F32FTZ:       {
+; CHECK-F32FTZ-NEXT:    .reg .b16 %rs<3>;
+; CHECK-F32FTZ-NEXT:    .reg .b32 %r<7>;
+; CHECK-F32FTZ-EMPTY:
+; CHECK-F32FTZ-NEXT:  // %bb.0:
+; CHECK-F32FTZ-NEXT:    ld.param.b16 %rs1, [test_fma_f32_bf16_multiuse_param_0];
+; CHECK-F32FTZ-NEXT:    cvt.ftz.f32.bf16 %r1, %rs1;
+; CHECK-F32FTZ-NEXT:    ld.param.b16 %rs2, [test_fma_f32_bf16_multiuse_param_1];
+; CHECK-F32FTZ-NEXT:    cvt.ftz.f32.bf16 %r2, %rs2;
+; CHECK-F32FTZ-NEXT:    ld.param.b32 %r3, [test_fma_f32_bf16_multiuse_param_2];
+; CHECK-F32FTZ-NEXT:    fma.rn.ftz.f32 %r4, %r1, %r2, %r3;
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r5, %r1, %r2;
+; CHECK-F32FTZ-NEXT:    add.rn.ftz.f32 %r6, %r4, %r5;
+; CHECK-F32FTZ-NEXT:    st.param.b32 [func_retval0], %r6;
+; CHECK-F32FTZ-NEXT:    ret;
+  %exta = fpext bfloat %a to float
+  %extb = fpext bfloat %b to float
+  %fma = call float @llvm.fma.f32(float %exta, float %extb, float %c)
+  %add = fadd float %exta, %extb
+  %result = fadd float %fma, %add
+  ret float %result
+}


### PR DESCRIPTION
## Summary

Require the `fpext` operands of generic mixed-precision `fadd`, `fsub`, and `llvm.fma` patterns to have one use.

This keeps the existing mixed FP16/BF16-to-FP32 selection when it eliminates a conversion, while retaining a shared conversion when the extension has multiple users. Explicit NVVM intrinsic lowering is unchanged.

## Motivation

On `sm_100`, the unconditional folds added by #168359 can keep the narrow source values live across multiple operations. In a 512-thread layer-normalization kernel, every FP16-to-FP32 extension feeds both the reduction and the normalization subtract. In combination with `--nvptx-mad-wide-opt`, this changes CUDA `ptxas` register allocation enough to cross an occupancy boundary on B200.

Using byte-identical LLVM IR and changing only this patch:

| | Mixed add/sub | Registers/thread | Latency |
|---|---:|---:|---:|
| Before | 63 | 72 | 84.75 us |
| After | 0 | 64 | 53.45 us |

Both variants have zero spills and pass the output correctness check. At 512 threads per block, 64 registers permits two resident blocks per B200 SM, while 72 registers permits only one.

Measurement environment:

- NVIDIA B200, driver 580.82.07
- CUDA 12.9.86 `ptxas`
- `sm_100a`, PTX 8.8
- `llc -O3 --nvptx-fma-level=1 --nvptx-mad-wide-opt`
- `ptxas --regAllocOptLevel=2`

Disabling `--nvptx-mad-wide-opt` also avoids the register cliff, but is too broad: that option exists to recover performance for other kernels (#160214). Restricting the mixed fold is local to the shared-conversion case.

## Testing

- `ninja -C build-nvptx check-llvm-codegen-nvptx`: 533 passed
- Standalone LLVM IR + CUDA Driver API B200 benchmark: correctness passed; 72 to 64 registers; 84.75 to 53.45 us
- Added FP16 and BF16 codegen coverage for add/sub and FMA with multi-use extensions; existing single-use coverage continues to select mixed instructions


## AI tool use

OpenAI Codex was used to assist with regression analysis, implementation, test generation, validation, and drafting this pull request description.
