### PR TITLE
[X86][AsmParser] Fix compiler crash on division by zero in MS inline asm

### DIFF
--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -890,6 +890,20 @@ private:
       default:
         State = IES_ERROR;
         break;
+      case IES_DIVIDE:
+        if (TmpInt == 0) {
+          ErrMsg = "division by zero in assembly expression";
+          State = IES_ERROR;
+          return true;
+        }
+        [[fallthrough]];
+      case IES_MOD:
+        if (TmpInt == 0) {
+          ErrMsg = "modulo by zero in assembly expression";
+          State = IES_ERROR;
+          return true;
+        }
+        [[fallthrough]];
       case IES_PLUS:
       case IES_MINUS:
       case IES_NOT:
@@ -904,8 +918,6 @@ private:
       case IES_GE:
       case IES_LSHIFT:
       case IES_RSHIFT:
-      case IES_DIVIDE:
-      case IES_MOD:
       case IES_MULTIPLY:
       case IES_LPAREN:
       case IES_INIT:

--- a/llvm/test/MC/X86/intel-expr-div-by-zero.s
+++ b/llvm/test/MC/X86/intel-expr-div-by-zero.s
@@ -1,0 +1,7 @@
+# RUN: not llvm-mc -triple x86_64-unknown-unknown -x86-asm-syntax=intel %s 2>&1 | FileCheck %s
+
+# CHECK: error: division by zero in assembly expression
+mov eax, 1 / 0
+
+# CHECK: error: modulo by zero in assembly expression
+mov eax, 1 % 0


### PR DESCRIPTION
This fixes issue #213415. If a user writes something like '1 / 0' or '1 % 0' in assembly, the compiler will now show a normal error message instead of crashing completely.

Fixes #213415