### PR TITLE
[libc] Enable UNIT_TEST_ONLY tests in hermetic mode

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -105,8 +105,8 @@ function(_get_common_test_compile_options output_var c_test flags)
   set(${output_var} ${compile_options} PARENT_SCOPE)
 endfunction()
 
-function(_get_hermetic_test_compile_options output_var flags)
-  _get_common_test_compile_options(compile_options "" "${flags}")
+function(_get_hermetic_test_compile_options output_var c_test flags)
+  _get_common_test_compile_options(compile_options "${c_test}" "${flags}")
   libc_add_definition(compile_options "LIBC_TEST=HERMETIC")
 
   # null check tests are death tests, remove from hermetic tests for now.
@@ -627,7 +627,7 @@ function(add_integration_test test_name)
   target_include_directories(${fq_build_target_name} SYSTEM PRIVATE ${LIBC_INCLUDE_DIR})
   target_include_directories(${fq_build_target_name} PRIVATE ${LIBC_SOURCE_DIR})
 
-  _get_hermetic_test_compile_options(compile_options "")
+  _get_hermetic_test_compile_options(compile_options "" "")
   target_compile_options(${fq_build_target_name} PRIVATE
                          ${compile_options} ${INTEGRATION_TEST_COMPILE_OPTIONS})
 
@@ -762,7 +762,7 @@ function(add_libc_hermetic test_name)
   endif()
   cmake_parse_arguments(
     "HERMETIC_TEST"
-    "IS_GPU_BENCHMARK;NO_RUN_POSTBUILD" # Optional arguments
+    "IS_GPU_BENCHMARK;NO_RUN_POSTBUILD;C_TEST" # Optional arguments
     "SUITE;CXX_STANDARD" # Single value arguments
     "SRCS;HDRS;DEPENDS;ARGS;ENV;COMPILE_OPTIONS;LINK_LIBRARIES;FLAGS;LOADER_ARGS" # Multi-value arguments
     ${ARGN}
@@ -798,7 +798,7 @@ function(add_libc_hermetic test_name)
   endif()
 
   # Syscalls used by death tests.
-  if(LIBC_TEST_SUBPROCESS_TESTS)
+  if(LIBC_TEST_SUBPROCESS_TESTS AND NOT HERMETIC_TEST_C_TEST)
     list(APPEND fq_deps_list
         libc.src.poll.poll
         libc.src.signal.kill
@@ -877,7 +877,8 @@ function(add_libc_hermetic test_name)
 
   target_include_directories(${fq_build_target_name} SYSTEM PRIVATE ${LIBC_INCLUDE_DIR})
   target_include_directories(${fq_build_target_name} PRIVATE ${LIBC_SOURCE_DIR})
-  _get_hermetic_test_compile_options(compile_options "${HERMETIC_TEST_FLAGS}")
+  _get_hermetic_test_compile_options(compile_options "${HERMETIC_TEST_C_TEST}"
+                                     "${HERMETIC_TEST_FLAGS}")
   target_compile_options(${fq_build_target_name} PRIVATE
                          ${compile_options}
                          ${HERMETIC_TEST_COMPILE_OPTIONS})

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -40,7 +40,7 @@ function(add_unittest_framework_library name)
   endif()
   target_compile_options(${name}.unit PRIVATE ${compile_options})
 
-  _get_hermetic_test_compile_options(compile_options "")
+  _get_hermetic_test_compile_options(compile_options "" "")
   target_include_directories(${name}.hermetic PRIVATE ${LIBC_INCLUDE_DIR})
   target_compile_options(${name}.hermetic PRIVATE ${compile_options} -nostdinc++)
 

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -75,7 +75,6 @@ add_libc_test(
 add_libc_test(
   stdbit_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   HDRS
@@ -108,7 +107,6 @@ add_libc_test(
 
 add_libc_test(
   sched_test
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -370,7 +368,6 @@ add_libc_test(
 add_libc_test(
   signbit_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -385,7 +382,6 @@ add_libc_test(
 add_libc_test(
   isnan_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -400,7 +396,6 @@ add_libc_test(
 add_libc_test(
   isnormal_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -416,7 +411,6 @@ add_libc_test(
 # add_libc_test(
 #   issignaling_c_test
 #   C_TEST
-#   UNIT_TEST_ONLY
 #   SUITE
 #     libc_include_tests
 #   SRCS
@@ -434,7 +428,6 @@ add_libc_test(
 # add_libc_test(
 #   iscanonical_c_test
 #   C_TEST
-#   UNIT_TEST_ONLY
 #   SUITE
 #     libc_include_tests
 #   SRCS
@@ -452,7 +445,6 @@ add_libc_test(
 add_libc_test(
   isinf_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -467,7 +459,6 @@ add_libc_test(
 add_libc_test(
   isfinite_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -482,7 +473,6 @@ add_libc_test(
 add_libc_test(
   issubnormal_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -497,7 +487,6 @@ add_libc_test(
 add_libc_test(
   fpclassify_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -512,7 +501,6 @@ add_libc_test(
 add_libc_test(
   iszero_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS
@@ -527,7 +515,6 @@ add_libc_test(
 add_libc_test(
   math_constants_c_test
   C_TEST
-  UNIT_TEST_ONLY
   SUITE
     libc_include_tests
   SRCS

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -867,7 +867,6 @@ add_fp_unittest(
 if(NOT LLVM_LIBC_FULL_BUILD)
 add_libc_test(
   shared_rpc_test
-  UNIT_TEST_ONLY
   SUITE
     libc-shared-tests
   SRCS

--- a/libc/test/src/__support/HashTable/CMakeLists.txt
+++ b/libc/test/src/__support/HashTable/CMakeLists.txt
@@ -20,7 +20,6 @@ add_libc_test(
     libc.src.__support.HashTable.table
     libc.src.__support.common
     libc.src.search.hsearch
-  UNIT_TEST_ONLY
 )
 
 add_libc_test(

--- a/libc/test/src/__support/regex/CMakeLists.txt
+++ b/libc/test/src/__support/regex/CMakeLists.txt
@@ -9,5 +9,4 @@ add_libc_test(
     libc.hdr.regex_macros
   # ExprPool allocates a 128KB hash table, which exceeds the 64KB limit
   # of the simple bump allocator used in hermetic tests.
-  UNIT_TEST_ONLY
 )

--- a/libc/test/src/fenv/CMakeLists.txt
+++ b/libc/test/src/fenv/CMakeLists.txt
@@ -111,7 +111,6 @@ if (NOT (LLVM_USE_SANITIZER OR (${LIBC_TARGET_OS} STREQUAL "windows")
   # and MacOS.
   add_fp_unittest(
     enabled_exceptions_test
-    UNIT_TEST_ONLY
     SUITE
       libc_fenv_unittests
     SRCS
@@ -129,7 +128,6 @@ if (NOT (LLVM_USE_SANITIZER OR (${LIBC_TARGET_OS} STREQUAL "windows")
 
   add_fp_unittest(
     feholdexcept_test
-    UNIT_TEST_ONLY
     SUITE
       libc_fenv_unittests
     SRCS

--- a/libc/test/src/libgen/CMakeLists.txt
+++ b/libc/test/src/libgen/CMakeLists.txt
@@ -23,7 +23,6 @@ add_libc_test(
 if (NOT LLVM_USE_SANITIZER AND LIBC_TEST_SUBPROCESS_TESTS)
   add_libc_test(
     basename_death_test
-    UNIT_TEST_ONLY
     SUITE
       libc-libgen-tests
     SRCS
@@ -34,7 +33,6 @@ if (NOT LLVM_USE_SANITIZER AND LIBC_TEST_SUBPROCESS_TESTS)
 
   add_libc_test(
     dirname_death_test
-    UNIT_TEST_ONLY
     SUITE
       libc-libgen-tests
     SRCS

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -3831,7 +3831,6 @@ add_fp_unittest(
     libc.src.__support.FPUtil.fp_bits
   # FIXME: The nan tests currently have death tests, which aren't supported for
   # hermetic tests.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -3846,7 +3845,6 @@ add_fp_unittest(
     libc.src.__support.FPUtil.fp_bits
   # FIXME: The nan tests currently have death tests, which aren't supported for
   # hermetic tests.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -3861,7 +3859,6 @@ add_fp_unittest(
     libc.src.__support.FPUtil.fp_bits
   # FIXME: The nan tests currently have death tests, which aren't supported for
   # hermetic tests.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -3876,7 +3873,6 @@ add_fp_unittest(
     libc.src.__support.FPUtil.fp_bits
   # FIXME: The nan tests currently have death tests, which aren't supported for
   # hermetic tests.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -3891,7 +3887,6 @@ add_fp_unittest(
     libc.src.__support.FPUtil.fp_bits
   # FIXME: The nan tests currently have death tests, which aren't supported for
   # hermetic tests.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -3907,7 +3902,6 @@ add_fp_unittest(
     libc.src.__support.FPUtil.fp_bits
   # FIXME: The nan tests currently have death tests, which aren't supported for
   # hermetic tests.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -4596,7 +4590,6 @@ add_fp_unittest(
     libc.src.math.fmodf
     libc.src.__support.FPUtil.fenv_impl
   # FIXME: Currently fails on the GPU build.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -4613,7 +4606,6 @@ add_fp_unittest(
     libc.src.math.fmod
     libc.src.__support.FPUtil.fenv_impl
   # FIXME: Currently fails on the GPU build.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -4630,7 +4622,6 @@ add_fp_unittest(
     libc.src.math.fmodl
     libc.src.__support.FPUtil.fenv_impl
   # FIXME: Currently fails on the GPU build.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -4647,7 +4638,6 @@ add_fp_unittest(
     libc.src.math.fmodf16
     libc.src.__support.FPUtil.fenv_impl
   # FIXME: Currently fails on the GPU build.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -4664,7 +4654,6 @@ add_fp_unittest(
     libc.src.math.fmodf128
     libc.src.__support.FPUtil.fenv_impl
   # FIXME: Currently fails on the GPU build.
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(
@@ -4681,7 +4670,6 @@ add_fp_unittest(
     libc.src.math.fmodbf16
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.fenv_impl
-  UNIT_TEST_ONLY
 )
 
 add_fp_unittest(

--- a/libc/test/src/stdio/CMakeLists.txt
+++ b/libc/test/src/stdio/CMakeLists.txt
@@ -167,7 +167,6 @@ endif()
 
 add_fp_unittest(
   sprintf_test
-  UNIT_TEST_ONLY
   SUITE
     libc_stdio_unittests
   SRCS
@@ -250,7 +249,6 @@ add_libc_test(
 
 add_fp_unittest(
   vsprintf_test
-  UNIT_TEST_ONLY
   SUITE
     libc_stdio_unittests
   SRCS

--- a/libc/test/src/string/memory_utils/CMakeLists.txt
+++ b/libc/test/src/string/memory_utils/CMakeLists.txt
@@ -17,5 +17,4 @@ add_libc_test(
     libc.src.__support.macros.properties.types
     libc.src.__support.macros.sanitizer
     libc.src.string.memory_utils.memory_utils
-  UNIT_TEST_ONLY
 )

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -689,7 +689,6 @@ add_libc_test(
 if(LLVM_LIBC_FULL_BUILD)
   add_libc_test(
     _exit_test
-    UNIT_TEST_ONLY
     SUITE
       libc_unistd_unittests
     SRCS


### PR DESCRIPTION
This mainly consists of removing the UNIT_TEST_ONLY lines as previous patches made sure the tests work. The only slightly nontrivial part is adding support for C_TEST to the hermetic test macro.

After this, the only UNIT_TEST_ONLY tests are those that require the MPFR library.