### PR TITLE
[llvm-calc-occupancy] Fix title underline length

### DIFF
--- a/llvm/docs/CommandGuide/llvm-calc-occupancy.rst
+++ b/llvm/docs/CommandGuide/llvm-calc-occupancy.rst
@@ -1,5 +1,5 @@
 llvm-calc-occupancy - AMDGPU occupancy calculator
-==================================================
+=================================================
 
 .. program:: llvm-calc-occupancy
 


### PR DESCRIPTION
Fix error: invalid header length in 'CommandGuide/llvm-calc-occupancy.rst' (does not match length of title) in our downstream Sphinx doc build.