### PR TITLE
[mlir][transform] Add ApplySwapExtractSliceWithFillPatternsOp transform op

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -165,6 +165,17 @@ def ApplyExtractSliceSinkingPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def ApplySwapExtractSliceWithFillPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.linalg.swap_extract_slice_with_fill",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+  let description = [{
+    Patterns to swap `tensor.extract_slice(linalg.fill(...))` with
+    `linalg.fill(tensor.extract_slice(...))`.
+  }];
+
+  let assemblyFormat = "attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // BufferizeToAllocationOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -292,6 +292,11 @@ void transform::ApplyExtractSliceSinkingPatternsOp::populatePatterns(
   linalg::populateExtractSliceSinkingPatterns(patterns, defaultControlFn);
 }
 
+void transform::ApplySwapExtractSliceWithFillPatternsOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  linalg::populateSwapExtractSliceWithFillPatterns(patterns);
+}
+
 //===----------------------------------------------------------------------===//
 // BufferizeToAllocationOp
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/Linalg/transform-op-swap-extract-slice-with-fill.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-swap-extract-slice-with-fill.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-opt %s -transform-interpreter | FileCheck %s
+
+func.func @swap_fill_extract_slice(%init : tensor<?x?x?xf32>, %offset0: index, %size1: index) -> tensor<?x6xf32> {
+  %f0 = arith.constant 0.000000e+00 : f32
+  %0 = linalg.fill ins(%f0 : f32) outs(%init : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  %1 = tensor.extract_slice %0[%offset0, 8, 4] [1, %size1, 6] [1, 3, 1]
+    : tensor<?x?x?xf32> to tensor<?x6xf32>
+  return %1: tensor<?x6xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %f = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %f {
+      transform.apply_patterns.linalg.swap_extract_slice_with_fill
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func.func @swap_fill_extract_slice
+// CHECK: %[[F0:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[EXT:.*]] = tensor.extract_slice %{{.*}}[%{{.*}}, 8, 4] [1, %{{.*}}, 6] [1, 3, 1]
+// CHECK: %[[FILL:.*]] = linalg.fill ins(%[[F0]] : f32) outs(%[[EXT]] : tensor<?x6xf32>) -> tensor<?x6xf32>
+// CHECK: return %[[FILL]] : tensor<?x6xf32>

--- a/mlir/test/python/dialects/transform.py
+++ b/mlir/test/python/dialects/transform.py
@@ -2,6 +2,7 @@
 
 from mlir.ir import *
 from mlir.dialects import transform
+from mlir.dialects.transform import structured
 from mlir.dialects.transform import pdl as transform_pdl
 
 
@@ -299,6 +300,19 @@ def testApplyPatternsOpWithType(module: Module):
         # CHECK: apply_patterns to
         # CHECK: transform.apply_patterns.canonicalization
         # CHECK: !transform.op<"test.dummy">
+
+
+@run
+def testApplyLinalgSwapExtractSliceWithFillPattern(module: Module):
+    sequence = transform.SequenceOp(
+        transform.FailurePropagationMode.Propagate, [], transform.AnyOpType.get()
+    )
+    with InsertionPoint(sequence.body):
+        with InsertionPoint(transform.ApplyPatternsOp(sequence.bodyTarget).patterns):
+            structured.apply_patterns_linalg_swap_extract_slice_with_fill()
+        transform.YieldOp()
+    # CHECK-LABEL: TEST: testApplyLinalgSwapExtractSliceWithFillPattern
+    # CHECK: transform.apply_patterns.linalg.swap_extract_slice_with_fill
 
 
 @run


### PR DESCRIPTION
Adds transform op for the existing linalg `SwapExtractSliceOfFill` pattern as `apply_patterns.linalg.swap_extract_slice_with_fill`.

For motivation, see https://github.com/llvm/llvm-project/pull/212974#issuecomment-5176932196

Assisted-by: GPT-5.3-Codex