### PR TITLE
[lldb] Convert commands tests to use require decorator

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1217,6 +1217,11 @@ def requireSignals(func):
     return requireNotPlatform(["windows", "wasip1", "wasi"])(func)
 
 
+def requireExpressionEvaluation(func):
+    """Mark the item as requiring expression evaluation."""
+    return requireNotWasm(func)
+
+
 def requireNotWasm(func):
     """Mark the item as inherently inapplicable to WebAssembly targets.
 

--- a/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
+++ b/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipUnlessDarwin
+@requireDarwin
 class AddDsymCommandCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
+++ b/lldb/test/API/commands/command/language/TestFrameLanguageCommands.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def _run_cmd(self, cmd: str) -> str:
         """Run the given lldb command and return its output."""

--- a/lldb/test/API/commands/dwim-print/objc/TestDWIMPrintObjC.py
+++ b/lldb/test/API/commands/dwim-print/objc/TestDWIMPrintObjC.py
@@ -9,7 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
@@ -18,7 +18,7 @@ class TestCase(TestBase):
             "dwim-print parent.child", patterns=[r'_name = 0x[0-9a-f]+ @"Seven"']
         )
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_with_summary(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))

--- a/lldb/test/API/commands/expression/anonymous-struct/TestCallUserAnonTypedef.py
+++ b/lldb/test/API/commands/expression/anonymous-struct/TestCallUserAnonTypedef.py
@@ -13,7 +13,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestExprLookupAnonStructTypedef(TestBase):
     def test(self):
         """Test typedeffed untagged struct arguments for function call expressions"""

--- a/lldb/test/API/commands/expression/argument_passing_restrictions/TestArgumentPassingRestrictions.py
+++ b/lldb/test/API/commands/expression/argument_passing_restrictions/TestArgumentPassingRestrictions.py
@@ -15,7 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestArgumentPassingRestrictions(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "7.0"])
     def test_argument_passing_restrictions(self):

--- a/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprCommandCallFunctionTestCase(TestBase):
     @expectedFailureAll(
         compiler="icc", bugnumber="llvm.org/pr14437, fails with ICC 13.1"

--- a/lldb/test/API/commands/expression/call-function/TestCallStopAndContinue.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStopAndContinue.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprCommandCallStopContinueTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/call-function/TestCallUserDefinedFunction.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallUserDefinedFunction.py
@@ -13,7 +13,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprCommandCallUserDefinedFunction(TestBase):
     def test(self):
         """Test return values of user defined function calls."""

--- a/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
+++ b/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfNoSignals
+@requireSignals
 class ExprCommandThatRestartsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
@@ -21,7 +21,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @skipIfDarwin  # llvm.org/pr19246: intermittent failure
-    @skipIfWindows  # Test relies on signals, unsupported on Windows
+    @requireNotWindows  # Test relies on signals, unsupported on Windows
     @expectedFlakeyAndroid(bugnumber="llvm.org/pr19246")
     @expectedFlakeyNetBSD
     def test(self):

--- a/lldb/test/API/commands/expression/class_template_specialization_empty_pack/TestClassTemplateSpecializationParametersHandling.py
+++ b/lldb/test/API/commands/expression/class_template_specialization_empty_pack/TestClassTemplateSpecializationParametersHandling.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestClassTemplateSpecializationParametersHandling(TestBase):
     def test_class_template_specialization(self):
         self.build()

--- a/lldb/test/API/commands/expression/context-object/TestContextObject.py
+++ b/lldb/test/API/commands/expression/context-object/TestContextObject.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ContextObjectTestCase(TestBase):
     def test_context_object(self):
         """Tests expression evaluation in context of an object."""

--- a/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
+++ b/lldb/test/API/commands/expression/expr-with-fork/TestExprWithFork.py
@@ -18,7 +18,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- Basic expression evaluation across fork/vfork ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork(self):
         """Test that expression evaluation succeeds when the expression calls fork()."""
@@ -31,7 +31,7 @@ class ExprWithForkTestCase(TestBase):
             "fork_and_return(42, false)", result_type="int", result_value="42"
         )
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork(self):
         """Test that expression evaluation succeeds when the expression calls vfork()."""
@@ -44,7 +44,7 @@ class ExprWithForkTestCase(TestBase):
             "fork_and_return(42, true)", result_type="int", result_value="42"
         )
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork_trap(self):
         """Test that expression evaluation handles a child process that triggers a SIGTRAP."""
@@ -66,7 +66,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- follow-fork-mode child override during expression evaluation ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork_follow_child(self):
         """Test that expression evaluation succeeds with follow-fork-mode child."""
@@ -87,7 +87,7 @@ class ExprWithForkTestCase(TestBase):
         # Verify we are still debugging the original process.
         self.assertEqual(process.GetProcessID(), original_pid)
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork_follow_child(self):
         """Test that expression evaluation succeeds with vfork and follow-fork-mode child."""
@@ -107,7 +107,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- stop-on-fork: fork interrupts expression immediately ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork_stop_on_fork(self):
         """Test that stop-on-fork interrupts expression evaluation on fork."""
@@ -126,7 +126,7 @@ class ExprWithForkTestCase(TestBase):
         # The expression should be interrupted due to the fork.
         self.assertTrue(value.GetError().Fail())
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork_stop_on_fork_process_state(self):
         """Test that process state is valid after stop-on-fork interrupts on fork."""
@@ -150,7 +150,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- stop-on-fork with vfork: deferred to vforkdone ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork_stop_on_fork(self):
         """Test that stop-on-fork with vfork defers to vforkdone and interrupts."""
@@ -170,7 +170,7 @@ class ExprWithForkTestCase(TestBase):
         # vfork) because stop-on-fork is set.
         self.assertTrue(value.GetError().Fail())
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork_stop_on_fork_process_state(self):
         """Test that process state is clean after vfork stop-on-fork interruption.
@@ -196,7 +196,7 @@ class ExprWithForkTestCase(TestBase):
         self.assertEqual(process.GetProcessID(), original_pid)
         self.assertEqual(process.GetState(), lldb.eStateStopped)
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork_stop_on_fork_breakpoints_work(self):
         """Test that breakpoints are functional after vfork stop-on-fork.
@@ -226,7 +226,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- stop-on-fork=false (default): no interruption ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork_stop_on_fork_false(self):
         """Test that stop-on-fork=false allows fork expression to complete."""
@@ -246,7 +246,7 @@ class ExprWithForkTestCase(TestBase):
         self.assertSuccess(value.GetError())
         self.assertEqual(value.GetValueAsSigned(), 42)
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork_stop_on_fork_false(self):
         """Test that stop-on-fork=false allows vfork expression to complete."""
@@ -285,7 +285,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- stop-on-fork with follow-fork-mode child ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_fork_stop_on_fork_follow_child(self):
         """Test stop-on-fork + follow-child: expression interrupted, still on parent."""
@@ -309,7 +309,7 @@ class ExprWithForkTestCase(TestBase):
         self.assertTrue(value.GetError().Fail())
         self.assertEqual(process.GetProcessID(), original_pid)
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_with_vfork_stop_on_fork_follow_child(self):
         """Test stop-on-fork + vfork + follow-child: interrupted at vforkdone, still on parent."""
@@ -335,7 +335,7 @@ class ExprWithForkTestCase(TestBase):
 
     # --- concurrent fork on another thread during expression ---
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_concurrent_fork_other_thread(self):
         """Test that a fork on another thread during expression is handled correctly.
@@ -373,7 +373,7 @@ class ExprWithForkTestCase(TestBase):
         # Breakpoints should still be functional.
         self.expect_expr("x", result_type="int", result_value="42")
 
-    @skipIfWindows
+    @requirePOSIX
     @add_test_categories(["fork"])
     def test_expr_concurrent_fork_other_thread_follow_child(self):
         """Test that follow-fork-mode child is overridden during expression evaluation.

--- a/lldb/test/API/commands/expression/expr_inside_lambda/TestExprInsideLambdas.py
+++ b/lldb/test/API/commands/expression/expr_inside_lambda/TestExprInsideLambdas.py
@@ -10,7 +10,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprInsideLambdaTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/commands/expression/formatters/TestFormatters.py
+++ b/lldb/test/API/commands/expression/formatters/TestFormatters.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprFormattersTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/inline-namespace/TestInlineNamespace.py
+++ b/lldb/test/API/commands/expression/inline-namespace/TestInlineNamespace.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestInlineNamespace(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/namespace-alias/TestInlineNamespaceAlias.py
+++ b/lldb/test/API/commands/expression/namespace-alias/TestInlineNamespaceAlias.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestInlineNamespace(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/persistent_types/TestNestedPersistentTypes.py
+++ b/lldb/test/API/commands/expression/persistent_types/TestNestedPersistentTypes.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class NestedPersistentTypesTestCase(TestBase):
     def test_persistent_types(self):
         """Test that nested persistent types work."""

--- a/lldb/test/API/commands/expression/persistent_types/TestPersistentTypes.py
+++ b/lldb/test/API/commands/expression/persistent_types/TestPersistentTypes.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class PersistenttypesTestCase(TestBase):
     def test_persistent_types(self):
         """Test that lldb persistent types works correctly."""

--- a/lldb/test/API/commands/expression/po_persistent_result/TestPoPersistentResult.py
+++ b/lldb/test/API/commands/expression/po_persistent_result/TestPoPersistentResult.py
@@ -14,12 +14,12 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_po_does_not_print_persistent_result(self):
         """Test `po` doesn't advertise a persistent result variable."""
         self.expect("po obj", matching=False, substrs=["$0 = "])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_po_does_not_keep_persistent_result(self):
         """Test `po` doesn't leak a persistent result variable."""
         self.expect("po obj")
@@ -28,7 +28,7 @@ class TestCase(TestBase):
         self.expect("expression $0", error=True)
         self.expect("expression obj", substrs=["$0 = "])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_expression_description_verbosity(self):
         """Test printing object description _and_ opt-in to persistent results."""
         self.expect("expression -O -vfull -- obj", substrs=["$0 = "])

--- a/lldb/test/API/commands/expression/pr35310/TestExprsBug35310.py
+++ b/lldb/test/API/commands/expression/pr35310/TestExprsBug35310.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprBug35310(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/radar_9531204/TestPrintfAfterUp.py
+++ b/lldb/test/API/commands/expression/radar_9531204/TestPrintfAfterUp.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class Radar9531204TestCase(TestBase):
     # rdar://problem/9531204
     def test_expr_commands(self):

--- a/lldb/test/API/commands/expression/radar_9673664/TestExprHelpExamples.py
+++ b/lldb/test/API/commands/expression/radar_9673664/TestExprHelpExamples.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class Radar9673644TestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/result_numbering/TestResultNumbering.py
+++ b/lldb/test/API/commands/expression/result_numbering/TestResultNumbering.py
@@ -10,7 +10,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestExpressionResultNumbering(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/expression/test/TestExprs.py
+++ b/lldb/test/API/commands/expression/test/TestExprs.py
@@ -19,7 +19,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class BasicExprCommandsTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/timeout/TestCallWithTimeout.py
+++ b/lldb/test/API/commands/expression/timeout/TestCallWithTimeout.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprCommandWithTimeoutsTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/unwind_expression/TestUnwindExpression.py
+++ b/lldb/test/API/commands/expression/unwind_expression/TestUnwindExpression.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class UnwindFromExpressionTest(TestBase):
     main_spec = lldb.SBFileSpec("main.cpp", False)
 

--- a/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
+++ b/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
@@ -15,7 +15,7 @@ class TestWeakSymbolsInExpressions(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(compiler="clang", compiler_version=["<", "19.0"])
     def test_weak_symbol_in_expr(self):
         """Tests that we can refer to weak symbols in expressions."""

--- a/lldb/test/API/commands/expression/xvalue/TestXValuePrinting.py
+++ b/lldb/test/API/commands/expression/xvalue/TestXValuePrinting.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class ExprXValuePrintingTestCase(TestBase):
     def test(self):
         """Printing an xvalue should work."""

--- a/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
+++ b/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
@@ -374,7 +374,7 @@ class FrameRecognizerTestCase(TestBase):
             substrs=["frame 0 is recognized by recognizer.MyFrameRecognizer"],
         )
 
-    @skipIfWasm  # $arg1/$arg2 need argument registers, unsupported on WebAssembly.
+    @requireNotWasm  # $arg1/$arg2 need argument registers, unsupported on WebAssembly.
     def test_frame_recognizer_not_only_first_instruction(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -112,7 +112,7 @@ class TestFrameVar(TestBase):
             self.assertIn(s, message)
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_darwin_dwarf_missing_obj(self):
         """
         Test that if we build a binary with DWARF in .o files and we remove
@@ -136,7 +136,7 @@ class TestFrameVar(TestBase):
         self.check_frame_variable_errors(thread, error_strings)
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_darwin_dwarf_obj_mod_time_mismatch(self):
         """
         Test that if we build a binary with DWARF in .o files and we update

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/TestFrameVarDirectIvarObjC.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/TestFrameVarDirectIvarObjC.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test_objc_self(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         )
         self.expect("frame variable _ivar", startstr="(int) _ivar = 30")
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_objc_self_capture_idiom(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/commands/frame/var/direct-ivar/objcpp/TestFrameVarDirectIvarObjCPlusPlus.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objcpp/TestFrameVarDirectIvarObjCPlusPlus.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test_objc_self(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         )
         self.expect("frame variable _ivar", startstr="(int) _ivar = 30")
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_objc_explicit_self(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -21,7 +21,7 @@ class TestCase(TestBase):
         )
         self.expect("frame variable _ivar", startstr="(int) _ivar = 30")
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_cpp_this(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/commands/platform/basic/TestPlatformPython.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformPython.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # platform shell needs a connected remote
+@requireNotWasm  # platform shell needs a connected remote
 class PlatformPythonTestCase(TestBase):
     @add_test_categories(["pyapi"])
     @no_debug_info_test

--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -5,7 +5,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no remote platform to connect to
+@requireNotWasm  # no remote platform to connect to
 class TestPlatformProcessConnect(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
+++ b/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
@@ -6,7 +6,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # cannot launch a gdbserver
+@requireNotWasm  # cannot launch a gdbserver
 class TestPlatformProcessLaunchGDBServer(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/commands/platform/process/list/TestProcessList.py
+++ b/lldb/test/API/commands/platform/process/list/TestProcessList.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # attaching requires launching the inferior as a host process
+@requireNotWasm  # attaching requires launching the inferior as a host process
 class ProcessListTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
+++ b/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
@@ -38,7 +38,7 @@ class PlatformSDKTestCase(TestBase):
         return None
 
     @no_debug_info_test
-    @skipUnlessDarwin
+    @requireDarwin
     @skipTestIfFn(no_debugserver)
     @skipTestIfFn(port_not_available)
     @skipIfRemote

--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -13,7 +13,7 @@ from lldbsuite.test import lldbutil
 exe_name = "ProcessAttach"  # Must match Makefile
 
 
-@skipIfWasm  # attaching requires launching the inferior as a host process
+@requireNotWasm  # attaching requires launching the inferior as a host process
 class ProcessAttachTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/commands/process/attach/attach_denied/TestAttachDenied.py
+++ b/lldb/test/API/commands/process/attach/attach_denied/TestAttachDenied.py
@@ -12,11 +12,11 @@ from lldbsuite.test import lldbutil
 exe_name = "AttachDenied"  # Must match Makefile
 
 
-@skipIfNoSignals
+@requireSignals
 class AttachDeniedTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfWindows
+    @requirePOSIX
     @skipIfiOSSimulator
     @skipIfDarwinEmbedded  # ptrace(ATTACH_REQUEST...) won't work on ios/tvos/etc
     @skipIfAsan # Times out inconsistently under asan

--- a/lldb/test/API/commands/process/handle/TestProcessHandle.py
+++ b/lldb/test/API/commands/process/handle/TestProcessHandle.py
@@ -6,7 +6,7 @@ from lldbsuite.test.decorators import *
 
 class TestProcessHandle(TestBase):
     @no_debug_info_test
-    @skipIfWindows
+    @requireNotWindows
     def test_process_handle(self):
         """Test that calling process handle before we have a target, and before we
         have a process will affect the process.  Also that the signal settings

--- a/lldb/test/API/commands/process/launch-with-shellexpand/TestLaunchWithShellExpand.py
+++ b/lldb/test/API/commands/process/launch-with-shellexpand/TestLaunchWithShellExpand.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no host shell to expand arguments
+@requireNotWasm  # no host shell to expand arguments
 class LaunchWithShellExpandTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/reverse-continue/TestReverseContinue.py
+++ b/lldb/test/API/commands/process/reverse-continue/TestReverseContinue.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbreverse import ReverseTestBase
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no reverse execution
+@requireNotWasm  # no reverse execution
 class TestReverseContinue(ReverseTestBase):
     @skipIfRemote
     def test_reverse_continue(self):

--- a/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
+++ b/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
@@ -11,7 +11,7 @@ MAX_SOCKET_PATH_LENGTH = 104
 
 
 class MCPUnixSocketCommandTestCase(TestBase):
-    @skipIfWindows
+    @requirePOSIX
     @skipIfRemote
     @no_debug_info_test
     def test_unix_socket(self):

--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -702,7 +702,7 @@ class RegisterCommandsTestCase(TestBase):
             "fs_base does not equal to pthread_self() value.",
         )
 
-    @skipIfWasm  # attaching requires launching the inferior as a host process
+    @requireNotWasm  # attaching requires launching the inferior as a host process
     def test_process_must_be_stopped(self):
         """Check that all register commands error when the process is not stopped."""
         self.build()

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -757,7 +757,7 @@ class TestCase(TestBase):
         self.assertIn("dwoErrorCount", debug_stats["modules"][0])
         self.assertEqual(debug_stats["modules"][0]["dwoErrorCount"], 1)
 
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test_dsym_binary_has_symfile_in_stats(self):
         """
@@ -801,7 +801,7 @@ class TestCase(TestBase):
         # statistics.
         self.assertNotIn("symbolFileModuleIdentifiers", exe_stats)
 
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test_no_dsym_binary_has_symfile_identifiers_in_stats(self):
         """
@@ -860,7 +860,7 @@ class TestCase(TestBase):
             # Make sure each .o file has some debug info bytes.
             self.assertGreater(o_module["debugInfoByteSize"], 0)
 
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test_had_frame_variable_errors(self):
         """

--- a/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
+++ b/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no remote platform to auto-install onto
+@requireNotWasm  # no remote platform to auto-install onto
 class TestAutoInstallMainExecutable(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
+++ b/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
@@ -13,7 +13,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @no_debug_info_test
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/target/dump-separate-debug-info/oso/TestDumpOso.py
+++ b/lldb/test/API/commands/target/dump-separate-debug-info/oso/TestDumpOso.py
@@ -25,7 +25,7 @@ class TestDumpOso(lldbtest.TestBase):
         return result
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_shows_oso_loaded_json_output(self):
         self.build(debug_info="dwarf")
         exe = self.getBuildArtifact("a.out")
@@ -47,7 +47,7 @@ class TestDumpOso(lldbtest.TestBase):
         self.assertTrue(osos[exe][foo_o]["loaded"])
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_shows_oso_not_loaded_json_output(self):
         self.build(debug_info="dwarf")
         exe = self.getBuildArtifact("a.out")
@@ -77,7 +77,7 @@ class TestDumpOso(lldbtest.TestBase):
         self.assertNotIn(foo_o, output[exe])
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_shows_oso_loaded_table_output(self):
         self.build(debug_info="dwarf")
         exe = self.getBuildArtifact("a.out")
@@ -103,7 +103,7 @@ class TestDumpOso(lldbtest.TestBase):
         )
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_shows_oso_not_loaded_table_output(self):
         self.build(debug_info="dwarf")
         exe = self.getBuildArtifact("a.out")
@@ -129,7 +129,7 @@ class TestDumpOso(lldbtest.TestBase):
         )
 
     @skipIfRemote
-    @skipUnlessDarwin
+    @requireDarwin
     def test_osos_loaded_symbols_on_demand(self):
         self.build(debug_info="dwarf")
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
+++ b/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
@@ -9,7 +9,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestStopHooks(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/212753 to convert the `commands` tests to use the `@require` decorator.