### PR TITLE
[libc] Add conversion tests between emulated and native f128

### DIFF
--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -49,6 +49,7 @@ add_fp_unittest(
     libc.hdr.limits_macros
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.float128
+    libc.src.__support.macros.properties.types
 )
 
 # TODO: Temporally disable bfloat16 test until MPCommon target is updated

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -11,6 +11,8 @@
 #include "src/__support/FPUtil/float128.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
+#include "src/__support/macros/properties/types.h"
+
 
 using LIBC_NAMESPACE::Sign;
 using LIBC_NAMESPACE::fputil::Float128;
@@ -142,3 +144,14 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
   ASSERT_EQ(static_cast<unsigned>(Float128(2147483648.0)), 2147483648U);
   EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_INVALID), 0);
 }
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+TEST(LlvmLibcFloat128Test, NativeFloat128Conversion) {
+  // native to emulated float128
+  ASSERT_TRUE(Float128(static_cast<float128>(1.5)) == Float128(1.5));
+
+  // emulated to native float128
+  ASSERT_TRUE(static_cast<float128>(Float128(3.14)) == static_cast<float128>(3.14));
+}
+#endif // LIBC_TYPES_HAS_FLOAT128
+

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -150,7 +150,7 @@ TEST(LlvmLibcFloat128Test, NativeFloat128Conversion) {
   ASSERT_TRUE(Float128(static_cast<float128>(1.5)) == Float128(1.5));
 
   // emulated to native float128
-  ASSERT_TRUE(static_cast<float128>(Float128(3.14)) == static_cast<float128>(3.14));
+  ASSERT_TRUE(static_cast<float128>(Float128(3.14)) ==
+              static_cast<float128>(3.14));
 }
 #endif // LIBC_TYPES_HAS_FLOAT128
-

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -147,10 +147,21 @@ TEST(LlvmLibcFloat128Test, FromIntegralTypes) {
 #ifdef LIBC_TYPES_HAS_FLOAT128
 TEST(LlvmLibcFloat128Test, NativeFloat128Conversion) {
   // native to emulated float128
+  ASSERT_TRUE(Float128(static_cast<float128>(0.0)) == Float128(0.0));
   ASSERT_TRUE(Float128(static_cast<float128>(1.5)) == Float128(1.5));
+  ASSERT_TRUE(Float128(static_cast<float128>(-1.5)) == Float128(-1.5));
+  ASSERT_TRUE(Float128(static_cast<float128>(1e300)) == Float128(1e300));
 
   // emulated to native float128
+  ASSERT_TRUE(static_cast<float128>(Float128(0.0)) ==
+              static_cast<float128>(0.0));
   ASSERT_TRUE(static_cast<float128>(Float128(3.14)) ==
               static_cast<float128>(3.14));
+  ASSERT_TRUE(static_cast<float128>(Float128(-3.14)) ==
+              static_cast<float128>(-3.14));
+  ASSERT_TRUE(static_cast<float128>(FPBits::inf(Sign::POS).get_val()) ==
+              static_cast<float128>(FPBits::inf(Sign::POS).get_val()));
+  ASSERT_TRUE(static_cast<float128>(Float128(1e-300)) ==
+              static_cast<float128>(1e-300));
 }
 #endif // LIBC_TYPES_HAS_FLOAT128

--- a/libc/test/src/__support/FPUtil/float128_test.cpp
+++ b/libc/test/src/__support/FPUtil/float128_test.cpp
@@ -9,10 +9,9 @@
 #include "hdr/limits_macros.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/float128.h"
+#include "src/__support/macros/properties/types.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
-#include "src/__support/macros/properties/types.h"
-
 
 using LIBC_NAMESPACE::Sign;
 using LIBC_NAMESPACE::fputil::Float128;


### PR DESCRIPTION
Adds conversion tests between emulated and native float128 type, which would be later used in f128 functions .