### PR TITLE
[libc] Add front() and erase() to FixedVector

### DIFF
--- a/libc/src/__support/fixedvector.h
+++ b/libc/src/__support/fixedvector.h
@@ -57,6 +57,16 @@ public:
     return true;
   }
 
+  LIBC_INLINE constexpr const T &front() const {
+    LIBC_ASSERT(!empty());
+    return store[0];
+  }
+
+  LIBC_INLINE constexpr T &front() {
+    LIBC_ASSERT(!empty());
+    return store[0];
+  }
+
   LIBC_INLINE constexpr const T &back() const {
     LIBC_ASSERT(!empty());
     return store[item_count - 1];
@@ -73,6 +83,14 @@ public:
     inline_memset(&store[item_count - 1], 0, sizeof(T));
     --item_count;
     return true;
+  }
+
+  LIBC_INLINE constexpr iterator erase(iterator pos) {
+    LIBC_ASSERT(pos >= begin() && pos < end());
+    for (iterator it = pos; it + 1 != end(); ++it)
+      *it = *(it + 1);
+    pop_back();
+    return pos;
   }
 
   LIBC_INLINE constexpr T &operator[](size_t idx) {

--- a/libc/test/src/__support/fixedvector_test.cpp
+++ b/libc/test/src/__support/fixedvector_test.cpp
@@ -106,3 +106,40 @@ TEST(LlvmLibcFixedVectorTest, ConstForwardIteration) {
     ASSERT_EQ(*it, arr[idx]);
   }
 }
+
+TEST(LlvmLibcFixedVectorTest, Front) {
+  LIBC_NAMESPACE::FixedVector<int, 20> fixed_vector;
+  for (int i = 0; i < 5; i++)
+    ASSERT_TRUE(fixed_vector.push_back(i));
+  ASSERT_EQ(fixed_vector.front(), 0);
+  fixed_vector.front() = 10;
+  ASSERT_EQ(fixed_vector.front(), 10);
+  fixed_vector.front() = 0;
+
+  const auto &const_vector = fixed_vector;
+  ASSERT_EQ(const_vector.front(), 0);
+}
+
+TEST(LlvmLibcFixedVectorTest, Erase) {
+  LIBC_NAMESPACE::FixedVector<int, 20> fixed_vector;
+  for (int i = 0; i < 5; i++)
+    ASSERT_TRUE(fixed_vector.push_back(i));
+
+  auto it = fixed_vector.erase(fixed_vector.begin());
+  ASSERT_EQ(it, fixed_vector.begin());
+  ASSERT_EQ(fixed_vector.size(), size_t(4));
+  ASSERT_EQ(fixed_vector.front(), 1);
+  ASSERT_EQ(fixed_vector.back(), 4);
+
+  it = fixed_vector.erase(fixed_vector.begin() + 1);
+  ASSERT_EQ(it, fixed_vector.begin() + 1);
+  ASSERT_EQ(fixed_vector.size(), size_t(3));
+  ASSERT_EQ(fixed_vector[0], 1);
+  ASSERT_EQ(fixed_vector[1], 3);
+  ASSERT_EQ(fixed_vector[2], 4);
+
+  it = fixed_vector.erase(fixed_vector.end() - 1);
+  ASSERT_EQ(it, fixed_vector.end());
+  ASSERT_EQ(fixed_vector.size(), size_t(2));
+  ASSERT_EQ(fixed_vector.back(), 3);
+}

--- a/libc/test/src/net/linux/if_nameindex_test.cpp
+++ b/libc/test/src/net/linux/if_nameindex_test.cpp
@@ -49,11 +49,8 @@ template <typename T, size_t CAPACITY>
 static optional<T> pop_front(FixedVector<T, CAPACITY> &vec) {
   if (vec.empty())
     return nullopt;
-  // TODO: Add front() and erase() to FixedVector, then clean this up.
-  T first = vec[0];
-  for (size_t i = 1; i < vec.size(); ++i)
-    vec[i - 1] = vec[i];
-  vec.pop_back();
+  T first = vec.front();
+  vec.erase(vec.begin());
   return first;
 }
 


### PR DESCRIPTION
Add front() accessors and erase() method to FixedVector. I use these to clean up the pop_front implementation in if_nameindex_test.cpp, which previously manually shifted elements and popped the back.

Assisted by Gemini.