### PR TITLE
[clang][bytecode] Protect against invalid C++26 string repr

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -208,7 +208,8 @@ bool Context::evaluateStringRepr(State &Parent, const Expr *SizeExpr,
       return false;
     }
 
-    if (!Ptr.isLive() || !Ptr.getFieldDesc()->isPrimitiveArray())
+    if (!Ptr.isLive() || !Ptr.isInitialized() || Ptr.isUnknownSizeArray() ||
+        !Ptr.getFieldDesc()->isPrimitiveArray())
       return false;
 
     // Must be char.

--- a/clang/test/AST/ByteCode/cxx26.cpp
+++ b/clang/test/AST/ByteCode/cxx26.cpp
@@ -91,3 +91,15 @@ namespace ConstexprUnknownReference {
   }
 
 }
+
+namespace UnknownSizeArrayString {
+  constexpr const char foo[] = {bar}; // both-error {{use of undeclared identifier}} \
+                                      // ref-note {{declared here}}
+  struct S {
+    constexpr int size() const { return 4; }
+    constexpr const char *data() const { return foo; }
+  };
+  static_assert(false, S{}); // both-error {{the message in a static assertion must be produced by a constant expression}} \
+                             // ref-note {{initializer of 'foo' is unknown}} \
+                             // both-error {{static assertion failed}}
+}


### PR DESCRIPTION
We can't call `getNumElems()` for unknown-size arrays.