### PR TITLE
Partial-revert "[IR] Make semantics of strictfp consistent v2"

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3925,10 +3925,8 @@ void Verifier::visitCallBase(CallBase &Call) {
   Check(!Attrs.hasFnAttr(Attribute::DenormalFPEnv),
         "denormal_fpenv attribute may not apply to call sites", Call);
 
-  Check(!Attrs.hasFnAttr(Attribute::StrictFP) ||
-            Call.getFunction()->isStrictFP(),
-        "call site marked strictfp without caller function marked strictfp",
-        Call);
+  // FIXME: Missing verifier check to forbid a call site marked strictfp without
+  // caller function marked strictfp.
 
   // Verify call attributes.
   verifyFunctionAttrs(FTy, Attrs, &Call, IsIntrinsic, Call.isInlineAsm());

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -817,9 +817,7 @@ TEST(VerifierTest, InvalidStrictFPAttribute) {
 
   std::string Error;
   raw_string_ostream ErrorOS(Error);
-  EXPECT_TRUE(verifyModule(M, &ErrorOS));
-  EXPECT_TRUE(StringRef(Error).starts_with(
-      "call site marked strictfp without caller function marked strictfp"))
-      << Error;
+  // FIXME: Missing verifier check for strictfp.
+  EXPECT_FALSE(verifyModule(M, &ErrorOS));
 }
 } // end anonymous namespace


### PR DESCRIPTION
This partially reverts 15bb4a97a7 ([IR] Make semantics of strictfp consistent v2, #211769) due to a verifier failure in real-world code, disabling just the verifier-check with a FIXME. The reason for a partial manual-revert is because a clean revert doesn't apply cleanly: in particular, the LangRef is untouched by this patch.

Ref: https://github.com/llvm/llvm-project/pull/211769#issuecomment-5169150682