### PR TITLE
[libc] Enable most tests in hermetic mode

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -242,7 +242,7 @@ endfunction()
 
 # Rule to add a libc unittest.
 # Usage
-#    add_libc_unittest(
+#    create_libc_unittest(
 #      <target name>
 #      SUITE <name of the suite this test belongs to>
 #      SRCS  <list of .cpp files for the test>
@@ -265,11 +265,11 @@ function(create_libc_unittest fq_target_name)
     ${ARGN}
   )
   if(NOT LIBC_UNITTEST_SRCS)
-    message(FATAL_ERROR "'add_libc_unittest' target requires a SRCS list of .cpp "
+    message(FATAL_ERROR "'create_libc_unittest' target requires a SRCS list of .cpp "
       "files.")
   endif()
   if(NOT LIBC_UNITTEST_DEPENDS)
-    message(FATAL_ERROR "'add_libc_unittest' target requires a DEPENDS list of "
+    message(FATAL_ERROR "'create_libc_unittest' target requires a DEPENDS list of "
       "'add_entrypoint_object' targets.")
   endif()
 
@@ -406,7 +406,7 @@ function(create_libc_unittest fq_target_name)
   endif()
 endfunction()
 
-function(add_libc_unittest target_name)
+function(_add_libc_unittest target_name)
   add_target_with_flags(
     ${target_name}
     CREATE_TARGET create_libc_unittest
@@ -1026,7 +1026,7 @@ function(add_libc_test test_name)
     ${ARGN}
   )
   if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
-    add_libc_unittest(${test_name}.__unit__ ${LIBC_TEST_UNPARSED_ARGUMENTS})
+    _add_libc_unittest(${test_name}.__unit__ ${LIBC_TEST_UNPARSED_ARGUMENTS})
   endif()
   if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
     add_libc_hermetic(

--- a/libc/test/integration/startup/CMakeLists.txt
+++ b/libc/test/integration/startup/CMakeLists.txt
@@ -1,5 +1,5 @@
 # A rule to add startup system tests. When we have a complete startup system,
-# we should be able to use the add_libc_unittest rule or an extension of it.
+# we should be able to use the add_libc_test rule or an extension of it.
 # But, while the system is being developed,  we need to use a special rule like
 # this.
 function(add_startup_test target_name)

--- a/libc/test/src/__support/printf_core/CMakeLists.txt
+++ b/libc/test/src/__support/printf_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_libc_unittest(
+add_libc_test(
   parser_test
   SUITE
     libc-support-tests
@@ -13,7 +13,7 @@ add_libc_unittest(
     libc.src.__support.arg_list
 )
 
-add_libc_unittest(
+add_libc_test(
   writer_test
   SUITE
     libc-support-tests
@@ -25,7 +25,7 @@ add_libc_unittest(
     libc.src.__support.CPP.string_view
 )
 
-add_libc_unittest(
+add_libc_test(
   converter_test
   SUITE
     libc-support-tests

--- a/libc/test/src/arpa/inet/CMakeLists.txt
+++ b/libc/test/src/arpa/inet/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_arpa_inet_unittests)
 
-add_libc_unittest(
+add_libc_test(
   htonl
   SUITE
     libc_arpa_inet_unittests
@@ -11,7 +11,7 @@ add_libc_unittest(
     libc.src.arpa.inet.ntohl
 )
 
-add_libc_unittest(
+add_libc_test(
   htons
   SUITE
     libc_arpa_inet_unittests
@@ -22,7 +22,7 @@ add_libc_unittest(
     libc.src.arpa.inet.ntohs
 )
 
-add_libc_unittest(
+add_libc_test(
   inet_addr
   SUITE
     libc_arpa_inet_unittests
@@ -33,7 +33,7 @@ add_libc_unittest(
     libc.src.arpa.inet.inet_addr
 )
 
-add_libc_unittest(
+add_libc_test(
   inet_aton
   SUITE
     libc_arpa_inet_unittests
@@ -44,7 +44,7 @@ add_libc_unittest(
     libc.src.arpa.inet.inet_aton
 )
 
-add_libc_unittest(
+add_libc_test(
   inet_ntoa
   SUITE
     libc_arpa_inet_unittests
@@ -56,7 +56,7 @@ add_libc_unittest(
     libc.src.__support.endian_internal
 )
 
-add_libc_unittest(
+add_libc_test(
   inet_ntop
   SUITE
     libc_arpa_inet_unittests
@@ -72,7 +72,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   ntohl
   SUITE
     libc_arpa_inet_unittests
@@ -83,7 +83,7 @@ add_libc_unittest(
     libc.src.arpa.inet.ntohl
 )
 
-add_libc_unittest(
+add_libc_test(
   ntohs
   SUITE
     libc_arpa_inet_unittests

--- a/libc/test/src/compiler/CMakeLists.txt
+++ b/libc/test/src/compiler/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_stack_chk_guard_unittests)
 
-add_libc_unittest(
+add_libc_test(
   stack_chk_guard_test
   SUITE
     libc_stack_chk_guard_unittests

--- a/libc/test/src/dirent/CMakeLists.txt
+++ b/libc/test/src/dirent/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(testdata)
 add_custom_target(libc_dirent_unittests)
 
-add_libc_unittest(
+add_libc_test(
   dirent_test
   SUITE
     libc_dirent_unittests
@@ -17,7 +17,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   fdopendir_test
   SUITE
     libc_dirent_unittests

--- a/libc/test/src/errno/CMakeLists.txt
+++ b/libc/test/src/errno/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 add_custom_target(libc_errno_unittests)
 
-add_libc_unittest(
+add_libc_test(
   errno_test
   SUITE
     libc_errno_unittests

--- a/libc/test/src/fcntl/CMakeLists.txt
+++ b/libc/test/src/fcntl/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_target(libc_fcntl_unittests)
 
 add_subdirectory(testdata)
 
-add_libc_unittest(
+add_libc_test(
   creat_test
   SUITE
     libc_fcntl_unittests
@@ -19,7 +19,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fcntl_test
   SUITE
     libc_fcntl_unittests
@@ -40,7 +40,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   openat_test
   SUITE
     libc_fcntl_unittests

--- a/libc/test/src/fenv/CMakeLists.txt
+++ b/libc/test/src/fenv/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_fenv_unittests)
 
-add_libc_unittest(
+add_libc_test(
   rounding_mode_test
   SUITE
     libc_fenv_unittests
@@ -13,7 +13,7 @@ add_libc_unittest(
     LibcFPTestHelpers
 )
 
-add_libc_unittest(
+add_libc_test(
   exception_status_test
   SUITE
     libc_fenv_unittests
@@ -29,7 +29,7 @@ add_libc_unittest(
     LibcFPTestHelpers
 )
 
-add_libc_unittest(
+add_libc_test(
   getenv_and_setenv_test
   SUITE
     libc_fenv_unittests
@@ -46,7 +46,7 @@ add_libc_unittest(
     LibcFPTestHelpers
 )
 
-add_libc_unittest(
+add_libc_test(
   exception_flags_test
   SUITE
     libc_fenv_unittests
@@ -61,7 +61,7 @@ add_libc_unittest(
     LibcFPTestHelpers
 )
 
-add_libc_unittest(
+add_libc_test(
   feupdateenv_test
   SUITE
     libc_fenv_unittests
@@ -75,7 +75,7 @@ add_libc_unittest(
     LibcFPTestHelpers
 )
 
-add_libc_unittest(
+add_libc_test(
   feclearexcept_test
   SUITE
     libc_fenv_unittests
@@ -88,7 +88,7 @@ add_libc_unittest(
     LibcFPTestHelpers
 )
 
-add_libc_unittest(
+add_libc_test(
   feenableexcept_test
   SUITE
     libc_fenv_unittests

--- a/libc/test/src/link/CMakeLists.txt
+++ b/libc/test/src/link/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_link_unittests)
 
-add_libc_unittest(
+add_libc_test(
   dl_iterate_phdr_test
   SUITE
     libc_link_unittests

--- a/libc/test/src/net/linux/CMakeLists.txt
+++ b/libc/test/src/net/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_net_unittests)
 
-add_libc_unittest(
+add_libc_test(
   if_indextoname_test
   SUITE
     libc_net_unittests
@@ -14,7 +14,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   if_nametoindex_test
   SUITE
     libc_net_unittests
@@ -26,7 +26,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   if_nameindex_test
   SUITE
     libc_net_unittests

--- a/libc/test/src/netinet/CMakeLists.txt
+++ b/libc/test/src/netinet/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_netinet_unittests)
 
-add_libc_unittest(
+add_libc_test(
   in_test
   SUITE
     libc_netinet_unittests
@@ -25,7 +25,7 @@ add_libc_unittest(
     libc.src.string.memcmp
 )
 
-add_libc_unittest(
+add_libc_test(
   udp_test
   SUITE
     libc_netinet_unittests

--- a/libc/test/src/poll/CMakeLists.txt
+++ b/libc/test/src/poll/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_poll_unittests)
 
-add_libc_unittest(
+add_libc_test(
   poll_test
   SUITE
     libc_poll_unittests

--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_pthread_unittests)
 
-add_libc_unittest(
+add_libc_test(
   pthread_attr_test
   SUITE
     libc_pthread_unittests
@@ -21,7 +21,7 @@ add_libc_unittest(
     libc.hdr.errno_macros
 )
 
-add_libc_unittest(
+add_libc_test(
   pthread_mutexattr_test
   SUITE
     libc_pthread_unittests
@@ -40,7 +40,7 @@ add_libc_unittest(
     libc.hdr.errno_macros
 )
 
-add_libc_unittest(
+add_libc_test(
   pthread_condattr_test
   SUITE
     libc_pthread_unittests
@@ -58,7 +58,7 @@ add_libc_unittest(
     libc.src.pthread.pthread_condattr_setpshared
 )
 
-add_libc_unittest(
+add_libc_test(
   pthread_rwlockattr_test
   SUITE
     libc_pthread_unittests

--- a/libc/test/src/pwd/CMakeLists.txt
+++ b/libc/test/src/pwd/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT TARGET libc.src.pwd.pwd_utils)
   return()
 endif()
 
-add_libc_unittest(
+add_libc_test(
   pwd_utils_test
   SUITE
     libc_pwd_unittests
@@ -16,7 +16,7 @@ add_libc_unittest(
     libc.src.pwd.pwd_utils
 )
 
-add_libc_unittest(
+add_libc_test(
   getpwent_test
   SUITE
     libc_pwd_unittests

--- a/libc/test/src/regex/CMakeLists.txt
+++ b/libc/test/src/regex/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(LLVM_LIBC_FULL_BUILD AND LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
   add_custom_target(libc_regex_unittests)
 
-  add_libc_unittest(
+  add_libc_test(
     regerror_test
     SUITE
       libc_regex_unittests
@@ -12,7 +12,7 @@ if(LLVM_LIBC_FULL_BUILD AND LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
       libc.src.regex.regerror
   )
 
-  add_libc_unittest(
+  add_libc_test(
     regex_basic_test
     SUITE
       libc_regex_unittests

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sched_unittests)
 
-add_libc_unittest(
+add_libc_test(
   affinity_test
   SUITE
     libc_sched_unittests
@@ -18,7 +18,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   yield_test
   SUITE
     libc_sched_unittests
@@ -30,7 +30,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   get_priority_test
   SUITE
     libc_sched_unittests
@@ -44,7 +44,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   getcpu_test
   SUITE
     libc_sched_unittests
@@ -56,7 +56,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   sched_getcpu_test
   SUITE
     libc_sched_unittests
@@ -68,7 +68,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   scheduler_test
   SUITE
     libc_sched_unittests
@@ -88,7 +88,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   sched_rr_get_interval_test
   SUITE
     libc_sched_unittests
@@ -106,7 +106,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   cpu_alloc_test
   SUITE
     libc_sched_unittests
@@ -123,7 +123,7 @@ add_libc_unittest(
     libc.src.sched.__sched_setcpuzero
 )
 
-add_libc_unittest(
+add_libc_test(
   cpu_count_test
   SUITE
     libc_sched_unittests
@@ -146,7 +146,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sched_andcpuset_test
   SUITE
     libc_sched_unittests
@@ -161,7 +161,7 @@ add_libc_unittest(
     libc.src.sched.__sched_setcpuzero
 )
 
-add_libc_unittest(
+add_libc_test(
   sched_cpuequal_test
   SUITE
     libc_sched_unittests
@@ -174,7 +174,7 @@ add_libc_unittest(
     libc.src.sched.__sched_setcpuzero
 )
 
-add_libc_unittest(
+add_libc_test(
   sched_orcpuset_test
   SUITE
     libc_sched_unittests
@@ -189,7 +189,7 @@ add_libc_unittest(
     libc.src.sched.__sched_setcpuzero
 )
 
-add_libc_unittest(
+add_libc_test(
   sched_xorcpuset_test
   SUITE
     libc_sched_unittests

--- a/libc/test/src/setjmp/CMakeLists.txt
+++ b/libc/test/src/setjmp/CMakeLists.txt
@@ -5,7 +5,7 @@ if(LLVM_USE_SANITIZER)
   return()
 endif()
 
-add_libc_unittest(
+add_libc_test(
   setjmp_test
   SUITE
     libc_setjmp_unittests
@@ -18,7 +18,7 @@ add_libc_unittest(
     libc.src.setjmp.setjmp
 )
 
-add_libc_unittest(
+add_libc_test(
   sigsetjmp_test
   SUITE
     libc_setjmp_unittests

--- a/libc/test/src/signal/CMakeLists.txt
+++ b/libc/test/src/signal/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_signal_unittests)
 
-add_libc_unittest(
+add_libc_test(
   raise_test
   SUITE
     libc_signal_unittests
@@ -11,7 +11,7 @@ add_libc_unittest(
     libc.src.signal.raise
 )
 
-add_libc_unittest(
+add_libc_test(
   kill_test
   SUITE
     libc_signal_unittests
@@ -25,7 +25,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sigaction_test
   SUITE
     libc_signal_unittests
@@ -39,7 +39,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sigprocmask_test
   SUITE
     libc_signal_unittests
@@ -55,7 +55,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   pthread_sigmask_test
   SUITE
     libc_signal_unittests
@@ -70,7 +70,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   sigaddset_test
   SUITE
     libc_signal_unittests
@@ -83,7 +83,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   signal_test
   SUITE
     libc_signal_unittests
@@ -97,7 +97,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sigfillset_test
   SUITE
     libc_signal_unittests
@@ -112,7 +112,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sigdelset_test
   SUITE
     libc_signal_unittests
@@ -128,7 +128,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sigaltstack_test
   SUITE
     libc_signal_unittests

--- a/libc/test/src/spawn/CMakeLists.txt
+++ b/libc/test/src/spawn/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_spawn_unittests)
 
-add_libc_unittest(
+add_libc_test(
   posix_spawn_file_actions_test
   SUITE
     libc_spawn_unittests

--- a/libc/test/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/test/src/stdio/scanf_core/CMakeLists.txt
@@ -3,7 +3,7 @@ if(NOT(LLVM_LIBC_FULL_BUILD))
   libc_set_definition(use_system_file "LIBC_COPT_STDIO_USE_SYSTEM_FILE")
 endif()
 
-add_libc_unittest(
+add_libc_test(
   parser_test
   SUITE
     libc_stdio_unittests
@@ -25,7 +25,7 @@ if(NOT(TARGET libc.src.__support.File.file) AND LLVM_LIBC_FULL_BUILD AND
   return()
 endif()
 
-add_libc_unittest(
+add_libc_test(
   reader_test
   SUITE
     libc_stdio_unittests
@@ -38,7 +38,7 @@ add_libc_unittest(
     ${use_system_file}
 )
 
-add_libc_unittest(
+add_libc_test(
   converter_test
   SUITE
     libc_stdio_unittests

--- a/libc/test/src/sys/epoll/linux/CMakeLists.txt
+++ b/libc/test/src/sys/epoll/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_epoll_unittests)
 
-add_libc_unittest(
+add_libc_test(
   epoll_create_test
   SUITE
     libc_sys_epoll_unittests
@@ -15,7 +15,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   epoll_create1_test
   SUITE
     libc_sys_epoll_unittests
@@ -30,7 +30,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   epoll_ctl_test
   SUITE
     libc_sys_epoll_unittests
@@ -48,7 +48,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   epoll_wait_test
   SUITE
     libc_sys_epoll_unittests
@@ -67,7 +67,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   epoll_pwait_test
   SUITE
     libc_sys_epoll_unittests
@@ -86,7 +86,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   epoll_pwait2_test
   SUITE
     libc_sys_epoll_unittests

--- a/libc/test/src/sys/ioctl/linux/CMakeLists.txt
+++ b/libc/test/src/sys/ioctl/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_ioctl_unittests)
 
-add_libc_unittest(
+add_libc_test(
   ioctl_test
   SUITE
     libc_sys_ioctl_unittests

--- a/libc/test/src/sys/ipc/linux/CMakeLists.txt
+++ b/libc/test/src/sys/ipc/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_ipc_unittests)
 
-add_libc_unittest(
+add_libc_test(
   ftok_test
   SUITE
     libc_sys_ipc_unittests

--- a/libc/test/src/sys/personality/linux/CMakeLists.txt
+++ b/libc/test/src/sys/personality/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_personality_unittests)
 
-add_libc_unittest(
+add_libc_test(
   personality_test
   SUITE
     libc_sys_personality_unittests

--- a/libc/test/src/sys/prctl/linux/CMakeLists.txt
+++ b/libc/test/src/sys/prctl/linux/CMakeLists.txt
@@ -5,7 +5,7 @@ add_custom_target(libc_sys_prctl_unittests)
 if(NOT (LIBC_TARGET_ARCHITECTURE_IS_ARM OR
   LIBC_TARGET_ARCHITECTURE_IS_RISCV32 OR
   LIBC_TARGET_ARCHITECTURE_IS_RISCV64))
-  add_libc_unittest(
+  add_libc_test(
     prctl_test
     SUITE
       libc_sys_prctl_unittests

--- a/libc/test/src/sys/random/linux/CMakeLists.txt
+++ b/libc/test/src/sys/random/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_random_unittests)
 
-add_libc_unittest(
+add_libc_test(
   getrandom_test
   SUITE
     libc_sys_random_unittests

--- a/libc/test/src/sys/resource/CMakeLists.txt
+++ b/libc/test/src/sys/resource/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_resource_unittests)
 
-add_libc_unittest(
+add_libc_test(
   getrlimit_setrlimit_test
   SUITE
     libc_sys_resource_unittests

--- a/libc/test/src/sys/select/CMakeLists.txt
+++ b/libc/test/src/sys/select/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_select_unittests)
 
-add_libc_unittest(
+add_libc_test(
   select_ui_test
   NO_RUN_POSTBUILD
   SUITE
@@ -16,7 +16,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   select_failure_test
   SUITE
     libc_sys_select_unittests

--- a/libc/test/src/sys/sem/linux/CMakeLists.txt
+++ b/libc/test/src/sys/sem/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_sem_unittests)
 
-add_libc_unittest(
+add_libc_test(
   sem_test
   SUITE
     libc_sys_sem_unittests

--- a/libc/test/src/sys/sendfile/CMakeLists.txt
+++ b/libc/test/src/sys/sendfile/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_target(libc_sys_sendfile_unittests)
 
 add_subdirectory(testdata)
 
-add_libc_unittest(
+add_libc_test(
   sendfile_test
   SUITE
     libc_sys_sendfile_unittests

--- a/libc/test/src/sys/sendfile/sendfile_test.cpp
+++ b/libc/test/src/sys/sendfile/sendfile_test.cpp
@@ -29,8 +29,9 @@ TEST_F(LlvmLibcSendfileTest, CreateAndTransfer) {
   //   2. Use sendfile to copy it to another file.
   //   3. Make sure that the data was actually copied.
   //   4. Clean up the temporary files.
-  constexpr const char *IN_FILE = "testdata/sendfile_in.test";
-  constexpr const char *OUT_FILE = "testdata/sendfile_out.test";
+  constexpr const char *IN_FILE = APPEND_LIBC_TEST("testdata/sendfile_in.test");
+  constexpr const char *OUT_FILE =
+      APPEND_LIBC_TEST("testdata/sendfile_out.test");
   const char IN_DATA[] = "sendfile test";
   constexpr ssize_t IN_SIZE = ssize_t(sizeof(IN_DATA));
 

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -20,7 +20,7 @@ add_header_library(
 
 add_custom_target(libc_sys_socket_unittests)
 
-add_libc_unittest(
+add_libc_test(
   socket_test
   SUITE
     libc_sys_socket_unittests
@@ -35,7 +35,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   bind_test
   SUITE
     libc_sys_socket_unittests
@@ -62,7 +62,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   connect_accept_test
   SUITE
     libc_sys_socket_unittests
@@ -92,7 +92,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   listen_test
   SUITE
     libc_sys_socket_unittests
@@ -114,7 +114,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   socketopt_test
   SUITE
     libc_sys_socket_unittests
@@ -142,7 +142,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   socketpair_test
   SUITE
     libc_sys_socket_unittests
@@ -157,7 +157,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sockatmark_test
   SUITE
     libc_sys_socket_unittests
@@ -176,7 +176,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sockname_test
   SUITE
     libc_sys_socket_unittests
@@ -203,7 +203,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   send_recv_test
   SUITE
     libc_sys_socket_unittests
@@ -221,7 +221,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sendto_recvfrom_test
   SUITE
     libc_sys_socket_unittests
@@ -239,7 +239,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sendrecvmmsg_test
   SUITE
     libc_sys_socket_unittests
@@ -261,7 +261,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sendmsg_recvmsg_test
   SUITE
     libc_sys_socket_unittests
@@ -285,7 +285,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   shutdown_test
   SUITE
     libc_sys_socket_unittests
@@ -305,7 +305,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   sockaddr_storage_test
   SUITE
     libc_sys_socket_unittests

--- a/libc/test/src/sys/stat/CMakeLists.txt
+++ b/libc/test/src/sys/stat/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_target(libc_sys_stat_unittests)
 
 add_subdirectory(testdata)
 
-add_libc_unittest(
+add_libc_test(
   chmod_test
   SUITE
     libc_sys_stat_unittests
@@ -21,7 +21,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fchmodat_test
   SUITE
     libc_sys_stat_unittests
@@ -40,7 +40,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fchmod_test
   SUITE
     libc_sys_stat_unittests
@@ -59,7 +59,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   mkdirat_test
   SUITE
     libc_sys_stat_unittests
@@ -75,7 +75,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   stat_test
   SUITE
     libc_sys_stat_unittests
@@ -94,7 +94,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   lstat_test
   SUITE
     libc_sys_stat_unittests
@@ -113,7 +113,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fstat_test
   SUITE
     libc_sys_stat_unittests
@@ -132,7 +132,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   utimensat_test
   SUITE
     libc_sys_stat_unittests

--- a/libc/test/src/sys/statfs/linux/CMakeLists.txt
+++ b/libc/test/src/sys/statfs/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_statfs_unittests)
 
-add_libc_unittest(
+add_libc_test(
   statfs_test
   SUITE
     libc_sys_statfs_unittests
@@ -16,7 +16,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fstatfs_test
   SUITE
     libc_sys_statfs_unittests

--- a/libc/test/src/sys/statvfs/linux/CMakeLists.txt
+++ b/libc/test/src/sys/statvfs/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_statvfs_unittests)
 
-add_libc_unittest(
+add_libc_test(
   statvfs_test
   SUITE
     libc_sys_statvfs_unittests
@@ -16,7 +16,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fstatvfs_test
   SUITE
     libc_sys_statvfs_unittests

--- a/libc/test/src/sys/time/CMakeLists.txt
+++ b/libc/test/src/sys/time/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_time_unittests)
 
-add_libc_unittest(
+add_libc_test(
   utimes_test
   SUITE
     libc_sys_time_unittests
@@ -20,7 +20,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   setitimer_test
   SUITE
     libc_sys_time_unittests
@@ -38,7 +38,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   getitimer_test
   SUITE
     libc_sys_time_unittests
@@ -53,7 +53,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   gettimeofday_test
   SUITE
     libc_sys_time_unittests

--- a/libc/test/src/sys/time/utimes_test.cpp
+++ b/libc/test/src/sys/time/utimes_test.cpp
@@ -26,7 +26,7 @@ using LlvmLibcUtimesTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *FILE_PATH = "utimes_pass.test";
+  constexpr const char *FILE_PATH = APPEND_LIBC_TEST("utimes_pass.test");
   auto TEST_FILE = libc_make_test_file_path(FILE_PATH);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/utsname/CMakeLists.txt
+++ b/libc/test/src/sys/utsname/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_utsname_unittests)
 
-add_libc_unittest(
+add_libc_test(
   uname_test
   SUITE
     libc_sys_utsname_unittests

--- a/libc/test/src/sys/wait/CMakeLists.txt
+++ b/libc/test/src/sys/wait/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_sys_wait_unittests)
 
-add_libc_unittest(
+add_libc_test(
   waitpid_test
   SUITE
     libc_sys_wait_unittests
@@ -14,7 +14,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   wait4_test
   SUITE
     libc_sys_wait_unittests

--- a/libc/test/src/termios/CMakeLists.txt
+++ b/libc/test/src/termios/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_termios_unittests)
 
-add_libc_unittest(
+add_libc_test(
   termios_test
   SUITE
     libc_termios_unittests

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -12,7 +12,7 @@ add_header_library(
     LibcTest
 )
 
-add_libc_unittest(
+add_libc_test(
   asctime_test
   SUITE
     libc_time_unittests
@@ -29,7 +29,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   asctime_r_test
   SUITE
     libc_time_unittests
@@ -46,7 +46,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   ctime_test
   SUITE
     libc_time_unittests
@@ -64,7 +64,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   ctime_r_test
   SUITE
     libc_time_unittests
@@ -82,7 +82,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   localtime_test
   SUITE
     libc_time_unittests
@@ -93,7 +93,7 @@ add_libc_unittest(
     libc.src.time.localtime
 )
 
-add_libc_unittest(
+add_libc_test(
   localtime_r_test
   SUITE
     libc_time_unittests
@@ -143,7 +143,7 @@ add_libc_test(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   difftime_test
   SUITE
     libc_time_unittests
@@ -155,7 +155,7 @@ add_libc_unittest(
     libc.src.__support.FPUtil.fp_bits
 )
 
-add_libc_unittest(
+add_libc_test(
   gmtime_test
   SUITE
     libc_time_unittests
@@ -172,7 +172,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   gmtime_r_test
   SUITE
     libc_time_unittests
@@ -238,7 +238,7 @@ add_libc_test(
     libc.src.time.strptime
 )
 
-add_libc_unittest(
+add_libc_test(
   time_test
   SUITE
     libc_time_unittests

--- a/libc/test/src/ucontext/CMakeLists.txt
+++ b/libc/test/src/ucontext/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_custom_target(libc_ucontext_unittests)
 
 if(TARGET libc.src.ucontext.getcontext)
-  add_libc_unittest(
+  add_libc_test(
     ucontext_test
     SUITE
       libc_ucontext_unittests

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_target(libc_unistd_unittests)
 
 add_subdirectory(testdata)
 
-add_libc_unittest(
+add_libc_test(
   alarm_test
   SUITE
     libc_unistd_unittests
@@ -17,7 +17,7 @@ add_libc_unittest(
     libc.src.unistd.alarm
 )
 
-add_libc_unittest(
+add_libc_test(
   access_test
   SUITE
     libc_unistd_unittests
@@ -35,7 +35,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   chdir_test
   SUITE
     libc_unistd_unittests
@@ -73,7 +73,7 @@ add_libc_test(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   dup_test
   SUITE
     libc_unistd_unittests
@@ -93,7 +93,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   dup2_test
   SUITE
     libc_unistd_unittests
@@ -113,7 +113,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   dup3_test
   SUITE
     libc_unistd_unittests
@@ -133,7 +133,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   faccessat_test
   SUITE
     libc_unistd_unittests
@@ -151,7 +151,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fchdir_test
   SUITE
     libc_unistd_unittests
@@ -167,7 +167,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   fchown_test
   SUITE
     libc_unistd_unittests
@@ -209,7 +209,7 @@ add_libc_test(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   pread_pwrite_test
   SUITE
     libc_unistd_unittests
@@ -247,7 +247,7 @@ add_libc_test(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   link_test
   SUITE
     libc_unistd_unittests
@@ -265,7 +265,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   linkat_test
   SUITE
     libc_unistd_unittests
@@ -283,7 +283,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   lseek_test
   SUITE
     libc_unistd_unittests
@@ -300,7 +300,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   pipe_test
   SUITE
     libc_unistd_unittests
@@ -315,7 +315,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   pipe2_test
   SUITE
     libc_unistd_unittests
@@ -330,7 +330,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   rmdir_test
   SUITE
     libc_unistd_unittests
@@ -346,7 +346,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   swab_test
   SUITE
     libc_unistd_unittests
@@ -356,7 +356,7 @@ add_libc_unittest(
     libc.src.unistd.swab
 )
 
-add_libc_unittest(
+add_libc_test(
   readlink_test
   SUITE
     libc_unistd_unittests
@@ -374,7 +374,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   readlinkat_test
   SUITE
     libc_unistd_unittests
@@ -393,7 +393,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   setsid_test
   SUITE
     libc_unistd_unittests
@@ -403,7 +403,7 @@ add_libc_unittest(
     libc.src.unistd.setsid
 )
 
-add_libc_unittest(
+add_libc_test(
   sleep_test
   SUITE
     libc_unistd_unittests
@@ -416,7 +416,7 @@ add_libc_unittest(
     libc.src.unistd.sleep
 )
 
-add_libc_unittest(
+add_libc_test(
   symlink_test
   SUITE
     libc_unistd_unittests
@@ -434,7 +434,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   symlinkat_test
   SUITE
     libc_unistd_unittests
@@ -452,7 +452,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   truncate_test
   SUITE
     libc_unistd_unittests
@@ -473,7 +473,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   unlink_test
   SUITE
     libc_unistd_unittests
@@ -490,7 +490,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   unlinkat_test
   SUITE
     libc_unistd_unittests
@@ -508,7 +508,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   usleep_test
   SUITE
     libc_unistd_unittests
@@ -522,7 +522,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   gethostname_test
   SUITE
     libc_unistd_unittests
@@ -534,7 +534,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   getpagesize_test
   SUITE
     libc_unistd_unittests
@@ -545,7 +545,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   getgid_test
   SUITE
     libc_unistd_unittests
@@ -555,7 +555,7 @@ add_libc_unittest(
     libc.src.unistd.getgid
 )
 
-add_libc_unittest(
+add_libc_test(
   getpid_test
   SUITE
     libc_unistd_unittests
@@ -565,7 +565,7 @@ add_libc_unittest(
     libc.src.unistd.getpid
 )
 
-add_libc_unittest(
+add_libc_test(
   getppid_test
   SUITE
     libc_unistd_unittests
@@ -575,7 +575,7 @@ add_libc_unittest(
     libc.src.unistd.getppid
 )
 
-add_libc_unittest(
+add_libc_test(
   getsid_test
   SUITE
     libc_unistd_unittests
@@ -587,7 +587,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   getuid_test
   SUITE
     libc_unistd_unittests
@@ -597,7 +597,7 @@ add_libc_unittest(
     libc.src.unistd.getuid
 )
 
-add_libc_unittest(
+add_libc_test(
   isatty_test
   SUITE
     libc_unistd_unittests
@@ -613,7 +613,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   geteuid_test
   SUITE
     libc_unistd_unittests
@@ -641,7 +641,7 @@ add_libc_test(
 )
 
 
-add_libc_unittest(
+add_libc_test(
   sysconf_test
   SUITE
     libc_unistd_unittests
@@ -652,7 +652,7 @@ add_libc_unittest(
     libc.src.unistd.sysconf
 )
 
-add_libc_unittest(
+add_libc_test(
   fpathconf_test
   SUITE
     libc_unistd_unittests
@@ -669,7 +669,7 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
-add_libc_unittest(
+add_libc_test(
   pathconf_test
   SUITE
     libc_unistd_unittests

--- a/libc/test/src/unistd/access_test.cpp
+++ b/libc/test/src/unistd/access_test.cpp
@@ -24,7 +24,7 @@ TEST_F(LlvmLibcAccessTest, CreateAndTest) {
   // test that it is accessable in those modes but not in others.
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = "access.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("access.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/dup2_test.cpp
+++ b/libc/test/src/unistd/dup2_test.cpp
@@ -22,7 +22,7 @@ using LlvmLibcdupTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcdupTest, ReadAndWriteViaDup) {
   constexpr int DUPFD = 0xD0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = "dup2.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("dup2.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/faccessat_test.cpp
+++ b/libc/test/src/unistd/faccessat_test.cpp
@@ -28,7 +28,7 @@ using LlvmLibcFaccessatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcFaccessatTest, WithAtFdcwd) {
   // Test access checks on a file with AT_FDCWD and no flags, equivalent to
   // access().
-  constexpr const char *FILENAME = "faccessat_basic.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("faccessat_basic.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   // Check permissions on a file with full permissions
@@ -71,7 +71,7 @@ TEST_F(LlvmLibcFaccessatTest, AtEaccess) {
   // With AT_EACCESS, faccessat checks permissions using the effective user ID,
   // but the effective and real user ID will be the same here and changing that
   // is not feasible in a test, so this is just a basic sanity check.
-  constexpr const char *FILENAME = "faccessat_eaccess.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("faccessat_eaccess.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
@@ -87,7 +87,8 @@ TEST_F(LlvmLibcFaccessatTest, AtEaccess) {
 }
 
 TEST_F(LlvmLibcFaccessatTest, AtEmptyPath) {
-  constexpr const char *FILENAME = "faccessat_atemptypath.test";
+  constexpr const char *FILENAME =
+      APPEND_LIBC_TEST("faccessat_atemptypath.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);

--- a/libc/test/src/unistd/pread_pwrite_test.cpp
+++ b/libc/test/src/unistd/pread_pwrite_test.cpp
@@ -33,7 +33,7 @@ TEST_F(LlvmLibcUniStd, PWriteAndPReadBackTest) {
 
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *FILENAME = "pread_pwrite.test";
+  constexpr const char *FILENAME = APPEND_LIBC_TEST("pread_pwrite.test");
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -517,7 +517,7 @@ add_libc_test(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_unittest(
+add_libc_test(
   wcsxfrm_test
   SUITE
     libc_wchar_unittests

--- a/libc/test/utils/FPUtil/CMakeLists.txt
+++ b/libc/test/utils/FPUtil/CMakeLists.txt
@@ -1,7 +1,9 @@
 if((${LIBC_TARGET_OS} STREQUAL "linux") AND ((${LIBC_TARGET_ARCHITECTURE_IS_X86})
   OR (${LIBC_TARGET_ARCHITECTURE_IS_X86_64})))
-  add_libc_unittest(
+  add_libc_test(
     x86_long_double_test
+    SUITE
+      libc-fputil-tests
     SRCS
       x86_long_double_test.cpp
     DEPENDS

--- a/libc/test/utils/UnitTest/CMakeLists.txt
+++ b/libc/test/utils/UnitTest/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 add_custom_target(libc_unittest_tests)
 
-add_libc_unittest(
+add_libc_test(
   testfilter_test
   SUITE
     libc_unittest_tests


### PR DESCRIPTION
This is mostly a straightforward search&replace, as I've addressed the blockers in previous patches. The nontrivial parts are:
- adding a SUITE to a single (FP) test which doesn't have it (turns out hermetic tests require a SUITE argument)
- using APPEND_LIBC_TESTS in a couple of tests creating files (to avoid races between unit and hermetic versions)
- renaming add_libc_unittest to _add_libc_unittest to prevent accidental creations of non-hermetic tests (one can still use the UNIT_TEST_ONLY arg to add_libc_test to achieve this effect)