### PR TITLE
Revert "[VPlan] Remove redundant x && (y && x) -> x && y combine (#213219)"

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1188,10 +1188,16 @@ static bool simplifyLogicalRecipe(VPSingleDefRecipe *Def, VPBuilder &Builder,
   }
 
   // x && (x && y) -> x && y
-  if (match(Def, m_c_LogicalAnd(m_VPValue(X),
-                                m_VPValue(Z, m_c_LogicalAnd(m_Deferred(X),
-                                                            m_VPValue()))))) {
-    Def->replaceAllUsesWith(Z);
+  if (match(Def, m_LogicalAnd(m_VPValue(X),
+                              m_LogicalAnd(m_Deferred(X), m_VPValue())))) {
+    Def->replaceAllUsesWith(Def->getOperand(1));
+    return true;
+  }
+
+  // x && (y && x) -> x && y
+  if (match(Def, m_LogicalAnd(m_VPValue(X),
+                              m_LogicalAnd(m_VPValue(Y), m_Deferred(X))))) {
+    Def->replaceAllUsesWith(Builder.createLogicalAnd(X, Y));
     return true;
   }
 

--- a/llvm/test/Transforms/LoopVectorize/simplify-logic.ll
+++ b/llvm/test/Transforms/LoopVectorize/simplify-logic.ll
@@ -143,8 +143,7 @@ define void @logical_and_inner_commute(ptr noalias %p, ptr noalias %q, ptr noali
 ; CHECK-NEXT:    [[WIDE_LOAD1:%.*]] = load <4 x i32>, ptr [[TMP3]], align 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = trunc <4 x i32> [[WIDE_LOAD]] to <4 x i1>
 ; CHECK-NEXT:    [[TMP5:%.*]] = trunc <4 x i32> [[WIDE_LOAD1]] to <4 x i1>
-; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP4]], <4 x i1> [[TMP5]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP7:%.*]] = select <4 x i1> [[TMP6]], <4 x i1> [[TMP4]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP7:%.*]] = select <4 x i1> [[TMP4]], <4 x i1> [[TMP5]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP8:%.*]] = zext <4 x i1> [[TMP7]] to <4 x i32>
 ; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i32, ptr [[R]], i32 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i32> [[TMP8]], ptr [[TMP9]], align 4


### PR DESCRIPTION
This reverts commit 8db13de265a5f12d49147930da6d16a3ad7b40e3.

Logical ands block poison, and commuting the operands doesn't preserve it