### PR TITLE
[InstCombine] Don't change the type of elementwise atomic loads

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -684,6 +684,9 @@ static Instruction *combineLoadToOperationType(InstCombinerImpl &IC,
   if (!Load.isUnordered())
     return nullptr;
 
+  if (Load.isElementwise())
+    return nullptr;
+
   if (Load.use_empty())
     return nullptr;
 

--- a/llvm/test/Transforms/InstCombine/atomic.ll
+++ b/llvm/test/Transforms/InstCombine/atomic.ll
@@ -452,4 +452,15 @@ define void @volatile_load_from_constant_global() {
   ret void
 }
 
+define i64 @load_elementwise_bitcast(ptr %p) {
+; CHECK-LABEL: @load_elementwise_bitcast(
+; CHECK-NEXT:    [[V:%.*]] = load atomic elementwise <2 x i32>, ptr [[P:%.*]] unordered, align 8
+; CHECK-NEXT:    [[R:%.*]] = bitcast <2 x i32> [[V]] to i64
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %v = load atomic elementwise <2 x i32>, ptr %p unordered, align 8
+  %r = bitcast <2 x i32> %v to i64
+  ret i64 %r
+}
+
 attributes #0 = { null_pointer_is_valid }


### PR DESCRIPTION
Skip load type canonicalization for elementwise atomic loads, which would
otherwise drop the vector type and produce an invalid scalar elementwise load.

Reference: https://github.com/llvm/llvm-project/pull/204556