### PR TITLE
[lldb] Step past a prologue the pc is inside

### DIFF
--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -246,12 +246,20 @@ bool ThreadPlanStepInRange::ShouldStop(Event *event_ptr) {
 
         if (sc.function) {
           func_start_address = sc.function->GetAddress();
-          if (curr_addr == func_start_address.GetLoadAddress(&GetTarget()))
-            bytes_to_skip = sc.function->GetPrologueByteSize();
+          bytes_to_skip = sc.function->GetPrologueByteSize();
         } else if (sc.symbol) {
           func_start_address = sc.symbol->GetAddress();
-          if (curr_addr == func_start_address.GetLoadAddress(&GetTarget()))
-            bytes_to_skip = sc.symbol->GetPrologueByteSize();
+          bytes_to_skip = sc.symbol->GetPrologueByteSize();
+        }
+
+        // The prologue has yet to run only if the pc is inside it. A function's
+        // entry point need not be its first address, so a pc past that address
+        // does not mean the prologue has already run.
+        if (bytes_to_skip != 0) {
+          const lldb::addr_t func_start =
+              func_start_address.GetLoadAddress(&GetTarget());
+          if (curr_addr < func_start || curr_addr >= func_start + bytes_to_skip)
+            bytes_to_skip = 0;
         }
 
         if (bytes_to_skip == 0 && sc.symbol) {

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -252,13 +252,13 @@ bool ThreadPlanStepInRange::ShouldStop(Event *event_ptr) {
           bytes_to_skip = sc.symbol->GetPrologueByteSize();
         }
 
-        // The prologue has yet to run only if the pc is inside it. A function's
-        // entry point need not be its first address, so a pc past that address
-        // does not mean the prologue has already run.
+        // A function's entry point need not be its first address, so a pc past
+        // the entry point can still be inside the prologue. What says the
+        // prologue has yet to run is the pc being below its end.
         if (bytes_to_skip != 0) {
-          const lldb::addr_t func_start =
-              func_start_address.GetLoadAddress(&GetTarget());
-          if (curr_addr < func_start || curr_addr >= func_start + bytes_to_skip)
+          const lldb::addr_t prologue_end =
+              func_start_address.GetLoadAddress(&GetTarget()) + bytes_to_skip;
+          if (curr_addr >= prologue_end)
             bytes_to_skip = 0;
         }
 


### PR DESCRIPTION
A step into a function ran past its prologue only when the pc was exactly the function's first address. A target whose entry point is not a function's first address (such as WebAssembly) is entered past it. This means that the check took every such call for one whose prologue had already run, and the step stopped on the opening brace instead of the first statement.

What says the prologue has yet to run is the pc being inside it, which for a target that does enter at the first address is the condition that was there before.