### PR TITLE
[lldb] Convert uses of RegisterTypeFlags into RegisterType

### DIFF
--- a/lldb/include/lldb/Core/DumpRegisterInfo.h
+++ b/lldb/include/lldb/Core/DumpRegisterInfo.h
@@ -18,7 +18,7 @@ namespace lldb_private {
 class Stream;
 class RegisterContext;
 struct RegisterInfo;
-class RegisterTypeFlags;
+class RegisterType;
 
 void DumpRegisterInfo(Stream &strm, RegisterContext &ctx,
                       const RegisterInfo &info, uint32_t terminal_width);
@@ -29,7 +29,7 @@ void DoDumpRegisterInfo(
     const std::vector<const char *> &invalidates,
     const std::vector<const char *> &read_from,
     const std::vector<std::pair<const char *, uint32_t>> &in_sets,
-    const RegisterTypeFlags *flags_type, uint32_t terminal_width);
+    const RegisterType *register_type, uint32_t terminal_width);
 
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Target/DynamicRegisterInfo.h
+++ b/lldb/include/lldb/Target/DynamicRegisterInfo.h
@@ -39,7 +39,7 @@ public:
     std::vector<uint32_t> invalidate_regs;
     uint32_t value_reg_offset = 0;
     // Non-null if there is an XML provided type.
-    const RegisterTypeFlags *flags_type = nullptr;
+    const RegisterType *register_type = nullptr;
   };
 
   DynamicRegisterInfo() = default;

--- a/lldb/include/lldb/Target/RegisterTypeBuilder.h
+++ b/lldb/include/lldb/Target/RegisterTypeBuilder.h
@@ -20,7 +20,7 @@ public:
 
   virtual CompilerType
   GetRegisterType(const std::string &name,
-                  const lldb_private::RegisterTypeFlags &flags,
+                  const lldb_private::RegisterType &type_info,
                   uint32_t byte_size) = 0;
 
 protected:

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1565,7 +1565,7 @@ public:
   llvm::Expected<lldb_private::Address> GetEntryPointAddress();
 
   CompilerType GetRegisterType(const std::string &name,
-                               const lldb_private::RegisterTypeFlags &flags,
+                               const lldb_private::RegisterType &type_info,
                                uint32_t byte_size);
 
   /// Sends a breakpoint notification event.

--- a/lldb/source/Core/DumpRegisterInfo.cpp
+++ b/lldb/source/Core/DumpRegisterInfo.cpp
@@ -92,7 +92,7 @@ void lldb_private::DoDumpRegisterInfo(
     Stream &strm, const char *name, const char *alt_name, uint32_t byte_size,
     const std::vector<const char *> &invalidates,
     const std::vector<const char *> &read_from,
-    const std::vector<SetInfo> &in_sets, const RegisterTypeFlags *flags_type,
+    const std::vector<SetInfo> &in_sets, const RegisterType *register_type,
     uint32_t terminal_width) {
   strm << "       Name: " << name;
   if (alt_name)
@@ -115,7 +115,8 @@ void lldb_private::DoDumpRegisterInfo(
   };
   DumpList(strm, "    In sets: ", in_sets, emit_set);
 
-  if (flags_type) {
+  if (auto flags_type =
+          llvm::dyn_cast_if_present<RegisterTypeFlags>(register_type)) {
     strm.Printf("\n\n%s", flags_type->AsTable(terminal_width).c_str());
 
     std::string enumerators = flags_type->DumpEnums(terminal_width);

--- a/lldb/source/Core/DumpRegisterInfo.cpp
+++ b/lldb/source/Core/DumpRegisterInfo.cpp
@@ -64,9 +64,7 @@ void lldb_private::DumpRegisterInfo(Stream &strm, RegisterContext &ctx,
   }
 
   DoDumpRegisterInfo(strm, info.name, info.alt_name, info.byte_size,
-                     invalidates, read_from, in_sets,
-                     llvm::dyn_cast_if_present<lldb_private::RegisterTypeFlags>(
-                         info.register_type),
+                     invalidates, read_from, in_sets, info.register_type,
                      terminal_width);
 }
 

--- a/lldb/source/Core/DumpRegisterValue.cpp
+++ b/lldb/source/Core/DumpRegisterValue.cpp
@@ -129,18 +129,20 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
       (reg_info.byte_size != 4 && reg_info.byte_size != 8))
     return;
 
-  CompilerType fields_compiler_type = target_sp->GetRegisterType(
-      reg_info.name, *flags_type, reg_info.byte_size);
+  CompilerType register_compiler_type = target_sp->GetRegisterType(
+      reg_info.name, *reg_info.register_type, reg_info.byte_size);
+  if (!register_compiler_type.IsValid())
+    return;
 
   // Use a new stream so we can remove a trailing newline later.
-  StreamString fields_stream;
+  StreamString register_type_stream;
 
   if (reg_info.byte_size == 4) {
-    dump_type_value(*flags_type, fields_compiler_type, reg_val.GetAsUInt32(),
-                    exe_scope, fields_stream);
+    dump_type_value(*flags_type, register_compiler_type, reg_val.GetAsUInt32(),
+                    exe_scope, register_type_stream);
   } else {
-    dump_type_value(*flags_type, fields_compiler_type, reg_val.GetAsUInt64(),
-                    exe_scope, fields_stream);
+    dump_type_value(*flags_type, register_compiler_type, reg_val.GetAsUInt64(),
+                    exe_scope, register_type_stream);
   }
 
   // Registers are indented like:
@@ -150,16 +152,18 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
 
   // First drop the extra newline that the value printer added. The register
   // command will add one itself.
-  llvm::StringRef fields_str = fields_stream.GetString().drop_back();
+  llvm::StringRef register_type_str =
+      register_type_stream.GetString().drop_back();
 
   // End the line that contains "    foo = 0x12345678".
   s.EOL();
 
   // Then split the value lines and indent each one.
   bool first = true;
-  while (fields_str.size()) {
-    std::pair<llvm::StringRef, llvm::StringRef> split = fields_str.split('\n');
-    fields_str = split.second;
+  while (register_type_str.size()) {
+    std::pair<llvm::StringRef, llvm::StringRef> split =
+        register_type_str.split('\n');
+    register_type_str = split.second;
     // Indent as much as the stream does.
     s.Indent();
     // Indent further to match where the register name finishes.
@@ -174,7 +178,7 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
 
     // On the last line we don't want a newline because the command will add
     // one too.
-    if (fields_str.size())
+    if (register_type_str.size())
       s.EOL();
   }
 }

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_riscv32.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_riscv32.cpp
@@ -336,6 +336,5 @@ RegisterContextCorePOSIX_riscv32::BuildDynamicRegister(
       CopyRegisterListToVector(reg_info.value_regs),
       CopyRegisterListToVector(reg_info.invalidate_regs),
       /*value_reg_offset=*/0,
-      llvm::dyn_cast_if_present<lldb_private::RegisterTypeFlags>(
-          reg_info.register_type)};
+      reg_info.register_type};
 }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -5394,7 +5394,7 @@ bool ParseRegisters(
           if (it != registers_flags_types.end()) {
             auto flags_type = it->second.get();
             if (reg_info.byte_size == flags_type->GetSize())
-              reg_info.flags_type = flags_type;
+              reg_info.register_type = flags_type;
             else
               LLDB_LOG(
                   log,

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -28,6 +28,7 @@
 #include "lldb/Utility/Broadcaster.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/GDBRemote.h"
+#include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StringExtractor.h"

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -36,13 +36,19 @@ RegisterTypeBuilderClang::RegisterTypeBuilderClang(Target &target)
     : m_target(target) {}
 
 CompilerType RegisterTypeBuilderClang::GetRegisterType(
-    const std::string &name, const lldb_private::RegisterTypeFlags &flags,
+    const std::string &name, const lldb_private::RegisterType &type_info,
     uint32_t byte_size) {
   lldb::TypeSystemClangSP type_system =
       ScratchTypeSystemClang::GetForTarget(m_target);
   assert(type_system);
 
   std::string register_type_name = "__lldb_register_fields_" + name;
+  // For now we can only build sets of flags.
+  const RegisterTypeFlags *flags =
+      llvm::dyn_cast<RegisterTypeFlags>(&type_info);
+  if (!flags)
+    return {};
+
   // See if we have made this type before and can reuse it.
   CompilerType fields_type =
       type_system->GetTypeForIdentifier<clang::CXXRecordDecl>(
@@ -63,7 +69,7 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
 
     // We assume that RegisterTypeFlags has padded and sorted the fields
     // already.
-    for (const RegisterTypeFlags::Field &field : flags.GetFields()) {
+    for (const RegisterTypeFlags::Field &field : flags->GetFields()) {
       CompilerType field_type = field_uint_type;
 
       if (const RegisterTypeEnum *enum_type = field.GetEnum()) {
@@ -115,7 +121,7 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
 
     // This should be true if RegisterTypeFlags padded correctly.
     assert(llvm::expectedToOptional(fields_type.GetByteSize(nullptr))
-               .value_or(0) == flags.GetSize());
+               .value_or(0) == flags->GetSize());
   }
 
   return fields_type;

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.h
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.h
@@ -29,7 +29,7 @@ public:
   static lldb::RegisterTypeBuilderSP CreateInstance(Target &target);
 
   CompilerType GetRegisterType(const std::string &name,
-                               const lldb_private::RegisterTypeFlags &flags,
+                               const lldb_private::RegisterType &type_info,
                                uint32_t byte_size) override;
 
 private:

--- a/lldb/source/Target/DynamicRegisterInfo.cpp
+++ b/lldb/source/Target/DynamicRegisterInfo.cpp
@@ -426,7 +426,7 @@ size_t DynamicRegisterInfo::SetRegisterInfo(
         // value_regs and invalidate_regs are filled by Finalize()
         nullptr,
         nullptr,
-        reg.flags_type};
+        reg.register_type};
 
     m_regs.push_back(reg_info);
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2741,12 +2741,13 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
 
 CompilerType
 Target::GetRegisterType(const std::string &name,
-                        const lldb_private::RegisterTypeFlags &flags,
+                        const lldb_private::RegisterType &type_info,
                         uint32_t byte_size) {
   if (!m_register_type_builder_sp)
     m_register_type_builder_sp = PluginManager::GetRegisterTypeBuilder(*this);
   assert(m_register_type_builder_sp);
-  return m_register_type_builder_sp->GetRegisterType(name, flags, byte_size);
+  return m_register_type_builder_sp->GetRegisterType(name, type_info,
+                                                     byte_size);
 }
 
 std::vector<lldb::TypeSystemSP>

--- a/lldb/unittests/Core/DumpRegisterInfoTest.cpp
+++ b/lldb/unittests/Core/DumpRegisterInfoTest.cpp
@@ -11,6 +11,8 @@
 #include "lldb/Utility/StreamString.h"
 #include "gtest/gtest.h"
 
+#include "llvm/Support/Casting.h"
+
 using namespace lldb_private;
 
 TEST(DoDumpRegisterInfoTest, MinimumInfo) {
@@ -95,7 +97,8 @@ TEST(DoDumpRegisterInfoTest, FieldsTable) {
                            RegisterTypeFlags::Field("C", 8, 15),
                            RegisterTypeFlags::Field("D", 0, 7)});
 
-  DoDumpRegisterInfo(strm, "foo", nullptr, 4, {}, {}, {}, &flags, 100);
+  const RegisterType *register_type = llvm::dyn_cast<RegisterType>(&flags);
+  DoDumpRegisterInfo(strm, "foo", nullptr, 4, {}, {}, {}, register_type, 100);
   ASSERT_EQ(strm.GetString(), "       Name: foo\n"
                               "       Size: 4 bytes (32 bits)\n"
                               "\n"
@@ -116,7 +119,8 @@ TEST(DoDumpRegisterInfoTest, Enumerators) {
                            RegisterTypeFlags::Field("B", 16, 23),
                            RegisterTypeFlags::Field("C", 8, 15, &enum_two)});
 
-  DoDumpRegisterInfo(strm, "abc", nullptr, 4, {}, {}, {}, &flags, 100);
+  const RegisterType *register_type = llvm::dyn_cast<RegisterType>(&flags);
+  DoDumpRegisterInfo(strm, "abc", nullptr, 4, {}, {}, {}, register_type, 100);
   ASSERT_EQ(strm.GetString(),
             "       Name: abc\n"
             "       Size: 4 bytes (32 bits)\n"


### PR DESCRIPTION
So we are using the generic interface that will work with
all future RegisterType derived classes.

Right now we'll only be asked to print RegisterTypeFlags, so
there's a few dyn_cast to that. Later we will switch on the
kind, and support rendering more types.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>