### PR TITLE
[Offload][Lang] Get LastError for bad Kernels

### DIFF
--- a/offload/languages/include/hip/hip_runtime.h
+++ b/offload/languages/include/hip/hip_runtime.h
@@ -43,19 +43,4 @@ template <class T> static inline hipError_t hipHostFree(T *Ptr) {
 }
 #endif
 
-#if defined(__AMDGPU__) || defined(__NVPTX__)
-#define HIP_KERNEL_NAME(...) __VA_ARGS__
-
-extern "C" hipError_t hipLaunchKernel(const char *Kernel, dim3 GridDim,
-                                      dim3 BlockDim, void **KernelArgs,
-                                      size_t DynamicSharedMem, void *Stream);
-
-template <typename... AT, typename FT = void (*)(AT...)>
-static inline void hipLaunchKernelGGL(FT Kernel, dim3 GridDim, dim3 BlockDim,
-                                      size_t DynamicSharedMem, void *Stream,
-                                      AT... KernelArgs) {
-  Kernel<<<GridDim, BlockDim, DynamicSharedMem, Stream>>>(KernelArgs...);
-}
-#endif
-
 #endif // LLVM_OFFLOAD_LANGUAGES_INCLUDE_HIP_HIP_RUNTIME_H

--- a/offload/languages/kernel/include/LanguageUtils.h
+++ b/offload/languages/kernel/include/LanguageUtils.h
@@ -22,6 +22,13 @@ static inline Error_t convertResult(ol_result_t Result) {
   case OL_ERRC_INVALID_ARGUMENT:
   case OL_ERRC_INVALID_NULL_POINTER:
     return ErrorInvalidValue;
+  case OL_ERRC_INVALID_SIZE:
+    return ErrorInvalidConfiguration;
+  case OL_ERRC_INVALID_NULL_HANDLE:
+  case OL_ERRC_INVALID_QUEUE:
+  case OL_ERRC_INVALID_EVENT:
+  case OL_ERRC_INVALID_CONTEXT:
+    return ErrorInvalidResourceHandle;
   case OL_ERRC_INVALID_DEVICE:
     return ErrorInvalidDevice;
   default:
@@ -34,6 +41,12 @@ static inline Error_t setLastError(Error_t Error) {
   // TODO: find a more efficient way to set last error
   return static_cast<Error_t>(
       llvm::offload::ThreadStateTy::setLastError(Error));
+}
+
+/// Convert an ol_result_t to the active language's Error_t and set it as the
+/// last error for the current thread.
+static inline Error_t convertAndSetLastError(ol_result_t Result) {
+  return setLastError(convertResult(Result));
 }
 
 /// Convert a Stream_t to an ol_queue_handle_t.

--- a/offload/languages/kernel/src/LanguageLaunch.cpp
+++ b/offload/languages/kernel/src/LanguageLaunch.cpp
@@ -7,13 +7,24 @@
 //===----------------------------------------------------------------------===//
 
 #include "LanguageLaunch.h"
+#include "LanguageUtils.h"
 #include "State.h"
-
-#include <algorithm>
 #include <cstdio>
 
 using RuntimeState = llvm::offload::StateTy;
 using ThreadState = llvm::offload::ThreadStateTy;
+
+static constexpr ol_error_struct_t InvalidKernelError = {
+    OL_ERRC_INVALID_NULL_HANDLE, "kernel is not registered"};
+
+static constexpr ol_error_struct_t InvalidDeviceError = {OL_ERRC_INVALID_DEVICE,
+                                                         "invalid device"};
+
+static constexpr ol_error_struct_t InvalidArgumentError = {
+    OL_ERRC_INVALID_ARGUMENT, "invalid argument to kernel launch"};
+
+static constexpr ol_error_struct_t InvalidConfigurationError = {
+    OL_ERRC_INVALID_SIZE, "invalid kernel launch configuration"};
 
 /// Internal kernel launch implementation
 ol_result_t __llvmLaunchKernelImpl(const char *KernelID, dim3 GridDim,
@@ -21,16 +32,26 @@ ol_result_t __llvmLaunchKernelImpl(const char *KernelID, dim3 GridDim,
                                    size_t DynamicSharedMem, void *Stream) {
   ol_device_handle_t Device = ThreadState::getDefaultDevice();
   ol_symbol_handle_t Kernel = RuntimeState::getKernel(KernelID);
+  if (!Device)
+    return &InvalidDeviceError;
+  if (!KernelID || !KernelArgsPtr)
+    return &InvalidArgumentError;
+  if (!Kernel)
+    return &InvalidKernelError;
+
+  if (GridDim.x == 0 || GridDim.y == 0 || GridDim.z == 0 || BlockDim.x == 0 ||
+      BlockDim.y == 0 || BlockDim.z == 0)
+    return &InvalidConfigurationError;
 
   ol_kernel_launch_size_args_t LaunchSizeArgs;
   LaunchSizeArgs.Dimensions =
       1 + (GridDim.y > 1 || BlockDim.y > 1) + (GridDim.z > 1 || BlockDim.z > 1);
   LaunchSizeArgs.NumGroups.x = GridDim.x;
-  LaunchSizeArgs.NumGroups.y = std::max(GridDim.y, 1u);
-  LaunchSizeArgs.NumGroups.z = std::max(GridDim.z, 1u);
+  LaunchSizeArgs.NumGroups.y = GridDim.y;
+  LaunchSizeArgs.NumGroups.z = GridDim.z;
   LaunchSizeArgs.GroupSize.x = BlockDim.x;
-  LaunchSizeArgs.GroupSize.y = std::max(BlockDim.y, 1u);
-  LaunchSizeArgs.GroupSize.z = std::max(BlockDim.z, 1u);
+  LaunchSizeArgs.GroupSize.y = BlockDim.y;
+  LaunchSizeArgs.GroupSize.z = BlockDim.z;
   LaunchSizeArgs.DynSharedMemory = DynamicSharedMem;
 
   ol_queue_handle_t Queue = Stream ? reinterpret_cast<ol_queue_handle_t>(Stream)
@@ -42,6 +63,13 @@ ol_result_t __llvmLaunchKernelImpl(const char *KernelID, dim3 GridDim,
     size_t *ArgSizes;
   };
   OffloadKernelArgs *OKA = static_cast<OffloadKernelArgs *>(KernelArgsPtr);
+  if ((!OKA->Args) != (!OKA->ArgSizes))
+    return &InvalidArgumentError;
+  if (OKA->NumArgs > 0 && !OKA->Args)
+    return &InvalidArgumentError;
+  for (size_t I = 0; I < OKA->NumArgs; ++I)
+    if (!OKA->Args[I] || OKA->ArgSizes[I] == 0)
+      return &InvalidArgumentError;
 
   return olLaunchKernel(Queue, Device, Kernel, &LaunchSizeArgs,
                         /*Properties=*/nullptr, OKA->NumArgs, OKA->Args,
@@ -78,6 +106,7 @@ unsigned llvmLaunchKernel(const char *KernelID, dim3 GridDim, dim3 BlockDim,
                           void *Stream) {
   ol_result_t Result = __llvmLaunchKernelImpl(
       KernelID, GridDim, BlockDim, KernelArgsPtr, DynamicSharedMem, Stream);
+  convertAndSetLastError(Result);
   return Result ? Result->Code : 0;
 }
 

--- a/offload/languages/kernel/src/LanguageRuntime.cpp
+++ b/offload/languages/kernel/src/LanguageRuntime.cpp
@@ -31,10 +31,6 @@
 using RuntimeState = llvm::offload::StateTy;
 using ThreadState = llvm::offload::ThreadStateTy;
 
-static inline Error_t convertAndSetLastError(ol_result_t Result) {
-  return setLastError(convertResult(Result));
-}
-
 Error_t Malloc(void **DevPtr, size_t Size) {
   ol_device_handle_t Device = ThreadState::getDefaultDevice();
   ol_result_t Result = olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, DevPtr);

--- a/offload/test/offloading/CUDA/get_errs.cu
+++ b/offload/test/offloading/CUDA/get_errs.cu
@@ -1,0 +1,82 @@
+// clang-format off
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -pthread -std=c++17
+// RUN: %t | %fcheck-generic
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -fopenmp -pthread -std=c++17
+// RUN: %t | %fcheck-generic
+// clang-format on
+
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: x86_64-unknown-linux-gnu
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// UNSUPPORTED: amdgcn-amd-amdhsa-LTO
+// UNSUPPORTED: amdgpu-amd-amdhsa-LTO
+// UNSUPPORTED: intelgpu
+
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <mutex>
+#include <thread>
+
+static std::mutex PrintMutex;
+
+static void printError(int ThreadId, const char *Label, cudaError_t Error) {
+  std::lock_guard<std::mutex> Lock(PrintMutex);
+  printf("thread %d %s: %s\n", ThreadId, Label, cudaGetErrorName(Error));
+  std::fflush(stdout);
+}
+
+__global__ void errorKernel(float *d_out) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  d_out[idx] = idx * 0.5f;
+}
+
+void runTask(int ThreadId) {
+  const int N = 1 << 20;
+  size_t bytes = N * sizeof(float);
+
+  float *d_data;
+  cudaMalloc(&d_data, bytes);
+  printError(ThreadId, "cudaMalloc", cudaGetLastError());
+
+  ThreadId == 1 ? errorKernel<<<4096, 256>>>(d_data)
+                : errorKernel<<<4096, 0>>>(d_data);
+  printError(ThreadId, "kernel launch", cudaPeekAtLastError());
+
+  printError(ThreadId, "kernel launch get", cudaGetLastError());
+
+  printError(ThreadId, "kernel launch get again", cudaGetLastError());
+
+  cudaDeviceSynchronize();
+  cudaFree(d_data);
+}
+
+int main() {
+  printError(0, "initial", cudaPeekAtLastError());
+  // CHECK: thread 0 initial: cudaSuccess
+
+  std::thread t1(runTask, 1);
+  std::thread t2(runTask, 2);
+
+  t1.join();
+  t2.join();
+  // CHECK-DAG: thread 1 cudaMalloc: cudaSuccess
+  // CHECK-DAG: thread 2 cudaMalloc: cudaSuccess
+  // CHECK-DAG: thread 1 kernel launch: cudaSuccess
+  // CHECK-DAG: thread 2 kernel launch: cudaErrorInvalidConfiguration
+  // CHECK-DAG: thread 1 kernel launch get: cudaSuccess
+  // CHECK-DAG: thread 2 kernel launch get: cudaErrorInvalidConfiguration
+  // CHECK-DAG: thread 1 kernel launch get again: cudaSuccess
+  // CHECK-DAG: thread 2 kernel launch get again: cudaSuccess
+
+  std::thread t3(runTask, 3);
+  t3.join();
+  // CHECK: thread 3 cudaMalloc: cudaSuccess
+  // CHECK: thread 3 kernel launch: cudaErrorInvalidConfiguration
+  // CHECK: thread 3 kernel launch get: cudaErrorInvalidConfiguration
+  // CHECK: thread 3 kernel launch get again: cudaSuccess
+
+  printError(0, "joined", cudaGetLastError());
+  // CHECK: thread 0 joined: cudaSuccess
+
+  return 0;
+}

--- a/offload/test/offloading/HIP/get_errs.hip
+++ b/offload/test/offloading/HIP/get_errs.hip
@@ -1,0 +1,81 @@
+// clang-format off
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -pthread -std=c++17
+// RUN: %t | %fcheck-generic
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -fopenmp -pthread -std=c++17
+// RUN: %t | %fcheck-generic
+// clang-format on
+
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: x86_64-unknown-linux-gnu
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// UNSUPPORTED: amdgcn-amd-amdhsa-LTO
+// UNSUPPORTED: amdgpu-amd-amdhsa-LTO
+// UNSUPPORTED: intelgpu
+
+#include <cstdio>
+#include <mutex>
+#include <thread>
+
+static std::mutex PrintMutex;
+
+static void printError(int ThreadId, const char *Label, hipError_t Error) {
+  std::lock_guard<std::mutex> Lock(PrintMutex);
+  printf("thread %d %s: %s\n", ThreadId, Label, hipGetErrorName(Error));
+  std::fflush(stdout);
+}
+
+__global__ void errorKernel(float *d_out) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  d_out[idx] = idx * 0.5f;
+}
+
+void runTask(int ThreadId) {
+  const int N = 1 << 20;
+  size_t Bytes = N * sizeof(float);
+
+  float *d_data;
+  hipMalloc(&d_data, Bytes);
+  printError(ThreadId, "hipMalloc", hipGetLastError());
+
+  ThreadId == 1 ? errorKernel<<<4096, 256>>>(d_data)
+                : errorKernel<<<4096, 0>>>(d_data);
+  printError(ThreadId, "kernel launch", hipPeekAtLastError());
+
+  printError(ThreadId, "kernel launch get", hipGetLastError());
+
+  printError(ThreadId, "kernel launch get again", hipGetLastError());
+
+  hipDeviceSynchronize();
+  hipFree(d_data);
+}
+
+int main() {
+  printError(0, "initial", hipPeekAtLastError());
+  // CHECK: thread 0 initial: hipSuccess
+
+  std::thread t1(runTask, 1);
+  std::thread t2(runTask, 2);
+
+  t1.join();
+  t2.join();
+  // CHECK-DAG: thread 1 hipMalloc: hipSuccess
+  // CHECK-DAG: thread 2 hipMalloc: hipSuccess
+  // CHECK-DAG: thread 1 kernel launch: hipSuccess
+  // CHECK-DAG: thread 2 kernel launch: hipErrorInvalidConfiguration
+  // CHECK-DAG: thread 1 kernel launch get: hipSuccess
+  // CHECK-DAG: thread 2 kernel launch get: hipErrorInvalidConfiguration
+  // CHECK-DAG: thread 1 kernel launch get again: hipSuccess
+  // CHECK-DAG: thread 2 kernel launch get again: hipSuccess
+
+  std::thread t3(runTask, 3);
+  t3.join();
+  // CHECK: thread 3 hipMalloc: hipSuccess
+  // CHECK: thread 3 kernel launch: hipErrorInvalidConfiguration
+  // CHECK: thread 3 kernel launch get: hipErrorInvalidConfiguration
+  // CHECK: thread 3 kernel launch get again: hipSuccess
+
+  printError(0, "joined", hipGetLastError());
+  // CHECK: thread 0 joined: hipSuccess
+
+  return 0;
+}


### PR DESCRIPTION
This test adds LastError setting for `llvmKernelLaunch` as well as additional checks for malformed kernels. It also adds tests for #213389. 

It also removes stale `hipKernelLaunch` declarations.

This PR depends on #213389  and its predecessors but because I do not have commit access I cannot stack the PR. For review only consider the LAST ONE commit.

Assisted by GPT-5.5, checked and reviewed manually