### PR TITLE
[clang][bytecode] Add DeclOrExpr

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2629,7 +2629,7 @@ bool Compiler<Emitter>::visitCallArgs(ArrayRef<const Expr *> Args,
         return false;
     } else {
 
-      DeclTy Source = Arg;
+      DeclOrExpr Source = Arg;
       if (FuncDecl) {
         // Try to use the parameter declaration instead of the argument
         // expression as a source.
@@ -5313,37 +5313,37 @@ bool Compiler<Emitter>::emitConst(const APSInt &Value, const Expr *E) {
 }
 
 template <class Emitter>
-unsigned Compiler<Emitter>::allocateLocalPrimitive(DeclTy &&Src, PrimType Ty,
-                                                   bool IsConst,
+unsigned Compiler<Emitter>::allocateLocalPrimitive(DeclOrExpr &&Src,
+                                                   PrimType Ty, bool IsConst,
                                                    bool IsVolatile,
                                                    ScopeKind SC) {
-  // FIXME: There are cases where Src.is<Expr*>() is wrong, e.g.
+  // FIXME: There are cases where Src.isExpr() is wrong, e.g.
   //   (int){12} in C. Consider using Expr::isTemporaryObject() instead
   //   or isa<MaterializeTemporaryExpr>().
   Descriptor *D = P.createDescriptor(Src, Ty, nullptr, Descriptor::InlineDescMD,
-                                     IsConst, isa<const Expr *>(Src),
+                                     IsConst, Src.isExpr(),
                                      /*IsMutable=*/false, IsVolatile);
   D->IsConstexprUnknown = this->VariablesAreConstexprUnknown;
   Scope::Local Local = this->createLocal(D);
-  if (auto *VD = dyn_cast_if_present<ValueDecl>(Src.dyn_cast<const Decl *>()))
+  if (auto *VD = Src.asValueDecl())
     Locals.insert({VD, Local});
   VarScope->addForScopeKind(Local, SC);
   return Local.Offset;
 }
 
 template <class Emitter>
-UnsignedOrNone Compiler<Emitter>::allocateLocal(DeclTy &&Src, QualType Ty,
+UnsignedOrNone Compiler<Emitter>::allocateLocal(DeclOrExpr &&Src, QualType Ty,
                                                 ScopeKind SC) {
   const ValueDecl *Key = nullptr;
   const Expr *Init = nullptr;
   bool IsTemporary = false;
-  if (auto *VD = dyn_cast_if_present<ValueDecl>(Src.dyn_cast<const Decl *>())) {
+  if (auto *VD = Src.asValueDecl()) {
     Key = VD;
 
     if (const auto *VarD = dyn_cast<VarDecl>(VD))
       Init = VarD->getInit();
   }
-  if (auto *E = Src.dyn_cast<const Expr *>()) {
+  if (const auto *E = Src.asExpr()) {
     IsTemporary = true;
     if (Ty.isNull())
       Ty = E->getType();
@@ -8704,7 +8704,7 @@ bool Compiler<Emitter>::emitDestructionPop(const Descriptor *Desc,
 /// Create a dummy pointer for the given decl (or expr) and
 /// push a pointer to it on the stack.
 template <class Emitter>
-bool Compiler<Emitter>::emitDummyPtr(const DeclTy &D, const Expr *E, bool CU) {
+bool Compiler<Emitter>::emitDummyPtr(DeclOrExpr D, const Expr *E, bool CU) {
   assert(!DiscardResult && "Should've been checked before");
   unsigned DummyID = P.getOrCreateDummy(D, CU);
 

--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_AST_INTERP_BYTECODEEXPRGEN_H
 
 #include "ByteCodeEmitter.h"
+#include "DeclOrExpr.h"
 #include "EvalEmitter.h"
 #include "Pointer.h"
 #include "PrimType.h"
@@ -339,12 +340,12 @@ protected:
                      bool Activate, bool IsOperatorCall);
 
   /// Creates a local primitive value.
-  unsigned allocateLocalPrimitive(DeclTy &&Decl, PrimType Ty, bool IsConst,
+  unsigned allocateLocalPrimitive(DeclOrExpr &&Decl, PrimType Ty, bool IsConst,
                                   bool IsVolatile = false,
                                   ScopeKind SC = ScopeKind::Block);
 
   /// Allocates a space storing a local given its type.
-  UnsignedOrNone allocateLocal(DeclTy &&Decl, QualType Ty = QualType(),
+  UnsignedOrNone allocateLocal(DeclOrExpr &&Decl, QualType Ty = QualType(),
                                ScopeKind = ScopeKind::Block);
   UnsignedOrNone allocateTemporary(const Expr *E);
 
@@ -427,7 +428,7 @@ private:
                              const BinaryOperator *E);
   bool emitRecordDestructionPop(const Record *R, SourceInfo Loc);
   bool emitDestructionPop(const Descriptor *Desc, SourceInfo Loc);
-  bool emitDummyPtr(const DeclTy &D, const Expr *E, bool CU = false);
+  bool emitDummyPtr(DeclOrExpr D, const Expr *E, bool CU = false);
   bool emitFloat(const APFloat &F, SourceInfo Info);
   unsigned collectBaseOffset(const QualType BaseType,
                              const QualType DerivedType);

--- a/clang/lib/AST/ByteCode/DeclOrExpr.h
+++ b/clang/lib/AST/ByteCode/DeclOrExpr.h
@@ -1,0 +1,65 @@
+//===------------------------- DeclOrExpr.h ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_AST_INTERP_DECLOREXPR_H
+#define LLVM_CLANG_AST_INTERP_DECLOREXPR_H
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/TypeBase.h"
+#include "llvm/ADT/PointerUnion.h"
+
+namespace clang {
+namespace interp {
+
+struct DeclOrExpr {
+  llvm::PointerUnion<const Decl *, const Expr *> V;
+
+  DeclOrExpr() : V(nullptr) {}
+  DeclOrExpr(std::nullptr_t) : V(nullptr) {}
+  DeclOrExpr(const Decl *VD) : V(VD) {}
+  DeclOrExpr(const Expr *E) : V(E) {}
+
+  bool isExpr() const { return isa_and_nonnull<const Expr *>(V); }
+  bool isDecl() const { return isa_and_nonnull<const Decl *>(V); }
+  bool isValueDecl() const { return isa_and_nonnull<ValueDecl>(asDecl()); }
+
+  const Expr *asExpr() const { return V.dyn_cast<const Expr *>(); }
+  const Decl *asDecl() const { return V.dyn_cast<const Decl *>(); }
+  const ValueDecl *asValueDecl() const {
+    return dyn_cast_if_present<ValueDecl>(asDecl());
+  }
+  const VarDecl *asVarDecl() const {
+    return dyn_cast_if_present<VarDecl>(asDecl());
+  }
+
+  const void *getOpaqueValue() const { return V.getOpaqueValue(); }
+
+  bool operator==(DeclOrExpr O) const { return O.V == V; }
+  bool operator!=(DeclOrExpr O) const { return O.V != V; }
+  explicit operator bool() const { return !V.isNull(); }
+
+  QualType getType() const {
+    if (const auto *VD = asValueDecl())
+      return VD->getType();
+    return asExpr()->getType();
+  }
+};
+static_assert(sizeof(DeclOrExpr) == sizeof(void *));
+
+inline DeclOrExpr getSwappedBytes(DeclOrExpr F) { return F; }
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, DeclOrExpr D) {
+  OS << D.getOpaqueValue();
+  return OS;
+}
+
+} // namespace interp
+} // namespace clang
+
+#endif

--- a/clang/lib/AST/ByteCode/Descriptor.cpp
+++ b/clang/lib/AST/ByteCode/Descriptor.cpp
@@ -280,7 +280,7 @@ static BlockDtorFn getDtorArrayPrim(PrimType Type) {
 }
 
 /// Primitives.
-Descriptor::Descriptor(const DeclTy &D, const Type *SourceTy, PrimType Type,
+Descriptor::Descriptor(DeclOrExpr D, const Type *SourceTy, PrimType Type,
                        MetadataSize MD, bool IsConst, bool IsTemporary,
                        bool IsMutable, bool IsVolatile)
     : Source(D), SourceType(SourceTy), ElemSize(primSize(Type)), Size(ElemSize),
@@ -293,7 +293,7 @@ Descriptor::Descriptor(const DeclTy &D, const Type *SourceTy, PrimType Type,
 }
 
 /// Primitive arrays.
-Descriptor::Descriptor(const DeclTy &D, const Type *SourceTy, PrimType Type,
+Descriptor::Descriptor(DeclOrExpr D, const Type *SourceTy, PrimType Type,
                        MetadataSize MD, size_t NumElems, bool IsConst,
                        bool IsTemporary, bool IsMutable, bool IsVolatile)
     : Source(D), SourceType(SourceTy), ElemSize(primSize(Type)),
@@ -307,7 +307,7 @@ Descriptor::Descriptor(const DeclTy &D, const Type *SourceTy, PrimType Type,
 }
 
 /// Primitive unknown-size arrays.
-Descriptor::Descriptor(const DeclTy &D, PrimType Type, MetadataSize MD,
+Descriptor::Descriptor(DeclOrExpr D, PrimType Type, MetadataSize MD,
                        bool IsTemporary, bool IsConst, UnknownSize)
     : Source(D), ElemSize(primSize(Type)), Size(UnknownSizeMark),
       MDSize(MD.value_or(0)),
@@ -319,7 +319,7 @@ Descriptor::Descriptor(const DeclTy &D, PrimType Type, MetadataSize MD,
 }
 
 /// Arrays of composite elements.
-Descriptor::Descriptor(const DeclTy &D, const Type *SourceTy,
+Descriptor::Descriptor(DeclOrExpr D, const Type *SourceTy,
                        const Descriptor *Elem, MetadataSize MD,
                        unsigned NumElems, bool IsConst, bool IsTemporary,
                        bool IsMutable)
@@ -334,7 +334,7 @@ Descriptor::Descriptor(const DeclTy &D, const Type *SourceTy,
 }
 
 /// Unknown-size arrays of composite elements.
-Descriptor::Descriptor(const DeclTy &D, const Descriptor *Elem, MetadataSize MD,
+Descriptor::Descriptor(DeclOrExpr D, const Descriptor *Elem, MetadataSize MD,
                        bool IsTemporary, UnknownSize)
     : Source(D), ElemSize(Elem->getAllocSize() + sizeof(InlineDescriptor)),
       Size(UnknownSizeMark), MDSize(MD.value_or(0)),
@@ -345,7 +345,7 @@ Descriptor::Descriptor(const DeclTy &D, const Descriptor *Elem, MetadataSize MD,
 }
 
 /// Composite records.
-Descriptor::Descriptor(const DeclTy &D, const Record *R, MetadataSize MD,
+Descriptor::Descriptor(DeclOrExpr D, const Record *R, MetadataSize MD,
                        bool IsConst, bool IsTemporary, bool IsMutable,
                        bool IsVolatile)
     : Source(D), ElemSize(std::max<size_t>(alignof(void *), R->getFullSize())),
@@ -357,7 +357,7 @@ Descriptor::Descriptor(const DeclTy &D, const Record *R, MetadataSize MD,
 }
 
 /// Dummy.
-Descriptor::Descriptor(const DeclTy &D, MetadataSize MD)
+Descriptor::Descriptor(DeclOrExpr D, MetadataSize MD)
     : Source(D), ElemSize(1), Size(1), MDSize(MD.value_or(0)),
       AllocSize(MDSize), ElemRecord(nullptr), IsConst(true), IsMutable(false),
       IsTemporary(false) {
@@ -470,17 +470,17 @@ QualType Descriptor::getDataType(const ASTContext &Ctx) const {
 }
 
 SourceLocation Descriptor::getLocation() const {
-  if (auto *D = dyn_cast<const Decl *>(Source))
+  if (auto *D = Source.asDecl())
     return D->getLocation();
-  if (auto *E = dyn_cast<const Expr *>(Source))
+  if (auto *E = Source.asExpr())
     return E->getExprLoc();
   llvm_unreachable("Invalid descriptor type");
 }
 
 SourceInfo Descriptor::getLoc() const {
-  if (const auto *D = dyn_cast<const Decl *>(Source))
+  if (const auto *D = Source.asDecl())
     return SourceInfo(D);
-  if (const auto *E = dyn_cast<const Expr *>(Source))
+  if (const auto *E = Source.asExpr())
     return SourceInfo(E);
   llvm_unreachable("Invalid descriptor type");
 }

--- a/clang/lib/AST/ByteCode/Descriptor.h
+++ b/clang/lib/AST/ByteCode/Descriptor.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CLANG_AST_INTERP_DESCRIPTOR_H
 #define LLVM_CLANG_AST_INTERP_DESCRIPTOR_H
 
+#include "DeclOrExpr.h"
 #include "InitMap.h"
 #include "PrimType.h"
 #include "clang/AST/Decl.h"
@@ -25,8 +26,6 @@ class Record;
 class SourceInfo;
 struct Descriptor;
 enum PrimType : uint8_t;
-
-using DeclTy = llvm::PointerUnion<const Decl *, const Expr *>;
 
 /// Invoked whenever a block is created. The constructor method fills in the
 /// inline descriptors of all fields and array elements. It also initializes
@@ -123,7 +122,7 @@ static_assert(sizeof(GlobalInlineDescriptor) != sizeof(InlineDescriptor), "");
 struct Descriptor final {
 private:
   /// Original declaration, used to emit the error message.
-  const DeclTy Source;
+  const DeclOrExpr Source;
   const Type *SourceType = nullptr;
   /// Size of an element, in host bytes.
   const unsigned ElemSize;
@@ -174,34 +173,33 @@ public:
   const BlockDtorFn DtorFn = nullptr;
 
   /// Allocates a descriptor for a primitive.
-  Descriptor(const DeclTy &D, const Type *SourceTy, PrimType Type,
-             MetadataSize MD, bool IsConst, bool IsTemporary, bool IsMutable,
-             bool IsVolatile);
+  Descriptor(DeclOrExpr D, const Type *SourceTy, PrimType Type, MetadataSize MD,
+             bool IsConst, bool IsTemporary, bool IsMutable, bool IsVolatile);
 
   /// Allocates a descriptor for an array of primitives.
-  Descriptor(const DeclTy &D, const Type *SourceTy, PrimType Type,
-             MetadataSize MD, size_t NumElems, bool IsConst, bool IsTemporary,
-             bool IsMutable, bool IsVolatile);
+  Descriptor(DeclOrExpr D, const Type *SourceTy, PrimType Type, MetadataSize MD,
+             size_t NumElems, bool IsConst, bool IsTemporary, bool IsMutable,
+             bool IsVolatile);
 
   /// Allocates a descriptor for an array of primitives of unknown size.
-  Descriptor(const DeclTy &D, PrimType Type, MetadataSize MDSize, bool IsConst,
+  Descriptor(DeclOrExpr D, PrimType Type, MetadataSize MDSize, bool IsConst,
              bool IsTemporary, UnknownSize);
 
   /// Allocates a descriptor for an array of composites.
-  Descriptor(const DeclTy &D, const Type *SourceTy, const Descriptor *Elem,
+  Descriptor(DeclOrExpr D, const Type *SourceTy, const Descriptor *Elem,
              MetadataSize MD, unsigned NumElems, bool IsConst, bool IsTemporary,
              bool IsMutable);
 
   /// Allocates a descriptor for an array of composites of unknown size.
-  Descriptor(const DeclTy &D, const Descriptor *Elem, MetadataSize MD,
+  Descriptor(DeclOrExpr D, const Descriptor *Elem, MetadataSize MD,
              bool IsTemporary, UnknownSize);
 
   /// Allocates a descriptor for a record.
-  Descriptor(const DeclTy &D, const Record *R, MetadataSize MD, bool IsConst,
+  Descriptor(DeclOrExpr D, const Record *R, MetadataSize MD, bool IsConst,
              bool IsTemporary, bool IsMutable, bool IsVolatile);
 
   /// Allocates a dummy descriptor.
-  Descriptor(const DeclTy &D, MetadataSize MD = std::nullopt);
+  Descriptor(DeclOrExpr D, MetadataSize MD = std::nullopt);
 
   QualType getType() const;
   QualType getElemQualType() const;
@@ -209,9 +207,9 @@ public:
   SourceLocation getLocation() const;
   SourceInfo getLoc() const;
 
-  const Decl *asDecl() const { return dyn_cast<const Decl *>(Source); }
-  const Expr *asExpr() const { return dyn_cast<const Expr *>(Source); }
-  const DeclTy &getSource() const { return Source; }
+  const Decl *asDecl() const { return Source.asDecl(); }
+  const Expr *asExpr() const { return Source.asExpr(); }
+  DeclOrExpr getSource() const { return Source; }
 
   const ValueDecl *asValueDecl() const {
     return dyn_cast_if_present<ValueDecl>(asDecl());

--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -148,9 +148,9 @@ bool EvaluationResult::checkFullyInitialized(InterpState &S,
     return true;
 
   SourceLocation InitLoc;
-  if (const auto *D = dyn_cast<const Decl *>(Source))
+  if (const auto *D = Source.asDecl())
     InitLoc = cast<VarDecl>(D)->getAnyInitializer()->getExprLoc();
-  else if (const auto *E = dyn_cast<const Expr *>(Source))
+  else if (const auto *E = Source.asExpr())
     InitLoc = E->getExprLoc();
 
   if (const Record *R = Ptr.getRecord())

--- a/clang/lib/AST/ByteCode/EvaluationResult.h
+++ b/clang/lib/AST/ByteCode/EvaluationResult.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_AST_INTERP_EVALUATION_RESULT_H
 #define LLVM_CLANG_AST_INTERP_EVALUATION_RESULT_H
 
+#include "DeclOrExpr.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
@@ -36,17 +37,15 @@ public:
     Valid,   // Result is valid and empty.
   };
 
-  using DeclTy = llvm::PointerUnion<const Decl *, const Expr *>;
-
 private:
 #ifndef NDEBUG
   const Context *Ctx = nullptr;
 #endif
   APValue Value;
   ResultKind Kind = Empty;
-  DeclTy Source = nullptr;
+  DeclOrExpr Source = nullptr;
 
-  void setSource(DeclTy D) { Source = D; }
+  void setSource(DeclOrExpr D) { Source = D; }
 
   void takeValue(APValue &&V) {
     assert(empty());
@@ -85,10 +84,9 @@ public:
                                const Pointer &Ptr, SourceInfo Info);
 
   QualType getSourceType() const {
-    if (const auto *D =
-            dyn_cast_if_present<ValueDecl>(Source.dyn_cast<const Decl *>()))
+    if (const auto *D = Source.asValueDecl())
       return D->getType();
-    if (const auto *E = Source.dyn_cast<const Expr *>())
+    if (const auto *E = Source.asExpr())
       return E->getType();
     return QualType();
   }

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -544,15 +544,15 @@ public:
   SourceLocation getDeclLoc() const { return getDeclDesc()->getLocation(); }
 
   /// Returns the expression or declaration the pointer has been created for.
-  DeclTy getSource() const {
+  DeclOrExpr getSource() const {
     if (isBlockPointer())
       return getDeclDesc()->getSource();
     if (isFunctionPointer()) {
       const Function *F = Fn.Func;
-      return F ? F->getDecl() : DeclTy();
+      return F ? F->getDecl() : DeclOrExpr();
     }
     llvm_unreachable("Unsupported pointer type in getSource()");
-    return DeclTy();
+    return DeclOrExpr();
   }
 
   /// Returns a pointer to the object of which this pointer is a field.

--- a/clang/lib/AST/ByteCode/Program.cpp
+++ b/clang/lib/AST/ByteCode/Program.cpp
@@ -124,10 +124,10 @@ UnsignedOrNone Program::getOrCreateGlobal(const ValueDecl *VD,
   return std::nullopt;
 }
 
-unsigned Program::getOrCreateDummy(DeclTy D, bool IsConstexprUnknown) {
+unsigned Program::getOrCreateDummy(DeclOrExpr D, bool IsConstexprUnknown) {
   assert(D);
 
-  if (const auto *VD = dyn_cast_if_present<VarDecl>(dyn_cast<const Decl *>(D)))
+  if (const auto *VD = D.asVarDecl())
     D = VD->getFirstDecl();
 
   // Dedup blocks since they are immutable and pointers cannot be compared.
@@ -137,10 +137,10 @@ unsigned Program::getOrCreateDummy(DeclTy D, bool IsConstexprUnknown) {
 
   QualType QT;
   bool IsWeak = false;
-  if (const auto *E = dyn_cast<const Expr *>(D)) {
+  if (const auto *E = D.asExpr()) {
     QT = E->getType();
   } else {
-    const auto *VD = cast<ValueDecl>(cast<const Decl *>(D));
+    const auto *VD = D.asValueDecl();
     IsWeak = VD->isWeak();
     QT = VD->getType();
     if (QT->isPointerOrReferenceType())
@@ -250,8 +250,8 @@ UnsignedOrNone Program::createGlobal(const Expr *E, QualType ExprType) {
   return std::nullopt;
 }
 
-UnsignedOrNone Program::createGlobal(const DeclTy &D, QualType Ty,
-                                     bool IsStatic, bool IsExtern, bool IsWeak,
+UnsignedOrNone Program::createGlobal(DeclOrExpr D, QualType Ty, bool IsStatic,
+                                     bool IsExtern, bool IsWeak,
                                      bool IsConstexprUnknown,
                                      const Expr *Init) {
   // Since this global variable is constexpr-unknown and a reference, register
@@ -263,7 +263,7 @@ UnsignedOrNone Program::createGlobal(const DeclTy &D, QualType Ty,
   // Create a descriptor for the global.
   Descriptor *Desc;
   const bool IsConst = Ty.isConstQualified();
-  const bool IsTemporary = D.dyn_cast<const Expr *>();
+  const bool IsTemporary = D.isExpr();
   const bool IsVolatile = Ty.isVolatileQualified();
   if (OptPrimType T = Ctx.classify(Ty))
     Desc = createDescriptor(D, *T, nullptr, Descriptor::GlobalMD, IsConst,
@@ -412,7 +412,7 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
   return R;
 }
 
-Descriptor *Program::createDescriptor(const DeclTy &D, const Type *Ty,
+Descriptor *Program::createDescriptor(DeclOrExpr D, const Type *Ty,
                                       Descriptor::MetadataSize MDSize,
                                       bool IsConst, bool IsTemporary,
                                       bool IsMutable, bool IsVolatile,

--- a/clang/lib/AST/ByteCode/Program.h
+++ b/clang/lib/AST/ByteCode/Program.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CLANG_AST_INTERP_PROGRAM_H
 #define LLVM_CLANG_AST_INTERP_PROGRAM_H
 
+#include "DeclOrExpr.h"
 #include "Function.h"
 #include "Pointer.h"
 #include "PrimType.h"
@@ -88,7 +89,7 @@ public:
                                    const Expr *Init = nullptr);
 
   /// Returns or creates a dummy value for unknown declarations.
-  unsigned getOrCreateDummy(DeclTy D, bool IsConstexprUnknown = false);
+  unsigned getOrCreateDummy(DeclOrExpr D, bool IsConstexprUnknown = false);
 
   /// Creates a global and returns its index.
   UnsignedOrNone createGlobal(const ValueDecl *VD, const Expr *Init,
@@ -119,7 +120,7 @@ public:
   Record *getOrCreateRecord(const RecordDecl *RD);
 
   /// Creates a descriptor for a primitive type.
-  Descriptor *createDescriptor(const DeclTy &D, PrimType T,
+  Descriptor *createDescriptor(DeclOrExpr D, PrimType T,
                                const Type *SourceTy = nullptr,
                                Descriptor::MetadataSize MDSize = std::nullopt,
                                bool IsConst = false, bool IsTemporary = false,
@@ -130,7 +131,7 @@ public:
   }
 
   /// Creates a descriptor for a composite type.
-  Descriptor *createDescriptor(const DeclTy &D, const Type *Ty,
+  Descriptor *createDescriptor(DeclOrExpr D, const Type *Ty,
                                Descriptor::MetadataSize MDSize = std::nullopt,
                                bool IsConst = false, bool IsTemporary = false,
                                bool IsMutable = false, bool IsVolatile = false,
@@ -168,7 +169,7 @@ public:
 private:
   friend class DeclScope;
 
-  UnsignedOrNone createGlobal(const DeclTy &D, QualType Ty, bool IsStatic,
+  UnsignedOrNone createGlobal(DeclOrExpr D, QualType Ty, bool IsStatic,
                               bool IsExtern, bool IsWeak,
                               bool IsConstexprUnknown,
                               const Expr *Init = nullptr);


### PR DESCRIPTION
And replace the previous usages of llvm::PointerUnion with this new struct. This is currently just a refactoring but we'll later need to have a proper type for the previos typedef so we can pass it to emit* functions.