### PR TITLE
clang: Replace Is*OffloadArch free functions with OffloadArch methods

### DIFF
--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -106,15 +106,6 @@ public:
   }
 };
 
-inline bool IsNVIDIAOffloadArch(OffloadArch A) { return A.isNVPTX(); }
-inline bool IsAMDOffloadArch(OffloadArch A) {
-  // amdgcnspirv is compiled through the AMDGPU toolchain.
-  return A.isAMDGPU() || A.isSPIRV();
-}
-inline bool IsIntelCPUOffloadArch(OffloadArch A) { return A.isIntelCPU(); }
-inline bool IsIntelGPUOffloadArch(OffloadArch A) { return A.isIntelGPU(); }
-inline bool IsIntelOffloadArch(OffloadArch A) { return A.isIntel(); }
-
 const char *OffloadArchToString(OffloadArch A);
 const char *OffloadArchToVirtualArchString(OffloadArch A);
 

--- a/clang/lib/Basic/Cuda.cpp
+++ b/clang/lib/Basic/Cuda.cpp
@@ -83,7 +83,7 @@ CudaVersion MinVersionForOffloadArch(OffloadArch A) {
     return CudaVersion::UNKNOWN;
 
   // AMD GPUs do not depend on CUDA versions.
-  if (IsAMDOffloadArch(A))
+  if (A.isAMDGPU() || A.isSPIRV())
     return CudaVersion::CUDA_70;
 
   switch (A.nvptxKind()) {
@@ -98,7 +98,7 @@ CudaVersion MinVersionForOffloadArch(OffloadArch A) {
 
 CudaVersion MaxVersionForOffloadArch(OffloadArch A) {
   // AMD GPUs do not depend on CUDA versions.
-  if (IsAMDOffloadArch(A))
+  if (A.isAMDGPU() || A.isSPIRV())
     return CudaVersion::NEW;
 
   if (!A.isNVPTX())

--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -176,7 +176,7 @@ void NVPTXTargetInfo::getTargetDefines(const LangOptions &Opts,
   Builder.defineMacro("__NVPTX__");
 
   // Skip setting architecture dependent macros if undefined.
-  if (!IsNVIDIAOffloadArch(GPU))
+  if (!GPU.isNVPTX())
     return;
 
   if (Opts.CUDAIsDevice || Opts.OpenMPIsTargetDevice || !HostTarget) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -965,12 +965,12 @@ static TripleSet inferOffloadToolchains(Compilation &C,
       ID = StringToOffloadArch(
           getProcessorFromTargetID(llvm::Triple("amdgcn-amd-amdhsa"), Arch));
 
-    if (Kind == Action::OFK_HIP && !IsAMDOffloadArch(ID)) {
+    if (Kind == Action::OFK_HIP && !ID.isAMDGPU() && !ID.isSPIRV()) {
       C.getDriver().Diag(clang::diag::err_drv_offload_bad_gpu_arch)
           << "HIP" << Arch;
       return {};
     }
-    if (Kind == Action::OFK_Cuda && !IsNVIDIAOffloadArch(ID)) {
+    if (Kind == Action::OFK_Cuda && !ID.isNVPTX()) {
       C.getDriver().Diag(clang::diag::err_drv_offload_bad_gpu_arch)
           << "CUDA" << Arch;
       return {};
@@ -4881,21 +4881,21 @@ static StringRef getCanonicalArchString(Compilation &C,
   // expecting the triple to be only NVPTX / AMDGPU.
   OffloadArch Arch =
       StringToOffloadArch(getProcessorFromTargetID(Triple, ArchStr));
-  if (Triple.isNVPTX() && (Arch.isUnknown() || !IsNVIDIAOffloadArch(Arch))) {
+  if (Triple.isNVPTX() && (Arch.isUnknown() || !Arch.isNVPTX())) {
     C.getDriver().Diag(clang::diag::err_drv_offload_bad_gpu_arch)
         << "CUDA" << ArchStr;
     return StringRef();
   } else if (Triple.isAMDGPU() &&
-             (Arch.isUnknown() || !IsAMDOffloadArch(Arch))) {
+             (Arch.isUnknown() || (!Arch.isAMDGPU() && !Arch.isSPIRV()))) {
     C.getDriver().Diag(clang::diag::err_drv_offload_bad_gpu_arch)
         << "HIP" << ArchStr;
     return StringRef();
   }
 
-  if (IsNVIDIAOffloadArch(Arch))
+  if (Arch.isNVPTX())
     return Args.MakeArgStringRef(OffloadArchToString(Arch));
 
-  if (IsAMDOffloadArch(Arch)) {
+  if (Arch.isAMDGPU() || Arch.isSPIRV()) {
     llvm::StringMap<bool> Features;
     std::optional<StringRef> Arch = parseTargetID(Triple, ArchStr, &Features);
     if (!Arch) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1060,7 +1060,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       const ToolChain *TC = I.second;
       for (BoundArch Arch :
            D.getOffloadArchs(C, C.getArgs(), Action::OFK_Cuda, *TC)) {
-        if (IsNVIDIAOffloadArch(Arch.Arch))
+        if (Arch.Arch.isNVPTX())
           ArchIDs.insert(CudaArchToID(Arch.Arch));
       }
     }

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -750,9 +750,9 @@ static Error runAOTCompile(StringRef InputFile, StringRef OutputFile,
                            const ArgList &Args) {
   StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
   OffloadArch OA = StringToOffloadArch(Arch);
-  if (IsIntelGPUOffloadArch(OA))
+  if (OA.isIntelGPU())
     return runAOTCompileIntelGPU(InputFile, OutputFile, Args);
-  if (IsIntelCPUOffloadArch(OA))
+  if (OA.isIntelCPU())
     return runAOTCompileIntelCPU(InputFile, OutputFile, Args);
 
   llvm_unreachable("runAOTCompile dispatched on unsupported arch");
@@ -978,8 +978,8 @@ static Error runSYCLLink(ArrayRef<std::unique_ptr<MemoryBuffer>> Inputs,
     SplitModules = std::move(*SplitModulesOrErr);
   }
 
-  bool IsAOTCompileNeeded = IsIntelOffloadArch(
-      StringToOffloadArch(Args.getLastArgValue(OPT_arch_EQ)));
+  bool IsAOTCompileNeeded =
+      StringToOffloadArch(Args.getLastArgValue(OPT_arch_EQ)).isIntel();
 
   StringRef OutputFileNameExt = ".spv";
 

--- a/clang/unittests/Basic/OffloadArchTest.cpp
+++ b/clang/unittests/Basic/OffloadArchTest.cpp
@@ -13,28 +13,38 @@ using namespace clang;
 
 static OffloadArch parse(llvm::StringRef S) { return StringToOffloadArch(S); }
 
-TEST(OffloadArchTest, VendorClassification) {
-  EXPECT_TRUE(IsNVIDIAOffloadArch(parse("sm_20")));
-  EXPECT_TRUE(IsNVIDIAOffloadArch(parse("sm_120a")));
-  EXPECT_FALSE(IsNVIDIAOffloadArch(parse("gfx600")));
+TEST(OffloadArchTest, TargetArchClassification) {
+  OffloadArch NV = parse("sm_120a");
+  EXPECT_TRUE(parse("sm_20").isNVPTX());
+  EXPECT_TRUE(NV.isNVPTX());
+  EXPECT_FALSE(NV.isAMDGPU());
 
-  EXPECT_FALSE(IsAMDOffloadArch(parse("sm_120a")));
-  EXPECT_TRUE(IsAMDOffloadArch(parse("gfx600")));
-  EXPECT_TRUE(IsAMDOffloadArch(parse("gfx1201")));
-  EXPECT_TRUE(IsAMDOffloadArch(parse("gfx12-generic")));
-  EXPECT_TRUE(IsAMDOffloadArch(parse("amdgcnspirv")));
-  EXPECT_FALSE(IsAMDOffloadArch(parse("graniterapids")));
+  EXPECT_TRUE(parse("gfx600").isAMDGPU());
+  EXPECT_TRUE(parse("gfx1201").isAMDGPU());
+  EXPECT_TRUE(parse("gfx12-generic").isAMDGPU());
+  EXPECT_FALSE(parse("gfx600").isNVPTX());
 
-  EXPECT_TRUE(IsIntelOffloadArch(parse("graniterapids")));
-  EXPECT_TRUE(IsIntelCPUOffloadArch(parse("graniterapids")));
-  EXPECT_FALSE(IsIntelGPUOffloadArch(parse("graniterapids")));
-  EXPECT_TRUE(IsIntelOffloadArch(parse("bmg_g21")));
-  EXPECT_FALSE(IsIntelCPUOffloadArch(parse("bmg_g21")));
-  EXPECT_TRUE(IsIntelGPUOffloadArch(parse("bmg_g21")));
+  OffloadArch SPIRV = parse("amdgcnspirv");
+  EXPECT_FALSE(SPIRV.isAMDGPU());
+  EXPECT_TRUE(SPIRV.isSPIRV());
 
-  EXPECT_FALSE(IsNVIDIAOffloadArch(parse("generic")));
-  EXPECT_FALSE(IsAMDOffloadArch(parse("generic")));
-  EXPECT_FALSE(IsIntelOffloadArch(parse("generic")));
+  OffloadArch IntelCPU = parse("graniterapids");
+  EXPECT_FALSE(IntelCPU.isAMDGPU());
+  EXPECT_FALSE(IntelCPU.isSPIRV());
+  EXPECT_TRUE(IntelCPU.isIntel());
+  EXPECT_TRUE(IntelCPU.isIntelCPU());
+  EXPECT_FALSE(IntelCPU.isIntelGPU());
+
+  OffloadArch IntelGPU = parse("bmg_g21");
+  EXPECT_TRUE(IntelGPU.isIntel());
+  EXPECT_FALSE(IntelGPU.isIntelCPU());
+  EXPECT_TRUE(IntelGPU.isIntelGPU());
+
+  OffloadArch Generic = parse("generic");
+  EXPECT_FALSE(Generic.isNVPTX());
+  EXPECT_FALSE(Generic.isAMDGPU());
+  EXPECT_FALSE(Generic.isSPIRV());
+  EXPECT_FALSE(Generic.isIntel());
 }
 
 TEST(OffloadArchTest, Unknown) {


### PR DESCRIPTION
Drop the IsNVIDIAOffloadArch/IsAMDOffloadArch/IsIntel*OffloadArch free
functions in favor of the OffloadArch member predicate functions.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>