### PR TITLE
[Support] Refactor SourceMgr location formatting to reduce code duplication (NFC)

### DIFF
--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -246,14 +246,12 @@ std::string SourceMgr::getFormattedLocationNoOffset(SMLoc Loc,
   assert(BufferID && "Invalid location!");
   auto FileSpec = getBufferInfo(BufferID).Buffer->getBufferIdentifier();
 
-  if (IncludePath) {
+  if (IncludePath)
     return FileSpec.str() + ":" + std::to_string(FindLineNumber(Loc, BufferID));
-  } else {
-    auto I = FileSpec.find_last_of("/\\");
-    I = (I == FileSpec.size()) ? 0 : (I + 1);
-    return FileSpec.substr(I).str() + ":" +
-           std::to_string(FindLineNumber(Loc, BufferID));
-  }
+  auto I = FileSpec.find_last_of("/\\");
+  I = (I == FileSpec.size()) ? 0 : (I + 1);
+  return FileSpec.substr(I).str() + ":" +
+         std::to_string(FindLineNumber(Loc, BufferID));
 }
 
 /// Given a line and column number in a mapped buffer, turn it into an SMLoc.


### PR DESCRIPTION
Extract the common line number formatting logic out of the `IncludePath` if-else branches to avoid redundancy.  

This patch addresses a `FIXME` in `llvm/lib/Support/SourceMgr.cpp`.  

Since the `if` block ends with a `return` statement, the subsequent `else` branch is redundant. Removing the `else` reduces indentation, improves code readability, and aligns with the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#don-t-use-else-after-a-return).  

NOTE:  
This is an NFC (No Functional Change) cleanup / refactoring.  

Changes:  
* Removed unnecessary `else` block in `SourceMgr.cpp`.  
* Reduced nesting level for the rest of the function logic.  

Test Plan:  
Ensure that the working directory is located in the `build/` directory under the project root, build the `SupportTests` module using `ninja`, and run `SourceMgr-related` tests using the `googletest` framework.  

```bash
ninja SupportTests && ./unittests/Support/SupportTests --gtest_filter=SourceMgrTest.*
```