### PR TITLE
[InstrProf] Disambiguate zero bitmaps in text profiles

### DIFF
--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -444,8 +444,12 @@ Error TextInstrProfReader::readNextRecord(NamedInstrProfRecord &Record) {
     Record.Counts.push_back(Count);
   }
 
-  // Bitmap byte information is indicated with special character.
-  if (Line->starts_with("$")) {
+  // Bitmap byte information is indicated by '$' followed by an integer. Only
+  // treat numeric-looking lines as bitmap records so function names such as
+  // Swift manglings beginning with "$s" remain unambiguous.
+  StringRef BitmapSize =
+      Line->starts_with("$") ? Line->drop_front(1).trim() : StringRef();
+  if (!BitmapSize.empty() && isDigit(BitmapSize.front())) {
     Record.BitmapBytes.clear();
     // Read the number of bitmap bytes.
     uint64_t NumBitmapBytes;

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -741,8 +741,8 @@ void InstrProfWriter::writeRecordInText(StringRef Name, uint64_t Hash,
   for (uint64_t Count : Func.Counts)
     OS << Count << "\n";
 
-  if (Func.BitmapBytes.size() > 0) {
-    OS << "# Num Bitmap Bytes:\n$" << Func.BitmapBytes.size() << "\n";
+  OS << "# Num Bitmap Bytes:\n$" << Func.BitmapBytes.size() << "\n";
+  if (!Func.BitmapBytes.empty()) {
     OS << "# Bitmap Byte Values:\n";
     for (uint8_t Byte : Func.BitmapBytes) {
       OS << "0x";

--- a/llvm/test/tools/llvm-profdata/Inputs/CSIR_profile.proftext
+++ b/llvm/test/tools/llvm-profdata/Inputs/CSIR_profile.proftext
@@ -8,4 +8,6 @@ bar
 # Counter Values:
 99938
 62
+# Num Bitmap Bytes:
+$0
 

--- a/llvm/test/tools/llvm-profdata/Inputs/IR_profile.proftext
+++ b/llvm/test/tools/llvm-profdata/Inputs/IR_profile.proftext
@@ -6,4 +6,6 @@ main
 1
 # Counter Values:
 1
+# Num Bitmap Bytes:
+$0
 

--- a/llvm/test/tools/llvm-profdata/Inputs/cs.proftext
+++ b/llvm/test/tools/llvm-profdata/Inputs/cs.proftext
@@ -8,3 +8,5 @@ bar
 # Counter Values:
 99938
 62
+# Num Bitmap Bytes:
+$0

--- a/llvm/test/tools/llvm-profdata/Inputs/instr-remap.expected
+++ b/llvm/test/tools/llvm-profdata/Inputs/instr-remap.expected
@@ -8,6 +8,8 @@ bar
 # Counter Values:
 31
 42
+# Num Bitmap Bytes:
+$0
 
 bar
 # Func Hash:
@@ -17,6 +19,8 @@ bar
 # Counter Values:
 500
 600
+# Num Bitmap Bytes:
+$0
 
 baz
 # Func Hash:
@@ -26,4 +30,6 @@ baz
 # Counter Values:
 7
 8
+# Num Bitmap Bytes:
+$0
 

--- a/llvm/test/tools/llvm-profdata/merge-filter.test
+++ b/llvm/test/tools/llvm-profdata/merge-filter.test
@@ -31,6 +31,8 @@ CHECK-NEXT: 2
 CHECK-NEXT: # Counter Values:
 CHECK-NEXT: 499500
 CHECK-NEXT: 179900
+CHECK-NEXT: # Num Bitmap Bytes:
+CHECK-NEXT: $0
 CHECK-NEXT: 
 CHECK-NEXT: foo2
 CHECK-NEXT: # Func Hash:
@@ -40,6 +42,8 @@ CHECK-NEXT: 2
 CHECK-NEXT: # Counter Values:
 CHECK-NEXT: 500500
 CHECK-NEXT: 180100
+CHECK-NEXT: # Num Bitmap Bytes:
+CHECK-NEXT: $0
 
 RUN: llvm-profdata merge --instr %p/Inputs/basic.proftext --text --function="foo" --no-function="^foo$" | FileCheck %s --check-prefix=CHECK-FILTER4
 CHECK-FILTER4: foo2
@@ -50,6 +54,8 @@ CHECK-NEXT: 2
 CHECK-NEXT: # Counter Values:
 CHECK-NEXT: 500500
 CHECK-NEXT: 180100
+CHECK-NEXT: # Num Bitmap Bytes:
+CHECK-NEXT: $0
 
 RUN: llvm-profdata merge --sample %p/Inputs/cs-sample.proftext --text --function="main.*@.*_Z5funcBi" | FileCheck %s --check-prefix=CHECK-FILTER5
 CHECK-FILTER5: [main:3.1 @ _Z5funcBi:1 @ _Z8funcLeafi]:500853:20
@@ -66,4 +72,3 @@ CHECK-NEXT:  0: 19
 CHECK-NEXT:  1: 19 _Z8funcLeafi:20
 CHECK-NEXT:  3: 12
 CHECK-NEXT:  !Attributes: 1
-

--- a/llvm/test/tools/llvm-profdata/text-zero-bitmap.test
+++ b/llvm/test/tools/llvm-profdata/text-zero-bitmap.test
@@ -7,12 +7,26 @@ RUN: FileCheck %s --input-file=%t/a --check-prefix=GENERATED
 RUN: llvm-profdata merge --instr --text %t/a -o %t/b
 RUN: diff %t/a %t/b
 
+# Numeric-looking function names remain ambiguous in legacy text, so verify
+# that explicit zero-bitmap records preserve them across writer round trips.
+RUN: llvm-profdata merge --instr --text %t/explicit.proftext -o %t/c
+RUN: FileCheck %s --input-file=%t/c --check-prefix=EXPLICIT
+RUN: llvm-profdata merge --instr --text %t/c -o %t/d
+RUN: diff %t/c %t/d
+
 GENERATED-LABEL: !zero_bitmap
 GENERATED: # Num Bitmap Bytes:
 GENERATED-NEXT: $0
 GENERATED: $s4main3fooyyF
 GENERATED: # Num Bitmap Bytes:
 GENERATED-NEXT: $0
+
+EXPLICIT-LABEL: !zero_bitmap
+EXPLICIT: # Num Bitmap Bytes:
+EXPLICIT-NEXT: $0
+EXPLICIT-LABEL: $1next
+EXPLICIT: # Num Bitmap Bytes:
+EXPLICIT-NEXT: $0
 
 ;--- legacy.proftext
 !zero_bitmap
@@ -23,3 +37,15 @@ $s4main3fooyyF
 2
 1
 9
+
+;--- explicit.proftext
+!zero_bitmap
+1
+1
+7
+$0
+$1next
+2
+1
+9
+$0

--- a/llvm/test/tools/llvm-profdata/text-zero-bitmap.test
+++ b/llvm/test/tools/llvm-profdata/text-zero-bitmap.test
@@ -1,0 +1,25 @@
+# A missing zero-bitmap record must not make a following Swift function name
+# look like a bitmap count. The text writer makes the record explicit so its
+# output can be read back without ambiguity.
+RUN: split-file %s %t
+RUN: llvm-profdata merge --instr --text %t/legacy.proftext -o %t/a
+RUN: FileCheck %s --input-file=%t/a --check-prefix=GENERATED
+RUN: llvm-profdata merge --instr --text %t/a -o %t/b
+RUN: diff %t/a %t/b
+
+GENERATED-LABEL: !zero_bitmap
+GENERATED: # Num Bitmap Bytes:
+GENERATED-NEXT: $0
+GENERATED: $s4main3fooyyF
+GENERATED: # Num Bitmap Bytes:
+GENERATED-NEXT: $0
+
+;--- legacy.proftext
+!zero_bitmap
+1
+1
+7
+$s4main3fooyyF
+2
+1
+9


### PR DESCRIPTION
## Summary

- Always emit the bitmap-byte count in instrumentation text profiles, including an explicit `$0` for records without bitmap data.
- Treat only numeric-looking `$...` lines as bitmap counts so a following Swift `$s...` function name is not consumed as malformed bitmap metadata.
- Add reduced legacy-input coverage and a second round-trip regression proving that explicit `$0` preserves a following function name beginning with `$` and a digit.

## Motivation

`InstrProfWriter` previously omitted the bitmap field when it was empty, while `TextInstrProfReader` treated any following line beginning with `$` as the bitmap-byte count. If the next function is a Swift mangled name such as `$s4main3fooyyF`, a valid writer-produced text profile could not be read back and `llvm-profdata merge` reported `number of bitmap bytes is not a valid integer`.

Writing `$0` makes new records self-delimiting. Narrowing the legacy reader check allows existing profiles with the omitted field to recover Swift names. A following name beginning with `$` and a digit remains inherently ambiguous in legacy text, which is why the writer-side `$0` is necessary in addition to the reader correction.

## Testing

- Rebased the two-commit series onto current `main`; `git range-diff` and aggregate stable patch IDs preserve the patch.
- Assertion-enabled Release build of the affected `llvm-profdata`, `FileCheck`, and `split-file` tools.
- Focused `llvm/test/tools/llvm-profdata/text-zero-bitmap.test`: 1/1 passed.
- `git diff --check` passed.
- The previous head passed LLVM premerge on Linux, Linux AArch64, Windows, and macOS arm64, plus formatter, ABI-annotation, project-computation, and libc++ checks. The rebased head starts a fresh CI cycle.
