### PR TITLE
[clang][darwin] armv6m Firmware crashes spilling the TLS wrapper

### DIFF
--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -110,8 +110,27 @@ public:
       // No TLS on DriverKit.
     } else if (Triple.isXROS())
       this->TLSSupported = true;
-    else if (Triple.isAppleFirmware())
-      this->TLSSupported = true;
+    else if (Triple.isAppleFirmware()) {
+      if (Triple.isAArch64() || Triple.isARM())
+        this->TLSSupported = true;
+      else if (Triple.isThumb()) {
+        switch (Triple.getSubArch()) {
+        case llvm::Triple::NoSubArch:
+        case llvm::Triple::ARMSubArch_v4t:
+        case llvm::Triple::ARMSubArch_v5:
+        case llvm::Triple::ARMSubArch_v5te:
+        case llvm::Triple::ARMSubArch_v6:
+        case llvm::Triple::ARMSubArch_v6k:
+        case llvm::Triple::ARMSubArch_v6m:
+          // Thumb-1 doesn't support TLS.
+          break;
+
+        default:
+          this->TLSSupported = true;
+          break;
+        }
+      }
+    }
 
     this->MCountName = "\01mcount";
   }

--- a/clang/test/Sema/darwin-tls.c
+++ b/clang/test/Sema/darwin-tls.c
@@ -15,7 +15,14 @@
 // RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple i386-apple-watchos3.0-simulator %s 2>&1 | FileCheck %s --check-prefix TLS
 // RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple arm64-apple-xros %s 2>&1 | FileCheck %s --check-prefix TLS
 // RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple arm64-apple-xros-simulator %s 2>&1 | FileCheck %s --check-prefix TLS
+
+// RUN: not %clang_cc1 -fsyntax-only -triple thumbv6m-apple-firmware %s 2>&1 | FileCheck %s --check-prefix NO-TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple thumbv7-apple-firmware %s 2>&1 | FileCheck %s --check-prefix TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple armv7k-apple-firmware %s 2>&1 | FileCheck %s --check-prefix TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple thumbv7m-apple-firmware %s 2>&1 | FileCheck %s --check-prefix TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple thumbv7em-apple-firmware %s 2>&1 | FileCheck %s --check-prefix TLS
 // RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple arm64-apple-firmware %s 2>&1 | FileCheck %s --check-prefix TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple arm64e-apple-firmware %s 2>&1 | FileCheck %s --check-prefix TLS
 
 
 __thread int a;


### PR DESCRIPTION
Thread local storage isn't universally supported on all architectures. Only enable it for the ones that are known to support it.

rdar://183822457