### PR TITLE
[Verifier] Reject elementwise atomicrmw with sub-byte element type

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -4761,6 +4761,8 @@ void Verifier::visitAtomicRMWInst(AtomicRMWInst &RMWI) {
     auto *VecTy = dyn_cast<FixedVectorType>(ElTy);
     Check(VecTy, "atomicrmw elementwise operand must have fixed vector type!",
           &RMWI, ElTy);
+    if (VecTy)
+      checkAtomicMemAccessSize(VecTy->getElementType(), &RMWI);
   }
 
   if (Op == AtomicRMWInst::Xchg) {

--- a/llvm/test/Assembler/invalid-atomicrmw-elementwise.ll
+++ b/llvm/test/Assembler/invalid-atomicrmw-elementwise.ll
@@ -1,6 +1,8 @@
 ; RUN: split-file %s %t
 ; RUN: not llvm-as -disable-output %t/scalar.ll              2>&1 | FileCheck %t/scalar.ll
 ; RUN: not llvm-as -disable-output %t/odd-sized.ll           2>&1 | FileCheck %t/odd-sized.ll
+; RUN: not llvm-as -disable-output %t/non-byte.ll            2>&1 | FileCheck %t/non-byte.ll
+; RUN: not llvm-as -disable-output %t/non-byte-element.ll    2>&1 | FileCheck %t/non-byte-element.ll
 ; RUN: not llvm-as -disable-output %t/add-must-be-integer.ll 2>&1 | FileCheck %t/add-must-be-integer.ll
 ; RUN: not llvm-as -disable-output %t/fadd-must-be-fp.ll     2>&1 | FileCheck %t/fadd-must-be-fp.ll
 ; RUN: not llvm-as -disable-output %t/seq-cst.ll             2>&1 | FileCheck %t/seq-cst.ll
@@ -17,6 +19,20 @@ define i32 @bad_scalar(ptr %p, i32 %v) {
 define <5 x i32> @bad_odd_sized_vector(ptr %p, <5 x i32> %v) {
   %old = atomicrmw elementwise add ptr %p, <5 x i32> %v monotonic, align 4
   ret <5 x i32> %old
+}
+
+;--- non-byte.ll
+; CHECK: atomic memory access' size must be byte-sized
+define <4 x i1> @bad_non_byte(ptr %p, <4 x i1> %v) {
+  %old = atomicrmw elementwise xchg ptr %p, <4 x i1> %v monotonic, align 1
+  ret <4 x i1> %old
+}
+
+;--- non-byte-element.ll
+; CHECK: atomic memory access' size must be byte-sized
+define <8 x i1> @bad_non_byte_element(ptr %p, <8 x i1> %v) {
+  %old = atomicrmw elementwise xchg ptr %p, <8 x i1> %v monotonic, align 1
+  ret <8 x i1> %old
 }
 
 ;--- add-must-be-integer.ll


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/208510/ I accidentally introduced a bug where I allowed sub-byte element types with atomicrmw elementwise (i.e. `<8 x i1>`).

The LangRef states:

```
The access type
must then be a fixed vector type whose total bit width is a power of two and
whose element type is supported by the corresponding scalar atomic instruction.
```

The second part of this sentence rejects sub-byte element types.

The fix is that elementwise atomics need to additionally call `checkAtomicMemAccessSize` on the vector element type (they already call it on the whole vector).