### PR TITLE
[libc++][test] Add `void` cast to a discarded call to `remquo`

### DIFF
--- a/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
@@ -862,7 +862,7 @@ struct test_two_args {
     (void)::remainder(T(), U());
     int ip;
     ASSERT_SAME_TYPE(decltype(::remquo(T(), U(), &ip)), PromoteResult);
-    ::remquo(T(), U(), &ip);
+    (void)::remquo(T(), U(), &ip);
   }
 };
 


### PR DESCRIPTION
For calls to `remquo`, the return values are generally expected to be used, while it is rare to only use the value written via the pointer parameter. Moreover, some implementors already planned to apply `[[nodiscard]]` to `remquo`, see also https://llvm.org/PR171763. As a result, it is perhaps better to add `void` cast to the discarded call to `remquo` in the test file.