### PR TITLE
[AArch64] Validate fixed-point SCVTF/UCVTF scale operands

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -881,6 +881,7 @@ class fixedpoint_recip_i32<ValueType FloatVT>
     ComplexPattern<FloatVT, 1, "SelectCVTFixedPosRecipOperand<32>", [fpimm, ld]> {
   let EncoderMethod = "getFixedPointScaleOpValue";
   let DecoderMethod = "DecodeFixedPointScaleImm32";
+  let ParserMatchClass = Imm1_32Operand;
   let OperandType = "OPERAND_IMMEDIATE";
 }
 
@@ -889,6 +890,7 @@ class fixedpoint_recip_i64<ValueType FloatVT>
     ComplexPattern<FloatVT, 1, "SelectCVTFixedPosRecipOperand<64>", [fpimm, ld]> {
   let EncoderMethod = "getFixedPointScaleOpValue";
   let DecoderMethod = "DecodeFixedPointScaleImm64";
+  let ParserMatchClass = Imm1_64Operand;
   let OperandType = "OPERAND_IMMEDIATE";
 }
 

--- a/llvm/test/MC/AArch64/basic-a64-diagnostics.s
+++ b/llvm/test/MC/AArch64/basic-a64-diagnostics.s
@@ -1792,6 +1792,43 @@ cbz w1, lsl
 // CHECK-ERROR-NEXT:        ucvtf sp, s19, #14
 // CHECK-ERROR-NEXT:              ^
 
+// Scale range depends on the integer source: [1, 32] for Wn, [1, 64] for Xn
+        scvtf s0, w0, #0
+        scvtf s0, w0, #33
+        ucvtf s0, w0, #33
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 32]
+// CHECK-ERROR-NEXT:        scvtf s0, w0, #0
+// CHECK-ERROR-NEXT:                      ^
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 32]
+// CHECK-ERROR-NEXT:        scvtf s0, w0, #33
+// CHECK-ERROR-NEXT:                      ^
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 32]
+// CHECK-ERROR-NEXT:        ucvtf s0, w0, #33
+// CHECK-ERROR-NEXT:                      ^
+
+        scvtf d0, x0, #0
+        scvtf d0, x0, #65
+        ucvtf d0, x0, #65
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 64]
+// CHECK-ERROR-NEXT:        scvtf d0, x0, #0
+// CHECK-ERROR-NEXT:                      ^
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 64]
+// CHECK-ERROR-NEXT:        scvtf d0, x0, #65
+// CHECK-ERROR-NEXT:                      ^
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 64]
+// CHECK-ERROR-NEXT:        ucvtf d0, x0, #65
+// CHECK-ERROR-NEXT:                      ^
+
+// Scale must be an immediate, not a symbol
+        scvtf s0, w0, f0
+        ucvtf d0, x0, f0
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 32]
+// CHECK-ERROR-NEXT:        scvtf s0, w0, f0
+// CHECK-ERROR-NEXT:                      ^
+// CHECK-ERROR-NEXT: error: immediate must be an integer in range [1, 64]
+// CHECK-ERROR-NEXT:        ucvtf d0, x0, f0
+// CHECK-ERROR-NEXT:                      ^
+
 //------------------------------------------------------------------------------
 // Floating-point immediate
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The fixed-point SCVTF/UCVTF operands are missing the ParserMatchClass used by
fixedpoint_i32/i64. Symbolic scales can therefore reach the encoder and hit
its MO.isImm() assertion, while out-of-range scales can alias valid encodings.

Use Imm1_32Operand and Imm1_64Operand for these operands and add diagnostics
for both source widths and symbolic scales.

Addresses the scvtf/ucvtf part of #185358. The ext case is tracked by #185361.