### PR TITLE
[clang][test] Use `FileCheck` in `Index/reparse-predef-objc-protocol.m`

### DIFF
--- a/clang/test/Index/reparse-predef-objc-protocol.m
+++ b/clang/test/Index/reparse-predef-objc-protocol.m
@@ -1,8 +1,7 @@
-// RUN: env CINDEXTEST_EDITING=1 c-index-test -test-load-source-reparse 3 local %s -I %S/Inputs
+// RUN: env CINDEXTEST_EDITING=1 c-index-test -test-load-source-reparse 3 local %s -I %S/Inputs | FileCheck %s
 #import "declare-objc-predef.h"
 // PR20633
 
-// CHECK: declare-objc-predef.h:1:8: ObjCInterfaceDecl=Protocol:1:8 Extent=[1:1 - 1:16]
 // CHECK: declare-objc-predef.h:1:8: ObjCClassRef=Protocol:1:8 Extent=[1:8 - 1:16]
 // CHECK: declare-objc-predef.h:2:16: StructDecl=objc_class:2:16 Extent=[2:9 - 2:26]
 // CHECK: declare-objc-predef.h:2:28: TypedefDecl=Class:2:28 (Definition) Extent=[2:1 - 2:33]


### PR DESCRIPTION
The test had `CHECK` directives that were never executed because the `RUN` line did not pipe output to `FileCheck`. This also drops the first `CHECK` directive in favor of the one below it due to `libclang` now reporting top-level forward class declarations as `ObjCClassRef` cursors which is the modern representation of that same declaration.