### PR TITLE
[lldb] Convert lang tests to use require decorator

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1217,6 +1217,11 @@ def requireSignals(func):
     return requireNotPlatform(["windows", "wasip1", "wasi"])(func)
 
 
+def requireExpressionEvaluation(func):
+    """Mark the item as requiring expression evaluation."""
+    return requireNotWasm(func)
+
+
 def requireNotWasm(func):
     """Mark the item as inherently inapplicable to WebAssembly targets.
 

--- a/lldb/test/API/lang/c/anonymous/TestAnonymous.py
+++ b/lldb/test/API/lang/c/anonymous/TestAnonymous.py
@@ -74,7 +74,7 @@ class AnonymousTestCase(TestBase):
             substrs=["(type_y) $", "dummy = 2"],
         )
 
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_expr_null(self):
         self.build()
         self.common_setup(self.line2)

--- a/lldb/test/API/lang/c/blocks/TestBlocks.py
+++ b/lldb/test/API/lang/c/blocks/TestBlocks.py
@@ -6,9 +6,9 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class BlocksTestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         self.build()
         src = lldb.SBFileSpec("main.c")
@@ -52,7 +52,7 @@ class BlocksTestCase(TestBase):
         self.expect_expr("*captured_ptr", result_type="int", result_value="42")
         self.expect_expr("captured_struct.x", result_type="int", result_value="10")
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_define(self):
         """Test defining and calling a block from the expression evaluator."""
         self.build()

--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -87,7 +87,7 @@ class TestCase(TestBase):
             return
         self.expect_expr("func(1, 2, 3, 4)", result_type="int", result_value="10")
 
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_sysv_abi(self):
         if not self.build_and_run("sysv_abi.c"):
             return

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -14,7 +14,7 @@ class EnumTypesTestCase(TestBase):
         # Find the line number to break inside main().
         self.line = line_number("main.c", "// Set break point at this line.")
 
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_command_line(self):
         """Test 'image lookup -t enum_test_days' and check for correct display and enum value printing."""
         self.build()

--- a/lldb/test/API/lang/c/fpeval/TestFPEval.py
+++ b/lldb/test/API/lang/c/fpeval/TestFPEval.py
@@ -6,7 +6,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class FPEvalTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/c/full_lto_stepping/TestFullLtoStepping.py
+++ b/lldb/test/API/lang/c/full_lto_stepping/TestFullLtoStepping.py
@@ -11,7 +11,7 @@ class TestFullLtoStepping(TestBase):
     @skipIfAsan
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "13.0"])
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_name_breakpoint(self, "main")

--- a/lldb/test/API/lang/c/function_types/TestFunctionTypes.py
+++ b/lldb/test/API/lang/c/function_types/TestFunctionTypes.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class FunctionTypesTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/c/libc_calls/TestLibcCalls.py
+++ b/lldb/test/API/lang/c/libc_calls/TestLibcCalls.py
@@ -15,7 +15,7 @@ LIBC_FUNCTIONS = [
 class LibcCallsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfRemote
     def test_libc_funcs_do_not_resolve_to_dyld(self):
         """The JIT-resolved address of each libc function must not lie in
@@ -54,7 +54,7 @@ class LibcCallsTestCase(TestBase):
                     resolved_module_name, "dyld", f"Called dyld version of {symbol}"
                 )
 
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_libc_calls_succeed(self):
         """Calling memset/memcpy/memmove/memcmp from expressions must
         execute without trapping."""

--- a/lldb/test/API/lang/c/modules/TestCModules.py
+++ b/lldb/test/API/lang/c/modules/TestCModules.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CModulesTestCase(TestBase):
     @expectedFailureAll(
         oslist=["freebsd", "linux"],

--- a/lldb/test/API/lang/c/sizeof/TestCSizeof.py
+++ b/lldb/test/API/lang/c/sizeof/TestCSizeof.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/c/strings/TestCStrings.py
+++ b/lldb/test/API/lang/c/strings/TestCStrings.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CStringsTestCase(TestBase):
     def test_with_run_command(self):
         """Tests that C strings work as expected in expressions"""

--- a/lldb/test/API/lang/c/struct_types/TestStructTypes.py
+++ b/lldb/test/API/lang/c/struct_types/TestStructTypes.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipIfWasm])
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.requireExpressionEvaluation])

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -19,7 +19,7 @@ class AbiTagStructorsTestCase(TestBase):
     )
     @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(oslist=["windows"])
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_with_structor_linkage_names(self):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})
 
@@ -127,14 +127,14 @@ class AbiTagStructorsTestCase(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "22"])
     @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(oslist=["windows"])
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_nested_with_structor_linkage_names(self):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})
         self.do_nested_structor_test()
 
     @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(oslist=["windows"])
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_nested_no_structor_linkage_names(self):
         # In older versions of Clang the -gno-structor-decl-linkage-names
         # behaviour was the default.

--- a/lldb/test/API/lang/cpp/accelerator-table/TestCPPAccelerator.py
+++ b/lldb/test/API/lang/cpp/accelerator-table/TestCPPAccelerator.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class CPPAcceleratorTableTestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(debug_info=no_match(["dwarf"]))
     @skipIf(dwarf_version=[">=", "5"])
     def test(self):

--- a/lldb/test/API/lang/cpp/auto/TestCPPAuto.py
+++ b/lldb/test/API/lang/cpp/auto/TestCPPAuto.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CPPAutoTestCase(TestBase):
     def test_with_run_command(self):
         """Test that auto types work in the expression parser"""

--- a/lldb/test/API/lang/cpp/call-function/TestCallCPPFunction.py
+++ b/lldb/test/API/lang/cpp/call-function/TestCallCPPFunction.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CallCPPFunctionTestCase(TestBase):
     def setUp(self):
         TestBase.setUp(self)

--- a/lldb/test/API/lang/cpp/chained-calls/TestCppChainedCalls.py
+++ b/lldb/test/API/lang/cpp/chained-calls/TestCppChainedCalls.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCppChainedCalls(TestBase):
     def test_with_run_command(self):
         self.build()

--- a/lldb/test/API/lang/cpp/class-template-parameter-pack/TestClassTemplateParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-parameter-pack/TestClassTemplateParameterPack.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/const_static_integral_member_int128/TestConstStaticIntegralMemberInt128.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member_int128/TestConstStaticIntegralMemberInt128.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     # int128 is not available on 32-bit ARM.
     @skipIf(archs=["arm$"])

--- a/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
+++ b/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     @expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc")
     def test_constructors(self):

--- a/lldb/test/API/lang/cpp/covariant-return-types/TestCovariantReturnTypes.py
+++ b/lldb/test/API/lang/cpp/covariant-return-types/TestCovariantReturnTypes.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/cpp/decl-from-submodule/TestDeclFromSubmodule.py
+++ b/lldb/test/API/lang/cpp/decl-from-submodule/TestDeclFromSubmodule.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class DeclFromSubmoduleTestCase(TestBase):
     # Requires DWARF debug info which is not retained when linking with link.exe.
     @skipIfWindows

--- a/lldb/test/API/lang/cpp/default-template-args/TestDefaultTemplateArgs.py
+++ b/lldb/test/API/lang/cpp/default-template-args/TestDefaultTemplateArgs.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestDefaultTemplateArgs(TestBase):
     @no_debug_info_test
     def test(self):

--- a/lldb/test/API/lang/cpp/enum-limits/TestCPPEnumLimits.py
+++ b/lldb/test/API/lang/cpp/enum-limits/TestCPPEnumLimits.py
@@ -56,7 +56,7 @@ class CPPEnumLimitsTestCase(TestBase):
         self.build()
         self.check_all(self.dbg.CreateTarget(self.getBuildArtifact("a.out")))
 
-    @skipUnlessPlatform(["windows"])
+    @requireWindows
     @skipUnlessMSVC
     @no_debug_info_test  # We only test MSVC
     def test_msvc(self):

--- a/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
+++ b/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # wasm inferiors are built with -fno-exceptions
+@requireNotWasm  # wasm inferiors are built with -fno-exceptions
 class CPPBreakpointTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/cv_qualified_objects/TestExprOnCVQualifiedObjects.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/cv_qualified_objects/TestExprOnCVQualifiedObjects.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/floating-types-specialization/TestCppFloatingTypesSpecialization.py
+++ b/lldb/test/API/lang/cpp/floating-types-specialization/TestCppFloatingTypesSpecialization.py
@@ -5,7 +5,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # _Float16/__bf16 are unsupported on the wasm target
+@requireNotWasm  # _Float16/__bf16 are unsupported on the wasm target
 class TestCase(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     def test(self):

--- a/lldb/test/API/lang/cpp/function-call-from-object-file/TestFunctionCallFromObjectFile.py
+++ b/lldb/test/API/lang/cpp/function-call-from-object-file/TestFunctionCallFromObjectFile.py
@@ -15,7 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestFunctionCallFromObjectFile(TestBase):
     def test_lib1(self):
         self.build()

--- a/lldb/test/API/lang/cpp/function-qualifiers/TestCppFunctionQualifiers.py
+++ b/lldb/test/API/lang/cpp/function-qualifiers/TestCppFunctionQualifiers.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestFunctionQualifiers(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/function-ref-qualifiers/TestCppFunctionRefQualifiers.py
+++ b/lldb/test/API/lang/cpp/function-ref-qualifiers/TestCppFunctionRefQualifiers.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestFunctionRefQualifiers(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
+++ b/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCppGlobalOperators(TestBase):
     def prepare_executable_and_get_frame(self):
         self.build()

--- a/lldb/test/API/lang/cpp/llvm-style/TestLLVMStyle.py
+++ b/lldb/test/API/lang/cpp/llvm-style/TestLLVMStyle.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipIfWasm])
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.requireNotWasm])

--- a/lldb/test/API/lang/cpp/modules-import/TestCXXModulesImport.py
+++ b/lldb/test/API/lang/cpp/modules-import/TestCXXModulesImport.py
@@ -19,7 +19,7 @@ class CXXModulesImportTestCase(TestBase):
             )
         super(CXXModulesImportTestCase, self).build()
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(macos_version=["<", "10.12"])
     @skipIf(compiler="clang", compiler_version=["<", "14.0"])
     def test_expr(self):
@@ -34,7 +34,7 @@ class CXXModulesImportTestCase(TestBase):
             "expr -l Objective-C++ -- @import THIS_MODULE_DOES_NOT_EXIST", error=True
         )
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(macos_version=["<", "10.12"])
     @skipIf(compiler="clang", compiler_version=["<", "14.0"])
     def test_expr_failing_import(self):

--- a/lldb/test/API/lang/cpp/multiple-inheritance/TestCppMultipleInheritance.py
+++ b/lldb/test/API/lang/cpp/multiple-inheritance/TestCppMultipleInheritance.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/namespace/TestNamespace.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespace.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class NamespaceBreakpointTestCase(TestBase):
     @expectedFailureAll(bugnumber="llvm.org/pr28548", compiler="gcc")
     @expectedFailureAll(oslist=["windows"])
@@ -133,7 +133,7 @@ class NamespaceTestCase(TestBase):
 
     # rdar://problem/8668674
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_with_run_command(self):
         """Test that anonymous and named namespace variables display correctly."""
         self.build()

--- a/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
@@ -100,7 +100,7 @@ class NamespaceLookupTestCase(TestBase):
         self.expect_expr("::func()", result_type="int", result_value="1")
 
     @skipIfWindows  # This is flakey on Windows: llvm.org/pr38373
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_scope_lookup_with_run_command(self):
         """Test scope lookup of functions in lldb."""
         self.build()
@@ -259,7 +259,7 @@ class NamespaceLookupTestCase(TestBase):
     # NOTE: this test may fail on older systems that don't emit import
     # entries in DWARF - may need to add checks for compiler versions here.
     @skipIf(compiler="gcc", oslist=["linux"], debug_info=["dwo"])  # Skip to avoid crash
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_scope_after_using_directive_lookup_with_run_command(self):
         """Test scope lookup after using directive in lldb."""
         self.build()
@@ -323,7 +323,7 @@ class NamespaceLookupTestCase(TestBase):
         # the same type.
         self.expect("expr -- func()", startstr="error")
 
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_scope_lookup_shadowed_by_using_with_run_command(self):
         """Test scope lookup shadowed by using in lldb."""
         self.build()

--- a/lldb/test/API/lang/cpp/namespace_conflicts/TestNamespaceConflicts.py
+++ b/lldb/test/API/lang/cpp/namespace_conflicts/TestNamespaceConflicts.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipIfWasm])
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.requireNotWasm])

--- a/lldb/test/API/lang/cpp/operators/TestCppOperators.py
+++ b/lldb/test/API/lang/cpp/operators/TestCppOperators.py
@@ -5,7 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     [
-        decorators.skipIfWasm,
+        decorators.requireNotWasm,
         decorators.expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc"),
     ],
 )

--- a/lldb/test/API/lang/cpp/overloaded-functions/TestOverloadedFunctions.py
+++ b/lldb/test/API/lang/cpp/overloaded-functions/TestOverloadedFunctions.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class OverloadedFunctionsTestCase(TestBase):
     def test_with_run_command(self):
         """Test that functions with the same name are resolved correctly"""

--- a/lldb/test/API/lang/cpp/pointer_to_member_type_depending_on_parent_size/TestPointerToMemberTypeDependingOnParentSize.py
+++ b/lldb/test/API/lang/cpp/pointer_to_member_type_depending_on_parent_size/TestPointerToMemberTypeDependingOnParentSize.py
@@ -10,7 +10,7 @@ class TestCase(TestBase):
     @skipIf(compiler="gcc")
     # On Windows both MSVC and Clang are rejecting the test code because
     # `ToLayout` is not complete when pointer_to_member_member is declared.
-    @skipIfWindows
+    @requireNotWindows
     @no_debug_info_test
     def test(self):
         """

--- a/lldb/test/API/lang/cpp/printf/TestPrintf.py
+++ b/lldb/test/API/lang/cpp/printf/TestPrintf.py
@@ -5,7 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     [
-        decorators.skipIfWasm,
+        decorators.requireNotWasm,
         decorators.expectedFailureAll(bugnumber="llvm.org/PR36715", oslist=["windows"]),
     ],
 )

--- a/lldb/test/API/lang/cpp/rvalue-references/TestRvalueReferences.py
+++ b/lldb/test/API/lang/cpp/rvalue-references/TestRvalueReferences.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class RvalueReferencesTestCase(TestBase):
     # rdar://problem/11479676
     @expectedFailureAll(

--- a/lldb/test/API/lang/cpp/scope/TestCppScope.py
+++ b/lldb/test/API/lang/cpp/scope/TestCppScope.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
     def test(self):

--- a/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
+++ b/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
@@ -12,7 +12,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     # We fail to lookup static members on Windows.
     @expectedFailureAll(oslist=["windows"])
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_access_from_main(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -25,7 +25,7 @@ class TestCase(TestBase):
 
     # We fail to lookup static members on Windows.
     @expectedFailureAll(oslist=["windows"])
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_access_from_member_function(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -48,7 +48,7 @@ class TestCase(TestBase):
 
     # We fail to lookup static members on Windows.
     @expectedFailureAll(oslist=["windows"])
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_no_crash_in_IR_arithmetic(self):
         """
         Test that LLDB doesn't crash on evaluating specific expression involving

--- a/lldb/test/API/lang/cpp/static_methods/TestCPPStaticMethods.py
+++ b/lldb/test/API/lang/cpp/static_methods/TestCPPStaticMethods.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CPPStaticMethodsTestCase(TestBase):
     def test_with_run_command(self):
         """Test that static methods are properly distinguished from regular methods"""

--- a/lldb/test/API/lang/cpp/symbols/TestSymbols.py
+++ b/lldb/test/API/lang/cpp/symbols/TestSymbols.py
@@ -5,7 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     [
-        decorators.skipIfWasm,
+        decorators.requireNotWasm,
         decorators.expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764"),
     ],
 )

--- a/lldb/test/API/lang/cpp/template-diagnostic-hint/TestTemplateDiagnosticHint.py
+++ b/lldb/test/API/lang/cpp/template-diagnostic-hint/TestTemplateDiagnosticHint.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     @expectedFailureWindows
     def test(self):

--- a/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
+++ b/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
@@ -56,7 +56,7 @@ class TemplateFunctionsTestCase(TestBase):
             self.expect_expr("d1 == d2", result_type="bool", result_value="true")
 
     @skipIfWindows
-    @skipIfWasm  # no expression evaluation
+    @requireExpressionEvaluation
     def test_template_function_with_cast(self):
         self.do_test_template_function(True)
 

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CPPThisTestCase(TestBase):
     # rdar://problem/9962849
     @expectedFailureAll(

--- a/lldb/test/API/lang/cpp/this_class_type_mixing/TestThisClassTypeMixing.py
+++ b/lldb/test/API/lang/cpp/this_class_type_mixing/TestThisClassTypeMixing.py
@@ -14,7 +14,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     @no_debug_info_test
     def test(self):

--- a/lldb/test/API/lang/cpp/thread_local/TestThreadLocal.py
+++ b/lldb/test/API/lang/cpp/thread_local/TestThreadLocal.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbtest
 
 
-@skipIfWasm  # checks the platform-specific TLS-uninitialized error, N/A to wasm
+@requireNotWasm  # checks the platform-specific TLS-uninitialized error, N/A to wasm
 class PlatformProcessCrashInfoTestCase(TestBase):
     @expectedFailureAll(oslist=["windows", "linux", "freebsd", "netbsd"])
     @skipIfDarwin  # rdar://120795095

--- a/lldb/test/API/lang/cpp/trivial_abi/TestTrivialABI.py
+++ b/lldb/test/API/lang/cpp/trivial_abi/TestTrivialABI.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # return value is unrecoverable from the operand stack at a step-out
+@requireNotWasm  # return value is unrecoverable from the operand stack at a step-out
 class TestTrivialABI(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/cpp/typedef/TestCppTypedef.py
+++ b/lldb/test/API/lang/cpp/typedef/TestCppTypedef.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCppTypedef(TestBase):
     def test_typedef(self):
         """

--- a/lldb/test/API/lang/cpp/unicode-literals/TestUnicodeLiterals.py
+++ b/lldb/test/API/lang/cpp/unicode-literals/TestUnicodeLiterals.py
@@ -23,7 +23,7 @@ from lldbsuite.test import lldbutil
 # }
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class UnicodeLiteralsTestCase(TestBase):
     def test_expr1(self):
         """Test that the expression parser returns proper Unicode strings."""

--- a/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
+++ b/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class CppUnionStaticMembersTestCase(TestBase):
     def test_print_union(self):
         """Tests that frame variable and expr work

--- a/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
+++ b/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class UniqueTypesTestCase4(TestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/lang/cpp/virtual-functions/TestCppVirtualFunctions.py
+++ b/lldb/test/API/lang/cpp/virtual-functions/TestCppVirtualFunctions.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no expression evaluation
+@requireExpressionEvaluation
 class TestCase(TestBase):
     def common_setup(self):
         self.build()

--- a/lldb/test/API/lang/objc/complete-type-check/TestObjCIsTypeComplete.py
+++ b/lldb/test/API/lang/objc/complete-type-check/TestObjCIsTypeComplete.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test(self):
         self.build()

--- a/lldb/test/API/lang/objc/conflicting-class-list-function-from-user/TestObjCClassListFunctionFromUser.py
+++ b/lldb/test/API/lang/objc/conflicting-class-list-function-from-user/TestObjCClassListFunctionFromUser.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     # LLDB ends up calling the user-defined function (but at least doesn't
     # crash).
     @skipIf(macos_version=["<", "13.0"])

--- a/lldb/test/API/lang/objc/cpp_keyword_identifiers/TestCppKeywordsAsObjCIdentifiers.py
+++ b/lldb/test/API/lang/objc/cpp_keyword_identifiers/TestCppKeywordsAsObjCIdentifiers.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test(self):
         self.build()

--- a/lldb/test/API/lang/objc/languageinfo/TestObjCLanguageSpecificData.py
+++ b/lldb/test/API/lang/objc/languageinfo/TestObjCLanguageSpecificData.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCiVarIMPTestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test_imp_ivar_type(self):
         self.build()

--- a/lldb/test/API/lang/objc/module-import-log/TestClangModuleImportLog.py
+++ b/lldb/test/API/lang/objc/module-import-log/TestClangModuleImportLog.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/objc/objc-class-method/TestObjCClassMethod.py
+++ b/lldb/test/API/lang/objc/objc-class-method/TestObjCClassMethod.py
@@ -15,7 +15,7 @@ class TestObjCClassMethod(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipUnlessDarwin
+    @requireDarwin
     @add_test_categories(["pyapi"])
     def test_without_class_stubs(self):
         self.do_test_with_python_api()

--- a/lldb/test/API/lang/objc/objc-optimized/TestObjcOptimized.py
+++ b/lldb/test/API/lang/objc/objc-optimized/TestObjcOptimized.py
@@ -17,7 +17,7 @@ from lldbsuite.test import lldbutil
 # test failure: objc_optimized does not work for "-C clang -A i386"
 
 
-@skipUnlessDarwin
+@requireDarwin
 class ObjcOptimizedTestCase(TestBase):
     myclass = "MyClass"
     mymethod = "description"

--- a/lldb/test/API/lang/objc/orderedset/TestOrderedSet.py
+++ b/lldb/test/API/lang/objc/orderedset/TestOrderedSet.py
@@ -11,7 +11,7 @@ class TestOrderedSet(TestBase):
         self.build()
         self.run_tests()
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_ordered_set_no_const(self):
         disable_constant_classes = {
             "CFLAGS_EXTRAS": "-fno-constant-nsnumber-literals "

--- a/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
+++ b/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
@@ -16,7 +16,7 @@ class ObjCSingleEntryDictionaryTestCase(TestBase):
         # Find the line number to break inside main().
         self.line = line_number("main.m", "// break here")
 
-    @skipUnlessDarwin
+    @requireDarwin
     @expectedFailureAll(
         oslist=["watchos"], bugnumber="rdar://problem/34642736"
     )  # bug in NSDictionary formatting on watchos
@@ -24,7 +24,7 @@ class ObjCSingleEntryDictionaryTestCase(TestBase):
         self.build()
         self.run_tests()
 
-    @skipUnlessDarwin
+    @requireDarwin
     @expectedFailureAll(
         oslist=["watchos"], bugnumber="rdar://problem/34642736"
     )  # bug in NSDictionary formatting on watchos

--- a/lldb/test/API/lang/objc/tagged-pointer-children/TestTaggedPointerChildren.py
+++ b/lldb/test/API/lang/objc/tagged-pointer-children/TestTaggedPointerChildren.py
@@ -26,7 +26,7 @@ class TaggedPointerChildrenTestCase(TestBase):
             )
             self.assert_no_unreadable_children(child)
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(archs=["i386", "i686"])
     def test(self):
         """
@@ -67,7 +67,7 @@ class TaggedPointerChildrenTestCase(TestBase):
         self.assertGreater(heap.GetNumChildren(), 0, "real object still has children")
         self.assert_no_unreadable_children(heap)
 
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIf(archs=["i386", "i686"])
     def test_registered_synthetic_takes_precedence(self):
         """

--- a/lldb/test/API/lang/objc/warnings-in-expr-parser/TestObjCWarningsInExprParser.py
+++ b/lldb/test/API/lang/objc/warnings-in-expr-parser/TestObjCWarningsInExprParser.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test(self):
         self.build()

--- a/lldb/test/API/lang/objcxx/cpp_keywords_enabled/TestObjCppKeywordsEnabled.py
+++ b/lldb/test/API/lang/objcxx/cpp_keywords_enabled/TestObjCppKeywordsEnabled.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipUnlessDarwin
+    @requireDarwin
     @no_debug_info_test
     def test_keyword(self):
         # Make sure that C++ keywords work in the expression parser when using


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/212753 to convert the `lang` tests to use the `@require` decorator.