### PR TITLE
[ELF][AArch64] Do not treat missing build attributes as defined

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -537,16 +537,19 @@ template <class ELFT>
 static void
 handleAArch64BAAndGnuProperties(ObjFile<ELFT> *file, Ctx &ctx,
                                 const AArch64BuildAttrSubsections &baInfo) {
+  // Missing subsections have zero-initialized data fields, so we must check
+  // presence before comparing against GNU properties.
+  bool baPauthInfoPresent = baInfo.Pauth.TagPlatform || baInfo.Pauth.TagSchema;
+
   if (file->aarch64PauthAbiCoreInfo) {
     // Check for data mismatch.
-    if (file->aarch64PauthAbiCoreInfo) {
-      if (baInfo.Pauth.TagPlatform != file->aarch64PauthAbiCoreInfo->platform ||
-          baInfo.Pauth.TagSchema != file->aarch64PauthAbiCoreInfo->version)
-        Err(ctx) << file
-                 << " GNU properties and build attributes have conflicting "
-                    "AArch64 PAuth data";
-    }
-    if (baInfo.AndFeatures != file->andFeatures)
+    if (baPauthInfoPresent &&
+        (baInfo.Pauth.TagPlatform != file->aarch64PauthAbiCoreInfo->platform ||
+         baInfo.Pauth.TagSchema != file->aarch64PauthAbiCoreInfo->version))
+      Err(ctx) << file
+               << " GNU properties and build attributes have conflicting "
+                  "AArch64 PAuth data";
+    if (baInfo.AndFeatures && baInfo.AndFeatures != file->andFeatures)
       Err(ctx) << file
                << " GNU properties and build attributes have conflicting "
                   "AArch64 PAuth data";
@@ -557,14 +560,14 @@ handleAArch64BAAndGnuProperties(ObjFile<ELFT> *file, Ctx &ctx,
     // PAuthAbiCoreInfo when there is at least one non-zero value. The
     // specification reserves TagPlatform = 0, TagSchema = 1 values to match the
     // 'Invalid' GNU property section with platform = 0, version = 0.
-    if (baInfo.Pauth.TagPlatform || baInfo.Pauth.TagSchema) {
+    if (baPauthInfoPresent) {
       if (baInfo.Pauth.TagPlatform == 0 && baInfo.Pauth.TagSchema == 1)
         file->aarch64PauthAbiCoreInfo = {0, 0};
       else
         file->aarch64PauthAbiCoreInfo = {baInfo.Pauth.TagPlatform,
                                          baInfo.Pauth.TagSchema};
     }
-    file->andFeatures = baInfo.AndFeatures;
+    file->andFeatures |= baInfo.AndFeatures;
   }
 }
 

--- a/lld/test/ELF/aarch64-build-attributes-private-subsection.s
+++ b/lld/test/ELF/aarch64-build-attributes-private-subsection.s
@@ -1,0 +1,55 @@
+// REQUIRES: aarch64
+
+/// Test that a build attributes section without 'aeabi_feature_and_bits' and
+/// 'aeabi_pauthabi' subsections does not conflict with GNU Program Properties.
+
+// RUN: llvm-mc -triple=aarch64 -mattr=+bti -aarch64-mark-bti-property -filetype=obj %s -o %t.o
+// RUN: ld.lld -shared %t.o -z force-bti -o %t.out 2>&1 | count 0
+// RUN: llvm-readobj --notes %t.out | FileCheck %s
+
+// RUN: llvm-mc -triple=aarch64 --defsym EMIT_GNU_PROPERTY=1 -filetype=obj %s -o %t.o
+// RUN: ld.lld -shared %t.o -z force-bti -o %t.out 2>&1 | count 0
+// RUN: llvm-readobj --notes %t.out | FileCheck %s --check-prefixes=CHECK,WITH_PAUTH
+
+// CHECK:      NoteSections [
+// CHECK-NEXT:   NoteSection {
+// CHECK-NEXT:     Name: .note.gnu.property
+// CHECK-NEXT:     Offset:
+// CHECK-NEXT:     Size:
+// CHECK-NEXT:     Notes [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         Owner: GNU
+// CHECK-NEXT:         Data size:
+// CHECK-NEXT:         Type: NT_GNU_PROPERTY_TYPE_0 (property note)
+// CHECK-NEXT:         Property [
+// CHECK-NEXT:           aarch64 feature: BTI
+// WITH_PAUTH-NEXT:      AArch64 PAuth ABI core info: platform 0x31 (unknown), version 0x13
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+
+.aeabi_subsection anon_dummy, optional, uleb128
+.aeabi_attribute 1, 1
+
+.ifdef EMIT_GNU_PROPERTY
+.section ".note.gnu.property", "a"
+  .long 0x4           // Name length 4 ("GNU")
+  .long end - begin   // Data length
+  .long 0x5           // Type: NT_GNU_PROPERTY_TYPE_0
+  .asciz "GNU"        // Name
+  .p2align 3
+begin:
+  .long 0xc0000000    // GNU_PROPERTY_AARCH64_FEATURE_1_AND
+  .long 0x4
+  .long 0x1           // GNU_PROPERTY_AARCH64_FEATURE_1_BTI
+  .long 0x0
+  // PAuth ABI property note
+  .long 0xc0000001    // GNU_PROPERTY_AARCH64_FEATURE_PAUTH
+  .long 0x10          // Data length
+  .quad 0x31          // PAuth ABI platform
+  .quad 0x13          // PAuth ABI version
+  .p2align 3          // Align to 8 byte for 64 bit
+end:
+.endif


### PR DESCRIPTION
Even if an AArch64 build attributes* section contains only private subsections and does not define feature flags or PAuth information, 'lld' still checks the values defined in the GNU Program Properties section against the build attribute defaults, producing warnings and errors. The patch adjusts the handling of build attributes so that only the existing attributes are used.

---
* https://github.com/ARM-software/abi-aa/blob/main/buildattr64/buildattr64.rst