### PR TITLE
[mlir][xegpu] Promote whole-buffer memrefs to vectors before VectorToXeGPU lowering

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -1752,6 +1752,14 @@ def ConvertVectorToXeGPU : Pass<"convert-vector-to-xegpu"> {
     "memref::MemRefDialect", "arith::ArithDialect",
     "vector::VectorDialect", "xegpu::XeGPUDialect"
   ];
+  let options = [
+    Option<"maxPromotedBufferBytes", "max-promoted-buffer-bytes", "uint64_t",
+           /*default=*/"4096",
+           "Maximum size in bytes of a whole-buffer `memref.alloc` that the "
+           "pre-lowering promotion may turn into a vector SSA value. Larger "
+           "buffers are left as memory to avoid materializing oversized "
+           "vectors.">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Conversion/VectorToXeGPU/VectorToXeGPU.h
+++ b/mlir/include/mlir/Conversion/VectorToXeGPU/VectorToXeGPU.h
@@ -12,6 +12,8 @@
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
+class DialectRegistry;
+class Operation;
 class Pass;
 class RewritePatternSet;
 
@@ -21,6 +23,25 @@ class RewritePatternSet;
 /// Collect a set of patterns to convert from the vector to XeGPU ops.
 void populateVectorToXeGPUConversionPatterns(RewritePatternSet &patterns);
 
+namespace xegpu {
+
+/// Attaches the Mem2Reg interface external models used by whole-buffer
+/// promotion to `memref.alloc`, `vector.transfer_read` and
+/// `vector.transfer_write`. Intended to be called from a pass's
+/// `getDependentDialects` so the models are visible only within pipelines that
+/// contain that pass.
+void registerWholeBufferPromotionExternalModels(DialectRegistry &registry);
+
+/// Promotes every `memref.alloc` under `scopeOp` that is only ever accessed as
+/// a whole buffer through `vector.transfer_read`/`vector.transfer_write` into a
+/// single vector SSA value, reusing the upstream Mem2Reg driver (which threads
+/// the value through `scf.for` as an iter_arg/result when the accesses live in
+/// a loop). Allocations larger than `maxPromotedBytes`, or with any other use,
+/// are left untouched. Requires the external models above to be registered on
+/// `scopeOp`'s context.
+void promoteWholeBufferAllocs(Operation *scopeOp, uint64_t maxPromotedBytes);
+
+} // namespace xegpu
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_VECTORTOXEGPU_VECTORTOXEGPU_H

--- a/mlir/lib/Conversion/VectorToXeGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToXeGPU/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_conversion_library(MLIRVectorToXeGPU
   VectorToXeGPU.cpp
+  WholeBufferPromotion.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToXeGPU
@@ -8,9 +9,12 @@ add_mlir_conversion_library(MLIRVectorToXeGPU
   MLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRAnalysis
   MLIRArithDialect
+  MLIRMemorySlotInterfaces
   MLIRMemRefDialect
   MLIRTransforms
+  MLIRUBDialect
   MLIRVectorDialect
   MLIRVectorToGPU
   MLIRXeGPUDialect

--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -1035,7 +1035,21 @@ static void promoteAllocasToSLM(Operation *root) {
 
 struct ConvertVectorToXeGPUPass
     : public impl::ConvertVectorToXeGPUBase<ConvertVectorToXeGPUPass> {
+  using ConvertVectorToXeGPUBase::ConvertVectorToXeGPUBase;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    ConvertVectorToXeGPUBase::getDependentDialects(registry);
+    // Register the Mem2Reg interface models used by whole-buffer promotion
+    // only for this pass, so no other pipeline is affected.
+    xegpu::registerWholeBufferPromotionExternalModels(registry);
+  }
+
   void runOnOperation() override {
+    // Promote whole-buffer scratch allocations (e.g. bufferized reduction /
+    // accumulator buffers carried across scf.for) into vector SSA values before
+    // lowering, so they are not spilled to the stack.
+    xegpu::promoteWholeBufferAllocs(getOperation(), maxPromotedBufferBytes);
+
     // Promote local allocations to SLM (address space 3) so that
     // load_matrix/store_matrix lowerings have well-typed memref operands.
     promoteAllocasToSLM(getOperation());

--- a/mlir/lib/Conversion/VectorToXeGPU/WholeBufferPromotion.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/WholeBufferPromotion.cpp
@@ -1,0 +1,256 @@
+//===- WholeBufferPromotion.cpp - Mem2Reg for XeGPU preprocessing ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements a VectorToXeGPU-local, Mem2Reg-style promotion of whole-buffer
+// `memref.alloc`s into vector SSA values. See WholeBufferPromotion.h for the
+// rationale. The heavy lifting (dominator walk, reaching-definition
+// construction, and `scf.for` iter_arg/result threading) is delegated to the
+// upstream `tryToPromoteMemorySlots` driver; this file only supplies the
+// interface models that teach that driver how a whole-buffer transfer behaves
+// as a load/store.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/VectorToXeGPU/VectorToXeGPU.h"
+
+#include "mlir/Analysis/DataLayoutAnalysis.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Interfaces/MemorySlotInterfaces.h"
+#include "mlir/Transforms/Mem2Reg.h"
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+//  Utilities
+//===----------------------------------------------------------------------===//
+
+/// Returns whether `xferOp` accesses exactly the whole contents of `slot`, so
+/// it can act as a plain whole-buffer load/store during promotion.
+static bool
+isWholeBufferTransfer(VectorTransferOpInterface xferOp, const MemorySlot &slot,
+                      const SmallPtrSetImpl<OpOperand *> &blockingUses) {
+  // The sole blocking use must be the slot pointer as the transfer's base.
+  if (blockingUses.size() != 1)
+    return false;
+  Value blockingUse = (*blockingUses.begin())->get();
+  if (blockingUse != slot.ptr || xferOp.getBase() != slot.ptr)
+    return false;
+
+  // Reject the tensor form (slot pointers are memrefs, so this is defensive).
+  if (!isa<MemRefType>(xferOp.getBase().getType()))
+    return false;
+
+  // Exact type match pins rank/extents/element type and rejects scalable
+  // vectors.
+  if (xferOp.getVectorType() != slot.elemType)
+    return false;
+
+  // Access must start at the buffer origin in every dimension.
+  for (Value index : xferOp.getIndices()) {
+    std::optional<int64_t> constIndex = getConstantIntValue(index);
+    if (!constIndex || *constIndex != 0)
+      return false;
+  }
+
+  // Identity map: no broadcast or transpose.
+  if (!xferOp.getPermutationMap().isIdentity())
+    return false;
+
+  // All dimensions in bounds: no out-of-buffer element, no padding applied.
+  if (xferOp.hasOutOfBoundsDim())
+    return false;
+
+  // A mask could make the access partial.
+  if (xferOp.getMask())
+    return false;
+
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//  Interface models
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Promotable-allocation model for `memref.alloc`. `memref.alloca` already
+/// carries this interface from ODS (and is only ever promoted as a scalar
+/// slot); attaching to `alloc` is conflict-free and lets whole-buffer heap
+/// scratch produced by bufferization be promoted without a prior
+/// promote-buffers-to-stack step.
+struct AllocOpPromotableModel
+    : public PromotableAllocationOpInterface::ExternalModel<
+          AllocOpPromotableModel, memref::AllocOp> {
+  SmallVector<MemorySlot> getPromotableSlots(Operation *op) const {
+    auto allocOp = cast<memref::AllocOp>(op);
+    MemRefType type = allocOp.getType();
+    if (!type.hasStaticShape())
+      return {};
+
+    // Only a whole-buffer vector slot is offered here; the single-element
+    // scalar case is already covered by memref.alloca upstream and is not the
+    // pattern this preprocessing targets. The buffer-size cap is applied by the
+    // caller (promoteWholeBufferAllocs), which filters the allocator list.
+    if (type.getNumElements() <= 1)
+      return {};
+    if (!VectorType::isValidElementType(type.getElementType()))
+      return {};
+
+    return {
+        MemorySlot{allocOp.getResult(),
+                   VectorType::get(type.getShape(), type.getElementType())}};
+  }
+
+  Value getDefaultValue(Operation *op, const MemorySlot &slot,
+                        OpBuilder &builder) const {
+    return ub::PoisonOp::create(builder, op->getLoc(), slot.elemType);
+  }
+
+  void handleBlockArgument(Operation *op, const MemorySlot &slot,
+                           BlockArgument argument, OpBuilder &builder) const {}
+
+  std::optional<PromotableAllocationOpInterface>
+  handlePromotionComplete(Operation *op, const MemorySlot &slot,
+                          Value defaultValue, OpBuilder &builder) const {
+    if (defaultValue && defaultValue.use_empty())
+      defaultValue.getDefiningOp()->erase();
+    op->erase();
+    return std::nullopt;
+  }
+};
+
+struct TransferReadOpMemOpModel
+    : public PromotableMemOpInterface::ExternalModel<TransferReadOpMemOpModel,
+                                                     vector::TransferReadOp> {
+  bool loadsFrom(Operation *op, const MemorySlot &slot) const {
+    return cast<vector::TransferReadOp>(op).getBase() == slot.ptr;
+  }
+
+  bool storesTo(Operation *op, const MemorySlot &slot) const { return false; }
+
+  Value getStored(Operation *op, const MemorySlot &slot, OpBuilder &builder,
+                  Value reachingDef, const DataLayout &dataLayout) const {
+    llvm_unreachable("getStored should not be called on TransferReadOp");
+  }
+
+  bool canUsesBeRemoved(Operation *op, const MemorySlot &slot,
+                        const SmallPtrSetImpl<OpOperand *> &blockingUses,
+                        SmallVectorImpl<OpOperand *> &newBlockingUses,
+                        const DataLayout &dataLayout) const {
+    return isWholeBufferTransfer(cast<vector::TransferReadOp>(op), slot,
+                                 blockingUses);
+  }
+
+  DeletionKind
+  removeBlockingUses(Operation *op, const MemorySlot &slot,
+                     const SmallPtrSetImpl<OpOperand *> &blockingUses,
+                     OpBuilder &builder, Value reachingDefinition,
+                     const DataLayout &dataLayout) const {
+    // Whole-buffer read: replace the loaded vector with the reaching
+    // definition.
+    cast<vector::TransferReadOp>(op).getVector().replaceAllUsesWith(
+        reachingDefinition);
+    return DeletionKind::Delete;
+  }
+};
+
+struct TransferWriteOpMemOpModel
+    : public PromotableMemOpInterface::ExternalModel<TransferWriteOpMemOpModel,
+                                                     vector::TransferWriteOp> {
+  bool loadsFrom(Operation *op, const MemorySlot &slot) const { return false; }
+
+  bool storesTo(Operation *op, const MemorySlot &slot) const {
+    return cast<vector::TransferWriteOp>(op).getBase() == slot.ptr;
+  }
+
+  Value getStored(Operation *op, const MemorySlot &slot, OpBuilder &builder,
+                  Value reachingDef, const DataLayout &dataLayout) const {
+    return cast<vector::TransferWriteOp>(op).getValueToStore();
+  }
+
+  bool canUsesBeRemoved(Operation *op, const MemorySlot &slot,
+                        const SmallPtrSetImpl<OpOperand *> &blockingUses,
+                        SmallVectorImpl<OpOperand *> &newBlockingUses,
+                        const DataLayout &dataLayout) const {
+    // No self-store guard needed: a vector value can never equal a memref slot.
+    return isWholeBufferTransfer(cast<vector::TransferWriteOp>(op), slot,
+                                 blockingUses);
+  }
+
+  DeletionKind
+  removeBlockingUses(Operation *op, const MemorySlot &slot,
+                     const SmallPtrSetImpl<OpOperand *> &blockingUses,
+                     OpBuilder &builder, Value reachingDefinition,
+                     const DataLayout &dataLayout) const {
+    return DeletionKind::Delete;
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+//  Public entry points
+//===----------------------------------------------------------------------===//
+
+void mlir::xegpu::registerWholeBufferPromotionExternalModels(
+    DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, memref::MemRefDialect *dialect) {
+    memref::AllocOp::attachInterface<AllocOpPromotableModel>(*ctx);
+  });
+  registry.addExtension(+[](MLIRContext *ctx, vector::VectorDialect *dialect) {
+    vector::TransferReadOp::attachInterface<TransferReadOpMemOpModel>(*ctx);
+    vector::TransferWriteOp::attachInterface<TransferWriteOpMemOpModel>(*ctx);
+  });
+}
+
+void mlir::xegpu::promoteWholeBufferAllocs(Operation *scopeOp,
+                                           uint64_t maxPromotedBytes) {
+  DataLayoutAnalysis dataLayoutAnalysis(scopeOp);
+  const DataLayout &dataLayout = dataLayoutAnalysis.getAtOrAbove(scopeOp);
+  DominanceInfo dominance(scopeOp);
+
+  // Returns the in-memory size in bytes of `allocOp`'s static, whole-buffer
+  // result, or nullopt if it is not a candidate for size-capped promotion.
+  auto allocByteSize = [&](PromotableAllocationOpInterface allocator)
+      -> std::optional<uint64_t> {
+    auto allocOp = dyn_cast<memref::AllocOp>(allocator.getOperation());
+    if (!allocOp)
+      return std::nullopt;
+    MemRefType type = allocOp.getType();
+    if (!type.hasStaticShape())
+      return std::nullopt;
+    uint64_t elementBytes = dataLayout.getTypeSize(type.getElementType());
+    return elementBytes * static_cast<uint64_t>(type.getNumElements());
+  };
+
+  for (Region &region : scopeOp->getRegions()) {
+    if (region.getBlocks().empty())
+      continue;
+
+    OpBuilder builder(&region.front(), region.front().begin());
+
+    SmallVector<PromotableAllocationOpInterface> allocators;
+    region.walk([&](PromotableAllocationOpInterface allocator) {
+      // Enforce the buffer-size cap here (the interface model cannot carry the
+      // pass option). Allocators too large to promote are simply not offered.
+      if (std::optional<uint64_t> bytes = allocByteSize(allocator))
+        if (*bytes > maxPromotedBytes)
+          return;
+      allocators.emplace_back(allocator);
+    });
+
+    // Iteratively promote as many slots as possible; the driver leaves any
+    // non-whole-buffer allocation untouched with zero IR mutation.
+    (void)tryToPromoteMemorySlots(allocators, builder, dataLayout, dominance);
+  }
+}

--- a/mlir/test/Conversion/VectorToXeGPU/whole-buffer-promotion-e2e.mlir
+++ b/mlir/test/Conversion/VectorToXeGPU/whole-buffer-promotion-e2e.mlir
@@ -1,0 +1,34 @@
+// RUN: mlir-opt %s -convert-vector-to-xegpu -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -convert-vector-to-xegpu="max-promoted-buffer-bytes=8" -split-input-file | FileCheck %s --check-prefix=CAP
+
+// End-to-end check that convert-vector-to-xegpu promotes a whole-buffer
+// accumulator carried across scf.for into a vector SSA value (threaded as an
+// iter_arg/result) before lowering, so nothing is spilled to memory.
+
+// CHECK-LABEL: func.func @acc_in_loop
+//    CHECK-NOT:   memref.alloc
+//    CHECK-NOT:   vector.transfer
+//    CHECK-NOT:   xegpu.
+//        CHECK:   %[[RES:.*]] = scf.for {{.*}} iter_args(%[[IT:.*]] = %{{.*}}) -> (vector<4xf32>)
+//        CHECK:     %[[NEXT:.*]] = arith.addf %[[IT]], %[[IT]] : vector<4xf32>
+//        CHECK:     scf.yield %[[NEXT]] : vector<4xf32>
+//        CHECK:   return %[[RES]] : vector<4xf32>
+
+// With an 8-byte cap the 16-byte buffer is not promoted and lowers to XeGPU
+// memory ops instead.
+// CAP-LABEL: func.func @acc_in_loop
+//       CAP:   scf.for
+//       CAP:   xegpu.{{load|store}}
+func.func @acc_in_loop(%pad: f32, %lb: index, %ub: index, %step: index) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  scf.for %i = %lb to %ub step %step {
+    %v = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+    %n = arith.addf %v, %v : vector<4xf32>
+    vector.transfer_write %n, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  }
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+  return %r : vector<4xf32>
+}

--- a/mlir/test/Conversion/VectorToXeGPU/whole-buffer-promotion.mlir
+++ b/mlir/test/Conversion/VectorToXeGPU/whole-buffer-promotion.mlir
@@ -1,0 +1,196 @@
+// RUN: mlir-opt %s --test-xegpu-whole-buffer-promotion --split-input-file | FileCheck %s
+// RUN: mlir-opt %s --test-xegpu-whole-buffer-promotion="max-promoted-buffer-bytes=8" --split-input-file | FileCheck %s --check-prefix=CAP
+
+// A memref.alloc that is only ever accessed as a whole buffer through
+// vector.transfer_read / vector.transfer_write is promoted to a single vector
+// SSA value. This is the VectorToXeGPU-local, Mem2Reg-style promotion used as a
+// pre-lowering step; it is exercised here in isolation.
+
+// CHECK-LABEL: func.func @whole_buffer_write_read
+//   CHECK-SAME:   (%[[PAD:.*]]: f32)
+//    CHECK-NOT:   memref.alloc
+//    CHECK-NOT:   vector.transfer_write
+//    CHECK-NOT:   vector.transfer_read
+//        CHECK:   %[[CST:.*]] = arith.constant dense<1.000000e+00> : vector<4xf32>
+//        CHECK:   return %[[CST]] : vector<4xf32>
+func.func @whole_buffer_write_read(%pad: f32) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// -----
+
+// A whole-buffer slot carried across scf.for is threaded as an iter_arg/result.
+
+// CHECK-LABEL: func.func @whole_buffer_in_loop
+//    CHECK-NOT:   memref.alloc
+//    CHECK-NOT:   vector.transfer_write
+//    CHECK-NOT:   vector.transfer_read
+//        CHECK:   %[[RES:.*]] = scf.for {{.*}} iter_args(%[[IT:.*]] = %{{.*}}) -> (vector<4xf32>)
+//        CHECK:     %[[NEXT:.*]] = arith.addf %[[IT]], %[[IT]] : vector<4xf32>
+//        CHECK:     scf.yield %[[NEXT]] : vector<4xf32>
+//        CHECK:   return %[[RES]] : vector<4xf32>
+func.func @whole_buffer_in_loop(%pad: f32, %lb: index, %ub: index, %step: index) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  scf.for %i = %lb to %ub step %step {
+    %v = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+    %n = arith.addf %v, %v : vector<4xf32>
+    vector.transfer_write %n, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  }
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// -----
+
+// A multi-dimensional whole-buffer memref is promoted to a matching vector.
+
+// CHECK-LABEL: func.func @whole_buffer_2d
+//    CHECK-NOT:   memref.alloc
+//    CHECK-NOT:   vector.transfer
+//        CHECK:   return %{{.*}} : vector<2x4xf32>
+func.func @whole_buffer_2d(%pad: f32) -> vector<2x4xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<2x4xf32>
+  %a = memref.alloc() : memref<2x4xf32>
+  vector.transfer_write %cst, %a[%c0, %c0] {in_bounds = [true, true]} : vector<2x4xf32>, memref<2x4xf32>
+  %r = vector.transfer_read %a[%c0, %c0], %pad {in_bounds = [true, true]} : memref<2x4xf32>, vector<2x4xf32>
+  return %r : vector<2x4xf32>
+}
+
+// -----
+
+// The byte cap gates promotion: a 16-byte buffer is promoted under the default
+// 4096-byte cap (CHECK) but left as memory under an 8-byte cap (CAP).
+
+//  CHECK-LABEL: func.func @size_cap
+//    CHECK-NOT:   memref.alloc
+//        CHECK:   return %{{.*}} : vector<4xf32>
+
+//    CAP-LABEL: func.func @size_cap
+//        CAP:   memref.alloc
+//        CAP:   vector.transfer_write
+//        CAP:   vector.transfer_read
+func.func @size_cap(%pad: f32) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// -----
+
+// Non-zero access offset: the transfer does not cover the whole buffer, so the
+// slot must NOT be promoted.
+
+// CHECK-LABEL: func.func @negative_nonzero_index
+//        CHECK:   memref.alloc
+//        CHECK:   vector.transfer_write
+//        CHECK:   vector.transfer_read
+func.func @negative_nonzero_index(%pad: f32) -> vector<4xf32> {
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<8xf32>
+  vector.transfer_write %cst, %a[%c1] {in_bounds = [true]} : vector<4xf32>, memref<8xf32>
+  %r = vector.transfer_read %a[%c1], %pad {in_bounds = [true]} : memref<8xf32>, vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// -----
+
+// A masked transfer only touches part of the buffer: must NOT be promoted.
+
+// CHECK-LABEL: func.func @negative_masked
+//        CHECK:   memref.alloc
+//        CHECK:   vector.transfer_write
+//        CHECK:   vector.transfer_read
+func.func @negative_masked(%pad: f32, %m: vector<4xi1>) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0], %m {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// -----
+
+// A partial (out-of-bounds) transfer must NOT be promoted.
+
+// CHECK-LABEL: func.func @negative_out_of_bounds
+//        CHECK:   memref.alloc
+//        CHECK:   vector.transfer_write
+//        CHECK:   vector.transfer_read
+func.func @negative_out_of_bounds(%pad: f32) -> vector<8xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<8xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] : vector<8xf32>, memref<4xf32>
+  %r = vector.transfer_read %a[%c0], %pad : memref<4xf32>, vector<8xf32>
+  return %r : vector<8xf32>
+}
+
+// -----
+
+// A non-identity (transposing) permutation map is not a whole-buffer identity
+// access: must NOT be promoted.
+
+// CHECK-LABEL: func.func @negative_transpose_map
+//        CHECK:   memref.alloc
+//        CHECK:   vector.transfer_write
+//        CHECK:   vector.transfer_read
+func.func @negative_transpose_map(%pad: f32) -> vector<4x2xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<2x4xf32>
+  %a = memref.alloc() : memref<2x4xf32>
+  vector.transfer_write %cst, %a[%c0, %c0] {in_bounds = [true, true]} : vector<2x4xf32>, memref<2x4xf32>
+  %r = vector.transfer_read %a[%c0, %c0], %pad {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>} : memref<2x4xf32>, vector<4x2xf32>
+  return %r : vector<4x2xf32>
+}
+
+// -----
+
+// An alloc also accessed through a scalar memref.load cannot be promoted to a
+// vector: must NOT be promoted.
+
+// CHECK-LABEL: func.func @negative_mixed_scalar_access
+//        CHECK:   memref.alloc
+//        CHECK:   vector.transfer_write
+//        CHECK:   vector.transfer_read
+//        CHECK:   memref.load
+func.func @negative_mixed_scalar_access(%pad: f32) -> (vector<4xf32>, f32) {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<4xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] {in_bounds = [true]} : vector<4xf32>, memref<4xf32>
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<4xf32>
+  %s = memref.load %a[%c0] : memref<4xf32>
+  return %r, %s : vector<4xf32>, f32
+}
+
+// -----
+
+// A scalable vector never equals the fixed-size slot type: must NOT be
+// promoted.
+
+// CHECK-LABEL: func.func @negative_scalable
+//        CHECK:   memref.alloc
+//        CHECK:   vector.transfer_write
+//        CHECK:   vector.transfer_read
+func.func @negative_scalable(%pad: f32) -> vector<[4]xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<1.0> : vector<[4]xf32>
+  %a = memref.alloc() : memref<4xf32>
+  vector.transfer_write %cst, %a[%c0] {in_bounds = [true]} : vector<[4]xf32>, memref<4xf32>
+  %r = vector.transfer_read %a[%c0], %pad {in_bounds = [true]} : memref<4xf32>, vector<[4]xf32>
+  return %r : vector<[4]xf32>
+}

--- a/mlir/test/lib/Dialect/XeGPU/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/XeGPU/CMakeLists.txt
@@ -6,8 +6,13 @@ add_mlir_dialect_library(MLIRXeGPUTestPasses
 
 mlir_target_link_libraries(MLIRXeGPUTestPasses PUBLIC
   MLIRAffineUtils
+  MLIRFuncDialect
   MLIRIR
   MLIRMemRefDialect
+  MLIRSCFDialect
+  MLIRUBDialect
+  MLIRVectorDialect
+  MLIRVectorToXeGPU
   MLIRXeGPUDialect
   MLIRPass
   MLIRTransforms

--- a/mlir/test/lib/Dialect/XeGPU/TestXeGPUTransforms.cpp
+++ b/mlir/test/lib/Dialect/XeGPU/TestXeGPUTransforms.cpp
@@ -6,11 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Conversion/VectorToXeGPU/VectorToXeGPU.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Dialect/XeGPU/IR/XeGPU.h"
 #include "mlir/Dialect/XeGPU/Transforms/Transforms.h"
@@ -546,6 +550,42 @@ private:
   }
 };
 
+struct TestXeGPUWholeBufferPromotion
+    : public PassWrapper<TestXeGPUWholeBufferPromotion,
+                         OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestXeGPUWholeBufferPromotion)
+
+  StringRef getArgument() const final {
+    return "test-xegpu-whole-buffer-promotion";
+  }
+
+  StringRef getDescription() const final {
+    return "Test the whole-buffer memref-to-vector promotion used by "
+           "convert-vector-to-xegpu in isolation";
+  }
+
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect>();
+    registry.insert<vector::VectorDialect>();
+    registry.insert<scf::SCFDialect>();
+    registry.insert<ub::UBDialect>();
+    xegpu::registerWholeBufferPromotionExternalModels(registry);
+  }
+
+  TestXeGPUWholeBufferPromotion() = default;
+  TestXeGPUWholeBufferPromotion(const TestXeGPUWholeBufferPromotion &pass)
+      : PassWrapper(pass) {}
+
+  Option<uint64_t> maxPromotedBufferBytes{
+      *this, "max-promoted-buffer-bytes",
+      llvm::cl::desc("Maximum size in bytes of a promoted whole-buffer alloc"),
+      llvm::cl::init(4096)};
+
+  void runOnOperation() override {
+    xegpu::promoteWholeBufferAllocs(getOperation(), maxPromotedBufferBytes);
+  }
+};
+
 } // namespace
 
 namespace mlir {
@@ -559,6 +599,7 @@ void registerTestXeGPULowerings() {
   PassRegistration<TestXeGPUResolveLayoutConflicts>();
   PassRegistration<TestXeGPUArrayLengthOptimization>();
   PassRegistration<TestXeGPUCoalesceGatherScatter>();
+  PassRegistration<TestXeGPUWholeBufferPromotion>();
 }
 } // namespace test
 } // namespace mlir


### PR DESCRIPTION
This adds a Mem2Reg-style pre-lowering step to `convert-vector-to-xegpu` that
promotes a `memref.alloc` accessed only as a whole buffer (via
`vector.transfer_read`/`vector.transfer_write`) into a single vector SSA value —
threaded through `scf.for` as an iter_arg/result when the accesses live inside a
loop.

### Motivation

When a vectorized `scf.for` carries a reduction/accumulation tensor (the
accumulator of a contraction, or a reduction buffer), bufferization materializes
it into a scratch memref whose only accesses are a whole-buffer store and a
whole-buffer reload at index 0. This is effectively an SSA vector spilled to
memory, and it blocks downstream vectorization and register allocation on XeGPU.

### Approach

Rather than modifying the general Mem2Reg infrastructure — which would affect all
downstream users — this reuses the upstream `tryToPromoteMemorySlots` driver but
registers the required interface external models **only** in this pass's
`getDependentDialects`, so no other pipeline is affected:

- `memref.AllocOp` gets a `PromotableAllocationOpInterface` model offering a
  whole-buffer vector slot. (`AllocOp`, unlike `AllocaOp`, does not declare this
  interface in ODS, so attaching an external model is conflict-free.)
- `vector.transfer_read`/`vector.transfer_write` get `PromotableMemOpInterface`
  models, gated by an `isWholeBufferTransfer` predicate: single blocking use on
  the slot pointer, exact vector/memref type match, all-zero indices, identity
  permutation map, all dims in bounds, and no mask. Any access that is not a
  whole-buffer transfer fails its own `canUsesBeRemoved` check and aborts
  promotion of that slot with zero IR mutation.

The upstream driver already threads a slot of arbitrary type through `scf.for` as
an iter_arg/result, so the loop-carried accumulator case works with no changes to
the pass or to SCF.

A `max-promoted-buffer-bytes` pass option (default 4096) caps promotion so large
buffers are not materialized as oversized vectors — the opposite of the intended
benefit.

### Tests

- `test-xegpu-whole-buffer-promotion`: an isolated test pass exercising the
  promotion directly — straight-line, `scf.for`-threaded, 2-D, the byte-size
  cap, and six negative cases (non-zero offset, mask, out-of-bounds, transposing
  map, mixed scalar access, scalable vector).
- An end-to-end `convert-vector-to-xegpu` test showing a loop-carried
  accumulator promoted to a vector iter_arg vs. left as XeGPU memory ops when the
  buffer exceeds the cap.


Assisted by Claude
