### PR TITLE
[ConstraintElim] Remove const op restriction from tightenBoundUsingNe.

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -1793,7 +1793,7 @@ void ConstraintInfo::addFact(CmpInst::Predicate Pred, Value *A, Value *B,
 void ConstraintInfo::tightenBoundUsingNe(
     Value *A, Value *B, unsigned NumIn, unsigned NumOut,
     SmallVectorImpl<StackEntry> &DFSInStack) {
-  if (!isa<ConstantInt>(B) || !A->getType()->isIntegerTy())
+  if (!A->getType()->isIntegerTy())
     return;
 
   for (bool IsSigned : {false, true}) {

--- a/llvm/test/Transforms/ConstraintElimination/ne-tightening.ll
+++ b/llvm/test/Transforms/ConstraintElimination/ne-tightening.ll
@@ -242,8 +242,7 @@ define i1 @neg_ne_non_constant(i64 %n, i64 %m) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[A]])
 ; CHECK-NEXT:    [[B:%.*]] = icmp ne i64 [[N]], [[M]]
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[B]])
-; CHECK-NEXT:    [[C:%.*]] = icmp sgt i64 [[N]], [[M]]
-; CHECK-NEXT:    ret i1 [[C]]
+; CHECK-NEXT:    ret i1 true
 ;
   %a = icmp sge i64 %n, %m
   call void @llvm.assume(i1 %a)


### PR DESCRIPTION
Remove the constant operand restriction for the bounds tightening logic added in https://github.com/llvm/llvm-project/pull/213049.

The condition is not needed for correctness, and there are a number of cases in practice where results can be improved: https://github.com/dtcxzyw/llvm-opt-benchmark-nightly/pull/839


Compile-time impact in the noise
https://llvm-compile-time-tracker.com/compare.php?from=60f965b1f62c0c77bcdb2997ea9bb6603aa0d002&to=1f7190605cc3a13cd992eaad3053b599cd5e4ed0&stat=instructions:u