### PR TITLE
[Verifier] Clean up load atomic elementwise mem access sizes check (NFC)

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -4617,7 +4617,6 @@ void Verifier::visitLoadInst(LoadInst &LI) {
               LI.getOrdering() != AtomicOrdering::AcquireRelease,
           "Load cannot have Release ordering", &LI);
 
-    Type *ScalarTy = ElTy;
     if (LI.isElementwise()) {
       Check(LI.getOrdering() != AtomicOrdering::SequentiallyConsistent,
             "atomic elementwise load cannot be sequentially consistent.", &LI);
@@ -4625,20 +4624,18 @@ void Verifier::visitLoadInst(LoadInst &LI) {
       Check(VecTy,
             "atomic elementwise load operand must have fixed vector type!", &LI,
             ElTy);
-      if (VecTy) {
-        checkAtomicMemAccessSize(ScalarTy, &LI);
-        ScalarTy = VecTy->getElementType();
-      }
+      if (VecTy)
+        checkAtomicMemAccessSize(VecTy->getElementType(), &LI);
     }
 
-    Check(ScalarTy->getScalarType()->isIntOrPtrTy() ||
-              ScalarTy->getScalarType()->isByteTy() ||
-              ScalarTy->getScalarType()->isFloatingPointTy(),
+    Check(ElTy->getScalarType()->isIntOrPtrTy() ||
+              ElTy->getScalarType()->isByteTy() ||
+              ElTy->getScalarType()->isFloatingPointTy(),
           "atomic load operand must have integer, byte, pointer, floating "
           "point, or vector type!",
           ElTy, &LI);
 
-    checkAtomicMemAccessSize(ScalarTy, &LI);
+    checkAtomicMemAccessSize(ElTy, &LI);
   } else {
     Check(!LI.isElementwise(), "non-atomic load cannot be elementwise", &LI);
     Check(LI.getSyncScopeID() == SyncScope::System,


### PR DESCRIPTION
I refactored the `load atomic elementwise` check to have the same cleaner pattern as `atomicrmw elementwise` and remove the `ScalarTy` intermediate.

The previous code had this segment:

```
      if (VecTy) {
        checkAtomicMemAccessSize(ScalarTy, &LI);
        ScalarTy = VecTy->getElementType();
      }
```

Which is confusing because it's checking the atomic access size on the whole vector and then assigning `ScalarTy` to the element type so that the second check does the check on the element type. It's cleaner to reverse this and have the first check operate on the element type so that the second check always checks the entire type.