### PR TITLE
[OpenACC][NFC] Minor clean up in ACCRoutineLowering.

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRoutineLowering.cpp
@@ -168,15 +168,13 @@ buildRoutineBody(func::FuncOp deviceFunc, func::FuncOp hostFunc,
 }
 
 /// Update acc.routine refs
-static LogicalResult finalizeRoutines(
-    SmallVectorImpl<std::tuple<func::FuncOp, func::FuncOp, RoutineOp>>
-        &accRoutineInfo,
-    ModuleOp mod, MLIRContext *ctx) {
-  for (auto &[hostFunc, deviceFunc, routineOp] : accRoutineInfo) {
+static void finalizeRoutines(
+    SmallVectorImpl<std::pair<func::FuncOp, RoutineOp>> &accRoutineInfo,
+    MLIRContext *ctx) {
+  for (auto &[deviceFunc, routineOp] : accRoutineInfo) {
     routineOp.setFuncNameAttr(SymbolRefAttr::get(ctx, deviceFunc.getName()));
     routineOp->moveBefore(deviceFunc);
   }
-  return success();
 }
 
 class ACCRoutineLowering
@@ -197,9 +195,8 @@ public:
     IRRewriter rewriter(ctx);
     DefaultACCToGPUMappingPolicy policy;
 
-    // Tuple: host function, device function, routine operation
-    SmallVector<std::tuple<func::FuncOp, func::FuncOp, RoutineOp>, 4>
-        accRoutineInfo;
+    // Pair: device function, routine operation
+    SmallVector<std::pair<func::FuncOp, RoutineOp>, 4> accRoutineInfo;
 
     for (RoutineOp routineOp : mod.getOps<RoutineOp>()) {
       if (routineOp.getBindNameValue() ||
@@ -226,12 +223,11 @@ public:
                                   parLevel, policy, rewriter)))
         return signalPassFailure();
 
-      accRoutineInfo.push_back({hostFunc, deviceFunc, routineOp});
+      accRoutineInfo.push_back({deviceFunc, routineOp});
       symTab.insert(deviceFunc);
     }
 
-    if (failed(finalizeRoutines(accRoutineInfo, mod, ctx)))
-      return signalPassFailure();
+    finalizeRoutines(accRoutineInfo, ctx);
   }
 };
 


### PR DESCRIPTION
Minor NFC clean up after recent changes to remove nohost handling from ACCRoutineLowering.

Assisted-by: Codex