### PR TITLE
[lldb-dap] Convert test to use the require decorator

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -10,8 +10,8 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import (
     expectedFailureWindows,
     expectedFailureWindowsAndNoLLDBServer,
+    requireNotWasm,
     skipIf,
-    skipIfWasm,
     skipIfWindowsAndLLDBServer,
 )
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
@@ -25,7 +25,7 @@ from lldbsuite.test.tools.lldb_dap.types import (
 # Often fails on Arm Linux, but not specifically because it's Arm, something in
 # process scheduling can cause a massive (minutes) delay during this test.
 @skipIf(oslist=["linux"], archs=["arm$"])
-@skipIfWasm  # No attach support
+@requireNotWasm  # No attach support
 class TestDAP_attach(DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -6,15 +6,18 @@ import importlib.util
 import os
 import unittest
 
-from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import requireNotWindows, requireNotWasm
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession
+from lldbsuite.test.skip_reason import UnsupportedReason
 
 
-skipUnlessPsutil = unittest.skipUnless(
+requirePsutil = unittest.skipUnless(
     importlib.util.find_spec("psutil") is not None,
-    "psutil not installed, please install using 'pip install psutil'.",
+    UnsupportedReason(
+        "psutil not installed, please install using 'pip install psutil'."
+    ),
 )
 
 
@@ -113,9 +116,9 @@ class TestDAP_console(DAPTestCaseBase):
     def test_empty_escape_prefix(self):
         self.do_test_with_escape_prefix("")
 
-    @skipIfWindows
-    @skipUnlessPsutil
-    @skipIfWasm  # the test signals the debug server, which for Wasm is the runtime
+    @requireNotWindows
+    @requirePsutil
+    @requireNotWasm  # the test signals the debug server, which for Wasm is the runtime
     def test_exit_status_message_sigterm(self):
         import psutil
 

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -2,13 +2,13 @@
 Test lldb-dap dataBreakpointInfo and setDataBreakpoints requests
 """
 
-from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import requireNotWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import DataBreakpoint, LaunchArgs
 
 
-@skipIfWasm  # data breakpoints map to watchpoints.
+@requireNotWasm  # data breakpoints map to watchpoints
 class TestDAP_setDataBreakpoints(DAPTestCaseBase):
     ACCESS_TYPES = ["read", "write", "readWrite"]
 

--- a/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
+++ b/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
@@ -11,7 +11,7 @@ import time
 import os
 
 
-@skipIfWasm  # no attach support
+@requireNotWasm  # no attach support
 class TestDAP_disconnect(lldbdap_testcase.DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -3,11 +3,11 @@ Test exception behavior in DAP with signal.
 """
 
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
-from lldbsuite.test.decorators import skipIfNoSignals
+from lldbsuite.test.decorators import requireSignals
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 
-@skipIfNoSignals
+@requireSignals
 class TestDAP_exception(DAPTestCaseBase):
     def test_stopped_description(self):
         """

--- a/lldb/test/API/tools/lldb-dap/exception/objc/TestDAP_exception_objc.py
+++ b/lldb/test/API/tools/lldb-dap/exception/objc/TestDAP_exception_objc.py
@@ -2,13 +2,13 @@
 Test exception behavior in DAP with obj-c throw.
 """
 
-from lldbsuite.test.decorators import skipUnlessDarwin
+from lldbsuite.test.decorators import requireDarwin
 from lldbsuite.test.tools.lldb_dap.types import ExceptionFilterOptions, LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 
 class TestDAP_exception_objc(DAPTestCaseBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test_stopped_description(self):
         """
         Test that exception description is shown correctly in stopped event.
@@ -34,7 +34,7 @@ class TestDAP_exception_objc(DAPTestCaseBase):
         stack_trace = self.expect_not_none(exception_details.stackTrace)
         self.assertRegex(stack_trace, "main.m")
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_break_on_throw_and_catch(self):
         """
         Test that breakpoints on exceptions work as expected.

--- a/lldb/test/API/tools/lldb-dap/extendedStackTrace/TestDAP_extendedStackTrace.py
+++ b/lldb/test/API/tools/lldb-dap/extendedStackTrace/TestDAP_extendedStackTrace.py
@@ -4,7 +4,7 @@ Test lldb-dap stackTrace request with an extended backtrace thread.
 
 import os
 
-from lldbsuite.test.decorators import skipUnlessDarwin
+from lldbsuite.test.decorators import requireDarwin
 from lldbsuite.test.lldbplatformutil import findBacktraceRecordingDylib
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
@@ -42,7 +42,7 @@ class TestDAP_extendedStackTrace(DAPTestCaseBase):
         stop_event = session.verify_stopped_on_breakpoint(bp_id, after=cm.process_event)
         return session, stop_event
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_stackTrace(self):
         """Tests the 'stackTrace' packet on a thread with an extended backtrace."""
         session, stop_event = self.build_and_run_to_breakpoint()
@@ -104,7 +104,7 @@ class TestDAP_extendedStackTrace(DAPTestCaseBase):
                 total_frames, i, "total frames should include a pagination offset"
             )
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_stackTraceWithFormat(self):
         """Tests the 'stackTrace' packet using stack trace formats."""
         session, stop_event = self.build_and_run_to_breakpoint(

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
@@ -2,14 +2,14 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipUnlessWindows, skipIfBuildType
+from lldbsuite.test.decorators import requireWindows, skipIfBuildType
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, Console
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from typing import List
 
 
 @skipIfBuildType(["debug"])
-@skipUnlessWindows
+@requireWindows
 class TestDAP_launch_win_debug_heap(DAPTestCaseBase):
     """
     Test that lldb-dap respects the debug heap setting on Windows when launching in an integrated terminal.

--- a/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
+++ b/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
@@ -7,14 +7,14 @@ import os
 import shutil
 
 from lldbsuite.test import lldbutil
-from lldbsuite.test.decorators import skipUnlessWindows
+from lldbsuite.test.decorators import requireWindows
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import ExitedEvent, LaunchArgs, TerminatedEvent
 
 MAX_PATH = 260
 
 
-@skipUnlessWindows
+@requireWindows
 class TestDAP_launch_longPath(DAPTestCaseBase):
     def _long_path(self, path):
         return lldbutil.get_extended_windows_path(path)

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -6,9 +6,9 @@ import platform
 import re
 
 from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
+    requireDarwin,
     skipIfWindows,
-    skipUnlessDarwin,
+    skipIfTargetDoesNotSupportSharedLibraries,
 )
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import (
@@ -112,7 +112,7 @@ class TestDAP_module(DAPTestCaseBase):
             "a.out", expect_debug_info_size=platform.system() != "Darwin"
         )
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_modules_dsym(self):
         """
         Darwin only test with dSYM file.

--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -76,7 +76,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         self.run_debug_session(connection, "Alice")
         self.run_debug_session(connection, "Bob")
 
-    @skipIfWindows
+    @requirePOSIX
     def test_server_unix_socket(self):
         """
         Test launching a binary with a lldb-dap in server mode on a unix socket.

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -8,9 +8,9 @@ from typing import List, Optional
 from lldbsuite.test import lldbplatformutil
 from lldbsuite.test.decorators import (
     no_debug_info_test,
+    requireDarwin,
     skipIfAsan,
     skipIfWindows,
-    skipUnlessDarwin,
 )
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import (
@@ -724,7 +724,7 @@ class TestDAP_variables(DAPTestCaseBase):
         self.assertIn("at main.cpp:", pc_reg.value)
 
     @no_debug_info_test
-    @skipUnlessDarwin
+    @requireDarwin
     def test_darwin_dwarf_missing_obj(self):
         """
         Test that if we build a binary with DWARF in .o files and we remove
@@ -738,7 +738,7 @@ class TestDAP_variables(DAPTestCaseBase):
         self.darwin_dwarf_missing_obj(None)
 
     @no_debug_info_test
-    @skipUnlessDarwin
+    @requireDarwin
     def test_darwin_dwarf_missing_obj_with_symbol_ondemand_enabled(self):
         """
         Test that if we build a binary with DWARF in .o files and we remove


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/212753 to convert the `lldb-dap` tests to use the `@require` decorators.