### PR TITLE
[clang][bytecode] Handle multiple base paths in dynamic_cast

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2166,9 +2166,13 @@ bool DynamicCast(InterpState &S, CodePtr OpPC, const Type *DestTypePtr,
 
     CXXBasePaths Paths;
     getRecord(P.getBase())->isDerivedFrom(getRecord(P), Paths);
-    assert(std::distance(Paths.begin(), Paths.end()) == 1);
 
-    return Paths.front().Access == AS_private;
+    // Through virtual bases, there might be more than one "direct" base. They
+    // can have different access specifiers. They must all be private to be
+    // considered private.
+    return llvm::all_of(Paths, [](const CXXBasePath &P) -> bool {
+      return P.Access == AS_private;
+    });
   };
 
   enum {

--- a/clang/test/AST/ByteCode/dynamic-cast.cpp
+++ b/clang/test/AST/ByteCode/dynamic-cast.cpp
@@ -338,3 +338,17 @@ namespace UnrelatedInitializingPtr {
   constexpr auto p = dynamic_cast<C &>(a); // both-error {{must be initialized by a constant expression}} \
                                            // both-note {{reference dynamic_cast failed: dynamic type 'UnrelatedInitializingPtr::D' of operand does not have a base class of type 'C'}}
 }
+
+namespace VirtualBase {
+  struct A { virtual constexpr ~A() = default; };
+  struct B : public virtual A {};
+  struct C : private virtual A {};
+  struct D : B, C {};
+
+  constexpr bool test() {
+    D d;
+    A *a = static_cast<B *>(&d);
+    return dynamic_cast<C *>(a) == static_cast<C *>(&d);
+  }
+  static_assert(test());
+}


### PR DESCRIPTION
This can happen via virtual bases.

Fixes https://github.com/llvm/llvm-project/issues/213569