### PR TITLE
[lldb-dap] Merge parent and user defined env when spawning server.

### DIFF
--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -59,8 +59,14 @@ export class LLDBDapServer implements vscode.Disposable {
       return this.serverInfo;
     }
 
+    // Merge the parent env with the user defined env (user defined takes priority).
+    const dapSpawnOptions: child_process.SpawnOptionsWithoutStdio = {
+      ...options,
+      env: { ...process.env, ...options?.env },
+    };
+
     this.serverInfo = new Promise((resolve, reject) => {
-      const process = child_process.spawn(dapPath, dapArgs, options);
+      const process = child_process.spawn(dapPath, dapArgs, dapSpawnOptions);
       process.on("error", (error) => {
         reject(error);
         this.cleanUp(process);


### PR DESCRIPTION
The DAP server was spawned using only the user defined `options.env`, which dropped the parent process's environment (e.g. PATH). Merge the two, giving user-defined values priority on conflicts.

Fixes #159498