### PR TITLE
[MLIR][GPU] Lower remaining Math ops in the XeVM pipeline

### DIFF
--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -145,6 +145,12 @@ void buildGPUPassPipeline(OpPassManager &pm,
     pm.addNestedPass<gpu::GPUModuleOp>(
         arith::createArithEmulateUnsupportedFloats(arithEmulateOptions));
   }
+  // Lower whatever Math ops are left. `convert-math-to-xevm` above only maps
+  // the ops that have a native or OpenCL counterpart; the rest (e.g.
+  // `math.isinf`) have no XeVM lowering and would otherwise survive into
+  // serialization, where translation to LLVM IR fails. This must run after the
+  // XeVM-specific conversions so those keep taking priority.
+  pm.addNestedPass<gpu::GPUModuleOp>(createConvertMathToLLVMPass());
   pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
   pm.addNestedPass<gpu::GPUModuleOp>(createReconcileUnrealizedCastsPass());
 }

--- a/mlir/test/Dialect/GPU/lower-to-xevm-pipeline-math.mlir
+++ b/mlir/test/Dialect/GPU/lower-to-xevm-pipeline-math.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=lane" | FileCheck %s
+
+// `convert-math-to-xevm` only maps the Math ops that have a native or OpenCL
+// counterpart. The rest must still be lowered, or they survive into
+// serialization and translation to LLVM IR fails.
+// See https://github.com/llvm/llvm-project/issues/213583.
+
+// CHECK-LABEL: gpu.module @kernels
+// CHECK-NOT: math.
+module attributes {gpu.container_module} {
+  gpu.module @kernels {
+    gpu.func @classify_inf(%input : memref<1xf32>,
+                           %output : memref<1xi32>) kernel {
+      %c0 = arith.constant 0 : index
+      %zero = arith.constant 0 : i32
+      %one = arith.constant 1 : i32
+      %value = memref.load %input[%c0] : memref<1xf32>
+      %is_inf = math.isinf %value : f32
+      %result = arith.select %is_inf, %one, %zero : i32
+      memref.store %result, %output[%c0] : memref<1xi32>
+      gpu.return
+    }
+  }
+}


### PR DESCRIPTION
`convert-math-to-xevm` only maps the Math ops that have a native or OpenCL counterpart. Anything else it doesn't cover, such as `math.isinf`, stays in the `gpu.module` through the rest of the device-side pipeline and reaches serialization, where translation to LLVM IR fails with a missing `LLVMTranslationDialectInterface` registration.

Add `convert-math-to-llvm` after the XeVM-specific conversions, mirroring what the NVVM pipeline already does. Running it last keeps the XeVM lowerings taking priority and leaves the generic path to handle the remainder.

Fixes #213583