### PR TITLE
[X86] vector-reduce-*-bool.ll - update IR to match middleend

### DIFF
--- a/llvm/test/CodeGen/X86/vector-reduce-and-bool.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-and-bool.ll
@@ -17,7 +17,7 @@
 ; Truncate
 ;
 
-define i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE2-LABEL: trunc_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    psllq $63, %xmm0
@@ -81,11 +81,12 @@ define i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX512VL-NEXT:    setb %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <2 x i64> %0 to <2 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp eq i2 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE2-LABEL: trunc_v4i32_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pslld $31, %xmm0
@@ -150,11 +151,12 @@ define i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX512VL-NEXT:    setb %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <4 x i32> %0 to <4 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE2-LABEL: trunc_v8i16_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    psllw $7, %xmm0
@@ -220,11 +222,12 @@ define i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX512VL-NEXT:    setb %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i16> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE2-LABEL: trunc_v16i8_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    psllw $7, %xmm0
@@ -289,11 +292,12 @@ define i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX512VL-NEXT:    setb %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <16 x i8> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE2-LABEL: trunc_v4i64_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    shufps {{.*#+}} xmm0 = xmm0[0,2],xmm1[0,2]
@@ -354,11 +358,12 @@ define i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <4 x i64> %0 to <4 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE2-LABEL: trunc_v8i32_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -420,11 +425,12 @@ define i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <8 x i32> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE2-LABEL: trunc_v16i16_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -487,11 +493,12 @@ define i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <16 x i16> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE2-LABEL: trunc_v32i8_v32i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -553,11 +560,12 @@ define i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <32 x i8> %0 to <32 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: trunc_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -663,11 +671,12 @@ define i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <8 x i64> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE2-LABEL: trunc_v16i32_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -762,11 +771,12 @@ define i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <16 x i32> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE2-LABEL: trunc_v32i16_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -885,11 +895,12 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <32 x i16> %0 to <32 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, -1
+  ret i1 %c
 }
 
-define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE2-LABEL: trunc_v64i8_v64i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1006,15 +1017,16 @@ define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <64 x i8> %0 to <64 x i1>
-  %b = call i1 @llvm.vector.reduce.and.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp eq i64 %b, -1
+  ret i1 %c
 }
 
 ;
 ; Comparison With Zero
 ;
 
-define i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE2-LABEL: icmp0_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm1, %xmm1
@@ -1035,12 +1047,13 @@ define i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <2 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <2 x i64> %0, zeroinitializer
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp eq i2 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE2-LABEL: icmp0_v4i32_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm1, %xmm1
@@ -1061,12 +1074,13 @@ define i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <4 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <4 x i32> %0, zeroinitializer
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE2-LABEL: icmp0_v8i16_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm1, %xmm1
@@ -1087,12 +1101,13 @@ define i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <8 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i16> %0, zeroinitializer
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE2-LABEL: icmp0_v16i8_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm1, %xmm1
@@ -1113,12 +1128,13 @@ define i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <16 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i8> %0, zeroinitializer
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE2-LABEL: icmp0_v4i64_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -1142,12 +1158,13 @@ define i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    vzeroupper
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <4 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <4 x i64> %0, zeroinitializer
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE2-LABEL: icmp0_v8i32_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -1171,12 +1188,13 @@ define i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    vzeroupper
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <8 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i32> %0, zeroinitializer
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE2-LABEL: icmp0_v16i16_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -1200,12 +1218,13 @@ define i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    vzeroupper
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <16 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i16> %0, zeroinitializer
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE2-LABEL: icmp0_v32i8_v32i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -1229,12 +1248,13 @@ define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    vzeroupper
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <32 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <32 x i8> %0, zeroinitializer
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp0_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1312,12 +1332,13 @@ define i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <8 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i64> %0, zeroinitializer
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE2-LABEL: icmp0_v16i32_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1395,12 +1416,13 @@ define i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <16 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i32> %0, zeroinitializer
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE2-LABEL: icmp0_v32i16_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1478,12 +1500,13 @@ define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <32 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <32 x i16> %0, zeroinitializer
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE2-LABEL: icmp0_v64i8_v64i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1561,70 +1584,100 @@ define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <64 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.and.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <64 x i8> %0, zeroinitializer
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp eq i64 %b, 0
+  ret i1 %c
 }
 
 define i8 @icmp0_v8i1(<8 x i8>) nounwind {
-; SSE2-LABEL: icmp0_v8i1:
-; SSE2:       # %bb.0:
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    psllw $15, %xmm0
-; SSE2-NEXT:    pmovmskb %xmm0, %eax
-; SSE2-NEXT:    testl $43690, %eax # imm = 0xAAAA
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    ret{{[l|q]}}
+; X86-SSE2-LABEL: icmp0_v8i1:
+; X86-SSE2:       # %bb.0:
+; X86-SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,1,1]
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    orl %eax, %ecx
+; X86-SSE2-NEXT:    sete %al
+; X86-SSE2-NEXT:    retl
 ;
-; SSE4-LABEL: icmp0_v8i1:
-; SSE4:       # %bb.0:
-; SSE4-NEXT:    pmovzxbw {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
-; SSE4-NEXT:    psllw $15, %xmm0
-; SSE4-NEXT:    pmovmskb %xmm0, %eax
-; SSE4-NEXT:    testl $43690, %eax # imm = 0xAAAA
-; SSE4-NEXT:    sete %al
-; SSE4-NEXT:    ret{{[l|q]}}
+; X64-SSE-LABEL: icmp0_v8i1:
+; X64-SSE:       # %bb.0:
+; X64-SSE-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; X64-SSE-NEXT:    movq %xmm0, %rax
+; X64-SSE-NEXT:    testq %rax, %rax
+; X64-SSE-NEXT:    sete %al
+; X64-SSE-NEXT:    retq
 ;
-; AVX1OR2-LABEL: icmp0_v8i1:
-; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpmovzxbw {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
-; AVX1OR2-NEXT:    vpsllw $15, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpmovmskb %xmm0, %eax
-; AVX1OR2-NEXT:    testl $43690, %eax # imm = 0xAAAA
-; AVX1OR2-NEXT:    sete %al
-; AVX1OR2-NEXT:    ret{{[l|q]}}
+; X86-SSE4-LABEL: icmp0_v8i1:
+; X86-SSE4:       # %bb.0:
+; X86-SSE4-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+; X86-SSE4-NEXT:    pextrd $1, %xmm0, %eax
+; X86-SSE4-NEXT:    movd %xmm0, %ecx
+; X86-SSE4-NEXT:    orl %eax, %ecx
+; X86-SSE4-NEXT:    sete %al
+; X86-SSE4-NEXT:    retl
+;
+; X86-AVX1-LABEL: icmp0_v8i1:
+; X86-AVX1:       # %bb.0:
+; X86-AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %eax
+; X86-AVX1-NEXT:    vmovd %xmm0, %ecx
+; X86-AVX1-NEXT:    orl %eax, %ecx
+; X86-AVX1-NEXT:    sete %al
+; X86-AVX1-NEXT:    retl
+;
+; X64-AVX1-LABEL: icmp0_v8i1:
+; X64-AVX1:       # %bb.0:
+; X64-AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    testq %rax, %rax
+; X64-AVX1-NEXT:    sete %al
+; X64-AVX1-NEXT:    retq
+;
+; X86-AVX2-LABEL: icmp0_v8i1:
+; X86-AVX2:       # %bb.0:
+; X86-AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %eax
+; X86-AVX2-NEXT:    vmovd %xmm0, %ecx
+; X86-AVX2-NEXT:    orl %eax, %ecx
+; X86-AVX2-NEXT:    sete %al
+; X86-AVX2-NEXT:    retl
+;
+; X64-AVX2-LABEL: icmp0_v8i1:
+; X64-AVX2:       # %bb.0:
+; X64-AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    testq %rax, %rax
+; X64-AVX2-NEXT:    sete %al
+; X64-AVX2-NEXT:    retq
 ;
 ; AVX512F-LABEL: icmp0_v8i1:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    testb %al, %al
+; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512F-NEXT:    vmovq %xmm0, %rax
+; AVX512F-NEXT:    testq %rax, %rax
 ; AVX512F-NEXT:    sete %al
-; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BW-LABEL: icmp0_v8i1:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX512BW-NEXT:    vpmovb2m %zmm0, %k0
-; AVX512BW-NEXT:    kmovd %k0, %eax
-; AVX512BW-NEXT:    testb %al, %al
+; AVX512BW-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512BW-NEXT:    vmovq %xmm0, %rax
+; AVX512BW-NEXT:    testq %rax, %rax
 ; AVX512BW-NEXT:    sete %al
-; AVX512BW-NEXT:    vzeroupper
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512VL-LABEL: icmp0_v8i1:
 ; AVX512VL:       # %bb.0:
-; AVX512VL-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX512VL-NEXT:    vpmovmskb %xmm0, %eax
-; AVX512VL-NEXT:    testb %al, %al
+; AVX512VL-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm0, %xmm0
+; AVX512VL-NEXT:    vmovq %xmm0, %rax
+; AVX512VL-NEXT:    testq %rax, %rax
 ; AVX512VL-NEXT:    sete %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i8> %0 to <8 x i1>
-  %b = icmp eq <8 x i1> %a, zeroinitializer
-  %c = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %b)
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
   %d = zext i1 %c to i8
   ret i8 %d
 }
@@ -1633,7 +1686,7 @@ define i8 @icmp0_v8i1(<8 x i8>) nounwind {
 ; Comparison With All Ones
 ;
 
-define i1 @icmp1_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @icmp1_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE2-LABEL: icmp1_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
@@ -1656,12 +1709,13 @@ define i1 @icmp1_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX-NEXT:    vptest %xmm1, %xmm0
 ; AVX-NEXT:    setb %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <2 x i64> %0, <i64 -1, i64 -1>
-  %b = call i1 @llvm.vector.reduce.and.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <2 x i64> %0, splat (i64 -1)
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp eq i2 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @icmp1_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE2-LABEL: icmp1_v4i32_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
@@ -1684,12 +1738,13 @@ define i1 @icmp1_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX-NEXT:    vptest %xmm1, %xmm0
 ; AVX-NEXT:    setb %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <4 x i32> %0, <i32 -1, i32 -1, i32 -1, i32 -1>
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <4 x i32> %0, splat (i32 -1)
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @icmp1_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE2-LABEL: icmp1_v8i16_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
@@ -1712,12 +1767,13 @@ define i1 @icmp1_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX-NEXT:    vptest %xmm1, %xmm0
 ; AVX-NEXT:    setb %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <8 x i16> %0, <i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1>
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i16> %0, splat (i16 -1)
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @icmp1_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE2-LABEL: icmp1_v16i8_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
@@ -1740,12 +1796,13 @@ define i1 @icmp1_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX-NEXT:    vptest %xmm1, %xmm0
 ; AVX-NEXT:    setb %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <16 x i8> %0, <i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1>
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i8> %0, splat (i8 -1)
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @icmp1_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE2-LABEL: icmp1_v4i64_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -1788,12 +1845,13 @@ define i1 @icmp1_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX512-NEXT:    setb %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <4 x i64> %0, <i64 -1, i64 -1, i64 -1, i64 -1>
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <4 x i64> %0, splat (i64 -1)
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @icmp1_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE2-LABEL: icmp1_v8i32_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -1836,12 +1894,13 @@ define i1 @icmp1_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX512-NEXT:    setb %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <8 x i32> %0, <i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1>
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i32> %0, splat (i32 -1)
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @icmp1_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE2-LABEL: icmp1_v16i16_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -1884,12 +1943,13 @@ define i1 @icmp1_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX512-NEXT:    setb %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <16 x i16> %0, <i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1>
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i16> %0, splat (i16 -1)
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @icmp1_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE2-LABEL: icmp1_v32i8_v32i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pand %xmm1, %xmm0
@@ -1932,12 +1992,13 @@ define i1 @icmp1_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX512-NEXT:    setb %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <32 x i8> %0, <i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1>
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <32 x i8> %0, splat (i8 -1)
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @icmp1_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp1_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2021,12 +2082,13 @@ define i1 @icmp1_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <8 x i64> %0, <i64 -1, i64 -1, i64 -1, i64 -1, i64 -1, i64 -1, i64 -1, i64 -1>
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i64> %0, splat (i64 -1)
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @icmp1_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE2-LABEL: icmp1_v16i32_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2110,12 +2172,13 @@ define i1 @icmp1_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <16 x i32> %0, <i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1, i32 -1>
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i32> %0, splat (i32 -1)
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @icmp1_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE2-LABEL: icmp1_v32i16_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2199,12 +2262,13 @@ define i1 @icmp1_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <32 x i16> %0, <i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1, i16 -1>
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <32 x i16> %0, splat (i16 -1)
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp1_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @icmp1_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE2-LABEL: icmp1_v64i8_v64i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2288,73 +2352,114 @@ define i1 @icmp1_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <64 x i8> %0, <i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1, i8 -1>
-  %b = call i1 @llvm.vector.reduce.and.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <64 x i8> %0, splat (i8 -1)
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp eq i64 %b, 0
+  ret i1 %c
 }
 
 define i8 @icmp1_v8i1(<8 x i8>) nounwind {
-; SSE2-LABEL: icmp1_v8i1:
-; SSE2:       # %bb.0:
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    psllw $15, %xmm0
-; SSE2-NEXT:    packsswb %xmm0, %xmm0
-; SSE2-NEXT:    pmovmskb %xmm0, %eax
-; SSE2-NEXT:    cmpb $-1, %al
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    ret{{[l|q]}}
+; X86-SSE2-LABEL: icmp1_v8i1:
+; X86-SSE2:       # %bb.0:
+; X86-SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    xorl $16843009, %eax # imm = 0x1010101
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,1,1]
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    xorl $16843009, %ecx # imm = 0x1010101
+; X86-SSE2-NEXT:    orl %eax, %ecx
+; X86-SSE2-NEXT:    sete %al
+; X86-SSE2-NEXT:    retl
 ;
-; SSE4-LABEL: icmp1_v8i1:
-; SSE4:       # %bb.0:
-; SSE4-NEXT:    pmovzxbw {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
-; SSE4-NEXT:    psllw $15, %xmm0
-; SSE4-NEXT:    packsswb %xmm0, %xmm0
-; SSE4-NEXT:    pmovmskb %xmm0, %eax
-; SSE4-NEXT:    cmpb $-1, %al
-; SSE4-NEXT:    sete %al
-; SSE4-NEXT:    ret{{[l|q]}}
+; X64-SSE-LABEL: icmp1_v8i1:
+; X64-SSE:       # %bb.0:
+; X64-SSE-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; X64-SSE-NEXT:    movq %xmm0, %rax
+; X64-SSE-NEXT:    movabsq $72340172838076673, %rcx # imm = 0x101010101010101
+; X64-SSE-NEXT:    cmpq %rcx, %rax
+; X64-SSE-NEXT:    sete %al
+; X64-SSE-NEXT:    retq
 ;
-; AVX1OR2-LABEL: icmp1_v8i1:
-; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpmovzxbw {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
-; AVX1OR2-NEXT:    vpsllw $15, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpacksswb %xmm0, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpmovmskb %xmm0, %eax
-; AVX1OR2-NEXT:    cmpb $-1, %al
-; AVX1OR2-NEXT:    sete %al
-; AVX1OR2-NEXT:    ret{{[l|q]}}
+; X86-SSE4-LABEL: icmp1_v8i1:
+; X86-SSE4:       # %bb.0:
+; X86-SSE4-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+; X86-SSE4-NEXT:    pextrd $1, %xmm0, %eax
+; X86-SSE4-NEXT:    xorl $16843009, %eax # imm = 0x1010101
+; X86-SSE4-NEXT:    movd %xmm0, %ecx
+; X86-SSE4-NEXT:    xorl $16843009, %ecx # imm = 0x1010101
+; X86-SSE4-NEXT:    orl %eax, %ecx
+; X86-SSE4-NEXT:    sete %al
+; X86-SSE4-NEXT:    retl
+;
+; X86-AVX1-LABEL: icmp1_v8i1:
+; X86-AVX1:       # %bb.0:
+; X86-AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %eax
+; X86-AVX1-NEXT:    xorl $16843009, %eax # imm = 0x1010101
+; X86-AVX1-NEXT:    vmovd %xmm0, %ecx
+; X86-AVX1-NEXT:    xorl $16843009, %ecx # imm = 0x1010101
+; X86-AVX1-NEXT:    orl %eax, %ecx
+; X86-AVX1-NEXT:    sete %al
+; X86-AVX1-NEXT:    retl
+;
+; X64-AVX1-LABEL: icmp1_v8i1:
+; X64-AVX1:       # %bb.0:
+; X64-AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    movabsq $72340172838076673, %rcx # imm = 0x101010101010101
+; X64-AVX1-NEXT:    cmpq %rcx, %rax
+; X64-AVX1-NEXT:    sete %al
+; X64-AVX1-NEXT:    retq
+;
+; X86-AVX2-LABEL: icmp1_v8i1:
+; X86-AVX2:       # %bb.0:
+; X86-AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %eax
+; X86-AVX2-NEXT:    xorl $16843009, %eax # imm = 0x1010101
+; X86-AVX2-NEXT:    vmovd %xmm0, %ecx
+; X86-AVX2-NEXT:    xorl $16843009, %ecx # imm = 0x1010101
+; X86-AVX2-NEXT:    orl %eax, %ecx
+; X86-AVX2-NEXT:    sete %al
+; X86-AVX2-NEXT:    retl
+;
+; X64-AVX2-LABEL: icmp1_v8i1:
+; X64-AVX2:       # %bb.0:
+; X64-AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    movabsq $72340172838076673, %rcx # imm = 0x101010101010101
+; X64-AVX2-NEXT:    cmpq %rcx, %rax
+; X64-AVX2-NEXT:    sete %al
+; X64-AVX2-NEXT:    retq
 ;
 ; AVX512F-LABEL: icmp1_v8i1:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    cmpb $-1, %al
+; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512F-NEXT:    vmovq %xmm0, %rax
+; AVX512F-NEXT:    movabsq $72340172838076673, %rcx # imm = 0x101010101010101
+; AVX512F-NEXT:    cmpq %rcx, %rax
 ; AVX512F-NEXT:    sete %al
-; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BW-LABEL: icmp1_v8i1:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX512BW-NEXT:    vpmovb2m %zmm0, %k0
-; AVX512BW-NEXT:    kmovd %k0, %eax
-; AVX512BW-NEXT:    cmpb $-1, %al
+; AVX512BW-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512BW-NEXT:    vmovq %xmm0, %rax
+; AVX512BW-NEXT:    movabsq $72340172838076673, %rcx # imm = 0x101010101010101
+; AVX512BW-NEXT:    cmpq %rcx, %rax
 ; AVX512BW-NEXT:    sete %al
-; AVX512BW-NEXT:    vzeroupper
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512VL-LABEL: icmp1_v8i1:
 ; AVX512VL:       # %bb.0:
-; AVX512VL-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX512VL-NEXT:    vpmovmskb %xmm0, %eax
-; AVX512VL-NEXT:    cmpb $-1, %al
+; AVX512VL-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm0, %xmm0
+; AVX512VL-NEXT:    vmovq %xmm0, %rax
+; AVX512VL-NEXT:    movabsq $72340172838076673, %rcx # imm = 0x101010101010101
+; AVX512VL-NEXT:    cmpq %rcx, %rax
 ; AVX512VL-NEXT:    sete %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i8> %0 to <8 x i1>
-  %b = icmp eq <8 x i1> %a, <i1 -1, i1 -1, i1 -1, i1 -1, i1 -1, i1 -1, i1 -1, i1 -1>
-  %c = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %b)
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, -1
   %d = zext i1 %c to i8
   ret i8 %d
 }
@@ -2363,7 +2468,7 @@ define i8 @icmp1_v8i1(<8 x i8>) nounwind {
 ; Comparison
 ;
 
-define i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
+define zeroext i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
 ; SSE2-LABEL: icmp_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm0
@@ -2385,12 +2490,13 @@ define i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <2 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <2 x i64> %0, %1
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp eq i2 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
+define zeroext i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
 ; SSE2-LABEL: icmp_v4i32_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm0
@@ -2412,12 +2518,13 @@ define i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <4 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <4 x i32> %0, %1
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
+define zeroext i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
 ; SSE2-LABEL: icmp_v8i16_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqb %xmm1, %xmm0
@@ -2439,12 +2546,13 @@ define i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <8 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i16> %0, %1
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
+define zeroext i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
 ; SSE2-LABEL: icmp_v16i8_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqb %xmm1, %xmm0
@@ -2466,12 +2574,13 @@ define i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
 ; AVX-NEXT:    vptest %xmm0, %xmm0
 ; AVX-NEXT:    sete %al
 ; AVX-NEXT:    ret{{[l|q]}}
-  %a = icmp eq <16 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i8> %0, %1
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
+define zeroext i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp_v4i64_v4i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2545,12 +2654,13 @@ define i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <4 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <4 x i64> %0, %1
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp eq i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
+define zeroext i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
 ; X86-SSE2-LABEL: icmp_v8i32_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2624,12 +2734,13 @@ define i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <8 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i32> %0, %1
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
+define zeroext i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
 ; X86-SSE2-LABEL: icmp_v16i16_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2703,12 +2814,13 @@ define i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <16 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i16> %0, %1
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
+define zeroext i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; X86-SSE2-LABEL: icmp_v32i8_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2782,12 +2894,13 @@ define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <32 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <32 x i8> %0, %1
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
+define zeroext i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2915,12 +3028,13 @@ define i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <8 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <8 x i64> %0, %1
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp eq i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
+define zeroext i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
 ; X86-SSE2-LABEL: icmp_v16i32_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -3048,12 +3162,13 @@ define i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <16 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <16 x i32> %0, %1
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp eq i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
+define zeroext i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; X86-SSE2-LABEL: icmp_v32i16_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -3181,12 +3296,13 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <32 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <32 x i16> %0, %1
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp eq i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
+define zeroext i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; X86-SSE2-LABEL: icmp_v64i8_v64i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -3314,18 +3430,13 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; AVX512-NEXT:    sete %al
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
-  %a = icmp eq <64 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.and.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %a = icmp ne <64 x i8> %0, %1
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp eq i64 %b, 0
+  ret i1 %c
 }
 
-declare i1 @llvm.vector.reduce.and.v2i1(<2 x i1>)
-declare i1 @llvm.vector.reduce.and.v4i1(<4 x i1>)
-declare i1 @llvm.vector.reduce.and.v8i1(<8 x i1>)
-declare i1 @llvm.vector.reduce.and.v16i1(<16 x i1>)
-declare i1 @llvm.vector.reduce.and.v32i1(<32 x i1>)
-declare i1 @llvm.vector.reduce.and.v64i1(<64 x i1>)
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
+; AVX1OR2: {{.*}}
 ; SSE: {{.*}}
-; X64-SSE: {{.*}}
 ; X86-SSE: {{.*}}

--- a/llvm/test/CodeGen/X86/vector-reduce-or-bool.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-or-bool.ll
@@ -17,7 +17,7 @@
 ; Truncate
 ;
 
-define i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE2-LABEL: trunc_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    psllq $63, %xmm0
@@ -81,11 +81,12 @@ define i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <2 x i64> %0 to <2 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp ne i2 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE2-LABEL: trunc_v4i32_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pslld $31, %xmm0
@@ -150,11 +151,12 @@ define i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <4 x i32> %0 to <4 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp ne i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE2-LABEL: trunc_v8i16_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    psllw $7, %xmm0
@@ -219,11 +221,12 @@ define i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i16> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE2-LABEL: trunc_v16i8_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    psllw $7, %xmm0
@@ -288,11 +291,12 @@ define i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <16 x i8> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE2-LABEL: trunc_v4i64_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    shufps {{.*#+}} xmm0 = xmm0[0,2],xmm1[0,2]
@@ -353,11 +357,12 @@ define i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <4 x i64> %0 to <4 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp ne i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE2-LABEL: trunc_v8i32_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -419,11 +424,12 @@ define i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <8 x i32> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE2-LABEL: trunc_v16i16_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -485,11 +491,12 @@ define i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <16 x i16> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE2-LABEL: trunc_v32i8_v32i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    por %xmm1, %xmm0
@@ -551,11 +558,12 @@ define i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <32 x i8> %0 to <32 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp ne i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: trunc_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -658,11 +666,12 @@ define i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <8 x i64> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE2-LABEL: trunc_v16i32_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -757,11 +766,12 @@ define i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <16 x i32> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE2-LABEL: trunc_v32i16_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -856,11 +866,12 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <32 x i16> %0 to <32 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp ne i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE2-LABEL: trunc_v64i8_v64i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -955,15 +966,16 @@ define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = trunc <64 x i8> %0 to <64 x i1>
-  %b = call i1 @llvm.vector.reduce.or.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp ne i64 %b, 0
+  ret i1 %c
 }
 
 ;
 ; Comparison With Zero
 ;
 
-define i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE2-LABEL: icmp0_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm1, %xmm1
@@ -1019,11 +1031,12 @@ define i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <2 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp ne i2 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE-LABEL: icmp0_v4i32_v4i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm1, %xmm1
@@ -1068,11 +1081,12 @@ define i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <4 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp ne i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE-LABEL: icmp0_v8i16_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm1, %xmm1
@@ -1119,11 +1133,12 @@ define i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE-LABEL: icmp0_v16i8_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm1, %xmm1
@@ -1167,11 +1182,12 @@ define i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE2-LABEL: icmp0_v4i64_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm2, %xmm2
@@ -1246,11 +1262,12 @@ define i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <4 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp ne i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE-LABEL: icmp0_v8i32_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm2, %xmm2
@@ -1311,11 +1328,12 @@ define i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE-LABEL: icmp0_v16i16_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm2, %xmm2
@@ -1378,11 +1396,12 @@ define i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE-LABEL: icmp0_v32i8_v32i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm2, %xmm2
@@ -1444,11 +1463,12 @@ define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <32 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp ne i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp0_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1591,11 +1611,12 @@ define i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE-LABEL: icmp0_v16i32_v16i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -1670,11 +1691,12 @@ define i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = icmp eq <16 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE-LABEL: icmp0_v32i16_v32i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -1771,11 +1793,12 @@ define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <32 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp ne i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE-LABEL: icmp0_v64i8_v64i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -1871,14 +1894,16 @@ define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <64 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.or.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp ne i64 %b, 0
+  ret i1 %c
 }
 
+;
 ; Comparison
 ;
 
-define i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
+define zeroext i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
 ; SSE2-LABEL: icmp_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm0
@@ -1933,11 +1958,12 @@ define i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <2 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %b = bitcast <2 x i1> %a to i2
+  %c = icmp ne i2 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
+define zeroext i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
 ; SSE-LABEL: icmp_v4i32_v4i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pcmpeqd %xmm1, %xmm0
@@ -1982,11 +2008,12 @@ define i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <4 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp ne i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
+define zeroext i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
 ; SSE-LABEL: icmp_v8i16_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pcmpeqw %xmm1, %xmm0
@@ -2031,11 +2058,12 @@ define i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
+define zeroext i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
 ; SSE-LABEL: icmp_v16i8_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pcmpeqb %xmm1, %xmm0
@@ -2077,11 +2105,12 @@ define i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
 ; AVX512VL-NEXT:    setne %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
+define zeroext i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp_v4i64_v4i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2190,11 +2219,12 @@ define i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <4 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = icmp ne i4 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
+define zeroext i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
 ; X86-SSE-LABEL: icmp_v8i32_v8i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2271,11 +2301,12 @@ define i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
+define zeroext i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
 ; X86-SSE-LABEL: icmp_v16i16_v16i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2352,11 +2383,12 @@ define i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
+define zeroext i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; X86-SSE-LABEL: icmp_v32i8_v32i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2432,11 +2464,12 @@ define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <32 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp ne i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
+define zeroext i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2616,11 +2649,12 @@ define i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = icmp ne i8 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
+define zeroext i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
 ; X86-SSE-LABEL: icmp_v16i32_v16i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2735,11 +2769,12 @@ define i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %a = icmp eq <16 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = icmp ne i16 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
+define zeroext i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; X86-SSE-LABEL: icmp_v32i16_v32i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2876,11 +2911,12 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <32 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = icmp ne i32 %b, 0
+  ret i1 %c
 }
 
-define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
+define zeroext i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; X86-SSE-LABEL: icmp_v64i8_v64i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -3016,15 +3052,10 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <64 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.or.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %b = bitcast <64 x i1> %a to i64
+  %c = icmp ne i64 %b, 0
+  ret i1 %c
 }
 
-declare i1 @llvm.vector.reduce.or.v2i1(<2 x i1>)
-declare i1 @llvm.vector.reduce.or.v4i1(<4 x i1>)
-declare i1 @llvm.vector.reduce.or.v8i1(<8 x i1>)
-declare i1 @llvm.vector.reduce.or.v16i1(<16 x i1>)
-declare i1 @llvm.vector.reduce.or.v32i1(<32 x i1>)
-declare i1 @llvm.vector.reduce.or.v64i1(<64 x i1>)
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
 ; AVX: {{.*}}

--- a/llvm/test/CodeGen/X86/vector-reduce-xor-bool.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-xor-bool.ll
@@ -17,7 +17,7 @@
 ; Truncate
 ;
 
-define i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE-LABEL: trunc_v2i64_v2i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    psllq $63, %xmm0
@@ -62,11 +62,13 @@ define i1 @trunc_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <2 x i64> %0 to <2 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %b = bitcast <2 x i1> %a to i2
+  %c = call i2 @llvm.ctpop.i2(i2 %b)
+  %d = trunc i2 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE-LABEL: trunc_v4i32_v4i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pslld $31, %xmm0
@@ -111,11 +113,13 @@ define i1 @trunc_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <4 x i32> %0 to <4 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = call i4 @llvm.ctpop.i4(i4 %b)
+  %d = trunc i4 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE-LABEL: trunc_v8i16_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    psllw $15, %xmm0
@@ -164,11 +168,13 @@ define i1 @trunc_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i16> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE-LABEL: trunc_v16i8_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    psllw $7, %xmm0
@@ -185,11 +191,13 @@ define i1 @trunc_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX-NEXT:    setnp %al
 ; AVX-NEXT:    ret{{[l|q]}}
   %a = trunc <16 x i8> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE-LABEL: trunc_v4i64_v4i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    shufps {{.*#+}} xmm0 = xmm0[0,2],xmm1[0,2]
@@ -248,11 +256,13 @@ define i1 @trunc_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <4 x i64> %0 to <4 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = call i4 @llvm.ctpop.i4(i4 %b)
+  %d = trunc i4 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE2-LABEL: trunc_v8i32_v8i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pslld $16, %xmm1
@@ -330,11 +340,13 @@ define i1 @trunc_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i32> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE2-LABEL: trunc_v16i16_v16i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
@@ -444,26 +456,38 @@ define i1 @trunc_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <16 x i16> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE-LABEL: trunc_v32i8_v32i1:
 ; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm0
 ; SSE-NEXT:    psllw $7, %xmm0
-; SSE-NEXT:    pmovmskb %xmm0, %eax
+; SSE-NEXT:    pmovmskb %xmm0, %ecx
+; SSE-NEXT:    psllw $7, %xmm1
+; SSE-NEXT:    pmovmskb %xmm1, %edx
+; SSE-NEXT:    movl %edx, %eax
+; SSE-NEXT:    shll $16, %eax
+; SSE-NEXT:    orl %ecx, %eax
+; SSE-NEXT:    xorl %edx, %eax
 ; SSE-NEXT:    xorb %ah, %al
 ; SSE-NEXT:    setnp %al
 ; SSE-NEXT:    ret{{[l|q]}}
 ;
 ; AVX1-LABEL: trunc_v32i8_v32i1:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX1-NEXT:    vpsllw $7, %xmm0, %xmm1
+; AVX1-NEXT:    vpmovmskb %xmm1, %ecx
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
 ; AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; AVX1-NEXT:    movl %edx, %eax
+; AVX1-NEXT:    shll $16, %eax
+; AVX1-NEXT:    orl %ecx, %eax
+; AVX1-NEXT:    xorl %edx, %eax
 ; AVX1-NEXT:    xorb %ah, %al
 ; AVX1-NEXT:    setnp %al
 ; AVX1-NEXT:    vzeroupper
@@ -481,55 +505,25 @@ define i1 @trunc_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX2-NEXT:    vzeroupper
 ; AVX2-NEXT:    ret{{[l|q]}}
 ;
-; AVX512F-LABEL: trunc_v32i8_v32i1:
-; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vextracti128 $1, %ymm0, %xmm1
-; AVX512F-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
-; AVX512F-NEXT:    vzeroupper
-; AVX512F-NEXT:    retq
-;
-; AVX512BW-LABEL: trunc_v32i8_v32i1:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsllw $7, %ymm0, %ymm0
-; AVX512BW-NEXT:    vpmovmskb %ymm0, %eax
-; AVX512BW-NEXT:    movl %eax, %ecx
-; AVX512BW-NEXT:    shrl $16, %ecx
-; AVX512BW-NEXT:    xorl %eax, %ecx
-; AVX512BW-NEXT:    xorb %ch, %cl
-; AVX512BW-NEXT:    setnp %al
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
-;
-; AVX512VL-LABEL: trunc_v32i8_v32i1:
-; AVX512VL:       # %bb.0:
-; AVX512VL-NEXT:    vpsllw $7, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpmovmskb %ymm0, %eax
-; AVX512VL-NEXT:    movl %eax, %ecx
-; AVX512VL-NEXT:    shrl $16, %ecx
-; AVX512VL-NEXT:    xorl %eax, %ecx
-; AVX512VL-NEXT:    xorb %ch, %cl
-; AVX512VL-NEXT:    setnp %al
-; AVX512VL-NEXT:    vzeroupper
-; AVX512VL-NEXT:    retq
+; AVX512-LABEL: trunc_v32i8_v32i1:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vpsllw $7, %ymm0, %ymm0
+; AVX512-NEXT:    vpmovmskb %ymm0, %eax
+; AVX512-NEXT:    movl %eax, %ecx
+; AVX512-NEXT:    shrl $16, %ecx
+; AVX512-NEXT:    xorl %eax, %ecx
+; AVX512-NEXT:    xorb %ch, %cl
+; AVX512-NEXT:    setnp %al
+; AVX512-NEXT:    vzeroupper
+; AVX512-NEXT:    retq
   %a = trunc <32 x i8> %0 to <32 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = call i32 @llvm.ctpop.i32(i32 %b)
+  %d = trunc i32 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: trunc_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -664,11 +658,13 @@ define i1 @trunc_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <8 x i64> %0 to <8 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE2-LABEL: trunc_v16i32_v16i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -814,27 +810,34 @@ define i1 @trunc_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <16 x i32> %0 to <16 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE2-LABEL: trunc_v32i16_v32i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $16, %esp
-; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [255,255,255,255,255,255,255,255]
+; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    packuswb %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm2
 ; X86-SSE2-NEXT:    pand 8(%ebp), %xmm3
 ; X86-SSE2-NEXT:    packuswb %xmm3, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
+; X86-SSE2-NEXT:    psllw $7, %xmm0
+; X86-SSE2-NEXT:    pmovmskb %xmm0, %ecx
 ; X86-SSE2-NEXT:    psllw $7, %xmm2
-; X86-SSE2-NEXT:    pmovmskb %xmm2, %eax
+; X86-SSE2-NEXT:    pmovmskb %xmm2, %edx
+; X86-SSE2-NEXT:    movl %edx, %eax
+; X86-SSE2-NEXT:    shll $16, %eax
+; X86-SSE2-NEXT:    orl %ecx, %eax
+; X86-SSE2-NEXT:    xorl %edx, %eax
 ; X86-SSE2-NEXT:    xorb %ah, %al
 ; X86-SSE2-NEXT:    setnp %al
 ; X86-SSE2-NEXT:    movl %ebp, %esp
@@ -843,16 +846,21 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ;
 ; X64-SSE2-LABEL: trunc_v32i16_v32i1:
 ; X64-SSE2:       # %bb.0:
-; X64-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [255,255,255,255,255,255,255,255]
+; X64-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
 ; X64-SSE2-NEXT:    pand %xmm4, %xmm3
 ; X64-SSE2-NEXT:    pand %xmm4, %xmm2
 ; X64-SSE2-NEXT:    packuswb %xmm3, %xmm2
 ; X64-SSE2-NEXT:    pand %xmm4, %xmm1
 ; X64-SSE2-NEXT:    pand %xmm4, %xmm0
 ; X64-SSE2-NEXT:    packuswb %xmm1, %xmm0
-; X64-SSE2-NEXT:    pxor %xmm2, %xmm0
 ; X64-SSE2-NEXT:    psllw $7, %xmm0
-; X64-SSE2-NEXT:    pmovmskb %xmm0, %eax
+; X64-SSE2-NEXT:    pmovmskb %xmm0, %ecx
+; X64-SSE2-NEXT:    psllw $7, %xmm2
+; X64-SSE2-NEXT:    pmovmskb %xmm2, %edx
+; X64-SSE2-NEXT:    movl %edx, %eax
+; X64-SSE2-NEXT:    shll $16, %eax
+; X64-SSE2-NEXT:    orl %ecx, %eax
+; X64-SSE2-NEXT:    xorl %edx, %eax
 ; X64-SSE2-NEXT:    xorb %ah, %al
 ; X64-SSE2-NEXT:    setnp %al
 ; X64-SSE2-NEXT:    retq
@@ -870,9 +878,14 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE4-NEXT:    pand %xmm3, %xmm2
 ; X86-SSE4-NEXT:    pand 8(%ebp), %xmm3
 ; X86-SSE4-NEXT:    packuswb %xmm3, %xmm2
-; X86-SSE4-NEXT:    pxor %xmm0, %xmm2
+; X86-SSE4-NEXT:    psllw $7, %xmm0
+; X86-SSE4-NEXT:    pmovmskb %xmm0, %ecx
 ; X86-SSE4-NEXT:    psllw $7, %xmm2
-; X86-SSE4-NEXT:    pmovmskb %xmm2, %eax
+; X86-SSE4-NEXT:    pmovmskb %xmm2, %edx
+; X86-SSE4-NEXT:    movl %edx, %eax
+; X86-SSE4-NEXT:    shll $16, %eax
+; X86-SSE4-NEXT:    orl %ecx, %eax
+; X86-SSE4-NEXT:    xorl %edx, %eax
 ; X86-SSE4-NEXT:    xorb %ah, %al
 ; X86-SSE4-NEXT:    setnp %al
 ; X86-SSE4-NEXT:    movl %ebp, %esp
@@ -888,38 +901,39 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; X64-SSE4-NEXT:    pand %xmm4, %xmm1
 ; X64-SSE4-NEXT:    pand %xmm4, %xmm0
 ; X64-SSE4-NEXT:    packuswb %xmm1, %xmm0
-; X64-SSE4-NEXT:    pxor %xmm2, %xmm0
 ; X64-SSE4-NEXT:    psllw $7, %xmm0
-; X64-SSE4-NEXT:    pmovmskb %xmm0, %eax
+; X64-SSE4-NEXT:    pmovmskb %xmm0, %ecx
+; X64-SSE4-NEXT:    psllw $7, %xmm2
+; X64-SSE4-NEXT:    pmovmskb %xmm2, %edx
+; X64-SSE4-NEXT:    movl %edx, %eax
+; X64-SSE4-NEXT:    shll $16, %eax
+; X64-SSE4-NEXT:    orl %ecx, %eax
+; X64-SSE4-NEXT:    xorl %edx, %eax
 ; X64-SSE4-NEXT:    xorb %ah, %al
 ; X64-SSE4-NEXT:    setnp %al
 ; X64-SSE4-NEXT:    retq
 ;
-; X86-AVX1-LABEL: trunc_v32i16_v32i1:
-; X86-AVX1:       # %bb.0:
-; X86-AVX1-NEXT:    vxorps %ymm1, %ymm0, %ymm0
-; X86-AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}, %ymm0, %ymm0
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; X86-AVX1-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vpmovmskb %xmm0, %eax
-; X86-AVX1-NEXT:    xorb %ah, %al
-; X86-AVX1-NEXT:    setnp %al
-; X86-AVX1-NEXT:    vzeroupper
-; X86-AVX1-NEXT:    retl
-;
-; X64-AVX1-LABEL: trunc_v32i16_v32i1:
-; X64-AVX1:       # %bb.0:
-; X64-AVX1-NEXT:    vxorps %ymm1, %ymm0, %ymm0
-; X64-AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
-; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; X64-AVX1-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vpmovmskb %xmm0, %eax
-; X64-AVX1-NEXT:    xorb %ah, %al
-; X64-AVX1-NEXT:    setnp %al
-; X64-AVX1-NEXT:    vzeroupper
-; X64-AVX1-NEXT:    retq
+; AVX1-LABEL: trunc_v32i16_v32i1:
+; AVX1:       # %bb.0:
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
+; AVX1-NEXT:    vandps %ymm2, %ymm1, %ymm1
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm3
+; AVX1-NEXT:    vpackuswb %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm2
+; AVX1-NEXT:    vpackuswb %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
+; AVX1-NEXT:    vpmovmskb %xmm0, %ecx
+; AVX1-NEXT:    vpsllw $7, %xmm1, %xmm0
+; AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; AVX1-NEXT:    movl %edx, %eax
+; AVX1-NEXT:    shll $16, %eax
+; AVX1-NEXT:    orl %ecx, %eax
+; AVX1-NEXT:    xorl %edx, %eax
+; AVX1-NEXT:    xorb %ah, %al
+; AVX1-NEXT:    setnp %al
+; AVX1-NEXT:    vzeroupper
+; AVX1-NEXT:    ret{{[l|q]}}
 ;
 ; AVX2-LABEL: trunc_v32i16_v32i1:
 ; AVX2:       # %bb.0:
@@ -940,21 +954,21 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ;
 ; AVX512F-LABEL: trunc_v32i16_v32i1:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmovsxwd %ymm0, %zmm1
+; AVX512F-NEXT:    vpslld $31, %zmm1, %zmm1
+; AVX512F-NEXT:    vptestmd %zmm1, %zmm1, %k0
+; AVX512F-NEXT:    kmovw %k0, %ecx
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
 ; AVX512F-NEXT:    vpmovsxwd %ymm0, %zmm0
 ; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
 ; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
 ; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    kmovw %k0, %edx
+; AVX512F-NEXT:    shll $16, %edx
+; AVX512F-NEXT:    orl %ecx, %edx
+; AVX512F-NEXT:    xorl %edx, %eax
+; AVX512F-NEXT:    xorb %ah, %al
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -984,22 +998,36 @@ define i1 @trunc_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <32 x i16> %0 to <32 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = call i32 @llvm.ctpop.i32(i32 %b)
+  %d = trunc i32 %c to i1
+  ret i1 %d
 }
 
-define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE-LABEL: trunc_v64i8_v64i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
 ; X86-SSE-NEXT:    movl %esp, %ebp
 ; X86-SSE-NEXT:    andl $-16, %esp
 ; X86-SSE-NEXT:    subl $16, %esp
-; X86-SSE-NEXT:    pxor %xmm2, %xmm0
-; X86-SSE-NEXT:    pxor 8(%ebp), %xmm1
-; X86-SSE-NEXT:    pxor %xmm0, %xmm1
+; X86-SSE-NEXT:    movdqa 8(%ebp), %xmm3
+; X86-SSE-NEXT:    psllw $7, %xmm2
+; X86-SSE-NEXT:    pmovmskb %xmm2, %ecx
+; X86-SSE-NEXT:    psllw $7, %xmm3
+; X86-SSE-NEXT:    pmovmskb %xmm3, %eax
+; X86-SSE-NEXT:    shll $16, %eax
+; X86-SSE-NEXT:    orl %ecx, %eax
+; X86-SSE-NEXT:    psllw $7, %xmm0
+; X86-SSE-NEXT:    pmovmskb %xmm0, %ecx
 ; X86-SSE-NEXT:    psllw $7, %xmm1
-; X86-SSE-NEXT:    pmovmskb %xmm1, %eax
+; X86-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X86-SSE-NEXT:    shll $16, %edx
+; X86-SSE-NEXT:    orl %ecx, %edx
+; X86-SSE-NEXT:    xorl %eax, %edx
+; X86-SSE-NEXT:    movl %edx, %eax
+; X86-SSE-NEXT:    shrl $16, %eax
+; X86-SSE-NEXT:    xorl %edx, %eax
 ; X86-SSE-NEXT:    xorb %ah, %al
 ; X86-SSE-NEXT:    setnp %al
 ; X86-SSE-NEXT:    movl %ebp, %esp
@@ -1008,26 +1036,75 @@ define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ;
 ; X64-SSE-LABEL: trunc_v64i8_v64i1:
 ; X64-SSE:       # %bb.0:
-; X64-SSE-NEXT:    pxor %xmm3, %xmm1
-; X64-SSE-NEXT:    pxor %xmm2, %xmm0
-; X64-SSE-NEXT:    pxor %xmm1, %xmm0
+; X64-SSE-NEXT:    psllw $7, %xmm2
+; X64-SSE-NEXT:    pmovmskb %xmm2, %eax
+; X64-SSE-NEXT:    psllw $7, %xmm3
+; X64-SSE-NEXT:    pmovmskb %xmm3, %ecx
+; X64-SSE-NEXT:    shll $16, %ecx
+; X64-SSE-NEXT:    orl %eax, %ecx
 ; X64-SSE-NEXT:    psllw $7, %xmm0
 ; X64-SSE-NEXT:    pmovmskb %xmm0, %eax
+; X64-SSE-NEXT:    psllw $7, %xmm1
+; X64-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X64-SSE-NEXT:    shll $16, %edx
+; X64-SSE-NEXT:    orl %eax, %edx
+; X64-SSE-NEXT:    xorl %ecx, %edx
+; X64-SSE-NEXT:    movl %edx, %eax
+; X64-SSE-NEXT:    shrl $16, %eax
+; X64-SSE-NEXT:    xorl %edx, %eax
 ; X64-SSE-NEXT:    xorb %ah, %al
 ; X64-SSE-NEXT:    setnp %al
 ; X64-SSE-NEXT:    retq
 ;
-; AVX1-LABEL: trunc_v64i8_v64i1:
-; AVX1:       # %bb.0:
-; AVX1-NEXT:    vxorps %ymm1, %ymm0, %ymm0
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vxorps %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX1-NEXT:    vpmovmskb %xmm0, %eax
-; AVX1-NEXT:    xorb %ah, %al
-; AVX1-NEXT:    setnp %al
-; AVX1-NEXT:    vzeroupper
-; AVX1-NEXT:    ret{{[l|q]}}
+; X86-AVX1-LABEL: trunc_v64i8_v64i1:
+; X86-AVX1:       # %bb.0:
+; X86-AVX1-NEXT:    vpsllw $7, %xmm1, %xmm2
+; X86-AVX1-NEXT:    vpmovmskb %xmm2, %ecx
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X86-AVX1-NEXT:    vpsllw $7, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vpmovmskb %xmm1, %eax
+; X86-AVX1-NEXT:    shll $16, %eax
+; X86-AVX1-NEXT:    orl %ecx, %eax
+; X86-AVX1-NEXT:    vpsllw $7, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vpmovmskb %xmm1, %ecx
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X86-AVX1-NEXT:    shll $16, %edx
+; X86-AVX1-NEXT:    orl %ecx, %edx
+; X86-AVX1-NEXT:    xorl %eax, %edx
+; X86-AVX1-NEXT:    movl %edx, %eax
+; X86-AVX1-NEXT:    shrl $16, %eax
+; X86-AVX1-NEXT:    xorl %edx, %eax
+; X86-AVX1-NEXT:    xorb %ah, %al
+; X86-AVX1-NEXT:    setnp %al
+; X86-AVX1-NEXT:    vzeroupper
+; X86-AVX1-NEXT:    retl
+;
+; X64-AVX1-LABEL: trunc_v64i8_v64i1:
+; X64-AVX1:       # %bb.0:
+; X64-AVX1-NEXT:    vpsllw $7, %xmm1, %xmm2
+; X64-AVX1-NEXT:    vpmovmskb %xmm2, %eax
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X64-AVX1-NEXT:    vpsllw $7, %xmm1, %xmm1
+; X64-AVX1-NEXT:    vpmovmskb %xmm1, %ecx
+; X64-AVX1-NEXT:    shll $16, %ecx
+; X64-AVX1-NEXT:    orl %eax, %ecx
+; X64-AVX1-NEXT:    vpsllw $7, %xmm0, %xmm1
+; X64-AVX1-NEXT:    vpmovmskb %xmm1, %eax
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X64-AVX1-NEXT:    vpsllw $7, %xmm0, %xmm0
+; X64-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X64-AVX1-NEXT:    shll $16, %edx
+; X64-AVX1-NEXT:    orl %eax, %edx
+; X64-AVX1-NEXT:    xorl %ecx, %edx
+; X64-AVX1-NEXT:    movl %edx, %eax
+; X64-AVX1-NEXT:    shrl $16, %eax
+; X64-AVX1-NEXT:    xorl %edx, %eax
+; X64-AVX1-NEXT:    xorb %ah, %al
+; X64-AVX1-NEXT:    setnp %al
+; X64-AVX1-NEXT:    vzeroupper
+; X64-AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: trunc_v64i8_v64i1:
 ; AVX2:       # %bb.0:
@@ -1045,24 +1122,14 @@ define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512F-LABEL: trunc_v64i8_v64i1:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vextracti128 $1, %ymm1, %xmm2
-; AVX512F-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; AVX512F-NEXT:    vpxor %xmm2, %xmm3, %xmm2
-; AVX512F-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX512F-NEXT:    vpxor %xmm2, %xmm0, %xmm0
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512F-NEXT:    vpsllw $7, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmovmskb %ymm0, %eax
+; AVX512F-NEXT:    movl %eax, %ecx
+; AVX512F-NEXT:    shrl $16, %ecx
+; AVX512F-NEXT:    xorl %eax, %ecx
+; AVX512F-NEXT:    xorb %ch, %cl
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -1098,15 +1165,13 @@ define i1 @trunc_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = trunc <64 x i8> %0 to <64 x i1>
-  %b = call i1 @llvm.vector.reduce.xor.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %b = bitcast <64 x i1> %a to i64
+  %c = call i64 @llvm.ctpop.i64(i64 %b)
+  %d = trunc i64 %c to i1
+  ret i1 %d
 }
 
-;
-; Comparison With Zero
-;
-
-define i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
+define zeroext i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
 ; SSE2-LABEL: icmp0_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm1, %xmm1
@@ -1164,11 +1229,13 @@ define i1 @icmp0_v2i64_v2i1(<2 x i64>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <2 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %b = bitcast <2 x i1> %a to i2
+  %c = call i2 @llvm.ctpop.i2(i2 %b)
+  %d = trunc i2 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
+define zeroext i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
 ; SSE-LABEL: icmp0_v4i32_v4i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm1, %xmm1
@@ -1215,11 +1282,13 @@ define i1 @icmp0_v4i32_v4i1(<4 x i32>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <4 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = call i4 @llvm.ctpop.i4(i4 %b)
+  %d = trunc i4 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
+define zeroext i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
 ; SSE-LABEL: icmp0_v8i16_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm1, %xmm1
@@ -1270,11 +1339,13 @@ define i1 @icmp0_v8i16_v8i1(<8 x i16>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
+define zeroext i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
 ; SSE-LABEL: icmp0_v16i8_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm1, %xmm1
@@ -1324,11 +1395,13 @@ define i1 @icmp0_v16i8_v16i1(<16 x i8>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
+define zeroext i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
 ; SSE2-LABEL: icmp0_v4i64_v4i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pxor %xmm2, %xmm2
@@ -1406,11 +1479,13 @@ define i1 @icmp0_v4i64_v4i1(<4 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <4 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %b = bitcast <4 x i1> %a to i4
+  %c = call i4 @llvm.ctpop.i4(i4 %b)
+  %d = trunc i4 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
+define zeroext i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
 ; SSE-LABEL: icmp0_v8i32_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm2, %xmm2
@@ -1475,11 +1550,13 @@ define i1 @icmp0_v8i32_v8i1(<8 x i32>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
+define zeroext i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
 ; SSE-LABEL: icmp0_v16i16_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm2, %xmm2
@@ -1553,30 +1630,40 @@ define i1 @icmp0_v16i16_v16i1(<16 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
+define zeroext i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; SSE-LABEL: icmp0_v32i8_v32i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pxor %xmm2, %xmm2
-; SSE-NEXT:    pcmpeqb %xmm2, %xmm1
 ; SSE-NEXT:    pcmpeqb %xmm2, %xmm0
-; SSE-NEXT:    pxor %xmm1, %xmm0
-; SSE-NEXT:    pmovmskb %xmm0, %eax
+; SSE-NEXT:    pmovmskb %xmm0, %ecx
+; SSE-NEXT:    pcmpeqb %xmm2, %xmm1
+; SSE-NEXT:    pmovmskb %xmm1, %edx
+; SSE-NEXT:    movl %edx, %eax
+; SSE-NEXT:    shll $16, %eax
+; SSE-NEXT:    orl %ecx, %eax
+; SSE-NEXT:    xorl %edx, %eax
 ; SSE-NEXT:    xorb %ah, %al
 ; SSE-NEXT:    setnp %al
 ; SSE-NEXT:    ret{{[l|q]}}
 ;
 ; AVX1-LABEL: icmp0_v32i8_v32i1:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; AVX1-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; AVX1-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
+; AVX1-NEXT:    vpmovmskb %xmm2, %ecx
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; AVX1-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; AVX1-NEXT:    movl %edx, %eax
+; AVX1-NEXT:    shll $16, %eax
+; AVX1-NEXT:    orl %ecx, %eax
+; AVX1-NEXT:    xorl %edx, %eax
 ; AVX1-NEXT:    xorb %ah, %al
 ; AVX1-NEXT:    setnp %al
 ; AVX1-NEXT:    vzeroupper
@@ -1599,20 +1686,12 @@ define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpxor %xmm1, %xmm1, %xmm1
 ; AVX512F-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vextracti128 $1, %ymm0, %xmm1
-; AVX512F-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    vpmovmskb %ymm0, %eax
+; AVX512F-NEXT:    movl %eax, %ecx
+; AVX512F-NEXT:    shrl $16, %ecx
+; AVX512F-NEXT:    xorl %eax, %ecx
+; AVX512F-NEXT:    xorb %ch, %cl
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -1641,11 +1720,13 @@ define i1 @icmp0_v32i8_v32i1(<32 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <32 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = call i32 @llvm.ctpop.i32(i32 %b)
+  %d = trunc i32 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
+define zeroext i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
 ; X86-SSE2-LABEL: icmp0_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -1796,11 +1877,13 @@ define i1 @icmp0_v8i64_v8i1(<8 x i64>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <8 x i64> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
+define zeroext i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
 ; X86-SSE-LABEL: icmp0_v16i32_v16i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -1903,11 +1986,13 @@ define i1 @icmp0_v16i32_v16i1(<16 x i32>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <16 x i32> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
+define zeroext i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE-LABEL: icmp0_v32i16_v32i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -1916,13 +2001,17 @@ define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; X86-SSE-NEXT:    subl $16, %esp
 ; X86-SSE-NEXT:    pxor %xmm3, %xmm3
 ; X86-SSE-NEXT:    pcmpeqw %xmm3, %xmm1
-; X86-SSE-NEXT:    pcmpeqw %xmm3, %xmm2
 ; X86-SSE-NEXT:    pcmpeqw %xmm3, %xmm0
-; X86-SSE-NEXT:    pxor %xmm2, %xmm0
+; X86-SSE-NEXT:    packsswb %xmm1, %xmm0
+; X86-SSE-NEXT:    pmovmskb %xmm0, %ecx
+; X86-SSE-NEXT:    pcmpeqw %xmm3, %xmm2
 ; X86-SSE-NEXT:    pcmpeqw 8(%ebp), %xmm3
-; X86-SSE-NEXT:    pxor %xmm1, %xmm3
-; X86-SSE-NEXT:    packsswb %xmm3, %xmm0
-; X86-SSE-NEXT:    pmovmskb %xmm0, %eax
+; X86-SSE-NEXT:    packsswb %xmm3, %xmm2
+; X86-SSE-NEXT:    pmovmskb %xmm2, %edx
+; X86-SSE-NEXT:    movl %edx, %eax
+; X86-SSE-NEXT:    shll $16, %eax
+; X86-SSE-NEXT:    orl %ecx, %eax
+; X86-SSE-NEXT:    xorl %edx, %eax
 ; X86-SSE-NEXT:    xorb %ah, %al
 ; X86-SSE-NEXT:    setnp %al
 ; X86-SSE-NEXT:    movl %ebp, %esp
@@ -1932,31 +2021,39 @@ define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; X64-SSE-LABEL: icmp0_v32i16_v32i1:
 ; X64-SSE:       # %bb.0:
 ; X64-SSE-NEXT:    pxor %xmm4, %xmm4
-; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm2
-; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm0
-; X64-SSE-NEXT:    pxor %xmm2, %xmm0
-; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm3
 ; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm1
-; X64-SSE-NEXT:    pxor %xmm3, %xmm1
+; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm0
 ; X64-SSE-NEXT:    packsswb %xmm1, %xmm0
-; X64-SSE-NEXT:    pmovmskb %xmm0, %eax
+; X64-SSE-NEXT:    pmovmskb %xmm0, %ecx
+; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm3
+; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm2
+; X64-SSE-NEXT:    packsswb %xmm3, %xmm2
+; X64-SSE-NEXT:    pmovmskb %xmm2, %edx
+; X64-SSE-NEXT:    movl %edx, %eax
+; X64-SSE-NEXT:    shll $16, %eax
+; X64-SSE-NEXT:    orl %ecx, %eax
+; X64-SSE-NEXT:    xorl %edx, %eax
 ; X64-SSE-NEXT:    xorb %ah, %al
 ; X64-SSE-NEXT:    setnp %al
 ; X64-SSE-NEXT:    retq
 ;
 ; AVX1-LABEL: icmp0_v32i16_v32i1:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vpxor %xmm3, %xmm4, %xmm3
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpacksswb %xmm0, %xmm3, %xmm0
-; AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm2
+; AVX1-NEXT:    vpxor %xmm3, %xmm3, %xmm3
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm2, %xmm2
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpacksswb %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpmovmskb %xmm0, %ecx
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpacksswb %xmm0, %xmm1, %xmm0
+; AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; AVX1-NEXT:    movl %edx, %eax
+; AVX1-NEXT:    shll $16, %eax
+; AVX1-NEXT:    orl %ecx, %eax
+; AVX1-NEXT:    xorl %edx, %eax
 ; AVX1-NEXT:    xorb %ah, %al
 ; AVX1-NEXT:    setnp %al
 ; AVX1-NEXT:    vzeroupper
@@ -1980,23 +2077,22 @@ define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ;
 ; AVX512F-LABEL: icmp0_v32i16_v32i1:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512F-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; AVX512F-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
+; AVX512F-NEXT:    vpmovsxwd %ymm2, %zmm2
+; AVX512F-NEXT:    vptestmd %zmm2, %zmm2, %k0
+; AVX512F-NEXT:    kmovw %k0, %ecx
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
+; AVX512F-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
 ; AVX512F-NEXT:    vpmovsxwd %ymm0, %zmm0
 ; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
 ; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    kmovw %k0, %edx
+; AVX512F-NEXT:    shll $16, %edx
+; AVX512F-NEXT:    orl %ecx, %edx
+; AVX512F-NEXT:    xorl %edx, %eax
+; AVX512F-NEXT:    xorb %ah, %al
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -2024,11 +2120,13 @@ define i1 @icmp0_v32i16_v32i1(<32 x i16>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <32 x i16> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %b = bitcast <32 x i1> %a to i32
+  %c = call i32 @llvm.ctpop.i32(i32 %b)
+  %d = trunc i32 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
+define zeroext i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE-LABEL: icmp0_v64i8_v64i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2036,14 +2134,22 @@ define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; X86-SSE-NEXT:    andl $-16, %esp
 ; X86-SSE-NEXT:    subl $16, %esp
 ; X86-SSE-NEXT:    pxor %xmm3, %xmm3
-; X86-SSE-NEXT:    pcmpeqb %xmm3, %xmm1
-; X86-SSE-NEXT:    pcmpeqb %xmm3, %xmm2
 ; X86-SSE-NEXT:    pcmpeqb %xmm3, %xmm0
-; X86-SSE-NEXT:    pxor %xmm2, %xmm0
+; X86-SSE-NEXT:    pmovmskb %xmm0, %ecx
+; X86-SSE-NEXT:    pcmpeqb %xmm3, %xmm1
+; X86-SSE-NEXT:    pmovmskb %xmm1, %eax
+; X86-SSE-NEXT:    shll $16, %eax
+; X86-SSE-NEXT:    orl %ecx, %eax
+; X86-SSE-NEXT:    pcmpeqb %xmm3, %xmm2
+; X86-SSE-NEXT:    pmovmskb %xmm2, %ecx
 ; X86-SSE-NEXT:    pcmpeqb 8(%ebp), %xmm3
-; X86-SSE-NEXT:    pxor %xmm1, %xmm3
-; X86-SSE-NEXT:    pxor %xmm0, %xmm3
-; X86-SSE-NEXT:    pmovmskb %xmm3, %eax
+; X86-SSE-NEXT:    pmovmskb %xmm3, %edx
+; X86-SSE-NEXT:    shll $16, %edx
+; X86-SSE-NEXT:    orl %ecx, %edx
+; X86-SSE-NEXT:    xorl %eax, %edx
+; X86-SSE-NEXT:    movl %edx, %eax
+; X86-SSE-NEXT:    shrl $16, %eax
+; X86-SSE-NEXT:    xorl %edx, %eax
 ; X86-SSE-NEXT:    xorb %ah, %al
 ; X86-SSE-NEXT:    setnp %al
 ; X86-SSE-NEXT:    movl %ebp, %esp
@@ -2054,34 +2160,76 @@ define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; X64-SSE:       # %bb.0:
 ; X64-SSE-NEXT:    pxor %xmm4, %xmm4
 ; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm2
-; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm0
-; X64-SSE-NEXT:    pxor %xmm2, %xmm0
+; X64-SSE-NEXT:    pmovmskb %xmm2, %eax
 ; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm3
+; X64-SSE-NEXT:    pmovmskb %xmm3, %ecx
+; X64-SSE-NEXT:    shll $16, %ecx
+; X64-SSE-NEXT:    orl %eax, %ecx
+; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm0
+; X64-SSE-NEXT:    pmovmskb %xmm0, %eax
 ; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm1
-; X64-SSE-NEXT:    pxor %xmm3, %xmm1
-; X64-SSE-NEXT:    pxor %xmm0, %xmm1
-; X64-SSE-NEXT:    pmovmskb %xmm1, %eax
+; X64-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X64-SSE-NEXT:    shll $16, %edx
+; X64-SSE-NEXT:    orl %eax, %edx
+; X64-SSE-NEXT:    xorl %ecx, %edx
+; X64-SSE-NEXT:    movl %edx, %eax
+; X64-SSE-NEXT:    shrl $16, %eax
+; X64-SSE-NEXT:    xorl %edx, %eax
 ; X64-SSE-NEXT:    xorb %ah, %al
 ; X64-SSE-NEXT:    setnp %al
 ; X64-SSE-NEXT:    retq
 ;
-; AVX1-LABEL: icmp0_v64i8_v64i1:
-; AVX1:       # %bb.0:
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vpxor %xmm3, %xmm4, %xmm3
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm3, %xmm0
-; AVX1-NEXT:    vpmovmskb %xmm0, %eax
-; AVX1-NEXT:    xorb %ah, %al
-; AVX1-NEXT:    setnp %al
-; AVX1-NEXT:    vzeroupper
-; AVX1-NEXT:    ret{{[l|q]}}
+; X86-AVX1-LABEL: icmp0_v64i8_v64i1:
+; X86-AVX1:       # %bb.0:
+; X86-AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
+; X86-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm3
+; X86-AVX1-NEXT:    vpmovmskb %xmm3, %ecx
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X86-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vpmovmskb %xmm1, %eax
+; X86-AVX1-NEXT:    shll $16, %eax
+; X86-AVX1-NEXT:    orl %ecx, %eax
+; X86-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vpmovmskb %xmm1, %ecx
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X86-AVX1-NEXT:    shll $16, %edx
+; X86-AVX1-NEXT:    orl %ecx, %edx
+; X86-AVX1-NEXT:    xorl %eax, %edx
+; X86-AVX1-NEXT:    movl %edx, %eax
+; X86-AVX1-NEXT:    shrl $16, %eax
+; X86-AVX1-NEXT:    xorl %edx, %eax
+; X86-AVX1-NEXT:    xorb %ah, %al
+; X86-AVX1-NEXT:    setnp %al
+; X86-AVX1-NEXT:    vzeroupper
+; X86-AVX1-NEXT:    retl
+;
+; X64-AVX1-LABEL: icmp0_v64i8_v64i1:
+; X64-AVX1:       # %bb.0:
+; X64-AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
+; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm3
+; X64-AVX1-NEXT:    vpmovmskb %xmm3, %eax
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm1
+; X64-AVX1-NEXT:    vpmovmskb %xmm1, %ecx
+; X64-AVX1-NEXT:    shll $16, %ecx
+; X64-AVX1-NEXT:    orl %eax, %ecx
+; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm1
+; X64-AVX1-NEXT:    vpmovmskb %xmm1, %eax
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
+; X64-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X64-AVX1-NEXT:    shll $16, %edx
+; X64-AVX1-NEXT:    orl %eax, %edx
+; X64-AVX1-NEXT:    xorl %ecx, %edx
+; X64-AVX1-NEXT:    movl %edx, %eax
+; X64-AVX1-NEXT:    shrl $16, %eax
+; X64-AVX1-NEXT:    xorl %edx, %eax
+; X64-AVX1-NEXT:    xorb %ah, %al
+; X64-AVX1-NEXT:    setnp %al
+; X64-AVX1-NEXT:    vzeroupper
+; X64-AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: icmp0_v64i8_v64i1:
 ; AVX2:       # %bb.0:
@@ -2104,24 +2252,13 @@ define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512F-NEXT:    vpxor %xmm2, %xmm2, %xmm2
 ; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vextracti128 $1, %ymm1, %xmm2
-; AVX512F-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; AVX512F-NEXT:    vpxor %xmm2, %xmm3, %xmm2
-; AVX512F-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX512F-NEXT:    vpxor %xmm2, %xmm0, %xmm0
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmovmskb %ymm0, %eax
+; AVX512F-NEXT:    movl %eax, %ecx
+; AVX512F-NEXT:    shrl $16, %ecx
+; AVX512F-NEXT:    xorl %eax, %ecx
+; AVX512F-NEXT:    xorb %ch, %cl
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -2155,14 +2292,13 @@ define i1 @icmp0_v64i8_v64i1(<64 x i8>) nounwind {
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
   %a = icmp eq <64 x i8> %0, zeroinitializer
-  %b = call i1 @llvm.vector.reduce.xor.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %b = bitcast <64 x i1> %a to i64
+  %c = call i64 @llvm.ctpop.i64(i64 %b)
+  %d = trunc i64 %c to i1
+  ret i1 %d
 }
 
-; Comparison
-;
-
-define i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
+define zeroext i1 @icmp_v2i64_v2i1(<2 x i64> %0, <2 x i64> %01) nounwind {
 ; SSE2-LABEL: icmp_v2i64_v2i1:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    pcmpeqd %xmm1, %xmm0
@@ -2218,12 +2354,14 @@ define i1 @icmp_v2i64_v2i1(<2 x i64>, <2 x i64>) nounwind {
 ; AVX512VL-NEXT:    testb %al, %al
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <2 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v2i1(<2 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <2 x i64> %0, %01
+  %b = bitcast <2 x i1> %a to i2
+  %c = call i2 @llvm.ctpop.i2(i2 %b)
+  %d = trunc i2 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
+define zeroext i1 @icmp_v4i32_v4i1(<4 x i32> %0, <4 x i32> %01) nounwind {
 ; SSE-LABEL: icmp_v4i32_v4i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pcmpeqd %xmm1, %xmm0
@@ -2269,12 +2407,14 @@ define i1 @icmp_v4i32_v4i1(<4 x i32>, <4 x i32>) nounwind {
 ; AVX512VL-NEXT:    testb %al, %al
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <4 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <4 x i32> %0, %01
+  %b = bitcast <4 x i1> %a to i4
+  %c = call i4 @llvm.ctpop.i4(i4 %b)
+  %d = trunc i4 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
+define zeroext i1 @icmp_v8i16_v8i1(<8 x i16> %0, <8 x i16> %01) nounwind {
 ; SSE-LABEL: icmp_v8i16_v8i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pcmpeqw %xmm1, %xmm0
@@ -2322,12 +2462,14 @@ define i1 @icmp_v8i16_v8i1(<8 x i16>, <8 x i16>) nounwind {
 ; AVX512VL-NEXT:    testb %al, %al
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <8 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <8 x i16> %0, %01
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
+define zeroext i1 @icmp_v16i8_v16i1(<16 x i8> %0, <16 x i8> %01) nounwind {
 ; SSE-LABEL: icmp_v16i8_v16i1:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    pcmpeqb %xmm1, %xmm0
@@ -2374,12 +2516,14 @@ define i1 @icmp_v16i8_v16i1(<16 x i8>, <16 x i8>) nounwind {
 ; AVX512VL-NEXT:    xorb %cl, %al
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <16 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <16 x i8> %0, %01
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
+define zeroext i1 @icmp_v4i64_v4i1(<4 x i64> %0, <4 x i64> %01) nounwind {
 ; X86-SSE2-LABEL: icmp_v4i64_v4i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2490,12 +2634,14 @@ define i1 @icmp_v4i64_v4i1(<4 x i64>, <4 x i64>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <4 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v4i1(<4 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <4 x i64> %0, %01
+  %b = bitcast <4 x i1> %a to i4
+  %c = call i4 @llvm.ctpop.i4(i4 %b)
+  %d = trunc i4 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
+define zeroext i1 @icmp_v8i32_v8i1(<8 x i32> %0, <8 x i32> %01) nounwind {
 ; X86-SSE-LABEL: icmp_v8i32_v8i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2576,12 +2722,14 @@ define i1 @icmp_v8i32_v8i1(<8 x i32>, <8 x i32>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <8 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <8 x i32> %0, %01
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
+define zeroext i1 @icmp_v16i16_v16i1(<16 x i16> %0, <16 x i16> %01) nounwind {
 ; X86-SSE-LABEL: icmp_v16i16_v16i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2668,12 +2816,14 @@ define i1 @icmp_v16i16_v16i1(<16 x i16>, <16 x i16>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <16 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <16 x i16> %0, %01
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
+define zeroext i1 @icmp_v32i8_v32i1(<32 x i8> %0, <32 x i8> %01) nounwind {
 ; X86-SSE-LABEL: icmp_v32i8_v32i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -2681,9 +2831,13 @@ define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; X86-SSE-NEXT:    andl $-16, %esp
 ; X86-SSE-NEXT:    subl $16, %esp
 ; X86-SSE-NEXT:    pcmpeqb %xmm2, %xmm0
+; X86-SSE-NEXT:    pmovmskb %xmm0, %ecx
 ; X86-SSE-NEXT:    pcmpeqb 8(%ebp), %xmm1
-; X86-SSE-NEXT:    pxor %xmm0, %xmm1
-; X86-SSE-NEXT:    pmovmskb %xmm1, %eax
+; X86-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X86-SSE-NEXT:    movl %edx, %eax
+; X86-SSE-NEXT:    shll $16, %eax
+; X86-SSE-NEXT:    orl %ecx, %eax
+; X86-SSE-NEXT:    xorl %edx, %eax
 ; X86-SSE-NEXT:    xorb %ah, %al
 ; X86-SSE-NEXT:    setnp %al
 ; X86-SSE-NEXT:    movl %ebp, %esp
@@ -2692,22 +2846,30 @@ define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ;
 ; X64-SSE-LABEL: icmp_v32i8_v32i1:
 ; X64-SSE:       # %bb.0:
-; X64-SSE-NEXT:    pcmpeqb %xmm3, %xmm1
 ; X64-SSE-NEXT:    pcmpeqb %xmm2, %xmm0
-; X64-SSE-NEXT:    pxor %xmm1, %xmm0
-; X64-SSE-NEXT:    pmovmskb %xmm0, %eax
+; X64-SSE-NEXT:    pmovmskb %xmm0, %ecx
+; X64-SSE-NEXT:    pcmpeqb %xmm3, %xmm1
+; X64-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X64-SSE-NEXT:    movl %edx, %eax
+; X64-SSE-NEXT:    shll $16, %eax
+; X64-SSE-NEXT:    orl %ecx, %eax
+; X64-SSE-NEXT:    xorl %edx, %eax
 ; X64-SSE-NEXT:    xorb %ah, %al
 ; X64-SSE-NEXT:    setnp %al
 ; X64-SSE-NEXT:    retq
 ;
 ; AVX1-LABEL: icmp_v32i8_v32i1:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm3, %xmm2
+; AVX1-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
+; AVX1-NEXT:    vpmovmskb %xmm2, %ecx
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
 ; AVX1-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; AVX1-NEXT:    movl %edx, %eax
+; AVX1-NEXT:    shll $16, %eax
+; AVX1-NEXT:    orl %ecx, %eax
+; AVX1-NEXT:    xorl %edx, %eax
 ; AVX1-NEXT:    xorb %ah, %al
 ; AVX1-NEXT:    setnp %al
 ; AVX1-NEXT:    vzeroupper
@@ -2728,20 +2890,12 @@ define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; AVX512F-LABEL: icmp_v32i8_v32i1:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vextracti128 $1, %ymm0, %xmm1
-; AVX512F-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    vpmovmskb %ymm0, %eax
+; AVX512F-NEXT:    movl %eax, %ecx
+; AVX512F-NEXT:    shrl $16, %ecx
+; AVX512F-NEXT:    xorl %eax, %ecx
+; AVX512F-NEXT:    xorb %ch, %cl
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -2770,12 +2924,14 @@ define i1 @icmp_v32i8_v32i1(<32 x i8>, <32 x i8>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <32 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <32 x i8> %0, %01
+  %b = bitcast <32 x i1> %a to i32
+  %c = call i32 @llvm.ctpop.i32(i32 %b)
+  %d = trunc i32 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
+define zeroext i1 @icmp_v8i64_v8i1(<8 x i64> %0, <8 x i64> %01) nounwind {
 ; X86-SSE2-LABEL: icmp_v8i64_v8i1:
 ; X86-SSE2:       # %bb.0:
 ; X86-SSE2-NEXT:    pushl %ebp
@@ -2965,12 +3121,14 @@ define i1 @icmp_v8i64_v8i1(<8 x i64>, <8 x i64>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <8 x i64> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v8i1(<8 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <8 x i64> %0, %01
+  %b = bitcast <8 x i1> %a to i8
+  %c = call i8 @llvm.ctpop.i8(i8 %b)
+  %d = trunc i8 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
+define zeroext i1 @icmp_v16i32_v16i1(<16 x i32> %0, <16 x i32> %01) nounwind {
 ; X86-SSE-LABEL: icmp_v16i32_v16i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -3115,12 +3273,14 @@ define i1 @icmp_v16i32_v16i1(<16 x i32>, <16 x i32>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <16 x i32> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v16i1(<16 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <16 x i32> %0, %01
+  %b = bitcast <16 x i1> %a to i16
+  %c = call i16 @llvm.ctpop.i16(i16 %b)
+  %d = trunc i16 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
+define zeroext i1 @icmp_v32i16_v32i1(<32 x i16> %0, <32 x i16> %01) nounwind {
 ; X86-SSE-LABEL: icmp_v32i16_v32i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -3128,14 +3288,18 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; X86-SSE-NEXT:    andl $-16, %esp
 ; X86-SSE-NEXT:    subl $16, %esp
 ; X86-SSE-NEXT:    movdqa 8(%ebp), %xmm3
-; X86-SSE-NEXT:    pcmpeqw 56(%ebp), %xmm2
-; X86-SSE-NEXT:    pcmpeqw 24(%ebp), %xmm0
-; X86-SSE-NEXT:    pxor %xmm2, %xmm0
-; X86-SSE-NEXT:    pcmpeqw 72(%ebp), %xmm3
 ; X86-SSE-NEXT:    pcmpeqw 40(%ebp), %xmm1
-; X86-SSE-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE-NEXT:    pcmpeqw 24(%ebp), %xmm0
 ; X86-SSE-NEXT:    packsswb %xmm1, %xmm0
-; X86-SSE-NEXT:    pmovmskb %xmm0, %eax
+; X86-SSE-NEXT:    pmovmskb %xmm0, %ecx
+; X86-SSE-NEXT:    pcmpeqw 72(%ebp), %xmm3
+; X86-SSE-NEXT:    pcmpeqw 56(%ebp), %xmm2
+; X86-SSE-NEXT:    packsswb %xmm3, %xmm2
+; X86-SSE-NEXT:    pmovmskb %xmm2, %edx
+; X86-SSE-NEXT:    movl %edx, %eax
+; X86-SSE-NEXT:    shll $16, %eax
+; X86-SSE-NEXT:    orl %ecx, %eax
+; X86-SSE-NEXT:    xorl %edx, %eax
 ; X86-SSE-NEXT:    xorb %ah, %al
 ; X86-SSE-NEXT:    setnp %al
 ; X86-SSE-NEXT:    movl %ebp, %esp
@@ -3144,14 +3308,18 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ;
 ; X64-SSE-LABEL: icmp_v32i16_v32i1:
 ; X64-SSE:       # %bb.0:
-; X64-SSE-NEXT:    pcmpeqw %xmm6, %xmm2
-; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm0
-; X64-SSE-NEXT:    pxor %xmm2, %xmm0
-; X64-SSE-NEXT:    pcmpeqw %xmm7, %xmm3
 ; X64-SSE-NEXT:    pcmpeqw %xmm5, %xmm1
-; X64-SSE-NEXT:    pxor %xmm3, %xmm1
+; X64-SSE-NEXT:    pcmpeqw %xmm4, %xmm0
 ; X64-SSE-NEXT:    packsswb %xmm1, %xmm0
-; X64-SSE-NEXT:    pmovmskb %xmm0, %eax
+; X64-SSE-NEXT:    pmovmskb %xmm0, %ecx
+; X64-SSE-NEXT:    pcmpeqw %xmm7, %xmm3
+; X64-SSE-NEXT:    pcmpeqw %xmm6, %xmm2
+; X64-SSE-NEXT:    packsswb %xmm3, %xmm2
+; X64-SSE-NEXT:    pmovmskb %xmm2, %edx
+; X64-SSE-NEXT:    movl %edx, %eax
+; X64-SSE-NEXT:    shll $16, %eax
+; X64-SSE-NEXT:    orl %ecx, %eax
+; X64-SSE-NEXT:    xorl %edx, %eax
 ; X64-SSE-NEXT:    xorb %ah, %al
 ; X64-SSE-NEXT:    setnp %al
 ; X64-SSE-NEXT:    retq
@@ -3162,17 +3330,21 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; X86-AVX1-NEXT:    movl %esp, %ebp
 ; X86-AVX1-NEXT:    andl $-32, %esp
 ; X86-AVX1-NEXT:    subl $32, %esp
-; X86-AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm3
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm4
+; X86-AVX1-NEXT:    vpcmpeqw %xmm3, %xmm4, %xmm3
 ; X86-AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vpcmpeqw 8(%ebp), %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpxor %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X86-AVX1-NEXT:    vpcmpeqw 24(%ebp), %xmm1, %xmm1
-; X86-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vpacksswb %xmm0, %xmm2, %xmm0
-; X86-AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; X86-AVX1-NEXT:    vpacksswb %xmm3, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpmovmskb %xmm0, %ecx
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
+; X86-AVX1-NEXT:    vpcmpeqw 24(%ebp), %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpcmpeqw 8(%ebp), %xmm1, %xmm1
+; X86-AVX1-NEXT:    vpacksswb %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X86-AVX1-NEXT:    movl %edx, %eax
+; X86-AVX1-NEXT:    shll $16, %eax
+; X86-AVX1-NEXT:    orl %ecx, %eax
+; X86-AVX1-NEXT:    xorl %edx, %eax
 ; X86-AVX1-NEXT:    xorb %ah, %al
 ; X86-AVX1-NEXT:    setnp %al
 ; X86-AVX1-NEXT:    movl %ebp, %esp
@@ -3182,18 +3354,22 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ;
 ; X64-AVX1-LABEL: icmp_v32i16_v32i1:
 ; X64-AVX1:       # %bb.0:
-; X64-AVX1-NEXT:    vpcmpeqw %xmm3, %xmm1, %xmm4
-; X64-AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm5
-; X64-AVX1-NEXT:    vpxor %xmm4, %xmm5, %xmm4
-; X64-AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm3
-; X64-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X64-AVX1-NEXT:    vpcmpeqw %xmm3, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
-; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm4
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm5
+; X64-AVX1-NEXT:    vpcmpeqw %xmm4, %xmm5, %xmm4
 ; X64-AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vpacksswb %xmm0, %xmm4, %xmm0
-; X64-AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; X64-AVX1-NEXT:    vpacksswb %xmm4, %xmm0, %xmm0
+; X64-AVX1-NEXT:    vpmovmskb %xmm0, %ecx
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm0
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
+; X64-AVX1-NEXT:    vpcmpeqw %xmm0, %xmm2, %xmm0
+; X64-AVX1-NEXT:    vpcmpeqw %xmm3, %xmm1, %xmm1
+; X64-AVX1-NEXT:    vpacksswb %xmm0, %xmm1, %xmm0
+; X64-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X64-AVX1-NEXT:    movl %edx, %eax
+; X64-AVX1-NEXT:    shll $16, %eax
+; X64-AVX1-NEXT:    orl %ecx, %eax
+; X64-AVX1-NEXT:    xorl %edx, %eax
 ; X64-AVX1-NEXT:    xorb %ah, %al
 ; X64-AVX1-NEXT:    setnp %al
 ; X64-AVX1-NEXT:    vzeroupper
@@ -3237,23 +3413,22 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ;
 ; AVX512F-LABEL: icmp_v32i16_v32i1:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm2
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm3
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm3, %ymm2
+; AVX512F-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
+; AVX512F-NEXT:    vpmovsxwd %ymm2, %zmm2
+; AVX512F-NEXT:    vptestmd %zmm2, %zmm2, %k0
+; AVX512F-NEXT:    kmovw %k0, %ecx
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm1
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
 ; AVX512F-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm2, %ymm0, %ymm0
 ; AVX512F-NEXT:    vpmovsxwd %ymm0, %zmm0
 ; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
 ; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    kmovw %k0, %edx
+; AVX512F-NEXT:    shll $16, %edx
+; AVX512F-NEXT:    orl %ecx, %edx
+; AVX512F-NEXT:    xorl %edx, %eax
+; AVX512F-NEXT:    xorb %ah, %al
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -3280,12 +3455,14 @@ define i1 @icmp_v32i16_v32i1(<32 x i16>, <32 x i16>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <32 x i16> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v32i1(<32 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <32 x i16> %0, %01
+  %b = bitcast <32 x i1> %a to i32
+  %c = call i32 @llvm.ctpop.i32(i32 %b)
+  %d = trunc i32 %c to i1
+  ret i1 %d
 }
 
-define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
+define zeroext i1 @icmp_v64i8_v64i1(<64 x i8> %0, <64 x i8> %01) nounwind {
 ; X86-SSE-LABEL: icmp_v64i8_v64i1:
 ; X86-SSE:       # %bb.0:
 ; X86-SSE-NEXT:    pushl %ebp
@@ -3294,13 +3471,21 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; X86-SSE-NEXT:    subl $16, %esp
 ; X86-SSE-NEXT:    movdqa 8(%ebp), %xmm3
 ; X86-SSE-NEXT:    pcmpeqb 56(%ebp), %xmm2
-; X86-SSE-NEXT:    pcmpeqb 24(%ebp), %xmm0
-; X86-SSE-NEXT:    pxor %xmm2, %xmm0
+; X86-SSE-NEXT:    pmovmskb %xmm2, %ecx
 ; X86-SSE-NEXT:    pcmpeqb 72(%ebp), %xmm3
+; X86-SSE-NEXT:    pmovmskb %xmm3, %eax
+; X86-SSE-NEXT:    shll $16, %eax
+; X86-SSE-NEXT:    orl %ecx, %eax
+; X86-SSE-NEXT:    pcmpeqb 24(%ebp), %xmm0
+; X86-SSE-NEXT:    pmovmskb %xmm0, %ecx
 ; X86-SSE-NEXT:    pcmpeqb 40(%ebp), %xmm1
-; X86-SSE-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE-NEXT:    pxor %xmm0, %xmm1
-; X86-SSE-NEXT:    pmovmskb %xmm1, %eax
+; X86-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X86-SSE-NEXT:    shll $16, %edx
+; X86-SSE-NEXT:    orl %ecx, %edx
+; X86-SSE-NEXT:    xorl %eax, %edx
+; X86-SSE-NEXT:    movl %edx, %eax
+; X86-SSE-NEXT:    shrl $16, %eax
+; X86-SSE-NEXT:    xorl %edx, %eax
 ; X86-SSE-NEXT:    xorb %ah, %al
 ; X86-SSE-NEXT:    setnp %al
 ; X86-SSE-NEXT:    movl %ebp, %esp
@@ -3310,13 +3495,21 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; X64-SSE-LABEL: icmp_v64i8_v64i1:
 ; X64-SSE:       # %bb.0:
 ; X64-SSE-NEXT:    pcmpeqb %xmm6, %xmm2
-; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm0
-; X64-SSE-NEXT:    pxor %xmm2, %xmm0
+; X64-SSE-NEXT:    pmovmskb %xmm2, %eax
 ; X64-SSE-NEXT:    pcmpeqb %xmm7, %xmm3
+; X64-SSE-NEXT:    pmovmskb %xmm3, %ecx
+; X64-SSE-NEXT:    shll $16, %ecx
+; X64-SSE-NEXT:    orl %eax, %ecx
+; X64-SSE-NEXT:    pcmpeqb %xmm4, %xmm0
+; X64-SSE-NEXT:    pmovmskb %xmm0, %eax
 ; X64-SSE-NEXT:    pcmpeqb %xmm5, %xmm1
-; X64-SSE-NEXT:    pxor %xmm3, %xmm1
-; X64-SSE-NEXT:    pxor %xmm0, %xmm1
-; X64-SSE-NEXT:    pmovmskb %xmm1, %eax
+; X64-SSE-NEXT:    pmovmskb %xmm1, %edx
+; X64-SSE-NEXT:    shll $16, %edx
+; X64-SSE-NEXT:    orl %eax, %edx
+; X64-SSE-NEXT:    xorl %ecx, %edx
+; X64-SSE-NEXT:    movl %edx, %eax
+; X64-SSE-NEXT:    shrl $16, %eax
+; X64-SSE-NEXT:    xorl %edx, %eax
 ; X64-SSE-NEXT:    xorb %ah, %al
 ; X64-SSE-NEXT:    setnp %al
 ; X64-SSE-NEXT:    retq
@@ -3328,16 +3521,24 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; X86-AVX1-NEXT:    andl $-32, %esp
 ; X86-AVX1-NEXT:    subl $32, %esp
 ; X86-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm3
+; X86-AVX1-NEXT:    vpmovmskb %xmm3, %ecx
 ; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
 ; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
 ; X86-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vpcmpeqb 8(%ebp), %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpxor %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X86-AVX1-NEXT:    vpcmpeqb 24(%ebp), %xmm1, %xmm1
-; X86-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vpxor %xmm0, %xmm2, %xmm0
 ; X86-AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; X86-AVX1-NEXT:    shll $16, %eax
+; X86-AVX1-NEXT:    orl %ecx, %eax
+; X86-AVX1-NEXT:    vpcmpeqb 8(%ebp), %xmm1, %xmm0
+; X86-AVX1-NEXT:    vpmovmskb %xmm0, %ecx
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
+; X86-AVX1-NEXT:    vpcmpeqb 24(%ebp), %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X86-AVX1-NEXT:    shll $16, %edx
+; X86-AVX1-NEXT:    orl %ecx, %edx
+; X86-AVX1-NEXT:    xorl %eax, %edx
+; X86-AVX1-NEXT:    movl %edx, %eax
+; X86-AVX1-NEXT:    shrl $16, %eax
+; X86-AVX1-NEXT:    xorl %edx, %eax
 ; X86-AVX1-NEXT:    xorb %ah, %al
 ; X86-AVX1-NEXT:    setnp %al
 ; X86-AVX1-NEXT:    movl %ebp, %esp
@@ -3348,17 +3549,25 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; X64-AVX1-LABEL: icmp_v64i8_v64i1:
 ; X64-AVX1:       # %bb.0:
 ; X64-AVX1-NEXT:    vpcmpeqb %xmm3, %xmm1, %xmm4
-; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm5
-; X64-AVX1-NEXT:    vpxor %xmm4, %xmm5, %xmm4
+; X64-AVX1-NEXT:    vpmovmskb %xmm4, %eax
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm3
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; X64-AVX1-NEXT:    vpcmpeqb %xmm3, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
+; X64-AVX1-NEXT:    vpmovmskb %xmm1, %ecx
+; X64-AVX1-NEXT:    shll $16, %ecx
+; X64-AVX1-NEXT:    orl %eax, %ecx
+; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm1
+; X64-AVX1-NEXT:    vpmovmskb %xmm1, %eax
+; X64-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm1
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
-; X64-AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vpxor %xmm0, %xmm4, %xmm0
-; X64-AVX1-NEXT:    vpmovmskb %xmm0, %eax
+; X64-AVX1-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; X64-AVX1-NEXT:    vpmovmskb %xmm0, %edx
+; X64-AVX1-NEXT:    shll $16, %edx
+; X64-AVX1-NEXT:    orl %eax, %edx
+; X64-AVX1-NEXT:    xorl %ecx, %edx
+; X64-AVX1-NEXT:    movl %edx, %eax
+; X64-AVX1-NEXT:    shrl $16, %eax
+; X64-AVX1-NEXT:    xorl %edx, %eax
 ; X64-AVX1-NEXT:    xorb %ah, %al
 ; X64-AVX1-NEXT:    setnp %al
 ; X64-AVX1-NEXT:    vzeroupper
@@ -3404,24 +3613,13 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm3
 ; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm3, %ymm2
 ; AVX512F-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vextracti128 $1, %ymm2, %xmm1
-; AVX512F-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; AVX512F-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; AVX512F-NEXT:    vpxor %xmm2, %xmm0, %xmm0
-; AVX512F-NEXT:    vpxor %xmm1, %xmm0, %xmm0
-; AVX512F-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512F-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; AVX512F-NEXT:    kshiftrw $8, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $4, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $2, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512F-NEXT:    kxorw %k1, %k0, %k0
-; AVX512F-NEXT:    kmovw %k0, %eax
-; AVX512F-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512F-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmovmskb %ymm0, %eax
+; AVX512F-NEXT:    movl %eax, %ecx
+; AVX512F-NEXT:    shrl $16, %ecx
+; AVX512F-NEXT:    xorl %eax, %ecx
+; AVX512F-NEXT:    xorb %ch, %cl
+; AVX512F-NEXT:    setnp %al
 ; AVX512F-NEXT:    vzeroupper
 ; AVX512F-NEXT:    retq
 ;
@@ -3454,16 +3652,9 @@ define i1 @icmp_v64i8_v64i1(<64 x i8>, <64 x i8>) nounwind {
 ; AVX512VL-NEXT:    setnp %al
 ; AVX512VL-NEXT:    vzeroupper
 ; AVX512VL-NEXT:    retq
-  %a = icmp eq <64 x i8> %0, %1
-  %b = call i1 @llvm.vector.reduce.xor.v64i1(<64 x i1> %a)
-  ret i1 %b
+  %a = icmp eq <64 x i8> %0, %01
+  %b = bitcast <64 x i1> %a to i64
+  %c = call i64 @llvm.ctpop.i64(i64 %b)
+  %d = trunc i64 %c to i1
+  ret i1 %d
 }
-
-declare i1 @llvm.vector.reduce.xor.v2i1(<2 x i1>)
-declare i1 @llvm.vector.reduce.xor.v4i1(<4 x i1>)
-declare i1 @llvm.vector.reduce.xor.v8i1(<8 x i1>)
-declare i1 @llvm.vector.reduce.xor.v16i1(<16 x i1>)
-declare i1 @llvm.vector.reduce.xor.v32i1(<32 x i1>)
-declare i1 @llvm.vector.reduce.xor.v64i1(<64 x i1>)
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; AVX512: {{.*}}


### PR DESCRIPTION
InstCombine converts vXi1 logic reductions to bitcasted scalar integer ops - we should be testing that, not llvm.vector.reduce.*.vXi1 calls

We were also failing to tag the i1 return values as zeroext

Shows a couple of hidden issues - poor handling of comparison results from sub-128-bit vectors and handling of v32i1/v64i1 MOVMSK patterns on pre-AVX2 targets