### PR TITLE
[lldb] Fix typo in SBUnixSignals.get_unix_signals_list

### DIFF
--- a/lldb/bindings/interface/SBUnixSignalsExtensions.i
+++ b/lldb/bindings/interface/SBUnixSignalsExtensions.i
@@ -11,7 +11,7 @@
         def get_unix_signals_list(self):
             signals = []
             for idx in range(0, self.GetNumSignals()):
-                signals.append(self.GetSignalAtIndex(sig))
+                signals.append(self.GetSignalAtIndex(idx))
             return signals
 
         threads = property(get_unix_signals_list, None, doc='''A read only property that returns a list() of valid signal numbers for this platform.''')

--- a/lldb/test/API/python_api/signals/TestSignalsAPI.py
+++ b/lldb/test/API/python_api/signals/TestSignalsAPI.py
@@ -50,3 +50,9 @@ class SignalsAPITestCase(TestBase):
         self.assertEqual(
             process.GetExitStatus(), 0, "The process should have returned 0"
         )
+
+        self.assertIn(
+            sigint,
+            unix_signals.get_unix_signals_list(),
+            "SIGINT should be in the list of supported signals",
+        )


### PR DESCRIPTION
Found when looking through the generated Python file. `sig` doesn't exist in that context, it should be `idx`.