### PR TITLE
[SPIR-V] Preserve float types through wide float shuffles and atan2 legalization

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -154,6 +154,7 @@ static SPIRVTypeInst deduceTypeFromUses(Register Reg, MachineFunction &MF,
     LLVM_DEBUG(dbgs() << "Looking at use " << Use);
     switch (Use.getOpcode()) {
     case TargetOpcode::G_BUILD_VECTOR:
+    case TargetOpcode::G_SHUFFLE_VECTOR:
     case TargetOpcode::G_EXTRACT_VECTOR_ELT:
     case TargetOpcode::G_UNMERGE_VALUES:
     case TargetOpcode::G_ADD:
@@ -169,6 +170,7 @@ static SPIRVTypeInst deduceTypeFromUses(Register Reg, MachineFunction &MF,
     case TargetOpcode::G_FDIV:
     case TargetOpcode::G_FREM:
     case TargetOpcode::G_FMA:
+    case TargetOpcode::G_FATAN2:
     case TargetOpcode::COPY:
     case TargetOpcode::G_STRICT_FMA:
       ResType = deduceTypeFromResultRegister(&Use, Reg, GR, MIB);

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan2_mat.ll
@@ -52,6 +52,7 @@
 @wide_f16_12 = internal addrspace(10) global [12 x half] zeroinitializer
 @wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
 @wide_f16_16 = internal addrspace(10) global [16 x half] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
 @mat_f32_4x4 = internal addrspace(10) global [4 x <4 x float>] zeroinitializer
 @mat_f16_4x4 = internal addrspace(10) global [4 x <4 x half>] zeroinitializer
 @mat_f32_3x3 = internal addrspace(10) global [3 x <3 x float>] zeroinitializer
@@ -572,11 +573,14 @@ entry:
 define internal void @atan2_float6() {
 entry:
   ; CHECK: OpFunction %[[#void]] None
+  ; CHECK: %[[#shuffle_f32:]] = OpLoad %[[#vec4_float_32]]
+  ; CHECK: OpCompositeExtract %[[#float_32]] %[[#shuffle_f32]] 0
   ; CHECK-COUNT-2: OpExtInst {{%[0-9]+}} %[[#op_ext_glsl]] Atan2
   ; CHECK: OpFunctionEnd
-  %va = load <6 x float>, ptr addrspace(10) @wide_f32_6
-  %vb = load <6 x float>, ptr addrspace(10) @wide_f32_6
-  %r = call <6 x float> @llvm.atan2.v6f32(<6 x float> %va, <6 x float> %vb)
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.atan2.v6f32(<6 x float> %va, <6 x float> %va)
   store <6 x float> %r, ptr addrspace(10) @wide_f32_6
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan2_mat.ll
@@ -570,7 +570,7 @@ entry:
   ret void
 }
 
-define internal void @atan2_float6() {
+define internal void @atan2_float6_from_shuffle() {
 entry:
   ; CHECK: OpFunction %[[#void]] None
   ; CHECK: %[[#shuffle_f32:]] = OpLoad %[[#vec4_float_32]]
@@ -710,7 +710,7 @@ entry:
   call void @atan2_half3x4(ptr addrspace(10) @mat_f16_3x4, ptr addrspace(10) @mat_f16_3x4, ptr addrspace(10) @mat_f16_3x4)
   call void @atan2_float4x3(ptr addrspace(10) @mat_f32_4x3, ptr addrspace(10) @mat_f32_4x3, ptr addrspace(10) @mat_f32_4x3)
   call void @atan2_half4x3(ptr addrspace(10) @mat_f16_4x3, ptr addrspace(10) @mat_f16_4x3, ptr addrspace(10) @mat_f16_4x3)
-  call void @atan2_float6()
+  call void @atan2_float6_from_shuffle()
   call void @atan2_half6()
   call void @atan2_float8()
   call void @atan2_half8()

--- a/llvm/test/CodeGen/SPIRV/legalization/vector-legalization-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/vector-legalization-shader.ll
@@ -2,7 +2,9 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-DAG: %[[#int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#float:]] = OpTypeFloat 32
 ; CHECK-DAG: %[[#double:]] = OpTypeFloat 64
+; CHECK-DAG: %[[#v4float:]] = OpTypeVector %[[#float]] 4
 ; CHECK-DAG: %[[#v4int:]] = OpTypeVector %[[#int]] 4
 ; CHECK-DAG: %[[#v4double:]] = OpTypeVector %[[#double]] 4
 ; CHECK-DAG: %[[#v2int:]] = OpTypeVector %[[#int]] 2
@@ -26,6 +28,8 @@
 @GVec3 = internal addrspace(10) global <3 x double> zeroinitializer
 @Lows3 = internal addrspace(10) global <3 x i32> zeroinitializer
 @Highs3 = internal addrspace(10) global <3 x i32> zeroinitializer
+@FloatVec4 = internal addrspace(10) global <4 x float> zeroinitializer
+@FloatVec6 = internal addrspace(10) global [6 x float] zeroinitializer
 
 ; Test splitting a vector of size 8.
 define internal void @test_split() {
@@ -122,11 +126,24 @@ entry:
   ret void
 }
 
+define internal void @test_float_shuffle() {
+entry:
+  ; CHECK: %[[#float_vec:]] = OpLoad %[[#v4float]]
+  ; CHECK: OpCompositeExtract %[[#float]] %[[#float_vec]] 0
+  ; CHECK: OpCompositeExtract %[[#float]] %[[#float_vec]] 1
+  %vec = load <4 x float>, ptr addrspace(10) @FloatVec4
+  %wide = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  store <6 x float> %wide, ptr addrspace(10) @FloatVec6
+  ret void
+}
+
 define void @main() local_unnamed_addr #0 {
 entry:
   call void @test_split()
   call void @test_recombine()
   call void @test_bitcast_expand()
+  call void @test_float_shuffle()
   ret void
 }
 


### PR DESCRIPTION


fixes https://github.com/llvm/llvm-project/issues/213783

Propagate result types through G_SHUFFLE_VECTOR and G_FATAN2 during post-legalizer type deduction. This prevents wide float vectors from producing integer-typed OpCompositeExtract instructions.

Add generic float shuffle and wide atan2 regression coverage.

assisted by Copilot (GPT-5.6-Sol)