### PR TITLE
[clang-tidy] Fix clang-tidy-diff with not producing blank lines

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
@@ -68,8 +68,9 @@ def run_tidy(task_queue, lock, timeout, failed_files):
                 failed_files.append(command)
 
             with lock:
-                sys.stdout.write(stdout.decode("utf-8") + "\n")
-                sys.stdout.flush()
+                if stdout:
+                    sys.stdout.write(stdout.decode("utf-8") + "\n")
+                    sys.stdout.flush()
                 if stderr:
                     sys.stderr.write(stderr.decode("utf-8") + "\n")
                     sys.stderr.flush()

--- a/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/clang-tidy-diff/test.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/clang-tidy-diff/test.cpp
@@ -1,0 +1,1 @@
+int add(int a, int b) { return PLACEHOLDER; }

--- a/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-diff.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-diff.cpp
@@ -9,6 +9,14 @@
 
 // RUN: not diff -U0 %s %t.cpp | %clang_tidy_diff -checks=-*,modernize-use-override -j 1 -- -std=c++11 2>&1 | FileCheck %s --check-prefix=CHECK-J1
 // CHECK-J1: Running clang-tidy in 1 threads...
+
+// Test that running over multiple files don't produce blank lines in output
+// RUN: not diff -U0 %s %t.cpp > %t.diff
+// RUN: sed 's/PLACEHOLDER/a + b + 0/' %S/Inputs/clang-tidy-diff/test.cpp > %t.clean.cpp
+// RUN: not diff -U0 %S/Inputs/clang-tidy-diff/test.cpp %t.clean.cpp > %t.clean.diff
+// RUN: cat %t.clean.diff %t.diff | %clang_tidy_diff -checks=-*,modernize-use-override -j 1 -- -std=c++11 2>&1 | FileCheck %s --check-prefix=CHECK-NOBLANK
+// CHECK-NOBLANK: Running clang-tidy in 1 threads...
+// CHECK-NOBLANK-NEXT: :8: warning: annotate this
 struct A {
   virtual void f() {}
   virtual void g() {}


### PR DESCRIPTION
clang-tidy-diff.py unconditionally wrote `stdout + "\n"` for every file it processed, even when clang-tidy produced no output so this bloated output with needless blank line (happened with `-quiet` flag enabled which made tidy produce 0  diagnostics).