### PR TITLE
[SampleProfile] Support Eytzinger layout in SecFuncOffsetTable

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -250,6 +250,9 @@ enum class SecFuncOffsetFlags : uint32_t {
   // Store function offsets in an order of contexts. The order ensures that
   // callee contexts of a given context laid out next to it.
   SecFlagOrdered = (1 << 0),
+  // Store function offsets in a parallel array aligned with Eytzinger NameTable
+  // span.
+  SecFlagEytzinger = (1 << 1),
 };
 
 // Verify section specific flag is used for the correct section.

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -1042,6 +1042,8 @@ inline constexpr EytzingerModeT EytzingerMode{};
 /// modification in on-disk mode.
 class SampleProfileFuncOffsetTable {
 public:
+  enum class TableMode { InMemory, OnDisk, Eytzinger };
+
   using OnDiskTableType =
       llvm::OnDiskIterableChainedHashTable<FuncOffsetHashTableInfo>;
 
@@ -1054,14 +1056,16 @@ public:
   operator=(SampleProfileFuncOffsetTable &&) = delete;
 
   explicit SampleProfileFuncOffsetTable(InMemoryModeT,
-                                        size_t InitialCapacity = 0) {
+                                        size_t InitialCapacity = 0)
+      : Mode(TableMode::InMemory) {
     InMemoryTable.reserve(InitialCapacity);
   }
 
   SampleProfileFuncOffsetTable(
       EytzingerModeT, EytzingerTableSpan<support::ulittle64_t> NameSpan,
       ArrayRef<support::ulittle32_t> FuncOffsetSpan)
-      : NameSpan(NameSpan), FuncOffsetSpan(FuncOffsetSpan) {}
+      : Mode(TableMode::Eytzinger), NameSpan(NameSpan),
+        FuncOffsetSpan(FuncOffsetSpan) {}
 
   /// Insert a function GUID and its profile offset into the in-memory map.
   /// Enforces that the on-disk table must not have been set first.
@@ -1073,7 +1077,8 @@ public:
 
   /// Instantiate the on-disk chained hash table using raw stream pointers.
   SampleProfileFuncOffsetTable(OnDiskModeT, const uint8_t *Buckets,
-                               const uint8_t *Payload, const uint8_t *Base) {
+                               const uint8_t *Payload, const uint8_t *Base)
+      : Mode(TableMode::OnDisk) {
     OnDiskTable.reset(OnDiskTableType::Create(Buckets, Payload, Base));
   }
 
@@ -1101,7 +1106,7 @@ public:
   }
 
   /// Direct read-only array (`ArrayRef`) of function offsets aligned parallel
-  /// to the corresponding Eytzinger name span:
+  /// to the corresponding Eytzinger name span.
   ArrayRef<support::ulittle32_t> getFuncOffsets() const {
     assert(isEytzinger() &&
            "Cannot call getFuncOffsets() on non-Eytzinger table");
@@ -1114,9 +1119,10 @@ public:
     return NameSpan.size();
   }
 
-  bool isEytzinger() const { return FuncOffsetSpan.data() != nullptr; }
+  bool isEytzinger() const { return Mode == TableMode::Eytzinger; }
 
 private:
+  TableMode Mode;
   llvm::DenseMap<hash_code, uint64_t> InMemoryTable;
   std::unique_ptr<OnDiskTableType> OnDiskTable;
   EytzingerTableSpan<support::ulittle64_t> NameSpan;

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -397,6 +397,12 @@ public:
   virtual size_t size() const = 0;
   bool empty() const { return size() == 0; }
   virtual FunctionId operator[](size_t Idx) const = 0;
+
+  virtual EytzingerTableSpan<support::ulittle64_t>
+  getEytzingerSpan(bool IsCS) const {
+    llvm_unreachable(
+        "getEytzingerSpan is exclusively supported for Eytzinger layout");
+  }
   virtual bool contains(StringRef Key) const {
     return contains(FunctionId(Key).getHashCode());
   }
@@ -512,6 +518,12 @@ public:
 
   FunctionId operator[](size_t Idx) const override {
     return FunctionId(Array[Idx]);
+  }
+
+  EytzingerTableSpan<support::ulittle64_t>
+  getEytzingerSpan(bool IsCS) const override {
+    return Spans[static_cast<size_t>(IsCS ? EytzingerSpan::CS
+                                          : EytzingerSpan::Flat)];
   }
 
   bool contains(uint64_t GUID) const override {
@@ -1004,8 +1016,11 @@ public:
 /// Tags to select the initialization mode of SampleProfileFuncOffsetTable.
 struct InMemoryModeT {};
 struct OnDiskModeT {};
+struct EytzingerModeT {};
+
 inline constexpr InMemoryModeT InMemoryMode{};
 inline constexpr OnDiskModeT OnDiskMode{};
+inline constexpr EytzingerModeT EytzingerMode{};
 
 /// A unified wrapper representing the function offset table.
 ///
@@ -1018,6 +1033,8 @@ inline constexpr OnDiskModeT OnDiskMode{};
 ///
 /// - An OnDiskIterableChainedHashTable providing the same mapping directly from
 ///   the file in (non-context-sensitive) version 104 profiles.
+///
+/// - A raw slice of 32-bit relative offsets for Eytzinger parallel lookups.
 ///
 /// It exposes a single, type-agnostic lookup interface, shielding the reader
 /// from the underlying container types. To prevent hybrid-state corruption, the
@@ -1041,6 +1058,11 @@ public:
     InMemoryTable.reserve(InitialCapacity);
   }
 
+  SampleProfileFuncOffsetTable(
+      EytzingerModeT, EytzingerTableSpan<support::ulittle64_t> NameSpan,
+      ArrayRef<support::ulittle32_t> FuncOffsetSpan)
+      : NameSpan(NameSpan), FuncOffsetSpan(FuncOffsetSpan) {}
+
   /// Insert a function GUID and its profile offset into the in-memory map.
   /// Enforces that the on-disk table must not have been set first.
   void insert(uint64_t GUID, uint64_t Offset) {
@@ -1058,6 +1080,14 @@ public:
   /// Query the offset table for the profile offset associated with the given
   /// GUID. Returns the offset if found, or std::nullopt if the key is missing.
   std::optional<uint64_t> lookup(uint64_t GUID) const {
+    if (isEytzinger()) {
+      if (std::optional<size_t> Idx = NameSpan.findIndex(GUID)) {
+        uint32_t RelOffset = FuncOffsetSpan[*Idx];
+        if (RelOffset != UINT32_MAX)
+          return RelOffset;
+      }
+      return std::nullopt;
+    }
     if (OnDiskTable) {
       auto Iter = OnDiskTable->find(GUID);
       if (Iter != OnDiskTable->end())
@@ -1070,9 +1100,27 @@ public:
     return std::nullopt;
   }
 
+  /// Direct read-only array (`ArrayRef`) of function offsets aligned parallel
+  /// to the corresponding Eytzinger name span:
+  ArrayRef<support::ulittle32_t> getFuncOffsets() const {
+    assert(isEytzinger() &&
+           "Cannot call getFuncOffsets() on non-Eytzinger table");
+    return FuncOffsetSpan;
+  }
+
+  size_t getExpectedSize() const {
+    assert(isEytzinger() &&
+           "Cannot call getExpectedSize() on non-Eytzinger table");
+    return NameSpan.size();
+  }
+
+  bool isEytzinger() const { return FuncOffsetSpan.data() != nullptr; }
+
 private:
   llvm::DenseMap<hash_code, uint64_t> InMemoryTable;
   std::unique_ptr<OnDiskTableType> OnDiskTable;
+  EytzingerTableSpan<support::ulittle64_t> NameSpan;
+  ArrayRef<support::ulittle32_t> FuncOffsetSpan;
 };
 
 /// SampleProfileReaderExtBinaryBase/SampleProfileWriterExtBinaryBase defines
@@ -1112,7 +1160,9 @@ protected:
   std::error_code readFuncMetadata(DenseSet<FunctionSamples *> &Profiles);
   std::error_code readFuncMetadata();
   std::error_code readFuncMetadata(FunctionSamples *FProfile);
-  std::error_code readFuncOffsetTable();
+  std::error_code readFuncOffsetTable(bool IsEytzinger, bool IsCS);
+  std::error_code readEytzingerFuncOffsetTable(bool IsCS);
+  std::error_code readLegacyFuncOffsetTable();
   std::error_code readFuncProfiles();
   std::error_code readFuncProfiles(const DenseSet<StringRef> &FuncsToUse,
                                    SampleProfileMap &Profiles);

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -417,7 +417,9 @@ protected:
   std::error_code writeNameTableSection(const SampleProfileMap &ProfileMap);
   std::error_code
   writeEytzingerNameTableSection(const SampleProfileMap &ProfileMap);
-  std::error_code writeFuncOffsetTable();
+  std::error_code writeFuncOffsetTable(bool IsCS);
+  std::error_code writeEytzingerFuncOffsetTable(bool IsCS);
+  std::error_code writeLegacyFuncOffsetTable();
   std::error_code writeProfileSymbolListSection();
   std::error_code writeStringBasedProfileSymbolListSection();
   std::error_code writeMD5ProfileSymbolListSection();
@@ -466,6 +468,8 @@ private:
   MapVector<SampleContext, uint64_t> FuncOffsetTable;
   // Whether to use MD5 to represent string.
   bool UseMD5 = false;
+  size_t NumCS = 0;
+  size_t NumFlat = 0;
 
   /// CSNameTable maps function context to its offset in SecCSNameTable section.
   /// The offset will be used everywhere where the context is referenced.

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -895,10 +895,18 @@ std::error_code SampleProfileReaderExtBinaryBase::readOneSection(
     if (!M) {
       Data = End;
     } else {
+      bool IsEytzinger =
+          hasSecFlag(Entry, SecFuncOffsetFlags::SecFlagEytzinger);
+      bool IsFlat = hasSecFlag(Entry, SecCommonFlags::SecFlagFlat);
+      // An unflagged function offset table inherently indexes the primary
+      // context-sensitive symbol span.
+      bool IsCS = !IsFlat;
       assert((!ProfileIsCS ||
-              hasSecFlag(Entry, SecFuncOffsetFlags::SecFlagOrdered)) &&
-             "func offset table should always be sorted in CS profile");
-      if (std::error_code EC = readFuncOffsetTable())
+              hasSecFlag(Entry, SecFuncOffsetFlags::SecFlagOrdered) ||
+              IsEytzinger) &&
+             "func offset table should always be sorted or in Eytzinger BFS "
+             "order in CS profile");
+      if (std::error_code EC = readFuncOffsetTable(IsEytzinger, IsCS))
         return EC;
     }
     break;
@@ -985,7 +993,36 @@ bool SampleProfileReaderExtBinaryBase::collectFuncsFromModule() {
   return true;
 }
 
-std::error_code SampleProfileReaderExtBinaryBase::readFuncOffsetTable() {
+std::error_code
+SampleProfileReaderExtBinaryBase::readFuncOffsetTable(bool IsEytzinger,
+                                                      bool IsCS) {
+  if (IsEytzinger)
+    return readEytzingerFuncOffsetTable(IsCS);
+  return readLegacyFuncOffsetTable();
+}
+
+std::error_code
+SampleProfileReaderExtBinaryBase::readEytzingerFuncOffsetTable(bool IsCS) {
+  // If there are more than one function offset section, the profile associated
+  // with the previous section has to be done reading before next one is read.
+  FuncOffsetTable.reset();
+
+  size_t Size = End - Data;
+  size_t SpanSize = NameTable->getEytzingerSpan(IsCS).size();
+  if (Size != SpanSize * sizeof(uint32_t))
+    return sampleprof_error::malformed;
+
+  auto *Array = reinterpret_cast<const support::ulittle32_t *>(Data);
+  ArrayRef<support::ulittle32_t> Offsets(Array, SpanSize);
+
+  FuncOffsetTable.emplace(EytzingerMode, NameTable->getEytzingerSpan(IsCS),
+                          Offsets);
+
+  Data = End;
+  return sampleprof_error::success;
+}
+
+std::error_code SampleProfileReaderExtBinaryBase::readLegacyFuncOffsetTable() {
   // If there are more than one function offset section, the profile associated
   // with the previous section has to be done reading before next one is read.
   FuncOffsetTable.reset();
@@ -1030,6 +1067,21 @@ std::error_code SampleProfileReaderExtBinaryBase::readFuncProfiles(
     for (auto Name : FuncsToUse) {
       Remapper->insert(Name);
     }
+  }
+
+  if (FuncOffsetTable && FuncOffsetTable->isEytzinger() &&
+      useFuncOffsetList()) {
+    ArrayRef<support::ulittle32_t> Offsets = FuncOffsetTable->getFuncOffsets();
+    if (Offsets.size() != FuncOffsetTable->getExpectedSize())
+      return sampleprof_error::malformed;
+    for (const auto &[LocalIdx, RelOffset] : llvm::enumerate(Offsets)) {
+      if (RelOffset == UINT32_MAX)
+        continue;
+      const uint8_t *FuncProfileAddr = Start + RelOffset;
+      if (std::error_code EC = readFuncProfile(FuncProfileAddr, Profiles))
+        return EC;
+    }
+    return sampleprof_error::success;
   }
 
   if (ProfileIsCS) {
@@ -1669,6 +1721,8 @@ static std::string getSecFlagsStr(const SecHdrTableEntry &Entry) {
   case SecFuncOffsetTable:
     if (hasSecFlag(Entry, SecFuncOffsetFlags::SecFlagOrdered))
       Flags.append("ordered,");
+    if (hasSecFlag(Entry, SecFuncOffsetFlags::SecFlagEytzinger))
+      Flags.append("eytzinger,");
     break;
   case SecFuncMetadata:
     if (hasSecFlag(Entry, SecFuncMetadataFlags::SecFlagIsProbeBased))

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -280,8 +280,13 @@ SampleProfileWriterExtBinaryBase::writeSample(const FunctionSamples &S) {
 
 std::error_code
 SampleProfileWriterExtBinaryBase::writeFuncOffsetTable(bool IsCS) {
-  if (WriteEytzingerNameTables)
+  if (WriteEytzingerNameTables) {
+    // Eytzinger layout requires MD5 representation and does not support
+    // multi-context Context-Sensitive profiles.
+    if (!UseMD5 || FunctionSamples::ProfileIsCS)
+      return sampleprof_error::unsupported_writing_format;
     return writeEytzingerFuncOffsetTable(IsCS);
+  }
   return writeLegacyFuncOffsetTable();
 }
 
@@ -460,6 +465,9 @@ std::error_code SampleProfileWriterExtBinaryBase::writeNameTableSection(
   }
 
   if (UseMD5 && WriteEytzingerNameTables) {
+    // Eytzinger name tables do not support Context-Sensitive profiles.
+    if (FunctionSamples::ProfileIsCS)
+      return sampleprof_error::unsupported_writing_format;
     if (auto EC = writeEytzingerNameTableSection(ProfileMap))
       return EC;
     return sampleprof_error::success;

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -58,7 +58,8 @@ static cl::opt<bool>
 
 static cl::opt<bool> WriteEytzingerNameTables(
     "sample-profile-write-eytzinger-name-tables", cl::init(false), cl::Hidden,
-    cl::desc("Write Eytzinger 3-span layout for NameTable"));
+    cl::desc("Write Eytzinger 3-span layout for NameTable and parallel "
+             "FuncOffsetTable"));
 
 namespace llvm {
 namespace support {
@@ -277,7 +278,57 @@ SampleProfileWriterExtBinaryBase::writeSample(const FunctionSamples &S) {
   return writeBody(S);
 }
 
-std::error_code SampleProfileWriterExtBinaryBase::writeFuncOffsetTable() {
+std::error_code
+SampleProfileWriterExtBinaryBase::writeFuncOffsetTable(bool IsCS) {
+  if (WriteEytzingerNameTables)
+    return writeEytzingerFuncOffsetTable(IsCS);
+  return writeLegacyFuncOffsetTable();
+}
+
+std::error_code
+SampleProfileWriterExtBinaryBase::writeEytzingerFuncOffsetTable(bool IsCS) {
+  assert((NumCS + NumFlat > 0 || FuncOffsetTable.empty()) &&
+         "SecNameTable must be written before SecFuncOffsetTable to establish "
+         "Eytzinger indices!");
+
+  size_t SpanSize = IsCS ? NumCS : NumFlat;
+  size_t BaseIdx = IsCS ? 0 : NumCS;
+
+  std::vector<support::ulittle32_t> FuncOffsets(
+      SpanSize, support::ulittle32_t(UINT32_MAX));
+
+  // Populate the function offset array parallel to the Eytzinger span.
+  for (const auto &[Context, RelativeOffset] : FuncOffsetTable) {
+    if (RelativeOffset >= UINT32_MAX)
+      return sampleprof_error::too_large;
+
+    FunctionId FId = Context.getFunction();
+    auto It = NameTable.find(FId);
+    if (It == NameTable.end())
+      continue;
+
+    size_t GlobalIdx = It->second;
+    if (GlobalIdx < BaseIdx || (GlobalIdx - BaseIdx) >= SpanSize)
+      continue;
+
+    size_t LocalIdx = GlobalIdx - BaseIdx;
+    assert(
+        FuncOffsets[LocalIdx] == UINT32_MAX &&
+        "Function offset slot already populated; duplicate GUID or collision!");
+    FuncOffsets[LocalIdx] = static_cast<uint32_t>(RelativeOffset);
+  }
+
+  assert(!llvm::is_contained(FuncOffsets, support::ulittle32_t(UINT32_MAX)) &&
+         "Unpopulated slot in Eytzinger function offset array!");
+
+  OutputStream->write(reinterpret_cast<const char *>(FuncOffsets.data()),
+                      SpanSize * sizeof(support::ulittle32_t));
+  addSectionFlag(SecFuncOffsetTable, SecFuncOffsetFlags::SecFlagEytzinger);
+  FuncOffsetTable.clear();
+  return sampleprof_error::success;
+}
+
+std::error_code SampleProfileWriterExtBinaryBase::writeLegacyFuncOffsetTable() {
   auto &OS = *OutputStream;
 
   // Write out the table size.
@@ -464,6 +515,10 @@ public:
       OS.write(reinterpret_cast<const char *>(Table.data()),
                Table.size() * sizeof(support::ulittle64_t));
   }
+
+  size_t size(EytzingerSpan S) const {
+    return Spans[static_cast<size_t>(S)].size();
+  }
 };
 
 } // end anonymous namespace
@@ -479,7 +534,9 @@ SampleProfileWriterExtBinaryBase::writeEytzingerNameTableSection(
     const SampleContext &Ctx = I.second.getContext();
     uint64_t GUID = Ctx.getFunction().getHashCode();
     if (TopLevelGUIDs.insert(GUID).second) {
-      if (I.second.isContextSensitiveTopLevel())
+      // In single-table default layouts, unify all top-level symbols in the CS
+      // partition so they match the single unflagged function offset table.
+      if (SecLayout != CtxSplitLayout || I.second.isContextSensitiveTopLevel())
         CSKeys.emplace_back(GUID);
       else
         FlatKeys.emplace_back(GUID);
@@ -502,6 +559,8 @@ SampleProfileWriterExtBinaryBase::writeEytzingerNameTableSection(
     Idx = Tables.findGlobalIdx(FId.getHashCode());
 
   Tables.write(*OutputStream);
+  NumCS = Tables.size(EytzingerSpan::CS);
+  NumFlat = Tables.size(EytzingerSpan::Flat);
 
   return sampleprof_error::success;
 }
@@ -606,10 +665,16 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
     if (std::error_code EC = writeFuncProfiles(ProfileMap))
       return EC;
     break;
-  case SecFuncOffsetTable:
-    if (auto EC = writeFuncOffsetTable())
+  case SecFuncOffsetTable: {
+    bool IsFlat =
+        hasSecFlag(SectionHdrLayout[LayoutIdx], SecCommonFlags::SecFlagFlat);
+    // An unflagged function offset table inherently indexes the primary
+    // context-sensitive symbol span.
+    bool IsCS = !IsFlat;
+    if (auto EC = writeFuncOffsetTable(IsCS))
       return EC;
     break;
+  }
   case SecFuncMetadata:
     if (std::error_code EC = writeFuncMetadata(ProfileMap))
       return EC;

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -465,7 +465,8 @@ std::error_code SampleProfileWriterExtBinaryBase::writeNameTableSection(
   }
 
   if (UseMD5 && WriteEytzingerNameTables) {
-    // Eytzinger name tables do not support Context-Sensitive profiles.
+    // Eytzinger name tables do not support CSSPGO profiles
+    // (FunctionSamples::ProfileIsCS).
     if (FunctionSamples::ProfileIsCS)
       return sampleprof_error::unsupported_writing_format;
     if (auto EC = writeEytzingerNameTableSection(ProfileMap))

--- a/llvm/test/tools/llvm-profdata/cs-sample-profile.test
+++ b/llvm/test/tools/llvm-profdata/cs-sample-profile.test
@@ -4,3 +4,6 @@ RUN: llvm-profdata merge --sample --extbinary %p/Inputs/cs-sample.proftext -o %t
 RUN: diff -b %t1.proftext %S/Inputs/cs-sample.proftext
 RUN: llvm-profdata show --sample -show-sec-info-only %t.prof | FileCheck %s
 CHECK: FunctionMetadata {{.*}} Flags: {attr}
+
+RUN: not llvm-profdata merge --sample --extbinary --use-md5 --sample-profile-write-eytzinger-name-tables %p/Inputs/cs-sample.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-CS-EYTZ
+ERR-CS-EYTZ: error: {{.*}}Profile encoding format unsupported for writing operations

--- a/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
+++ b/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
@@ -2,6 +2,8 @@
 # RUN:   --sample-profile-write-eytzinger-name-tables %s -o %t.xfdo
 # RUN: llvm-profdata show --sample --show-sec-info-only %t.xfdo > %t.secinfo
 # RUN: FileCheck %s -input-file %t.secinfo
+# RUN: llvm-profdata merge --sample --text %t.xfdo -o %t.text
+# RUN: FileCheck %s --check-prefix=TEXT -input-file %t.text
 # Extract and verify the Eytzinger span counts (NumCS, NumFlat,
 # NumInlinees) from NameTableSection to ensure correct symbol
 # partitioning.
@@ -15,6 +17,13 @@
 # CHECK: LBRProfileSection - Offset: {{.*}}, Size: {{.*}}, Flags: {flat}
 
 # COUNTS: [1, 1, 1]
+
+# TEXT: 15822663052811949562:1000:10
+# TEXT:  1: 1000
+# TEXT:  2: 6699318081062747564:500
+# TEXT:   1: 500
+# TEXT: 110832587303349897:100:5
+# TEXT:  1: 100
 
 main:1000:10
  1: 1000

--- a/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
+++ b/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
@@ -9,9 +9,9 @@
 
 # CHECK: ProfileSummarySection - Offset: {{.*}}, Size: {{.*}}, Flags: {}
 # CHECK: NameTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {eytzinger,fixlenmd5}
-# CHECK: FuncOffsetTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {}
+# CHECK: FuncOffsetTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {eytzinger}
 # CHECK: LBRProfileSection - Offset: {{.*}}, Size: {{.*}}, Flags: {}
-# CHECK: FuncOffsetTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {flat}
+# CHECK: FuncOffsetTableSection - Offset: {{.*}}, Size: {{.*}}, Flags: {flat,eytzinger}
 # CHECK: LBRProfileSection - Offset: {{.*}}, Size: {{.*}}, Flags: {flat}
 
 # COUNTS: [1, 1, 1]


### PR DESCRIPTION
This patch supports writing SecFuncOffsetTable as an array of
fixed-length uint32_t file offsets parallel to the Eytzinger spans in
SecNameTable for ExtBinary sample profiles.

Without this patch, SecFuncOffsetTable stores pairs of variable-length
ULEB128 integers for GUIDs and file offsets, requiring us to eagerly
load and decode the entire section into an in-memory map.

This patch implements parallel arrays to avoid eager loading:

- In the writer, when -sample-profile-write-eytzinger-name-tables is set,
  SecFuncOffsetTable holds only an array of uint32_t offsets into
  SecLBRProfile. The k-th offset entry corresponds to the k-th GUID in the
  CSKeys or FlatKeys Eytzinger span of SecNameTable.

- In the reader, when SecFlagEytzinger is set on SecFuncOffsetTable, the
  reader accesses the memory-mapped offset array directly without eagerly
  decoding ULEB128 pairs or constructing an in-memory map.

This patch does not add a unit test but renames an existing one because
the test that is being renamed already covers the roundtrip test with
-sample-profile-write-eytzinger-name-tables set.

RFC:
https://discourse.llvm.org/t/rfc-faster-sample-profile-loading/90957/8

Assisted-by: Antigravity
