### PR TITLE
[DWP] Eagerly clear buffers after writing

### DIFF
--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -95,6 +95,12 @@ class LLVM_ABI DWPWriter {
       if (!Buffer.empty())
         OS.write(Buffer.data(), Buffer.size());
     }
+
+    void clear() {
+      Chunks = {};
+      Buffer = {};
+      OwnedBuffers = {};
+    }
   };
 
   SectionData Sections[DS_NumSections];
@@ -170,6 +176,8 @@ public:
 
     return Pair.first->second;
   }
+
+  void clear() { Pool = DenseMap<StringRef, uint64_t>(); }
 };
 
 struct UnitIndexEntry {

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -89,14 +89,13 @@ class LLVM_ABI DWPWriter {
 
     bool empty() const { return Chunks.empty() && Buffer.empty(); }
 
-    void writeTo(raw_ostream &OS) const {
+    void writeTo(raw_ostream &OS) {
       for (auto &C : Chunks)
         OS.write(C.data(), C.size());
       if (!Buffer.empty())
         OS.write(Buffer.data(), Buffer.size());
-    }
 
-    void clear() {
+      // Clear buffers to save some memory.
       Chunks = {};
       Buffer = {};
       OwnedBuffers = {};

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -1041,6 +1041,8 @@ Error write(DWPWriter &Out, ArrayRef<std::string> Inputs,
       break;
   }
 
+  Strings.clear();
+
   if (Version < 5) {
     // Lie about there being no info contributions so the TU index only includes
     // the type unit contribution for DWARF < 5. In DWARFv5 the TU index has a
@@ -1059,6 +1061,8 @@ Error write(DWPWriter &Out, ArrayRef<std::string> Inputs,
   }
 
   writeIndex(Out, DS_CUIndex, ContributionOffsets, IndexEntries, IndexVersion);
+  IndexEntries.clear();
+  TypeIndexEntries.clear();
 
   // Write ELF output while input data is still alive (zero-copy chunks
   // reference mmap'd input data held by the Objects vector above).
@@ -1101,12 +1105,13 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
 
   // Collect non-empty sections and build the section name string table.
   struct OutputEntry {
-    const SectionData *Data;
+    SectionData *Data;
     const char *Name;
     uint64_t Flags;
     uint64_t EntSize;
     uint32_t NameOffset;
     uint64_t FileOffset; // filled in during layout
+    uint64_t Size;       // filled in during layout
   };
   SmallVector<OutputEntry> Entries;
 
@@ -1120,7 +1125,7 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
     Strtab.append(M.Name);
     Strtab.push_back('\0');
     Entries.push_back(
-        {&Sections[M.Id], M.Name, M.Flags, M.EntSize, NameOff, 0});
+        {&Sections[M.Id], M.Name, M.Flags, M.EntSize, NameOff, 0, 0});
   }
 
   // Add .strtab and .symtab name entries.
@@ -1146,7 +1151,8 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
   uint64_t Offset = EhdrSize;
   for (auto &E : Entries) {
     E.FileOffset = Offset;
-    Offset += E.Data->totalSize();
+    E.Size = E.Data->totalSize();
+    Offset += E.Size;
   }
 
   uint64_t StrtabOffset = Offset;
@@ -1167,8 +1173,10 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
                    /*EFlags=*/0, SHTOffset, NumSections, StrtabIdx);
 
   // --- Write section data ---
-  for (const auto &E : Entries)
+  for (auto &E : Entries) {
     E.Data->writeTo(OS);
+    E.Data->clear();
+  }
 
   // --- Write .strtab ---
   OS.write(Strtab.data(), Strtab.size());
@@ -1187,8 +1195,7 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
   // [1..N] data sections
   for (const auto &E : Entries)
     ELF::writeSectionHeader(Wr, true, E.NameOffset, ELF::SHT_PROGBITS, E.Flags,
-                            0, E.FileOffset, E.Data->totalSize(), 0, 0, 1,
-                            E.EntSize);
+                            0, E.FileOffset, E.Size, 0, 0, 1, E.EntSize);
 
   // [N+1] .strtab
   ELF::writeSectionHeader(Wr, true, StrtabNameOff, ELF::SHT_STRTAB, 0, 0,
@@ -1233,7 +1240,7 @@ Error DWPWriter::writeWASM(raw_pwrite_stream &OS) {
 
   // Emit each non-empty section as a WASM custom section (id=0).
   for (const auto &M : Meta) {
-    const SectionData &SD = Sections[M.Id];
+    SectionData &SD = Sections[M.Id];
     if (SD.empty())
       continue;
 
@@ -1257,6 +1264,7 @@ Error DWPWriter::writeWASM(raw_pwrite_stream &OS) {
 
     // Data
     SD.writeTo(OS);
+    SD.clear();
   }
 
   return Error::success();

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -1171,9 +1171,8 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
                    /*EFlags=*/0, SHTOffset, NumSections, StrtabIdx);
 
   // --- Write section data ---
-  for (auto &E : Entries) {
+  for (auto &E : Entries)
     E.Data->writeTo(OS);
-  }
 
   // --- Write .strtab ---
   OS.write(Strtab.data(), Strtab.size());

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -1173,7 +1173,6 @@ Error DWPWriter::writeELF(raw_pwrite_stream &OS) {
   // --- Write section data ---
   for (auto &E : Entries) {
     E.Data->writeTo(OS);
-    E.Data->clear();
   }
 
   // --- Write .strtab ---
@@ -1262,7 +1261,6 @@ Error DWPWriter::writeWASM(raw_pwrite_stream &OS) {
 
     // Data
     SD.writeTo(OS);
-    SD.clear();
   }
 
   return Error::success();

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -1061,8 +1061,6 @@ Error write(DWPWriter &Out, ArrayRef<std::string> Inputs,
   }
 
   writeIndex(Out, DS_CUIndex, ContributionOffsets, IndexEntries, IndexVersion);
-  IndexEntries.clear();
-  TypeIndexEntries.clear();
 
   // Write ELF output while input data is still alive (zero-copy chunks
   // reference mmap'd input data held by the Objects vector above).


### PR DESCRIPTION
Lowers peak memory usage on a llvm-dwp invocation from 12.37GB -> 11.19GB.

This actually now beats out GNU dwp (11.35GB) at least when the output file is in tmpfs.