### PR TITLE
[SandboxVec][SeedCollector] Fix seed insert if can't determine mem access distance

### DIFF
--- a/llvm/include/llvm/SandboxIR/Utils.h
+++ b/llvm/include/llvm/SandboxIR/Utils.h
@@ -87,7 +87,7 @@ public:
   }
 
   /// \Returns the gap between the memory locations accessed by \p I0 and
-  /// \p I1 in bytes.
+  /// \p I1 in bytes. Returns nullopt if the gap can't be determined.
   template <typename LoadOrStoreT>
   static std::optional<int> getPointerDiffInBytes(LoadOrStoreT *I0,
                                                   LoadOrStoreT *I1,
@@ -100,21 +100,22 @@ public:
     llvm::Value *Ptr0 = getUnderlyingObject(Opnd0);
     llvm::Value *Ptr1 = getUnderlyingObject(Opnd1);
     if (Ptr0 != Ptr1)
-      return false;
+      return std::nullopt;
     llvm::Type *ElemTy = llvm::Type::getInt8Ty(SE.getContext());
     return getPointersDiff(ElemTy, Opnd0, ElemTy, Opnd1, I0->getDataLayout(),
                            SE, /*StrictCheck=*/false, /*CheckType=*/false);
   }
 
   /// \Returns true if \p I0 accesses a memory location lower than \p I1.
-  /// Returns false if the difference cannot be determined, if the memory
-  /// locations are equal, or if I1 accesses a memory location greater than I0.
+  /// Returns false if the memory locations are equal, or if I1 accesses a
+  /// memory location greater than I0. Returns nullopt if the difference cannot
+  /// be determined.
   template <typename LoadOrStoreT>
-  static bool atLowerAddress(LoadOrStoreT *I0, LoadOrStoreT *I1,
-                             ScalarEvolution &SE) {
+  static std::optional<bool> atLowerAddress(LoadOrStoreT *I0, LoadOrStoreT *I1,
+                                            ScalarEvolution &SE) {
     auto Diff = getPointerDiffInBytes(I0, I1, SE);
     if (!Diff)
-      return false;
+      return std::nullopt;
     return *Diff > 0;
   }
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
@@ -55,7 +55,7 @@ public:
     NumUnusedBits += Utils::getNumBits(I);
   }
 
-  virtual void insert(Instruction *I, ScalarEvolution &SE) = 0;
+  virtual bool tryInsert(Instruction *I, ScalarEvolution &SE) = 0;
 
   unsigned getFirstUnusedElementIdx() const {
     for (unsigned ElmIdx : seq<unsigned>(0, Seeds.size()))
@@ -143,8 +143,8 @@ public:
     assert(all_of(Seeds, [](auto *S) { return isa<LoadOrStoreT>(S); }) &&
            "Expected Load or Store instructions!");
     auto Cmp = [&SE](Instruction *I0, Instruction *I1) {
-      return Utils::atLowerAddress(cast<LoadOrStoreT>(I0),
-                                   cast<LoadOrStoreT>(I1), SE);
+      return *Utils::atLowerAddress(cast<LoadOrStoreT>(I0),
+                                    cast<LoadOrStoreT>(I1), SE);
     };
     std::sort(Seeds.begin(), Seeds.end(), Cmp);
   }
@@ -154,14 +154,21 @@ public:
                   "Expected LoadInst or StoreInst!");
     assert(isa<LoadOrStoreT>(MemI) && "Expected Load or Store!");
   }
-  void insert(sandboxir::Instruction *I, ScalarEvolution &SE) override {
+  bool tryInsert(sandboxir::Instruction *I, ScalarEvolution &SE) override {
     assert(isa<LoadOrStoreT>(I) && "Expected a Store or a Load!");
+    // Early return if we can't determine the mem access ordering.
+    auto DiffOpt = Utils::getPointerDiffInBytes(
+        cast<LoadOrStoreT>(Seeds.back()), cast<LoadOrStoreT>(I), SE);
+    if (!DiffOpt)
+      return false;
+
     auto Cmp = [&SE](Instruction *I0, Instruction *I1) {
-      return Utils::atLowerAddress(cast<LoadOrStoreT>(I0),
-                                   cast<LoadOrStoreT>(I1), SE);
+      return *Utils::atLowerAddress(cast<LoadOrStoreT>(I0),
+                                    cast<LoadOrStoreT>(I1), SE);
     };
     // Find the first element after I in mem. Then insert I before it.
     insertAt(llvm::upper_bound(*this, I, Cmp), I);
+    return true;
   }
 };
 

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SeedCollector.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SeedCollector.cpp
@@ -116,7 +116,7 @@ void SeedContainer::insert(LoadOrStoreT *LSI, bool AllowDiffTypes) {
   if (BundleVec.empty() || BundleVec.back()->size() == SeedBundleSizeLimit)
     BundleVec.emplace_back(std::make_unique<MemSeedBundle<LoadOrStoreT>>(LSI));
   else
-    BundleVec.back()->insert(LSI, SE);
+    BundleVec.back()->tryInsert(LSI, SE);
 
   SeedLookupMap[LSI] = BundleVec.back().get();
 }

--- a/llvm/test/Transforms/SandboxVectorizer/Passes/SeedCollection/seed_collection.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/Passes/SeedCollection/seed_collection.ll
@@ -18,3 +18,17 @@ define void @collect_seeds_of_diff_types(ptr %ptr) {
   store i8 %ld2, ptr %ptr2
   ret void
 }
+
+; Insertion used to crash because the comparator for upper_bound was broken.
+define void @partitioning_required(ptr %ptr, i64 %offset) {
+  %ptr0 = getelementptr inbounds nuw i8, ptr %ptr, i64 0
+  %ptr1 = getelementptr inbounds nuw i8, ptr %ptr, i64 1
+  %ptr3 = getelementptr inbounds nuw i8, ptr %ptr, i64 %offset
+
+  store i8 42, ptr %ptr0
+  store i8 42, ptr %ptr1
+  store i8 42, ptr %ptr3
+
+  store i8 42, ptr %ptr0
+  ret void
+}

--- a/llvm/unittests/SandboxIR/UtilsTest.cpp
+++ b/llvm/unittests/SandboxIR/UtilsTest.cpp
@@ -64,16 +64,20 @@ define void @foo(ptr %arg0) {
 
 TEST_F(UtilsTest, GetPointerDiffInBytes) {
   parseIR(C, R"IR(
-define void @foo(ptr %ptr) {
+define void @foo(ptr %ptr, i64 %val, ptr %ptrY) {
   %gep0 = getelementptr inbounds float, ptr %ptr, i64 0
   %gep1 = getelementptr inbounds float, ptr %ptr, i64 1
   %gep2 = getelementptr inbounds float, ptr %ptr, i64 2
   %gep3 = getelementptr inbounds float, ptr %ptr, i64 3
+  %gepX = getelementptr inbounds float, ptr %ptr, i64 %val
 
   %ld0 = load float, ptr %gep0
   %ld1 = load float, ptr %gep1
   %ld2 = load float, ptr %gep2
   %ld3 = load float, ptr %gep3
+
+  %ldX = load float, ptr %gepX
+  %ldY = load float, ptr %ptrY
 
   %v2ld0 = load <2 x float>, ptr %gep0
   %v2ld1 = load <2 x float>, ptr %gep1
@@ -102,11 +106,13 @@ define void @foo(ptr %ptr) {
 
   auto &F = *Ctx.createFunction(&LLVMF);
   auto &BB = *F.begin();
-  auto It = std::next(BB.begin(), 4);
+  auto It = std::next(BB.begin(), 5);
   auto *L0 = cast<sandboxir::LoadInst>(&*It++);
   auto *L1 = cast<sandboxir::LoadInst>(&*It++);
   auto *L2 = cast<sandboxir::LoadInst>(&*It++);
   [[maybe_unused]] auto *L3 = cast<sandboxir::LoadInst>(&*It++);
+  auto *LX = cast<sandboxir::LoadInst>(&*It++);
+  auto *LY = cast<sandboxir::LoadInst>(&*It++);
 
   auto *V2L0 = cast<sandboxir::LoadInst>(&*It++);
   auto *V2L1 = cast<sandboxir::LoadInst>(&*It++);
@@ -119,6 +125,8 @@ define void @foo(ptr %ptr) {
   [[maybe_unused]] auto *V3L3 = cast<sandboxir::LoadInst>(&*It++);
 
   // getPointerDiffInBytes
+  EXPECT_EQ(sandboxir::Utils::getPointerDiffInBytes(L0, LX, SE), std::nullopt);
+  EXPECT_EQ(sandboxir::Utils::getPointerDiffInBytes(L0, LY, SE), std::nullopt);
   EXPECT_EQ(*sandboxir::Utils::getPointerDiffInBytes(L0, L1, SE), 4);
   EXPECT_EQ(*sandboxir::Utils::getPointerDiffInBytes(L0, L2, SE), 8);
   EXPECT_EQ(*sandboxir::Utils::getPointerDiffInBytes(L1, L0, SE), -4);
@@ -131,9 +139,11 @@ define void @foo(ptr %ptr) {
   EXPECT_EQ(*sandboxir::Utils::getPointerDiffInBytes(V2L3, V2L0, SE), -12);
 
   // atLowerAddress
-  EXPECT_TRUE(sandboxir::Utils::atLowerAddress(L0, L1, SE));
-  EXPECT_FALSE(sandboxir::Utils::atLowerAddress(L1, L0, SE));
-  EXPECT_FALSE(sandboxir::Utils::atLowerAddress(L3, V3L3, SE));
+  EXPECT_EQ(sandboxir::Utils::atLowerAddress(L0, LX, SE), std::nullopt);
+  EXPECT_EQ(sandboxir::Utils::atLowerAddress(L0, LY, SE), std::nullopt);
+  EXPECT_TRUE(*sandboxir::Utils::atLowerAddress(L0, L1, SE));
+  EXPECT_FALSE(*sandboxir::Utils::atLowerAddress(L1, L0, SE));
+  EXPECT_FALSE(*sandboxir::Utils::atLowerAddress(L3, V3L3, SE));
 }
 
 TEST_F(UtilsTest, GetExpected) {

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SeedCollectorTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SeedCollectorTest.cpp
@@ -60,8 +60,9 @@ struct SeedBundleTest : public testing::Test {
 class SeedBundleForTest : public sandboxir::SeedBundle {
 public:
   using sandboxir::SeedBundle::SeedBundle;
-  void insert(sandboxir::Instruction *I, ScalarEvolution &SE) override {
+  bool tryInsert(sandboxir::Instruction *I, ScalarEvolution &SE) override {
     insertAt(Seeds.end(), I);
+    return true;
   }
 };
 
@@ -203,9 +204,9 @@ bb:
 
   // Single instruction constructor; test insert out of memory order
   sandboxir::StoreSeedBundle SB(S3);
-  SB.insert(S1, SE);
-  SB.insert(S2, SE);
-  SB.insert(S0, SE);
+  EXPECT_TRUE(SB.tryInsert(S1, SE));
+  EXPECT_TRUE(SB.tryInsert(S2, SE));
+  EXPECT_TRUE(SB.tryInsert(S0, SE));
   EXPECT_THAT(SB, testing::ElementsAre(S0, S1, S2, S3));
 
   // Instruction list constructor; test list out of order
@@ -220,6 +221,65 @@ bb:
   Loads.push_back(L0);
   sandboxir::LoadSeedBundle LB(std::move(Loads), SE);
   EXPECT_THAT(LB, testing::ElementsAre(L0, L1, L2, L3));
+}
+
+TEST_F(SeedBundleTest, TryInsert) {
+  parseIR(C, R"IR(
+define void @foo(float %val, ptr %ptr, i32 %arg, ptr %ptrY) {
+bb:
+  %gep0 = getelementptr float, ptr %ptr, i32 0
+  %gep1 = getelementptr float, ptr %ptr, i32 1
+  %gep2 = getelementptr float, ptr %ptr, i32 2
+  %gepX = getelementptr float, ptr %ptr, i32 %arg
+
+  store float %val, ptr %gep0
+  store float %val, ptr %gep1
+  store float %val, ptr %gepX
+  store float %val, ptr %ptrY
+  ret void
+}
+)IR");
+  Function &LLVMF = *M->getFunction("foo");
+
+  DominatorTree DT(LLVMF);
+  TargetLibraryInfoImpl TLII(M->getTargetTriple());
+  TargetLibraryInfo TLI(TLII);
+  DataLayout DL(M->getDataLayout());
+  LoopInfo LI(DT);
+  AssumptionCache AC(LLVMF);
+  ScalarEvolution SE(LLVMF, TLI, AC, DT, LI);
+
+  sandboxir::Context Ctx(C);
+  auto &F = *Ctx.createFunction(&LLVMF);
+  auto *BB = &*F.begin();
+  auto It = std::next(BB->begin(), 4);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *SX = cast<sandboxir::StoreInst>(&*It++);
+  auto *SY = cast<sandboxir::StoreInst>(&*It++);
+
+  {
+    sandboxir::StoreSeedBundle Seeds(S0);
+    EXPECT_TRUE(Seeds.tryInsert(S1, SE));
+    EXPECT_FALSE(Seeds.tryInsert(SX, SE));
+    ExpectThatElementsAre(Seeds, {S0, S1});
+    EXPECT_FALSE(Seeds.tryInsert(SY, SE));
+    ExpectThatElementsAre(Seeds, {S0, S1});
+  }
+  {
+    sandboxir::StoreSeedBundle Seeds(SX);
+    EXPECT_FALSE(Seeds.tryInsert(S1, SE));
+    EXPECT_FALSE(Seeds.tryInsert(S0, SE));
+    EXPECT_FALSE(Seeds.tryInsert(SY, SE));
+    ExpectThatElementsAre(Seeds, {SX});
+  }
+  {
+    sandboxir::StoreSeedBundle Seeds(SY);
+    EXPECT_FALSE(Seeds.tryInsert(S1, SE));
+    EXPECT_FALSE(Seeds.tryInsert(S0, SE));
+    EXPECT_FALSE(Seeds.tryInsert(SX, SE));
+    ExpectThatElementsAre(Seeds, {SY});
+  }
 }
 
 TEST_F(SeedBundleTest, Container) {


### PR DESCRIPTION
Up until now we would insert a memory instruction in a MemSeedBundle even if we could not determine the access distance against the existing bundle instructionss. This was causing a crash in the invocation of upper_bound() as the vector could no longer be partitioned.

The fix is to extend the functions that check the memory access ordering to return nullopt when the access difference can't be determined.