### PR TITLE
[libclc] Enable 64-bit atomics for nvptx64

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -159,6 +159,13 @@ public:
     Opts["cl_khr_global_int32_extended_atomics"] = true;
     Opts["cl_khr_local_int32_base_atomics"] = true;
     Opts["cl_khr_local_int32_extended_atomics"] = true;
+    // PTX supports 64-bit atomics natively on 64-bit targets even though the
+    // NVIDIA OpenCL runtime does not report these extensions. libclc needs
+    // them enabled to define the 64-bit atomic builtins.
+    if (getMaxAtomicInlineWidth() >= 64) {
+      Opts["cl_khr_int64_base_atomics"] = true;
+      Opts["cl_khr_int64_extended_atomics"] = true;
+    }
 
     Opts["__opencl_c_images"] = true;
     Opts["__opencl_c_3d_image_writes"] = true;

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -159,10 +159,10 @@ public:
     Opts["cl_khr_global_int32_extended_atomics"] = true;
     Opts["cl_khr_local_int32_base_atomics"] = true;
     Opts["cl_khr_local_int32_extended_atomics"] = true;
-    // PTX supports 64-bit atomics natively on 64-bit targets even though the
-    // NVIDIA OpenCL runtime does not report these extensions. libclc needs
-    // them enabled to define the 64-bit atomic builtins.
-    if (getMaxAtomicInlineWidth() >= 64) {
+    // 64-bit atomics are supported natively on 64-bit targets, where
+    // MaxAtomicInlineWidth is the target pointer width. libclc needs these
+    // extensions enabled to define the 64-bit atomic builtins.
+    if (MaxAtomicInlineWidth >= 64) {
       Opts["cl_khr_int64_base_atomics"] = true;
       Opts["cl_khr_int64_extended_atomics"] = true;
     }

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -159,9 +159,6 @@ public:
     Opts["cl_khr_global_int32_extended_atomics"] = true;
     Opts["cl_khr_local_int32_base_atomics"] = true;
     Opts["cl_khr_local_int32_extended_atomics"] = true;
-    // 64-bit atomics are supported natively on 64-bit targets, where
-    // MaxAtomicInlineWidth is the target pointer width. libclc needs these
-    // extensions enabled to define the 64-bit atomic builtins.
     if (MaxAtomicInlineWidth >= 64) {
       Opts["cl_khr_int64_base_atomics"] = true;
       Opts["cl_khr_int64_extended_atomics"] = true;

--- a/libclc/clc/lib/generic/atomic/clc_atomic_compare_exchange.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_compare_exchange.inc
@@ -8,16 +8,16 @@
 
 #ifdef __CLC_SCALAR
 
-#if defined(__SPIR32__) || defined(__NVPTX__)
+#ifdef __SPIR32__
 #if (defined(__CLC_FPSIZE) && __CLC_FPSIZE <= 32) ||                           \
     (defined(__CLC_GENSIZE) && (__CLC_GENSIZE == 32))
 #define __CLC_HAS_ATOMIC
 #endif
-#else // defined(__SPIR32__) || defined(__NVPTX__)
+#else // __SPIR32__
 #if defined(__CLC_FPSIZE) || (__CLC_GENSIZE >= 32)
 #define __CLC_HAS_ATOMIC
 #endif
-#endif // defined(__SPIR32__) || defined(__NVPTX__)
+#endif // __SPIR32__
 
 #ifdef __CLC_HAS_ATOMIC
 

--- a/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_def.inc
@@ -8,16 +8,16 @@
 
 #ifdef __CLC_SCALAR
 
-#if defined(__SPIR32__) || defined(__NVPTX__)
+#ifdef __SPIR32__
 #if (defined(__CLC_FPSIZE) && __CLC_FPSIZE <= 32) ||                           \
     (defined(__CLC_GENSIZE) && (__CLC_GENSIZE == 32))
 #define __CLC_HAS_ATOMIC
 #endif
-#else // defined(__SPIR32__) || defined(__NVPTX__)
+#else // __SPIR32__
 #if defined(__CLC_FPSIZE) || (__CLC_GENSIZE >= 32)
 #define __CLC_HAS_ATOMIC
 #endif
-#endif // defined(__SPIR32__) || defined(__NVPTX__)
+#endif // __SPIR32__
 
 #ifdef __CLC_HAS_ATOMIC
 


### PR DESCRIPTION
The `__CLC_HAS_ATOMIC` guards in `clc_atomic_def.inc` and
`clc_atomic_compare_exchange.inc` restrict atomics to 32-bit types when
`__NVPTX__` is defined. Per the discussion in #146814, that exclusion was added
to silence the `large atomic operation may incur significant performance
penalty` warning on 32-bit targets, but `__NVPTX__` is defined for both nvptx
and nvptx64.

NVPTX sets `MaxAtomicInlineWidth` to the target pointer width
(`clang/lib/Basic/Targets/NVPTX.cpp`), so nvptx64 lowers 64-bit atomics
natively and never emits that warning; only the 32-bit nvptx target did. libclc
no longer builds a 32-bit nvptx target (`LIBCLC_ARCHS_NVPTX` is just
`nvptx64`), so the exclusion now only prevents nvptx64 from getting the 64-bit
atomics that `atomic_decl.inc` declares unconditionally, leaving them declared
but never defined.

This restricts the 32-bit-only guard to `__SPIR32__` in both files, matching the
intent of the original change.

## Test plan

Compiling `clc/lib/generic/atomic/*.cl` for `nvptx64--nvidiacl` with the libclc
build flags:

- No new warnings, in particular no `large atomic operation` warnings. For
  contrast, the same sources built for 32-bit `nvptx--nvidiacl` do produce them,
  which is the case the `__NVPTX__` guard was covering.
- `clc_atomic_compare_exchange.cl` now defines 21 functions instead of 12; the
  `long`/`ulong`/`double` overloads are defined for global (AS1), local (AS3)
  and generic address spaces, where previously they were declared but undefined.
- The 64-bit overloads emit `cmpxchg ... i64`, and the linked atomic bitcode has
  no undefined symbols, i.e. no atomic libcalls are introduced.

Downstream this fixes `Unresolved extern function
'_Z29__clc_atomic_compare_exchange...'` ptxas failures in intel/llvm for SYCL
programs using 64-bit compare-and-swap (see intel/llvm#22750, where it was
verified end-to-end on an A100 with `-fsycl-targets=nvptx64-nvidia-cuda`).
intel/llvm already carries the `clc_atomic_def.inc` half of this change locally
as a not-yet-upstreamed patch; `clc_atomic_compare_exchange.inc` was missed
there.
