### PR TITLE
[PowerPC] Remove tlbie one-operand InstAlias for ISA 3.0+

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -5003,7 +5003,6 @@ def : InstAlias<"mficcr $Rx", (MFSPR gprc:$Rx, 1019)>, Requires<[IsPPC4xx]>;
 
 def : InstAlias<"tlbie $RB", (TLBIE R0, gprc:$RB)>,  Requires<[IsNotISA3_0]>;
 let Predicates = [IsISA3_0] in {
-  def : InstAlias<"tlbie $RB", (TLBIEP9 R0, gprc:$RB, 0, 0, 0)>;
   def : InstAlias<"tlbie $RB, $RS", (TLBIEP9 gprc:$RB, gprc:$RS, 0, 0, 0)>;
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -5003,7 +5003,7 @@ def : InstAlias<"mficcr $Rx", (MFSPR gprc:$Rx, 1019)>, Requires<[IsPPC4xx]>;
 
 def : InstAlias<"tlbie $RB", (TLBIE R0, gprc:$RB)>,  Requires<[IsNotISA3_0]>;
 let Predicates = [IsISA3_0] in {
-  def : InstAlias<"tlbie $RB", (TLBIEP9 R0, gprc:$RB, 0, 0, 0)>;
+  def : InstAlias<"tlbie $RB", (TLBIEP9 gprc:$RB, R0, 0, 0, 0)>;
   def : InstAlias<"tlbie $RB, $RS", (TLBIEP9 gprc:$RB, gprc:$RS, 0, 0, 0)>;
 }
 

--- a/llvm/test/MC/PowerPC/ppc64-encoding-bookIII.s
+++ b/llvm/test/MC/PowerPC/ppc64-encoding-bookIII.s
@@ -170,6 +170,22 @@
 # CHECK-LE: tlbie 4                         # encoding: [0x64,0x22,0x00,0x7c]
             tlbie %r4
 
+# CHECK-BE: tlbie 4, 0                      # encoding: [0x7c,0x00,0x22,0x64]
+# CHECK-LE: tlbie 4, 0                      # encoding: [0x64,0x22,0x00,0x7c]
+            tlbie 4, 0, 0, 0, 0
+
+# CHECK-BE: tlbie 0, 4                      # encoding: [0x7c,0x80,0x02,0x64]
+# CHECK-LE: tlbie 0, 4                      # encoding: [0x64,0x02,0x80,0x7c]
+            tlbie 0, 4, 0, 0, 0
+
+# CHECK-BE: tlbie 4, 5                      # encoding: [0x7c,0xa0,0x22,0x64]
+# CHECK-LE: tlbie 4, 5                      # encoding: [0x64,0x22,0xa0,0x7c]
+            tlbie 4, 5, 0, 0, 0
+
+# CHECK-BE: tlbie 4, 5, 2, 1, 0             # encoding: [0x7c,0xaa,0x22,0x64]
+# CHECK-LE: tlbie 4, 5, 2, 1, 0             # encoding: [0x64,0x22,0xaa,0x7c]
+            tlbie 4, 5, 2, 1, 0
+
 # CHECK-BE: tlbilx 1, 4, 5                  # encoding: [0x7c,0x24,0x28,0x24]
 # CHECK-LE: tlbilx 1, 4, 5                  # encoding: [0x24,0x28,0x24,0x7c]
             tlbilx 1, %r4, %r5

--- a/llvm/test/MC/PowerPC/ppc64-encoding-bookIII.s
+++ b/llvm/test/MC/PowerPC/ppc64-encoding-bookIII.s
@@ -170,6 +170,14 @@
 # CHECK-LE: tlbie 4                         # encoding: [0x64,0x22,0x00,0x7c]
             tlbie %r4
 
+# CHECK-BE: tlbie 4                         # encoding: [0x7c,0x00,0x22,0x64]
+# CHECK-LE: tlbie 4                         # encoding: [0x64,0x22,0x00,0x7c]
+            tlbie 4, 0, 0, 0, 0
+
+# CHECK-BE: tlbie 4, 5                      # encoding: [0x7c,0xa0,0x22,0x64]
+# CHECK-LE: tlbie 4, 5                      # encoding: [0x64,0x22,0xa0,0x7c]
+            tlbie 4, 5, 0, 0, 0
+
 # CHECK-BE: tlbilx 1, 4, 5                  # encoding: [0x7c,0x24,0x28,0x24]
 # CHECK-LE: tlbilx 1, 4, 5                  # encoding: [0x24,0x28,0x24,0x7c]
             tlbilx 1, %r4, %r5


### PR DESCRIPTION
tlbie for ISA 3.0+, aka TLBIEP9, only has a two-operand form or a 5-operand form.