### PR TITLE
[CIR]Add RecordType to our dense-array optimization in lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2313,7 +2313,7 @@ static mlir::Type getConstArrayBaseElementType(mlir::Type ty) {
 
 static bool isBulkLowerableConstArrayBaseElement(mlir::Type baseElemTy) {
   return mlir::isa<cir::PointerType, cir::IntType, cir::BoolType,
-                   cir::FPTypeInterface>(baseElemTy);
+                   cir::FPTypeInterface, cir::RecordType>(baseElemTy);
 }
 
 mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -214,6 +214,11 @@ static bool containsPoison(mlir::Attribute attr) {
   return false;
 }
 
+static std::optional<mlir::Attribute>
+lowerConstRecordMemberAttr(mlir::Attribute attr,
+                           const mlir::TypeConverter *converter,
+                           mlir::ModuleOp moduleOp);
+
 std::optional<mlir::Attribute>
 lowerConstArrayAttr(cir::ConstArrayAttr constArr,
                     const mlir::TypeConverter *converter,
@@ -275,6 +280,31 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
       lowered.push_back(*llvmElt);
     }
     return mlir::ArrayAttr::get(ctx, lowered);
+  }
+
+  if (mlir::isa<cir::RecordType>(type)) {
+    // A record type is just an array of the element values.
+    auto eltsArr = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts());
+    if (!eltsArr)
+      return std::nullopt;
+
+    llvm::SmallVector<mlir::Attribute> loweredElts;
+    loweredElts.reserve(cirArrayType.getSize());
+
+    for (mlir::Attribute elt : eltsArr) {
+      std::optional<mlir::Attribute> llvmElt =
+          lowerConstRecordMemberAttr(elt, converter, moduleOp);
+      if (!llvmElt)
+        return std::nullopt;
+      loweredElts.push_back(*llvmElt);
+    }
+
+    // Remaining elts are either going to be padding (and should be undef), or
+    // trailing-zeros. We can't really tell the difference as CIR lowering
+    // doesn't differentiate anyway, so just zero-fill them.
+    while (loweredElts.size() < cirArrayType.getSize())
+      loweredElts.push_back(mlir::LLVM::ZeroAttr::get(constArr.getContext()));
+    return mlir::ArrayAttr::get(constArr.getContext(), loweredElts);
   }
 
   return std::nullopt;

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -105,6 +105,29 @@ int h[16] = {1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0};
 // OGCG-SAME:               i32 5, i32 6, i32 7, i32 8],
 // OGCG-SAME:             [8 x i32] zeroinitializer }>
 
+struct Pair {
+  int a;
+  int b;
+  constexpr Pair(int x) : a(x), b(x * x) {}
+};
+Pair pairs[3] = {Pair(2), Pair(3), Pair(4)};
+
+// CIR: cir.global external @pairs = #cir.const_array<[#cir.const_record<{#cir.int<2> : !s32i, #cir.int<4> : !s32i}> : !rec_Pair, #cir.const_record<{#cir.int<3> : !s32i, #cir.int<9> : !s32i}> : !rec_Pair, #cir.const_record<{#cir.int<4> : !s32i, #cir.int<16> : !s32i}> : !rec_Pair]> : !cir.array<!rec_Pair x 3>
+
+// LLVM: @pairs = global [3 x %struct.Pair] [%struct.Pair { i32 2, i32 4 }, %struct.Pair { i32 3, i32 9 }, %struct.Pair { i32 4, i32 16 }]
+// OGCG: @pairs = global [3 x %struct.Pair] [%struct.Pair { i32 2, i32 4 }, %struct.Pair { i32 3, i32 9 }, %struct.Pair { i32 4, i32 16 }]
+
+struct Flagged {
+  int value;
+  bool active = true;
+};
+Flagged items[2] = {{10}, {20}};
+
+// CIR: cir.global external @items = #cir.const_array<[#cir.const_record<{#cir.int<10> : !s32i, #true, #cir.zero : !cir.array<!u8i x 3>}> : !rec_Flagged, #cir.const_record<{#cir.int<20> : !s32i, #true, #cir.zero : !cir.array<!u8i x 3>}> : !rec_Flagged]> : !cir.array<!rec_Flagged x 2>
+
+// LLVM: @items = global [2 x %struct.Flagged] [%struct.Flagged <{ i32 10, i8 1, [3 x i8] zeroinitializer }>, %struct.Flagged <{ i32 20, i8 1, [3 x i8] zeroinitializer }>]
+// OGCG: @items = global [2 x { i32, i8 }] [{ i32, i8 } { i32 10, i8 1 }, { i32, i8 } { i32 20, i8 1 }]
+
 char huge[0x1FFFFFFFFFFFFFFFULL];
 // CIR: cir.global external @huge = #cir.zero : !cir.array<!s8i x 2305843009213693951>
 // LLVM: @huge = global [2305843009213693951 x i8] zeroinitializer

--- a/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
+++ b/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
@@ -2,8 +2,14 @@
 
 !s32i = !cir.int<s, 32>
 !s8i = !cir.int<s, 8>
+!u16i = !cir.int<u, 16>
+!bi33 = !cir.int<s, 33, bitint>
 !rec_data = !cir.struct<{!cir.array<!s8i x 4>, !cir.array<!s8i x 2>}>
 !rec_mixed = !cir.struct<{!s32i, !cir.ptr<!s32i>}>
+!rec_entry = !cir.struct<{!u16i, !s32i}>
+!rec_iptr = !cir.struct<{!cir.ptr<!s8i>}>
+!rec_bitint = !cir.struct<{!bi33, !s32i}>
+!rec_poison = !cir.struct<{!s32i}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   cir.global external @tz_arr =
@@ -37,8 +43,26 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
       ]> : !cir.array<!cir.ptr<!s8i> x 2>
   ]> : !cir.array<!cir.array<!cir.ptr<!s8i> x 2> x 2>
 
+  cir.global external @entries = #cir.const_array<[
+      #cir.const_record<{#cir.int<1> : !u16i, #cir.int<10> : !s32i}> : !rec_entry,
+      #cir.const_record<{#cir.int<2> : !u16i, #cir.int<20> : !s32i}> : !rec_entry
+  ]> : !cir.array<!rec_entry x 2>
+
+  cir.global external @iptr_entries = #cir.const_array<[
+      #cir.const_record<{#cir.global_view<@s0, [1]> : !cir.ptr<!s8i>}> : !rec_iptr
+  ]> : !cir.array<!rec_iptr x 1>
+
+  cir.global external @bitint_entries = #cir.const_array<[
+      #cir.const_record<{#cir.int<7> : !bi33, #cir.int<3> : !s32i}> : !rec_bitint
+  ]> : !cir.array<!rec_bitint x 1>
+
+  cir.global external @poison_entries = #cir.const_array<[
+      #cir.const_record<{#cir.poison : !s32i}> : !rec_poison
+  ]> : !cir.array<!rec_poison x 1>
+
   cir.global constant external dso_local @blob = #cir.const_record<{
-      #cir.const_array<[#cir.int<66> : !s8i, #cir.int<76> : !s8i, #cir.int<69> : !s8i, #cir.int<78> : !s8i]> : !cir.array<!s8i x 4>,
+      #cir.const_array<[#cir.int<66> : !s8i, #cir.int<76> : !s8i, 
+         #cir.int<69> : !s8i, #cir.int<78> : !s8i]> : !cir.array<!s8i x 4>,
       #cir.zero : !cir.array<!s8i x 2>
   }> : !rec_data
 }
@@ -59,6 +83,22 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 // CHECK-SAME:    dense<
 
 // CHECK-LABEL: llvm.mlir.global external @ptr2d
+// CHECK:       llvm.insertvalue
+
+// CHECK-LABEL: llvm.mlir.global external @entries(
+// CHECK-SAME:    {{\[\[}}1 : i16, 10 : i32], [2 : i16, 20 : i32]]
+// CHECK-SAME:    : !llvm.array<2 x struct<(i16, i32)>>
+// CHECK-NOT:   llvm.insertvalue
+
+// CHECK-LABEL: llvm.mlir.global external @iptr_entries
+// CHECK:       llvm.getelementptr
+// CHECK:       llvm.insertvalue
+
+// CHECK-LABEL: llvm.mlir.global external @bitint_entries
+// CHECK:       llvm.insertvalue
+
+// CHECK-LABEL: llvm.mlir.global external @poison_entries
+// CHECK:       llvm.mlir.poison
 // CHECK:       llvm.insertvalue
 
 // CHECK-LABEL: llvm.mlir.global external constant @blob(


### PR DESCRIPTION
This is an issue in AMDGPUAsmParser.cpp self-build, we have a lot of record elements (~360k+!) in an array that causes us to have this TU be near-never-ending(hour+).  Classic codegen compiles this sub-minute on my machine.  With this patch, we are only about a 30% increase in time.

Note: Claude wrote much of the tests after I got through every exception I could think of.  I think this covers everything, and I hope there is no missing coverage.