### PR TITLE
[LangRef] Fix language around strictfp semantics

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -2800,8 +2800,7 @@ fn -> other_fn -> other_fn ; fn is norecurse
     optimizations that require assumptions about the floating-point rounding
     mode or that might alter the state of floating-point status flags that
     might otherwise be set or cleared by calling this function. LLVM will
-    not introduce any new floating-point instructions that may trap. All
-    function definitions that contain strictfp calls must be marked strictfp.
+    not introduce any new floating-point instructions that may trap.
 
 (denormal_fpenv)=
 
@@ -26740,6 +26739,9 @@ All function *calls* done in a function that uses constrained floating
 point intrinsics must have the `strictfp` attribute either on the
 calling instruction or on the declaration or definition of the function
 being called.
+
+All function *definitions* that use constrained floating point intrinsics
+must have the `strictfp` attribute.
 
 #### '`llvm.experimental.constrained.fadd`' Intrinsic
 


### PR DESCRIPTION
The LangRef wording changed in 15bb4a97a7 ([IR] Make semantics of strictfp consistent v2, #211769) is unfortunately incorrect. There are some open questions around its semantics, but a simple revert should do for the moment.

Reported-by: Ömer Sinan Ağacan <omer@osa1.net>