### PR TITLE
[X86AsmBackend] Define reset() hook

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -163,6 +163,13 @@ public:
         AllowAutoPadding && TargetPrefixMax != 0 && X86PadForBranchAlign;
   }
 
+  void reset() override {
+    PrevInst = MCInst();
+    PrevInstOpcode = 0;
+    PendingBA = nullptr;
+    PrevInstPosition = {};
+  }
+
   void emitInstructionBegin(MCObjectStreamer &OS, const MCInst &Inst,
                             const MCSubtargetInfo &STI);
   void emitInstructionEnd(MCObjectStreamer &OS, const MCInst &Inst);


### PR DESCRIPTION
Noticed when reviewing #175830: MCObjectStreamer::reset frees the
fragments PendingBA and PrevInstPosition point into, but X86AsmBackend
keeps them. Define the hook.