### PR TITLE
[libc] Implement sleep and usleep for Linux

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -411,12 +411,14 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setsid
+    libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat
+    libc.src.unistd.usleep
     libc.src.unistd.write
 
     # wchar.h entrypoints

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -447,12 +447,14 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setsid
+    libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat
+    libc.src.unistd.usleep
     libc.src.unistd.write
 
     # wchar.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -452,12 +452,14 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir
     libc.src.unistd.setsid
+    libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
     libc.src.unistd.sysconf
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat
+    libc.src.unistd.usleep
     libc.src.unistd.write
 
     # wchar.h entrypoints

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -299,6 +299,14 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  useconds_t
+  HDRS
+    useconds_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.useconds_t
+)
+
+add_proxy_header_library(
   struct_timeval
   HDRS
     struct_timeval.h
@@ -710,7 +718,6 @@ add_proxy_header_library(
     libc.include.llvm-libc-types.wint_t
     libc.include.wchar
 )
-
 
 add_proxy_header_library(
   wctype_t

--- a/libc/hdr/types/useconds_t.h
+++ b/libc/hdr/types/useconds_t.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy header for the useconds_t type.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_USECONDS_T_H
+#define LLVM_LIBC_HDR_TYPES_USECONDS_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/useconds_t.h"
+
+#else // Overlay mode
+
+#include <sys/types.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_USECONDS_T_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -490,6 +490,7 @@ add_header_macro(
     .llvm-libc-types.size_t
     .llvm-libc-types.ssize_t
     .llvm-libc-types.uid_t
+    .llvm-libc-types.useconds_t
     .llvm-libc-types.__getoptargv_t
 )
 

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -42,6 +42,7 @@ types:
   - type_name: __getoptargv_t
   - type_name: __exec_envp_t
   - type_name: __exec_argv_t
+  - type_name: useconds_t
 enums: []
 objects:
   - object_name: environ
@@ -384,6 +385,12 @@ functions:
     return_type: pid_t
     arguments:
       - type: void
+  - name: sleep
+    standards:
+      - posix
+    return_type: unsigned int
+    arguments:
+      - type: unsigned int
   - name: symlink
     standards:
       - posix
@@ -426,6 +433,12 @@ functions:
       - type: int
       - type: const char *
       - type: int
+  - name: usleep
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: useconds_t
   - name: write
     standards:
       - posix

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -745,7 +745,6 @@ add_header_library(
     libc.include.sys_syscall
 )
 
-
 add_header_library(
   dup
   HDRS
@@ -921,6 +920,20 @@ add_header_library(
     fstatfs.h
   DEPENDS
     libc.hdr.types.struct_statfs
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  nanosleep
+  HDRS
+    nanosleep.h
+  DEPENDS
+    libc.hdr.types.struct_timespec
+    libc.hdr.time_macros
     libc.src.__support.OSUtil.osutil
     libc.src.__support.common
     libc.src.__support.error_or

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/nanosleep.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/nanosleep.h
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for nanosleep syscall wrapper.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_NANOSLEEP_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_NANOSLEEP_H
+
+#include "hdr/time_macros.h"
+#include "hdr/types/struct_timespec.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_checked
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h>
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> nanosleep(const timespec *req, timespec *rem) {
+#if defined(SYS_clock_nanosleep_time64)
+  static_assert(
+      sizeof(time_t) == sizeof(int64_t),
+      "SYS_clock_nanosleep_time64 requires struct timespec with 64-bit "
+      "members.");
+  return syscall_checked<int>(SYS_clock_nanosleep_time64, CLOCK_REALTIME, 0,
+                              req, rem);
+#elif defined(SYS_nanosleep)
+  static_assert(
+      sizeof(timespec::tv_nsec) == sizeof(long),
+      "This legacy syscall fallback is only safe on platforms where tv_nsec "
+      "matches the register size (long). It is unsafe on 32-bit platforms "
+      "with 64-bit tv_nsec.");
+  return syscall_checked<int>(SYS_nanosleep, req, rem);
+#else
+#error "SYS_nanosleep and SYS_clock_nanosleep_time64 syscalls not available."
+#endif
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_NANOSLEEP_H

--- a/libc/src/time/linux/CMakeLists.txt
+++ b/libc/src/time/linux/CMakeLists.txt
@@ -40,10 +40,10 @@ add_entrypoint_object(
     ../nanosleep.h
   DEPENDS
     libc.hdr.types.struct_timespec
-    libc.hdr.stdint_proxy
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.__support.CPP.limits
+    libc.src.__support.OSUtil.linux.syscall_wrappers.nanosleep
+    libc.src.__support.common
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
     libc.src.errno.errno
 )
 

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -236,7 +236,6 @@ add_entrypoint_object(
     .${LIBC_TARGET_OS}.pathconf
 )
 
-
 add_entrypoint_object(
   pipe
   ALIAS
@@ -301,6 +300,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  sleep
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.sleep
+)
+
+add_entrypoint_object(
   symlink
   ALIAS
   DEPENDS
@@ -347,6 +353,13 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.unlinkat
+)
+
+add_entrypoint_object(
+  usleep
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.usleep
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -542,6 +542,20 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  sleep
+  SRCS
+    sleep.cpp
+  HDRS
+    ../sleep.h
+  DEPENDS
+    libc.hdr.types.struct_timespec
+    libc.hdr.types.time_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.nanosleep
+    libc.src.__support.common
+    libc.src.__support.macros.config
+)
+
+add_entrypoint_object(
   symlink
   SRCS
     symlink.cpp
@@ -635,6 +649,22 @@ add_entrypoint_object(
     ../unlinkat.h
   DEPENDS
     libc.src.__support.OSUtil.linux.syscall_wrappers.unlinkat
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  usleep
+  SRCS
+    usleep.cpp
+  HDRS
+    ../usleep.h
+  DEPENDS
+    libc.hdr.types.useconds_t
+    libc.hdr.types.struct_timespec
+    libc.src.__support.OSUtil.linux.syscall_wrappers.nanosleep
+    libc.src.__support.common
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
     libc.src.errno.errno
 )
 

--- a/libc/src/unistd/linux/sleep.cpp
+++ b/libc/src/unistd/linux/sleep.cpp
@@ -7,25 +7,30 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Linux implementation of nanosleep function.
+/// Linux implementation of sleep.
 ///
 //===----------------------------------------------------------------------===//
 
-#include "src/time/nanosleep.h"
+#include "src/unistd/sleep.h"
+#include "hdr/types/struct_timespec.h"
+#include "hdr/types/time_t.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/nanosleep.h"
 #include "src/__support/common.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
-  auto result = linux_syscalls::nanosleep(req, rem);
+LLVM_LIBC_FUNCTION(unsigned int, sleep, (unsigned int seconds)) {
+  static_assert(sizeof(unsigned int) <= sizeof(time_t), "Avoids overflow");
+  struct timespec req = {seconds, 0};
+  struct timespec rem = {};
+  ErrorOr<int> result = linux_syscalls::nanosleep(&req, &rem);
   if (!result) {
-    libc_errno = result.error();
-    return -1;
+    // Cast does not lose information as `remaining` cannot be greater than
+    // `seconds`.
+    return static_cast<unsigned int>(rem.tv_sec);
   }
-  return result.value();
+  return 0;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/usleep.cpp
+++ b/libc/src/unistd/linux/usleep.cpp
@@ -7,11 +7,12 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Linux implementation of nanosleep function.
+/// Linux implementation of usleep.
 ///
 //===----------------------------------------------------------------------===//
 
-#include "src/time/nanosleep.h"
+#include "src/unistd/usleep.h"
+#include "hdr/types/struct_timespec.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/nanosleep.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
@@ -19,13 +20,16 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
-  auto result = linux_syscalls::nanosleep(req, rem);
+LLVM_LIBC_FUNCTION(int, usleep, (useconds_t usec)) {
+  static_assert(sizeof(useconds_t) >= 4, "Avoids overflow in ns computation");
+  constexpr useconds_t US_IN_S = 1'000'000;
+  struct timespec ts = {usec / US_IN_S, (usec % US_IN_S) * 1000};
+  auto result = linux_syscalls::nanosleep(&ts, nullptr);
   if (!result) {
     libc_errno = result.error();
     return -1;
   }
-  return result.value();
+  return 0;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/sleep.h
+++ b/libc/src/unistd/sleep.h
@@ -7,25 +7,19 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Linux implementation of nanosleep function.
+/// Implementation header for sleep.
 ///
 //===----------------------------------------------------------------------===//
 
-#include "src/time/nanosleep.h"
-#include "src/__support/OSUtil/linux/syscall_wrappers/nanosleep.h"
-#include "src/__support/common.h"
-#include "src/__support/libc_errno.h"
+#ifndef LLVM_LIBC_SRC_UNISTD_SLEEP_H
+#define LLVM_LIBC_SRC_UNISTD_SLEEP_H
+
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
-  auto result = linux_syscalls::nanosleep(req, rem);
-  if (!result) {
-    libc_errno = result.error();
-    return -1;
-  }
-  return result.value();
-}
+unsigned int sleep(unsigned int seconds);
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SLEEP_H

--- a/libc/src/unistd/usleep.h
+++ b/libc/src/unistd/usleep.h
@@ -7,25 +7,20 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Linux implementation of nanosleep function.
+/// Implementation header for usleep.
 ///
 //===----------------------------------------------------------------------===//
 
-#include "src/time/nanosleep.h"
-#include "src/__support/OSUtil/linux/syscall_wrappers/nanosleep.h"
-#include "src/__support/common.h"
-#include "src/__support/libc_errno.h"
+#ifndef LLVM_LIBC_SRC_UNISTD_USLEEP_H
+#define LLVM_LIBC_SRC_UNISTD_USLEEP_H
+
+#include "hdr/types/useconds_t.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
-  auto result = linux_syscalls::nanosleep(req, rem);
-  if (!result) {
-    libc_errno = result.error();
-    return -1;
-  }
-  return result.value();
-}
+int usleep(useconds_t usec);
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_USLEEP_H

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -209,9 +209,10 @@ add_libc_test(
   SRCS
     nanosleep_test.cpp
   DEPENDS
-    libc.include.time
     libc.hdr.types.struct_timespec
+    libc.hdr.signal_macros
     libc.src.time.nanosleep
+    libc.src.__support.macros.config
     libc.test.UnitTest.ErrnoCheckingTest
 )
 

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -404,6 +404,19 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  sleep_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    sleep_test.cpp
+  DEPENDS
+    libc.hdr.time_macros
+    libc.hdr.types.struct_timespec
+    libc.src.__support.time.clock_gettime
+    libc.src.unistd.sleep
+)
+
+add_libc_unittest(
   symlink_test
   SUITE
     libc_unistd_unittests
@@ -493,6 +506,20 @@ add_libc_unittest(
     libc.src.unistd.unlinkat
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_unittest(
+  usleep_test
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    usleep_test.cpp
+  DEPENDS
+    libc.hdr.time_macros
+    libc.hdr.types.struct_timespec
+    libc.src.__support.time.clock_gettime
+    libc.src.unistd.usleep
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(

--- a/libc/test/src/unistd/sleep_test.cpp
+++ b/libc/test/src/unistd/sleep_test.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for sleep.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/time_macros.h"
+#include "hdr/types/struct_timespec.h"
+#include "src/__support/time/clock_gettime.h"
+#include "src/unistd/sleep.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcSleepTest, SmokeTest) {
+  struct timespec start, end;
+  ASSERT_TRUE(LIBC_NAMESPACE::internal::clock_gettime(CLOCK_MONOTONIC, &start)
+                  .has_value());
+
+  // Sleep for 1 second.
+  ASSERT_EQ(LIBC_NAMESPACE::sleep(1), 0u);
+
+  ASSERT_TRUE(LIBC_NAMESPACE::internal::clock_gettime(CLOCK_MONOTONIC, &end)
+                  .has_value());
+
+  // Calculate elapsed time in seconds.
+  uint64_t elapsed_sec = static_cast<uint64_t>(end.tv_sec - start.tv_sec);
+  if (end.tv_nsec < start.tv_nsec)
+    --elapsed_sec;
+
+  // It should have slept for at least 1 second.
+  ASSERT_GE(elapsed_sec, uint64_t{1});
+}
+
+TEST(LlvmLibcSleepTest, Zero) { ASSERT_EQ(LIBC_NAMESPACE::sleep(0), 0u); }

--- a/libc/test/src/unistd/usleep_test.cpp
+++ b/libc/test/src/unistd/usleep_test.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for usleep.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/time_macros.h"
+#include "hdr/types/struct_timespec.h"
+#include "src/__support/time/clock_gettime.h"
+#include "src/unistd/usleep.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcUsleepTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcUsleepTest, SmokeTest) {
+  struct timespec start, end;
+  ASSERT_TRUE(LIBC_NAMESPACE::internal::clock_gettime(CLOCK_MONOTONIC, &start)
+                  .has_value());
+
+  // Sleep for 10000 microseconds (10 ms).
+  ASSERT_EQ(LIBC_NAMESPACE::usleep(10000), 0);
+
+  ASSERT_TRUE(LIBC_NAMESPACE::internal::clock_gettime(CLOCK_MONOTONIC, &end)
+                  .has_value());
+
+  // Calculate elapsed time in nanoseconds.
+  int64_t diff_sec = end.tv_sec - start.tv_sec;
+  int64_t diff_nsec = end.tv_nsec - start.tv_nsec;
+  int64_t elapsed_ns = diff_sec * 1000000000LL + diff_nsec;
+
+  // It should have slept for at least 10 ms (10,000,000 ns).
+  ASSERT_GE(elapsed_ns, int64_t{10000000});
+}
+
+TEST_F(LlvmLibcUsleepTest, Zero) { ASSERT_EQ(LIBC_NAMESPACE::usleep(0), 0); }


### PR DESCRIPTION
Implemented the sleep and usleep entrypoints for Linux. Refactored the syscall implementation out of the public nanosleep entrypoint into a standard internal syscall wrapper.