### PR TITLE
[clang][CIR][docs] Fix invalid MyST toctree 'numbered' option

### DIFF
--- a/clang/docs/CIR/index.md
+++ b/clang/docs/CIR/index.md
@@ -14,7 +14,7 @@ a position between Clang's AST and LLVM IR.
 
 ```{toctree}
 :maxdepth: 1
-:numbered: true
+:numbered:
 
 ABILowering
 CleanupAndEHDesign


### PR DESCRIPTION
Similar to #207217

The RST-to-Markdown migration (#206181) converted the RST flag `:numbered:` into `:numbered: true`.

MyST parses the toctree `numbered` option as `int_or_nothing`, so the string `true` fails with:

```
'toctree': Invalid option value for 'numbered': true:
invalid literal for int() with base 10: 'true'
```

This breaks the `-W` (warnings-as-errors) `docs-clang-html` build. Make `numbered` a valueless flag, which MyST accepts (equivalent to the original RST behavior of numbering all levels).