### PR TITLE
[ELF] Quote the value in "unknown -z" diagnostics

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -521,8 +521,8 @@ static uint8_t getZStartStopVisibility(Ctx &ctx, opt::InputArgList &args) {
       else if (kv.second == "protected")
         ret = STV_PROTECTED;
       else
-        ErrAlways(ctx) << "unknown -z start-stop-visibility= value: "
-                       << StringRef(kv.second);
+        Err(ctx) << "unknown -z start-stop-visibility= value '"
+                 << StringRef(kv.second) << "'";
     }
   }
   return ret;
@@ -541,7 +541,7 @@ static GcsPolicy getZGcs(Ctx &ctx, opt::InputArgList &args) {
       else if (kv.second == "always")
         ret = GcsPolicy::Always;
       else
-        ErrAlways(ctx) << "unknown -z gcs= value: " << kv.second;
+        Err(ctx) << "unknown -z gcs= value '" << kv.second << "'";
     }
   }
   return ret;
@@ -562,7 +562,7 @@ static ZicfilpPolicy getZZicfilp(Ctx &ctx, opt::InputArgList &args) {
       else if (kv.second == "implicit")
         ret = ZicfilpPolicy::Implicit;
       else
-        ErrAlways(ctx) << "unknown -z zicfilp= value: " << kv.second;
+        Err(ctx) << "unknown -z zicfilp= value '" << kv.second << "'";
     }
   }
   return ret;
@@ -581,7 +581,7 @@ static ZicfissPolicy getZZicfiss(Ctx &ctx, opt::InputArgList &args) {
       else if (kv.second == "implicit")
         ret = ZicfissPolicy::Implicit;
       else
-        ErrAlways(ctx) << "unknown -z zicfiss= value: " << kv.second;
+        Err(ctx) << "unknown -z zicfiss= value '" << kv.second << "'";
     }
   }
   return ret;
@@ -600,7 +600,7 @@ static int getZMemtagMode(Ctx &ctx, opt::InputArgList &args) {
       else if (kv.second == "async")
         ret = ELF::NT_MEMTAG_LEVEL_ASYNC;
       else
-        ErrAlways(ctx) << "unknown -z memtag-mode= value: " << kv.second;
+        Err(ctx) << "unknown -z memtag-mode= value '" << kv.second << "'";
     }
   }
   return ret;
@@ -616,7 +616,7 @@ static void checkZOptions(Ctx &ctx, opt::InputArgList &args) {
   getZFlag(args, "dynamic-undefined-weak", "nodynamic-undefined-weak", false);
   for (auto *arg : args.filtered(OPT_z))
     if (!arg->isClaimed())
-      Warn(ctx) << "unknown -z value: " << StringRef(arg->getValue());
+      Warn(ctx) << "unknown -z value '" << StringRef(arg->getValue()) << "'";
 }
 
 constexpr const char *saveTempsValues[] = {
@@ -640,6 +640,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       args.hasFlag(OPT_fatal_warnings, OPT_no_fatal_warnings, false) &&
       !args.hasArg(OPT_no_warnings);
   ctx.e.suppressWarnings = args.hasArg(OPT_no_warnings);
+  ctx.arg.noinhibitExec = args.hasArg(OPT_noinhibit_exec);
 
   // Handle -help
   if (args.hasArg(OPT_help)) {
@@ -1511,7 +1512,6 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.mmapOutputFile =
       args.hasFlag(OPT_mmap_output_file, OPT_no_mmap_output_file, false);
   ctx.arg.nmagic = args.hasFlag(OPT_nmagic, OPT_no_nmagic, false);
-  ctx.arg.noinhibitExec = args.hasArg(OPT_noinhibit_exec);
   ctx.arg.nostdlib = args.hasArg(OPT_nostdlib);
   ctx.arg.oFormatBinary = isOutputFormatBinary(ctx, args);
   ctx.arg.omagic = args.hasFlag(OPT_omagic, OPT_no_omagic, false);
@@ -1766,8 +1766,8 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
       else if (option.second == "error")
         *reportArg.second = ReportPolicy::Error;
       else {
-        ErrAlways(ctx) << "unknown -z " << reportArg.first
-                       << "= value: " << option.second;
+        Err(ctx) << "unknown -z " << reportArg.first << "= value '"
+                 << option.second << "'";
         continue;
       }
       hasGcsReportDynamic |= option.first == "gcs-report-dynamic";

--- a/lld/test/ELF/aarch64-feature-bti.s
+++ b/lld/test/ELF/aarch64-feature-bti.s
@@ -262,7 +262,7 @@
 # FORCE-NEXT:           nop
 
 # RUN: not ld.lld %t.o -z bti-report=u -o /dev/null 2>&1 | FileCheck --check-prefix=REPORT-ERR %s
-# REPORT-ERR: error: unknown -z bti-report= value: u{{$}}
+# REPORT-ERR: error: unknown -z bti-report= value 'u'
 # REPORT-EMPTY:
 
 .section ".note.gnu.property", "a"

--- a/lld/test/ELF/aarch64-feature-gcs.s
+++ b/lld/test/ELF/aarch64-feature-gcs.s
@@ -68,10 +68,12 @@
 
 ## An invalid gcs option should give an error
 # RUN: not ld.lld f1-s.o -z gcs=x -z gcs-report=x -z gcs-report-dynamic=x 2>&1 | FileCheck --check-prefix=INVALID %s
+# RUN: ld.lld f1-s.o -z gcs=x --noinhibit-exec -o /dev/null 2>&1 | FileCheck --check-prefix=INVALID-WARN %s
 
-# INVALID: error: unknown -z gcs= value: x
-# INVALID: error: unknown -z gcs-report= value: x
-# INVALID: error: unknown -z gcs-report-dynamic= value: x
+# INVALID: error: unknown -z gcs= value 'x'
+# INVALID: error: unknown -z gcs-report= value 'x'
+# INVALID: error: unknown -z gcs-report-dynamic= value 'x'
+# INVALID-WARN: warning: unknown -z gcs= value 'x'
 
 #--- f1-s.s
 .section ".note.gnu.property", "a"

--- a/lld/test/ELF/aarch64-feature-pauth.s
+++ b/lld/test/ELF/aarch64-feature-pauth.s
@@ -88,7 +88,7 @@
 # PACPLT-NEXT:     nop
 
 # RUN: not ld.lld tag1.o -z pauth-report=u 2>&1 | FileCheck --check-prefix=REPORT-ERR %s
-# REPORT-ERR:  error: unknown -z pauth-report= value: u{{$}}
+# REPORT-ERR:  error: unknown -z pauth-report= value 'u'
 # REPORT-EMPTY:
 
 #--- abi-tag-short.s

--- a/lld/test/ELF/aarch64-memtag-abi.s
+++ b/lld/test/ELF/aarch64-memtag-abi.s
@@ -43,7 +43,7 @@
 
 # RUN: not ld.lld -shared -z memtag-mode=asymm -z memtag-heap 2>&1 | \
 # RUN:    FileCheck %s --check-prefix=BAD-MODE
-# BAD-MODE: error: unknown -z memtag-mode= value: asymm
+# BAD-MODE: error: unknown -z memtag-mode= value 'asymm'
 
 # RUN: ld.lld -static -z memtag-mode=sync -z memtag-heap \
 # RUN:    -z memtag-stack %t.o -o %t

--- a/lld/test/ELF/aarch64-memtag-android-abi.s
+++ b/lld/test/ELF/aarch64-memtag-android-abi.s
@@ -55,7 +55,7 @@
 
 # RUN: not ld.lld -shared -z memtag-mode=asymm -z memtag-heap --android-memtag-note 2>&1 | \
 # RUN:    FileCheck %s --check-prefix=BAD-MODE
-# BAD-MODE: error: unknown -z memtag-mode= value: asymm
+# BAD-MODE: error: unknown -z memtag-mode= value 'asymm'
 
 # RUN: ld.lld -static -z memtag-mode=sync -z memtag-heap \
 # RUN:    -z memtag-stack --android-memtag-note %t.o -o %t

--- a/lld/test/ELF/driver.test
+++ b/lld/test/ELF/driver.test
@@ -50,14 +50,14 @@
 # RUN: ld.lld %t -z foo -z rel -z rela -z max-page-size=1 -z common-page-size=1 -z dynamic-undefined-weak \
 # RUN:   -z nodynamic-undefined-weak -o /dev/null --version 2>&1 | \
 # RUN:   FileCheck -check-prefix=ERR10 %s --implicit-check-not=warning:
-# ERR10: warning: unknown -z value: foo
+# ERR10: warning: unknown -z value 'foo'
 
 ## Check we report "unknown -z value" error even with -v.
 # RUN: ld.lld %t -z foo -z rel -o /dev/null -v 2>&1 | FileCheck -check-prefix=ERR10 %s --implicit-check-not=warning:
 
 ## Note: in GNU ld, --fatal-warning still leads to a warning.
 # RUN: not ld.lld %t -z foo --fatal-warnings 2>&1 | FileCheck --check-prefix=ERR10-FATAL %s
-# ERR10-FATAL: error: unknown -z value: foo
+# ERR10-FATAL: error: unknown -z value 'foo'
 
 # RUN: not ld.lld %t -z max-page-size 2>&1 | FileCheck -check-prefix=ERR11 %s
 # ERR11: error: invalid max-page-size:

--- a/lld/test/ELF/i386-feature-cet.s
+++ b/lld/test/ELF/i386-feature-cet.s
@@ -25,7 +25,7 @@
 
 # RUN: not ld.lld -e func1 %t.o %t3.o -o /dev/null -z cet-report=something 2>&1 \
 # RUN:   | FileCheck --check-prefix=REPORT_INVALID %s
-# REPORT_INVALID: error: unknown -z cet-report= value: something
+# REPORT_INVALID: error: unknown -z cet-report= value 'something'
 # REPORT_INVALID-EMPTY:
 
 # RUN: ld.lld -e func1 %t.o %t3.o -o /dev/null -z cet-report=warning 2>&1 \

--- a/lld/test/ELF/riscv-feature-zicfilp-func-sig.s
+++ b/lld/test/ELF/riscv-feature-zicfilp-func-sig.s
@@ -53,7 +53,7 @@
 
 ## An invalid -z zicfilp-func-sig-report option should give an error
 # RUN: not ld.lld f2-s.o -z zicfilp-func-sig-report=x 2>&1 | FileCheck --check-prefix=INVALID %s
-# INVALID: error: unknown -z zicfilp-func-sig-report= value: x
+# INVALID: error: unknown -z zicfilp-func-sig-report= value 'x'
 
 ## ZICFILP-unlabeled and ZICFILP-func-sig should conflict with each other.
 # RUN: ld.lld f3-u.o -o out.override -z zicfilp=func-sig 2>&1 | FileCheck --check-prefix=FORCE-CONFLICT %s

--- a/lld/test/ELF/riscv-feature-zicfilp-unlabeled.s
+++ b/lld/test/ELF/riscv-feature-zicfilp-unlabeled.s
@@ -61,8 +61,8 @@
 
 ## An invalid -z zicfilp-unlabeled-report option should give an error
 # RUN: not ld.lld f2-s.o -z zicfilp=x -z zicfilp-unlabeled-report=x 2>&1 | FileCheck --check-prefix=INVALID %s
-# INVALID: error: unknown -z zicfilp= value: x
-# INVALID: error: unknown -z zicfilp-unlabeled-report= value: x
+# INVALID: error: unknown -z zicfilp= value 'x'
+# INVALID: error: unknown -z zicfilp-unlabeled-report= value 'x'
 
 ## ZICFILP-unlabeled and ZICFILP-func-sig should conflict with each other
 # RUN: not ld.lld f1-c.o 2>&1 | FileCheck --check-prefix=CONFLICT %s

--- a/lld/test/ELF/riscv-feature-zicfiss.s
+++ b/lld/test/ELF/riscv-feature-zicfiss.s
@@ -50,8 +50,8 @@
 
 ## An invalid -z zicfiss-report option should give an error
 # RUN: not ld.lld f2-s.o f3-s.o -z zicfiss=x -z zicfiss-report=x 2>&1 | FileCheck --check-prefix=INVALID %s
-# INVALID: error: unknown -z zicfiss= value: x
-# INVALID: error: unknown -z zicfiss-report= value: x
+# INVALID: error: unknown -z zicfiss= value 'x'
+# INVALID: error: unknown -z zicfiss-report= value 'x'
 
 #--- rv32-f1-s.s
 .section ".note.gnu.property", "a"

--- a/lld/test/ELF/startstop-visibility.s
+++ b/lld/test/ELF/startstop-visibility.s
@@ -33,7 +33,7 @@
 # CHECK-PROTECTED: 0 NOTYPE GLOBAL PROTECTED 2 __stop_aaa
 
 # RUN: not ld.lld -z start-stop-visibility=aaa %t.o -o /dev/null
-# CHECK-ERROR: error: unknown -z start-stop-visibility= value: aaa
+# CHECK-ERROR: error: unknown -z start-stop-visibility= value 'aaa'
 
 .quad __start_aaa
 .quad __stop_aaa

--- a/lld/test/ELF/target-specific-options.s
+++ b/lld/test/ELF/target-specific-options.s
@@ -44,7 +44,7 @@
 
 # RUN: not ld.lld a.o -z execute-only-report=foo 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=ERR-EXECUTE-ONLY-INVALID
-# ERR-EXECUTE-ONLY-INVALID: error: unknown -z execute-only-report= value: foo
+# ERR-EXECUTE-ONLY-INVALID: error: unknown -z execute-only-report= value 'foo'
 
 .globl _start
 _start:

--- a/lld/test/ELF/x86-64-feature-cet.s
+++ b/lld/test/ELF/x86-64-feature-cet.s
@@ -25,7 +25,7 @@
 
 # RUN:not ld.lld -e func1 %t.o %t3.o -o /dev/null -z cet-report=something 2>&1 \
 # RUN:   | FileCheck --check-prefix=REPORT_INVALID %s
-# REPORT_INVALID: error: unknown -z cet-report= value: something
+# REPORT_INVALID: error: unknown -z cet-report= value 'something'
 # REPORT_INVALID-EMPTY:
 
 # RUN: ld.lld -e func1 %t.o %t3.o -o /dev/null  -z force-ibt -z cet-report=warning 2>&1 \


### PR DESCRIPTION
To make stray whitespace more visible (see #212523)
```
$ echo end > tmp.f90 &&  flang -fuse-ld=lld  -Wl,"-z execstack" tmp.f90
ld.lld: warning: unknown -z value:  execstack
```

Drop the colon (colon is typically used without quotes in lld/ELF
diagnostics).

Change ErrAlways to Err so that --noinhibit-exec downgrades the errors
to warnings. Read --noinhibit-exec before readConfigs, as Err depends on
it.
