### PR TITLE
[LLVMABI] Drop the union arm of bitsContainNoUserData

### DIFF
--- a/clang/test/CodeGen/X86/x86_64-union-abi.c
+++ b/clang/test/CodeGen/X86/x86_64-union-abi.c
@@ -1,0 +1,78 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fexperimental-abi-lowering %s -o - | FileCheck %s
+
+// A union member covering the tail makes the whole eightbyte data, so the
+// coercion spans the union.
+union NarrowStorage {
+  int i;
+  char c[8];
+};
+
+void take_narrow_storage(union NarrowStorage u);
+void call_narrow_storage(union NarrowStorage u) { take_narrow_storage(u); }
+
+// CHECK-DAG: declare void @take_narrow_storage(i64)
+
+// Nothing covers the tail of an over-aligned union, so those bytes are padding
+// and the coercion is the int alone rather than the full eightbyte.
+union OverAligned {
+  int i;
+} __attribute__((aligned(16)));
+
+void take_over_aligned(union OverAligned u);
+void call_over_aligned(union OverAligned u) { take_over_aligned(u); }
+
+// CHECK-DAG: declare void @take_over_aligned(i32)
+
+// Returning one runs the same walk from the return classifier.
+union OverAligned ret_over_aligned(void);
+void call_ret_over_aligned(void) { ret_over_aligned(); }
+
+// CHECK-DAG: declare i32 @ret_over_aligned()
+
+// Same shape at 8-byte alignment, where the padded tail sits inside the single
+// eightbyte rather than beyond it.
+union OverAligned8 {
+  short s;
+} __attribute__((aligned(8)));
+
+void take_over_aligned8(union OverAligned8 u);
+void call_over_aligned8(union OverAligned8 u) { take_over_aligned8(u); }
+
+// CHECK-DAG: declare void @take_over_aligned8(i16)
+
+// A 16-byte union whose array member covers both eightbytes is passed in two
+// integer registers.
+union TwoEightbytes {
+  long l;
+  char c[16];
+};
+
+void take_two_eightbytes(union TwoEightbytes u);
+void call_two_eightbytes(union TwoEightbytes u) { take_two_eightbytes(u); }
+
+// CHECK-DAG: declare void @take_two_eightbytes(i64, i64)
+
+// A union sitting at a nonzero offset inside a struct reaches the field walk
+// with an already-shifted range, so its padded tail must still read as padding
+// on the second eightbyte.
+struct WrapsOverAligned {
+  double d;
+  union OverAligned8 u;
+};
+
+void take_wraps(struct WrapsOverAligned s);
+void call_wraps(struct WrapsOverAligned s) { take_wraps(s); }
+
+// CHECK-DAG: declare void @take_wraps(double, i16)
+
+// An unnamed bitfield is a member like any other, not skipped.
+union WideUnnamedBitfield {
+  char c;
+  long : 64;
+};
+
+void take_wide_unnamed(union WideUnnamedBitfield u);
+void call_wide_unnamed(union WideUnnamedBitfield u) { take_wide_unnamed(u); }
+
+// CHECK-DAG: declare void @take_wide_unnamed(i64)

--- a/llvm/lib/ABI/Targets/X86.cpp
+++ b/llvm/lib/ABI/Targets/X86.cpp
@@ -948,36 +948,9 @@ static bool bitsContainNoUserData(const Type *Ty, unsigned StartBit,
     return true;
   }
 
-  // Handle structs - check all fields and base classes
+  // Handle records - check all fields and base classes.  getUnionType places a
+  // union's members at offset zero, so the field loop covers a union too.
   if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
-    if (RT->isUnion()) {
-      for (const auto &Field : RT->getFields()) {
-        if (Field.IsUnnamedBitfield)
-          continue;
-
-        unsigned FieldStart =
-            (Field.OffsetInBits < StartBit) ? StartBit - Field.OffsetInBits : 0;
-        unsigned FieldEnd =
-            FieldStart + Field.FieldType->getSizeInBits().getFixedValue();
-
-        // Check if field overlaps with the queried range
-        if (FieldStart < EndBit && FieldEnd > StartBit) {
-          // There's an overlap, so there is user data
-          unsigned RelativeStart =
-              (StartBit > FieldStart) ? StartBit - FieldStart : 0;
-          unsigned RelativeEnd =
-              (EndBit < FieldEnd)
-                  ? EndBit - FieldStart
-                  : Field.FieldType->getSizeInBits().getFixedValue();
-
-          if (!bitsContainNoUserData(Field.FieldType, RelativeStart,
-                                     RelativeEnd)) {
-            return false;
-          }
-        }
-      }
-      return true;
-    }
     // Check base classes first (for C++ records)
     if (RT->isCXXRecord()) {
       for (unsigned I = 0; I < RT->getNumBaseClasses(); ++I) {
@@ -1007,7 +980,7 @@ static bool bitsContainNoUserData(const Type *Ty, unsigned StartBit,
     return true;
   }
 
-  // For unions, vectors, and primitives - assume all bits are user data
+  // For any other type - assume all bits are user data
   return false;
 }
 


### PR DESCRIPTION
A union whose widest member is narrower than the union itself, such as one carrying `__attribute__((aligned(16)))`, has its tail padding classified as user data. The union arm of `bitsContainNoUserData`, which came in with the System V x86-64 implementation in [#194718](https://github.com/llvm/llvm-project/pull/194718), computes a member-relative start offset and then compares it against the absolute end of the queried range, so an `int` member occupying bits 0 to 32 is judged to overlap a query over bits 32 to 64, and the recursion that follows re-queries that member from its own bit 0. The eightbyte then coerces to `i64` where clang's own ABI code uses `i32`, which the cross-check in `CodeGenModule::computeABIInfoUsingLib` turns into an abort on an assertions build.

A union needs no arm of its own. `TypeBuilder::getUnionType` places every member at offset zero, so the generic field loop already queries each member over the same range as the union, and a member ending before that range returns through the size check at the top of the function. That is also why clang has no union case in `BitsContainNoUserData`. Deleting the arm fixes the classification and removes the duplicate walk, along with an unnamed-bitfield skip the generic loop does not have.

The test covers a union whose tail is padding at both alignments that reach the walk, as an argument and as a return, one nested at a nonzero offset inside a struct, unions whose members do cover the tail so the wider coercion is right, and one carrying an unnamed bitfield, which the shared loop visits where the deleted arm skipped it.

Assisted-by: Cursor / claude-opus-5
