### PR TITLE
[TLI] Update `getWCharSize` documentation (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -230,7 +230,7 @@ public:
     ShouldSignExtI32Return = Val;
   }
 
-  /// Returns the size of the wchar_t type in bytes or 0 if the size is unknown.
+  /// Returns the size of the wchar_t type in bytes.
   /// This queries the 'wchar_size' metadata.
   LLVM_ABI unsigned getWCharSize(const Module &M) const;
 


### PR DESCRIPTION
`return 0` part of `getWCharSize` was added in cc603ee3d563 but then removed in 5a88dffc40d2. Update the documentation as it no longer returns 0 when the size is unknown (instead returns the default).