### PR TITLE
[lldb][test] Skip the JSON symbol file test on WebAssembly

### DIFF
--- a/lldb/test/API/functionalities/json/symbol-file/TestSymbolFileJSON.py
+++ b/lldb/test/API/functionalities/json/symbol-file/TestSymbolFileJSON.py
@@ -14,6 +14,7 @@ class TargetSymbolsFileJSON(TestBase):
 
     @no_debug_info_test
     @skipIfWindows  # No 'strip'
+    @skipIfWasm  # Wasm modules have no UUID
     def test_symbol_file_json_address(self):
         """Test that 'target symbols add' can load the symbols from a JSON file using file addresses."""
 


### PR DESCRIPTION
A JSON symbol file requires the UUID of the module it describes, and a WebAssembly module carries no UUID.