### PR TITLE
Add Region and Block support to PDL and PDLL.

### DIFF
--- a/mlir/docs/PDLL.md
+++ b/mlir/docs/PDLL.md
@@ -819,6 +819,246 @@ let trueConstant = op<arith.constant> {value = attr<"true">};
 let applyResult = op<affine.apply>(args: ValueRange) {map = attr<"affine_map<(d0, d1) -> (d1 - 3)>">}
 ```
 
+### Region Expressions
+
+A region expression in PDLL represents a match/rewrite of an MLIR region
+attached to an operation. PDLL operations can have trailing `{ ... }` region
+expressions that describe the structural contents of their regions. This enables
+matching and constraining the nested structure below an operation including the
+number of regions, blocks within those regions, block arguments, and the
+operations within blocks.
+
+#### Grammar
+
+Region and block expressions extend the operation grammar as follows:
+
+```
+OperationExpr ::= 'op' '<' name '>' '(' operands ')' AttrDict?
+                  '->' '(' results ')'
+                  RegionExpr*
+
+AttrDict      ::= '{' NamedAttr (',' NamedAttr)* '}'
+
+RegionExpr    ::= '{' BlockExpr* '}'         // explicit blocks
+                | '{' Expr* '}'              // shorthand: implicit single block
+
+BlockExpr     ::= '^' identifier? ('(' ArgList? ')')? ':' '{' Expr* '}'
+
+BlockRef      ::= '^' identifier             // reference to a labeled block
+
+ArgList       ::= Arg (',' Arg)*
+Arg           ::= identifier ':' TypeConstraint
+
+RewriteStmt   ::= 'move_block' Expr 'before' Expr ';'
+                | 'take_region' Expr 'before' Expr ';'
+```
+
+Every explicit block begins with the `^` introducer, mirroring MLIR's
+`^bb0(%arg0: i32):` assembly syntax. When parsing a region body, a leading `^`
+selects explicit block parsing; any other token is treated as shorthand region
+contents. This keeps parsing unambiguous: `^` never starts an attribute
+dictionary or a bare expression, so labeled block references such as `^name` are
+always distinguishable in rewrite statements.
+
+#### Shorthand Form
+
+The simplest form wraps expressions directly in `{ ... }`. This matches a region
+with a single implicit block whose arguments are unconstrained:
+
+```pdll
+// Match an operation with a single region containing a specific inner op.
+Pattern {
+  erase op<my_dialect.outer> {
+    op<my_dialect.inner>;
+  };
+}
+```
+
+#### Multiple Regions
+
+Multiple regions are specified as consecutive `{ ... }` expressions after the
+operation:
+
+```pdll
+// Match an operation with two regions.
+Pattern {
+  erase op<scf.if>
+    { op<arith.addi>; }     // "then" region
+    { op<arith.muli>; };    // "else" region
+}
+```
+
+#### Explicit Blocks with `^`
+
+For finer control, blocks can be explicitly specified using the `^` introducer.
+This mirrors MLIR's `^bb0:` block label syntax. Every explicit block starts with
+a `^`:
+
+```pdll
+// Explicit (named and unnamed) blocks in a region.
+Pattern {
+  erase op<my_dialect.branch> {
+    ^: { op<my_dialect.entry>; }
+    ^bb: { op<my_dialect.exit>; }
+  };
+}
+```
+
+#### Block Arguments
+
+Block arguments are first-class PDLL variables. They can be bound and
+constrained using standard PDLL variable syntax. The presence of parentheses
+controls argument matching:
+
+Syntax                     | Meaning
+-------------------------- | ------------------------------------------------
+`^: { ... }`               | Unnamed block, argument count unconstrained
+`^foo: { ... }`            | Named block, argument count unconstrained
+`^(): { ... }`             | Unnamed block, exactly zero arguments
+`^foo(): { ... }`          | Named block, exactly zero arguments
+`^(iv: Value): { ... }`    | Unnamed block, argument(s) bound and constrained
+`^foo(iv: Value): { ... }` | Named block, argument(s) bound and constrained
+
+```pdll
+// Match an scf.for by its induction variable.
+Pattern {
+  let forOp = op<scf.for> {
+    ^(iv: Value, iterArg: Value): {
+      op<arith.addi>(iv);
+    }
+  };
+  rewrite forOp { ... }
+}
+```
+
+#### Variadic Block Argument Capture
+
+A trailing `ValueRange` block argument captures all remaining block arguments as
+a range, analogous to operand `ValueRange` capture. This is useful when only the
+leading arguments have known roles. The `ValueRange` argument must be the
+**last** in the argument list. To prevent PDLL from optimizing away the unused
+`ValueRange`, pass it to an operation; if the element count is unknown, use an
+unregistered operation to bypass strict signature checking:
+
+```pdll
+Pattern MatchForWithVarArgs {
+  let forOp = op<scf.for> {
+    ^(iv: Value, rest: ValueRange): {
+      op<test.custom_op>(iv, rest);
+    }
+  };
+  rewrite forOp { ... }
+}
+```
+
+This generates `check_block_arg_count ... at_least N` (where N is the number of
+scalar arguments) and captures the tail via `pdl_interp.get_block_arguments`.
+
+#### Block Labels
+
+Blocks can be labeled with `^name` to create a `!pdl.block`-typed variable.
+These labels can be referenced later in rewrite expressions (e.g., for
+`move_block` operations):
+
+```pdll
+Pattern MoveEntryBlock {
+  let srcOp = op<my_dialect.source> {
+    ^entry: {
+      op<my_dialect.body>;
+    }
+  };
+  let destOp = op<my_dialect.dest> {
+    ^target: {}
+  };
+  rewrite srcOp {
+    move_block ^entry before ^target;
+  }
+}
+```
+
+#### Nested Regions
+
+Regions can be nested naturally as each `{ ... }` after an operation is that
+operation's region:
+
+```pdll
+Pattern MatchNested {
+  erase op<my_dialect.pipeline> {
+    op<my_dialect.stage> {
+      op<my_dialect.compute>;
+    };
+  };
+}
+```
+
+#### Matching Semantics
+
+Region and block matching follows PDLL's refinement model:
+
+*   **Elision means unconstrained.** An operation with no trailing `{ ... }` has
+    no constraint on its regions. A block with no `()` has no constraint on its
+    arguments.
+*   **Block body matching is existential.** When a block body specifies inner
+    operations, the block must *contain* those operations, but may also contain
+    others. This is consistent with how top-level PDL matching works — patterns
+    search for a matching subgraph, not an exact graph.
+*   **Block argument matching is positional.** Arguments in `^(iv: Value):`
+    constrain by count and position, analogous to operation operand matching.
+
+#### End-to-End Examples
+
+The following examples show concrete IR input and the resulting output after
+applying a region/block pattern.
+
+Match and replace by region count:
+
+```
+Input:                              Output:
+"test.op_with_region"() ({          "test.success"() : () -> ()
+  "test.inner"() : () -> ()         "test.no_region"() : () -> ()
+}) : () -> ()
+"test.no_region"() : () -> ()
+```
+
+Match by inner operation name:
+
+```
+Input:                              Output:
+"test.container"() ({               "test.success"() : () -> ()
+  "test.target"() : () -> ()        "test.other_container"() ({
+}) : () -> ()                         "test.other"() : () -> ()
+"test.other_container"() ({         }) : () -> ()
+  "test.other"() : () -> ()
+}) : () -> ()
+```
+
+Extract block argument type for rewrite:
+
+```
+Input:                              Output:
+"test.with_block_arg"() ({          "test.success"() : () -> i32
+^bb0(%arg0: i32):                   // result type = extracted block arg type
+  "test.use"(%arg0) : (i32) -> ()
+}) : () -> ()
+```
+
+#### Common Region and Block Idioms
+
+The following table summarizes how common region and block transformations in
+LLVM and MLIR map to PDLL constructs:
+
+Category | C++ Idiom / Example | PDLL Support | Implementation Guide
+-------- | ------------------- | ------------ | --------------------
+**Region Body Transfer** | `newOp.getRegion().takeBody(oldOp.getRegion())` | **Yes** | Use `take_region src before dest;` in the rewrite block.
+**Special Inliners** | Handling terminators and block merging during inlining | **Yes** | Use `move_block` to preserve operation pointers, then match and replace terminators directly.
+**Block Manipulation** | `region.hasOneBlock()` | **Yes** | Checked automatically or via interpreter constraints.
+**Control Flow Lowering** | Lowering `scf.for` / `scf.if` to branches | **C++ Fallback** | Full CFG generation and block argument remapping require custom C++ rewriters.
+**Branch / Case Analysis** | Accessing blocks in specific branches | **Yes** | Use `pdl.region_of` and `pdl.block_of` for indexed access.
+
+**Summary:** Structural inspection and whole-body transfer are fully supported
+in PDLL. Complex Control Flow Graph (CFG) generation and custom inlining logic
+remain as areas where C++ rewrite fallbacks should be used.
+
 ### Type Expression
 
 A type expression represents a literal MLIR type. It allows for statically
@@ -1343,6 +1583,86 @@ of nested rewriters. The root operation is not implicitly erased or replaced,
 and any transformations to it must be expressed within the nested rewrite block.
 The inner body may contain any number of other rewrite statements, variables, or
 expressions.
+
+##### `take_region` statement
+
+```pdll
+// Move the entire body of one operation's region to another.
+Pattern {
+  let src = op<my_dialect.source> -> (type<"i32">);
+  let dest = op<my_dialect.dest>(src.0);
+  rewrite src with {
+    take_region src before dest;
+  };
+}
+```
+
+The `take_region` statement transfers all blocks from the source operation's
+region to the destination operation's region, corresponding to the
+`Region::takeBody` API. When the operands are `Op`-typed variables, the codegen
+automatically inserts `pdl.region_of` ops to extract the first region. For
+explicit control over which region to move, use a region-typed variable.
+
+##### `move_block` statement
+
+```pdll
+// Move a specific block before another block.
+Pattern {
+  let src = op<my_dialect.source> -> (type<"i32">);
+  let dest = op<my_dialect.dest>(src.0);
+  rewrite src with {
+    move_block src before dest;
+  };
+}
+```
+
+The `move_block` statement moves a source block before a destination block,
+corresponding to the `Block::moveBefore` API. When the operands are `Op`-typed
+variables, the codegen automatically inserts `pdl.region_of` and `pdl.block_of`
+ops to extract the entry block of the first region.
+
+Named blocks from the match section can also be referenced directly:
+
+```pdll
+Pattern {
+  let outer = op<test.outer> -> (type<"i32">) {
+    ^body: {
+      op<test.inner>;
+    }
+  };
+  let dest = op<test.dest>(outer.0);
+  rewrite outer with {
+    move_block ^body before dest;
+  };
+}
+```
+
+`move_block` preserves operation pointers (it relinks the block in MLIR's
+intrusive list), so a terminator matched in the source block remains valid after
+the move and can be replaced using the existing handle:
+
+```pdll
+Pattern InlineWithTerminatorRewrite {
+  let srcOp = op<my_dialect.source> {
+    ^body(iv: Value): {
+      op<my_dialect.work>;
+      let term = op<my_dialect.old_terminator>;
+    }
+  };
+  let destOp = op<my_dialect.dest> {
+    ^target(): {}
+  };
+  rewrite srcOp {
+    move_block ^body before ^target;
+    // `term` still points to the same operation, now in ^target's region.
+    replace term with op<my_dialect.new_terminator>;
+  }
+}
+```
+
+This covers common inlining scenarios where the terminator of the inlined block
+must be adapted to the destination's control-flow convention (e.g., replacing
+`my_dialect.old_terminator` with `scf.yield`) without requiring a C++ fallback.
 
 #### Defining Rewriters in PDLL
 

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -266,12 +266,22 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
     a handle to the operation itself. Handles to the results of the operation
     can be extracted via `pdl.result`.
 
+    An optional `parentBlock` operand may be specified to scope the operation
+    match to a specific block. When set, the operation is only matched within
+    the given block rather than globally. This is typically used for matching
+    inner operations within region/block structural patterns.
+
     Example:
 
     ```mlir
     // Define an instance of a `foo.op` operation.
     %op = pdl.operation "foo.op"(%arg0, %arg1 : !pdl.value, !pdl.value)
       {"attrA" = %attr0} -> (%type, %type : !pdl.type, !pdl.type)
+
+    // Define an operation scoped to a specific block.
+    %region = pdl.region_of %op at 0
+    %block = pdl.block_of %region at 0
+    %inner = pdl.operation "bar.op" in %block
     ```
 
     When used within a matching context, the name of the operation may be
@@ -352,12 +362,15 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
                        Variadic<PDL_InstOrRangeOf<PDL_Value>>:$operandValues,
                        Variadic<PDL_Attribute>:$attributeValues,
                        StrArrayAttr:$attributeValueNames,
-                       Variadic<PDL_InstOrRangeOf<PDL_Type>>:$typeValues);
+                       Variadic<PDL_InstOrRangeOf<PDL_Type>>:$typeValues,
+                       Optional<PDL_Block>:$parentBlock);
   let results = (outs PDL_Operation:$op);
   let assemblyFormat = [{
     ($opName^)? (`(` $operandValues^ `:` type($operandValues) `)`)?
     custom<OperationOpAttributes>($attributeValues, $attributeValueNames)
-    (`->` `(` $typeValues^ `:` type($typeValues) `)`)? attr-dict
+    (`->` `(` $typeValues^ `:` type($typeValues) `)`)?
+    (`in` $parentBlock^)?
+    attr-dict
   }];
 
   let builders =
@@ -365,12 +378,13 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
                      CArg<"ValueRange", "{}">:$operandValues,
                      CArg<"ArrayRef<StringRef>", "{}">:$attrNames,
                      CArg<"ValueRange", "{}">:$attrValues,
-                     CArg<"ValueRange", "{}">:$resultTypes),
+                     CArg<"ValueRange", "{}">:$resultTypes,
+                     CArg<"Value", "{}">:$parentBlock),
                  [{
       auto nameAttr = name ? $_builder.getStringAttr(*name) : StringAttr();
       build($_builder, $_state, $_builder.getType<OperationType>(), nameAttr,
             operandValues, attrValues, $_builder.getStrArrayAttr(attrNames),
-            resultTypes);
+            resultTypes, parentBlock);
     }]>,
   ];
   let extraClassDeclaration = [{
@@ -718,6 +732,176 @@ def PDL_TypesOp : PDL_Op<"types"> {
   let results = (outs PDL_RangeOf<PDL_Type>:$result);
   let assemblyFormat = "attr-dict (`:` $constantTypes^)?";
   let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::RegionOp
+//===----------------------------------------------------------------------===//
+
+def PDL_RegionOp : PDL_Op<"region_of", [Pure]> {
+  let summary = "Extract a region from an operation by index";
+  let description = [{
+    `pdl.region_of` operations extract region edges from an operation node
+    within a pattern or rewrite region. The provided index is zero-based.
+
+    Example:
+
+    ```mlir
+    // Extract the first region of an operation:
+    %operation = pdl.operation ...
+    %region = pdl.region_of %operation at 0
+    ```
+  }];
+
+  let arguments = (ins PDL_Operation:$parent, ConfinedAttr<I32Attr, [IntNonNegative]>:$index);
+  let results = (outs PDL_Region:$region);
+  let assemblyFormat = "$parent `at` $index attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::BlockOp
+//===----------------------------------------------------------------------===//
+
+def PDL_BlockOp : PDL_Op<"block_of", [Pure]> {
+  let summary = "Extract a block from a region by index";
+  let description = [{
+    `pdl.block_of` operations extract a block from a region at a given
+    index. The provided index is zero-based, where index 0 refers to the
+    entry block.
+
+    Example:
+
+    ```mlir
+    // Extract the entry block of a region:
+    %region = pdl.region_of %operation at 0
+    %block = pdl.block_of %region at 0
+    ```
+  }];
+
+  let arguments = (ins PDL_Region:$parent, ConfinedAttr<I32Attr, [IntNonNegative]>:$index);
+  let results = (outs PDL_Block:$block);
+  let assemblyFormat = "$parent `at` $index attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::BlockArgOp
+//===----------------------------------------------------------------------===//
+
+def PDL_BlockArgOp : PDL_Op<"block_arg", [Pure]> {
+  let summary = "Extract a block argument by index";
+  let description = [{
+    `pdl.block_arg` operations extract a block argument from a block at a
+    given index. This is used for matching block arguments within regions,
+    such as loop induction variables or function parameters.
+
+    Example:
+
+    ```mlir
+    // Extract the first block argument:
+    %block = pdl.block_of %region at 0
+    %arg0 = pdl.block_arg %block at 0
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$parent, ConfinedAttr<I32Attr, [IntNonNegative]>:$index);
+  let results = (outs PDL_Value:$val);
+  let assemblyFormat = "$parent `at` $index attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::BlockArgsOp
+//===----------------------------------------------------------------------===//
+
+def PDL_BlockArgsOp : PDL_Op<"block_args", [Pure]> {
+  let summary = "Extract a block argument group from a block";
+  let description = [{
+    `pdl.block_args` operations extract a range of block arguments from a block.
+    If an index is provided, this operation extracts block arguments starting
+    from that index. If no index is provided, this operation extracts all block
+    arguments.
+
+    Example:
+
+    ```mlir
+    // Extract all block arguments:
+    %block = pdl.block_of %region at 0
+    %args = pdl.block_args %block
+
+    // Extract block arguments starting at index 1:
+    %block = pdl.block_of %region at 0
+    %rest = pdl.block_args %block at 1 -> !pdl.range<value>
+
+    // Extract a single block argument at index 0 (scalar):
+    %block = pdl.block_of %region at 0
+    %arg0 = pdl.block_args %block at 0 -> !pdl.value
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$parent, OptionalAttr<I32Attr>:$index);
+  let results = (outs PDL_InstOrRangeOf<PDL_Value>:$val);
+  let assemblyFormat = [{
+    $parent (`at` $index^)? custom<ResultsValueType>(ref($index), type($val))
+    attr-dict
+  }];
+  let builders = [
+    OpBuilder<(ins "Type":$resultType, "Value":$parent,
+                   "std::optional<unsigned>":$index), [{
+      build($_builder, $_state, resultType, parent,
+            index ? $_builder.getI32IntegerAttr(*index) : IntegerAttr());
+    }]>,
+    OpBuilder<(ins "Value":$parent), [{
+      build($_builder, $_state,
+            RangeType::get($_builder.getType<ValueType>()), parent,
+            IntegerAttr());
+    }]>,
+  ];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::TakeRegionOp
+//===----------------------------------------------------------------------===//
+
+def PDL_TakeRegionOp
+    : PDL_Op<"take_region", [HasParent<"pdl::RewriteOp">]> {
+  let summary = "Move the contents of a region to a destination region";
+  let description = [{
+    `pdl.take_region` operations are used within `pdl.rewrite` regions to move
+    all blocks from a source region into a destination region. This corresponds
+    to the `Region::takeBody` or `PatternRewriter::inlineRegionBefore` API.
+
+    Example:
+
+    ```mlir
+    pdl.take_region %source_region before %dest_region
+    ```
+  }];
+
+  let arguments = (ins PDL_Region:$sourceRegion, PDL_Region:$destRegion);
+  let assemblyFormat = "$sourceRegion `before` $destRegion attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::MoveBlockOp
+//===----------------------------------------------------------------------===//
+
+def PDL_MoveBlockOp
+    : PDL_Op<"move_block", [HasParent<"pdl::RewriteOp">]> {
+  let summary = "Move a block before a destination block";
+  let description = [{
+    `pdl.move_block` operations are used within `pdl.rewrite` regions to move
+    a source block before a destination block. This corresponds to the
+    `Block::moveBefore` API.
+
+    Example:
+
+    ```mlir
+    pdl.move_block %source_block before %dest_block
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$sourceBlock, PDL_Block:$insertBeforeBlock);
+  let assemblyFormat = "$sourceBlock `before` $insertBeforeBlock attr-dict";
 }
 
 #endif // MLIR_DIALECT_PDL_IR_PDLOPS

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLTypes.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLTypes.td
@@ -96,6 +96,31 @@ def PDL_Value : PDL_Type<"Value", "value"> {
 }
 
 //===----------------------------------------------------------------------===//
+// pdl::RegionType
+//===----------------------------------------------------------------------===//
+
+def PDL_Region : PDL_Type<"Region", "region"> {
+  let summary = "PDL handle to an `mlir::Region *`";
+  let description = [{
+    This type represents a handle to an instance of an `mlir::Region *`,
+    bound to a value that is usable within a PDL pattern or rewrite.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl::BlockType
+//===----------------------------------------------------------------------===//
+
+def PDL_Block : PDL_Type<"Block", "block"> {
+  let summary = "PDL handle to an `mlir::Block *`";
+  let description = [{
+    This type represents a handle to an instance of an `mlir::Block *`,
+    bound to a value that is usable within a PDL pattern or rewrite.
+    Blocks are always accessed through a parent region.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Additional Type Constraints
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
+++ b/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
@@ -362,7 +362,7 @@ def PDLInterp_CheckTypesOp
 
 def PDLInterp_ContinueOp
     : PDLInterp_Op<"continue", [Pure, HasParent<"ForEachOp">,
-                               Terminator]> {
+                                Terminator]> {
   let summary = "Breaks the current iteration";
   let description = [{
     `pdl_interp.continue` operation breaks the current iteration within the
@@ -1323,6 +1323,325 @@ def PDLInterp_SwitchTypesOp : PDLInterp_SwitchOp<"switch_types",
     auto getCaseTypes() { return getCaseValues().getAsRange<ArrayAttr>(); }
   }];
   let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::CheckRegionCountOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_CheckRegionCountOp
+    : PDLInterp_PredicateOp<"check_region_count", [Pure]> {
+  let summary = "Check the number of regions of an `Operation`";
+  let description = [{
+    `pdl_interp.check_region_count` operations compare the number of regions
+    of a given operation value with a constant. The comparison is either exact
+    or at_least. On success, this operation branches to the true destination,
+    otherwise the false destination is taken.
+
+    Example:
+
+    ```mlir
+    // Check for exact equality.
+    pdl_interp.check_region_count of %op is 1 -> ^matchDest, ^failureDest
+
+    // Check for at least N regions.
+    pdl_interp.check_region_count of %op is at_least 1 -> ^matchDest, ^failureDest
+    ```
+  }];
+
+  let arguments = (ins PDL_Operation:$inputOp,
+                       ConfinedAttr<I32Attr, [IntNonNegative]>:$count,
+                       UnitAttr:$compareAtLeast);
+  let assemblyFormat = [{
+    `of` $inputOp `is` (`at_least` $compareAtLeast^)? $count attr-dict
+    `->` successors
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::CheckBlockCountOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_CheckBlockCountOp
+    : PDLInterp_PredicateOp<"check_block_count", [Pure]> {
+  let summary = "Check the number of blocks in a `Region`";
+  let description = [{
+    `pdl_interp.check_block_count` operations compare the number of blocks
+    in a given region with a constant. The comparison is either exact or
+    at_least. On success, this operation branches to the true destination,
+    otherwise the false destination is taken.
+
+    Example:
+
+    ```mlir
+    // Check for exact equality.
+    pdl_interp.check_block_count of %region is 1 -> ^matchDest, ^failureDest
+
+    // Check for at least N blocks.
+    pdl_interp.check_block_count of %region is at_least 2 -> ^matchDest, ^failureDest
+    ```
+  }];
+
+  let arguments = (ins PDL_Region:$inputRegion,
+                       ConfinedAttr<I32Attr, [IntNonNegative]>:$count,
+                       UnitAttr:$compareAtLeast);
+  let assemblyFormat = [{
+    `of` $inputRegion `is` (`at_least` $compareAtLeast^)? $count attr-dict
+    `->` successors
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::CheckBlockArgCountOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_CheckBlockArgCountOp
+    : PDLInterp_PredicateOp<"check_block_arg_count", [Pure]> {
+  let summary = "Check the number of arguments of a `Block`";
+  let description = [{
+    `pdl_interp.check_block_arg_count` operations compare the number of
+    arguments of a given block with a constant. The comparison is either exact
+    or at_least. On success, this operation branches to the true destination,
+    otherwise the false destination is taken.
+
+    Example:
+
+    ```mlir
+    // Check for exact equality.
+    pdl_interp.check_block_arg_count of %block is 2 -> ^matchDest, ^failureDest
+
+    // Check for at least N arguments.
+    pdl_interp.check_block_arg_count of %block is at_least 1 -> ^matchDest, ^failureDest
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$inputBlock,
+                       ConfinedAttr<I32Attr, [IntNonNegative]>:$count,
+                       UnitAttr:$compareAtLeast);
+  let assemblyFormat = [{
+    `of` $inputBlock `is` (`at_least` $compareAtLeast^)? $count attr-dict
+    `->` successors
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::CheckParentBlockOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_CheckParentBlockOp
+    : PDLInterp_PredicateOp<"check_parent_block", [Pure]> {
+  let summary = "Check if an operation is contained within a specific block";
+  let description = [{
+    `pdl_interp.check_parent_block` operations check whether a given operation
+    is contained within (i.e., is a direct child of) a specified block. On
+    success, this operation branches to the true destination, otherwise the
+    false destination is taken.
+
+    Example:
+
+    ```mlir
+    pdl_interp.check_parent_block of %op is %block -> ^matchDest, ^failureDest
+    ```
+  }];
+
+  let arguments = (ins PDL_Operation:$inputOp,
+                       PDL_Block:$inputBlock);
+  let assemblyFormat = [{
+    `of` $inputOp `is` $inputBlock attr-dict `->` successors
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetRegionOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_GetRegionOp : PDLInterp_Op<"get_region", [Pure]> {
+  let summary = "Get a specified region from an `Operation`";
+  let description = [{
+    `pdl_interp.get_region` operations try to get a specific region from an
+    operation. If the operation does not have a region for the given index, a
+    null value is returned.
+
+    Example:
+
+    ```mlir
+    %region = pdl_interp.get_region %op at 0
+    ```
+  }];
+
+  let arguments = (ins PDL_Operation:$inputOp,
+                       ConfinedAttr<I32Attr, [IntNonNegative]>:$index);
+  let results = (outs PDL_Region:$region);
+  let assemblyFormat = "$inputOp `at` $index attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetBlockOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_GetBlockOp : PDLInterp_Op<"get_block", [Pure]> {
+  let summary = "Get a specified block from a `Region`";
+  let description = [{
+    `pdl_interp.get_block` operations try to get a specific block from a
+    region. If the region does not have a block at the given index, a null
+    value is returned.
+
+    Example:
+
+    ```mlir
+    %block = pdl_interp.get_block %region at 0
+    ```
+  }];
+
+  let arguments = (ins PDL_Region:$inputRegion,
+                       ConfinedAttr<I32Attr, [IntNonNegative]>:$index);
+  let results = (outs PDL_Block:$block);
+  let assemblyFormat = "$inputRegion `at` $index attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetBlockArgumentOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_GetBlockArgumentOp
+    : PDLInterp_Op<"get_block_argument", [Pure]> {
+  let summary = "Get a specified argument from a `Block`";
+  let description = [{
+    `pdl_interp.get_block_argument` operations try to get a specific argument
+    from a block. If the block does not have an argument at the given index,
+    a null value is returned.
+
+    Example:
+
+    ```mlir
+    %arg = pdl_interp.get_block_argument %block at 0
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$inputBlock,
+                       ConfinedAttr<I32Attr, [IntNonNegative]>:$index);
+  let results = (outs PDL_Value:$value);
+  let assemblyFormat = "$inputBlock `at` $index attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetBlockArgumentsOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_GetBlockArgumentsOp
+    : PDLInterp_Op<"get_block_arguments", [Pure]> {
+  let summary = "Get a group of arguments from a `Block`";
+  let description = [{
+    `pdl_interp.get_block_arguments` operations try to get a group of
+    arguments from a block. If an index is provided, this operation extracts
+    arguments starting from that index. The result may be a single
+    `!pdl.value` or a `!pdl.range<value>` depending on whether an index is
+    provided and the expected result type. If no index is provided, all block
+    arguments are returned as a range.
+
+    Example:
+
+    ```mlir
+    // Get all block arguments.
+    %args = pdl_interp.get_block_arguments %block : !pdl.range<value>
+
+    // Get block arguments starting at index 1.
+    %rest = pdl_interp.get_block_arguments %block at 1 : !pdl.range<value>
+    ```
+  }];
+
+  let arguments = (ins
+    PDL_Block:$inputBlock,
+    OptionalAttr<ConfinedAttr<I32Attr, [IntNonNegative]>>:$index
+  );
+  let results = (outs PDL_InstOrRangeOf<PDL_Value>:$value);
+  let assemblyFormat = "$inputBlock (`at` $index^)? `:` type($value) attr-dict";
+  let builders = [
+    OpBuilder<(ins "Type":$resultType, "Value":$inputBlock,
+                   "std::optional<unsigned>":$index), [{
+      build($_builder, $_state, resultType, inputBlock,
+            index ? $_builder.getI32IntegerAttr(*index) : IntegerAttr());
+    }]>,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetBlockOpsOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_GetBlockOpsOp : PDLInterp_Op<"get_block_ops", [Pure]> {
+  let summary = "Get all operations within a `Block`";
+  let description = [{
+    `pdl_interp.get_block_ops` operations get all operations contained within
+    a given block as a range. This can be combined with `pdl_interp.foreach`
+    to iterate over the operations in a block.
+
+    Example:
+
+    ```mlir
+    %ops = pdl_interp.get_block_ops of %block
+    pdl_interp.foreach %op : !pdl.operation in %ops {
+      // match against %op
+      pdl_interp.continue
+    } -> ^next
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$block);
+  let results = (outs PDL_RangeOf<PDL_Operation>:$operations);
+  let assemblyFormat = "`of` $block attr-dict";
+
+  let builders = [
+    OpBuilder<(ins "Value":$block), [{
+      build($_builder, $_state,
+            pdl::RangeType::get($_builder.getType<pdl::OperationType>()),
+            block);
+    }]>
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::TakeRegionOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_TakeRegionOp : PDLInterp_Op<"take_region"> {
+  let summary = "Move the contents of a region to a destination region";
+  let description = [{
+    `pdl_interp.take_region` operations move all blocks from a source region
+    into a destination region. The source region is left empty after the
+    operation. This corresponds to `Region::takeBody` or
+    `PatternRewriter::inlineRegionBefore`.
+
+    Example:
+
+    ```mlir
+    pdl_interp.take_region %source before %dest
+    ```
+  }];
+
+  let arguments = (ins PDL_Region:$source, PDL_Region:$dest);
+  let assemblyFormat = "$source `before` $dest attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::MoveBlockOp
+//===----------------------------------------------------------------------===//
+
+def PDLInterp_MoveBlockOp : PDLInterp_Op<"move_block"> {
+  let summary = "Move a block before a destination block";
+  let description = [{
+    `pdl_interp.move_block` operations move a block before a destination block.
+    This corresponds to `Block::moveBefore`.
+
+    Example:
+
+    ```mlir
+    pdl_interp.move_block %block before %dest_block
+    ```
+  }];
+
+  let arguments = (ins PDL_Block:$block, PDL_Block:$dest);
+  let assemblyFormat = "$block `before` $dest attr-dict";
 }
 
 #endif // MLIR_DIALECT_PDLINTERP_IR_PDLINTERPOPS

--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -29,14 +29,25 @@ namespace mlir {
 class PDLValue {
 public:
   /// The underlying kind of a PDL value.
-  enum class Kind { Attribute, Operation, Type, TypeRange, Value, ValueRange };
+  enum class Kind {
+    Attribute,
+    Block,
+    Operation,
+    Region,
+    Type,
+    TypeRange,
+    Value,
+    ValueRange
+  };
 
   /// Construct a new PDL value.
   PDLValue(const PDLValue &other) = default;
   PDLValue(std::nullptr_t = nullptr) {}
   PDLValue(Attribute value)
       : value(value.getAsOpaquePointer()), kind(Kind::Attribute) {}
+  PDLValue(Block *value) : value(value), kind(Kind::Block) {}
   PDLValue(Operation *value) : value(value), kind(Kind::Operation) {}
+  PDLValue(Region *value) : value(value), kind(Kind::Region) {}
   PDLValue(Type value) : value(value.getAsOpaquePointer()), kind(Kind::Type) {}
   PDLValue(TypeRange *value) : value(value), kind(Kind::TypeRange) {}
   PDLValue(Value value)
@@ -95,8 +106,9 @@ private:
   /// Return the kind used for the given T.
   template <typename T>
   static Kind getKindOf() {
-    return static_cast<Kind>(index_of_t<T, Attribute, Operation *, Type,
-                                        TypeRange, Value, ValueRange>::value);
+    return static_cast<Kind>(
+        index_of_t<T, Attribute, Block *, Operation *, Region *, Type,
+                   TypeRange, Value, ValueRange>::value);
   }
 
   /// The internal implementation of `cast`, that returns the underlying value

--- a/mlir/include/mlir/Tools/PDLL/AST/Nodes.h
+++ b/mlir/include/mlir/Tools/PDLL/AST/Nodes.h
@@ -341,6 +341,68 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
+// TakeRegionStmt
+//===----------------------------------------------------------------------===//
+
+/// This statement represents the `take_region` statement in PDLL. This
+/// statement moves a region from one operation to another, corresponding
+/// roughly to the Region::takeBody or PatternRewriter::inlineRegionBefore API.
+///
+/// Syntax: `take_region <source_region> before <dest_region>;`
+class TakeRegionStmt final : public Node::NodeBase<TakeRegionStmt, Stmt> {
+public:
+  static TakeRegionStmt *create(Context &ctx, SMRange loc, Expr *region,
+                                Expr *destOp);
+
+  /// Return the region being moved.
+  Expr *getRegion() const { return region; }
+
+  /// Return the destination operation.
+  Expr *getDestOp() const { return destOp; }
+
+private:
+  TakeRegionStmt(SMRange loc, Expr *region, Expr *destOp)
+      : Base(loc), region(region), destOp(destOp) {}
+
+  /// The region to move.
+  Expr *region;
+
+  /// The destination operation to move the region to.
+  Expr *destOp;
+};
+
+//===----------------------------------------------------------------------===//
+// MoveBlockStmt
+//===----------------------------------------------------------------------===//
+
+/// This statement represents the `move_block` statement in PDLL. This
+/// statement moves a block before another block, corresponding
+/// to the Block::moveBefore API.
+///
+/// Syntax: `move_block <source_block> before <dest_block>;`
+class MoveBlockStmt final : public Node::NodeBase<MoveBlockStmt, Stmt> {
+public:
+  static MoveBlockStmt *create(Context &ctx, SMRange loc, Expr *block,
+                               Expr *destBlock);
+
+  /// Return the block being moved.
+  Expr *getBlock() const { return block; }
+
+  /// Return the destination block to move before.
+  Expr *getDestBlock() const { return destBlock; }
+
+private:
+  MoveBlockStmt(SMRange loc, Expr *block, Expr *destBlock)
+      : Base(loc), block(block), destBlock(destBlock) {}
+
+  /// The block to move.
+  Expr *block;
+
+  /// The destination block to move before.
+  Expr *destBlock;
+};
+
+//===----------------------------------------------------------------------===//
 // Expr
 //===----------------------------------------------------------------------===//
 
@@ -365,8 +427,7 @@ private:
 // AttributeExpr
 //===----------------------------------------------------------------------===//
 
-/// This expression represents a literal MLIR Attribute, and contains the
-/// textual assembly format of that attribute.
+/// This expression represents an MLIR Attribute value.
 class AttributeExpr : public Node::NodeBase<AttributeExpr, Expr> {
 public:
   static AttributeExpr *create(Context &ctx, SMRange loc, StringRef value);
@@ -379,8 +440,58 @@ private:
   AttributeExpr(Context &ctx, SMRange loc, StringRef value)
       : Base(loc, AttributeType::get(ctx)), value(value) {}
 
-  /// The value referenced by this expression.
+  /// The value of this attribute expression.
   StringRef value;
+};
+
+//===----------------------------------------------------------------------===//
+// BlockExpr
+//===----------------------------------------------------------------------===//
+
+/// This expression represents a structural match of an MLIR Block. It contains
+/// block argument variable declarations and operation match expressions that
+/// describe the expected contents of the block. Block arguments enable binding
+/// names to block parameters, e.g. `(iv: Type<"index">) { op<inner>; }`.
+class BlockExpr final
+    : public Node::NodeBase<BlockExpr, Expr>,
+      private llvm::TrailingObjects<BlockExpr, VariableDecl *, Expr *> {
+public:
+  static BlockExpr *create(Context &ctx, SMRange loc,
+                           ArrayRef<VariableDecl *> args,
+                           ArrayRef<Expr *> children);
+
+  /// Return the block argument declarations.
+  MutableArrayRef<VariableDecl *> getArgs() {
+    return getTrailingObjects<VariableDecl *>(numArgs);
+  }
+  ArrayRef<VariableDecl *> getArgs() const {
+    return getTrailingObjects<VariableDecl *>(numArgs);
+  }
+
+  /// Return the child operation expressions of this block.
+  MutableArrayRef<Expr *> getChildren() {
+    return getTrailingObjects<Expr *>(numChildren);
+  }
+  ArrayRef<Expr *> getChildren() const {
+    return getTrailingObjects<Expr *>(numChildren);
+  }
+
+private:
+  BlockExpr(Context &ctx, SMRange loc, unsigned numArgs, unsigned numChildren)
+      : Base(loc, BlockType::get(ctx)), numArgs(numArgs),
+        numChildren(numChildren) {}
+
+  /// The number of block arguments.
+  unsigned numArgs;
+
+  /// The number of children (operation match expressions) in this block.
+  unsigned numChildren;
+
+  /// TrailingObject utilities.
+  friend class llvm::TrailingObjects<BlockExpr, VariableDecl *, Expr *>;
+  size_t numTrailingObjects(OverloadToken<VariableDecl *>) const {
+    return numArgs;
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -516,7 +627,8 @@ public:
                                const OpNameDecl *nameDecl,
                                ArrayRef<Expr *> operands,
                                ArrayRef<Expr *> resultTypes,
-                               ArrayRef<NamedAttributeDecl *> attributes);
+                               ArrayRef<NamedAttributeDecl *> attributes,
+                               ArrayRef<Expr *> regions = {});
 
   /// Return the name of the operation, or std::nullopt if there isn't one.
   std::optional<StringRef> getName() const;
@@ -544,6 +656,15 @@ public:
     return const_cast<OperationExpr *>(this)->getResultTypes();
   }
 
+  /// Return the region expressions of this operation.
+  MutableArrayRef<Expr *> getRegions() {
+    return {getTrailingObjects<Expr *>() + numOperands + numResultTypes,
+            numRegions};
+  }
+  ArrayRef<Expr *> getRegions() const {
+    return const_cast<OperationExpr *>(this)->getRegions();
+  }
+
   /// Return the attributes of this operation.
   MutableArrayRef<NamedAttributeDecl *> getAttributes() {
     return getTrailingObjects<NamedAttributeDecl *>(numAttributes);
@@ -555,16 +676,17 @@ public:
 private:
   OperationExpr(SMRange loc, Type type, const OpNameDecl *nameDecl,
                 unsigned numOperands, unsigned numResultTypes,
-                unsigned numAttributes, SMRange nameLoc)
+                unsigned numAttributes, unsigned numRegions, SMRange nameLoc)
       : Base(loc, type), nameDecl(nameDecl), numOperands(numOperands),
         numResultTypes(numResultTypes), numAttributes(numAttributes),
-        nameLoc(nameLoc) {}
+        numRegions(numRegions), nameLoc(nameLoc) {}
 
   /// The name decl of this expression.
   const OpNameDecl *nameDecl;
 
-  /// The number of operands, result types, and attributes of the operation.
-  unsigned numOperands, numResultTypes, numAttributes;
+  /// The number of operands, result types, attributes, and regions of the
+  /// operation.
+  unsigned numOperands, numResultTypes, numAttributes, numRegions;
 
   /// The location of the operation name in the expression if it has a name.
   SMRange nameLoc;
@@ -572,7 +694,7 @@ private:
   /// TrailingObject utilities.
   friend llvm::TrailingObjects<OperationExpr, Expr *, NamedAttributeDecl *>;
   size_t numTrailingObjects(OverloadToken<Expr *>) const {
-    return numOperands + numResultTypes;
+    return numOperands + numResultTypes + numRegions;
   }
 };
 
@@ -608,6 +730,33 @@ private:
 
   /// TrailingObject utilities.
   friend class llvm::TrailingObjects<RangeExpr, Expr *>;
+};
+
+//===----------------------------------------------------------------------===//
+// RegionExpr
+//===----------------------------------------------------------------------===//
+
+/// This expression represents a structural match of an MLIR Region. It
+/// contains block match expressions that describe the expected contents of
+/// the region.
+class RegionExpr final : public Node::NodeBase<RegionExpr, Expr>,
+                         private llvm::TrailingObjects<RegionExpr, Expr *> {
+public:
+  static RegionExpr *create(Context &ctx, SMRange loc, ArrayRef<Expr *> blocks);
+
+  /// Return the block expressions of this region.
+  MutableArrayRef<Expr *> getBlocks() { return getTrailingObjects(numBlocks); }
+  ArrayRef<Expr *> getBlocks() const { return getTrailingObjects(numBlocks); }
+
+private:
+  RegionExpr(Context &ctx, SMRange loc, unsigned numBlocks)
+      : Base(loc, RegionType::get(ctx)), numBlocks(numBlocks) {}
+
+  /// The number of block expressions in this region.
+  unsigned numBlocks;
+
+  /// TrailingObject utilities.
+  friend class llvm::TrailingObjects<RegionExpr, Expr *>;
 };
 
 //===----------------------------------------------------------------------===//
@@ -788,6 +937,36 @@ protected:
 
   /// The operation name of this constraint.
   const OpNameDecl *nameDecl;
+};
+
+//===----------------------------------------------------------------------===//
+// BlockConstraintDecl
+//===----------------------------------------------------------------------===//
+
+/// The class represents a Block constraint, and constrains a variable to be a
+/// Block.
+class BlockConstraintDecl
+    : public Node::NodeBase<BlockConstraintDecl, CoreConstraintDecl> {
+public:
+  static BlockConstraintDecl *create(Context &ctx, SMRange loc);
+
+protected:
+  using Base::Base;
+};
+
+//===----------------------------------------------------------------------===//
+// RegionConstraintDecl
+//===----------------------------------------------------------------------===//
+
+/// The class represents a Region constraint, and constrains a variable to be a
+/// Region.
+class RegionConstraintDecl
+    : public Node::NodeBase<RegionConstraintDecl, CoreConstraintDecl> {
+public:
+  static RegionConstraintDecl *create(Context &ctx, SMRange loc);
+
+protected:
+  using Base::Base;
 };
 
 //===----------------------------------------------------------------------===//
@@ -1331,14 +1510,14 @@ inline bool ConstraintDecl::classof(const Node *node) {
 }
 
 inline bool CoreConstraintDecl::classof(const Node *node) {
-  return isa<AttrConstraintDecl, OpConstraintDecl, TypeConstraintDecl,
-             TypeRangeConstraintDecl, ValueConstraintDecl,
+  return isa<AttrConstraintDecl, OpConstraintDecl, RegionConstraintDecl,
+             TypeConstraintDecl, TypeRangeConstraintDecl, ValueConstraintDecl,
              ValueRangeConstraintDecl>(node);
 }
 
 inline bool Expr::classof(const Node *node) {
-  return isa<AttributeExpr, CallExpr, DeclRefExpr, MemberAccessExpr,
-             OperationExpr, RangeExpr, TupleExpr, TypeExpr>(node);
+  return isa<AttributeExpr, BlockExpr, CallExpr, DeclRefExpr, MemberAccessExpr,
+             OperationExpr, RangeExpr, RegionExpr, TupleExpr, TypeExpr>(node);
 }
 
 inline bool OpRewriteStmt::classof(const Node *node) {
@@ -1346,7 +1525,8 @@ inline bool OpRewriteStmt::classof(const Node *node) {
 }
 
 inline bool Stmt::classof(const Node *node) {
-  return isa<CompoundStmt, LetStmt, OpRewriteStmt, Expr>(node);
+  return isa<CompoundStmt, LetStmt, OpRewriteStmt, ReturnStmt, TakeRegionStmt,
+             MoveBlockStmt, Expr>(node);
 }
 
 } // namespace ast

--- a/mlir/include/mlir/Tools/PDLL/AST/Types.h
+++ b/mlir/include/mlir/Tools/PDLL/AST/Types.h
@@ -140,6 +140,12 @@ struct TypeStorageBase<ConcreteT, void> : public Type::Storage {
 struct AttributeTypeStorage : public TypeStorageBase<AttributeTypeStorage> {};
 
 //===----------------------------------------------------------------------===//
+// BlockTypeStorage
+//===----------------------------------------------------------------------===//
+
+struct BlockTypeStorage : public TypeStorageBase<BlockTypeStorage> {};
+
+//===----------------------------------------------------------------------===//
 // ConstraintTypeStorage
 //===----------------------------------------------------------------------===//
 
@@ -169,6 +175,12 @@ struct OperationTypeStorage
 struct RangeTypeStorage : public TypeStorageBase<RangeTypeStorage, Type> {
   using Base::Base;
 };
+
+//===----------------------------------------------------------------------===//
+// RegionTypeStorage
+//===----------------------------------------------------------------------===//
+
+struct RegionTypeStorage : public TypeStorageBase<RegionTypeStorage> {};
 
 //===----------------------------------------------------------------------===//
 // RewriteTypeStorage
@@ -221,6 +233,19 @@ public:
 
   /// Return an instance of the Attribute type.
   static AttributeType get(Context &context);
+};
+
+//===----------------------------------------------------------------------===//
+// BlockType
+//===----------------------------------------------------------------------===//
+
+/// This class represents a PDLL type that corresponds to an mlir::Block.
+class BlockType : public Type::TypeBase<detail::BlockTypeStorage> {
+public:
+  using Base::Base;
+
+  /// Return an instance of the Block type.
+  static BlockType get(Context &context);
 };
 
 //===----------------------------------------------------------------------===//
@@ -311,6 +336,19 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// RegionType
+//===----------------------------------------------------------------------===//
+
+/// This class represents a PDLL type that corresponds to an mlir::Region.
+class RegionType : public Type::TypeBase<detail::RegionTypeStorage> {
+public:
+  using Base::Base;
+
+  /// Return an instance of the Region type.
+  static RegionType get(Context &context);
+};
+
+//===----------------------------------------------------------------------===//
 // RewriteType
 //===----------------------------------------------------------------------===//
 
@@ -383,9 +421,11 @@ public:
 } // namespace mlir
 
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::AttributeTypeStorage)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::BlockTypeStorage)
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::ConstraintTypeStorage)
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::OperationTypeStorage)
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::RangeTypeStorage)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::RegionTypeStorage)
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::RewriteTypeStorage)
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::TupleTypeStorage)
 MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::TypeTypeStorage)

--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -85,6 +85,12 @@ private:
   void generateRewriter(pdl::EraseOp eraseOp,
                         DenseMap<Value, Value> &rewriteValues,
                         function_ref<Value(Value)> mapRewriteValue);
+  void generateRewriter(pdl::TakeRegionOp takeRegionOp,
+                        DenseMap<Value, Value> &rewriteValues,
+                        function_ref<Value(Value)> mapRewriteValue);
+  void generateRewriter(pdl::MoveBlockOp moveBlockOp,
+                        DenseMap<Value, Value> &rewriteValues,
+                        function_ref<Value(Value)> mapRewriteValue);
   void generateRewriter(pdl::OperationOp operationOp,
                         DenseMap<Value, Value> &rewriteValues,
                         function_ref<Value(Value)> mapRewriteValue);
@@ -380,6 +386,41 @@ Value PatternLowering::getValueAt(Block *&currentBlock, Position *pos) {
     value = i->second->getResult(constrResPos->getIndex());
     break;
   }
+  case Predicates::RegionPos: {
+    auto *regionPos = cast<RegionPosition>(pos);
+    value = pdl_interp::GetRegionOp::create(
+        builder, loc, builder.getType<pdl::RegionType>(), parentVal,
+        regionPos->getRegionNumber());
+    break;
+  }
+  case Predicates::BlockPos: {
+    auto *blockPos = cast<BlockPosition>(pos);
+    value = pdl_interp::GetBlockOp::create(
+        builder, loc, builder.getType<pdl::BlockType>(), parentVal,
+        blockPos->getBlockNumber());
+    break;
+  }
+  case Predicates::BlockArgPos: {
+    auto *blockArgPos = cast<BlockArgPosition>(pos);
+    value = pdl_interp::GetBlockArgumentOp::create(
+        builder, loc, builder.getType<pdl::ValueType>(), parentVal,
+        blockArgPos->getArgNumber());
+    break;
+  }
+  case Predicates::BlockArgRangePos: {
+    auto *blockArgRangePos = cast<BlockArgRangePosition>(pos);
+    Type valueTy = builder.getType<pdl::ValueType>();
+    value = pdl_interp::GetBlockArgumentsOp::create(
+        builder, loc, pdl::RangeType::get(valueTy), parentVal,
+        std::optional<unsigned>(blockArgRangePos->getStartIndex()));
+    break;
+  }
+  case Predicates::BlockOpsPos: {
+    value = pdl_interp::GetBlockOpsOp::create(
+        builder, loc,
+        pdl::RangeType::get(builder.getType<pdl::OperationType>()), parentVal);
+    break;
+  }
   default:
     llvm_unreachable("Generating unknown Position getter");
     break;
@@ -404,6 +445,9 @@ void PatternLowering::generate(BoolNode *boolNode, Block *&currentBlock,
   } else if (auto *cstQuestion = dyn_cast<ConstraintQuestion>(question)) {
     for (Position *position : cstQuestion->getArgs())
       args.push_back(getValueAt(currentBlock, position));
+  } else if (auto *parentBlockQ =
+                 dyn_cast<CheckParentBlockQuestion>(question)) {
+    args = {getValueAt(currentBlock, parentBlockQ->getBlockPosition())};
   }
 
   // Generate a new block as success successor and get the failure successor.
@@ -456,6 +500,27 @@ void PatternLowering::generate(BoolNode *boolNode, Block *&currentBlock,
         /*compareAtLeast=*/kind == Predicates::ResultCountAtLeastQuestion,
         success, failure);
     break;
+  case Predicates::RegionCountQuestion:
+    pdl_interp::CheckRegionCountOp::create(
+        builder, loc, val, cast<UnsignedAnswer>(answer)->getValue(),
+        /*compareAtLeast=*/false, success, failure);
+    break;
+  case Predicates::BlockCountQuestion:
+    pdl_interp::CheckBlockCountOp::create(
+        builder, loc, val, cast<UnsignedAnswer>(answer)->getValue(),
+        /*compareAtLeast=*/false, success, failure);
+    break;
+  case Predicates::BlockArgCountAtLeastQuestion:
+  case Predicates::BlockArgCountQuestion:
+    pdl_interp::CheckBlockArgCountOp::create(
+        builder, loc, val, cast<UnsignedAnswer>(answer)->getValue(),
+        /*compareAtLeast=*/kind == Predicates::BlockArgCountAtLeastQuestion,
+        success, failure);
+    break;
+  case Predicates::CheckParentBlockQuestion:
+    pdl_interp::CheckParentBlockOp::create(builder, loc, val, args.front(),
+                                           success, failure);
+    break;
   case Predicates::EqualToQuestion: {
     bool trueAnswer = isa<TrueAnswer>(answer);
     pdl_interp::AreEqualOp::create(builder, loc, val, args.front(),
@@ -505,7 +570,8 @@ void PatternLowering::generate(SwitchNode *switchNode, Block *currentBlock,
   // cases, we generate a special block sequence.
   Predicates::Kind kind = question->getKind();
   if (kind == Predicates::OperandCountAtLeastQuestion ||
-      kind == Predicates::ResultCountAtLeastQuestion) {
+      kind == Predicates::ResultCountAtLeastQuestion ||
+      kind == Predicates::BlockArgCountAtLeastQuestion) {
     // Order the children such that the cases are in reverse numerical order.
     SmallVector<unsigned> sortedChildren = llvm::to_vector<16>(
         llvm::seq<unsigned>(0, switchNode->getChildren().size()));
@@ -549,6 +615,11 @@ void PatternLowering::generate(SwitchNode *switchNode, Block *currentBlock,
         pdl_interp::CheckResultCountOp::create(builder, loc, val, ans,
                                                /*compareAtLeast=*/true,
                                                childBlock, defaultDest);
+        break;
+      case Predicates::BlockArgCountAtLeastQuestion:
+        pdl_interp::CheckBlockArgCountOp::create(builder, loc, val, ans,
+                                                 /*compareAtLeast=*/true,
+                                                 childBlock, defaultDest);
         break;
       default:
         llvm_unreachable("Generating invalid AtLeast operation");
@@ -702,8 +773,9 @@ SymbolRefAttr PatternLowering::generateRewriter(
     for (Operation &rewriteOp : *rewriter.getBody()) {
       llvm::TypeSwitch<Operation *>(&rewriteOp)
           .Case<pdl::ApplyNativeRewriteOp, pdl::AttributeOp, pdl::EraseOp,
-                pdl::OperationOp, pdl::RangeOp, pdl::ReplaceOp, pdl::ResultOp,
-                pdl::ResultsOp, pdl::TypeOp, pdl::TypesOp>([&](auto op) {
+                pdl::TakeRegionOp, pdl::MoveBlockOp, pdl::OperationOp,
+                pdl::RangeOp, pdl::ReplaceOp, pdl::ResultOp, pdl::ResultsOp,
+                pdl::TypeOp, pdl::TypesOp>([&](auto op) {
             this->generateRewriter(op, rewriteValues, mapRewriteValue);
           });
     }
@@ -888,6 +960,24 @@ void PatternLowering::generateRewriter(
     rewriteValues[typeOp] = pdl_interp::CreateTypesOp::create(
         builder, typeOp.getLoc(), typeOp.getType(), typeAttr);
   }
+}
+
+void PatternLowering::generateRewriter(
+    pdl::TakeRegionOp takeRegionOp, DenseMap<Value, Value> &rewriteValues,
+    function_ref<Value(Value)> mapRewriteValue) {
+  pdl_interp::TakeRegionOp::create(
+      builder, takeRegionOp.getLoc(),
+      mapRewriteValue(takeRegionOp.getSourceRegion()),
+      mapRewriteValue(takeRegionOp.getDestRegion()));
+}
+
+void PatternLowering::generateRewriter(
+    pdl::MoveBlockOp moveBlockOp, DenseMap<Value, Value> &rewriteValues,
+    function_ref<Value(Value)> mapRewriteValue) {
+  pdl_interp::MoveBlockOp::create(
+      builder, moveBlockOp.getLoc(),
+      mapRewriteValue(moveBlockOp.getSourceBlock()),
+      mapRewriteValue(moveBlockOp.getInsertBeforeBlock()));
 }
 
 void PatternLowering::generateOperationResultTypeRewriter(

--- a/mlir/lib/Conversion/PDLToPDLInterp/Predicate.h
+++ b/mlir/lib/Conversion/PDLToPDLInterp/Predicate.h
@@ -50,6 +50,11 @@ enum Kind : unsigned {
   ConstraintResultPos,
   ResultPos,
   ResultGroupPos,
+  RegionPos,
+  BlockPos,
+  BlockArgPos,
+  BlockArgRangePos,
+  BlockOpsPos,
   TypePos,
   AttributeLiteralPos,
   TypeLiteralPos,
@@ -65,6 +70,11 @@ enum Kind : unsigned {
   OperandCountQuestion,
   ResultCountAtLeastQuestion,
   ResultCountQuestion,
+  RegionCountQuestion,
+  BlockCountQuestion,
+  BlockArgCountQuestion,
+  BlockArgCountAtLeastQuestion,
+  CheckParentBlockQuestion,
   EqualToQuestion,
   ConstraintQuestion,
 
@@ -355,6 +365,84 @@ struct ResultGroupPosition
 };
 
 //===----------------------------------------------------------------------===//
+// RegionPosition
+//===----------------------------------------------------------------------===//
+
+/// A position describing a region of an operation.
+struct RegionPosition
+    : public PredicateBase<RegionPosition, Position,
+                           std::pair<OperationPosition *, unsigned>,
+                           Predicates::RegionPos> {
+  explicit RegionPosition(const KeyTy &key) : Base(key) { parent = key.first; }
+
+  /// Returns the region number of this position.
+  unsigned getRegionNumber() const { return key.second; }
+};
+
+//===----------------------------------------------------------------------===//
+// BlockPosition
+//===----------------------------------------------------------------------===//
+
+/// A position describing a block within a region.
+struct BlockPosition
+    : public PredicateBase<BlockPosition, Position,
+                           std::pair<RegionPosition *, unsigned>,
+                           Predicates::BlockPos> {
+  explicit BlockPosition(const KeyTy &key) : Base(key) { parent = key.first; }
+
+  /// Returns the block number of this position.
+  unsigned getBlockNumber() const { return key.second; }
+};
+
+//===----------------------------------------------------------------------===//
+// BlockArgPosition
+//===----------------------------------------------------------------------===//
+
+/// A position describing a block argument.
+struct BlockArgPosition
+    : public PredicateBase<BlockArgPosition, Position,
+                           std::pair<BlockPosition *, unsigned>,
+                           Predicates::BlockArgPos> {
+  explicit BlockArgPosition(const KeyTy &key) : Base(key) {
+    parent = key.first;
+  }
+
+  /// Returns the argument number of this position.
+  unsigned getArgNumber() const { return key.second; }
+};
+
+//===----------------------------------------------------------------------===//
+// BlockArgRangePosition
+//===----------------------------------------------------------------------===//
+
+/// A position describing a range of block arguments starting from a given
+/// index. This is used for variadic block argument capture (e.g.,
+/// `^(iv: Value, rest: ValueRange):` where `rest` starts at index 1).
+struct BlockArgRangePosition
+    : public PredicateBase<BlockArgRangePosition, Position,
+                           std::pair<BlockPosition *, unsigned>,
+                           Predicates::BlockArgRangePos> {
+  explicit BlockArgRangePosition(const KeyTy &key) : Base(key) {
+    parent = key.first;
+  }
+
+  /// Returns the starting argument index for this range.
+  unsigned getStartIndex() const { return key.second; }
+};
+
+//===----------------------------------------------------------------------===//
+// BlockOpsPosition
+//===----------------------------------------------------------------------===//
+
+/// A position describing the range of all operations within a block.
+/// Used for inner operation matching: get_block_ops → foreach.
+struct BlockOpsPosition
+    : public PredicateBase<BlockOpsPosition, Position, BlockPosition *,
+                           Predicates::BlockOpsPos> {
+  explicit BlockOpsPosition(const KeyTy &key) : Base(key) { parent = key; }
+};
+
+//===----------------------------------------------------------------------===//
 // TypePosition
 //===----------------------------------------------------------------------===//
 
@@ -545,6 +633,34 @@ struct OperationNameQuestion
     : public PredicateBase<OperationNameQuestion, Qualifier, void,
                            Predicates::OperationNameQuestion> {};
 
+/// Compare the number of regions of an operation with a known value.
+struct RegionCountQuestion
+    : public PredicateBase<RegionCountQuestion, Qualifier, void,
+                           Predicates::RegionCountQuestion> {};
+
+/// Compare the number of blocks in a region with a known value.
+struct BlockCountQuestion
+    : public PredicateBase<BlockCountQuestion, Qualifier, void,
+                           Predicates::BlockCountQuestion> {};
+
+/// Compare the number of block arguments with a known value.
+struct BlockArgCountQuestion
+    : public PredicateBase<BlockArgCountQuestion, Qualifier, void,
+                           Predicates::BlockArgCountQuestion> {};
+struct BlockArgCountAtLeastQuestion
+    : public PredicateBase<BlockArgCountAtLeastQuestion, Qualifier, void,
+                           Predicates::BlockArgCountAtLeastQuestion> {};
+
+/// Check the parent block of an operation matches a known block.
+struct CheckParentBlockQuestion
+    : public PredicateBase<CheckParentBlockQuestion, Qualifier, Position *,
+                           Predicates::CheckParentBlockQuestion> {
+  using Base::Base;
+
+  /// Return the expected block position.
+  Position *getBlockPosition() const { return key; }
+};
+
 /// Compare the number of results of an operation with a known value.
 struct ResultCountQuestion
     : public PredicateBase<ResultCountQuestion, Qualifier, void,
@@ -569,11 +685,16 @@ public:
     // Register the types of Positions with the uniquer.
     registerParametricStorageType<AttributePosition>();
     registerParametricStorageType<AttributeLiteralPosition>();
+    registerParametricStorageType<BlockArgPosition>();
+    registerParametricStorageType<BlockArgRangePosition>();
+    registerParametricStorageType<BlockOpsPosition>();
+    registerParametricStorageType<BlockPosition>();
     registerParametricStorageType<ConstraintPosition>();
     registerParametricStorageType<ForEachPosition>();
     registerParametricStorageType<OperandPosition>();
     registerParametricStorageType<OperandGroupPosition>();
     registerParametricStorageType<OperationPosition>();
+    registerParametricStorageType<RegionPosition>();
     registerParametricStorageType<ResultPosition>();
     registerParametricStorageType<ResultGroupPosition>();
     registerParametricStorageType<TypePosition>();
@@ -592,10 +713,15 @@ public:
     registerParametricStorageType<ConstraintQuestion>();
     registerParametricStorageType<EqualToQuestion>();
     registerSingletonStorageType<AttributeQuestion>();
+    registerSingletonStorageType<BlockArgCountQuestion>();
+    registerSingletonStorageType<BlockArgCountAtLeastQuestion>();
+    registerParametricStorageType<CheckParentBlockQuestion>();
+    registerSingletonStorageType<BlockCountQuestion>();
     registerSingletonStorageType<IsNotNullQuestion>();
     registerSingletonStorageType<OperandCountQuestion>();
     registerSingletonStorageType<OperandCountAtLeastQuestion>();
     registerSingletonStorageType<OperationNameQuestion>();
+    registerSingletonStorageType<RegionCountQuestion>();
     registerSingletonStorageType<ResultCountQuestion>();
     registerSingletonStorageType<ResultCountAtLeastQuestion>();
     registerSingletonStorageType<TypeQuestion>();
@@ -689,6 +815,33 @@ public:
     return TypeLiteralPosition::get(uniquer, attr);
   }
 
+  /// Returns a region position for a region of the given operation.
+  RegionPosition *getRegion(OperationPosition *p, unsigned region) {
+    return RegionPosition::get(uniquer, p, region);
+  }
+
+  /// Returns a block position for a block of the given region.
+  BlockPosition *getBlock(RegionPosition *p, unsigned block) {
+    return BlockPosition::get(uniquer, p, block);
+  }
+
+  /// Returns a block argument position for an argument of the given block.
+  BlockArgPosition *getBlockArg(BlockPosition *p, unsigned arg) {
+    return BlockArgPosition::get(uniquer, p, arg);
+  }
+
+  /// Returns a position for a range of block arguments starting at the given
+  /// index.
+  BlockArgRangePosition *getBlockArgRange(BlockPosition *p,
+                                          unsigned startIndex) {
+    return BlockArgRangePosition::get(uniquer, p, startIndex);
+  }
+
+  /// Returns a position for the range of all operations in the given block.
+  BlockOpsPosition *getBlockOps(BlockPosition *p) {
+    return BlockOpsPosition::get(uniquer, p);
+  }
+
   /// Returns the users of a position using the value at the given operand.
   UsersPosition *getUsers(Position *p, bool useRepresentative) {
     assert((isa<OperandPosition, OperandGroupPosition, ResultPosition,
@@ -750,6 +903,38 @@ public:
   Predicate getOperationName(StringRef name) {
     return {OperationNameQuestion::get(uniquer),
             OperationNameAnswer::get(uniquer, OperationName(name, ctx))};
+  }
+
+  /// Create a predicate comparing the number of regions of an operation to a
+  /// known value.
+  Predicate getRegionCount(unsigned count) {
+    return {RegionCountQuestion::get(uniquer),
+            UnsignedAnswer::get(uniquer, count)};
+  }
+
+  /// Create a predicate comparing the number of blocks in a region to a
+  /// known value.
+  Predicate getBlockCount(unsigned count) {
+    return {BlockCountQuestion::get(uniquer),
+            UnsignedAnswer::get(uniquer, count)};
+  }
+
+  /// Create a predicate comparing the number of block arguments to a known
+  /// value.
+  Predicate getBlockArgCount(unsigned count) {
+    return {BlockArgCountQuestion::get(uniquer),
+            UnsignedAnswer::get(uniquer, count)};
+  }
+  Predicate getBlockArgCountAtLeast(unsigned count) {
+    return {BlockArgCountAtLeastQuestion::get(uniquer),
+            UnsignedAnswer::get(uniquer, count)};
+  }
+
+  /// Create a predicate checking that an operation's parent block matches
+  /// the given block position.
+  Predicate getCheckParentBlock(Position *blockPos) {
+    return {CheckParentBlockQuestion::get(uniquer, blockPos),
+            TrueAnswer::get(uniquer)};
   }
 
   /// Create a predicate comparing the number of results of an operation to a

--- a/mlir/lib/Conversion/PDLToPDLInterp/PredicateTree.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PredicateTree.cpp
@@ -365,7 +365,82 @@ static void getNonTreePredicates(pdl::PatternOp pattern,
           getTypePredicates(
               typeOp, [&] { return typeOp.getConstantTypesAttr(); }, builder,
               inputs);
+        })
+        .Case([&](pdl::RegionOp regionOp) {
+          Position *&regionPos = inputs[regionOp];
+          if (regionPos)
+            return;
+          auto *parentPos =
+              cast<OperationPosition>(inputs.lookup(regionOp.getParent()));
+          regionPos = builder.getRegion(parentPos, regionOp.getIndex());
+        })
+        .Case([&](pdl::BlockOp blockOp) {
+          Position *&blockPos = inputs[blockOp];
+          if (blockPos)
+            return;
+          auto *parentPos =
+              cast<RegionPosition>(inputs.lookup(blockOp.getParent()));
+          blockPos = builder.getBlock(parentPos, blockOp.getIndex());
+        })
+        .Case([&](pdl::BlockArgOp blockArgOp) {
+          Position *&argPos = inputs[blockArgOp];
+          if (argPos)
+            return;
+          auto *parentPos =
+              cast<BlockPosition>(inputs.lookup(blockArgOp.getParent()));
+          argPos = builder.getBlockArg(parentPos, blockArgOp.getIndex());
+        })
+        .Case([&](pdl::BlockArgsOp blockArgsOp) {
+          Position *&argPos = inputs[blockArgsOp];
+          if (argPos)
+            return;
+          auto *parentPos =
+              cast<BlockPosition>(inputs.lookup(blockArgsOp.getParent()));
+          unsigned startIndex = blockArgsOp.getIndex().value_or(0);
+          argPos = builder.getBlockArgRange(parentPos, startIndex);
+        })
+        .Case([&](pdl::OperationOp operationOp) {
+          // If this operation has a parentBlock, add a predicate to check
+          // that the matched operation is contained within the expected block.
+          Value parentBlock = operationOp.getParentBlock();
+          if (!parentBlock)
+            return;
+          Position *opPos = inputs.lookup(operationOp);
+          Position *blockPos = inputs.lookup(parentBlock);
+          if (!opPos || !blockPos)
+            return;
+          predList.emplace_back(opPos, builder.getCheckParentBlock(blockPos));
         });
+  }
+
+  // Emit block arg count predicates. For each block, count how many
+  // block_arg (scalar) and block_args (range) ops reference it.
+  DenseMap<Value, std::pair<unsigned, bool>> blockArgInfo;
+  for (Operation &op : pattern.getBodyRegion().getOps()) {
+    if (auto blockArgOp = dyn_cast<pdl::BlockArgOp>(op)) {
+      auto &info = blockArgInfo[blockArgOp.getParent()];
+      info.first = std::max(info.first, blockArgOp.getIndex() + 1);
+    } else if (auto blockArgsOp = dyn_cast<pdl::BlockArgsOp>(op)) {
+      auto &info = blockArgInfo[blockArgsOp.getParent()];
+      info.second = true; // has variadic
+      if (blockArgsOp.getIndex()) {
+        unsigned minCount = *blockArgsOp.getIndex();
+        info.first = std::max(info.first, minCount);
+      }
+    }
+  }
+  for (auto &[blockVal, info] : blockArgInfo) {
+    Position *blockPos = inputs.lookup(blockVal);
+    if (!blockPos)
+      continue;
+    auto [minArgs, hasVariadic] = info;
+    if (hasVariadic) {
+      if (minArgs)
+        predList.emplace_back(blockPos,
+                              builder.getBlockArgCountAtLeast(minArgs));
+    } else {
+      predList.emplace_back(blockPos, builder.getBlockArgCount(minArgs));
+    }
   }
 }
 
@@ -460,6 +535,7 @@ static void buildCostGraph(ArrayRef<Value> roots, RootOrderingGraph &graph,
     while (!toVisit.empty()) {
       Entry entry = toVisit.front();
       toVisit.pop();
+
       // Skip if already visited.
       if (!parentMap.insert({entry.value, {entry.parent, entry.index}}).second)
         continue;
@@ -479,18 +555,50 @@ static void buildCostGraph(ArrayRef<Value> roots, RootOrderingGraph &graph,
                 isa<pdl::RangeType>(operands[0].getType())) {
               toVisit.emplace(operands[0], entry.value, std::nullopt,
                               entry.depth + 1);
-              return;
+            } else {
+              // Default case: visit all the operands.
+              for (const auto &p :
+                   llvm::enumerate(operationOp.getOperandValues()))
+                toVisit.emplace(p.value(), entry.value, p.index(),
+                                entry.depth + 1);
             }
 
-            // Default case: visit all the operands.
-            for (const auto &p :
-                 llvm::enumerate(operationOp.getOperandValues()))
-              toVisit.emplace(p.value(), entry.value, p.index(),
+            // Follow structural edges: traverse into regions via
+            // region_of ops that reference this operation.
+            for (Operation *user : operationOp->getUsers()) {
+              if (auto regionOp = dyn_cast<pdl::RegionOp>(user))
+                toVisit.emplace(regionOp.getResult(), entry.value,
+                                static_cast<unsigned>(regionOp.getIndex()),
+                                entry.depth + 1);
+            }
+
+            // Follow parentBlock edge upward: if this operation has a
+            // parentBlock, the block value is a connector to the outer
+            // root.
+            if (Value parentBlock = operationOp.getParentBlock()) {
+              toVisit.emplace(parentBlock, entry.value, std::nullopt,
                               entry.depth + 1);
+            }
           })
           .Case<pdl::ResultOp, pdl::ResultsOp>([&](auto resultOp) {
             toVisit.emplace(resultOp.getParent(), entry.value,
                             resultOp.getIndex(), entry.depth);
+          })
+          // Follow structural navigation: region → blocks.
+          .Case([&](pdl::RegionOp regionOp) {
+            // Traverse from a region into its blocks via block_of ops.
+            for (Operation *user : regionOp->getUsers()) {
+              if (auto blockOp = dyn_cast<pdl::BlockOp>(user))
+                toVisit.emplace(blockOp.getResult(), entry.value,
+                                static_cast<unsigned>(blockOp.getIndex()),
+                                entry.depth + 1);
+            }
+          })
+          .Case([&](pdl::BlockOp blockOp) {
+            // A block can connect to inner ops via their parentBlock.
+            // No explicit traversal needed here -- the parentBlock
+            // traversal on OperationOp handles the reverse direction.
+            // But we do need to register the block value as visited.
           });
     }
   }
@@ -521,7 +629,6 @@ static void buildCostGraph(ArrayRef<Value> roots, RootOrderingGraph &graph,
       }
     }
   }
-
   assert((llvm::hasSingleElement(roots) || graph.size() == roots.size()) &&
          "the pattern contains a candidate root disconnected from the others");
 }
@@ -607,6 +714,30 @@ static void visitUpward(std::vector<PositionalPredicate> &predList,
       });
 }
 
+/// Visit a node during downward structural traversal. This is the analog of
+/// visitUpward for structural edges: instead of traversing from operand users
+/// to reach a secondary root, we traverse from a block (via get_block_ops +
+/// forEach) to reach an inner operation root.
+static void visitDownward(std::vector<PositionalPredicate> &predList,
+                          Value target, PredicateBuilder &builder,
+                          DenseMap<Value, Position *> &valueToPosition,
+                          Position *blockPos, unsigned rootID) {
+  // Emit: getBlockOps(block) → forEach(ops) → op candidate
+  auto *typedBlockPos = cast<BlockPosition>(blockPos);
+  Position *blockOpsPos = builder.getBlockOps(typedBlockPos);
+  Position *foreachPos = builder.getForEach(blockOpsPos, rootID);
+  OperationPosition *opPos = builder.getPassthroughOp(foreachPos);
+
+  // Ensure the operation is not null.
+  predList.emplace_back(opPos, builder.getIsNotNull());
+
+  // Register the inner op's position.
+  valueToPosition[target] = opPos;
+
+  // Get the tree predicates for the inner op.
+  getTreePredicates(predList, target, builder, valueToPosition, opPos);
+}
+
 /// Given a pattern operation, build the set of matcher predicates necessary to
 /// match this pattern.
 static Value buildPredicateList(pdl::PatternOp pattern,
@@ -687,15 +818,45 @@ static Value buildPredicateList(pdl::PatternOp pattern,
     assert(connector && "invalid edge");
     LDBG() << "  * Connector: " << connector.getLoc();
     DenseMap<Value, OpIndex> parentMap = parentMaps.lookup(target);
-    Position *pos = valueToPosition.lookup(connector);
-    assert(pos && "connector has not been traversed yet");
 
-    // Traverse from the connector upwards towards the target root.
-    for (Value value = connector; value != target;) {
-      OpIndex opIndex = parentMap.lookup(value);
-      assert(opIndex.parent && "missing parent");
-      visitUpward(predList, opIndex, builder, valueToPosition, pos, it.index());
-      value = opIndex.parent;
+    // Traverse from the connector towards the target root.
+    // Detect whether this is a structural edge (connector is a block value
+    // reached via region_of/block_of) or an operand-result edge.
+    if (auto blockOp =
+            dyn_cast_or_null<pdl::BlockOp>(connector.getDefiningOp())) {
+      // Structural traversal: the connector is a block, and the target
+      // is an inner operation with parentBlock = that block.
+
+      // Materialize the structural chain positions (region → block)
+      // since getNonTreePredicates hasn't run yet.
+      auto regionOp = cast<pdl::RegionOp>(blockOp.getParent().getDefiningOp());
+      auto *outerOpPos =
+          cast<OperationPosition>(valueToPosition.lookup(regionOp.getParent()));
+
+      // Build region position.
+      RegionPosition *regionPos =
+          builder.getRegion(outerOpPos, regionOp.getIndex());
+      valueToPosition.try_emplace(regionOp, regionPos);
+
+      // Build block position.
+      BlockPosition *blockPos = builder.getBlock(regionPos, blockOp.getIndex());
+      valueToPosition.try_emplace(connector, blockPos);
+
+      // Use visitDownward to emit get_block_ops + forEach.
+      visitDownward(predList, target, builder, valueToPosition, blockPos,
+                    it.index());
+    } else {
+      Position *pos = valueToPosition.lookup(connector);
+      assert(pos && "connector has not been traversed yet");
+
+      // Standard upward traversal via operand-result edges.
+      for (Value value = connector; value != target;) {
+        OpIndex opIndex = parentMap.lookup(value);
+        assert(opIndex.parent && "missing parent");
+        visitUpward(predList, opIndex, builder, valueToPosition, pos,
+                    it.index());
+        value = opIndex.parent;
+      }
     }
   }
 

--- a/mlir/lib/Dialect/PDL/IR/PDL.cpp
+++ b/mlir/lib/Dialect/PDL/IR/PDL.cpp
@@ -39,7 +39,10 @@ void PDLDialect::initialize() {
 static bool hasBindingUse(Operation *op) {
   for (Operation *user : op->getUsers())
     // A result by itself is not binding, it must also be bound.
-    if (!isa<ResultOp, ResultsOp>(user) || hasBindingUse(user))
+    // Region/block navigation ops (RegionOp, BlockOp) count as binding because
+    // they establish structural constraints on the parent operation/region.
+    if (isa<RegionOp, BlockOp>(user) || !isa<ResultOp, ResultsOp>(user) ||
+        hasBindingUse(user))
       return true;
   return false;
 }
@@ -50,6 +53,11 @@ static LogicalResult verifyHasBindingUse(Operation *op) {
   // If the parent is not a pattern, there is nothing to do.
   if (!llvm::isa_and_nonnull<PatternOp>(op->getParentOp()))
     return success();
+  // An OperationOp with a parentBlock is structurally bound to its containing
+  // block — it is inherently connected to the pattern's match tree.
+  if (auto opOp = dyn_cast<OperationOp>(op))
+    if (opOp.getParentBlock())
+      return success();
   if (hasBindingUse(op))
     return success();
   return op->emitOpError(
@@ -57,8 +65,8 @@ static LogicalResult verifyHasBindingUse(Operation *op) {
       "`pdl.pattern`");
 }
 
-/// Visits all the pdl.operand(s), pdl.result(s), and pdl.operation(s)
-/// connected to the given operation.
+/// Visits all the pdl.operand(s), pdl.result(s), pdl.operation(s),
+/// pdl.region_of(s), and pdl.block_of(s) connected to the given operation.
 static void visit(Operation *op, DenseSet<Operation *> &visited) {
   // If the parent is not a pattern, there is nothing to do.
   if (!isa<PatternOp>(op->getParentOp()) || isa<RewriteOp>(op))
@@ -73,9 +81,21 @@ static void visit(Operation *op, DenseSet<Operation *> &visited) {
       .Case([&visited](OperationOp operation) {
         for (Value operand : operation.getOperandValues())
           visit(operand.getDefiningOp(), visited);
+        // Traverse the parent block if this operation is scoped.
+        if (Value block = operation.getParentBlock())
+          visit(block.getDefiningOp(), visited);
       })
       .Case<ResultOp, ResultsOp>([&visited](auto result) {
         visit(result.getParent().getDefiningOp(), visited);
+      })
+      .Case([&visited](RegionOp regionOp) {
+        visit(regionOp.getParent().getDefiningOp(), visited);
+      })
+      .Case([&visited](BlockOp blockOp) {
+        visit(blockOp.getParent().getDefiningOp(), visited);
+      })
+      .Case<BlockArgOp, BlockArgsOp>([&visited](auto blockArgOp) {
+        visit(blockArgOp.getParent().getDefiningOp(), visited);
       });
 
   // Traverse the users.
@@ -350,7 +370,8 @@ LogicalResult PatternOp::verifyRegions() {
   DenseSet<Operation *> visited;
   for (Operation &op : body.front()) {
     // The following are the operations forming the connected component.
-    if (!isa<OperandOp, OperandsOp, ResultOp, ResultsOp, OperationOp>(op))
+    if (!isa<OperandOp, OperandsOp, ResultOp, ResultsOp, OperationOp, RegionOp,
+             BlockOp, BlockArgOp, BlockArgsOp>(op))
       continue;
 
     // Determine if the operation has a user in `pdl.rewrite`.
@@ -460,13 +481,23 @@ static ParseResult parseResultsValueType(OpAsmParser &p, IntegerAttr index,
   return success();
 }
 
-static void printResultsValueType(OpAsmPrinter &p, ResultsOp op,
+template <typename OpTy>
+static void printResultsValueType(OpAsmPrinter &p, OpTy /*op*/,
                                   IntegerAttr index, Type resultType) {
   if (index)
     p << " -> " << resultType;
 }
 
 LogicalResult ResultsOp::verify() {
+  if (!getIndex() && llvm::isa<pdl::ValueType>(getType())) {
+    return emitOpError() << "expected `pdl.range<value>` result type when "
+                            "no index is specified, but got: "
+                         << getType();
+  }
+  return success();
+}
+
+LogicalResult BlockArgsOp::verify() {
   if (!getIndex() && llvm::isa<pdl::ValueType>(getType())) {
     return emitOpError() << "expected `pdl.range<value>` result type when "
                             "no index is specified, but got: "

--- a/mlir/lib/IR/PDL/PDLPatternMatch.cpp
+++ b/mlir/lib/IR/PDL/PDLPatternMatch.cpp
@@ -25,8 +25,14 @@ void PDLValue::print(raw_ostream &os) const {
   case Kind::Attribute:
     os << cast<Attribute>();
     break;
+  case Kind::Block:
+    os << *cast<Block *>();
+    break;
   case Kind::Operation:
     os << *cast<Operation *>();
+    break;
+  case Kind::Region:
+    os << *cast<Region *>();
     break;
   case Kind::Type:
     os << cast<Type>();
@@ -48,8 +54,14 @@ void PDLValue::print(raw_ostream &os, Kind kind) {
   case Kind::Attribute:
     os << "Attribute";
     break;
+  case Kind::Block:
+    os << "Block";
+    break;
   case Kind::Operation:
     os << "Operation";
+    break;
+  case Kind::Region:
+    os << "Region";
     break;
   case Kind::Type:
     os << "Type";

--- a/mlir/lib/Rewrite/ByteCode.cpp
+++ b/mlir/lib/Rewrite/ByteCode.cpp
@@ -92,10 +92,18 @@ enum OpCode : ByteCodeField {
   AreRangesEqual,
   /// Unconditional branch.
   Branch,
+  /// Compare the number of block arguments with a constant.
+  CheckBlockArgCount,
+  /// Compare the number of blocks in a region with a constant.
+  CheckBlockCount,
+  /// Check if an operation's parent block matches an expected block.
+  CheckParentBlock,
   /// Compare the operand count of an operation with a constant.
   CheckOperandCount,
   /// Compare the name of an operation with a constant.
   CheckOperationName,
+  /// Compare the number of regions of an operation with a constant.
+  CheckRegionCount,
   /// Compare the result count of an operation with a constant.
   CheckResultCount,
   /// Compare a range of types to a constant range of types.
@@ -122,10 +130,18 @@ enum OpCode : ByteCodeField {
   Finalize,
   /// Iterate over a range of values.
   ForEach,
+  /// Get all operations within a block.
+  GetBlockOps,
   /// Get a specific attribute of an operation.
   GetAttribute,
   /// Get the type of an attribute.
   GetAttributeType,
+  /// Get a specific block from a region.
+  GetBlock,
+  /// Get a specific argument from a block.
+  GetBlockArgument,
+  /// Get a group of arguments from a block.
+  GetBlockArguments,
   /// Get the defining operation of a value.
   GetDefiningOp,
   /// Get a specific operand of an operation.
@@ -136,6 +152,8 @@ enum OpCode : ByteCodeField {
   GetOperandN,
   /// Get a specific operand group of an operation.
   GetOperands,
+  /// Get a specific region from an operation.
+  GetRegion,
   /// Get a specific result of an operation.
   GetResult0,
   GetResult1,
@@ -152,6 +170,10 @@ enum OpCode : ByteCodeField {
   GetValueRangeTypes,
   /// Check if a generic value is not null.
   IsNotNull,
+  /// Move a block before another block.
+  MoveBlock,
+  /// Move the contents of one region into another.
+  TakeRegion,
   /// Record a successful pattern match.
   RecordMatch,
   /// Replace an operation.
@@ -265,8 +287,12 @@ private:
   void generate(pdl_interp::AreEqualOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::BranchOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::CheckAttributeOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::CheckBlockArgCountOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::CheckBlockCountOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::CheckParentBlockOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::CheckOperandCountOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::CheckOperationNameOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::CheckRegionCountOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::CheckResultCountOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::CheckTypeOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::CheckTypesOp op, ByteCodeWriter &writer);
@@ -280,16 +306,23 @@ private:
   void generate(pdl_interp::ExtractOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::FinalizeOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::ForEachOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::GetBlockOpsOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetAttributeOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetAttributeTypeOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::GetBlockOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::GetBlockArgumentOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::GetBlockArgumentsOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetDefiningOpOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetOperandOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetOperandsOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::GetRegionOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetResultOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetResultsOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetUsersOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::GetValueTypeOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::IsNotNullOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::MoveBlockOp op, ByteCodeWriter &writer);
+  void generate(pdl_interp::TakeRegionOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::RecordMatchOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::ReplaceOp op, ByteCodeWriter &writer);
   void generate(pdl_interp::SwitchAttributeOp op, ByteCodeWriter &writer);
@@ -402,8 +435,10 @@ struct ByteCodeWriter {
         TypeSwitch<Type, PDLValue::Kind>(type)
             .Case<pdl::AttributeType>(
                 [](Type) { return PDLValue::Kind::Attribute; })
+            .Case<pdl::BlockType>([](Type) { return PDLValue::Kind::Block; })
             .Case<pdl::OperationType>(
                 [](Type) { return PDLValue::Kind::Operation; })
+            .Case<pdl::RegionType>([](Type) { return PDLValue::Kind::Region; })
             .Case([](pdl::RangeType rangeTy) {
               if (isa<pdl::TypeType>(rangeTy.getElementType()))
                 return PDLValue::Kind::TypeRange;
@@ -746,23 +781,28 @@ void Generator::generate(Operation *op, ByteCodeWriter &writer) {
   TypeSwitch<Operation *>(op)
       .Case<pdl_interp::ApplyConstraintOp, pdl_interp::ApplyRewriteOp,
             pdl_interp::AreEqualOp, pdl_interp::BranchOp,
-            pdl_interp::CheckAttributeOp, pdl_interp::CheckOperandCountOp,
-            pdl_interp::CheckOperationNameOp, pdl_interp::CheckResultCountOp,
+            pdl_interp::CheckAttributeOp, pdl_interp::CheckBlockArgCountOp,
+            pdl_interp::CheckBlockCountOp, pdl_interp::CheckParentBlockOp,
+            pdl_interp::CheckOperandCountOp, pdl_interp::CheckOperationNameOp,
+            pdl_interp::CheckRegionCountOp, pdl_interp::CheckResultCountOp,
             pdl_interp::CheckTypeOp, pdl_interp::CheckTypesOp,
             pdl_interp::ContinueOp, pdl_interp::CreateAttributeOp,
             pdl_interp::CreateOperationOp, pdl_interp::CreateRangeOp,
             pdl_interp::CreateTypeOp, pdl_interp::CreateTypesOp,
             pdl_interp::EraseOp, pdl_interp::ExtractOp, pdl_interp::FinalizeOp,
             pdl_interp::ForEachOp, pdl_interp::GetAttributeOp,
-            pdl_interp::GetAttributeTypeOp, pdl_interp::GetDefiningOpOp,
+            pdl_interp::GetAttributeTypeOp, pdl_interp::GetBlockOp,
+            pdl_interp::GetBlockArgumentOp, pdl_interp::GetBlockArgumentsOp,
+            pdl_interp::GetBlockOpsOp, pdl_interp::GetDefiningOpOp,
             pdl_interp::GetOperandOp, pdl_interp::GetOperandsOp,
-            pdl_interp::GetResultOp, pdl_interp::GetResultsOp,
-            pdl_interp::GetUsersOp, pdl_interp::GetValueTypeOp,
-            pdl_interp::IsNotNullOp, pdl_interp::RecordMatchOp,
-            pdl_interp::ReplaceOp, pdl_interp::SwitchAttributeOp,
-            pdl_interp::SwitchTypeOp, pdl_interp::SwitchTypesOp,
-            pdl_interp::SwitchOperandCountOp, pdl_interp::SwitchOperationNameOp,
-            pdl_interp::SwitchResultCountOp>(
+            pdl_interp::GetRegionOp, pdl_interp::GetResultOp,
+            pdl_interp::GetResultsOp, pdl_interp::GetUsersOp,
+            pdl_interp::GetValueTypeOp, pdl_interp::IsNotNullOp,
+            pdl_interp::MoveBlockOp, pdl_interp::TakeRegionOp,
+            pdl_interp::RecordMatchOp, pdl_interp::ReplaceOp,
+            pdl_interp::SwitchAttributeOp, pdl_interp::SwitchTypeOp,
+            pdl_interp::SwitchTypesOp, pdl_interp::SwitchOperandCountOp,
+            pdl_interp::SwitchOperationNameOp, pdl_interp::SwitchResultCountOp>(
           [&](auto interpOp) { this->generate(interpOp, writer); })
       .DefaultUnreachable("unknown `pdl_interp` operation");
 }
@@ -829,6 +869,23 @@ void Generator::generate(pdl_interp::CheckAttributeOp op,
   writer.append(OpCode::AreEqual, op.getAttribute(), op.getConstantValue(),
                 op.getSuccessors());
 }
+void Generator::generate(pdl_interp::CheckBlockArgCountOp op,
+                         ByteCodeWriter &writer) {
+  writer.append(OpCode::CheckBlockArgCount, op.getInputBlock(), op.getCount(),
+                static_cast<ByteCodeField>(op.getCompareAtLeast()),
+                op.getSuccessors());
+}
+void Generator::generate(pdl_interp::CheckBlockCountOp op,
+                         ByteCodeWriter &writer) {
+  writer.append(OpCode::CheckBlockCount, op.getInputRegion(), op.getCount(),
+                static_cast<ByteCodeField>(op.getCompareAtLeast()),
+                op.getSuccessors());
+}
+void Generator::generate(pdl_interp::CheckParentBlockOp op,
+                         ByteCodeWriter &writer) {
+  writer.append(OpCode::CheckParentBlock, op.getInputOp(), op.getInputBlock(),
+                op.getSuccessors());
+}
 void Generator::generate(pdl_interp::CheckOperandCountOp op,
                          ByteCodeWriter &writer) {
   writer.append(OpCode::CheckOperandCount, op.getInputOp(), op.getCount(),
@@ -839,6 +896,12 @@ void Generator::generate(pdl_interp::CheckOperationNameOp op,
                          ByteCodeWriter &writer) {
   writer.append(OpCode::CheckOperationName, op.getInputOp(),
                 OperationName(op.getName(), ctx), op.getSuccessors());
+}
+void Generator::generate(pdl_interp::CheckRegionCountOp op,
+                         ByteCodeWriter &writer) {
+  writer.append(OpCode::CheckRegionCount, op.getInputOp(), op.getCount(),
+                static_cast<ByteCodeField>(op.getCompareAtLeast()),
+                op.getSuccessors());
 }
 void Generator::generate(pdl_interp::CheckResultCountOp op,
                          ByteCodeWriter &writer) {
@@ -928,6 +991,11 @@ void Generator::generate(pdl_interp::ForEachOp op, ByteCodeWriter &writer) {
   generate(&op.getRegion(), writer);
   --curLoopLevel;
 }
+void Generator::generate(pdl_interp::GetBlockOpsOp op, ByteCodeWriter &writer) {
+  writer.append(OpCode::GetBlockOps, op.getBlock());
+  writer.append(getMemIndex(op.getOperations()),
+                getRangeStorageIndex(op.getOperations()));
+}
 void Generator::generate(pdl_interp::GetAttributeOp op,
                          ByteCodeWriter &writer) {
   writer.append(OpCode::GetAttribute, op.getAttribute(), op.getInputOp(),
@@ -936,6 +1004,28 @@ void Generator::generate(pdl_interp::GetAttributeOp op,
 void Generator::generate(pdl_interp::GetAttributeTypeOp op,
                          ByteCodeWriter &writer) {
   writer.append(OpCode::GetAttributeType, op.getResult(), op.getValue());
+}
+void Generator::generate(pdl_interp::GetBlockOp op, ByteCodeWriter &writer) {
+  writer.append(OpCode::GetBlock, op.getIndex(), op.getInputRegion(),
+                op.getBlock());
+}
+void Generator::generate(pdl_interp::GetBlockArgumentOp op,
+                         ByteCodeWriter &writer) {
+  writer.append(OpCode::GetBlockArgument, op.getIndex(), op.getInputBlock(),
+                op.getValue());
+}
+void Generator::generate(pdl_interp::GetBlockArgumentsOp op,
+                         ByteCodeWriter &writer) {
+  Value result = op.getValue();
+  std::optional<uint32_t> index = op.getIndex();
+  writer.append(OpCode::GetBlockArguments,
+                index.value_or(std::numeric_limits<uint32_t>::max()),
+                op.getInputBlock());
+  if (isa<pdl::RangeType>(result.getType()))
+    writer.append(getRangeStorageIndex(result));
+  else
+    writer.append(std::numeric_limits<ByteCodeField>::max());
+  writer.append(result);
 }
 void Generator::generate(pdl_interp::GetDefiningOpOp op,
                          ByteCodeWriter &writer) {
@@ -961,6 +1051,10 @@ void Generator::generate(pdl_interp::GetOperandsOp op, ByteCodeWriter &writer) {
   else
     writer.append(std::numeric_limits<ByteCodeField>::max());
   writer.append(result);
+}
+void Generator::generate(pdl_interp::GetRegionOp op, ByteCodeWriter &writer) {
+  writer.append(OpCode::GetRegion, op.getIndex(), op.getInputOp(),
+                op.getRegion());
 }
 void Generator::generate(pdl_interp::GetResultOp op, ByteCodeWriter &writer) {
   uint32_t index = op.getIndex();
@@ -1000,6 +1094,12 @@ void Generator::generate(pdl_interp::GetValueTypeOp op,
 }
 void Generator::generate(pdl_interp::IsNotNullOp op, ByteCodeWriter &writer) {
   writer.append(OpCode::IsNotNull, op.getValue(), op.getSuccessors());
+}
+void Generator::generate(pdl_interp::MoveBlockOp op, ByteCodeWriter &writer) {
+  writer.append(OpCode::MoveBlock, op.getBlock(), op.getDest());
+}
+void Generator::generate(pdl_interp::TakeRegionOp op, ByteCodeWriter &writer) {
+  writer.append(OpCode::TakeRegion, op.getSource(), op.getDest());
 }
 void Generator::generate(pdl_interp::RecordMatchOp op, ByteCodeWriter &writer) {
   ByteCodeField patternIndex = patterns.size();
@@ -1151,8 +1251,12 @@ private:
   void executeAreEqual();
   void executeAreRangesEqual();
   void executeBranch();
+  void executeCheckBlockArgCount();
+  void executeCheckBlockCount();
+  void executeCheckParentBlock();
   void executeCheckOperandCount();
   void executeCheckOperationName();
+  void executeCheckRegionCount();
   void executeCheckResultCount();
   void executeCheckTypes();
   void executeContinue();
@@ -1166,17 +1270,24 @@ private:
   void executeExtract();
   void executeFinalize();
   void executeForEach();
+  void executeGetBlockOps();
   void executeGetAttribute();
   void executeGetAttributeType();
+  void executeGetBlock();
+  void executeGetBlockArgument();
+  void executeGetBlockArguments();
   void executeGetDefiningOp();
   void executeGetOperand(unsigned index);
   void executeGetOperands();
+  void executeGetRegion();
   void executeGetResult(unsigned index);
   void executeGetResults();
   void executeGetUsers();
   void executeGetValueType();
   void executeGetValueRangeTypes();
   void executeIsNotNull();
+  void executeMoveBlock(PatternRewriter &rewriter);
+  void executeTakeRegion(PatternRewriter &rewriter);
   void executeRecordMatch(PatternRewriter &rewriter,
                           SmallVectorImpl<PDLByteCode::MatchResult> &matches);
   void executeReplaceOp(PatternRewriter &rewriter);
@@ -1326,8 +1437,12 @@ private:
     switch (read<PDLValue::Kind>()) {
     case PDLValue::Kind::Attribute:
       return read<Attribute>();
+    case PDLValue::Kind::Block:
+      return read<Block *>();
     case PDLValue::Kind::Operation:
       return read<Operation *>();
+    case PDLValue::Kind::Region:
+      return read<Region *>();
     case PDLValue::Kind::Type:
       return read<Type>();
     case PDLValue::Kind::Value:
@@ -1559,6 +1674,46 @@ void ByteCodeExecutor::executeBranch() {
   curCodeIt = &code[read<ByteCodeAddr>()];
 }
 
+void ByteCodeExecutor::executeCheckBlockArgCount() {
+  LDBG() << "Executing CheckBlockArgCount:";
+  auto *block = read<Block *>();
+  uint32_t expectedCount = read<uint32_t>();
+  bool compareAtLeast = read();
+
+  unsigned numArgs = block ? block->getNumArguments() : 0;
+  LDBG() << "  * Found: " << numArgs << "\n  * Expected: " << expectedCount
+         << "\n  * Comparator: " << (compareAtLeast ? ">=" : "==");
+  if (compareAtLeast)
+    selectJump(numArgs >= expectedCount);
+  else
+    selectJump(numArgs == expectedCount);
+}
+
+void ByteCodeExecutor::executeCheckBlockCount() {
+  LDBG() << "Executing CheckBlockCount:";
+  auto *region = read<Region *>();
+  uint32_t expectedCount = read<uint32_t>();
+  bool compareAtLeast = read();
+
+  unsigned numBlocks = region ? llvm::range_size(region->getBlocks()) : 0;
+  LDBG() << "  * Found: " << numBlocks << "\n  * Expected: " << expectedCount
+         << "\n  * Comparator: " << (compareAtLeast ? ">=" : "==");
+  if (compareAtLeast)
+    selectJump(numBlocks >= expectedCount);
+  else
+    selectJump(numBlocks == expectedCount);
+}
+
+void ByteCodeExecutor::executeCheckParentBlock() {
+  LDBG() << "Executing CheckParentBlock:";
+  auto *op = read<Operation *>();
+  auto *expectedBlock = read<Block *>();
+  Block *actualBlock = op ? op->getBlock() : nullptr;
+  LDBG() << "  * Op: " << op << "\n  * Expected Block: " << expectedBlock
+         << "\n  * Actual Block: " << actualBlock;
+  selectJump(actualBlock == expectedBlock);
+}
+
 void ByteCodeExecutor::executeCheckOperandCount() {
   LDBG() << "Executing CheckOperandCount:";
   Operation *op = read<Operation *>();
@@ -1582,6 +1737,21 @@ void ByteCodeExecutor::executeCheckOperationName() {
   LDBG() << "  * Found: \"" << op->getName() << "\"\n  * Expected: \""
          << expectedName << "\"";
   selectJump(op->getName() == expectedName);
+}
+
+void ByteCodeExecutor::executeCheckRegionCount() {
+  LDBG() << "Executing CheckRegionCount:";
+  Operation *op = read<Operation *>();
+  uint32_t expectedCount = read<uint32_t>();
+  bool compareAtLeast = read();
+
+  unsigned numRegions = op ? op->getNumRegions() : 0;
+  LDBG() << "  * Found: " << numRegions << "\n  * Expected: " << expectedCount
+         << "\n  * Comparator: " << (compareAtLeast ? ">=" : "==");
+  if (compareAtLeast)
+    selectJump(numRegions >= expectedCount);
+  else
+    selectJump(numRegions == expectedCount);
 }
 
 void ByteCodeExecutor::executeCheckResultCount() {
@@ -1718,6 +1888,24 @@ void ByteCodeExecutor::executeExtract() {
 
 void ByteCodeExecutor::executeFinalize() { LDBG() << "Executing Finalize"; }
 
+void ByteCodeExecutor::executeGetBlockOps() {
+  LDBG() << "Executing GetBlockOps:";
+  auto *block = read<Block *>();
+  unsigned memIndex = read();
+  unsigned rangeIndex = read();
+
+  std::vector<Operation *> &range = opRangeMemory[rangeIndex];
+  range.clear();
+
+  if (block) {
+    for (Operation &op : block->getOperations())
+      range.push_back(&op);
+  }
+
+  LDBG() << "  * Result: " << range.size() << " operations";
+  memory[memIndex] = &range;
+}
+
 void ByteCodeExecutor::executeForEach() {
   LDBG() << "Executing ForEach:";
   const ByteCodeField *prevCodeIt = getPrevCodeIt();
@@ -1807,6 +1995,73 @@ void ByteCodeExecutor::executeGetAttributeType() {
   memory[memIndex] = type.getAsOpaquePointer();
 }
 
+void ByteCodeExecutor::executeGetBlock() {
+  LDBG() << "Executing GetBlock:";
+  unsigned index = read<uint32_t>();
+  auto *region = read<Region *>();
+  unsigned memIndex = read();
+
+  Block *block = nullptr;
+  if (region && !region->empty()) {
+    auto it = region->begin();
+    while (index-- > 0 && it != region->end())
+      ++it;
+    if (it != region->end())
+      block = &*it;
+  }
+
+  LDBG() << "  * Index: " << index << "\n  * Result: " << block;
+  memory[memIndex] = block;
+}
+
+void ByteCodeExecutor::executeGetBlockArgument() {
+  LDBG() << "Executing GetBlockArgument:";
+  unsigned index = read<uint32_t>();
+  auto *block = read<Block *>();
+  unsigned memIndex = read();
+
+  Value arg;
+  if (block && index < block->getNumArguments())
+    arg = block->getArgument(index);
+
+  LDBG() << "  * Index: " << index << "\n  * Result: " << arg;
+  memory[memIndex] = arg.getAsOpaquePointer();
+}
+
+void ByteCodeExecutor::executeGetBlockArguments() {
+  LDBG() << "Executing GetBlockArguments:";
+  unsigned index = read<uint32_t>();
+  auto *block = read<Block *>();
+  ByteCodeField rangeIndex = read();
+
+  if (!block) {
+    LDBG() << "  * Null block";
+    memory[read()] = nullptr;
+    return;
+  }
+
+  // Get all block arguments or a subrange starting at the given index.
+  auto args = block->getArguments();
+  if (index != std::numeric_limits<uint32_t>::max()) {
+    if (index <= args.size())
+      args = args.drop_front(index);
+    else
+      args = args.drop_front(args.size()); // empty
+  }
+
+  LDBG() << "  * Index: " << index << "\n  * Num args: " << args.size();
+
+  // If the range index is valid, we are returning a range.
+  if (rangeIndex != std::numeric_limits<ByteCodeField>::max()) {
+    valueRangeMemory[rangeIndex] = args;
+    memory[read()] = &valueRangeMemory[rangeIndex];
+  } else {
+    // Scalar case: the range must have exactly one element.
+    memory[read()] =
+        args.size() == 1 ? args.front().getAsOpaquePointer() : nullptr;
+  }
+}
+
 void ByteCodeExecutor::executeGetDefiningOp() {
   LDBG() << "Executing GetDefiningOp:";
   unsigned memIndex = read();
@@ -1837,6 +2092,21 @@ void ByteCodeExecutor::executeGetOperand(unsigned index) {
   LDBG() << "  * Operation: " << *op << "\n  * Index: " << index
          << "\n  * Result: " << operand;
   memory[memIndex] = operand.getAsOpaquePointer();
+}
+
+void ByteCodeExecutor::executeGetRegion() {
+  LDBG() << "Executing GetRegion:";
+  unsigned index = read<uint32_t>();
+  Operation *op = read<Operation *>();
+  unsigned memIndex = read();
+
+  Region *region = nullptr;
+  if (op && index < op->getNumRegions())
+    region = &op->getRegion(index);
+
+  LDBG() << "  * Operation: " << (op ? op->getName().getStringRef() : "null")
+         << "\n  * Index: " << index << "\n  * Result: " << region;
+  memory[memIndex] = region;
 }
 
 /// This function is the internal implementation of `GetResults` and
@@ -2054,6 +2324,27 @@ void ByteCodeExecutor::executeRecordMatch(
   curCodeIt = dest;
 }
 
+void ByteCodeExecutor::executeMoveBlock(PatternRewriter &rewriter) {
+  LDBG() << "Executing MoveBlock:";
+  Block *block = read<Block *>();
+  Block *destBlock = read<Block *>();
+  LDBG() << "  * Moving block before destination block";
+  assert(block && destBlock && "Invalid block or destination block");
+  rewriter.moveBlockBefore(block, destBlock);
+}
+
+void ByteCodeExecutor::executeTakeRegion(PatternRewriter &rewriter) {
+  LDBG() << "Executing TakeRegion:";
+  Region *source = read<Region *>();
+  Region *dest = read<Region *>();
+  LDBG() << "  * Moving region contents into destination region";
+  // Move the source region's body into the destination region.
+  // This uses inlineRegionBefore to preserve proper notification to the pattern
+  // rewriter.
+  assert(source && dest && "Invalid source or destination region");
+  rewriter.inlineRegionBefore(*source, *dest, dest->end());
+}
+
 void ByteCodeExecutor::executeReplaceOp(PatternRewriter &rewriter) {
   LDBG() << "Executing ReplaceOp:";
   Operation *op = read<Operation *>();
@@ -2164,11 +2455,23 @@ ByteCodeExecutor::execute(PatternRewriter &rewriter,
     case Branch:
       executeBranch();
       break;
+    case CheckBlockArgCount:
+      executeCheckBlockArgCount();
+      break;
+    case CheckBlockCount:
+      executeCheckBlockCount();
+      break;
+    case CheckParentBlock:
+      executeCheckParentBlock();
+      break;
     case CheckOperandCount:
       executeCheckOperandCount();
       break;
     case CheckOperationName:
       executeCheckOperationName();
+      break;
+    case CheckRegionCount:
+      executeCheckRegionCount();
       break;
     case CheckResultCount:
       executeCheckResultCount();
@@ -2211,11 +2514,23 @@ ByteCodeExecutor::execute(PatternRewriter &rewriter,
     case ForEach:
       executeForEach();
       break;
+    case GetBlockOps:
+      executeGetBlockOps();
+      break;
     case GetAttribute:
       executeGetAttribute();
       break;
     case GetAttributeType:
       executeGetAttributeType();
+      break;
+    case GetBlock:
+      executeGetBlock();
+      break;
+    case GetBlockArgument:
+      executeGetBlockArgument();
+      break;
+    case GetBlockArguments:
+      executeGetBlockArguments();
       break;
     case GetDefiningOp:
       executeGetDefiningOp();
@@ -2235,6 +2550,9 @@ ByteCodeExecutor::execute(PatternRewriter &rewriter,
       break;
     case GetOperands:
       executeGetOperands();
+      break;
+    case GetRegion:
+      executeGetRegion();
       break;
     case GetResult0:
     case GetResult1:
@@ -2263,6 +2581,12 @@ ByteCodeExecutor::execute(PatternRewriter &rewriter,
       break;
     case IsNotNull:
       executeIsNotNull();
+      break;
+    case MoveBlock:
+      executeMoveBlock(rewriter);
+      break;
+    case TakeRegion:
+      executeTakeRegion(rewriter);
       break;
     case RecordMatch:
       assert(matches &&

--- a/mlir/lib/Tools/PDLL/AST/Context.cpp
+++ b/mlir/lib/Tools/PDLL/AST/Context.cpp
@@ -14,7 +14,9 @@ using namespace mlir::pdll::ast;
 
 Context::Context(ods::Context &odsContext) : odsContext(odsContext) {
   typeUniquer.registerSingletonStorageType<detail::AttributeTypeStorage>();
+  typeUniquer.registerSingletonStorageType<detail::BlockTypeStorage>();
   typeUniquer.registerSingletonStorageType<detail::ConstraintTypeStorage>();
+  typeUniquer.registerSingletonStorageType<detail::RegionTypeStorage>();
   typeUniquer.registerSingletonStorageType<detail::RewriteTypeStorage>();
   typeUniquer.registerSingletonStorageType<detail::TypeTypeStorage>();
   typeUniquer.registerSingletonStorageType<detail::ValueTypeStorage>();

--- a/mlir/lib/Tools/PDLL/AST/NodePrinter.cpp
+++ b/mlir/lib/Tools/PDLL/AST/NodePrinter.cpp
@@ -78,18 +78,24 @@ private:
   void printImpl(const ReplaceStmt *stmt);
   void printImpl(const ReturnStmt *stmt);
   void printImpl(const RewriteStmt *stmt);
+  void printImpl(const TakeRegionStmt *stmt);
+  void printImpl(const MoveBlockStmt *stmt);
 
   void printImpl(const AttributeExpr *expr);
+  void printImpl(const BlockExpr *expr);
   void printImpl(const CallExpr *expr);
   void printImpl(const DeclRefExpr *expr);
   void printImpl(const MemberAccessExpr *expr);
   void printImpl(const OperationExpr *expr);
   void printImpl(const RangeExpr *expr);
+  void printImpl(const RegionExpr *expr);
   void printImpl(const TupleExpr *expr);
   void printImpl(const TypeExpr *expr);
 
   void printImpl(const AttrConstraintDecl *decl);
+  void printImpl(const BlockConstraintDecl *decl);
   void printImpl(const OpConstraintDecl *decl);
+  void printImpl(const RegionConstraintDecl *decl);
   void printImpl(const TypeConstraintDecl *decl);
   void printImpl(const TypeRangeConstraintDecl *decl);
   void printImpl(const UserConstraintDecl *decl);
@@ -130,6 +136,7 @@ void NodePrinter::print(Type type) {
 
   TypeSwitch<Type>(type)
       .Case([&](AttributeType) { os << "Attr"; })
+      .Case([&](BlockType) { os << "Block"; })
       .Case([&](ConstraintType) { os << "Constraint"; })
       .Case([&](OperationType type) {
         os << "Op";
@@ -140,6 +147,7 @@ void NodePrinter::print(Type type) {
         print(type.getElementType());
         os << "Range";
       })
+      .Case([&](RegionType) { os << "Region"; })
       .Case([&](RewriteType) { os << "Rewrite"; })
       .Case([&](TupleType type) {
         os << "Tuple<";
@@ -166,15 +174,17 @@ void NodePrinter::print(const Node *node) {
       .Case<
           // Statements.
           const CompoundStmt, const EraseStmt, const LetStmt, const ReplaceStmt,
-          const ReturnStmt, const RewriteStmt,
+          const ReturnStmt, const RewriteStmt, const TakeRegionStmt,
+          const MoveBlockStmt,
 
           // Expressions.
-          const AttributeExpr, const CallExpr, const DeclRefExpr,
-          const MemberAccessExpr, const OperationExpr, const RangeExpr,
-          const TupleExpr, const TypeExpr,
+          const AttributeExpr, const BlockExpr, const CallExpr,
+          const DeclRefExpr, const MemberAccessExpr, const OperationExpr,
+          const RangeExpr, const RegionExpr, const TupleExpr, const TypeExpr,
 
           // Decls.
-          const AttrConstraintDecl, const OpConstraintDecl,
+          const AttrConstraintDecl, const BlockConstraintDecl,
+          const OpConstraintDecl, const RegionConstraintDecl,
           const TypeConstraintDecl, const TypeRangeConstraintDecl,
           const UserConstraintDecl, const ValueConstraintDecl,
           const ValueRangeConstraintDecl, const NamedAttributeDecl,
@@ -217,8 +227,26 @@ void NodePrinter::printImpl(const RewriteStmt *stmt) {
   printChildren(stmt->getRootOpExpr(), stmt->getRewriteBody());
 }
 
+void NodePrinter::printImpl(const TakeRegionStmt *stmt) {
+  os << "TakeRegionStmt " << stmt << "\n";
+  printChildren(stmt->getRegion(), stmt->getDestOp());
+}
+
+void NodePrinter::printImpl(const MoveBlockStmt *stmt) {
+  os << "MoveBlockStmt " << stmt << "\n";
+  printChildren(stmt->getBlock(), stmt->getDestBlock());
+}
+
 void NodePrinter::printImpl(const AttributeExpr *expr) {
   os << "AttributeExpr " << expr << " Value<\"" << expr->getValue() << "\">\n";
+}
+
+void NodePrinter::printImpl(const BlockExpr *expr) {
+  os << "BlockExpr " << expr << " Type<";
+  print(expr->getType());
+  os << ">\n";
+  printChildren("Args", expr->getArgs());
+  printChildren("Children", expr->getChildren());
 }
 
 void NodePrinter::printImpl(const CallExpr *expr) {
@@ -256,6 +284,7 @@ void NodePrinter::printImpl(const OperationExpr *expr) {
   printChildren("Operands", expr->getOperands());
   printChildren("Result Types", expr->getResultTypes());
   printChildren("Attributes", expr->getAttributes());
+  printChildren("Regions", expr->getRegions());
 }
 
 void NodePrinter::printImpl(const RangeExpr *expr) {
@@ -264,6 +293,13 @@ void NodePrinter::printImpl(const RangeExpr *expr) {
   os << ">\n";
 
   printChildren(expr->getElements());
+}
+
+void NodePrinter::printImpl(const RegionExpr *expr) {
+  os << "RegionExpr " << expr << " Type<";
+  print(expr->getType());
+  os << ">\n";
+  printChildren("Blocks", expr->getBlocks());
 }
 
 void NodePrinter::printImpl(const TupleExpr *expr) {
@@ -287,6 +323,14 @@ void NodePrinter::printImpl(const AttrConstraintDecl *decl) {
 void NodePrinter::printImpl(const OpConstraintDecl *decl) {
   os << "OpConstraintDecl " << decl << "\n";
   printChildren(decl->getNameDecl());
+}
+
+void NodePrinter::printImpl(const RegionConstraintDecl *decl) {
+  os << "RegionConstraintDecl " << decl << "\n";
+}
+
+void NodePrinter::printImpl(const BlockConstraintDecl *decl) {
+  os << "BlockConstraintDecl " << decl << "\n";
 }
 
 void NodePrinter::printImpl(const TypeConstraintDecl *decl) {

--- a/mlir/lib/Tools/PDLL/AST/Nodes.cpp
+++ b/mlir/lib/Tools/PDLL/AST/Nodes.cpp
@@ -54,15 +54,17 @@ public:
         .Case<
             // Statements.
             const CompoundStmt, const EraseStmt, const LetStmt,
-            const ReplaceStmt, const ReturnStmt, const RewriteStmt,
+            const TakeRegionStmt, const MoveBlockStmt, const ReplaceStmt,
+            const ReturnStmt, const RewriteStmt,
 
             // Expressions.
-            const AttributeExpr, const CallExpr, const DeclRefExpr,
-            const MemberAccessExpr, const OperationExpr, const RangeExpr,
-            const TupleExpr, const TypeExpr,
+            const AttributeExpr, const BlockExpr, const CallExpr,
+            const DeclRefExpr, const MemberAccessExpr, const OperationExpr,
+            const RangeExpr, const RegionExpr, const TupleExpr, const TypeExpr,
 
             // Core Constraint Decls.
-            const AttrConstraintDecl, const OpConstraintDecl,
+            const AttrConstraintDecl, const BlockConstraintDecl,
+            const OpConstraintDecl, const RegionConstraintDecl,
             const TypeConstraintDecl, const TypeRangeConstraintDecl,
             const ValueConstraintDecl, const ValueRangeConstraintDecl,
 
@@ -92,8 +94,22 @@ private:
     visit(stmt->getRootOpExpr());
     visit(stmt->getRewriteBody());
   }
+  void visitImpl(const TakeRegionStmt *stmt) {
+    visit(stmt->getRegion());
+    visit(stmt->getDestOp());
+  }
+  void visitImpl(const MoveBlockStmt *stmt) {
+    visit(stmt->getBlock());
+    visit(stmt->getDestBlock());
+  }
 
   void visitImpl(const AttributeExpr *expr) {}
+  void visitImpl(const BlockExpr *expr) {
+    for (const Node *arg : expr->getArgs())
+      visit(arg);
+    for (const Node *child : expr->getChildren())
+      visit(child);
+  }
   void visitImpl(const CallExpr *expr) {
     visit(expr->getCallableExpr());
     for (const Node *child : expr->getArguments())
@@ -109,9 +125,15 @@ private:
       visit(child);
     for (const Node *child : expr->getAttributes())
       visit(child);
+    for (const Node *child : expr->getRegions())
+      visit(child);
   }
   void visitImpl(const RangeExpr *expr) {
     for (const Node *child : expr->getElements())
+      visit(child);
+  }
+  void visitImpl(const RegionExpr *expr) {
+    for (const Node *child : expr->getBlocks())
       visit(child);
   }
   void visitImpl(const TupleExpr *expr) {
@@ -122,6 +144,8 @@ private:
 
   void visitImpl(const AttrConstraintDecl *decl) { visit(decl->getTypeExpr()); }
   void visitImpl(const OpConstraintDecl *decl) { visit(decl->getNameDecl()); }
+  void visitImpl(const BlockConstraintDecl *decl) {}
+  void visitImpl(const RegionConstraintDecl *decl) {}
   void visitImpl(const TypeConstraintDecl *decl) {}
   void visitImpl(const TypeRangeConstraintDecl *decl) {}
   void visitImpl(const ValueConstraintDecl *decl) {
@@ -253,6 +277,26 @@ ReturnStmt *ReturnStmt::create(Context &ctx, SMRange loc, Expr *resultExpr) {
 }
 
 //===----------------------------------------------------------------------===//
+// TakeRegionStmt
+//===----------------------------------------------------------------------===//
+
+TakeRegionStmt *TakeRegionStmt::create(Context &ctx, SMRange loc, Expr *region,
+                                       Expr *destOp) {
+  return new (ctx.getAllocator().Allocate<TakeRegionStmt>())
+      TakeRegionStmt(loc, region, destOp);
+}
+
+//===----------------------------------------------------------------------===//
+// MoveBlockStmt
+//===----------------------------------------------------------------------===//
+
+MoveBlockStmt *MoveBlockStmt::create(Context &ctx, SMRange loc, Expr *block,
+                                     Expr *destBlock) {
+  return new (ctx.getAllocator().Allocate<MoveBlockStmt>())
+      MoveBlockStmt(loc, block, destBlock);
+}
+
+//===----------------------------------------------------------------------===//
 // AttributeExpr
 //===----------------------------------------------------------------------===//
 
@@ -260,6 +304,24 @@ AttributeExpr *AttributeExpr::create(Context &ctx, SMRange loc,
                                      StringRef value) {
   return new (ctx.getAllocator().Allocate<AttributeExpr>())
       AttributeExpr(ctx, loc, copyStringWithNull(ctx, value));
+}
+
+//===----------------------------------------------------------------------===//
+// BlockExpr
+//===----------------------------------------------------------------------===//
+
+BlockExpr *BlockExpr::create(Context &ctx, SMRange loc,
+                             ArrayRef<VariableDecl *> args,
+                             ArrayRef<Expr *> children) {
+  unsigned allocSize = BlockExpr::totalSizeToAlloc<VariableDecl *, Expr *>(
+      args.size(), children.size());
+  void *rawData = ctx.getAllocator().Allocate(allocSize, alignof(BlockExpr));
+
+  BlockExpr *expr =
+      new (rawData) BlockExpr(ctx, loc, args.size(), children.size());
+  llvm::uninitialized_copy(args, expr->getArgs().begin());
+  llvm::uninitialized_copy(children, expr->getChildren().begin());
+  return expr;
 }
 
 //===----------------------------------------------------------------------===//
@@ -303,23 +365,27 @@ MemberAccessExpr *MemberAccessExpr::create(Context &ctx, SMRange loc,
 // OperationExpr
 //===----------------------------------------------------------------------===//
 
-OperationExpr *
-OperationExpr::create(Context &ctx, SMRange loc, const ods::Operation *odsOp,
-                      const OpNameDecl *name, ArrayRef<Expr *> operands,
-                      ArrayRef<Expr *> resultTypes,
-                      ArrayRef<NamedAttributeDecl *> attributes) {
+OperationExpr *OperationExpr::create(Context &ctx, SMRange loc,
+                                     const ods::Operation *odsOp,
+                                     const OpNameDecl *name,
+                                     ArrayRef<Expr *> operands,
+                                     ArrayRef<Expr *> resultTypes,
+                                     ArrayRef<NamedAttributeDecl *> attributes,
+                                     ArrayRef<Expr *> regions) {
   unsigned allocSize =
       OperationExpr::totalSizeToAlloc<Expr *, NamedAttributeDecl *>(
-          operands.size() + resultTypes.size(), attributes.size());
+          operands.size() + resultTypes.size() + regions.size(),
+          attributes.size());
   void *rawData =
       ctx.getAllocator().Allocate(allocSize, alignof(OperationExpr));
 
   Type resultType = OperationType::get(ctx, name->getName(), odsOp);
   OperationExpr *opExpr = new (rawData)
       OperationExpr(loc, resultType, name, operands.size(), resultTypes.size(),
-                    attributes.size(), name->getLoc());
+                    attributes.size(), regions.size(), name->getLoc());
   llvm::uninitialized_copy(operands, opExpr->getOperands().begin());
   llvm::uninitialized_copy(resultTypes, opExpr->getResultTypes().begin());
+  llvm::uninitialized_copy(regions, opExpr->getRegions().begin());
   llvm::uninitialized_copy(attributes, opExpr->getAttributes().begin());
   return opExpr;
 }
@@ -339,6 +405,20 @@ RangeExpr *RangeExpr::create(Context &ctx, SMRange loc,
 
   RangeExpr *expr = new (rawData) RangeExpr(loc, type, elements.size());
   llvm::uninitialized_copy(elements, expr->getElements().begin());
+  return expr;
+}
+
+//===----------------------------------------------------------------------===//
+// RegionExpr
+//===----------------------------------------------------------------------===//
+
+RegionExpr *RegionExpr::create(Context &ctx, SMRange loc,
+                               ArrayRef<Expr *> blocks) {
+  unsigned allocSize = RegionExpr::totalSizeToAlloc<Expr *>(blocks.size());
+  void *rawData = ctx.getAllocator().Allocate(allocSize, alignof(RegionExpr));
+
+  RegionExpr *expr = new (rawData) RegionExpr(ctx, loc, blocks.size());
+  llvm::uninitialized_copy(blocks, expr->getBlocks().begin());
   return expr;
 }
 
@@ -403,6 +483,24 @@ OpConstraintDecl *OpConstraintDecl::create(Context &ctx, SMRange loc,
 
 std::optional<StringRef> OpConstraintDecl::getName() const {
   return getNameDecl()->getName();
+}
+
+//===----------------------------------------------------------------------===//
+// BlockConstraintDecl
+//===----------------------------------------------------------------------===//
+
+BlockConstraintDecl *BlockConstraintDecl::create(Context &ctx, SMRange loc) {
+  return new (ctx.getAllocator().Allocate<BlockConstraintDecl>())
+      BlockConstraintDecl(loc);
+}
+
+//===----------------------------------------------------------------------===//
+// RegionConstraintDecl
+//===----------------------------------------------------------------------===//
+
+RegionConstraintDecl *RegionConstraintDecl::create(Context &ctx, SMRange loc) {
+  return new (ctx.getAllocator().Allocate<RegionConstraintDecl>())
+      RegionConstraintDecl(loc);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Tools/PDLL/AST/Types.cpp
+++ b/mlir/lib/Tools/PDLL/AST/Types.cpp
@@ -15,9 +15,11 @@ using namespace mlir::pdll;
 using namespace mlir::pdll::ast;
 
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::AttributeTypeStorage)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::BlockTypeStorage)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::ConstraintTypeStorage)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::OperationTypeStorage)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::RangeTypeStorage)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::RegionTypeStorage)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::RewriteTypeStorage)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::TupleTypeStorage)
 MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::pdll::ast::detail::TypeTypeStorage)
@@ -54,6 +56,14 @@ Type Type::refineWith(Type other) const {
 //===----------------------------------------------------------------------===//
 
 AttributeType AttributeType::get(Context &context) {
+  return context.getTypeUniquer().get<ImplTy>();
+}
+
+//===----------------------------------------------------------------------===//
+// BlockType
+//===----------------------------------------------------------------------===//
+
+BlockType BlockType::get(Context &context) {
   return context.getTypeUniquer().get<ImplTy>();
 }
 
@@ -133,6 +143,14 @@ ValueRangeType ValueRangeType::get(Context &context) {
 //===----------------------------------------------------------------------===//
 
 RewriteType RewriteType::get(Context &context) {
+  return context.getTypeUniquer().get<ImplTy>();
+}
+
+//===----------------------------------------------------------------------===//
+// RegionType
+//===----------------------------------------------------------------------===//
+
+RegionType RegionType::get(Context &context) {
   return context.getTypeUniquer().get<ImplTy>();
 }
 

--- a/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
+++ b/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
@@ -65,6 +65,8 @@ private:
   void genImpl(const ast::ReplaceStmt *stmt);
   void genImpl(const ast::RewriteStmt *stmt);
   void genImpl(const ast::ReturnStmt *stmt);
+  void genImpl(const ast::TakeRegionStmt *stmt);
+  void genImpl(const ast::MoveBlockStmt *stmt);
 
   //===--------------------------------------------------------------------===//
   // Decls
@@ -87,6 +89,12 @@ private:
   /// to the MLIR values of the variable.
   void applyVarConstraints(const ast::VariableDecl *varDecl, ValueRange values);
 
+  /// Coerce a value to the target PDL type by inserting structural navigation
+  /// ops. For example, coercing !pdl.operation to !pdl.region inserts a
+  /// pdl::RegionOp (region_of at 0), and to !pdl.block inserts region_of +
+  /// block_of.
+  Value coerceToType(Value val, Type targetType, Location loc);
+
   //===--------------------------------------------------------------------===//
   // Expressions
   //===--------------------------------------------------------------------===//
@@ -94,11 +102,13 @@ private:
   Value genSingleExpr(const ast::Expr *expr);
   SmallVector<Value> genExpr(const ast::Expr *expr);
   Value genExprImpl(const ast::AttributeExpr *expr);
+  Value genExprImpl(const ast::BlockExpr *expr);
   SmallVector<Value> genExprImpl(const ast::CallExpr *expr);
   SmallVector<Value> genExprImpl(const ast::DeclRefExpr *expr);
   Value genExprImpl(const ast::MemberAccessExpr *expr);
   Value genExprImpl(const ast::OperationExpr *expr);
   Value genExprImpl(const ast::RangeExpr *expr);
+  Value genExprImpl(const ast::RegionExpr *expr);
   SmallVector<Value> genExprImpl(const ast::TupleExpr *expr);
   Value genExprImpl(const ast::TypeExpr *expr);
 
@@ -123,6 +133,13 @@ private:
   using VariableMapTy =
       llvm::ScopedHashTable<const ast::VariableDecl *, SmallVector<Value>>;
   VariableMapTy variables;
+
+  /// A map from BlockExpr AST nodes to the pdl::BlockOp values created during
+  /// OperationExpr processing. This enables cross-context block references:
+  /// when a named block (^entry) is matched, the real pdl::BlockOp value is
+  /// stored here so that genExprImpl(BlockExpr) can return it instead of a
+  /// placeholder UnrealizedConversionCastOp.
+  llvm::DenseMap<const ast::BlockExpr *, Value> blockExprValues;
 
   /// A reference to the ODS context.
   const ods::Context &odsContext;
@@ -159,8 +176,14 @@ Type CodeGen::genType(ast::Type type) {
       .Case([&](ast::AttributeType astType) -> Type {
         return builder.getType<pdl::AttributeType>();
       })
+      .Case([&](ast::BlockType astType) -> Type {
+        return builder.getType<pdl::BlockType>();
+      })
       .Case([&](ast::OperationType astType) -> Type {
         return builder.getType<pdl::OperationType>();
+      })
+      .Case([&](ast::RegionType astType) -> Type {
+        return builder.getType<pdl::RegionType>();
       })
       .Case([&](ast::TypeType astType) -> Type {
         return builder.getType<pdl::TypeType>();
@@ -177,7 +200,8 @@ void CodeGen::gen(const ast::Node *node) {
   TypeSwitch<const ast::Node *>(node)
       .Case<const ast::CompoundStmt, const ast::EraseStmt, const ast::LetStmt,
             const ast::ReplaceStmt, const ast::RewriteStmt,
-            const ast::ReturnStmt, const ast::UserConstraintDecl,
+            const ast::ReturnStmt, const ast::TakeRegionStmt,
+            const ast::MoveBlockStmt, const ast::UserConstraintDecl,
             const ast::UserRewriteDecl, const ast::PatternDecl>(
           [&](auto derivedNode) { this->genImpl(derivedNode); })
       .Case([&](const ast::Expr *expr) { genExpr(expr); });
@@ -255,6 +279,69 @@ void CodeGen::genImpl(const ast::RewriteStmt *stmt) {
 void CodeGen::genImpl(const ast::ReturnStmt *stmt) {
   // ReturnStmt generation is handled by the respective constraint or rewrite
   // parent node.
+}
+
+Value CodeGen::coerceToType(Value val, Type targetType, Location loc) {
+  if (val.getType() == targetType)
+    return val;
+
+  // Operation -> Region: insert pdl::RegionOp (region_of at index 0).
+  if (isa<pdl::OperationType>(val.getType()) &&
+      isa<pdl::RegionType>(targetType))
+    return pdl::RegionOp::create(builder, loc, targetType, val,
+                                 builder.getI32IntegerAttr(0));
+
+  // Operation -> Block: insert region_of + block_of (both at index 0).
+  if (isa<pdl::OperationType>(val.getType()) &&
+      isa<pdl::BlockType>(targetType)) {
+    auto regionType = builder.getType<pdl::RegionType>();
+    Value region = pdl::RegionOp::create(builder, loc, regionType, val,
+                                         builder.getI32IntegerAttr(0));
+    return pdl::BlockOp::create(builder, loc, targetType, region,
+                                builder.getI32IntegerAttr(0));
+  }
+
+  // Region -> Block: insert pdl::BlockOp (block_of at index 0).
+  if (isa<pdl::RegionType>(val.getType()) && isa<pdl::BlockType>(targetType))
+    return pdl::BlockOp::create(builder, loc, targetType, val,
+                                builder.getI32IntegerAttr(0));
+
+  return val;
+}
+
+void CodeGen::genImpl(const ast::TakeRegionStmt *stmt) {
+  OpBuilder::InsertionGuard insertGuard(builder);
+  Value regionExpr = genSingleExpr(stmt->getRegion());
+  Value destOpExpr = genSingleExpr(stmt->getDestOp());
+  Location loc = genLoc(stmt->getLoc());
+
+  // Coerce operands to !pdl.region if they are !pdl.operation-typed.
+  auto regionType = builder.getType<pdl::RegionType>();
+  regionExpr = coerceToType(regionExpr, regionType, loc);
+  destOpExpr = coerceToType(destOpExpr, regionType, loc);
+
+  // Make sure we are nested in a RewriteOp.
+  checkAndNestUnderRewriteOp(builder, destOpExpr, loc);
+
+  pdl::TakeRegionOp::create(builder, loc, regionExpr, destOpExpr);
+}
+
+void CodeGen::genImpl(const ast::MoveBlockStmt *stmt) {
+  OpBuilder::InsertionGuard insertGuard(builder);
+  Value blockExpr = genSingleExpr(stmt->getBlock());
+  Value destBlockExpr = genSingleExpr(stmt->getDestBlock());
+  Location loc = genLoc(stmt->getLoc());
+
+  // Coerce operands to !pdl.block if they are !pdl.operation or
+  // !pdl.region-typed. Both source and dest are blocks (Block::moveBefore).
+  auto blockType = builder.getType<pdl::BlockType>();
+  blockExpr = coerceToType(blockExpr, blockType, loc);
+  destBlockExpr = coerceToType(destBlockExpr, blockType, loc);
+
+  // Make sure we are nested in a RewriteOp.
+  checkAndNestUnderRewriteOp(builder, blockExpr, loc);
+
+  pdl::MoveBlockOp::create(builder, loc, blockExpr, destBlockExpr);
 }
 
 //===----------------------------------------------------------------------===//
@@ -378,9 +465,9 @@ void CodeGen::applyVarConstraints(const ast::VariableDecl *varDecl,
 
 Value CodeGen::genSingleExpr(const ast::Expr *expr) {
   return TypeSwitch<const ast::Expr *, Value>(expr)
-      .Case<const ast::AttributeExpr, const ast::MemberAccessExpr,
-            const ast::OperationExpr, const ast::RangeExpr,
-            const ast::TypeExpr>(
+      .Case<const ast::AttributeExpr, const ast::BlockExpr,
+            const ast::MemberAccessExpr, const ast::OperationExpr,
+            const ast::RangeExpr, const ast::RegionExpr, const ast::TypeExpr>(
           [&](auto derivedNode) { return this->genExprImpl(derivedNode); })
       .Case<const ast::CallExpr, const ast::DeclRefExpr, const ast::TupleExpr>(
           [&](auto derivedNode) {
@@ -401,6 +488,54 @@ Value CodeGen::genExprImpl(const ast::AttributeExpr *expr) {
   Attribute attr = parseAttribute(expr->getValue(), builder.getContext());
   assert(attr && "invalid MLIR attribute data");
   return pdl::AttributeOp::create(builder, genLoc(expr->getLoc()), attr);
+}
+
+Value CodeGen::genExprImpl(const ast::BlockExpr *expr) {
+  // If this BlockExpr was already processed by genExprImpl(OperationExpr),
+  // return the real pdl::BlockOp value. This enables cross-context block
+  // references (e.g., ^entry matched in match, referenced in rewrite).
+  auto it = blockExprValues.find(expr);
+  if (it != blockExprValues.end())
+    return it->second;
+
+  Location loc = genLoc(expr->getLoc());
+
+  // Generate block argument variable declarations. Each block argument
+  // becomes a pdl.Value variable that will be constrained to the corresponding
+  // block argument index via a native constraint during structural navigation.
+  for (const ast::VariableDecl *arg : expr->getArgs())
+    genVar(arg);
+
+  // Generate each child operation expression within this block.
+  // Children are operation constraints/declarations that need to be created
+  // first, establishing the structural nesting via PDL's declarative pattern.
+  for (const ast::Expr *child : expr->getChildren())
+    genSingleExpr(child);
+
+  // Create a placeholder block-typed value. In the match context, the
+  // enclosing RegionExpr and OperationExpr will establish the structural
+  // navigation (pdl.region_of/pdl.block_of). The PDL-to-PDLInterp lowering
+  // handles wiring block constraints from the predicate tree.
+  return mlir::UnrealizedConversionCastOp::create(
+             builder, loc, genType(expr->getType()), ValueRange{})
+      .getResult(0);
+}
+
+Value CodeGen::genExprImpl(const ast::RegionExpr *expr) {
+  Location loc = genLoc(expr->getLoc());
+
+  // Generate each block expression within this region.
+  SmallVector<Value> blockValues;
+  for (const ast::Expr *block : expr->getBlocks())
+    blockValues.push_back(genSingleExpr(block));
+
+  // Create a placeholder region-typed value. Similar to BlockExpr, the
+  // structural navigation is established by the PDL-to-PDLInterp lowering
+  // which generates pdl_interp.get_region/get_block/check_* from the
+  // predicate tree built during pattern analysis.
+  return mlir::UnrealizedConversionCastOp::create(
+             builder, loc, genType(expr->getType()), blockValues)
+      .getResult(0);
 }
 
 SmallVector<Value> CodeGen::genExprImpl(const ast::CallExpr *expr) {
@@ -514,8 +649,73 @@ Value CodeGen::genExprImpl(const ast::OperationExpr *expr) {
   for (const ast::Expr *result : expr->getResultTypes())
     results.push_back(genSingleExpr(result));
 
-  return pdl::OperationOp::create(builder, loc, opName, operands, attrNames,
-                                  attrValues, results);
+  Value opVal = pdl::OperationOp::create(builder, loc, opName, operands,
+                                         attrNames, attrValues, results);
+
+  // Generate structural navigation for attached regions.
+  // For each attached RegionExpr, generate pdl.region_of from the parent
+  // operation and pdl.block_of from each region, connecting the structural
+  // constraints.
+  for (auto [regionIdx, regionExpr] : llvm::enumerate(expr->getRegions())) {
+    const auto *rgnExpr = cast<ast::RegionExpr>(regionExpr);
+
+    // Navigate to the region from the parent operation.
+    auto regionType = builder.getType<pdl::RegionType>();
+    auto regionIdxAttr = builder.getI32IntegerAttr(regionIdx);
+    Value regionVal =
+        pdl::RegionOp::create(builder, loc, regionType, opVal, regionIdxAttr);
+
+    // Navigate to each block within the region.
+    auto blockType = builder.getType<pdl::BlockType>();
+    for (auto [blockIdx, blockExpr] : llvm::enumerate(rgnExpr->getBlocks())) {
+      const auto *blkExpr = cast<ast::BlockExpr>(blockExpr);
+      auto blockIdxAttr = builder.getI32IntegerAttr(blockIdx);
+      Value blockVal = pdl::BlockOp::create(builder, loc, blockType, regionVal,
+                                            blockIdxAttr);
+
+      // Bind each block argument to its index within the block using
+      // pdl.block_arg or pdl.block_args. Scalar args use pdl.block_arg,
+      // while variadic args (ValueRange) use pdl.block_args for range
+      // capture.
+      for (auto [argIdx, argDecl] : llvm::enumerate(blkExpr->getArgs())) {
+        Value blockArgVal;
+        if (isa<ast::ValueRangeType>(argDecl->getType())) {
+          // ValueRange arg — emit pdl.block_args with the starting index.
+          auto rangeType =
+              pdl::RangeType::get(builder.getType<pdl::ValueType>());
+          auto argIdxAttr = builder.getI32IntegerAttr(argIdx);
+          blockArgVal = pdl::BlockArgsOp::create(builder, loc, rangeType,
+                                                 blockVal, argIdxAttr);
+        } else {
+          // Scalar Value arg — emit pdl.block_arg.
+          auto valueType = builder.getType<pdl::ValueType>();
+          auto argIdxAttr = builder.getI32IntegerAttr(argIdx);
+          blockArgVal = pdl::BlockArgOp::create(builder, loc, valueType,
+                                                blockVal, argIdxAttr);
+        }
+        // Register the block arg value as the variable for this decl.
+        variables.insert(argDecl, {blockArgVal});
+        // Apply any constraints declared on the block argument.
+        applyVarConstraints(argDecl, {blockArgVal});
+      }
+
+      // Generate each child operation within this block and scope it to
+      // the parent block via the parentBlock operand.
+      for (const ast::Expr *child : blkExpr->getChildren()) {
+        Value innerOp = genSingleExpr(child);
+        // Set the parentBlock operand on the inner pdl.operation.
+        if (auto opOp = innerOp.getDefiningOp<pdl::OperationOp>())
+          opOp.getParentBlockMutable().assign(blockVal);
+      }
+
+      // Register this block value for the BlockExpr so that named block
+      // variables (e.g., ^entry) can resolve to the real pdl::BlockOp
+      // value when referenced in the rewrite context.
+      blockExprValues[blkExpr] = blockVal;
+    }
+  }
+
+  return opVal;
 }
 
 Value CodeGen::genExprImpl(const ast::RangeExpr *expr) {

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -211,6 +211,8 @@ Token Lexer::lexToken() {
       return formToken(Token::equal, tokStart);
     case ';':
       return formToken(Token::semicolon, tokStart);
+    case '^':
+      return formToken(Token::caret, tokStart);
     case '[':
       if (*curPtr == '{') {
         ++curPtr;
@@ -311,14 +313,18 @@ Token Lexer::lexIdentifier(const char *tokStart) {
   Token::Kind kind = StringSwitch<Token::Kind>(str)
                          .Case("attr", Token::kw_attr)
                          .Case("Attr", Token::kw_Attr)
+                         .Case("Block", Token::kw_Block)
                          .Case("erase", Token::kw_erase)
                          .Case("let", Token::kw_let)
+                         .Case("move_block", Token::kw_move_block)
+                         .Case("take_region", Token::kw_take_region)
                          .Case("Constraint", Token::kw_Constraint)
                          .Case("not", Token::kw_not)
                          .Case("op", Token::kw_op)
                          .Case("Op", Token::kw_Op)
                          .Case("OpName", Token::kw_OpName)
                          .Case("Pattern", Token::kw_Pattern)
+                         .Case("Region", Token::kw_Region)
                          .Case("replace", Token::kw_replace)
                          .Case("return", Token::kw_return)
                          .Case("rewrite", Token::kw_rewrite)

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -52,13 +52,17 @@ public:
 
     /// General keywords.
     kw_Attr,
+    kw_Block,
     kw_erase,
     kw_let,
+    kw_move_block,
+    kw_take_region,
     kw_Constraint,
     kw_not,
     kw_Op,
     kw_OpName,
     kw_Pattern,
+    kw_Region,
     kw_replace,
     kw_return,
     kw_rewrite,
@@ -88,6 +92,7 @@ public:
     l_square,
     r_square,
     underscore,
+    caret,
 
     /// Tokens.
     directive,

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -314,6 +314,10 @@ private:
 
   /// Identifier expressions.
   FailureOr<ast::Expr *> parseAttributeExpr();
+  FailureOr<ast::Expr *>
+  parseBlockExpr(std::optional<StringRef> blockName = std::nullopt,
+                 SMRange nameLoc = SMRange());
+  FailureOr<ast::Expr *> parseCaretExpr();
   FailureOr<ast::Expr *> parseCallExpr(ast::Expr *parentExpr,
                                        bool isNegated = false);
   FailureOr<ast::Expr *> parseDeclRefExpr(StringRef name, SMRange loc);
@@ -327,6 +331,7 @@ private:
   FailureOr<ast::Expr *>
   parseOperationExpr(OpResultTypeContext inputResultTypeContext =
                          OpResultTypeContext::Explicit);
+  FailureOr<ast::Expr *> parseRegionExpr();
   FailureOr<ast::Expr *> parseTupleExpr();
   FailureOr<ast::Expr *> parseTypeExpr();
   FailureOr<ast::Expr *> parseUnderscoreExpr();
@@ -341,6 +346,12 @@ private:
   FailureOr<ast::ReplaceStmt *> parseReplaceStmt();
   FailureOr<ast::ReturnStmt *> parseReturnStmt();
   FailureOr<ast::RewriteStmt *> parseRewriteStmt();
+  FailureOr<ast::TakeRegionStmt *> parseTakeRegionStmt();
+  FailureOr<ast::MoveBlockStmt *> parseMoveBlockStmt();
+
+  template <typename T>
+  FailureOr<T *> parseMoveStmt(StringRef stmtKeyword, StringRef srcName,
+                               Token::Kind kw);
 
   //===--------------------------------------------------------------------===//
   // Creation+Analysis
@@ -424,7 +435,8 @@ private:
                       OpResultTypeContext resultTypeContext,
                       SmallVectorImpl<ast::Expr *> &operands,
                       MutableArrayRef<ast::NamedAttributeDecl *> attributes,
-                      SmallVectorImpl<ast::Expr *> &results);
+                      SmallVectorImpl<ast::Expr *> &results,
+                      ArrayRef<ast::Expr *> regions = {});
   LogicalResult
   validateOperationOperands(SMRange loc, std::optional<StringRef> name,
                             const ods::Operation *odsOp,
@@ -1697,6 +1709,9 @@ Parser::parseConstraint(std::optional<SMRange> &typeConstraint,
     return ast::ConstraintRef(
         ast::AttrConstraintDecl::create(ctx, loc, typeExpr), loc);
   }
+  case Token::kw_Block:
+    consumeToken(Token::kw_Block);
+    return ast::ConstraintRef(ast::BlockConstraintDecl::create(ctx, loc), loc);
   case Token::kw_Op: {
     consumeToken(Token::kw_Op);
 
@@ -1710,6 +1725,9 @@ Parser::parseConstraint(std::optional<SMRange> &typeConstraint,
     return ast::ConstraintRef(ast::OpConstraintDecl::create(ctx, loc, *opName),
                               loc);
   }
+  case Token::kw_Region:
+    consumeToken(Token::kw_Region);
+    return ast::ConstraintRef(ast::RegionConstraintDecl::create(ctx, loc), loc);
   case Token::kw_Type:
     consumeToken(Token::kw_Type);
     return ast::ConstraintRef(ast::TypeConstraintDecl::create(ctx, loc), loc);
@@ -1822,6 +1840,9 @@ FailureOr<ast::Expr *> Parser::parseExpr() {
   case Token::l_paren:
     lhsExpr = parseTupleExpr();
     break;
+  case Token::caret:
+    lhsExpr = parseCaretExpr();
+    break;
   default:
     return emitError("expected expression");
   }
@@ -1866,6 +1887,126 @@ FailureOr<ast::Expr *> Parser::parseAttributeExpr() {
           parseToken(Token::greater, "expected `>` after attribute literal")))
     return failure();
   return ast::AttributeExpr::create(ctx, loc, attrExpr);
+}
+
+FailureOr<ast::Expr *>
+Parser::parseBlockExpr(std::optional<StringRef> blockName, SMRange nameLoc) {
+  SMRange loc = blockName ? nameLoc : curToken.getLoc();
+
+  StringRef label;
+  if (blockName) {
+    // Name was pre-parsed by parseCaretExpr (^ already consumed).
+    label = *blockName;
+  } else {
+    // Called from parseRegionExpr — consume ^ and optional name.
+    if (failed(
+            parseToken(Token::caret, "expected `^` to start block definition")))
+      return failure();
+    if (curToken.is(Token::identifier)) {
+      label = curToken.getSpelling();
+      nameLoc = curToken.getLoc();
+      consumeToken(Token::identifier);
+    }
+  }
+
+  // Parse optional block argument list: (name: Constraint, ...)
+  //   No parens      → unconstrained (don't check block arg count)
+  //   ()             → exactly zero block args
+  //   (iv: Value)    → exactly those block args
+  SmallVector<ast::VariableDecl *> args;
+  if (consumeIf(Token::l_paren)) {
+    if (!consumeIf(Token::r_paren)) {
+      do {
+        // Parse each block argument as `name: Constraint`.
+        if (curToken.isNot(Token::identifier) && !curToken.isDependentKeyword())
+          return emitError("expected identifier for block argument name");
+
+        StringRef name = curToken.getSpelling();
+        SMRange argNameLoc = curToken.getLoc();
+        consumeToken();
+
+        if (failed(parseToken(Token::colon,
+                              "expected `:` before block argument constraint")))
+          return failure();
+
+        FailureOr<ast::ConstraintRef> cst = parseArgOrResultConstraint();
+        if (failed(cst))
+          return failure();
+
+        FailureOr<ast::VariableDecl *> argDecl =
+            createArgOrResultVariableDecl(name, argNameLoc, *cst);
+        if (failed(argDecl))
+          return failure();
+        args.push_back(*argDecl);
+      } while (consumeIf(Token::comma));
+
+      // Validate that ValueRange args are trailing: only the last block
+      // argument may have a ValueRange type.
+      for (unsigned i = 0, e = args.size(); i < e; ++i) {
+        if (isa<ast::ValueRangeType>(args[i]->getType()) && i != e - 1)
+          return emitError(args[i]->getLoc(),
+                           "variadic block argument (ValueRange) must be the "
+                           "last argument in the block argument list");
+      }
+
+      if (failed(parseToken(Token::r_paren,
+                            "expected `)` after block argument list")))
+        return failure();
+    }
+  }
+
+  // Require `:` after block header.
+  if (failed(parseToken(Token::colon, "expected `:` after block header")))
+    return failure();
+
+  // Parse the block body: `{` ... `}`
+  if (failed(parseToken(Token::l_brace, "expected `{` to start block body")))
+    return failure();
+
+  SmallVector<ast::Expr *> children;
+  while (curToken.isNot(Token::r_brace)) {
+    FailureOr<ast::Expr *> child = parseExpr();
+    if (failed(child))
+      return failure();
+    children.push_back(*child);
+
+    // Consume an optional semicolon between children.
+    consumeIf(Token::semicolon);
+  }
+
+  loc.End = curToken.getEndLoc();
+  if (failed(parseToken(Token::r_brace, "expected `}` to close block body")))
+    return failure();
+
+  ast::Expr *blockExpr = ast::BlockExpr::create(ctx, loc, args, children);
+
+  // Register block label in scope if present.
+  if (!label.empty()) {
+    ast::Type blockType = ast::BlockType::get(ctx);
+    auto varDecl = defineVariableDecl(label, nameLoc, blockType, blockExpr, {});
+    if (failed(varDecl))
+      return failure();
+  }
+
+  return blockExpr;
+}
+
+FailureOr<ast::Expr *> Parser::parseCaretExpr() {
+  SMRange loc = curToken.getLoc();
+  consumeToken(Token::caret);
+
+  if (curToken.isNot(Token::identifier))
+    return emitError("expected identifier after `^`");
+
+  StringRef name = curToken.getSpelling();
+  SMRange nameLoc = curToken.getLoc();
+  consumeToken(Token::identifier);
+
+  if (curToken.isAny(Token::l_paren, Token::colon)) {
+    return parseBlockExpr(name, nameLoc);
+  }
+
+  return parseDeclRefExpr(name, nameLoc);
 }
 
 FailureOr<ast::Expr *> Parser::parseCallExpr(ast::Expr *parentExpr,
@@ -2089,19 +2230,53 @@ Parser::parseOperationExpr(OpResultTypeContext inputResultTypeContext) {
   }
 
   // Check for the optional list of attributes.
+  // Disambiguate between attribute dict `{ name = val }` and region body
+  // `{ op<...>; }` by looking ahead. An attribute dict starts with
+  // `{ (identifier|keyword|string) (= | , | })` while a region body starts
+  // with any other expression, like `op<`, `(`, nested `{`, etc.
   SmallVector<ast::NamedAttributeDecl *> attributes;
-  if (consumeIf(Token::l_brace)) {
-    do {
-      FailureOr<ast::NamedAttributeDecl *> decl =
-          parseNamedAttributeDecl(opName);
-      if (failed(decl))
-        return failure();
-      attributes.emplace_back(*decl);
-    } while (consumeIf(Token::comma));
+  if (curToken.is(Token::l_brace)) {
+    SMRange braceStart = curToken.getLoc();
+    consumeToken(Token::l_brace);
 
-    if (failed(parseToken(Token::r_brace,
-                          "expected `}` after operation attribute list")))
-      return failure();
+    // Check if this looks like an attribute dict by examining the first token.
+    bool isAttrDict = false;
+    if (curToken.is(Token::identifier) || curToken.isKeyword() ||
+        curToken.isString()) {
+      // Save position, peek at what follows the name.
+      Token nameTok = curToken;
+      consumeToken();
+      isAttrDict = curToken.isAny(Token::equal, Token::comma, Token::r_brace);
+      // Reset back to the name token — we'll re-parse properly.
+      resetToken(nameTok.getLoc());
+    } else if (curToken.is(Token::code_complete)) {
+      // Code completion in attribute context.
+      isAttrDict = true;
+    } else if (curToken.is(Token::r_brace)) {
+      // Empty `{}` — treat as empty attribute dict for backward compat.
+      isAttrDict = true;
+    }
+
+    if (isAttrDict) {
+      // Parse attribute dict normally.
+      if (curToken.isNot(Token::r_brace)) {
+        do {
+          FailureOr<ast::NamedAttributeDecl *> decl =
+              parseNamedAttributeDecl(opName);
+          if (failed(decl))
+            return failure();
+          attributes.emplace_back(*decl);
+        } while (consumeIf(Token::comma));
+      }
+
+      if (failed(parseToken(Token::r_brace,
+                            "expected `}` after operation attribute list")))
+        return failure();
+    } else {
+      // Not an attribute dict — reset to before the `{` so region parsing
+      // can consume it.
+      resetToken(braceStart);
+    }
   }
 
   // Handle the result types of the operation.
@@ -2153,8 +2328,63 @@ Parser::parseOperationExpr(OpResultTypeContext inputResultTypeContext) {
     resultTypeContext = OpResultTypeContext::Interface;
   }
 
+  // Parse optional attached region expressions.
+  // Regions use brace syntax: op<name> { ... } where `{` starts a region.
+  SmallVector<ast::Expr *> regions;
+  while (curToken.is(Token::l_brace)) {
+    FailureOr<ast::Expr *> region = parseRegionExpr();
+    if (failed(region))
+      return failure();
+    regions.push_back(*region);
+  }
+
   return createOperationExpr(loc, *opNameDecl, resultTypeContext, operands,
-                             attributes, resultTypes);
+                             attributes, resultTypes, regions);
+}
+
+FailureOr<ast::Expr *> Parser::parseRegionExpr() {
+  SMRange loc = curToken.getLoc();
+  consumeToken(Token::l_brace);
+
+  // A Region expression uses `{ ... }` containing block expressions.
+  // All explicit blocks start with `^` — the universal block introducer.
+  // Bare expressions are shorthand — implicit single block, unconstrained args.
+  SmallVector<ast::Expr *> blocks;
+
+  // Check if the region body contains explicit blocks.
+  bool hasExplicitBlocks = false;
+  if (curToken.isNot(Token::r_brace)) {
+    hasExplicitBlocks = curToken.is(Token::caret);
+  }
+
+  if (hasExplicitBlocks) {
+    // Parse explicit block(s).
+    while (curToken.isNot(Token::r_brace)) {
+      FailureOr<ast::Expr *> block = parseBlockExpr();
+      if (failed(block))
+        return failure();
+      blocks.push_back(*block);
+    }
+  } else {
+    // Shorthand: treat the entire region body as a single implicit block
+    // with no arguments.
+    SmallVector<ast::Expr *> children;
+    while (curToken.isNot(Token::r_brace)) {
+      FailureOr<ast::Expr *> child = parseExpr();
+      if (failed(child))
+        return failure();
+      children.push_back(*child);
+      consumeIf(Token::semicolon);
+    }
+    blocks.push_back(ast::BlockExpr::create(ctx, loc, /*args=*/{}, children));
+  }
+
+  loc.End = curToken.getEndLoc();
+  if (failed(parseToken(Token::r_brace,
+                        "expected `}` to close region expression body")))
+    return failure();
+
+  return ast::RegionExpr::create(ctx, loc, blocks);
 }
 
 FailureOr<ast::Expr *> Parser::parseTupleExpr() {
@@ -2272,6 +2502,12 @@ FailureOr<ast::Stmt *> Parser::parseStmt(bool expectTerminalSemicolon) {
     break;
   case Token::kw_rewrite:
     stmt = parseRewriteStmt();
+    break;
+  case Token::kw_take_region:
+    stmt = parseTakeRegionStmt();
+    break;
+  case Token::kw_move_block:
+    stmt = parseMoveBlockStmt();
     break;
   default:
     stmt = parseExpr();
@@ -2481,6 +2717,43 @@ FailureOr<ast::RewriteStmt *> Parser::parseRewriteStmt() {
   return createRewriteStmt(loc, *rootOp, *rewriteBody);
 }
 
+template <typename T>
+FailureOr<T *> Parser::parseMoveStmt(StringRef stmtKeyword, StringRef srcName,
+                                     Token::Kind kw) {
+  if (parserContext == ParserContext::Constraint)
+    return emitError("`" + stmtKeyword +
+                     "` cannot be used within a Constraint");
+  SMRange loc = curToken.getLoc();
+  consumeToken(kw);
+
+  FailureOr<ast::Expr *> srcExpr = parseExpr();
+  if (failed(srcExpr))
+    return failure();
+
+  // 'before' is a contextual keyword, parsed as an identifier rather than a
+  // dedicated Token::kw_before, since it is only used in move statements.
+  if (curToken.isNot(Token::identifier) || curToken.getSpelling() != "before")
+    return emitError("expected `before` after source " + srcName +
+                     " expression");
+  consumeToken();
+
+  FailureOr<ast::Expr *> destExpr = parseExpr();
+  if (failed(destExpr))
+    return failure();
+
+  return T::create(ctx, loc, *srcExpr, *destExpr);
+}
+
+FailureOr<ast::TakeRegionStmt *> Parser::parseTakeRegionStmt() {
+  return parseMoveStmt<ast::TakeRegionStmt>("take_region", "region",
+                                            Token::kw_take_region);
+}
+
+FailureOr<ast::MoveBlockStmt *> Parser::parseMoveBlockStmt() {
+  return parseMoveStmt<ast::MoveBlockStmt>("move_block", "block",
+                                           Token::kw_move_block);
+}
+
 //===----------------------------------------------------------------------===//
 // Creation+Analysis
 //===----------------------------------------------------------------------===//
@@ -2635,6 +2908,10 @@ LogicalResult Parser::validateVariableConstraint(const ast::ConstraintRef &ref,
         return failure();
     }
     constraintType = valueRangeTy;
+  } else if (isa<ast::RegionConstraintDecl>(ref.constraint)) {
+    constraintType = ast::RegionType::get(ctx);
+  } else if (isa<ast::BlockConstraintDecl>(ref.constraint)) {
+    constraintType = ast::BlockType::get(ctx);
   } else if (const auto *cst =
                  dyn_cast<ast::UserConstraintDecl>(ref.constraint)) {
     ArrayRef<ast::VariableDecl *> inputs = cst->getInputs();
@@ -2838,7 +3115,7 @@ FailureOr<ast::OperationExpr *> Parser::createOperationExpr(
     OpResultTypeContext resultTypeContext,
     SmallVectorImpl<ast::Expr *> &operands,
     MutableArrayRef<ast::NamedAttributeDecl *> attributes,
-    SmallVectorImpl<ast::Expr *> &results) {
+    SmallVectorImpl<ast::Expr *> &results, ArrayRef<ast::Expr *> regions) {
   std::optional<StringRef> opNameRef = name->getName();
   const ods::Operation *odsOp = lookupODSOperation(opNameRef);
 
@@ -2875,7 +3152,7 @@ FailureOr<ast::OperationExpr *> Parser::createOperationExpr(
   }
 
   return ast::OperationExpr::create(ctx, loc, odsOp, name, operands, results,
-                                    attributes);
+                                    attributes, regions);
 }
 
 LogicalResult

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -1992,7 +1992,6 @@ Parser::parseBlockExpr(std::optional<StringRef> blockName, SMRange nameLoc) {
 }
 
 FailureOr<ast::Expr *> Parser::parseCaretExpr() {
-  SMRange loc = curToken.getLoc();
   consumeToken(Token::caret);
 
   if (curToken.isNot(Token::identifier))

--- a/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
@@ -583,7 +583,9 @@ PDLDocument::buildHoverForCoreConstraint(const ast::CoreConstraintDecl *decl,
         .Case([&](const ast::ValueConstraintDecl *) { hoverOS << "Value"; })
         .Case([&](const ast::ValueRangeConstraintDecl *) {
           hoverOS << "ValueRange";
-        });
+        })
+        .Case([&](const ast::RegionConstraintDecl *) { hoverOS << "Region"; })
+        .Case([&](const ast::BlockConstraintDecl *) { hoverOS << "Block"; });
     hoverOS << "`\n";
   }
   return hover;
@@ -814,6 +816,8 @@ public:
       addCoreConstraint("ValueRange", "mlir::ValueRange");
       addCoreConstraint("Type", "mlir::Type");
       addCoreConstraint("TypeRange", "mlir::TypeRange");
+      addCoreConstraint("Region", "mlir::Region *");
+      addCoreConstraint("Block", "mlir::Block *");
     }
     if (allowInlineTypeConstraints) {
       /// Attr<Type>.

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
@@ -756,3 +756,123 @@ module @common_connector_range {
     rewrite with "rewriter"(%rootA, %rootB, %rootC : !pdl.operation, !pdl.operation, !pdl.operation)
   }
 }
+// -----
+
+// Test that basic region navigation ops are accepted by the lowering pass
+// (even though the region/block values may be unused in the matcher tree).
+// CHECK-LABEL: module @region_navigation
+// CHECK: pdl_interp.func @matcher
+// CHECK: pdl_interp.check_operation_name of %{{.*}} is "test.op_with_region"
+module @region_navigation {
+  pdl.pattern : benefit(1) {
+    %root = operation "test.op_with_region"
+    %region = pdl.region_of %root at 0
+    %block = pdl.block_of %region at 0
+    %arg0 = pdl.block_arg %block at 0
+    rewrite %root with "rewriter"
+  }
+}
+
+// -----
+
+// Test multi-region navigation.
+// CHECK-LABEL: module @multi_region_navigation
+// CHECK: pdl_interp.func @matcher
+// CHECK: pdl_interp.check_operation_name of %{{.*}} is "test.op_with_two_regions"
+module @multi_region_navigation {
+  pdl.pattern : benefit(1) {
+    %root = operation "test.op_with_two_regions"
+    %region0 = pdl.region_of %root at 0
+    %region1 = pdl.region_of %root at 1
+    %block0 = pdl.block_of %region0 at 0
+    %block1 = pdl.block_of %region1 at 0
+    rewrite %root with "rewriter"
+  }
+}
+
+// -----
+
+// Test deep navigation with multiple block arguments.
+// CHECK-LABEL: module @deep_block_arg_navigation
+// CHECK: pdl_interp.func @matcher
+// CHECK: pdl_interp.check_operation_name of %{{.*}} is "test.op_with_region"
+module @deep_block_arg_navigation {
+  pdl.pattern : benefit(1) {
+    %root = operation "test.op_with_region"
+    %region = pdl.region_of %root at 0
+    %block = pdl.block_of %region at 0
+    %arg0 = pdl.block_arg %block at 0
+    %arg1 = pdl.block_arg %block at 1
+    rewrite %root with "rewriter"
+  }
+}
+
+// -----
+
+// Test variadic block arg range navigation (pdl.block_args).
+// CHECK-LABEL: module @block_args_range_navigation
+// CHECK: pdl_interp.func @matcher
+// CHECK: pdl_interp.check_operation_name of %{{.*}} is "test.op_with_region"
+module @block_args_range_navigation {
+  pdl.pattern : benefit(1) {
+    %root = operation "test.op_with_region"
+    %region = pdl.region_of %root at 0
+    %block = pdl.block_of %region at 0
+    %first = pdl.block_arg %block at 0
+    %rest = pdl.block_args %block at 1 -> !pdl.range<value>
+    rewrite %root with "rewriter"
+  }
+}
+
+// -----
+
+// Test inner operation matching via parentBlock.
+// The lowering should emit get_block_ops + foreach + check_parent_block.
+// CHECK-LABEL: module @inner_op_matching
+// CHECK: pdl_interp.func @matcher
+// CHECK: pdl_interp.get_region %{{.*}} at 0
+// CHECK: pdl_interp.get_block %{{.*}} at 0
+// CHECK: pdl_interp.get_block_ops
+// CHECK: pdl_interp.foreach
+// CHECK:   pdl_interp.check_operation_name of %{{.*}} is "test.outer"
+// CHECK:   pdl_interp.check_operation_name of %{{.*}} is "test.inner"
+// CHECK:   pdl_interp.check_parent_block
+module @inner_op_matching {
+  pdl.pattern : benefit(1) {
+    %root = operation "test.outer"
+    %region = pdl.region_of %root at 0
+    %block = pdl.block_of %region at 0
+    %inner = operation "test.inner" in %block
+    rewrite %root with "rewriter"
+  }
+}
+
+// -----
+
+// Test predicate tree fusion: two patterns sharing structural prefix
+// should emit get_block_ops and foreach only once, with a switch on
+// the inner operation name.
+// CHECK-LABEL: module @structural_fusion
+// CHECK: pdl_interp.func @matcher
+// CHECK: pdl_interp.get_region %{{.*}} at 0
+// CHECK: pdl_interp.get_block %{{.*}} at 0
+// CHECK: pdl_interp.get_block_ops
+// CHECK: pdl_interp.foreach
+// CHECK:   pdl_interp.check_operation_name of %{{.*}} is "test.outer"
+// CHECK:   pdl_interp.switch_operation_name of %{{.*}} to ["test.inner_a", "test.inner_b"]
+module @structural_fusion {
+  pdl.pattern @A : benefit(1) {
+    %root = operation "test.outer"
+    %region = pdl.region_of %root at 0
+    %block = pdl.block_of %region at 0
+    %inner = operation "test.inner_a" in %block
+    rewrite %root with "rewriter_a"
+  }
+  pdl.pattern @B : benefit(1) {
+    %root = operation "test.outer"
+    %region = pdl.region_of %root at 0
+    %block = pdl.block_of %region at 0
+    %inner = operation "test.inner_b" in %block
+    rewrite %root with "rewriter_b"
+  }
+}

--- a/mlir/test/Dialect/PDL/invalid.mlir
+++ b/mlir/test/Dialect/PDL/invalid.mlir
@@ -334,3 +334,20 @@ pdl.pattern : benefit(1) {
   %op = operation "foo.op"
   rewrite %op with "rewriter"
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// pdl::BlockArgsOp
+//===----------------------------------------------------------------------===//
+
+pdl.pattern : benefit(1) {
+  %root = operation "test.op"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  // expected-error@below {{expected `pdl.range<value>` result type when no index is specified, but got: '!pdl.value'}}
+  %arg = "pdl.block_args"(%block) : (!pdl.block) -> !pdl.value
+  %op = operation "foo.op"(%arg : !pdl.value)
+  rewrite %op with "rewriter"
+}
+

--- a/mlir/test/Dialect/PDL/ops.mlir
+++ b/mlir/test/Dialect/PDL/ops.mlir
@@ -173,3 +173,119 @@ pdl.pattern @attribute_with_loc : benefit(1) {
   %root = operation {"attribute" = %attr}
   rewrite %root with "rewriter"
 }
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @region_of
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[REGION:.*]] = region_of %[[OP]] at 0
+pdl.pattern @region_of : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @block_of
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[REGION:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+pdl.pattern @block_of : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @block_arg
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[REGION:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[ARG:.*]] = block_arg %[[BLOCK]] at 0
+pdl.pattern @block_arg : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  %arg0 = pdl.block_arg %block at 0
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @multi_region
+// CHECK: %[[OP:.*]] = operation "test.op_with_two_regions"
+// CHECK: %[[R0:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[R1:.*]] = region_of %[[OP]] at 1
+pdl.pattern @multi_region : benefit(1) {
+  %root = operation "test.op_with_two_regions"
+  %region0 = pdl.region_of %root at 0
+  %region1 = pdl.region_of %root at 1
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @deep_navigation
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[R:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[B:.*]] = block_of %[[R]] at 0
+// CHECK: %[[A0:.*]] = block_arg %[[B]] at 0
+// CHECK: %[[A1:.*]] = block_arg %[[B]] at 1
+pdl.pattern @deep_navigation : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  %arg0 = pdl.block_arg %block at 0
+  %arg1 = pdl.block_arg %block at 1
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @block_args_range
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[REGION:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[ARGS:.*]] = block_args %[[BLOCK]] at 1 -> !pdl.range<value>
+pdl.pattern @block_args_range : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  %rest = pdl.block_args %block at 1 -> !pdl.range<value>
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @block_args_all
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[REGION:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[ARGS:.*]] = block_args %[[BLOCK]]
+pdl.pattern @block_args_all : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  %allArgs = pdl.block_args %block
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+// CHECK-LABEL: pdl.pattern @mixed_block_arg_and_args
+// CHECK: %[[OP:.*]] = operation "test.op_with_region"
+// CHECK: %[[REGION:.*]] = region_of %[[OP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[FIRST:.*]] = block_arg %[[BLOCK]] at 0
+// CHECK: %[[REST:.*]] = block_args %[[BLOCK]] at 1 -> !pdl.range<value>
+pdl.pattern @mixed_block_arg_and_args : benefit(1) {
+  %root = operation "test.op_with_region"
+  %region = pdl.region_of %root at 0
+  %block = pdl.block_of %region at 0
+  %first = pdl.block_arg %block at 0
+  %rest = pdl.block_args %block at 1 -> !pdl.range<value>
+  rewrite %root with "rewriter"
+}

--- a/mlir/test/Dialect/PDLInterp/ops.mlir
+++ b/mlir/test/Dialect/PDLInterp/ops.mlir
@@ -73,3 +73,110 @@ func.func @users(%value: !pdl.value, %values: !pdl.range<value>) {
 
   pdl_interp.finalize
 }
+
+// -----
+
+// Region/Block navigation operations
+func.func @region_block_navigation(%op : !pdl.operation) {
+  // get region at index 0
+  %region = pdl_interp.get_region %op at 0
+
+  // get block at index 0
+  %block = pdl_interp.get_block %region at 0
+
+  // get block argument at index 0
+  %arg = pdl_interp.get_block_argument %block at 0
+
+  // get block arguments starting from index 1 as a range
+  %args = pdl_interp.get_block_arguments %block at 1 : !pdl.range<value>
+
+  pdl_interp.finalize
+}
+
+// -----
+
+// Region/Block predicate operations
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_region_count of %root is 1 -> ^bb1, ^end
+
+  ^bb1:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.check_block_count of %region is 1 -> ^bb2, ^end
+
+  ^bb2:
+    %block = pdl_interp.get_block %region at 0
+    pdl_interp.check_block_arg_count of %block is 2 -> ^bb3, ^end
+
+  ^bb3:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// -----
+
+// GetBlockOps + ForEach pattern for iterating over operations in a block
+module @patterns_foreach {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    %region = pdl_interp.get_region %root at 0
+    %block = pdl_interp.get_block %region at 0
+    %ops = pdl_interp.get_block_ops of %block
+    pdl_interp.foreach %op : !pdl.operation in %ops {
+      pdl_interp.continue
+    } -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      pdl_interp.finalize
+    }
+  }
+}
+
+// -----
+
+// TakeRegion and MoveBlock operations
+module @patterns_move {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_region_count of %root is 2 -> ^bb1, ^end
+
+  ^bb1:
+    pdl_interp.record_match @rewriters::@move_region(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @move_region(%root : !pdl.operation) {
+      %region0 = pdl_interp.get_region %root at 0
+      %region1 = pdl_interp.get_region %root at 1
+
+      // Transfer all blocks from region0 into region1.
+      pdl_interp.take_region %region0 before %region1
+
+      // Get blocks from region1 and reorder.
+      %block0 = pdl_interp.get_block %region1 at 0
+      %block1 = pdl_interp.get_block %region1 at 1
+
+      pdl_interp.move_block %block1 before %block0
+
+      pdl_interp.finalize
+    }
+  }
+}
+

--- a/mlir/test/Rewrite/pdl-bytecode.mlir
+++ b/mlir/test/Rewrite/pdl-bytecode.mlir
@@ -1816,3 +1816,544 @@ module @patterns {
 module @ir attributes { test.switch_types_1 } {
   %results:2 = "test.op"() : () -> (i64, i64)
 }
+
+// -----
+
+// Note: These tests exercise the region/block structural matching and rewrite
+// primitives added to the PDL bytecode interpreter.
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::CheckRegionCountOp
+//===----------------------------------------------------------------------===//
+
+// Test matching an operation based on its region count.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.op_with_region" -> ^check_regions, ^end
+
+  ^check_regions:
+    pdl_interp.check_region_count of %root is 1 -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.check_region_count_1
+// CHECK-NOT: "test.op_with_region"
+// CHECK: "test.success"
+// CHECK: "test.no_region"
+module @ir attributes { test.check_region_count_1 } {
+  "test.op_with_region"() ({
+    "test.inner"() : () -> ()
+  }) : () -> ()
+  "test.no_region"() : () -> ()
+}
+
+// -----
+
+// Test matching with at_least region count.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_region_count of %root is at_least 2 -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.check_region_count_at_least
+// CHECK: "test.one_region"
+// CHECK-NOT: "test.two_regions"
+// CHECK: "test.success"
+module @ir attributes { test.check_region_count_at_least } {
+  "test.one_region"() ({
+    "test.inner"() : () -> ()
+  }) : () -> ()
+  "test.two_regions"() ({
+    "test.inner1"() : () -> ()
+  }, {
+    "test.inner2"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetRegionOp + pdl_interp::CheckBlockCountOp
+//===----------------------------------------------------------------------===//
+
+// Test navigating from an operation to its region and checking block count.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.op_with_region" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^check_blocks, ^end
+
+  ^check_blocks:
+    pdl_interp.check_block_count of %region is 1 -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.get_region_check_block_count
+// CHECK-NOT: "test.op_with_region"
+// CHECK: "test.success"
+module @ir attributes { test.get_region_check_block_count } {
+  "test.op_with_region"() ({
+    "test.inner"() : () -> ()
+  }) : () -> ()
+}
+
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::CheckBlockArgCountOp
+//===----------------------------------------------------------------------===//
+
+// Test matching based on block argument count.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.op_with_args" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^get_block, ^end
+
+  ^get_block:
+    %block = pdl_interp.get_block %region at 0
+    pdl_interp.is_not_null %block : !pdl.block -> ^check_args, ^end
+
+  ^check_args:
+    pdl_interp.check_block_arg_count of %block is 2 -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.check_block_arg_count_1
+// The op with 2 block args should match, the one with 1 should not.
+// CHECK: "test.op_with_args"
+// CHECK-NOT: test.op_with_args
+// CHECK: "test.success"
+module @ir attributes { test.check_block_arg_count_1 } {
+  "test.op_with_args"() ({
+  ^bb0(%arg0: i32):
+    "test.inner"(%arg0) : (i32) -> ()
+  }) : () -> ()
+  "test.op_with_args"() ({
+  ^bb0(%arg0: i32, %arg1: i64):
+    "test.inner"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetBlockArgumentOp
+//===----------------------------------------------------------------------===//
+
+// Test getting a block argument and using it in a rewrite.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.with_block_arg" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^get_block, ^end
+
+  ^get_block:
+    %block = pdl_interp.get_block %region at 0
+    pdl_interp.is_not_null %block : !pdl.block -> ^check_args, ^end
+
+  ^check_args:
+    pdl_interp.check_block_arg_count of %block is at_least 1 -> ^get_arg, ^end
+
+  ^get_arg:
+    %arg = pdl_interp.get_block_argument %block at 0
+    pdl_interp.is_not_null %arg : !pdl.value -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root, %arg : !pdl.operation, !pdl.value) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation, %arg : !pdl.value) {
+      %argType = pdl_interp.get_value_type of %arg : !pdl.type
+      %op = pdl_interp.create_operation "test.success" -> (%argType : !pdl.type)
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.get_block_argument_1
+// CHECK-NOT: "test.with_block_arg"
+// CHECK: "test.success"() : () -> i32
+module @ir attributes { test.get_block_argument_1 } {
+  "test.with_block_arg"() ({
+  ^bb0(%arg0: i32):
+    "test.use"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::MoveBlockOp
+//===----------------------------------------------------------------------===//
+
+// Test moving a block before another block (reversing block order).
+// Uses unregistered op successor syntax [^bb1] to make the second block
+// reachable, preventing the greedy driver from removing it.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.two_blocks" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^check_blocks, ^end
+
+  ^check_blocks:
+    pdl_interp.check_block_count of %region is 2 -> ^get_blocks, ^end
+
+  ^get_blocks:
+    %block0 = pdl_interp.get_block %region at 0
+    %block1 = pdl_interp.get_block %region at 1
+    pdl_interp.is_not_null %block0 : !pdl.block -> ^check1, ^end
+
+  ^check1:
+    pdl_interp.is_not_null %block1 : !pdl.block -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@move_block(%root, %block0, %block1 : !pdl.operation, !pdl.block, !pdl.block) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @move_block(%root : !pdl.operation, %block0 : !pdl.block, %block1 : !pdl.block) {
+      // Move block1 before block0, making block1 the new entry block.
+      pdl_interp.move_block %block1 before %block0
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.move_block_1
+// After moving block1 before block0, "test.second" should be the entry block.
+// The greedy driver then removes the now-unreachable old block0.
+// CHECK: "test.two_blocks"
+// CHECK:   "test.second"
+// CHECK:   "test.ret"
+// CHECK-NOT: "test.first"
+module @ir attributes { test.move_block_1 } {
+  "test.two_blocks"() ({
+    "test.first"() : () -> ()
+    "test.br"()[^bb1] : () -> ()
+  ^bb1:
+    "test.second"() : () -> ()
+    "test.ret"() : () -> ()
+  }) : () -> ()
+}
+
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// pdl_interp::GetBlockArgumentsOp
+//===----------------------------------------------------------------------===//
+
+// Test getting a range of block arguments starting from an index.
+// This matches a block with at least 2 args, captures the first as a scalar
+// and the rest (from index 1) as a range. The rewrite creates a success op
+// whose result type matches the first block arg's type.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.with_varargs" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^get_block, ^end
+
+  ^get_block:
+    %block = pdl_interp.get_block %region at 0
+    pdl_interp.is_not_null %block : !pdl.block -> ^check_args, ^end
+
+  ^check_args:
+    pdl_interp.check_block_arg_count of %block is at_least 2 -> ^get_args, ^end
+
+  ^get_args:
+    %first = pdl_interp.get_block_argument %block at 0
+    %rest = pdl_interp.get_block_arguments %block at 1 : !pdl.range<value>
+    pdl_interp.is_not_null %first : !pdl.value -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root, %first : !pdl.operation, !pdl.value) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation, %first : !pdl.value) {
+      %firstType = pdl_interp.get_value_type of %first : !pdl.type
+      %op = pdl_interp.create_operation "test.success" -> (%firstType : !pdl.type)
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.get_block_arguments_1
+// The op with 3 block args should match (at_least 2); result type = first arg type.
+// CHECK-NOT: "test.with_varargs"
+// CHECK: "test.success"() : () -> i32
+module @ir attributes { test.get_block_arguments_1 } {
+  "test.with_varargs"() ({
+  ^bb0(%arg0: i32, %arg1: i64, %arg2: f32):
+    "test.use"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}
+
+// -----
+
+// Test that get_block_arguments with at_least 2 does NOT match a single-arg block.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.with_varargs" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^get_block, ^end
+
+  ^get_block:
+    %block = pdl_interp.get_block %region at 0
+    pdl_interp.is_not_null %block : !pdl.block -> ^check_args, ^end
+
+  ^check_args:
+    pdl_interp.check_block_arg_count of %block is at_least 2 -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.get_block_arguments_no_match
+// The op with only 1 block arg should NOT match (needs at_least 2).
+// CHECK: "test.with_varargs"
+// CHECK-NOT: "test.success"
+module @ir attributes { test.get_block_arguments_no_match } {
+  "test.with_varargs"() ({
+  ^bb0(%arg0: i32):
+    "test.use"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}
+
+// -----
+
+// Test out-of-bounds get_block call (returns null, which fails is_not_null).
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.one_block" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^get_block, ^end
+
+  ^get_block:
+    // Out of bounds (only 1 block exists)
+    %block = pdl_interp.get_block %region at 1
+    pdl_interp.is_not_null %block : !pdl.block -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.get_block_out_of_bounds
+// CHECK: "test.one_block"
+// CHECK-NOT: "test.success"
+module @ir attributes { test.get_block_out_of_bounds } {
+  "test.one_block"() ({
+  ^bb0:
+    "test.inner"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+// Test extracting an empty block args range (returns empty range).
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.empty_args_range" -> ^get_region, ^end
+
+  ^get_region:
+    %region = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %region : !pdl.region -> ^get_block, ^end
+
+  ^get_block:
+    %block = pdl_interp.get_block %region at 0
+    pdl_interp.is_not_null %block : !pdl.block -> ^check_args, ^end
+
+  ^check_args:
+    // Exact match for 1 arg
+    pdl_interp.check_block_arg_count of %block is 1 -> ^get_args, ^end
+
+  ^get_args:
+    %first = pdl_interp.get_block_argument %block at 0
+    // Extract range starting at 1 (which is empty)
+    %rest = pdl_interp.get_block_arguments %block at 1 : !pdl.range<value>
+    pdl_interp.is_not_null %first : !pdl.value -> ^pat, ^end
+
+  ^pat:
+    // Pass empty range to rewriter
+    pdl_interp.record_match @rewriters::@success(%root, %rest : !pdl.operation, !pdl.range<value>) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation, %rest : !pdl.range<value>) {
+      // Create a success operation and pass the empty range as operands
+      %op = pdl_interp.create_operation "test.success"(%rest : !pdl.range<value>)
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.empty_block_args_range
+// CHECK-NOT: "test.empty_args_range"
+// CHECK: "test.success"() : () -> ()
+module @ir attributes { test.empty_block_args_range } {
+  "test.empty_args_range"() ({
+  ^bb0(%arg0: i32):
+    "test.inner"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+// Test take_region: moving blocks from one region to another, leaving the first empty.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.two_regions" -> ^get_src_region, ^end
+
+  ^get_src_region:
+    %srcRegion = pdl_interp.get_region %root at 0
+    pdl_interp.is_not_null %srcRegion : !pdl.region -> ^get_dest_region, ^end
+
+  ^get_dest_region:
+    %destRegion = pdl_interp.get_region %root at 1
+    pdl_interp.is_not_null %destRegion : !pdl.region -> ^check_src, ^end
+
+  ^check_src:
+    pdl_interp.check_block_count of %srcRegion is at_least 1 -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@take_region(%root, %srcRegion, %destRegion : !pdl.operation, !pdl.region, !pdl.region) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @take_region(%root : !pdl.operation, %srcRegion : !pdl.region, %destRegion : !pdl.region) {
+      pdl_interp.take_region %srcRegion before %destRegion
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.take_region_leaves_empty
+// CHECK: "test.two_regions"() ({
+// CHECK-NEXT: }, {
+// CHECK-NEXT:   "test.inner_a"() : () -> ()
+// CHECK-NEXT:   "test.inner_b"() : () -> ()
+// CHECK-NEXT: }) : () -> ()
+module @ir attributes { test.take_region_leaves_empty } {
+  "test.two_regions"() ({
+  ^bb0:
+    "test.inner_a"() : () -> ()
+    "test.inner_b"() : () -> ()
+  }, {
+  }) : () -> ()
+}

--- a/mlir/test/lib/Tools/PDLL/TestPDLL.pdll
+++ b/mlir/test/lib/Tools/PDLL/TestPDLL.pdll
@@ -26,3 +26,95 @@ Pattern {
   TestConstraintWithNamedOpOperand(op);
   replace op with op<test.success>;
 }
+
+// Match an operation with a specific inner op (shorthand and explicit)
+Pattern MatchInnerOp {
+  erase op<test.outer> {
+    op<test.inner>;
+  };
+}
+Pattern MatchInnerOpExplicit {
+  erase op<test.outer_explicit> { ^(): { op<test.inner_explicit>; } };
+}
+
+// Match multiple regions
+Pattern MatchIfElse {
+  erase op<test.if>
+    { op<test.then_op>; }
+    { op<test.else_op>; };
+}
+
+// Match multiple blocks in a region
+Pattern MatchMultiBlock {
+  erase op<test.branch> {
+    ^: { op<test.entry>; }
+    ^: { op<test.exit>; }
+  };
+}
+
+// Named blocks (and move_block)
+Pattern MatchAndMoveBlock {
+  let wrapper = op<test.wrapper> {
+    op<test.source_move> {
+      ^entry(iv: Value): {
+        op<test.body>;
+      }
+    };
+    op<test.dest_move> {
+      ^target(): { op<test.placeholder>; }
+    };
+  };
+  rewrite wrapper with {
+    move_block ^entry before ^target;
+  };
+}
+
+// Block arguments
+Pattern MatchInductionVar {
+  let forOp = op<test.for> {
+    ^(iv: Value, iterArg: Value): {
+      op<test.addi>(iv, iterArg);
+    }
+  };
+  rewrite forOp with { erase forOp; };
+}
+
+
+// Variadic block argument capture
+Pattern MatchForWithVarArgs {
+  let forOp = op<test.for_var_args> {
+    ^(iv: Value, rest: ValueRange): {
+      op<test.custom_op>(iv, rest);
+    }
+  };
+  rewrite forOp with { erase forOp; };
+}
+
+// Nested regions
+Pattern MatchNested {
+  erase op<test.pipeline> {
+    op<test.stage> {
+      op<test.compute>;
+    };
+  };
+}
+
+// Inline with terminator rewriting
+Pattern InlineWithTerminatorRewrite {
+  let wrapper = op<test.wrapper> {
+    op<test.source_inline> {
+      ^body(iv: Value): {
+        op<test.work>;
+        term: Op<test.old_terminator>;
+      }
+    };
+    op<test.dest_inline> {
+      ^target(): {}
+    };
+  };
+  rewrite wrapper with {
+    move_block ^body before ^target;
+    replace term with op<test.new_terminator>;
+  };
+}
+

--- a/mlir/test/mlir-lsp-server/completion.test
+++ b/mlir/test/mlir-lsp-server/completion.test
@@ -257,6 +257,18 @@
 // CHECK-NEXT:        "kind": 14,
 // CHECK-NEXT:        "label": "value",
 // CHECK-NEXT:        "sortText": "0"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "insertTextFormat": 1,
+// CHECK-NEXT:        "kind": 14,
+// CHECK-NEXT:        "label": "region",
+// CHECK-NEXT:        "sortText": "0"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "insertTextFormat": 1,
+// CHECK-NEXT:        "kind": 14,
+// CHECK-NEXT:        "label": "block",
+// CHECK-NEXT:        "sortText": "0"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }

--- a/mlir/test/mlir-pdll-lsp-server/completion.test
+++ b/mlir/test/mlir-pdll-lsp-server/completion.test
@@ -156,6 +156,28 @@
 // CHECK-NEXT:        "sortText": "0"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "detail": "Region constraint",
+// CHECK-NEXT:        "documentation": {
+// CHECK-NEXT:          "kind": "markdown",
+// CHECK-NEXT:          "value": "A single entity core constraint of type `mlir::Region *`"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        "insertTextFormat": 1,
+// CHECK-NEXT:        "kind": 7,
+// CHECK-NEXT:        "label": "Region",
+// CHECK-NEXT:        "sortText": "0"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "detail": "Block constraint",
+// CHECK-NEXT:        "documentation": {
+// CHECK-NEXT:          "kind": "markdown",
+// CHECK-NEXT:          "value": "A single entity core constraint of type `mlir::Block *`"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        "insertTextFormat": 1,
+// CHECK-NEXT:        "kind": 7,
+// CHECK-NEXT:        "label": "Block",
+// CHECK-NEXT:        "sortText": "0"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
 // CHECK-NEXT:        "detail": "Attr<type> constraint",
 // CHECK-NEXT:        "documentation": {
 // CHECK-NEXT:          "kind": "markdown",

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -156,3 +156,73 @@ Pattern RangeExpr {
 // CHECK: %[[TYPE:.*]] = type : i32
 // CHECK: operation({{.*}}) -> (%[[TYPE]] : !pdl.type)
 Pattern TypeExpr => erase op<> -> (type<"i32">);
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// OperationExpr with attached Region
+//===----------------------------------------------------------------------===//
+
+// CHECK: pdl.pattern @OperationWithRegion
+// CHECK: %[[OUTER:.*]] = operation "my_dialect.outer"
+// CHECK: %[[REGION:.*]] = region_of %[[OUTER]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[INNER:.*]] = operation "my_dialect.inner"
+// CHECK-SAME: in %[[BLOCK]]
+Pattern OperationWithRegion {
+  erase op<my_dialect.outer> {
+    op<my_dialect.inner>;
+  };
+}
+
+// -----
+
+// CHECK: pdl.pattern @OperationWithBlockArgs
+// CHECK: %[[LOOP:.*]] = operation "my_dialect.loop"
+// CHECK: %[[REGION:.*]] = region_of %[[LOOP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[IV:.*]] = block_arg %[[BLOCK]] at 0
+// CHECK: %[[BODY:.*]] = operation "my_dialect.body"
+// CHECK-SAME: in %[[BLOCK]]
+Pattern OperationWithBlockArgs {
+  erase op<my_dialect.loop> {
+    ^(iv: Value): {
+      op<my_dialect.body>;
+    }
+  };
+}
+
+// -----
+
+// CHECK: pdl.pattern @OperationWithVariadicBlockArgs
+// CHECK: %[[LOOP:.*]] = operation "my_dialect.loop"
+// CHECK: %[[REGION:.*]] = region_of %[[LOOP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[IV:.*]] = block_arg %[[BLOCK]] at 0
+// CHECK: %[[REST:.*]] = block_args %[[BLOCK]] at 1 -> !pdl.range<value>
+// CHECK: %[[BODY:.*]] = operation "my_dialect.body"
+// CHECK-SAME: in %[[BLOCK]]
+Pattern OperationWithVariadicBlockArgs {
+  erase op<my_dialect.loop> {
+    ^(iv: Value, rest: ValueRange): {
+      op<my_dialect.body>;
+    }
+  };
+}
+
+// -----
+
+// CHECK: pdl.pattern @OperationWithAllBlockArgs
+// CHECK: %[[LOOP:.*]] = operation "my_dialect.loop"
+// CHECK: %[[REGION:.*]] = region_of %[[LOOP]] at 0
+// CHECK: %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK: %[[ALL:.*]] = block_args %[[BLOCK]] at 0 -> !pdl.range<value>
+// CHECK: %[[BODY:.*]] = operation "my_dialect.body"
+// CHECK-SAME: in %[[BLOCK]]
+Pattern OperationWithAllBlockArgs {
+  erase op<my_dialect.loop> {
+    ^(allArgs: ValueRange): {
+      op<my_dialect.body>;
+    }
+  };
+}

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/move.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/move.pdll
@@ -1,0 +1,134 @@
+// RUN: mlir-pdll %s -I %S -split-input-file -x mlir | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// TestTakeRegion: Region-to-Region transfer via native constraint extraction
+//===----------------------------------------------------------------------===//
+
+// CHECK: pdl.pattern @TestTakeRegion
+// CHECK: %[[SRC_OP:.*]] = operation "test.src_op"
+// CHECK: %[[SRC_R:.*]] = apply_native_constraint "GetRegion"(%[[SRC_OP]]
+// CHECK: %[[DEST_OP:.*]] = operation "test.dest_op"
+// CHECK: %[[DEST_R:.*]] = apply_native_constraint "GetRegion"(%[[DEST_OP]]
+// CHECK: %[[ROOT:.*]] = operation "test.root"
+// CHECK: rewrite %[[ROOT]]
+// CHECK:   take_region %[[SRC_R]] before %[[DEST_R]]
+
+Constraint GetRegion(op: Op) -> Region;
+
+Pattern TestTakeRegion {
+  let srcOp = op<test.src_op>;
+  let srcR = GetRegion(srcOp);
+  let destOp = op<test.dest_op>;
+  let destR = GetRegion(destOp);
+  let root = op<test.root>;
+  rewrite root with {
+    take_region srcR before destR;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// TestMoveBlock: Block-to-Block move via native constraint extraction
+//===----------------------------------------------------------------------===//
+
+// CHECK: pdl.pattern @TestMoveBlock
+// CHECK: %[[SRC_OP:.*]] = operation "test.src_op"
+// CHECK: %[[SRC_B:.*]] = apply_native_constraint "GetBlock"(%[[SRC_OP]]
+// CHECK: %[[DEST_OP:.*]] = operation "test.dest_op"
+// CHECK: %[[DEST_B:.*]] = apply_native_constraint "GetBlock"(%[[DEST_OP]]
+// CHECK: rewrite %[[SRC_OP]]
+// CHECK:   move_block %[[SRC_B]] before %[[DEST_B]]
+
+Constraint GetBlock(op: Op) -> Block;
+
+Pattern TestMoveBlock {
+  let srcOp = op<test.src_op>;
+  let srcB = GetBlock(srcOp);
+  let destOp = op<test.dest_op>;
+  let destB = GetBlock(destOp);
+  rewrite srcOp with {
+    move_block srcB before destB;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// TakeRegionStmt - Auto-coercion from Op to Region
+//
+// When take_region operands are Op-typed, the codegen auto-inserts
+// pdl.region_of ops to coerce them to !pdl.region.
+//===----------------------------------------------------------------------===//
+
+// CHECK: pdl.pattern @TakeRegionStmt
+// CHECK:   %[[ROOT:.*]] = operation "test.root"
+// CHECK:   %[[DEST:.*]] = operation "test.dest"
+// CHECK:   rewrite %[[ROOT]]
+// CHECK:     %[[SRC_R:.*]] = region_of %[[ROOT]] at 0
+// CHECK:     %[[DST_R:.*]] = region_of %[[DEST]] at 0
+// CHECK:     take_region %[[SRC_R]] before %[[DST_R]]
+Pattern TakeRegionStmt {
+  let root = op<test.root> -> (type<"i32">);
+  let dest = op<test.dest>(root.0);
+  rewrite root with {
+    take_region root before dest;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// MoveBlockStmt - Auto-coercion from Op to Block
+//
+// When move_block operands are Op-typed, the codegen auto-inserts
+// pdl.region_of + pdl.block_of ops to coerce them to !pdl.block.
+//===----------------------------------------------------------------------===//
+
+// CHECK: pdl.pattern @MoveBlockStmt
+// CHECK:   %[[SRC:.*]] = operation "test.src"
+// CHECK:   %[[DEST:.*]] = operation "test.dest"
+// CHECK:   rewrite %[[SRC]]
+// CHECK:     %[[SRC_R:.*]] = region_of %[[SRC]] at 0
+// CHECK:     %[[SRC_B:.*]] = block_of %[[SRC_R]] at 0
+// CHECK:     %[[DST_R:.*]] = region_of %[[DEST]] at 0
+// CHECK:     %[[DST_B:.*]] = block_of %[[DST_R]] at 0
+// CHECK:     move_block %[[SRC_B]] before %[[DST_B]]
+Pattern MoveBlockStmt {
+  let src = op<test.src> -> (type<"i32">);
+  let dest = op<test.dest>(src.0);
+  rewrite src with {
+    move_block src before dest;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// CrossContextBlockRef - Named block from match used in rewrite
+//
+// A named block (^body) matched in the match section can be referenced
+// in the rewrite section. The codegen should use the real pdl::BlockOp
+// value from the match context rather than creating a placeholder.
+//===----------------------------------------------------------------------===//
+
+// CHECK: pdl.pattern @CrossContextBlockRef
+// CHECK:   %[[OUTER:.*]] = operation "test.outer"
+// CHECK:   %[[REGION:.*]] = region_of %[[OUTER]] at 0
+// CHECK:   %[[BLOCK:.*]] = block_of %[[REGION]] at 0
+// CHECK:   %[[DEST:.*]] = operation "test.dest"
+// CHECK:   rewrite %[[OUTER]]
+// CHECK:     %[[DST_R:.*]] = region_of %[[DEST]] at 0
+// CHECK:     %[[DST_B:.*]] = block_of %[[DST_R]] at 0
+// CHECK:     move_block %[[BLOCK]] before %[[DST_B]]
+Pattern CrossContextBlockRef {
+  let outer = op<test.outer> -> (type<"i32">) {
+    ^body: {
+      op<test.inner>;
+    }
+  };
+  let dest = op<test.dest>(outer.0);
+  rewrite outer with {
+    move_block ^body before dest;
+  };
+}

--- a/mlir/test/mlir-pdll/Integration/test-pdll.mlir
+++ b/mlir/test/mlir-pdll/Integration/test-pdll.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -test-pdll-pass | FileCheck %s
+// RUN: mlir-opt %s -test-pdll-pass -allow-unregistered-dialect | FileCheck %s
 
 // CHECK-LABEL: func @simpleTest
 func.func @simpleTest() {
@@ -22,3 +22,108 @@ func.func @testWithConstraint(%a: i32) {
     %b = "test.op_a"(%a) { attr = 0 : i32} : (i32) -> (i32)
     return
 }
+
+// CHECK-LABEL: func @testMatchInnerOp
+func.func @testMatchInnerOp() {
+  // CHECK-NOT: test.outer
+  "test.outer"() ({
+    "test.inner"() : () -> ()
+  }) : () -> ()
+  // CHECK-NOT: test.outer_explicit
+  "test.outer_explicit"() ({
+    "test.inner_explicit"() : () -> ()
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testMatchIfElse
+func.func @testMatchIfElse() {
+  // CHECK-NOT: test.if
+  "test.if"() ({
+    "test.then_op"() : () -> ()
+  }, {
+    "test.else_op"() : () -> ()
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testMatchMultiBlock
+func.func @testMatchMultiBlock() {
+  // CHECK-NOT: test.branch
+  "test.branch"() ({
+  ^bb0:
+    "test.entry"() : () -> ()
+    "test.br"()[^bb1] : () -> ()
+  ^bb1:
+    "test.exit"() : () -> ()
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testMatchAndMoveBlock
+func.func @testMatchAndMoveBlock(%arg0: i32) {
+  // CHECK: "test.dest_move"() ({
+  // CHECK-NEXT: ^bb0(%{{.*}}: i32):
+  // CHECK-NEXT: "test.body"
+  "test.wrapper"() ({
+    "test.source_move"() ({
+    ^bb0(%arg1: i32):
+      "test.body"() : () -> ()
+    }) : () -> ()
+    "test.dest_move"() ({
+      "test.placeholder"() : () -> ()
+    }) : () -> ()
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testMatchInductionVar
+func.func @testMatchInductionVar() {
+  // CHECK-NOT: test.for
+  "test.for"() ({
+  ^bb0(%arg0: i32, %arg1: i32):
+    %0 = "test.addi"(%arg0, %arg1) : (i32, i32) -> i32
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testMatchForWithVarArgs
+func.func @testMatchForWithVarArgs() {
+  // CHECK-NOT: test.for_var_args
+  "test.for_var_args"() ({
+  ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
+    %0 = "test.custom_op"(%arg0, %arg1, %arg2) : (i32, i32, i32) -> i32
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testMatchNested
+func.func @testMatchNested() {
+  // CHECK-NOT: test.pipeline
+  "test.pipeline"() ({
+    "test.stage"() ({
+      "test.compute"() : () -> ()
+    }) : () -> ()
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func @testInlineWithTerminatorRewrite
+func.func @testInlineWithTerminatorRewrite() {
+  // CHECK: "test.new_terminator"
+  // CHECK: "test.dest_inline"() ({
+  // CHECK-NEXT: ^bb0(%{{.*}}: i32):
+  // CHECK-NEXT: "test.work"
+  "test.wrapper"() ({
+    "test.source_inline"() ({
+    ^bb0(%arg0: i32):
+      "test.work"() : () -> ()
+      "test.old_terminator"() : () -> ()
+    }) : () -> ()
+    "test.dest_inline"() ({
+    ^bb0:
+    }) : () -> ()
+  }) : () -> ()
+  return
+}
+

--- a/mlir/test/mlir-pdll/Parser/constraint.pdll
+++ b/mlir/test/mlir-pdll/Parser/constraint.pdll
@@ -80,3 +80,36 @@ Constraint Outer() {
   Constraint() {};
   Constraint() => attr<"10">;
 }
+
+// -----
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<FooRegion> ResultType<Tuple<>>
+// CHECK:   `Inputs`
+// CHECK:     `-VariableDecl {{.*}} Name<r> Type<Region>
+// CHECK:       `Constraints`
+// CHECK:         `-RegionConstraintDecl {{.*}}
+Constraint FooRegion(r: Region);
+
+// -----
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<BarRegion> ResultType<Region>
+Constraint BarRegion() -> Region;
+
+// -----
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<BazBlock> ResultType<Tuple<>>
+// CHECK:   `Inputs`
+// CHECK:     `-VariableDecl {{.*}} Name<b> Type<Block>
+// CHECK:       `Constraints`
+// CHECK:         `-BlockConstraintDecl {{.*}}
+Constraint BazBlock(b: Block);
+
+// -----
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<QuxBlock> ResultType<Block>
+Constraint QuxBlock() -> Block;
+

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -285,7 +285,7 @@ Pattern {
 // -----
 
 Pattern {
-  // CHECK: expected identifier or string attribute name
+  // CHECK: expected expression
   let foo = op<> { 10;
 }
 
@@ -299,7 +299,7 @@ Pattern {
 // -----
 
 Pattern {
-  // CHECK: expected `}` after operation attribute list
+  // CHECK: expected expression
   let foo = op<> { "foo" {;
 }
 
@@ -398,4 +398,90 @@ Pattern {
 Pattern {
   // CHECK: expected `>` after type literal
   let foo = type<"";
+}
+// -----
+
+//===----------------------------------------------------------------------===//
+// Region/Block Structural Syntax
+//===----------------------------------------------------------------------===//
+
+// Missing `:` before block argument constraint.
+Pattern {
+  // CHECK: expected `:` before block argument constraint
+  erase op<my_dialect.test> {
+    ^(arg Value): { op<my_dialect.inner>; }
+  };
+}
+
+// -----
+
+// Invalid block argument — non-identifier token.
+Pattern {
+  // CHECK: expected identifier for block argument name
+  erase op<my_dialect.test> {
+    ^(42: Value): { op<my_dialect.inner>; }
+  };
+}
+
+// -----
+
+// Missing `)` after block argument list.
+Pattern {
+  // CHECK: expected identifier for block argument name
+  erase op<my_dialect.test> {
+    ^(arg: Value, : { op<my_dialect.inner>; }
+  };
+}
+
+// -----
+
+// Missing `:` after block header (unnamed block, no args).
+Pattern {
+  // CHECK: expected `:` after block header
+  erase op<my_dialect.test> {
+    ^ { op<my_dialect.inner>; }
+  };
+}
+
+// -----
+
+// Missing `:` after named block header.
+Pattern {
+  // CHECK: expected `:` after block header
+  erase op<my_dialect.test> {
+    ^bb0 { op<my_dialect.inner>; };
+  };
+}
+
+// -----
+
+// Undefined block reference via caret.
+Pattern {
+  // CHECK: undefined reference to `unknown_block`
+  let b = ^unknown_block;
+  erase op<my_dialect.test>;
+}
+
+// -----
+
+// Variadic (ValueRange) block argument must be the last in the list.
+Pattern {
+  // CHECK: variadic block argument (ValueRange) must be the last argument in the block argument list
+  erase op<my_dialect.test> {
+    ^(rest: ValueRange, iv: Value): {
+      op<my_dialect.inner>;
+    }
+  };
+}
+
+// -----
+
+// Duplicate block names within the same region.
+Pattern {
+  // CHECK: `entry` has already been defined
+  // CHECK: see previous definition here
+  erase op<my_dialect.test> {
+    ^entry: { op<my_dialect.first>; }
+    ^entry: { op<my_dialect.second>; }
+  };
 }

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -313,3 +313,285 @@ Pattern {
 
   erase _: Op;
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// BlockExpr (within operation region)
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<my_dialect.func>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<my_dialect.foo>>
+Pattern {
+  erase op<my_dialect.func> {
+    op<my_dialect.foo>;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// RegionExpr
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-RegionExpr {{.*}} Type<Region>
+// CHECK:   `Blocks`
+// CHECK:     `-BlockExpr {{.*}} Type<Block>
+// CHECK:       `Children`
+// CHECK:         `-OperationExpr {{.*}} Type<Op<my_dialect.bar>>
+// CHECK:           `-OpNameDecl {{.*}} Name<my_dialect.bar>
+Pattern {
+  // Shorthand: region body is an implicit single block.
+  let rgn = op<my_dialect.foo> {
+    op<my_dialect.bar>;
+  };
+
+  erase _: Op;
+}
+
+// -----
+
+// Test region with multiple explicit blocks.
+
+// CHECK: Module
+// CHECK: `-RegionExpr {{.*}} Type<Region>
+// CHECK:   `Blocks`
+// CHECK:     |-BlockExpr {{.*}} Type<Block>
+// CHECK:       `Children`
+// CHECK:         `-OperationExpr {{.*}} Type<Op<my_dialect.entry>>
+// CHECK:     `-BlockExpr {{.*}} Type<Block>
+// CHECK:       `Children`
+// CHECK:         `-OperationExpr {{.*}} Type<Op<my_dialect.exit>>
+Pattern {
+  let outer = op<my_dialect.foo> {
+    ^: { op<my_dialect.entry>; }
+    ^: { op<my_dialect.exit>; }
+  };
+
+  erase _: Op;
+}
+
+// -----
+
+// Test operation with attached region using shorthand syntax.
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<my_dialect.outer>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<my_dialect.inner>>
+Pattern {
+  erase op<my_dialect.outer> {
+    op<my_dialect.inner>;
+  };
+}
+
+// -----
+
+// Test block with arguments.
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<my_dialect.loop>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Args`
+// CHECK:             `-VariableDecl {{.*}} Name<iv>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<my_dialect.body>>
+Pattern {
+  erase op<my_dialect.loop> {
+    ^(iv: Value): {
+      op<my_dialect.body>;
+    }
+  };
+}
+
+// -----
+
+// Test block with ValueRange (variadic) block argument.
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<my_dialect.loop>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Args`
+// CHECK:             |-VariableDecl {{.*}} Name<iv>
+// CHECK:             `-VariableDecl {{.*}} Name<rest> Type<ValueRange>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<my_dialect.body>>
+Pattern {
+  erase op<my_dialect.loop> {
+    ^(iv: Value, rest: ValueRange): {
+      op<my_dialect.body>;
+    }
+  };
+}
+
+// -----
+
+// Test block with only a ValueRange block argument (captures all args).
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<my_dialect.loop>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Args`
+// CHECK:             `-VariableDecl {{.*}} Name<allArgs> Type<ValueRange>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<my_dialect.body>>
+Pattern {
+  erase op<my_dialect.loop> {
+    ^(allArgs: ValueRange): {
+      op<my_dialect.body>;
+    }
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Named block: basic definition and reference (unconstrained args)
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<test.op>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK: VariableDecl {{.*}} Name<b> Type<Block>
+// CHECK:   `-DeclRefExpr {{.*}} Type<Block>
+// CHECK:     `-VariableDecl {{.*}} Name<bb0> Type<Block>
+Pattern {
+  let op = op<test.op> {
+    ^bb0: {}
+  };
+
+  let b = ^bb0;
+
+  erase op;
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Named block: with arguments
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<test.loop>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Args`
+// CHECK:             `-VariableDecl {{.*}} Name<iv>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<test.body>>
+Pattern {
+  erase op<test.loop> {
+    ^entry(iv: Value): {
+      op<test.body>;
+    }
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multiple named blocks with zero-arg constraint
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<test.branch>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         |-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<test.entry>>
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<test.exit>>
+Pattern {
+  erase op<test.branch> {
+    ^bb0(): { op<test.entry>; }
+    ^bb1(): { op<test.exit>; }
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Named block: reference in let binding
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: VariableDecl {{.*}} Name<entryBlock> Type<Block>
+// CHECK:   `-DeclRefExpr {{.*}} Type<Block>
+// CHECK:     `-VariableDecl {{.*}} Name<entry> Type<Block>
+Pattern {
+  let op = op<test.func> {
+    ^entry(arg: Value): {
+      op<test.use>;
+    }
+  };
+
+  let entryBlock = ^entry;
+
+  erase op;
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Unnamed block: unconstrained args
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<test.simple>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+// CHECK:           `Children`
+// CHECK:             `-OperationExpr {{.*}} Type<Op<test.inner>>
+Pattern {
+  erase op<test.simple> {
+    ^: { op<test.inner>; }
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Unnamed block: zero args
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-OperationExpr {{.*}} Type<Op<test.zero>>
+// CHECK:   `Regions`
+// CHECK:     `-RegionExpr {{.*}} Type<Region>
+// CHECK:       `Blocks`
+// CHECK:         `-BlockExpr {{.*}} Type<Block>
+Pattern {
+  erase op<test.zero> {
+    ^(): {}
+  };
+}

--- a/mlir/test/mlir-pdll/Parser/stmt-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/stmt-failure.pdll
@@ -376,3 +376,61 @@ Pattern {
       return root;
   };
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `take_region`
+//===----------------------------------------------------------------------===//
+
+// CHECK: expected `before` after source region expression
+Pattern {
+  rewrite root: Op with {
+    take_region root;
+  };
+}
+
+// -----
+
+// CHECK: expected expression
+Pattern {
+  rewrite root: Op with {
+    take_region;
+  };
+}
+
+// -----
+
+// CHECK: `take_region` cannot be used within a Constraint
+Constraint Foo(arg: Op) {
+  take_region arg before arg;
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `move_block`
+//===----------------------------------------------------------------------===//
+
+// CHECK: expected `before` after source block expression
+Pattern {
+  rewrite root: Op with {
+    move_block root;
+  };
+}
+
+// -----
+
+// CHECK: expected expression
+Pattern {
+  rewrite root: Op with {
+    move_block;
+  };
+}
+
+// -----
+
+// CHECK: `move_block` cannot be used within a Constraint
+Constraint Bar(arg: Op) {
+  move_block arg before arg;
+}

--- a/mlir/test/mlir-pdll/Parser/stmt.pdll
+++ b/mlir/test/mlir-pdll/Parser/stmt.pdll
@@ -204,3 +204,78 @@ Pattern {
     replace root with op<my_dialect.foo>;
   };
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// MoveRegionStmt
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-TakeRegionStmt
+// CHECK:   |-DeclRefExpr {{.*}} Type<Region>
+// CHECK:   | `-VariableDecl {{.*}} Name<region> Type<Region>
+// CHECK:   `-DeclRefExpr {{.*}} Type<Op>
+// CHECK:     `-VariableDecl {{.*}} Name<root> Type<Op>
+Pattern {
+  let root: Op;
+  let region: Region;
+  rewrite root with {
+    take_region region before root;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// MoveBlockStmt
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-MoveBlockStmt
+// CHECK:   |-DeclRefExpr {{.*}} Type<Block>
+// CHECK:   | `-VariableDecl {{.*}} Name<block> Type<Block>
+// CHECK:   `-DeclRefExpr {{.*}} Type<Region>
+// CHECK:     `-VariableDecl {{.*}} Name<region> Type<Region>
+Pattern {
+  let root: Op;
+  let block: Block;
+  let region: Region;
+  rewrite root with {
+    move_block block before region;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// TakeRegionStmt
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-TakeRegionStmt
+// CHECK:   |-DeclRefExpr {{.*}} Type<Op>
+// CHECK:   `-DeclRefExpr {{.*}} Type<Op>
+Pattern {
+  rewrite root: Op with {
+    let dest: Op;
+    take_region root before dest;
+  };
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// MoveBlockStmt
+//===----------------------------------------------------------------------===//
+
+// CHECK: Module
+// CHECK: `-MoveBlockStmt
+// CHECK:   |-DeclRefExpr {{.*}} Type<Op>
+// CHECK:   `-DeclRefExpr {{.*}} Type<Op>
+Pattern {
+  rewrite root: Op with {
+    let dest: Op;
+    move_block root before dest;
+  };
+}

--- a/utils/bazel/llvm-project-overlay/mlir/test/mlir-pdll/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/mlir-pdll/BUILD.bazel
@@ -14,12 +14,16 @@ package(default_visibility = ["//visibility:public"])
             "CodeGen/CPP/include/**",
         ]) + [
             "//mlir:OpBaseTdFiles",
+            "//mlir:mlir-opt",
             "//mlir:mlir-pdll",
             "//mlir/test:lit_data",
         ],
     )
     for src in glob(
-        include = ["**/*.pdll"],
+        include = [
+            "**/*.pdll",
+            "**/*.mlir",
+        ],
         exclude = ["Parser/include/included.pdll"],
     )
 ]


### PR DESCRIPTION
This change introduces first-class support for MLIR Regions and Blocks within the PDL and PDLL frameworks. This includes new PDL operations for navigating & extracting regions, blocks and block arguments within patterns. New rewrite operations to manipulate region and block structures during rewrites. Interpreter, parser, LSP all updates to match too.

Addresses a long standing gap to enable PDLL for ops with regions. My usage is rather sparse, but attempted to add sufficiently general support/place to iterate from that would cover common rewrite patterns seen.

I was unsure whether to use PDL ops with regions for the region based matching, but kept them without as I felt part of lowered form. This could be changed in future, but should be opaque to user/PDLL side.

Assisted-by: Gemini