### PR TITLE
[lldb] Fix test_case_insensitivity's register value for canonical/PAC constraints

### DIFF
--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -727,7 +727,10 @@ class RegisterCommandsTestCase(TestBase):
             self.build()
             self.common_setup()
 
-        expected = "0x1122334455667788"
+        # Top 20 bits zeroed: a non-canonical x86_64 address fails to write to
+        # rsp, and Darwin AArch64 masks non-addressing bits off pc/lr/sp/fp
+        # on read, so anything higher isn't safe to round-trip here.
+        expected = "0x0000034455667788"
 
         if self.getArchitecture() in ["amd64", "x86_64"]:
             setup()


### PR DESCRIPTION
This addresses a test failure introduced in 4f6cf2c2072ccf5780ac30bf69ebf99b788dbd52.

`0x1122334455667788` is a non-canonical address on x86_64 (fails to write to rsp) and gets its non-addressing bits masked off on read for pc/lr/sp/fp on Darwin AArch64, so it doesn't round-trip on either. Zero the top 20 bits to stay clear of both.