### PR TITLE
[libc++][CI] run-buildbot and libcxx-lit need a way to pass the paths to cmake and ninja

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -29,6 +29,11 @@ ${PROGNAME} [options] <BUILDER>
                     this is '<llvm-root>/build/<builder>'.
 
 Environment variables
+CMAKE               The cmake binary to use. This variable is optional.
+
+NINJA               The ninja binary to use, this value is used by CMake. This
+                    variable is optional.
+
 CC                  The C compiler to use, this value is used by CMake. This
                     variable is mandatory.
 
@@ -95,6 +100,16 @@ MONOREPO_ROOT="${MONOREPO_ROOT:="$(git rev-parse --show-toplevel)"}"
 BUILD_DIR="${BUILD_DIR:=${MONOREPO_ROOT}/build/${BUILDER}}"
 INSTALL_DIR="${BUILD_DIR}/install"
 
+if [ -z ${CMAKE+x} ]; then
+    CMAKE=cmake
+fi
+
+if [ -z ${NINJA+x} ]; then
+    NINJA=ninja
+else
+    MAKE_PROGRAM=-DCMAKE_MAKE_PROGRAM=${NINJA}
+fi
+
 if [ -z ${CC+x} ]; then
     error "Environment variable CC must be defined"
     exit 1
@@ -107,8 +122,8 @@ fi
 
 # Print the version of a few tools to aid diagnostics in some cases
 step "Diagnose tools in use"
-cmake --version
-ninja --version
+${CMAKE} --version
+${NINJA} --version
 ${CC} --version
 ${CXX} --version
 
@@ -124,10 +139,11 @@ function generate-cmake-base() {
     export PATH="$PATH:/opt/compiler-explorer/clang-trunk/bin"
 
     # We can remove -DCMAKE_INSTALL_MESSAGE=NEVER once https://gitlab.kitware.com/cmake/cmake/-/issues/26085 is fixed.
-    cmake \
+    ${CMAKE} \
           -S "${MONOREPO_ROOT}/runtimes" \
           -B "${BUILD_DIR}" \
           -GNinja \
+          ${MAKE_PROGRAM} \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
           -DLIBCXX_ENABLE_WERROR=YES \
@@ -159,25 +175,25 @@ function generate-cmake-android() {
 
 function check-runtimes() {
     step "Building libc++ test dependencies"
-    ninja -vC "${BUILD_DIR}" cxx-test-depends
+    ${NINJA} -vC "${BUILD_DIR}" cxx-test-depends
 
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
 
     step "Running the libc++abi tests"
-    ninja -vC "${BUILD_DIR}" check-cxxabi
+    ${NINJA} -vC "${BUILD_DIR}" check-cxxabi
 
     step "Running the libunwind tests"
-    ninja -vC "${BUILD_DIR}" check-unwind
+    ${NINJA} -vC "${BUILD_DIR}" check-unwind
 }
 
 # TODO: The goal is to test this against all configurations. We should also move
 #       this to the Lit test suite instead of being a separate CMake target.
 function check-abi-list() {
     step "Running the libc++ ABI list test"
-    ninja -vC "${BUILD_DIR}" check-cxx-abilist || (
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx-abilist || (
         error "Generating the libc++ ABI list after failed check"
-        ninja -vC "${BUILD_DIR}" generate-cxx-abilist
+        ${NINJA} -vC "${BUILD_DIR}" generate-cxx-abilist
         false
     )
 }
@@ -203,10 +219,11 @@ function test-armv7m-picolibc() {
     # architecture name, which is not what Clang's driver expects to find.
     # The install location will however be wrong with
     # LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON, so we correct that below.
-    cmake \
+    ${CMAKE} \
         -S "${MONOREPO_ROOT}/compiler-rt" \
         -B "${BUILD_DIR}/compiler-rt" \
         -GNinja \
+        ${MAKE_PROGRAM} \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
         -DCMAKE_C_FLAGS="${flags}" \
@@ -225,7 +242,7 @@ function test-armv7m-picolibc() {
         "${@}"
 
     step "Installing compiler-rt"
-    ninja -vC "${BUILD_DIR}/compiler-rt" install
+    ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
     # Move compiler-rt libs into the same directory as all the picolib objects.
     mv "${INSTALL_DIR}/lib/armv7m-unknown-none-eabi"/* "${INSTALL_DIR}/lib"
 
@@ -242,7 +259,7 @@ check-generated-output)
     # Reject patches that forgot to re-run the generator scripts.
     step "Making sure the generator scripts were run"
     set +x # Printing all the commands below just creates extremely confusing output
-    ninja -vC "${BUILD_DIR}" libcxx-generate-files
+    ${NINJA} -vC "${BUILD_DIR}" libcxx-generate-files
     git diff | tee ${BUILD_DIR}/generated_output.patch
     git ls-files -o --exclude-standard | tee ${BUILD_DIR}/generated_output.status
     ! grep -q '^--- a' ${BUILD_DIR}/generated_output.patch || false
@@ -411,10 +428,11 @@ bootstrapping-build)
     fi
 
     step "Generating CMake"
-    cmake \
+    ${CMAKE} \
           -S "${MONOREPO_ROOT}/llvm" \
           -B "${BUILD_DIR}" \
           -GNinja \
+          ${MAKE_PROGRAM} \
           ${COMPILER_LAUNCHER} \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
@@ -429,13 +447,13 @@ bootstrapping-build)
           -DLLVM_LIT_ARGS="-sv --xunit-xml-output test-results.xml --timeout=1500 --time-tests"
 
     step "Running the libc++ and libc++abi tests"
-    ninja -vC "${BUILD_DIR}" check-runtimes
+    ${NINJA} -vC "${BUILD_DIR}" check-runtimes
 
     step "Installing libc++ and libc++abi to a fake location"
-    ninja -vC "${BUILD_DIR}" install-runtimes
+    ${NINJA} -vC "${BUILD_DIR}" install-runtimes
 
     step "Running the LLDB libc++ data formatter tests"
-    ninja -vC "${BUILD_DIR}" lldb-api-test-deps
+    ${NINJA} -vC "${BUILD_DIR}" lldb-api-test-deps
     ${BUILD_DIR}/bin/llvm-lit -sv --param dotest-args='--category libc++' "${MONOREPO_ROOT}/lldb/test/API"
 
     ccache -s
@@ -501,7 +519,7 @@ generic-llvm-libc)
                         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     # Ensure we have the builtins archive built as we pass it in explicitly in
     # the test config.
-    ninja -vC "${BUILD_DIR}" libclang_rt.builtins-x86_64.a
+    ${NINJA} -vC "${BUILD_DIR}" libclang_rt.builtins-x86_64.a
     check-runtimes
 ;;
 #
@@ -617,10 +635,11 @@ apple-system|apple-system-hardened)
 
     # In the Apple system configuration, we build libc++ and libunwind separately.
     step "Installing libc++ and libc++abi in Apple-system configuration"
-    cmake \
+    ${CMAKE} \
         -S "${MONOREPO_ROOT}/runtimes" \
         -B "${BUILD_DIR}/cxx" \
         -GNinja \
+        ${MAKE_PROGRAM} \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}/cxx" \
         -DLLVM_LIT_ARGS="-sv --xunit-xml-output test-results.xml --timeout=1500 --time-tests" \
@@ -633,10 +652,11 @@ apple-system|apple-system-hardened)
         -DLIBCXXABI_TEST_PARAMS="${params}"
 
     step "Installing libunwind in Apple-system configuration"
-    cmake \
+    ${CMAKE} \
         -S "${MONOREPO_ROOT}/runtimes" \
         -B "${BUILD_DIR}/unwind" \
         -GNinja \
+        ${MAKE_PROGRAM} \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}/unwind" \
         -DLLVM_LIT_ARGS="-sv --xunit-xml-output test-results.xml --timeout=1500 --time-tests" \
@@ -646,13 +666,13 @@ apple-system|apple-system-hardened)
         -DCMAKE_INSTALL_NAME_DIR="/usr/lib/system"
 
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}/cxx" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}/cxx" check-cxx
 
     step "Running the libc++abi tests"
-    ninja -vC "${BUILD_DIR}/cxx" check-cxxabi
+    ${NINJA} -vC "${BUILD_DIR}/cxx" check-cxxabi
 
     step "Running the libunwind tests"
-    ninja -vC "${BUILD_DIR}/unwind" check-unwind
+    ${NINJA} -vC "${BUILD_DIR}/unwind" check-unwind
 ;;
 aarch64)
     clean
@@ -710,13 +730,13 @@ clang-cl-dll)
     # setting when cmake and the test driver does the right thing automatically.
     generate-cmake-libcxx-win -DLIBCXX_TEST_PARAMS="enable_experimental=False"
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-static)
     clean
     generate-cmake-libcxx-win -DLIBCXX_ENABLE_SHARED=OFF
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-no-vcruntime)
     clean
@@ -727,14 +747,14 @@ clang-cl-no-vcruntime)
     generate-cmake-libcxx-win -DLIBCXX_TEST_PARAMS="enable_experimental=False" \
                               -DLIBCXX_TEST_CONFIG="llvm-libc++-shared-no-vcruntime-clangcl.cfg.in"
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-debug)
     clean
     generate-cmake-libcxx-win -DLIBCXX_TEST_PARAMS="enable_experimental=False" \
                               -DCMAKE_BUILD_TYPE=Debug
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 clang-cl-static-crt)
     clean
@@ -743,7 +763,7 @@ clang-cl-static-crt)
     generate-cmake-libcxx-win -DLIBCXX_ENABLE_SHARED=OFF \
                               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
 ;;
 mingw-dll)
     clean
@@ -781,7 +801,7 @@ mingw-incomplete-sysroot)
     # Only test that building succeeds; there's not much extra value in running
     # the tests here, as it would be equivalent to the mingw-dll config above.
     step "Building the runtimes"
-    ninja -vC "${BUILD_DIR}"
+    ${NINJA} -vC "${BUILD_DIR}"
 ;;
 aix)
     clean
@@ -814,7 +834,7 @@ android-ndk-*)
                            -DLIBCXX_TEST_PARAMS="${PARAMS}" \
                            -DLIBCXXABI_TEST_PARAMS="${PARAMS}"
     check-abi-list
-    ninja -vC "${BUILD_DIR}" install-cxx install-cxxabi
+    ${NINJA} -vC "${BUILD_DIR}" install-cxx install-cxxabi
 
     # Start the emulator and make sure we can connect to the adb server running
     # inside of it.
@@ -827,9 +847,9 @@ android-ndk-*)
     adb shell mkdir -p /data/local/tmp/adb_run
     adb push "${BUILD_DIR}/lib/libc++_shared.so" /data/local/tmp/libc++/libc++_shared.so
     step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
     step "Running the libc++abi tests"
-    ninja -vC "${BUILD_DIR}" check-cxxabi
+    ${NINJA} -vC "${BUILD_DIR}" check-cxxabi
 ;;
 #################################################################
 # Insert vendor-specific internal configurations below.

--- a/libcxx/utils/libcxx-lit
+++ b/libcxx/utils/libcxx-lit
@@ -15,6 +15,9 @@ Shortcut to build the libc++ testing dependencies and run the libc++ tests with 
 [lit options...]   Optional options to pass to 'llvm-lit'.
 tests...           Paths of the tests to run. Those paths are relative to '<monorepo-root>'.
 
+Environment variables
+CMAKE              The cmake binary to use. This variable is optional.
+
 Example
 =======
 $ cmake -S runtimes -B build/ -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi"
@@ -41,9 +44,13 @@ fi
 build_dir="${1}"
 shift
 
+if [ -z ${CMAKE+x} ]; then
+    CMAKE=cmake
+fi
+
 if [[ "${type}" == "runtimes" ]]; then
         echo "N.B.: In a bootstrap build, lit needs a prefix to work correctly;"
         echo "      See libcxx/docs/Testinglibcxx.rst for more information."
 fi
-cmake --build "${build_dir}" --target ${type}-test-depends
+"${CMAKE}" --build "${build_dir}" --target ${type}-test-depends
 "${build_dir}/bin/llvm-lit" ${@}


### PR DESCRIPTION
macOS/Xcode don't have cmake or ninja anywhere in a default PATH, so run-buildbot and libcxx-lit fail unless you do some PATH surgery before running them. Allow passing them as environment variables instead, so run-buildbot can be invoked as `CMAKE=$(xcrun --find cmake) NINJA=$(xcrun --find ninja) CC=$(xcrun --find clang) CXX=$(xcrun --find clang++) run-buildbot` on macOS. Allow cmake to be passed to libcxx-lit in a similar fashion.