### PR TITLE
[NVPTX] Pass `-Xcuda-ptxas` to the nvlink wrapper for LTO

### DIFF
--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -618,6 +618,12 @@ void NVPTX::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString(
         "--ptxas-path=" + Args.getLastArgValue(options::OPT_ptxas_path_EQ)));
 
+  // The wrapper runs 'ptxas' itself when doing LTO, so it needs these.
+  for (const Arg *A : Args.filtered(options::OPT_Xcuda_ptxas)) {
+    A->claim();
+    CmdArgs.append({"-Xptxas", A->getValue()});
+  }
+
   if (Args.hasArg(options::OPT_cuda_path_EQ) || TC.CudaInstallation.isValid()) {
     StringRef CudaPath = Args.getLastArgValue(
         options::OPT_cuda_path_EQ,

--- a/clang/test/Driver/cuda-cross-compiling.c
+++ b/clang/test/Driver/cuda-cross-compiling.c
@@ -118,6 +118,10 @@
 
 // PTXAS-PATH: clang-nvlink-wrapper{{.*}}"--ptxas-path=/some/path/to/ptxas"
 
+// RUN: %clang -target nvptx64-nvidia-cuda -march=sm_52 -Xcuda-ptxas -maxrregcount=32 \
+// RUN:   -nogpulib -nogpuinc -### %s 2>&1 | FileCheck -check-prefix=PTXAS-ARGS %s
+// PTXAS-ARGS: clang-nvlink-wrapper{{.*}}"-Xptxas" "-maxrregcount=32"
+
 // RUN: %clang -### --target=nvptx64-nvidia-cuda -march=sm_89 -nogpulib \
 // RUN:   -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir \
 // RUN:   -fprofile-generate %s 2>&1 | FileCheck -check-prefixes=PROFILE %s

--- a/clang/test/Driver/cuda-external-tools.cu
+++ b/clang/test/Driver/cuda-external-tools.cu
@@ -89,6 +89,15 @@
 // RUN:   -Xcuda-ptxas -foo2 -- %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK,SM35,PTXAS-EXTRA %s
 
+// Check that -Xcuda-ptxas reaches the device link job with '-fgpu-rdc' and LTO,
+// where 'ptxas' is run by the nvlink wrapper instead of the driver.
+// RUN: %clang -### --target=x86_64-linux-gnu -fgpu-rdc -foffload-lto \
+// RUN:   --offload-arch=sm_35 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN:   -Xcuda-ptxas -foo1 %s 2>&1 \
+// RUN: | FileCheck -check-prefix=RDC-LTO %s
+
+// RDC-LTO: clang-linker-wrapper{{.*}}"--device-compiler=nvptx64-nvidia-cuda=-Xcuda-ptxas" "--device-compiler=nvptx64-nvidia-cuda=-foo1"
+
 // MacOS spot-checks
 // RUN: %clang -### --target=x86_64-apple-macosx -O0 -c %s 2>&1 \
 // RUN:   --offload-arch=sm_35 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \

--- a/clang/test/OffloadTools/clang-nvlink-wrapper/nvlink-wrapper.c
+++ b/clang/test/OffloadTools/clang-nvlink-wrapper/nvlink-wrapper.c
@@ -75,6 +75,19 @@ int baz() { return y + x; }
 // LTO: nvlink{{.*}} -arch sm_52 -o a.out [[CUBIN]].cubin {{.*}}-u-{{.*}}.cubin {{.*}}-y-{{.*}}.cubin
 
 //
+// Check that '-Xptxas' is forwarded to 'ptxas' and not to 'nvlink'.
+//
+// RUN: clang-nvlink-wrapper --dry-run --assume-device-object %t.o %t-u.o %t-y.a \
+// RUN:   -Xptxas -maxrregcount=32 -arch sm_52 -o a.out 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=PTXAS-ARGS
+// RUN: clang-nvlink-wrapper --dry-run --assume-device-object %t.o %t-u.o %t-y.a \
+// RUN:   -Xptxas=-maxrregcount=32 -arch sm_52 -o a.out 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=PTXAS-ARGS
+// PTXAS-ARGS: ptxas{{.*}} -arch sm_52 -maxrregcount=32 -o [[CUBIN:.+]].cubin
+// PTXAS-ARGS: nvlink{{.*}} -arch sm_52 -o a.out
+// PTXAS-ARGS-NOT: -maxrregcount=32
+
+//
 // Check that we don't forward some arguments.
 //
 // RUN: clang-nvlink-wrapper --dry-run %t.o %t-u.o %t-y.a \

--- a/clang/tools/clang-nvlink-wrapper/ClangNVLinkWrapper.cpp
+++ b/clang/tools/clang-nvlink-wrapper/ClangNVLinkWrapper.cpp
@@ -332,6 +332,8 @@ Expected<StringRef> runPTXAs(StringRef File, const ArgList &Args) {
         Args.MakeArgString("-O" + Args.getLastArgValue(OPT_O, "3")));
   }
   AssemblerArgs.append({"-arch", Args.getLastArgValue(OPT_arch)});
+  for (const Arg *A : Args.filtered(OPT_Xptxas))
+    AssemblerArgs.push_back(A->getValue());
   AssemblerArgs.append({"-o", *TempFileOrErr});
 
   if (Args.hasArg(OPT_dry_run) || Args.hasArg(OPT_verbose))

--- a/clang/tools/clang-nvlink-wrapper/NVLinkOpts.td
+++ b/clang/tools/clang-nvlink-wrapper/NVLinkOpts.td
@@ -19,6 +19,10 @@ def cuda_path_EQ : Joined<["--"], "cuda-path=">, Flags<[WrapperOnlyOption]>,
   MetaVarName<"<dir>">, HelpText<"Set the system CUDA path">;
 def ptxas_path_EQ : Joined<["--"], "ptxas-path=">, Flags<[WrapperOnlyOption]>,
   MetaVarName<"<dir>">, HelpText<"Set the 'ptxas' path">;
+def Xptxas : Separate<["-", "--"], "Xptxas">, Flags<[WrapperOnlyOption]>,
+  MetaVarName<"<arg>">, HelpText<"Pass <arg> to the 'ptxas' invocation">;
+def Xptxas_EQ : Joined<["-", "--"], "Xptxas=">, Flags<[HelpHidden]>,
+  Alias<Xptxas>;
 
 def o : JoinedOrSeparate<["-"], "o">, MetaVarName<"<path>">,
   HelpText<"Path to file to write output">;


### PR DESCRIPTION
Summary:
This allows `-foffload-lto -fgpu-rdc -Xcuda-ptxas` to work properly by
forwarding it.
