### PR TITLE
[lldb][test] Give a directly created lldb-dap session the init commands

### DIFF
--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -44,7 +44,9 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         self, connection: str, name: str, *, sleep_seconds_in_middle: float = 0
     ):
         self.dap_server = dap_server.DebugAdapterServer(
-            connection=connection, spawn_helper=self.spawnSubprocess
+            connection=connection,
+            init_commands=self.setUpCommands(),
+            spawn_helper=self.spawnSubprocess,
         )
         program = self.getBuildArtifact("a.out")
         source = "main.c"


### PR DESCRIPTION
create_debug_adapter passes the commands that carry the configuration the test suite was invoked with, and a test that builds a DebugAdapterServer itself got none of them, so that session ran unconfigured. It matters wherever the suite configures the debugger through settings, such as pointing a platform at the runtime it launches.