### PR TITLE
[libc++][NFC] Make __libcpp_is_trivially_relocatable a variable template

### DIFF
--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -472,9 +472,7 @@ public:
   using unexpected_type = unexpected<_Err>;
 
   using __trivially_relocatable _LIBCPP_NODEBUG =
-      __conditional_t<__libcpp_is_trivially_relocatable<_Tp>::value && __libcpp_is_trivially_relocatable<_Err>::value,
-                      expected,
-                      void>;
+      __conditional_t<__is_trivially_relocatable_v<_Tp> && __is_trivially_relocatable_v<_Err>, expected, void>;
 
   template <class _Up>
   using rebind = expected<_Up, error_type>;

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -397,7 +397,7 @@ inline const bool __allocator_has_trivial_destroy_v<allocator<_Tp>, _Up> = true;
 // The strong exception guarantee is provided if any of the following are true:
 // - is_nothrow_move_constructible<_ValueType>
 // - is_copy_constructible<_ValueType>
-// - __libcpp_is_trivially_relocatable<_ValueType>
+// - __is_trivially_relocatable_v<_ValueType>
 template <class _Alloc, class _ContiguousIterator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void __uninitialized_allocator_relocate(
     _Alloc& __alloc, _ContiguousIterator __first, _ContiguousIterator __last, _ContiguousIterator __result) {
@@ -405,7 +405,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void __uninitialized_allocat
   using _ValueType = typename iterator_traits<_ContiguousIterator>::value_type;
   static_assert(
       __is_cpp17_move_insertable_v<_Alloc>, "The specified type does not meet the requirements of Cpp17MoveInsertable");
-  if (__libcpp_is_constant_evaluated() || !__libcpp_is_trivially_relocatable<_ValueType>::value ||
+  if (__libcpp_is_constant_evaluated() || !__is_trivially_relocatable_v<_ValueType> ||
       !__allocator_has_trivial_move_construct_v<_Alloc, _ValueType> ||
       !__allocator_has_trivial_destroy_v<_Alloc, _ValueType>) {
     auto __destruct_first = __result;

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -129,10 +129,10 @@ public:
   //
   // This unique_ptr implementation only contains a pointer to the unique object and a deleter, so there are no
   // references to itself. This means that the entire structure is trivially relocatable if its members are.
-  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<
-      __libcpp_is_trivially_relocatable<pointer>::value && __libcpp_is_trivially_relocatable<deleter_type>::value,
-      unique_ptr,
-      void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG =
+      __conditional_t<__is_trivially_relocatable_v<pointer> && __is_trivially_relocatable_v<deleter_type>,
+                      unique_ptr,
+                      void>;
 
 private:
   _LIBCPP_COMPRESSED_PAIR(pointer, __ptr_, deleter_type, __deleter_);
@@ -383,10 +383,10 @@ public:
   //
   // This unique_ptr implementation only contains a pointer to the unique object and a deleter, so there are no
   // references to itself. This means that the entire structure is trivially relocatable if its members are.
-  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<
-      __libcpp_is_trivially_relocatable<pointer>::value && __libcpp_is_trivially_relocatable<deleter_type>::value,
-      unique_ptr,
-      void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG =
+      __conditional_t<__is_trivially_relocatable_v<pointer> && __is_trivially_relocatable_v<deleter_type>,
+                      unique_ptr,
+                      void>;
 
 private:
   template <class _Up, class _OtherDeleter>

--- a/libcxx/include/__optional/optional.h
+++ b/libcxx/include/__optional/optional.h
@@ -414,8 +414,7 @@ class _LIBCPP_DECLSPEC_EMPTY_BASES optional
 public:
   using value_type = __libcpp_remove_reference_t<_Tp>;
 
-  using __trivially_relocatable _LIBCPP_NODEBUG =
-      conditional_t<__libcpp_is_trivially_relocatable<_Tp>::value, optional, void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG = conditional_t<__is_trivially_relocatable_v<_Tp>, optional, void>;
 
 private:
   static_assert(!is_same_v<remove_cv_t<_Tp>, in_place_t>, "instantiation of optional with in_place_t is ill-formed");

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -589,10 +589,10 @@ public:
   // - pointer: may be trivially relocatable, so it's checked
   // - allocator_type: may be trivially relocatable, so it's checked
   // __split_buffer doesn't have any self-references, so it's trivially relocatable if its members are.
-  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<
-      __libcpp_is_trivially_relocatable<pointer>::value && __libcpp_is_trivially_relocatable<allocator_type>::value,
-      __split_buffer,
-      void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG =
+      __conditional_t<__is_trivially_relocatable_v<pointer> && __is_trivially_relocatable_v<allocator_type>,
+                      __split_buffer,
+                      void>;
 
   __split_buffer(const __split_buffer&)            = delete;
   __split_buffer& operator=(const __split_buffer&) = delete;

--- a/libcxx/include/__type_traits/is_trivially_relocatable.h
+++ b/libcxx/include/__type_traits/is_trivially_relocatable.h
@@ -28,19 +28,19 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // incorrect optimizations on some platforms (Windows) and supported compilers (AppleClang).
 #if __has_builtin(__is_trivially_relocatable) && 0
 template <class _Tp, class = void>
-struct __libcpp_is_trivially_relocatable : integral_constant<bool, __is_trivially_relocatable(_Tp)> {};
+inline const bool __is_trivially_relocatable_v = __is_trivially_relocatable(_Tp);
 #else
 template <class _Tp, class = void>
-struct __libcpp_is_trivially_relocatable : is_trivially_copyable<_Tp> {};
+inline const bool __is_trivially_relocatable_v = is_trivially_copyable<_Tp>::value;
 #endif
 
 // __trivially_relocatable on libc++'s builtin types does not currently return the right answer with PFP
 // in tagged mode, in which the address of the pointer is used as part of the pointer encoding.
 #if !defined(__POINTER_FIELD_PROTECTION_TAGGED__)
 template <class _Tp>
-struct __libcpp_is_trivially_relocatable<_Tp,
-                                         __enable_if_t<is_same<_Tp, typename _Tp::__trivially_relocatable>::value> >
-    : true_type {};
+inline const bool
+    __is_trivially_relocatable_v<_Tp, __enable_if_t<is_same<_Tp, typename _Tp::__trivially_relocatable>::value> > =
+        true;
 #endif
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -96,9 +96,7 @@ struct pair
   _T2 second;
 
   using __trivially_relocatable _LIBCPP_NODEBUG =
-      __conditional_t<__libcpp_is_trivially_relocatable<_T1>::value && __libcpp_is_trivially_relocatable<_T2>::value,
-                      pair,
-                      void>;
+      __conditional_t<__is_trivially_relocatable_v<_T1> && __is_trivially_relocatable_v<_T2>, pair, void>;
 
   pair(pair const&) = default;
   pair(pair&&)      = default;

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -121,10 +121,10 @@ public:
   // - pointer: may be trivially relocatable, so it's checked
   // - allocator_type: may be trivially relocatable, so it's checked
   // vector doesn't contain any self-references, so it's trivially relocatable if its members are.
-  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<
-      __libcpp_is_trivially_relocatable<pointer>::value && __libcpp_is_trivially_relocatable<allocator_type>::value,
-      vector,
-      void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG =
+      __conditional_t<__is_trivially_relocatable_v<pointer> && __is_trivially_relocatable_v<allocator_type>,
+                      vector,
+                      void>;
 
   static_assert(__check_valid_allocator<allocator_type>::value, "");
   static_assert(is_same<typename allocator_type::value_type, value_type>::value,

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -173,8 +173,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, size_t _Size>
 struct array {
-  using __trivially_relocatable _LIBCPP_NODEBUG =
-      __conditional_t<__libcpp_is_trivially_relocatable<_Tp>::value, array, void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<__is_trivially_relocatable_v<_Tp>, array, void>;
 
   // types:
   using __self _LIBCPP_NODEBUG = array;

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -545,10 +545,8 @@ public:
   // - size_type: is always trivially relocatable, since it is required to be an integral type
   // - allocator_type: may not be trivially relocatable, so it's checked
   // None of these are referencing the `deque` itself, so if all of them are trivially relocatable, `deque` is too.
-  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<
-      __libcpp_is_trivially_relocatable<__map>::value && __libcpp_is_trivially_relocatable<allocator_type>::value,
-      deque,
-      void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG =
+      __conditional_t<__is_trivially_relocatable_v<__map> && __is_trivially_relocatable_v<allocator_type>, deque, void>;
 
   static_assert(is_nothrow_default_constructible<allocator_type>::value ==
                     is_nothrow_default_constructible<__pointer_allocator>::value,

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -756,10 +756,10 @@ public:
   //
   // This string implementation doesn't contain any references into itself. It only contains a bit that says whether
   // it is in small or large string mode, so the entire structure is trivially relocatable if its members are.
-  using __trivially_relocatable _LIBCPP_NODEBUG = __conditional_t<
-      __libcpp_is_trivially_relocatable<allocator_type>::value && __libcpp_is_trivially_relocatable<pointer>::value,
-      basic_string,
-      void>;
+  using __trivially_relocatable _LIBCPP_NODEBUG =
+      __conditional_t<__is_trivially_relocatable_v<allocator_type> && __is_trivially_relocatable_v<pointer>,
+                      basic_string,
+                      void>;
 
   static_assert(!is_array<value_type>::value, "Character type of basic_string must not be an array");
   static_assert(is_standard_layout<value_type>::value, "Character type of basic_string must be standard-layout");

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -571,7 +571,7 @@ class _LIBCPP_NO_SPECIALIZATIONS tuple {
 
 public:
   using __trivially_relocatable _LIBCPP_NODEBUG =
-      __conditional_t<_And<__libcpp_is_trivially_relocatable<_Tp>...>::value, tuple, void>;
+      __conditional_t<__all<__is_trivially_relocatable_v<_Tp>...>::value, tuple, void>;
 
   // [tuple.cnstr]
 

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1180,7 +1180,7 @@ class _LIBCPP_DECLSPEC_EMPTY_BASES _LIBCPP_NO_SPECIALIZATIONS variant
 
 public:
   using __trivially_relocatable _LIBCPP_NODEBUG =
-      conditional_t<_And<__libcpp_is_trivially_relocatable<_Types>...>::value, variant, void>;
+      conditional_t<__all<__is_trivially_relocatable_v<_Types>...>::value, variant, void>;
 
   template <class _FirstType = __first_type, enable_if_t<is_default_constructible_v<_FirstType>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI constexpr variant() noexcept(is_nothrow_default_constructible_v<__first_type>)

--- a/libcxx/test/libcxx/type_traits/is_trivially_relocatable.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/is_trivially_relocatable.compile.pass.cpp
@@ -26,25 +26,25 @@
 #  include <locale>
 #endif
 
-static_assert(std::__libcpp_is_trivially_relocatable<char>::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<int>::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<double>::value, "");
+static_assert(std::__is_trivially_relocatable_v<char>, "");
+static_assert(std::__is_trivially_relocatable_v<int>, "");
+static_assert(std::__is_trivially_relocatable_v<double>, "");
 
 struct Empty {};
-static_assert(std::__libcpp_is_trivially_relocatable<Empty>::value, "");
+static_assert(std::__is_trivially_relocatable_v<Empty>, "");
 
 struct TriviallyCopyable {
   char c;
   int i;
   Empty s;
 };
-static_assert(std::__libcpp_is_trivially_relocatable<TriviallyCopyable>::value, "");
+static_assert(std::__is_trivially_relocatable_v<TriviallyCopyable>, "");
 
 struct NotTriviallyCopyable {
   NotTriviallyCopyable(const NotTriviallyCopyable&);
   ~NotTriviallyCopyable();
 };
-static_assert(!std::__libcpp_is_trivially_relocatable<NotTriviallyCopyable>::value, "");
+static_assert(!std::__is_trivially_relocatable_v<NotTriviallyCopyable>, "");
 
 struct MoveOnlyTriviallyCopyable {
   MoveOnlyTriviallyCopyable(const MoveOnlyTriviallyCopyable&)            = delete;
@@ -52,55 +52,55 @@ struct MoveOnlyTriviallyCopyable {
   MoveOnlyTriviallyCopyable(MoveOnlyTriviallyCopyable&&)                 = default;
   MoveOnlyTriviallyCopyable& operator=(MoveOnlyTriviallyCopyable&&)      = default;
 };
-static_assert(std::__libcpp_is_trivially_relocatable<MoveOnlyTriviallyCopyable>::value, "");
+static_assert(std::__is_trivially_relocatable_v<MoveOnlyTriviallyCopyable>, "");
 
 struct NonTrivialMoveConstructor {
   NonTrivialMoveConstructor(NonTrivialMoveConstructor&&);
 };
-static_assert(!std::__libcpp_is_trivially_relocatable<NonTrivialMoveConstructor>::value, "");
+static_assert(!std::__is_trivially_relocatable_v<NonTrivialMoveConstructor>, "");
 
 struct NonTrivialDestructor {
   ~NonTrivialDestructor() {}
 };
-static_assert(!std::__libcpp_is_trivially_relocatable<NonTrivialDestructor>::value, "");
+static_assert(!std::__is_trivially_relocatable_v<NonTrivialDestructor>, "");
 
 // library-internal types
 // ----------------------
 
 // __split_buffer
-static_assert(std::__libcpp_is_trivially_relocatable<
-                  std::__split_buffer<int, std::allocator<int>, std::__split_buffer_pointer_layout> >::value,
+static_assert(std::__is_trivially_relocatable_v<
+                  std::__split_buffer<int, std::allocator<int>, std::__split_buffer_pointer_layout> >,
               "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::__split_buffer<NotTriviallyCopyable,
-                                                                         std::allocator<NotTriviallyCopyable>,
-                                                                         std::__split_buffer_pointer_layout> >::value,
+static_assert(std::__is_trivially_relocatable_v<std::__split_buffer<NotTriviallyCopyable,
+                                                                    std::allocator<NotTriviallyCopyable>,
+                                                                    std::__split_buffer_pointer_layout> >,
               "");
-static_assert(!std::__libcpp_is_trivially_relocatable<
-                  std::__split_buffer<int, test_allocator<int>, std::__split_buffer_pointer_layout > >::value,
+static_assert(!std::__is_trivially_relocatable_v<
+                  std::__split_buffer<int, test_allocator<int>, std::__split_buffer_pointer_layout > >,
               "");
 
-static_assert(std::__libcpp_is_trivially_relocatable<
-                  std::__split_buffer<int, std::allocator<int>, std::__split_buffer_size_layout> >::value,
+static_assert(
+    std::__is_trivially_relocatable_v< std::__split_buffer<int, std::allocator<int>, std::__split_buffer_size_layout> >,
+    "");
+static_assert(std::__is_trivially_relocatable_v<std::__split_buffer<NotTriviallyCopyable,
+                                                                    std::allocator<NotTriviallyCopyable>,
+                                                                    std::__split_buffer_size_layout> >,
               "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::__split_buffer<NotTriviallyCopyable,
-                                                                         std::allocator<NotTriviallyCopyable>,
-                                                                         std::__split_buffer_size_layout> >::value,
-              "");
-static_assert(!std::__libcpp_is_trivially_relocatable<
-                  std::__split_buffer<int, test_allocator<int>, std::__split_buffer_size_layout > >::value,
+static_assert(!std::__is_trivially_relocatable_v<
+                  std::__split_buffer<int, test_allocator<int>, std::__split_buffer_size_layout > >,
               "");
 
 // standard library types
 // ----------------------
 
 // array
-static_assert(std::__libcpp_is_trivially_relocatable<std::array<int, 0> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::array<NotTriviallyCopyable, 0> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::array<std::unique_ptr<int>, 0> >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::array<int, 0> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::array<NotTriviallyCopyable, 0> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::array<std::unique_ptr<int>, 0> >, "");
 
-static_assert(std::__libcpp_is_trivially_relocatable<std::array<int, 1> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::array<NotTriviallyCopyable, 1> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::array<std::unique_ptr<int>, 1> >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::array<int, 1> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::array<NotTriviallyCopyable, 1> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::array<std::unique_ptr<int>, 1> >, "");
 
 // basic_string
 #if !_LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS_FOR_STRING
@@ -114,90 +114,81 @@ struct NotTriviallyRelocatableCharTraits : constexpr_char_traits<T> {
   ~NotTriviallyRelocatableCharTraits();
 };
 
-static_assert(std::__libcpp_is_trivially_relocatable<
-                  std::basic_string<char, std::char_traits<char>, std::allocator<char> > >::value,
+static_assert(
+    std::__is_trivially_relocatable_v< std::basic_string<char, std::char_traits<char>, std::allocator<char> > >, "");
+static_assert(std::__is_trivially_relocatable_v<
+                  std::basic_string<char, NotTriviallyRelocatableCharTraits<char>, std::allocator<char> > >,
               "");
-static_assert(std::__libcpp_is_trivially_relocatable<
-                  std::basic_string<char, NotTriviallyRelocatableCharTraits<char>, std::allocator<char> > >::value,
+static_assert(std::__is_trivially_relocatable_v<
+                  std::basic_string<MyChar, constexpr_char_traits<MyChar>, std::allocator<MyChar> > >,
               "");
-static_assert(std::__libcpp_is_trivially_relocatable<
-                  std::basic_string<MyChar, constexpr_char_traits<MyChar>, std::allocator<MyChar> > >::value,
+static_assert(std::__is_trivially_relocatable_v<
+                  std::basic_string<MyChar, NotTriviallyRelocatableCharTraits<MyChar>, std::allocator<MyChar> > >,
               "");
 static_assert(
-    std::__libcpp_is_trivially_relocatable<
-        std::basic_string<MyChar, NotTriviallyRelocatableCharTraits<MyChar>, std::allocator<MyChar> > >::value,
-    "");
-static_assert(!std::__libcpp_is_trivially_relocatable<
-                  std::basic_string<char, std::char_traits<char>, test_allocator<char> > >::value,
+    !std::__is_trivially_relocatable_v< std::basic_string<char, std::char_traits<char>, test_allocator<char> > >, "");
+static_assert(!std::__is_trivially_relocatable_v<
+                  std::basic_string<MyChar, NotTriviallyRelocatableCharTraits<MyChar>, test_allocator<MyChar> > >,
               "");
-static_assert(
-    !std::__libcpp_is_trivially_relocatable<
-        std::basic_string<MyChar, NotTriviallyRelocatableCharTraits<MyChar>, test_allocator<MyChar> > >::value,
-    "");
 #endif
 
 // deque
-static_assert(std::__libcpp_is_trivially_relocatable<std::deque<int> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::deque<NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::deque<int, test_allocator<int> > >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::deque<int> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::deque<NotTriviallyCopyable> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::deque<int, test_allocator<int> > >, "");
 
 // exception_ptr
 #ifndef _LIBCPP_ABI_MICROSOFT // FIXME: Is this also the case on windows?
-static_assert(std::__libcpp_is_trivially_relocatable<std::exception_ptr>::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::exception_ptr>, "");
 #endif
 
 // expected
 #if TEST_STD_VER >= 23
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<int, int> >::value);
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<std::unique_ptr<int>, int>>::value);
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<int, std::unique_ptr<int>>>::value);
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<std::unique_ptr<int>, std::unique_ptr<int>>>::value);
+static_assert(std::__is_trivially_relocatable_v<std::expected<int, int> >);
+static_assert(std::__is_trivially_relocatable_v<std::expected<std::unique_ptr<int>, int>>);
+static_assert(std::__is_trivially_relocatable_v<std::expected<int, std::unique_ptr<int>>>);
+static_assert(std::__is_trivially_relocatable_v<std::expected<std::unique_ptr<int>, std::unique_ptr<int>>>);
 
-static_assert(!std::__libcpp_is_trivially_relocatable<std::expected<int, NotTriviallyCopyable>>::value);
-static_assert(!std::__libcpp_is_trivially_relocatable<std::expected<NotTriviallyCopyable, int>>::value);
-static_assert(
-    !std::__libcpp_is_trivially_relocatable<std::expected<NotTriviallyCopyable, NotTriviallyCopyable>>::value);
+static_assert(!std::__is_trivially_relocatable_v<std::expected<int, NotTriviallyCopyable>>);
+static_assert(!std::__is_trivially_relocatable_v<std::expected<NotTriviallyCopyable, int>>);
+static_assert(!std::__is_trivially_relocatable_v<std::expected<NotTriviallyCopyable, NotTriviallyCopyable>>);
 #endif
 
 // locale
 #ifndef TEST_HAS_NO_LOCALIZATION
-static_assert(std::__libcpp_is_trivially_relocatable<std::locale>::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::locale>, "");
 #endif
 
 // optional
 #if TEST_STD_VER >= 17
-static_assert(std::__libcpp_is_trivially_relocatable<std::optional<int>>::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::optional<NotTriviallyCopyable>>::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::optional<std::unique_ptr<int>>>::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::optional<int>>, "");
+static_assert(!std::__is_trivially_relocatable_v<std::optional<NotTriviallyCopyable>>, "");
+static_assert(std::__is_trivially_relocatable_v<std::optional<std::unique_ptr<int>>>, "");
 #endif // TEST_STD_VER >= 17
 
 // pair
-static_assert(std::__libcpp_is_trivially_relocatable<std::pair<int, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::pair<NotTriviallyCopyable, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::pair<int, NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::pair<NotTriviallyCopyable, NotTriviallyCopyable> >::value,
-              "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::pair<std::unique_ptr<int>, std::unique_ptr<int> > >::value,
-              "");
+static_assert(std::__is_trivially_relocatable_v<std::pair<int, int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::pair<NotTriviallyCopyable, int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::pair<int, NotTriviallyCopyable> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::pair<NotTriviallyCopyable, NotTriviallyCopyable> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::pair<std::unique_ptr<int>, std::unique_ptr<int> > >, "");
 
 // shared_ptr
-static_assert(std::__libcpp_is_trivially_relocatable<std::shared_ptr<NotTriviallyCopyable> >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::shared_ptr<NotTriviallyCopyable> >, "");
 
 // tuple
 #if TEST_STD_VER >= 11
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<> >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::tuple<> >, "");
 
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<NotTriviallyCopyable> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<std::unique_ptr<int> > >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::tuple<int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::tuple<NotTriviallyCopyable> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::tuple<std::unique_ptr<int> > >, "");
 
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<int, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<NotTriviallyCopyable, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<int, NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<NotTriviallyCopyable, NotTriviallyCopyable> >::value,
-              "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<std::unique_ptr<int>, std::unique_ptr<int> > >::value,
-              "");
+static_assert(std::__is_trivially_relocatable_v<std::tuple<int, int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::tuple<NotTriviallyCopyable, int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::tuple<int, NotTriviallyCopyable> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::tuple<NotTriviallyCopyable, NotTriviallyCopyable> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::tuple<std::unique_ptr<int>, std::unique_ptr<int> > >, "");
 #endif // TEST_STD_VER >= 11
 
 // unique_ptr
@@ -221,39 +212,33 @@ struct NotTriviallyRelocatablePointer {
   void operator()(T*);
 };
 
-static_assert(std::__libcpp_is_trivially_relocatable<std::unique_ptr<int> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::unique_ptr<NotTriviallyCopyable> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::unique_ptr<int[]> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::unique_ptr<int, NotTriviallyRelocatableDeleter> >::value,
-              "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::unique_ptr<int[], NotTriviallyRelocatableDeleter> >::value,
-              "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::unique_ptr<int, NotTriviallyRelocatablePointer> >::value,
-              "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::unique_ptr<int[], NotTriviallyRelocatablePointer> >::value,
-              "");
+static_assert(std::__is_trivially_relocatable_v<std::unique_ptr<int> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::unique_ptr<NotTriviallyCopyable> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::unique_ptr<int[]> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::unique_ptr<int, NotTriviallyRelocatableDeleter> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::unique_ptr<int[], NotTriviallyRelocatableDeleter> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::unique_ptr<int, NotTriviallyRelocatablePointer> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::unique_ptr<int[], NotTriviallyRelocatablePointer> >, "");
 
 // variant
 #if TEST_STD_VER >= 17
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<NotTriviallyCopyable> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<std::unique_ptr<int> > >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::variant<int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::variant<NotTriviallyCopyable> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::variant<std::unique_ptr<int> > >, "");
 
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<int, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<NotTriviallyCopyable, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<int, NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<NotTriviallyCopyable, NotTriviallyCopyable> >::value,
-              "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<std::unique_ptr<int>, std::unique_ptr<int> > >::value,
-              "");
+static_assert(std::__is_trivially_relocatable_v<std::variant<int, int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::variant<NotTriviallyCopyable, int> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::variant<int, NotTriviallyCopyable> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::variant<NotTriviallyCopyable, NotTriviallyCopyable> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::variant<std::unique_ptr<int>, std::unique_ptr<int> > >, "");
 #endif // TEST_STD_VER >= 17
 
 // vector
-static_assert(std::__libcpp_is_trivially_relocatable<std::vector<int> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::vector<NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::vector<int, test_allocator<int> > >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::vector<int> >, "");
+static_assert(std::__is_trivially_relocatable_v<std::vector<NotTriviallyCopyable> >, "");
+static_assert(!std::__is_trivially_relocatable_v<std::vector<int, test_allocator<int> > >, "");
 
 // weak_ptr
-static_assert(std::__libcpp_is_trivially_relocatable<std::weak_ptr<NotTriviallyCopyable> >::value, "");
+static_assert(std::__is_trivially_relocatable_v<std::weak_ptr<NotTriviallyCopyable> >, "");
 
 // TODO: Mark all the trivially relocatable STL types as such

--- a/libcxx/test/std/containers/sequences/vector/trivial_relocation.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/trivial_relocation.pass.cpp
@@ -38,7 +38,7 @@ struct NotTriviallyMovable {
   Inner inner_;
 };
 static_assert(!std::is_trivially_copyable<NotTriviallyMovable>::value, "");
-LIBCPP_STATIC_ASSERT(!std::__libcpp_is_trivially_relocatable<NotTriviallyMovable>::value, "");
+LIBCPP_NON_FROZEN_STATIC_ASSERT(!std::__is_trivially_relocatable_v<NotTriviallyMovable>, "");
 
 TEST_CONSTEXPR_CXX20 bool tests() {
   Tracker track;

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/common.h
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/common.h
@@ -11,7 +11,7 @@
 
 #include "test_macros.h"
 
-#include <type_traits> // for __libcpp_is_trivially_relocatable
+#include <type_traits> // for __is_trivially_relocatable_v
 
 #ifndef TEST_HAS_NO_EXCEPTIONS
 struct Throws {
@@ -109,6 +109,6 @@ struct NonTriviallyRelocatable {
     return a.value_ == b.value_;
   }
 };
-LIBCPP_STATIC_ASSERT(!std::__libcpp_is_trivially_relocatable<NonTriviallyRelocatable>::value, "");
+LIBCPP_NON_FROZEN_STATIC_ASSERT(!std::__is_trivially_relocatable_v<NonTriviallyRelocatable>, "");
 
 #endif // TEST_STD_CONTAINERS_SEQUENCES_VECTOR_VECTOR_MODIFIERS_COMMON_H

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -273,8 +273,10 @@
 
 #ifdef _LIBCPP_USE_FROZEN_CXX03_HEADERS
 #  define LIBCPP_NON_FROZEN_ASSERT(...) static_assert(true, "")
+#  define LIBCPP_NON_FROZEN_STATIC_ASSERT(...) static_assert(true, "")
 #else
 #  define LIBCPP_NON_FROZEN_ASSERT(...) LIBCPP_ASSERT(__VA_ARGS__)
+#  define LIBCPP_NON_FROZEN_STATIC_ASSERT(...) LIBCPP_STATIC_ASSERT(__VA_ARGS__)
 #endif
 
 #if __has_cpp_attribute(nodiscard)


### PR DESCRIPTION
Variable templates are a bit nicer to read and improve compile times a bit.
