### PR TITLE
[lldb] Rename some register type classes

### DIFF
--- a/lldb/include/lldb/Core/DumpRegisterInfo.h
+++ b/lldb/include/lldb/Core/DumpRegisterInfo.h
@@ -18,7 +18,7 @@ namespace lldb_private {
 class Stream;
 class RegisterContext;
 struct RegisterInfo;
-class RegisterFlags;
+class RegisterTypeFlags;
 
 void DumpRegisterInfo(Stream &strm, RegisterContext &ctx,
                       const RegisterInfo &info, uint32_t terminal_width);
@@ -29,7 +29,7 @@ void DoDumpRegisterInfo(
     const std::vector<const char *> &invalidates,
     const std::vector<const char *> &read_from,
     const std::vector<std::pair<const char *, uint32_t>> &in_sets,
-    const RegisterFlags *flags_type, uint32_t terminal_width);
+    const RegisterTypeFlags *flags_type, uint32_t terminal_width);
 
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Core/FormatEntity.h
+++ b/lldb/include/lldb/Core/FormatEntity.h
@@ -78,7 +78,7 @@ struct Entry {
     FrameRegisterPC,
     FrameRegisterSP,
     FrameRegisterFP,
-    FrameRegisterFlags,
+    FrameRegisterTypeFlags,
     FrameRegisterByName,
     FrameIsArtificial,
     FrameKind,

--- a/lldb/include/lldb/Target/DynamicRegisterInfo.h
+++ b/lldb/include/lldb/Target/DynamicRegisterInfo.h
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include "lldb/Utility/ConstString.h"
-#include "lldb/Utility/RegisterFlags.h"
 #include "lldb/Utility/RegisterInfo.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/lldb-private.h"
 
@@ -39,7 +39,7 @@ public:
     std::vector<uint32_t> invalidate_regs;
     uint32_t value_reg_offset = 0;
     // Non-null if there is an XML provided type.
-    const RegisterFlags *flags_type = nullptr;
+    const RegisterTypeFlags *flags_type = nullptr;
   };
 
   DynamicRegisterInfo() = default;

--- a/lldb/include/lldb/Target/RegisterTypeBuilder.h
+++ b/lldb/include/lldb/Target/RegisterTypeBuilder.h
@@ -18,9 +18,10 @@ class RegisterTypeBuilder : public PluginInterface {
 public:
   ~RegisterTypeBuilder() override = default;
 
-  virtual CompilerType GetRegisterType(const std::string &name,
-                                       const lldb_private::RegisterFlags &flags,
-                                       uint32_t byte_size) = 0;
+  virtual CompilerType
+  GetRegisterType(const std::string &name,
+                  const lldb_private::RegisterTypeFlags &flags,
+                  uint32_t byte_size) = 0;
 
 protected:
   RegisterTypeBuilder() = default;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1565,7 +1565,7 @@ public:
   llvm::Expected<lldb_private::Address> GetEntryPointAddress();
 
   CompilerType GetRegisterType(const std::string &name,
-                               const lldb_private::RegisterFlags &flags,
+                               const lldb_private::RegisterTypeFlags &flags,
                                uint32_t byte_size);
 
   /// Sends a breakpoint notification event.

--- a/lldb/include/lldb/Utility/RegisterTypeFlags.h
+++ b/lldb/include/lldb/Utility/RegisterTypeFlags.h
@@ -1,4 +1,4 @@
-//===-- RegisterFlags.h -----------------------------------------*- C++ -*-===//
+//===------------------------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,15 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_UTILITY_REGISTERFLAGS_H
-#define LLDB_UTILITY_REGISTERFLAGS_H
-
-#include "lldb/Utility/RegisterType.h"
+#ifndef LLDB_UTILITY_REGISTERTYPEFLAGS_H
+#define LLDB_UTILITY_REGISTERTYPEFLAGS_H
 
 #include <stdint.h>
 #include <string>
 #include <vector>
 
+#include "lldb/Utility/RegisterType.h"
 #include "llvm/ADT/StringSet.h"
 
 namespace lldb_private {
@@ -22,7 +21,7 @@ namespace lldb_private {
 class Stream;
 class Log;
 
-class FieldEnum : public RegisterType {
+class RegisterTypeEnum : public RegisterType {
 public:
   struct Enumerator {
     uint64_t m_value;
@@ -43,11 +42,9 @@ public:
   // GDB also includes a "size" that is the size of the underlying register.
   // We will not store that here but instead use the size of the register
   // this gets attached to when emitting XML.
-  FieldEnum(std::string id, const Enumerators &enumerators);
+  RegisterTypeEnum(std::string id, const Enumerators &enumerators);
 
   const Enumerators &GetEnumerators() const { return m_enumerators; }
-
-  void ToXML(Stream &strm, unsigned size) const;
 
   void DumpToLog(Log *log) const;
 
@@ -62,7 +59,7 @@ private:
   Enumerators m_enumerators;
 };
 
-class RegisterFlags : public RegisterType {
+class RegisterTypeFlags : public RegisterType {
 public:
   class Field {
   public:
@@ -72,7 +69,7 @@ public:
 
     /// Construct a field that also has some known enum values.
     Field(std::string name, unsigned start, unsigned end,
-          const FieldEnum *enum_type);
+          const RegisterTypeEnum *enum_type);
 
     /// Construct a field that occupies a single bit.
     Field(std::string name, unsigned bit_position);
@@ -100,7 +97,7 @@ public:
     const std::string &GetName() const { return m_name; }
     unsigned GetStart() const { return m_start; }
     unsigned GetEnd() const { return m_end; }
-    const FieldEnum *GetEnum() const { return m_enum_type; }
+    const RegisterTypeEnum *GetEnum() const { return m_enum_type; }
     bool Overlaps(const Field &other) const;
     void DumpToLog(Log *log) const;
 
@@ -129,15 +126,15 @@ public:
     unsigned m_start;
     unsigned m_end;
 
-    const FieldEnum *m_enum_type;
+    const RegisterTypeEnum *m_enum_type;
   };
 
   /// This assumes that:
   /// * There is at least one field.
   /// * The fields are sorted in descending order.
   /// Gaps are allowed, they will be filled with anonymous padding fields.
-  RegisterFlags(std::string id, unsigned size,
-                const std::vector<Field> &fields);
+  RegisterTypeFlags(std::string id, unsigned size,
+                    const std::vector<Field> &fields);
 
   /// Replace all the fields with the new set of fields. All the assumptions
   /// and checks apply as when you use the constructor. Intended to only be used
@@ -167,6 +164,7 @@ public:
 
   const std::vector<Field> &GetFields() const { return m_fields; }
   unsigned GetSize() const { return m_size; }
+
   void DumpToLog(Log *log) const;
 
   /// Produce a text table showing the layout of all the fields. Unnamed/padding
@@ -191,4 +189,4 @@ private:
 
 } // namespace lldb_private
 
-#endif // LLDB_UTILITY_REGISTERFLAGS_H
+#endif // LLDB_UTILITY_REGISTERTYPEFLAGS_H

--- a/lldb/source/Core/DumpRegisterInfo.cpp
+++ b/lldb/source/Core/DumpRegisterInfo.cpp
@@ -8,7 +8,7 @@
 
 #include "lldb/Core/DumpRegisterInfo.h"
 #include "lldb/Target/RegisterContext.h"
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/Stream.h"
 
 #include "llvm/Support/Casting.h"
@@ -65,7 +65,7 @@ void lldb_private::DumpRegisterInfo(Stream &strm, RegisterContext &ctx,
 
   DoDumpRegisterInfo(strm, info.name, info.alt_name, info.byte_size,
                      invalidates, read_from, in_sets,
-                     llvm::dyn_cast_if_present<lldb_private::RegisterFlags>(
+                     llvm::dyn_cast_if_present<lldb_private::RegisterTypeFlags>(
                          info.register_type),
                      terminal_width);
 }
@@ -92,7 +92,7 @@ void lldb_private::DoDumpRegisterInfo(
     Stream &strm, const char *name, const char *alt_name, uint32_t byte_size,
     const std::vector<const char *> &invalidates,
     const std::vector<const char *> &read_from,
-    const std::vector<SetInfo> &in_sets, const RegisterFlags *flags_type,
+    const std::vector<SetInfo> &in_sets, const RegisterTypeFlags *flags_type,
     uint32_t terminal_width) {
   strm << "       Name: " << name;
   if (alt_name)

--- a/lldb/source/Core/DumpRegisterValue.cpp
+++ b/lldb/source/Core/DumpRegisterValue.cpp
@@ -11,7 +11,7 @@
 #include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Endian.h"
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -22,7 +22,7 @@
 using namespace lldb;
 
 template <typename T>
-static void dump_type_value(const lldb_private::RegisterFlags &flags_type,
+static void dump_type_value(const lldb_private::RegisterTypeFlags &flags_type,
                             lldb_private::CompilerType &fields_compiler_type,
                             T value,
                             lldb_private::ExecutionContextScope *exe_scope,
@@ -123,8 +123,8 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
                     0,                    // item_bit_offset
                     exe_scope);
 
-  const RegisterFlags *flags_type =
-      llvm::dyn_cast_if_present<RegisterFlags>(reg_info.register_type);
+  const RegisterTypeFlags *flags_type =
+      llvm::dyn_cast_if_present<RegisterTypeFlags>(reg_info.register_type);
   if (!print_flags || !flags_type || !exe_scope || !target_sp ||
       (reg_info.byte_size != 4 && reg_info.byte_size != 8))
     return;

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -104,7 +104,7 @@ constexpr Definition g_frame_child_entries[] = {
     Definition("pc", EntryType::FrameRegisterPC),
     Definition("fp", EntryType::FrameRegisterFP),
     Definition("sp", EntryType::FrameRegisterSP),
-    Definition("flags", EntryType::FrameRegisterFlags),
+    Definition("flags", EntryType::FrameRegisterTypeFlags),
     Definition("no-debug", EntryType::FrameNoDebug),
     Entry::DefinitionWithChildren("reg", EntryType::FrameRegisterByName,
                                   g_string_entry),
@@ -380,7 +380,7 @@ const char *FormatEntity::Entry::TypeToCString(Type t) {
     ENUM_TO_CSTR(FrameRegisterPC);
     ENUM_TO_CSTR(FrameRegisterSP);
     ENUM_TO_CSTR(FrameRegisterFP);
-    ENUM_TO_CSTR(FrameRegisterFlags);
+    ENUM_TO_CSTR(FrameRegisterTypeFlags);
     ENUM_TO_CSTR(FrameRegisterByName);
     ENUM_TO_CSTR(FrameIsArtificial);
     ENUM_TO_CSTR(FrameKind);
@@ -1708,7 +1708,7 @@ bool FormatEntity::Formatter::Format(const Entry &entry, Stream &s,
     }
     return false;
 
-  case Entry::Type::FrameRegisterFlags:
+  case Entry::Type::FrameRegisterTypeFlags:
     if (m_exe_ctx) {
       StackFrame *frame = m_exe_ctx->GetFramePtr();
       if (frame) {

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "RegisterFlagsDetector_arm64.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/lldb-private-types.h"
 
 // This file is built on all systems because it is used by native processes and
@@ -40,17 +41,17 @@ Arm64RegisterFlagsDetector::DetectPOREL0Fields(uint64_t hwcap, uint64_t hwcap2,
   if (!(hwcap2 & HWCAP2_POE))
     return {};
 
-  static const FieldEnum por_el0_perm_enum("por_el0_perm_enum",
-                                           {
-                                               {0b0000, "No Access"},
-                                               {0b0001, "Read"},
-                                               {0b0010, "Execute"},
-                                               {0b0011, "Read, Execute"},
-                                               {0b0100, "Write"},
-                                               {0b0101, "Write, Read"},
-                                               {0b0110, "Write, Execute"},
-                                               {0b0111, "Read, Write, Execute"},
-                                           });
+  static const RegisterTypeEnum por_el0_perm_enum(
+      "por_el0_perm_enum", {
+                               {0b0000, "No Access"},
+                               {0b0001, "Read"},
+                               {0b0010, "Execute"},
+                               {0b0011, "Read, Execute"},
+                               {0b0100, "Write"},
+                               {0b0101, "Write, Read"},
+                               {0b0110, "Write, Execute"},
+                               {0b0111, "Read, Write, Execute"},
+                           });
 
   return {
       {"Perm15", 60, 63, &por_el0_perm_enum},
@@ -81,10 +82,11 @@ Arm64RegisterFlagsDetector::DetectFPMRFields(uint64_t hwcap, uint64_t hwcap2,
   if (!(hwcap2 & HWCAP2_FPMR))
     return {};
 
-  static const FieldEnum fp8_format_enum("fp8_format_enum", {
-                                                                {0, "FP8_E5M2"},
-                                                                {1, "FP8_E4M3"},
-                                                            });
+  static const RegisterTypeEnum fp8_format_enum("fp8_format_enum",
+                                                {
+                                                    {0, "FP8_E5M2"},
+                                                    {1, "FP8_E4M3"},
+                                                });
   return {
       {"LSCALE2", 32, 37},
       {"NSCALE", 24, 31},
@@ -144,12 +146,12 @@ Arm64RegisterFlagsDetector::DetectMTECtrlFields(uint64_t hwcap, uint64_t hwcap2,
   // to prctl(PR_TAGGED_ADDR_CTRL...). Fields are derived from the defines
   // used to build the value.
 
-  std::vector<RegisterFlags::Field> fields;
+  std::vector<RegisterTypeFlags::Field> fields;
   fields.reserve(4);
   if (hwcap3 & HWCAP3_MTE_STORE_ONLY)
     fields.push_back({"STORE_ONLY", 19});
 
-  static const FieldEnum tcf_enum(
+  static const RegisterTypeEnum tcf_enum(
       "tcf_enum",
       {{0, "TCF_NONE"}, {1, "TCF_SYNC"}, {2, "TCF_ASYNC"}, {3, "TCF_ASYMM"}});
 
@@ -167,11 +169,14 @@ Arm64RegisterFlagsDetector::DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2,
                                              uint64_t hwcap3) {
   (void)hwcap3;
 
-  static const FieldEnum rmode_enum(
+  static const RegisterTypeEnum rmode_enum(
       "rmode_enum", {{0, "RN"}, {1, "RP"}, {2, "RM"}, {3, "RZ"}});
 
-  std::vector<RegisterFlags::Field> fpcr_fields{
-      {"AHP", 26}, {"DN", 25}, {"FZ", 24}, {"RMode", 22, 23, &rmode_enum},
+  std::vector<RegisterTypeFlags::Field> fpcr_fields{
+      {"AHP", 26},
+      {"DN", 25},
+      {"FZ", 24},
+      {"RMode", 22, 23, &rmode_enum},
       // Bits 21-20 are "Stride" which is unused in AArch64 state.
   };
 
@@ -236,8 +241,11 @@ Arm64RegisterFlagsDetector::DetectCPSRFields(uint64_t hwcap, uint64_t hwcap2,
   // or at least not from userspace.
 
   // Status bits that are always present.
-  std::vector<RegisterFlags::Field> cpsr_fields{
-      {"N", 31}, {"Z", 30}, {"C", 29}, {"V", 28},
+  std::vector<RegisterTypeFlags::Field> cpsr_fields{
+      {"N", 31},
+      {"Z", 30},
+      {"C", 29},
+      {"V", 28},
       // Bits 27-26 reserved.
   };
 
@@ -290,7 +298,7 @@ void Arm64RegisterFlagsDetector::UpdateRegisterInfo(
   // Register names will not be duplicated, so we do not want to compare against
   // one if it has already been found. Each time we find one, we erase it from
   // this list.
-  std::vector<std::pair<llvm::StringRef, const RegisterFlags *>>
+  std::vector<std::pair<llvm::StringRef, const RegisterTypeFlags *>>
       search_registers;
   for (const auto &reg : m_registers) {
     // It is possible that a register is all extension dependent fields, and

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.h
@@ -9,8 +9,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERFLAGSDETECTOR_ARM64_H
 #define LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERFLAGSDETECTOR_ARM64_H
 
-#include "lldb/Utility/RegisterFlags.h"
-#include "lldb/Utility/RegisterInfo.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "llvm/ADT/StringRef.h"
 #include <functional>
 
@@ -53,7 +52,7 @@ public:
   bool HasDetected() const { return m_has_detected; }
 
 private:
-  using Fields = std::vector<RegisterFlags::Field>;
+  using Fields = std::vector<RegisterTypeFlags::Field>;
   using DetectorFn = std::function<Fields(uint64_t, uint64_t, uint64_t)>;
 
   static Fields DetectCPSRFields(uint64_t hwcap, uint64_t hwcap2,
@@ -79,7 +78,7 @@ private:
           m_detector(detector) {}
 
     llvm::StringRef m_name;
-    RegisterFlags m_flags;
+    RegisterTypeFlags m_flags;
     DetectorFn m_detector;
   } m_registers[9] = {
       RegisterEntry("cpsr", 4, DetectCPSRFields),

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_riscv32.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_riscv32.cpp
@@ -336,6 +336,6 @@ RegisterContextCorePOSIX_riscv32::BuildDynamicRegister(
       CopyRegisterListToVector(reg_info.value_regs),
       CopyRegisterListToVector(reg_info.invalidate_regs),
       /*value_reg_offset=*/0,
-      llvm::dyn_cast_if_present<lldb_private::RegisterFlags>(
+      llvm::dyn_cast_if_present<lldb_private::RegisterTypeFlags>(
           reg_info.register_type)};
 }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -75,7 +75,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
@@ -4938,7 +4938,8 @@ struct GdbServerTargetInfo {
   RegisterSetMap reg_set_map;
 };
 
-static FieldEnum::Enumerators ParseEnumEvalues(const XMLNode &enum_node) {
+static RegisterTypeEnum::Enumerators
+ParseEnumEvalues(const XMLNode &enum_node) {
   Log *log(GetLog(GDBRLog::Process));
   // We will use the last instance of each value. Also we preserve the order
   // of declaration in the XML, as it may not be numerical.
@@ -4952,7 +4953,7 @@ static FieldEnum::Enumerators ParseEnumEvalues(const XMLNode &enum_node) {
   // 2 = pre-startup, 1 = startup, 0 = startup
   // This only matters for "register info" but let's trust what the server
   // chose regardless.
-  std::map<uint64_t, FieldEnum::Enumerator> enumerators;
+  std::map<uint64_t, RegisterTypeEnum::Enumerator> enumerators;
 
   enum_node.ForEachChildElementWithName(
       "evalue", [&enumerators, &log](const XMLNode &enumerator_node) {
@@ -4991,22 +4992,22 @@ static FieldEnum::Enumerators ParseEnumEvalues(const XMLNode &enum_node) {
 
         if (value && name)
           enumerators.insert_or_assign(
-              *value, FieldEnum::Enumerator(*value, name->str()));
+              *value, RegisterTypeEnum::Enumerator(*value, name->str()));
 
         // Find all evalue elements.
         return true;
       });
 
-  FieldEnum::Enumerators final_enumerators;
+  RegisterTypeEnum::Enumerators final_enumerators;
   for (auto [_, enumerator] : enumerators)
     final_enumerators.push_back(enumerator);
 
   return final_enumerators;
 }
 
-static void
-ParseEnums(XMLNode feature_node,
-           llvm::StringMap<std::unique_ptr<FieldEnum>> &registers_enum_types) {
+static void ParseEnums(
+    XMLNode feature_node,
+    llvm::StringMap<std::unique_ptr<RegisterTypeEnum>> &registers_enum_types) {
   Log *log(GetLog(GDBRLog::Process));
 
   // The top level element is "<enum...".
@@ -5033,13 +5034,14 @@ ParseEnums(XMLNode feature_node,
         });
 
         if (!id.empty()) {
-          FieldEnum::Enumerators enumerators = ParseEnumEvalues(enum_node);
+          RegisterTypeEnum::Enumerators enumerators =
+              ParseEnumEvalues(enum_node);
           if (!enumerators.empty()) {
             LLDB_LOG(log,
                      "ProcessGDBRemote::ParseEnums Found enum type \"{0}\"",
                      id);
             registers_enum_types.insert_or_assign(
-                id, std::make_unique<FieldEnum>(id, enumerators));
+                id, std::make_unique<RegisterTypeEnum>(id, enumerators));
           }
         }
 
@@ -5048,14 +5050,15 @@ ParseEnums(XMLNode feature_node,
       });
 }
 
-static std::vector<RegisterFlags::Field> ParseFlagsFields(
-    XMLNode flags_node, unsigned size,
-    const llvm::StringMap<std::unique_ptr<FieldEnum>> &registers_enum_types) {
+static std::vector<RegisterTypeFlags::Field>
+ParseFlagsFields(XMLNode flags_node, unsigned size,
+                 const llvm::StringMap<std::unique_ptr<RegisterTypeEnum>>
+                     &registers_enum_types) {
   Log *log(GetLog(GDBRLog::Process));
   const unsigned max_start_bit = size * 8 - 1;
 
   // Process the fields of this set of flags.
-  std::vector<RegisterFlags::Field> fields;
+  std::vector<RegisterTypeFlags::Field> fields;
   flags_node.ForEachChildElementWithName("field", [&fields, max_start_bit, &log,
                                                    &registers_enum_types](
                                                       const XMLNode
@@ -5132,14 +5135,14 @@ static std::vector<RegisterFlags::Field> ParseFlagsFields(
             "\"{2}\", ignoring",
             *start, *end, name->data());
       else {
-        if (RegisterFlags::Field::GetSizeInBits(*start, *end) > 64)
+        if (RegisterTypeFlags::Field::GetSizeInBits(*start, *end) > 64)
           LLDB_LOG(log,
                    "ProcessGDBRemote::ParseFlagsFields Ignoring field \"{}\" "
                    "that has size > 64 bits, this is not supported",
                    name->data());
         else {
           // A field's type may be set to the name of an enum type.
-          const FieldEnum *enum_type = nullptr;
+          const RegisterTypeEnum *enum_type = nullptr;
           if (type && !type->empty()) {
             auto found = registers_enum_types.find(*type);
             if (found != registers_enum_types.end()) {
@@ -5147,7 +5150,7 @@ static std::vector<RegisterFlags::Field> ParseFlagsFields(
 
               // No enumerator can exceed the range of the field itself.
               uint64_t max_value =
-                  RegisterFlags::Field::GetMaxValue(*start, *end);
+                  RegisterTypeFlags::Field::GetMaxValue(*start, *end);
               for (const auto &enumerator : enum_type->GetEnumerators()) {
                 if (enumerator.m_value > max_value) {
                   enum_type = nullptr;
@@ -5171,7 +5174,7 @@ static std::vector<RegisterFlags::Field> ParseFlagsFields(
           }
 
           fields.push_back(
-              RegisterFlags::Field(name->str(), *start, *end, enum_type));
+              RegisterTypeFlags::Field(name->str(), *start, *end, enum_type));
         }
       }
     }
@@ -5183,8 +5186,9 @@ static std::vector<RegisterFlags::Field> ParseFlagsFields(
 
 void ParseFlags(
     XMLNode feature_node,
-    llvm::StringMap<std::unique_ptr<RegisterFlags>> &registers_flags_types,
-    const llvm::StringMap<std::unique_ptr<FieldEnum>> &registers_enum_types) {
+    llvm::StringMap<std::unique_ptr<RegisterTypeFlags>> &registers_flags_types,
+    const llvm::StringMap<std::unique_ptr<RegisterTypeEnum>>
+        &registers_enum_types) {
   Log *log(GetLog(GDBRLog::Process));
 
   feature_node.ForEachChildElementWithName(
@@ -5222,15 +5226,15 @@ void ParseFlags(
 
         if (id && size) {
           // Process the fields of this set of flags.
-          std::vector<RegisterFlags::Field> fields =
+          std::vector<RegisterTypeFlags::Field> fields =
               ParseFlagsFields(flags_node, *size, registers_enum_types);
           if (fields.size()) {
             // Sort so that the fields with the MSBs are first.
             std::sort(fields.rbegin(), fields.rend());
-            std::vector<RegisterFlags::Field>::const_iterator overlap =
+            std::vector<RegisterTypeFlags::Field>::const_iterator overlap =
                 std::adjacent_find(fields.begin(), fields.end(),
-                                   [](const RegisterFlags::Field &lhs,
-                                      const RegisterFlags::Field &rhs) {
+                                   [](const RegisterTypeFlags::Field &lhs,
+                                      const RegisterTypeFlags::Field &rhs) {
                                      return lhs.Overlaps(rhs);
                                    });
 
@@ -5256,12 +5260,12 @@ void ParseFlags(
                     id->data());
               } else {
                 registers_flags_types.insert_or_assign(
-                    *id, std::make_unique<RegisterFlags>(id->str(), *size,
-                                                         std::move(fields)));
+                    *id, std::make_unique<RegisterTypeFlags>(
+                             id->str(), *size, std::move(fields)));
               }
             } else {
               // If any fields overlap, ignore the whole set of flags.
-              std::vector<RegisterFlags::Field>::const_iterator next =
+              std::vector<RegisterTypeFlags::Field>::const_iterator next =
                   std::next(overlap);
               LLDB_LOG(
                   log,
@@ -5288,8 +5292,8 @@ void ParseFlags(
 bool ParseRegisters(
     XMLNode feature_node, GdbServerTargetInfo &target_info,
     std::vector<DynamicRegisterInfo::Register> &registers,
-    llvm::StringMap<std::unique_ptr<RegisterFlags>> &registers_flags_types,
-    llvm::StringMap<std::unique_ptr<FieldEnum>> &registers_enum_types) {
+    llvm::StringMap<std::unique_ptr<RegisterTypeFlags>> &registers_flags_types,
+    llvm::StringMap<std::unique_ptr<RegisterTypeEnum>> &registers_enum_types) {
   if (!feature_node)
     return false;
 
@@ -5385,7 +5389,7 @@ bool ParseRegisters(
 
         if (!gdb_type.empty()) {
           // gdb_type could reference some flags type defined in XML.
-          llvm::StringMap<std::unique_ptr<RegisterFlags>>::iterator it =
+          llvm::StringMap<std::unique_ptr<RegisterTypeFlags>>::iterator it =
               registers_flags_types.find(gdb_type);
           if (it != registers_flags_types.end()) {
             auto flags_type = it->second.get();

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -560,18 +560,18 @@ private:
                                lldb::ThreadSP thread_sp);
 
   // Lists of register fields generated from the remote's target XML.
-  // Pointers to these RegisterFlags will be set in the register info passed
+  // Pointers to these RegisterTypeFlags will be set in the register info passed
   // back to the upper levels of lldb. Doing so is safe because this class will
   // live at least as long as the debug session. We therefore do not store the
   // data directly in the map because the map may reallocate it's storage as new
   // entries are added. Which would invalidate any pointers set in the register
   // info up to that point.
-  llvm::StringMap<std::unique_ptr<RegisterFlags>> m_registers_flags_types;
+  llvm::StringMap<std::unique_ptr<RegisterTypeFlags>> m_registers_flags_types;
 
   // Enum types are referenced by register fields. This does not store the data
   // directly because the map may reallocate. Pointers to these are contained
-  // within instances of RegisterFlags.
-  llvm::StringMap<std::unique_ptr<FieldEnum>> m_registers_enum_types;
+  // within instances of RegisterTypeFlags.
+  llvm::StringMap<std::unique_ptr<RegisterTypeEnum>> m_registers_enum_types;
 };
 
 } // namespace process_gdb_remote

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -61,7 +61,7 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
         llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
     type_system->StartTagDeclarationDefinition(fields_type);
 
-    // We assume that RegisterFlags has padded and sorted the fields
+    // We assume that RegisterTypeFlags has padded and sorted the fields
     // already.
     for (const RegisterTypeFlags::Field &field : flags.GetFields()) {
       CompilerType field_type = field_uint_type;
@@ -113,7 +113,7 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
     // So that the size of the type matches the size of the register.
     type_system->SetIsPacked(fields_type);
 
-    // This should be true if RegisterFlags padded correctly.
+    // This should be true if RegisterTypeFlags padded correctly.
     assert(llvm::expectedToOptional(fields_type.GetByteSize(nullptr))
                .value_or(0) == flags.GetSize());
   }

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -11,7 +11,7 @@
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "RegisterTypeBuilderClang.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/lldb-enumerations.h"
 
 using namespace lldb_private;
@@ -36,7 +36,7 @@ RegisterTypeBuilderClang::RegisterTypeBuilderClang(Target &target)
     : m_target(target) {}
 
 CompilerType RegisterTypeBuilderClang::GetRegisterType(
-    const std::string &name, const lldb_private::RegisterFlags &flags,
+    const std::string &name, const lldb_private::RegisterTypeFlags &flags,
     uint32_t byte_size) {
   lldb::TypeSystemClangSP type_system =
       ScratchTypeSystemClang::GetForTarget(m_target);
@@ -63,11 +63,12 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
 
     // We assume that RegisterFlags has padded and sorted the fields
     // already.
-    for (const RegisterFlags::Field &field : flags.GetFields()) {
+    for (const RegisterTypeFlags::Field &field : flags.GetFields()) {
       CompilerType field_type = field_uint_type;
 
-      if (const FieldEnum *enum_type = field.GetEnum()) {
-        const FieldEnum::Enumerators &enumerators = enum_type->GetEnumerators();
+      if (const RegisterTypeEnum *enum_type = field.GetEnum()) {
+        const RegisterTypeEnum::Enumerators &enumerators =
+            enum_type->GetEnumerators();
         if (!enumerators.empty()) {
           // Enums can be used by many registers and the size of each register
           // may be different. The register size is used as the underlying size

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.h
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.h
@@ -29,7 +29,7 @@ public:
   static lldb::RegisterTypeBuilderSP CreateInstance(Target &target);
 
   CompilerType GetRegisterType(const std::string &name,
-                               const lldb_private::RegisterFlags &flags,
+                               const lldb_private::RegisterTypeFlags &flags,
                                uint32_t byte_size) override;
 
 private:

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2729,9 +2729,10 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                                                             create_on_demand);
 }
 
-CompilerType Target::GetRegisterType(const std::string &name,
-                                     const lldb_private::RegisterFlags &flags,
-                                     uint32_t byte_size) {
+CompilerType
+Target::GetRegisterType(const std::string &name,
+                        const lldb_private::RegisterTypeFlags &flags,
+                        uint32_t byte_size) {
   if (!m_register_type_builder_sp)
     m_register_type_builder_sp = PluginManager::GetRegisterTypeBuilder(*this);
   assert(m_register_type_builder_sp);

--- a/lldb/source/Utility/CMakeLists.txt
+++ b/lldb/source/Utility/CMakeLists.txt
@@ -53,8 +53,8 @@ add_lldb_library(lldbUtility NO_INTERNAL_DEPENDENCIES
   Policy.cpp
   ProcessInfo.cpp
   RealpathPrefixes.cpp
-  RegisterFlags.cpp
   RegisterType.cpp
+  RegisterTypeFlags.cpp
   RegisterValue.cpp
   RegularExpression.cpp
   Instrumentation.cpp

--- a/lldb/source/Utility/RegisterTypeFlags.cpp
+++ b/lldb/source/Utility/RegisterTypeFlags.cpp
@@ -1,4 +1,4 @@
-//===-- RegisterFlags.cpp -------------------------------------------------===//
+//===-- RegisterTypeFlags.cpp ---------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 
@@ -21,18 +21,18 @@
 
 using namespace lldb_private;
 
-RegisterFlags::Field::Field(std::string name, unsigned start, unsigned end)
+RegisterTypeFlags::Field::Field(std::string name, unsigned start, unsigned end)
     : m_name(std::move(name)), m_start(start), m_end(end),
       m_enum_type(nullptr) {
   assert(m_start <= m_end && "Start bit must be <= end bit.");
 }
 
-RegisterFlags::Field::Field(std::string name, unsigned bit_position)
+RegisterTypeFlags::Field::Field(std::string name, unsigned bit_position)
     : m_name(std::move(name)), m_start(bit_position), m_end(bit_position),
       m_enum_type(nullptr) {}
 
-RegisterFlags::Field::Field(std::string name, unsigned start, unsigned end,
-                            const FieldEnum *enum_type)
+RegisterTypeFlags::Field::Field(std::string name, unsigned start, unsigned end,
+                                const RegisterTypeEnum *enum_type)
     : m_name(std::move(name)), m_start(start), m_end(end),
       m_enum_type(enum_type) {
   if (m_enum_type) {
@@ -50,18 +50,18 @@ RegisterFlags::Field::Field(std::string name, unsigned start, unsigned end,
   }
 }
 
-void RegisterFlags::Field::DumpToLog(Log *log) const {
+void RegisterTypeFlags::Field::DumpToLog(Log *log) const {
   LLDB_LOG(log, "  Name: \"{0}\" Start: {1} End: {2}", m_name.c_str(), m_start,
            m_end);
 }
 
-bool RegisterFlags::Field::Overlaps(const Field &other) const {
+bool RegisterTypeFlags::Field::Overlaps(const Field &other) const {
   unsigned overlap_start = std::max(GetStart(), other.GetStart());
   unsigned overlap_end = std::min(GetEnd(), other.GetEnd());
   return overlap_start <= overlap_end;
 }
 
-unsigned RegisterFlags::Field::PaddingDistance(const Field &other) const {
+unsigned RegisterTypeFlags::Field::PaddingDistance(const Field &other) const {
   assert(!Overlaps(other) &&
          "Cannot get padding distance for overlapping fields.");
   assert((other < (*this)) && "Expected fields in MSB to LSB order.");
@@ -81,15 +81,15 @@ unsigned RegisterFlags::Field::PaddingDistance(const Field &other) const {
   return lhs_start - rhs_end - 1;
 }
 
-unsigned RegisterFlags::Field::GetSizeInBits(unsigned start, unsigned end) {
+unsigned RegisterTypeFlags::Field::GetSizeInBits(unsigned start, unsigned end) {
   return end - start + 1;
 }
 
-unsigned RegisterFlags::Field::GetSizeInBits() const {
+unsigned RegisterTypeFlags::Field::GetSizeInBits() const {
   return GetSizeInBits(m_start, m_end);
 }
 
-uint64_t RegisterFlags::Field::GetMaxValue(unsigned start, unsigned end) {
+uint64_t RegisterTypeFlags::Field::GetMaxValue(unsigned start, unsigned end) {
   uint64_t max = std::numeric_limits<uint64_t>::max();
   unsigned bits = GetSizeInBits(start, end);
   // If the field is >= 64 bits the shift below would be undefined.
@@ -102,15 +102,15 @@ uint64_t RegisterFlags::Field::GetMaxValue(unsigned start, unsigned end) {
   return max;
 }
 
-uint64_t RegisterFlags::Field::GetMaxValue() const {
+uint64_t RegisterTypeFlags::Field::GetMaxValue() const {
   return GetMaxValue(m_start, m_end);
 }
 
-uint64_t RegisterFlags::Field::GetMask() const {
+uint64_t RegisterTypeFlags::Field::GetMask() const {
   return GetMaxValue() << m_start;
 }
 
-void RegisterFlags::SetFields(const std::vector<Field> &fields) {
+void RegisterTypeFlags::SetFields(const std::vector<Field> &fields) {
   // We expect that these are unsorted but do not overlap.
   // They could fill the register but may have gaps.
   std::vector<Field> provided_fields = fields;
@@ -155,13 +155,13 @@ void RegisterFlags::SetFields(const std::vector<Field> &fields) {
   SetDependencies(std::move(dependencies));
 }
 
-RegisterFlags::RegisterFlags(std::string id, unsigned size,
-                             const std::vector<Field> &fields)
+RegisterTypeFlags::RegisterTypeFlags(std::string id, unsigned size,
+                                     const std::vector<Field> &fields)
     : RegisterType(RegisterType::eRegisterTypeKindFlags, id), m_size(size) {
   SetFields(fields);
 }
 
-void RegisterFlags::DumpToLog(Log *log) const {
+void RegisterTypeFlags::DumpToLog(Log *log) const {
   LLDB_LOG(log, "ID: \"{0}\" Size: {1}", GetID().c_str(), m_size);
   for (const Field &field : m_fields)
     field.DumpToLog(log);
@@ -194,13 +194,13 @@ static void EmitTable(std::string &out, std::array<std::string, 3> &table) {
                          });
 }
 
-std::string RegisterFlags::AsTable(uint32_t max_width) const {
+std::string RegisterTypeFlags::AsTable(uint32_t max_width) const {
   std::string table;
   // position / gridline / name
   std::array<std::string, 3> lines;
   uint32_t current_width = 0;
 
-  for (const RegisterFlags::Field &field : m_fields) {
+  for (const RegisterTypeFlags::Field &field : m_fields) {
     StreamString position;
     if (field.GetEnd() == field.GetStart())
       position.Printf(" %d ", field.GetEnd());
@@ -254,7 +254,7 @@ std::string RegisterFlags::AsTable(uint32_t max_width) const {
 // Subject to the limits of the terminal width.
 static void DumpEnumerators(StreamString &strm, size_t indent,
                             size_t current_width, uint32_t max_width,
-                            const FieldEnum::Enumerators &enumerators) {
+                            const RegisterTypeEnum::Enumerators &enumerators) {
   for (auto it = enumerators.cbegin(); it != enumerators.cend(); ++it) {
     StreamString enumerator_strm;
     // The first enumerator of a line doesn't need to be separated.
@@ -294,12 +294,12 @@ static void DumpEnumerators(StreamString &strm, size_t indent,
   }
 }
 
-std::string RegisterFlags::DumpEnums(uint32_t max_width) const {
+std::string RegisterTypeFlags::DumpEnums(uint32_t max_width) const {
   // Accumulate all fields that use the same enum, so that each enum is only
   // printed once.
-  llvm::MapVector<const FieldEnum *, std::vector<std::string>> enum_uses;
+  llvm::MapVector<const RegisterTypeEnum *, std::vector<std::string>> enum_uses;
   for (const auto &field : m_fields)
-    if (const FieldEnum *enum_type = field.GetEnum())
+    if (const RegisterTypeEnum *enum_type = field.GetEnum())
       enum_uses[enum_type].push_back(field.GetName());
 
   StreamString strm;
@@ -325,7 +325,8 @@ std::string RegisterFlags::DumpEnums(uint32_t max_width) const {
   return strm.GetString().str();
 }
 
-void FieldEnum::ToXMLElement(Stream &strm, const RegisterType *user) const {
+void RegisterTypeEnum::ToXMLElement(Stream &strm,
+                                    const RegisterType *user) const {
   // Example XML:
   // <enum id="foo" size="4">
   //  <evalue name="bar" value="1"/>
@@ -338,8 +339,8 @@ void FieldEnum::ToXMLElement(Stream &strm, const RegisterType *user) const {
 
   // We don't expect the user of an enum type to be anything but a register,
   // but we cannot crash if that isn't true.
-  if (const RegisterFlags *flags_type =
-          llvm::dyn_cast_if_present<RegisterFlags>(user)) {
+  if (const RegisterTypeFlags *flags_type =
+          llvm::dyn_cast_if_present<RegisterTypeFlags>(user)) {
     // This is the size of the underlying enum type if this were a C type.
     // In other words, the size of the register in bytes.
     strm.Printf(" size=\"%d\"", flags_type->GetSize());
@@ -362,7 +363,7 @@ void FieldEnum::ToXMLElement(Stream &strm, const RegisterType *user) const {
   strm.Indent("</enum>\n");
 }
 
-void FieldEnum::Enumerator::ToXMLElement(Stream &strm) const {
+void RegisterTypeEnum::Enumerator::ToXMLElement(Stream &strm) const {
   std::string escaped_name;
   llvm::raw_string_ostream escape_strm(escaped_name);
   llvm::printHTMLEscaped(m_name, escape_strm);
@@ -370,17 +371,18 @@ void FieldEnum::Enumerator::ToXMLElement(Stream &strm) const {
               escaped_name.c_str(), m_value);
 }
 
-void FieldEnum::Enumerator::DumpToLog(Log *log) const {
+void RegisterTypeEnum::Enumerator::DumpToLog(Log *log) const {
   LLDB_LOG(log, "  Name: \"{0}\" Value: {1}", m_name.c_str(), m_value);
 }
 
-void FieldEnum::DumpToLog(Log *log) const {
+void RegisterTypeEnum::DumpToLog(Log *log) const {
   LLDB_LOG(log, "ID: \"{0}\"", GetID().c_str());
   for (const auto &enumerator : GetEnumerators())
     enumerator.DumpToLog(log);
 }
 
-void RegisterFlags::ToXMLElement(Stream &strm, const RegisterType *user) const {
+void RegisterTypeFlags::ToXMLElement(Stream &strm,
+                                     const RegisterType *user) const {
   (void)user;
   // Example XML:
   // <flags id="cpsr_flags" size="4">
@@ -404,7 +406,7 @@ void RegisterFlags::ToXMLElement(Stream &strm, const RegisterType *user) const {
   strm.Indent("</flags>\n");
 }
 
-void RegisterFlags::Field::ToXMLElement(Stream &strm) const {
+void RegisterTypeFlags::Field::ToXMLElement(Stream &strm) const {
   // Example XML with an enum:
   // <field name="correct" start="0" end="0" type="some_enum">
   // Without:
@@ -419,13 +421,14 @@ void RegisterFlags::Field::ToXMLElement(Stream &strm) const {
 
   strm.Printf("start=\"%d\" end=\"%d\"", GetStart(), GetEnd());
 
-  if (const FieldEnum *enum_type = GetEnum())
+  if (const RegisterTypeEnum *enum_type = GetEnum())
     strm << " type=\"" << enum_type->GetID() << "\"";
 
   strm << "/>";
 }
 
-FieldEnum::FieldEnum(std::string id, const Enumerators &enumerators)
+RegisterTypeEnum::RegisterTypeEnum(std::string id,
+                                   const Enumerators &enumerators)
     : RegisterType(RegisterType::eRegisterTypeKindEnum, id),
       m_enumerators(enumerators) {
   for (const auto &enumerator : m_enumerators) {

--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -608,7 +608,7 @@ class RegisterCommandsTestCase(TestBase):
         # The behaviour of this command is generic but the specific registers
         # are not, so this is written for AArch64 only.
         # Text alignment and ordering are checked in the DumpRegisterInfo and
-        # RegisterFlags unit tests.
+        # RegisterTypeFlags unit tests.
         self.build()
         self.common_setup()
 

--- a/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterFlags.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterFlags.py
@@ -41,7 +41,7 @@ class MultiDocResponder(MockGDBServerResponder):
         )
 
 
-class TestXMLRegisterFlags(GDBRemoteTestBase):
+class TestXMLRegisterTypeFlags(GDBRemoteTestBase):
     def setup_multidoc_test(self, docs):
         self.server.responder = MultiDocResponder(docs)
         target = self.dbg.CreateTarget("")
@@ -609,7 +609,7 @@ class TestXMLRegisterFlags(GDBRemoteTestBase):
     @skipIfXmlSupportMissing
     @skipIfRemote
     def test_flags_in_register_info(self):
-        # See RegisterFlags for comprehensive formatting tests.
+        # See RegisterTypeFlags for comprehensive formatting tests.
         self.setup_flags_test(
             '<field name="D" start="0" end="7"/>'
             '<field name="C" start="8" end="15"/>'

--- a/lldb/unittests/Core/DumpRegisterInfoTest.cpp
+++ b/lldb/unittests/Core/DumpRegisterInfoTest.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Core/DumpRegisterInfo.h"
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/StreamString.h"
 #include "gtest/gtest.h"
 
@@ -86,13 +86,14 @@ TEST(DoDumpRegisterInfoTest, MaxInfo) {
 }
 
 TEST(DoDumpRegisterInfoTest, FieldsTable) {
-  // This is thoroughly tested in RegisterFlags itself, only checking the
+  // This is thoroughly tested in RegisterTypeFlags itself, only checking the
   // integration here.
   StreamString strm;
-  RegisterFlags flags(
-      "", 4,
-      {RegisterFlags::Field("A", 24, 31), RegisterFlags::Field("B", 16, 23),
-       RegisterFlags::Field("C", 8, 15), RegisterFlags::Field("D", 0, 7)});
+  RegisterTypeFlags flags("", 4,
+                          {RegisterTypeFlags::Field("A", 24, 31),
+                           RegisterTypeFlags::Field("B", 16, 23),
+                           RegisterTypeFlags::Field("C", 8, 15),
+                           RegisterTypeFlags::Field("D", 0, 7)});
 
   DoDumpRegisterInfo(strm, "foo", nullptr, 4, {}, {}, {}, &flags, 100);
   ASSERT_EQ(strm.GetString(), "       Name: foo\n"
@@ -106,14 +107,14 @@ TEST(DoDumpRegisterInfoTest, FieldsTable) {
 TEST(DoDumpRegisterInfoTest, Enumerators) {
   StreamString strm;
 
-  FieldEnum enum_one("enum_one", {{0, "an_enumerator"}});
-  FieldEnum enum_two("enum_two",
-                     {{1, "another_enumerator"}, {2, "another_enumerator_2"}});
+  RegisterTypeEnum enum_one("enum_one", {{0, "an_enumerator"}});
+  RegisterTypeEnum enum_two(
+      "enum_two", {{1, "another_enumerator"}, {2, "another_enumerator_2"}});
 
-  RegisterFlags flags("", 4,
-                      {RegisterFlags::Field("A", 24, 31, &enum_one),
-                       RegisterFlags::Field("B", 16, 23),
-                       RegisterFlags::Field("C", 8, 15, &enum_two)});
+  RegisterTypeFlags flags("", 4,
+                          {RegisterTypeFlags::Field("A", 24, 31, &enum_one),
+                           RegisterTypeFlags::Field("B", 16, 23),
+                           RegisterTypeFlags::Field("C", 8, 15, &enum_two)});
 
   DoDumpRegisterInfo(strm, "abc", nullptr, 4, {}, {}, {}, &flags, 100);
   ASSERT_EQ(strm.GetString(),

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -9,7 +9,6 @@ add_lldb_unittest(TargetTests
   MemoryTagMapTest.cpp
   ModuleCacheTest.cpp
   PathMappingListTest.cpp
-  RegisterFlagsTest.cpp
   RemoteAwarePlatformTest.cpp
   ScratchTypeSystemTest.cpp
   StackFrameRecognizerTest.cpp

--- a/lldb/unittests/Utility/CMakeLists.txt
+++ b/lldb/unittests/Utility/CMakeLists.txt
@@ -28,6 +28,7 @@ add_lldb_unittest(UtilityTests
   RangeMapTest.cpp
   RangeTest.cpp
   RealpathPrefixesTest.cpp
+  RegisterTypeTest.cpp
   RegisterValueTest.cpp
   RegularExpressionTest.cpp
   ScalarTest.cpp

--- a/lldb/unittests/Utility/RegisterTypeTest.cpp
+++ b/lldb/unittests/Utility/RegisterTypeTest.cpp
@@ -1,4 +1,4 @@
-//===-- RegisterTypeTest.cpp ---------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/unittests/Utility/RegisterTypeTest.cpp
+++ b/lldb/unittests/Utility/RegisterTypeTest.cpp
@@ -1,4 +1,4 @@
-//===-- RegisterFlagsTest.cpp ---------------------------------------------===//
+//===-- RegisterTypeTest.cpp ---------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/StreamString.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -16,10 +16,10 @@
 using namespace lldb_private;
 using namespace lldb;
 
-TEST(RegisterFlagsTest, Field) {
+TEST(RegisterTypeTest, Field) {
   // We assume that start <= end is always true, so that is not tested here.
 
-  RegisterFlags::Field f1("abc", 0);
+  RegisterTypeFlags::Field f1("abc", 0);
   ASSERT_EQ(f1.GetName(), "abc");
   // start == end means a 1 bit field.
   ASSERT_EQ(f1.GetSizeInBits(), (unsigned)1);
@@ -29,7 +29,7 @@ TEST(RegisterFlagsTest, Field) {
 
   // End is inclusive meaning that start 0 to end 1 includes bit 1
   // to make a 2 bit field.
-  RegisterFlags::Field f2("", 0, 1);
+  RegisterTypeFlags::Field f2("", 0, 1);
   ASSERT_EQ(f2.GetSizeInBits(), (unsigned)2);
   ASSERT_EQ(f2.GetMask(), (uint64_t)3);
   ASSERT_EQ(f2.GetValue(UINT64_MAX), (uint64_t)3);
@@ -37,7 +37,7 @@ TEST(RegisterFlagsTest, Field) {
 
   // If the field doesn't start at 0 we need to shift up/down
   // to account for it.
-  RegisterFlags::Field f3("", 2, 5);
+  RegisterTypeFlags::Field f3("", 2, 5);
   ASSERT_EQ(f3.GetSizeInBits(), (unsigned)4);
   ASSERT_EQ(f3.GetMask(), (uint64_t)0x3c);
   ASSERT_EQ(f3.GetValue(UINT64_MAX), (uint64_t)0xf);
@@ -50,15 +50,15 @@ TEST(RegisterFlagsTest, Field) {
   ASSERT_FALSE(f1 < f1);
 }
 
-static RegisterFlags::Field make_field(unsigned start, unsigned end) {
-  return RegisterFlags::Field("", start, end);
+static RegisterTypeFlags::Field make_field(unsigned start, unsigned end) {
+  return RegisterTypeFlags::Field("", start, end);
 }
 
-static RegisterFlags::Field make_field(unsigned bit) {
-  return RegisterFlags::Field("", bit);
+static RegisterTypeFlags::Field make_field(unsigned bit) {
+  return RegisterTypeFlags::Field("", bit);
 }
 
-TEST(RegisterFlagsTest, FieldOverlaps) {
+TEST(RegisterTypeTest, FieldOverlaps) {
   // Single bit fields
   ASSERT_FALSE(make_field(0, 0).Overlaps(make_field(1)));
   ASSERT_TRUE(make_field(1, 1).Overlaps(make_field(1)));
@@ -73,7 +73,7 @@ TEST(RegisterFlagsTest, FieldOverlaps) {
   ASSERT_FALSE(make_field(15, 30).Overlaps(make_field(7, 12)));
 }
 
-TEST(RegisterFlagsTest, PaddingDistance) {
+TEST(RegisterTypeTest, PaddingDistance) {
   // We assume that this method is always called with a more significant
   // (start bit is higher) field first and that they do not overlap.
 
@@ -87,21 +87,22 @@ TEST(RegisterFlagsTest, PaddingDistance) {
   ASSERT_EQ(make_field(31, 31).PaddingDistance(make_field(0)), 30ULL);
 }
 
-static void test_padding(const std::vector<RegisterFlags::Field> &fields,
-                         const std::vector<RegisterFlags::Field> &expected) {
-  RegisterFlags rf("", 4, fields);
+static void
+test_padding(const std::vector<RegisterTypeFlags::Field> &fields,
+             const std::vector<RegisterTypeFlags::Field> &expected) {
+  RegisterTypeFlags rf("", 4, fields);
   EXPECT_THAT(expected, ::testing::ContainerEq(rf.GetFields()));
 }
 
-TEST(RegisterFlagsTest, RegisterFlagsPadding) {
+TEST(RegisterTypeFlagsTest, RegisterTypeFlagsPadding) {
   // When creating a set of flags we assume that:
   // * There are >= 1 fields.
   // * They are sorted in descending order.
   // * There may be gaps between each field.
 
   // Needs no padding
-  auto fields =
-      std::vector<RegisterFlags::Field>{make_field(16, 31), make_field(0, 15)};
+  auto fields = std::vector<RegisterTypeFlags::Field>{make_field(16, 31),
+                                                      make_field(0, 15)};
   test_padding(fields, fields);
 
   // Needs padding in between the fields, single bit.
@@ -131,60 +132,61 @@ TEST(RegisterFlagsTest, RegisterFlagsPadding) {
 
 TEST(RegisterFieldsTest, ReverseFieldOrder) {
   // Unchanged
-  RegisterFlags rf("", 4, {make_field(0, 31)});
+  RegisterTypeFlags rf("", 4, {make_field(0, 31)});
   ASSERT_EQ(0x12345678ULL, (unsigned long long)rf.ReverseFieldOrder(0x12345678));
 
   // Swap the two halves around.
-  RegisterFlags rf2("", 4, {make_field(16, 31), make_field(0, 15)});
+  RegisterTypeFlags rf2("", 4, {make_field(16, 31), make_field(0, 15)});
   ASSERT_EQ(0x56781234ULL, (unsigned long long)rf2.ReverseFieldOrder(0x12345678));
 
   // Many small fields.
-  RegisterFlags rf3(
+  RegisterTypeFlags rf3(
       "", 4, {make_field(31), make_field(30), make_field(29), make_field(28)});
   ASSERT_EQ(0x00000005ULL, rf3.ReverseFieldOrder(0xA0000000));
 }
 
-TEST(RegisterFlagsTest, AsTable) {
+TEST(RegisterTypeFlagsTest, AsTable) {
   // Anonymous fields are shown with an empty name cell,
   // whether they are known up front or added during construction.
-  RegisterFlags anon_field("", 4, {make_field(0, 31)});
+  RegisterTypeFlags anon_field("", 4, {make_field(0, 31)});
   ASSERT_EQ("| 31-0 |\n"
             "|------|\n"
             "|      |",
             anon_field.AsTable(100));
 
-  RegisterFlags anon_with_pad("", 4, {make_field(16, 31)});
+  RegisterTypeFlags anon_with_pad("", 4, {make_field(16, 31)});
   ASSERT_EQ("| 31-16 | 15-0 |\n"
             "|-------|------|\n"
             "|       |      |",
             anon_with_pad.AsTable(100));
 
   // Use the wider of position and name to set the column width.
-  RegisterFlags name_wider("", 4, {RegisterFlags::Field("aardvark", 0, 31)});
+  RegisterTypeFlags name_wider("", 4,
+                               {RegisterTypeFlags::Field("aardvark", 0, 31)});
   ASSERT_EQ("|   31-0   |\n"
             "|----------|\n"
             "| aardvark |",
             name_wider.AsTable(100));
   // When the padding is an odd number, put the remaining 1 on the right.
-  RegisterFlags pos_wider("", 4, {RegisterFlags::Field("?", 0, 31)});
+  RegisterTypeFlags pos_wider("", 4, {RegisterTypeFlags::Field("?", 0, 31)});
   ASSERT_EQ("| 31-0 |\n"
             "|------|\n"
             "|  ?   |",
             pos_wider.AsTable(100));
 
   // Single bit fields don't need to show start and end, just one of them.
-  RegisterFlags single_bit("", 4, {make_field(31)});
+  RegisterTypeFlags single_bit("", 4, {make_field(31)});
   ASSERT_EQ("| 31 | 30-0 |\n"
             "|----|------|\n"
             "|    |      |",
             single_bit.AsTable(100));
 
   // Columns are printed horizontally if max width allows.
-  RegisterFlags many_fields("", 4,
-                            {RegisterFlags::Field("cat", 28, 31),
-                             RegisterFlags::Field("pigeon", 20, 23),
-                             RegisterFlags::Field("wolf", 12),
-                             RegisterFlags::Field("x", 0, 4)});
+  RegisterTypeFlags many_fields("", 4,
+                                {RegisterTypeFlags::Field("cat", 28, 31),
+                                 RegisterTypeFlags::Field("pigeon", 20, 23),
+                                 RegisterTypeFlags::Field("wolf", 12),
+                                 RegisterTypeFlags::Field("x", 0, 4)});
   ASSERT_EQ("| 31-28 | 27-24 | 23-20  | 19-13 |  12  | 11-5 | 4-0 |\n"
             "|-------|-------|--------|-------|------|------|-----|\n"
             "|  cat  |       | pigeon |       | wolf |      |  x  |",
@@ -192,14 +194,15 @@ TEST(RegisterFlagsTest, AsTable) {
 
   // max_width tells us when we need to split into further tables.
   // Here no split is needed.
-  RegisterFlags exact_max_single_col("", 4, {RegisterFlags::Field("?", 0, 31)});
+  RegisterTypeFlags exact_max_single_col(
+      "", 4, {RegisterTypeFlags::Field("?", 0, 31)});
   ASSERT_EQ("| 31-0 |\n"
             "|------|\n"
             "|  ?   |",
             exact_max_single_col.AsTable(9));
-  RegisterFlags exact_max_two_col(
-      "", 4,
-      {RegisterFlags::Field("?", 16, 31), RegisterFlags::Field("#", 0, 15)});
+  RegisterTypeFlags exact_max_two_col("", 4,
+                                      {RegisterTypeFlags::Field("?", 16, 31),
+                                       RegisterTypeFlags::Field("#", 0, 15)});
   ASSERT_EQ("| 31-16 | 15-0 |\n"
             "|-------|------|\n"
             "|   ?   |  #   |",
@@ -207,16 +210,17 @@ TEST(RegisterFlagsTest, AsTable) {
 
   // If max is less than a single column, just print the single column. The user
   // will have to put up with some wrapping in this niche case.
-  RegisterFlags zero_max_single_col("", 4, {RegisterFlags::Field("?", 0, 31)});
+  RegisterTypeFlags zero_max_single_col("", 4,
+                                        {RegisterTypeFlags::Field("?", 0, 31)});
   ASSERT_EQ("| 31-0 |\n"
             "|------|\n"
             "|  ?   |",
             zero_max_single_col.AsTable(0));
   // Same logic for any following columns. Effectively making a "vertical"
   // table, just with more grid lines.
-  RegisterFlags zero_max_two_col(
-      "", 4,
-      {RegisterFlags::Field("?", 16, 31), RegisterFlags::Field("#", 0, 15)});
+  RegisterTypeFlags zero_max_two_col("", 4,
+                                     {RegisterTypeFlags::Field("?", 16, 31),
+                                      RegisterTypeFlags::Field("#", 0, 15)});
   ASSERT_EQ("| 31-16 |\n"
             "|-------|\n"
             "|   ?   |\n"
@@ -226,15 +230,16 @@ TEST(RegisterFlagsTest, AsTable) {
             "|  #   |",
             zero_max_two_col.AsTable(0));
 
-  RegisterFlags max_less_than_single_col("", 4,
-                                         {RegisterFlags::Field("?", 0, 31)});
+  RegisterTypeFlags max_less_than_single_col(
+      "", 4, {RegisterTypeFlags::Field("?", 0, 31)});
   ASSERT_EQ("| 31-0 |\n"
             "|------|\n"
             "|  ?   |",
             max_less_than_single_col.AsTable(3));
-  RegisterFlags max_less_than_two_col(
+  RegisterTypeFlags max_less_than_two_col(
       "", 4,
-      {RegisterFlags::Field("?", 16, 31), RegisterFlags::Field("#", 0, 15)});
+      {RegisterTypeFlags::Field("?", 16, 31),
+       RegisterTypeFlags::Field("#", 0, 15)});
   ASSERT_EQ("| 31-16 |\n"
             "|-------|\n"
             "|   ?   |\n"
@@ -243,11 +248,12 @@ TEST(RegisterFlagsTest, AsTable) {
             "|------|\n"
             "|  #   |",
             max_less_than_two_col.AsTable(9));
-  RegisterFlags max_many_columns(
+  RegisterTypeFlags max_many_columns(
       "", 4,
-      {RegisterFlags::Field("A", 24, 31), RegisterFlags::Field("B", 16, 23),
-       RegisterFlags::Field("C", 8, 15),
-       RegisterFlags::Field("really long name", 0, 7)});
+      {RegisterTypeFlags::Field("A", 24, 31),
+       RegisterTypeFlags::Field("B", 16, 23),
+       RegisterTypeFlags::Field("C", 8, 15),
+       RegisterTypeFlags::Field("really long name", 0, 7)});
   ASSERT_EQ("| 31-24 | 23-16 |\n"
             "|-------|-------|\n"
             "|   A   |   B   |\n"
@@ -262,28 +268,32 @@ TEST(RegisterFlagsTest, AsTable) {
             max_many_columns.AsTable(23));
 }
 
-TEST(RegisterFlagsTest, DumpEnums) {
-  ASSERT_EQ(RegisterFlags("", 8, {RegisterFlags::Field{"A", 0}}).DumpEnums(80),
+TEST(RegisterTypeTest, DumpEnums) {
+  ASSERT_EQ(RegisterTypeFlags("", 8, {RegisterTypeFlags::Field{"A", 0}})
+                .DumpEnums(80),
             "");
 
-  FieldEnum basic_enum("test", {{0, "an_enumerator"}});
-  ASSERT_EQ(RegisterFlags("", 8, {RegisterFlags::Field{"A", 0, 0, &basic_enum}})
+  RegisterTypeEnum basic_enum("test", {{0, "an_enumerator"}});
+  ASSERT_EQ(RegisterTypeFlags(
+                "", 8, {RegisterTypeFlags::Field{"A", 0, 0, &basic_enum}})
                 .DumpEnums(80),
             "A: 0 = an_enumerator");
 
   // If width is smaller than the enumerator name, print it anyway.
-  ASSERT_EQ(RegisterFlags("", 8, {RegisterFlags::Field{"A", 0, 0, &basic_enum}})
+  ASSERT_EQ(RegisterTypeFlags(
+                "", 8, {RegisterTypeFlags::Field{"A", 0, 0, &basic_enum}})
                 .DumpEnums(5),
             "A: 0 = an_enumerator");
 
-  // Multiple values can go on the same line, up to the width.
-  FieldEnum more_enum("long_enum",
-                      {{0, "an_enumerator"},
-                       {1, "another_enumerator"},
-                       {2, "a_very_very_long_enumerator_has_its_own_line"},
-                       {3, "small"},
-                       {4, "small2"}});
-  ASSERT_EQ(RegisterFlags("", 8, {RegisterFlags::Field{"A", 0, 2, &more_enum}})
+  // Mutliple values can go on the same line, up to the width.
+  RegisterTypeEnum more_enum(
+      "long_enum", {{0, "an_enumerator"},
+                    {1, "another_enumerator"},
+                    {2, "a_very_very_long_enumerator_has_its_own_line"},
+                    {3, "small"},
+                    {4, "small2"}});
+  ASSERT_EQ(RegisterTypeFlags("", 8,
+                              {RegisterTypeFlags::Field{"A", 0, 2, &more_enum}})
                 // Width is chosen to be exactly enough to allow 0 and 1
                 // enumerators on the first line.
                 .DumpEnums(45),
@@ -292,21 +302,21 @@ TEST(RegisterFlagsTest, DumpEnums) {
             "   3 = small, 4 = small2");
 
   // If they all exceed width, one per line.
-  FieldEnum another_enum("another_enum", {{0, "an_enumerator"},
-                                          {1, "another_enumerator"},
-                                          {2, "a_longer_enumerator"}});
-  ASSERT_EQ(
-      RegisterFlags("", 8, {RegisterFlags::Field{"A", 0, 1, &another_enum}})
-          .DumpEnums(5),
-      "A: 0 = an_enumerator,\n"
-      "   1 = another_enumerator,\n"
-      "   2 = a_longer_enumerator");
+  RegisterTypeEnum another_enum("another_enum", {{0, "an_enumerator"},
+                                                 {1, "another_enumerator"},
+                                                 {2, "a_longer_enumerator"}});
+  ASSERT_EQ(RegisterTypeFlags(
+                "", 8, {RegisterTypeFlags::Field{"A", 0, 1, &another_enum}})
+                .DumpEnums(5),
+            "A: 0 = an_enumerator,\n"
+            "   1 = another_enumerator,\n"
+            "   2 = a_longer_enumerator");
 
   // If the name is already > the width, put one value per line.
-  FieldEnum short_enum("short_enum", {{0, "a"}, {1, "b"}, {2, "c"}});
-  ASSERT_EQ(RegisterFlags("", 8,
-                          {RegisterFlags::Field{"AReallyLongFieldName", 0, 1,
-                                                &short_enum}})
+  RegisterTypeEnum short_enum("short_enum", {{0, "a"}, {1, "b"}, {2, "c"}});
+  ASSERT_EQ(RegisterTypeFlags("", 8,
+                              {RegisterTypeFlags::Field{"AReallyLongFieldName",
+                                                        0, 1, &short_enum}})
                 .DumpEnums(10),
             "AReallyLongFieldName: 0 = a,\n"
             "                      1 = b,\n"
@@ -315,12 +325,13 @@ TEST(RegisterFlagsTest, DumpEnums) {
   // Fields are separated by a blank line. Indentation of lines split by width
   // is set by the size of the fields name (as opposed to some max of all field
   // names).
-  FieldEnum enum_1("enum_1", {{0, "an_enumerator"}, {1, "another_enumerator"}});
-  FieldEnum enum_2("enum_2",
-                   {{0, "Cdef_enumerator_1"}, {1, "Cdef_enumerator_2"}});
-  ASSERT_EQ(RegisterFlags("", 8,
-                          {RegisterFlags::Field{"Ab", 1, 1, &enum_1},
-                           RegisterFlags::Field{"Cdef", 0, 0, &enum_2}})
+  RegisterTypeEnum enum_1("enum_1",
+                          {{0, "an_enumerator"}, {1, "another_enumerator"}});
+  RegisterTypeEnum enum_2("enum_2",
+                          {{0, "Cdef_enumerator_1"}, {1, "Cdef_enumerator_2"}});
+  ASSERT_EQ(RegisterTypeFlags("", 8,
+                              {RegisterTypeFlags::Field{"Ab", 1, 1, &enum_1},
+                               RegisterTypeFlags::Field{"Cdef", 0, 0, &enum_2}})
                 .DumpEnums(10),
             "Ab: 0 = an_enumerator,\n"
             "    1 = another_enumerator\n"
@@ -329,47 +340,49 @@ TEST(RegisterFlagsTest, DumpEnums) {
             "      1 = Cdef_enumerator_2");
 
   // Having fields without enumerators shouldn't produce any extra newlines.
-  ASSERT_EQ(RegisterFlags("", 8,
-                          {
-                              RegisterFlags::Field{"A", 4, 4},
-                              RegisterFlags::Field{"B", 3, 3, &enum_1},
-                              RegisterFlags::Field{"C", 2, 2},
-                              RegisterFlags::Field{"D", 1, 1, &enum_1},
-                              RegisterFlags::Field{"E", 0, 0},
-                          })
+  ASSERT_EQ(RegisterTypeFlags("", 8,
+                              {
+                                  RegisterTypeFlags::Field{"A", 4, 4},
+                                  RegisterTypeFlags::Field{"B", 3, 3, &enum_1},
+                                  RegisterTypeFlags::Field{"C", 2, 2},
+                                  RegisterTypeFlags::Field{"D", 1, 1, &enum_1},
+                                  RegisterTypeFlags::Field{"E", 0, 0},
+                              })
                 .DumpEnums(80),
             "B, D: 0 = an_enumerator, 1 = another_enumerator");
 
   // Fields using the same enum should be grouped together.
-  FieldEnum repeated_enum("repeated_enum",
-                          {{0, "zero"}, {1, "one"}, {2, "two"}});
-  ASSERT_EQ(RegisterFlags("", 8,
-                          {
-                              RegisterFlags::Field{"A", 6, 7, &repeated_enum},
-                              RegisterFlags::Field{"B", 4, 5, &repeated_enum},
-                              RegisterFlags::Field{"C", 2, 3, &enum_2},
-                              RegisterFlags::Field{"D", 0, 1, &repeated_enum},
-                          })
-                .DumpEnums(80),
-            "A, B, D: 0 = zero, 1 = one, 2 = two\n"
-            "\n"
-            "C: 0 = Cdef_enumerator_1, 1 = Cdef_enumerator_2");
+  RegisterTypeEnum repeated_enum("repeated_enum",
+                                 {{0, "zero"}, {1, "one"}, {2, "two"}});
+  ASSERT_EQ(
+      RegisterTypeFlags("", 8,
+                        {
+                            RegisterTypeFlags::Field{"A", 6, 7, &repeated_enum},
+                            RegisterTypeFlags::Field{"B", 4, 5, &repeated_enum},
+                            RegisterTypeFlags::Field{"C", 2, 3, &enum_2},
+                            RegisterTypeFlags::Field{"D", 0, 1, &repeated_enum},
+                        })
+          .DumpEnums(80),
+      "A, B, D: 0 = zero, 1 = one, 2 = two\n"
+      "\n"
+      "C: 0 = Cdef_enumerator_1, 1 = Cdef_enumerator_2");
 }
 
 TEST(RegisterFieldsTest, FlagsToXMLElementElement) {
   StreamString strm;
 
-  // RegisterFlags requires that some fields be given, so no testing of empty
-  // input.
+  // RegisterTypeFlags requires that some fields be given, so no testing of
+  // empty input.
 
   // Unnamed fields are padding that are ignored. This applies to fields passed
   // in, and those generated to fill the other bits (31-1 here).
-  RegisterFlags("Foo", 4, {RegisterFlags::Field("", 0, 0)}).ToXMLElement(strm);
+  RegisterTypeFlags("Foo", 4, {RegisterTypeFlags::Field("", 0, 0)})
+      .ToXMLElement(strm);
   ASSERT_EQ(strm.GetString(), "<flags id=\"Foo\" size=\"4\">\n"
                               "</flags>\n");
 
   strm.Clear();
-  RegisterFlags("Foo", 4, {RegisterFlags::Field("abc", 0, 0)})
+  RegisterTypeFlags("Foo", 4, {RegisterTypeFlags::Field("abc", 0, 0)})
       .ToXMLElement(strm);
   ASSERT_EQ(strm.GetString(), "<flags id=\"Foo\" size=\"4\">\n"
                               "  <field name=\"abc\" start=\"0\" end=\"0\"/>\n"
@@ -378,9 +391,9 @@ TEST(RegisterFieldsTest, FlagsToXMLElementElement) {
   strm.Clear();
   // Should use the current indentation level as a starting point.
   strm.IndentMore();
-  RegisterFlags(
-      "Bar", 5,
-      {RegisterFlags::Field("f1", 25, 32), RegisterFlags::Field("f2", 10, 24)})
+  RegisterTypeFlags("Bar", 5,
+                    {RegisterTypeFlags::Field("f1", 25, 32),
+                     RegisterTypeFlags::Field("f2", 10, 24)})
       .ToXMLElement(strm);
   ASSERT_EQ(strm.GetString(),
             "  <flags id=\"Bar\" size=\"5\">\n"
@@ -391,10 +404,11 @@ TEST(RegisterFieldsTest, FlagsToXMLElementElement) {
   strm.Clear();
   strm.IndentLess();
   // Should replace any XML unsafe characters in field names.
-  RegisterFlags("Safe", 8,
-                {RegisterFlags::Field("A<", 4), RegisterFlags::Field("B>", 3),
-                 RegisterFlags::Field("C'", 2), RegisterFlags::Field("D\"", 1),
-                 RegisterFlags::Field("E&", 0)})
+  RegisterTypeFlags(
+      "Safe", 8,
+      {RegisterTypeFlags::Field("A<", 4), RegisterTypeFlags::Field("B>", 3),
+       RegisterTypeFlags::Field("C'", 2), RegisterTypeFlags::Field("D\"", 1),
+       RegisterTypeFlags::Field("E&", 0)})
       .ToXMLElement(strm);
   ASSERT_EQ(strm.GetString(),
             "<flags id=\"Safe\" size=\"8\">\n"
@@ -407,10 +421,11 @@ TEST(RegisterFieldsTest, FlagsToXMLElementElement) {
 
   // Should include enumerators as the "type".
   strm.Clear();
-  FieldEnum enum_single("enum_single", {{0, "a"}});
-  RegisterFlags("Enumerators", 8,
-                {RegisterFlags::Field("NoEnumerators", 4),
-                 RegisterFlags::Field("OneEnumerator", 3, 3, &enum_single)})
+  RegisterTypeEnum enum_single("enum_single", {{0, "a"}});
+  RegisterTypeFlags(
+      "Enumerators", 8,
+      {RegisterTypeFlags::Field("NoEnumerators", 4),
+       RegisterTypeFlags::Field("OneEnumerator", 3, 3, &enum_single)})
       .ToXMLElement(strm);
   ASSERT_EQ(strm.GetString(),
             "<flags id=\"Enumerators\" size=\"8\">\n"
@@ -420,23 +435,23 @@ TEST(RegisterFieldsTest, FlagsToXMLElementElement) {
             "</flags>\n");
 }
 
-TEST(RegisterFlagsTest, EnumeratorToXMLElement) {
+TEST(RegisterTypeTest, EnumeratorToXMLElement) {
   StreamString strm;
 
-  FieldEnum::Enumerator(1234, "test").ToXMLElement(strm);
+  RegisterTypeEnum::Enumerator(1234, "test").ToXMLElement(strm);
   ASSERT_EQ(strm.GetString(), "<evalue name=\"test\" value=\"1234\"/>");
 
   // Special XML chars in names must be escaped.
   std::array special_names = {
-      std::make_pair(FieldEnum::Enumerator(0, "A<"),
+      std::make_pair(RegisterTypeEnum::Enumerator(0, "A<"),
                      "<evalue name=\"A&lt;\" value=\"0\"/>"),
-      std::make_pair(FieldEnum::Enumerator(1, "B>"),
+      std::make_pair(RegisterTypeEnum::Enumerator(1, "B>"),
                      "<evalue name=\"B&gt;\" value=\"1\"/>"),
-      std::make_pair(FieldEnum::Enumerator(2, "C'"),
+      std::make_pair(RegisterTypeEnum::Enumerator(2, "C'"),
                      "<evalue name=\"C&apos;\" value=\"2\"/>"),
-      std::make_pair(FieldEnum::Enumerator(3, "D\""),
+      std::make_pair(RegisterTypeEnum::Enumerator(3, "D\""),
                      "<evalue name=\"D&quot;\" value=\"3\"/>"),
-      std::make_pair(FieldEnum::Enumerator(4, "E&"),
+      std::make_pair(RegisterTypeEnum::Enumerator(4, "E&"),
                      "<evalue name=\"E&amp;\" value=\"4\"/>"),
   };
 
@@ -447,17 +462,18 @@ TEST(RegisterFlagsTest, EnumeratorToXMLElement) {
   }
 }
 
-TEST(RegisterFlagsTest, EnumToXMLElement) {
+TEST(RegisterTypeTest, EnumToXMLElement) {
   StreamString strm;
 
-  RegisterFlags user_4("Foo", 4, {RegisterFlags::Field("", 0, 0)});
-  FieldEnum("empty_enum", {})
+  RegisterTypeFlags user_4("Foo", 4, {RegisterTypeFlags::Field("", 0, 0)});
+  RegisterTypeEnum("empty_enum", {})
       .ToXMLElement(strm, llvm::dyn_cast<const RegisterType>(&user_4));
   ASSERT_EQ(strm.GetString(), "<enum id=\"empty_enum\" size=\"4\"/>\n");
 
   strm.Clear();
-  RegisterFlags user_5("Foo", 5, {RegisterFlags::Field("", 0, 0)});
-  FieldEnum("single_enumerator", {FieldEnum::Enumerator(0, "zero")})
+  RegisterTypeFlags user_5("Foo", 5, {RegisterTypeFlags::Field("", 0, 0)});
+  RegisterTypeEnum("single_enumerator",
+                   {RegisterTypeEnum::Enumerator(0, "zero")})
       .ToXMLElement(strm, llvm::dyn_cast<const RegisterType>(&user_5));
   ASSERT_EQ(strm.GetString(), "<enum id=\"single_enumerator\" size=\"5\">\n"
                               "  <evalue name=\"zero\" value=\"0\"/>\n"
@@ -466,8 +482,9 @@ TEST(RegisterFlagsTest, EnumToXMLElement) {
   // Currently we don't emit size if the user of this type is not a flags.
   // We don't expect to see this situation in real use.
   strm.Clear();
-  FieldEnum("multiple_enumerator",
-            {FieldEnum::Enumerator(0, "zero"), FieldEnum::Enumerator(1, "one")})
+  RegisterTypeEnum("multiple_enumerator",
+                   {RegisterTypeEnum::Enumerator(0, "zero"),
+                    RegisterTypeEnum::Enumerator(1, "one")})
       .ToXMLElement(strm, nullptr);
   ASSERT_EQ(strm.GetString(), "<enum id=\"multiple_enumerator\">\n"
                               "  <evalue name=\"zero\" value=\"0\"/>\n"
@@ -475,7 +492,7 @@ TEST(RegisterFlagsTest, EnumToXMLElement) {
                               "</enum>\n");
 }
 
-TEST(RegisterFlagsTest, RegisterFlagsToXML) {
+TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
   // This method should output all the enums used by the register flag set,
   // then the flags set itself. There should only be one definition of each
   // enum, even if it is used by multiple fields.
@@ -484,25 +501,28 @@ TEST(RegisterFlagsTest, RegisterFlagsToXML) {
   // that to deduplicate them. So here we heap allocate them to simulate that.
 
   StreamString strm;
-  auto enum_a = std::make_shared<FieldEnum>(
-      "enum_a", FieldEnum::Enumerators{FieldEnum::Enumerator(0, "zero")});
-  auto enum_b = std::make_shared<FieldEnum>(
-      "enum_b", FieldEnum::Enumerators{FieldEnum::Enumerator(1, "one")});
-  auto enum_c = std::make_shared<FieldEnum>(
-      "enum_c", FieldEnum::Enumerators{FieldEnum::Enumerator(2, "two")});
+  auto enum_a = std::make_shared<RegisterTypeEnum>(
+      "enum_a",
+      RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(0, "zero")});
+  auto enum_b = std::make_shared<RegisterTypeEnum>(
+      "enum_b",
+      RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(1, "one")});
+  auto enum_c = std::make_shared<RegisterTypeEnum>(
+      "enum_c",
+      RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(2, "two")});
 
   std::unordered_set<const RegisterType *> previously_emitted;
   // Pretend that enum_c was already emitted for a different flag set.
   previously_emitted.insert(enum_c.get());
 
-  std::vector<RegisterFlags::Field> fields{
-      RegisterFlags::Field("f1", 31, 31, enum_a.get()),
-      RegisterFlags::Field("f2", 30, 30, enum_a.get()),
-      RegisterFlags::Field("f3", 29, 29, enum_b.get()),
-      RegisterFlags::Field("f4", 27, 28, enum_c.get()),
+  std::vector<RegisterTypeFlags::Field> fields{
+      RegisterTypeFlags::Field("f1", 31, 31, enum_a.get()),
+      RegisterTypeFlags::Field("f2", 30, 30, enum_a.get()),
+      RegisterTypeFlags::Field("f3", 29, 29, enum_b.get()),
+      RegisterTypeFlags::Field("f4", 27, 28, enum_c.get()),
   };
 
-  auto TestFlags = std::make_shared<RegisterFlags>("Test", 4, fields);
+  auto TestFlags = std::make_shared<RegisterTypeFlags>("Test", 4, fields);
   TestFlags->ToXML(strm, previously_emitted);
   ASSERT_EQ(strm.GetString(),
             "<enum id=\"enum_a\" size=\"4\">\n"
@@ -520,10 +540,11 @@ TEST(RegisterFlagsTest, RegisterFlagsToXML) {
 
   // If another flag set were to use the same enums we should not output them
   // again. Only output new things.
-  auto enum_d = std::make_shared<FieldEnum>(
-      "enum_d", FieldEnum::Enumerators{FieldEnum::Enumerator(3, "three")});
-  fields.push_back(RegisterFlags::Field("f5", 25, 26, enum_d.get()));
-  auto TestFlags2 = std::make_shared<RegisterFlags>("Test", 4, fields);
+  auto enum_d = std::make_shared<RegisterTypeEnum>(
+      "enum_d",
+      RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(3, "three")});
+  fields.push_back(RegisterTypeFlags::Field("f5", 25, 26, enum_d.get()));
+  auto TestFlags2 = std::make_shared<RegisterTypeFlags>("Test", 4, fields);
 
   strm.Clear();
   TestFlags2->ToXML(strm, previously_emitted);

--- a/lldb/unittests/Utility/RegisterTypeTest.cpp
+++ b/lldb/unittests/Utility/RegisterTypeTest.cpp
@@ -133,11 +133,13 @@ TEST(RegisterTypeFlagsTest, RegisterTypeFlagsPadding) {
 TEST(RegisterFieldsTest, ReverseFieldOrder) {
   // Unchanged
   RegisterTypeFlags rf("", 4, {make_field(0, 31)});
-  ASSERT_EQ(0x12345678ULL, (unsigned long long)rf.ReverseFieldOrder(0x12345678));
+  ASSERT_EQ(0x12345678ULL,
+            (unsigned long long)rf.ReverseFieldOrder(0x12345678));
 
   // Swap the two halves around.
   RegisterTypeFlags rf2("", 4, {make_field(16, 31), make_field(0, 15)});
-  ASSERT_EQ(0x56781234ULL, (unsigned long long)rf2.ReverseFieldOrder(0x12345678));
+  ASSERT_EQ(0x56781234ULL,
+            (unsigned long long)rf2.ReverseFieldOrder(0x12345678));
 
   // Many small fields.
   RegisterTypeFlags rf3(


### PR DESCRIPTION
Follow up to #196960.

So that when more types are added, the hierarchy is clear.

RegisterType
  -> RegisterTypeEnum
  -> RegisterTypeFlags
  (in future also...)
  -> RegisterTypeUnion
  -> RegisterTypeVector

Renamed and moved the test file as it will cover all the classes derived from RegisterType.