### PR TITLE
[OpenMP] Remove Wasm limitation from openmp/runtime/cmake/config-ix.cmake

### DIFF
--- a/openmp/runtime/cmake/config-ix.cmake
+++ b/openmp/runtime/cmake/config-ix.cmake
@@ -151,20 +151,15 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Intel" OR CMAKE_C_COMPILER_ID STREQUAL "IntelLL
   check_library_exists(irc_pic _intel_fast_memcpy "" LIBOMP_HAVE_IRC_PIC_LIBRARY)
 endif()
 
-# Checking threading requirements. Note that compiling to WebAssembly threads
-# with either the Emscripten or wasi-threads flavor ends up using the pthreads
-# interface in a WebAssembly-compiled libc; CMake does not yet know how to
-# detect this.
-if (NOT WASM)
-  find_package(Threads REQUIRED)
-  if(WIN32)
-    if(NOT CMAKE_USE_WIN32_THREADS_INIT)
-      libomp_error_say("Need Win32 thread interface on Windows.")
-    endif()
-  else()
-    if(NOT CMAKE_USE_PTHREADS_INIT)
-      libomp_error_say("Need pthread interface on Unix-like systems.")
-    endif()
+# Checking threading requirements
+find_package(Threads REQUIRED)
+if(WIN32)
+  if(NOT CMAKE_USE_WIN32_THREADS_INIT)
+    libomp_error_say("Need Win32 thread interface on Windows.")
+  endif()
+else()
+  if(NOT CMAKE_USE_PTHREADS_INIT)
+    libomp_error_say("Need pthread interface on Unix-like systems.")
   endif()
 endif()
 


### PR DESCRIPTION
This was originally added #71297, but this limitation no longer applies to emscripten, and wasi-sdk will surly support this once threading is ready there.