### PR TITLE
[docs][clang] refactor diagnostic spec instruction and grammar nit

### DIFF
--- a/clang/docs/InternalsManual.md
+++ b/clang/docs/InternalsManual.md
@@ -3612,8 +3612,8 @@ int A = B; // expected-error {{use of undeclared identifier 'B'}}
 ```
 
 You can place as many diagnostics on one line as you wish. To make the code
-more readable, you can use a backslash to split the diagnostics into multiple
-lines.
+more readable, you can use backslashes to separate out the diagnostics into
+multiple lines.
 
 Alternatively, it is possible to specify the line on which the diagnostic
 should appear by appending `@<line>` to `expected-<type>`, for example:

--- a/clang/docs/InternalsManual.md
+++ b/clang/docs/InternalsManual.md
@@ -45,7 +45,7 @@ when the code is incorrect or dubious. In Clang, each diagnostic produced has
 {ref}`SourceLocation <SourceLocation>` to "put the caret", and a severity
 (e.g., `WARNING` or `ERROR`). They can also optionally include a number of
 arguments to the diagnostic (which fill in "%0"'s in the string) as well as a
-number of source ranges that related to the diagnostic.
+number of source ranges that are related to the diagnostic.
 
 In this section, we'll be giving examples produced by the Clang command line
 driver, but diagnostics can be {ref}`rendered in many different ways
@@ -3612,7 +3612,8 @@ int A = B; // expected-error {{use of undeclared identifier 'B'}}
 ```
 
 You can place as many diagnostics on one line as you wish. To make the code
-more readable, you can use slash-newline to separate out the diagnostics.
+more readable, you can use back-slash to separate out the diagnostics into
+multiple lines.
 
 Alternatively, it is possible to specify the line on which the diagnostic
 should appear by appending `@<line>` to `expected-<type>`, for example:

--- a/clang/docs/InternalsManual.md
+++ b/clang/docs/InternalsManual.md
@@ -3612,8 +3612,8 @@ int A = B; // expected-error {{use of undeclared identifier 'B'}}
 ```
 
 You can place as many diagnostics on one line as you wish. To make the code
-more readable, you can use back-slash to separate out the diagnostics into
-multiple lines.
+more readable, you can use a backslash to split the diagnostics into multiple
+lines.
 
 Alternatively, it is possible to specify the line on which the diagnostic
 should appear by appending `@<line>` to `expected-<type>`, for example:


### PR DESCRIPTION
A grammar nit found in the description of the Clang Diagnostic Subsystem is improved.

Replace the instruction mentioning the use of "slash-newline" for writing multiple diagnostics with the appropriate "back slash" as that's what is actually used for separting multiple diagnostics into more than one line.

The change makes it more obvious on how to implement multi-line diagnostics by dropping the slightly ambigious slash-newline.