### PR TITLE
[clang-tidy] Segregate clang-tidy tests requiring static-analyzer

### DIFF
--- a/clang-tools-extra/test/clang-tidy/infrastructure/empty-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/empty-database.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: static-analyzer
 // UNSUPPORTED: system-windows
 
 // RUN: clang-tidy -checks='-*,clang-analyzer-*' -p %S/Inputs/empty-database %s 2>&1 | FileCheck %s

--- a/clang-tools-extra/test/clang-tidy/infrastructure/invalid-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/invalid-database.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: static-analyzer
 // UNSUPPORTED: system-windows
 
 // RUN: not --crash clang-tidy -checks='-*,clang-analyzer-*' -p %S/Inputs/invalid-database %s 2>&1 | FileCheck %s

--- a/clang-tools-extra/test/clang-tidy/infrastructure/pr37091.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/pr37091.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: static-analyzer
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 

--- a/clang-tools-extra/test/clang-tidy/infrastructure/verify-config-static-analyzer.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/verify-config-static-analyzer.cpp
@@ -1,0 +1,8 @@
+// REQUIRES: static-analyzer
+// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n  clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic: true' > %t.MyClangTidyConfigCSA
+// RUN: clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSA 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-OK -implicit-check-not='{{warnings|error}}'
+// CHECK-VERIFY-CSA-OK: No config errors detected.
+
+// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n  clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic: true' > %t.MyClangTidyConfigCSABad
+// RUN: not clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSABad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-BAD -implicit-check-not='{{warnings|error}}'
+// CHECK-VERIFY-CSA-BAD: command-line option '-config': warning: unknown check option 'clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic'; did you mean 'clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic' [-verify-config]

--- a/clang-tools-extra/test/clang-tidy/infrastructure/verify-config.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/verify-config.cpp
@@ -28,11 +28,3 @@
 // RUN: --config-file=%t.MyClangTidyConfigBad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-BLOCK-BAD
 // CHECK-VERIFY-BLOCK-BAD: command-line option '-config': warning: check glob 'bugprone-arguments-*' doesn't match any known check [-verify-config]
 // CHECK-VERIFY-BLOCK-BAD: command-line option '-config': warning: unknown check 'bugprone-assert-side-effects'; did you mean 'bugprone-assert-side-effect' [-verify-config]
-
-// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic: true' > %t.MyClangTidyConfigCSA
-// RUN: clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSA 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-OK -implicit-check-not='{{warnings|error}}'
-// CHECK-VERIFY-CSA-OK: No config errors detected.
-
-// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic: true' > %t.MyClangTidyConfigCSABad
-// RUN: not clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSABad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-BAD -implicit-check-not='{{warnings|error}}'
-// CHECK-VERIFY-CSA-BAD: command-line option '-config': warning: unknown check option 'clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic'; did you mean 'clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic' [-verify-config]


### PR DESCRIPTION
When LLVM is configured with `-DCLANG_ENABLE_STATIC_ANALYZER=OFF`,
`clang-tidy` tests that invoke `clang-analyzer-*` checks or verify
`clang-analyzer` check options fail because static analyzer support is
not compiled into `clang-tidy`.

These tests started failing recently for `-DCLANG_ENABLE_STATIC_ANALYZER=OFF`
builds due to a chain of upstream changes:
- Commit #157306 removed `clang-analyzer-*` from `clang-tidy`'s default
  checks.
- Commit #170895 updated `empty-database.cpp` and `invalid-database.cpp`
  to explicitly pass `-checks='-*,clang-analyzer-*'` on the command line.
  Passing this explicitly causes `clang-tidy` to attempt loading the
  analyzer checks, which fails when static analyzer support is disabled.

Add `// REQUIRES: static-analyzer` to `empty-database.cpp`,
`invalid-database.cpp`, and `pr37091.cpp`, and move the static analyzer
test cases from `verify-config.cpp` into a new
`verify-config-static-analyzer.cpp` file with
`// REQUIRES: static-analyzer`.