### PR TITLE
[X86] movmsk-cmp.ll - update PR39665_c_ray test to match middle-end output

### DIFF
--- a/llvm/test/CodeGen/X86/movmsk-cmp.ll
+++ b/llvm/test/CodeGen/X86/movmsk-cmp.ll
@@ -4370,94 +4370,31 @@ define i1 @movmsk_v2f64_var(<2 x double> %x, <2 x double> %y, i32 %z) {
   ret i1 %val
 }
 
-; TODO: We expect similar result as for PR39665_c_ray_opt,
-; but this is not the case in practice.
 define i32 @PR39665_c_ray(<2 x double> %x, <2 x double> %y) {
 ; SSE-LABEL: PR39665_c_ray:
 ; SSE:       # %bb.0:
-; SSE-NEXT:    cmpltpd %xmm0, %xmm1
-; SSE-NEXT:    movmskpd %xmm1, %ecx
-; SSE-NEXT:    testb $2, %cl
-; SSE-NEXT:    movl $42, %eax
-; SSE-NEXT:    movl $99, %edx
-; SSE-NEXT:    cmovel %edx, %eax
-; SSE-NEXT:    testb $1, %cl
-; SSE-NEXT:    cmovel %edx, %eax
+; SSE-NEXT:    cmpnltpd %xmm0, %xmm1
+; SSE-NEXT:    movmskpd %xmm1, %eax
+; SSE-NEXT:    testl %eax, %eax
+; SSE-NEXT:    movl $42, %ecx
+; SSE-NEXT:    movl $99, %eax
+; SSE-NEXT:    cmovel %ecx, %eax
 ; SSE-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: PR39665_c_ray:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vcmpltpd %xmm0, %xmm1, %xmm0
-; AVX1OR2-NEXT:    vmovmskpd %xmm0, %ecx
-; AVX1OR2-NEXT:    testb $2, %cl
-; AVX1OR2-NEXT:    movl $42, %eax
-; AVX1OR2-NEXT:    movl $99, %edx
-; AVX1OR2-NEXT:    cmovel %edx, %eax
-; AVX1OR2-NEXT:    testb $1, %cl
-; AVX1OR2-NEXT:    cmovel %edx, %eax
+; AVX1OR2-NEXT:    vcmpnltpd %xmm0, %xmm1, %xmm0
+; AVX1OR2-NEXT:    vtestpd %xmm0, %xmm0
+; AVX1OR2-NEXT:    movl $42, %ecx
+; AVX1OR2-NEXT:    movl $99, %eax
+; AVX1OR2-NEXT:    cmovel %ecx, %eax
 ; AVX1OR2-NEXT:    retq
 ;
 ; KNL-LABEL: PR39665_c_ray:
 ; KNL:       # %bb.0:
 ; KNL-NEXT:    # kill: def $xmm1 killed $xmm1 def $zmm1
 ; KNL-NEXT:    # kill: def $xmm0 killed $xmm0 def $zmm0
-; KNL-NEXT:    vcmpltpd %zmm0, %zmm1, %k0
-; KNL-NEXT:    kmovw %k0, %ecx
-; KNL-NEXT:    testb $2, %cl
-; KNL-NEXT:    movl $42, %eax
-; KNL-NEXT:    movl $99, %edx
-; KNL-NEXT:    cmovel %edx, %eax
-; KNL-NEXT:    testb $1, %cl
-; KNL-NEXT:    cmovel %edx, %eax
-; KNL-NEXT:    vzeroupper
-; KNL-NEXT:    retq
-;
-; SKX-LABEL: PR39665_c_ray:
-; SKX:       # %bb.0:
-; SKX-NEXT:    vcmpltpd %xmm0, %xmm1, %k0
-; SKX-NEXT:    kmovd %k0, %ecx
-; SKX-NEXT:    testb $2, %cl
-; SKX-NEXT:    movl $42, %eax
-; SKX-NEXT:    movl $99, %edx
-; SKX-NEXT:    cmovel %edx, %eax
-; SKX-NEXT:    testb $1, %cl
-; SKX-NEXT:    cmovel %edx, %eax
-; SKX-NEXT:    retq
-  %cmp = fcmp ogt <2 x double> %x, %y
-  %e1 = extractelement <2 x i1> %cmp, i32 0
-  %e2 = extractelement <2 x i1> %cmp, i32 1
-  %u = and i1 %e1, %e2
-  %r = select i1 %u, i32 42, i32 99
-  ret i32 %r
-}
-
-define i32 @PR39665_c_ray_opt(<2 x double> %x, <2 x double> %y) {
-; SSE-LABEL: PR39665_c_ray_opt:
-; SSE:       # %bb.0:
-; SSE-NEXT:    cmpltpd %xmm0, %xmm1
-; SSE-NEXT:    movmskpd %xmm1, %eax
-; SSE-NEXT:    cmpl $3, %eax
-; SSE-NEXT:    movl $42, %ecx
-; SSE-NEXT:    movl $99, %eax
-; SSE-NEXT:    cmovel %ecx, %eax
-; SSE-NEXT:    retq
-;
-; AVX1OR2-LABEL: PR39665_c_ray_opt:
-; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vcmpltpd %xmm0, %xmm1, %xmm0
-; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vtestpd %xmm1, %xmm0
-; AVX1OR2-NEXT:    movl $42, %ecx
-; AVX1OR2-NEXT:    movl $99, %eax
-; AVX1OR2-NEXT:    cmovbl %ecx, %eax
-; AVX1OR2-NEXT:    retq
-;
-; KNL-LABEL: PR39665_c_ray_opt:
-; KNL:       # %bb.0:
-; KNL-NEXT:    # kill: def $xmm1 killed $xmm1 def $zmm1
-; KNL-NEXT:    # kill: def $xmm0 killed $xmm0 def $zmm0
-; KNL-NEXT:    vcmpltpd %zmm0, %zmm1, %k0
-; KNL-NEXT:    knotw %k0, %k0
+; KNL-NEXT:    vcmpnltpd %zmm0, %zmm1, %k0
 ; KNL-NEXT:    kmovw %k0, %eax
 ; KNL-NEXT:    testb $3, %al
 ; KNL-NEXT:    movl $42, %ecx
@@ -4466,19 +4403,17 @@ define i32 @PR39665_c_ray_opt(<2 x double> %x, <2 x double> %y) {
 ; KNL-NEXT:    vzeroupper
 ; KNL-NEXT:    retq
 ;
-; SKX-LABEL: PR39665_c_ray_opt:
+; SKX-LABEL: PR39665_c_ray:
 ; SKX:       # %bb.0:
-; SKX-NEXT:    vcmpltpd %xmm0, %xmm1, %k0
-; SKX-NEXT:    kmovd %k0, %eax
-; SKX-NEXT:    cmpb $3, %al
+; SKX-NEXT:    vcmpnltpd %xmm0, %xmm1, %k0
+; SKX-NEXT:    kortestb %k0, %k0
 ; SKX-NEXT:    movl $42, %ecx
 ; SKX-NEXT:    movl $99, %eax
 ; SKX-NEXT:    cmovel %ecx, %eax
 ; SKX-NEXT:    retq
-  %cmp = fcmp ogt <2 x double> %x, %y
-  %shift = shufflevector <2 x i1> %cmp, <2 x i1> poison, <2 x i32> <i32 1, i32 undef>
-  %1 = and <2 x i1> %cmp, %shift
-  %u = extractelement <2 x i1> %1, i64 0
+  %cmp = fcmp ule <2 x double> %x, %y
+  %bc = bitcast <2 x i1> %cmp to i2
+  %u = icmp eq i2 %bc, 0
   %r = select i1 %u, i32 42, i32 99
   ret i32 %r
 }
@@ -4550,10 +4485,10 @@ define i32 @pr67287(<2 x i64> %broadcast.splatinsert25) {
 ; SSE2-NEXT:    movd %xmm1, %ecx
 ; SSE2-NEXT:    orb %al, %cl
 ; SSE2-NEXT:    testb $1, %cl
-; SSE2-NEXT:    je .LBB98_2
+; SSE2-NEXT:    je .LBB97_2
 ; SSE2-NEXT:  # %bb.1:
 ; SSE2-NEXT:    movw $0, 0
-; SSE2-NEXT:  .LBB98_2: # %middle.block
+; SSE2-NEXT:  .LBB97_2: # %middle.block
 ; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    retq
 ;
@@ -4568,10 +4503,10 @@ define i32 @pr67287(<2 x i64> %broadcast.splatinsert25) {
 ; SSE41-NEXT:    movd %xmm0, %ecx
 ; SSE41-NEXT:    orb %al, %cl
 ; SSE41-NEXT:    testb $1, %cl
-; SSE41-NEXT:    je .LBB98_2
+; SSE41-NEXT:    je .LBB97_2
 ; SSE41-NEXT:  # %bb.1:
 ; SSE41-NEXT:    movw $0, 0
-; SSE41-NEXT:  .LBB98_2: # %middle.block
+; SSE41-NEXT:  .LBB97_2: # %middle.block
 ; SSE41-NEXT:    xorl %eax, %eax
 ; SSE41-NEXT:    retq
 ;
@@ -4585,10 +4520,10 @@ define i32 @pr67287(<2 x i64> %broadcast.splatinsert25) {
 ; AVX1-NEXT:    vmovd %xmm0, %ecx
 ; AVX1-NEXT:    orb %al, %cl
 ; AVX1-NEXT:    testb $1, %cl
-; AVX1-NEXT:    je .LBB98_2
+; AVX1-NEXT:    je .LBB97_2
 ; AVX1-NEXT:  # %bb.1:
 ; AVX1-NEXT:    movw $0, 0
-; AVX1-NEXT:  .LBB98_2: # %middle.block
+; AVX1-NEXT:  .LBB97_2: # %middle.block
 ; AVX1-NEXT:    xorl %eax, %eax
 ; AVX1-NEXT:    retq
 ;
@@ -4602,10 +4537,10 @@ define i32 @pr67287(<2 x i64> %broadcast.splatinsert25) {
 ; AVX2-NEXT:    vmovd %xmm0, %ecx
 ; AVX2-NEXT:    orb %al, %cl
 ; AVX2-NEXT:    testb $1, %cl
-; AVX2-NEXT:    je .LBB98_2
+; AVX2-NEXT:    je .LBB97_2
 ; AVX2-NEXT:  # %bb.1:
 ; AVX2-NEXT:    movw $0, 0
-; AVX2-NEXT:  .LBB98_2: # %middle.block
+; AVX2-NEXT:  .LBB97_2: # %middle.block
 ; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    retq
 ;
@@ -4620,10 +4555,10 @@ define i32 @pr67287(<2 x i64> %broadcast.splatinsert25) {
 ; KNL-NEXT:    setne %cl
 ; KNL-NEXT:    orb %cl, %al
 ; KNL-NEXT:    testb $1, %al
-; KNL-NEXT:    je .LBB98_2
+; KNL-NEXT:    je .LBB97_2
 ; KNL-NEXT:  # %bb.1:
 ; KNL-NEXT:    movw $0, 0
-; KNL-NEXT:  .LBB98_2: # %middle.block
+; KNL-NEXT:  .LBB97_2: # %middle.block
 ; KNL-NEXT:    xorl %eax, %eax
 ; KNL-NEXT:    vzeroupper
 ; KNL-NEXT:    retq
@@ -4638,10 +4573,10 @@ define i32 @pr67287(<2 x i64> %broadcast.splatinsert25) {
 ; SKX-NEXT:    kmovd %k0, %ecx
 ; SKX-NEXT:    orb %al, %cl
 ; SKX-NEXT:    testb $1, %cl
-; SKX-NEXT:    je .LBB98_2
+; SKX-NEXT:    je .LBB97_2
 ; SKX-NEXT:  # %bb.1:
 ; SKX-NEXT:    movw $0, 0
-; SKX-NEXT:  .LBB98_2: # %middle.block
+; SKX-NEXT:  .LBB97_2: # %middle.block
 ; SKX-NEXT:    xorl %eax, %eax
 ; SKX-NEXT:    retq
 entry:


### PR DESCRIPTION
These now lower to vXi1 reduction (as bitcast) patterns

The PR39665_c_ray_opt test folds to the same IR, so I've merged the tests