### PR TITLE
[OpenMP][Flang] Add integer-kind wrappers to omp_lib

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -322,6 +322,13 @@ else ()
   set(sources ${supported_sources} ${host_sources} ${f128_sources})
 endif ()
 
+# Include the Fortran OpenMP module implementation (omp_lib.o) in
+# libflang_rt.runtime when the OpenMP runtime is also being built.
+# Skip for GPU-default targets: omp_lib is a host-side Fortran module.
+if (TARGET libomp-mod AND NOT "${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx")
+  list(APPEND sources "$<TARGET_OBJECTS:libomp-mod>")
+endif ()
+
 
 if (NOT WIN32)
   add_flangrt_library(flang_rt.runtime STATIC SHARED
@@ -332,6 +339,11 @@ if (NOT WIN32)
   )
 
   enable_cuda_compilation(flang_rt.runtime "${sources}")
+
+  if (TARGET libomp-mod AND TARGET flang_rt.runtime.shared AND TARGET omp)
+    # Resolve bind(c) references from omp_lib when building the shared runtime.
+    target_link_libraries(flang_rt.runtime.shared PUBLIC omp)
+  endif ()
 
   # Select a default runtime, which is used for unit and regression tests.
   if (TARGET flang_rt.runtime.default)

--- a/flang/test/Lower/OpenMP/omp-lib-integer-wrappers.f90
+++ b/flang/test/Lower/OpenMP/omp-lib-integer-wrappers.f90
@@ -1,0 +1,237 @@
+! REQUIRES: openmp_runtime
+
+! RUN: %flang_fc1 -emit-hlfir %openmp_flags %s -o - 2>&1 | FileCheck %s
+! RUN: bbc %openmp_flags -emit-hlfir -o - %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-fir %openmp_flags %s -o - 2>&1 | FileCheck %s
+! RUN: bbc -emit-fir %openmp_flags -o - %s 2>&1 | FileCheck %s
+!
+! Test that omp_lib integer-kind wrapper procedures lower to module
+! procedures instead of failing intrinsic resolution.
+
+program main
+  use omp_lib
+  integer(1) :: i1 = 1_1
+  integer(2) :: i2 = 2_2
+  integer(4) :: i4 = 4_4
+  integer(8) :: i8 = 8_8
+  integer(omp_integer_kind) :: ires
+  integer(omp_sched_kind) :: sched_kind
+  integer(kmp_affinity_mask_kind) :: mask
+
+  call omp_set_num_threads(i1)
+  call omp_set_num_threads(i2)
+  call omp_set_num_threads(i4)
+  call omp_set_num_threads(i8)
+
+  call omp_set_max_active_levels(i1)
+  call omp_set_max_active_levels(i2)
+  call omp_set_max_active_levels(i4)
+  call omp_set_max_active_levels(i8)
+
+  call omp_set_default_device(i1)
+  call omp_set_default_device(i2)
+  call omp_set_default_device(i4)
+  call omp_set_default_device(i8)
+
+  call omp_set_num_teams(i1)
+  call omp_set_num_teams(i2)
+  call omp_set_num_teams(i4)
+  call omp_set_num_teams(i8)
+
+  call omp_set_teams_thread_limit(i1)
+  call omp_set_teams_thread_limit(i2)
+  call omp_set_teams_thread_limit(i4)
+  call omp_set_teams_thread_limit(i8)
+
+  call kmp_set_stacksize(i1)
+  call kmp_set_stacksize(i2)
+  call kmp_set_stacksize(i4)
+  call kmp_set_stacksize(i8)
+
+  call kmp_set_blocktime(i1)
+  call kmp_set_blocktime(i2)
+  call kmp_set_blocktime(i4)
+  call kmp_set_blocktime(i8)
+
+  call kmp_set_library(i1)
+  call kmp_set_library(i2)
+  call kmp_set_library(i4)
+  call kmp_set_library(i8)
+
+  call kmp_set_disp_num_buffers(i1)
+  call kmp_set_disp_num_buffers(i2)
+  call kmp_set_disp_num_buffers(i4)
+  call kmp_set_disp_num_buffers(i8)
+
+  ires = omp_get_ancestor_thread_num(i1)
+  ires = omp_get_ancestor_thread_num(i2)
+  ires = omp_get_ancestor_thread_num(i4)
+  ires = omp_get_ancestor_thread_num(i8)
+
+  ires = omp_get_team_size(i1)
+  ires = omp_get_team_size(i2)
+  ires = omp_get_team_size(i4)
+  ires = omp_get_team_size(i8)
+
+  ires = omp_get_place_num_procs(i1)
+  ires = omp_get_place_num_procs(i2)
+  ires = omp_get_place_num_procs(i4)
+  ires = omp_get_place_num_procs(i8)
+
+  call omp_set_schedule(omp_sched_static, i1)
+  call omp_set_schedule(omp_sched_static, i2)
+  call omp_set_schedule(omp_sched_static, i4)
+  call omp_set_schedule(omp_sched_static, i8)
+
+  call omp_get_schedule(sched_kind, i1)
+  call omp_get_schedule(sched_kind, i2)
+  call omp_get_schedule(sched_kind, i4)
+  call omp_get_schedule(sched_kind, i8)
+
+  ires = omp_pause_resource(omp_pause_soft, i1)
+  ires = omp_pause_resource(omp_pause_soft, i2)
+  ires = omp_pause_resource(omp_pause_soft, i4)
+  ires = omp_pause_resource(omp_pause_soft, i8)
+
+  call kmp_create_affinity_mask(mask)
+  ires = kmp_set_affinity_mask_proc(i1, mask)
+  ires = kmp_set_affinity_mask_proc(i2, mask)
+  ires = kmp_set_affinity_mask_proc(i4, mask)
+  ires = kmp_set_affinity_mask_proc(i8, mask)
+
+  ires = kmp_unset_affinity_mask_proc(i1, mask)
+  ires = kmp_unset_affinity_mask_proc(i2, mask)
+  ires = kmp_unset_affinity_mask_proc(i4, mask)
+  ires = kmp_unset_affinity_mask_proc(i8, mask)
+
+  ires = kmp_get_affinity_mask_proc(i1, mask)
+  ires = kmp_get_affinity_mask_proc(i2, mask)
+  ires = kmp_get_affinity_mask_proc(i4, mask)
+  ires = kmp_get_affinity_mask_proc(i8, mask)
+
+  block
+    integer(4) :: ids4(1)
+    integer(8) :: ids8(1)
+    integer(4) :: parts4(1)
+    integer(8) :: parts8(1)
+    call omp_get_place_proc_ids(i4, ids4)
+    call omp_get_place_proc_ids(i8, ids8)
+    call omp_get_partition_place_nums(parts4)
+    call omp_get_partition_place_nums(parts8)
+  end block
+end program
+
+!CHECK-NOT: not yet implemented: intrinsic: omp_set_max_active_levels
+!CHECK-NOT: not yet implemented: intrinsic: omp_set_default_device
+!CHECK-NOT: not yet implemented: intrinsic: omp_set_num_teams
+!CHECK-NOT: not yet implemented: intrinsic: omp_set_teams_thread_limit
+!CHECK-NOT: not yet implemented: intrinsic: kmp_set_stacksize
+!CHECK-NOT: not yet implemented: intrinsic: kmp_set_blocktime
+!CHECK-NOT: not yet implemented: intrinsic: kmp_set_library
+!CHECK-NOT: not yet implemented: intrinsic: kmp_set_disp_num_buffers
+!CHECK-NOT: not yet implemented: intrinsic: omp_get_ancestor_thread_num
+!CHECK-NOT: not yet implemented: intrinsic: omp_get_team_size
+!CHECK-NOT: not yet implemented: intrinsic: omp_get_place_num_procs
+!CHECK-NOT: not yet implemented: intrinsic: omp_set_schedule
+!CHECK-NOT: not yet implemented: intrinsic: omp_get_schedule
+!CHECK-NOT: not yet implemented: intrinsic: omp_pause_resource
+!CHECK-NOT: not yet implemented: intrinsic: kmp_set_affinity_mask_proc
+!CHECK-NOT: not yet implemented: intrinsic: kmp_unset_affinity_mask_proc
+!CHECK-NOT: not yet implemented: intrinsic: kmp_get_affinity_mask_proc
+!CHECK-NOT: not yet implemented: intrinsic: omp_get_place_proc_ids
+!CHECK-NOT: not yet implemented: intrinsic: omp_get_partition_place_nums
+
+!CHECK: fir.call @_QMomp_libPomp_set_num_threads_i1
+!CHECK: fir.call @_QMomp_libPomp_set_num_threads_i2
+!CHECK: fir.call @_QMomp_libPomp_set_num_threads_i4
+!CHECK: fir.call @_QMomp_libPomp_set_num_threads_i8
+
+!CHECK: fir.call @_QMomp_libPomp_set_max_active_levels_i1
+!CHECK: fir.call @_QMomp_libPomp_set_max_active_levels_i2
+!CHECK: fir.call @_QMomp_libPomp_set_max_active_levels_i4
+!CHECK: fir.call @_QMomp_libPomp_set_max_active_levels_i8
+
+!CHECK: fir.call @_QMomp_libPomp_set_default_device_i1
+!CHECK: fir.call @_QMomp_libPomp_set_default_device_i2
+!CHECK: fir.call @_QMomp_libPomp_set_default_device_i4
+!CHECK: fir.call @_QMomp_libPomp_set_default_device_i8
+
+!CHECK: fir.call @_QMomp_libPomp_set_num_teams_i1
+!CHECK: fir.call @_QMomp_libPomp_set_num_teams_i2
+!CHECK: fir.call @_QMomp_libPomp_set_num_teams_i4
+!CHECK: fir.call @_QMomp_libPomp_set_num_teams_i8
+
+!CHECK: fir.call @_QMomp_libPomp_set_teams_thread_limit_i1
+!CHECK: fir.call @_QMomp_libPomp_set_teams_thread_limit_i2
+!CHECK: fir.call @_QMomp_libPomp_set_teams_thread_limit_i4
+!CHECK: fir.call @_QMomp_libPomp_set_teams_thread_limit_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_set_stacksize_i1
+!CHECK: fir.call @_QMomp_libPkmp_set_stacksize_i2
+!CHECK: fir.call @_QMomp_libPkmp_set_stacksize_i4
+!CHECK: fir.call @_QMomp_libPkmp_set_stacksize_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_set_blocktime_i1
+!CHECK: fir.call @_QMomp_libPkmp_set_blocktime_i2
+!CHECK: fir.call @_QMomp_libPkmp_set_blocktime_i4
+!CHECK: fir.call @_QMomp_libPkmp_set_blocktime_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_set_library_i1
+!CHECK: fir.call @_QMomp_libPkmp_set_library_i2
+!CHECK: fir.call @_QMomp_libPkmp_set_library_i4
+!CHECK: fir.call @_QMomp_libPkmp_set_library_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_set_disp_num_buffers_i1
+!CHECK: fir.call @_QMomp_libPkmp_set_disp_num_buffers_i2
+!CHECK: fir.call @_QMomp_libPkmp_set_disp_num_buffers_i4
+!CHECK: fir.call @_QMomp_libPkmp_set_disp_num_buffers_i8
+
+!CHECK: fir.call @_QMomp_libPomp_get_ancestor_thread_num_i1
+!CHECK: fir.call @_QMomp_libPomp_get_ancestor_thread_num_i2
+!CHECK: fir.call @_QMomp_libPomp_get_ancestor_thread_num_i4
+!CHECK: fir.call @_QMomp_libPomp_get_ancestor_thread_num_i8
+
+!CHECK: fir.call @_QMomp_libPomp_get_team_size_i1
+!CHECK: fir.call @_QMomp_libPomp_get_team_size_i2
+!CHECK: fir.call @_QMomp_libPomp_get_team_size_i4
+!CHECK: fir.call @_QMomp_libPomp_get_team_size_i8
+
+!CHECK: fir.call @_QMomp_libPomp_get_place_num_procs_i1
+!CHECK: fir.call @_QMomp_libPomp_get_place_num_procs_i2
+!CHECK: fir.call @_QMomp_libPomp_get_place_num_procs_i4
+!CHECK: fir.call @_QMomp_libPomp_get_place_num_procs_i8
+
+!CHECK: fir.call @_QMomp_libPomp_set_schedule_i1
+!CHECK: fir.call @_QMomp_libPomp_set_schedule_i2
+!CHECK: fir.call @_QMomp_libPomp_set_schedule_i4
+!CHECK: fir.call @_QMomp_libPomp_set_schedule_i8
+
+!CHECK: fir.call @_QMomp_libPomp_get_schedule_i1
+!CHECK: fir.call @_QMomp_libPomp_get_schedule_i2
+!CHECK: fir.call @_QMomp_libPomp_get_schedule_i4
+!CHECK: fir.call @_QMomp_libPomp_get_schedule_i8
+
+!CHECK: fir.call @_QMomp_libPomp_pause_resource_i1
+!CHECK: fir.call @_QMomp_libPomp_pause_resource_i2
+!CHECK: fir.call @_QMomp_libPomp_pause_resource_i4
+!CHECK: fir.call @_QMomp_libPomp_pause_resource_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_set_affinity_mask_proc_i1
+!CHECK: fir.call @_QMomp_libPkmp_set_affinity_mask_proc_i2
+!CHECK: fir.call @_QMomp_libPkmp_set_affinity_mask_proc_i4
+!CHECK: fir.call @_QMomp_libPkmp_set_affinity_mask_proc_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_unset_affinity_mask_proc_i1
+!CHECK: fir.call @_QMomp_libPkmp_unset_affinity_mask_proc_i2
+!CHECK: fir.call @_QMomp_libPkmp_unset_affinity_mask_proc_i4
+!CHECK: fir.call @_QMomp_libPkmp_unset_affinity_mask_proc_i8
+
+!CHECK: fir.call @_QMomp_libPkmp_get_affinity_mask_proc_i1
+!CHECK: fir.call @_QMomp_libPkmp_get_affinity_mask_proc_i2
+!CHECK: fir.call @_QMomp_libPkmp_get_affinity_mask_proc_i4
+!CHECK: fir.call @_QMomp_libPkmp_get_affinity_mask_proc_i8
+
+!CHECK: fir.call @_QMomp_libPomp_get_place_proc_ids_i4
+!CHECK: fir.call @_QMomp_libPomp_get_place_proc_ids_i8
+!CHECK: fir.call @_QMomp_libPomp_get_partition_place_nums_i4
+!CHECK: fir.call @_QMomp_libPomp_get_partition_place_nums_i8

--- a/flang/test/Lower/OpenMP/omp-lib-num-threads.f90
+++ b/flang/test/Lower/OpenMP/omp-lib-num-threads.f90
@@ -21,5 +21,5 @@ end program
 
 !CHECK-NOT: not yet implemented: intrinsic: omp_set_num_threads
 !CHECK-NOT: not yet implemented: intrinsic: omp_get_num_threads
-!CHECK: fir.call @omp_set_num_threads
+!CHECK: fir.call @_QMomp_libPomp_set_num_threads_i4
 !CHECK: fir.call @omp_get_num_threads

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -302,6 +302,7 @@ function(runtime_default_target)
     # OpenMP tests. install-libomp-mod is a separate distribution component
     # so that install-openmp does not require building flang.
     list(APPEND extra_targets "libomp-mod")
+    list(APPEND extra_targets "libomp-mod-barrier")
     list(APPEND extra_targets "install-libomp-mod")
     list(APPEND extra_targets "install-libomp-mod-stripped")
 
@@ -864,6 +865,7 @@ ${_flag_values}\
     endif ()
     if (TARGET libomp-mod)
       add_dependencies(flang-rt-test-deps libomp-mod)
+      add_dependencies(flang-rt-test-deps libomp-mod-barrier)
     endif ()
   endif ()
 endif()

--- a/openmp/module/CMakeLists.txt
+++ b/openmp/module/CMakeLists.txt
@@ -9,13 +9,16 @@
 # Build the module files if a Fortran compiler is available.
 
 configure_file(omp_lib.F90.var "${CMAKE_CURRENT_BINARY_DIR}/omp_lib.F90" @ONLY)
+configure_file(omp_lib_impl.F90.var "${CMAKE_CURRENT_BINARY_DIR}/omp_lib_impl.F90" @ONLY)
 configure_file(omp_lib.h.var "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.h" @ONLY)
 
-# One compilation step creates both, omp_lib.mod and omp_lib_kinds.mod. Only
-# these files are used, the object file itself can be discarded.
+# omp_lib.F90 declares the interfaces and creates both omp_lib.mod and
+# omp_lib_kinds.mod; omp_lib_impl.F90 holds the bodies of the separate module
+# procedures and creates omp_lib-omp_lib_impl.mod.
 # TODO: Adding it to libomp ($<TARGET_OBJECTS:libomp-mod>) would allow implementing Fortran API in Fortran
 add_library(libomp-mod OBJECT
   "${CMAKE_CURRENT_BINARY_DIR}/omp_lib.F90"
+  "${CMAKE_CURRENT_BINARY_DIR}/omp_lib_impl.F90"
 )
 set_target_properties(libomp-mod PROPERTIES FOLDER "OpenMP/Fortran Modules")
 
@@ -33,6 +36,38 @@ if (LIBOMP_TARGET_IS_GPU)
 endif ()
 
 flang_module_target(libomp-mod PUBLIC)
+
+# flang_module_target(PUBLIC) emits the .mod files directly into the toolchain
+# resource directory, but that directory is also Flang's intrinsic module
+# directory, and when resolving the parent of a SUBMODULE Flang searches only
+# the non-intrinsic module path. omp_lib.mod would therefore be invisible to
+# omp_lib_impl.F90. Emit the module files into a private directory instead,
+# where the submodule can find its parent, and publish the importable ones
+# afterwards. omp_lib-omp_lib_impl.mod is only needed to compile further
+# submodules of omp_lib, so it stays private.
+set(libomp_mod_dir "${CMAKE_CURRENT_BINARY_DIR}/mod/${CMAKE_CFG_INTDIR}")
+set_target_properties(libomp-mod PROPERTIES
+  Fortran_MODULE_DIRECTORY "${libomp_mod_dir}"
+)
+
+set(libomp_public_mods
+  "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.mod"
+  "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib_kinds.mod"
+)
+add_custom_command(OUTPUT ${libomp_public_mods}
+  COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+          "${libomp_mod_dir}/omp_lib.mod"
+          "${libomp_mod_dir}/omp_lib_kinds.mod"
+          "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}"
+  DEPENDS libomp-mod
+  COMMENT "Publishing omp_lib module files"
+)
+
+# libomp-mod is an OBJECT library, so the module files it writes are opaque to
+# CMake. Dependees on omp_lib.mod must add a target-level dependency on this
+# barrier to ensure the module files exist before they are used.
+add_custom_target(libomp-mod-barrier ALL DEPENDS ${libomp_public_mods})
+set_target_properties(libomp-mod-barrier PROPERTIES FOLDER "OpenMP/Fortran Modules")
 
 install(FILES
   "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.h"

--- a/openmp/module/omp_lib.F90.var
+++ b/openmp/module/omp_lib.F90.var
@@ -63,6 +63,27 @@
         ! to be exported by this MODULE.
         private
 
+        private :: kmp_get_affinity_mask_proc_c
+        private :: kmp_set_affinity_mask_proc_c
+        private :: kmp_set_blocktime_c
+        private :: kmp_set_disp_num_buffers_c
+        private :: kmp_set_library_c
+        private :: kmp_set_stacksize_c
+        private :: kmp_unset_affinity_mask_proc_c
+        private :: omp_get_ancestor_thread_num_c
+        private :: omp_get_partition_place_nums_c
+        private :: omp_get_place_num_procs_c
+        private :: omp_get_place_proc_ids_c
+        private :: omp_get_schedule_c
+        private :: omp_get_team_size_c
+        private :: omp_pause_resource_c
+        private :: omp_set_default_device_c
+        private :: omp_set_max_active_levels_c
+        private :: omp_set_num_teams_c
+        private :: omp_set_num_threads_c
+        private :: omp_set_schedule_c
+        private :: omp_set_teams_thread_limit_c
+
         ! Re-export definitions in omp_lib_kinds
         public :: omp_integer_kind
         public :: omp_logical_kind
@@ -250,10 +271,11 @@
 !         *** omp_* entry points
 !         ***
 
-          subroutine omp_set_num_threads(num_threads) bind(c)
+          subroutine omp_set_num_threads_c(num_threads) bind(c,                &
+              name='omp_set_num_threads')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: num_threads
-          end subroutine omp_set_num_threads
+          end subroutine omp_set_num_threads_c
 
           subroutine omp_set_dynamic(dynamic_threads) bind(c)
             use omp_lib_kinds
@@ -310,10 +332,11 @@
             integer (kind=omp_integer_kind) omp_get_thread_limit
           end function omp_get_thread_limit
 
-          subroutine omp_set_max_active_levels(max_levels) bind(c)
+          subroutine omp_set_max_active_levels_c(max_levels) bind(c,           &
+              name='omp_set_max_active_levels')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: max_levels
-          end subroutine omp_set_max_active_levels
+          end subroutine omp_set_max_active_levels_c
 
           function omp_get_max_active_levels() bind(c)
             use omp_lib_kinds
@@ -330,29 +353,32 @@
             integer (kind=omp_integer_kind) omp_get_active_level
           end function omp_get_active_level
 
-          function omp_get_ancestor_thread_num(level) bind(c)
+          function omp_get_ancestor_thread_num_c(level) bind(c,                &
+              name='omp_get_ancestor_thread_num')
             use omp_lib_kinds
-            integer (kind=omp_integer_kind) omp_get_ancestor_thread_num
+            integer (kind=omp_integer_kind) omp_get_ancestor_thread_num_c
             integer (kind=omp_integer_kind), value :: level
-          end function omp_get_ancestor_thread_num
+          end function omp_get_ancestor_thread_num_c
 
-          function omp_get_team_size(level) bind(c)
+          function omp_get_team_size_c(level) bind(c, name='omp_get_team_size')
             use omp_lib_kinds
-            integer (kind=omp_integer_kind) omp_get_team_size
+            integer (kind=omp_integer_kind) omp_get_team_size_c
             integer (kind=omp_integer_kind), value :: level
-          end function omp_get_team_size
+          end function omp_get_team_size_c
 
-          subroutine omp_set_schedule(kind, chunk_size) bind(c)
+          subroutine omp_set_schedule_c(kind, chunk_size) bind(c,              &
+              name='omp_set_schedule')
             use omp_lib_kinds
             integer (kind=omp_sched_kind), value :: kind
             integer (kind=omp_integer_kind), value :: chunk_size
-          end subroutine omp_set_schedule
+          end subroutine omp_set_schedule_c
 
-          subroutine omp_get_schedule(kind, chunk_size) bind(c)
+          subroutine omp_get_schedule_c(kind, chunk_size) bind(c,              &
+              name='omp_get_schedule')
             use omp_lib_kinds
             integer (kind=omp_sched_kind) kind
             integer (kind=omp_integer_kind) chunk_size
-          end subroutine omp_get_schedule
+          end subroutine omp_get_schedule_c
 
           function omp_get_proc_bind() bind(c)
             use omp_lib_kinds
@@ -364,17 +390,19 @@
             integer (kind=omp_integer_kind) omp_get_num_places
           end function omp_get_num_places
 
-          function omp_get_place_num_procs(place_num) bind(c)
+          function omp_get_place_num_procs_c(place_num) bind(c,                &
+              name='omp_get_place_num_procs')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: place_num
-            integer (kind=omp_integer_kind) omp_get_place_num_procs
-          end function omp_get_place_num_procs
+            integer (kind=omp_integer_kind) omp_get_place_num_procs_c
+          end function omp_get_place_num_procs_c
 
-          subroutine omp_get_place_proc_ids(place_num, ids) bind(c)
+          subroutine omp_get_place_proc_ids_c(place_num, ids) bind(c,          &
+              name='omp_get_place_proc_ids')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: place_num
             integer (kind=omp_integer_kind) ids(*)
-          end subroutine omp_get_place_proc_ids
+          end subroutine omp_get_place_proc_ids_c
 
           function omp_get_place_num() bind(c)
             use omp_lib_kinds
@@ -386,10 +414,11 @@
             integer (kind=omp_integer_kind) omp_get_partition_num_places
           end function omp_get_partition_num_places
 
-          subroutine omp_get_partition_place_nums(place_nums) bind(c)
+          subroutine omp_get_partition_place_nums_c(place_nums) bind(c,        &
+              name='omp_get_partition_place_nums')
             use omp_lib_kinds
             integer (kind=omp_integer_kind) place_nums(*)
-          end subroutine omp_get_partition_place_nums
+          end subroutine omp_get_partition_place_nums_c
 
           function omp_get_wtime() bind(c)
             use omp_lib_kinds
@@ -406,10 +435,11 @@
             integer (kind=omp_integer_kind) omp_get_default_device
           end function omp_get_default_device
 
-          subroutine omp_set_default_device(device_num) bind(c)
+          subroutine omp_set_default_device_c(device_num) bind(c,              &
+              name='omp_set_default_device')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: device_num
-          end subroutine omp_set_default_device
+          end subroutine omp_set_default_device_c
 
           function omp_get_num_devices() bind(c)
             use omp_lib_kinds
@@ -446,12 +476,13 @@
             integer (kind=omp_integer_kind) omp_get_device_num
           end function omp_get_device_num
 
-          function omp_pause_resource(kind, device_num) bind(c)
+          function omp_pause_resource_c(kind, device_num) bind(c,              &
+              name='omp_pause_resource')
             use omp_lib_kinds
             integer (kind=omp_pause_resource_kind), value :: kind
             integer (kind=omp_integer_kind), value :: device_num
-            integer (kind=omp_integer_kind) omp_pause_resource
-          end function omp_pause_resource
+            integer (kind=omp_integer_kind) omp_pause_resource_c
+          end function omp_pause_resource_c
 
           function omp_pause_resource_all(kind) bind(c)
             use omp_lib_kinds
@@ -640,20 +671,22 @@
             integer (kind=kmp_size_t_kind) :: omp_capture_affinity
           end function omp_capture_affinity
 
-          subroutine omp_set_num_teams(num_teams) bind(c)
+          subroutine omp_set_num_teams_c(num_teams) bind(c,                    &
+              name='omp_set_num_teams')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: num_teams
-          end subroutine omp_set_num_teams
+          end subroutine omp_set_num_teams_c
 
           function omp_get_max_teams() bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_max_teams
           end function omp_get_max_teams
 
-          subroutine omp_set_teams_thread_limit(thread_limit) bind(c)
+          subroutine omp_set_teams_thread_limit_c(thread_limit) bind(c,        &
+              name='omp_set_teams_thread_limit')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: thread_limit
-          end subroutine omp_set_teams_thread_limit
+          end subroutine omp_set_teams_thread_limit_c
 
           function omp_get_teams_thread_limit() bind(c)
             use omp_lib_kinds
@@ -937,20 +970,20 @@
 !         *** kmp_* entry points
 !         ***
 
-          subroutine kmp_set_stacksize(size) bind(c)
+          subroutine kmp_set_stacksize_c(size) bind(c, name='kmp_set_stacksize')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: size
-          end subroutine kmp_set_stacksize
+          end subroutine kmp_set_stacksize_c
 
           subroutine kmp_set_stacksize_s(size) bind(c)
             use omp_lib_kinds
             integer (kind=kmp_size_t_kind), value :: size
           end subroutine kmp_set_stacksize_s
 
-          subroutine kmp_set_blocktime(msec) bind(c)
+          subroutine kmp_set_blocktime_c(msec) bind(c, name='kmp_set_blocktime')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: msec
-          end subroutine kmp_set_blocktime
+          end subroutine kmp_set_blocktime_c
 
           subroutine kmp_set_library_serial() bind(c)
           end subroutine kmp_set_library_serial
@@ -961,10 +994,10 @@
           subroutine kmp_set_library_throughput() bind(c)
           end subroutine kmp_set_library_throughput
 
-          subroutine kmp_set_library(libnum) bind(c)
+          subroutine kmp_set_library_c(libnum) bind(c, name='kmp_set_library')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: libnum
-          end subroutine kmp_set_library
+          end subroutine kmp_set_library_c
 
           subroutine kmp_set_defaults(string)
             character (len=*) :: string
@@ -990,10 +1023,11 @@
             integer (kind=omp_integer_kind) kmp_get_library
           end function kmp_get_library
 
-          subroutine kmp_set_disp_num_buffers(num) bind(c)
+          subroutine kmp_set_disp_num_buffers_c(num) bind(c,                   &
+              name='kmp_set_disp_num_buffers')
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: num
-          end subroutine kmp_set_disp_num_buffers
+          end subroutine kmp_set_disp_num_buffers_c
 
           function kmp_set_affinity(mask) bind(c)
             use omp_lib_kinds
@@ -1022,26 +1056,29 @@
             integer (kind=kmp_affinity_mask_kind) mask
           end subroutine kmp_destroy_affinity_mask
 
-          function kmp_set_affinity_mask_proc(proc, mask) bind(c)
+          function kmp_set_affinity_mask_proc_c(proc, mask) bind(c,            &
+              name='kmp_set_affinity_mask_proc')
             use omp_lib_kinds
-            integer (kind=omp_integer_kind) kmp_set_affinity_mask_proc
+            integer (kind=omp_integer_kind) kmp_set_affinity_mask_proc_c
             integer (kind=omp_integer_kind), value :: proc
             integer (kind=kmp_affinity_mask_kind) mask
-          end function kmp_set_affinity_mask_proc
+          end function kmp_set_affinity_mask_proc_c
 
-          function kmp_unset_affinity_mask_proc(proc, mask) bind(c)
+          function kmp_unset_affinity_mask_proc_c(proc, mask) bind(c,          &
+              name='kmp_unset_affinity_mask_proc')
             use omp_lib_kinds
-            integer (kind=omp_integer_kind) kmp_unset_affinity_mask_proc
+            integer (kind=omp_integer_kind) kmp_unset_affinity_mask_proc_c
             integer (kind=omp_integer_kind), value :: proc
             integer (kind=kmp_affinity_mask_kind) mask
-          end function kmp_unset_affinity_mask_proc
+          end function kmp_unset_affinity_mask_proc_c
 
-          function kmp_get_affinity_mask_proc(proc, mask) bind(c)
+          function kmp_get_affinity_mask_proc_c(proc, mask) bind(c,            &
+              name='kmp_get_affinity_mask_proc')
             use omp_lib_kinds
-            integer (kind=omp_integer_kind) kmp_get_affinity_mask_proc
+            integer (kind=omp_integer_kind) kmp_get_affinity_mask_proc_c
             integer (kind=omp_integer_kind), value :: proc
             integer (kind=kmp_affinity_mask_kind) mask
-          end function kmp_get_affinity_mask_proc
+          end function kmp_get_affinity_mask_proc_c
 
           function kmp_malloc(size) bind(c)
             use omp_lib_kinds
@@ -1149,6 +1186,98 @@
           end function omp_get_interop_rc_desc
 
         end interface
+
+        ! Generic interfaces for multiple integer kinds
+        interface omp_set_num_threads
+          module procedure omp_set_num_threads_i1, omp_set_num_threads_i2,     &
+              omp_set_num_threads_i4, omp_set_num_threads_i8
+        end interface omp_set_num_threads
+        interface omp_set_max_active_levels
+          module procedure omp_set_max_active_levels_i1,                       &
+              omp_set_max_active_levels_i2, omp_set_max_active_levels_i4,      &
+              omp_set_max_active_levels_i8
+        end interface omp_set_max_active_levels
+        interface omp_set_default_device
+          module procedure omp_set_default_device_i1,                          &
+              omp_set_default_device_i2, omp_set_default_device_i4,            &
+              omp_set_default_device_i8
+        end interface omp_set_default_device
+        interface omp_set_num_teams
+          module procedure omp_set_num_teams_i1, omp_set_num_teams_i2,         &
+              omp_set_num_teams_i4, omp_set_num_teams_i8
+        end interface omp_set_num_teams
+        interface omp_set_teams_thread_limit
+          module procedure omp_set_teams_thread_limit_i1,                      &
+              omp_set_teams_thread_limit_i2, omp_set_teams_thread_limit_i4,    &
+              omp_set_teams_thread_limit_i8
+        end interface omp_set_teams_thread_limit
+        interface kmp_set_stacksize
+          module procedure kmp_set_stacksize_i1, kmp_set_stacksize_i2,         &
+              kmp_set_stacksize_i4, kmp_set_stacksize_i8
+        end interface kmp_set_stacksize
+        interface kmp_set_blocktime
+          module procedure kmp_set_blocktime_i1, kmp_set_blocktime_i2,         &
+              kmp_set_blocktime_i4, kmp_set_blocktime_i8
+        end interface kmp_set_blocktime
+        interface kmp_set_library
+          module procedure kmp_set_library_i1, kmp_set_library_i2,             &
+              kmp_set_library_i4, kmp_set_library_i8
+        end interface kmp_set_library
+        interface kmp_set_disp_num_buffers
+          module procedure kmp_set_disp_num_buffers_i1,                        &
+              kmp_set_disp_num_buffers_i2, kmp_set_disp_num_buffers_i4,        &
+              kmp_set_disp_num_buffers_i8
+        end interface kmp_set_disp_num_buffers
+        interface omp_get_ancestor_thread_num
+          module procedure omp_get_ancestor_thread_num_i1,                     &
+              omp_get_ancestor_thread_num_i2, omp_get_ancestor_thread_num_i4,  &
+              omp_get_ancestor_thread_num_i8
+        end interface omp_get_ancestor_thread_num
+        interface omp_get_team_size
+          module procedure omp_get_team_size_i1, omp_get_team_size_i2,         &
+              omp_get_team_size_i4, omp_get_team_size_i8
+        end interface omp_get_team_size
+        interface omp_get_place_num_procs
+          module procedure omp_get_place_num_procs_i1,                         &
+              omp_get_place_num_procs_i2, omp_get_place_num_procs_i4,          &
+              omp_get_place_num_procs_i8
+        end interface omp_get_place_num_procs
+        interface omp_set_schedule
+          module procedure omp_set_schedule_i1, omp_set_schedule_i2,           &
+              omp_set_schedule_i4, omp_set_schedule_i8
+        end interface omp_set_schedule
+        interface omp_get_schedule
+          module procedure omp_get_schedule_i1, omp_get_schedule_i2,           &
+              omp_get_schedule_i4, omp_get_schedule_i8
+        end interface omp_get_schedule
+        interface omp_pause_resource
+          module procedure omp_pause_resource_i1, omp_pause_resource_i2,       &
+              omp_pause_resource_i4, omp_pause_resource_i8
+        end interface omp_pause_resource
+        interface omp_get_place_proc_ids
+          module procedure omp_get_place_proc_ids_i4, omp_get_place_proc_ids_i8
+        end interface omp_get_place_proc_ids
+        interface omp_get_partition_place_nums
+          module procedure omp_get_partition_place_nums_i4,                    &
+              omp_get_partition_place_nums_i8
+        end interface omp_get_partition_place_nums
+        interface kmp_set_affinity_mask_proc
+          module procedure kmp_set_affinity_mask_proc_i1,                      &
+              kmp_set_affinity_mask_proc_i2, kmp_set_affinity_mask_proc_i4,    &
+              kmp_set_affinity_mask_proc_i8
+        end interface kmp_set_affinity_mask_proc
+        interface kmp_unset_affinity_mask_proc
+          module procedure kmp_unset_affinity_mask_proc_i1,                    &
+              kmp_unset_affinity_mask_proc_i2,                                 &
+              kmp_unset_affinity_mask_proc_i4,                                 &
+              kmp_unset_affinity_mask_proc_i8
+        end interface kmp_unset_affinity_mask_proc
+        interface kmp_get_affinity_mask_proc
+          module procedure kmp_get_affinity_mask_proc_i1,                      &
+              kmp_get_affinity_mask_proc_i2, kmp_get_affinity_mask_proc_i4,    &
+              kmp_get_affinity_mask_proc_i8
+        end interface kmp_get_affinity_mask_proc
+
 
         ! make the above routine definitions public
         public :: omp_set_num_threads
@@ -1277,4 +1406,407 @@
         public :: omp_get_interop_type_desc
         public :: omp_get_interop_rc_desc
 
+
+
+        ! Submodule procedure declarations for integer-kind wrappers.
+        interface
+          module subroutine omp_set_num_threads_i1(num_threads)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: num_threads
+          end subroutine omp_set_num_threads_i1
+          module subroutine omp_set_num_threads_i2(num_threads)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: num_threads
+          end subroutine omp_set_num_threads_i2
+          module subroutine omp_set_num_threads_i4(num_threads)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: num_threads
+          end subroutine omp_set_num_threads_i4
+          module subroutine omp_set_num_threads_i8(num_threads)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: num_threads
+          end subroutine omp_set_num_threads_i8
+          module subroutine omp_set_max_active_levels_i1(max_levels)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: max_levels
+          end subroutine omp_set_max_active_levels_i1
+          module subroutine omp_set_max_active_levels_i2(max_levels)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: max_levels
+          end subroutine omp_set_max_active_levels_i2
+          module subroutine omp_set_max_active_levels_i4(max_levels)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: max_levels
+          end subroutine omp_set_max_active_levels_i4
+          module subroutine omp_set_max_active_levels_i8(max_levels)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: max_levels
+          end subroutine omp_set_max_active_levels_i8
+          module subroutine omp_set_default_device_i1(device_num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: device_num
+          end subroutine omp_set_default_device_i1
+          module subroutine omp_set_default_device_i2(device_num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: device_num
+          end subroutine omp_set_default_device_i2
+          module subroutine omp_set_default_device_i4(device_num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: device_num
+          end subroutine omp_set_default_device_i4
+          module subroutine omp_set_default_device_i8(device_num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: device_num
+          end subroutine omp_set_default_device_i8
+          module subroutine omp_set_num_teams_i1(num_teams)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: num_teams
+          end subroutine omp_set_num_teams_i1
+          module subroutine omp_set_num_teams_i2(num_teams)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: num_teams
+          end subroutine omp_set_num_teams_i2
+          module subroutine omp_set_num_teams_i4(num_teams)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: num_teams
+          end subroutine omp_set_num_teams_i4
+          module subroutine omp_set_num_teams_i8(num_teams)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: num_teams
+          end subroutine omp_set_num_teams_i8
+          module subroutine omp_set_teams_thread_limit_i1(thread_limit)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: thread_limit
+          end subroutine omp_set_teams_thread_limit_i1
+          module subroutine omp_set_teams_thread_limit_i2(thread_limit)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: thread_limit
+          end subroutine omp_set_teams_thread_limit_i2
+          module subroutine omp_set_teams_thread_limit_i4(thread_limit)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: thread_limit
+          end subroutine omp_set_teams_thread_limit_i4
+          module subroutine omp_set_teams_thread_limit_i8(thread_limit)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: thread_limit
+          end subroutine omp_set_teams_thread_limit_i8
+          module subroutine kmp_set_stacksize_i1(size)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: size
+          end subroutine kmp_set_stacksize_i1
+          module subroutine kmp_set_stacksize_i2(size)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: size
+          end subroutine kmp_set_stacksize_i2
+          module subroutine kmp_set_stacksize_i4(size)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: size
+          end subroutine kmp_set_stacksize_i4
+          module subroutine kmp_set_stacksize_i8(size)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: size
+          end subroutine kmp_set_stacksize_i8
+          module subroutine kmp_set_blocktime_i1(msec)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: msec
+          end subroutine kmp_set_blocktime_i1
+          module subroutine kmp_set_blocktime_i2(msec)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: msec
+          end subroutine kmp_set_blocktime_i2
+          module subroutine kmp_set_blocktime_i4(msec)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: msec
+          end subroutine kmp_set_blocktime_i4
+          module subroutine kmp_set_blocktime_i8(msec)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: msec
+          end subroutine kmp_set_blocktime_i8
+          module subroutine kmp_set_library_i1(libnum)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: libnum
+          end subroutine kmp_set_library_i1
+          module subroutine kmp_set_library_i2(libnum)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: libnum
+          end subroutine kmp_set_library_i2
+          module subroutine kmp_set_library_i4(libnum)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: libnum
+          end subroutine kmp_set_library_i4
+          module subroutine kmp_set_library_i8(libnum)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: libnum
+          end subroutine kmp_set_library_i8
+          module subroutine kmp_set_disp_num_buffers_i1(num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: num
+          end subroutine kmp_set_disp_num_buffers_i1
+          module subroutine kmp_set_disp_num_buffers_i2(num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: num
+          end subroutine kmp_set_disp_num_buffers_i2
+          module subroutine kmp_set_disp_num_buffers_i4(num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: num
+          end subroutine kmp_set_disp_num_buffers_i4
+          module subroutine kmp_set_disp_num_buffers_i8(num)
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: num
+          end subroutine kmp_set_disp_num_buffers_i8
+          module function omp_get_ancestor_thread_num_i1(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_ancestor_thread_num_i1
+          end function omp_get_ancestor_thread_num_i1
+          module function omp_get_ancestor_thread_num_i2(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_ancestor_thread_num_i2
+          end function omp_get_ancestor_thread_num_i2
+          module function omp_get_ancestor_thread_num_i4(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_ancestor_thread_num_i4
+          end function omp_get_ancestor_thread_num_i4
+          module function omp_get_ancestor_thread_num_i8(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_ancestor_thread_num_i8
+          end function omp_get_ancestor_thread_num_i8
+          module function omp_get_team_size_i1(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_team_size_i1
+          end function omp_get_team_size_i1
+          module function omp_get_team_size_i2(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_team_size_i2
+          end function omp_get_team_size_i2
+          module function omp_get_team_size_i4(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_team_size_i4
+          end function omp_get_team_size_i4
+          module function omp_get_team_size_i8(level)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: level
+          integer(kind=omp_integer_kind) :: omp_get_team_size_i8
+          end function omp_get_team_size_i8
+          module function omp_get_place_num_procs_i1(place_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: place_num
+          integer(kind=omp_integer_kind) :: omp_get_place_num_procs_i1
+          end function omp_get_place_num_procs_i1
+          module function omp_get_place_num_procs_i2(place_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: place_num
+          integer(kind=omp_integer_kind) :: omp_get_place_num_procs_i2
+          end function omp_get_place_num_procs_i2
+          module function omp_get_place_num_procs_i4(place_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: place_num
+          integer(kind=omp_integer_kind) :: omp_get_place_num_procs_i4
+          end function omp_get_place_num_procs_i4
+          module function omp_get_place_num_procs_i8(place_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: place_num
+          integer(kind=omp_integer_kind) :: omp_get_place_num_procs_i8
+          end function omp_get_place_num_procs_i8
+          module subroutine omp_set_schedule_i1(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(kind=omp_sched_kind), value :: kind
+          integer(c_int8_t), value :: chunk_size
+          end subroutine omp_set_schedule_i1
+          module subroutine omp_set_schedule_i2(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(kind=omp_sched_kind), value :: kind
+          integer(c_int16_t), value :: chunk_size
+          end subroutine omp_set_schedule_i2
+          module subroutine omp_set_schedule_i4(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(kind=omp_sched_kind), value :: kind
+          integer(c_int), value :: chunk_size
+          end subroutine omp_set_schedule_i4
+          module subroutine omp_set_schedule_i8(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(kind=omp_sched_kind), value :: kind
+          integer(c_int64_t), value :: chunk_size
+          end subroutine omp_set_schedule_i8
+          module subroutine omp_get_schedule_i1(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(kind=omp_sched_kind), intent(out) :: kind
+          integer(c_int8_t), intent(out) :: chunk_size
+          end subroutine omp_get_schedule_i1
+          module subroutine omp_get_schedule_i2(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(kind=omp_sched_kind), intent(out) :: kind
+          integer(c_int16_t), intent(out) :: chunk_size
+          end subroutine omp_get_schedule_i2
+          module subroutine omp_get_schedule_i4(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(kind=omp_sched_kind), intent(out) :: kind
+          integer(c_int), intent(out) :: chunk_size
+          end subroutine omp_get_schedule_i4
+          module subroutine omp_get_schedule_i8(kind, chunk_size)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(kind=omp_sched_kind), intent(out) :: kind
+          integer(c_int64_t), intent(out) :: chunk_size
+          end subroutine omp_get_schedule_i8
+          module function omp_pause_resource_i1(kind, device_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(kind=omp_pause_resource_kind), value :: kind
+          integer(c_int8_t), value :: device_num
+          integer(kind=omp_integer_kind) :: omp_pause_resource_i1
+          end function omp_pause_resource_i1
+          module function omp_pause_resource_i2(kind, device_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(kind=omp_pause_resource_kind), value :: kind
+          integer(c_int16_t), value :: device_num
+          integer(kind=omp_integer_kind) :: omp_pause_resource_i2
+          end function omp_pause_resource_i2
+          module function omp_pause_resource_i4(kind, device_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(kind=omp_pause_resource_kind), value :: kind
+          integer(c_int), value :: device_num
+          integer(kind=omp_integer_kind) :: omp_pause_resource_i4
+          end function omp_pause_resource_i4
+          module function omp_pause_resource_i8(kind, device_num)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(kind=omp_pause_resource_kind), value :: kind
+          integer(c_int64_t), value :: device_num
+          integer(kind=omp_integer_kind) :: omp_pause_resource_i8
+          end function omp_pause_resource_i8
+          module function kmp_set_affinity_mask_proc_i1(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_set_affinity_mask_proc_i1
+          end function kmp_set_affinity_mask_proc_i1
+          module function kmp_set_affinity_mask_proc_i2(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_set_affinity_mask_proc_i2
+          end function kmp_set_affinity_mask_proc_i2
+          module function kmp_set_affinity_mask_proc_i4(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_set_affinity_mask_proc_i4
+          end function kmp_set_affinity_mask_proc_i4
+          module function kmp_set_affinity_mask_proc_i8(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_set_affinity_mask_proc_i8
+          end function kmp_set_affinity_mask_proc_i8
+          module function kmp_unset_affinity_mask_proc_i1(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_unset_affinity_mask_proc_i1
+          end function kmp_unset_affinity_mask_proc_i1
+          module function kmp_unset_affinity_mask_proc_i2(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_unset_affinity_mask_proc_i2
+          end function kmp_unset_affinity_mask_proc_i2
+          module function kmp_unset_affinity_mask_proc_i4(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_unset_affinity_mask_proc_i4
+          end function kmp_unset_affinity_mask_proc_i4
+          module function kmp_unset_affinity_mask_proc_i8(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_unset_affinity_mask_proc_i8
+          end function kmp_unset_affinity_mask_proc_i8
+          module function kmp_get_affinity_mask_proc_i1(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int8_t
+          integer(c_int8_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_get_affinity_mask_proc_i1
+          end function kmp_get_affinity_mask_proc_i1
+          module function kmp_get_affinity_mask_proc_i2(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int16_t
+          integer(c_int16_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_get_affinity_mask_proc_i2
+          end function kmp_get_affinity_mask_proc_i2
+          module function kmp_get_affinity_mask_proc_i4(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_get_affinity_mask_proc_i4
+          end function kmp_get_affinity_mask_proc_i4
+          module function kmp_get_affinity_mask_proc_i8(proc, mask)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: proc
+          integer(kind=kmp_affinity_mask_kind) :: mask
+          integer(kind=omp_integer_kind) :: kmp_get_affinity_mask_proc_i8
+          end function kmp_get_affinity_mask_proc_i8
+          module subroutine omp_get_place_proc_ids_i4(place_num, ids)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), value :: place_num
+          integer(c_int), intent(out) :: ids(*)
+          end subroutine omp_get_place_proc_ids_i4
+          module subroutine omp_get_place_proc_ids_i8(place_num, ids)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), value :: place_num
+          integer(c_int64_t), intent(out) :: ids(*)
+          end subroutine omp_get_place_proc_ids_i8
+          module subroutine omp_get_partition_place_nums_i4(place_nums)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int
+          integer(c_int), intent(out) :: place_nums(*)
+          end subroutine omp_get_partition_place_nums_i4
+          module subroutine omp_get_partition_place_nums_i8(place_nums)
+          use omp_lib_kinds
+          use, intrinsic :: iso_c_binding, only: c_int, c_int64_t
+          integer(c_int64_t), intent(out) :: place_nums(*)
+          end subroutine omp_get_partition_place_nums_i8
+        end interface
       end module omp_lib

--- a/openmp/module/omp_lib_impl.F90.var
+++ b/openmp/module/omp_lib_impl.F90.var
@@ -1,0 +1,465 @@
+! include/omp_lib_impl.f90.var
+!
+!//===----------------------------------------------------------------------===//
+!//
+!// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+!// See https://llvm.org/LICENSE.txt for license information.
+!// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!//
+!//===----------------------------------------------------------------------===//
+!
+! Integer-kind wrapper procedures for omp_lib
+
+      submodule (omp_lib) omp_lib_impl
+        use omp_lib_kinds
+      contains
+
+        module procedure omp_set_num_threads_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_threads_c(int(num_threads, kind=c_int))
+        end procedure omp_set_num_threads_i1
+
+        module procedure omp_set_num_threads_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_threads_c(int(num_threads, kind=c_int))
+        end procedure omp_set_num_threads_i2
+
+        module procedure omp_set_num_threads_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_threads_c(int(num_threads, kind=c_int))
+        end procedure omp_set_num_threads_i4
+
+        module procedure omp_set_num_threads_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_threads_c(int(num_threads, kind=c_int))
+        end procedure omp_set_num_threads_i8
+
+        module procedure omp_set_max_active_levels_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_max_active_levels_c(int(max_levels, kind=c_int))
+        end procedure omp_set_max_active_levels_i1
+
+        module procedure omp_set_max_active_levels_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_max_active_levels_c(int(max_levels, kind=c_int))
+        end procedure omp_set_max_active_levels_i2
+
+        module procedure omp_set_max_active_levels_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_max_active_levels_c(int(max_levels, kind=c_int))
+        end procedure omp_set_max_active_levels_i4
+
+        module procedure omp_set_max_active_levels_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_max_active_levels_c(int(max_levels, kind=c_int))
+        end procedure omp_set_max_active_levels_i8
+
+        module procedure omp_set_default_device_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_default_device_c(int(device_num, kind=c_int))
+        end procedure omp_set_default_device_i1
+
+        module procedure omp_set_default_device_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_default_device_c(int(device_num, kind=c_int))
+        end procedure omp_set_default_device_i2
+
+        module procedure omp_set_default_device_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_default_device_c(int(device_num, kind=c_int))
+        end procedure omp_set_default_device_i4
+
+        module procedure omp_set_default_device_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_default_device_c(int(device_num, kind=c_int))
+        end procedure omp_set_default_device_i8
+
+        module procedure omp_set_num_teams_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_teams_c(int(num_teams, kind=c_int))
+        end procedure omp_set_num_teams_i1
+
+        module procedure omp_set_num_teams_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_teams_c(int(num_teams, kind=c_int))
+        end procedure omp_set_num_teams_i2
+
+        module procedure omp_set_num_teams_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_teams_c(int(num_teams, kind=c_int))
+        end procedure omp_set_num_teams_i4
+
+        module procedure omp_set_num_teams_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_num_teams_c(int(num_teams, kind=c_int))
+        end procedure omp_set_num_teams_i8
+
+        module procedure omp_set_teams_thread_limit_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_teams_thread_limit_c(int(thread_limit, kind=c_int))
+        end procedure omp_set_teams_thread_limit_i1
+
+        module procedure omp_set_teams_thread_limit_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_teams_thread_limit_c(int(thread_limit, kind=c_int))
+        end procedure omp_set_teams_thread_limit_i2
+
+        module procedure omp_set_teams_thread_limit_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_teams_thread_limit_c(int(thread_limit, kind=c_int))
+        end procedure omp_set_teams_thread_limit_i4
+
+        module procedure omp_set_teams_thread_limit_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_teams_thread_limit_c(int(thread_limit, kind=c_int))
+        end procedure omp_set_teams_thread_limit_i8
+
+        module procedure kmp_set_stacksize_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_stacksize_c(int(size, kind=c_int))
+        end procedure kmp_set_stacksize_i1
+
+        module procedure kmp_set_stacksize_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_stacksize_c(int(size, kind=c_int))
+        end procedure kmp_set_stacksize_i2
+
+        module procedure kmp_set_stacksize_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_stacksize_c(int(size, kind=c_int))
+        end procedure kmp_set_stacksize_i4
+
+        module procedure kmp_set_stacksize_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_stacksize_c(int(size, kind=c_int))
+        end procedure kmp_set_stacksize_i8
+
+        module procedure kmp_set_blocktime_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_blocktime_c(int(msec, kind=c_int))
+        end procedure kmp_set_blocktime_i1
+
+        module procedure kmp_set_blocktime_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_blocktime_c(int(msec, kind=c_int))
+        end procedure kmp_set_blocktime_i2
+
+        module procedure kmp_set_blocktime_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_blocktime_c(int(msec, kind=c_int))
+        end procedure kmp_set_blocktime_i4
+
+        module procedure kmp_set_blocktime_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_blocktime_c(int(msec, kind=c_int))
+        end procedure kmp_set_blocktime_i8
+
+        module procedure kmp_set_library_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_library_c(int(libnum, kind=c_int))
+        end procedure kmp_set_library_i1
+
+        module procedure kmp_set_library_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_library_c(int(libnum, kind=c_int))
+        end procedure kmp_set_library_i2
+
+        module procedure kmp_set_library_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_library_c(int(libnum, kind=c_int))
+        end procedure kmp_set_library_i4
+
+        module procedure kmp_set_library_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_library_c(int(libnum, kind=c_int))
+        end procedure kmp_set_library_i8
+
+        module procedure kmp_set_disp_num_buffers_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_disp_num_buffers_c(int(num, kind=c_int))
+        end procedure kmp_set_disp_num_buffers_i1
+
+        module procedure kmp_set_disp_num_buffers_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_disp_num_buffers_c(int(num, kind=c_int))
+        end procedure kmp_set_disp_num_buffers_i2
+
+        module procedure kmp_set_disp_num_buffers_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_disp_num_buffers_c(int(num, kind=c_int))
+        end procedure kmp_set_disp_num_buffers_i4
+
+        module procedure kmp_set_disp_num_buffers_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call kmp_set_disp_num_buffers_c(int(num, kind=c_int))
+        end procedure kmp_set_disp_num_buffers_i8
+
+        module procedure omp_get_ancestor_thread_num_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_ancestor_thread_num_i1 =                                     &
+          omp_get_ancestor_thread_num_c(int(level, kind=c_int))
+        end procedure omp_get_ancestor_thread_num_i1
+
+        module procedure omp_get_ancestor_thread_num_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_ancestor_thread_num_i2 =                                     &
+          omp_get_ancestor_thread_num_c(int(level, kind=c_int))
+        end procedure omp_get_ancestor_thread_num_i2
+
+        module procedure omp_get_ancestor_thread_num_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_ancestor_thread_num_i4 =                                     &
+          omp_get_ancestor_thread_num_c(int(level, kind=c_int))
+        end procedure omp_get_ancestor_thread_num_i4
+
+        module procedure omp_get_ancestor_thread_num_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_ancestor_thread_num_i8 =                                     &
+          omp_get_ancestor_thread_num_c(int(level, kind=c_int))
+        end procedure omp_get_ancestor_thread_num_i8
+
+        module procedure omp_get_team_size_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_team_size_i1 = omp_get_team_size_c(int(level, kind=c_int))
+        end procedure omp_get_team_size_i1
+
+        module procedure omp_get_team_size_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_team_size_i2 = omp_get_team_size_c(int(level, kind=c_int))
+        end procedure omp_get_team_size_i2
+
+        module procedure omp_get_team_size_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_team_size_i4 = omp_get_team_size_c(int(level, kind=c_int))
+        end procedure omp_get_team_size_i4
+
+        module procedure omp_get_team_size_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_team_size_i8 = omp_get_team_size_c(int(level, kind=c_int))
+        end procedure omp_get_team_size_i8
+
+        module procedure omp_get_place_num_procs_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_place_num_procs_i1 =                                         &
+          omp_get_place_num_procs_c(int(place_num, kind=c_int))
+        end procedure omp_get_place_num_procs_i1
+
+        module procedure omp_get_place_num_procs_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_place_num_procs_i2 =                                         &
+          omp_get_place_num_procs_c(int(place_num, kind=c_int))
+        end procedure omp_get_place_num_procs_i2
+
+        module procedure omp_get_place_num_procs_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_place_num_procs_i4 =                                         &
+          omp_get_place_num_procs_c(int(place_num, kind=c_int))
+        end procedure omp_get_place_num_procs_i4
+
+        module procedure omp_get_place_num_procs_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_get_place_num_procs_i8 =                                         &
+          omp_get_place_num_procs_c(int(place_num, kind=c_int))
+        end procedure omp_get_place_num_procs_i8
+
+        module procedure omp_set_schedule_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_schedule_c(kind, int(chunk_size, kind=c_int))
+        end procedure omp_set_schedule_i1
+
+        module procedure omp_set_schedule_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_schedule_c(kind, int(chunk_size, kind=c_int))
+        end procedure omp_set_schedule_i2
+
+        module procedure omp_set_schedule_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_schedule_c(kind, int(chunk_size, kind=c_int))
+        end procedure omp_set_schedule_i4
+
+        module procedure omp_set_schedule_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          call omp_set_schedule_c(kind, int(chunk_size, kind=c_int))
+        end procedure omp_set_schedule_i8
+
+        module procedure omp_get_schedule_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: kind_c, chunk_c
+          call omp_get_schedule_c(kind_c, chunk_c)
+          kind = kind_c
+          chunk_size = chunk_c
+        end procedure omp_get_schedule_i1
+
+        module procedure omp_get_schedule_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: kind_c, chunk_c
+          call omp_get_schedule_c(kind_c, chunk_c)
+          kind = kind_c
+          chunk_size = chunk_c
+        end procedure omp_get_schedule_i2
+
+        module procedure omp_get_schedule_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: kind_c, chunk_c
+          call omp_get_schedule_c(kind_c, chunk_c)
+          kind = kind_c
+          chunk_size = chunk_c
+        end procedure omp_get_schedule_i4
+
+        module procedure omp_get_schedule_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: kind_c, chunk_c
+          call omp_get_schedule_c(kind_c, chunk_c)
+          kind = kind_c
+          chunk_size = chunk_c
+        end procedure omp_get_schedule_i8
+
+        module procedure omp_pause_resource_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_pause_resource_i1 =                                              &
+          omp_pause_resource_c(kind, int(device_num, kind=c_int))
+        end procedure omp_pause_resource_i1
+
+        module procedure omp_pause_resource_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_pause_resource_i2 =                                              &
+          omp_pause_resource_c(kind, int(device_num, kind=c_int))
+        end procedure omp_pause_resource_i2
+
+        module procedure omp_pause_resource_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_pause_resource_i4 =                                              &
+          omp_pause_resource_c(kind, int(device_num, kind=c_int))
+        end procedure omp_pause_resource_i4
+
+        module procedure omp_pause_resource_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          omp_pause_resource_i8 =                                              &
+          omp_pause_resource_c(kind, int(device_num, kind=c_int))
+        end procedure omp_pause_resource_i8
+
+        module procedure kmp_set_affinity_mask_proc_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_set_affinity_mask_proc_i1 =                                      &
+          kmp_set_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_set_affinity_mask_proc_i1
+
+        module procedure kmp_set_affinity_mask_proc_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_set_affinity_mask_proc_i2 =                                      &
+          kmp_set_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_set_affinity_mask_proc_i2
+
+        module procedure kmp_set_affinity_mask_proc_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_set_affinity_mask_proc_i4 =                                      &
+          kmp_set_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_set_affinity_mask_proc_i4
+
+        module procedure kmp_set_affinity_mask_proc_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_set_affinity_mask_proc_i8 =                                      &
+          kmp_set_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_set_affinity_mask_proc_i8
+
+        module procedure kmp_unset_affinity_mask_proc_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_unset_affinity_mask_proc_i1 =                                    &
+          kmp_unset_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_unset_affinity_mask_proc_i1
+
+        module procedure kmp_unset_affinity_mask_proc_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_unset_affinity_mask_proc_i2 =                                    &
+          kmp_unset_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_unset_affinity_mask_proc_i2
+
+        module procedure kmp_unset_affinity_mask_proc_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_unset_affinity_mask_proc_i4 =                                    &
+          kmp_unset_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_unset_affinity_mask_proc_i4
+
+        module procedure kmp_unset_affinity_mask_proc_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_unset_affinity_mask_proc_i8 =                                    &
+          kmp_unset_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_unset_affinity_mask_proc_i8
+
+        module procedure kmp_get_affinity_mask_proc_i1
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_get_affinity_mask_proc_i1 =                                      &
+          kmp_get_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_get_affinity_mask_proc_i1
+
+        module procedure kmp_get_affinity_mask_proc_i2
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_get_affinity_mask_proc_i2 =                                      &
+          kmp_get_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_get_affinity_mask_proc_i2
+
+        module procedure kmp_get_affinity_mask_proc_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_get_affinity_mask_proc_i4 =                                      &
+          kmp_get_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_get_affinity_mask_proc_i4
+
+        module procedure kmp_get_affinity_mask_proc_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          kmp_get_affinity_mask_proc_i8 =                                      &
+          kmp_get_affinity_mask_proc_c(int(proc, kind=c_int), mask)
+        end procedure kmp_get_affinity_mask_proc_i8
+
+        module procedure omp_get_place_proc_ids_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: n, i
+          integer(c_int), allocatable :: ids_c(:)
+          n = omp_get_place_num_procs_c(int(place_num, kind=c_int))
+          allocate(ids_c(n))
+          call omp_get_place_proc_ids_c(int(place_num, kind=c_int), ids_c)
+          do i = 1, n
+          ids(i) = ids_c(i)
+          end do
+          deallocate(ids_c)
+        end procedure omp_get_place_proc_ids_i4
+
+        module procedure omp_get_place_proc_ids_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: n, i
+          integer(c_int), allocatable :: ids_c(:)
+          n = omp_get_place_num_procs_c(int(place_num, kind=c_int))
+          allocate(ids_c(n))
+          call omp_get_place_proc_ids_c(int(place_num, kind=c_int), ids_c)
+          do i = 1, n
+          ids(i) = ids_c(i)
+          end do
+          deallocate(ids_c)
+        end procedure omp_get_place_proc_ids_i8
+
+        module procedure omp_get_partition_place_nums_i4
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: n, i
+          integer(c_int), allocatable :: place_nums_c(:)
+          n = omp_get_partition_num_places()
+          allocate(place_nums_c(n))
+          call omp_get_partition_place_nums_c(place_nums_c)
+          do i = 1, n
+          place_nums(i) = place_nums_c(i)
+          end do
+          deallocate(place_nums_c)
+        end procedure omp_get_partition_place_nums_i4
+
+        module procedure omp_get_partition_place_nums_i8
+        use, intrinsic :: iso_c_binding, only: c_int
+          integer(c_int) :: n, i
+          integer(c_int), allocatable :: place_nums_c(:)
+          n = omp_get_partition_num_places()
+          allocate(place_nums_c(n))
+          call omp_get_partition_place_nums_c(place_nums_c)
+          do i = 1, n
+          place_nums(i) = place_nums_c(i)
+          end do
+          deallocate(place_nums_c)
+        end procedure omp_get_partition_place_nums_i8
+
+      end submodule omp_lib_impl

--- a/openmp/runtime/cmake/LibompExports.cmake
+++ b/openmp/runtime/cmake/LibompExports.cmake
@@ -72,7 +72,7 @@ if(LIBOMP_FORTRAN_MODULES)
     COMMAND ${CMAKE_COMMAND} -E copy "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.mod" ${LIBOMP_EXPORTS_MOD_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib_kinds.mod" ${LIBOMP_EXPORTS_MOD_DIR}
   )
-  add_dependencies(omp libomp-mod)
+  add_dependencies(omp libomp-mod libomp-mod-barrier)
   add_custom_command(TARGET omp POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.h" ${LIBOMP_EXPORTS_CMN_DIR}
   )


### PR DESCRIPTION
Many OpenMP routines in omp_lib currently accept only integer(kind=omp_integer_kind) arguments, where omp_integer_kind maps to c_int. As a result, Flang's type checking rejects calls that pass integer(1), integer(2), or integer(8) arguments. To improve compatibility, wrapper procedures have been added in the omp_lib module for applicable routines, enabling support for integer(1), integer(2), integer(4), and integer(8) argument types. The interfaces are added in omp_lib module and the implementations are part of omp_lib_impl sub module.

Similar changes are required in omp_lib.h and will be addressed in a separate pull request.

Fixes #123948.

Assisted-by: Cursor