### PR TITLE
[flang][CodeGen] Add `fir::ShiftType` to LLVM type conversion

### DIFF
--- a/flang/lib/Optimizer/CodeGen/TypeConverter.cpp
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.cpp
@@ -135,6 +135,12 @@ LLVMTypeConverter::LLVMTypeConverter(mlir::ModuleOp module, bool applyTBAA,
     return mlir::LLVM::LLVMStructType::getLiteral(&getContext(), members,
                                                   /*isPacked=*/false);
   });
+  addConversion([&](fir::ShiftType shift) {
+    mlir::Type i64Ty = mlir::IntegerType::get(&getContext(), 64);
+    llvm::SmallVector<mlir::Type> members(shift.getRank(), i64Ty);
+    return mlir::LLVM::LLVMStructType::getLiteral(&getContext(), members,
+                                                  /*isPacked=*/false);
+  });
   addConversion([&](fir::TypeDescType tdesc) {
     return convertTypeDescType(tdesc.getContext());
   });

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -1391,6 +1391,22 @@ func.func @dead_shift() {
 // CHECK: %{{.*}} = llvm.mlir.constant(0 : index) : i{{.*}}
 // CHECK-NEXT: llvm.return
 
+// -----
+
+// Test that !fir.shift<N> flowing through the IR as a value (here, a
+// function argument) has a working type conversion to a struct of i64s,
+// matching !fir.shape<N> / !fir.shape_shift<N>.
+
+func.func @shift_value(%s: !fir.shift<1>) -> !fir.shift<1> {
+  return %s : !fir.shift<1>
+}
+
+// CHECK-LABEL: llvm.func @shift_value
+// CHECK-SAME:  (%[[ARG:.*]]: !llvm.struct<(i64)>) -> !llvm.struct<(i64)>
+// CHECK:       llvm.return %[[ARG]] : !llvm.struct<(i64)>
+
+// -----
+
 func.func @dead_shape() {
   %c0 = arith.constant 0 : index
   %0 = fir.shape %c0 : (index) -> !fir.shape<1>


### PR DESCRIPTION
Mirrors the existing ShapeType / ShapeShiftType converters: a `!fir.shift<N>` becomes `!llvm.struct<(i64 x N)>`.

Co-Authored-By: Claude