### PR TITLE
[GitHub] Use base repository to fetch test merge commit in test-suite workflow

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -85,7 +85,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ fromJSON(steps.get-pr.outputs.result).merge_commit_sha }}
-          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+          # test merge commits are stored in the base repository, not the head
+          repository: ${{ github.repository }}
           fetch-depth: 2
           path: llvm-project
           persist-credentials: false


### PR DESCRIPTION
From time to time we'll fail to fetch the test merge commit during the checkout step, e.g. see https://github.com/llvm/llvm-project/actions/runs/30626469894/job/91931527829

After a bit of research apparently the test merge commit is actually stored on the base repository, not the fork. I think this just happened to work previously because the fork repository synced objects in the background, but it's not always guaranteed to be available.

So switch the checkout step to use llvm/llvm-project as the remote.