### PR TITLE
[lld-macho] Add native LTO optimization remark options

### DIFF
--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -170,6 +170,10 @@ struct Configuration {
   llvm::StringRef mapFile;
   llvm::StringRef ltoNewPmPasses;
   llvm::StringRef ltoObjPath;
+  llvm::StringRef optRemarksFilename;
+  std::optional<uint64_t> optRemarksHotnessThreshold = 0;
+  llvm::StringRef optRemarksPasses;
+  llvm::StringRef optRemarksFormat;
   llvm::StringRef thinLTOJobs;
   llvm::StringRef umbrella;
   uint32_t ltoo = 2;
@@ -217,6 +221,7 @@ struct Configuration {
   std::vector<SectionAlign> sectionAlignments;
   std::vector<SegmentProtection> segmentProtections;
   bool ltoDebugPassManager = false;
+  bool optRemarksWithHotness = false;
   bool emitLLVM = false;
   llvm::StringRef codegenDataGeneratePath;
   bool csProfileGenerate = false;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -41,6 +41,7 @@
 #include "llvm/LTO/LTO.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Option/ArgList.h"
+#include "llvm/Remarks/HotnessThresholdParser.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
@@ -1986,6 +1987,18 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   }
   config->ltoObjPath = args.getLastArgValue(OPT_object_path_lto);
   config->ltoNewPmPasses = args.getLastArgValue(OPT_lto_newpm_passes);
+  config->optRemarksFilename = args.getLastArgValue(OPT_opt_remarks_filename);
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_hotness_threshold)) {
+    auto threshold = remarks::parseHotnessThresholdOption(arg->getValue());
+    if (!threshold)
+      error(arg->getSpelling() + ": invalid argument '" + arg->getValue() +
+            "', only integer or 'auto' is supported");
+    else
+      config->optRemarksHotnessThreshold = *threshold;
+  }
+  config->optRemarksPasses = args.getLastArgValue(OPT_opt_remarks_passes);
+  config->optRemarksWithHotness = args.hasArg(OPT_opt_remarks_with_hotness);
+  config->optRemarksFormat = args.getLastArgValue(OPT_opt_remarks_format);
   config->thinLTOCacheDir = args.getLastArgValue(OPT_cache_path_lto);
   config->thinLTOCachePolicy = getLTOCachePolicy(args);
   config->thinLTOEmitImportsFiles = args.hasArg(OPT_thinlto_emit_imports_files);

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1987,8 +1987,9 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   }
   config->ltoObjPath = args.getLastArgValue(OPT_object_path_lto);
   config->ltoNewPmPasses = args.getLastArgValue(OPT_lto_newpm_passes);
-  config->optRemarksFilename = args.getLastArgValue(
-      OPT_opt_remarks_filename, OPT_opt_remarks_filename_eq);
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_filename,
+                                       OPT_opt_remarks_filename_eq))
+    config->optRemarksFilename = arg->getValue();
   if (const Arg *arg = args.getLastArg(OPT_opt_remarks_hotness_threshold,
                                        OPT_opt_remarks_hotness_threshold_eq)) {
     auto threshold = remarks::parseHotnessThresholdOption(arg->getValue());
@@ -1998,11 +1999,13 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     else
       config->optRemarksHotnessThreshold = *threshold;
   }
-  config->optRemarksPasses =
-      args.getLastArgValue(OPT_opt_remarks_passes, OPT_opt_remarks_passes_eq);
+  if (const Arg *arg =
+          args.getLastArg(OPT_opt_remarks_passes, OPT_opt_remarks_passes_eq))
+    config->optRemarksPasses = arg->getValue();
   config->optRemarksWithHotness = args.hasArg(OPT_opt_remarks_with_hotness);
-  config->optRemarksFormat =
-      args.getLastArgValue(OPT_opt_remarks_format, OPT_opt_remarks_format_eq);
+  if (const Arg *arg =
+          args.getLastArg(OPT_opt_remarks_format, OPT_opt_remarks_format_eq))
+    config->optRemarksFormat = arg->getValue();
   config->thinLTOCacheDir = args.getLastArgValue(OPT_cache_path_lto);
   config->thinLTOCachePolicy = getLTOCachePolicy(args);
   config->thinLTOEmitImportsFiles = args.hasArg(OPT_thinlto_emit_imports_files);

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1987,8 +1987,10 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   }
   config->ltoObjPath = args.getLastArgValue(OPT_object_path_lto);
   config->ltoNewPmPasses = args.getLastArgValue(OPT_lto_newpm_passes);
-  config->optRemarksFilename = args.getLastArgValue(OPT_opt_remarks_filename);
-  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_hotness_threshold)) {
+  config->optRemarksFilename = args.getLastArgValue(
+      OPT_opt_remarks_filename, OPT_opt_remarks_filename_eq);
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_hotness_threshold,
+                                       OPT_opt_remarks_hotness_threshold_eq)) {
     auto threshold = remarks::parseHotnessThresholdOption(arg->getValue());
     if (!threshold)
       error(arg->getSpelling() + ": invalid argument '" + arg->getValue() +
@@ -1996,9 +1998,11 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     else
       config->optRemarksHotnessThreshold = *threshold;
   }
-  config->optRemarksPasses = args.getLastArgValue(OPT_opt_remarks_passes);
+  config->optRemarksPasses =
+      args.getLastArgValue(OPT_opt_remarks_passes, OPT_opt_remarks_passes_eq);
   config->optRemarksWithHotness = args.hasArg(OPT_opt_remarks_with_hotness);
-  config->optRemarksFormat = args.getLastArgValue(OPT_opt_remarks_format);
+  config->optRemarksFormat =
+      args.getLastArgValue(OPT_opt_remarks_format, OPT_opt_remarks_format_eq);
   config->thinLTOCacheDir = args.getLastArgValue(OPT_cache_path_lto);
   config->thinLTOCachePolicy = getLTOCachePolicy(args);
   config->thinLTOEmitImportsFiles = args.hasArg(OPT_thinlto_emit_imports_files);

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1987,24 +1987,22 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   }
   config->ltoObjPath = args.getLastArgValue(OPT_object_path_lto);
   config->ltoNewPmPasses = args.getLastArgValue(OPT_lto_newpm_passes);
-  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_filename,
-                                       OPT_opt_remarks_filename_eq))
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_filename))
     config->optRemarksFilename = arg->getValue();
-  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_hotness_threshold,
-                                       OPT_opt_remarks_hotness_threshold_eq)) {
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_hotness_threshold)) {
     auto threshold = remarks::parseHotnessThresholdOption(arg->getValue());
-    if (!threshold)
+    if (threshold) {
+      config->optRemarksHotnessThreshold = *threshold;
+    } else {
+      consumeError(threshold.takeError());
       error(arg->getSpelling() + ": invalid argument '" + arg->getValue() +
             "', only integer or 'auto' is supported");
-    else
-      config->optRemarksHotnessThreshold = *threshold;
+    }
   }
-  if (const Arg *arg =
-          args.getLastArg(OPT_opt_remarks_passes, OPT_opt_remarks_passes_eq))
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_passes))
     config->optRemarksPasses = arg->getValue();
   config->optRemarksWithHotness = args.hasArg(OPT_opt_remarks_with_hotness);
-  if (const Arg *arg =
-          args.getLastArg(OPT_opt_remarks_format, OPT_opt_remarks_format_eq))
+  if (const Arg *arg = args.getLastArg(OPT_opt_remarks_format))
     config->optRemarksFormat = arg->getValue();
   config->thinLTOCacheDir = args.getLastArgValue(OPT_cache_path_lto);
   config->thinLTOCachePolicy = getLTOCachePolicy(args);

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -66,6 +66,12 @@ static lto::Config createConfig() {
   c.PTO.LoopVectorization = c.OptLevel > 1;
   c.PTO.SLPVectorization = c.OptLevel > 1;
 
+  c.RemarksFilename = std::string(config->optRemarksFilename);
+  c.RemarksPasses = std::string(config->optRemarksPasses);
+  c.RemarksWithHotness = config->optRemarksWithHotness;
+  c.RemarksHotnessThreshold = config->optRemarksHotnessThreshold;
+  c.RemarksFormat = std::string(config->optRemarksFormat);
+
   if (config->saveTemps)
     checkError(c.addSaveTemps(config->outputFile.str() + ".",
                               /*UseInputModulePath=*/true));

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -100,6 +100,41 @@ def lto_CGO: Joined<["--"], "lto-CGO">,
     HelpText<"Set codegen optimization level for LTO (default: 2)">,
     MetaVarName<"<cgopt-level>">,
     Group<grp_lld>;
+def opt_remarks_filename: Separate<["--"], "opt-remarks-filename">,
+    HelpText<"Output file for LTO optimization remarks">,
+    MetaVarName<"<file>">,
+    Group<grp_lld>;
+def opt_remarks_filename_eq: Joined<["--"], "opt-remarks-filename=">,
+    Alias<!cast<Separate>(opt_remarks_filename)>,
+    Group<grp_lld>;
+def opt_remarks_hotness_threshold:
+    Separate<["--"], "opt-remarks-hotness-threshold">,
+    HelpText<"Minimum profile count required for an optimization remark to be "
+             "output. Use 'auto' to apply the threshold from profile summary.">,
+    MetaVarName<"<value>">,
+    Group<grp_lld>;
+def opt_remarks_hotness_threshold_eq:
+    Joined<["--"], "opt-remarks-hotness-threshold=">,
+    Alias<!cast<Separate>(opt_remarks_hotness_threshold)>,
+    Group<grp_lld>;
+def opt_remarks_passes: Separate<["--"], "opt-remarks-passes">,
+    HelpText<"Regex for the passes that need to be serialized to the output "
+             "file">,
+    MetaVarName<"<regex>">,
+    Group<grp_lld>;
+def opt_remarks_passes_eq: Joined<["--"], "opt-remarks-passes=">,
+    Alias<!cast<Separate>(opt_remarks_passes)>,
+    Group<grp_lld>;
+def opt_remarks_with_hotness: Flag<["--"], "opt-remarks-with-hotness">,
+    HelpText<"Include hotness information in the optimization remarks file">,
+    Group<grp_lld>;
+def opt_remarks_format: Separate<["--"], "opt-remarks-format">,
+    HelpText<"The format used for serializing remarks (default: YAML)">,
+    MetaVarName<"<format>">,
+    Group<grp_lld>;
+def opt_remarks_format_eq: Joined<["--"], "opt-remarks-format=">,
+    Alias<!cast<Separate>(opt_remarks_format)>,
+    Group<grp_lld>;
 def disable_verify : Flag<["--"], "disable_verify">,
                      HelpText<"Do not verify LLVM modules during LTO">,
                      Group<grp_lld>;

--- a/lld/test/MachO/lto-opt-remarks.ll
+++ b/lld/test/MachO/lto-opt-remarks.ll
@@ -28,6 +28,9 @@
 ; RUN: not %lld -dylib %t/full.o -o /dev/null \
 ; RUN:   --opt-remarks-hotness-threshold invalid 2>&1 | \
 ; RUN:   FileCheck %s --check-prefix=ERR
+; RUN: not %lld -dylib %t/full.o -o /dev/null \
+; RUN:   --opt-remarks-hotness-threshold=invalid 2>&1 | \
+; RUN:   FileCheck %s --check-prefix=ERR
 
 ; REMARK:      --- !Passed
 ; REMARK:      Pass:            inline

--- a/lld/test/MachO/lto-opt-remarks.ll
+++ b/lld/test/MachO/lto-opt-remarks.ll
@@ -26,7 +26,7 @@
 ; RUN: cat %t/thin.yaml.thin.*.yaml | FileCheck %s --check-prefix=THIN
 
 ; RUN: not %lld -dylib %t/full.o -o /dev/null \
-; RUN:   --opt-remarks-hotness-threshold=invalid 2>&1 | \
+; RUN:   --opt-remarks-hotness-threshold invalid 2>&1 | \
 ; RUN:   FileCheck %s --check-prefix=ERR
 
 ; REMARK:      --- !Passed

--- a/lld/test/MachO/lto-opt-remarks.ll
+++ b/lld/test/MachO/lto-opt-remarks.ll
@@ -1,0 +1,62 @@
+; REQUIRES: x86
+
+; RUN: rm -rf %t; mkdir %t
+; RUN: llvm-as %s -o %t/full.o
+; RUN: %lld -dylib %t/full.o -o %t/full.dylib \
+; RUN:   --opt-remarks-filename %t/full.yaml \
+; RUN:   --opt-remarks-passes inline \
+; RUN:   --opt-remarks-with-hotness \
+; RUN:   --opt-remarks-hotness-threshold 300
+; RUN: FileCheck %s --check-prefix=REMARK < %t/full.yaml
+; RUN: %lld -dylib %t/full.o -o %t/threshold.dylib \
+; RUN:   --opt-remarks-filename %t/threshold.yaml \
+; RUN:   --opt-remarks-with-hotness \
+; RUN:   --opt-remarks-hotness-threshold 301
+; RUN: count 0 < %t/threshold.yaml
+; RUN: %lld -dylib %t/full.o -o %t/filtered.dylib \
+; RUN:   --opt-remarks-filename %t/filtered.yaml \
+; RUN:   --opt-remarks-passes does-not-match
+; RUN: count 0 < %t/filtered.yaml
+
+; RUN: opt -module-summary %s -o %t/thin.o
+; RUN: %lld -dylib %t/thin.o -o %t/thin.dylib \
+; RUN:   --opt-remarks-filename=%t/thin.yaml \
+; RUN:   --opt-remarks-passes=inline \
+; RUN:   --opt-remarks-format=yaml
+; RUN: cat %t/thin.yaml.thin.*.yaml | FileCheck %s --check-prefix=THIN
+
+; RUN: not %lld -dylib %t/full.o -o /dev/null \
+; RUN:   --opt-remarks-hotness-threshold=invalid 2>&1 | \
+; RUN:   FileCheck %s --check-prefix=ERR
+
+; REMARK:      --- !Passed
+; REMARK:      Pass:            inline
+; REMARK:      Name:            Inlined
+; REMARK:      Function:        caller
+; REMARK:      Hotness:         300
+; REMARK:      Callee:          callee
+; REMARK:      Caller:          caller
+
+; THIN:        --- !Passed
+; THIN:        Pass:            inline
+; THIN:        Name:            Inlined
+; THIN:        Function:        caller
+; THIN:        Callee:          callee
+; THIN:        Caller:          caller
+
+; ERR: --opt-remarks-hotness-threshold: invalid argument 'invalid', only integer or 'auto' is supported
+
+target triple = "x86_64-apple-macosx10.15.0"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @callee(i32 %x) {
+  %add = add i32 %x, 1
+  ret i32 %add
+}
+
+define i32 @caller(i32 %x) !prof !0 {
+  %result = call i32 @callee(i32 %x)
+  ret i32 %result
+}
+
+!0 = !{!"function_entry_count", i64 300}


### PR DESCRIPTION
## Summary

Add native Mach-O lld options for LTO optimization remarks, matching the
structured remark configuration already exposed by ELF lld:

- `--opt-remarks-filename`
- `--opt-remarks-passes`
- `--opt-remarks-format`
- `--opt-remarks-with-hotness`
- `--opt-remarks-hotness-threshold`

The driver validates integer/`auto` hotness thresholds and forwards all five
values to `llvm::lto::Config`. Both separate and `=` spellings are accepted for
the value options.

This is opt-in and has no effect when the options are absent. It lets Mach-O
ThinLTO users collect structured applied/missed optimization records without
depending on internal `-mllvm` remark flags.

## Testing

- Added a Mach-O regression covering Full LTO YAML output, pass filtering,
  hotness thresholds, ThinLTO per-task output, joined option spellings, and an
  invalid-threshold diagnostic.
- Generated the current option parser with `llvm-tblgen`.
- Passed `clang-format --dry-run --Werror`, `git diff --check`, and `llvm-as` on
  the regression input.
- Replayed the regression's common LTO remark expectations with installed LLVM
  22 tools after changing only the object triple to ELF.

A matched local monorepo build was not attempted because the machine did not
have safe disk headroom. Upstream premerge at
`194fc12c755380f47c859840f77d8807314062bd` built the current-main toolchain and
passed the build/test jobs on Linux, Linux AArch64, macOS arm64, and Windows,
including Mach-O lit execution on the Unix builders. The formatter, LLVM ABI
annotation check, macOS project computation, and libc++ CI also passed.
