### PR TITLE
[GlobalsAA] Handle self-referencing stores in `AnalyzeUsesOfPointer`

### DIFF
--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -328,7 +328,8 @@ bool GlobalsAAResult::AnalyzeUsesOfPointer(Value *V,
       if (Readers)
         Readers->insert(LI->getParent()->getParent());
     } else if (StoreInst *SI = dyn_cast<StoreInst>(I)) {
-      if (V == SI->getOperand(1)) {
+      // Check the pointer operand use of the store.
+      if (&U == &SI->getOperandUse(1)) {
         if (Writers)
           Writers->insert(SI->getParent()->getParent());
       } else if (SI->getOperand(1) != OkayStoreDest) {

--- a/llvm/test/Analysis/GlobalsModRef/self-addresstaken.ll
+++ b/llvm/test/Analysis/GlobalsModRef/self-addresstaken.ll
@@ -1,0 +1,16 @@
+; RUN: opt < %s -passes='require<globals-aa>,aa-eval' -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+
+; Ensure @g is correctly marked as address taken when it is stored into itself.
+
+@g = internal global ptr null
+
+; CHECK-LABEL: self_addresstaken
+; CHECK:       NoAlias:	ptr* %p, ptr* @g
+
+define ptr @self_addresstaken() {
+  store ptr @g, ptr @g, align 8
+  %p = load ptr, ptr @g, align 8
+  store ptr null, ptr %p, align 8
+  %q = load ptr, ptr @g, align 8
+  ret ptr %q
+}

--- a/llvm/test/Analysis/GlobalsModRef/self-addresstaken.ll
+++ b/llvm/test/Analysis/GlobalsModRef/self-addresstaken.ll
@@ -5,7 +5,7 @@
 @g = internal global ptr null
 
 ; CHECK-LABEL: self_addresstaken
-; CHECK:       NoAlias:	ptr* %p, ptr* @g
+; CHECK:       MayAlias:	ptr* %p, ptr* @g
 
 define ptr @self_addresstaken() {
   store ptr @g, ptr @g, align 8


### PR DESCRIPTION
Correctly recognize that a global address does escape when it is stored into itself. Such globals were previously incorrectly marked as non-address-taken.

Fixes: https://github.com/llvm/llvm-project/issues/213232.