### PR TITLE
[AMDGPU][LibCallSimplify] Use target type's float-semantics in `ConstantFP::get`

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -802,8 +802,8 @@ bool AMDGPULibCalls::fold(CallInst *CI) {
   return false;
 }
 
-static Constant *getConstantFloatVector(const ArrayRef<APFloat> Values,
-                                        const Type *Ty) {
+static Constant *getConstantFloat(const ArrayRef<APFloat> Values,
+                                  const Type *Ty) {
   Type *ElemTy = Ty->getScalarType();
   const fltSemantics &FltSem = ElemTy->getFltSemantics();
 
@@ -814,6 +814,12 @@ static Constant *getConstantFloatVector(const ArrayRef<APFloat> Values,
     APF.convert(FltSem, APFloat::rmNearestTiesToEven, &Unused);
     ConstValues.push_back(ConstantFP::get(ElemTy, APF));
   }
+
+  if (!Ty->isVectorTy()) {
+    assert(Values.size() == 1 && "Expected exactly one constant value");
+    return ConstValues[0];
+  }
+
   return ConstantVector::get(ConstValues);
 }
 
@@ -843,7 +849,7 @@ bool AMDGPULibCalls::TDOFold(CallInst *CI, const FuncInfo &FInfo) {
           return false;
         Values.push_back(APFloat(MatchingRow->result));
       }
-      Constant *NewValues = getConstantFloatVector(Values, CI->getType());
+      Constant *NewValues = getConstantFloat(Values, CI->getType());
       LLVM_DEBUG(errs() << "AMDIC: " << *CI << " ---> " << *NewValues << "\n");
       replaceCall(CI, NewValues);
       return true;
@@ -2017,16 +2023,10 @@ bool AMDGPULibCalls::evaluateCall(CallInst *aCI, const FuncInfo &FInfo) {
     }
   }
 
-  Constant *nval0 = nullptr, *nval1 = nullptr;
-  if (FuncVecSize == 1) {
-    nval0 = ConstantFP::get(aCI->getType(), Val0[0]);
-    if (hasTwoResults)
-      nval1 = ConstantFP::get(aCI->getType(), Val1[0]);
-  } else {
-    nval0 = getConstantFloatVector(Val0, aCI->getType());
-    if (hasTwoResults)
-      nval1 = getConstantFloatVector(Val1, aCI->getType());
-  }
+  Constant *nval0 = getConstantFloat(Val0, aCI->getType());
+  Constant *nval1 = nullptr;
+  if (hasTwoResults)
+    nval1 = getConstantFloat(Val1, aCI->getType());
 
   if (hasTwoResults) {
     // sincos

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -2028,14 +2028,12 @@ bool AMDGPULibCalls::evaluateCall(CallInst *aCI, const FuncInfo &FInfo) {
   }
 
   Constant *nval0 = getConstantFloat(Val0, aCI->getType());
-  Constant *nval1 = nullptr;
-  if (hasTwoResults)
-    nval1 = getConstantFloat(Val1, aCI->getType());
 
   if (hasTwoResults) {
     // sincos
     assert(FInfo.getId() == AMDGPULibFunc::EI_SINCOS &&
            "math function with ptr arg not supported yet");
+    Constant *nval1 = getConstantFloat(Val1, aCI->getType());
     new StoreInst(nval1, aCI->getArgOperand(1), aCI->getIterator());
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -2029,8 +2029,7 @@ bool AMDGPULibCalls::evaluateCall(CallInst *aCI, const FuncInfo &FInfo) {
   Constant *nval0 = getConstantFloat(Val0, aCI->getType());
 
   // sincos
-  bool hasTwoResults = (FInfo.getId() == AMDGPULibFunc::EI_SINCOS);
-  if (hasTwoResults) {
+  if (FInfo.getId() == AMDGPULibFunc::EI_SINCOS) {
     Constant *nval1 = getConstantFloat(Val1, aCI->getType());
     new StoreInst(nval1, aCI->getArgOperand(1), aCI->getIterator());
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -807,10 +807,10 @@ static Constant *getConstantFloat(const ArrayRef<APFloat> Values,
 
   assert(Ty->isSingleValueType() &&
          "Type must either be a scalar or a vector.");
-  assert((!Ty->isVectorType() || Ty->isScalableTy() ||
+  assert((!Ty->isVectorTy() || Ty->isScalableTy() ||
           Values.size() == cast<FixedVectorType>(Ty)->getNumElements()) &&
          "Unexpected number of constant values.");
-  assert((Ty->isVectorType() || Values.size() == 1) &&
+  assert((Ty->isVectorTy() || Values.size() == 1) &&
          "Expected exactly one constant value");
 
   Type *ElemTy = Ty->getScalarType();
@@ -2008,7 +2008,6 @@ bool AMDGPULibCalls::evaluateCall(CallInst *aCI, const FuncInfo &FInfo) {
   // max vector size is 16, and sincos will generate two results.
   SmallVector<APFloat, 16> Val0, Val1;
   int FuncVecSize = getVecSize(FInfo);
-  bool hasTwoResults = (FInfo.getId() == AMDGPULibFunc::EI_SINCOS);
   if (FuncVecSize == 1) {
     if (!evaluateScalarMathFunc(FInfo, Val0.emplace_back(0.0),
                                 Val1.emplace_back(0.0), copr0, copr1)) {
@@ -2029,10 +2028,9 @@ bool AMDGPULibCalls::evaluateCall(CallInst *aCI, const FuncInfo &FInfo) {
 
   Constant *nval0 = getConstantFloat(Val0, aCI->getType());
 
+  // sincos
+  bool hasTwoResults = (FInfo.getId() == AMDGPULibFunc::EI_SINCOS);
   if (hasTwoResults) {
-    // sincos
-    assert(FInfo.getId() == AMDGPULibFunc::EI_SINCOS &&
-           "math function with ptr arg not supported yet");
     Constant *nval1 = getConstantFloat(Val1, aCI->getType());
     new StoreInst(nval1, aCI->getArgOperand(1), aCI->getIterator());
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -804,6 +804,15 @@ bool AMDGPULibCalls::fold(CallInst *CI) {
 
 static Constant *getConstantFloat(const ArrayRef<APFloat> Values,
                                   const Type *Ty) {
+
+  assert(Ty->isSingleValueType() &&
+         "Type must either be a scalar or a vector.");
+  assert((!Ty->isVectorType() || Ty->isScalableTy() ||
+          Values.size() == cast<FixedVectorType>(Ty)->getNumElements()) &&
+         "Unexpected number of constant values.");
+  assert((Ty->isVectorType() || Values.size() == 1) &&
+         "Expected exactly one constant value");
+
   Type *ElemTy = Ty->getScalarType();
   const fltSemantics &FltSem = ElemTy->getFltSemantics();
 
@@ -815,12 +824,7 @@ static Constant *getConstantFloat(const ArrayRef<APFloat> Values,
     ConstValues.push_back(ConstantFP::get(ElemTy, APF));
   }
 
-  if (!Ty->isVectorTy()) {
-    assert(Values.size() == 1 && "Expected exactly one constant value");
-    return ConstValues[0];
-  }
-
-  return ConstantVector::get(ConstValues);
+  return Ty->isVectorTy() ? ConstantVector::get(ConstValues) : ConstValues[0];
 }
 
 bool AMDGPULibCalls::TDOFold(CallInst *CI, const FuncInfo &FInfo) {

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
@@ -6110,6 +6110,9 @@ define <2 x float> @test_pow_v2f32_known_integral_constant_vector_poison_elt(<2 
 }
 
 define float @test_pow_f32_known_args_with_fpclass() {
+; CHECK-LABEL: define float @test_pow_f32_known_args_with_fpclass() {
+; CHECK-NEXT:    ret float 1.000000e+00
+;
   %pow = call fast nofpclass(nan inf) float @_Z3powff(float noundef nofpclass(nan inf) 0.0, float noundef nofpclass(nan inf) 0.0)
   ret float %pow
 }

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
@@ -6109,6 +6109,11 @@ define <2 x float> @test_pow_v2f32_known_integral_constant_vector_poison_elt(<2 
   ret <2 x float> %pow
 }
 
+define float @test_pow_f32_known_args_with_fpclass() {
+  %pow = call fast nofpclass(nan inf) float @_Z3powff(float noundef nofpclass(nan inf) 0.0, float noundef nofpclass(nan inf) 0.0)
+  ret float %pow
+}
+
 attributes #0 = { minsize }
 attributes #1 = { noinline }
 attributes #2 = { strictfp }


### PR DESCRIPTION
Compiler was crashing with:

```
Constants.cpp:1124: static llvm::ConstantFP* llvm::ConstantFP::get(llvm::Type*, const llvm::APFloat&):
    Assertion `Ty->getScalarType() == Type::getFloatingPointTy(Cont ext, V.getSemantics()) &&
    "ConstantFP type doesn't match the type implied by its value!"' failed.
```

Since the code was quite similar to `getConstantFloatVector`, I've ended
up modifying its implementation to also handle scalars and renamed it.