### PR TITLE
[lldb/Interpreter] Remove Interpreter's layering dependency on API

### DIFF
--- a/lldb/include/lldb/API/SBAttachInfo.h
+++ b/lldb/include/lldb/API/SBAttachInfo.h
@@ -199,7 +199,7 @@ protected:
   friend class SBTarget;
   friend class SBPlatform;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   lldb_private::ProcessAttachInfo &ref();
 

--- a/lldb/include/lldb/API/SBBreakpoint.h
+++ b/lldb/include/lldb/API/SBBreakpoint.h
@@ -171,7 +171,7 @@ private:
   friend class SBBreakpointName;
   friend class SBTarget;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::python::SWIGBridge;
 
   SBBreakpoint(const lldb::BreakpointSP &bp_sp);

--- a/lldb/include/lldb/API/SBBreakpointLocation.h
+++ b/lldb/include/lldb/API/SBBreakpointLocation.h
@@ -24,7 +24,7 @@ class SWIGBridge;
 namespace lldb {
 
 class LLDB_API SBBreakpointLocation {
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
 public:
   SBBreakpointLocation();

--- a/lldb/include/lldb/API/SBCommandReturnObject.h
+++ b/lldb/include/lldb/API/SBCommandReturnObject.h
@@ -145,7 +145,7 @@ protected:
 
   friend class lldb_private::CommandPluginInterfaceImplementation;
   friend class lldb_private::python::SWIGBridge;
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   SBCommandReturnObject(lldb_private::CommandReturnObject &ref);
 

--- a/lldb/include/lldb/API/SBData.h
+++ b/lldb/include/lldb/API/SBData.h
@@ -154,7 +154,7 @@ private:
   friend class SBTarget;
   friend class SBValue;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   lldb::DataExtractorSP m_opaque_sp;
 };

--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -678,7 +678,7 @@ public:
 protected:
   friend class lldb_private::CommandPluginInterfaceImplementation;
   friend class lldb_private::python::SWIGBridge;
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::SystemInitializerFull;
 
   SBDebugger(const lldb::DebuggerSP &debugger_sp);

--- a/lldb/include/lldb/API/SBError.h
+++ b/lldb/include/lldb/API/SBError.h
@@ -109,7 +109,7 @@ protected:
   friend class SBValueList;
   friend class SBWatchpoint;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::python::SWIGBridge;
 
   SBError(lldb_private::Status &&error);

--- a/lldb/include/lldb/API/SBEvent.h
+++ b/lldb/include/lldb/API/SBEvent.h
@@ -74,7 +74,7 @@ protected:
   friend class SBThread;
   friend class SBWatchpoint;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::python::SWIGBridge;
 
   SBEvent(lldb::EventSP &event_sp);

--- a/lldb/include/lldb/API/SBExecutionContext.h
+++ b/lldb/include/lldb/API/SBExecutionContext.h
@@ -57,7 +57,7 @@ public:
 protected:
   friend class SBInstructionList;
   friend class lldb_private::python::SWIGBridge;
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   lldb_private::ExecutionContextRef *get() const;
 

--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -231,7 +231,7 @@ protected:
   friend class SBThread;
   friend class SBValue;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::python::SWIGBridge;
   friend class lldb_private::lua::SWIGBridge;
 

--- a/lldb/include/lldb/API/SBFrameList.h
+++ b/lldb/include/lldb/API/SBFrameList.h
@@ -78,7 +78,7 @@ protected:
 
   friend class lldb_private::python::SWIGBridge;
   friend class lldb_private::lua::SWIGBridge;
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
 private:
   SBFrameList(const lldb::StackFrameListSP &frame_list_sp);

--- a/lldb/include/lldb/API/SBLaunchInfo.h
+++ b/lldb/include/lldb/API/SBLaunchInfo.h
@@ -210,7 +210,7 @@ protected:
   friend class SBPlatform;
   friend class SBTarget;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   const lldb_private::ProcessLaunchInfo &ref() const;
   void set_ref(const lldb_private::ProcessLaunchInfo &info);

--- a/lldb/include/lldb/API/SBMemoryRegionInfo.h
+++ b/lldb/include/lldb/API/SBMemoryRegionInfo.h
@@ -132,7 +132,7 @@ private:
   friend class SBProcess;
   friend class SBMemoryRegionInfoList;
   friend class SBSaveCoreOptions;
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   lldb_private::MemoryRegionInfo &ref();
 

--- a/lldb/include/lldb/API/SBStream.h
+++ b/lldb/include/lldb/API/SBStream.h
@@ -108,7 +108,7 @@ protected:
   friend class SBValue;
   friend class SBWatchpoint;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   lldb_private::Stream *operator->();
 

--- a/lldb/include/lldb/API/SBSymbolContext.h
+++ b/lldb/include/lldb/API/SBSymbolContext.h
@@ -66,7 +66,7 @@ protected:
   friend class SBTarget;
   friend class SBSymbolContextList;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::python::SWIGBridge;
 
   SBSymbolContext(const lldb_private::SymbolContext &sc_ptr);
@@ -80,8 +80,6 @@ protected:
   const lldb_private::SymbolContext &operator*() const;
 
   lldb_private::SymbolContext *get() const;
-
-  friend class lldb_private::ScriptInterpreter;
 
 private:
   std::unique_ptr<lldb_private::SymbolContext> m_opaque_up;

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -1067,7 +1067,7 @@ protected:
 
   friend class lldb_private::python::SWIGBridge;
   friend class lldb_private::lua::SWIGBridge;
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
   // Constructors are private, use static Target::Create function to create an
   // instance of this class.

--- a/lldb/include/lldb/API/SBThread.h
+++ b/lldb/include/lldb/API/SBThread.h
@@ -256,7 +256,7 @@ private:
   friend class SBThreadPlan;
   friend class SBTrace;
 
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
   friend class lldb_private::python::SWIGBridge;
 
   SBThread(const lldb::ThreadSP &lldb_object_sp);

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -532,7 +532,7 @@ protected:
              bool use_synthetic, const char *name);
 
 protected:
-  friend class lldb_private::ScriptInterpreter;
+  friend class lldb_private::ScriptInterpreterBridge;
 
 private:
   typedef std::shared_ptr<lldb_private::ValueImpl> ValueImplSP;

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedFrameInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedFrameInterface.h
@@ -10,7 +10,6 @@
 #define LLDB_INTERPRETER_INTERFACES_SCRIPTEDFRAMEINTERFACE_H
 
 #include "ScriptedInterface.h"
-#include "lldb/API/SBValueList.h"
 #include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/lldb-private.h"

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -9,21 +9,6 @@
 #ifndef LLDB_INTERPRETER_SCRIPTINTERPRETER_H
 #define LLDB_INTERPRETER_SCRIPTINTERPRETER_H
 
-#include "lldb/API/SBAttachInfo.h"
-#include "lldb/API/SBBreakpoint.h"
-#include "lldb/API/SBBreakpointLocation.h"
-#include "lldb/API/SBCommandReturnObject.h"
-#include "lldb/API/SBData.h"
-#include "lldb/API/SBDebugger.h"
-#include "lldb/API/SBError.h"
-#include "lldb/API/SBEvent.h"
-#include "lldb/API/SBExecutionContext.h"
-#include "lldb/API/SBFrameList.h"
-#include "lldb/API/SBLaunchInfo.h"
-#include "lldb/API/SBMemoryRegionInfo.h"
-#include "lldb/API/SBStream.h"
-#include "lldb/API/SBSymbolContext.h"
-#include "lldb/API/SBThread.h"
 #include "lldb/Breakpoint/BreakpointOptions.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Core/SearchFilter.h"
@@ -37,7 +22,6 @@
 #include "lldb/Interpreter/Interfaces/ScriptedProcessInterface.h"
 #include "lldb/Interpreter/Interfaces/ScriptedThreadInterface.h"
 #include "lldb/Interpreter/ScriptObject.h"
-#include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Utility/Broadcaster.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/StructuredData.h"
@@ -530,54 +514,6 @@ public:
 
   virtual SanitizedScriptingModuleName
   GetSanitizedScriptingModuleName(llvm::StringRef name);
-
-  lldb::DataExtractorSP
-  GetDataExtractorFromSBData(const lldb::SBData &data) const;
-
-  Status GetStatusFromSBError(const lldb::SBError &error) const;
-
-  Event *GetOpaqueTypeFromSBEvent(const lldb::SBEvent &event) const;
-
-  lldb::StreamSP GetOpaqueTypeFromSBStream(const lldb::SBStream &stream) const;
-
-  lldb::ThreadSP GetOpaqueTypeFromSBThread(const lldb::SBThread &exe_ctx) const;
-
-  lldb::StackFrameSP GetOpaqueTypeFromSBFrame(const lldb::SBFrame &frame) const;
-
-  SymbolContext
-  GetOpaqueTypeFromSBSymbolContext(const lldb::SBSymbolContext &sym_ctx) const;
-
-  lldb::BreakpointSP
-  GetOpaqueTypeFromSBBreakpoint(const lldb::SBBreakpoint &breakpoint) const;
-
-  lldb::BreakpointLocationSP GetOpaqueTypeFromSBBreakpointLocation(
-      const lldb::SBBreakpointLocation &break_loc) const;
-
-  CommandReturnObject *GetOpaqueTypeFromSBCommandReturnObject(
-      const lldb::SBCommandReturnObject &cmd_retobj) const;
-
-  lldb::DebuggerSP
-  GetOpaqueTypeFromSBDebugger(const lldb::SBDebugger &debugger) const;
-
-  lldb::ProcessAttachInfoSP
-  GetOpaqueTypeFromSBAttachInfo(const lldb::SBAttachInfo &attach_info) const;
-
-  lldb::ProcessLaunchInfoSP
-  GetOpaqueTypeFromSBLaunchInfo(const lldb::SBLaunchInfo &launch_info) const;
-
-  std::optional<MemoryRegionInfo> GetOpaqueTypeFromSBMemoryRegionInfo(
-      const lldb::SBMemoryRegionInfo &mem_region) const;
-
-  lldb::ExecutionContextRefSP GetOpaqueTypeFromSBExecutionContext(
-      const lldb::SBExecutionContext &exe_ctx) const;
-
-  lldb::StackFrameListSP
-  GetOpaqueTypeFromSBFrameList(const lldb::SBFrameList &exe_ctx) const;
-
-  lldb::ValueObjectSP
-  GetOpaqueTypeFromSBValue(const lldb::SBValue &value) const;
-
-  lldb::TargetSP GetOpaqueTypeFromSBTarget(const lldb::SBTarget &target) const;
 
   /// Get the debugger associated with this script interpreter.
   Debugger &GetDebugger() { return m_debugger; }

--- a/lldb/include/lldb/Utility/StreamString.h
+++ b/lldb/include/lldb/Utility/StreamString.h
@@ -47,7 +47,7 @@ public:
   void FillLastLineToColumn(uint32_t column, char fill_char);
 
 protected:
-  friend class ScriptInterpreter;
+  friend class ScriptInterpreterBridge;
 
   std::string m_packet;
   size_t WriteImpl(const void *s, size_t length) override;

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -188,6 +188,7 @@ class RichManglingContext;
 class SaveCoreOptions;
 class Scalar;
 class ScriptInterpreter;
+class ScriptInterpreterBridge;
 class ScriptInterpreterLocker;
 class ScriptedFrameInterface;
 class ScriptedFrameProviderInterface;

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -116,6 +116,7 @@ add_lldb_library(liblldb SHARED ${option_framework}
   SBVariablesOptions.cpp
   SBWatchpoint.cpp
   SBWatchpointOptions.cpp
+  ScriptInterpreterBridge.cpp
   SystemInitializerFull.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lldb/source/API/ScriptInterpreterBridge.cpp
+++ b/lldb/source/API/ScriptInterpreterBridge.cpp
@@ -1,0 +1,147 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ScriptInterpreterBridge.h"
+#include "API/SBCommandReturnObjectImpl.h"
+#include "lldb/API/SBAttachInfo.h"
+#include "lldb/API/SBBreakpoint.h"
+#include "lldb/API/SBBreakpointLocation.h"
+#include "lldb/API/SBCommandReturnObject.h"
+#include "lldb/API/SBData.h"
+#include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBError.h"
+#include "lldb/API/SBEvent.h"
+#include "lldb/API/SBExecutionContext.h"
+#include "lldb/API/SBFrame.h"
+#include "lldb/API/SBFrameList.h"
+#include "lldb/API/SBLaunchInfo.h"
+#include "lldb/API/SBMemoryRegionInfo.h"
+#include "lldb/API/SBStream.h"
+#include "lldb/API/SBSymbolContext.h"
+#include "lldb/API/SBTarget.h"
+#include "lldb/API/SBThread.h"
+#include "lldb/API/SBValue.h"
+#include "lldb/Host/ProcessLaunchInfo.h"
+#include "lldb/Interpreter/CommandReturnObject.h"
+#include "lldb/Target/ExecutionContext.h"
+#include "lldb/Utility/StreamString.h"
+#include "lldb/ValueObject/ValueObject.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+lldb::DataExtractorSP
+ScriptInterpreterBridge::GetDataExtractor(const lldb::SBData &data) {
+  return data.m_opaque_sp;
+}
+
+lldb::BreakpointSP
+ScriptInterpreterBridge::GetBreakpoint(const lldb::SBBreakpoint &breakpoint) {
+  return breakpoint.m_opaque_wp.lock();
+}
+
+lldb::BreakpointLocationSP ScriptInterpreterBridge::GetBreakpointLocation(
+    const lldb::SBBreakpointLocation &break_loc) {
+  return break_loc.m_opaque_wp.lock();
+}
+
+CommandReturnObject *ScriptInterpreterBridge::GetCommandReturnObject(
+    const lldb::SBCommandReturnObject &cmd_retobj) {
+  return cmd_retobj.m_opaque_up->get();
+}
+
+lldb::DebuggerSP
+ScriptInterpreterBridge::GetDebugger(const lldb::SBDebugger &debugger) {
+  return debugger.m_opaque_sp;
+}
+
+lldb::ProcessAttachInfoSP ScriptInterpreterBridge::GetProcessAttachInfo(
+    const lldb::SBAttachInfo &attach_info) {
+  return attach_info.m_opaque_sp;
+}
+
+lldb::ProcessLaunchInfoSP ScriptInterpreterBridge::GetProcessLaunchInfo(
+    const lldb::SBLaunchInfo &launch_info) {
+  return std::make_shared<ProcessLaunchInfo>(
+      *reinterpret_cast<ProcessLaunchInfo *>(launch_info.m_opaque_sp.get()));
+}
+
+Status ScriptInterpreterBridge::GetStatus(const lldb::SBError &error) {
+  if (error.m_opaque_up)
+    return error.m_opaque_up->Clone();
+
+  return Status();
+}
+
+lldb::ThreadSP
+ScriptInterpreterBridge::GetThread(const lldb::SBThread &thread) {
+  if (thread.m_opaque_sp)
+    return thread.m_opaque_sp->GetThreadSP();
+  return nullptr;
+}
+
+lldb::StackFrameSP
+ScriptInterpreterBridge::GetStackFrame(const lldb::SBFrame &frame) {
+  if (frame.m_opaque_sp)
+    return frame.m_opaque_sp->GetFrameSP();
+  return nullptr;
+}
+
+Event *ScriptInterpreterBridge::GetEvent(const lldb::SBEvent &event) {
+  return event.m_opaque_ptr;
+}
+
+lldb::StreamSP
+ScriptInterpreterBridge::GetStream(const lldb::SBStream &stream) {
+  if (stream.m_opaque_up) {
+    lldb::StreamSP s = std::make_shared<lldb_private::StreamString>();
+    *s << reinterpret_cast<StreamString *>(stream.m_opaque_up.get())->m_packet;
+    return s;
+  }
+
+  return nullptr;
+}
+
+SymbolContext ScriptInterpreterBridge::GetSymbolContext(
+    const lldb::SBSymbolContext &sb_sym_ctx) {
+  if (sb_sym_ctx.m_opaque_up)
+    return *sb_sym_ctx.m_opaque_up;
+  return {};
+}
+
+std::optional<lldb_private::MemoryRegionInfo>
+ScriptInterpreterBridge::GetMemoryRegionInfo(
+    const lldb::SBMemoryRegionInfo &mem_region) {
+  if (!mem_region.m_opaque_up)
+    return std::nullopt;
+  return *mem_region.m_opaque_up.get();
+}
+
+lldb::ExecutionContextRefSP ScriptInterpreterBridge::GetExecutionContextRef(
+    const lldb::SBExecutionContext &exe_ctx) {
+  return exe_ctx.m_exe_ctx_sp;
+}
+
+lldb::StackFrameListSP ScriptInterpreterBridge::GetStackFrameList(
+    const lldb::SBFrameList &frame_list) {
+  return frame_list.m_opaque_sp;
+}
+
+lldb::TargetSP
+ScriptInterpreterBridge::GetTarget(const lldb::SBTarget &target) {
+  return target.m_opaque_sp;
+}
+
+lldb::ValueObjectSP
+ScriptInterpreterBridge::GetValueObject(const lldb::SBValue &value) {
+  if (!value.m_opaque_sp)
+    return lldb::ValueObjectSP();
+
+  lldb_private::ValueLocker locker;
+  return locker.GetLockedSP(*value.m_opaque_sp);
+}

--- a/lldb/source/API/ScriptInterpreterBridge.h
+++ b/lldb/source/API/ScriptInterpreterBridge.h
@@ -1,0 +1,78 @@
+//===-- ScriptInterpreterBridge.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_API_SCRIPTINTERPRETERBRIDGE_H
+#define LLDB_SOURCE_API_SCRIPTINTERPRETERBRIDGE_H
+
+#include "lldb/API/SBDefines.h"
+#include "lldb/Symbol/SymbolContext.h"
+#include "lldb/Target/MemoryRegionInfo.h"
+#include "lldb/Utility/Status.h"
+#include "lldb/lldb-forward.h"
+#include <optional>
+
+namespace lldb_private {
+
+class CommandReturnObject;
+class Event;
+
+/// Unwraps the opaque internal object held by an SB (public API) instance,
+/// for scripting-language plugins that need to convert values passed across
+/// the script callback boundary back to their lldb_private form. Every SB
+/// class this needs to reach into grants friendship to this class alone, so
+/// that access to API internals stays confined to this single bridge rather
+/// than spreading across the Interpreter layer.
+class ScriptInterpreterBridge {
+public:
+  static lldb::DataExtractorSP GetDataExtractor(const lldb::SBData &data);
+
+  static Status GetStatus(const lldb::SBError &error);
+
+  static Event *GetEvent(const lldb::SBEvent &event);
+
+  static lldb::StreamSP GetStream(const lldb::SBStream &stream);
+
+  static lldb::ThreadSP GetThread(const lldb::SBThread &thread);
+
+  static lldb::StackFrameSP GetStackFrame(const lldb::SBFrame &frame);
+
+  static SymbolContext GetSymbolContext(const lldb::SBSymbolContext &sym_ctx);
+
+  static lldb::BreakpointSP GetBreakpoint(const lldb::SBBreakpoint &breakpoint);
+
+  static lldb::BreakpointLocationSP
+  GetBreakpointLocation(const lldb::SBBreakpointLocation &break_loc);
+
+  static CommandReturnObject *
+  GetCommandReturnObject(const lldb::SBCommandReturnObject &cmd_retobj);
+
+  static lldb::DebuggerSP GetDebugger(const lldb::SBDebugger &debugger);
+
+  static lldb::ProcessAttachInfoSP
+  GetProcessAttachInfo(const lldb::SBAttachInfo &attach_info);
+
+  static lldb::ProcessLaunchInfoSP
+  GetProcessLaunchInfo(const lldb::SBLaunchInfo &launch_info);
+
+  static std::optional<MemoryRegionInfo>
+  GetMemoryRegionInfo(const lldb::SBMemoryRegionInfo &mem_region);
+
+  static lldb::ExecutionContextRefSP
+  GetExecutionContextRef(const lldb::SBExecutionContext &exe_ctx);
+
+  static lldb::StackFrameListSP
+  GetStackFrameList(const lldb::SBFrameList &frame_list);
+
+  static lldb::ValueObjectSP GetValueObject(const lldb::SBValue &value);
+
+  static lldb::TargetSP GetTarget(const lldb::SBTarget &target);
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_API_SCRIPTINTERPRETERBRIDGE_H

--- a/lldb/source/Interpreter/CMakeLists.txt
+++ b/lldb/source/Interpreter/CMakeLists.txt
@@ -65,12 +65,26 @@ add_lldb_library(lldbInterpreter NO_PLUGIN_DEPENDENCIES
     Support
   LINK_LIBS
     lldbInterpreterInterfaces
+    lldbBreakpoint
     lldbCommands
     lldbCore
     lldbDataFormatters
     lldbHost
+    lldbSymbol
     lldbTarget
     lldbUtility
+    lldbValueObject
+  ALLOWED_INTERNAL_DEPENDENCIES
+    lldbInterpreterInterfaces
+    lldbBreakpoint
+    lldbCommands
+    lldbCore
+    lldbDataFormatters
+    lldbHost
+    lldbSymbol
+    lldbTarget
+    lldbUtility
+    lldbValueObject
   )
 
 add_dependencies(lldbInterpreter

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Interpreter/ScriptInterpreter.h"
-#include "API/SBCommandReturnObjectImpl.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Host/ConnectionFileDescriptor.h"
 #include "lldb/Host/Pipe.h"
@@ -17,7 +16,6 @@
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StringList.h"
 #include "lldb/Utility/UnimplementedError.h"
-#include "lldb/ValueObject/ValueObject.h"
 #include "llvm/ADT/StringSwitch.h"
 #if defined(_WIN32)
 #include "lldb/Host/windows/ConnectionGenericFileWindows.h"
@@ -79,121 +77,6 @@ std::string ScriptInterpreter::LanguageToString(lldb::ScriptLanguage language) {
     return "Unknown";
   }
   llvm_unreachable("Unhandled ScriptInterpreter!");
-}
-
-lldb::DataExtractorSP
-ScriptInterpreter::GetDataExtractorFromSBData(const lldb::SBData &data) const {
-  return data.m_opaque_sp;
-}
-
-lldb::BreakpointSP ScriptInterpreter::GetOpaqueTypeFromSBBreakpoint(
-    const lldb::SBBreakpoint &breakpoint) const {
-  return breakpoint.m_opaque_wp.lock();
-}
-
-lldb::BreakpointLocationSP
-ScriptInterpreter::GetOpaqueTypeFromSBBreakpointLocation(
-    const lldb::SBBreakpointLocation &break_loc) const {
-  return break_loc.m_opaque_wp.lock();
-}
-
-CommandReturnObject *ScriptInterpreter::GetOpaqueTypeFromSBCommandReturnObject(
-    const lldb::SBCommandReturnObject &cmd_retobj) const {
-  return cmd_retobj.m_opaque_up->get();
-}
-
-lldb::DebuggerSP ScriptInterpreter::GetOpaqueTypeFromSBDebugger(
-    const lldb::SBDebugger &debugger) const {
-  return debugger.m_opaque_sp;
-}
-
-lldb::ProcessAttachInfoSP ScriptInterpreter::GetOpaqueTypeFromSBAttachInfo(
-    const lldb::SBAttachInfo &attach_info) const {
-  return attach_info.m_opaque_sp;
-}
-
-lldb::ProcessLaunchInfoSP ScriptInterpreter::GetOpaqueTypeFromSBLaunchInfo(
-    const lldb::SBLaunchInfo &launch_info) const {
-  return std::make_shared<ProcessLaunchInfo>(
-      *reinterpret_cast<ProcessLaunchInfo *>(launch_info.m_opaque_sp.get()));
-}
-
-Status
-ScriptInterpreter::GetStatusFromSBError(const lldb::SBError &error) const {
-  if (error.m_opaque_up)
-    return error.m_opaque_up->Clone();
-
-  return Status();
-}
-
-lldb::ThreadSP ScriptInterpreter::GetOpaqueTypeFromSBThread(
-    const lldb::SBThread &thread) const {
-  if (thread.m_opaque_sp)
-    return thread.m_opaque_sp->GetThreadSP();
-  return nullptr;
-}
-
-lldb::StackFrameSP
-ScriptInterpreter::GetOpaqueTypeFromSBFrame(const lldb::SBFrame &frame) const {
-  if (frame.m_opaque_sp)
-    return frame.m_opaque_sp->GetFrameSP();
-  return nullptr;
-}
-
-Event *
-ScriptInterpreter::GetOpaqueTypeFromSBEvent(const lldb::SBEvent &event) const {
-  return event.m_opaque_ptr;
-}
-
-lldb::StreamSP ScriptInterpreter::GetOpaqueTypeFromSBStream(
-    const lldb::SBStream &stream) const {
-  if (stream.m_opaque_up) {
-    lldb::StreamSP s = std::make_shared<lldb_private::StreamString>();
-    *s << reinterpret_cast<StreamString *>(stream.m_opaque_up.get())->m_packet;
-    return s;
-  }
-
-  return nullptr;
-}
-
-SymbolContext ScriptInterpreter::GetOpaqueTypeFromSBSymbolContext(
-    const lldb::SBSymbolContext &sb_sym_ctx) const {
-  if (sb_sym_ctx.m_opaque_up)
-    return *sb_sym_ctx.m_opaque_up;
-  return {};
-}
-
-std::optional<lldb_private::MemoryRegionInfo>
-ScriptInterpreter::GetOpaqueTypeFromSBMemoryRegionInfo(
-    const lldb::SBMemoryRegionInfo &mem_region) const {
-  if (!mem_region.m_opaque_up)
-    return std::nullopt;
-  return *mem_region.m_opaque_up.get();
-}
-
-lldb::ExecutionContextRefSP
-ScriptInterpreter::GetOpaqueTypeFromSBExecutionContext(
-    const lldb::SBExecutionContext &exe_ctx) const {
-  return exe_ctx.m_exe_ctx_sp;
-}
-
-lldb::StackFrameListSP ScriptInterpreter::GetOpaqueTypeFromSBFrameList(
-    const lldb::SBFrameList &frame_list) const {
-  return frame_list.m_opaque_sp;
-}
-
-lldb::TargetSP ScriptInterpreter::GetOpaqueTypeFromSBTarget(
-    const lldb::SBTarget &target) const {
-  return target.m_opaque_sp;
-}
-
-lldb::ValueObjectSP
-ScriptInterpreter::GetOpaqueTypeFromSBValue(const lldb::SBValue &value) const {
-  if (!value.m_opaque_sp)
-    return lldb::ValueObjectSP();
-
-  lldb_private::ValueLocker locker;
-  return locker.GetLockedSP(*value.m_opaque_sp);
 }
 
 lldb::ScriptLanguage

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -8,7 +8,9 @@
 
 #include "../lldb-python.h"
 
-#include "lldb/API/SBDebugger.h"
+#include "API/ScriptInterpreterBridge.h"
+#include "lldb/API/SBValue.h"
+#include "lldb/API/SBValueList.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/lldb-enumerations.h"
@@ -47,7 +49,7 @@ Status ScriptedPythonInterface::ExtractValueFromPythonObject<Status>(
     python::PythonObject &p, Status &error) {
   if (lldb::SBError *sb_error = reinterpret_cast<lldb::SBError *>(
           python::LLDBSWIGPython_CastPyObjectToSBError(p.get())))
-    return m_interpreter.GetStatusFromSBError(*sb_error);
+    return ScriptInterpreterBridge::GetStatus(*sb_error);
   error =
       Status::FromErrorString("Couldn't cast lldb::SBError to lldb::Status.");
 
@@ -59,7 +61,7 @@ Event *ScriptedPythonInterface::ExtractValueFromPythonObject<Event *>(
     python::PythonObject &p, Status &error) {
   if (lldb::SBEvent *sb_event = reinterpret_cast<lldb::SBEvent *>(
           python::LLDBSWIGPython_CastPyObjectToSBEvent(p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBEvent(*sb_event);
+    return ScriptInterpreterBridge::GetEvent(*sb_event);
   error = Status::FromErrorString(
       "Couldn't cast lldb::SBEvent to lldb_private::Event.");
 
@@ -74,7 +76,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<CommandReturnObject *>(
           reinterpret_cast<lldb::SBCommandReturnObject *>(
               python::LLDBSWIGPython_CastPyObjectToSBCommandReturnObject(
                   p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBCommandReturnObject(*sb_cmd_retobj);
+    return ScriptInterpreterBridge::GetCommandReturnObject(*sb_cmd_retobj);
   error =
       Status::FromErrorString("couldn't cast lldb::SBCommandReturnObject to "
                               "lldb_private::CommandReturnObject.");
@@ -87,7 +89,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::StreamSP>(
     python::PythonObject &p, Status &error) {
   if (lldb::SBStream *sb_stream = reinterpret_cast<lldb::SBStream *>(
           python::LLDBSWIGPython_CastPyObjectToSBStream(p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBStream(*sb_stream);
+    return ScriptInterpreterBridge::GetStream(*sb_stream);
   error = Status::FromErrorString(
       "Couldn't cast lldb::SBStream to lldb_private::Stream.");
 
@@ -100,7 +102,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::StackFrameSP>(
     python::PythonObject &p, Status &error) {
   if (lldb::SBFrame *sb_frame = reinterpret_cast<lldb::SBFrame *>(
           python::LLDBSWIGPython_CastPyObjectToSBFrame(p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBFrame(*sb_frame);
+    return ScriptInterpreterBridge::GetStackFrame(*sb_frame);
   error = Status::FromErrorString(
       "Couldn't cast lldb::SBFrame to lldb_private::StackFrame.");
 
@@ -113,7 +115,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ThreadSP>(
     python::PythonObject &p, Status &error) {
   if (lldb::SBThread *sb_thread = reinterpret_cast<lldb::SBThread *>(
           python::LLDBSWIGPython_CastPyObjectToSBThread(p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBThread(*sb_thread);
+    return ScriptInterpreterBridge::GetThread(*sb_thread);
   error = Status::FromErrorString(
       "Couldn't cast lldb::SBThread to lldb_private::Thread.");
 
@@ -127,7 +129,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<SymbolContext>(
   if (lldb::SBSymbolContext *sb_symbol_context =
           reinterpret_cast<lldb::SBSymbolContext *>(
               python::LLDBSWIGPython_CastPyObjectToSBSymbolContext(p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBSymbolContext(*sb_symbol_context);
+    return ScriptInterpreterBridge::GetSymbolContext(*sb_symbol_context);
   error = Status::FromErrorString(
       "Couldn't cast lldb::SBSymbolContext to lldb_private::SymbolContext.");
 
@@ -147,7 +149,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::DataExtractorSP>(
     return nullptr;
   }
 
-  return m_interpreter.GetDataExtractorFromSBData(*sb_data);
+  return ScriptInterpreterBridge::GetDataExtractor(*sb_data);
 }
 
 template <>
@@ -163,7 +165,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::BreakpointSP>(
     return nullptr;
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBBreakpoint(*sb_breakpoint);
+  return ScriptInterpreterBridge::GetBreakpoint(*sb_breakpoint);
 }
 
 template <>
@@ -181,7 +183,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<
     return nullptr;
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBBreakpointLocation(*sb_break_loc);
+  return ScriptInterpreterBridge::GetBreakpointLocation(*sb_break_loc);
 }
 
 template <>
@@ -196,7 +198,7 @@ lldb::ProcessAttachInfoSP ScriptedPythonInterface::ExtractValueFromPythonObject<
     return nullptr;
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBAttachInfo(*sb_attach_info);
+  return ScriptInterpreterBridge::GetProcessAttachInfo(*sb_attach_info);
 }
 
 template <>
@@ -211,7 +213,7 @@ lldb::ProcessLaunchInfoSP ScriptedPythonInterface::ExtractValueFromPythonObject<
     return nullptr;
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBLaunchInfo(*sb_launch_info);
+  return ScriptInterpreterBridge::GetProcessLaunchInfo(*sb_launch_info);
 }
 
 template <>
@@ -230,7 +232,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<
     return {};
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBMemoryRegionInfo(*sb_mem_reg_info);
+  return ScriptInterpreterBridge::GetMemoryRegionInfo(*sb_mem_reg_info);
 }
 
 template <>
@@ -249,7 +251,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<
     return {};
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBExecutionContext(*sb_exe_ctx);
+  return ScriptInterpreterBridge::GetExecutionContextRef(*sb_exe_ctx);
 }
 
 template <>
@@ -284,7 +286,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::StackFrameListSP>(
     return {};
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBFrameList(*sb_frame_list);
+  return ScriptInterpreterBridge::GetStackFrameList(*sb_frame_list);
 }
 
 template <>
@@ -299,7 +301,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ValueObjectSP>(
     return {};
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBValue(*sb_value);
+  return ScriptInterpreterBridge::GetValueObject(*sb_value);
 }
 
 template <>
@@ -314,7 +316,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::TargetSP>(
     return {};
   }
 
-  return m_interpreter.GetOpaqueTypeFromSBTarget(*sb_target);
+  return ScriptInterpreterBridge::GetTarget(*sb_target);
 }
 
 template <>
@@ -330,7 +332,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ValueObjectListSP>(
           python::LLDBSWIGPython_CastPyObjectToSBValueList(p.get()))) {
     for (uint32_t i = 0, e = sb_value_list->GetSize(); i < e; ++i) {
       SBValue value = sb_value_list->GetValueAtIndex(i);
-      out->Append(m_interpreter.GetOpaqueTypeFromSBValue(value));
+      out->Append(ScriptInterpreterBridge::GetValueObject(value));
     }
     return out;
   }
@@ -359,7 +361,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ValueObjectListSP>(
           python::LLDBSWIGPython_CastPyObjectToSBValue(
               static_cast<PyObject *>(generic->GetValue())));
       if (sb_value)
-        if (auto valobj_sp = m_interpreter.GetOpaqueTypeFromSBValue(*sb_value))
+        if (auto valobj_sp = ScriptInterpreterBridge::GetValueObject(*sb_value))
           out->Append(valobj_sp);
       ++index;
       return true;
@@ -403,7 +405,7 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::DebuggerSP>(
     python::PythonObject &p, Status &error) {
   if (lldb::SBDebugger *sb_dbg = reinterpret_cast<lldb::SBDebugger *>(
           python::LLDBSWIGPython_CastPyObjectToSBDebugger(p.get())))
-    return m_interpreter.GetOpaqueTypeFromSBDebugger(*sb_dbg);
+    return ScriptInterpreterBridge::GetDebugger(*sb_dbg);
   error = Status::FromErrorString(
       "couldn't cast lldb::SBDebugger to lldb::DebuggerSP.");
   return {};


### PR DESCRIPTION
`ScriptInterpreter` reached into the private state of 18 SB classes to unwrap opaque objects for scripting callbacks, pulling `lldb/API/*.h` into `lldbInterpreter`'s public header and requiring friend access from a class that conceptually sits below the `API` layer. Move that unwrapping into a new `ScriptInterpreterBridge` class in `source/API`, which is where reaching into an SB class's own internals belongs.