### PR TITLE
[clang][LifetimeSafety] Fix unnamed TimeTraceScope in computePersistentOrigins

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -29,7 +29,7 @@ namespace clang::lifetimes::internal {
 // referenced in more than one basic block.
 static llvm::BitVector computePersistentOrigins(const FactManager &FactMgr,
                                                 const CFG &C) {
-  llvm::TimeTraceScope("ComputePersistentOrigins");
+  llvm::TimeTraceScope TimeProfile("ComputePersistentOrigins");
   unsigned NumOrigins = FactMgr.getOriginMgr().getNumOrigins();
   llvm::BitVector PersistentOrigins(NumOrigins);
 


### PR DESCRIPTION
The TimeTraceScope was constructed as a temporary and destroyed immediately, so the prepass was reported as taking ~0. It actually accounts for ~14% of LoanPropagation in some cases. 