### PR TITLE
[lldb][test] Recognize a Wasm trap as a crash

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -979,6 +979,10 @@ def is_thread_crashed(test, thread):
         )
     elif test.getPlatform() == "windows":
         return "Exception 0xc0000005" in thread.GetStopDescription(200)
+    elif test.getPlatform() in ["wasip1", "wasi"]:
+        # Wasm has no signals. What a bad access raises is a trap, which a
+        # runtime reports as an exception described by the trap it hit.
+        return thread.GetStopReason() == lldb.eStopReasonException
     else:
         return "invalid address" in thread.GetStopDescription(100)
 


### PR DESCRIPTION
is_thread_crashed maps how each platform reports the bad access the test suite uses to simulate a crash, and had no case for Wasm, where there are no signals and a bad access raises a trap that a runtime reports as an exception. Without one it fell through to a description match that never held, so a crashed thread read as running fine.