### PR TITLE
[lldb] Launch the Wasm runtime with the file the target has

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -10,6 +10,7 @@
 #include "Plugins/Platform/WebAssembly/PlatformWasmRemoteGDBServer.h"
 #include "Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.h"
 #include "Plugins/Process/wasm/ProcessWasm.h"
+#include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/ProcessLaunchInfo.h"
@@ -183,7 +184,19 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
       args.AppendArgument(
           llvm::formatv("{0}{1}", env_arg, Environment::compose(kv)).str());
 
-  args.AppendArguments(launch_info.GetArguments());
+  // The runtime is handed the module to run as a path on this host. A launch
+  // takes its executable from the name the module goes by on the platform,
+  // which for a module reported by a stub is a name of the stub's choosing
+  // rather than a path that resolves here, so run the file the target has.
+  Args inferior_args = launch_info.GetArguments();
+  if (ModuleSP exe_module_sp = target.GetExecutableModule()) {
+    const std::string exe_path = exe_module_sp->GetFileSpec().GetPath();
+    if (inferior_args.GetArgumentCount() > 0)
+      inferior_args.ReplaceArgumentAtIndex(0, exe_path);
+    else
+      inferior_args.AppendArgument(exe_path);
+  }
+  args.AppendArguments(inferior_args);
 
   launch_info.SetArguments(args, true);
   launch_info.SetLaunchInSeparateProcessGroup(true);


### PR DESCRIPTION
PlatformWasm hands the runtime the module to run as a path on the host it launches the runtime on. It takes that path from the launch info, whose executable is the name the module goes by on the platform. That name is whatever a stub reported the module under, which need not be a path that resolves on this host, so a relaunch runs a file that does not exist:

```
(lldb) run
error: WebAssembly runtime exited with exit code 255
```

Run the file the target has instead. Only a runtime launched on this host is affected, since a connection to a remote Wasm platform delegates the launch to that platform.