### PR TITLE
[ASan] Handle allocas in non-default address spaces

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3734,6 +3734,8 @@ void FunctionStackPoisoner::processStaticAllocas() {
     replaceDbgDeclare(AI, LocalStackBaseAlloca, DIB, DIExprFlags, Desc.Offset);
     Value *NewAllocaPtr = IRB.CreatePtrAdd(
         LocalStackBase, ConstantInt::get(IntptrTy, Desc.Offset));
+    if (NewAllocaPtr->getType() != AI->getType())
+      NewAllocaPtr = IRB.CreateAddrSpaceCast(NewAllocaPtr, AI->getType());
     AI->replaceAllUsesWith(NewAllocaPtr);
     NewAllocaPtrs.push_back(NewAllocaPtr);
   }

--- a/llvm/test/Instrumentation/AddressSanitizer/alloca-addrspace.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/alloca-addrspace.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -passes=asan -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @use(ptr)
+
+; CHECK-LABEL: define ptr addrspace(3) @only_addrspace_alloca()
+; CHECK:         %[[BASE:[0-9]+]] = phi ptr
+; CHECK:         %[[SLOT:[0-9]+]] = getelementptr i8, ptr %[[BASE]], i64 32
+; CHECK-NEXT:    %[[CAST:[0-9]+]] = addrspacecast ptr %[[SLOT]] to ptr addrspace(3)
+; CHECK:         ret ptr addrspace(3) %[[CAST]]
+define ptr addrspace(3) @only_addrspace_alloca() sanitize_address {
+  %p = alloca float, align 4, addrspace(3)
+  ret ptr addrspace(3) %p
+}
+
+; CHECK-LABEL: define ptr addrspace(3) @mixed_allocas()
+; CHECK:         %[[BASE:[0-9]+]] = phi ptr
+; CHECK:         %[[QSLOT:[0-9]+]] = getelementptr i8, ptr %[[BASE]], i64 32
+; CHECK-NEXT:    %[[PSLOT:[0-9]+]] = getelementptr i8, ptr %[[BASE]], i64 48
+; CHECK-NEXT:    %[[PCAST:[0-9]+]] = addrspacecast ptr %[[PSLOT]] to ptr addrspace(3)
+; CHECK:         call void @use(ptr %[[QSLOT]])
+; CHECK:         ret ptr addrspace(3) %[[PCAST]]
+define ptr addrspace(3) @mixed_allocas() sanitize_address {
+  %q = alloca i32, align 4
+  %p = alloca float, align 4, addrspace(3)
+  call void @use(ptr %q)
+  ret ptr addrspace(3) %p
+}


### PR DESCRIPTION
Do addrspace cast for allocas that live in address space different from the datalayout's alloca address space, otherwise ASan will crash during use replacement