### PR TITLE
[libcxx][test] Fix a few test conditions

### DIFF
--- a/libcxx/test/libcxx/vendor/apple/availability-with-pedantic-errors.compile.pass.cpp
+++ b/libcxx/test/libcxx/vendor/apple/availability-with-pedantic-errors.compile.pass.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: stdlib=apple-libc++
+// UNSUPPORTED: libcpp-has-no-availability-markup
 
 // Test that using -pedantic-errors doesn't turn off availability annotations.
 // This used to be the case because we used __has_extension(...) to enable the

--- a/libcxx/test/libcxx/vendor/apple/disable-availability.sh.cpp
+++ b/libcxx/test/libcxx/vendor/apple/disable-availability.sh.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: stdlib=apple-libc++
+// UNSUPPORTED: libcpp-has-no-availability-markup
 
 // This test ensures that we retain a way to disable availability markup on Apple platforms
 // in order to work around Clang bug https://llvm.org/PR134151.

--- a/libcxx/test/std/time/time.hash/time.hash_enabled.pass.cpp
+++ b/libcxx/test/std/time/time.hash/time.hash_enabled.pass.cpp
@@ -34,9 +34,10 @@ static_assert(
 static_assert(std::is_nothrow_invocable_v<std::hash<std::chrono::year_month_weekday>, std::chrono::year_month_weekday>);
 static_assert(
     std::is_nothrow_invocable_v<std::hash<std::chrono::year_month_weekday_last>, std::chrono::year_month_weekday_last>);
-#ifndef TEST_HAS_NO_EXPERIMENTAL_TZDB
+#if !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM) &&                                    \
+    !defined(TEST_HAS_NO_LOCALIZATION) && !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
 static_assert(std::is_nothrow_invocable_v<std::hash<std::chrono::leap_second>, std::chrono::leap_second>);
-#endif // TEST_HAS_NO_EXPERIMENTAL_TZDB
+#endif
 
 int main(int, char**) {
   test_hash_enabled<std::chrono::nanoseconds>();
@@ -78,18 +79,15 @@ int main(int, char**) {
   test_hash_enabled(std::chrono::year_month_weekday_last(
       std::chrono::year{}, std::chrono::month{}, std::chrono::weekday_last(std::chrono::weekday{})));
 
-#ifndef TEST_HAS_NO_EXPERIMENTAL_TZDB
+#if !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM) &&                                    \
+    !defined(TEST_HAS_NO_LOCALIZATION) && !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
 
   test_hash_enabled(std::chrono::leap_second({}, std::chrono::sys_seconds{}, std::chrono::seconds{}));
 
-#  if !defined(TEST_HAS_NO_LOCALIZATION) && !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM)
-
   test_hash_enabled<std::chrono::zoned_time<std::chrono::milliseconds>>();
 
-#  endif // !defined(TEST_HAS_NO_LOCALIZATION) && !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) &&
-         // !defined(TEST_HAS_NO_FILESYSTEM)
-
-#endif // TEST_HAS_NO_EXPERIMENTAL_TZDB
+#endif // !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM) &&
+       // !defined(TEST_HAS_NO_LOCALIZATION) && !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
 
   return 0;
 }


### PR DESCRIPTION
libcxx/vendor/apple/{availability-with-pedantic-errors.compile.pass.cpp,disable-availability.sh.cpp} both require the platform to support availability markup but weren't labeled as such. std/time/time.hash/time.hash_enabled.pass.cpp has some leap second tests that are missing the guards <chrono> uses to include <__chrono/leap_second.h> and will fail if experimental tzdb is set but the other ones aren't.