### PR TITLE
[clang][Driver] Make -pthreads an alias to -pthread

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6674,12 +6674,12 @@ def print_diagnostic_options : Flag<["-", "--"], "print-diagnostic-options">,
   HelpText<"Print all of Clang's warning options">,
   Visibility<[ClangOption, CLOption]>;
 def private__bundle : Flag<["-"], "private_bundle">;
-def pthreads : Flag<["-"], "pthreads">;
 defm pthread : BoolOption<"", "pthread",
   LangOpts<"POSIXThreads">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption], "Support POSIX threads in generated code">,
   NegFlag<SetFalse>,
   BothFlags<[], [ClangOption, CC1Option, FlangOption, FC1Option]>>;
+def : Flag<["-"], "pthreads">, Alias<pthread>;
 def static_pie : Flag<["-"], "static-pie">, Group<Link_Group>;
 def read__only__relocs : Separate<["-"], "read_only_relocs">;
 def remap : Flag<["-"], "remap">;

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -312,8 +312,8 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-lpthreads");
       }
 
-      // Support POSIX threads if "-pthreads" or "-pthread" is present.
-      if (Args.hasArg(options::OPT_pthreads, options::OPT_pthread))
+      // Support POSIX threads if "-pthread" is present.
+      if (Args.hasArg(options::OPT_pthread))
         CmdArgs.push_back("-lpthreads");
 
       if (D.CCCIsCXX())

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -807,7 +807,6 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
       // No need to do anything for pthreads. Claim argument to avoid warning.
       Args.ClaimAllArgs(options::OPT_pthread);
-      Args.ClaimAllArgs(options::OPT_pthreads);
     }
   }
 

--- a/clang/lib/Driver/ToolChains/Fuchsia.cpp
+++ b/clang/lib/Driver/ToolChains/Fuchsia.cpp
@@ -149,7 +149,7 @@ void fuchsia::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   bool NoLibc = Args.hasArg(options::OPT_nolibc);
   bool OnlyLibstdcxxStatic = Args.hasArg(options::OPT_static_libstdcxx) &&
                              !Args.hasArg(options::OPT_static);
-  bool Pthreads = Args.hasArg(options::OPT_pthread, options::OPT_pthreads);
+  bool Pthreads = Args.hasArg(options::OPT_pthread);
   bool SplitStack = Args.hasArg(options::OPT_fsplit_stack);
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
                    options::OPT_r)) {

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -494,8 +494,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       if (NeedsXRayDeps)
         linkXRayRuntimeDeps(ToolChain, Args, CmdArgs);
 
-      bool WantPthread = Args.hasArg(options::OPT_pthread) ||
-                         Args.hasArg(options::OPT_pthreads);
+      bool WantPthread = Args.hasArg(options::OPT_pthread);
 
       // Use the static OpenMP runtime with -static-openmp
       bool StaticOpenMP = Args.hasArg(options::OPT_static_openmp) &&

--- a/clang/lib/Driver/ToolChains/Haiku.cpp
+++ b/clang/lib/Driver/ToolChains/Haiku.cpp
@@ -139,7 +139,7 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // No need to do anything for pthreads. Claim argument to avoid warning.
-  Args.claimAllArgs(options::OPT_pthread, options::OPT_pthreads);
+  Args.claimAllArgs(options::OPT_pthread);
 
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
                    options::OPT_r)) {

--- a/clang/lib/Driver/ToolChains/Solaris.cpp
+++ b/clang/lib/Driver/ToolChains/Solaris.cpp
@@ -119,7 +119,6 @@ void solaris::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // libpthread has been folded into libc since Solaris 10, no need to do
     // anything for pthreads. Claim argument to avoid warning.
     Args.ClaimAllArgs(options::OPT_pthread);
-    Args.ClaimAllArgs(options::OPT_pthreads);
   }
 
   if (LinkerIsGnuLd) {

--- a/clang/test/Driver/darwin-ld-pthread.c
+++ b/clang/test/Driver/darwin-ld-pthread.c
@@ -1,4 +1,6 @@
 // RUN: %clang -Wunused-command-line-argument -pthread -target x86_64-apple-darwin -### /dev/null -o /dev/null 2>&1 | FileCheck %s
+// RUN: %clang -Wunused-command-line-argument -pthreads -target x86_64-apple-darwin -### /dev/null -o /dev/null 2>&1 | FileCheck %s
 
 // There is nothing to do at link time to get pthread support. But do not warn.
 // CHECK-NOT: argument unused during compilation: '-pthread'
+// CHECK-NOT: argument unused during compilation: '-pthreads'


### PR DESCRIPTION
Remove `OPT_pthreads` and make `-pthreads` an alias to `-pthread`.

`-pthreads` was originally added in c800391fb9 as a distinct flag. I believe this is because in GCC it is supported as an alias for `-pthread` (on Solaris 2 only).

In LLVM this setting is only checked by a subset of toolchains during linking and is never checked during compilation (`-c`), so it currently causes `argument unused during compilation: '-pthreads'` (and does not set `_REENTRANT`).  So you could argue that even a Solaris specific alias it is currently broken.

Aliasing `-pthreads` to `-pthread` makes `-pthreads` work consistently for both compilation and linking across all targets, and allows removing `OPT_pthreads` checks in individual toolchains.

Alternatively, if legacy we don't care about Solaris 2 compatibility we could just drop the `-pthreads` form completely?  That option does have some risk though.  This one seems fairly risk-free.