### PR TITLE
[lldb][test] Skip the API tests a WebAssembly target cannot support

### DIFF
--- a/lldb/test/API/commands/command/nested_alias/TestNestedAlias.py
+++ b/lldb/test/API/commands/command/nested_alias/TestNestedAlias.py
@@ -4,6 +4,7 @@ Test that an alias can reference other aliases without crashing.
 
 
 import lldb
+from lldbsuite.test.decorators import skipIfWasm
 from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
@@ -17,6 +18,7 @@ class NestedAliasTestCase(TestBase):
         # Find the line number to break inside main().
         self.line = line_number("main.cpp", "// break here")
 
+    @skipIfWasm  # the test reads memory at the address an expression computes
     def test_nested_alias(self):
         """Test that an alias can reference other aliases without crashing."""
         self.build()

--- a/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
+++ b/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
@@ -14,6 +14,7 @@ import recognizer
 class FrameRecognizerTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfWasm  # the recognizer reads the arguments from $argN, and Wasm has no argument registers
     def test_frame_recognizer_1(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
@@ -162,6 +163,7 @@ class FrameRecognizerTestCase(TestBase):
                     substrs=['*a = 78'])
         """
 
+    @skipIfWasm  # the recognizer reads the arguments from $argN, and Wasm has no argument registers
     def test_recognized_args_filtered_by_name(self):
         """Test that 'frame variable <name>' only prints matching recognized args."""
         self.build()

--- a/lldb/test/API/commands/platform/basic/TestPlatformCommand.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformCommand.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # a platform command needs a connection to the host it runs on
 class PlatformCommandTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/launch/TestProcessLaunch.py
+++ b/lldb/test/API/commands/process/launch/TestProcessLaunch.py
@@ -116,6 +116,7 @@ class ProcessLaunchTestCase(TestBase):
         )
 
     @skipIfRemote
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_set_working_dir_existing(self):
         """Test that '-w dir' sets the working dir when running the inferior."""
         d = {"CXX_SOURCES": "print_cwd.cpp"}
@@ -210,6 +211,7 @@ class ProcessLaunchTestCase(TestBase):
         self.assertState(process.GetState(), lldb.eStateExited, PROCESS_EXITED)
 
     @skipIfRemote
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_target_launch_working_dir_prop(self):
         """Test that the setting `target.launch-working-dir` is correctly used when launching a process."""
         d = {"CXX_SOURCES": "print_cwd.cpp"}

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -406,10 +406,12 @@ class SettingsCommandTestCase(TestBase):
         self.expect("settings set target.jit-engine bogus", error=True)
 
     @skipIfDarwinEmbedded  # <rdar://problem/34446098> debugserver on ios etc can't write files
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_run_args_and_env_vars(self):
         self.do_test_run_args_and_env_vars(use_launchsimple=False)
 
     @skipIfDarwinEmbedded  # <rdar://problem/34446098> debugserver on ios etc can't write files
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_launchsimple_args_and_env_vars(self):
         self.do_test_run_args_and_env_vars(use_launchsimple=True)
 
@@ -490,6 +492,7 @@ class SettingsCommandTestCase(TestBase):
         )
 
     @skipIfRemote  # it doesn't make sense to send host env to remote target
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_pass_host_env_vars(self):
         """Test that the host env vars are passed to the launched process."""
         self.build()
@@ -612,6 +615,7 @@ class SettingsCommandTestCase(TestBase):
         )
 
     @skipIfDarwinEmbedded  # <rdar://problem/34446098> debugserver on ios etc can't write files
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_set_error_output_path(self):
         """Test that setting target.error/output-path for the launched process works."""
         self.build()
@@ -666,6 +670,7 @@ class SettingsCommandTestCase(TestBase):
         )
 
     @skipIfDarwinEmbedded  # <rdar://problem/34446098> debugserver on ios etc can't write files
+    @skipIfWasm  # WASI gives the inferior no working directory and no file system
     def test_same_error_output_path(self):
         """Test that setting target.error and output-path to the same file path for the launched process works."""
         self.build()

--- a/lldb/test/API/commands/settings/quoting/TestQuoting.py
+++ b/lldb/test/API/commands/settings/quoting/TestQuoting.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # WASI gives the inferior no working directory and no file system
 class SettingsCommandTestCase(TestBase):
     output_file_name = "output.txt"
 

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -81,6 +81,7 @@ class TestCase(TestBase):
             return debug_stats["commands"]
         return None
 
+    @skipIfWasm  # no expression evaluation
     def test_expressions_frame_var_counts(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/commands/target/basic/TestTargetCommand.py
+++ b/lldb/test/API/commands/target/basic/TestTargetCommand.py
@@ -38,6 +38,7 @@ class targetCommandTestCase(TestBase):
         self.build(dictionary=dc)
         self.addTearDownCleanup(dictionary=dc)
 
+    @skipIfWasm  # a null dereference is a valid read in a Wasm linear memory, so the inferior does not fault
     def test_target_command(self):
         """Test some target commands: create, list, select."""
         self.buildAll()
@@ -563,6 +564,7 @@ class targetCommandTestCase(TestBase):
     @expectedFailureAll(
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56079"
     )
+    @skipIfWasm  # a Wasm executable statically links the C library, so its debug info holds many ints
     def test_target_modules_type(self):
         self.buildB()
         self.runCmd("file " + self.getBuildArtifact("b.out"), CURRENT_EXECUTABLE_SET)

--- a/lldb/test/API/driver/quit_speed/TestQuitWithProcess.py
+++ b/lldb/test/API/driver/quit_speed/TestQuitWithProcess.py
@@ -35,6 +35,7 @@ class DriverQuitSpeedTest(PExpectTest):
         child.expect(pexpect.EOF, timeout=30)
 
     @skipIfAsan
+    @skipIfWasm  # quitting detaches from the runtime, so there is nothing to confirm
     def test_run_quit_with_prompt(self):
         """Test that the lldb driver's batch mode works correctly with trailing space in confimation."""
         import pexpect

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
@@ -7,7 +7,7 @@ we still handle the remaining locations correctly.
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
 import os
 
 
@@ -20,6 +20,7 @@ class TestLocationsAfterRebuild(TestBase):
 
     # On Windows we cannot remove a file that lldb is debugging.
     @skipIfWindows
+    @skipIfWasm  # a WASI executable wraps main, so a breakpoint on it takes two locations
     def test_remaining_location_spec(self):
         """If we rebuild a couple of times some of the old locations
         get removed.  Make sure the command-line breakpoint id

--- a/lldb/test/API/functionalities/breakpoint/thread_plan_user_breakpoint/TestThreadPlanUserBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/thread_plan_user_breakpoint/TestThreadPlanUserBreakpoint.py
@@ -102,6 +102,7 @@ class ThreadPlanUserBreakpointsTestCase(TestBase):
         # Set breakpoint callback to return True/False
         bp.SetScriptCallbackBody("return %s" % condition)
 
+    @skipIfWasm  # a step on Wasm ends at the breakpoint's address without hitting it
     def test_thread_plan_user_breakpoint_conditional_active(self):
         # Test with breakpoints having true condition
         self.check_thread_plan_user_breakpoint(
@@ -114,6 +115,7 @@ class ThreadPlanUserBreakpointsTestCase(TestBase):
             condition=False, set_up_breakpoint_func=self.set_up_breakpoints_condition
         )
 
+    @skipIfWasm  # a step on Wasm ends at the breakpoint's address without hitting it
     def test_thread_plan_user_breakpoint_unconditional_active(self):
         # Test with breakpoints enabled unconditionally
         self.check_thread_plan_user_breakpoint(
@@ -126,6 +128,7 @@ class ThreadPlanUserBreakpointsTestCase(TestBase):
             condition=False, set_up_breakpoint_func=self.set_up_breakpoints_enable
         )
 
+    @skipIfWasm  # a step on Wasm ends at the breakpoint's address without hitting it
     def test_thread_plan_user_breakpoint_callback_active(self):
         # Test with breakpoints with callback that returns 'True'
         self.check_thread_plan_user_breakpoint(

--- a/lldb/test/API/functionalities/bt-interrupt/TestInterruptBacktrace.py
+++ b/lldb/test/API/functionalities/bt-interrupt/TestInterruptBacktrace.py
@@ -14,6 +14,7 @@ class TestInterruptingBacktrace(TestBase):
 
     @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIf(oslist=["linux"], archs=["arm$"])
+    @skipIfWasm  # the runtime ends the process on a stack exhaustion trap without stopping
     def test_backtrace_interrupt(self):
         """Use RequestInterrupt followed by stack operations
         to ensure correct interrupt behavior for stacks."""

--- a/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
+++ b/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
@@ -10,6 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCPPResultVariables(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/functionalities/inferior-assert/TestInferiorAssert.py
+++ b/lldb/test/API/functionalities/inferior-assert/TestInferiorAssert.py
@@ -7,6 +7,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # assert() ends a WASI process, there is no signal to stop on
 class AssertingInferiorTestCase(TestBase):
     @expectedFailureAll(
         oslist=["windows"],

--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 class MultipleSlidesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfWasm  # a Wasm section sits at a fixed address in its address space, so it cannot be slid
     def test_mulitple_slides(self):
         """Test that a binary can be slid multiple times correctly."""
         self.build()

--- a/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/TestRunLockReentrantDeadlock.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/runlock_reentrant_deadlock/TestRunLockReentrantDeadlock.py
@@ -33,6 +33,7 @@ class TestRunLockReentrantDeadlock(TestBase):
         bugnumber="llvm.org/pr24528 (scripted breakpoint resolvers fail on "
         "Windows; same XFAIL as the sibling tests in this directory)",
     )
+    @skipIfWasm  # the was_hit callback increments the value with an expression
     def test_runlock_reentrant_no_deadlock(self):
         """
         Test that a frame provider calling SBFrame.IsValid from

--- a/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/TestWasHitWithFrameProviderDeadlock.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/TestWasHitWithFrameProviderDeadlock.py
@@ -31,6 +31,7 @@ class TestWasHitWithFrameProviderDeadlock(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    @skipIfWasm  # the was_hit callback increments the value with an expression
     def test_was_hit_with_frame_provider_no_deadlock(self):
         """
         Test that a scripted breakpoint doing EvaluateExpression in was_hit

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -279,6 +279,7 @@ class TestStatusline(PExpectTest):
     @skipIfDarwin
     @skipIfLinux  # https://github.com/llvm/llvm-project/issues/154763
     @add_test_categories(["lldb-server"])
+    @skipIfWasm  # the test drives a native debug server for the program
     def test_modulelist_deadlock(self):
         """Regression test for a deadlock that occurs when the status line is enabled before connecting
         to a gdb-remote server.

--- a/lldb/test/API/functionalities/thread/jump/TestThreadJump.py
+++ b/lldb/test/API/functionalities/thread/jump/TestThreadJump.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # Wasm has no writable PC to jump
 class ThreadJumpTestCase(TestBase):
     def setUp(self):
         TestBase.setUp(self)

--- a/lldb/test/API/lang/c/const_variables/TestConstVariables.py
+++ b/lldb/test/API/lang/c/const_variables/TestConstVariables.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ConstVariableTestCase(TestBase):
     @expectedFailureAll(oslist=["freebsd", "linux"], compiler="icc")
     @expectedFailureAll(archs=["mips", "mipsel", "mips64", "mips64el"])

--- a/lldb/test/API/lang/c/inlines/TestRedefinitionsInInlines.py
+++ b/lldb/test/API/lang/c/inlines/TestRedefinitionsInInlines.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 class TestRedefinitionsInInlines(TestBase):
     # https://github.com/llvm/llvm-project/issues/28219
     @skipIf(compiler="clang", compiler_version=["<", "3.5"])
+    @skipIfWasm  # no expression evaluation
     def test(self):
         self.source = "main.c"
         self.build()

--- a/lldb/test/API/lang/c/set_values/TestSetValues.py
+++ b/lldb/test/API/lang/c/set_values/TestSetValues.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class SetValuesTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/c/stepping/TestStepAndBreakpoints.py
+++ b/lldb/test/API/lang/c/stepping/TestStepAndBreakpoints.py
@@ -19,6 +19,7 @@ class TestCStepping(TestBase):
     @expectedFailureAll(oslist=["linux"], archs=no_match(["i386", "x86_64"]))
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24777")
     @expectedFailureNetBSD
+    @skipIfWasm  # no expression evaluation
     def test_and_python_api(self):
         """Test stepping over vrs. hitting breakpoints & subsequent stepping in various forms."""
         self.build()

--- a/lldb/test/API/lang/cpp/dynamic-value/TestDynamicValue.py
+++ b/lldb/test/API/lang/cpp/dynamic-value/TestDynamicValue.py
@@ -284,6 +284,7 @@ class DynamicValueTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24663")
     @expectedFailureAll(archs=["arm$"])  # Minidump saving not implemented
     @skipIf(archs=["arm64e"])  # arm64e incompatible with minidump
+    @skipIfWasm  # No core file format for Wasm
     def test_from_core_file(self):
         """Test fetching C++ dynamic values from core files. Specifically, test
         that we can determine the dynamic type of the value if the core file

--- a/lldb/test/API/lang/cpp/extern_c/TestExternCSymbols.py
+++ b/lldb/test/API/lang/cpp/extern_c/TestExternCSymbols.py
@@ -1,4 +1,6 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[decorators.skipIfWasm]  # no expression evaluation
+)

--- a/lldb/test/API/lang/cpp/function-local-class/TestCppFunctionLocalClass.py
+++ b/lldb/test/API/lang/cpp/function-local-class/TestCppFunctionLocalClass.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     @no_debug_info_test
     def test(self):

--- a/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
+++ b/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @no_debug_info_test
     @skipIf(compiler="clang", compiler_version=["<", "20.0"])
+    @skipIfWasm  # wasm32 supports neither _Float16 nor __bf16
     def test(self):
         self.build()
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))

--- a/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
+++ b/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
@@ -11,6 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TemplateArgsTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     def prepareProcess(self):

--- a/lldb/test/API/python_api/find_in_memory/TestFindInMemory.py
+++ b/lldb/test/API/python_api/find_in_memory/TestFindInMemory.py
@@ -3,6 +3,7 @@ Test Process::FindInMemory.
 """
 
 import lldb
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from address_ranges_helper import *
@@ -27,6 +28,7 @@ class FindInMemoryTestCase(TestBase):
         )
         self.assertTrue(self.bp.IsValid())
 
+    @skipIfWasm  # Wasm exposes no stack pointer register
     def test_check_stack_pointer(self):
         """Make sure the 'stack_pointer' variable lives on the stack"""
         self.assertTrue(self.process, PROCESS_IS_VALID)

--- a/lldb/test/API/python_api/find_in_memory/TestFindRangesInMemory.py
+++ b/lldb/test/API/python_api/find_in_memory/TestFindRangesInMemory.py
@@ -3,6 +3,7 @@ Test Process::FindRangesInMemory.
 """
 
 import lldb
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from address_ranges_helper import *
@@ -43,6 +44,7 @@ class FindRangesInMemoryTestCase(TestBase):
         self.assertSuccess(error)
         self.assertEqual(matches.GetSize(), 2)
 
+    @skipIfWasm  # Wasm linear memory is one region, which holds more than the stack
     def test_find_ranges_in_memory_one_match(self):
         """Make sure exactly one match exists in the heap memory and the right address ranges are provided"""
         self.assertTrue(self.process, PROCESS_IS_VALID)
@@ -61,6 +63,7 @@ class FindRangesInMemoryTestCase(TestBase):
         self.assertSuccess(error)
         self.assertEqual(matches.GetSize(), 1)
 
+    @skipIfWasm  # Wasm linear memory is one region, which holds more than the stack
     def test_find_ranges_in_memory_one_match_multiple_ranges(self):
         """Make sure exactly one match exists in the heap memory and multiple address ranges are provided"""
         self.assertTrue(self.process, PROCESS_IS_VALID)

--- a/lldb/test/API/python_api/frame/TestFrames.py
+++ b/lldb/test/API/python_api/frame/TestFrames.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 
 class FrameAPITestCase(TestBase):
+    @skipIfWasm  # Wasm exposes no register sets, so there is no pc or sp register to read
     def test_get_arg_vals_for_call_stack(self):
         """Exercise SBFrame.GetVariables() API to get argument vals."""
         self.build()

--- a/lldb/test/API/python_api/persistent_decls/TestPersistentDecls.py
+++ b/lldb/test/API/python_api/persistent_decls/TestPersistentDecls.py
@@ -6,9 +6,11 @@ and values.
 
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import skipIfWasm
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class TestPersistentDecls(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -374,6 +374,7 @@ class ProcessAPITestCase(TestBase):
 
     @no_debug_info_test
     @skipIfRemote
+    @skipIfWasm  # the Wasm platform cannot look a process up by its id
     def test_get_process_info(self):
         """Test SBProcess::GetProcessInfo() API with a locally launched process."""
         self.build()
@@ -463,6 +464,7 @@ class ProcessAPITestCase(TestBase):
         process_info.GetParentProcessID()
 
     @expectedFailureWindows  # Not yet implemented.
+    @skipIfWasm  # the Wasm platform cannot look a process up by its id
     def test_get_process_info_arguments(self):
         """Test SBProcessInfo Arguments returns the correct values."""
         self.build()
@@ -495,6 +497,7 @@ class ProcessAPITestCase(TestBase):
         self.assertEqual(process_info.GetArgumentAtIndex(3), "מזל טוב")
         self.assertEqual(process_info.GetArgumentAtIndex(4), None)
 
+    @skipIfWasm  # the test reads the allocation back with an expression
     def test_allocate_deallocate_memory(self):
         """Test Python SBProcess.AllocateMemory() and SBProcess.DeallocateMemory() APIs."""
         self.build()

--- a/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
+++ b/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
@@ -15,6 +15,7 @@ class AttachCancelTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfRemote
+    @skipIfWasm  # the Wasm platform cannot attach to a process by name
     @skipIf(
         hostoslist=["windows", "linux"],
         bugnumber="https://github.com/llvm/llvm-project/issues/115618",

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -111,6 +111,7 @@ class TargetAPITestCase(TestBase):
             "Arch name is equal to the first item of the triple",
         )
 
+    @skipIfWasm  # there is no ABI plugin for Wasm to name
     def test_get_ABIName(self):
         d = {"EXE": "b.out"}
         self.build(dictionary=d)
@@ -134,6 +135,7 @@ class TargetAPITestCase(TestBase):
             abi_pre_launch, abi_after_launch, "ABI's match before and during run"
         )
 
+    @skipIfWasm  # zero is a valid address in a Wasm linear memory, so a read of it succeeds
     def test_read_memory(self):
         d = {"EXE": "b.out"}
         self.build(dictionary=d)
@@ -498,6 +500,7 @@ class TargetAPITestCase(TestBase):
         )
 
     @skipIfRemote
+    @skipIfWasm  # the default architecture is the host's, which no Wasm module matches
     def test_default_arch(self):
         """Test the other two target create methods using LLDB_ARCH_DEFAULT."""
         self.build()

--- a/lldb/test/API/python_api/thread/TestThreadAPI.py
+++ b/lldb/test/API/python_api/thread/TestThreadAPI.py
@@ -54,6 +54,7 @@ class ThreadAPITestCase(TestBase):
         self.build()
         self.validate_negative_indexing()
  
+    @skipIfWasm  # the test calls a function with an expression
     def test_StepInstruction(self):
         """Test that StepInstruction preserves the plan stack."""
         self.build()

--- a/lldb/test/API/python_api/value/change_ptr/TestChangePtr.py
+++ b/lldb/test/API/python_api/value/change_ptr/TestChangePtr.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class ChangePtrTest(TestBase):
+    @skipIfWasm  # the test checks the address of a persistent expression result
     def test(self):
         self.build()
 

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -23,6 +23,7 @@ class ChangeValueAPITestCase(TestBase):
 
     @expectedFlakeyLinux("llvm.org/pr25652")
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24772")
+    @skipIfWasm  # Wasm exposes no stack pointer register
     def test_change_value(self):
         """Exercise the SBValue::SetValueFromCString API."""
         d = {"EXE": self.exe_name}

--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -2,13 +2,14 @@
 Test lldb-dap attach commands
 """
 
-from lldbsuite.test.decorators import skipIfNetBSD
+from lldbsuite.test.decorators import skipIfNetBSD, skipIfWasm
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import AttachArgs, PauseArgs
 
 
 class TestDAP_attachCommands(DAPTestCaseBase):
     @skipIfNetBSD  # Hangs on NetBSD as well
+    @skipIfWasm  # the test releases the inferior with an expression
     def test_commands(self):
         """
         Tests the "initCommands", "preRunCommands", "stopCommands",

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -6,7 +6,7 @@ from typing import List
 
 from lldbgdbserverutils import Pipe
 from lldbsuite.test import lldbplatformutil
-from lldbsuite.test.decorators import skipIfNetBSD, skipIfWindows
+from lldbsuite.test.decorators import skipIfNetBSD, skipIfWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import AttachArgs
@@ -26,6 +26,7 @@ def debug_server_start_args() -> List[str]:
     return args
 
 
+@skipIfWasm  # the test drives a native debug server for the program
 class TestDAP_attachByPortNum(DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -6,7 +6,7 @@ import importlib.util
 import os
 import unittest
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession
@@ -115,6 +115,7 @@ class TestDAP_console(DAPTestCaseBase):
 
     @skipIfWindows
     @skipUnlessPsutil
+    @skipIfWasm  # the test signals the debug server, which for Wasm is the runtime
     def test_exit_status_message_sigterm(self):
         import psutil
 

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -5,13 +5,14 @@ Test lldb-dap evaluate request
 import re
 from typing import Optional, Union
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.session_helpers import ExpectEval, FrameContext
 from lldbsuite.test.tools.lldb_dap.types import EvaluateContext, LaunchArgs, ValueFormat
 
 
+@skipIfWasm  # no expression evaluation
 class TestDAP_evaluate(DAPTestCaseBase):
     # The frame that `assert_eval*` functions calls evaluate in.
     _eval_frame: Optional[FrameContext] = None

--- a/lldb/test/API/tools/lldb-dap/invalidated-event/TestDAP_invalidatedEvent.py
+++ b/lldb/test/API/tools/lldb-dap/invalidated-event/TestDAP_invalidatedEvent.py
@@ -4,12 +4,14 @@ stack, variables, threads has changes but the client does not
 know about it.
 """
 
+from lldbsuite.test.decorators import skipIfWasm
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 
 class TestDAP_invalidatedEvent(DAPTestCaseBase):
+    @skipIfWasm  # No ABI plugin for Wasm to set a return value with
     def test_invalidated_stack_area_event(self):
         """
         Test an invalidated event for the stack area.

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_cwd.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_cwd.py
@@ -4,10 +4,12 @@ Test lldb-dap launch request.
 
 import os
 
+from lldbsuite.test.decorators import skipIfWasm
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 
+@skipIfWasm  # WASI gives the inferior no working directory and no file system
 class TestDAP_launch_cwd(DAPTestCaseBase):
     """
     Tests the default launch of a simple program with a current working

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
@@ -4,11 +4,12 @@ Test lldb-dap launch request.
 
 import os
 
-from lldbsuite.test.decorators import expectedFailureAll, skipIfLinux
+from lldbsuite.test.decorators import expectedFailureAll, skipIfLinux, skipIfWasm
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 
+@skipIfWasm  # a Wasm runtime is handed its arguments directly, with no shell to expand them
 class TestDAP_launch_shellExpandArguments_enabled(DAPTestCaseBase):
     """
     Tests the default launch of a simple program with shell expansion

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import (
     skipIf,
     skipIfAsan,
     skipIfBuildType,
+    skipIfWasm,
     skipIfWindows,
 )
 from lldbsuite.test.tools.lldb_dap.types import Console, LaunchArgs
@@ -21,6 +22,7 @@ class TestDAP_launch_stdio_redirection_and_console(DAPTestCaseBase):
     """
 
     @skipIfAsan
+    @skipIfWasm  # runInTerminal has the client run the program, and a Wasm module is not executable
     @skipIfWindows  # https://github.com/llvm/llvm-project/issues/198763
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     @skipIfBuildType(["debug"])

--- a/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io_integratedTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io_integratedTerminal.py
@@ -7,6 +7,7 @@ from lldbsuite.test.decorators import (
     skipIfAsan,
     skipIfBuildType,
     skipIfRemote,
+    skipIfWasm,
     skipIfWindows,
 )
 from lldbsuite.test.tools.lldb_dap import DAPTestSession
@@ -17,6 +18,7 @@ from lldbsuite.test.tools.lldb_dap.types import Console, RunInTerminalRequest
 @skipIfAsan
 @skipIfBuildType(["debug"])
 @skipIfWindows
+@skipIfWasm  # runInTerminal has the client run the program, and a Wasm module is not executable
 class TestDAP_launch_io_IntegratedTerminal(DAP_launchIO):
     console = Console.INTEGRATED_TERMINAL
 

--- a/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
+++ b/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
@@ -2,7 +2,7 @@
 Test lldb-dap locations request
 """
 
-from lldbsuite.test.decorators import skipIf, skipIfWindows
+from lldbsuite.test.decorators import skipIf, skipIfWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
@@ -14,6 +14,7 @@ class TestDAP_locations(DAPTestCaseBase):
     @skipIf(
         bugnumber="https://github.com/llvm/llvm-project/issues/203127", archs=["arm64e"]
     )
+    @skipIfWasm  # a Wasm function pointer is a table index, not a code address
     def test_locations(self):
         """
         Tests the 'locations' request.

--- a/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
+++ b/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
@@ -76,6 +76,7 @@ class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
         )
 
     @skipIfWindows
+    @skipIfWasm  # the test finds the memory to read by evaluating an expression
     def test_readMemory(self):
         """
         Tests the 'readMemory' request
@@ -126,6 +127,7 @@ class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
 
     # Flakey on 32-bit Arm Linux.
     @skipIf(oslist=["linux"], archs=["arm$"])
+    @skipIfWasm  # the test finds the memory to write by evaluating an expression
     def test_writeMemory(self):
         """
         Tests the 'writeMemory' request

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -5,7 +5,11 @@ Test lldb-dap module request
 import platform
 import re
 
-from lldbsuite.test.decorators import skipIfWindows, skipUnlessDarwin
+from lldbsuite.test.decorators import (
+    skipIfTargetDoesNotSupportSharedLibraries,
+    skipIfWindows,
+    skipUnlessDarwin,
+)
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import (
     CompileUnitsArgs,
@@ -16,6 +20,7 @@ from lldbsuite.test.tools.lldb_dap.types import (
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 
+@skipIfTargetDoesNotSupportSharedLibraries()
 class TestDAP_module(DAPTestCaseBase):
     def run_test(self, symbol_basename: str, expect_debug_info_size: bool):
         session = self.build_and_create_session()

--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -2,7 +2,7 @@
 Test lldb-dap variables/stackTrace request for optimized code
 """
 
-from lldbsuite.test.decorators import skipIfAsan, skipIfWindows
+from lldbsuite.test.decorators import skipIfAsan, skipIfWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
@@ -32,6 +32,7 @@ class TestDAP_optimized(DAPTestCaseBase):
 
     @skipIfAsan  # On ASAN builds this test intermittently fails https://github.com/llvm/llvm-project/issues/111061
     @skipIfWindows
+    @skipIfWasm  # an optimized out variable keeps a reused local, so reading it succeeds
     def test_optimized_variable(self):
         """Test optimized variable value contains error."""
         program = self.getBuildArtifact("a.out")

--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -2,7 +2,7 @@
 Test lldb-dap output events
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
@@ -10,6 +10,7 @@ from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 class TestDAP_output(DAPTestCaseBase):
     @skipIfWindows
+    @skipIfWasm  # WASI block buffers a redirected stdout, so the writes arrive out of order
     def test_output(self):
         """
         Test output handling for the running process.

--- a/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py
+++ b/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py
@@ -2,13 +2,20 @@
 Test lldb-dap RestartRequest.
 """
 
-from lldbsuite.test.decorators import skipIf, skipIfAsan, skipIfBuildType, skipIfWindows
+from lldbsuite.test.decorators import (
+    skipIf,
+    skipIfAsan,
+    skipIfBuildType,
+    skipIfWasm,
+    skipIfWindows,
+)
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import Console, LaunchArgs
 
 
 @skipIfBuildType(["debug"])
+@skipIfWasm  # runInTerminal has the client run the program, and a Wasm module is not executable
 class TestDAP_restart_console(DAPTestCaseBase):
     @skipIfAsan
     @skipIfWindows  # https://github.com/llvm/llvm-project/issues/200840

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -66,6 +66,7 @@ def read_pipe_message(pipe):
 
 
 @skipIfBuildType(["debug"])
+@skipIfWasm  # runInTerminal has the client run the program, and a Wasm module is not executable
 class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/tools/lldb-dap/stackTraceMissingFunctionName/TestDAP_stackTraceMissingFunctionName.py
+++ b/lldb/test/API/tools/lldb-dap/stackTraceMissingFunctionName/TestDAP_stackTraceMissingFunctionName.py
@@ -2,13 +2,14 @@
 Test lldb-dap stack trace response
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 
 class TestDAP_stackTraceMissingFunctionName(DAPTestCaseBase):
     @skipIfWindows
+    @skipIfWasm  # a Wasm indirect call traps without transferring control to the callee
     def test_missingFunctionName(self):
         """
         Test that the stack frame without a function name is given its pc in the response.

--- a/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import (
     expectedFailureAll,
     expectedFailureNetBSD,
     skipIfLinux,
+    skipIfTargetDoesNotSupportThreads,
     skipIfWindows,
 )
 from lldbsuite.test.lldbtest import line_number
@@ -17,6 +18,7 @@ from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedEvent, Thread
 
 @skipIfWindows  # This is flakey on Windows: llvm.org/pr24668, llvm.org/pr38373
 @skipIfLinux
+@skipIfTargetDoesNotSupportThreads()
 class TestDAP_stopped_events(DAPTestCaseBase):
     """
     Test validates different operations that produce 'stopped' events.

--- a/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
+++ b/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
@@ -1,4 +1,4 @@
-from lldbsuite.test.decorators import expectedFailureAll
+from lldbsuite.test.decorators import expectedFailureAll, skipIfWasm
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
@@ -40,6 +40,7 @@ class TestDAP_variables_children(DAPTestCaseBase):
         self.assertIn("['Indexed']", resp_body.result)
 
     @expectedFailureAll(archs=["arm$", "arm64", "aarch64"])
+    @skipIfWasm  # there is no ABI plugin for Wasm to find a return value with
     def test_return_variable_with_children(self):
         """
         Test the stepping out of a function with return value show the children correctly

--- a/lldb/test/API/tools/lldb-server/cached-memory-region-info/TestCachedMemoryRegionInfo.py
+++ b/lldb/test/API/tools/lldb-server/cached-memory-region-info/TestCachedMemoryRegionInfo.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 @skipIfWindowsAndNoLLDBServer
+@skipIfTargetDoesNotSupportThreads()
 class MemoryRegionInfoPacketsCached(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 


### PR DESCRIPTION
This is the final batch of skips. Together with a handful of local changes to LLDB and WAMR, the test suite now passes when targeting WebAssembly. Each test has a short comment explaining why it's skipped.