### PR TITLE
[flang][MIF] Fix undef reference to a coarray_handle in mif.dealloc_coarray #193157

### DIFF
--- a/flang/lib/Optimizer/Transforms/MIFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/MIFOpConversion.cpp
@@ -1360,6 +1360,32 @@ struct MIFImageIndexOpConversion
   }
 };
 
+static void genCoarrayHandle(fir::FirOpBuilder &builder, mlir::ModuleOp mod,
+                             fir::DeclareOp op) {
+  builder.setInsertionPointAfter(op);
+  mlir::Location loc = op.getLoc();
+  mlir::Type ty = fir::unwrapRefType(op.getMemref().getType());
+
+  if (auto boxTy = mlir::dyn_cast<fir::BaseBoxType>(ty)) {
+    if (boxTy.isCoarray()) {
+      mlir::Type handleTy =
+          fir::BoxType::get(getCoarrayHandleType(builder, loc));
+      std::string globalName =
+          op.getUniqName().str() + coarrayHandleSuffix.str();
+      fir::GlobalOp global = builder.createGlobal(
+          loc, handleTy, globalName, builder.createLinkOnceLinkage());
+      mlir::Region &region = global.getRegion();
+      region.push_back(new mlir::Block);
+      mlir::Block &block = region.back();
+      auto insertPt = builder.saveInsertionPoint();
+      builder.setInsertionPointToStart(&block);
+      auto box = fir::factory::createUnallocatedBox(builder, loc, handleTy, {});
+      fir::HasValueOp::create(builder, loc, box);
+      builder.restoreInsertionPoint(insertPt);
+    }
+  }
+}
+
 class MIFOpConversion : public fir::impl::MIFOpConversionBase<MIFOpConversion> {
 public:
   void runOnOperation() override {
@@ -1384,11 +1410,15 @@ public:
 
     fir::LLVMTypeConverter typeConverter(module, /*applyTBAA=*/false,
                                          /*forceUnifiedTBAATree=*/false, *dl);
-    mif::populateMIFOpConversionPatterns(typeConverter, *dl, patterns);
-
     target.addLegalDialect<fir::FIROpsDialect, mlir::cf::ControlFlowDialect>();
     target.addLegalOp<mlir::ModuleOp>();
 
+    // Generate non-allocated missing coarray_handle
+    fir::FirOpBuilder builder(op, fir::getKindMapping(op));
+    module.walk(
+        [&](fir::DeclareOp op) { genCoarrayHandle(builder, module, op); });
+
+    mif::populateMIFOpConversionPatterns(typeConverter, *dl, patterns);
     if (mlir::failed(mlir::applyPartialConversion(getOperation(), target,
                                                   std::move(patterns)))) {
       mlir::emitError(mlir::UnknownLoc::get(ctx),

--- a/flang/test/Lower/MIF/coarray_dealloc_not_alloc.f90
+++ b/flang/test/Lower/MIF/coarray_dealloc_not_alloc.f90
@@ -1,0 +1,15 @@
+! RUN: %flang_fc1 -emit-llvm -fcoarray %s -o - 2>&1 | FileCheck %s --check-prefix=LLVM
+
+! LLVM: @_QFB1Ekk_coarray_handle = linkonce global { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } { ptr null, i64 40, i32 20240719, i8 0, i8 42, i8 0, i8 1, ptr @_QMprifEXdtXprif_coarray_handle, [1 x i64] zeroinitializer }, comdat
+
+! LLVM-LABEL:  @_QQmain()
+! LLVM:       call void @llvm.memcpy.p0.p0.i32(ptr align 8 %[[VAL_1:.*]], ptr align 8 @_QFB1Ekk_coarray_handle, i32 40, i1 false)
+! LLVM-NEXT:  call void @_QMprifPprif_deallocate_coarray(ptr %[[VAL_1]], ptr null, ptr null, ptr null)
+
+
+block
+integer :: kk
+allocatable :: kk(:)[:]
+endblock
+end
+


### PR DESCRIPTION
This PR fixes the behavior reported in issue #193157. The coarray_handle was only defined if a call to mif.alloc_coarray was present.
If a call to mif.dealloc_coarray was encountered without a prior call to mif.alloc_coarray, then the coarray_handle was missing, and therefore llvm.address_of pointed to a non-existent address, which is not allowed. 
We now define a coarray_handle that has not been allocated by PRIF for each coarray variables.