### PR TITLE
[lldb] Skip flaky test_circular_dependency_evaluate_expression_in_get_frame

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
@@ -164,6 +164,7 @@ class FrameProviderCircularDependencyTestCase(TestBase):
             )
 
     @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24778")
+    @skipIf(bugnumber="https://github.com/llvm/llvm-project/pull/208992")
     def test_circular_dependency_evaluate_expression_in_get_frame(self):
         """
         Test that calling EvaluateExpression in get_frame_at_index doesn't


### PR DESCRIPTION
This provider's identity-forwarding pattern intermittently hits a known frame-identity-aliasing bug in ScriptedFrameProvider::GetFrameAtIndex, tracked in https://github.com/llvm/llvm-project/pull/208992.