### PR TITLE
[Hexagon][Driver] Tell llvm-mc about PIC under -fno-integrated-as

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -218,6 +218,9 @@ void hexagon::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
       "-mcpu=hexagon" +
       toolchains::HexagonToolChain::GetTargetCPUVersion(Args)));
 
+  if (std::get<0>(ParsePICArgs(HTC, Args)) == llvm::Reloc::PIC_)
+    CmdArgs.push_back("-position-independent");
+
   addSanitizerRuntimes(HTC, Args, CmdArgs);
 
   assert((Output.isFilename() || Output.isNothing()) && "Invalid output.");

--- a/clang/test/Driver/hexagon-eh-frame-pic.c
+++ b/clang/test/Driver/hexagon-eh-frame-pic.c
@@ -1,0 +1,36 @@
+/// Hexagon selects the .eh_frame FDE pointer encoding from whether the code is
+/// position independent (DW_EH_PE_pcrel vs DW_EH_PE_absptr, see
+/// MCObjectFileInfo::initELFMCObjectFileInfo).  llvm-mc defaults to non-PIC, so
+/// the driver has to tell it, or -fno-integrated-as produces unwind tables that
+/// disagree with the ones the integrated assembler produces for the same input
+/// (R_HEX_32 instead of R_HEX_32_PCREL).
+
+/// hexagon-unknown-linux-musl defaults to PIC.
+// RUN: %clang --target=hexagon-unknown-linux-musl -fno-integrated-as \
+// RUN:   -funwind-tables -c %s -### 2>&1 | FileCheck %s --check-prefix=PIC
+
+// RUN: %clang --target=hexagon-unknown-linux-musl -fno-integrated-as -fPIC \
+// RUN:   -funwind-tables -c %s -### 2>&1 | FileCheck %s --check-prefix=PIC
+
+// RUN: %clang --target=hexagon-unknown-linux-musl -fno-integrated-as -fpie \
+// RUN:   -funwind-tables -c %s -### 2>&1 | FileCheck %s --check-prefix=PIC
+
+/// Non-PIC keeps DW_EH_PE_absptr, so llvm-mc must not be told otherwise.
+// RUN: %clang --target=hexagon-unknown-linux-musl -fno-integrated-as -fno-pic \
+// RUN:   -funwind-tables -c %s -### 2>&1 | FileCheck %s --check-prefix=NOPIC
+
+/// Bare-metal ELF defaults to non-PIC.
+// RUN: %clang --target=hexagon-unknown-elf -fno-integrated-as \
+// RUN:   -funwind-tables -c %s -### 2>&1 | FileCheck %s --check-prefix=NOPIC
+
+// RUN: %clang --target=hexagon-unknown-elf -fno-integrated-as -fPIC \
+// RUN:   -funwind-tables -c %s -### 2>&1 | FileCheck %s --check-prefix=PIC
+
+// PIC: llvm-mc
+// PIC: "-position-independent"
+
+// NOPIC: llvm-mc
+// NOPIC-NOT: "-position-independent"
+
+void f(void);
+void g(void) { f(); }


### PR DESCRIPTION
Hexagon picks the .eh_frame FDE pointer encoding from whether the code is position independent: DW_EH_PE_pcrel if so, DW_EH_PE_absptr otherwise (MCObjectFileInfo::initELFMCObjectFileInfo).  Unlike most targets, Hexagon uses llvm-mc rather than GNU as for -fno-integrated-as, and the driver was not passing the PIC setting along.  llvm-mc defaults to non-PIC, so the same source assembled the two ways produced different unwind tables: the integrated assembler emitted R_HEX_32_PCREL, while -fno-integrated-as emitted R_HEX_32 with an absptr CIE augmentation.

hexagon-unknown-linux-musl defaults to PIC, so it was the default config that diverged.

Pass -position-independent to llvm-mc when the relocation model is PIC. Non-PIC keeps DW_EH_PE_absptr, unchanged.