### PR TITLE
workflows/libclang-abi-tests: Cache baseline results

### DIFF
--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -105,21 +105,34 @@ jobs:
             ref: ${{ github.sha }}
             repo: ${{ github.repository }}
     steps:
+      - name: Check for cached baseline ABI
+        if: ${{ matrix.name == 'build-baseline' }}
+        id: cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          key: ${{ matrix.ref}}.abi
+          path: |
+            *${{ matrix.ref }}.abi
+
       - name: Download source code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: steps.cache.outputs.cache-hit != 'true'
         with:
           persist-credentials: false
           ref: ${{ matrix.ref }}
           repository: ${{ matrix.repo }}
       - name: Configure
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           mkdir install
           cmake -B build -S llvm -G Ninja -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD="" -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_INSTALL_PREFIX="$(pwd)"/install llvm
       - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           ABI_LIBS: ${{ needs.abi-dump-setup.outputs.ABI_LIBS }}
         run: ninja -C build/ $ABI_LIBS install-clang-headers
       - name: Dump ABI
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           REF: ${{ matrix.ref }}
           ABI_HEADERS: ${{ needs.abi-dump-setup.outputs.ABI_HEADERS }}
@@ -135,6 +148,13 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: '*${{ matrix.ref }}.abi'
+      - name: Cache baseline ABI
+        if: ${{ matrix.name == 'build-baseline' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          key: ${{ matrix.ref }}.abi
+          path: |
+            *${{ matrix.ref }}.abi
 
   abi-compare:
     if: github.repository_owner == 'llvm'


### PR DESCRIPTION
This way we don't need to recompute them on every run.