### PR TITLE
[Polly] Reject SCoPs with an escaping scalar defined in an empty-doma…

### DIFF
--- a/polly/include/polly/ScopBuilder.h
+++ b/polly/include/polly/ScopBuilder.h
@@ -243,6 +243,10 @@ class ScopBuilder final {
   bool addLoopBoundsToHeaderDomain(
       Loop *L, DenseMap<BasicBlock *, isl::set> &InvalidDomainMap);
 
+  /// Ensure escaping scalars whose defining statement has an empty domain
+  /// retain a Value ScopArrayInfo before that statement is pruned.
+  void ensureEscapingValuesOfEmptyDomainStmts();
+
   /// Compute the isl representation for the SCEV @p E in this BB.
   ///
   /// @param BB               The BB for which isl representation is to be

--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -3663,6 +3663,39 @@ static void verifyUses(Scop *S, LoopInfo &LI, DominatorTree &DT) {
 }
 #endif
 
+void ScopBuilder::ensureEscapingValuesOfEmptyDomainStmts() {
+  for (ScopStmt &Stmt : scop->Stmts) {
+    BasicBlock *BB = Stmt.getEntryBlock();
+    if (!BB)
+      continue;
+
+    // A statement with a null or empty domain is pruned before code generation.
+    isl::set Domain = scop->DomainMap.lookup(BB);
+    if (!(Domain.is_null() || Domain.is_empty()))
+      continue;
+
+    // When that statement is pruned we lose the ScopArrayInfo for any escaping
+    // scalar it defines. Codegen then skips the merge PHI for the escaping use
+    // at the versioned region exit, and we're left with a use that doesn't
+    // dominate the merge block. So create the Value ScopArrayInfo up front,
+    // before the prune, and codegen will still build the merge PHI. On the
+    // optimized-copy edge that PHI reloads an alloca nobody ever stored to
+    // which is poison.
+    for (MemoryAccess *MA : Stmt) {
+      if (!MA->isValueKind() || !MA->isMustWrite())
+        continue;
+      auto *AccInst = dyn_cast<Instruction>(MA->getAccessValue());
+      if (!AccInst || !scop->contains(AccInst))
+        continue;
+      if (!scop->isEscaping(AccInst))
+        continue;
+
+      scop->getOrCreateScopArrayInfo(AccInst, AccInst->getType(), {},
+                                     MemoryKind::Value);
+    }
+  }
+}
+
 void ScopBuilder::buildScop(Region &R, AssumptionCache &AC) {
   scop = Scop::makeScop(R, SE, LI, DT, *SD.getDetectionContext(&R), ORE,
                         SD.getNextID());
@@ -3744,6 +3777,10 @@ void ScopBuilder::buildScop(Region &R, AssumptionCache &AC) {
     else
       Stmt.setInvalidDomain(InvalidDomainMap[getRegionNodeBasicBlock(
           Stmt.getRegion()->getNode())]);
+
+  // Preserve the ScopArrayInfo of escaping scalars whose defining statement is
+  // about to be removed.
+  ensureEscapingValuesOfEmptyDomainStmts();
 
   // Remove empty statements.
   // Exit early in case there are no executable statements left in this scop.

--- a/polly/test/CodeGen/broken-dominance-escaping-scalar.ll
+++ b/polly/test/CodeGen/broken-dominance-escaping-scalar.ll
@@ -1,0 +1,62 @@
+; RUN: opt %loadNPMPolly '-passes=polly-custom<codegen>' -S %s | FileCheck %s
+;
+; https://github.com/llvm/llvm-project/issues/206551
+;
+; Regression test for a verifier crash ("Instruction does not dominate all
+; uses!") triggered when an escaping scalar (%cond47.us.us.us) is defined in a
+; statement whose iteration domain is empty. The inner loop trip count depends
+; on a parameter that the runtime check restricts to a range where the loop
+; body never executes, making the defining statement's domain empty. Polly
+; prunes it, but the scalar still escapes via the outer-loop header PHI.
+;
+; Without the fix the generated merge block refers to a definition that only
+; exists in the original (unoptimized) copy, breaking dominance. With the fix
+; the region stays versioned and a proper .merge PHI is built, so we check that
+; the versioning infrastructure (.s2a alloca, .merge PHI, .final_reload) is
+; present and well-formed.
+;
+; CHECK: %cond47.us.us.us.s2a = alloca
+; CHECK: polly.merge_new_and_old:
+; CHECK: %cond47.us.us.us.merge = phi i32 [ %cond47.us.us.us.final_reload, %polly.exiting ], [ %cond47.us.us.us, %for.cond.cleanup6.us.us ]
+; CHECK: %cond47.us.us116.us = phi i32 [ 0, %entry ], [ %cond47.us.us.us.merge, %polly.merge_new_and_old ]
+; CHECK: polly.exiting:
+; CHECK: %cond47.us.us.us.final_reload = load i32, ptr %cond47.us.us.us.s2a
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @_Z1iiPA4_A4_iiPA4_A4_cS4_S1_(ptr %j, i32 %k, ptr %0) {
+entry:
+  %sext = shl i32 %k, 24
+  %conv10 = ashr i32 %sext, 24
+  %sub11 = add i32 %conv10, -127
+  %wide.trip.count = zext i32 %sub11 to i64
+  br label %for.cond4.preheader.us.us
+
+for.cond4.preheader.us.us:                        ; preds = %for.cond.cleanup6.us.us, %entry
+  %cond47.us.us116.us = phi i32 [ 0, %entry ], [ %cond47.us.us.us, %for.cond.cleanup6.us.us ]
+  br label %for.body7.us.us.us
+
+for.cond.cleanup6.us.us:                          ; preds = %for.cond9.for.cond.cleanup13_crit_edge.us.us.us
+  br label %for.cond4.preheader.us.us
+
+for.body7.us.us.us:                               ; preds = %for.cond9.for.cond.cleanup13_crit_edge.us.us.us, %for.cond4.preheader.us.us
+  br label %for.cond15.preheader.us.us.us
+
+cond.false.us.us.us.1:                            ; preds = %for.cond15.preheader.us.us.us
+  %cond47.us.us.us = select i1 false, i32 0, i32 0
+  store i32 0, ptr null, align 4
+  %indvars.iv.next = add nsw i64 %indvars.iv, 1
+  %exitcond.not = icmp eq i64 %indvars.iv.next, %wide.trip.count
+  br i1 %exitcond.not, label %for.cond9.for.cond.cleanup13_crit_edge.us.us.us, label %for.cond15.preheader.us.us.us
+
+for.cond15.preheader.us.us.us:                    ; preds = %cond.false.us.us.us.1, %for.body7.us.us.us
+  %indvars.iv = phi i64 [ %indvars.iv.next, %cond.false.us.us.us.1 ], [ 0, %for.body7.us.us.us ]
+  %cond478486.us.us.us = phi i32 [ 1, %cond.false.us.us.us.1 ], [ 0, %for.body7.us.us.us ]
+  %1 = load i32, ptr %0, align 4
+  store i32 0, ptr %j, align 8
+  br label %cond.false.us.us.us.1
+
+for.cond9.for.cond.cleanup13_crit_edge.us.us.us:  ; preds = %cond.false.us.us.us.1
+  br i1 true, label %for.cond.cleanup6.us.us, label %for.body7.us.us.us
+}


### PR DESCRIPTION
Summary
-------
Polly can generate invalid IR that fails the verifier with "Instruction
does not dominate all uses!" . This patch detects the situation
early and has Polly keep the original loop instead of producing broken
output. Below is what goes wrong and why declining to optimize is
the conservative but correct fix.

Background
----------
Versioning:
Polly optimizes SCoPs. Rather than overwriting a loop, it emits TWO versions
-> an optimized one and the original as a fallback and a runtime check picks
which runs; the two paths rejoin at a block named "polly.merge_new_and_old".

A value computed in the loop but still needed afterwards is an "escaping"
value (e.g. read by a phi just past the region). The merge block is
responsible for forwarding the right version of it. To arrange this, Polly
records a "scalar write" for the value -- a "must-write", i.e. one that
happens whenever the producing statement runs (unlike a conditional
"may-write").

What goes wrong (issue #206551)
-------------------------------
For each statement Polly computes its "domain": the set of iterations in
which it runs. If a statement provably never runs, its domain is empty and
Polly deletes it before codegen (in removeStmtNotInDomainMap).

The bug appears when the ONLY producer of an escaping value is such an
empty-domain statement:

  1. Polly deletes the statement, so the optimized version never computes
     the value.
  2. Polly still builds the merge block to forward it.
  3. The merge block then refers to a value that exists only in the
     original version.

The result is a value used on a path where it was never defined -- the
definition does not dominate its uses, and the verifier aborts with
"Instruction does not dominate all uses!".

Why we decline to optimize instead of fixing codegen
----------------------------------------------------
Option 1: make the optimized version also produce the escaping value. In
the reduced test case this looks easy, but only by accident -- there the
value is a select that collapses to the constant 0, so storing 0 "works".
In a realistic case the value is not constant: reproducing it would mean
re-creating it and its entire dependency chain inside a statement that, by
definition, never runs. 
There is no correct value for it to compute and no machinery to rebuild
that computation in dead code;
Thus any shortcut is UB or simply wrong.

Option 2: keep optimizing but skip versioning. Versioning is not optional
-- executeScopConditionally always emits the split and merge block for any
generated SCoP. "Skipping" it just disables the optimized copy and falls
back to the original loop -- the same outcome as declining, only reached
later after wasted AST/IR generation.

The fix
-------
Inside buildScop, at the point where statement domains are known but the empty statements have not yet been deleted, Polly now checks for the dangerous situation: an escaping value whose must-write lives in a statement that is about to be deleted for having an empty domain. When this is found, Polly rejects the whole SCoP by recording a new assumption (ESCAPINGSCALAR). The region then keeps its original, correct code. This is a local, per-region decision: every other loop in the function is detected and optimized exactly as before.

A regression test is added in
polly/test/CodeGen/broken-dominance-escaping-scalar.ll.

Fixes https://github.com/llvm/llvm-project/issues/206551