### PR TITLE
[Clang] Restrict ClangScanDeps darwin-specific test not to run in cross-compile

### DIFF
--- a/clang/test/ClangScanDeps/canonicalize-macros-multiarch.c
+++ b/clang/test/ClangScanDeps/canonicalize-macros-multiarch.c
@@ -1,7 +1,7 @@
 // Verify cc1 jobs from a multi-arch driver command perform identical macro
 // canonicalization.
 
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json


### PR DESCRIPTION
The test added in 316a29603228c5d5000e0ddf8dfba2a494ac7ee9 fails when run on MacOS but targeting Linux as a cross compiler.