### PR TITLE
[SPARC] use `divideCeil` to calculate register offset

### DIFF
--- a/clang/include/clang/CodeGen/CGFunctionInfo.h
+++ b/clang/include/clang/CodeGen/CGFunctionInfo.h
@@ -161,22 +161,24 @@ public:
     return AI;
   }
 
-  static ABIArgInfo getSignExtend(QualType Ty, llvm::Type *T = nullptr) {
+  static ABIArgInfo getSignExtend(QualType Ty, llvm::Type *T = nullptr,
+                                  llvm::Type *Padding = nullptr) {
     assert(Ty->isIntegralOrEnumerationType() && "Unexpected QualType");
     auto AI = ABIArgInfo(Extend);
     AI.setCoerceToType(T);
-    AI.setPaddingType(nullptr);
+    AI.setPaddingType(Padding);
     AI.setDirectOffset(0);
     AI.setDirectAlign(0);
     AI.setSignExt(true);
     return AI;
   }
 
-  static ABIArgInfo getZeroExtend(QualType Ty, llvm::Type *T = nullptr) {
+  static ABIArgInfo getZeroExtend(QualType Ty, llvm::Type *T = nullptr,
+                                  llvm::Type *Padding = nullptr) {
     assert(Ty->isIntegralOrEnumerationType() && "Unexpected QualType");
     auto AI = ABIArgInfo(Extend);
     AI.setCoerceToType(T);
-    AI.setPaddingType(nullptr);
+    AI.setPaddingType(Padding);
     AI.setDirectOffset(0);
     AI.setDirectAlign(0);
     AI.setZeroExt(true);
@@ -185,11 +187,12 @@ public:
 
   // ABIArgInfo will record the argument as being extended based on the sign
   // of its type. Produces a sign or zero extension.
-  static ABIArgInfo getExtend(QualType Ty, llvm::Type *T = nullptr) {
+  static ABIArgInfo getExtend(QualType Ty, llvm::Type *T = nullptr,
+                              llvm::Type *Padding = nullptr) {
     assert(Ty->isIntegralOrEnumerationType() && "Unexpected QualType");
     if (Ty->hasSignedIntegerRepresentation())
-      return getSignExtend(Ty, T);
-    return getZeroExtend(Ty, T);
+      return getSignExtend(Ty, T, Padding);
+    return getZeroExtend(Ty, T, Padding);
   }
 
   // Struct in register marked explicitly as not needing extension.

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -248,8 +248,15 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   auto &Context = getContext();
   auto &VMContext = getVMContext();
 
-  uint64_t Size = Context.getTypeSize(Ty);
+  // FIXME: the GCC-style `aligned` attribute on typedefs is not taken into
+  // account here, because the canonicalized type no longer has that
+  // information. Hence such over-aligned typedefs are not ABI-compatible with
+  // GCC.
+  //
+  // This is different from the `aligned` attribute on structs or fields, which
+  // is taken into account.
   unsigned Alignment = Context.getTypeAlign(Ty);
+  uint64_t Size = Context.getTypeSize(Ty);
 
   // Anything too big to fit in registers is passed with an explicit indirect
   // pointer / sret pointer.

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -269,7 +269,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
                             ? llvm::Type::getInt64Ty(VMContext)
                             : nullptr;
   unsigned PaddingSlots = Padding ? 1 : 0;
-  unsigned SizeSlots = 1;
+  unsigned SizeSlots = llvm::divideCeil(Size, 64);
 
   // Treat an enum type as its underlying type.
   if (const auto *ED = Ty->getAsEnumDecl())
@@ -289,7 +289,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
 
   // Other non-aggregates go in registers.
   if (!isAggregateTypeForABI(Ty)) {
-    RegOffset += PaddingSlots + llvm::divideCeil(Size, 64);
+    RegOffset += PaddingSlots + SizeSlots;
     return ABIArgInfo::getDirect(/*T=*/nullptr, /*Offset=*/0, Padding);
   }
 
@@ -305,7 +305,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   // Build a coercion type from the LLVM struct type.
   llvm::StructType *StrTy = dyn_cast<llvm::StructType>(CGT.ConvertType(Ty));
   if (!StrTy) {
-    RegOffset += PaddingSlots + llvm::divideCeil(Size, 64);
+    RegOffset += PaddingSlots + SizeSlots;
     return ABIArgInfo::getDirect(/*T=*/nullptr, /*Offset=*/0, Padding);
   }
 

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -269,6 +269,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
                             ? llvm::Type::getInt64Ty(VMContext)
                             : nullptr;
   unsigned PaddingSlots = Padding ? 1 : 0;
+  unsigned SizeSlots = 1;
 
   // Treat an enum type as its underlying type.
   if (const auto *ED = Ty->getAsEnumDecl())
@@ -276,13 +277,13 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
 
   // Integer types smaller than a register are extended.
   if (Size < 64 && Ty->isIntegerType()) {
-    RegOffset += PaddingSlots + 1;
+    RegOffset += PaddingSlots + SizeSlots;
     return ABIArgInfo::getExtend(Ty, /*T=*/nullptr, Padding);
   }
 
   if (const auto *EIT = Ty->getAs<BitIntType>())
     if (EIT->getNumBits() < 64) {
-      RegOffset += PaddingSlots + 1;
+      RegOffset += PaddingSlots + SizeSlots;
       return ABIArgInfo::getExtend(Ty, /*T=*/nullptr, Padding);
     }
 

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -279,7 +279,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
 
   // Other non-aggregates go in registers.
   if (!isAggregateTypeForABI(Ty)) {
-    RegOffset += Size / 64;
+    RegOffset += llvm::divideCeil(Size, 64);
     return ABIArgInfo::getDirect();
   }
 
@@ -295,7 +295,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   // Build a coercion type from the LLVM struct type.
   llvm::StructType *StrTy = dyn_cast<llvm::StructType>(CGT.ConvertType(Ty));
   if (!StrTy) {
-    RegOffset += Size / 64;
+    RegOffset += llvm::divideCeil(Size, 64);
     return ABIArgInfo::getDirect();
   }
 

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -250,7 +250,6 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
 
   uint64_t Size = Context.getTypeSize(Ty);
   unsigned Alignment = Context.getTypeAlign(Ty);
-  bool NeedPadding = (Alignment > 64) && (RegOffset % 2 != 0);
 
   // Anything too big to fit in registers is passed with an explicit indirect
   // pointer / sret pointer.
@@ -261,26 +260,36 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
         /*ByVal=*/false);
   }
 
+  // An argument that is passed in registers but has an alignment higher than 8
+  // bytes must be register-aligned. Insert a dummy i64 argument to fill the
+  // odd-numbered register.
+  //
+  // See SCD 2.4.1, pages 3P-11 and 3P-12.
+  llvm::Type *Padding = (Alignment > 64 && RegOffset % 2 != 0)
+                            ? llvm::Type::getInt64Ty(VMContext)
+                            : nullptr;
+  unsigned PaddingSlots = Padding ? 1 : 0;
+
   // Treat an enum type as its underlying type.
   if (const auto *ED = Ty->getAsEnumDecl())
     Ty = ED->getIntegerType();
 
   // Integer types smaller than a register are extended.
   if (Size < 64 && Ty->isIntegerType()) {
-    RegOffset += 1;
-    return ABIArgInfo::getExtend(Ty);
+    RegOffset += PaddingSlots + 1;
+    return ABIArgInfo::getExtend(Ty, /*T=*/nullptr, Padding);
   }
 
   if (const auto *EIT = Ty->getAs<BitIntType>())
     if (EIT->getNumBits() < 64) {
-      RegOffset += 1;
-      return ABIArgInfo::getExtend(Ty);
+      RegOffset += PaddingSlots + 1;
+      return ABIArgInfo::getExtend(Ty, /*T=*/nullptr, Padding);
     }
 
   // Other non-aggregates go in registers.
   if (!isAggregateTypeForABI(Ty)) {
-    RegOffset += llvm::divideCeil(Size, 64);
-    return ABIArgInfo::getDirect();
+    RegOffset += PaddingSlots + llvm::divideCeil(Size, 64);
+    return ABIArgInfo::getDirect(/*T=*/nullptr, /*Offset=*/0, Padding);
   }
 
   // If a C++ object has either a non-trivial copy constructor or a non-trivial
@@ -295,8 +304,8 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   // Build a coercion type from the LLVM struct type.
   llvm::StructType *StrTy = dyn_cast<llvm::StructType>(CGT.ConvertType(Ty));
   if (!StrTy) {
-    RegOffset += llvm::divideCeil(Size, 64);
-    return ABIArgInfo::getDirect();
+    RegOffset += PaddingSlots + llvm::divideCeil(Size, 64);
+    return ABIArgInfo::getDirect(/*T=*/nullptr, /*Offset=*/0, Padding);
   }
 
   CoerceBuilder CB(VMContext, getDataLayout());
@@ -306,15 +315,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   CB.pad(llvm::alignTo(
       std::max(CB.DL.getTypeSizeInBits(StrTy).getKnownMinValue(), uint64_t(1)),
       64));
-  RegOffset += CB.Size / 64;
-
-  // If we're dealing with overaligned structs we may need to add a padding in
-  // the front, to preserve the correct register-memory mapping.
-  //
-  // See SCD 2.4.1, pages 3P-11 and 3P-12.
-  llvm::Type *Padding =
-      NeedPadding ? llvm::Type::getInt64Ty(VMContext) : nullptr;
-  RegOffset += NeedPadding ? 1 : 0;
+  RegOffset += PaddingSlots + CB.Size / 64;
 
   // Try to use the original type for coercion.
   llvm::Type *CoerceTy = CB.isUsableType(StrTy) ? StrTy : CB.getType();

--- a/clang/test/CodeGen/Sparc/sparcv9-abi.c
+++ b/clang/test/CodeGen/Sparc/sparcv9-abi.c
@@ -64,6 +64,12 @@ int f_float_pair_aligned(float a, float b, struct align16_int c) {
 	return c.x;
 }
 
+// define{{.*}} i64 @f_char_int128_aligned(i8 noundef signext %x, i64 %0, i128 noundef %v, i64 %q.coerce0, i64 %q.coerce1)
+struct aligned16_struct { long a, b; } __attribute__((aligned(16)));
+long f_char_int128_aligned(char x, __int128 v, struct aligned16_struct q) {
+    return q.a;
+}
+
 // CHECK-LABEL: define{{.*}} i64 @f_emptyvar(i32 noundef zeroext %count, ...)
 long f_emptyvar(unsigned count, ...) {
     long ret;

--- a/clang/test/CodeGen/Sparc/sparcv9-abi.c
+++ b/clang/test/CodeGen/Sparc/sparcv9-abi.c
@@ -54,6 +54,16 @@ long double f_longdouble(long a, struct align16_longdouble b) {
 	return b.x;
 }
 
+// CHECK-LABEL: define{{.*}} signext i32 @f_float_aligned(float noundef %a, i64 %0, i64 %b.coerce0, i64 %b.coerce1)
+int f_float_aligned(float a, struct align16_int b) {
+	return b.x;
+}
+
+// CHECK-LABEL: define{{.*}} signext i32 @f_float_pair_aligned(float noundef %a, float noundef %b, i64 %c.coerce0, i64 %c.coerce1)
+int f_float_pair_aligned(float a, float b, struct align16_int c) {
+	return c.x;
+}
+
 // CHECK-LABEL: define{{.*}} i64 @f_emptyvar(i32 noundef zeroext %count, ...)
 long f_emptyvar(unsigned count, ...) {
     long ret;

--- a/clang/test/CodeGen/Sparc/sparcv9-abi.c
+++ b/clang/test/CodeGen/Sparc/sparcv9-abi.c
@@ -64,7 +64,7 @@ int f_float_pair_aligned(float a, float b, struct align16_int c) {
 	return c.x;
 }
 
-// define{{.*}} i64 @f_char_int128_aligned(i8 noundef signext %x, i64 %0, i128 noundef %v, i64 %q.coerce0, i64 %q.coerce1)
+// CHECK-LABEL: define{{.*}} i64 @f_char_int128_aligned(i8 noundef signext %x, i64 %0, i128 noundef %v, i64 %q.coerce0, i64 %q.coerce1)
 struct aligned16_struct { long a, b; } __attribute__((aligned(16)));
 long f_char_int128_aligned(char x, __int128 v, struct aligned16_struct q) {
     return q.a;

--- a/clang/test/CodeGen/Sparc/sparcv9-abi.c
+++ b/clang/test/CodeGen/Sparc/sparcv9-abi.c
@@ -70,6 +70,13 @@ long f_char_int128_aligned(char x, __int128 v, struct aligned16_struct q) {
     return q.a;
 }
 
+// FIXME: alignment on typedefs should be taken into account, but isn't.
+// CHECK-LABEL: define {{.*}} i32 @f_typedef_aligned(i32 noundef signext %x, i32 noundef signext %i)
+typedef int typedef_aligned_int __attribute__((aligned(16)));
+int f_typedef_aligned(int x, typedef_aligned_int i) {
+    return i;
+}
+
 // CHECK-LABEL: define{{.*}} i64 @f_emptyvar(i32 noundef zeroext %count, ...)
 long f_emptyvar(unsigned count, ...) {
     long ret;


### PR DESCRIPTION
So that later arguments get the correct register alignment

https://godbolt.org/z/oaEf4Thvx

On current clang the aligned struct starts in `o1`, but with GCC it is aligned and starts in `o2`. In practice I think only `float` could hit this (not an int, not an aggregate, smaller than 64 bits).