### PR TITLE
[benchmark] Fix -Wunused-but-set-variable warning in basic_test

### DIFF
--- a/third-party/benchmark/test/basic_test.cc
+++ b/third-party/benchmark/test/basic_test.cc
@@ -147,7 +147,7 @@ BENCHMARK(BM_RangedFor);
 template <typename T>
 void BM_OneTemplateFunc(benchmark::State& state) {
   auto arg = state.range(0);
-  T sum = 0;
+  [[maybe_unused]] T sum = 0;
   for (auto _ : state) {
     sum += static_cast<T>(arg);
   }
@@ -158,8 +158,8 @@ BENCHMARK(BM_OneTemplateFunc<double>)->Arg(1);
 template <typename A, typename B>
 void BM_TwoTemplateFunc(benchmark::State& state) {
   auto arg = state.range(0);
-  A sum = 0;
-  B prod = 1;
+  [[maybe_unused]] A sum = 0;
+  [[maybe_unused]] B prod = 1;
   for (auto _ : state) {
     sum += static_cast<A>(arg);
     prod *= static_cast<B>(arg);


### PR DESCRIPTION
Fix a build error when building benchmark unit tests with modern GCC/Clang compilers under strict warning options (-Werror).  

In `test/basic_test.cc`, the variable `sum` in `BM_OneTemplateFunc` was assigned but never read, triggering `-Wunused-but-set-variable`.  

Silenced the warning by marking sum with `[[maybe_unused]]`, preserving the benchmark function's logic while ensuring clean build output.  

### Description  
Fixes a build error when compiling `third-party/benchmark` unit tests with modern GCC/Clang compilers under `-Werror`.  

In `test/basic_text.cc`, the variable `sum` in `BM_OneTemplatcFunc` was assigned but never read, triggering `-Wunused-but-set-variable`.   

### Solution  
Silenced the warning by marking sum with `[[maybe_unused]]`, preserving the benchmark function's logic while ensuring clean build output.  

### Test Plan  
1. Configured CMake with `-DBENCHMARK_ENABLE_TESTING=ON` and `-DBENCHMARK_ENABLE_WERROR=ON`.  
2. Built the target: `cmake --build build -j$(nproc)` -> Build succeed with zero warnings/errors.  
3. Executed unit tests: `ctest --test-dir build` -> 100% test passed.  

### Environment  
- **OS**: Linux (6.6.87.2-microsoft-standard-WSL2)  
- **Compiler**: Clang 22.1.8 / GCC 16.1.1 20260728  
- **CMake**: 4.4.2  