### PR TITLE
[clang][PowerPC] Support the Swift calling convention on 32-bit PowerPC

### DIFF
--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -432,6 +432,18 @@ public:
     return TargetInfo::PowerABIBuiltinVaList;
   }
 
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    switch (CC) {
+    case CC_C:
+    case CC_Swift:
+      return CCCR_OK;
+    case CC_SwiftAsync:
+      return CCCR_Error;
+    default:
+      return CCCR_Warning;
+    }
+  }
+
   std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {
     return std::make_pair(32, 32);
   }

--- a/clang/lib/CodeGen/Targets/PPC.cpp
+++ b/clang/lib/CodeGen/Targets/PPC.cpp
@@ -388,7 +388,10 @@ public:
   PPC32TargetCodeGenInfo(CodeGenTypes &CGT, bool SoftFloatABI,
                          bool RetSmallStructInRegABI)
       : TargetCodeGenInfo(std::make_unique<PPC32_SVR4_ABIInfo>(
-            CGT, SoftFloatABI, RetSmallStructInRegABI)) {}
+            CGT, SoftFloatABI, RetSmallStructInRegABI)) {
+    SwiftInfo =
+        std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/false);
+  }
 
   static bool isStructReturnInRegABI(const llvm::Triple &Triple,
                                      const CodeGenOptions &Opts);

--- a/clang/test/Sema/ppc32-swiftcall.c
+++ b/clang/test/Sema/ppc32-swiftcall.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple powerpc-unknown-linux-gnu -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple powerpcle-unknown-linux-gnu -fsyntax-only -verify %s
+
+// swiftcall is supported on 32-bit PowerPC, matching the 64-bit target;
+// swiftasynccall is not, for the same reason it is refused there.
+
+void __attribute__((swiftcall)) f(void *__attribute__((swift_context)) ctx) {}
+
+#if !__has_extension(swiftcc)
+#error swiftcc should be available on 32-bit PowerPC
+#endif
+
+#if __has_extension(swiftasynccc)
+#error swiftasynccc should not be available on 32-bit PowerPC
+#endif
+
+// expected-error@+1 {{'swiftasynccall' calling convention is not supported for this target}}
+void __attribute__((swiftasynccall)) g(void *__attribute__((swift_async_context)) ctx) {}

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -5980,9 +5980,9 @@ SDValue PPCTargetLowering::LowerCall_32SVR4(
   const bool IsVarArg = CFlags.IsVarArg;
   const bool IsTailCall = CFlags.IsTailCall;
 
-  assert((CallConv == CallingConv::C ||
-          CallConv == CallingConv::Cold ||
-          CallConv == CallingConv::Fast) && "Unknown calling convention!");
+  assert((CallConv == CallingConv::C || CallConv == CallingConv::Cold ||
+          CallConv == CallingConv::Fast || CallConv == CallingConv::Swift) &&
+         "Unknown calling convention!");
 
   const Align PtrAlign(4);
 

--- a/llvm/test/CodeGen/PowerPC/swiftcc.ll
+++ b/llvm/test/CodeGen/PowerPC/swiftcc.ll
@@ -1,0 +1,24 @@
+; RUN: llc -mtriple=powerpc-unknown-linux-gnu -verify-machineinstrs < %s | FileCheck %s
+
+; swiftcc is lowered like the C convention on 32-bit PowerPC. Check that it
+; is accepted at all: LowerCall_32SVR4 used to assert on it.
+
+define swiftcc i32 @swiftcc_param(i32 %a, i32 %b) {
+; CHECK-LABEL: swiftcc_param:
+; CHECK: blr
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define swiftcc i32 @call_swiftcc(i32 %a, i32 %b) {
+; CHECK-LABEL: call_swiftcc:
+; CHECK: bl swiftcc_param
+  %r = call swiftcc i32 @swiftcc_param(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+define swiftcc ptr @swiftself_param(ptr swiftself %addr) {
+; CHECK-LABEL: swiftself_param:
+; CHECK: blr
+  ret ptr %addr
+}


### PR DESCRIPTION
`PPC64TargetInfo` accepts `CC_Swift`, but `PPC32TargetInfo` overrides `checkCallingConvention` nowhere, so 32-bit targets inherit the base implementation that accepts only `CC_C`. Sema drops `swiftcall` with `-Wignored-attributes` and substitutes the default convention, and every `swift_context` parameter then fails:

```
error: 'swift_context' parameter can only be used with swiftcall or
swiftasynccall calling convention
```

This adds the table to `PPC32TargetInfo`, registers a `SwiftABIInfo` in `PPC32TargetCodeGenInfo`, and lets `LowerCall_32SVR4` accept `CallingConv::Swift` rather than assert "Unknown calling convention!" on it.

The table follows PPC64's, with one difference: it keeps `CC_C` returning `CCCR_OK`, as `SystemZTargetInfo` does. PPC64's version omits it, so an explicit `__attribute__((cdecl))` warns there; adding the override without `CC_C` would introduce that same behaviour on 32-bit, which this patch is not trying to change. Happy to drop it for exact symmetry if reviewers prefer.

The convention is lowered like the C convention, and `SwiftErrorInRegister` is false so the error is passed indirectly - no separate argument assignment is required.

`CC_SwiftAsync` stays refused, exactly as on PPC64.

Found while building the Swift standard library for 32-bit PowerPC with Buildroot.