### PR TITLE
[TableGen][AsmMatcher] Resolve RegClassByHwMode kinds for all operands

### DIFF
--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -102,7 +102,7 @@ include "Common/RegClassByHwModeCommon.td"
 
 // ASMMATCHER: switch (Kind) {
 
-// ASMMATCHER: if (Operand.isReg() && Kind > MCK_LAST_REGISTER && Kind <= MCK_LAST_REGCLASS_BY_HWMODE) {
+// ASMMATCHER: if (Kind > MCK_LAST_REGISTER && Kind <= MCK_LAST_REGCLASS_BY_HWMODE) {
 // ASMMATCHER-NEXT:    static constexpr MatchClassKind RegClassByHwModeMatchTable[4][3] = {
 // ASMMATCHER-NEXT:      { // DefaultMode
 // ASMMATCHER-NEXT:        MCK_PtrRegs32, // MyPtrRC

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2569,7 +2569,11 @@ static void emitValidateOperandClass(const CodeGenTarget &Target,
   unsigned NumClassesByHwMode = RegClassesByHwMode.size();
 
   if (!RegClassesByHwMode.empty()) {
-    OS << "  if (Operand.isReg() && Kind > MCK_LAST_REGISTER &&"
+    // Resolve RegClassByHwMode kinds to their concrete class regardless of
+    // whether Operand is actually a register, so that the diagnostic
+    // fallback paths below (for both register and non-register operands)
+    // see a concrete class rather than an unresolved by-hwmode one.
+    OS << "  if (Kind > MCK_LAST_REGISTER &&"
           " Kind <= MCK_LAST_REGCLASS_BY_HWMODE) {\n";
 
     const CodeGenHwModes &CGH = Target.getHwModes();


### PR DESCRIPTION
validateOperandClass() only remapped a RegClassByHwMode operand kind
when the actual parsed operand was a register. When the operand was
something else entirely (e.g. a bare immediate where a register was
expected), this fell through to the generic "Kind <= MCK_LAST_REGISTER"
diagnostic check, so we end up with a generic Match_InvalidOperand.

No test changes here, but this is needed to avoid diagnostic regressions
with the RVY load/store support (PR #177073).
