### PR TITLE
workflows: Remove unnecessary checkouts before uses of upload-release-artifact

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -372,20 +372,8 @@ jobs:
       attestations: write # For artifact attestations
 
     steps:
-      - name: Checkout Release Scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/workflows/require-team-membership
-            .github/workflows/upload-release-artifact
-            .github/workflows/validate-release-version
-            llvm/utils/release/github-upload-release.py
-            llvm/utils/git/requirements.txt
-          sparse-checkout-cone-mode: false
-
       - name: Upload Artifacts
-        uses: ./.github/workflows/upload-release-artifact
+        uses: $/.github/workflows/upload-release-artifact
         with:
           release-version: ${{ needs.prepare.outputs.release-version }}
           artifact-id: ${{ needs.build-release-package.outputs.artifact-id }}

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -199,16 +199,9 @@ jobs:
       attestations: write # For artifact attestations
 
     steps:
-     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-       with:
-         persist-credentials: false
-         sparse-checkout: |
-           .github/workflows/upload-release-artifact
-         sparse-checkout-cone-mode: false
-
      - name: Upload Man Page Artifacts
        id: man-page-artifact-upload
-       uses: ./.github/workflows/upload-release-artifact
+       uses: $/.github/workflows/upload-release-artifact
        with:
          release-version: ${{ needs.release-documentation.outputs.man-page-release-version }}
          artifact-id: ${{ needs.release-documentation.outputs.man-page-artifact-id }}

--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -130,18 +130,8 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Checkout Release Scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/
-            llvm/utils/release/github-upload-release.py
-            llvm/utils/git/requirements.txt
-          sparse-checkout-cone-mode: false
-
       - name: Upload Artifacts
-        uses: ./.github/workflows/upload-release-artifact
+        uses: $/.github/workflows/upload-release-artifact
         with:
           release-version: ${{ inputs.release-version }}
           artifact-id: ${{ needs.release-sources.outputs.artifact-id }}


### PR DESCRIPTION
The workflow is now self-contained and checks out its own scripts, so we don't need to do this in the calling workflow.  The '$' prefix in the uses tag tells github actions to load the action from the repository directly rather than searching for it on the local file system.

https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/