### PR TITLE
[runtimes] Drop reviewers-libcxx from reviews touching runtimes/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,6 @@
 /libcxx/ @llvm/reviewers-libcxx
 /libcxxabi/ @llvm/reviewers-libcxxabi
 /libunwind/ @llvm/reviewers-libunwind
-/runtimes/ @llvm/reviewers-libcxx
 
 /llvm/lib/Analysis/BasicAliasAnalysis.cpp @nikic
 /llvm/lib/Analysis/HashRecognize.cpp @artagnon @pfusik


### PR DESCRIPTION
Since runtimes/ has been picked up by other subprojects, it doesn't make sense anymore for reviewers-libcxx to watch all changes to it.