### PR TITLE
[MLIR][Python] Drop the LLVMSupport link dependency from the python extensions

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -249,7 +249,9 @@ endfunction()
 #   SOURCES: C++ sources making up the module.
 #   PRIVATE_LINK_LIBS: List of libraries to link in privately to the module
 #     regardless of how it is included in the project (generally should be
-#     static libraries that can be included with hidden visibility).
+#     static libraries that can be included with hidden visibility). Do not
+#     list C++ LLVM/MLIR libraries here; use the C++ standard library instead,
+#     or wrap the functionality in the C API first.
 #   EMBED_CAPI_LINK_LIBS: Dependent CAPI libraries that this extension depends
 #     on. These will be collected for all extensions and put into an
 #     aggregate dylib that is linked against.

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -249,9 +249,7 @@ endfunction()
 #   SOURCES: C++ sources making up the module.
 #   PRIVATE_LINK_LIBS: List of libraries to link in privately to the module
 #     regardless of how it is included in the project (generally should be
-#     static libraries that can be included with hidden visibility). Do not
-#     list C++ LLVM/MLIR libraries here; use the C++ standard library instead,
-#     or wrap the functionality in the C API first.
+#     static libraries that can be included with hidden visibility).
 #   EMBED_CAPI_LINK_LIBS: Dependent CAPI libraries that this extension depends
 #     on. These will be collected for all extensions and put into an
 #     aggregate dylib that is linked against.

--- a/mlir/examples/standalone/python/CMakeLists.txt
+++ b/mlir/examples/standalone/python/CMakeLists.txt
@@ -25,8 +25,6 @@ declare_mlir_python_extension(StandalonePythonSources.NanobindExtension
   ADD_TO_PARENT StandalonePythonSources
   SOURCES
     StandaloneExtensionNanobind.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPIArith

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -568,8 +568,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Core
     # Headers must be included explicitly so they are installed.
     Pass.h
     Rewrite.h
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIDebug
     MLIRCAPIIR
@@ -591,8 +589,6 @@ declare_mlir_python_extension(MLIRPythonExtension.RegisterEverything
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     RegisterEverything.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIConversion
     MLIRCAPITransforms
@@ -605,8 +601,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.Linalg.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectLinalg.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPILinalg
@@ -618,8 +612,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.GPU.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectGPU.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPIGPU
@@ -631,8 +623,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.LLVM.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectLLVM.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPILLVM
@@ -646,8 +636,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.Quant.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectQuant.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPIQuant
@@ -659,8 +647,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.NVGPU.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectNVGPU.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPINVGPU
@@ -672,8 +658,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.PDL.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectPDL.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPIPDL
@@ -685,8 +669,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.SparseTensor.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectSparseTensor.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPISparseTensor
@@ -700,7 +682,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.Transform.Nanobind
     DialectTransform.cpp
     Rewrite.h
   PRIVATE_LINK_LIBS
-    LLVMSupport
     MLIRPythonExtension.Core
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
@@ -713,8 +694,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.IRDL.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectIRDL.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPIIRDL
@@ -726,8 +705,6 @@ declare_mlir_python_extension(MLIRPythonExtension.AsyncDialectPasses
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     AsyncPasses.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIAsync
 )
@@ -739,8 +716,6 @@ if(MLIR_ENABLE_EXECUTION_ENGINE)
     ROOT_DIR "${PYTHON_SOURCE_DIR}"
     SOURCES
       ExecutionEngineModule.cpp
-    PRIVATE_LINK_LIBS
-      LLVMSupport
     EMBED_CAPI_LINK_LIBS
       MLIRCAPIExecutionEngine
   )
@@ -752,8 +727,6 @@ declare_mlir_python_extension(MLIRPythonExtension.GPUDialectPasses
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     GPUPasses.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIGPU
 )
@@ -764,8 +737,6 @@ declare_mlir_python_extension(MLIRPythonExtension.LinalgPasses
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     LinalgPasses.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPILinalg
 )
@@ -776,8 +747,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.SMT.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectSMT.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPISMT
@@ -790,8 +759,6 @@ declare_mlir_python_extension(MLIRPythonExtension.SparseTensorDialectPasses
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     SparseTensorPasses.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPISparseTensor
 )
@@ -802,8 +769,6 @@ declare_mlir_python_extension(MLIRPythonExtension.TransformInterpreter
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     TransformInterpreter.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPITransformDialectTransforms
 )
@@ -814,8 +779,6 @@ declare_mlir_python_extension(MLIRPythonExtension.Dialects.AMDGPU.Nanobind
   ROOT_DIR "${PYTHON_SOURCE_DIR}"
   SOURCES
     DialectAMDGPU.cpp
-  PRIVATE_LINK_LIBS
-    LLVMSupport
   EMBED_CAPI_LINK_LIBS
     MLIRCAPIIR
     MLIRCAPIAMDGPU
@@ -861,8 +824,6 @@ if(MLIR_INCLUDE_TESTS)
     ROOT_DIR "${MLIR_SOURCE_DIR}/test/python/lib"
     SOURCES
       PythonTestModuleNanobind.cpp
-    PRIVATE_LINK_LIBS
-      LLVMSupport
     EMBED_CAPI_LINK_LIBS
       MLIRCAPIPythonTestDialect
   )


### PR DESCRIPTION
Follow-up to #180986, which completed the series started in #178290: it switched the last python bindings off the C++ LLVM APIs and dropped `LLVMSupport` from the support library in `AddMLIRPython.cmake`. But the per-extension `PRIVATE_LINK_LIBS LLVMSupport` in `mlir/python/CMakeLists.txt` was missed, so the dependency is still there for every extension module.

Assisted by: Claude
