### PR TITLE
[lld][macho] Fold functions with the same Dwarf FDE

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -628,8 +628,10 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
             continue;
           // Zero out "abs-ified" relocation section data so we can fold them
           MutableArrayRef<uint8_t> copy = unwindIsec->data.copy(bAlloc());
-          for (const auto &[offset, size] : fdesIt->second.absifiedRanges)
+          for (const auto &[offset, size] : fdesIt->second.absifiedRanges) {
+            assert(offset + size <= copy.size());
             memset(copy.data() + offset, 0, size);
+          }
           unwindIsec->data = copy;
         }
       }

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -623,7 +623,8 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
           if (!obj)
             continue;
           auto fdesIt = obj->fdes.find(unwindIsec);
-          if (fdesIt == obj->fdes.end() || fdesIt->second.absifiedRanges.empty())
+          if (fdesIt == obj->fdes.end() ||
+              fdesIt->second.absifiedRanges.empty())
             continue;
           // Zero out "abs-ified" relocation section data so we can fold them
           MutableArrayRef<uint8_t> copy = unwindIsec->data.copy(bAlloc());

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -615,9 +615,23 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
                       !isec->shouldOmitFromOutput() && hasFoldableFlags;
     if (isFoldable) {
       foldable.push_back(isec);
-      for (Defined *d : isec->symbols)
-        if (d->unwindEntry())
-          foldable.push_back(d->unwindEntry());
+      for (Defined *d : isec->symbols) {
+        if (auto *unwindIsec = d->unwindEntry()) {
+          foldable.push_back(unwindIsec);
+
+          auto *obj = dyn_cast_or_null<ObjFile>(unwindIsec->getFile());
+          if (!obj)
+            continue;
+          auto fdesIt = obj->fdes.find(unwindIsec);
+          if (fdesIt == obj->fdes.end() || fdesIt->second.absifiedRanges.empty())
+            continue;
+          // Zero out "abs-ified" relocation section data so we can fold them
+          MutableArrayRef<uint8_t> copy = unwindIsec->data.copy(bAlloc());
+          for (const auto &[offset, size] : fdesIt->second.absifiedRanges)
+            memset(copy.data() + offset, 0, size);
+          unwindIsec->data = copy;
+        }
+      }
 
       // Some sections have embedded addends that foil ICF's hashing / equality
       // checks. (We can ignore embedded addends when doing ICF because the same

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -633,9 +633,16 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
                               /*relocVA=*/0);
         isec->data = copy;
       }
-    } else if (!isEhFrameSection(isec)) {
-      // EH frames are gathered as foldables from unwindEntry above; give a
-      // unique ID to everything else.
+    } else if (isEhFrameSection(isec)) {
+      // An __eh_frame isec that is not an FDE is a CIE, which is not gather via
+      // unwindEntry() above. Mark them as foldable to compute icfEqClass for
+      // them
+      auto *obj = dyn_cast_or_null<ObjFile>(isec->getFile());
+      if (!onlyCfStrings && obj && !obj->fdes.contains(isec) &&
+          !isec->shouldOmitFromOutput())
+        foldable.push_back(isec);
+    } else {
+      // give a unique ID to everything else
       isec->icfEqClass[0] = ++icfUniqueID;
     }
   }

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -1560,7 +1560,7 @@ void ObjFile::registerEhFrames(Section &ehFrameSection) {
       ehRelocator.makePcRel(lsdaAddrOff, lsdaIsec, target->p2WordSize);
     }
 
-    SmallVector<std::pair<uint32_t, uint8_t>> absifiedRanges;
+    SmallVector<std::pair<uint32_t, uint8_t>, 3> absifiedRanges;
     if (config->icfLevel != ICFLevel::none) {
       // "abs-ified" relocations can have data embedded in their section data.
       // Record these offsets so ICF can fold these sections
@@ -1569,7 +1569,8 @@ void ObjFile::registerEhFrames(Section &ehFrameSection) {
       if (lsdaIsec)
         absifiedRanges.emplace_back(lsdaAddrOff, cie.lsdaPtrSize);
     }
-    fdes[isec] = {funcLength, cie.personalitySymbol, lsdaIsec, absifiedRanges};
+    fdes[isec] = {funcLength, cie.personalitySymbol, lsdaIsec,
+                  std::move(absifiedRanges)};
     funcSym->originalUnwindEntry = isec;
     ehRelocator.commit();
   }

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -1560,22 +1560,18 @@ void ObjFile::registerEhFrames(Section &ehFrameSection) {
       ehRelocator.makePcRel(lsdaAddrOff, lsdaIsec, target->p2WordSize);
     }
 
-    fdes[isec] = {funcLength, cie.personalitySymbol, lsdaIsec};
+    SmallVector<std::pair<uint32_t, uint8_t>> absifiedRanges;
+    if (config->icfLevel != ICFLevel::none) {
+      // "abs-ified" relocations can have data embedded in their section data.
+      // Record these offsets so ICF can fold these sections
+      absifiedRanges.emplace_back(funcAddrOff, cie.funcPtrSize);
+      absifiedRanges.emplace_back(cieOffOff, sizeof(uint32_t));
+      if (lsdaIsec)
+        absifiedRanges.emplace_back(lsdaAddrOff, cie.lsdaPtrSize);
+    }
+    fdes[isec] = {funcLength, cie.personalitySymbol, lsdaIsec, absifiedRanges};
     funcSym->originalUnwindEntry = isec;
     ehRelocator.commit();
-    if (config->icfLevel != ICFLevel::none) {
-      // Zero out "abs-ified" relocations so ICF can fold them
-      MutableArrayRef<uint8_t> copy = isec->data.copy(bAlloc());
-      assert(isec->getRelocAt(funcAddrOff));
-      memset(copy.data() + funcAddrOff, 0, cie.funcPtrSize);
-      assert(isec->getRelocAt(cieOffOff));
-      memset(copy.data() + cieOffOff, 0, sizeof(uint32_t));
-      if (lsdaIsec) {
-        assert(isec->getRelocAt(lsdaAddrOff));
-        memset(copy.data() + lsdaAddrOff, 0, cie.lsdaPtrSize);
-      }
-      isec->data = copy;
-    }
   }
 
   // __eh_frame is marked as S_ATTR_LIVE_SUPPORT in input files, because FDEs

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -1563,6 +1563,19 @@ void ObjFile::registerEhFrames(Section &ehFrameSection) {
     fdes[isec] = {funcLength, cie.personalitySymbol, lsdaIsec};
     funcSym->originalUnwindEntry = isec;
     ehRelocator.commit();
+    if (config->icfLevel != ICFLevel::none) {
+      // Zero out "abs-ified" relocations so ICF can fold them
+      MutableArrayRef<uint8_t> copy = isec->data.copy(bAlloc());
+      assert(isec->getRelocAt(funcAddrOff));
+      memset(copy.data() + funcAddrOff, 0, cie.funcPtrSize);
+      assert(isec->getRelocAt(cieOffOff));
+      memset(copy.data() + cieOffOff, 0, sizeof(uint32_t));
+      if (lsdaIsec) {
+        assert(isec->getRelocAt(lsdaAddrOff));
+        memset(copy.data() + lsdaAddrOff, 0, cie.lsdaPtrSize);
+      }
+      isec->data = copy;
+    }
   }
 
   // __eh_frame is marked as S_ATTR_LIVE_SUPPORT in input files, because FDEs

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -154,7 +154,7 @@ struct FDE {
   uint32_t funcLength;
   Symbol *personality;
   InputSection *lsda;
-  SmallVector<std::pair<uint32_t, uint8_t>> absifiedRanges;
+  SmallVector<std::pair<uint32_t, uint8_t>, 3> absifiedRanges;
 };
 
 // .o file

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -154,6 +154,7 @@ struct FDE {
   uint32_t funcLength;
   Symbol *personality;
   InputSection *lsda;
+  SmallVector<std::pair<uint32_t, uint8_t>> absifiedRanges;
 };
 
 // .o file

--- a/lld/test/MachO/fold-dwarf-lsda.s
+++ b/lld/test/MachO/fold-dwarf-lsda.s
@@ -22,7 +22,7 @@
 # POST: [[#%x,EXCEPT_ADDR:]] l   O __TEXT,__gcc_except_tab GCC_except_table0
 # POST: [[#%x,EXCEPT_ADDR]]  l   O __TEXT,__gcc_except_tab GCC_except_table1
 # POST: [[#%.16x,F0_ADDR:]]  g   F __TEXT,__text _f0
-# POST: [[#%.16x,F1_ADDR:]]  g   F __TEXT,__text _f1
+# POST: [[#%.16x,F0_ADDR]]   g   F __TEXT,__text _f1
 # POST: [[#%.16x,G_ADDR:]]   g   F __TEXT,__text _g
 
 # POST-LABEL: .eh_frame contents:
@@ -31,10 +31,6 @@
 # POST: {{.*}} FDE cie={{.+}} pc=[[#%x,F0_ADDR]]...{{.+}}
 # POST: Format:       DWARF32 
 # POST: LSDA Address: [[#%.16x,EXCEPT_ADDR]]
-
-# POST: {{.*}} FDE cie={{.+}} pc=[[#%x,F1_ADDR]]...{{.+}}
-# POST Format:       DWARF32 
-# POST LSDA Address: [[#%.16x,EXCEPT_ADDR]]
 
 	.section        __TEXT,__text,regular,pure_instructions
 	.globl	_f0

--- a/lld/test/MachO/icf-fold-dwarf-frame.s
+++ b/lld/test/MachO/icf-fold-dwarf-frame.s
@@ -1,0 +1,173 @@
+# REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11 %s -o %t.o
+# RUN: %lld -arch arm64 %t.o -o %t.dylib -undefined dynamic_lookup --icf=all
+# RUN: llvm-objdump --macho --syms --dwarf=frames --unwind-info %t.dylib | FileCheck %s
+
+# CHECK-LABEL: SYMBOL TABLE:
+# CHECK-DAG:  [[#%.16x,FOLD0:]] {{.*}} __TEXT,__text _foldA
+# CHECK-DAG:  [[#FOLD0]]        {{.*}} __TEXT,__text _foldB
+# CHECK-DAG:  [[#FOLD0]]        {{.*}} __TEXT,__text _foldC
+# CHECK-NOT:  [[#FOLD0]]        {{.*}} __TEXT,__text _diffLSDA
+# CHECK-NOT:  [[#FOLD0]]        {{.*}} __TEXT,__text _diffPersonality
+# CHECK-NOT:  [[#FOLD0]]        {{.*}} __TEXT,__text _diffCFI
+# CHECK-DAG:  [[#%.16x,FOLD1:]] {{.*}} __TEXT,__gcc_except_tab GCC_except_table0
+# CHECK-DAG:  [[#FOLD1]]        {{.*}} __TEXT,__gcc_except_tab GCC_except_table1
+# CHECK-NOT:  [[#FOLD1]]        {{.*}} __TEXT,__gcc_except_tab GCC_except_table2
+
+# CHECK-LABEL: Contents of __unwind_info section:
+
+# CHECK-LABEL: .eh_frame contents:
+# CHECK: {{^}}[[#%.8x,CIE0:]] {{.*}} CIE
+# CHECK: FDE cie=[[#%.8x,CIE0]]
+# CHECK: FDE cie=[[#%.8x,CIE0]]
+# CHECK: FDE cie=[[#%.8x,CIE0]]
+# CHECK: FDE cie=[[#%.8x,CIE0]]
+# CHECK: {{^}}[[#%.8x,CIE1:]] {{.*}} CIE
+# CHECK: FDE cie=[[#%.8x,CIE1]]
+# CHECK: FDE cie=[[#%.8x,CIE1]]
+
+# Due to padding, we need to emit a throwaway FDE for each personality, so that
+# subsequent FDEs are the same size and can be folded
+# TODO: Could we detect padding differences and fold anyway?
+_padA:
+  .cfi_startproc
+  .cfi_personality 155, _p0
+  .cfi_lsda 16, Lexception0
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+_padB:
+  .cfi_startproc
+  .cfi_personality 155, _p1
+  .cfi_lsda 16, Lexception0
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+_foldA:
+  .cfi_startproc
+  .cfi_personality 155, _p0
+  .cfi_lsda 16, Lexception0
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+_foldB:
+  .cfi_startproc
+  .cfi_personality 155, _p0
+  .cfi_lsda 16, Lexception0
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+# LSDA points to a different symbol, but the contents are the same as Lexception1 so it can be folded
+_foldC:
+  .cfi_startproc
+  .cfi_personality 155, _p0
+  .cfi_lsda 16, Lexception1
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+# Different LSDAs cannot be folded
+_diffLSDA:
+  .cfi_startproc
+  .cfi_personality 155, _p0
+  .cfi_lsda 16, Lexception2
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+_diffPersonality:
+  .cfi_startproc
+  .cfi_personality 155, _p1
+  .cfi_lsda 16, Lexception0
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 16
+  .cfi_offset w30, -16
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+_diffCFI:
+  .cfi_startproc
+  .cfi_personality 155, _p0
+  .cfi_lsda 16, Lexception0
+  str x30, [sp, #-16]!
+  .cfi_def_cfa_offset 160
+  .cfi_offset w30, -160
+  bl _may_throw
+  ldr x30, [sp], #16
+  ret
+  .cfi_endproc
+
+.section __TEXT,__gcc_except_tab
+.p2align 2
+GCC_except_table0:
+Lexception0:
+  .byte 0xFF
+  .byte 0x9B
+  .uleb128 Lttbase0-Lttbaseref0
+Lttbaseref0:
+  .byte 1
+  .uleb128 0
+  .p2align 2
+  .long 0
+Lttbase0:
+
+# Contents are identical to above. It should be folded
+.p2align 2
+GCC_except_table1:
+Lexception1:
+  .byte 0xFF
+  .byte 0x9B
+  .uleb128 Lttbase1-Lttbaseref1
+Lttbaseref1:
+  .byte 1
+  .uleb128 0
+  .p2align 2
+  .long 0
+Lttbase1:
+
+.p2align 2
+GCC_except_table2:
+Lexception2:
+  .byte 0xFF
+  .byte 0x9B
+  .uleb128 Lttbase2-Lttbaseref2
+Lttbaseref2:
+  .byte 1
+  .uleb128 1
+  .byte 0xAA
+  .p2align 2
+  .long 0
+Lttbase2:
+
+.subsections_via_symbols

--- a/lld/test/MachO/icf.s
+++ b/lld/test/MachO/icf.s
@@ -40,8 +40,8 @@
 # CHECK: [[#%x,HAS_UNWIND_4:]]              l     F __TEXT,__text _has_unwind_4
 # CHECK: [[#%x,HAS_ABS_PERSONALITY_1:]]     l     F __TEXT,__text _has_abs_personality_1
 # CHECK: [[#%x,HAS_ABS_PERSONALITY_2:]]     l     F __TEXT,__text _has_abs_personality_2
-# CHECK: [[#%x,HAS_EH_FRAME_1:]]            l     F __TEXT,__text _has_eh_frame_1
-# CHECK: [[#%x,HAS_EH_FRAME_2:]]            l     F __TEXT,__text _has_eh_frame_2
+# CHECK: [[#%x,HAS_EH_FRAME_2:]]            l     F __TEXT,__text _has_eh_frame_1
+# CHECK: [[#%x,HAS_EH_FRAME_2]]             l     F __TEXT,__text _has_eh_frame_2
 # CHECK: [[#%x,HAS_EH_FRAME_3:]]            l     F __TEXT,__text _has_eh_frame_3
 # CHECK: [[#%x,MUTALLY_RECURSIVE_2:]]       l     F __TEXT,__text _mutually_recursive_1
 # CHECK: [[#%x,MUTALLY_RECURSIVE_2]]        l     F __TEXT,__text _mutually_recursive_2
@@ -55,8 +55,6 @@
 # CHECK: [[#%x,GCC_EXCEPT_0]]               l     O __TEXT,__gcc_except_tab GCC_except_table1
 # CHECK: [[#%x,GCC_EXCEPT_2:]]              l     O __TEXT,__gcc_except_tab GCC_except_table2
 
-## Check that we don't accidentally dedup distinct EH frames.
-# CHECK: FDE {{.*}} pc=[[#%x,HAS_EH_FRAME_1]]
 # CHECK: FDE {{.*}} pc=[[#%x,HAS_EH_FRAME_2]]
 # CHECK: FDE {{.*}} pc=[[#%x,HAS_EH_FRAME_3]]
 
@@ -89,7 +87,7 @@
 # CHECK: callq 0x[[#%x,HAS_UNWIND_4]]              <_has_unwind_4>
 # CHECK: callq 0x[[#%x,HAS_ABS_PERSONALITY_1]]     <_has_abs_personality_1>
 # CHECK: callq 0x[[#%x,HAS_ABS_PERSONALITY_2]]     <_has_abs_personality_2>
-# CHECK: callq 0x[[#%x,HAS_EH_FRAME_1]]            <_has_eh_frame_1>
+# CHECK: callq 0x[[#%x,HAS_EH_FRAME_2]]            <_has_eh_frame_2>
 # CHECK: callq 0x[[#%x,HAS_EH_FRAME_2]]            <_has_eh_frame_2>
 # CHECK: callq 0x[[#%x,HAS_EH_FRAME_3]]            <_has_eh_frame_3>
 # CHECK: callq 0x[[#%x,MUTALLY_RECURSIVE_2]]       <_mutually_recursive_2>
@@ -261,8 +259,6 @@ _has_abs_personality_2:
 _abs_personality_1 = 0x1
 _abs_personality_2 = 0x2
 
-## In theory _has_eh_frame_{1, 2} can be dedup'ed, but we don't support this
-## yet.
 _has_eh_frame_1:
   .cfi_startproc
   .cfi_def_cfa_offset 8


### PR DESCRIPTION
Functions with Dwarf FDE were not folded by ICF prior to this diff because the `_eh_frame` section contains "abs-ified" relocations.

https://github.com/llvm/llvm-project/blob/7d9580d588df77aa5128055b006a90de9442a994/lld/MachO/InputFiles.cpp#L1434-L1437

To fix, we zero out this data so that ICF can correctly match duplicate section data. This is safe because `registerEhFrames()` generates relocations from this "abs-ified" data, which will overwrite the correct data later.

LLM assisted. I claim authorship and responsibility.