### PR TITLE
Speed up std::invoke() compile times (~60%-85% reduction)

### DIFF
--- a/libcxx/include/__functional/invoke.h
+++ b/libcxx/include/__functional/invoke.h
@@ -23,11 +23,33 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-template <class _Fn, class... _Args>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 invoke_result_t<_Fn, _Args...>
-invoke(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_invocable_v<_Fn, _Args...>) {
-  return std::__invoke(std::forward<_Fn>(__f), std::forward<_Args>(__args)...);
+#  if __has_builtin(__builtin_invoke)
+
+template <class... _Args>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __invoke_result_t<_Args...> invoke(_Args&&... __args)
+    _NOEXCEPT_(noexcept(__builtin_invoke(static_cast<_Args&&>(__args)...))) {
+  return __builtin_invoke(static_cast<_Args&&>(__args)...);
 }
+
+#  else
+
+template <class _Fp, class... _Args>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR auto invoke(_Fp&& __f, _Args&&... __args)
+    _NOEXCEPT_(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)))
+        -> decltype(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)) {
+  return static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...);
+}
+
+template <class _Member, class _Class, class _A0, class... _Args>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR auto invoke(_Member _Class::* __f, _A0&& __a0, _Args&&... __args)
+    _NOEXCEPT_(noexcept(
+        std::__invoker_t<_Member, _Class, _A0>::_Fn(__f, static_cast<_A0&&>(__a0), static_cast<_Args&&>(__args)...)))
+        -> decltype(std::__invoker_t<_Member, _Class, _A0>::_Fn(
+            __f, static_cast<_A0&&>(__a0), static_cast<_Args&&>(__args)...)) {
+  return std::__invoker_t<_Member, _Class, _A0>::_Fn(__f, static_cast<_A0&&>(__a0), static_cast<_Args&&>(__args)...);
+}
+
+#  endif
 
 #  if _LIBCPP_STD_VER >= 23
 template <class _Result, class _Fn, class... _Args>

--- a/libcxx/include/__type_traits/invoke.h
+++ b/libcxx/include/__type_traits/invoke.h
@@ -17,11 +17,14 @@
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_base_of.h>
 #include <__type_traits/is_core_convertible.h>
-#include <__type_traits/is_member_pointer.h>
+#include <__type_traits/is_function.h>
 #include <__type_traits/is_reference_wrapper.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_void.h>
 #include <__type_traits/nat.h>
+#include <__type_traits/remove_cvref.h>
+#include <__type_traits/remove_reference.h>
+#include <__type_traits/type_identity.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
 #include <__utility/forward.h>
@@ -55,10 +58,10 @@
 // inline const bool __is_nothrow_invocable_v = is_nothrow_invocable_v<Func, Args...>;
 //
 // template <class Func, class... Args>
-// inline const bool __is_nothrow_invocable_r_v = is_nothrow_invocable_r_v<Func, Args...>;
+// struct __is_nothrow_invocable_r : is_nothrow_invocable_r<Func, Args...> {};
 //
 // template <class Func, class... Args>
-// struct __invoke_result : invoke_result {};
+// struct __invoke_result : invoke_result<Func, Args...> {};
 //
 // template <class Func, class... Args>
 // using __invoke_result_t = invoke_result_t<Func, Args...>;
@@ -70,25 +73,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if __has_builtin(__builtin_invoke)
 
-template <class, class... _Args>
-struct __invoke_result_impl {};
-
 template <class... _Args>
-struct __invoke_result_impl<__void_t<decltype(__builtin_invoke(std::declval<_Args>()...))>, _Args...> {
-  using type _LIBCPP_NODEBUG = decltype(__builtin_invoke(std::declval<_Args>()...));
-};
-
-template <class... _Args>
-using __invoke_result _LIBCPP_NODEBUG = __invoke_result_impl<void, _Args...>;
-
-template <class... _Args>
-using __invoke_result_t _LIBCPP_NODEBUG = typename __invoke_result<_Args...>::type;
-
-template <class... _Args>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __invoke_result_t<_Args...> __invoke(_Args&&... __args)
-    _NOEXCEPT_(noexcept(__builtin_invoke(std::forward<_Args>(__args)...))) {
-  return __builtin_invoke(std::forward<_Args>(__args)...);
-}
+using __invoke_result_t _LIBCPP_NODEBUG =
+    decltype(__builtin_invoke(reinterpret_cast<_Args&&>(static_cast<int&&>(0))...));
 
 template <class _Void, class... _Args>
 inline const bool __is_invocable_impl = false;
@@ -100,7 +87,7 @@ template <class... _Args>
 inline const bool __is_invocable_v = __is_invocable_impl<void, _Args...>;
 
 template <class... _Args>
-struct __is_invocable : integral_constant<bool, __is_invocable_v<_Args...> > {};
+using __is_invocable _LIBCPP_NODEBUG = _BoolConstant<__is_invocable_v<_Args...> >;
 
 template <class _Ret, bool, class... _Args>
 inline const bool __is_invocable_r_impl = false;
@@ -110,18 +97,22 @@ inline const bool __is_invocable_r_impl<_Ret, true, _Args...> =
     __is_core_convertible<__invoke_result_t<_Args...>, _Ret>::value || is_void<_Ret>::value;
 
 template <class _Ret, class... _Args>
-inline const bool __is_invocable_r_v = __is_invocable_r_impl<_Ret, __is_invocable_v<_Args...>, _Args...>;
+_LIBCPP_NO_SPECIALIZATIONS inline const bool __is_invocable_r_v =
+    __is_invocable_r_impl<_Ret, __is_invocable_v<_Args...>, _Args...>;
 
-template <bool __is_invocable, class... _Args>
-inline const bool __is_nothrow_invocable_impl = false;
+template <bool _Expected, class... _Args>
+inline const bool __nothrow_invocability_matches_v = false;
 
 #  ifndef _LIBCPP_CXX03_LANG
 template <class... _Args>
-inline const bool __is_nothrow_invocable_impl<true, _Args...> = noexcept(__builtin_invoke(std::declval<_Args>()...));
+inline const bool
+    __nothrow_invocability_matches_v<noexcept(__builtin_invoke(reinterpret_cast<_Args&&>(static_cast<int&&>(0))...)),
+                                     _Args...> = true;
 #  endif
 
 template <class... _Args>
-inline const bool __is_nothrow_invocable_v = __is_nothrow_invocable_impl<__is_invocable_v<_Args...>, _Args...>;
+_LIBCPP_NO_SPECIALIZATIONS inline const bool __is_nothrow_invocable_v =
+    __nothrow_invocability_matches_v<true, _Args...>;
 
 template <bool __is_invocable, class _Ret, class... _Args>
 inline const bool __is_nothrow_invocable_r_impl = false;
@@ -131,229 +122,190 @@ inline const bool __is_nothrow_invocable_r_impl<true, _Ret, _Args...> =
     __is_nothrow_core_convertible_v<__invoke_result_t<_Args...>, _Ret> || is_void<_Ret>::value;
 
 template <class _Ret, class... _Args>
-inline const bool __is_nothrow_invocable_r_v =
-    __is_nothrow_invocable_r_impl<__is_nothrow_invocable_v<_Args...>, _Ret, _Args...>;
+using __is_nothrow_invocable_r _LIBCPP_NODEBUG =
+    _BoolConstant<__is_nothrow_invocable_r_impl<__is_nothrow_invocable_v<_Args...>, _Ret, _Args...> >;
+
+template <class... _Args>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __invoke_result_t<_Args...> __invoke(_Args&&... __args)
+    _NOEXCEPT_(__is_nothrow_invocable_v<_Args...>) {
+  return __builtin_invoke(static_cast<_Args&&>(__args)...);
+}
 
 #else // __has_builtin(__builtin_invoke)
 
-template <class _DecayedFp>
-struct __member_pointer_class_type {};
+// The _Kind is the bullet number in the standard
+template <unsigned _Kind>
+struct _Invoker;
 
-template <class _Ret, class _ClassType>
-struct __member_pointer_class_type<_Ret _ClassType::*> {
-  typedef _ClassType type;
-};
-
-template <class _Fp,
+template <class _Member,
+          class _Class,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
-          class _DecayA0 = __decay_t<_A0>,
-          class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
-using __enable_if_bullet1 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_function_pointer<_DecayFp>::value &&
-                  (is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value)>;
-
-template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = __decay_t<_A0> >
-using __enable_if_bullet2 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
-
-template <class _Fp,
-          class _A0,
-          class _DecayFp = __decay_t<_Fp>,
-          class _DecayA0 = __decay_t<_A0>,
-          class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
-using __enable_if_bullet3 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_function_pointer<_DecayFp>::value &&
-                  !(is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value) &&
-                  !__is_reference_wrapper<_DecayA0>::value>;
-
-template <class _Fp,
-          class _A0,
-          class _DecayFp = __decay_t<_Fp>,
-          class _DecayA0 = __decay_t<_A0>,
-          class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
-using __enable_if_bullet4 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_object_pointer<_DecayFp>::value &&
-                  (is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value)>;
-
-template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = __decay_t<_A0> >
-using __enable_if_bullet5 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
-
-template <class _Fp,
-          class _A0,
-          class _DecayFp = __decay_t<_Fp>,
-          class _DecayA0 = __decay_t<_A0>,
-          class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
-using __enable_if_bullet6 _LIBCPP_NODEBUG =
-    __enable_if_t<is_member_object_pointer<_DecayFp>::value &&
-                  !(is_same<_ClassT, _DecayA0>::value || is_base_of<_ClassT, _DecayA0>::value) &&
-                  !__is_reference_wrapper<_DecayA0>::value>;
-
-// __invoke forward declarations
-
-// fall back - none of the bullets
-
-template <class... _Args>
-__nat __invoke(_Args&&... __args);
+          class _DecayA0      = __decay_t<_A0>,
+          class _IsRefWrapper = __is_reference_wrapper<_DecayA0> >
+using __invoker_t _LIBCPP_NODEBUG = _Invoker<
+    (!is_function<_Member>::value * 3) +
+    (!_If< _IsRefWrapper::value,
+           false_type,
+           _If<is_same<_Class, _DecayA0>::value, is_same<_Class, _DecayA0>, is_base_of<_Class, _DecayA0> > >::value
+     << 1) +
+    !_IsRefWrapper::value>;
 
 // bullets 1, 2 and 3
 
-// clang-format off
-template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet1<_Fp, _A0> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype((std::declval<_A0>().*std::declval<_Fp>())(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args)
-    _NOEXCEPT_(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
-               { return (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...); }
+template <>
+struct _Invoker<1> {
+  template <class _Fp, class _A0, class... _Args>
+  static inline _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR decltype((std::declval<_A0>().*std::declval<_Fp>())(std::declval<_Args>()...))
+  _Fn(_Fp __f, _A0&& __a0, _Args&&... __args)
+      _NOEXCEPT_(noexcept((static_cast<_A0&&>(__a0).*static_cast<_Fp&&>(__f))(static_cast<_Args&&>(__args)...))) {
+    return (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...);
+  }
+};
 
-template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet2<_Fp, _A0> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype((std::declval<_A0>().get().*std::declval<_Fp>())(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args)
-    _NOEXCEPT_(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
-               { return (__a0.get().*__f)(static_cast<_Args&&>(__args)...); }
+template <>
+struct _Invoker<2> {
+  template <class _Fp, class _A0, class... _Args>
+  static inline _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR decltype((std::declval<_A0&>().*std::declval<_Fp>())(std::declval<_Args>()...))
+  _Fn(_Fp __f, reference_wrapper<_A0> __a0, _Args&&... __args)
+      _NOEXCEPT_(noexcept((std::declval<_A0&>().*static_cast<_Fp&&>(__f))(static_cast<_Args&&>(__args)...))) {
+    return (__a0.get().*__f)(static_cast<_Args&&>(__args)...);
+  }
+};
 
-template <class _Fp, class _A0, class... _Args, class = __enable_if_bullet3<_Fp, _A0> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(((*std::declval<_A0>()).*std::declval<_Fp>())(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _A0&& __a0, _Args&&... __args)
-    _NOEXCEPT_(noexcept(((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...)))
-               { return ((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...); }
+template <>
+struct _Invoker<3> {
+  template <class _Fp, class _A0, class... _Args>
+  static inline _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR decltype(((*std::declval<_A0>()).*std::declval<_Fp>())(std::declval<_Args>()...))
+  _Fn(_Fp __f, _A0&& __a0, _Args&&... __args)
+      _NOEXCEPT_(noexcept(((*static_cast<_A0&&>(__a0)).*static_cast<_Fp&&>(__f))(static_cast<_Args&&>(__args)...))) {
+    return ((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...);
+  }
+};
 
 // bullets 4, 5 and 6
 
-template <class _Fp, class _A0, class = __enable_if_bullet4<_Fp, _A0> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(std::declval<_A0>().*std::declval<_Fp>())
-__invoke(_Fp&& __f, _A0&& __a0)
-    _NOEXCEPT_(noexcept(static_cast<_A0&&>(__a0).*__f))
-               { return static_cast<_A0&&>(__a0).*__f; }
-
-template <class _Fp, class _A0, class = __enable_if_bullet5<_Fp, _A0> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(std::declval<_A0>().get().*std::declval<_Fp>())
-__invoke(_Fp&& __f, _A0&& __a0)
-    _NOEXCEPT_(noexcept(__a0.get().*__f))
-               { return __a0.get().*__f; }
-
-template <class _Fp, class _A0, class = __enable_if_bullet6<_Fp, _A0> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype((*std::declval<_A0>()).*std::declval<_Fp>())
-__invoke(_Fp&& __f, _A0&& __a0)
-    _NOEXCEPT_(noexcept((*static_cast<_A0&&>(__a0)).*__f))
-               { return (*static_cast<_A0&&>(__a0)).*__f; }
-
-// bullet 7
-
-template <class _Fp, class... _Args>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-decltype(std::declval<_Fp>()(std::declval<_Args>()...))
-__invoke(_Fp&& __f, _Args&&... __args)
-    _NOEXCEPT_(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)))
-               { return static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...); }
-// clang-format on
-
-// __invokable
-template <class _Ret, class _Fp, class... _Args>
-struct __invokable_r {
-  template <class _XFp, class... _XArgs>
-  static decltype(std::__invoke(std::declval<_XFp>(), std::declval<_XArgs>()...)) __try_call(int);
-  template <class _XFp, class... _XArgs>
-  static __nat __try_call(...);
-
-  // FIXME: Check that _Ret, _Fp, and _Args... are all complete types, cv void,
-  // or incomplete array types as required by the standard.
-  using _Result _LIBCPP_NODEBUG = decltype(__try_call<_Fp, _Args...>(0));
-
-  using type              = __conditional_t<_IsNotSame<_Result, __nat>::value,
-                                            __conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret> >,
-                                            false_type>;
-  static const bool value = type::value;
-};
-template <class _Fp, class... _Args>
-using __is_invocable _LIBCPP_NODEBUG = __invokable_r<void, _Fp, _Args...>;
-
-template <bool _IsInvokable, bool _IsCVVoid, class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp {
-  static const bool value = false;
-};
-
-template <class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...> {
-  typedef __nothrow_invokable_r_imp _ThisT;
-
-  template <class _Tp>
-  static void __test_noexcept(_Tp) _NOEXCEPT;
-
-#  ifdef _LIBCPP_CXX03_LANG
-  static const bool value = false;
-#  else
-  static const bool value =
-      noexcept(_ThisT::__test_noexcept<_Ret>(std::__invoke(std::declval<_Fp>(), std::declval<_Args>()...)));
-#  endif
-};
-
-template <class _Ret, class _Fp, class... _Args>
-struct __nothrow_invokable_r_imp<true, true, _Ret, _Fp, _Args...> {
-#  ifdef _LIBCPP_CXX03_LANG
-  static const bool value = false;
-#  else
-  static const bool value = noexcept(std::__invoke(std::declval<_Fp>(), std::declval<_Args>()...));
-#  endif
-};
-
-template <class _Ret, class _Fp, class... _Args>
-using __nothrow_invokable_r _LIBCPP_NODEBUG =
-    __nothrow_invokable_r_imp<__invokable_r<_Ret, _Fp, _Args...>::value, is_void<_Ret>::value, _Ret, _Fp, _Args...>;
-
-template <class _Fp, class... _Args>
-using __nothrow_invokable _LIBCPP_NODEBUG =
-    __nothrow_invokable_r_imp<__is_invocable<_Fp, _Args...>::value, true, void, _Fp, _Args...>;
-
-template <class _Func, class... _Args>
-inline const bool __is_invocable_v = __is_invocable<_Func, _Args...>::value;
-
-template <class _Ret, class _Func, class... _Args>
-inline const bool __is_invocable_r_v = __invokable_r<_Ret, _Func, _Args...>::value;
-
-template <class _Func, class... _Args>
-inline const bool __is_nothrow_invocable_v = __nothrow_invokable<_Func, _Args...>::value;
-
-template <class _Ret, class _Func, class... _Args>
-inline const bool __is_nothrow_invocable_r_v = __nothrow_invokable_r<_Ret, _Func, _Args...>::value;
-
-template <class _Func, class... _Args>
-struct __invoke_result
-    : enable_if<__is_invocable_v<_Func, _Args...>, typename __invokable_r<void, _Func, _Args...>::_Result> {};
-
-template <class _Func, class... _Args>
-using __invoke_result_t _LIBCPP_NODEBUG = typename __invoke_result<_Func, _Args...>::type;
-
-#endif // __has_builtin(__builtin_invoke_r)
-
-template <class _Ret, class _Func, class... _Args>
-struct __is_invocable_r : integral_constant<bool, __is_invocable_r_v<_Ret, _Func, _Args...> > {};
-
-template <class _Ret, bool = is_void<_Ret>::value>
-struct __invoke_void_return_wrapper {
-  template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static _Ret __call(_Args&&... __args) {
-    return std::__invoke(std::forward<_Args>(__args)...);
+template <>
+struct _Invoker<4> {
+  template <class _Fp, class _A0>
+  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR decltype(std::declval<_A0>().*std::declval<_Fp>())
+  _Fn(_Fp __f, _A0&& __a0) _NOEXCEPT_(noexcept(static_cast<_A0&&>(__a0).*static_cast<_Fp&&>(__f))) {
+    return static_cast<_A0&&>(__a0).*__f;
   }
 };
 
-template <class _Ret>
-struct __invoke_void_return_wrapper<_Ret, true> {
-  template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static void __call(_Args&&... __args) {
-    std::__invoke(std::forward<_Args>(__args)...);
+template <>
+struct _Invoker<5> {
+  template <class _Fp, class _A0>
+  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR decltype(std::declval<_A0&>().*std::declval<_Fp>())
+  _Fn(_Fp __f, reference_wrapper<_A0> __a0) _NOEXCEPT_(noexcept(std::declval<_A0&>().*static_cast<_Fp&&>(__f))) {
+    return __a0.get().*__f;
   }
 };
+
+template <>
+struct _Invoker<6> {
+  template <class _Fp, class _A0>
+  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR decltype((*std::declval<_A0>()).*std::declval<_Fp>())
+  _Fn(_Fp __f, _A0&& __a0) _NOEXCEPT_(noexcept((*static_cast<_A0&&>(__a0)).*static_cast<_Fp&&>(__f))) {
+    return (*static_cast<_A0&&>(__a0)).*__f;
+  }
+};
+
+template <class _Fp, class... _Args>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR decltype(std::declval<_Fp>()(std::declval<_Args>()...))
+__invoke(_Fp&& __f, _Args&&... __args) _NOEXCEPT_(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...))) {
+  return static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...);
+}
+
+template <class _Member, class _Class, class _A0, class... _Args>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR decltype(std::__invoker_t<_Member, _Class, _A0>::_Fn(
+    std::declval<_Member _Class::*>(), std::declval<_A0>(), std::declval<_Args>()...))
+__invoke(_Member _Class::* __f, _A0&& __a0, _Args&&... __args) _NOEXCEPT_(noexcept(
+    std::__invoker_t<_Member, _Class, _A0>::_Fn(__f, static_cast<_A0&&>(__a0), static_cast<_Args&&>(__args)...))) {
+  return std::__invoker_t<_Member, _Class, _A0>::_Fn(__f, static_cast<_A0&&>(__a0), static_cast<_Args&&>(__args)...);
+}
+
+template <class... _Args>
+using __invoke_result_t _LIBCPP_NODEBUG = decltype(std::__invoke(reinterpret_cast<_Args&&>(static_cast<int&&>(0))...));
+
+template <class _Void, class _Ret, class... _Args>
+inline const bool __is_invocable_r_impl = false;
 
 template <class _Ret, class... _Args>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Ret __invoke_r(_Args&&... __args) {
-  return __invoke_void_return_wrapper<_Ret>::__call(std::forward<_Args>(__args)...);
+inline const bool __is_invocable_r_impl<decltype(void(std::__invoke(std::declval<_Args>()...))), _Ret, _Args...> =
+    is_void<_Ret>::value || __is_core_convertible<__invoke_result_t<_Args...>, _Ret>::value;
+
+template <class... _Args>
+_LIBCPP_NO_SPECIALIZATIONS inline const bool __is_invocable_r_v = __is_invocable_r_impl<void, _Args...>;
+
+template <class... _Args>
+_LIBCPP_NO_SPECIALIZATIONS inline const bool __is_invocable_v = __is_invocable_r_v<void, _Args...>;
+
+template <class... _Args>
+using __is_invocable _LIBCPP_NODEBUG = _BoolConstant<__is_invocable_v<_Args...> >;
+
+template <class _Void, class... _Args>
+inline const bool __nothrow_invocability_matches_v = false;
+
+#  ifndef _LIBCPP_CXX03_LANG
+template <class... _Args>
+inline const bool
+    __nothrow_invocability_matches_v<__enable_if_t<noexcept(std::__invoke(std::declval<_Args>()...))>, _Args...> = true;
+#  endif
+
+template <class... _Args>
+_LIBCPP_NO_SPECIALIZATIONS inline const bool __is_nothrow_invocable_v =
+    __nothrow_invocability_matches_v<void, _Args...>;
+
+template <class _Void, class _Ret, class... _Args>
+inline const bool __nothrow_invocable_r_imp = false;
+
+#  ifndef _LIBCPP_CXX03_LANG
+template <class _Ret, class _Fp, class... _Args>
+inline const bool __nothrow_invocable_r_imp<
+    __enable_if_t<noexcept(static_cast<void (*)(_Ret) _NOEXCEPT>(nullptr)(
+        std::__invoke(std::declval<__enable_if_t<!is_void<_Ret>::value, _Fp> >(), std::declval<_Args>()...)))>,
+    _Ret,
+    _Fp,
+    _Args...> = true;
+#  endif
+
+template <class... _Args>
+inline const bool __nothrow_invocable_r_imp<__enable_if_t<__is_nothrow_invocable_v<_Args...> >, void, _Args...> = true;
+
+template <class _Ret, class... _Args>
+using __is_nothrow_invocable_r _LIBCPP_NODEBUG =
+    _BoolConstant<__nothrow_invocable_r_imp<void, _If<is_void<_Ret>::value, void, _Ret>, _Args...> >;
+
+#endif // __has_builtin(__builtin_invoke)
+
+template <class _Void, class... _Args>
+struct __invoke_result_impl {};
+
+template <class... _Args>
+struct __invoke_result_impl<__void_t<__invoke_result_t<_Args...> >, _Args...> {
+  using type _LIBCPP_NODEBUG = __invoke_result_t<_Args...>;
+};
+
+template <class... _Args>
+using __invoke_result _LIBCPP_NODEBUG = __invoke_result_impl<void, _Args...>;
+
+template <class... _Args>
+using __is_invocable_r _LIBCPP_NODEBUG = _BoolConstant<__is_invocable_r_v<_Args...> >;
+
+template <class _Ret, class... _Args>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __enable_if_t<!is_void<_Ret>::value, _Ret>
+__invoke_r(_Args&&... __args) {
+  return std::__invoke(static_cast<_Args&&>(__args)...);
+}
+
+template <class _Ret, class... _Args>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __enable_if_t<is_void<_Ret>::value, _Ret>
+__invoke_r(_Args&&... __args) {
+  std::__invoke(static_cast<_Args&&>(__args)...);
 }
 
 #if _LIBCPP_STD_VER >= 17
@@ -364,7 +316,7 @@ template <class _Fn, class... _Args>
 struct _LIBCPP_NO_SPECIALIZATIONS is_invocable : bool_constant<__is_invocable_v<_Fn, _Args...> > {};
 
 template <class _Ret, class _Fn, class... _Args>
-struct _LIBCPP_NO_SPECIALIZATIONS is_invocable_r : bool_constant<__is_invocable_r_v<_Ret, _Fn, _Args...>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_invocable_r : bool_constant<__is_invocable_r_v<_Ret, _Fn, _Args...> > {};
 
 template <class _Fn, class... _Args>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_invocable_v = __is_invocable_v<_Fn, _Args...>;
@@ -379,20 +331,20 @@ struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_invocable : bool_constant<__is_noth
 
 template <class _Ret, class _Fn, class... _Args>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_invocable_r
-    : bool_constant<__is_nothrow_invocable_r_v<_Ret, _Fn, _Args...>> {};
+    : bool_constant<__is_nothrow_invocable_r<_Ret, _Fn, _Args...>::value> {};
 
 template <class _Fn, class... _Args>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_invocable_v = __is_nothrow_invocable_v<_Fn, _Args...>;
 
 template <class _Ret, class _Fn, class... _Args>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_invocable_r_v =
-    __is_nothrow_invocable_r_v<_Ret, _Fn, _Args...>;
+    __is_nothrow_invocable_r<_Ret, _Fn, _Args...>::value;
 
 template <class _Fn, class... _Args>
 struct _LIBCPP_NO_SPECIALIZATIONS invoke_result : __invoke_result<_Fn, _Args...> {};
 
-template <class _Fn, class... _Args>
-using invoke_result_t = __invoke_result_t<_Fn, _Args...>;
+template <class... _Args>
+using invoke_result_t = typename invoke_result<_Args...>::type;
 
 #endif
 


### PR DESCRIPTION
There are a lot of changes here, but they fall into the following categories:

- Avoiding overload resolution as much as possible, or terminating it as early as possible. Overload resolution is an expensive operation that requires a lot of redundant work on similar invocations. Instead, we disambiguate the possibilities early on, select a single overload, and guide the compiler to the correct function ourselves.

- Reducing unnecessary template instantiations. For example, making `__is_invocable_r` be an alias to a `std::integral_constant` rather than its own, named trait.

- Preferring inline-variable-based traits to type-based traits wherever possible. Type machinery is more expensive for the compiler than a simple variable.

- Avoiding redundant work in general. For example, instead of checking "is this a member-type" and then "get the type of the class if this is a member-pointer type", we simply SFINAE on the latter, which implies the former.

Benchmark via `time clang++ -std=c++20 -fsyntax-only -DTOGGLE`:

```
#include <stdio.h>
#include <functional>
#include <utility>

template <int N>
struct S { int x[N]; };

int main(int argc, char* argv[]) {
  int v = argc;
  int n = 0;
  (void)(++n, (void)std::invoke([]() {}));
  (void)(++n, (void)std::invoke([](int) {}, std::ref(n)));
  (void)(++n, (void)std::invoke([](S<__COUNTER__>*) {}, nullptr));
  { using F = S<__COUNTER__>; ++n; std::invoke(&F::x, F()); }
// #define X3(V) ++n; std::invoke([](S<__COUNTER__>*) {}, nullptr)
#define X3(V) { using F = S<__COUNTER__>; ++n; std::invoke(&F::x, F()); }
#define X2(V) X3(V); X3(V); X3(V); X3(V)
#define X(V) X2(V); X2(V); X2(V); X2(V); X2(V); X2(V); X2(V); X2(V)
#ifdef TOGGLE
  // clang-format off
  X(v); X(v); X(v); X(v); X(v); X(v); X(v); X(v);
  X(v); X(v); X(v); X(v); X(v); X(v); X(v); X(v);
  X(v); X(v); X(v); X(v); X(v); X(v); X(v); X(v);
  X(v); X(v); X(v); X(v); X(v); X(v); X(v); X(v);
  // clang-format on
#else
  (void)v;
#endif
#undef X
#undef X2
#undef X3
  return n;
}
```

Subtractions are with and without `-DTOGGLE`, thus isolating the cost of `std::invoke`.

Plain function calls, legacy:
- Before: 1170 - 392 = 778 ms
- After:  469 - 376 = 93 ms (>8.3x faster)

Plain function calls, with `__builtin_invoke`:
- Before: 803 - 380 = 423 ms
- After:  477 - 381 = 96 ms (>4.4x faster)

Result: **This makes the legacy compile performance _beat_ that of `__builtin_invoke`** for plain function calls. (!)

Member calls, legacy:
- Before: 1521 - 390 = 1131 ms
- After:  788 - 371 = 417 ms (>2.7x faster)

Member calls, with `__builtin_invoke`:
- Before: 800 - 381 = 419 ms
- After:  483 - 374 = 109 ms (>3.8x faster)

Result: This improves legacy compile performance for member calls, but doesn't match that of `__builtin_invoke`.