### PR TITLE
[libc++] Remove _IsThisTuple

### DIFF
--- a/libcxx/include/__configuration/namespace.h
+++ b/libcxx/include/__configuration/namespace.h
@@ -30,10 +30,12 @@
     _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                             \
     _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                             \
     _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++23-extensions")                                                             \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++26-extensions")                                                             \
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                               \
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                               \
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                               \
-    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")                                                               \
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++26-extensions")
 #  define _LIBCPP_POP_EXTENSION_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
 #  define _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS                                                                          \
     _LIBCPP_DIAGNOSTIC_PUSH _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wpragma-clang-attribute")                               \

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -605,13 +605,9 @@ public:
 
   // tuple(U&& ...) constructors (including allocator_arg_t variants)
   template <class... _Up>
-  struct _IsThisTuple : false_type {};
-  template <class _Up>
-  struct _IsThisTuple<_Up> : is_same<__remove_cvref_t<_Up>, tuple> {};
-
-  template <class... _Up>
   struct _EnableUTypesCtor
-      : _And<_Not<_IsThisTuple<_Up...> >, // extension to allow mis-behaved user constructors
+      : _And<_Or<integral_constant<bool, sizeof...(_Up) != 1>,
+                 _IsNotSame<__remove_cvref_t<_Up...[0]>, tuple>>, // extension to allow mis-behaved user constructors
              is_constructible<_Tp, _Up>... > {};
 
   template <class... _Up,


### PR DESCRIPTION
We can inline it into `_EnableUTypesCtor` instead.
