### PR TITLE
[AArch64][GlobalISel] Use a concrete type for store merging.

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LoadStoreOpt.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LoadStoreOpt.cpp
@@ -364,7 +364,7 @@ bool LoadStoreOpt::doSingleStoreMerge(SmallVectorImpl<GStore *> &Stores) {
   const unsigned NumStores = Stores.size();
   LLT SmallTy = MRI->getType(FirstStore->getValueReg());
   LLT WideValueTy =
-      LLT::scalar(NumStores * SmallTy.getSizeInBits().getFixedValue());
+      LLT::integer(NumStores * SmallTy.getSizeInBits().getFixedValue());
 
   // For each store, compute pairwise merged debug locs.
   DebugLoc MergedLoc = Stores.front()->getDebugLoc();

--- a/llvm/test/CodeGen/AArch64/GlobalISel/store-merging-debug.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/store-merging-debug.mir
@@ -116,8 +116,8 @@ body:             |
     ; CHECK-NEXT: DBG_VALUE 2, $noreg, !9, !DIExpression(), debug-location !DILocation(line: 12, column: 1, scope: !5)
     ; CHECK-NEXT: DBG_VALUE %8:_(i64), $noreg, !9, !DIExpression(), debug-location !DILocation(line: 13, column: 1, scope: !5)
     ; CHECK-NEXT: DBG_VALUE %9:_(p0), $noreg, !9, !DIExpression(), debug-location !DILocation(line: 14, column: 1, scope: !5)
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 3940688328982532
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[COPY]](p0), debug-location !DILocation(line: 9, scope: !5) :: (store (s64), align 2)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 3940688328982532
+    ; CHECK-NEXT: G_STORE [[C]](i64), [[COPY]](p0), debug-location !DILocation(line: 9, scope: !5) :: (store (i64), align 2)
     ; CHECK-NEXT: DBG_VALUE 3, $noreg, !9, !DIExpression(), debug-location !DILocation(line: 15, column: 1, scope: !5)
     ; CHECK-NEXT: RET_ReallyLR debug-location !DILocation(line: 16, column: 1, scope: !5)
     %0:_(p0) = COPY $x0, debug-location !11

--- a/llvm/test/CodeGen/AArch64/GlobalISel/store-merging.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/store-merging.mir
@@ -221,8 +221,8 @@ body:             |
     ; CHECK: liveins: $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 327684
-    ; CHECK-NEXT: G_STORE [[C]](s32), [[COPY]](p0) :: (store (s32) into %ir.addr11, align 2)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 327684
+    ; CHECK-NEXT: G_STORE [[C]](i32), [[COPY]](p0) :: (store (i32) into %ir.addr11, align 2)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(i16) = G_CONSTANT i16 4
@@ -251,8 +251,8 @@ body:             |
     ; CHECK: liveins: $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 3940688328982532
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[COPY]](p0) :: (store (s64) into %ir.addr11, align 2)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 3940688328982532
+    ; CHECK-NEXT: G_STORE [[C]](i64), [[COPY]](p0) :: (store (i64) into %ir.addr11, align 2)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(i16) = G_CONSTANT i16 4
@@ -289,8 +289,8 @@ body:             |
     ; CHECK: liveins: $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 21474836484
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[COPY]](p0) :: (store (s64) into %ir.addr11, align 4)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 21474836484
+    ; CHECK-NEXT: G_STORE [[C]](i64), [[COPY]](p0) :: (store (i64) into %ir.addr11, align 4)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(i32) = G_CONSTANT i32 4
@@ -444,8 +444,8 @@ body:             |
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 4
     ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C2]](i64)
     ; CHECK-NEXT: G_STORE [[C1]](i32), [[PTR_ADD]](p0) :: (store (i32) into %ir.addr2)
-    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 73014444041
-    ; CHECK-NEXT: G_STORE [[C3]](s64), [[COPY1]](p0) :: (store (s64) into %ir.addr32, align 4)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 73014444041
+    ; CHECK-NEXT: G_STORE [[C3]](i64), [[COPY1]](p0) :: (store (i64) into %ir.addr32, align 4)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(p0) = COPY $x1
@@ -602,8 +602,8 @@ body:             |
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i16) = G_CONSTANT i16 9
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i16) = G_CONSTANT i16 0
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i16) = G_CONSTANT i16 14
-    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 327684
-    ; CHECK-NEXT: G_STORE [[C3]](s32), [[COPY]](p0) :: (store (s32) into %ir.addr11, align 2)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 327684
+    ; CHECK-NEXT: G_STORE [[C3]](i32), [[COPY]](p0) :: (store (i32) into %ir.addr11, align 2)
     ; CHECK-NEXT: [[C4:%[0-9]+]]:_(i64) = G_CONSTANT i64 4
     ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C4]](i64)
     ; CHECK-NEXT: G_STORE [[C]](i16), [[PTR_ADD]](p0) :: (store (i16) into %ir.addr3)
@@ -661,8 +661,8 @@ body:             |
     ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
     ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C3]](i64)
     ; CHECK-NEXT: G_STORE [[C1]](i16), [[COPY2]](p0) :: (store (i16) into %ir.ptr3)
-    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 589829
-    ; CHECK-NEXT: G_STORE [[C4]](s32), [[PTR_ADD]](p0) :: (store (s32) into %ir.addr2, align 2)
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(i32) = G_CONSTANT i32 589829
+    ; CHECK-NEXT: G_STORE [[C4]](i32), [[PTR_ADD]](p0) :: (store (i32) into %ir.addr2, align 2)
     ; CHECK-NEXT: G_STORE [[C1]](i16), [[COPY1]](p0) :: (store (i16) into %ir.ptr2)
     ; CHECK-NEXT: [[C5:%[0-9]+]]:_(i64) = G_CONSTANT i64 6
     ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C5]](i64)
@@ -781,8 +781,8 @@ body:             |
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0.a1
     ; CHECK-NEXT: [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.1.a2
     ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[FRAME_INDEX1]](p0) :: (dereferenceable load (i32) from %ir.a2)
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 21474836484
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[FRAME_INDEX]](p0) :: (store (s64) into %ir.addr11, align 4)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 21474836484
+    ; CHECK-NEXT: G_STORE [[C]](i64), [[FRAME_INDEX]](p0) :: (store (i64) into %ir.addr11, align 4)
     ; CHECK-NEXT: $w0 = COPY [[LOAD]](i32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %3:_(i32) = G_CONSTANT i32 4
@@ -815,8 +815,8 @@ body:             |
     ; CHECK: liveins: $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 21474836484
-    ; CHECK-NEXT: G_STORE [[C]](s64), [[COPY]](p0) :: (store (s64) into %ir.addr11, align 2)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 21474836484
+    ; CHECK-NEXT: G_STORE [[C]](i64), [[COPY]](p0) :: (store (i64) into %ir.addr11, align 2)
     ; CHECK-NEXT: RET_ReallyLR
     %0:_(p0) = COPY $x0
     %1:_(i32) = G_CONSTANT i32 4


### PR DESCRIPTION
This is just to reduce the number of scalar types in the MIR, as the value is between a constant and a store it should have little effect.