### PR TITLE
[NFC][Cuda][test] Fix CHECK-NOT patterns matching the build directory

### DIFF
--- a/clang/test/Driver/cuda-omp-unsupported-debug-options.cu
+++ b/clang/test/Driver/cuda-omp-unsupported-debug-options.cu
@@ -57,6 +57,6 @@
 // WARN-GES-SAME: requires DWARF-5 but target 'nvptx64-nvidia-cuda' only provides DWARF-2 [-Wunsupported-target-opt]
 // COMMON-NOT: debug information option '{{.*}}' is not supported for target 'x86
 // COMMON: "-triple" "nvptx64-nvidia-cuda"
-// COMMON-NOT: {{-compress-debug|-fdebug-info-for-profiling|lldb|codeview|module-format|embed-source|debug-info-macro|gnu-pubnames|generate-arange-section|generate-type-units}}
+// COMMON-NOT: {{-compress-debug-sections=|-fdebug-info-for-profiling|-debugger-tuning=lldb|-gcodeview|-fmodule-format=|-gembed-source|-debug-info-macro|-ggnu-pubnames|-generate-arange-section|-generate-type-units}}
 // COMMON: "-triple" "x86_64
-// COMMON-SAME: {{-compress-debug|-fdebug-info-for-profiling|split-dwarf|lldb|codeview|module-format|embed-source|debug-info-macro|gnu-pubnames|generate-arange-section|generate-type-units}}
+// COMMON-SAME: {{-compress-debug-sections=|-fdebug-info-for-profiling|-split-dwarf-|-debugger-tuning=lldb|-gcodeview|-fmodule-format=|-gembed-source|-debug-info-macro|-ggnu-pubnames|-generate-arange-section|-generate-type-units}}


### PR DESCRIPTION
`cuda-omp-unsupported-debug-options.cu`'s COMMON-NOT: ...|lldb|... can match against the build directory path that may contain `lldb` in the pathname. Change the test to check the exact cc1 arguments.