### PR TITLE
[analyzer] Discard stack frames that are not on the current live stack

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -52,9 +52,17 @@ static bool isDanglingStackSource(const MemRegion *Source,
         })) {
       return false;
     }
-
-    if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
-      return true;
+    // Only a source whose frame is still live on the current stack can
+    // dangle. If that frame is not on the stack then the source outlives
+    // the returned value. The source is still alive when the returned value
+    // is used, so it does not dangle.
+    if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
+          if (&Frame != SF)
+            return false;
+          return true;
+        }))
+      if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
+        return true;
   }
   return false;
 }
@@ -117,7 +125,27 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
         State = bindSource(State, RetVal, ArgValRegion);
     }
   }
+  /*
+  auto ViewObj = Call.getReturnValue().getAs<nonloc::LazyCompoundVal>();
+  llvm::errs() << ViewObj << "\n";
+  RetVal.dump();
+  if (!ViewObj)
+    return;
 
+  llvm::errs() << ViewObj;
+  const MemRegion *LCVRegion = ViewObj->getRegion();
+  if (!LCVRegion)
+    return;
+  llvm::errs() << LCVRegion << "\n";
+  for (const ParmVarDecl *PVD : FD->parameters()) {
+    if (PVD->hasAttr<LifetimeBoundAttr>()) {
+      unsigned Idx = PVD->getFunctionScopeIndex();
+      SVal Arg = Call.getArgSVal(Idx);
+      if (const MemRegion *ArgValRegion = Arg.getAsRegion())
+        State = bindSource(State, RetVal, ArgValRegion);
+    }
+  }
+  */
   const auto *IC = dyn_cast<CXXInstanceCall>(&Call);
   if (IC && lifetimes::implicitObjectParamIsLifetimeBound(FD)) {
     if (const MemRegion *ThisRegion = IC->getCXXThisVal().getAsRegion())

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -56,11 +56,10 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // dangle. If that frame is not on the stack then the source outlives
     // the returned value. The source is still alive when the returned value
     // is used, so it does not dangle.
-    if (llvm::any_of(C.stackframes(),
-                     [&](const StackFrame &Frame) { return &Frame == SF; }))
+    return is_contained(make_pointer_range(C.stackframes()), SF);
 
-      if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
-        return true;
+    if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
+      return true;
   }
   return false;
 }

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -58,9 +58,7 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // is used, so it does not dangle.
     /*
     if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
-          if (&Frame != SF)
-            return false;
-          return true;
+          return &Frame == SF;
         }))
     */
     if (SF == CurrentSF || !SF->isParentOf(CurrentSF))

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -56,13 +56,11 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // dangle. If that frame is not on the stack then the source outlives
     // the returned value. The source is still alive when the returned value
     // is used, so it does not dangle.
-    /*
-    if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
-          return &Frame == SF;
-        }))
-    */
-    if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
-      return true;
+    if (llvm::any_of(C.stackframes(),
+                     [&](const StackFrame &Frame) { return &Frame == SF; }))
+
+      if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
+        return true;
   }
   return false;
 }
@@ -92,7 +90,6 @@ static ProgramStateRef bindSource(ProgramStateRef State, SVal RetVal,
   LifetimeSourceSet Set = LSet ? *LSet : F.getEmptySet();
   Set = F.add(Set, Source);
   State = State->set<LifetimeBoundMap>(RetVal, Set);
-
   return State;
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -56,10 +56,10 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // dangle. If that frame is not on the stack then the source outlives
     // the returned value. The source is still alive when the returned value
     // is used, so it does not dangle.
-    return is_contained(make_pointer_range(C.stackframes()), SF);
-
-    if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
-      return true;
+    if (is_contained(make_pointer_range(C.stackframes()), SF)) {
+      if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
+        return true;
+    }
   }
   return false;
 }

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -92,6 +92,7 @@ static ProgramStateRef bindSource(ProgramStateRef State, SVal RetVal,
   LifetimeSourceSet Set = LSet ? *LSet : F.getEmptySet();
   Set = F.add(Set, Source);
   State = State->set<LifetimeBoundMap>(RetVal, Set);
+
   return State;
 }
 
@@ -125,27 +126,7 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
         State = bindSource(State, RetVal, ArgValRegion);
     }
   }
-  /*
-  auto ViewObj = Call.getReturnValue().getAs<nonloc::LazyCompoundVal>();
-  llvm::errs() << ViewObj << "\n";
-  RetVal.dump();
-  if (!ViewObj)
-    return;
 
-  llvm::errs() << ViewObj;
-  const MemRegion *LCVRegion = ViewObj->getRegion();
-  if (!LCVRegion)
-    return;
-  llvm::errs() << LCVRegion << "\n";
-  for (const ParmVarDecl *PVD : FD->parameters()) {
-    if (PVD->hasAttr<LifetimeBoundAttr>()) {
-      unsigned Idx = PVD->getFunctionScopeIndex();
-      SVal Arg = Call.getArgSVal(Idx);
-      if (const MemRegion *ArgValRegion = Arg.getAsRegion())
-        State = bindSource(State, RetVal, ArgValRegion);
-    }
-  }
-  */
   const auto *IC = dyn_cast<CXXInstanceCall>(&Call);
   if (IC && lifetimes::implicitObjectParamIsLifetimeBound(FD)) {
     if (const MemRegion *ThisRegion = IC->getCXXThisVal().getAsRegion())

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -56,13 +56,15 @@ static bool isDanglingStackSource(const MemRegion *Source,
     // dangle. If that frame is not on the stack then the source outlives
     // the returned value. The source is still alive when the returned value
     // is used, so it does not dangle.
+    /*
     if (llvm::any_of(C.stackframes(), [&](const StackFrame &Frame) {
           if (&Frame != SF)
             return false;
           return true;
         }))
-      if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
-        return true;
+    */
+    if (SF == CurrentSF || !SF->isParentOf(CurrentSF))
+      return true;
   }
   return false;
 }

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -379,16 +379,21 @@ CustomStringView dangling_sv() {
   return CustomStringView(s); // expected-warning {{address of stack memory associated with local variable 's' returned}} 
 }
 
-struct Chained {
-  Chained &self() [[clang::lifetimebound]] { return *this; }
-  Chained() {
+// `self()` is annotated [[clang::lifetimebound]], so its return is bound to
+// *this. The BoundToSelf instance is built as a by-value argument temporary,
+// so its frame is not live on the stack when self() returns. 
+struct BoundToSelf {
+  BoundToSelf &self() [[clang::lifetimebound]] { return *this; } // no-warning
+  BoundToSelf() {
     self();
-    self(); // no-warning
+    self();
   }
 };
 
-void takes_by_value(Chained arg);
+void takes_by_value(BoundToSelf arg);
 
 void no_dangling_by_value_argument() {
-  takes_by_value(Chained()); // no-warning
+  // The BoundToSelf temporary's frame is not live on the stack when `self()` returns.
+  // The returned reference does not dangle.
+  takes_by_value(BoundToSelf());
 }

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -378,3 +378,17 @@ CustomStringView dangling_sv() {
   char s[] = "dangling";
   return CustomStringView(s); // expected-warning {{address of stack memory associated with local variable 's' returned}} 
 }
+
+struct Chained {
+  Chained &self() [[clang::lifetimebound]] { return *this; }
+  Chained() {
+    self();
+    self(); // no-warning
+  }
+};
+
+void takes_by_value(Chained arg);
+
+void no_dangling_by_value_argument() {
+  takes_by_value(Chained()); // no-warning
+}


### PR DESCRIPTION
When a source's stack frame is not live on the current stack the `UseAfterLifetimeEnd` checker emitted a false positive. Such sources outlive the returned value, so they are not dangling stack sources. This led to multiple false positives when I ran the `UseAfterLifetimeEnd` checker on the LLVM project. 