### PR TITLE
[bazel] Export TripleName.def and get_triple_system_name.py in LLVM overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -51,6 +51,9 @@ exports_files([
     "include/llvm/Frontend/OpenMP/OMP.td",
     "include/llvm/IR/Intrinsics.td",
     "include/llvm/Option/OptParser.td",
+    # Needed to run TargetParser regression lit tests in downstream sandboxed builds.
+    "include/llvm/TargetParser/TripleName.def",
+    "utils/get_triple_system_name.py",
     # This one is needed for building and vendoring out lldb from off tree.
     "utils/lldbDataFormatters.py",
 ])


### PR DESCRIPTION
The TargetParser lit regression test (`llvm/test/tools/TargetParser/get-triple-system-name.test`) runs `get_triple_system_name_test.py`, which imports `get_triple_system_name.py` from `llvm/utils/` and reads `TripleName.def` from `llvm/include/llvm/TargetParser/`.

When executing lit regression tests in downstream sandboxed build systems, the test fails with `ModuleNotFoundError: No module named 'get_triple_system_name'` because these standalone files are located outside the test directory and are not staged into the test runfiles sandbox.

Add `TripleName.def` and `get_triple_system_name.py` to `exports_files` in the overlay so downstream builds can reference them as test runfile dependencies.

Assited by: Gemini