### PR TITLE
[ADT] Fix - gcc warning: buf may be used uninitialized [-Werror=maybe-uninitialized]

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -306,7 +306,7 @@ template <typename... Ts> hash_code hash_combine(const Ts &...args) {
   constexpr size_t Total = hashing::detail::total_hashable_size<Ts...>();
   // Round up so `data()` is non-null when Total == 0; combine_bytes won't
   // read the buffer in that case (len=0 short-circuits in xxh3_64bits).
-  std::array<char, std::max<size_t>(1, Total)> buf;
+  std::array<char, std::max<size_t>(1, Total)> buf{};
   [[maybe_unused]] size_t off = 0;
   (hashing::detail::store_hashable_data(buf.data(), off, args), ...);
   return hashing::detail::combine_bytes(buf.data(), Total);


### PR DESCRIPTION
When compiled with `gcc`, the uninitialized `buf` triggers a warning. Since some external projects (e.g., `TPP-MLIR`) treat warnings as errors, the build fails. This patch initializes `buf` to eliminate the warning and prevent those build failures