### PR TITLE
[mlir][ODS] Allow parameters on side-effect resources

### DIFF
--- a/mlir/docs/Rationale/SideEffectsAndSpeculation.md
+++ b/mlir/docs/Rationale/SideEffectsAndSpeculation.md
@@ -86,22 +86,9 @@ effects on it can alias pointer-based memory; non-addressable resources (e.g.
 runtime state) do not alias with any value-based memory location. The
 canonical definition and API live in `mlir/Interfaces/SideEffectInterfaces.h`.
 
-Resources can also attach an attribute to their effect instances without
-changing which resource an operation accesses. For example, different access
-modes for the same memory resource can be modeled as follows:
-
-```tablegen
-def AsyncSharedMemory : Resource<"SharedMemory", [{
-  ::mlir::StringAttr::get(getContext(), "async")
-}]>;
-
-def AsyncLoadOp : MyDialect_Op<"async_load"> {
-  let arguments = (ins Arg<AnyMemRef, "", [MemRead<AsyncSharedMemory>]>:$src);
-}
-```
-
-The generated effect accesses `SharedMemory` and carries the `"async"`
-attribute, which consumers can retrieve with `EffectInstance::getParameters()`.
+Resources can attach arbitrary attributes to their effect instances. These
+attributes provide additional metadata about memory effects and can be used,
+for example, to distinguish how a resource is accessed.
 
 **Scope and limitations.** This mechanism is deliberately *not* intended for
 fine-grained regions with specific addresses or sizes, or for alias classes /

--- a/mlir/docs/Rationale/SideEffectsAndSpeculation.md
+++ b/mlir/docs/Rationale/SideEffectsAndSpeculation.md
@@ -86,6 +86,23 @@ effects on it can alias pointer-based memory; non-addressable resources (e.g.
 runtime state) do not alias with any value-based memory location. The
 canonical definition and API live in `mlir/Interfaces/SideEffectInterfaces.h`.
 
+Resources can also attach an attribute to their effect instances without
+changing which resource an operation accesses. For example, different access
+modes for the same memory resource can be modeled as follows:
+
+```tablegen
+def AsyncSharedMemory : Resource<"SharedMemory", [{
+  ::mlir::StringAttr::get(getContext(), "async")
+}]>;
+
+def AsyncLoadOp : MyDialect_Op<"async_load"> {
+  let arguments = (ins Arg<AnyMemRef, "", [MemRead<AsyncSharedMemory>]>:$src);
+}
+```
+
+The generated effect accesses `SharedMemory` and carries the `"async"`
+attribute, which consumers can retrieve with `EffectInstance::getParameters()`.
+
 **Scope and limitations.** This mechanism is deliberately *not* intended for
 fine-grained regions with specific addresses or sizes, or for alias classes /
 offset-based disambiguation. Those concerns are out of scope for the resource

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaceBase.td
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaceBase.td
@@ -22,9 +22,12 @@ include "mlir/IR/OpBase.td"
 //===----------------------------------------------------------------------===//
 
 // A generic resource that can be attached to a general base side effect.
-class Resource<string resourceName> {
+class Resource<string resourceName, code resourceParameters = [{}]> {
   /// The resource that the associated effect is being applied to.
   string name = resourceName;
+
+  /// An optional C++ expression producing the effect parameters attribute.
+  code parameters = resourceParameters;
 }
 
 // An intrinsic resource that lives in the ::mlir::SideEffects namespace.
@@ -176,6 +179,9 @@ class SideEffect<EffectOpInterfaceBase interface, string effectName,
 
   /// The resource that the effect is being applied to.
   string resource = resourceReference.name;
+
+  /// An optional C++ expression producing the effect parameters attribute.
+  code parameters = resourceReference.parameters;
 
   /// The stage of side effects, we use it to describe the sequence in which
   /// effects occur.

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaceBase.td
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaceBase.td
@@ -26,7 +26,7 @@ class Resource<string resourceName, code resourceParameters = [{}]> {
   /// The resource that the associated effect is being applied to.
   string name = resourceName;
 
-  /// An optional C++ expression producing the effect parameters attribute.
+  /// The optional effect parameters attribute.
   code parameters = resourceParameters;
 }
 
@@ -180,7 +180,7 @@ class SideEffect<EffectOpInterfaceBase interface, string effectName,
   /// The resource that the effect is being applied to.
   string resource = resourceReference.name;
 
-  /// An optional C++ expression producing the effect parameters attribute.
+  /// The optional effect parameters attribute.
   code parameters = resourceReference.parameters;
 
   /// The stage of side effects, we use it to describe the sequence in which

--- a/mlir/include/mlir/TableGen/SideEffects.h
+++ b/mlir/include/mlir/TableGen/SideEffects.h
@@ -35,7 +35,7 @@ public:
   // Return the name of the resource class.
   StringRef getResource() const;
 
-  // Return the C++ expression producing the effect parameters attribute.
+  // Return the effect parameters attribute.
   StringRef getParameters() const;
 
   // Return the stage of the effect happen.

--- a/mlir/include/mlir/TableGen/SideEffects.h
+++ b/mlir/include/mlir/TableGen/SideEffects.h
@@ -35,6 +35,9 @@ public:
   // Return the name of the resource class.
   StringRef getResource() const;
 
+  // Return the C++ expression producing the effect parameters attribute.
+  StringRef getParameters() const;
+
   // Return the stage of the effect happen.
   int64_t getStage() const;
 

--- a/mlir/lib/TableGen/SideEffects.cpp
+++ b/mlir/lib/TableGen/SideEffects.cpp
@@ -36,6 +36,10 @@ StringRef SideEffect::getResource() const {
   return def->getValueAsString("resource");
 }
 
+StringRef SideEffect::getParameters() const {
+  return def->getValueAsString("parameters");
+}
+
 int64_t SideEffect::getStage() const { return def->getValueAsInt("stage"); }
 
 bool SideEffect::getEffectOnfullRegion() const {

--- a/mlir/test/IR/test-side-effects.mlir
+++ b/mlir/test/IR/test-side-effects.mlir
@@ -67,3 +67,9 @@ func.func @side_effect(%arg : index) {
 
   func.return 
 }
+
+func.func @parameterized_side_effect(%arg : memref<4xf32>) {
+  // expected-remark@+1 {{found an instance of 'read' on op operand 0, on resource '<Test>' with parameters "test parameter"}}
+  "test.op_with_parameterized_effects"(%arg) : (memref<4xf32>) -> ()
+  func.return
+}

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3313,6 +3313,8 @@ def TestDefaultAttrPrintOp : TEST_Op<"default_value_print"> {
 //===----------------------------------------------------------------------===//
 
 def TestResource : Resource<"TestResource">;
+def ParameterizedTestResource : Resource<"TestResource",
+    [{::mlir::StringAttr::get(getContext(), "test parameter")}]>;
 
 def TestEffectsOpA : TEST_Op<"op_with_effects_a"> {
   let arguments = (ins
@@ -3327,6 +3329,11 @@ def TestEffectsOpA : TEST_Op<"op_with_effects_a"> {
 
 def TestEffectsOpB : TEST_Op<"op_with_effects_b",
     [MemoryEffects<[MemWrite<TestResource, 0>]>]>;
+
+def TestParameterizedEffectsOp : TEST_Op<"op_with_parameterized_effects"> {
+  let arguments =
+      (ins Arg<AnyMemRef, "", [MemRead<ParameterizedTestResource>]>:$input);
+}
 
 def TestEffectsRead : TEST_Op<"op_with_memread",
     [MemoryEffects<[MemRead]>]> {

--- a/mlir/test/lib/IR/TestSideEffects.cpp
+++ b/mlir/test/lib/IR/TestSideEffects.cpp
@@ -62,6 +62,8 @@ struct SideEffectsPass
           diag << " on a symbol '" << symbolRef << "',";
 
         diag << " on resource '" << instance.getResource()->getName() << "'";
+        if (Attribute parameters = instance.getParameters())
+          diag << " with parameters " << parameters;
       }
     });
 

--- a/mlir/test/mlir-tblgen/op-side-effects.td
+++ b/mlir/test/mlir-tblgen/op-side-effects.td
@@ -27,14 +27,7 @@ def SideEffectOpB : TEST_Op<"side_effect_op_b",
     [MemoryEffects<[MemWrite<CustomResource, 0>]>]>;
 
 def SideEffectOpC : TEST_Op<"side_effect_op_c"> {
-  let arguments = (ins
-    Arg<AnyMemRef, "", [MemRead<ParameterizedResource, 2, FullEffect>]>,
-    Arg<SymbolRefAttr, "", [MemWrite<ParameterizedResource>]>:$symbol,
-    Arg<OptionalAttr<SymbolRefAttr>, "",
-        [MemRead<ParameterizedResource>]>:$optional_symbol
-  );
-  let results =
-      (outs Res<AnyMemRef, "", [MemAlloc<ParameterizedResource>]>);
+  let arguments = (ins Arg<AnyMemRef, "", [MemRead<ParameterizedResource>]>);
 }
 
 def SideEffectOpD : TEST_Op<"side_effect_op_d",
@@ -67,22 +60,8 @@ def SideEffectOpD : TEST_Op<"side_effect_op_d",
 // CHECK: void SideEffectOpB::getEffects
 // CHECK:   effects.emplace_back(::mlir::MemoryEffects::Write::get(), 0, false, CustomResource::get());
 
-// CHECK: void SideEffectOpC::getEffects
-// CHECK: effects.emplace_back(::mlir::MemoryEffects::Read::get(), &getOperation()->getOpOperand(idx),
-// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
-// CHECK-SAME: , 2, true, CustomResource::get());
-// CHECK: effects.emplace_back(::mlir::MemoryEffects::Write::get(), getSymbolAttr(),
-// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
-// CHECK-SAME: , 0, false, CustomResource::get());
-// CHECK: if (auto symbolRef = getOptionalSymbolAttr())
-// CHECK: effects.emplace_back(::mlir::MemoryEffects::Read::get(), symbolRef,
-// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
-// CHECK-SAME: , 0, false, CustomResource::get());
-// CHECK: effects.emplace_back(::mlir::MemoryEffects::Allocate::get(), getOperation()->getOpResult(idx),
-// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
-// CHECK-SAME: , 0, false, CustomResource::get());
+// CHECK-LABEL: void SideEffectOpC::getEffects
+// CHECK: "parameter"), 0, false, CustomResource::get());
 
-// CHECK: void SideEffectOpD::getEffects
-// CHECK: effects.emplace_back(::mlir::MemoryEffects::Write::get(),
-// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
-// CHECK-SAME: , 0, false, CustomResource::get());
+// CHECK-LABEL: void SideEffectOpD::getEffects
+// CHECK: "parameter"), 0, false, CustomResource::get());

--- a/mlir/test/mlir-tblgen/op-side-effects.td
+++ b/mlir/test/mlir-tblgen/op-side-effects.td
@@ -9,6 +9,8 @@ class TEST_Op<string mnemonic, list<Trait> traits = []> :
     Op<TEST_Dialect, mnemonic, traits>;
 
 def CustomResource : Resource<"CustomResource">;
+def ParameterizedResource : Resource<"CustomResource",
+    [{::mlir::StringAttr::get(getContext(), "parameter")}]>;
 
 def SideEffectOpA : TEST_Op<"side_effect_op_a"> {
   let arguments = (ins
@@ -23,6 +25,20 @@ def SideEffectOpA : TEST_Op<"side_effect_op_a"> {
 
 def SideEffectOpB : TEST_Op<"side_effect_op_b",
     [MemoryEffects<[MemWrite<CustomResource, 0>]>]>;
+
+def SideEffectOpC : TEST_Op<"side_effect_op_c"> {
+  let arguments = (ins
+    Arg<AnyMemRef, "", [MemRead<ParameterizedResource, 2, FullEffect>]>,
+    Arg<SymbolRefAttr, "", [MemWrite<ParameterizedResource>]>:$symbol,
+    Arg<OptionalAttr<SymbolRefAttr>, "",
+        [MemRead<ParameterizedResource>]>:$optional_symbol
+  );
+  let results =
+      (outs Res<AnyMemRef, "", [MemAlloc<ParameterizedResource>]>);
+}
+
+def SideEffectOpD : TEST_Op<"side_effect_op_d",
+    [MemoryEffects<[MemWrite<ParameterizedResource>]>]>;
 
 // CHECK: void SideEffectOpA::getEffects
 // CHECK:  {
@@ -50,3 +66,23 @@ def SideEffectOpB : TEST_Op<"side_effect_op_b",
 
 // CHECK: void SideEffectOpB::getEffects
 // CHECK:   effects.emplace_back(::mlir::MemoryEffects::Write::get(), 0, false, CustomResource::get());
+
+// CHECK: void SideEffectOpC::getEffects
+// CHECK: effects.emplace_back(::mlir::MemoryEffects::Read::get(), &getOperation()->getOpOperand(idx),
+// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
+// CHECK-SAME: , 2, true, CustomResource::get());
+// CHECK: effects.emplace_back(::mlir::MemoryEffects::Write::get(), getSymbolAttr(),
+// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
+// CHECK-SAME: , 0, false, CustomResource::get());
+// CHECK: if (auto symbolRef = getOptionalSymbolAttr())
+// CHECK: effects.emplace_back(::mlir::MemoryEffects::Read::get(), symbolRef,
+// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
+// CHECK-SAME: , 0, false, CustomResource::get());
+// CHECK: effects.emplace_back(::mlir::MemoryEffects::Allocate::get(), getOperation()->getOpResult(idx),
+// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
+// CHECK-SAME: , 0, false, CustomResource::get());
+
+// CHECK: void SideEffectOpD::getEffects
+// CHECK: effects.emplace_back(::mlir::MemoryEffects::Write::get(),
+// CHECK-SAME: ::mlir::StringAttr::get(getContext(), "parameter")
+// CHECK-SAME: , 0, false, CustomResource::get());

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -3678,11 +3678,12 @@ void OpEmitter::genSideEffectInterfaceMethods() {
   // The code used to add an effect instance.
   // {0}: The effect class.
   // {1}: Optional value or symbol reference.
-  // {2}: The side effect stage.
-  // {3}: Does this side effect act on every single value of resource.
-  // {4}: The resource class.
+  // {2}: Optional parameters attribute.
+  // {3}: The side effect stage.
+  // {4}: Does this side effect act on every single value of resource.
+  // {5}: The resource class.
   const char *addEffectCode =
-      "  effects.emplace_back({0}::get(), {1}{2}, {3}, {4}::get());\n";
+      "  effects.emplace_back({0}::get(), {1}{2}{3}, {4}, {5}::get());\n";
 
   for (auto &it : interfaceEffects) {
     // Generate the 'getEffects' method.
@@ -3699,11 +3700,14 @@ void OpEmitter::genSideEffectInterfaceMethods() {
     for (auto &location : it.second) {
       StringRef effect = location.effect.getName();
       StringRef resource = location.effect.getResource();
+      std::string parameters = location.effect.getParameters().str();
+      if (!parameters.empty())
+        parameters += ", ";
       int stage = (int)location.effect.getStage();
       bool effectOnFullRegion = (int)location.effect.getEffectOnfullRegion();
       if (location.kind == EffectKind::Static) {
         // A static instance has no attached value.
-        body << llvm::formatv(addEffectCode, effect, "", stage,
+        body << llvm::formatv(addEffectCode, effect, "", parameters, stage,
                               effectOnFullRegion, resource)
                     .str();
       } else if (location.kind == EffectKind::Symbol) {
@@ -3712,12 +3716,12 @@ void OpEmitter::genSideEffectInterfaceMethods() {
         std::string argName = op.getGetterName(attr->name);
         if (attr->attr.isOptional()) {
           body << "  if (auto symbolRef = " << argName << "Attr())\n  "
-               << llvm::formatv(addEffectCode, effect, "symbolRef, ", stage,
-                                effectOnFullRegion, resource)
+               << llvm::formatv(addEffectCode, effect, "symbolRef, ",
+                                parameters, stage, effectOnFullRegion, resource)
                       .str();
         } else {
           body << llvm::formatv(addEffectCode, effect, argName + "Attr(), ",
-                                stage, effectOnFullRegion, resource)
+                                parameters, stage, effectOnFullRegion, resource)
                       .str();
         }
       } else {
@@ -3732,7 +3736,7 @@ void OpEmitter::genSideEffectInterfaceMethods() {
                               (location.kind == EffectKind::Operand
                                    ? "&getOperation()->getOpOperand(idx), "
                                    : "getOperation()->getOpResult(idx), "),
-                              stage, effectOnFullRegion, resource)
+                              parameters, stage, effectOnFullRegion, resource)
              << "    }\n  }\n";
       }
     }


### PR DESCRIPTION
Memory effect resources can have arbitrary Attribute parameters attached by each operation to give extra metadata about how the operation's memory effects vis-a-vis the resource. This PR adds the ability to attach these attributes through the ODS markers, making it more convenient to define.