### PR TITLE
[llvm][NFC] add -Wparentheses suggestion in assert statement

### DIFF
--- a/llvm/lib/Analysis/AssumptionCache.cpp
+++ b/llvm/lib/Analysis/AssumptionCache.cpp
@@ -166,7 +166,7 @@ void AssumptionCache::removeAffectedValues(AssumeInst *CI) {
     }
 
     assert(ExpectedMatches[AV.Assume] == 0 ||
-           Found && "already unregistered or incorrect cache state");
+           (Found && "already unregistered or incorrect cache state"));
 
     if (!HasNonnull)
       AffectedValues.erase(AVI);


### PR DESCRIPTION
Add parenthesis in an assert expression as per the warning below.

```bash
/home/xane/Documents/shallowllvm/llvm-project/llvm/lib/Analysis/AssumptionCache.cpp:169:18: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
  169 |            Found && "already unregistered or incorrect cache state");
      |            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The patch helps to make it more obvious that the AND part will execute first, and also improves the readibilty of the code, and results in one less warning.