### PR TITLE
[RISCV] Fix Xqci Fusions with Frame Indexes

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -24,6 +24,7 @@ def TuneMOVIMMALUXqciFusion
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
+                     CheckIsRegOperand<1>,
                      CheckRegOperand<1, X0>
                    ]>,
                    CheckOpcode<LoadImmOp>,
@@ -44,6 +45,7 @@ def TuneMOVIMMMULXqciFusion
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
+                     CheckIsRegOperand<1>,
                      CheckRegOperand<1, X0>
                    ]>,
                    CheckOpcode<LoadImmOp>,
@@ -57,6 +59,7 @@ def TuneMOVIMMLoadStoreXqciFusion
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
+                     CheckIsRegOperand<1>,
                      CheckRegOperand<1, X0>
                    ]>,
                    CheckOpcode<LoadImmOp>,
@@ -70,6 +73,7 @@ def TuneMOVIMMJumpXqciFusion
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
+                     CheckIsRegOperand<1>,
                      CheckRegOperand<1, X0>
                    ]>,
                    CheckOpcode<LoadImmOp>,
@@ -86,6 +90,7 @@ def TuneMOVIMMLongAccumXciFusion
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
+                     CheckIsRegOperand<1>,
                      CheckRegOperand<1, X0>
                    ]>,
                    CheckOpcode<LoadImmOp>,
@@ -100,7 +105,7 @@ def TuneMovALUXqciFusion
                  CheckAll<[
                    CheckOpcode<[ADDI]>,
                    CheckIsImmOperand<2>,
-                   CheckImmOperand<2, 0>
+                   CheckImmOperand<2, 0>,
                  ]>,
                  CheckOpcode<LongAccumXqciOp>,
                  epilog=[TieReg<0, 0>]>;

--- a/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
@@ -101,3 +101,20 @@ body:             |
     $x13 = COPY $x12
     $x10 = COPY $x11
 ...
+
+# CHECK: movimm_alu_xqci_frameindex
+## No Reg in the ADDI, needs to not crash
+name: movimm_alu_xqci_frameindex
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 4, alignment: 4 }
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = ADDI %stack.0, 0
+    %3:gpr = ADD %2, %1
+    $x10 = COPY %3
+    PseudoRET implicit $x10
+...
+


### PR DESCRIPTION
Pre-RA, the ADDI can contain a frame index rather than a register, which causes `getReg()` to assert. These were missing the `CheckIsRegOperand` that most other fusions have.

---

Probably best we didn't backport this, I guess.