### PR TITLE
[llvm][lld] Respect temporal profile weights in balanced partitioning

### DIFF
--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -83,6 +83,7 @@ template <class D> struct BPOrderer {
 } // namespace lld
 
 using UtilityNodes = SmallVector<BPFunctionNode::UtilityNodeT>;
+using WeightedUtilityNodes = SmallVector<BPFunctionNode::WeightedUtilityNode>;
 
 template <class D>
 static SmallVector<std::pair<unsigned, UtilityNodes>> getUnsForCompression(
@@ -172,9 +173,7 @@ auto BPOrderer<D>::computeOrder(
     sectionToIdx.try_emplace(isec, i);
 
   BPFunctionNode::UtilityNodeT maxUN = 0;
-  MapVector<unsigned, UtilityNodes> startupSectionIdxUNs;
-  DenseMap<unsigned, SmallVector<BPFunctionNode::UtilityNodeWeightT>>
-      startupSectionIdxUNWeights;
+  MapVector<unsigned, WeightedUtilityNodes> startupSectionIdxUNs;
   // Used to define the initial order for startup functions.
   DenseMap<unsigned, size_t> sectionIdxToTimestamp;
   uint64_t numProfiledFunctionRefs = 0, numResolvedProfiledFunctionRefs = 0;
@@ -250,10 +249,8 @@ auto BPOrderer<D>::computeOrder(
           sectionIdxToFirstUN.try_emplace(sectionIdx, maxUN);
       }
       for (auto &[sectionIdx, firstUN] : sectionIdxToFirstUN)
-        for (auto un = firstUN; un <= maxUN; ++un) {
-          startupSectionIdxUNs[sectionIdx].push_back(un);
-          startupSectionIdxUNWeights[sectionIdx].push_back(traceWeight);
-        }
+        for (auto un = firstUN; un <= maxUN; ++un)
+          startupSectionIdxUNs[sectionIdx].emplace_back(un, traceWeight);
       ++maxUN;
       sectionIdxToFirstUN.clear();
     }
@@ -346,27 +343,16 @@ auto BPOrderer<D>::computeOrder(
     for (auto &[sectionIdx, compressionUns] :
          unsForStartupFunctionCompression) {
       auto &uns = startupSectionIdxUNs[sectionIdx];
-      auto &weights = startupSectionIdxUNWeights[sectionIdx];
-      uns.append(compressionUns);
-      weights.append(compressionUns.size(), 1);
-
-      SmallVector<std::pair<BPFunctionNode::UtilityNodeT,
-                            BPFunctionNode::UtilityNodeWeightT>>
-          weightedUNs;
-      for (auto [un, weight] : llvm::zip(uns, weights))
-        weightedUNs.emplace_back(un, weight);
-      llvm::sort(weightedUNs);
-      weightedUNs.erase(llvm::unique(weightedUNs,
-                                     [](const auto &left, const auto &right) {
-                                       return left.first == right.first;
-                                     }),
-                        weightedUNs.end());
-      uns.clear();
-      weights.clear();
-      for (auto [un, weight] : weightedUNs) {
-        uns.push_back(un);
-        weights.push_back(weight);
-      }
+      for (auto un : compressionUns)
+        uns.emplace_back(un, 1);
+      llvm::sort(uns, [](const auto &left, const auto &right) {
+        return left.Id < right.Id;
+      });
+      uns.erase(llvm::unique(uns,
+                             [](const auto &left, const auto &right) {
+                               return left.Id == right.Id;
+                             }),
+                uns.end());
     }
   }
 
@@ -388,8 +374,8 @@ auto BPOrderer<D>::computeOrder(
 
   std::vector<BPFunctionNode> nodesForStartup;
   for (auto &[sectionIdx, uns] : startupSectionIdxUNs)
-    nodesForStartup.emplace_back(sectionIdx, uns,
-                                 startupSectionIdxUNWeights[sectionIdx]);
+    nodesForStartup.push_back(
+        BPFunctionNode::createWithWeightedUtilities(sectionIdx, uns));
 
   // Use the first timestamp to define the initial order for startup nodes.
   llvm::sort(nodesForStartup, [&sectionIdxToTimestamp](auto &L, auto &R) {

--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -178,8 +178,6 @@ auto BPOrderer<D>::computeOrder(
   // Used to define the initial order for startup functions.
   DenseMap<unsigned, size_t> sectionIdxToTimestamp;
   uint64_t numProfiledFunctionRefs = 0, numResolvedProfiledFunctionRefs = 0;
-  // Weighted verbose counts saturate instead of wrapping on malformed or
-  // artificially large profile weights.
   DenseSet<CachedHashStringRef> uniqueProfiledFunctions;
   DenseSet<CachedHashStringRef> uniqueResolvedProfiledFunctions;
   std::unique_ptr<InstrProfReader> reader;

--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -34,6 +34,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/ProfileData/InstrProfReader.h"
 #include "llvm/Support/BalancedPartitioning.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <memory>
@@ -172,9 +173,13 @@ auto BPOrderer<D>::computeOrder(
 
   BPFunctionNode::UtilityNodeT maxUN = 0;
   MapVector<unsigned, UtilityNodes> startupSectionIdxUNs;
+  DenseMap<unsigned, SmallVector<BPFunctionNode::UtilityNodeWeightT>>
+      startupSectionIdxUNWeights;
   // Used to define the initial order for startup functions.
   DenseMap<unsigned, size_t> sectionIdxToTimestamp;
   uint64_t numProfiledFunctionRefs = 0, numResolvedProfiledFunctionRefs = 0;
+  // Weighted verbose counts saturate instead of wrapping on malformed or
+  // artificially large profile weights.
   DenseSet<CachedHashStringRef> uniqueProfiledFunctions;
   DenseSet<CachedHashStringRef> uniqueResolvedProfiledFunctions;
   std::unique_ptr<InstrProfReader> reader;
@@ -195,6 +200,10 @@ auto BPOrderer<D>::computeOrder(
 
     MapVector<unsigned, BPFunctionNode::UtilityNodeT> sectionIdxToFirstUN;
     for (size_t traceIdx = 0; traceIdx < traces.size(); traceIdx++) {
+      const uint64_t traceWeight = traces[traceIdx].Weight;
+      // A zero-weight trace is equivalent to no copies of the trace.
+      if (traceWeight == 0)
+        continue;
       uint64_t currentSize = 0, cutoffSize = 1;
       size_t cutoffTimestamp = 1;
       auto &trace = traces[traceIdx].FunctionNameRefs;
@@ -203,7 +212,8 @@ auto BPOrderer<D>::computeOrder(
             reader->getSymtab().getFuncOrVarName(trace[timestamp]));
         parsedFuncName = lld::utils::getRootSymbol(parsedFuncName);
         if (verbose) {
-          ++numProfiledFunctionRefs;
+          numProfiledFunctionRefs =
+              SaturatingAdd(numProfiledFunctionRefs, traceWeight);
           uniqueProfiledFunctions.insert(CachedHashStringRef(parsedFuncName));
         }
 
@@ -212,7 +222,8 @@ auto BPOrderer<D>::computeOrder(
         if (sectionIdxsIt == rootSymbolToSectionIdxs.end())
           continue;
         if (verbose) {
-          ++numResolvedProfiledFunctionRefs;
+          numResolvedProfiledFunctionRefs =
+              SaturatingAdd(numResolvedProfiledFunctionRefs, traceWeight);
           uniqueResolvedProfiledFunctions.insert(
               CachedHashStringRef(parsedFuncName));
         }
@@ -239,8 +250,10 @@ auto BPOrderer<D>::computeOrder(
           sectionIdxToFirstUN.try_emplace(sectionIdx, maxUN);
       }
       for (auto &[sectionIdx, firstUN] : sectionIdxToFirstUN)
-        for (auto un = firstUN; un <= maxUN; ++un)
+        for (auto un = firstUN; un <= maxUN; ++un) {
           startupSectionIdxUNs[sectionIdx].push_back(un);
+          startupSectionIdxUNWeights[sectionIdx].push_back(traceWeight);
+        }
       ++maxUN;
       sectionIdxToFirstUN.clear();
     }
@@ -333,9 +346,27 @@ auto BPOrderer<D>::computeOrder(
     for (auto &[sectionIdx, compressionUns] :
          unsForStartupFunctionCompression) {
       auto &uns = startupSectionIdxUNs[sectionIdx];
+      auto &weights = startupSectionIdxUNWeights[sectionIdx];
       uns.append(compressionUns);
-      llvm::sort(uns);
-      uns.erase(llvm::unique(uns), uns.end());
+      weights.append(compressionUns.size(), 1);
+
+      SmallVector<std::pair<BPFunctionNode::UtilityNodeT,
+                            BPFunctionNode::UtilityNodeWeightT>>
+          weightedUNs;
+      for (auto [un, weight] : llvm::zip(uns, weights))
+        weightedUNs.emplace_back(un, weight);
+      llvm::sort(weightedUNs);
+      weightedUNs.erase(llvm::unique(weightedUNs,
+                                     [](const auto &left, const auto &right) {
+                                       return left.first == right.first;
+                                     }),
+                        weightedUNs.end());
+      uns.clear();
+      weights.clear();
+      for (auto [un, weight] : weightedUNs) {
+        uns.push_back(un);
+        weights.push_back(weight);
+      }
     }
   }
 
@@ -357,7 +388,8 @@ auto BPOrderer<D>::computeOrder(
 
   std::vector<BPFunctionNode> nodesForStartup;
   for (auto &[sectionIdx, uns] : startupSectionIdxUNs)
-    nodesForStartup.emplace_back(sectionIdx, uns);
+    nodesForStartup.emplace_back(sectionIdx, uns,
+                                 startupSectionIdxUNWeights[sectionIdx]);
 
   // Use the first timestamp to define the initial order for startup nodes.
   llvm::sort(nodesForStartup, [&sectionIdxToTimestamp](auto &L, auto &R) {
@@ -459,9 +491,14 @@ auto BPOrderer<D>::computeOrder(
 
       // The area under the curve F where F(t) is the total number of page
       // faults at step t.
-      unsigned area = 0;
+      // Saturation makes an oversized weighted profile deterministic rather
+      // than allowing the diagnostic-only aggregate to wrap.
+      uint64_t area = 0;
       for (auto &trace : reader->getTemporalProfTraces()) {
+        if (trace.Weight == 0)
+          continue;
         SmallSet<uint64_t, 0> touchedPages;
+        uint64_t traceArea = 0;
         for (unsigned step = 0; step < trace.FunctionNameRefs.size(); step++) {
           auto traceId = trace.FunctionNameRefs[step];
           auto [Filename, ParsedFuncName] =
@@ -473,8 +510,10 @@ auto BPOrderer<D>::computeOrder(
             for (uint64_t i = firstPage; i <= lastPage; i++)
               touchedPages.insert(i);
           }
-          area += touchedPages.size();
+          traceArea = SaturatingAdd(traceArea,
+                                    static_cast<uint64_t>(touchedPages.size()));
         }
+        area = SaturatingMultiplyAdd(traceArea, trace.Weight, area);
       }
       dbgs() << "Total area under the page fault curve: " << (float)area
              << "\n";

--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -83,7 +83,6 @@ template <class D> struct BPOrderer {
 } // namespace lld
 
 using UtilityNodes = SmallVector<BPFunctionNode::UtilityNodeT>;
-using WeightedUtilityNodes = SmallVector<BPFunctionNode::WeightedUtilityNode>;
 
 template <class D>
 static SmallVector<std::pair<unsigned, UtilityNodes>> getUnsForCompression(
@@ -173,7 +172,9 @@ auto BPOrderer<D>::computeOrder(
     sectionToIdx.try_emplace(isec, i);
 
   BPFunctionNode::UtilityNodeT maxUN = 0;
-  MapVector<unsigned, WeightedUtilityNodes> startupSectionIdxUNs;
+  MapVector<unsigned, UtilityNodes> startupSectionIdxUNs;
+  DenseMap<BPFunctionNode::UtilityNodeT, BPFunctionNode::UtilityNodeWeightT>
+      nonUnitStartupUNWeights;
   // Used to define the initial order for startup functions.
   DenseMap<unsigned, size_t> sectionIdxToTimestamp;
   uint64_t numProfiledFunctionRefs = 0, numResolvedProfiledFunctionRefs = 0;
@@ -203,6 +204,7 @@ auto BPOrderer<D>::computeOrder(
       // A zero-weight trace is equivalent to no copies of the trace.
       if (traceWeight == 0)
         continue;
+      const BPFunctionNode::UtilityNodeT firstTraceUN = maxUN;
       uint64_t currentSize = 0, cutoffSize = 1;
       size_t cutoffTimestamp = 1;
       auto &trace = traces[traceIdx].FunctionNameRefs;
@@ -250,7 +252,10 @@ auto BPOrderer<D>::computeOrder(
       }
       for (auto &[sectionIdx, firstUN] : sectionIdxToFirstUN)
         for (auto un = firstUN; un <= maxUN; ++un)
-          startupSectionIdxUNs[sectionIdx].emplace_back(un, traceWeight);
+          startupSectionIdxUNs[sectionIdx].push_back(un);
+      if (traceWeight != 1)
+        for (auto un = firstTraceUN; un <= maxUN; ++un)
+          nonUnitStartupUNWeights.try_emplace(un, traceWeight);
       ++maxUN;
       sectionIdxToFirstUN.clear();
     }
@@ -344,15 +349,9 @@ auto BPOrderer<D>::computeOrder(
          unsForStartupFunctionCompression) {
       auto &uns = startupSectionIdxUNs[sectionIdx];
       for (auto un : compressionUns)
-        uns.emplace_back(un, 1);
-      llvm::sort(uns, [](const auto &left, const auto &right) {
-        return left.Id < right.Id;
-      });
-      uns.erase(llvm::unique(uns,
-                             [](const auto &left, const auto &right) {
-                               return left.Id == right.Id;
-                             }),
-                uns.end());
+        uns.push_back(un);
+      llvm::sort(uns);
+      uns.erase(llvm::unique(uns), uns.end());
     }
   }
 
@@ -374,8 +373,7 @@ auto BPOrderer<D>::computeOrder(
 
   std::vector<BPFunctionNode> nodesForStartup;
   for (auto &[sectionIdx, uns] : startupSectionIdxUNs)
-    nodesForStartup.push_back(
-        BPFunctionNode::createWithWeightedUtilities(sectionIdx, uns));
+    nodesForStartup.emplace_back(sectionIdx, uns);
 
   // Use the first timestamp to define the initial order for startup nodes.
   llvm::sort(nodesForStartup, [&sectionIdxToTimestamp](auto &L, auto &R) {
@@ -387,7 +385,7 @@ auto BPOrderer<D>::computeOrder(
     TimeTraceScope timeScope("Balanced Partitioning");
     BalancedPartitioningConfig config;
     BalancedPartitioning bp(config);
-    bp.run(nodesForStartup);
+    bp.run(nodesForStartup, nonUnitStartupUNWeights);
     for (auto &nodes : nodesForCompression)
       bp.run(nodes);
   }

--- a/lld/test/ELF/bp-section-orderer-weighted-profile.s
+++ b/lld/test/ELF/bp-section-orderer-weighted-profile.s
@@ -1,0 +1,130 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %t/input.s -o %t/input.o
+# RUN: llvm-profdata merge %t/weighted.proftext %t/functions.proftext -o %t/weighted.profdata
+# RUN: llvm-profdata merge %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext \
+# RUN:   %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext \
+# RUN:   %t/competing.proftext %t/functions.proftext -o %t/replicated.profdata
+# RUN: llvm-profdata merge %t/primary.proftext %t/competing.proftext %t/functions.proftext -o %t/unweighted.profdata
+
+# A weight of 10 is equivalent to ten copies of the same trace in the ELF
+# balanced-partitioning consumer.
+# RUN: ld.lld -e _start -o %t/weighted.out %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function
+# RUN: ld.lld -e _start -o %t/replicated.out %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function
+# RUN: ld.lld -e _start -o %t/unweighted.out %t/input.o --irpgo-profile=%t/unweighted.profdata --bp-startup-sort=function
+# RUN: llvm-nm -jn %t/weighted.out > %t/weighted.order
+# RUN: llvm-nm -jn %t/replicated.out > %t/replicated.order
+# RUN: llvm-nm -jn %t/unweighted.out > %t/unweighted.order
+# RUN: cmp %t/weighted.order %t/replicated.order
+# RUN: not cmp %t/weighted.order %t/unweighted.order
+# RUN: FileCheck %s --input-file=%t/weighted.order --check-prefix=FUNCTIONS
+
+# FUNCTIONS-DAG: A
+# FUNCTIONS-DAG: B
+# FUNCTIONS-DAG: C
+# FUNCTIONS-DAG: D
+# FUNCTIONS-DAG: E
+# FUNCTIONS-DAG: F
+
+#--- input.s
+.section .text._start,"ax",@progbits
+.globl _start
+_start:
+  ret
+
+.section .text.A,"ax",@progbits
+.globl A
+A:
+  ret
+
+.section .text.B,"ax",@progbits
+.globl B
+B:
+  ret
+
+.section .text.C,"ax",@progbits
+.globl C
+C:
+  ret
+
+.section .text.D,"ax",@progbits
+.globl D
+D:
+  ret
+
+.section .text.E,"ax",@progbits
+.globl E
+E:
+  ret
+
+.section .text.F,"ax",@progbits
+.globl F
+F:
+  ret
+
+#--- weighted.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+2
+# Trace Stream Size
+11
+# Weight
+10
+A, B, C, D, E, F
+# Weight
+1
+A, D, B, C, E, F
+
+#--- primary.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+1
+# Trace Stream Size
+1
+# Weight
+1
+A, B, C, D, E, F
+
+#--- competing.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+1
+# Trace Stream Size
+1
+# Weight
+1
+A, D, B, C, E, F
+
+#--- functions.proftext
+:ir
+A
+# Func Hash
+1
+# Num Counters
+1
+# Counter Values
+1
+B
+2
+1
+1
+C
+3
+1
+1
+D
+4
+1
+1
+E
+5
+1
+1
+F
+6
+1
+1

--- a/lld/test/MachO/bp-section-orderer-weighted-profile.s
+++ b/lld/test/MachO/bp-section-orderer-weighted-profile.s
@@ -3,13 +3,20 @@
 # RUN: rm -rf %t && split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/input.s -o %t/input.o
 # RUN: llvm-profdata merge %t/weighted.proftext %t/functions.proftext -o %t/weighted.profdata
-# RUN: llvm-profdata merge %t/replicated.proftext %t/functions.proftext -o %t/replicated.profdata
-# RUN: llvm-profdata merge %t/unweighted.proftext %t/functions.proftext -o %t/unweighted.profdata
+# RUN: llvm-profdata merge %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext \
+# RUN:   %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext \
+# RUN:   %t/competing.proftext %t/functions.proftext -o %t/replicated.profdata
+# RUN: llvm-profdata merge %t/primary.proftext %t/competing.proftext %t/functions.proftext -o %t/unweighted.profdata
+# RUN: llvm-profdata merge %t/saturated.proftext %t/functions.proftext -o %t/saturated.profdata
 
 # A weight of 10 is equivalent to ten copies of the same trace.
-# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=WEIGHTED
-# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=WEIGHTED
-# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/unweighted.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=UNWEIGHTED
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - > %t/weighted.order
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - > %t/replicated.order
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/unweighted.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - > %t/unweighted.order
+# RUN: cmp %t/weighted.order %t/replicated.order
+# RUN: not cmp %t/weighted.order %t/unweighted.order
+# RUN: FileCheck %s --input-file=%t/weighted.order --check-prefix=WEIGHTED
+# RUN: FileCheck %s --input-file=%t/unweighted.order --check-prefix=UNWEIGHTED
 
 # WEIGHTED: D
 # WEIGHTED-NEXT: A
@@ -24,11 +31,24 @@
 # UNWEIGHTED-NEXT: E
 # UNWEIGHTED-NEXT: F
 
+# Combining weight-one compression utilities with weighted temporal utilities
+# preserves the same weighted-versus-replicated equivalence.
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function --bp-compression-sort-startup-functions | llvm-nm --numeric-sort --format=just-symbols - > %t/weighted-compression.order
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function --bp-compression-sort-startup-functions | llvm-nm --numeric-sort --format=just-symbols - > %t/replicated-compression.order
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/unweighted.profdata --bp-startup-sort=function --bp-compression-sort-startup-functions | llvm-nm --numeric-sort --format=just-symbols - > %t/unweighted-compression.order
+# RUN: cmp %t/weighted-compression.order %t/replicated-compression.order
+# RUN: not cmp %t/weighted-compression.order %t/unweighted-compression.order
+
 # Verbose trace-reference counts and the page-fault area also respect weights.
 # RUN: %lld -arch arm64 -lSystem -e _main -o %t/weighted.out %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=WEIGHTED-STATS
 # RUN: %lld -arch arm64 -lSystem -e _main -o %t/replicated.out %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=WEIGHTED-STATS
 # WEIGHTED-STATS: Temporal profile function references: 66 / 66 resolved (6 / 6 unique)
 # WEIGHTED-STATS: Total area under the page fault curve: 6.600000e+01
+
+# Oversized weights saturate verbose diagnostics instead of wrapping.
+# RUN: %lld -arch arm64 -lSystem -e _main -o %t/saturated.out %t/input.o --irpgo-profile=%t/saturated.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=SATURATED-STATS
+# SATURATED-STATS: Temporal profile function references: 18446744073709551615 / 18446744073709551615 resolved (2 / 2 unique)
+# SATURATED-STATS: Total area under the page fault curve: 1.844674e+19
 
 #--- input.s
 .text
@@ -36,16 +56,22 @@
 _main:
   ret
 A:
+  add w0, w0, #1
   ret
 B:
+  add w0, w0, #1
   ret
 C:
+  add w0, w0, #2
   ret
 D:
+  add w0, w0, #2
   ret
 E:
+  add w0, w0, #3
   ret
 F:
+  add w0, w0, #3
   ret
 .subsections_via_symbols
 
@@ -63,60 +89,38 @@ A, B, C, D, E, F
 1
 A, D, B, C, E, F
 
-#--- replicated.proftext
+#--- primary.proftext
 :ir
 :temporal_prof_traces
 # Num Traces
-11
+1
 # Trace Stream Size
-11
+1
 # Weight
 1
 A, B, C, D, E, F
-# Weight
+
+#--- competing.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
 1
-A, B, C, D, E, F
-# Weight
+# Trace Stream Size
 1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
-# Weight
-1
-A, B, C, D, E, F
 # Weight
 1
 A, D, B, C, E, F
 
-#--- unweighted.proftext
+#--- saturated.proftext
 :ir
 :temporal_prof_traces
 # Num Traces
-2
+1
 # Trace Stream Size
-2
-# Weight
 1
-A, B, C, D, E, F
 # Weight
-1
-A, D, B, C, E, F
+18446744073709551615
+A, B
 
 #--- functions.proftext
 :ir

--- a/lld/test/MachO/bp-section-orderer-weighted-profile.s
+++ b/lld/test/MachO/bp-section-orderer-weighted-profile.s
@@ -1,0 +1,149 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/input.s -o %t/input.o
+# RUN: llvm-profdata merge %t/weighted.proftext %t/functions.proftext -o %t/weighted.profdata
+# RUN: llvm-profdata merge %t/replicated.proftext %t/functions.proftext -o %t/replicated.profdata
+# RUN: llvm-profdata merge %t/unweighted.proftext %t/functions.proftext -o %t/unweighted.profdata
+
+# A weight of 10 is equivalent to ten copies of the same trace.
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=WEIGHTED
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=WEIGHTED
+# RUN: %lld -arch arm64 -lSystem -e _main -o - %t/input.o --irpgo-profile=%t/unweighted.profdata --bp-startup-sort=function | llvm-nm --numeric-sort --format=just-symbols - | FileCheck %s --check-prefix=UNWEIGHTED
+
+# WEIGHTED: D
+# WEIGHTED-NEXT: A
+# WEIGHTED-NEXT: B
+# WEIGHTED-NEXT: C
+# WEIGHTED-NEXT: E
+# WEIGHTED-NEXT: F
+# UNWEIGHTED: A
+# UNWEIGHTED-NEXT: B
+# UNWEIGHTED-NEXT: D
+# UNWEIGHTED-NEXT: C
+# UNWEIGHTED-NEXT: E
+# UNWEIGHTED-NEXT: F
+
+# Verbose trace-reference counts and the page-fault area also respect weights.
+# RUN: %lld -arch arm64 -lSystem -e _main -o %t/weighted.out %t/input.o --irpgo-profile=%t/weighted.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=WEIGHTED-STATS
+# RUN: %lld -arch arm64 -lSystem -e _main -o %t/replicated.out %t/input.o --irpgo-profile=%t/replicated.profdata --bp-startup-sort=function --verbose-bp-section-orderer 2>&1 | FileCheck %s --check-prefix=WEIGHTED-STATS
+# WEIGHTED-STATS: Temporal profile function references: 66 / 66 resolved (6 / 6 unique)
+# WEIGHTED-STATS: Total area under the page fault curve: 6.600000e+01
+
+#--- input.s
+.text
+.globl _main, A, B, C, D, E, F
+_main:
+  ret
+A:
+  ret
+B:
+  ret
+C:
+  ret
+D:
+  ret
+E:
+  ret
+F:
+  ret
+.subsections_via_symbols
+
+#--- weighted.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+2
+# Trace Stream Size
+11
+# Weight
+10
+A, B, C, D, E, F
+# Weight
+1
+A, D, B, C, E, F
+
+#--- replicated.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+11
+# Trace Stream Size
+11
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, D, B, C, E, F
+
+#--- unweighted.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+2
+# Trace Stream Size
+2
+# Weight
+1
+A, B, C, D, E, F
+# Weight
+1
+A, D, B, C, E, F
+
+#--- functions.proftext
+:ir
+A
+# Func Hash
+1
+# Num Counters
+1
+# Counter Values
+1
+B
+2
+1
+1
+C
+3
+1
+1
+D
+4
+1
+1
+E
+5
+1
+1
+F
+6
+1
+1

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -449,10 +449,10 @@ struct TemporalProfTraceTy {
   /// Use a set of temporal profile traces to create a list of balanced
   /// partitioning function nodes used by BalancedPartitioning to generate a
   /// function order that reduces page faults during startup
-  LLVM_ABI static void
-  createBPFunctionNodes(ArrayRef<TemporalProfTraceTy> Traces,
-                        std::vector<BPFunctionNode> &Nodes,
-                        bool RemoveOutlierUNs = true);
+  LLVM_ABI static void createBPFunctionNodes(
+      ArrayRef<TemporalProfTraceTy> Traces, std::vector<BPFunctionNode> &Nodes,
+      bool RemoveOutlierUNs = true,
+      BalancedPartitioning::UtilityNodeWeightsT *UtilityNodeWeights = nullptr);
 };
 
 inline std::error_code make_error_code(instrprof_error E) {

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -41,9 +41,12 @@
 
 #include "raw_ostream.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
 
 #include <atomic>
+#include <cassert>
 #include <condition_variable>
 #include <mutex>
 #include <random>
@@ -60,10 +63,30 @@ class BPFunctionNode {
 public:
   using IDT = uint64_t;
   using UtilityNodeT = uint32_t;
+  using UtilityNodeWeightT = uint64_t;
 
   /// \param UtilityNodes the set of utility nodes (must be unique'd)
   BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes)
-      : Id(Id), UtilityNodes(UtilityNodes) {}
+      : Id(Id), UtilityNodes(UtilityNodes),
+        UtilityNodeWeights(UtilityNodes.size(), 1) {}
+
+  /// \param UtilityNodes the set of utility nodes (must be unique'd)
+  /// \param UtilityNodeWeights the weight of each corresponding utility node.
+  /// All occurrences of a utility node must have the same weight. Zero-weight
+  /// utility nodes are ignored.
+  BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes,
+                 ArrayRef<UtilityNodeWeightT> UtilityNodeWeights)
+      : Id(Id) {
+    assert(UtilityNodes.size() == UtilityNodeWeights.size() &&
+           "each utility node must have a weight");
+    for (auto [UtilityNode, Weight] :
+         llvm::zip(UtilityNodes, UtilityNodeWeights)) {
+      if (Weight == 0)
+        continue;
+      this->UtilityNodes.push_back(UtilityNode);
+      this->UtilityNodeWeights.push_back(Weight);
+    }
+  }
 
   /// The ID of this node
   IDT Id;
@@ -73,6 +96,9 @@ public:
 protected:
   /// The list of utility nodes associated with this node
   SmallVector<UtilityNodeT, 4> UtilityNodes;
+  /// The weight of each corresponding utility node. A utility node's cost is
+  /// multiplied by its weight without materializing duplicate utility nodes.
+  SmallVector<UtilityNodeWeightT, 4> UtilityNodeWeights;
   /// The bucket assigned by balanced partitioning
   std::optional<unsigned> Bucket;
   /// The index of the input order of the FunctionNodes
@@ -189,6 +215,8 @@ private:
     float CachedGainRL;
     /// Whether \p CachedGainLR and \p CachedGainRL are valid
     bool CachedGainIsValid = false;
+    /// The number of times this utility contributes to the objective
+    BPFunctionNode::UtilityNodeWeightT Weight = 1;
   };
 
 protected:

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -41,6 +41,7 @@
 
 #include "raw_ostream.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
 
@@ -63,39 +64,9 @@ public:
   using UtilityNodeT = uint32_t;
   using UtilityNodeWeightT = uint64_t;
 
-  struct WeightedUtilityNode {
-    UtilityNodeT Id;
-    UtilityNodeWeightT Weight;
-
-    WeightedUtilityNode(UtilityNodeT Id, UtilityNodeWeightT Weight)
-        : Id(Id), Weight(Weight) {}
-
-    bool operator==(const WeightedUtilityNode &Other) const {
-      return Id == Other.Id && Weight == Other.Weight;
-    }
-  };
-
   /// \param UtilityNodes the set of utility nodes (must be unique'd)
-  BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes) : Id(Id) {
-    for (UtilityNodeT UtilityNode : UtilityNodes)
-      this->UtilityNodes.emplace_back(UtilityNode, 1);
-  }
-
-  /// Create a node with weighted utility nodes (which must be unique'd). All
-  /// occurrences of a utility node must have the same weight. A utility's cost
-  /// is multiplied by its weight without materializing duplicate utility
-  /// nodes. Zero-weight utility nodes are ignored.
-  static BPFunctionNode
-  createWithWeightedUtilities(IDT Id,
-                              ArrayRef<WeightedUtilityNode> UtilityNodes) {
-    BPFunctionNode Node(Id);
-    for (WeightedUtilityNode UtilityNode : UtilityNodes) {
-      if (UtilityNode.Weight == 0)
-        continue;
-      Node.UtilityNodes.push_back(UtilityNode);
-    }
-    return Node;
-  }
+  BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes)
+      : Id(Id), UtilityNodes(UtilityNodes) {}
 
   /// The ID of this node
   IDT Id;
@@ -104,7 +75,7 @@ public:
 
 protected:
   /// The list of utility nodes associated with this node
-  SmallVector<WeightedUtilityNode, 4> UtilityNodes;
+  SmallVector<UtilityNodeT, 4> UtilityNodes;
   /// The bucket assigned by balanced partitioning
   std::optional<unsigned> Bucket;
   /// The index of the input order of the FunctionNodes
@@ -113,9 +84,6 @@ protected:
   friend class BPFunctionNodeTest_Basic_Test;
   friend class BalancedPartitioningTest_Basic_Test;
   friend class BalancedPartitioningTest_Large_Test;
-
-private:
-  explicit BPFunctionNode(IDT Id) : Id(Id) {}
 };
 
 /// Algorithm parameters; default values are tuned on real-world binaries
@@ -135,10 +103,18 @@ struct BalancedPartitioningConfig {
 
 class BalancedPartitioning {
 public:
+  using UtilityNodeWeightsT = DenseMap<BPFunctionNode::UtilityNodeT,
+                                       BPFunctionNode::UtilityNodeWeightT>;
+
   LLVM_ABI BalancedPartitioning(const BalancedPartitioningConfig &Config);
 
   /// Run recursive graph partitioning that optimizes a given objective.
   LLVM_ABI void run(std::vector<BPFunctionNode> &Nodes) const;
+  /// Run recursive graph partitioning with positive, non-unit utility weights.
+  /// A utility's cost is multiplied by its weight without materializing
+  /// duplicate utility nodes. Missing utilities have weight one.
+  LLVM_ABI void run(std::vector<BPFunctionNode> &Nodes,
+                    const UtilityNodeWeightsT &UtilityNodeWeights) const;
 
 private:
   struct UtilitySignature;
@@ -173,19 +149,30 @@ private:
   /// \param RootBucket the initial bucket of the dataVertices
   /// \param Offset the assigned buckets are the range [Offset, Offset +
   /// Nodes.size()]
+  template <typename UtilityNodeWeightsPtrT>
   void bisect(const FunctionNodeRange Nodes, unsigned RecDepth,
               unsigned RootBucket, unsigned Offset,
-              std::optional<BPThreadPool> &TP) const;
+              std::optional<BPThreadPool> &TP,
+              UtilityNodeWeightsPtrT UtilityNodeWeights) const;
 
   /// Run bisection iterations
-  void runIterations(const FunctionNodeRange Nodes, unsigned LeftBucket,
-                     unsigned RightBucket, std::mt19937 &RNG) const;
+  template <typename UtilityNodeWeightsPtrT>
+  UtilityNodeWeightsPtrT
+  runIterations(const FunctionNodeRange Nodes, unsigned LeftBucket,
+                unsigned RightBucket, UtilityNodeWeightsPtrT UtilityNodeWeights,
+                std::mt19937 &RNG) const;
 
   /// Run a bisection iteration to improve the optimization goal
   /// \returns the total number of moved FunctionNodes
+  template <typename UtilityNodeWeightsRefT>
   unsigned runIteration(const FunctionNodeRange Nodes, unsigned LeftBucket,
                         unsigned RightBucket, SignaturesT &Signatures,
+                        UtilityNodeWeightsRefT UtilityNodeWeights,
                         std::mt19937 &RNG) const;
+
+  template <typename UtilityNodeWeightsPtrT>
+  void runImpl(std::vector<BPFunctionNode> &Nodes,
+               UtilityNodeWeightsPtrT UtilityNodeWeights) const;
 
   /// Try to move \p N from one bucket to another
   /// \returns true iff \p N is moved
@@ -224,8 +211,6 @@ private:
     float CachedGainRL;
     /// Whether \p CachedGainLR and \p CachedGainRL are valid
     bool CachedGainIsValid = false;
-    /// The number of times this utility contributes to the objective
-    BPFunctionNode::UtilityNodeWeightT Weight = 1;
   };
 
 protected:

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -41,12 +41,10 @@
 
 #include "raw_ostream.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
 
 #include <atomic>
-#include <cassert>
 #include <condition_variable>
 #include <mutex>
 #include <random>
@@ -65,27 +63,38 @@ public:
   using UtilityNodeT = uint32_t;
   using UtilityNodeWeightT = uint64_t;
 
-  /// \param UtilityNodes the set of utility nodes (must be unique'd)
-  BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes)
-      : Id(Id), UtilityNodes(UtilityNodes),
-        UtilityNodeWeights(UtilityNodes.size(), 1) {}
+  struct WeightedUtilityNode {
+    UtilityNodeT Id;
+    UtilityNodeWeightT Weight;
+
+    WeightedUtilityNode(UtilityNodeT Id, UtilityNodeWeightT Weight)
+        : Id(Id), Weight(Weight) {}
+
+    bool operator==(const WeightedUtilityNode &Other) const {
+      return Id == Other.Id && Weight == Other.Weight;
+    }
+  };
 
   /// \param UtilityNodes the set of utility nodes (must be unique'd)
-  /// \param UtilityNodeWeights the weight of each corresponding utility node.
-  /// All occurrences of a utility node must have the same weight. Zero-weight
-  /// utility nodes are ignored.
-  BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes,
-                 ArrayRef<UtilityNodeWeightT> UtilityNodeWeights)
-      : Id(Id) {
-    assert(UtilityNodes.size() == UtilityNodeWeights.size() &&
-           "each utility node must have a weight");
-    for (auto [UtilityNode, Weight] :
-         llvm::zip(UtilityNodes, UtilityNodeWeights)) {
-      if (Weight == 0)
+  BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes) : Id(Id) {
+    for (UtilityNodeT UtilityNode : UtilityNodes)
+      this->UtilityNodes.emplace_back(UtilityNode, 1);
+  }
+
+  /// Create a node with weighted utility nodes (which must be unique'd). All
+  /// occurrences of a utility node must have the same weight. A utility's cost
+  /// is multiplied by its weight without materializing duplicate utility
+  /// nodes. Zero-weight utility nodes are ignored.
+  static BPFunctionNode
+  createWithWeightedUtilities(IDT Id,
+                              ArrayRef<WeightedUtilityNode> UtilityNodes) {
+    BPFunctionNode Node(Id);
+    for (WeightedUtilityNode UtilityNode : UtilityNodes) {
+      if (UtilityNode.Weight == 0)
         continue;
-      this->UtilityNodes.push_back(UtilityNode);
-      this->UtilityNodeWeights.push_back(Weight);
+      Node.UtilityNodes.push_back(UtilityNode);
     }
+    return Node;
   }
 
   /// The ID of this node
@@ -95,10 +104,7 @@ public:
 
 protected:
   /// The list of utility nodes associated with this node
-  SmallVector<UtilityNodeT, 4> UtilityNodes;
-  /// The weight of each corresponding utility node. A utility node's cost is
-  /// multiplied by its weight without materializing duplicate utility nodes.
-  SmallVector<UtilityNodeWeightT, 4> UtilityNodeWeights;
+  SmallVector<WeightedUtilityNode, 4> UtilityNodes;
   /// The bucket assigned by balanced partitioning
   std::optional<unsigned> Bucket;
   /// The index of the input order of the FunctionNodes
@@ -107,6 +113,9 @@ protected:
   friend class BPFunctionNodeTest_Basic_Test;
   friend class BalancedPartitioningTest_Basic_Test;
   friend class BalancedPartitioningTest_Large_Test;
+
+private:
+  explicit BPFunctionNode(IDT Id) : Id(Id) {}
 };
 
 /// Algorithm parameters; default values are tuned on real-world binaries

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -718,9 +718,10 @@ Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
   std::string UncompressedNameStrings =
       join(NameStrs.begin(), NameStrs.end(), getInstrProfNameSeparator());
 
-  assert(StringRef(UncompressedNameStrings)
-                 .count(getInstrProfNameSeparator()) == (NameStrs.size() - 1) &&
-         "PGO name is invalid (contains separator token)");
+  assert(
+      StringRef(UncompressedNameStrings).count(getInstrProfNameSeparator()) ==
+          (NameStrs.size() - 1) &&
+      "PGO name is invalid (contains separator token)");
 
   unsigned EncLen = encodeULEB128(UncompressedNameStrings.length(), P);
   P += EncLen;
@@ -1152,8 +1153,7 @@ void TemporalProfTraceTy::createBPFunctionNodes(
   UtilityNodeT MaxUN = 0;
   DenseMap<IDT, size_t> IdToFirstTimestamp;
   DenseMap<IDT, UtilityNodeT> IdToFirstUN;
-  DenseMap<IDT, SmallVector<UtilityNodeT>> IdToUNs;
-  DenseMap<IDT, SmallVector<BPFunctionNode::UtilityNodeWeightT>> IdToUNWeights;
+  DenseMap<IDT, SmallVector<BPFunctionNode::WeightedUtilityNode>> IdToUNs;
   for (auto &Trace : Traces) {
     // A zero-weight trace is equivalent to no copies of the trace.
     if (Trace.Weight == 0)
@@ -1172,10 +1172,8 @@ void TemporalProfTraceTy::createBPFunctionNodes(
       IdToFirstUN.try_emplace(Id, MaxUN);
     }
     for (auto &[Id, FirstUN] : IdToFirstUN)
-      for (auto UN = FirstUN; UN <= MaxUN; ++UN) {
-        IdToUNs[Id].push_back(UN);
-        IdToUNWeights[Id].push_back(Trace.Weight);
-      }
+      for (auto UN = FirstUN; UN <= MaxUN; ++UN)
+        IdToUNs[Id].emplace_back(UN, Trace.Weight);
     ++MaxUN;
     IdToFirstUN.clear();
   }
@@ -1184,28 +1182,18 @@ void TemporalProfTraceTy::createBPFunctionNodes(
     DenseMap<UtilityNodeT, unsigned> UNFrequency;
     for (auto &[Id, UNs] : IdToUNs)
       for (auto &UN : UNs)
-        ++UNFrequency[UN];
+        ++UNFrequency[UN.Id];
     // Filter out utility nodes that are too infrequent or too prevalent to make
     // BalancedPartitioning more effective.
-    for (auto &[Id, UNs] : IdToUNs) {
-      auto &Weights = IdToUNWeights[Id];
-      size_t WriteIndex = 0;
-      for (size_t ReadIndex = 0; ReadIndex < UNs.size(); ++ReadIndex) {
-        auto UN = UNs[ReadIndex];
-        unsigned Freq = UNFrequency[UN];
-        if (Freq <= 1 || 2 * Freq > IdToUNs.size())
-          continue;
-        UNs[WriteIndex] = UN;
-        Weights[WriteIndex] = Weights[ReadIndex];
-        ++WriteIndex;
-      }
-      UNs.resize(WriteIndex);
-      Weights.resize(WriteIndex);
-    }
+    for (auto &[Id, UNs] : IdToUNs)
+      llvm::erase_if(UNs, [&](auto &UN) {
+        unsigned Freq = UNFrequency[UN.Id];
+        return Freq <= 1 || 2 * Freq > IdToUNs.size();
+      });
   }
 
   for (auto &[Id, UNs] : IdToUNs)
-    Nodes.emplace_back(Id, UNs, IdToUNWeights[Id]);
+    Nodes.push_back(BPFunctionNode::createWithWeightedUtilities(Id, UNs));
 
   // Since BalancedPartitioning is sensitive to the initial order, we explicitly
   // order nodes by their earliest timestamp.
@@ -1228,13 +1216,13 @@ uint32_t getNumValueKindsInstrProf(const void *Record) {
 }
 
 uint32_t getNumValueSitesInstrProf(const void *Record, uint32_t VKind) {
-  return reinterpret_cast<const InstrProfRecord *>(Record)
-      ->getNumValueSites(VKind);
+  return reinterpret_cast<const InstrProfRecord *>(Record)->getNumValueSites(
+      VKind);
 }
 
 uint32_t getNumValueDataInstrProf(const void *Record, uint32_t VKind) {
-  return reinterpret_cast<const InstrProfRecord *>(Record)
-      ->getNumValueData(VKind);
+  return reinterpret_cast<const InstrProfRecord *>(Record)->getNumValueData(
+      VKind);
 }
 
 uint32_t getNumValueDataForSiteInstrProf(const void *R, uint32_t VK,
@@ -1435,9 +1423,8 @@ void annotateValueSite(Module &M, Instruction &Inst,
 }
 
 void annotateValueSite(Module &M, Instruction &Inst,
-                       ArrayRef<InstrProfValueData> VDs,
-                       uint64_t Sum, InstrProfValueKind ValueKind,
-                       uint32_t MaxMDCount) {
+                       ArrayRef<InstrProfValueData> VDs, uint64_t Sum,
+                       InstrProfValueKind ValueKind, uint32_t MaxMDCount) {
   if (VDs.empty())
     return;
   LLVMContext &Ctx = M.getContext();

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -1153,9 +1153,11 @@ void TemporalProfTraceTy::createBPFunctionNodes(
   DenseMap<IDT, size_t> IdToFirstTimestamp;
   DenseMap<IDT, UtilityNodeT> IdToFirstUN;
   DenseMap<IDT, SmallVector<UtilityNodeT>> IdToUNs;
-  // TODO: We need to use the Trace.Weight field to give more weight to more
-  // important utilities
+  DenseMap<IDT, SmallVector<BPFunctionNode::UtilityNodeWeightT>> IdToUNWeights;
   for (auto &Trace : Traces) {
+    // A zero-weight trace is equivalent to no copies of the trace.
+    if (Trace.Weight == 0)
+      continue;
     size_t CutoffTimestamp = 1;
     for (size_t Timestamp = 0; Timestamp < Trace.FunctionNameRefs.size();
          Timestamp++) {
@@ -1170,8 +1172,10 @@ void TemporalProfTraceTy::createBPFunctionNodes(
       IdToFirstUN.try_emplace(Id, MaxUN);
     }
     for (auto &[Id, FirstUN] : IdToFirstUN)
-      for (auto UN = FirstUN; UN <= MaxUN; ++UN)
+      for (auto UN = FirstUN; UN <= MaxUN; ++UN) {
         IdToUNs[Id].push_back(UN);
+        IdToUNWeights[Id].push_back(Trace.Weight);
+      }
     ++MaxUN;
     IdToFirstUN.clear();
   }
@@ -1183,15 +1187,25 @@ void TemporalProfTraceTy::createBPFunctionNodes(
         ++UNFrequency[UN];
     // Filter out utility nodes that are too infrequent or too prevalent to make
     // BalancedPartitioning more effective.
-    for (auto &[Id, UNs] : IdToUNs)
-      llvm::erase_if(UNs, [&](auto &UN) {
+    for (auto &[Id, UNs] : IdToUNs) {
+      auto &Weights = IdToUNWeights[Id];
+      size_t WriteIndex = 0;
+      for (size_t ReadIndex = 0; ReadIndex < UNs.size(); ++ReadIndex) {
+        auto UN = UNs[ReadIndex];
         unsigned Freq = UNFrequency[UN];
-        return Freq <= 1 || 2 * Freq > IdToUNs.size();
-      });
+        if (Freq <= 1 || 2 * Freq > IdToUNs.size())
+          continue;
+        UNs[WriteIndex] = UN;
+        Weights[WriteIndex] = Weights[ReadIndex];
+        ++WriteIndex;
+      }
+      UNs.resize(WriteIndex);
+      Weights.resize(WriteIndex);
+    }
   }
 
   for (auto &[Id, UNs] : IdToUNs)
-    Nodes.emplace_back(Id, UNs);
+    Nodes.emplace_back(Id, UNs, IdToUNWeights[Id]);
 
   // Since BalancedPartitioning is sensitive to the initial order, we explicitly
   // order nodes by their earliest timestamp.

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -718,10 +718,9 @@ Error collectGlobalObjectNameStrings(ArrayRef<std::string> NameStrs,
   std::string UncompressedNameStrings =
       join(NameStrs.begin(), NameStrs.end(), getInstrProfNameSeparator());
 
-  assert(
-      StringRef(UncompressedNameStrings).count(getInstrProfNameSeparator()) ==
-          (NameStrs.size() - 1) &&
-      "PGO name is invalid (contains separator token)");
+  assert(StringRef(UncompressedNameStrings)
+                 .count(getInstrProfNameSeparator()) == (NameStrs.size() - 1) &&
+         "PGO name is invalid (contains separator token)");
 
   unsigned EncLen = encodeULEB128(UncompressedNameStrings.length(), P);
   P += EncLen;
@@ -1147,17 +1146,20 @@ void InstrProfRecord::addValueData(uint32_t ValueKind, uint32_t Site,
 
 void TemporalProfTraceTy::createBPFunctionNodes(
     ArrayRef<TemporalProfTraceTy> Traces, std::vector<BPFunctionNode> &Nodes,
-    bool RemoveOutlierUNs) {
+    bool RemoveOutlierUNs,
+    BalancedPartitioning::UtilityNodeWeightsT *UtilityNodeWeights) {
   using IDT = BPFunctionNode::IDT;
   using UtilityNodeT = BPFunctionNode::UtilityNodeT;
   UtilityNodeT MaxUN = 0;
   DenseMap<IDT, size_t> IdToFirstTimestamp;
   DenseMap<IDT, UtilityNodeT> IdToFirstUN;
-  DenseMap<IDT, SmallVector<BPFunctionNode::WeightedUtilityNode>> IdToUNs;
+  DenseMap<IDT, SmallVector<UtilityNodeT>> IdToUNs;
+  DenseMap<UtilityNodeT, BPFunctionNode::UtilityNodeWeightT> NonUnitUNWeights;
   for (auto &Trace : Traces) {
     // A zero-weight trace is equivalent to no copies of the trace.
     if (Trace.Weight == 0)
       continue;
+    const UtilityNodeT FirstTraceUN = MaxUN;
     size_t CutoffTimestamp = 1;
     for (size_t Timestamp = 0; Timestamp < Trace.FunctionNameRefs.size();
          Timestamp++) {
@@ -1173,7 +1175,10 @@ void TemporalProfTraceTy::createBPFunctionNodes(
     }
     for (auto &[Id, FirstUN] : IdToFirstUN)
       for (auto UN = FirstUN; UN <= MaxUN; ++UN)
-        IdToUNs[Id].emplace_back(UN, Trace.Weight);
+        IdToUNs[Id].push_back(UN);
+    if (Trace.Weight != 1)
+      for (auto UN = FirstTraceUN; UN <= MaxUN; ++UN)
+        NonUnitUNWeights.try_emplace(UN, Trace.Weight);
     ++MaxUN;
     IdToFirstUN.clear();
   }
@@ -1182,18 +1187,20 @@ void TemporalProfTraceTy::createBPFunctionNodes(
     DenseMap<UtilityNodeT, unsigned> UNFrequency;
     for (auto &[Id, UNs] : IdToUNs)
       for (auto &UN : UNs)
-        ++UNFrequency[UN.Id];
+        ++UNFrequency[UN];
     // Filter out utility nodes that are too infrequent or too prevalent to make
     // BalancedPartitioning more effective.
     for (auto &[Id, UNs] : IdToUNs)
       llvm::erase_if(UNs, [&](auto &UN) {
-        unsigned Freq = UNFrequency[UN.Id];
+        unsigned Freq = UNFrequency[UN];
         return Freq <= 1 || 2 * Freq > IdToUNs.size();
       });
   }
 
   for (auto &[Id, UNs] : IdToUNs)
-    Nodes.push_back(BPFunctionNode::createWithWeightedUtilities(Id, UNs));
+    Nodes.emplace_back(Id, UNs);
+  if (UtilityNodeWeights)
+    *UtilityNodeWeights = std::move(NonUnitUNWeights);
 
   // Since BalancedPartitioning is sensitive to the initial order, we explicitly
   // order nodes by their earliest timestamp.
@@ -1216,13 +1223,13 @@ uint32_t getNumValueKindsInstrProf(const void *Record) {
 }
 
 uint32_t getNumValueSitesInstrProf(const void *Record, uint32_t VKind) {
-  return reinterpret_cast<const InstrProfRecord *>(Record)->getNumValueSites(
-      VKind);
+  return reinterpret_cast<const InstrProfRecord *>(Record)
+      ->getNumValueSites(VKind);
 }
 
 uint32_t getNumValueDataInstrProf(const void *Record, uint32_t VKind) {
-  return reinterpret_cast<const InstrProfRecord *>(Record)->getNumValueData(
-      VKind);
+  return reinterpret_cast<const InstrProfRecord *>(Record)
+      ->getNumValueData(VKind);
 }
 
 uint32_t getNumValueDataForSiteInstrProf(const void *R, uint32_t VK,
@@ -1423,8 +1430,9 @@ void annotateValueSite(Module &M, Instruction &Inst,
 }
 
 void annotateValueSite(Module &M, Instruction &Inst,
-                       ArrayRef<InstrProfValueData> VDs, uint64_t Sum,
-                       InstrProfValueKind ValueKind, uint32_t MaxMDCount) {
+                       ArrayRef<InstrProfValueData> VDs,
+                       uint64_t Sum, InstrProfValueKind ValueKind,
+                       uint32_t MaxMDCount) {
   if (VDs.empty())
     return;
   LLVMContext &Ctx = M.getContext();

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -175,11 +175,20 @@ void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
       ++UtilityNodeIndex[UN];
   // Remove utility nodes if they have just one edge or are connected to all
   // functions
-  for (auto &N : Nodes)
-    llvm::erase_if(N.UtilityNodes, [&](auto &UN) {
+  for (auto &N : Nodes) {
+    size_t WriteIndex = 0;
+    for (size_t ReadIndex = 0; ReadIndex < N.UtilityNodes.size(); ++ReadIndex) {
+      auto UN = N.UtilityNodes[ReadIndex];
       unsigned UNI = UtilityNodeIndex[UN];
-      return UNI == 1 || UNI == NumNodes;
-    });
+      if (UNI == 1 || UNI == NumNodes)
+        continue;
+      N.UtilityNodes[WriteIndex] = UN;
+      N.UtilityNodeWeights[WriteIndex] = N.UtilityNodeWeights[ReadIndex];
+      ++WriteIndex;
+    }
+    N.UtilityNodes.resize(WriteIndex);
+    N.UtilityNodeWeights.resize(WriteIndex);
+  }
 
   // Renumber utility nodes so they can be used to index into Signatures
   UtilityNodeIndex.clear();
@@ -190,12 +199,17 @@ void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
   // Initialize signatures
   SignaturesT Signatures(/*Size=*/UtilityNodeIndex.size());
   for (auto &N : Nodes) {
-    for (auto &UN : N.UtilityNodes) {
+    for (auto [UN, Weight] : llvm::zip(N.UtilityNodes, N.UtilityNodeWeights)) {
       assert(UN < Signatures.size());
+      auto &Signature = Signatures[UN];
+      if (Signature.LeftCount != 0 || Signature.RightCount != 0)
+        assert(Signature.Weight == Weight &&
+               "a utility node must have a consistent weight");
+      Signature.Weight = Weight;
       if (N.Bucket == LeftBucket) {
-        Signatures[UN].LeftCount++;
+        Signature.LeftCount++;
       } else {
-        Signatures[UN].RightCount++;
+        Signature.RightCount++;
       }
     }
   }
@@ -227,6 +241,14 @@ unsigned BalancedPartitioning::runIteration(const FunctionNodeRange Nodes,
       Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
     if (R > 0)
       Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
+    // Scaling a utility's move gain is mathematically equivalent to adding
+    // Weight distinct utility nodes with the same signature, but avoids
+    // expanding the graph. Weight == 1 deliberately takes no FP operation so
+    // unweighted inputs preserve their previous behavior.
+    if (Signature.Weight != 1) {
+      Signature.CachedGainLR *= static_cast<float>(Signature.Weight);
+      Signature.CachedGainRL *= static_cast<float>(Signature.Weight);
+    }
     Signature.CachedGainIsValid = true;
   }
 

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -22,8 +22,15 @@ using namespace llvm;
 #define DEBUG_TYPE "balanced-partitioning"
 
 void BPFunctionNode::dump(raw_ostream &OS) const {
-  OS << formatv("{{ID={0} Utilities={{{1:$[,]}} Bucket={2}}", Id,
-                make_range(UtilityNodes.begin(), UtilityNodes.end()), Bucket);
+  OS << "{ID=" << Id << " Utilities={";
+  for (const auto &UN : UtilityNodes)
+    OS << "(" << UN.Id << ", " << UN.Weight << ")";
+  OS << "} Bucket=";
+  if (Bucket)
+    OS << *Bucket;
+  else
+    OS << "none";
+  OS << "}";
 }
 
 template <typename Func>
@@ -172,40 +179,33 @@ void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
   DenseMap<BPFunctionNode::UtilityNodeT, unsigned> UtilityNodeIndex;
   for (auto &N : Nodes)
     for (auto &UN : N.UtilityNodes)
-      ++UtilityNodeIndex[UN];
+      ++UtilityNodeIndex[UN.Id];
   // Remove utility nodes if they have just one edge or are connected to all
   // functions
-  for (auto &N : Nodes) {
-    size_t WriteIndex = 0;
-    for (size_t ReadIndex = 0; ReadIndex < N.UtilityNodes.size(); ++ReadIndex) {
-      auto UN = N.UtilityNodes[ReadIndex];
-      unsigned UNI = UtilityNodeIndex[UN];
-      if (UNI == 1 || UNI == NumNodes)
-        continue;
-      N.UtilityNodes[WriteIndex] = UN;
-      N.UtilityNodeWeights[WriteIndex] = N.UtilityNodeWeights[ReadIndex];
-      ++WriteIndex;
-    }
-    N.UtilityNodes.resize(WriteIndex);
-    N.UtilityNodeWeights.resize(WriteIndex);
-  }
+  for (auto &N : Nodes)
+    llvm::erase_if(N.UtilityNodes, [&](auto &UN) {
+      unsigned UNI = UtilityNodeIndex[UN.Id];
+      return UNI == 1 || UNI == NumNodes;
+    });
 
   // Renumber utility nodes so they can be used to index into Signatures
   UtilityNodeIndex.clear();
   for (auto &N : Nodes)
     for (auto &UN : N.UtilityNodes)
-      UN = UtilityNodeIndex.insert({UN, UtilityNodeIndex.size()}).first->second;
+      UN.Id = UtilityNodeIndex.insert({UN.Id, UtilityNodeIndex.size()})
+                  .first->second;
 
   // Initialize signatures
   SignaturesT Signatures(/*Size=*/UtilityNodeIndex.size());
   for (auto &N : Nodes) {
-    for (auto [UN, Weight] : llvm::zip(N.UtilityNodes, N.UtilityNodeWeights)) {
-      assert(UN < Signatures.size());
-      auto &Signature = Signatures[UN];
-      if (Signature.LeftCount != 0 || Signature.RightCount != 0)
-        assert(Signature.Weight == Weight &&
+    for (auto &UN : N.UtilityNodes) {
+      assert(UN.Id < Signatures.size());
+      auto &Signature = Signatures[UN.Id];
+      if (Signature.LeftCount == 0 && Signature.RightCount == 0)
+        Signature.Weight = UN.Weight;
+      else
+        assert(Signature.Weight == UN.Weight &&
                "a utility node must have a consistent weight");
-      Signature.Weight = Weight;
       if (N.Bucket == LeftBucket) {
         Signature.LeftCount++;
       } else {
@@ -307,14 +307,14 @@ bool BalancedPartitioning::moveFunctionNode(BPFunctionNode &N,
   // Update signatures and invalidate gain cache
   if (FromLeftToRight) {
     for (auto &UN : N.UtilityNodes) {
-      auto &Signature = Signatures[UN];
+      auto &Signature = Signatures[UN.Id];
       Signature.LeftCount--;
       Signature.RightCount++;
       Signature.CachedGainIsValid = false;
     }
   } else {
     for (auto &UN : N.UtilityNodes) {
-      auto &Signature = Signatures[UN];
+      auto &Signature = Signatures[UN.Id];
       Signature.LeftCount++;
       Signature.RightCount--;
       Signature.CachedGainIsValid = false;
@@ -343,8 +343,8 @@ float BalancedPartitioning::moveGain(const BPFunctionNode &N,
                                      const SignaturesT &Signatures) {
   float Gain = 0.f;
   for (auto &UN : N.UtilityNodes)
-    Gain += (FromLeftToRight ? Signatures[UN].CachedGainLR
-                             : Signatures[UN].CachedGainRL);
+    Gain += (FromLeftToRight ? Signatures[UN.Id].CachedGainLR
+                             : Signatures[UN.Id].CachedGainRL);
   return Gain;
 }
 

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -12,25 +12,22 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/BalancedPartitioning.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_THREADS
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/ThreadPool.h"
 
+#include <memory>
+#include <type_traits>
+
 using namespace llvm;
 #define DEBUG_TYPE "balanced-partitioning"
 
 void BPFunctionNode::dump(raw_ostream &OS) const {
-  OS << "{ID=" << Id << " Utilities={";
-  for (const auto &UN : UtilityNodes)
-    OS << "(" << UN.Id << ", " << UN.Weight << ")";
-  OS << "} Bucket=";
-  if (Bucket)
-    OS << *Bucket;
-  else
-    OS << "none";
-  OS << "}";
+  OS << formatv("{{ID={0} Utilities={{{1:$[,]}} Bucket={2}}", Id,
+                make_range(UtilityNodes.begin(), UtilityNodes.end()), Bucket);
 }
 
 template <typename Func>
@@ -84,6 +81,29 @@ BalancedPartitioning::BalancedPartitioning(
 }
 
 void BalancedPartitioning::run(std::vector<BPFunctionNode> &Nodes) const {
+  runImpl(Nodes, nullptr);
+}
+
+void BalancedPartitioning::run(
+    std::vector<BPFunctionNode> &Nodes,
+    const UtilityNodeWeightsT &UtilityNodeWeights) const {
+  assert(llvm::all_of(UtilityNodeWeights,
+                      [](const auto &Entry) { return Entry.second > 0; }) &&
+         "utility weights must be positive");
+  auto HasNonUnitWeight = llvm::any_of(
+      UtilityNodeWeights, [](const auto &Entry) { return Entry.second != 1; });
+  if (!HasNonUnitWeight) {
+    run(Nodes);
+    return;
+  }
+  runImpl(Nodes,
+          std::make_shared<const UtilityNodeWeightsT>(UtilityNodeWeights));
+}
+
+template <typename UtilityNodeWeightsPtrT>
+void BalancedPartitioning::runImpl(
+    std::vector<BPFunctionNode> &Nodes,
+    UtilityNodeWeightsPtrT UtilityNodeWeights) const {
   LLVM_DEBUG(
       dbgs() << format(
           "Partitioning %d nodes using depth %d and %d iterations per split\n",
@@ -100,8 +120,10 @@ void BalancedPartitioning::run(std::vector<BPFunctionNode> &Nodes) const {
     Nodes[I].InputOrderIndex = I;
 
   auto NodesRange = llvm::make_range(Nodes.begin(), Nodes.end());
-  auto BisectTask = [this, NodesRange, &TP]() {
-    bisect(NodesRange, /*RecDepth=*/0, /*RootBucket=*/1, /*Offset=*/0, TP);
+  auto BisectTask = [this, NodesRange, &TP,
+                     UtilityNodeWeights = std::move(UtilityNodeWeights)]() {
+    bisect(NodesRange, /*RecDepth=*/0, /*RootBucket=*/1, /*Offset=*/0, TP,
+           std::move(UtilityNodeWeights));
   };
   if (TP) {
     TP->async(std::move(BisectTask));
@@ -117,10 +139,11 @@ void BalancedPartitioning::run(std::vector<BPFunctionNode> &Nodes) const {
   LLVM_DEBUG(dbgs() << "Balanced partitioning completed\n");
 }
 
-void BalancedPartitioning::bisect(const FunctionNodeRange Nodes,
-                                  unsigned RecDepth, unsigned RootBucket,
-                                  unsigned Offset,
-                                  std::optional<BPThreadPool> &TP) const {
+template <typename UtilityNodeWeightsPtrT>
+void BalancedPartitioning::bisect(
+    const FunctionNodeRange Nodes, unsigned RecDepth, unsigned RootBucket,
+    unsigned Offset, std::optional<BPThreadPool> &TP,
+    UtilityNodeWeightsPtrT UtilityNodeWeights) const {
   unsigned NumNodes = llvm::size(Nodes);
   if (NumNodes <= 1 || RecDepth >= Config.SplitDepth) {
     // We've reach the lowest level of the recursion tree. Fall back to the
@@ -144,7 +167,8 @@ void BalancedPartitioning::bisect(const FunctionNodeRange Nodes,
   // Split into two and assign to the left and right buckets
   split(Nodes, LeftBucket);
 
-  runIterations(Nodes, LeftBucket, RightBucket, RNG);
+  auto ChildUtilityNodeWeights = runIterations(
+      Nodes, LeftBucket, RightBucket, std::move(UtilityNodeWeights), RNG);
 
   // Split nodes wrt the resulting buckets
   auto NodesMid =
@@ -154,12 +178,15 @@ void BalancedPartitioning::bisect(const FunctionNodeRange Nodes,
   auto LeftNodes = llvm::make_range(Nodes.begin(), NodesMid);
   auto RightNodes = llvm::make_range(NodesMid, Nodes.end());
 
-  auto LeftRecTask = [this, LeftNodes, RecDepth, LeftBucket, Offset, &TP]() {
-    bisect(LeftNodes, RecDepth + 1, LeftBucket, Offset, TP);
+  auto LeftRecTask = [this, LeftNodes, RecDepth, LeftBucket, Offset, &TP,
+                      ChildUtilityNodeWeights]() {
+    bisect(LeftNodes, RecDepth + 1, LeftBucket, Offset, TP,
+           ChildUtilityNodeWeights);
   };
-  auto RightRecTask = [this, RightNodes, RecDepth, RightBucket, MidOffset,
-                       &TP]() {
-    bisect(RightNodes, RecDepth + 1, RightBucket, MidOffset, TP);
+  auto RightRecTask = [this, RightNodes, RecDepth, RightBucket, MidOffset, &TP,
+                       ChildUtilityNodeWeights]() {
+    bisect(RightNodes, RecDepth + 1, RightBucket, MidOffset, TP,
+           ChildUtilityNodeWeights);
   };
 
   if (TP && RecDepth < Config.TaskSplitDepth && NumNodes >= 4) {
@@ -171,85 +198,137 @@ void BalancedPartitioning::bisect(const FunctionNodeRange Nodes,
   }
 }
 
-void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
-                                         unsigned LeftBucket,
-                                         unsigned RightBucket,
-                                         std::mt19937 &RNG) const {
+template <typename UtilityNodeWeightsPtrT>
+UtilityNodeWeightsPtrT BalancedPartitioning::runIterations(
+    const FunctionNodeRange Nodes, unsigned LeftBucket, unsigned RightBucket,
+    UtilityNodeWeightsPtrT UtilityNodeWeights, std::mt19937 &RNG) const {
   unsigned NumNodes = llvm::size(Nodes);
   DenseMap<BPFunctionNode::UtilityNodeT, unsigned> UtilityNodeIndex;
   for (auto &N : Nodes)
     for (auto &UN : N.UtilityNodes)
-      ++UtilityNodeIndex[UN.Id];
+      ++UtilityNodeIndex[UN];
   // Remove utility nodes if they have just one edge or are connected to all
   // functions
   for (auto &N : Nodes)
     llvm::erase_if(N.UtilityNodes, [&](auto &UN) {
-      unsigned UNI = UtilityNodeIndex[UN.Id];
+      unsigned UNI = UtilityNodeIndex[UN];
       return UNI == 1 || UNI == NumNodes;
     });
 
   // Renumber utility nodes so they can be used to index into Signatures
   UtilityNodeIndex.clear();
-  for (auto &N : Nodes)
-    for (auto &UN : N.UtilityNodes)
-      UN.Id = UtilityNodeIndex.insert({UN.Id, UtilityNodeIndex.size()})
-                  .first->second;
+  if constexpr (std::is_same_v<UtilityNodeWeightsPtrT, std::nullptr_t>) {
+    for (auto &N : Nodes)
+      for (auto &UN : N.UtilityNodes)
+        UN = UtilityNodeIndex.insert({UN, UtilityNodeIndex.size()})
+                 .first->second;
+  } else {
+    auto RenumberedWeights = std::make_shared<UtilityNodeWeightsT>();
+    for (auto &N : Nodes) {
+      for (auto &UN : N.UtilityNodes) {
+        auto WeightIt = UtilityNodeWeights->find(UN);
+        BPFunctionNode::UtilityNodeWeightT Weight =
+            WeightIt == UtilityNodeWeights->end() ? 1 : WeightIt->second;
+        auto [IndexIt, WasInserted] =
+            UtilityNodeIndex.insert({UN, UtilityNodeIndex.size()});
+        UN = IndexIt->second;
+        if (WasInserted) {
+          if (Weight != 1)
+            RenumberedWeights->try_emplace(UN, Weight);
+          continue;
+        }
+        auto RenumberedWeightIt = RenumberedWeights->find(UN);
+        BPFunctionNode::UtilityNodeWeightT RenumberedWeight =
+            RenumberedWeightIt == RenumberedWeights->end()
+                ? 1
+                : RenumberedWeightIt->second;
+        assert(RenumberedWeight == Weight &&
+               "a utility node must have a consistent weight");
+      }
+    }
+    UtilityNodeWeights = std::move(RenumberedWeights);
+  }
 
   // Initialize signatures
   SignaturesT Signatures(/*Size=*/UtilityNodeIndex.size());
   for (auto &N : Nodes) {
     for (auto &UN : N.UtilityNodes) {
-      assert(UN.Id < Signatures.size());
-      auto &Signature = Signatures[UN.Id];
-      if (Signature.LeftCount == 0 && Signature.RightCount == 0)
-        Signature.Weight = UN.Weight;
-      else
-        assert(Signature.Weight == UN.Weight &&
-               "a utility node must have a consistent weight");
+      assert(UN < Signatures.size());
       if (N.Bucket == LeftBucket) {
-        Signature.LeftCount++;
+        Signatures[UN].LeftCount++;
       } else {
-        Signature.RightCount++;
+        Signatures[UN].RightCount++;
       }
     }
   }
 
+  SmallVector<BPFunctionNode::UtilityNodeWeightT, 4> RenumberedWeights;
+  if constexpr (!std::is_same_v<UtilityNodeWeightsPtrT, std::nullptr_t>) {
+    if (!UtilityNodeWeights->empty()) {
+      RenumberedWeights.assign(Signatures.size(), 1);
+      for (auto [UN, Weight] : *UtilityNodeWeights)
+        RenumberedWeights[UN] = Weight;
+    }
+  }
+
   for (unsigned I = 0; I < Config.IterationsPerSplit; I++) {
-    unsigned NumMovedNodes =
-        runIteration(Nodes, LeftBucket, RightBucket, Signatures, RNG);
+    unsigned NumMovedNodes;
+    if (RenumberedWeights.empty())
+      NumMovedNodes = runIteration(Nodes, LeftBucket, RightBucket, Signatures,
+                                   nullptr, RNG);
+    else
+      NumMovedNodes = runIteration(
+          Nodes, LeftBucket, RightBucket, Signatures,
+          ArrayRef<BPFunctionNode::UtilityNodeWeightT>(RenumberedWeights), RNG);
     if (NumMovedNodes == 0)
       break;
   }
+  return UtilityNodeWeights;
 }
 
-unsigned BalancedPartitioning::runIteration(const FunctionNodeRange Nodes,
-                                            unsigned LeftBucket,
-                                            unsigned RightBucket,
-                                            SignaturesT &Signatures,
-                                            std::mt19937 &RNG) const {
+template <typename UtilityNodeWeightsRefT>
+unsigned BalancedPartitioning::runIteration(
+    const FunctionNodeRange Nodes, unsigned LeftBucket, unsigned RightBucket,
+    SignaturesT &Signatures, UtilityNodeWeightsRefT UtilityNodeWeights,
+    std::mt19937 &RNG) const {
   // Init signature cost caches
-  for (auto &Signature : Signatures) {
-    if (Signature.CachedGainIsValid)
-      continue;
-    unsigned L = Signature.LeftCount;
-    unsigned R = Signature.RightCount;
-    assert((L > 0 || R > 0) && "incorrect signature");
-    float Cost = logCost(L, R);
-    Signature.CachedGainLR = 0.f;
-    Signature.CachedGainRL = 0.f;
-    if (L > 0)
-      Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
-    if (R > 0)
-      Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
-    // Scaling a utility's move gain is mathematically equivalent to adding
-    // Weight distinct utility nodes with the same signature, but avoids
-    // expanding the graph. Weight == 1 deliberately takes no FP operation so
-    // unweighted inputs preserve their previous behavior.
-    if (Signature.Weight != 1) {
-      Signature.CachedGainLR *= static_cast<float>(Signature.Weight);
-      Signature.CachedGainRL *= static_cast<float>(Signature.Weight);
+  if constexpr (std::is_same_v<UtilityNodeWeightsRefT, std::nullptr_t>) {
+    for (auto &Signature : Signatures) {
+      if (Signature.CachedGainIsValid)
+        continue;
+      unsigned L = Signature.LeftCount;
+      unsigned R = Signature.RightCount;
+      assert((L > 0 || R > 0) && "incorrect signature");
+      float Cost = logCost(L, R);
+      Signature.CachedGainLR = 0.f;
+      Signature.CachedGainRL = 0.f;
+      if (L > 0)
+        Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
+      if (R > 0)
+        Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
+      Signature.CachedGainIsValid = true;
     }
-    Signature.CachedGainIsValid = true;
+  } else {
+    for (auto [I, Signature] : llvm::enumerate(Signatures)) {
+      if (Signature.CachedGainIsValid)
+        continue;
+      unsigned L = Signature.LeftCount;
+      unsigned R = Signature.RightCount;
+      assert((L > 0 || R > 0) && "incorrect signature");
+      float Cost = logCost(L, R);
+      Signature.CachedGainLR = 0.f;
+      Signature.CachedGainRL = 0.f;
+      if (L > 0)
+        Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
+      if (R > 0)
+        Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
+      // Scaling a utility's move gain is mathematically equivalent to adding
+      // Weight distinct utility nodes with the same signature, but avoids
+      // expanding the graph.
+      Signature.CachedGainLR *= static_cast<float>(UtilityNodeWeights[I]);
+      Signature.CachedGainRL *= static_cast<float>(UtilityNodeWeights[I]);
+      Signature.CachedGainIsValid = true;
+    }
   }
 
   // Compute move gains
@@ -307,14 +386,14 @@ bool BalancedPartitioning::moveFunctionNode(BPFunctionNode &N,
   // Update signatures and invalidate gain cache
   if (FromLeftToRight) {
     for (auto &UN : N.UtilityNodes) {
-      auto &Signature = Signatures[UN.Id];
+      auto &Signature = Signatures[UN];
       Signature.LeftCount--;
       Signature.RightCount++;
       Signature.CachedGainIsValid = false;
     }
   } else {
     for (auto &UN : N.UtilityNodes) {
-      auto &Signature = Signatures[UN.Id];
+      auto &Signature = Signatures[UN];
       Signature.LeftCount++;
       Signature.RightCount--;
       Signature.CachedGainIsValid = false;
@@ -343,8 +422,8 @@ float BalancedPartitioning::moveGain(const BPFunctionNode &N,
                                      const SignaturesT &Signatures) {
   float Gain = 0.f;
   for (auto &UN : N.UtilityNodes)
-    Gain += (FromLeftToRight ? Signatures[UN.Id].CachedGainLR
-                             : Signatures[UN.Id].CachedGainRL);
+    Gain += (FromLeftToRight ? Signatures[UN].CachedGainLR
+                             : Signatures[UN].CachedGainRL);
   return Gain;
 }
 

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -292,43 +292,24 @@ unsigned BalancedPartitioning::runIteration(
     SignaturesT &Signatures, UtilityNodeWeightsRefT UtilityNodeWeights,
     std::mt19937 &RNG) const {
   // Init signature cost caches
-  if constexpr (std::is_same_v<UtilityNodeWeightsRefT, std::nullptr_t>) {
-    for (auto &Signature : Signatures) {
-      if (Signature.CachedGainIsValid)
-        continue;
-      unsigned L = Signature.LeftCount;
-      unsigned R = Signature.RightCount;
-      assert((L > 0 || R > 0) && "incorrect signature");
-      float Cost = logCost(L, R);
-      Signature.CachedGainLR = 0.f;
-      Signature.CachedGainRL = 0.f;
-      if (L > 0)
-        Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
-      if (R > 0)
-        Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
-      Signature.CachedGainIsValid = true;
-    }
-  } else {
-    for (auto [I, Signature] : llvm::enumerate(Signatures)) {
-      if (Signature.CachedGainIsValid)
-        continue;
-      unsigned L = Signature.LeftCount;
-      unsigned R = Signature.RightCount;
-      assert((L > 0 || R > 0) && "incorrect signature");
-      float Cost = logCost(L, R);
-      Signature.CachedGainLR = 0.f;
-      Signature.CachedGainRL = 0.f;
-      if (L > 0)
-        Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
-      if (R > 0)
-        Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
-      // Scaling a utility's move gain is mathematically equivalent to adding
-      // Weight distinct utility nodes with the same signature, but avoids
-      // expanding the graph.
+  for (auto [I, Signature] : llvm::enumerate(Signatures)) {
+    if (Signature.CachedGainIsValid)
+      continue;
+    unsigned L = Signature.LeftCount;
+    unsigned R = Signature.RightCount;
+    assert((L > 0 || R > 0) && "incorrect signature");
+    float Cost = logCost(L, R);
+    Signature.CachedGainLR = 0.f;
+    Signature.CachedGainRL = 0.f;
+    if (L > 0)
+      Signature.CachedGainLR = Cost - logCost(L - 1, R + 1);
+    if (R > 0)
+      Signature.CachedGainRL = Cost - logCost(L + 1, R - 1);
+    if constexpr (!std::is_same_v<UtilityNodeWeightsRefT, std::nullptr_t>) {
       Signature.CachedGainLR *= static_cast<float>(UtilityNodeWeights[I]);
       Signature.CachedGainRL *= static_cast<float>(UtilityNodeWeights[I]);
-      Signature.CachedGainIsValid = true;
     }
+    Signature.CachedGainIsValid = true;
   }
 
   // Compute move gains

--- a/llvm/test/tools/llvm-profdata/order-weighted-traces.test
+++ b/llvm/test/tools/llvm-profdata/order-weighted-traces.test
@@ -1,0 +1,87 @@
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-profdata merge %t/weighted.proftext %t/functions.proftext -o %t/weighted.profdata
+# RUN: llvm-profdata merge %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext \
+# RUN:   %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext %t/primary.proftext \
+# RUN:   %t/competing.proftext %t/functions.proftext -o %t/replicated.profdata
+# RUN: llvm-profdata merge %t/primary.proftext %t/competing.proftext %t/functions.proftext -o %t/unweighted.profdata
+# RUN: llvm-profdata order %t/weighted.profdata -o %t/weighted.order
+# RUN: llvm-profdata order %t/replicated.profdata -o %t/replicated.order
+# RUN: llvm-profdata order %t/unweighted.profdata -o %t/unweighted.order
+
+# A weight of 10 has the same ordering objective as ten copies of the trace.
+# RUN: cmp %t/weighted.order %t/replicated.order
+# RUN: not cmp %t/weighted.order %t/unweighted.order
+# RUN: FileCheck %s --input-file=%t/weighted.order --check-prefix=FUNCTIONS
+
+# FUNCTIONS-DAG: A
+# FUNCTIONS-DAG: B
+# FUNCTIONS-DAG: C
+# FUNCTIONS-DAG: D
+# FUNCTIONS-DAG: E
+# FUNCTIONS-DAG: F
+
+#--- weighted.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+2
+# Trace Stream Size
+11
+# Weight
+10
+A, B, C, D, E, F
+# Weight
+1
+A, D, B, C, E, F
+
+#--- primary.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+1
+# Trace Stream Size
+1
+# Weight
+1
+A, B, C, D, E, F
+
+#--- competing.proftext
+:ir
+:temporal_prof_traces
+# Num Traces
+1
+# Trace Stream Size
+1
+# Weight
+1
+A, D, B, C, E, F
+
+#--- functions.proftext
+:ir
+A
+# Func Hash
+1
+# Num Counters
+1
+# Counter Values
+1
+B
+2
+1
+1
+C
+3
+1
+1
+D
+4
+1
+1
+E
+5
+1
+1
+F
+6
+1
+1

--- a/llvm/test/tools/llvm-profdata/show-order-weight-saturation.proftext
+++ b/llvm/test/tools/llvm-profdata/show-order-weight-saturation.proftext
@@ -1,0 +1,31 @@
+# RUN: llvm-profdata order %s --num-test-traces=1 | FileCheck %s
+
+# CHECK: # Total area under the page fault curve: 1.844674e+19
+
+:ir
+:temporal_prof_traces
+# Num Traces
+3
+# Trace Stream Size
+3
+# Weight
+1
+a, b
+# Weight
+1
+b, a
+# Weight
+18446744073709551615
+a, b
+
+a
+# Func Hash
+1
+# Num Counters
+1
+# Counter Values
+1
+b
+2
+1
+1

--- a/llvm/test/tools/llvm-profdata/show-order.proftext
+++ b/llvm/test/tools/llvm-profdata/show-order.proftext
@@ -1,6 +1,6 @@
 # RUN: llvm-profdata order %s --num-test-traces=1 | FileCheck %s
 
-# CHECK: # Total area under the page fault curve: 4.000000e+00
+# CHECK: # Total area under the page fault curve: 4.000000e+01
 
 # CHECK: a
 # CHECK: b
@@ -24,7 +24,7 @@ a, x, main.c:b, c
 1
 a, main.c:b, c
 # Weight
-1
+10
 a, main.c:b, c, x
 
 a

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -38,6 +38,7 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MD5.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Regex.h"
@@ -638,7 +639,7 @@ public:
     return New.empty() ? Name : FunctionId(New);
   }
 };
-}
+} // namespace
 
 struct WeightedFile {
   std::string Filename;
@@ -894,13 +895,11 @@ getFuncName(const StringMap<InstrProfWriter::ProfilingData>::value_type &Val) {
   return Val.first();
 }
 
-static std::string
-getFuncName(const SampleProfileMap::value_type &Val) {
+static std::string getFuncName(const SampleProfileMap::value_type &Val) {
   return Val.second.getContext().toString();
 }
 
-template <typename T>
-static void filterFunctions(T &ProfileMap) {
+template <typename T> static void filterFunctions(T &ProfileMap) {
   bool hasFilter = !FuncNameFilter.empty();
   bool hasNegativeFilter = !FuncNameNegativeFilter.empty();
   if (!hasFilter && !hasNegativeFilter)
@@ -1499,8 +1498,8 @@ remapSamples(const sampleprof::FunctionSamples &Samples,
                           BodySample.second.getSamples());
     for (const auto &Target : BodySample.second.getCallTargets()) {
       Result.addCalledTargetSamples(BodySample.first.LineOffset,
-                                    MaskedDiscriminator,
-                                    Remapper(Target.first), Target.second);
+                                    MaskedDiscriminator, Remapper(Target.first),
+                                    Target.second);
     }
   }
   for (const auto &CallsiteSamples : Samples.getCallsiteSamples()) {
@@ -1517,12 +1516,8 @@ remapSamples(const sampleprof::FunctionSamples &Samples,
 }
 
 static sampleprof::SampleProfileFormat FormatMap[] = {
-    sampleprof::SPF_None,
-    sampleprof::SPF_Text,
-    sampleprof::SPF_None,
-    sampleprof::SPF_Ext_Binary,
-    sampleprof::SPF_GCC,
-    sampleprof::SPF_Binary};
+    sampleprof::SPF_None,       sampleprof::SPF_Text, sampleprof::SPF_None,
+    sampleprof::SPF_Ext_Binary, sampleprof::SPF_GCC,  sampleprof::SPF_Binary};
 
 static std::unique_ptr<MemoryBuffer>
 getInputFileBuf(const StringRef &InputFile) {
@@ -3396,7 +3391,8 @@ static int show_main(StringRef ProgName) {
     exitWithErrorCode(EC, OutputFilename);
 
   if (ShowAllFunctions && !FuncNameFilter.empty())
-    WithColor::warning() << "-function argument ignored: showing all functions\n";
+    WithColor::warning()
+        << "-function argument ignored: showing all functions\n";
 
   if (!DebugInfoFilename.empty())
     return showDebugInfoCorrelation(DebugInfoFilename, SFormat, OS);
@@ -3446,15 +3442,20 @@ static int order_main() {
       IdToPageNumber[Node.Id] = IdToPageNumber.size() / 32;
 
     SmallSet<unsigned, 0> TouchedPages;
-    unsigned Area = 0;
+    uint64_t Area = 0;
     for (auto &Trace : TestTraces) {
+      if (Trace.Weight == 0)
+        continue;
+      uint64_t TraceArea = 0;
       for (auto Id : Trace.FunctionNameRefs) {
         auto It = IdToPageNumber.find(Id);
         if (It == IdToPageNumber.end())
           continue;
         TouchedPages.insert(It->getSecond());
-        Area += TouchedPages.size();
+        TraceArea = SaturatingAdd(TraceArea,
+                                  static_cast<uint64_t>(TouchedPages.size()));
       }
+      Area = SaturatingMultiplyAdd(TraceArea, Trace.Weight, Area);
       TouchedPages.clear();
     }
     OS << "# Total area under the page fault curve: " << (float)Area << "\n";

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -639,7 +639,7 @@ public:
     return New.empty() ? Name : FunctionId(New);
   }
 };
-} // namespace
+}
 
 struct WeightedFile {
   std::string Filename;
@@ -895,11 +895,13 @@ getFuncName(const StringMap<InstrProfWriter::ProfilingData>::value_type &Val) {
   return Val.first();
 }
 
-static std::string getFuncName(const SampleProfileMap::value_type &Val) {
+static std::string
+getFuncName(const SampleProfileMap::value_type &Val) {
   return Val.second.getContext().toString();
 }
 
-template <typename T> static void filterFunctions(T &ProfileMap) {
+template <typename T>
+static void filterFunctions(T &ProfileMap) {
   bool hasFilter = !FuncNameFilter.empty();
   bool hasNegativeFilter = !FuncNameNegativeFilter.empty();
   if (!hasFilter && !hasNegativeFilter)
@@ -1498,8 +1500,8 @@ remapSamples(const sampleprof::FunctionSamples &Samples,
                           BodySample.second.getSamples());
     for (const auto &Target : BodySample.second.getCallTargets()) {
       Result.addCalledTargetSamples(BodySample.first.LineOffset,
-                                    MaskedDiscriminator, Remapper(Target.first),
-                                    Target.second);
+                                    MaskedDiscriminator,
+                                    Remapper(Target.first), Target.second);
     }
   }
   for (const auto &CallsiteSamples : Samples.getCallsiteSamples()) {
@@ -1516,8 +1518,12 @@ remapSamples(const sampleprof::FunctionSamples &Samples,
 }
 
 static sampleprof::SampleProfileFormat FormatMap[] = {
-    sampleprof::SPF_None,       sampleprof::SPF_Text, sampleprof::SPF_None,
-    sampleprof::SPF_Ext_Binary, sampleprof::SPF_GCC,  sampleprof::SPF_Binary};
+    sampleprof::SPF_None,
+    sampleprof::SPF_Text,
+    sampleprof::SPF_None,
+    sampleprof::SPF_Ext_Binary,
+    sampleprof::SPF_GCC,
+    sampleprof::SPF_Binary};
 
 static std::unique_ptr<MemoryBuffer>
 getInputFileBuf(const StringRef &InputFile) {
@@ -3391,8 +3397,7 @@ static int show_main(StringRef ProgName) {
     exitWithErrorCode(EC, OutputFilename);
 
   if (ShowAllFunctions && !FuncNameFilter.empty())
-    WithColor::warning()
-        << "-function argument ignored: showing all functions\n";
+    WithColor::warning() << "-function argument ignored: showing all functions\n";
 
   if (!DebugInfoFilename.empty())
     return showDebugInfoCorrelation(DebugInfoFilename, SFormat, OS);
@@ -3429,10 +3434,12 @@ static int order_main() {
   Traces = Traces.drop_back(NumTestTraces);
 
   std::vector<BPFunctionNode> Nodes;
-  TemporalProfTraceTy::createBPFunctionNodes(Traces, Nodes);
+  BalancedPartitioning::UtilityNodeWeightsT UtilityNodeWeights;
+  TemporalProfTraceTy::createBPFunctionNodes(
+      Traces, Nodes, /*RemoveOutlierUNs=*/true, &UtilityNodeWeights);
   BalancedPartitioningConfig Config;
   BalancedPartitioning BP(Config);
-  BP.run(Nodes);
+  BP.run(Nodes, UtilityNodeWeights);
 
   OS << "# Ordered " << Nodes.size() << " functions\n";
   if (!TestTraces.empty()) {

--- a/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
+++ b/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 
 using testing::Field;
+using testing::Truly;
 using testing::UnorderedElementsAre;
 using testing::UnorderedElementsAreArray;
 
@@ -23,16 +24,37 @@ void PrintTo(const BPFunctionNode &Node, std::ostream *OS) {
 }
 
 TEST(BPFunctionNodeTest, Basic) {
-  auto NodeIs = [](BPFunctionNode::IDT Id,
-                   ArrayRef<BPFunctionNode::WeightedUtilityNode> UNs) {
+  using WeightedUtilityNode = std::pair<BPFunctionNode::UtilityNodeT,
+                                        BPFunctionNode::UtilityNodeWeightT>;
+  BalancedPartitioning::UtilityNodeWeightsT UtilityNodeWeights;
+  auto NodeIs = [&UtilityNodeWeights](BPFunctionNode::IDT Id,
+                                      ArrayRef<WeightedUtilityNode> UNs) {
+    SmallVector<WeightedUtilityNode> Expected(UNs);
     return AllOf(Field("Id", &BPFunctionNode::Id, Id),
-                 Field("UtilityNodes", &BPFunctionNode::UtilityNodes,
-                       UnorderedElementsAreArray(UNs)));
+                 Truly([Expected = std::move(Expected),
+                        &UtilityNodeWeights](const BPFunctionNode &Node) {
+                   if (Node.UtilityNodes.size() != Expected.size())
+                     return false;
+                   for (auto [ExpectedUN, ExpectedWeight] : Expected) {
+                     bool Found = false;
+                     for (auto UN : Node.UtilityNodes) {
+                       auto WeightIt = UtilityNodeWeights.find(UN);
+                       uint64_t Weight = WeightIt == UtilityNodeWeights.end()
+                                             ? 1
+                                             : WeightIt->second;
+                       Found |= UN == ExpectedUN && Weight == ExpectedWeight;
+                     }
+                     if (!Found)
+                       return false;
+                   }
+                   return true;
+                 }));
   };
 
   std::vector<BPFunctionNode> Nodes;
   TemporalProfTraceTy::createBPFunctionNodes(
-      {TemporalProfTraceTy({0, 1, 2, 3})}, Nodes, /*RemoveOutlierUNs=*/false);
+      {TemporalProfTraceTy({0, 1, 2, 3})}, Nodes,
+      /*RemoveOutlierUNs=*/false, &UtilityNodeWeights);
   // Utility nodes that are too infrequent or too prevalent are filtered out.
   EXPECT_THAT(Nodes,
               UnorderedElementsAre(NodeIs(0, {{0, 1}, {1, 1}, {2, 1}}),
@@ -40,9 +62,10 @@ TEST(BPFunctionNodeTest, Basic) {
                                    NodeIs(2, {{2, 1}}), NodeIs(3, {{2, 1}})));
 
   Nodes.clear();
+  UtilityNodeWeights.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
       {TemporalProfTraceTy({0, 1, 2, 3, 4}), TemporalProfTraceTy({4, 2})},
-      Nodes, /*RemoveOutlierUNs=*/false);
+      Nodes, /*RemoveOutlierUNs=*/false, &UtilityNodeWeights);
 
   EXPECT_THAT(Nodes,
               UnorderedElementsAre(NodeIs(0, {{0, 1}, {1, 1}, {2, 1}, {3, 1}}),
@@ -52,9 +75,10 @@ TEST(BPFunctionNodeTest, Basic) {
                                    NodeIs(4, {{3, 1}, {4, 1}, {5, 1}})));
 
   Nodes.clear();
+  UtilityNodeWeights.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
       {TemporalProfTraceTy({0, 1, 2, 3, 4}), TemporalProfTraceTy({4, 2})},
-      Nodes, /*RemoveOutlierUNs=*/true);
+      Nodes, /*RemoveOutlierUNs=*/true, &UtilityNodeWeights);
 
   EXPECT_THAT(Nodes,
               UnorderedElementsAre(NodeIs(0, {{1, 1}}), NodeIs(1, {{1, 1}}),
@@ -62,10 +86,11 @@ TEST(BPFunctionNodeTest, Basic) {
                                    NodeIs(4, {{5, 1}})));
 
   Nodes.clear();
+  UtilityNodeWeights.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
       {TemporalProfTraceTy({0, 1, 2, 3}, 10), TemporalProfTraceTy({0, 4, 1}, 1),
        TemporalProfTraceTy({5, 6}, 0)},
-      Nodes, /*RemoveOutlierUNs=*/false);
+      Nodes, /*RemoveOutlierUNs=*/false, &UtilityNodeWeights);
   EXPECT_THAT(
       Nodes, UnorderedElementsAre(
                  NodeIs(0, {{0, 10}, {1, 10}, {2, 10}, {3, 1}, {4, 1}, {5, 1}}),

--- a/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
+++ b/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
@@ -24,14 +24,10 @@ void PrintTo(const BPFunctionNode &Node, std::ostream *OS) {
 
 TEST(BPFunctionNodeTest, Basic) {
   auto NodeIs = [](BPFunctionNode::IDT Id,
-                   ArrayRef<BPFunctionNode::UtilityNodeT> UNs,
-                   ArrayRef<BPFunctionNode::UtilityNodeWeightT> Weights) {
+                   ArrayRef<BPFunctionNode::WeightedUtilityNode> UNs) {
     return AllOf(Field("Id", &BPFunctionNode::Id, Id),
                  Field("UtilityNodes", &BPFunctionNode::UtilityNodes,
-                       UnorderedElementsAreArray(UNs)),
-                 Field("UtilityNodeWeights",
-                       &BPFunctionNode::UtilityNodeWeights,
-                       UnorderedElementsAreArray(Weights)));
+                       UnorderedElementsAreArray(UNs)));
   };
 
   std::vector<BPFunctionNode> Nodes;
@@ -39,20 +35,21 @@ TEST(BPFunctionNodeTest, Basic) {
       {TemporalProfTraceTy({0, 1, 2, 3})}, Nodes, /*RemoveOutlierUNs=*/false);
   // Utility nodes that are too infrequent or too prevalent are filtered out.
   EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {0, 1, 2}, {1, 1, 1}),
-                                   NodeIs(1, {1, 2}, {1, 1}),
-                                   NodeIs(2, {2}, {1}), NodeIs(3, {2}, {1})));
+              UnorderedElementsAre(NodeIs(0, {{0, 1}, {1, 1}, {2, 1}}),
+                                   NodeIs(1, {{1, 1}, {2, 1}}),
+                                   NodeIs(2, {{2, 1}}), NodeIs(3, {{2, 1}})));
 
   Nodes.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
       {TemporalProfTraceTy({0, 1, 2, 3, 4}), TemporalProfTraceTy({4, 2})},
       Nodes, /*RemoveOutlierUNs=*/false);
 
-  EXPECT_THAT(Nodes, UnorderedElementsAre(NodeIs(0, {0, 1, 2, 3}, {1, 1, 1, 1}),
-                                          NodeIs(1, {1, 2, 3}, {1, 1, 1}),
-                                          NodeIs(2, {2, 3, 5}, {1, 1, 1}),
-                                          NodeIs(3, {2, 3}, {1, 1}),
-                                          NodeIs(4, {3, 4, 5}, {1, 1, 1})));
+  EXPECT_THAT(Nodes,
+              UnorderedElementsAre(NodeIs(0, {{0, 1}, {1, 1}, {2, 1}, {3, 1}}),
+                                   NodeIs(1, {{1, 1}, {2, 1}, {3, 1}}),
+                                   NodeIs(2, {{2, 1}, {3, 1}, {5, 1}}),
+                                   NodeIs(3, {{2, 1}, {3, 1}}),
+                                   NodeIs(4, {{3, 1}, {4, 1}, {5, 1}})));
 
   Nodes.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
@@ -60,18 +57,20 @@ TEST(BPFunctionNodeTest, Basic) {
       Nodes, /*RemoveOutlierUNs=*/true);
 
   EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {1}, {1}), NodeIs(1, {1}, {1}),
-                                   NodeIs(2, {5}, {1}), NodeIs(3, {}, {}),
-                                   NodeIs(4, {5}, {1})));
+              UnorderedElementsAre(NodeIs(0, {{1, 1}}), NodeIs(1, {{1, 1}}),
+                                   NodeIs(2, {{5, 1}}), NodeIs(3, {}),
+                                   NodeIs(4, {{5, 1}})));
 
   Nodes.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
-      {TemporalProfTraceTy({0, 1, 2, 3}, 10), TemporalProfTraceTy({4, 5}, 0)},
+      {TemporalProfTraceTy({0, 1, 2, 3}, 10), TemporalProfTraceTy({0, 4, 1}, 1),
+       TemporalProfTraceTy({5, 6}, 0)},
       Nodes, /*RemoveOutlierUNs=*/false);
-  EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {0, 1, 2}, {10, 10, 10}),
-                                   NodeIs(1, {1, 2}, {10, 10}),
-                                   NodeIs(2, {2}, {10}), NodeIs(3, {2}, {10})));
+  EXPECT_THAT(
+      Nodes, UnorderedElementsAre(
+                 NodeIs(0, {{0, 10}, {1, 10}, {2, 10}, {3, 1}, {4, 1}, {5, 1}}),
+                 NodeIs(1, {{1, 10}, {2, 10}, {5, 1}}), NodeIs(2, {{2, 10}}),
+                 NodeIs(3, {{2, 10}}), NodeIs(4, {{4, 1}, {5, 1}})));
 }
 
 } // end namespace llvm

--- a/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
+++ b/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
@@ -24,10 +24,14 @@ void PrintTo(const BPFunctionNode &Node, std::ostream *OS) {
 
 TEST(BPFunctionNodeTest, Basic) {
   auto NodeIs = [](BPFunctionNode::IDT Id,
-                   ArrayRef<BPFunctionNode::UtilityNodeT> UNs) {
+                   ArrayRef<BPFunctionNode::UtilityNodeT> UNs,
+                   ArrayRef<BPFunctionNode::UtilityNodeWeightT> Weights) {
     return AllOf(Field("Id", &BPFunctionNode::Id, Id),
                  Field("UtilityNodes", &BPFunctionNode::UtilityNodes,
-                       UnorderedElementsAreArray(UNs)));
+                       UnorderedElementsAreArray(UNs)),
+                 Field("UtilityNodeWeights",
+                       &BPFunctionNode::UtilityNodeWeights,
+                       UnorderedElementsAreArray(Weights)));
   };
 
   std::vector<BPFunctionNode> Nodes;
@@ -35,27 +39,39 @@ TEST(BPFunctionNodeTest, Basic) {
       {TemporalProfTraceTy({0, 1, 2, 3})}, Nodes, /*RemoveOutlierUNs=*/false);
   // Utility nodes that are too infrequent or too prevalent are filtered out.
   EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {0, 1, 2}), NodeIs(1, {1, 2}),
-                                   NodeIs(2, {2}), NodeIs(3, {2})));
+              UnorderedElementsAre(NodeIs(0, {0, 1, 2}, {1, 1, 1}),
+                                   NodeIs(1, {1, 2}, {1, 1}),
+                                   NodeIs(2, {2}, {1}), NodeIs(3, {2}, {1})));
 
   Nodes.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
       {TemporalProfTraceTy({0, 1, 2, 3, 4}), TemporalProfTraceTy({4, 2})},
       Nodes, /*RemoveOutlierUNs=*/false);
 
-  EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {0, 1, 2, 3}),
-                                   NodeIs(1, {1, 2, 3}), NodeIs(2, {2, 3, 5}),
-                                   NodeIs(3, {2, 3}), NodeIs(4, {3, 4, 5})));
+  EXPECT_THAT(Nodes, UnorderedElementsAre(NodeIs(0, {0, 1, 2, 3}, {1, 1, 1, 1}),
+                                          NodeIs(1, {1, 2, 3}, {1, 1, 1}),
+                                          NodeIs(2, {2, 3, 5}, {1, 1, 1}),
+                                          NodeIs(3, {2, 3}, {1, 1}),
+                                          NodeIs(4, {3, 4, 5}, {1, 1, 1})));
 
   Nodes.clear();
   TemporalProfTraceTy::createBPFunctionNodes(
       {TemporalProfTraceTy({0, 1, 2, 3, 4}), TemporalProfTraceTy({4, 2})},
       Nodes, /*RemoveOutlierUNs=*/true);
 
-  EXPECT_THAT(Nodes, UnorderedElementsAre(NodeIs(0, {1}), NodeIs(1, {1}),
-                                          NodeIs(2, {5}), NodeIs(3, {}),
-                                          NodeIs(4, {5})));
+  EXPECT_THAT(Nodes,
+              UnorderedElementsAre(NodeIs(0, {1}, {1}), NodeIs(1, {1}, {1}),
+                                   NodeIs(2, {5}, {1}), NodeIs(3, {}, {}),
+                                   NodeIs(4, {5}, {1})));
+
+  Nodes.clear();
+  TemporalProfTraceTy::createBPFunctionNodes(
+      {TemporalProfTraceTy({0, 1, 2, 3}, 10), TemporalProfTraceTy({4, 5}, 0)},
+      Nodes, /*RemoveOutlierUNs=*/false);
+  EXPECT_THAT(Nodes,
+              UnorderedElementsAre(NodeIs(0, {0, 1, 2}, {10, 10, 10}),
+                                   NodeIs(1, {1, 2}, {10, 10}),
+                                   NodeIs(2, {2}, {10}), NodeIs(3, {2}, {10})));
 }
 
 } // end namespace llvm

--- a/llvm/unittests/Support/BalancedPartitioningTest.cpp
+++ b/llvm/unittests/Support/BalancedPartitioningTest.cpp
@@ -100,12 +100,18 @@ TEST_F(BalancedPartitioningTest, MoveGain) {
 TEST_F(BalancedPartitioningTest, WeightedUtilitiesMatchReplication) {
   Config.SkipProbability = 0;
   Config.TaskSplitDepth = 0;
+  using WeightedUtilityNode = BPFunctionNode::WeightedUtilityNode;
 
   std::vector<BPFunctionNode> WeightedNodes = {
-      BPFunctionNode(0, {1}, {1}),
-      BPFunctionNode(1, {1, 2}, {1, 1}),
-      BPFunctionNode(2, {0, 1, 2}, {10, 1, 1}),
-      BPFunctionNode(3, {0, 2}, {10, 1}),
+      BPFunctionNode::createWithWeightedUtilities(0,
+                                                  {WeightedUtilityNode(1, 1)}),
+      BPFunctionNode::createWithWeightedUtilities(
+          1, {WeightedUtilityNode(1, 1), WeightedUtilityNode(2, 1)}),
+      BPFunctionNode::createWithWeightedUtilities(
+          2, {WeightedUtilityNode(0, 10), WeightedUtilityNode(1, 1),
+              WeightedUtilityNode(2, 1)}),
+      BPFunctionNode::createWithWeightedUtilities(
+          3, {WeightedUtilityNode(0, 10), WeightedUtilityNode(2, 1)}),
   };
   std::vector<BPFunctionNode> ReplicatedNodes = {
       BPFunctionNode(0, {10}),
@@ -120,10 +126,15 @@ TEST_F(BalancedPartitioningTest, WeightedUtilitiesMatchReplication) {
       BPFunctionNode(3, {0, 2}),
   };
   std::vector<BPFunctionNode> WeightOneNodes = {
-      BPFunctionNode(0, {1}, {1}),
-      BPFunctionNode(1, {1, 2}, {1, 1}),
-      BPFunctionNode(2, {0, 1, 2}, {1, 1, 1}),
-      BPFunctionNode(3, {0, 2}, {1, 1}),
+      BPFunctionNode::createWithWeightedUtilities(0,
+                                                  {WeightedUtilityNode(1, 1)}),
+      BPFunctionNode::createWithWeightedUtilities(
+          1, {WeightedUtilityNode(1, 1), WeightedUtilityNode(2, 1)}),
+      BPFunctionNode::createWithWeightedUtilities(
+          2, {WeightedUtilityNode(0, 1), WeightedUtilityNode(1, 1),
+              WeightedUtilityNode(2, 1)}),
+      BPFunctionNode::createWithWeightedUtilities(
+          3, {WeightedUtilityNode(0, 1), WeightedUtilityNode(2, 1)}),
   };
 
   Bp.run(WeightedNodes);

--- a/llvm/unittests/Support/BalancedPartitioningTest.cpp
+++ b/llvm/unittests/Support/BalancedPartitioningTest.cpp
@@ -100,19 +100,14 @@ TEST_F(BalancedPartitioningTest, MoveGain) {
 TEST_F(BalancedPartitioningTest, WeightedUtilitiesMatchReplication) {
   Config.SkipProbability = 0;
   Config.TaskSplitDepth = 0;
-  using WeightedUtilityNode = BPFunctionNode::WeightedUtilityNode;
 
   std::vector<BPFunctionNode> WeightedNodes = {
-      BPFunctionNode::createWithWeightedUtilities(0,
-                                                  {WeightedUtilityNode(1, 1)}),
-      BPFunctionNode::createWithWeightedUtilities(
-          1, {WeightedUtilityNode(1, 1), WeightedUtilityNode(2, 1)}),
-      BPFunctionNode::createWithWeightedUtilities(
-          2, {WeightedUtilityNode(0, 10), WeightedUtilityNode(1, 1),
-              WeightedUtilityNode(2, 1)}),
-      BPFunctionNode::createWithWeightedUtilities(
-          3, {WeightedUtilityNode(0, 10), WeightedUtilityNode(2, 1)}),
+      BPFunctionNode(0, {1}),
+      BPFunctionNode(1, {1, 2}),
+      BPFunctionNode(2, {0, 1, 2}),
+      BPFunctionNode(3, {0, 2}),
   };
+  BalancedPartitioning::UtilityNodeWeightsT UtilityNodeWeights = {{0, 10}};
   std::vector<BPFunctionNode> ReplicatedNodes = {
       BPFunctionNode(0, {10}),
       BPFunctionNode(1, {10, 11}),
@@ -126,24 +121,49 @@ TEST_F(BalancedPartitioningTest, WeightedUtilitiesMatchReplication) {
       BPFunctionNode(3, {0, 2}),
   };
   std::vector<BPFunctionNode> WeightOneNodes = {
-      BPFunctionNode::createWithWeightedUtilities(0,
-                                                  {WeightedUtilityNode(1, 1)}),
-      BPFunctionNode::createWithWeightedUtilities(
-          1, {WeightedUtilityNode(1, 1), WeightedUtilityNode(2, 1)}),
-      BPFunctionNode::createWithWeightedUtilities(
-          2, {WeightedUtilityNode(0, 1), WeightedUtilityNode(1, 1),
-              WeightedUtilityNode(2, 1)}),
-      BPFunctionNode::createWithWeightedUtilities(
-          3, {WeightedUtilityNode(0, 1), WeightedUtilityNode(2, 1)}),
+      BPFunctionNode(0, {1}),
+      BPFunctionNode(1, {1, 2}),
+      BPFunctionNode(2, {0, 1, 2}),
+      BPFunctionNode(3, {0, 2}),
   };
+  BalancedPartitioning::UtilityNodeWeightsT WeightOneUtilityNodeWeights = {
+      {0, 1}, {1, 1}, {2, 1}};
 
-  Bp.run(WeightedNodes);
+  Bp.run(WeightedNodes, UtilityNodeWeights);
   Bp.run(ReplicatedNodes);
   Bp.run(UnweightedNodes);
-  Bp.run(WeightOneNodes);
+  Bp.run(WeightOneNodes, WeightOneUtilityNodeWeights);
 
   EXPECT_EQ(getIds(WeightedNodes), getIds(ReplicatedNodes));
   EXPECT_NE(getIds(WeightedNodes), getIds(UnweightedNodes));
+  EXPECT_EQ(getIds(WeightOneNodes), getIds(UnweightedNodes));
+}
+
+TEST_F(BalancedPartitioningTest, WeightOneUtilitiesPreserveLargeOrder) {
+  const int ProblemSize = 1000;
+  std::vector<BPFunctionNode::UtilityNodeT> AllUNs;
+  for (int I = 0; I < ProblemSize; ++I)
+    AllUNs.push_back(I);
+
+  std::mt19937 RNG;
+  std::vector<BPFunctionNode> UnweightedNodes;
+  std::vector<BPFunctionNode> WeightOneNodes;
+  BalancedPartitioning::UtilityNodeWeightsT WeightOneUtilityNodeWeights;
+  for (int I = 0; I < ProblemSize; ++I) {
+    std::vector<BPFunctionNode::UtilityNodeT> UNs;
+    int SampleSize =
+        std::uniform_int_distribution<int>(0, AllUNs.size() - 1)(RNG);
+    std::sample(AllUNs.begin(), AllUNs.end(), std::back_inserter(UNs),
+                SampleSize, RNG);
+    UnweightedNodes.emplace_back(I, UNs);
+
+    for (auto UN : UNs)
+      WeightOneUtilityNodeWeights.try_emplace(UN, 1);
+    WeightOneNodes.emplace_back(I, UNs);
+  }
+
+  Bp.run(UnweightedNodes);
+  Bp.run(WeightOneNodes, WeightOneUtilityNodeWeights);
   EXPECT_EQ(getIds(WeightOneNodes), getIds(UnweightedNodes));
 }
 

--- a/llvm/unittests/Support/BalancedPartitioningTest.cpp
+++ b/llvm/unittests/Support/BalancedPartitioningTest.cpp
@@ -97,4 +97,43 @@ TEST_F(BalancedPartitioningTest, MoveGain) {
                   30.f);
 }
 
+TEST_F(BalancedPartitioningTest, WeightedUtilitiesMatchReplication) {
+  Config.SkipProbability = 0;
+  Config.TaskSplitDepth = 0;
+
+  std::vector<BPFunctionNode> WeightedNodes = {
+      BPFunctionNode(0, {1}, {1}),
+      BPFunctionNode(1, {1, 2}, {1, 1}),
+      BPFunctionNode(2, {0, 1, 2}, {10, 1, 1}),
+      BPFunctionNode(3, {0, 2}, {10, 1}),
+  };
+  std::vector<BPFunctionNode> ReplicatedNodes = {
+      BPFunctionNode(0, {10}),
+      BPFunctionNode(1, {10, 11}),
+      BPFunctionNode(2, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}),
+      BPFunctionNode(3, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11}),
+  };
+  std::vector<BPFunctionNode> UnweightedNodes = {
+      BPFunctionNode(0, {1}),
+      BPFunctionNode(1, {1, 2}),
+      BPFunctionNode(2, {0, 1, 2}),
+      BPFunctionNode(3, {0, 2}),
+  };
+  std::vector<BPFunctionNode> WeightOneNodes = {
+      BPFunctionNode(0, {1}, {1}),
+      BPFunctionNode(1, {1, 2}, {1, 1}),
+      BPFunctionNode(2, {0, 1, 2}, {1, 1, 1}),
+      BPFunctionNode(3, {0, 2}, {1, 1}),
+  };
+
+  Bp.run(WeightedNodes);
+  Bp.run(ReplicatedNodes);
+  Bp.run(UnweightedNodes);
+  Bp.run(WeightOneNodes);
+
+  EXPECT_EQ(getIds(WeightedNodes), getIds(ReplicatedNodes));
+  EXPECT_NE(getIds(WeightedNodes), getIds(UnweightedNodes));
+  EXPECT_EQ(getIds(WeightOneNodes), getIds(UnweightedNodes));
+}
+
 } // end namespace llvm


### PR DESCRIPTION
## Summary

Temporal profile traces carry a `Weight` field, and profile merging preserves it on stored traces, but balanced partitioning currently treats every stored trace as one observation. This makes a weighted profile behave differently from explicit trace replication.

This revives and extends the weighted-utility support originally landed in #72717, which was reverted by 30aa9fb because its unit test did not compile with MSVC. In addition to the generic balanced-partitioning support, this patch wires stored temporal trace weights through both concrete consumers:

- `llvm-profdata order`, including its held-out page-fault-area evaluation;
- lld's common ELF/Mach-O startup orderer, including verbose reference and page-fault-area diagnostics.

Balanced partitioning scales a utility's move gain without materializing duplicate utility nodes. Actual non-unit weights are kept in sparse side metadata and remapped with utility IDs during recursive partitioning. The existing `BPFunctionNode` and `UtilitySignature` layouts remain unchanged. An absent or all-one weight map dispatches to the original unweighted path, preserving its storage, floating-point operations, and ordering.

Zero-weight traces contribute nothing. Compression-only utilities retain weight one when combined with weighted startup utilities. Diagnostic arithmetic saturates rather than wrapping for oversized weights.

`Weight` is objective multiplicity for an already-stored trace. This patch does not change temporal-profile reservoir selection or trace-stream-size accounting.

## Testing

- Support unit coverage proves a 10:1 weighted graph matches ten explicit utility copies, differs from 1:1, and preserves exact all-one ordering on a deterministic 1,000-node dense graph.
- ProfileData unit coverage verifies exact `(utility ID, weight)` associations across overlapping differently weighted traces and omits zero-weight traces.
- An `llvm-profdata order` integration test proves a weighted stored trace produces the same complete order as ten explicitly merged trace copies and differs from 1:1.
- Held-out `llvm-profdata order` evaluation covers normal weighted multiplication and `uint64_t` saturation.
- Mach-O lld coverage proves weighted-versus-replicated equivalence, the 1:1 negative control, weighted verbose diagnostics, saturation, and the combined `--bp-compression-sort-startup-functions` path.
- ELF lld coverage independently proves the common orderer's weighted-versus-replicated behavior.
- A generated AArch64 ELF control with 30,000 functions and 320,000 resolved all-one temporal references produced exactly the same symbol order before and after the change. Forty warmed, interleaved link pairs found only noise-scale timing differences (within 1% in mean wall and CPU time for both default threading and `--threads=1`).
- Built the affected Support, ProfileData, `llvm-profdata`, ELF lld, and Mach-O lld targets, then passed the focused Support/ProfileData unit suites and all new llvm-profdata/ELF/Mach-O integration tests locally.

This patch fixes profile-consumption semantics. It does not claim an application size or runtime improvement; those depend on the supplied weights and workload.
