### PR TITLE
[MLIR][OpenMP] Ensure -fopenmp-force-usm doesn't override requirements

### DIFF
--- a/mlir/lib/Dialect/OpenMP/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/OpenMP/Utils/Utils.cpp
@@ -23,7 +23,8 @@ void mlir::omp::setOffloadModuleInterfaceAttributes(
     offloadMod.setIsTargetDevice(opts.isTargetDevice);
     offloadMod.setIsGPU(opts.isGPU);
     if (opts.forceUSM)
-      offloadMod.setRequires(ClauseRequires::unified_shared_memory);
+      offloadMod.setRequires(offloadMod.getRequires() |
+                             ClauseRequires::unified_shared_memory);
     offloadMod.setFlags(opts.targetDebugKind, opts.assumeTeamsOversubscription,
                         opts.assumeThreadsOversubscription,
                         opts.assumeNoThreadState,


### PR DESCRIPTION
The `mlir::omp::setOffloadModuleInterfaceAttributes` utility function can currently override any pre-existing OpenMP `requires` clauses in the module. This doesn't cause any problems at the moment because all calls to this function happen before any other `requires` are processed. However, it's safer to make sure it never deletes pre-existing flags in case the same function is reused in a different context.