### PR TITLE
AMDGPU/GlobalISel: Switch more FP opcodes to extended LLTs (part 5)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -724,23 +724,11 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
 
   const std::initializer_list<LLT> AddrSpaces128 = {RsrcPtr};
 
-  const std::initializer_list<LLT> FPTypesBase = {
-    S32, S64
-  };
-
-  const std::initializer_list<LLT> FPTypes16 = {
-    S32, S64, S16
-  };
-
-  const std::initializer_list<LLT> FPTypesPK16 = {
-    S32, S64, S16, V2S16
-  };
-
-  const std::initializer_list<LLT> ExtendedFPTypesBase = {F32, F64};
-  const std::initializer_list<LLT> ExtendedFPTypes16 = {F32, F64, F16};
-  const std::initializer_list<LLT> ExtendedFPTypesPK16 = {F32, F64, F16, V2F16};
-  const std::initializer_list<LLT> ExtendedFPTypesPK16_64 = {F32, F64, F16,
-                                                             V2F16, V2F64};
+  const std::initializer_list<LLT> FPTypesBase = {F32, F64};
+  const std::initializer_list<LLT> FPTypes16 = {F32, F64, F16};
+  const std::initializer_list<LLT> FPTypesPK16 = {F32, F64, F16, V2F16};
+  const std::initializer_list<LLT> FPTypesPK16_64 = {F32, F64, F16, V2F16,
+                                                     V2F64};
 
   const LLT MinExtendedFPTy = ST.has16BitInsts() ? F16 : F32;
   const LLT I1 = LLT::integer(1);
@@ -1024,34 +1012,34 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
       getActionDefinitionsBuilder({G_FMINNUM_IEEE, G_FMAXNUM_IEEE});
 
   if (ST.hasVOP3PInsts()) {
-    MinNumMaxNumIeee.legalFor(ExtendedFPTypesPK16)
+    MinNumMaxNumIeee.legalFor(FPTypesPK16)
         .moreElementsIf(isSmallOddVector(0), oneMoreElement(0))
         .clampMaxNumElements(0, F16, 2)
         .scalarize(0);
   } else if (ST.has16BitInsts()) {
-    MinNumMaxNumIeee.legalFor(ExtendedFPTypes16).scalarize(0);
+    MinNumMaxNumIeee.legalFor(FPTypes16).scalarize(0);
   } else {
-    MinNumMaxNumIeee.legalFor(ExtendedFPTypesBase).scalarize(0);
+    MinNumMaxNumIeee.legalFor(FPTypesBase).scalarize(0);
   }
 
   auto &MinNumMaxNum = getActionDefinitionsBuilder(
       {G_FMINNUM, G_FMAXNUM, G_FMINIMUMNUM, G_FMAXIMUMNUM});
 
   if (ST.hasAnyPackedFP64Ops()) {
-    MinNumMaxNum.customFor(ExtendedFPTypesPK16_64)
+    MinNumMaxNum.customFor(FPTypesPK16_64)
         .moreElementsIf(isSmallOddVector(0), oneMoreElement(0))
         .clampMaxNumElements(0, F16, 2)
         .clampMaxNumElements(0, F64, 2)
         .scalarize(0);
   } else if (ST.hasVOP3PInsts()) {
-    MinNumMaxNum.customFor(ExtendedFPTypesPK16)
+    MinNumMaxNum.customFor(FPTypesPK16)
         .moreElementsIf(isSmallOddVector(0), oneMoreElement(0))
         .clampMaxNumElements(0, F16, 2)
         .scalarize(0);
   } else if (ST.has16BitInsts()) {
-    MinNumMaxNum.customFor(ExtendedFPTypes16).scalarize(0);
+    MinNumMaxNum.customFor(FPTypes16).scalarize(0);
   } else {
-    MinNumMaxNum.customFor(ExtendedFPTypesBase).scalarize(0);
+    MinNumMaxNum.customFor(FPTypesBase).scalarize(0);
   }
 
   if (!ST.has16BitInsts()) {
@@ -1073,29 +1061,28 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
 
   auto &FNegAbs = getActionDefinitionsBuilder({G_FNEG, G_FABS});
   FNegAbs.legalFor(FPTypesPK16)
-      .legalFor(ST.hasAnyPackedFP32Ops(), {V2S32})
-      .clampMaxNumElementsStrict(0, S16, 2);
+      .legalFor(ST.hasAnyPackedFP32Ops(), {V2F32})
+      .clampMaxNumElementsStrict(0, F16, 2);
   if (ST.hasAnyPackedFP32Ops())
-    FNegAbs.clampMaxNumElementsStrict(0, S32, 2);
-  FNegAbs.scalarize(0).clampScalar(0, S16, S64);
+    FNegAbs.clampMaxNumElementsStrict(0, F32, 2);
+  FNegAbs.scalarize(0);
 
   if (ST.has16BitInsts()) {
     getActionDefinitionsBuilder(G_FSQRT)
-      .legalFor({S16})
-      .customFor({S32, S64})
-      .scalarize(0)
-      .unsupported();
+        .legalFor({F16})
+        .customFor({F32, F64})
+        .scalarize(0)
+        .unsupported();
     getActionDefinitionsBuilder(G_FFLOOR)
-      .legalFor({S32, S64, S16})
-      .scalarize(0)
-      .clampScalar(0, S16, S64);
+        .legalFor({F32, F64, F16})
+        .scalarize(0);
 
     getActionDefinitionsBuilder({G_FLDEXP, G_STRICT_FLDEXP})
-      .legalFor({{S32, S32}, {S64, S32}, {S16, S16}})
-      .scalarize(0)
-      .maxScalarIf(typeIs(0, S16), 1, S16)
-      .clampScalar(1, S32, S32)
-      .lower();
+        .legalFor({{F32, I32}, {F64, I32}, {F16, I16}})
+        .scalarize(0)
+        .maxScalarIf(typeIs(0, F16), 1, I16)
+        .clampScalar(1, I32, I32)
+        .lower();
 
     getActionDefinitionsBuilder(G_FFREXP)
         .customFor({{F32, I32}, {F64, I32}, {F16, I16}, {F16, I32}})
@@ -1108,30 +1095,29 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
         .lower();
   } else {
     getActionDefinitionsBuilder(G_FSQRT)
-      .customFor({S32, S64, S16})
-      .scalarize(0)
-      .unsupported();
-
+        .customFor({F32, F64, F16})
+        .scalarize(0)
+        .unsupported();
 
     if (ST.hasFractBug()) {
       getActionDefinitionsBuilder(G_FFLOOR)
-        .customFor({S64})
-        .legalFor({S32, S64})
-        .scalarize(0)
-        .clampScalar(0, S32, S64);
+          .customFor({F64})
+          .legalFor({F32, F64})
+          .scalarize(0)
+          .minScalar(0, F32);
     } else {
       getActionDefinitionsBuilder(G_FFLOOR)
-        .legalFor({S32, S64})
-        .scalarize(0)
-        .clampScalar(0, S32, S64);
+          .legalFor({F32, F64})
+          .scalarize(0)
+          .minScalar(0, F32);
     }
 
     getActionDefinitionsBuilder({G_FLDEXP, G_STRICT_FLDEXP})
-      .legalFor({{S32, S32}, {S64, S32}})
-      .scalarize(0)
-      .clampScalar(0, S32, S64)
-      .clampScalar(1, S32, S32)
-      .lower();
+        .legalFor({{F32, I32}, {F64, I32}})
+        .scalarize(0)
+        .minScalar(0, F32)
+        .clampScalar(1, I32, I32)
+        .lower();
 
     getActionDefinitionsBuilder(G_FFREXP)
         .customFor({{F32, I32}, {F64, I32}})
@@ -1337,15 +1323,12 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
 
   auto &FCmpBuilder =
       getActionDefinitionsBuilder(G_FCMP).legalForCartesianProduct(
-          {S1}, ST.has16BitInsts() ? FPTypes16 : FPTypesBase);
+          {I1}, ST.has16BitInsts() ? FPTypes16 : FPTypesBase);
 
   if (ST.hasSALUFloatInsts())
-    FCmpBuilder.legalForCartesianProduct({S32}, {S16, S32});
+    FCmpBuilder.legalForCartesianProduct({I32}, {F16, F32});
 
-  FCmpBuilder
-    .widenScalarToNextPow2(1)
-    .clampScalar(1, S32, S64)
-    .scalarize(0);
+  FCmpBuilder.widenScalarToNextPow2(1).minScalar(1, F32).scalarize(0);
 
   // FIXME: fpow has a selection pattern that should move to custom lowering.
   auto &ExpOps = getActionDefinitionsBuilder(G_FPOW);
@@ -1391,14 +1374,14 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
   // If no 16 bit instr is available, lower into different instructions.
   if (ST.has16BitInsts())
     getActionDefinitionsBuilder(G_IS_FPCLASS)
-        .legalForCartesianProduct({S1}, FPTypes16)
+        .legalForCartesianProduct({I1}, FPTypes16)
         .widenScalarToNextPow2(1)
         .scalarize(0)
         .lower();
   else
     getActionDefinitionsBuilder(G_IS_FPCLASS)
-        .legalForCartesianProduct({S1}, FPTypesBase)
-        .lowerFor({S1, S16})
+        .legalForCartesianProduct({I1}, FPTypesBase)
+        .lowerFor({I1, F16})
         .widenScalarToNextPow2(1)
         .scalarize(0)
         .lower();
@@ -2257,7 +2240,7 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
 
   if (ST.hasIEEEMinimumMaximumInsts()) {
     getActionDefinitionsBuilder({G_FMINIMUM, G_FMAXIMUM})
-        .legalFor(ExtendedFPTypesPK16)
+        .legalFor(FPTypesPK16)
         .clampMaxNumElements(0, F16, 2)
         .scalarize(0);
   } else if (ST.hasVOP3PInsts()) {
@@ -5942,7 +5925,7 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF32(MachineInstr &MI,
   Register Dst = MI.getOperand(0).getReg();
   Register X = MI.getOperand(1).getReg();
   const unsigned Flags = MI.getFlags();
-  const LLT S1 = LLT::scalar(1);
+  const LLT I1 = LLT::integer(1);
   const LLT I32 = LLT::integer(32);
 
   if (allowApproxFunc(MF, Flags)) {
@@ -5954,7 +5937,7 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF32(MachineInstr &MI,
   }
 
   auto ScaleThreshold = B.buildFConstant(F32, 0x1.0p-96f);
-  auto NeedScale = B.buildFCmp(CmpInst::FCMP_OGT, S1, ScaleThreshold, X, Flags);
+  auto NeedScale = B.buildFCmp(CmpInst::FCMP_OGT, I1, ScaleThreshold, X, Flags);
   auto ScaleUpFactor = B.buildFConstant(F32, 0x1.0p+32f);
   auto ScaledX = B.buildFMul(F32, X, ScaleUpFactor, Flags);
   auto SqrtX = B.buildSelect(F32, NeedScale, ScaledX, X, Flags);
@@ -5979,12 +5962,12 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF32(MachineInstr &MI,
     auto SqrtVS = B.buildFMA(F32, NegSqrtSNextUp, SqrtS, SqrtX, Flags);
 
     auto Zero = B.buildFConstant(F32, 0.0f);
-    auto SqrtVPLE0 = B.buildFCmp(CmpInst::FCMP_OLE, S1, SqrtVP, Zero, Flags);
+    auto SqrtVPLE0 = B.buildFCmp(CmpInst::FCMP_OLE, I1, SqrtVP, Zero, Flags);
 
     SqrtS =
         B.buildSelect(F32, SqrtVPLE0, SqrtSNextDown, SqrtS, Flags).getReg(0);
 
-    auto SqrtVPVSGT0 = B.buildFCmp(CmpInst::FCMP_OGT, S1, SqrtVS, Zero, Flags);
+    auto SqrtVPVSGT0 = B.buildFCmp(CmpInst::FCMP_OGT, I1, SqrtVS, Zero, Flags);
     SqrtS =
         B.buildSelect(F32, SqrtVPVSGT0, SqrtSNextUp, SqrtS, Flags).getReg(0);
   } else {
@@ -6009,7 +5992,7 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF32(MachineInstr &MI,
 
   SqrtS = B.buildSelect(F32, NeedScale, ScaledDown, SqrtS, Flags).getReg(0);
 
-  auto IsZeroOrInf = B.buildIsFPClass(LLT::scalar(1), SqrtX, fcZero | fcPosInf);
+  auto IsZeroOrInf = B.buildIsFPClass(I1, SqrtX, fcZero | fcPosInf);
   B.buildSelect(Dst, IsZeroOrInf, SqrtX, SqrtS, Flags);
 
   MI.eraseFromParent();
@@ -6039,7 +6022,7 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF64(MachineInstr &MI,
   //
   //   sqrt(x) = g3
 
-  const LLT S1 = LLT::scalar(1);
+  const LLT I1 = LLT::integer(1);
   const LLT I32 = LLT::integer(32);
 
   Register Dst = MI.getOperand(0).getReg();
@@ -6054,7 +6037,7 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF64(MachineInstr &MI,
     auto ScaleConstant = B.buildFConstant(F64, 0x1.0p-767);
 
     ZeroInt = B.buildConstant(I32, 0).getReg(0);
-    Scaling = B.buildFCmp(FCmpInst::FCMP_OLT, S1, X, ScaleConstant).getReg(0);
+    Scaling = B.buildFCmp(FCmpInst::FCMP_OLT, I1, X, ScaleConstant).getReg(0);
 
     // Scale up input if it is too small.
     auto ScaleUpFactor = B.buildConstant(I32, 256);
@@ -6094,9 +6077,9 @@ bool AMDGPULegalizerInfo::legalizeFSQRTF64(MachineInstr &MI,
   Register IsZeroOrInf;
   if (MI.getFlag(MachineInstr::FmNoInfs)) {
     auto ZeroFP = B.buildFConstant(F64, 0.0);
-    IsZeroOrInf = B.buildFCmp(FCmpInst::FCMP_OEQ, S1, SqrtX, ZeroFP).getReg(0);
+    IsZeroOrInf = B.buildFCmp(FCmpInst::FCMP_OEQ, I1, SqrtX, ZeroFP).getReg(0);
   } else {
-    IsZeroOrInf = B.buildIsFPClass(S1, SqrtX, fcZero | fcPosInf).getReg(0);
+    IsZeroOrInf = B.buildIsFPClass(I1, SqrtX, fcZero | fcPosInf).getReg(0);
   }
 
   // TODO: Check for DAZ and expand to subnormals

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fabs.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fabs.mir
@@ -7,380 +7,352 @@
 
 
 ---
-name: test_fabs_s32
+name: test_fabs_f32
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fabs_s32
+    ; SI-LABEL: name: test_fabs_f32
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[COPY]]
-    ; SI-NEXT: $vgpr0 = COPY [[FABS]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[COPY]]
+    ; SI-NEXT: $vgpr0 = COPY [[FABS]](f32)
     ;
-    ; VI-LABEL: name: test_fabs_s32
+    ; VI-LABEL: name: test_fabs_f32
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[COPY]]
-    ; VI-NEXT: $vgpr0 = COPY [[FABS]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[COPY]]
+    ; VI-NEXT: $vgpr0 = COPY [[FABS]](f32)
     ;
-    ; GFX9-LABEL: name: test_fabs_s32
+    ; GFX9-LABEL: name: test_fabs_f32
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[COPY]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FABS]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[COPY]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FABS]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(f32) = G_FABS %0
     $vgpr0 = COPY %1
 
 ...
 ---
-name: test_fabs_s64
+name: test_fabs_f64
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fabs_s64
+    ; SI-LABEL: name: test_fabs_f64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(s64) = G_FABS [[COPY]]
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FABS]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(f64) = G_FABS [[COPY]]
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FABS]](f64)
     ;
-    ; VI-LABEL: name: test_fabs_s64
+    ; VI-LABEL: name: test_fabs_f64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(s64) = G_FABS [[COPY]]
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FABS]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(f64) = G_FABS [[COPY]]
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FABS]](f64)
     ;
-    ; GFX9-LABEL: name: test_fabs_s64
+    ; GFX9-LABEL: name: test_fabs_f64
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(s64) = G_FABS [[COPY]]
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FABS]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(f64) = G_FABS [[COPY]]
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FABS]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = G_FABS %0
     $vgpr0_vgpr1 = COPY %1
 ...
 ---
-name: test_fabs_s16
+name: test_fabs_f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fabs_s16
+    ; SI-LABEL: name: test_fabs_f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(s16) = G_FABS [[TRUNC]]
-    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FABS]](s16)
-    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(f16) = G_FABS [[TRUNC]]
+    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FABS]](f16)
+    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; VI-LABEL: name: test_fabs_s16
+    ; VI-LABEL: name: test_fabs_f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(s16) = G_FABS [[TRUNC]]
-    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FABS]](s16)
-    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(f16) = G_FABS [[TRUNC]]
+    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FABS]](f16)
+    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_fabs_s16
+    ; GFX9-LABEL: name: test_fabs_f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(s16) = G_FABS [[TRUNC]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FABS]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
-    %2:_(s16) = G_FABS %1
-    %3:_(s32) = G_ANYEXT %2
-    $vgpr0 = COPY %3
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(f16) = G_FABS [[TRUNC]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FABS]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(i32) = COPY $vgpr0
+    %1:_(i16) = G_TRUNC %0
+    %2:_(f16) = G_BITCAST %1
+    %3:_(f16) = G_FABS %2
+    %4:_(i16) = G_BITCAST %3
+    %5:_(i32) = G_ANYEXT %4
+    $vgpr0 = COPY %5
 ...
 
 ---
-name: test_fabs_v2s32
+name: test_fabs_v2f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_fabs_v2s32
+    ; SI-LABEL: name: test_fabs_v2f32
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[UV]]
-    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(s32) = G_FABS [[UV1]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FABS]](s32), [[FABS1]](s32)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[UV]]
+    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[UV1]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FABS]](f32), [[FABS1]](f32)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; VI-LABEL: name: test_fabs_v2s32
+    ; VI-LABEL: name: test_fabs_v2f32
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[UV]]
-    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(s32) = G_FABS [[UV1]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FABS]](s32), [[FABS1]](s32)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[UV]]
+    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[UV1]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FABS]](f32), [[FABS1]](f32)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; GFX9-LABEL: name: test_fabs_v2s32
+    ; GFX9-LABEL: name: test_fabs_v2f32
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[UV]]
-    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(s32) = G_FABS [[UV1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FABS]](s32), [[FABS1]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[UV]]
+    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[UV1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FABS]](f32), [[FABS1]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %1:_(<2 x f32>) = G_FABS %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
 ---
-name: test_fabs_v3s32
+name: test_fabs_v3f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2
 
-    ; SI-LABEL: name: test_fabs_v3s32
+    ; SI-LABEL: name: test_fabs_v3f32
     ; SI: liveins: $vgpr0_vgpr1_vgpr2
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[UV]]
-    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(s32) = G_FABS [[UV1]]
-    ; SI-NEXT: [[FABS2:%[0-9]+]]:_(s32) = G_FABS [[UV2]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FABS]](s32), [[FABS1]](s32), [[FABS2]](s32)
-    ; SI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[UV]]
+    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[UV1]]
+    ; SI-NEXT: [[FABS2:%[0-9]+]]:_(f32) = G_FABS [[UV2]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FABS]](f32), [[FABS1]](f32), [[FABS2]](f32)
+    ; SI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; VI-LABEL: name: test_fabs_v3s32
+    ; VI-LABEL: name: test_fabs_v3f32
     ; VI: liveins: $vgpr0_vgpr1_vgpr2
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[UV]]
-    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(s32) = G_FABS [[UV1]]
-    ; VI-NEXT: [[FABS2:%[0-9]+]]:_(s32) = G_FABS [[UV2]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FABS]](s32), [[FABS1]](s32), [[FABS2]](s32)
-    ; VI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[UV]]
+    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[UV1]]
+    ; VI-NEXT: [[FABS2:%[0-9]+]]:_(f32) = G_FABS [[UV2]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FABS]](f32), [[FABS1]](f32), [[FABS2]](f32)
+    ; VI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; GFX9-LABEL: name: test_fabs_v3s32
+    ; GFX9-LABEL: name: test_fabs_v3f32
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(s32) = G_FABS [[UV]]
-    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(s32) = G_FABS [[UV1]]
-    ; GFX9-NEXT: [[FABS2:%[0-9]+]]:_(s32) = G_FABS [[UV2]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FABS]](s32), [[FABS1]](s32), [[FABS2]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    %1:_(<3 x  s32>) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(f32) = G_FABS [[UV]]
+    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(f32) = G_FABS [[UV1]]
+    ; GFX9-NEXT: [[FABS2:%[0-9]+]]:_(f32) = G_FABS [[UV2]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FABS]](f32), [[FABS1]](f32), [[FABS2]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
+    %0:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    %1:_(<3 x f32>) = G_FABS %0
     $vgpr0_vgpr1_vgpr2 = COPY %1
 ...
 
 ---
-name: test_fabs_v2s64
+name: test_fabs_v2f64
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2_vgpr3
 
-    ; SI-LABEL: name: test_fabs_v2s64
+    ; SI-LABEL: name: test_fabs_v2f64
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(s64) = G_FABS [[UV]]
-    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(s64) = G_FABS [[UV1]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FABS]](s64), [[FABS1]](s64)
-    ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(f64) = G_FABS [[UV]]
+    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(f64) = G_FABS [[UV1]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FABS]](f64), [[FABS1]](f64)
+    ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
-    ; VI-LABEL: name: test_fabs_v2s64
+    ; VI-LABEL: name: test_fabs_v2f64
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(s64) = G_FABS [[UV]]
-    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(s64) = G_FABS [[UV1]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FABS]](s64), [[FABS1]](s64)
-    ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(f64) = G_FABS [[UV]]
+    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(f64) = G_FABS [[UV1]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FABS]](f64), [[FABS1]](f64)
+    ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
-    ; GFX9-LABEL: name: test_fabs_v2s64
+    ; GFX9-LABEL: name: test_fabs_v2f64
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(s64) = G_FABS [[UV]]
-    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(s64) = G_FABS [[UV1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FABS]](s64), [[FABS1]](s64)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %1:_(<2 x s64>) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(f64) = G_FABS [[UV]]
+    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(f64) = G_FABS [[UV1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FABS]](f64), [[FABS1]](f64)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %1:_(<2 x f64>) = G_FABS %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
 
 ---
-name: test_fabs_v2s16
+name: test_fabs_v2f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fabs_v2s16
+    ; SI-LABEL: name: test_fabs_v2f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[COPY]]
-    ; SI-NEXT: $vgpr0 = COPY [[FABS]](<2 x s16>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[COPY]]
+    ; SI-NEXT: $vgpr0 = COPY [[FABS]](<2 x f16>)
     ;
-    ; VI-LABEL: name: test_fabs_v2s16
+    ; VI-LABEL: name: test_fabs_v2f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[COPY]]
-    ; VI-NEXT: $vgpr0 = COPY [[FABS]](<2 x s16>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[COPY]]
+    ; VI-NEXT: $vgpr0 = COPY [[FABS]](<2 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fabs_v2s16
+    ; GFX9-LABEL: name: test_fabs_v2f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[COPY]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FABS]](<2 x s16>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[COPY]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FABS]](<2 x f16>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = G_FABS %0
     $vgpr0 = COPY %1
 ...
 
 ---
-name: test_fabs_v3s16
+name: test_fabs_v3f16
 body: |
   bb.0:
 
-    ; SI-LABEL: name: test_fabs_v3s16
+    ; SI-LABEL: name: test_fabs_v3f16
     ; SI: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
     ; SI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[C]], [[C1]](i32)
     ; SI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[C]], [[SHL]]
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY [[OR]](i32)
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[COPY]](i32)
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[BITCAST]]
-    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x s16>) = G_FABS [[BITCAST1]]
-    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FABS]](<2 x s16>)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[COPY]](i32)
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[BITCAST]]
+    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x f16>) = G_FABS [[BITCAST1]]
+    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FABS]](<2 x f16>)
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST2]], [[C1]](i32)
-    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FABS1]](<2 x s16>)
-    ; SI-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 65535
-    ; SI-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[BITCAST2]], [[C2]]
-    ; SI-NEXT: [[SHL1:%[0-9]+]]:_(i32) = G_SHL [[LSHR]], [[C1]](i32)
-    ; SI-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[AND]], [[SHL1]]
-    ; SI-NEXT: [[BITCAST4:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](i32)
-    ; SI-NEXT: [[AND1:%[0-9]+]]:_(i32) = G_AND [[BITCAST3]], [[C2]]
-    ; SI-NEXT: [[SHL2:%[0-9]+]]:_(i32) = G_SHL [[AND]], [[C1]](i32)
-    ; SI-NEXT: [[OR2:%[0-9]+]]:_(i32) = G_OR [[AND1]], [[SHL2]]
-    ; SI-NEXT: [[BITCAST5:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR2]](i32)
-    ; SI-NEXT: [[SHL3:%[0-9]+]]:_(i32) = G_SHL [[AND1]], [[C1]](i32)
-    ; SI-NEXT: [[OR3:%[0-9]+]]:_(i32) = G_OR [[LSHR]], [[SHL3]]
-    ; SI-NEXT: [[BITCAST6:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR3]](i32)
-    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<6 x s16>) = G_CONCAT_VECTORS [[BITCAST4]](<2 x s16>), [[BITCAST5]](<2 x s16>), [[BITCAST6]](<2 x s16>)
-    ; SI-NEXT: S_NOP 0, implicit [[CONCAT_VECTORS]](<6 x s16>)
+    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FABS1]](<2 x f16>)
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[BITCAST2]](i32), [[LSHR]](i32), [[BITCAST3]](i32)
+    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; VI-LABEL: name: test_fabs_v3s16
+    ; VI-LABEL: name: test_fabs_v3f16
     ; VI: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
     ; VI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[C]], [[C1]](i32)
     ; VI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[C]], [[SHL]]
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY [[OR]](i32)
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[COPY]](i32)
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[BITCAST]]
-    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x s16>) = G_FABS [[BITCAST1]]
-    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FABS]](<2 x s16>)
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[COPY]](i32)
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[BITCAST]]
+    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x f16>) = G_FABS [[BITCAST1]]
+    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FABS]](<2 x f16>)
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST2]], [[C1]](i32)
-    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FABS1]](<2 x s16>)
-    ; VI-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 65535
-    ; VI-NEXT: [[AND:%[0-9]+]]:_(i32) = G_AND [[BITCAST2]], [[C2]]
-    ; VI-NEXT: [[SHL1:%[0-9]+]]:_(i32) = G_SHL [[LSHR]], [[C1]](i32)
-    ; VI-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[AND]], [[SHL1]]
-    ; VI-NEXT: [[BITCAST4:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](i32)
-    ; VI-NEXT: [[AND1:%[0-9]+]]:_(i32) = G_AND [[BITCAST3]], [[C2]]
-    ; VI-NEXT: [[SHL2:%[0-9]+]]:_(i32) = G_SHL [[AND]], [[C1]](i32)
-    ; VI-NEXT: [[OR2:%[0-9]+]]:_(i32) = G_OR [[AND1]], [[SHL2]]
-    ; VI-NEXT: [[BITCAST5:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR2]](i32)
-    ; VI-NEXT: [[SHL3:%[0-9]+]]:_(i32) = G_SHL [[AND1]], [[C1]](i32)
-    ; VI-NEXT: [[OR3:%[0-9]+]]:_(i32) = G_OR [[LSHR]], [[SHL3]]
-    ; VI-NEXT: [[BITCAST6:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR3]](i32)
-    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<6 x s16>) = G_CONCAT_VECTORS [[BITCAST4]](<2 x s16>), [[BITCAST5]](<2 x s16>), [[BITCAST6]](<2 x s16>)
-    ; VI-NEXT: S_NOP 0, implicit [[CONCAT_VECTORS]](<6 x s16>)
+    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FABS1]](<2 x f16>)
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[BITCAST2]](i32), [[LSHR]](i32), [[BITCAST3]](i32)
+    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fabs_v3s16
-    ; GFX9: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[BUILD_VECTOR]]
-    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(<2 x s16>) = G_FABS [[BUILD_VECTOR1]]
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[FABS]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-LABEL: name: test_fabs_v3f16
+    ; GFX9: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[DEF]](f16), [[DEF]](f16)
+    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[DEF]](f16), [[DEF]](f16)
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[BUILD_VECTOR]]
+    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(<2 x f16>) = G_FABS [[BUILD_VECTOR1]]
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[FABS]](<2 x f16>)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[FABS1]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
-    ; GFX9-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR3:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC2]](s16), [[TRUNC]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR4:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC1]](s16), [[TRUNC2]](s16)
-    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<6 x s16>) = G_CONCAT_VECTORS [[BUILD_VECTOR2]](<2 x s16>), [[BUILD_VECTOR3]](<2 x s16>), [[BUILD_VECTOR4]](<2 x s16>)
-    ; GFX9-NEXT: S_NOP 0, implicit [[CONCAT_VECTORS]](<6 x s16>)
-    %0:_(<3 x s16>) = G_IMPLICIT_DEF
-    %1:_(<3 x s16>) = G_FABS %0
-    %2:_(<6 x s16>) = G_CONCAT_VECTORS %1, %1
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[FABS1]](<2 x f16>)
+    ; GFX9-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[BITCAST]](i32), [[LSHR]](i32), [[BITCAST1]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR2]](<3 x i32>)
+    %0:_(<3 x f16>) = G_IMPLICIT_DEF
+    %1:_(<3 x f16>) = G_FABS %0
+    %2:_(<3 x i32>) = G_ANYEXT %1
     S_NOP 0, implicit %2
 ...
 
 ---
-name: test_fabs_v4s16
+name: test_fabs_v4f16
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_fabs_v4s16
+    ; SI-LABEL: name: test_fabs_v4f16
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; SI-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[UV]]
-    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x s16>) = G_FABS [[UV1]]
-    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[FABS]](<2 x s16>), [[FABS1]](<2 x s16>)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; SI-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[UV]]
+    ; SI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x f16>) = G_FABS [[UV1]]
+    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[FABS]](<2 x f16>), [[FABS1]](<2 x f16>)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; VI-LABEL: name: test_fabs_v4s16
+    ; VI-LABEL: name: test_fabs_v4f16
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; VI-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[UV]]
-    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x s16>) = G_FABS [[UV1]]
-    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[FABS]](<2 x s16>), [[FABS1]](<2 x s16>)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; VI-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[UV]]
+    ; VI-NEXT: [[FABS1:%[0-9]+]]:_(<2 x f16>) = G_FABS [[UV1]]
+    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[FABS]](<2 x f16>), [[FABS1]](<2 x f16>)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fabs_v4s16
+    ; GFX9-LABEL: name: test_fabs_v4f16
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(<2 x s16>) = G_FABS [[UV]]
-    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(<2 x s16>) = G_FABS [[UV1]]
-    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[FABS]](<2 x s16>), [[FABS1]](<2 x s16>)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
-    %0:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    %1:_(<4 x s16>) = G_FABS %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; GFX9-NEXT: [[FABS:%[0-9]+]]:_(<2 x f16>) = G_FABS [[UV]]
+    ; GFX9-NEXT: [[FABS1:%[0-9]+]]:_(<2 x f16>) = G_FABS [[UV1]]
+    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[FABS]](<2 x f16>), [[FABS1]](<2 x f16>)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
+    %0:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    %1:_(<4 x f16>) = G_FABS %0
     $vgpr0_vgpr1 = COPY %1
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fcmp-s32.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fcmp-s32.mir
@@ -10,13 +10,13 @@ body:             |
     ; GFX1150-LABEL: name: f32_olt
     ; GFX1150: liveins: $sgpr0, $sgpr1
     ; GFX1150-NEXT: {{  $}}
-    ; GFX1150-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr0
-    ; GFX1150-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr1
-    ; GFX1150-NEXT: [[FCMP:%[0-9]+]]:_(s32) = G_FCMP floatpred(olt), [[COPY]](s32), [[COPY1]]
-    ; GFX1150-NEXT: $sgpr0 = COPY [[FCMP]](s32)
-    %0:_(s32) = COPY $sgpr0
-    %1:_(s32) = COPY $sgpr1
-    %2:_(s32) = G_FCMP floatpred(olt), %0(s32), %1
+    ; GFX1150-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $sgpr0
+    ; GFX1150-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $sgpr1
+    ; GFX1150-NEXT: [[FCMP:%[0-9]+]]:_(i32) = G_FCMP floatpred(olt), [[COPY]](f32), [[COPY1]]
+    ; GFX1150-NEXT: $sgpr0 = COPY [[FCMP]](i32)
+    %0:_(f32) = COPY $sgpr0
+    %1:_(f32) = COPY $sgpr1
+    %2:_(i32) = G_FCMP floatpred(olt), %0, %1
     $sgpr0 = COPY %2
 
 ...
@@ -30,17 +30,21 @@ body:             |
     ; GFX1150-LABEL: name: f16_olt
     ; GFX1150: liveins: $sgpr0, $sgpr1
     ; GFX1150-NEXT: {{  $}}
-    ; GFX1150-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr0
-    ; GFX1150-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX1150-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr1
-    ; GFX1150-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[COPY1]](s32)
-    ; GFX1150-NEXT: [[FCMP:%[0-9]+]]:_(s32) = G_FCMP floatpred(olt), [[TRUNC]](s16), [[TRUNC1]]
-    ; GFX1150-NEXT: $sgpr0 = COPY [[FCMP]](s32)
-    %0:_(s32) = COPY $sgpr0
-    %1:_(s16) = G_TRUNC %0(s32)
-    %2:_(s32) = COPY $sgpr1
-    %3:_(s16) = G_TRUNC %2(s32)
-    %4:_(s32) = G_FCMP floatpred(olt), %1(s16), %3
-    $sgpr0 = COPY %4
+    ; GFX1150-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $sgpr0
+    ; GFX1150-NEXT: [[TRUNC:%[0-9]+]]:_(i16) = G_TRUNC [[COPY]](i32)
+    ; GFX1150-NEXT: [[BITCAST:%[0-9]+]]:_(f16) = G_BITCAST [[TRUNC]](i16)
+    ; GFX1150-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $sgpr1
+    ; GFX1150-NEXT: [[TRUNC1:%[0-9]+]]:_(i16) = G_TRUNC [[COPY1]](i32)
+    ; GFX1150-NEXT: [[BITCAST1:%[0-9]+]]:_(f16) = G_BITCAST [[TRUNC1]](i16)
+    ; GFX1150-NEXT: [[FCMP:%[0-9]+]]:_(i32) = G_FCMP floatpred(olt), [[BITCAST]](f16), [[BITCAST1]]
+    ; GFX1150-NEXT: $sgpr0 = COPY [[FCMP]](i32)
+    %0:_(i32) = COPY $sgpr0
+    %1:_(i16) = G_TRUNC %0
+    %2:_(f16) = G_BITCAST %1
+    %3:_(i32) = COPY $sgpr1
+    %4:_(i16) = G_TRUNC %3
+    %5:_(f16) = G_BITCAST %4
+    %6:_(i32) = G_FCMP floatpred(olt), %2, %5
+    $sgpr0 = COPY %6
 
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fcmp.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fcmp.mir
@@ -7,448 +7,450 @@
 # RUN: llc -O0 -mtriple=amdgpu11.50 -mattr=-real-true16 -run-pass=legalizer -verify-machineinstrs -o - %s | FileCheck -check-prefix=GFX9 %s
 
 ---
-name: test_fcmp_s32
+name: test_fcmp_f32
 body: |
   bb.0:
     liveins: $vgpr0
-    ; GFX7-LABEL: name: test_fcmp_s32
+    ; GFX7-LABEL: name: test_fcmp_f32
     ; GFX7: liveins: $vgpr0
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[COPY]]
-    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[FCMP]](s1), [[C]], [[COPY]]
-    ; GFX7-NEXT: $vgpr0 = COPY [[SELECT]](s32)
+    ; GFX7-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[COPY]]
+    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[C]], [[COPY]]
+    ; GFX7-NEXT: $vgpr0 = COPY [[SELECT]](f32)
     ;
-    ; GFX8-LABEL: name: test_fcmp_s32
+    ; GFX8-LABEL: name: test_fcmp_f32
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[COPY]]
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[FCMP]](s1), [[C]], [[COPY]]
-    ; GFX8-NEXT: $vgpr0 = COPY [[SELECT]](s32)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[COPY]]
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[C]], [[COPY]]
+    ; GFX8-NEXT: $vgpr0 = COPY [[SELECT]](f32)
     ;
-    ; GFX9-LABEL: name: test_fcmp_s32
+    ; GFX9-LABEL: name: test_fcmp_f32
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[COPY]]
-    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[FCMP]](s1), [[C]], [[COPY]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[SELECT]](s32)
-    %0:_(s32) = G_CONSTANT i32 0
-    %1:_(s32) = COPY $vgpr0
-    %2:_(s1) = G_FCMP floatpred(oeq), %0, %1
-    %3:_(s32) = G_SELECT %2, %0, %1
+    ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[COPY]]
+    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[C]], [[COPY]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[SELECT]](f32)
+    %0:_(f32) = G_FCONSTANT float 0.0
+    %1:_(f32) = COPY $vgpr0
+    %2:_(i1) = G_FCMP floatpred(oeq), %0, %1
+    %3:_(f32) = G_SELECT %2, %0, %1
     $vgpr0 = COPY %3
 ...
 
 ---
-name: test_fcmp_s64
+name: test_fcmp_f64
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
-    ; GFX7-LABEL: name: test_fcmp_s64
+    ; GFX7-LABEL: name: test_fcmp_f64
     ; GFX7: liveins: $vgpr0_vgpr1
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s64), [[COPY]]
-    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[FCMP]](s1), [[C]], [[COPY]]
-    ; GFX7-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
+    ; GFX7-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f64), [[COPY]]
+    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](i1), [[C]], [[COPY]]
+    ; GFX7-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
     ;
-    ; GFX8-LABEL: name: test_fcmp_s64
+    ; GFX8-LABEL: name: test_fcmp_f64
     ; GFX8: liveins: $vgpr0_vgpr1
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s64), [[COPY]]
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[FCMP]](s1), [[C]], [[COPY]]
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f64), [[COPY]]
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](i1), [[C]], [[COPY]]
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
     ;
-    ; GFX9-LABEL: name: test_fcmp_s64
+    ; GFX9-LABEL: name: test_fcmp_f64
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s64), [[COPY]]
-    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(s64) = G_SELECT [[FCMP]](s1), [[C]], [[COPY]]
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](s64)
-    %0:_(s64) = G_CONSTANT i64 0
-    %1:_(s64) = COPY $vgpr0_vgpr1
-    %2:_(s1) = G_FCMP floatpred(oeq), %0, %1
-    %3:_(s64) = G_SELECT %2, %0, %1
+    ; GFX9-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f64), [[COPY]]
+    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](i1), [[C]], [[COPY]]
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[SELECT]](f64)
+    %0:_(f64) = G_FCONSTANT double 0.0
+    %1:_(f64) = COPY $vgpr0_vgpr1
+    %2:_(i1) = G_FCMP floatpred(oeq), %0, %1
+    %3:_(f64) = G_SELECT %2, %0, %1
     $vgpr0_vgpr1 = COPY %3
 ...
 
 ---
-name: test_fcmp_s16
+name: test_fcmp_f16
 body: |
   bb.0:
     liveins: $vgpr0
-    ; GFX7-LABEL: name: test_fcmp_s16
+    ; GFX7-LABEL: name: test_fcmp_f16
     ; GFX7: liveins: $vgpr0
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[C:%[0-9]+]]:_(s16) = G_CONSTANT i16 0
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX7-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX7-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[C]](s16)
-    ; GFX7-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[FPEXT]](s32), [[FPEXT1]]
-    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[FCMP]](s1), [[C]], [[TRUNC]]
-    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
-    ; GFX7-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; GFX7-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX7-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX7-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[C]](f16)
+    ; GFX7-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[FPEXT]](f32), [[FPEXT1]]
+    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[FCMP]](i1), [[C]], [[TRUNC]]
+    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[SELECT]](f16)
+    ; GFX7-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX8-LABEL: name: test_fcmp_s16
+    ; GFX8-LABEL: name: test_fcmp_f16
     ; GFX8: liveins: $vgpr0
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s16) = G_CONSTANT i16 0
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s16), [[TRUNC]]
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[FCMP]](s1), [[C]], [[TRUNC]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
-    ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f16), [[TRUNC]]
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[FCMP]](i1), [[C]], [[TRUNC]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[SELECT]](f16)
+    ; GFX8-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_fcmp_s16
+    ; GFX9-LABEL: name: test_fcmp_f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[C:%[0-9]+]]:_(s16) = G_CONSTANT i16 0
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s16), [[TRUNC]]
-    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(s16) = G_SELECT [[FCMP]](s1), [[C]], [[TRUNC]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[SELECT]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s16) = G_CONSTANT i16 0
-    %1:_(s32) = COPY $vgpr0
-    %2:_(s16) = G_TRUNC %1
-    %3:_(s1) = G_FCMP floatpred(oeq), %0, %2
-    %4:_(s16) = G_SELECT %3, %0, %2
-    %5:_(s32) = G_ANYEXT %4
-    $vgpr0 = COPY %5
+    ; GFX9-NEXT: [[C:%[0-9]+]]:_(f16) = G_FCONSTANT half 0.000000e+00
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f16), [[TRUNC]]
+    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(f16) = G_SELECT [[FCMP]](i1), [[C]], [[TRUNC]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[SELECT]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(f16) = G_FCONSTANT half 0.0
+    %1:_(i32) = COPY $vgpr0
+    %2:_(i16) = G_TRUNC %1
+    %3:_(f16) = G_BITCAST %2
+    %4:_(i1) = G_FCMP floatpred(oeq), %0, %3
+    %5:_(f16) = G_SELECT %4, %0, %3
+    %6:_(i16) = G_BITCAST %5
+    %7:_(i32) = G_ANYEXT %6
+    $vgpr0 = COPY %7
 ...
 
 ---
-name: test_fcmp_v2s32
+name: test_fcmp_v2f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
-    ; GFX7-LABEL: name: test_fcmp_v2s32
+    ; GFX7-LABEL: name: test_fcmp_v2f32
     ; GFX7: liveins: $vgpr0_vgpr1
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[UV]]
-    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[UV1]]
-    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32)
-    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX7-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[UV]]
+    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[UV1]]
+    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32)
+    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x i32>)
     ;
-    ; GFX8-LABEL: name: test_fcmp_v2s32
+    ; GFX8-LABEL: name: test_fcmp_v2f32
     ; GFX8: liveins: $vgpr0_vgpr1
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[UV]]
-    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[UV1]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32)
-    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[UV]]
+    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[UV1]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32)
+    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fcmp_v2s32
+    ; GFX9-LABEL: name: test_fcmp_v2f32
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[UV]]
-    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[C]](s32), [[UV1]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(s32) = G_CONSTANT i32 0
-    %1:_(<2 x s32>) = G_BUILD_VECTOR %0, %0
-    %2:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %3:_(<2 x s1>) = G_FCMP floatpred(oeq), %1, %2
-    %4:_(<2 x s32>) = G_ANYEXT %3
+    ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[UV]]
+    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[C]](f32), [[UV1]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x i32>)
+    %0:_(f32) = G_FCONSTANT float 0.0
+    %1:_(<2 x f32>) = G_BUILD_VECTOR %0, %0
+    %2:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %3:_(<2 x i1>) = G_FCMP floatpred(oeq), %1, %2
+    %4:_(<2 x i32>) = G_ANYEXT %3
     S_NOP 0, implicit %4
 ...
 
 ---
-name: test_fcmp_v2s32_flags
+name: test_fcmp_v2f32_flags
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
-    ; GFX7-LABEL: name: test_fcmp_v2s32_flags
+    ; GFX7-LABEL: name: test_fcmp_v2f32_flags
     ; GFX7: liveins: $vgpr0_vgpr1
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(oeq), [[C]](s32), [[UV]]
-    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(oeq), [[C]](s32), [[UV1]]
-    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32)
-    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX7-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = nnan G_FCMP floatpred(oeq), [[C]](f32), [[UV]]
+    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = nnan G_FCMP floatpred(oeq), [[C]](f32), [[UV1]]
+    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32)
+    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x i32>)
     ;
-    ; GFX8-LABEL: name: test_fcmp_v2s32_flags
+    ; GFX8-LABEL: name: test_fcmp_v2f32_flags
     ; GFX8: liveins: $vgpr0_vgpr1
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(oeq), [[C]](s32), [[UV]]
-    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(oeq), [[C]](s32), [[UV1]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32)
-    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX8-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = nnan G_FCMP floatpred(oeq), [[C]](f32), [[UV]]
+    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = nnan G_FCMP floatpred(oeq), [[C]](f32), [[UV1]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32)
+    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fcmp_v2s32_flags
+    ; GFX9-LABEL: name: test_fcmp_v2f32_flags
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(oeq), [[C]](s32), [[UV]]
-    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = nnan G_FCMP floatpred(oeq), [[C]](s32), [[UV1]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(s32) = G_CONSTANT i32 0
-    %1:_(<2 x s32>) = G_BUILD_VECTOR %0, %0
-    %2:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %3:_(<2 x s1>) = nnan G_FCMP floatpred(oeq), %1, %2
-    %4:_(<2 x s32>) = G_ANYEXT %3
+    ; GFX9-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = nnan G_FCMP floatpred(oeq), [[C]](f32), [[UV]]
+    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = nnan G_FCMP floatpred(oeq), [[C]](f32), [[UV1]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<2 x i32>)
+    %0:_(f32) = G_FCONSTANT float 0.0
+    %1:_(<2 x f32>) = G_BUILD_VECTOR %0, %0
+    %2:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %3:_(<2 x i1>) = nnan G_FCMP floatpred(oeq), %1, %2
+    %4:_(<2 x i32>) = G_ANYEXT %3
     S_NOP 0, implicit %4
 ...
 
 ---
-name: test_fcmp_v3s32
+name: test_fcmp_v3f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2
 
-    ; GFX7-LABEL: name: test_fcmp_v3s32
+    ; GFX7-LABEL: name: test_fcmp_v3f32
     ; GFX7: liveins: $vgpr0_vgpr1_vgpr2
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV]]
-    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV1]]
-    ; GFX7-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV2]]
-    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX7-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP2]](s1)
-    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; GFX7-NEXT: [[DEF:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV]]
+    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV1]]
+    ; GFX7-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV2]]
+    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX7-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP2]](i1)
+    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; GFX8-LABEL: name: test_fcmp_v3s32
+    ; GFX8-LABEL: name: test_fcmp_v3f32
     ; GFX8: liveins: $vgpr0_vgpr1_vgpr2
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV]]
-    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV1]]
-    ; GFX8-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV2]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX8-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP2]](s1)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; GFX8-NEXT: [[DEF:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV]]
+    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV1]]
+    ; GFX8-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV2]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX8-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP2]](i1)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fcmp_v3s32
+    ; GFX9-LABEL: name: test_fcmp_v3f32
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV]]
-    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV1]]
-    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[DEF]](s32), [[UV2]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP2]](s1)
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s32>) = G_IMPLICIT_DEF
-    %1:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    %2:_(<3 x s1>) = G_FCMP floatpred(oeq), %0, %1
-    %3:_(<3 x s32>) = G_ANYEXT %2
+    ; GFX9-NEXT: [[DEF:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV]]
+    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV1]]
+    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[DEF]](f32), [[UV2]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP2]](i1)
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
+    %0:_(<3 x f32>) = G_IMPLICIT_DEF
+    %1:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    %2:_(<3 x i1>) = G_FCMP floatpred(oeq), %0, %1
+    %3:_(<3 x i32>) = G_ANYEXT %2
     S_NOP 0, implicit %3
 
 ...
 
 ---
-name: test_fcmp_v4s32
+name: test_fcmp_v4f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2_vgpr3
 
-    ; GFX7-LABEL: name: test_fcmp_v4s32
+    ; GFX7-LABEL: name: test_fcmp_v4f32
     ; GFX7: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX7-NEXT: {{  $}}
     ; GFX7-NEXT: [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-    ; GFX7-NEXT: [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<4 x s32>))
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<4 x s32>)
-    ; GFX7-NEXT: [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV]](s32), [[UV4]]
-    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV1]](s32), [[UV5]]
-    ; GFX7-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV2]](s32), [[UV6]]
-    ; GFX7-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV3]](s32), [[UV7]]
-    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX7-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP2]](s1)
-    ; GFX7-NEXT: [[ANYEXT3:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP3]](s1)
-    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32), [[ANYEXT3]](s32)
-    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<4 x s32>)
+    ; GFX7-NEXT: [[LOAD:%[0-9]+]]:_(<4 x f32>) = G_LOAD [[DEF]](p1) :: (volatile load (<4 x s32>))
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[LOAD]](<4 x f32>)
+    ; GFX7-NEXT: [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32), [[UV6:%[0-9]+]]:_(f32), [[UV7:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV]](f32), [[UV4]]
+    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV1]](f32), [[UV5]]
+    ; GFX7-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV2]](f32), [[UV6]]
+    ; GFX7-NEXT: [[FCMP3:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV3]](f32), [[UV7]]
+    ; GFX7-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX7-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX7-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP2]](i1)
+    ; GFX7-NEXT: [[ANYEXT3:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP3]](i1)
+    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32), [[ANYEXT3]](i32)
+    ; GFX7-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<4 x i32>)
     ;
-    ; GFX8-LABEL: name: test_fcmp_v4s32
+    ; GFX8-LABEL: name: test_fcmp_v4f32
     ; GFX8: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX8-NEXT: {{  $}}
     ; GFX8-NEXT: [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-    ; GFX8-NEXT: [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<4 x s32>))
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<4 x s32>)
-    ; GFX8-NEXT: [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV]](s32), [[UV4]]
-    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV1]](s32), [[UV5]]
-    ; GFX8-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV2]](s32), [[UV6]]
-    ; GFX8-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV3]](s32), [[UV7]]
-    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX8-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP2]](s1)
-    ; GFX8-NEXT: [[ANYEXT3:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP3]](s1)
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32), [[ANYEXT3]](s32)
-    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<4 x s32>)
+    ; GFX8-NEXT: [[LOAD:%[0-9]+]]:_(<4 x f32>) = G_LOAD [[DEF]](p1) :: (volatile load (<4 x s32>))
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[LOAD]](<4 x f32>)
+    ; GFX8-NEXT: [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32), [[UV6:%[0-9]+]]:_(f32), [[UV7:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV]](f32), [[UV4]]
+    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV1]](f32), [[UV5]]
+    ; GFX8-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV2]](f32), [[UV6]]
+    ; GFX8-NEXT: [[FCMP3:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV3]](f32), [[UV7]]
+    ; GFX8-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX8-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX8-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP2]](i1)
+    ; GFX8-NEXT: [[ANYEXT3:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP3]](i1)
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32), [[ANYEXT3]](i32)
+    ; GFX8-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<4 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fcmp_v4s32
+    ; GFX9-LABEL: name: test_fcmp_v4f32
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: {{  $}}
     ; GFX9-NEXT: [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<4 x s32>))
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<4 x s32>)
-    ; GFX9-NEXT: [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV]](s32), [[UV4]]
-    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV1]](s32), [[UV5]]
-    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV2]](s32), [[UV6]]
-    ; GFX9-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[UV3]](s32), [[UV7]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP]](s1)
-    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP1]](s1)
-    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP2]](s1)
-    ; GFX9-NEXT: [[ANYEXT3:%[0-9]+]]:_(s32) = G_ANYEXT [[FCMP3]](s1)
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32), [[ANYEXT3]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<4 x s32>)
+    ; GFX9-NEXT: [[LOAD:%[0-9]+]]:_(<4 x f32>) = G_LOAD [[DEF]](p1) :: (volatile load (<4 x s32>))
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[LOAD]](<4 x f32>)
+    ; GFX9-NEXT: [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32), [[UV6:%[0-9]+]]:_(f32), [[UV7:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV]](f32), [[UV4]]
+    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV1]](f32), [[UV5]]
+    ; GFX9-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV2]](f32), [[UV6]]
+    ; GFX9-NEXT: [[FCMP3:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[UV3]](f32), [[UV7]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP]](i1)
+    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP1]](i1)
+    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP2]](i1)
+    ; GFX9-NEXT: [[ANYEXT3:%[0-9]+]]:_(i32) = G_ANYEXT [[FCMP3]](i1)
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32), [[ANYEXT3]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<4 x i32>)
     %0:_(p1) = G_IMPLICIT_DEF
-    %1:_(<4 x s32>) = G_LOAD %0 :: (volatile load (<4 x s32>))
-    %2:_(<4 x s32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %3:_(<4 x s1>) = G_FCMP floatpred(oeq) , %1, %2
-    %4:_(<4 x s32>) = G_ANYEXT %3
+    %1:_(<4 x f32>) = G_LOAD %0 :: (volatile load (<4 x s32>))
+    %2:_(<4 x f32>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %3:_(<4 x i1>) = G_FCMP floatpred(oeq) , %1, %2
+    %4:_(<4 x i32>) = G_ANYEXT %3
     S_NOP 0, implicit %4
 
 ...
 
 ---
-name: test_icmp_v2s16
+name: test_fcmp_v2f16
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5
-    ; GFX7-LABEL: name: test_icmp_v2s16
+    ; GFX7-LABEL: name: test_fcmp_v2f16
     ; GFX7: liveins: $vgpr0, $vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5
     ; GFX7-NEXT: {{  $}}
-    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX7-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX7-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    ; GFX7-NEXT: [[COPY3:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr4_vgpr5
-    ; GFX7-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX7-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX7-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX7-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX7-NEXT: [[COPY2:%[0-9]+]]:_(<2 x i32>) = COPY $vgpr2_vgpr3
+    ; GFX7-NEXT: [[COPY3:%[0-9]+]]:_(<2 x i32>) = COPY $vgpr4_vgpr5
+    ; GFX7-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX7-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX7-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX7-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX7-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX7-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX7-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX7-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX7-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX7-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX7-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX7-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX7-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; GFX7-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC2]](s16)
-    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[FPEXT]](s32), [[FPEXT1]]
-    ; GFX7-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; GFX7-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC3]](s16)
-    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[FPEXT2]](s32), [[FPEXT3]]
-    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY2]](<2 x s32>)
-    ; GFX7-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY3]](<2 x s32>)
-    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[FCMP]](s1), [[UV]], [[UV2]]
-    ; GFX7-NEXT: [[SELECT1:%[0-9]+]]:_(s32) = G_SELECT [[FCMP1]](s1), [[UV1]], [[UV3]]
-    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[SELECT]](s32), [[SELECT1]](s32)
-    ; GFX7-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX7-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX7-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; GFX7-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](f16)
+    ; GFX7-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[FPEXT]](f32), [[FPEXT1]]
+    ; GFX7-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; GFX7-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](f16)
+    ; GFX7-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[FPEXT2]](f32), [[FPEXT3]]
+    ; GFX7-NEXT: [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY2]](<2 x i32>)
+    ; GFX7-NEXT: [[UV2:%[0-9]+]]:_(i32), [[UV3:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY3]](<2 x i32>)
+    ; GFX7-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[UV]], [[UV2]]
+    ; GFX7-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](i1), [[UV1]], [[UV3]]
+    ; GFX7-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[SELECT]](i32), [[SELECT1]](i32)
+    ; GFX7-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x i32>)
     ;
-    ; GFX8-LABEL: name: test_icmp_v2s16
+    ; GFX8-LABEL: name: test_fcmp_v2f16
     ; GFX8: liveins: $vgpr0, $vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5
     ; GFX8-NEXT: {{  $}}
-    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX8-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX8-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    ; GFX8-NEXT: [[COPY3:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr4_vgpr5
-    ; GFX8-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX8-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX8-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX8-NEXT: [[COPY2:%[0-9]+]]:_(<2 x i32>) = COPY $vgpr2_vgpr3
+    ; GFX8-NEXT: [[COPY3:%[0-9]+]]:_(<2 x i32>) = COPY $vgpr4_vgpr5
+    ; GFX8-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX8-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX8-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX8-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX8-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX8-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX8-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX8-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX8-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX8-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX8-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX8-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[TRUNC]](s16), [[TRUNC2]]
-    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[TRUNC1]](s16), [[TRUNC3]]
-    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY2]](<2 x s32>)
-    ; GFX8-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY3]](<2 x s32>)
-    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[FCMP]](s1), [[UV]], [[UV2]]
-    ; GFX8-NEXT: [[SELECT1:%[0-9]+]]:_(s32) = G_SELECT [[FCMP1]](s1), [[UV1]], [[UV3]]
-    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[SELECT]](s32), [[SELECT1]](s32)
-    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; GFX8-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX8-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[TRUNC]](f16), [[TRUNC2]]
+    ; GFX8-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[TRUNC1]](f16), [[TRUNC3]]
+    ; GFX8-NEXT: [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY2]](<2 x i32>)
+    ; GFX8-NEXT: [[UV2:%[0-9]+]]:_(i32), [[UV3:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY3]](<2 x i32>)
+    ; GFX8-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[UV]], [[UV2]]
+    ; GFX8-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](i1), [[UV1]], [[UV3]]
+    ; GFX8-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[SELECT]](i32), [[SELECT1]](i32)
+    ; GFX8-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x i32>)
     ;
-    ; GFX9-LABEL: name: test_icmp_v2s16
+    ; GFX9-LABEL: name: test_fcmp_v2f16
     ; GFX9: liveins: $vgpr0, $vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
-    ; GFX9-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    ; GFX9-NEXT: [[COPY3:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr4_vgpr5
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr1
+    ; GFX9-NEXT: [[COPY2:%[0-9]+]]:_(<2 x i32>) = COPY $vgpr2_vgpr3
+    ; GFX9-NEXT: [[COPY3:%[0-9]+]]:_(<2 x i32>) = COPY $vgpr4_vgpr5
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[COPY1]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[TRUNC]](s16), [[TRUNC2]]
-    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[TRUNC1]](s16), [[TRUNC3]]
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY2]](<2 x s32>)
-    ; GFX9-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY3]](<2 x s32>)
-    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(s32) = G_SELECT [[FCMP]](s1), [[UV]], [[UV2]]
-    ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(s32) = G_SELECT [[FCMP1]](s1), [[UV1]], [[UV3]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[SELECT]](s32), [[SELECT1]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = COPY $vgpr1
-    %2:_(<2 x s32>) = COPY $vgpr2_vgpr3
-    %3:_(<2 x s32>) = COPY $vgpr4_vgpr5
-    %4:_(<2 x s1>) = G_FCMP floatpred(oeq), %0, %1
-    %5:_(<2 x s32>) = G_SELECT %4, %2, %3
+    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX9-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[TRUNC]](f16), [[TRUNC2]]
+    ; GFX9-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[TRUNC1]](f16), [[TRUNC3]]
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY2]](<2 x i32>)
+    ; GFX9-NEXT: [[UV2:%[0-9]+]]:_(i32), [[UV3:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY3]](<2 x i32>)
+    ; GFX9-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[UV]], [[UV2]]
+    ; GFX9-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](i1), [[UV1]], [[UV3]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[SELECT]](i32), [[SELECT1]](i32)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x i32>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = COPY $vgpr1
+    %2:_(<2 x i32>) = COPY $vgpr2_vgpr3
+    %3:_(<2 x i32>) = COPY $vgpr4_vgpr5
+    %4:_(<2 x i1>) = G_FCMP floatpred(oeq), %0, %1
+    %5:_(<2 x i32>) = G_SELECT %4, %2, %3
     $vgpr0_vgpr1 = COPY %5
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-ffloor.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-ffloor.mir
@@ -6,535 +6,537 @@
 # RUN: llc -mtriple=amdgpu11.00-mesa-mesa3d -mattr=-real-true16 -run-pass=legalizer %s -o - | FileCheck -check-prefixes=GFX9  %s
 
 ---
-name: test_ffloor_s32
+name: test_ffloor_f32
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_ffloor_s32
+    ; SI-LABEL: name: test_ffloor_f32
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[COPY]]
-    ; SI-NEXT: $vgpr0 = COPY [[FFLOOR]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[COPY]]
+    ; SI-NEXT: $vgpr0 = COPY [[FFLOOR]](f32)
     ;
-    ; VI-LABEL: name: test_ffloor_s32
+    ; VI-LABEL: name: test_ffloor_f32
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[COPY]]
-    ; VI-NEXT: $vgpr0 = COPY [[FFLOOR]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[COPY]]
+    ; VI-NEXT: $vgpr0 = COPY [[FFLOOR]](f32)
     ;
-    ; GFX9-LABEL: name: test_ffloor_s32
+    ; GFX9-LABEL: name: test_ffloor_f32
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[COPY]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FFLOOR]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[COPY]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FFLOOR]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(f32) = G_FFLOOR %0
     $vgpr0 = COPY %1
 ...
 
 ---
-name: test_ffloor_s64
+name: test_ffloor_f64
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_ffloor_s64
+    ; SI-LABEL: name: test_ffloor_f64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[COPY]](f64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT]], [[C]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[COPY]](s64), [[COPY]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[COPY]](f64), [[COPY]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](s1), [[COPY]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[SELECT]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[COPY]], [[FNEG]]
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[COPY]], [[FNEG]]
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     ;
-    ; VI-LABEL: name: test_ffloor_s64
+    ; VI-LABEL: name: test_ffloor_f64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[COPY]]
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[COPY]]
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](f64)
     ;
-    ; GFX9-LABEL: name: test_ffloor_s64
+    ; GFX9-LABEL: name: test_ffloor_f64
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[COPY]]
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[COPY]]
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = G_FFLOOR %0
     $vgpr0_vgpr1 = COPY %1
 
 ...
 
 ---
-name: test_ffloor_s64_nnan
+name: test_ffloor_f64_nnan
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_ffloor_s64_nnan
+    ; SI-LABEL: name: test_ffloor_f64_nnan
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = nnan G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[COPY]](f64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = nnan G_FMINNUM_IEEE [[INT]], [[C]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = nnan G_FNEG [[FMINNUM_IEEE]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = nnan G_FADD [[COPY]], [[FNEG]]
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = nnan G_FADD [[COPY]], [[FNEG]]
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     ;
-    ; VI-LABEL: name: test_ffloor_s64_nnan
+    ; VI-LABEL: name: test_ffloor_f64_nnan
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = nnan G_FFLOOR [[COPY]]
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = nnan G_FFLOOR [[COPY]]
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](f64)
     ;
-    ; GFX9-LABEL: name: test_ffloor_s64_nnan
+    ; GFX9-LABEL: name: test_ffloor_f64_nnan
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = nnan G_FFLOOR [[COPY]]
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = nnan G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = nnan G_FFLOOR [[COPY]]
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = nnan G_FFLOOR %0
     $vgpr0_vgpr1 = COPY %1
 
 ...
 
 ---
-name: test_ffloor_s64_nssaz
+name: test_ffloor_f64_nssaz
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_ffloor_s64_nssaz
+    ; SI-LABEL: name: test_ffloor_f64_nssaz
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[COPY]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = nsz G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[COPY]](f64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = nsz G_FMINNUM_IEEE [[INT]], [[C]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nsz G_FCMP floatpred(ord), [[COPY]](s64), [[COPY]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = nsz G_FCMP floatpred(ord), [[COPY]](f64), [[COPY]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(f64) = nsz G_SELECT [[FCMP]](s1), [[COPY]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = nsz G_FNEG [[SELECT]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = nsz G_FADD [[COPY]], [[FNEG]]
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = nsz G_FADD [[COPY]], [[FNEG]]
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FADD]](f64)
     ;
-    ; VI-LABEL: name: test_ffloor_s64_nssaz
+    ; VI-LABEL: name: test_ffloor_f64_nssaz
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = nsz G_FFLOOR [[COPY]]
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = nsz G_FFLOOR [[COPY]]
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](f64)
     ;
-    ; GFX9-LABEL: name: test_ffloor_s64_nssaz
+    ; GFX9-LABEL: name: test_ffloor_f64_nssaz
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = nsz G_FFLOOR [[COPY]]
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = nsz G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = nsz G_FFLOOR [[COPY]]
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FFLOOR]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = nsz G_FFLOOR %0
     $vgpr0_vgpr1 = COPY %1
 
 ...
 
 ---
-name: test_ffloor_s16
+name: test_ffloor_f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_ffloor_s16
+    ; SI-LABEL: name: test_ffloor_f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT]]
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR]](s32)
-    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT]]
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR]](f32)
+    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; VI-LABEL: name: test_ffloor_s16
+    ; VI-LABEL: name: test_ffloor_f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC]]
-    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR]](s16)
-    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC]]
+    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR]](f16)
+    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_ffloor_s16
+    ; GFX9-LABEL: name: test_ffloor_f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
-    %2:_(s16) = G_FFLOOR %1
-    %3:_(s32) = G_ANYEXT %2
-    $vgpr0 = COPY %3
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(i32) = COPY $vgpr0
+    %1:_(i16) = G_TRUNC %0
+    %2:_(f16) = G_BITCAST %1
+    %3:_(f16) = G_FFLOOR %2
+    %4:_(i16) = G_BITCAST %3
+    %5:_(i32) = G_ANYEXT %4
+    $vgpr0 = COPY %5
 ...
 
 ---
-name: test_ffloor_v2s32
+name: test_ffloor_v2f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_ffloor_v2s32
+    ; SI-LABEL: name: test_ffloor_v2f32
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[UV]]
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[UV1]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FFLOOR]](s32), [[FFLOOR1]](s32)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[UV]]
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[UV1]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FFLOOR]](f32), [[FFLOOR1]](f32)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; VI-LABEL: name: test_ffloor_v2s32
+    ; VI-LABEL: name: test_ffloor_v2f32
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[UV]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[UV1]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FFLOOR]](s32), [[FFLOOR1]](s32)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[UV]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[UV1]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FFLOOR]](f32), [[FFLOOR1]](f32)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; GFX9-LABEL: name: test_ffloor_v2s32
+    ; GFX9-LABEL: name: test_ffloor_v2f32
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[UV]]
-    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[UV1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FFLOOR]](s32), [[FFLOOR1]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[UV]]
+    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[UV1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FFLOOR]](f32), [[FFLOOR1]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %1:_(<2 x f32>) = G_FFLOOR %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
 ---
-name: test_ffloor_v3s32
+name: test_ffloor_v3f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2
 
-    ; SI-LABEL: name: test_ffloor_v3s32
+    ; SI-LABEL: name: test_ffloor_v3f32
     ; SI: liveins: $vgpr0_vgpr1_vgpr2
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[UV]]
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[UV1]]
-    ; SI-NEXT: [[FFLOOR2:%[0-9]+]]:_(s32) = G_FFLOOR [[UV2]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FFLOOR]](s32), [[FFLOOR1]](s32), [[FFLOOR2]](s32)
-    ; SI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[UV]]
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[UV1]]
+    ; SI-NEXT: [[FFLOOR2:%[0-9]+]]:_(f32) = G_FFLOOR [[UV2]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FFLOOR]](f32), [[FFLOOR1]](f32), [[FFLOOR2]](f32)
+    ; SI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; VI-LABEL: name: test_ffloor_v3s32
+    ; VI-LABEL: name: test_ffloor_v3f32
     ; VI: liveins: $vgpr0_vgpr1_vgpr2
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[UV]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[UV1]]
-    ; VI-NEXT: [[FFLOOR2:%[0-9]+]]:_(s32) = G_FFLOOR [[UV2]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FFLOOR]](s32), [[FFLOOR1]](s32), [[FFLOOR2]](s32)
-    ; VI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[UV]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[UV1]]
+    ; VI-NEXT: [[FFLOOR2:%[0-9]+]]:_(f32) = G_FFLOOR [[UV2]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FFLOOR]](f32), [[FFLOOR1]](f32), [[FFLOOR2]](f32)
+    ; VI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; GFX9-LABEL: name: test_ffloor_v3s32
+    ; GFX9-LABEL: name: test_ffloor_v3f32
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[UV]]
-    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[UV1]]
-    ; GFX9-NEXT: [[FFLOOR2:%[0-9]+]]:_(s32) = G_FFLOOR [[UV2]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FFLOOR]](s32), [[FFLOOR1]](s32), [[FFLOOR2]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    %1:_(<3 x  s32>) = G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[UV]]
+    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[UV1]]
+    ; GFX9-NEXT: [[FFLOOR2:%[0-9]+]]:_(f32) = G_FFLOOR [[UV2]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FFLOOR]](f32), [[FFLOOR1]](f32), [[FFLOOR2]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
+    %0:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    %1:_(<3 x f32>) = G_FFLOOR %0
     $vgpr0_vgpr1_vgpr2 = COPY %1
 ...
 
 ---
-name: test_ffloor_v2s64
+name: test_ffloor_v2f64
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2_vgpr3
 
-    ; SI-LABEL: name: test_ffloor_v2s64
+    ; SI-LABEL: name: test_ffloor_v2f64
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[UV]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[UV]](f64)
     ; SI-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x3FEFFFFFFFFFFFFF
     ; SI-NEXT: [[FMINNUM_IEEE:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT]], [[C]]
-    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[UV]](s64), [[UV]]
+    ; SI-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[UV]](f64), [[UV]]
     ; SI-NEXT: [[SELECT:%[0-9]+]]:_(f64) = G_SELECT [[FCMP]](s1), [[UV]], [[FMINNUM_IEEE]]
     ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[SELECT]]
-    ; SI-NEXT: [[FADD:%[0-9]+]]:_(s64) = G_FADD [[UV]], [[FNEG]]
-    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[UV1]](s64)
+    ; SI-NEXT: [[FADD:%[0-9]+]]:_(f64) = G_FADD [[UV]], [[FNEG]]
+    ; SI-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.fract), [[UV1]](f64)
     ; SI-NEXT: [[FMINNUM_IEEE1:%[0-9]+]]:_(f64) = G_FMINNUM_IEEE [[INT1]], [[C]]
-    ; SI-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[UV1]](s64), [[UV1]]
+    ; SI-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ord), [[UV1]](f64), [[UV1]]
     ; SI-NEXT: [[SELECT1:%[0-9]+]]:_(f64) = G_SELECT [[FCMP1]](s1), [[UV1]], [[FMINNUM_IEEE1]]
     ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(f64) = G_FNEG [[SELECT1]]
-    ; SI-NEXT: [[FADD1:%[0-9]+]]:_(s64) = G_FADD [[UV1]], [[FNEG1]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FADD]](s64), [[FADD1]](s64)
-    ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; SI-NEXT: [[FADD1:%[0-9]+]]:_(f64) = G_FADD [[UV1]], [[FNEG1]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FADD]](f64), [[FADD1]](f64)
+    ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
-    ; VI-LABEL: name: test_ffloor_v2s64
+    ; VI-LABEL: name: test_ffloor_v2f64
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[UV]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s64) = G_FFLOOR [[UV1]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FFLOOR]](s64), [[FFLOOR1]](s64)
-    ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[UV]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f64) = G_FFLOOR [[UV1]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FFLOOR]](f64), [[FFLOOR1]](f64)
+    ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
-    ; GFX9-LABEL: name: test_ffloor_v2s64
+    ; GFX9-LABEL: name: test_ffloor_v2f64
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s64) = G_FFLOOR [[UV]]
-    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(s64) = G_FFLOOR [[UV1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FFLOOR]](s64), [[FFLOOR1]](s64)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %1:_(<2 x s64>) = G_FFLOOR %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f64) = G_FFLOOR [[UV]]
+    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(f64) = G_FFLOOR [[UV1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FFLOOR]](f64), [[FFLOOR1]](f64)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %1:_(<2 x f64>) = G_FFLOOR %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
 
 ---
-name: test_ffloor_v2s16
+name: test_ffloor_v2f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_ffloor_v2s16
+    ; SI-LABEL: name: test_ffloor_v2f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT]]
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT1]]
-    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR1]](s32)
-    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT]]
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT1]]
+    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR1]](f32)
+    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; SI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; SI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; SI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x s16>)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; SI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x f16>)
     ;
-    ; VI-LABEL: name: test_ffloor_v2s16
+    ; VI-LABEL: name: test_ffloor_v2f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC1]]
-    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR]](s16)
-    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR1]](s16)
+    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC1]]
+    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR]](f16)
+    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR1]](f16)
     ; VI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; VI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; VI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x s16>)
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; VI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x f16>)
     ;
-    ; GFX9-LABEL: name: test_ffloor_v2s16
+    ; GFX9-LABEL: name: test_ffloor_v2f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC]]
-    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FFLOOR]](s16), [[FFLOOR1]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x s16>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = G_FFLOOR %0
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC]]
+    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FFLOOR]](f16), [[FFLOOR1]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x f16>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = G_FFLOOR %0
     $vgpr0 = COPY %1
 ...
 
 ---
-name: test_ffloor_v3s16
+name: test_ffloor_v3f16
 body: |
   bb.0:
 
-    ; SI-LABEL: name: test_ffloor_v3s16
-    ; SI: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[DEF]](s16)
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT]]
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[DEF]](s16)
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT1]]
-    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR1]](s32)
-    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[DEF]](s16)
-    ; SI-NEXT: [[FFLOOR2:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT2]]
-    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR2]](s32)
-    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC1]](s16)
-    ; SI-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC2]](s16)
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; SI-LABEL: name: test_ffloor_v3f16
+    ; SI: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](f16)
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT]]
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](f16)
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT1]]
+    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR1]](f32)
+    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](f16)
+    ; SI-NEXT: [[FFLOOR2:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT2]]
+    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR2]](f32)
+    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC1]](f16)
+    ; SI-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC2]](f16)
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; VI-LABEL: name: test_ffloor_v3s16
-    ; VI: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[DEF]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s16) = G_FFLOOR [[DEF]]
-    ; VI-NEXT: [[FFLOOR2:%[0-9]+]]:_(s16) = G_FFLOOR [[DEF]]
-    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR]](s16)
-    ; VI-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR1]](s16)
-    ; VI-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR2]](s16)
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; VI-LABEL: name: test_ffloor_v3f16
+    ; VI: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[DEF]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f16) = G_FFLOOR [[DEF]]
+    ; VI-NEXT: [[FFLOOR2:%[0-9]+]]:_(f16) = G_FFLOOR [[DEF]]
+    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR]](f16)
+    ; VI-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR1]](f16)
+    ; VI-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR2]](f16)
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; GFX9-LABEL: name: test_ffloor_v3s16
-    ; GFX9: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[DEF]]
-    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(s16) = G_FFLOOR [[DEF]]
-    ; GFX9-NEXT: [[FFLOOR2:%[0-9]+]]:_(s16) = G_FFLOOR [[DEF]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR]](s16)
-    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR1]](s16)
-    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FFLOOR2]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s16>) = G_IMPLICIT_DEF
-    %1:_(<3 x s16>) = G_FFLOOR %0
-    %2:_(<3 x s32>) = G_ANYEXT %1
+    ; GFX9-LABEL: name: test_ffloor_v3f16
+    ; GFX9: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[DEF]]
+    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(f16) = G_FFLOOR [[DEF]]
+    ; GFX9-NEXT: [[FFLOOR2:%[0-9]+]]:_(f16) = G_FFLOOR [[DEF]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR]](f16)
+    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR1]](f16)
+    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FFLOOR2]](f16)
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
+    %0:_(<3 x f16>) = G_IMPLICIT_DEF
+    %1:_(<3 x f16>) = G_FFLOOR %0
+    %2:_(<3 x i32>) = G_ANYEXT %1
     S_NOP 0, implicit %2
 ...
 
 ---
-name: test_ffloor_v4s16
+name: test_ffloor_v4f16
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_ffloor_v4s16
+    ; SI-LABEL: name: test_ffloor_v4f16
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; SI-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC]](s16)
-    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT]]
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR]](s32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC1]](s16)
-    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT1]]
-    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR1]](s32)
-    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC2]](s16)
-    ; SI-NEXT: [[FFLOOR2:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT2]]
-    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR2]](s32)
-    ; SI-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[TRUNC3]](s16)
-    ; SI-NEXT: [[FFLOOR3:%[0-9]+]]:_(s32) = G_FFLOOR [[FPEXT3]]
-    ; SI-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[FFLOOR3]](s32)
-    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; SI-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
+    ; SI-NEXT: [[FFLOOR:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT]]
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR]](f32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
+    ; SI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT1]]
+    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR1]](f32)
+    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](f16)
+    ; SI-NEXT: [[FFLOOR2:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT2]]
+    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR2]](f32)
+    ; SI-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](f16)
+    ; SI-NEXT: [[FFLOOR3:%[0-9]+]]:_(f32) = G_FFLOOR [[FPEXT3]]
+    ; SI-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[FFLOOR3]](f32)
+    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; SI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; SI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; SI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC2]](s16)
-    ; SI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC3]](s16)
+    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; SI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC2]](f16)
+    ; SI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC3]](f16)
     ; SI-NEXT: [[SHL1:%[0-9]+]]:_(i32) = G_SHL [[ZEXT3]], [[C]](i32)
     ; SI-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[ZEXT2]], [[SHL1]]
-    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](i32)
-    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x s16>), [[BITCAST3]](<2 x s16>)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR1]](i32)
+    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x f16>), [[BITCAST3]](<2 x f16>)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; VI-LABEL: name: test_ffloor_v4s16
+    ; VI-LABEL: name: test_ffloor_v4f16
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; VI-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC]]
-    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC1]]
-    ; VI-NEXT: [[FFLOOR2:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC2]]
-    ; VI-NEXT: [[FFLOOR3:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC3]]
-    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR]](s16)
-    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR1]](s16)
+    ; VI-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; VI-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC]]
+    ; VI-NEXT: [[FFLOOR1:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC1]]
+    ; VI-NEXT: [[FFLOOR2:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC2]]
+    ; VI-NEXT: [[FFLOOR3:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC3]]
+    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR]](f16)
+    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR1]](f16)
     ; VI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; VI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; VI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR2]](s16)
-    ; VI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR3]](s16)
+    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; VI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR2]](f16)
+    ; VI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FFLOOR3]](f16)
     ; VI-NEXT: [[SHL1:%[0-9]+]]:_(i32) = G_SHL [[ZEXT3]], [[C]](i32)
     ; VI-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[ZEXT2]], [[SHL1]]
-    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](i32)
-    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x s16>), [[BITCAST3]](<2 x s16>)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR1]](i32)
+    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x f16>), [[BITCAST3]](<2 x f16>)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; GFX9-LABEL: name: test_ffloor_v4s16
+    ; GFX9-LABEL: name: test_ffloor_v4f16
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC]]
-    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC1]]
-    ; GFX9-NEXT: [[FFLOOR2:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC2]]
-    ; GFX9-NEXT: [[FFLOOR3:%[0-9]+]]:_(s16) = G_FFLOOR [[TRUNC3]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FFLOOR]](s16), [[FFLOOR1]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FFLOOR2]](s16), [[FFLOOR3]](s16)
-    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BUILD_VECTOR]](<2 x s16>), [[BUILD_VECTOR1]](<2 x s16>)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
-    %0:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    %1:_(<4 x s16>) = G_FFLOOR %0
+    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX9-NEXT: [[FFLOOR:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC]]
+    ; GFX9-NEXT: [[FFLOOR1:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC1]]
+    ; GFX9-NEXT: [[FFLOOR2:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC2]]
+    ; GFX9-NEXT: [[FFLOOR3:%[0-9]+]]:_(f16) = G_FFLOOR [[TRUNC3]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FFLOOR]](f16), [[FFLOOR1]](f16)
+    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FFLOOR2]](f16), [[FFLOOR3]](f16)
+    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[BUILD_VECTOR]](<2 x f16>), [[BUILD_VECTOR1]](<2 x f16>)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
+    %0:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    %1:_(<4 x f16>) = G_FFLOOR %0
     $vgpr0_vgpr1 = COPY %1
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fneg.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fneg.mir
@@ -6,358 +6,351 @@
 # RUN: llc -mtriple=amdgpu11.00-mesa-mesa3d -mattr=-real-true16 -run-pass=legalizer %s -o - | FileCheck -check-prefixes=GFX9  %s
 
 ---
-name: test_fneg_s32
+name: test_fneg_f32
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fneg_s32
+    ; SI-LABEL: name: test_fneg_f32
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[COPY]]
-    ; SI-NEXT: $vgpr0 = COPY [[FNEG]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[COPY]]
+    ; SI-NEXT: $vgpr0 = COPY [[FNEG]](f32)
     ;
-    ; VI-LABEL: name: test_fneg_s32
+    ; VI-LABEL: name: test_fneg_f32
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[COPY]]
-    ; VI-NEXT: $vgpr0 = COPY [[FNEG]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[COPY]]
+    ; VI-NEXT: $vgpr0 = COPY [[FNEG]](f32)
     ;
-    ; GFX9-LABEL: name: test_fneg_s32
+    ; GFX9-LABEL: name: test_fneg_f32
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[COPY]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FNEG]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[COPY]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FNEG]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(f32) = G_FNEG %0
     $vgpr0 = COPY %1
 ...
 ---
-name: test_fneg_s64
+name: test_fneg_f64
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fneg_s64
+    ; SI-LABEL: name: test_fneg_f64
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(s64) = G_FNEG [[COPY]]
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FNEG]](s64)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[COPY]]
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[FNEG]](f64)
     ;
-    ; VI-LABEL: name: test_fneg_s64
+    ; VI-LABEL: name: test_fneg_f64
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(s64) = G_FNEG [[COPY]]
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FNEG]](s64)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[COPY]]
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[FNEG]](f64)
     ;
-    ; GFX9-LABEL: name: test_fneg_s64
+    ; GFX9-LABEL: name: test_fneg_f64
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(s64) = G_FNEG [[COPY]]
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FNEG]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[COPY]]
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[FNEG]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = G_FNEG %0
     $vgpr0_vgpr1 = COPY %1
 ...
 ---
-name: test_fneg_s16
+name: test_fneg_f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fneg_s16
+    ; SI-LABEL: name: test_fneg_f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(s16) = G_FNEG [[TRUNC]]
-    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FNEG]](s16)
-    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f16) = G_FNEG [[TRUNC]]
+    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FNEG]](f16)
+    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; VI-LABEL: name: test_fneg_s16
+    ; VI-LABEL: name: test_fneg_f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(s16) = G_FNEG [[TRUNC]]
-    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FNEG]](s16)
-    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(f16) = G_FNEG [[TRUNC]]
+    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FNEG]](f16)
+    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_fneg_s16
+    ; GFX9-LABEL: name: test_fneg_f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(s16) = G_FNEG [[TRUNC]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FNEG]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
-    %2:_(s16) = G_FNEG %1
-    %3:_(s32) = G_ANYEXT %2
-    $vgpr0 = COPY %3
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(f16) = G_FNEG [[TRUNC]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FNEG]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(i32) = COPY $vgpr0
+    %1:_(i16) = G_TRUNC %0
+    %2:_(f16) = G_BITCAST %1
+    %3:_(f16) = G_FNEG %2
+    %4:_(i16) = G_BITCAST %3
+    %5:_(i32) = G_ANYEXT %4
+    $vgpr0 = COPY %5
 ...
 
 ---
-name: test_fneg_v2s32
+name: test_fneg_v2f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_fneg_v2s32
+    ; SI-LABEL: name: test_fneg_v2f32
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[UV]]
-    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[UV1]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FNEG]](s32), [[FNEG1]](s32)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[UV]]
+    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[UV1]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FNEG]](f32), [[FNEG1]](f32)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; VI-LABEL: name: test_fneg_v2s32
+    ; VI-LABEL: name: test_fneg_v2f32
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[UV]]
-    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[UV1]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FNEG]](s32), [[FNEG1]](s32)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[UV]]
+    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[UV1]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FNEG]](f32), [[FNEG1]](f32)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ;
-    ; GFX9-LABEL: name: test_fneg_v2s32
+    ; GFX9-LABEL: name: test_fneg_v2f32
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[UV]]
-    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[UV1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[FNEG]](s32), [[FNEG1]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[UV]]
+    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[UV1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[FNEG]](f32), [[FNEG1]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %1:_(<2 x f32>) = G_FNEG %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
 ---
-name: test_fneg_v3s32
+name: test_fneg_v3f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2
 
-    ; SI-LABEL: name: test_fneg_v3s32
+    ; SI-LABEL: name: test_fneg_v3f32
     ; SI: liveins: $vgpr0_vgpr1_vgpr2
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[UV]]
-    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[UV1]]
-    ; SI-NEXT: [[FNEG2:%[0-9]+]]:_(s32) = G_FNEG [[UV2]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FNEG]](s32), [[FNEG1]](s32), [[FNEG2]](s32)
-    ; SI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[UV]]
+    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[UV1]]
+    ; SI-NEXT: [[FNEG2:%[0-9]+]]:_(f32) = G_FNEG [[UV2]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FNEG]](f32), [[FNEG1]](f32), [[FNEG2]](f32)
+    ; SI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; VI-LABEL: name: test_fneg_v3s32
+    ; VI-LABEL: name: test_fneg_v3f32
     ; VI: liveins: $vgpr0_vgpr1_vgpr2
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[UV]]
-    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[UV1]]
-    ; VI-NEXT: [[FNEG2:%[0-9]+]]:_(s32) = G_FNEG [[UV2]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FNEG]](s32), [[FNEG1]](s32), [[FNEG2]](s32)
-    ; VI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[UV]]
+    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[UV1]]
+    ; VI-NEXT: [[FNEG2:%[0-9]+]]:_(f32) = G_FNEG [[UV2]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FNEG]](f32), [[FNEG1]](f32), [[FNEG2]](f32)
+    ; VI-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
     ;
-    ; GFX9-LABEL: name: test_fneg_v3s32
+    ; GFX9-LABEL: name: test_fneg_v3f32
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(s32) = G_FNEG [[UV]]
-    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(s32) = G_FNEG [[UV1]]
-    ; GFX9-NEXT: [[FNEG2:%[0-9]+]]:_(s32) = G_FNEG [[UV2]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[FNEG]](s32), [[FNEG1]](s32), [[FNEG2]](s32)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    %1:_(<3 x  s32>) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(f32) = G_FNEG [[UV]]
+    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[UV1]]
+    ; GFX9-NEXT: [[FNEG2:%[0-9]+]]:_(f32) = G_FNEG [[UV2]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[FNEG]](f32), [[FNEG1]](f32), [[FNEG2]](f32)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
+    %0:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    %1:_(<3 x f32>) = G_FNEG %0
     $vgpr0_vgpr1_vgpr2 = COPY %1
 ...
 
 ---
-name: test_fneg_v2s64
+name: test_fneg_v2f64
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2_vgpr3
 
-    ; SI-LABEL: name: test_fneg_v2s64
+    ; SI-LABEL: name: test_fneg_v2f64
     ; SI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(s64) = G_FNEG [[UV]]
-    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(s64) = G_FNEG [[UV1]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FNEG]](s64), [[FNEG1]](s64)
-    ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[UV]]
+    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(f64) = G_FNEG [[UV1]]
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FNEG]](f64), [[FNEG1]](f64)
+    ; SI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
-    ; VI-LABEL: name: test_fneg_v2s64
+    ; VI-LABEL: name: test_fneg_v2f64
     ; VI: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(s64) = G_FNEG [[UV]]
-    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(s64) = G_FNEG [[UV1]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FNEG]](s64), [[FNEG1]](s64)
-    ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[UV]]
+    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(f64) = G_FNEG [[UV1]]
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FNEG]](f64), [[FNEG1]](f64)
+    ; VI-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ;
-    ; GFX9-LABEL: name: test_fneg_v2s64
+    ; GFX9-LABEL: name: test_fneg_v2f64
     ; GFX9: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(s64) = G_FNEG [[UV]]
-    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(s64) = G_FNEG [[UV1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[FNEG]](s64), [[FNEG1]](s64)
-    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %1:_(<2 x s64>) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(f64) = G_FNEG [[UV]]
+    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(f64) = G_FNEG [[UV1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[FNEG]](f64), [[FNEG1]](f64)
+    ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %1:_(<2 x f64>) = G_FNEG %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
 
 ---
-name: test_fneg_v2s16
+name: test_fneg_v2f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fneg_v2s16
+    ; SI-LABEL: name: test_fneg_v2f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[COPY]]
-    ; SI-NEXT: $vgpr0 = COPY [[FNEG]](<2 x s16>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[COPY]]
+    ; SI-NEXT: $vgpr0 = COPY [[FNEG]](<2 x f16>)
     ;
-    ; VI-LABEL: name: test_fneg_v2s16
+    ; VI-LABEL: name: test_fneg_v2f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[COPY]]
-    ; VI-NEXT: $vgpr0 = COPY [[FNEG]](<2 x s16>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[COPY]]
+    ; VI-NEXT: $vgpr0 = COPY [[FNEG]](<2 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fneg_v2s16
+    ; GFX9-LABEL: name: test_fneg_v2f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[COPY]]
-    ; GFX9-NEXT: $vgpr0 = COPY [[FNEG]](<2 x s16>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[COPY]]
+    ; GFX9-NEXT: $vgpr0 = COPY [[FNEG]](<2 x f16>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = G_FNEG %0
     $vgpr0 = COPY %1
 ...
 
 ---
-name: test_fneg_v3s16
+name: test_fneg_v3f16
 body: |
   bb.0:
 
-    ; SI-LABEL: name: test_fneg_v3s16
+    ; SI-LABEL: name: test_fneg_v3f16
     ; SI: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
     ; SI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[C]], [[C1]](i32)
     ; SI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[C]], [[SHL]]
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
     ; SI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY [[OR]](i32)
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[COPY]](i32)
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[BITCAST]]
-    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[BITCAST1]]
-    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG]](<2 x s16>)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[COPY]](i32)
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[BITCAST]]
+    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[BITCAST1]]
+    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG]](<2 x f16>)
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST2]], [[C1]](i32)
-    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG1]](<2 x s16>)
-    ; SI-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
-    ; SI-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[BITCAST2]], [[C2]]
-    ; SI-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[BITCAST3]], [[C2]]
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[AND]](s32), [[LSHR]](i32), [[AND1]](s32)
-    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG1]](<2 x f16>)
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[BITCAST2]](i32), [[LSHR]](i32), [[BITCAST3]](i32)
+    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; VI-LABEL: name: test_fneg_v3s16
+    ; VI-LABEL: name: test_fneg_v3f16
     ; VI: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
     ; VI-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[C]], [[C1]](i32)
     ; VI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[C]], [[SHL]]
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
     ; VI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY [[OR]](i32)
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[COPY]](i32)
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[BITCAST]]
-    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[BITCAST1]]
-    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG]](<2 x s16>)
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[COPY]](i32)
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[BITCAST]]
+    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[BITCAST1]]
+    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG]](<2 x f16>)
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST2]], [[C1]](i32)
-    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG1]](<2 x s16>)
-    ; VI-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
-    ; VI-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[BITCAST2]], [[C2]]
-    ; VI-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[BITCAST3]], [[C2]]
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[AND]](s32), [[LSHR]](i32), [[AND1]](s32)
-    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG1]](<2 x f16>)
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[BITCAST2]](i32), [[LSHR]](i32), [[BITCAST3]](i32)
+    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fneg_v3s16
-    ; GFX9: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[BUILD_VECTOR]]
-    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[BUILD_VECTOR1]]
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG]](<2 x s16>)
+    ; GFX9-LABEL: name: test_fneg_v3f16
+    ; GFX9: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[DEF]](f16), [[DEF]](f16)
+    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[DEF]](f16), [[DEF]](f16)
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[BUILD_VECTOR]]
+    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[BUILD_VECTOR1]]
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG]](<2 x f16>)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG1]](<2 x s16>)
-    ; GFX9-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
-    ; GFX9-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[BITCAST]], [[C1]]
-    ; GFX9-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[BITCAST1]], [[C1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[AND]](s32), [[LSHR]](i32), [[AND1]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR2]](<3 x s32>)
-    %0:_(<3 x s16>) = G_IMPLICIT_DEF
-    %1:_(<3 x s16>) = G_FNEG %0
-    %2:_(<3 x s32>) = G_ZEXT %1
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[FNEG1]](<2 x f16>)
+    ; GFX9-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[BITCAST]](i32), [[LSHR]](i32), [[BITCAST1]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR2]](<3 x i32>)
+    %0:_(<3 x f16>) = G_IMPLICIT_DEF
+    %1:_(<3 x f16>) = G_FNEG %0
+    %2:_(<3 x i32>) = G_ANYEXT %1
     S_NOP 0, implicit %2
 ...
 
 ---
-name: test_fneg_v4s16
+name: test_fneg_v4f16
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_fneg_v4s16
+    ; SI-LABEL: name: test_fneg_v4f16
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[UV]]
-    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[UV1]]
-    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[FNEG]](<2 x s16>), [[FNEG1]](<2 x s16>)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; SI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[UV]]
+    ; SI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[UV1]]
+    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[FNEG]](<2 x f16>), [[FNEG1]](<2 x f16>)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; VI-LABEL: name: test_fneg_v4s16
+    ; VI-LABEL: name: test_fneg_v4f16
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[UV]]
-    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[UV1]]
-    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[FNEG]](<2 x s16>), [[FNEG1]](<2 x s16>)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; VI-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[UV]]
+    ; VI-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[UV1]]
+    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[FNEG]](<2 x f16>), [[FNEG1]](<2 x f16>)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fneg_v4s16
+    ; GFX9-LABEL: name: test_fneg_v4f16
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[UV]]
-    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x s16>) = G_FNEG [[UV1]]
-    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[FNEG]](<2 x s16>), [[FNEG1]](<2 x s16>)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
-    %0:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    %1:_(<4 x s16>) = G_FNEG %0
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; GFX9-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[UV]]
+    ; GFX9-NEXT: [[FNEG1:%[0-9]+]]:_(<2 x f16>) = G_FNEG [[UV1]]
+    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[FNEG]](<2 x f16>), [[FNEG1]](<2 x f16>)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
+    %0:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    %1:_(<4 x f16>) = G_FNEG %0
     $vgpr0_vgpr1 = COPY %1
 ...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fsqrt.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-fsqrt.mir
@@ -6,20 +6,20 @@
 # RUN: llc -mtriple=amdgpu11.00-mesa-mesa3d -mattr=-real-true16 -run-pass=legalizer %s -o - | FileCheck -check-prefixes=GFX9,GCN  %s
 
 ---
-name: test_fsqrt_s32
+name: test_fsqrt_f32
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; GCN-LABEL: name: test_fsqrt_s32
+    ; GCN-LABEL: name: test_fsqrt_f32
     ; GCN: liveins: $vgpr0
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $vgpr0
     ; GCN-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x0F800000
-    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[C]](f32), [[COPY]]
+    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[C]](f32), [[COPY]]
     ; GCN-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GCN-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[COPY]], [[C1]]
-    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[FMUL]], [[COPY]]
+    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[FMUL]], [[COPY]]
     ; GCN-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[SELECT]](f32)
     ; GCN-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[INT]](f32)
     ; GCN-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 -1
@@ -33,36 +33,36 @@ body: |
     ; GCN-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[BITCAST2]]
     ; GCN-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FNEG1]], [[INT]], [[SELECT]]
     ; GCN-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
-    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ole), [[FMA]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[BITCAST1]], [[INT]]
-    ; GCN-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[FMA1]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[BITCAST2]], [[SELECT1]]
+    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(ole), [[FMA]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](i1), [[BITCAST1]], [[INT]]
+    ; GCN-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[FMA1]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](i1), [[BITCAST2]], [[SELECT1]]
     ; GCN-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x37800000
     ; GCN-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[SELECT2]], [[C5]]
-    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[FMUL1]], [[SELECT2]]
-    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[SELECT]](f32), 608
-    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(s32) = G_SELECT [[IS_FPCLASS]](s1), [[SELECT]], [[SELECT3]]
-    ; GCN-NEXT: $vgpr0 = COPY [[SELECT4]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s32) = G_FSQRT %0
+    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[FMUL1]], [[SELECT2]]
+    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[SELECT]](f32), 608
+    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[IS_FPCLASS]](i1), [[SELECT]], [[SELECT3]]
+    ; GCN-NEXT: $vgpr0 = COPY [[SELECT4]](f32)
+    %0:_(f32) = COPY $vgpr0
+    %1:_(f32) = G_FSQRT %0
     $vgpr0 = COPY %1
 ...
 
 ---
-name: test_fsqrt_s64
+name: test_fsqrt_f64
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; GCN-LABEL: name: test_fsqrt_s64
+    ; GCN-LABEL: name: test_fsqrt_f64
     ; GCN: liveins: $vgpr0
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
     ; GCN-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x1000000000000000
     ; GCN-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
-    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s64), [[C]]
+    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(olt), [[COPY]](f64), [[C]]
     ; GCN-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 256
-    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](s1), [[C2]], [[C1]]
+    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[C2]], [[C1]]
     ; GCN-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = G_FLDEXP [[COPY]], [[SELECT]](i32)
     ; GCN-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.rsq), [[FLDEXP]](f64)
     ; GCN-NEXT: [[C3:%[0-9]+]]:_(f64) = G_FCONSTANT double 5.000000e-01
@@ -79,32 +79,32 @@ body: |
     ; GCN-NEXT: [[FMA5:%[0-9]+]]:_(f64) = G_FMA [[FNEG2]], [[FMA4]], [[FLDEXP]]
     ; GCN-NEXT: [[FMA6:%[0-9]+]]:_(f64) = G_FMA [[FMA5]], [[FMA2]], [[FMA4]]
     ; GCN-NEXT: [[C4:%[0-9]+]]:_(i32) = G_CONSTANT i32 -128
-    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](s1), [[C4]], [[C1]]
+    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[C4]], [[C1]]
     ; GCN-NEXT: [[FLDEXP1:%[0-9]+]]:_(f64) = G_FLDEXP [[FMA6]], [[SELECT1]](i32)
-    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[FLDEXP]](f64), 608
-    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(s64) = G_SELECT [[IS_FPCLASS]](s1), [[FLDEXP]], [[FLDEXP1]]
-    ; GCN-NEXT: $vgpr0_vgpr1 = COPY [[SELECT2]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = G_FSQRT %0
+    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[FLDEXP]](f64), 608
+    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = G_SELECT [[IS_FPCLASS]](i1), [[FLDEXP]], [[FLDEXP1]]
+    ; GCN-NEXT: $vgpr0_vgpr1 = COPY [[SELECT2]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = G_FSQRT %0
     $vgpr0_vgpr1 = COPY %1
 
 ...
 
 ---
-name: test_fsqrt_s64_ninf
+name: test_fsqrt_f64_ninf
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; GCN-LABEL: name: test_fsqrt_s64_ninf
+    ; GCN-LABEL: name: test_fsqrt_f64_ninf
     ; GCN: liveins: $vgpr0
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $vgpr0_vgpr1
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $vgpr0_vgpr1
     ; GCN-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x1000000000000000
     ; GCN-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
-    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[COPY]](s64), [[C]]
+    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(olt), [[COPY]](f64), [[C]]
     ; GCN-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 256
-    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](s1), [[C2]], [[C1]]
+    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[C2]], [[C1]]
     ; GCN-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = ninf G_FLDEXP [[COPY]], [[SELECT]](i32)
     ; GCN-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.rsq), [[FLDEXP]](f64)
     ; GCN-NEXT: [[C3:%[0-9]+]]:_(f64) = G_FCONSTANT double 5.000000e-01
@@ -121,74 +121,76 @@ body: |
     ; GCN-NEXT: [[FMA5:%[0-9]+]]:_(f64) = G_FMA [[FNEG2]], [[FMA4]], [[FLDEXP]]
     ; GCN-NEXT: [[FMA6:%[0-9]+]]:_(f64) = G_FMA [[FMA5]], [[FMA2]], [[FMA4]]
     ; GCN-NEXT: [[C4:%[0-9]+]]:_(i32) = G_CONSTANT i32 -128
-    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](s1), [[C4]], [[C1]]
+    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[C4]], [[C1]]
     ; GCN-NEXT: [[FLDEXP1:%[0-9]+]]:_(f64) = ninf G_FLDEXP [[FMA6]], [[SELECT1]](i32)
     ; GCN-NEXT: [[C5:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
-    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(oeq), [[FLDEXP]](f64), [[C5]]
-    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(s64) = ninf G_SELECT [[FCMP1]](s1), [[FLDEXP]], [[FLDEXP1]]
-    ; GCN-NEXT: $vgpr0_vgpr1 = COPY [[SELECT2]](s64)
-    %0:_(s64) = COPY $vgpr0_vgpr1
-    %1:_(s64) = ninf G_FSQRT %0
+    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(oeq), [[FLDEXP]](f64), [[C5]]
+    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = ninf G_SELECT [[FCMP1]](i1), [[FLDEXP]], [[FLDEXP1]]
+    ; GCN-NEXT: $vgpr0_vgpr1 = COPY [[SELECT2]](f64)
+    %0:_(f64) = COPY $vgpr0_vgpr1
+    %1:_(f64) = ninf G_FSQRT %0
     $vgpr0_vgpr1 = COPY %1
 
 ...
 ---
-name: test_fsqrt_s16
+name: test_fsqrt_f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fsqrt_s16
+    ; SI-LABEL: name: test_fsqrt_f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](s16)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
     ; SI-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT]](f32)
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT]](f32)
-    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
+    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; VI-LABEL: name: test_fsqrt_s16
+    ; VI-LABEL: name: test_fsqrt_f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC]]
-    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT]](s16)
-    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC]]
+    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT]](f16)
+    ; VI-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
     ;
-    ; GFX9-LABEL: name: test_fsqrt_s16
+    ; GFX9-LABEL: name: test_fsqrt_f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
-    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
-    %0:_(s32) = COPY $vgpr0
-    %1:_(s16) = G_TRUNC %0
-    %2:_(s16) = G_FSQRT %1
-    %3:_(s32) = G_ANYEXT %2
-    $vgpr0 = COPY %3
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $vgpr0
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[COPY]](i32)
+    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[ANYEXT]](i32)
+    %0:_(i32) = COPY $vgpr0
+    %1:_(i16) = G_TRUNC %0
+    %2:_(f16) = G_BITCAST %1
+    %3:_(f16) = G_FSQRT %2
+    %4:_(i16) = G_BITCAST %3
+    %5:_(i32) = G_ANYEXT %4
+    $vgpr0 = COPY %5
 ...
 
 ---
-name: test_fsqrt_v2s32
+name: test_fsqrt_v2f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; GCN-LABEL: name: test_fsqrt_v2s32
+    ; GCN-LABEL: name: test_fsqrt_v2f32
     ; GCN: liveins: $vgpr0_vgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    ; GCN-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    ; GCN-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
     ; GCN-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x0F800000
-    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV]]
+    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV]]
     ; GCN-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GCN-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[UV]], [[C1]]
-    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[FMUL]], [[UV]]
+    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[FMUL]], [[UV]]
     ; GCN-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[SELECT]](f32)
     ; GCN-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[INT]](f32)
     ; GCN-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 -1
@@ -202,18 +204,18 @@ body: |
     ; GCN-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[BITCAST2]]
     ; GCN-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FNEG1]], [[INT]], [[SELECT]]
     ; GCN-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
-    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ole), [[FMA]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[BITCAST1]], [[INT]]
-    ; GCN-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[FMA1]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[BITCAST2]], [[SELECT1]]
+    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(ole), [[FMA]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](i1), [[BITCAST1]], [[INT]]
+    ; GCN-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[FMA1]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](i1), [[BITCAST2]], [[SELECT1]]
     ; GCN-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x37800000
     ; GCN-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[SELECT2]], [[C5]]
-    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[FMUL1]], [[SELECT2]]
-    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[SELECT]](f32), 608
-    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(s32) = G_SELECT [[IS_FPCLASS]](s1), [[SELECT]], [[SELECT3]]
-    ; GCN-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV1]]
+    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[FMUL1]], [[SELECT2]]
+    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[SELECT]](f32), 608
+    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[IS_FPCLASS]](i1), [[SELECT]], [[SELECT3]]
+    ; GCN-NEXT: [[FCMP3:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV1]]
     ; GCN-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV1]], [[C1]]
-    ; GCN-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[FMUL2]], [[UV1]]
+    ; GCN-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](i1), [[FMUL2]], [[UV1]]
     ; GCN-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[SELECT5]](f32)
     ; GCN-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[INT1]](f32)
     ; GCN-NEXT: [[ADD2:%[0-9]+]]:_(i32) = G_ADD [[BITCAST3]], [[C2]]
@@ -224,37 +226,37 @@ body: |
     ; GCN-NEXT: [[BITCAST5:%[0-9]+]]:_(f32) = G_BITCAST [[ADD3]](i32)
     ; GCN-NEXT: [[FNEG3:%[0-9]+]]:_(f32) = G_FNEG [[BITCAST5]]
     ; GCN-NEXT: [[FMA3:%[0-9]+]]:_(f32) = G_FMA [[FNEG3]], [[INT1]], [[SELECT5]]
-    ; GCN-NEXT: [[FCMP4:%[0-9]+]]:_(s1) = G_FCMP floatpred(ole), [[FMA2]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](s1), [[BITCAST4]], [[INT1]]
-    ; GCN-NEXT: [[FCMP5:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[FMA3]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[BITCAST5]], [[SELECT6]]
+    ; GCN-NEXT: [[FCMP4:%[0-9]+]]:_(i1) = G_FCMP floatpred(ole), [[FMA2]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](i1), [[BITCAST4]], [[INT1]]
+    ; GCN-NEXT: [[FCMP5:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[FMA3]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](i1), [[BITCAST5]], [[SELECT6]]
     ; GCN-NEXT: [[FMUL3:%[0-9]+]]:_(f32) = G_FMUL [[SELECT7]], [[C5]]
-    ; GCN-NEXT: [[SELECT8:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[FMUL3]], [[SELECT7]]
-    ; GCN-NEXT: [[IS_FPCLASS1:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[SELECT5]](f32), 608
-    ; GCN-NEXT: [[SELECT9:%[0-9]+]]:_(s32) = G_SELECT [[IS_FPCLASS1]](s1), [[SELECT5]], [[SELECT8]]
-    ; GCN-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[SELECT4]](s32), [[SELECT9]](s32)
-    ; GCN-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $vgpr0_vgpr1
-    %1:_(<2 x s32>) = G_FSQRT %0
+    ; GCN-NEXT: [[SELECT8:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](i1), [[FMUL3]], [[SELECT7]]
+    ; GCN-NEXT: [[IS_FPCLASS1:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[SELECT5]](f32), 608
+    ; GCN-NEXT: [[SELECT9:%[0-9]+]]:_(f32) = G_SELECT [[IS_FPCLASS1]](i1), [[SELECT5]], [[SELECT8]]
+    ; GCN-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[SELECT4]](f32), [[SELECT9]](f32)
+    ; GCN-NEXT: $vgpr0_vgpr1 = COPY [[BUILD_VECTOR]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $vgpr0_vgpr1
+    %1:_(<2 x f32>) = G_FSQRT %0
     $vgpr0_vgpr1 = COPY %1
 ...
 
 ---
-name: test_fsqrt_v3s32
+name: test_fsqrt_v3f32
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2
 
-    ; GCN-LABEL: name: test_fsqrt_v3s32
+    ; GCN-LABEL: name: test_fsqrt_v3f32
     ; GCN: liveins: $vgpr0_vgpr1_vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    ; GCN-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<3 x s32>)
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    ; GCN-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<3 x f32>)
     ; GCN-NEXT: [[C:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x0F800000
-    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV]]
+    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV]]
     ; GCN-NEXT: [[C1:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x4F800000
     ; GCN-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[UV]], [[C1]]
-    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[FMUL]], [[UV]]
+    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[FMUL]], [[UV]]
     ; GCN-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[SELECT]](f32)
     ; GCN-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[INT]](f32)
     ; GCN-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 -1
@@ -268,18 +270,18 @@ body: |
     ; GCN-NEXT: [[FNEG1:%[0-9]+]]:_(f32) = G_FNEG [[BITCAST2]]
     ; GCN-NEXT: [[FMA1:%[0-9]+]]:_(f32) = G_FMA [[FNEG1]], [[INT]], [[SELECT]]
     ; GCN-NEXT: [[C4:%[0-9]+]]:_(f32) = G_FCONSTANT float 0.000000e+00
-    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(ole), [[FMA]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](s1), [[BITCAST1]], [[INT]]
-    ; GCN-NEXT: [[FCMP2:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[FMA1]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](s1), [[BITCAST2]], [[SELECT1]]
+    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(ole), [[FMA]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(f32) = G_SELECT [[FCMP1]](i1), [[BITCAST1]], [[INT]]
+    ; GCN-NEXT: [[FCMP2:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[FMA1]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f32) = G_SELECT [[FCMP2]](i1), [[BITCAST2]], [[SELECT1]]
     ; GCN-NEXT: [[C5:%[0-9]+]]:_(f32) = G_FCONSTANT float f0x37800000
     ; GCN-NEXT: [[FMUL1:%[0-9]+]]:_(f32) = G_FMUL [[SELECT2]], [[C5]]
-    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](s1), [[FMUL1]], [[SELECT2]]
-    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[SELECT]](f32), 608
-    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(s32) = G_SELECT [[IS_FPCLASS]](s1), [[SELECT]], [[SELECT3]]
-    ; GCN-NEXT: [[FCMP3:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV1]]
+    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(f32) = G_SELECT [[FCMP]](i1), [[FMUL1]], [[SELECT2]]
+    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[SELECT]](f32), 608
+    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(f32) = G_SELECT [[IS_FPCLASS]](i1), [[SELECT]], [[SELECT3]]
+    ; GCN-NEXT: [[FCMP3:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV1]]
     ; GCN-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV1]], [[C1]]
-    ; GCN-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[FMUL2]], [[UV1]]
+    ; GCN-NEXT: [[SELECT5:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](i1), [[FMUL2]], [[UV1]]
     ; GCN-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[SELECT5]](f32)
     ; GCN-NEXT: [[BITCAST3:%[0-9]+]]:_(i32) = G_BITCAST [[INT1]](f32)
     ; GCN-NEXT: [[ADD2:%[0-9]+]]:_(i32) = G_ADD [[BITCAST3]], [[C2]]
@@ -290,17 +292,17 @@ body: |
     ; GCN-NEXT: [[BITCAST5:%[0-9]+]]:_(f32) = G_BITCAST [[ADD3]](i32)
     ; GCN-NEXT: [[FNEG3:%[0-9]+]]:_(f32) = G_FNEG [[BITCAST5]]
     ; GCN-NEXT: [[FMA3:%[0-9]+]]:_(f32) = G_FMA [[FNEG3]], [[INT1]], [[SELECT5]]
-    ; GCN-NEXT: [[FCMP4:%[0-9]+]]:_(s1) = G_FCMP floatpred(ole), [[FMA2]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](s1), [[BITCAST4]], [[INT1]]
-    ; GCN-NEXT: [[FCMP5:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[FMA3]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](s1), [[BITCAST5]], [[SELECT6]]
+    ; GCN-NEXT: [[FCMP4:%[0-9]+]]:_(i1) = G_FCMP floatpred(ole), [[FMA2]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT6:%[0-9]+]]:_(f32) = G_SELECT [[FCMP4]](i1), [[BITCAST4]], [[INT1]]
+    ; GCN-NEXT: [[FCMP5:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[FMA3]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT7:%[0-9]+]]:_(f32) = G_SELECT [[FCMP5]](i1), [[BITCAST5]], [[SELECT6]]
     ; GCN-NEXT: [[FMUL3:%[0-9]+]]:_(f32) = G_FMUL [[SELECT7]], [[C5]]
-    ; GCN-NEXT: [[SELECT8:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](s1), [[FMUL3]], [[SELECT7]]
-    ; GCN-NEXT: [[IS_FPCLASS1:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[SELECT5]](f32), 608
-    ; GCN-NEXT: [[SELECT9:%[0-9]+]]:_(s32) = G_SELECT [[IS_FPCLASS1]](s1), [[SELECT5]], [[SELECT8]]
-    ; GCN-NEXT: [[FCMP6:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV2]]
+    ; GCN-NEXT: [[SELECT8:%[0-9]+]]:_(f32) = G_SELECT [[FCMP3]](i1), [[FMUL3]], [[SELECT7]]
+    ; GCN-NEXT: [[IS_FPCLASS1:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[SELECT5]](f32), 608
+    ; GCN-NEXT: [[SELECT9:%[0-9]+]]:_(f32) = G_SELECT [[IS_FPCLASS1]](i1), [[SELECT5]], [[SELECT8]]
+    ; GCN-NEXT: [[FCMP6:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[C]](f32), [[UV2]]
     ; GCN-NEXT: [[FMUL4:%[0-9]+]]:_(f32) = G_FMUL [[UV2]], [[C1]]
-    ; GCN-NEXT: [[SELECT10:%[0-9]+]]:_(f32) = G_SELECT [[FCMP6]](s1), [[FMUL4]], [[UV2]]
+    ; GCN-NEXT: [[SELECT10:%[0-9]+]]:_(f32) = G_SELECT [[FCMP6]](i1), [[FMUL4]], [[UV2]]
     ; GCN-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[SELECT10]](f32)
     ; GCN-NEXT: [[BITCAST6:%[0-9]+]]:_(i32) = G_BITCAST [[INT2]](f32)
     ; GCN-NEXT: [[ADD4:%[0-9]+]]:_(i32) = G_ADD [[BITCAST6]], [[C2]]
@@ -311,37 +313,37 @@ body: |
     ; GCN-NEXT: [[BITCAST8:%[0-9]+]]:_(f32) = G_BITCAST [[ADD5]](i32)
     ; GCN-NEXT: [[FNEG5:%[0-9]+]]:_(f32) = G_FNEG [[BITCAST8]]
     ; GCN-NEXT: [[FMA5:%[0-9]+]]:_(f32) = G_FMA [[FNEG5]], [[INT2]], [[SELECT10]]
-    ; GCN-NEXT: [[FCMP7:%[0-9]+]]:_(s1) = G_FCMP floatpred(ole), [[FMA4]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT11:%[0-9]+]]:_(f32) = G_SELECT [[FCMP7]](s1), [[BITCAST7]], [[INT2]]
-    ; GCN-NEXT: [[FCMP8:%[0-9]+]]:_(s1) = G_FCMP floatpred(ogt), [[FMA5]](f32), [[C4]]
-    ; GCN-NEXT: [[SELECT12:%[0-9]+]]:_(f32) = G_SELECT [[FCMP8]](s1), [[BITCAST8]], [[SELECT11]]
+    ; GCN-NEXT: [[FCMP7:%[0-9]+]]:_(i1) = G_FCMP floatpred(ole), [[FMA4]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT11:%[0-9]+]]:_(f32) = G_SELECT [[FCMP7]](i1), [[BITCAST7]], [[INT2]]
+    ; GCN-NEXT: [[FCMP8:%[0-9]+]]:_(i1) = G_FCMP floatpred(ogt), [[FMA5]](f32), [[C4]]
+    ; GCN-NEXT: [[SELECT12:%[0-9]+]]:_(f32) = G_SELECT [[FCMP8]](i1), [[BITCAST8]], [[SELECT11]]
     ; GCN-NEXT: [[FMUL5:%[0-9]+]]:_(f32) = G_FMUL [[SELECT12]], [[C5]]
-    ; GCN-NEXT: [[SELECT13:%[0-9]+]]:_(f32) = G_SELECT [[FCMP6]](s1), [[FMUL5]], [[SELECT12]]
-    ; GCN-NEXT: [[IS_FPCLASS2:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[SELECT10]](f32), 608
-    ; GCN-NEXT: [[SELECT14:%[0-9]+]]:_(s32) = G_SELECT [[IS_FPCLASS2]](s1), [[SELECT10]], [[SELECT13]]
-    ; GCN-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[SELECT4]](s32), [[SELECT9]](s32), [[SELECT14]](s32)
-    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s32>) = COPY $vgpr0_vgpr1_vgpr2
-    %1:_(<3 x  s32>) = G_FSQRT %0
+    ; GCN-NEXT: [[SELECT13:%[0-9]+]]:_(f32) = G_SELECT [[FCMP6]](i1), [[FMUL5]], [[SELECT12]]
+    ; GCN-NEXT: [[IS_FPCLASS2:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[SELECT10]](f32), 608
+    ; GCN-NEXT: [[SELECT14:%[0-9]+]]:_(f32) = G_SELECT [[IS_FPCLASS2]](i1), [[SELECT10]], [[SELECT13]]
+    ; GCN-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x f32>) = G_BUILD_VECTOR [[SELECT4]](f32), [[SELECT9]](f32), [[SELECT14]](f32)
+    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2 = COPY [[BUILD_VECTOR]](<3 x f32>)
+    %0:_(<3 x f32>) = COPY $vgpr0_vgpr1_vgpr2
+    %1:_(<3 x f32>) = G_FSQRT %0
     $vgpr0_vgpr1_vgpr2 = COPY %1
 ...
 
 ---
-name: test_fsqrt_v2s64
+name: test_fsqrt_v2f64
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1_vgpr2_vgpr3
 
-    ; GCN-LABEL: name: test_fsqrt_v2s64
+    ; GCN-LABEL: name: test_fsqrt_v2f64
     ; GCN: liveins: $vgpr0_vgpr1_vgpr2_vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GCN-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    ; GCN-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
     ; GCN-NEXT: [[C:%[0-9]+]]:_(f64) = G_FCONSTANT double f0x1000000000000000
     ; GCN-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
-    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV]](s64), [[C]]
+    ; GCN-NEXT: [[FCMP:%[0-9]+]]:_(i1) = G_FCMP floatpred(olt), [[UV]](f64), [[C]]
     ; GCN-NEXT: [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 256
-    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](s1), [[C2]], [[C1]]
+    ; GCN-NEXT: [[SELECT:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[C2]], [[C1]]
     ; GCN-NEXT: [[FLDEXP:%[0-9]+]]:_(f64) = G_FLDEXP [[UV]], [[SELECT]](i32)
     ; GCN-NEXT: [[INT:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.rsq), [[FLDEXP]](f64)
     ; GCN-NEXT: [[C3:%[0-9]+]]:_(f64) = G_FCONSTANT double 5.000000e-01
@@ -358,12 +360,12 @@ body: |
     ; GCN-NEXT: [[FMA5:%[0-9]+]]:_(f64) = G_FMA [[FNEG2]], [[FMA4]], [[FLDEXP]]
     ; GCN-NEXT: [[FMA6:%[0-9]+]]:_(f64) = G_FMA [[FMA5]], [[FMA2]], [[FMA4]]
     ; GCN-NEXT: [[C4:%[0-9]+]]:_(i32) = G_CONSTANT i32 -128
-    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](s1), [[C4]], [[C1]]
+    ; GCN-NEXT: [[SELECT1:%[0-9]+]]:_(i32) = G_SELECT [[FCMP]](i1), [[C4]], [[C1]]
     ; GCN-NEXT: [[FLDEXP1:%[0-9]+]]:_(f64) = G_FLDEXP [[FMA6]], [[SELECT1]](i32)
-    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[FLDEXP]](f64), 608
-    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(s64) = G_SELECT [[IS_FPCLASS]](s1), [[FLDEXP]], [[FLDEXP1]]
-    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(s1) = G_FCMP floatpred(olt), [[UV1]](s64), [[C]]
-    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](s1), [[C2]], [[C1]]
+    ; GCN-NEXT: [[IS_FPCLASS:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[FLDEXP]](f64), 608
+    ; GCN-NEXT: [[SELECT2:%[0-9]+]]:_(f64) = G_SELECT [[IS_FPCLASS]](i1), [[FLDEXP]], [[FLDEXP1]]
+    ; GCN-NEXT: [[FCMP1:%[0-9]+]]:_(i1) = G_FCMP floatpred(olt), [[UV1]](f64), [[C]]
+    ; GCN-NEXT: [[SELECT3:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](i1), [[C2]], [[C1]]
     ; GCN-NEXT: [[FLDEXP2:%[0-9]+]]:_(f64) = G_FLDEXP [[UV1]], [[SELECT3]](i32)
     ; GCN-NEXT: [[INT1:%[0-9]+]]:_(f64) = G_INTRINSIC intrinsic(@llvm.amdgcn.rsq), [[FLDEXP2]](f64)
     ; GCN-NEXT: [[FMUL2:%[0-9]+]]:_(f64) = G_FMUL [[INT1]], [[C3]]
@@ -378,229 +380,229 @@ body: |
     ; GCN-NEXT: [[FNEG5:%[0-9]+]]:_(f64) = G_FNEG [[FMA11]]
     ; GCN-NEXT: [[FMA12:%[0-9]+]]:_(f64) = G_FMA [[FNEG5]], [[FMA11]], [[FLDEXP2]]
     ; GCN-NEXT: [[FMA13:%[0-9]+]]:_(f64) = G_FMA [[FMA12]], [[FMA9]], [[FMA11]]
-    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](s1), [[C4]], [[C1]]
+    ; GCN-NEXT: [[SELECT4:%[0-9]+]]:_(i32) = G_SELECT [[FCMP1]](i1), [[C4]], [[C1]]
     ; GCN-NEXT: [[FLDEXP3:%[0-9]+]]:_(f64) = G_FLDEXP [[FMA13]], [[SELECT4]](i32)
-    ; GCN-NEXT: [[IS_FPCLASS1:%[0-9]+]]:_(s1) = G_IS_FPCLASS [[FLDEXP2]](f64), 608
-    ; GCN-NEXT: [[SELECT5:%[0-9]+]]:_(s64) = G_SELECT [[IS_FPCLASS1]](s1), [[FLDEXP2]], [[FLDEXP3]]
-    ; GCN-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[SELECT2]](s64), [[SELECT5]](s64)
-    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
-    %1:_(<2 x s64>) = G_FSQRT %0
+    ; GCN-NEXT: [[IS_FPCLASS1:%[0-9]+]]:_(i1) = G_IS_FPCLASS [[FLDEXP2]](f64), 608
+    ; GCN-NEXT: [[SELECT5:%[0-9]+]]:_(f64) = G_SELECT [[IS_FPCLASS1]](i1), [[FLDEXP2]], [[FLDEXP3]]
+    ; GCN-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[SELECT2]](f64), [[SELECT5]](f64)
+    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = COPY [[BUILD_VECTOR]](<2 x f64>)
+    %0:_(<2 x f64>) = COPY $vgpr0_vgpr1_vgpr2_vgpr3
+    %1:_(<2 x f64>) = G_FSQRT %0
     $vgpr0_vgpr1_vgpr2_vgpr3 = COPY %1
 ...
 
 ---
-name: test_fsqrt_v2s16
+name: test_fsqrt_v2f16
 body: |
   bb.0:
     liveins: $vgpr0
 
-    ; SI-LABEL: name: test_fsqrt_v2s16
+    ; SI-LABEL: name: test_fsqrt_v2f16
     ; SI: liveins: $vgpr0
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](s16)
+    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
     ; SI-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT]](f32)
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT]](f32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](s16)
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
     ; SI-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT1]](f32)
-    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT1]](f32)
-    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT1]](f32)
+    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; SI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; SI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; SI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x s16>)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; SI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x f16>)
     ;
-    ; VI-LABEL: name: test_fsqrt_v2s16
+    ; VI-LABEL: name: test_fsqrt_v2f16
     ; VI: liveins: $vgpr0
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC]]
-    ; VI-NEXT: [[FSQRT1:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC1]]
-    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT]](s16)
-    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT1]](s16)
+    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC]]
+    ; VI-NEXT: [[FSQRT1:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC1]]
+    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT]](f16)
+    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT1]](f16)
     ; VI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; VI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; VI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x s16>)
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; VI-NEXT: $vgpr0 = COPY [[BITCAST1]](<2 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fsqrt_v2s16
+    ; GFX9-LABEL: name: test_fsqrt_v2f16
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[COPY]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC]]
-    ; GFX9-NEXT: [[FSQRT1:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC1]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FSQRT]](s16), [[FSQRT1]](s16)
-    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x s16>)
-    %0:_(<2 x s16>) = COPY $vgpr0
-    %1:_(<2 x s16>) = G_FSQRT %0
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC]]
+    ; GFX9-NEXT: [[FSQRT1:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC1]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FSQRT]](f16), [[FSQRT1]](f16)
+    ; GFX9-NEXT: $vgpr0 = COPY [[BUILD_VECTOR]](<2 x f16>)
+    %0:_(<2 x f16>) = COPY $vgpr0
+    %1:_(<2 x f16>) = G_FSQRT %0
     $vgpr0 = COPY %1
 ...
 
 ---
-name: test_fsqrt_v3s16
+name: test_fsqrt_v3f16
 body: |
   bb.0:
 
-    ; SI-LABEL: name: test_fsqrt_v3s16
-    ; SI: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](s16)
+    ; SI-LABEL: name: test_fsqrt_v3f16
+    ; SI: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](f16)
     ; SI-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT]](f32)
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT]](f32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](s16)
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](f16)
     ; SI-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT1]](f32)
-    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT1]](f32)
-    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](s16)
+    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT1]](f32)
+    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[DEF]](f16)
     ; SI-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT2]](f32)
-    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT2]](f32)
-    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC1]](s16)
-    ; SI-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FPTRUNC2]](s16)
-    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT2]](f32)
+    ; SI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC1]](f16)
+    ; SI-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FPTRUNC2]](f16)
+    ; SI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; SI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; VI-LABEL: name: test_fsqrt_v3s16
-    ; VI: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[DEF]]
-    ; VI-NEXT: [[FSQRT1:%[0-9]+]]:_(s16) = G_FSQRT [[DEF]]
-    ; VI-NEXT: [[FSQRT2:%[0-9]+]]:_(s16) = G_FSQRT [[DEF]]
-    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT]](s16)
-    ; VI-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT1]](s16)
-    ; VI-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT2]](s16)
-    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
+    ; VI-LABEL: name: test_fsqrt_v3f16
+    ; VI: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[DEF]]
+    ; VI-NEXT: [[FSQRT1:%[0-9]+]]:_(f16) = G_FSQRT [[DEF]]
+    ; VI-NEXT: [[FSQRT2:%[0-9]+]]:_(f16) = G_FSQRT [[DEF]]
+    ; VI-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT]](f16)
+    ; VI-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT1]](f16)
+    ; VI-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT2]](f16)
+    ; VI-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; VI-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
     ;
-    ; GFX9-LABEL: name: test_fsqrt_v3s16
-    ; GFX9: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[DEF]]
-    ; GFX9-NEXT: [[FSQRT1:%[0-9]+]]:_(s16) = G_FSQRT [[DEF]]
-    ; GFX9-NEXT: [[FSQRT2:%[0-9]+]]:_(s16) = G_FSQRT [[DEF]]
-    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT]](s16)
-    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT1]](s16)
-    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(s32) = G_ANYEXT [[FSQRT2]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[ANYEXT]](s32), [[ANYEXT1]](s32), [[ANYEXT2]](s32)
-    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x s32>)
-    %0:_(<3 x s16>) = G_IMPLICIT_DEF
-    %1:_(<3 x s16>) = G_FSQRT %0
-    %2:_(<3 x s32>) = G_ANYEXT %1
+    ; GFX9-LABEL: name: test_fsqrt_v3f16
+    ; GFX9: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[DEF]]
+    ; GFX9-NEXT: [[FSQRT1:%[0-9]+]]:_(f16) = G_FSQRT [[DEF]]
+    ; GFX9-NEXT: [[FSQRT2:%[0-9]+]]:_(f16) = G_FSQRT [[DEF]]
+    ; GFX9-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT]](f16)
+    ; GFX9-NEXT: [[ANYEXT1:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT1]](f16)
+    ; GFX9-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[FSQRT2]](f16)
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<3 x i32>) = G_BUILD_VECTOR [[ANYEXT]](i32), [[ANYEXT1]](i32), [[ANYEXT2]](i32)
+    ; GFX9-NEXT: S_NOP 0, implicit [[BUILD_VECTOR]](<3 x i32>)
+    %0:_(<3 x f16>) = G_IMPLICIT_DEF
+    %1:_(<3 x f16>) = G_FSQRT %0
+    %2:_(<3 x i32>) = G_ANYEXT %1
     S_NOP 0, implicit %2
 ...
 
 ---
-name: test_fsqrt_v4s16
+name: test_fsqrt_v4f16
 body: |
   bb.0:
     liveins: $vgpr0_vgpr1
 
-    ; SI-LABEL: name: test_fsqrt_v4s16
+    ; SI-LABEL: name: test_fsqrt_v4f16
     ; SI: liveins: $vgpr0_vgpr1
     ; SI-NEXT: {{  $}}
-    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; SI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; SI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; SI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x s16>)
-    ; SI-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; SI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; SI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x f16>)
+    ; SI-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; SI-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; SI-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](s16)
+    ; SI-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; SI-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC]](f16)
     ; SI-NEXT: [[INT:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT]](f32)
-    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT]](f32)
-    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](s16)
+    ; SI-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT]](f32)
+    ; SI-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC1]](f16)
     ; SI-NEXT: [[INT1:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT1]](f32)
-    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT1]](f32)
-    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](s16)
+    ; SI-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT1]](f32)
+    ; SI-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC2]](f16)
     ; SI-NEXT: [[INT2:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT2]](f32)
-    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT2]](f32)
-    ; SI-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](s16)
+    ; SI-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT2]](f32)
+    ; SI-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[TRUNC3]](f16)
     ; SI-NEXT: [[INT3:%[0-9]+]]:_(f32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[FPEXT3]](f32)
-    ; SI-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[INT3]](f32)
-    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](s16)
-    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](s16)
+    ; SI-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[INT3]](f32)
+    ; SI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC]](f16)
+    ; SI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC1]](f16)
     ; SI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; SI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; SI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC2]](s16)
-    ; SI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC3]](s16)
+    ; SI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; SI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC2]](f16)
+    ; SI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FPTRUNC3]](f16)
     ; SI-NEXT: [[SHL1:%[0-9]+]]:_(i32) = G_SHL [[ZEXT3]], [[C]](i32)
     ; SI-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[ZEXT2]], [[SHL1]]
-    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](i32)
-    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x s16>), [[BITCAST3]](<2 x s16>)
-    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; SI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR1]](i32)
+    ; SI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x f16>), [[BITCAST3]](<2 x f16>)
+    ; SI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; VI-LABEL: name: test_fsqrt_v4s16
+    ; VI-LABEL: name: test_fsqrt_v4f16
     ; VI: liveins: $vgpr0_vgpr1
     ; VI-NEXT: {{  $}}
-    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; VI-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; VI-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; VI-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x s16>)
-    ; VI-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; VI-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; VI-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x f16>)
+    ; VI-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; VI-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; VI-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC]]
-    ; VI-NEXT: [[FSQRT1:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC1]]
-    ; VI-NEXT: [[FSQRT2:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC2]]
-    ; VI-NEXT: [[FSQRT3:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC3]]
-    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT]](s16)
-    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT1]](s16)
+    ; VI-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; VI-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC]]
+    ; VI-NEXT: [[FSQRT1:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC1]]
+    ; VI-NEXT: [[FSQRT2:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC2]]
+    ; VI-NEXT: [[FSQRT3:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC3]]
+    ; VI-NEXT: [[ZEXT:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT]](f16)
+    ; VI-NEXT: [[ZEXT1:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT1]](f16)
     ; VI-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[ZEXT1]], [[C]](i32)
     ; VI-NEXT: [[OR:%[0-9]+]]:_(i32) = G_OR [[ZEXT]], [[SHL]]
-    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](i32)
-    ; VI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT2]](s16)
-    ; VI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT3]](s16)
+    ; VI-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR]](i32)
+    ; VI-NEXT: [[ZEXT2:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT2]](f16)
+    ; VI-NEXT: [[ZEXT3:%[0-9]+]]:_(i32) = G_ZEXT [[FSQRT3]](f16)
     ; VI-NEXT: [[SHL1:%[0-9]+]]:_(i32) = G_SHL [[ZEXT3]], [[C]](i32)
     ; VI-NEXT: [[OR1:%[0-9]+]]:_(i32) = G_OR [[ZEXT2]], [[SHL1]]
-    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](i32)
-    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x s16>), [[BITCAST3]](<2 x s16>)
-    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
+    ; VI-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x f16>) = G_BITCAST [[OR1]](i32)
+    ; VI-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[BITCAST2]](<2 x f16>), [[BITCAST3]](<2 x f16>)
+    ; VI-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
     ;
-    ; GFX9-LABEL: name: test_fsqrt_v4s16
+    ; GFX9-LABEL: name: test_fsqrt_v4f16
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST]](i32)
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    ; GFX9-NEXT: [[UV:%[0-9]+]]:_(<2 x f16>), [[UV1:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(i32) = G_BITCAST [[UV]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST]](i32)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 16
     ; GFX9-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR]](i32)
-    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x s16>)
-    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(s16) = G_TRUNC [[BITCAST1]](i32)
+    ; GFX9-NEXT: [[TRUNC1:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR]](i32)
+    ; GFX9-NEXT: [[BITCAST1:%[0-9]+]]:_(i32) = G_BITCAST [[UV1]](<2 x f16>)
+    ; GFX9-NEXT: [[TRUNC2:%[0-9]+]]:_(f16) = G_TRUNC [[BITCAST1]](i32)
     ; GFX9-NEXT: [[LSHR1:%[0-9]+]]:_(i32) = G_LSHR [[BITCAST1]], [[C]](i32)
-    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(s16) = G_TRUNC [[LSHR1]](i32)
-    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC]]
-    ; GFX9-NEXT: [[FSQRT1:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC1]]
-    ; GFX9-NEXT: [[FSQRT2:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC2]]
-    ; GFX9-NEXT: [[FSQRT3:%[0-9]+]]:_(s16) = G_FSQRT [[TRUNC3]]
-    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FSQRT]](s16), [[FSQRT1]](s16)
-    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[FSQRT2]](s16), [[FSQRT3]](s16)
-    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BUILD_VECTOR]](<2 x s16>), [[BUILD_VECTOR1]](<2 x s16>)
-    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x s16>)
-    %0:_(<4 x s16>) = COPY $vgpr0_vgpr1
-    %1:_(<4 x s16>) = G_FSQRT %0
+    ; GFX9-NEXT: [[TRUNC3:%[0-9]+]]:_(f16) = G_TRUNC [[LSHR1]](i32)
+    ; GFX9-NEXT: [[FSQRT:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC]]
+    ; GFX9-NEXT: [[FSQRT1:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC1]]
+    ; GFX9-NEXT: [[FSQRT2:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC2]]
+    ; GFX9-NEXT: [[FSQRT3:%[0-9]+]]:_(f16) = G_FSQRT [[TRUNC3]]
+    ; GFX9-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FSQRT]](f16), [[FSQRT1]](f16)
+    ; GFX9-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f16>) = G_BUILD_VECTOR [[FSQRT2]](f16), [[FSQRT3]](f16)
+    ; GFX9-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f16>) = G_CONCAT_VECTORS [[BUILD_VECTOR]](<2 x f16>), [[BUILD_VECTOR1]](<2 x f16>)
+    ; GFX9-NEXT: $vgpr0_vgpr1 = COPY [[CONCAT_VECTORS]](<4 x f16>)
+    %0:_(<4 x f16>) = COPY $vgpr0_vgpr1
+    %1:_(<4 x f16>) = G_FSQRT %0
     $vgpr0_vgpr1 = COPY %1
 ...


### PR DESCRIPTION
Migrate G_FNEG, G_FABS, G_FSQRT, G_FFLOOR, G_FLDEXP, G_STRICT_FLDEXP, G_FCMP, and G_IS_FPCLASS to extended LLTs.

Remove redundant scalar clamps that request unsupported f128-to-f64 narrowing.

Update the relevant MIR tests.