### PR TITLE
workflows/upload-release-artifact: Make this action self-contained

### DIFF
--- a/.github/workflows/upload-release-artifact/action.yml
+++ b/.github/workflows/upload-release-artifact/action.yml
@@ -41,6 +41,23 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check Permissions
+      uses: $/.github/workflows/require-team-membership
+      with:
+        team-slug: llvm-release-managers
+        LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+        LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+
+    # Checkout the files used by this action.
+     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+       with:
+         persist-credentials: false
+         path: upload-release-artifact
+         sparse-checkout: |
+            llvm/utils/release/github-upload-release.py
+            llvm/utils/git/requirements.txt
+         sparse-checkout-cone-mode: false
+
     - name: Validate Input
       uses: $/.github/workflows/validate-release-version
       with:
@@ -99,14 +116,7 @@ runs:
       if: inputs.upload == 'true'
       shell: bash
       run: |
-        pip install --require-hashes -r ./llvm/utils/git/requirements.txt
-
-    - name: Check Permissions
-      uses: $/.github/workflows/require-team-membership
-      with:
-        team-slug: llvm-release-managers
-        LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
-        LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+        pip install --require-hashes -r ./upload-release-artifact/llvm/utils/git/requirements.txt
 
     - name: Upload Release
       shell: bash
@@ -115,7 +125,7 @@ runs:
         INPUTS_RELEASE_VERSION: ${{ inputs.release-version }}
         DOWNLOAD_PATH: ${{ steps.download-artifact.outputs.download-path }}
       run: |
-        ./llvm/utils/release/github-upload-release.py \
+        ./upload-release-artifact/llvm/utils/release/github-upload-release.py \
         --token ${{ github.token }} \
         --release "$INPUTS_RELEASE_VERSION" \
         upload \

--- a/.github/workflows/upload-release-artifact/action.yml
+++ b/.github/workflows/upload-release-artifact/action.yml
@@ -48,16 +48,6 @@ runs:
         LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
         LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
-    # Checkout the files used by this action.
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        persist-credentials: false
-        path: upload-release-artifact
-        sparse-checkout: |
-           llvm/utils/release/github-upload-release.py
-           llvm/utils/git/requirements.txt
-        sparse-checkout-cone-mode: false
-
     - name: Validate Input
       uses: $/.github/workflows/validate-release-version
       with:
@@ -111,6 +101,17 @@ runs:
         name: ${{ inputs.attestation-name }}
         path: |
           *.jsonl
+    
+    # Checkout the files used by this action.
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      if: inputs.upload == 'true'
+      with:
+        persist-credentials: false
+        path: upload-release-artifact
+        sparse-checkout: |
+           llvm/utils/release/github-upload-release.py
+           llvm/utils/git/requirements.txt
+        sparse-checkout-cone-mode: false
 
     - name: Install Python Requirements
       if: inputs.upload == 'true'

--- a/.github/workflows/upload-release-artifact/action.yml
+++ b/.github/workflows/upload-release-artifact/action.yml
@@ -49,14 +49,14 @@ runs:
         LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
     # Checkout the files used by this action.
-     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-       with:
-         persist-credentials: false
-         path: upload-release-artifact
-         sparse-checkout: |
-            llvm/utils/release/github-upload-release.py
-            llvm/utils/git/requirements.txt
-         sparse-checkout-cone-mode: false
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+        path: upload-release-artifact
+        sparse-checkout: |
+           llvm/utils/release/github-upload-release.py
+           llvm/utils/git/requirements.txt
+        sparse-checkout-cone-mode: false
 
     - name: Validate Input
       uses: $/.github/workflows/validate-release-version


### PR DESCRIPTION
The action now checks out its own files so calling workflows don't need
to do this.  This helps prevent mistakes where the calling workflow
does not checkout the right files causing this action to fail.