### PR TITLE
[dsymutil][ARM][NFC] Require AArch64 for fat-dylib-update.test

### DIFF
--- a/llvm/test/tools/dsymutil/ARM/fat-dylib-update.test
+++ b/llvm/test/tools/dsymutil/ARM/fat-dylib-update.test
@@ -1,4 +1,4 @@
-# REQUIRES: object-emission,system-darwin
+# REQUIRES: object-emission,system-darwin,aarch64-registered-target
 # RUN: dsymutil --linker classic -oso-prepend-path %p/..  %p/../Inputs/fat-test.arm.dylib -o %t.dSYM
 # RUN: llvm-dwarfdump -a -v %t.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
 # RUN: dsymutil --linker classic -u %t.dSYM


### PR DESCRIPTION
fat-test.arm.dylib contains armv7, armv7s, and arm64 slices, so the test needs the AArch64 backend in addition to ARM.