### PR TITLE
[Flang] Handle spurious DATA error for PDT character components

### DIFF
--- a/flang/lib/Semantics/check-data.cpp
+++ b/flang/lib/Semantics/check-data.cpp
@@ -58,6 +58,12 @@ public:
     const Scope &scope{context_.FindScope(source_)};
     bool isFirstSymbol{isFirstSymbol_};
     isFirstSymbol_ = false;
+    if (IsAutomatic(symbol) &&
+        symbol.owner().IsParameterizedDerivedTypeInstantiation()) {
+      context_.Say(source_,
+          "DATA statement initialization of a component in a parameterized derived type instance"_todo_en_US);
+      return false;
+    }
     // Ordered so that most egregious errors are first
     if (const char *whyNot{IsProcedure(symbol) && !IsPointer(symbol)
                 ? "Procedure"

--- a/flang/test/Semantics/data-pdt.f90
+++ b/flang/test/Semantics/data-pdt.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! DATA on components of a parameterized derived type instance is not yet
+! supported.
+program test
+    type ut(n)
+      integer, len :: n
+      character(n) :: sar(2)
+    end type
+    type(ut(1)) pdt
+    !ERROR: not yet implemented: DATA statement initialization of a component in a parameterized derived type instance
+    data pdt%sar/'o','k'/
+end program


### PR DESCRIPTION
Fixes #193188 

IsAutomatic treats PDT character components with length type parameters as automatic because length is not folded to a constant in instantiation scope. 
Emit a not-yet-implemented diagnostic for DATA initialization of components in parameterized derived type instances instead of the spurious automatic-variable error.