### PR TITLE
[lldb] Convert all the tests to use require decorator

### DIFF
--- a/lldb/test/API/attach/TestWindowsAttachBreakpoint.py
+++ b/lldb/test/API/attach/TestWindowsAttachBreakpoint.py
@@ -98,7 +98,7 @@ class WindowsAttachLoaderBreakpointTestCase(TestBase):
             process_information.hThread,
         )
 
-    @skipUnlessWindows
+    @requireWindows
     def test_attach_ignores_loader_breakpoint(self):
         """
         lldb must not report the loader's int3 (raised in a system module while

--- a/lldb/test/API/driver/batch_mode/TestBatchMode.py
+++ b/lldb/test/API/driver/batch_mode/TestBatchMode.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
-@skipIfWasm  # driver cannot launch a Wasm inferior
+@requireNotWasm  # driver cannot launch a Wasm inferior
 class DriverBatchModeTest(PExpectTest):
     source = "main.c"
 

--- a/lldb/test/API/driver/longpath/TestLongPathDriver.py
+++ b/lldb/test/API/driver/longpath/TestLongPathDriver.py
@@ -15,7 +15,7 @@ from lldbsuite.test import lldbutil
 MAX_PATH = 260
 
 
-@skipUnlessWindows
+@requireWindows
 class DriverLongPathTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/iohandler/sigint/TestIOHandlerPythonREPLSigint.py
+++ b/lldb/test/API/iohandler/sigint/TestIOHandlerPythonREPLSigint.py
@@ -22,7 +22,7 @@ class TestCase(PExpectTest):
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
     @skipIfAsan
-    @skipIfWindows
+    @requirePOSIX
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])
     def test_while_evaluating_code(self):
         """Tests SIGINT handling while Python code is being evaluated."""
@@ -56,7 +56,7 @@ class TestCase(PExpectTest):
     # FIXME: On Linux the Python code that reads from stdin seems to block until
     # it has finished reading a line before handling any queued signals.
     @skipIf(hostoslist=["linux"])
-    @skipIfWindows
+    @requirePOSIX
     def test_while_waiting_on_input(self):
         """Tests SIGINT handling while the REPL is waiting on input from
         stdin."""

--- a/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
+++ b/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
-@skipIfNoSignals  # no signal support
+@requireSignals  # no signal support
 class TestCase(PExpectTest):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
+++ b/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
@@ -21,7 +21,7 @@ class SBTypeMemberFunctionsTest(TestBase):
         self.source = "main.mm"
         self.line = line_number(self.source, "// set breakpoint here")
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test(self):
         """Test SBType APIs to fetch member function types."""
         d = {"EXE": self.exe_name}

--- a/lldb/test/API/python_api/exprpath_register/TestExprPathRegisters.py
+++ b/lldb/test/API/python_api/exprpath_register/TestExprPathRegisters.py
@@ -50,7 +50,7 @@ class TestExprPathRegisters(TestBase):
             if reg_value:
                 self.verify_register_path(reg_value)
 
-    @skipIfWasm  # wasm exposes no registers
+    @requireNotWasm  # wasm exposes no registers
     def test_all_registers(self):
         """Test all the registers that is avaiable on the machine"""
         self.build()

--- a/lldb/test/API/python_api/exprpath_synthetic/TestExprPathSynthetic.py
+++ b/lldb/test/API/python_api/exprpath_synthetic/TestExprPathSynthetic.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import decorators
 from lldbsuite.test import lldbinline
 
-lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipUnlessDarwin])
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.requireDarwin])

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -12,7 +12,7 @@ import shutil
 import time
 
 
-@skipIfWasm  # modules carry no build ID to cache on
+@requireNotWasm  # modules carry no build ID to cache on
 class GlobalModuleCacheTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     # NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/python_api/hello_world/TestHelloWorld.py
+++ b/lldb/test/API/python_api/hello_world/TestHelloWorld.py
@@ -72,7 +72,7 @@ class HelloWorldTestCase(TestBase):
 
     @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIfiOSSimulator
-    @skipIfWasm  # attaching requires launching the inferior as a host process
+    @requireNotWasm  # attaching requires launching the inferior as a host process
     def test_with_attach_to_process_with_id_api(self):
         """Create target, spawn a process, and attach to it with process id."""
         exe = "%s_%d" % (self.testMethodName, os.getpid())
@@ -105,7 +105,7 @@ class HelloWorldTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIfiOSSimulator
     @skipIfAsan  # FIXME: Hangs indefinitely.
-    @skipIfWasm  # attaching requires launching the inferior as a host process
+    @requireNotWasm  # attaching requires launching the inferior as a host process
     def test_with_attach_to_process_with_name_api(self):
         """Create target, spawn a process, and attach to it with process name."""
         exe = "%s_%d" % (self.testMethodName, os.getpid())

--- a/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
+++ b/lldb/test/API/python_api/process/address-masks/TestAddressMasks.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no ABI plugin, so address masks are never applied
+@requireNotWasm  # no ABI plugin, so address masks are never applied
 class AddressMasksTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
+++ b/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 class TestReadMemCString(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfWasm  # linear memory has no unmapped pages, so a bad in-range pointer still reads
+    @requireNotWasm  # linear memory has no unmapped pages, so a bad in-range pointer still reads
     def test_read_memory_c_string(self):
         """Test corner case behavior of SBProcess::ReadCStringFromMemory"""
         self.build()

--- a/lldb/test/API/python_api/sbenvironment/TestSBEnvironment.py
+++ b/lldb/test/API/python_api/sbenvironment/TestSBEnvironment.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no remote environment support
+@requireNotWasm  # no remote environment support
 class SBEnvironmentAPICase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/sbmodule/SeperateDebugInfo/TestSBModuleSeparateDebugInfo.py
+++ b/lldb/test/API/python_api/sbmodule/SeperateDebugInfo/TestSBModuleSeparateDebugInfo.py
@@ -53,7 +53,7 @@ class SBModuleSeparateDebugInfoCase(TestBase):
         self.assertTrue(module_specs[0].GetFileSpec().Exists())
 
     @no_debug_info_test
-    @skipUnlessPlatform(["darwin"])
+    @requirePlatform(["darwin"])
     def test_darwin_oso(self):
         """DWARF in .o files (no dSYM) -- returns .o file paths."""
         self.build(debug_info="dwarf")

--- a/lldb/test/API/python_api/sbplatform/TestSBPlatform.py
+++ b/lldb/test/API/python_api/sbplatform/TestSBPlatform.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWasm  # no remote platform file/process APIs
+@requireNotWasm  # no remote platform file/process APIs
 class SBPlatformAPICase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/signals/TestSignalsAPI.py
+++ b/lldb/test/API/python_api/signals/TestSignalsAPI.py
@@ -10,7 +10,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.lldbutil import get_stopped_thread, state_type_to_str
 
 
-@skipIfNoSignals
+@requireSignals
 class SignalsAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/target-arch-from-module/TestTargetArchFromModule.py
+++ b/lldb/test/API/python_api/target-arch-from-module/TestTargetArchFromModule.py
@@ -18,7 +18,7 @@ class TargetArchFromModule(TestBase):
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",
     )
-    @skipUnlessDarwin
+    @requireDarwin
     @skipIfRemote
     def test_target_arch_init(self):
         self.build()

--- a/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
+++ b/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
@@ -15,7 +15,7 @@ from lldbsuite.test.lldbutil import symbol_type_to_str
 class ModuleUnifiedSectionList(TestBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
+    @requirePlatform(["linux", "freebsd", "netbsd"])
     def test_unified_section_list(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/qemu/TestQemuLaunch.py
+++ b/lldb/test/API/qemu/TestQemuLaunch.py
@@ -14,7 +14,7 @@ from lldbsuite.test.gdbclientutils import *
 @skipIfRemote
 @skipIfWindows
 @skipIf(archs=["arm64e"])
-@skipIfWasm  # no qemu-wasm32
+@requireNotWasm  # no qemu-wasm32
 class TestQemuLaunch(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteAuxvSupport.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteAuxvSupport.py
@@ -69,14 +69,14 @@ class TestGdbRemoteAuxvSupport(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.assertIsNotNone(content_raw)
         return (word_size, self.decode_gdbremote_binary(content_raw))
 
-    @skipIfWindows  # no auxv support.
-    @skipIfDarwin
+    @requireNotWindows  # no auxv support.
+    @requireNotDarwin
     def test_supports_auxv(self):
         self.build()
         self.set_inferior_startup_launch()
         self.assertTrue(self.has_auxv_support())
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     def test_auxv_data_is_correct_size(self):
         self.build()
@@ -90,7 +90,7 @@ class TestGdbRemoteAuxvSupport(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.assertEqual(len(auxv_data) % (2 * word_size), 0)
         self.trace("auxv contains {} entries".format(len(auxv_data) / (2 * word_size)))
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     def test_auxv_keys_look_valid(self):
         self.build()
@@ -120,7 +120,7 @@ class TestGdbRemoteAuxvSupport(gdbremote_testcase.GdbRemoteTestCaseBase):
             self.assertGreaterEqual(auxv_key, 1)
             self.assertLessEqual(auxv_key, 2500)
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     def test_auxv_chunked_reads_work(self):
         self.build()

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteHostInfo.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteHostInfo.py
@@ -116,7 +116,7 @@ class TestGdbRemoteHostInfo(GdbRemoteTestCaseBase):
         self.build()
         self.get_qHostInfo_response()
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_qHostInfo_contains_darwin_required_keys(self):
         self.build()
         host_info_dict = self.get_qHostInfo_response()

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -479,7 +479,7 @@ class LldbGdbServerTestCase(
             self.assertEqual(post_handle_thread_id, print_thread_id)
 
     @expectedFailureDarwin
-    @skipIfWindows  # no SIGSEGV support
+    @requireNotWindows  # no SIGSEGV support
     @expectedFailureNetBSD
     def test_Hc_then_Csignal_signals_correct_thread_launch(self):
         self.build()

--- a/lldb/test/API/tools/lldb-server/TestNonStop.py
+++ b/lldb/test/API/tools/lldb-server/TestNonStop.py
@@ -5,7 +5,7 @@ import gdbremote_testcase
 
 
 class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
-    @skipIfWindows  # no SIGSEGV support
+    @requireNotWindows  # no SIGSEGV support
     @add_test_categories(["llgs"])
     def test_run(self):
         self.build()

--- a/lldb/test/API/tools/lldb-server/commandline/TestStubSetSID.py
+++ b/lldb/test/API/tools/lldb-server/commandline/TestStubSetSID.py
@@ -26,7 +26,7 @@ class TestStubSetSIDTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.start_new_session = False
         self.set_inferior_startup_launch()
 
-    @skipIfWindows
+    @requirePOSIX
     @skipIfRemote  # --setsid not used on remote platform and currently it is also impossible to get the sid of lldb-platform running on a remote target
     def test_sid_is_same_without_setsid(self):
         self.prepare_test()
@@ -34,7 +34,7 @@ class TestStubSetSIDTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         stub_sid = self.get_stub_sid()
         self.assertEqual(stub_sid, os.getsid(0))
 
-    @skipIfWindows
+    @requirePOSIX
     @skipIfRemote  # --setsid not used on remote platform and currently it is also impossible to get the sid of lldb-platform running on a remote target
     def test_sid_is_different_with_setsid(self):
         self.prepare_test()
@@ -42,7 +42,7 @@ class TestStubSetSIDTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         stub_sid = self.get_stub_sid(["--setsid"])
         self.assertNotEqual(stub_sid, os.getsid(0))
 
-    @skipIfWindows
+    @requirePOSIX
     @skipIfRemote  # --setsid not used on remote platform and currently it is also impossible to get the sid of lldb-platform running on a remote target
     def test_sid_is_different_with_S_llgs(self):
         self.prepare_test()

--- a/lldb/test/API/tools/lldb-server/inferior-crash/TestGdbRemoteAbort.py
+++ b/lldb/test/API/tools/lldb-server/inferior-crash/TestGdbRemoteAbort.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestGdbRemoteAbort(gdbremote_testcase.GdbRemoteTestCaseBase):
-    @skipIfWindows  # No signal is sent on Windows.
+    @requireNotWindows  # No signal is sent on Windows.
     # std::abort() on <= API 16 raises SIGSEGV - b.android.com/179836
     @expectedFailureAndroid(api_levels=list(range(16 + 1)))
     def test_inferior_abort_received_llgs(self):

--- a/lldb/test/API/tools/lldb-server/inferior-crash/TestGdbRemoteSegFault.py
+++ b/lldb/test/API/tools/lldb-server/inferior-crash/TestGdbRemoteSegFault.py
@@ -30,7 +30,7 @@ class TestGdbRemoteSegFault(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.assertIsNotNone(hex_exit_code)
         self.assertEqual(int(hex_exit_code, 16), expected_signo)
 
-    @skipIfWindows  # No signal is sent on Windows.
+    @requireNotWindows  # No signal is sent on Windows.
     def test_inferior_seg_fault_received(self):
         self.build()
         if self.platformIsDarwin():

--- a/lldb/test/API/tools/lldb-server/signal-filtering/TestGdbRemote_QPassSignals.py
+++ b/lldb/test/API/tools/lldb-server/signal-filtering/TestGdbRemote_QPassSignals.py
@@ -87,7 +87,7 @@ class TestGdbRemote_QPassSignals(gdbremote_testcase.GdbRemoteTestCaseBase):
                 self.ignore_signals(signals_to_ignore)
         self.expect_exit_code(len(signals_to_ignore))
 
-    @skipIfWindows  # no signal support
+    @requireNotWindows  # no signal support
     @expectedFailureNetBSD
     def test_default_signals_behavior(self):
         self.build()

--- a/lldb/test/API/tools/lldb-server/vCont-threads/TestSignal.py
+++ b/lldb/test/API/tools/lldb-server/vCont-threads/TestSignal.py
@@ -54,7 +54,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
         procinfo = self.parse_process_info_response(context)
         return int(procinfo["pid"], 16)
 
-    @skipIfWindows
+    @requireNotWindows
     @skipIfDarwin
     @expectedFailureNetBSD
     @expectedFailureAll(
@@ -85,7 +85,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             "C{0:x}:{1:x};c".format(lldbutil.get_signal_number("SIGUSR1")), threads[:1]
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @skipIfDarwin
     @expectedFailureNetBSD
     @expectedFailureAll(
@@ -106,7 +106,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             threads,
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56086"
@@ -126,7 +126,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             threads,
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56086"
@@ -143,7 +143,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             "C{0:x}:p-1".format(lldbutil.get_signal_number("SIGUSR1")), threads
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56086"
@@ -159,7 +159,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             "C{0:x}:-1".format(lldbutil.get_signal_number("SIGUSR1")), threads
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56086"
@@ -180,7 +180,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             threads,
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56086"
@@ -200,7 +200,7 @@ class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
             threads,
         )
 
-    @skipIfWindows
+    @requireNotWindows
     @expectedFailureNetBSD
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56086"

--- a/lldb/test/API/types/TestCharType.py
+++ b/lldb/test/API/types/TestCharType.py
@@ -12,7 +12,7 @@ class CharTypeTestCase(AbstractBase.GenericTester):
         """Test that char-type variables are displayed correctly."""
         self.build_and_run("char.cpp", ["char"], qd=True)
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_char_type_from_block(self):
         """Test that char-type variables are displayed correctly from a block."""
         self.build_and_run("char.cpp", ["char"], bc=True, qd=True)
@@ -21,7 +21,7 @@ class CharTypeTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned_char'-type variables are displayed correctly."""
         self.build_and_run("unsigned_char.cpp", ["unsigned", "char"], qd=True)
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_char_type_from_block(self):
         """Test that 'unsigned char'-type variables are displayed correctly from a block."""
         self.build_and_run("unsigned_char.cpp", ["unsigned", "char"], bc=True, qd=True)

--- a/lldb/test/API/types/TestCharTypeExpr.py
+++ b/lldb/test/API/types/TestCharTypeExpr.py
@@ -12,7 +12,7 @@ class CharTypeExprTestCase(AbstractBase.GenericTester):
         """Test that char-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("char.cpp", ["char"], qd=True)
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_char_type_from_block(self):
         """Test that char-type variables are displayed correctly from a block."""
         self.build_and_run_expr("char.cpp", ["char"], bc=True, qd=True)
@@ -21,7 +21,7 @@ class CharTypeExprTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned_char'-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("unsigned_char.cpp", ["unsigned", "char"], qd=True)
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_char_type_from_block(self):
         """Test that 'unsigned char'-type variables are displayed correctly from a block."""
         self.build_and_run_expr(

--- a/lldb/test/API/types/TestDoubleTypes.py
+++ b/lldb/test/API/types/TestDoubleTypes.py
@@ -16,7 +16,7 @@ class DoubleTypesTestCase(AbstractBase.GenericTester):
         """Test that double-type variables are displayed correctly."""
         self.build_and_run("double.cpp", set(["double"]))
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_double_type_from_block(self):
         """Test that double-type variables are displayed correctly from a block."""
         self.build_and_run("double.cpp", set(["double"]), bc=True)

--- a/lldb/test/API/types/TestDoubleTypesExpr.py
+++ b/lldb/test/API/types/TestDoubleTypesExpr.py
@@ -20,7 +20,7 @@ class DoubleTypesExprTestCase(AbstractBase.GenericTester):
         """Test that double-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("double.cpp", set(["double"]))
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_double_type_from_block(self):
         """Test that double-type variables are displayed correctly from a block."""
         self.build_and_run_expr("double.cpp", set(["double"]), bc=True)

--- a/lldb/test/API/types/TestFloatTypes.py
+++ b/lldb/test/API/types/TestFloatTypes.py
@@ -16,7 +16,7 @@ class FloatTypesTestCase(AbstractBase.GenericTester):
         """Test that float-type variables are displayed correctly."""
         self.build_and_run("float.cpp", set(["float"]))
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_float_type_from_block(self):
         """Test that float-type variables are displayed correctly from a block."""
         self.build_and_run("float.cpp", set(["float"]), bc=True)

--- a/lldb/test/API/types/TestFloatTypesExpr.py
+++ b/lldb/test/API/types/TestFloatTypesExpr.py
@@ -20,7 +20,7 @@ class FloatTypesExprTestCase(AbstractBase.GenericTester):
         """Test that float-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("float.cpp", set(["float"]))
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_float_type_from_block(self):
         """Test that float-type variables are displayed correctly from a block."""
         self.build_and_run_expr("float.cpp", set(["float"]), bc=True)

--- a/lldb/test/API/types/TestIntegerType.py
+++ b/lldb/test/API/types/TestIntegerType.py
@@ -12,7 +12,7 @@ class IntegerTypesTestCase(AbstractBase.GenericTester):
         """Test that int-type variables are displayed correctly."""
         self.build_and_run("int.cpp", ["int"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_int_type_from_block(self):
         """Test that int-type variables are displayed correctly from a block."""
         self.build_and_run("int.cpp", ["int"])
@@ -21,7 +21,7 @@ class IntegerTypesTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned_int'-type variables are displayed correctly."""
         self.build_and_run("unsigned_int.cpp", ["unsigned", "int"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_int_type_from_block(self):
         """Test that 'unsigned int'-type variables are displayed correctly from a block."""
         self.build_and_run("unsigned_int.cpp", ["unsigned", "int"], bc=True)

--- a/lldb/test/API/types/TestIntegerTypeExpr.py
+++ b/lldb/test/API/types/TestIntegerTypeExpr.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 
 class IntegerTypeExprTestCase(AbstractBase.GenericTester):
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_short_type_from_block(self):
         """Test that 'unsigned short'-type variables are displayed correctly from a block."""
         self.build_and_run_expr("unsigned_short.cpp", ["unsigned", "short"], bc=True)
@@ -17,7 +17,7 @@ class IntegerTypeExprTestCase(AbstractBase.GenericTester):
         """Test that int-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("int.cpp", ["int"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_int_type_from_block(self):
         """Test that int-type variables are displayed correctly from a block."""
         self.build_and_run_expr("int.cpp", ["int"])
@@ -26,7 +26,7 @@ class IntegerTypeExprTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned_int'-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("unsigned_int.cpp", ["unsigned", "int"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_int_type_from_block(self):
         """Test that 'unsigned int'-type variables are displayed correctly from a block."""
         self.build_and_run_expr("unsigned_int.cpp", ["unsigned", "int"], bc=True)

--- a/lldb/test/API/types/TestLongTypes.py
+++ b/lldb/test/API/types/TestLongTypes.py
@@ -12,7 +12,7 @@ class LongTypesTestCase(AbstractBase.GenericTester):
         """Test that long-type variables are displayed correctly."""
         self.build_and_run("long.cpp", ["long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_long_type_from_block(self):
         """Test that long-type variables are displayed correctly from a block."""
         self.build_and_run("long.cpp", ["long"], bc=True)
@@ -21,7 +21,7 @@ class LongTypesTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned long'-type variables are displayed correctly."""
         self.build_and_run("unsigned_long.cpp", ["unsigned", "long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_long_type_from_block(self):
         """Test that 'unsigned_long'-type variables are displayed correctly from a block."""
         self.build_and_run("unsigned_long.cpp", ["unsigned", "long"], bc=True)
@@ -30,7 +30,7 @@ class LongTypesTestCase(AbstractBase.GenericTester):
         """Test that 'long long'-type variables are displayed correctly."""
         self.build_and_run("long_long.cpp", ["long long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_long_long_type_from_block(self):
         """Test that 'long_long'-type variables are displayed correctly from a block."""
         self.build_and_run("long_long.cpp", ["long long"], bc=True)
@@ -39,7 +39,7 @@ class LongTypesTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned long long'-type variables are displayed correctly."""
         self.build_and_run("unsigned_long_long.cpp", ["unsigned", "long long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_long_long_type_from_block(self):
         """Test that 'unsigned_long_long'-type variables are displayed correctly from a block."""
         self.build_and_run("unsigned_long_long.cpp", ["unsigned", "long long"], bc=True)

--- a/lldb/test/API/types/TestLongTypesExpr.py
+++ b/lldb/test/API/types/TestLongTypesExpr.py
@@ -12,7 +12,7 @@ class LongTypesExprTestCase(AbstractBase.GenericTester):
         """Test that long-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("long.cpp", ["long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_long_type_from_block(self):
         """Test that long-type variables are displayed correctly from a block."""
         self.build_and_run_expr("long.cpp", ["long"], bc=True)
@@ -21,7 +21,7 @@ class LongTypesExprTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned long'-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("unsigned_long.cpp", ["unsigned", "long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_long_type_from_block(self):
         """Test that 'unsigned_long'-type variables are displayed correctly from a block."""
         self.build_and_run_expr("unsigned_long.cpp", ["unsigned", "long"], bc=True)
@@ -30,7 +30,7 @@ class LongTypesExprTestCase(AbstractBase.GenericTester):
         """Test that 'long long'-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("long_long.cpp", ["long long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_long_long_type_from_block(self):
         """Test that 'long_long'-type variables are displayed correctly from a block."""
         self.build_and_run_expr("long_long.cpp", ["long long"], bc=True)
@@ -39,7 +39,7 @@ class LongTypesExprTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned long long'-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("unsigned_long_long.cpp", ["unsigned", "long long"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_long_long_type_from_block(self):
         """Test that 'unsigned_long_long'-type variables are displayed correctly from a block."""
         self.build_and_run_expr(

--- a/lldb/test/API/types/TestShortType.py
+++ b/lldb/test/API/types/TestShortType.py
@@ -12,7 +12,7 @@ class ShortTypeTestCase(AbstractBase.GenericTester):
         """Test that short-type variables are displayed correctly."""
         self.build_and_run("short.cpp", ["short"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_short_type_from_block(self):
         """Test that short-type variables are displayed correctly from a block."""
         self.build_and_run("short.cpp", ["short"], bc=True)
@@ -21,7 +21,7 @@ class ShortTypeTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned_short'-type variables are displayed correctly."""
         self.build_and_run("unsigned_short.cpp", ["unsigned", "short"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_short_type_from_block(self):
         """Test that 'unsigned short'-type variables are displayed correctly from a block."""
         self.build_and_run("unsigned_short.cpp", ["unsigned", "short"], bc=True)

--- a/lldb/test/API/types/TestShortTypeExpr.py
+++ b/lldb/test/API/types/TestShortTypeExpr.py
@@ -12,7 +12,7 @@ class ShortExprTestCase(AbstractBase.GenericTester):
         """Test that short-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("short.cpp", ["short"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_short_type_from_block(self):
         """Test that short-type variables are displayed correctly from a block."""
         self.build_and_run_expr("short.cpp", ["short"], bc=True)
@@ -21,7 +21,7 @@ class ShortExprTestCase(AbstractBase.GenericTester):
         """Test that 'unsigned_short'-type variable expressions are evaluated correctly."""
         self.build_and_run_expr("unsigned_short.cpp", ["unsigned", "short"])
 
-    @skipUnlessDarwin
+    @requireDarwin
     def test_unsigned_short_type_from_block(self):
         """Test that 'unsigned short'-type variables are displayed correctly from a block."""
         self.build_and_run_expr("unsigned_short.cpp", ["unsigned", "short"], bc=True)


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/212753 to convert all the tests to use the `@require` decorator.