### PR TITLE
[Clang][OpenMP] Fix crash with enum omp_interop_t

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -19083,7 +19083,8 @@ static bool isValidInteropVariable(Sema &SemaRef, Expr *InteropVarExpr,
   if (SemaRef.LookupName(Result, SemaRef.getCurScope())) {
     NamedDecl *ND = Result.getFoundDecl();
     if (const auto *TD = dyn_cast<TypeDecl>(ND)) {
-      InteropType = QualType(TD->getTypeForDecl(), 0);
+      InteropType = SemaRef.Context.getTypeDeclType(
+          ElaboratedTypeKeyword::None, /*Qualifier=*/std::nullopt, TD);
     } else {
       HasError = true;
     }

--- a/clang/test/OpenMP/interop_enum.cpp
+++ b/clang/test/OpenMP/interop_enum.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -verify -fopenmp -std=c++11 -fsyntax-only %s
+
+// expected-no-diagnostics
+
+enum omp_interop_t : unsigned long {};
+
+template <typename T> void foo() {
+  T t;
+#pragma omp interop init(target : t)
+}
+
+void bar(int *y) {
+  foo<omp_interop_t>();
+  --y;
+}


### PR DESCRIPTION
Fixes #213666.

`isValidInteropVariable` looks up `omp_interop_t` and previously used
`TypeDecl::getTypeForDecl()` to obtain its type. This low-level accessor
cannot be used with `TagDecl`s, so defining `omp_interop_t` as an enum caused
Clang to hit an assertion during template instantiation.

Use `ASTContext::getTypeDeclType()` instead, which correctly handles tag
declarations as well as other `TypeDecl` kinds.

Add a regression test covering an enum `omp_interop_t` used in an OpenMP
`interop` directive through template instantiation.