### PR TITLE
[libc++] Stop emit range opt assumptions volatile pointers

### DIFF
--- a/libcxx/include/__memory/valid_range.h
+++ b/libcxx/include/__memory/valid_range.h
@@ -63,7 +63,7 @@ __assume_valid_range([[__maybe_unused__]] _Iter&& __first, [[__maybe_unused__]] 
                             "Valid range assumption does not hold");
     using __pointer_type = decltype(std::__to_address(__first));
     if constexpr (!is_volatile<__remove_pointer_t<__pointer_type>>::value) {
-      if (!__libcpp_is_constant_evaluated() && __first != __last) {
+      if (!__libcpp_is_constant_evaluated()) {
         using __value_type = typename iterator_traits<__remove_cvref_t<_Iter>>::value_type;
         __builtin_assume_dereferenceable(std::__to_address(__first), (__last - __first) * sizeof(__value_type));
         (void)std::__assume_aligned<_LIBCPP_ALIGNOF(__value_type)>(std::__to_address(__first));

--- a/libcxx/include/__memory/valid_range.h
+++ b/libcxx/include/__memory/valid_range.h
@@ -17,7 +17,9 @@
 #include <__memory/pointer_traits.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_same.h>
+#include <__type_traits/is_volatile.h>
 #include <__type_traits/remove_cvref.h>
+#include <__type_traits/remove_pointer.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -36,7 +38,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // The checks may be extended in the future.
 template <class _Tp>
 _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
-__is_valid_range(const _Tp* __first, const _Tp* __last) {
+__is_valid_range(const volatile _Tp* __first, const volatile _Tp* __last) {
   if (__libcpp_is_constant_evaluated()) {
     // If this is not a constant during constant evaluation, that is because __first and __last are not
     // part of the same allocation. If they are part of the same allocation, we must still make sure they
@@ -59,11 +61,14 @@ __assume_valid_range([[__maybe_unused__]] _Iter&& __first, [[__maybe_unused__]] 
                 is_same<__remove_cvref_t<_Iter>, __remove_cvref_t<_Sent>>::value) {
     _LIBCPP_ASSERT_INTERNAL(std::__is_valid_range(std::__to_address(__first), std::__to_address(__last)),
                             "Valid range assumption does not hold");
-    if (!__libcpp_is_constant_evaluated()) {
-      using __value_type = typename iterator_traits<__remove_cvref_t<_Iter>>::value_type;
-      __builtin_assume_dereferenceable(std::__to_address(__first), (__last - __first) * sizeof(__value_type));
-      (void)std::__assume_aligned<_LIBCPP_ALIGNOF(__value_type)>(std::__to_address(__first));
-      (void)std::__assume_aligned<_LIBCPP_ALIGNOF(__value_type)>(std::__to_address(__last));
+    using __pointer_type = decltype(std::__to_address(__first));
+    if constexpr (!is_volatile<__remove_pointer_t<__pointer_type>>::value) {
+      if (!__libcpp_is_constant_evaluated() && __first != __last) {
+        using __value_type = typename iterator_traits<__remove_cvref_t<_Iter>>::value_type;
+        __builtin_assume_dereferenceable(std::__to_address(__first), (__last - __first) * sizeof(__value_type));
+        (void)std::__assume_aligned<_LIBCPP_ALIGNOF(__value_type)>(std::__to_address(__first));
+        (void)std::__assume_aligned<_LIBCPP_ALIGNOF(__value_type)>(std::__to_address(__last));
+      }
     }
   }
 #endif

--- a/libcxx/test/libcxx/algorithms/volatile_pointers.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/volatile_pointers.pass.cpp
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Algorithms in libc++ may make alignment and dereferenceability assumptions
+// for optimization purposes. This test ensures that we don't emit these assumptions
+// for volatile pointers, as doing so can break algorithms operating on volatile data.
+
+// UNSUPPORTED: c++03
+
+#include <__memory/valid_range.h>
+#include <algorithm>
+#include <cassert>
+
+#include "test_macros.h"
+
+TEST_CONSTEXPR_CXX14 bool test_constexpr() {
+  int arr[3] = {1, 2, 3};
+  std::__assume_valid_range(arr, arr + 3);
+  return true;
+}
+
+void test_volatile_pointers() {
+  volatile int arr[3] = {1, 1, 1};
+  std::__assume_valid_range(arr, arr + 3);
+
+  bool all_ones = std::all_of(arr, arr + 3, [](volatile int& val) { return val == 1; });
+  assert(all_ones);
+
+  auto* found = std::find_if(arr, arr + 3, [](volatile int& val) { return val == 1; });
+  assert(found == arr);
+}
+
+int main(int, char**) {
+  test_constexpr();
+  test_volatile_pointers();
+
+#if TEST_STD_VER >= 14
+  static_assert(test_constexpr(), "");
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
Following up on #207274... PR #207274 ([libc++] Implement any_of in terms of find_if) uncovered a regression when instantiating standard algorithms over `volatile` contiguous iterators.
### Bug Description
PR #207274 replaced the standalone loop in `__any_of` with a delegation to `std::__find_if`, which unconditionally invokes `std::__assume_valid_range(__first, __last)`. 
When `__assume_valid_range` is called with a `volatile` pointer (e.g., `volatile int*`), it passes the pointer to `__builtin_assume_dereferenceable(const void*, size_t)`. Because `__builtin_assume_dereferenceable` requires `const void*` and does not accept `volatile`-qualified pointers, this causes a compilation failure:
> `cannot initialize a parameter of type 'const void *' with an rvalue of type 'volatile T *'`
### Changes in this PR
- Update `std::__is_valid_range` parameter types from `const _Tp*` to `const volatile _Tp*` so internal range ordering debug assertions (`_LIBCPP_ASSERT_INTERNAL`) work with `volatile` iterators.
- Add a `!is_volatile<__remove_pointer_t<__pointer_type>>::value` check in `std::__assume_valid_range` before invoking `__builtin_assume_dereferenceable` and `std::__assume_aligned`. This matches the existing pattern in `libcxx/include/__algorithm/equal.h` where `!is_volatile<_Tp>::value` is checked before opting into `memcmp` optimizations.
- Add unit tests in libcxx/test/libcxx/algorithms/volatile_pointers.pass.cpp covering std:: algorithms over volatile pointers.
### Verification
- Verified with the reproducer: `bool test(volatile int* p, int n) { return std::all_of(p, p + n, [](volatile int& x) { return x == 1; }); }` ([Godbolt](https://godbolt.org/z/r8KjzMTvP)).
- All `libcxx` algorithm tests pass locally.
