### PR TITLE
[LAA] SCEV-licm-reduce depend_diff_types test (NFC)

### DIFF
--- a/llvm/test/Analysis/LoopAccessAnalysis/depend_diff_types.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/depend_diff_types.ll
@@ -265,9 +265,8 @@ exit:
 
 ;       i16       i32
 ; [ . . 0 0 . . 1 1] [ 1 1 0 0 . . 1 1 ]
-;  ^~~^ gep i8 = 1
-;  ^ ~~ ^ iv.2 = iv + 2
-;       ^ ~~~~~ ^ dependence distance = 4
+;   ^~^ gep i8 = 1
+;       ^ ~~~~ ^ dependence distance = 4
 ;              ^ ~~~~~~~~~~~~~~~~~ ^ 8
 ;       ^ ~~~~~~~~~~~~~~~~ ^ 8
 ;   ^ ~~~~~~~~~~~~~~~~ ^ iv.next = iv + 8
@@ -284,8 +283,8 @@ define void @different_type_sizes_strided_accesses_independent(ptr %dst) {
 ; CHECK-NEXT:  Unknown data dependence.
 ; CHECK-NEXT:      Dependences:
 ; CHECK-NEXT:        Unknown:
-; CHECK-NEXT:            store i16 0, ptr %gep.iv, align 2 ->
-; CHECK-NEXT:            store i32 1, ptr %gep.4.iv, align 4
+; CHECK-NEXT:            store i16 0, ptr %gep.2.iv, align 2 ->
+; CHECK-NEXT:            store i32 1, ptr %gep.6.iv, align 4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Run-time memory checks:
 ; CHECK-NEXT:      Grouped accesses:
@@ -296,16 +295,16 @@ define void @different_type_sizes_strided_accesses_independent(ptr %dst) {
 ; CHECK-NEXT:      Expressions re-written:
 ;
 entry:
-  %gep.4 = getelementptr nuw i8, ptr %dst, i64 4
+  %gep.2 = getelementptr nuw i8, ptr %dst, i64 2
+  %gep.6 = getelementptr nuw i8, ptr %dst, i64 6
   br label %loop
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %iv.2 = add nuw nsw i64 %iv, 2
-  %gep.iv = getelementptr i8, ptr %dst, i64 %iv.2
-  store i16 0, ptr %gep.iv
-  %gep.4.iv = getelementptr i8, ptr %gep.4, i64 %iv.2
-  store i32 1, ptr %gep.4.iv
+  %gep.2.iv = getelementptr i8, ptr %gep.2, i64 %iv
+  store i16 0, ptr %gep.2.iv
+  %gep.6.iv = getelementptr i8, ptr %gep.6, i64 %iv
+  store i32 1, ptr %gep.6.iv
   %iv.next = add nuw nsw i64 %iv, 8
   %ec = icmp eq i64 %iv.next, 64
   br i1 %ec, label %exit, label %loop
@@ -317,9 +316,8 @@ exit:
 
 ;     i16      i64
 ; [ . 0 0 . 1 1 1 1] [ 1 x x 1 1 1 1 1 ]
-;  ^~~^ gep i8 = 1
-;  ^~~^ iv.1 = iv + 1
-;     ^ ~~ ^ dependence distance = 3
+;   ^~^ gep i8 = 1
+;     ^ ~~~ ^ dependence distance = 3
 ;     ^ ~~~~~~~~~~~~~~~~ ^ 8
 ;           ^ ~~~~~~~~~~~~~~~~ ^ 8
 ;   ^ ~~~~~~~~~~~~~~~~ ^ iv.next = iv + 8
@@ -333,8 +331,8 @@ define void @different_type_sizes_strided_accesses_dependent(ptr %dst) {
 ; CHECK-NEXT:  Unknown data dependence.
 ; CHECK-NEXT:      Dependences:
 ; CHECK-NEXT:        Unknown:
-; CHECK-NEXT:            store i16 0, ptr %gep.iv, align 2 ->
-; CHECK-NEXT:            store i64 1, ptr %gep.3.iv, align 4
+; CHECK-NEXT:            store i16 0, ptr %gep.1.iv, align 2 ->
+; CHECK-NEXT:            store i64 1, ptr %gep.4.iv, align 4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Run-time memory checks:
 ; CHECK-NEXT:      Grouped accesses:
@@ -345,16 +343,16 @@ define void @different_type_sizes_strided_accesses_dependent(ptr %dst) {
 ; CHECK-NEXT:      Expressions re-written:
 ;
 entry:
-  %gep.3 = getelementptr nuw i8, ptr %dst, i64 3
+  %gep.1 = getelementptr nuw i8, ptr %dst, i64 1
+  %gep.4 = getelementptr nuw i8, ptr %dst, i64 4
   br label %loop
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %iv.1 = add nuw nsw i64 %iv, 1
-  %gep.iv = getelementptr i8, ptr %dst, i64 %iv.1
-  store i16 0, ptr %gep.iv
-  %gep.3.iv = getelementptr i8, ptr %gep.3, i64 %iv.1
-  store i64 1, ptr %gep.3.iv
+  %gep.1.iv = getelementptr i8, ptr %gep.1, i64 %iv
+  store i16 0, ptr %gep.1.iv
+  %gep.4.iv = getelementptr i8, ptr %gep.4, i64 %iv
+  store i64 1, ptr %gep.4.iv
   %iv.next = add nuw nsw i64 %iv, 8
   %ec = icmp eq i64 %iv.next, 64
   br i1 %ec, label %exit, label %loop

--- a/llvm/test/Analysis/LoopAccessAnalysis/depend_diff_types.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/depend_diff_types.ll
@@ -295,6 +295,7 @@ define void @different_type_sizes_strided_accesses_independent(ptr %dst) {
 ; CHECK-NEXT:      Expressions re-written:
 ;
 entry:
+  ; Intentionally offset both to test logic.
   %gep.2 = getelementptr nuw i8, ptr %dst, i64 2
   %gep.6 = getelementptr nuw i8, ptr %dst, i64 6
   br label %loop
@@ -343,6 +344,7 @@ define void @different_type_sizes_strided_accesses_dependent(ptr %dst) {
 ; CHECK-NEXT:      Expressions re-written:
 ;
 entry:
+  ; Intentionally offset both to test logic.
   %gep.1 = getelementptr nuw i8, ptr %dst, i64 1
   %gep.4 = getelementptr nuw i8, ptr %dst, i64 4
   br label %loop


### PR DESCRIPTION
Reduce a couple of tests in depend_diff_types in a way that preserves SCEV expressions, by creating invariants that we hoist outside the loop. This makes the tests a bit clearer.

Illustration: https://godbolt.org/z/eTqdoPPzn