### PR TITLE
[Clang] Skip type-aware operator delete resolution for incomplete pointee types

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10444,6 +10444,10 @@ def err_destroying_operator_delete_not_usual : Error<
 def err_type_aware_destroying_operator_delete : Error<
   "destroying delete is not permitted to be type aware">;
 
+def warn_type_aware_delete_incomplete : Warning<
+  "type-aware deallocation is not used for deletion of "
+  "pointer to incomplete type %0">,
+  InGroup<DeleteIncomplete>;
 def warn_ext_type_aware_allocators : ExtWarn<
   "type aware allocators are a Clang extension">, InGroup<DiagGroup<"ext-cxx-type-aware-allocators">>;
 def err_type_aware_allocator_missing_matching_operator : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10448,6 +10448,9 @@ def warn_type_aware_delete_incomplete : Warning<
   "type-aware deallocation is not used for deletion of "
   "pointer to incomplete type %0">,
   InGroup<DeleteIncomplete>;
+def err_type_aware_delete_incomplete : Error<
+  "type-aware deallocation function matches incomplete type %0; "
+  "the type must be complete to use type-aware deallocation">;
 def warn_ext_type_aware_allocators : ExtWarn<
   "type aware allocators are a Clang extension">, InGroup<DiagGroup<"ext-cxx-type-aware-allocators">>;
 def err_type_aware_allocator_missing_matching_operator : Error<

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4149,10 +4149,15 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
     DeclarationName DeleteName = Context.DeclarationNames.getCXXOperatorName(
                                       ArrayForm ? OO_Array_Delete : OO_Delete);
 
+    bool IsComplete = isCompleteType(StartLoc, Pointee);
+    TypeAwareAllocationMode PassTypeIdentity =
+        IsComplete ? ShouldUseTypeAwareOperatorNewOrDelete()
+                   : TypeAwareAllocationMode::No;
+
     if (PointeeRD) {
-      ImplicitDeallocationParameters IDP = {
-          Pointee, ShouldUseTypeAwareOperatorNewOrDelete(),
-          AlignedAllocationMode::No, SizedDeallocationMode::No};
+      ImplicitDeallocationParameters IDP = {Pointee, PassTypeIdentity,
+                                            AlignedAllocationMode::No,
+                                            SizedDeallocationMode::No};
       if (!UseGlobal &&
           FindDeallocationFunction(StartLoc, PointeeRD, DeleteName,
                                    OperatorDelete, IDP))
@@ -4199,7 +4204,6 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
         return ExprError();
       }
 
-      bool IsComplete = isCompleteType(StartLoc, Pointee);
       bool CanProvideSize =
           IsComplete && (!ArrayForm || UsualArrayDeleteWantsSize ||
                          Pointee.isDestructedType());
@@ -4207,8 +4211,7 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
 
       // Look for a global declaration.
       ImplicitDeallocationParameters IDP = {
-          Pointee, ShouldUseTypeAwareOperatorNewOrDelete(),
-          alignedAllocationModeFromBool(Overaligned),
+          Pointee, PassTypeIdentity, alignedAllocationModeFromBool(Overaligned),
           sizedDeallocationModeFromBool(CanProvideSize)};
       OperatorDelete = FindUsualDeallocationFunction(StartLoc, IDP, DeleteName);
       if (!OperatorDelete)

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4151,8 +4151,11 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
 
     bool IsComplete = isCompleteType(StartLoc, Pointee);
     TypeAwareAllocationMode PassTypeIdentity =
-        IsComplete ? ShouldUseTypeAwareOperatorNewOrDelete()
-                   : TypeAwareAllocationMode::No;
+        ShouldUseTypeAwareOperatorNewOrDelete();
+    if (!IsComplete && isTypeAwareAllocation(PassTypeIdentity)) {
+      Diag(StartLoc, diag::warn_type_aware_delete_incomplete) << Pointee;
+      PassTypeIdentity = TypeAwareAllocationMode::No;
+    }
 
     if (PointeeRD) {
       ImplicitDeallocationParameters IDP = {Pointee, PassTypeIdentity,

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4243,7 +4243,8 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
         return ExprError();
       }
       QualType TypeIdentity = OperatorDelete->getParamDecl(0)->getType();
-      if (RequireCompleteType(StartLoc, TypeIdentity, diag::err_incomplete_type))
+      if (RequireCompleteType(StartLoc, TypeIdentity,
+                              diag::err_incomplete_type))
         return ExprError();
       AddressParamIdx = 1;
     } else if (!IsComplete && isTypeAwareAllocation(PassTypeIdentity)) {

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4152,10 +4152,6 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
     bool IsComplete = isCompleteType(StartLoc, Pointee);
     TypeAwareAllocationMode PassTypeIdentity =
         ShouldUseTypeAwareOperatorNewOrDelete();
-    if (!IsComplete && isTypeAwareAllocation(PassTypeIdentity)) {
-      Diag(StartLoc, diag::warn_type_aware_delete_incomplete) << Pointee;
-      PassTypeIdentity = TypeAwareAllocationMode::No;
-    }
 
     if (PointeeRD) {
       ImplicitDeallocationParameters IDP = {Pointee, PassTypeIdentity,
@@ -4242,11 +4238,16 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
 
     unsigned AddressParamIdx = 0;
     if (OperatorDelete->isTypeAwareOperatorNewOrDelete()) {
+      if (!IsComplete) {
+        Diag(StartLoc, diag::err_type_aware_delete_incomplete) << Pointee;
+        return ExprError();
+      }
       QualType TypeIdentity = OperatorDelete->getParamDecl(0)->getType();
-      if (RequireCompleteType(StartLoc, TypeIdentity,
-                              diag::err_incomplete_type))
+      if (RequireCompleteType(StartLoc, TypeIdentity, diag::err_incomplete_type))
         return ExprError();
       AddressParamIdx = 1;
+    } else if (!IsComplete && isTypeAwareAllocation(PassTypeIdentity)) {
+      Diag(StartLoc, diag::warn_type_aware_delete_incomplete) << Pointee;
     }
 
     // Convert the operand to the type of the first parameter of operator

--- a/clang/test/SemaCXX/type-aware-delete-incomplete-type.cpp
+++ b/clang/test/SemaCXX/type-aware-delete-incomplete-type.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify=warn %s
 // RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify=warn %s
 // RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify=err %s
-// RUN: %clang_cc1 -std=c++17 -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
 
 class Foo; // warn-note {{forward declaration of 'Foo'}} \
            // err-note {{forward declaration of 'Foo'}}
@@ -21,8 +21,10 @@ void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); /
 
 void f(Foo *o) {
   delete o;
-  // warn-warning@-1 {{deleting pointer to incomplete type 'Foo' is incompatible with C++2c and may cause undefined behavior}}
-  // err-error@-2 {{cannot delete pointer to incomplete type 'Foo'}}
+  // warn-warning@-1 {{type-aware deallocation is not used for deletion of pointer to incomplete type 'Foo'}}
+  // warn-warning@-2 {{deleting pointer to incomplete type 'Foo' is incompatible with C++2c and may cause undefined behavior}}
+  // err-warning@-3 {{type-aware deallocation is not used for deletion of pointer to incomplete type 'Foo'}}
+  // err-error@-4 {{cannot delete pointer to incomplete type 'Foo'}}
 }
 
 // CHECK-LABEL: define {{.*}} @_Z1fP3Foo

--- a/clang/test/SemaCXX/type-aware-delete-incomplete-type.cpp
+++ b/clang/test/SemaCXX/type-aware-delete-incomplete-type.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify=warn %s
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify=warn %s
+// RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify=err %s
+// RUN: %clang_cc1 -std=c++17 -emit-llvm -o - %s | FileCheck %s
+
+class Foo; // warn-note {{forward declaration of 'Foo'}} \
+           // err-note {{forward declaration of 'Foo'}}
+
+typedef __SIZE_TYPE__ size_t;
+
+namespace std {
+  enum class align_val_t : size_t {};
+  template <class T> struct type_identity {
+    typedef T type;
+  };
+}
+
+template <class T>
+void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); // warn-warning {{type aware allocators are a Clang extension}} \
+                                                                                 // err-warning {{type aware allocators are a Clang extension}}
+
+void f(Foo *o) {
+  delete o;
+  // warn-warning@-1 {{deleting pointer to incomplete type 'Foo' is incompatible with C++2c and may cause undefined behavior}}
+  // err-error@-2 {{cannot delete pointer to incomplete type 'Foo'}}
+}
+
+// CHECK-LABEL: define {{.*}} @_Z1fP3Foo
+// CHECK-NOT: call {{.*}} @{{.*}}operator delete{{.*}}type_identity
+// CHECK: call void @_ZdlPv

--- a/clang/test/SemaCXX/type-aware-delete-incomplete-type.cpp
+++ b/clang/test/SemaCXX/type-aware-delete-incomplete-type.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify=warn %s
 // RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify=warn %s
 // RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify=err %s
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -DCODEGEN -emit-llvm -o - %s | FileCheck %s
 
 class Foo; // warn-note {{forward declaration of 'Foo'}} \
            // err-note {{forward declaration of 'Foo'}}
@@ -15,18 +15,30 @@ namespace std {
   };
 }
 
-template <class T>
-void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); // warn-warning {{type aware allocators are a Clang extension}} \
+void operator delete(std::type_identity<Foo>, void *, size_t, std::align_val_t); // warn-warning {{type aware allocators are a Clang extension}} \
                                                                                  // err-warning {{type aware allocators are a Clang extension}}
 
+#ifndef CODEGEN
 void f(Foo *o) {
   delete o;
-  // warn-warning@-1 {{type-aware deallocation is not used for deletion of pointer to incomplete type 'Foo'}}
-  // warn-warning@-2 {{deleting pointer to incomplete type 'Foo' is incompatible with C++2c and may cause undefined behavior}}
-  // err-warning@-3 {{type-aware deallocation is not used for deletion of pointer to incomplete type 'Foo'}}
-  // err-error@-4 {{cannot delete pointer to incomplete type 'Foo'}}
+  // warn-warning@-1 {{deleting pointer to incomplete type 'Foo' is incompatible with C++2c and may cause undefined behavior}}
+  // warn-error@-2 {{type-aware deallocation function matches incomplete type 'Foo'; the type must be complete to use type-aware deallocation}}
+  // err-error@-3 {{cannot delete pointer to incomplete type 'Foo'}}
+  // err-error@-4 {{type-aware deallocation function matches incomplete type 'Foo'; the type must be complete to use type-aware deallocation}}
+}
+#endif
+
+class Bar; // warn-note {{forward declaration of 'Bar'}} \
+           // err-note {{forward declaration of 'Bar'}}
+
+void g(Bar *b) {
+  delete b;
+  // warn-warning@-1 {{type-aware deallocation is not used for deletion of pointer to incomplete type 'Bar'}}
+  // warn-warning@-2 {{deleting pointer to incomplete type 'Bar' is incompatible with C++2c and may cause undefined behavior}}
+  // err-warning@-3 {{type-aware deallocation is not used for deletion of pointer to incomplete type 'Bar'}}
+  // err-error@-4 {{cannot delete pointer to incomplete type 'Bar'}}
 }
 
-// CHECK-LABEL: define {{.*}} @_Z1fP3Foo
+// CHECK-LABEL: define {{.*}} @_Z1gP3Bar
 // CHECK-NOT: call {{.*}} @{{.*}}operator delete{{.*}}type_identity
 // CHECK: call void @_ZdlPv


### PR DESCRIPTION
This PR adds a completeness check in `Sema::ActOnCXXDelete` so type-aware operator delete lookup is skipped when the pointee type is incomplete. 

Added a test covering C++17/23 (warn) and C++26 (error).

Fixes #212675
