### PR TITLE
[offload][test] Instruct clang-format to not reflow comments

### DIFF
--- a/offload/test/.clang-format
+++ b/offload/test/.clang-format
@@ -1,0 +1,1 @@
+ReflowComments: false


### PR DESCRIPTION
Without this, clang-format attempts to reflow check lines in tests, resulting in broken tests.