### PR TITLE
[libc++] Fix the clang-tidy source filter to cover libcxx/src again

### DIFF
--- a/libcxx/test/libcxx/clang_tidy.sh.py
+++ b/libcxx/test/libcxx/clang_tidy.sh.py
@@ -11,6 +11,6 @@
 # RUN: %{python} %{libcxx-dir}/../clang-tools-extra/clang-tidy/tool/run-clang-tidy.py   \
 # RUN:      -clang-tidy-binary %{clang-tidy}                                            \
 # RUN:      -warnings-as-errors "*"                                                     \
-# RUN:      -source-filter=".*libcxx(abi?)/src.*"                                       \
+# RUN:      -source-filter=".*libcxx(abi)?/src.*"                                       \
 # RUN:      -quiet -p %{bin-dir}/..                                                     \
-# RUN:      -header-filter=".*libcxx(abi?)/src.*"
+# RUN:      -header-filter=".*libcxx(abi)?/src.*"


### PR DESCRIPTION
The filter regex used `libcxx(abi?)`, which matches `libcxxab` and `libcxxabi`, but never just `libcxx`.