### PR TITLE
[clang] Disable type-aware allocator lookup for older C++ versions

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -16656,6 +16656,9 @@ bool Sema::CompleteConstructorCall(CXXConstructorDecl *Constructor,
 }
 
 TypeAwareAllocationMode Sema::ShouldUseTypeAwareOperatorNewOrDelete() const {
+  if (!LangOpts.CPlusPlus23)
+    return TypeAwareAllocationMode::No;
+
   bool SeenTypedOperators = Context.hasSeenTypeAwareOperatorNewOrDelete();
   return typeAwareAllocationModeFromBool(SeenTypedOperators);
 }

--- a/clang/test/CodeGenCXX/type-aware-delete-pre-cxx23.cpp
+++ b/clang/test/CodeGenCXX/type-aware-delete-pre-cxx23.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -emit-llvm -o - %s | FileCheck %s
+
+class Foo;
+typedef __SIZE_TYPE__ size_t;
+
+namespace std {
+enum class align_val_t : size_t {};
+template <class T> struct type_identity {
+  typedef T type;
+};
+} // namespace std
+
+template <class T>
+void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t);
+
+// CHECK-LABEL: define{{.*}} void @_Z1fP3Foo(
+// CHECK: call void @_ZdlPv(
+// CHECK-NOT: call void @_ZdlI3FooEvSt13type_identityIT_EPvmSt11align_val_t(
+void f(Foo *o) {
+  delete o;
+}


### PR DESCRIPTION
Closes #212675

Type-aware delete should only be considered in cpp23 and later.

In older language modes (< cpp23), deleting an incomplete type is only a warning, so Clang can still reach CodeGen. If a type-aware operator delete is selected there, CodeGen may assert because the deleted type is incomplete.

So, this commit disables type-aware allocator selection before cpp23 and adds a cpp17 regression test for the crash.

I have run all the clang tests along with the newly added one and it seems to be passing, can confirm with gh ci as well if there are any problems with this logic.