### PR TITLE
[clang] Fix include behavior for leading double slashes

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -447,6 +447,9 @@ features cannot lower the translation-unit ABI level;
   non-reproducible across runs. (#GH209639)
 
 #### Miscellaneous Bug Fixes
+- Fixed incorrect header search when filename starts with two path separators.
+  Clang now treats path in `#include <//foo.h>` as `/foo.h` instead of `foo.h`.
+  (GH#133174)
 
 #### Miscellaneous Clang Crashes Fixed
 - Fixed a crash when instantiating an invalid dependent friend destructor declaration in a class template. (#GH210234)

--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -967,8 +967,10 @@ OptionalFileEntryRef HeaderSearch::LookupFile(
   if (SuggestedModule)
     *SuggestedModule = ModuleMap::KnownHeader();
 
-  // If 'Filename' is absolute, check to see if it exists and no searching.
-  if (llvm::sys::path::is_absolute(Filename)) {
+  // If 'Filename' is absolute under GNU rules, check it directly without
+  // searching in paths. Paths with leading native separator are treated as
+  // absolute, including '//' and Windows UNC paths.
+  if (llvm::sys::path::is_absolute_gnu(Filename)) {
     CurDir = nullptr;
 
     // If this was an #include_next "/absolute/file", fail.

--- a/clang/test/Preprocessor/include-leading-double-backslash.c
+++ b/clang/test/Preprocessor/include-leading-double-backslash.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 %s -verify -I %S/Inputs
+// REQUIRES: system-windows
+
+#include "\\leading-double-slash.h" // expected-error {{'\\leading-double-slash.h' file not found}}

--- a/clang/test/Preprocessor/include-leading-double-slash.c
+++ b/clang/test/Preprocessor/include-leading-double-slash.c
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 %s -verify -I %S/Inputs
+
+#include "//leading-double-slash.h" // expected-error {{'//leading-double-slash.h' file not found}}


### PR DESCRIPTION
Fixes #133174 