### PR TITLE
[flang][OpenMP] Detect conflicting data-sharing clauses for common blocks

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -3353,23 +3353,16 @@ static bool WithMultipleAppearancesOmpException(const Symbol &symbol,
 
 void OmpAttributeVisitor::CheckMultipleAppearances(
     const parser::Name &name, const Symbol &symbol, Symbol::Flag ompFlag) {
-  const auto *target{&symbol};
-  if (ompFlagsRequireNewSymbol.test(ompFlag)) {
-    if (const auto *details{symbol.detailsIf<HostAssocDetails>()}) {
-      target = &details->symbol();
-    }
-  }
-  const Symbol &ultimate{target->GetUltimate()};
+  const Symbol &ultimate{symbol.GetUltimate()};
   bool conflicts{HasDataSharingAttributeObject(ultimate)};
   if (!conflicts) {
     if (const Symbol *commonBlock{FindCommonBlockContaining(ultimate)}) {
       conflicts = HasDataSharingAttributeObject(*commonBlock);
     } else if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
       for (const auto &object : details->objects()) {
-        const Symbol &member{object->GetUltimate()};
-        if (HasDataSharingAttributeObject(member) &&
-            !WithMultipleAppearancesOmpException(member, ompFlag,
-                GetContext().FindObjectWithDSAByUltimate(member))) {
+        if (HasDataSharingAttributeObject(*object) &&
+            !WithMultipleAppearancesOmpException(*object, ompFlag,
+                GetContext().FindObjectWithDSAByUltimate(*object))) {
           conflicts = true;
           break;
         }
@@ -3385,7 +3378,7 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
     AddDataSharingAttributeObject(ultimate);
     if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
       for (const auto &object : details->objects()) {
-        AddDataSharingAttributeObject(object->GetUltimate());
+        AddDataSharingAttributeObject(*object);
       }
     }
   }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -73,7 +73,8 @@ protected:
       return std::nullopt;
     }
 
-    std::optional<Symbol::Flag> FindExplicitDSAForMember(const Symbol &symbol) {
+    std::optional<Symbol::Flag> FindObjectWithDSAByUltimate(
+        const Symbol &symbol) {
       if (auto flag{FindSymbolWithDSA(symbol)}) {
         return flag;
       }
@@ -3335,20 +3336,19 @@ Symbol *OmpAttributeVisitor::DeclareOrMarkOtherAccessEntity(
   return &object;
 }
 
-static bool WithMultipleAppearancesOmpException(
-    const Symbol &symbol, Symbol::Flag flag) {
+static bool WithMultipleAppearancesOmpException(const Symbol &symbol,
+    Symbol::Flag flag, std::optional<Symbol::Flag> prevFlag = std::nullopt) {
+  if (prevFlag &&
+      ((flag == Symbol::Flag::OmpFirstPrivate &&
+           *prevFlag == Symbol::Flag::OmpLastPrivate) ||
+          (flag == Symbol::Flag::OmpLastPrivate &&
+              *prevFlag == Symbol::Flag::OmpFirstPrivate))) {
+    return true;
+  }
   return (flag == Symbol::Flag::OmpFirstPrivate &&
              symbol.test(Symbol::Flag::OmpLastPrivate)) ||
       (flag == Symbol::Flag::OmpLastPrivate &&
           symbol.test(Symbol::Flag::OmpFirstPrivate));
-}
-
-static bool IsFirstPrivateLastPrivatePair(
-    Symbol::Flag flag, Symbol::Flag prevFlag) {
-  return (flag == Symbol::Flag::OmpFirstPrivate &&
-             prevFlag == Symbol::Flag::OmpLastPrivate) ||
-      (flag == Symbol::Flag::OmpLastPrivate &&
-          prevFlag == Symbol::Flag::OmpFirstPrivate);
 }
 
 void OmpAttributeVisitor::CheckMultipleAppearances(
@@ -3367,17 +3367,11 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
     } else if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
       for (const auto &object : details->objects()) {
         const Symbol &member{object->GetUltimate()};
-        if (HasDataSharingAttributeObject(member)) {
-          bool allowed{WithMultipleAppearancesOmpException(member, ompFlag)};
-          if (!allowed) {
-            if (auto prevFlag{GetContext().FindExplicitDSAForMember(member)}) {
-              allowed = IsFirstPrivateLastPrivatePair(ompFlag, *prevFlag);
-            }
-          }
-          if (!allowed) {
-            conflicts = true;
-            break;
-          }
+        if (HasDataSharingAttributeObject(member) &&
+            !WithMultipleAppearancesOmpException(member, ompFlag,
+                GetContext().FindObjectWithDSAByUltimate(member))) {
+          conflicts = true;
+          break;
         }
       }
     }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -73,6 +73,19 @@ protected:
       return std::nullopt;
     }
 
+    std::optional<Symbol::Flag> FindExplicitDSAForMember(const Symbol &symbol) {
+      if (auto flag{FindSymbolWithDSA(symbol)}) {
+        return flag;
+      }
+      const Symbol &ultimate{symbol.GetUltimate()};
+      for (const auto &entry : objectWithDSA) {
+        if (entry.first->GetUltimate() == ultimate) {
+          return entry.second;
+        }
+      }
+      return std::nullopt;
+    }
+
     bool withinConstruct{false};
     std::int64_t associatedLoopLevel{0};
   };
@@ -603,6 +616,7 @@ public:
 
   bool Pre(const parser::OmpDeclareSimdDirective &x) {
     PushContext(x.source, llvm::omp::Directive::OMPD_declare_simd);
+    ClearDataSharingAttributeObjects();
     for (const parser::OmpArgument &arg : x.v.Arguments().v) {
       if (auto *object{parser::omp::GetArgumentObject(arg)}) {
         ResolveOmpObject(*object, Symbol::Flag::OmpDeclareSimd);
@@ -3219,7 +3233,7 @@ void OmpAttributeVisitor::ResolveOmpCommonBlock(
                   !it->second.test(Symbol::Flag::OmpUseDeviceAddr)))};
       it->second.set(ompFlag);
       if (!allowRepeatedAppearance) {
-        CheckMultipleAppearances(name, *symbol, Symbol::Flag::OmpCommonBlock);
+        CheckMultipleAppearances(name, *symbol, ompFlag);
       }
     }
     // 2.15.3 When a named common block appears in a list, it has the
@@ -3329,6 +3343,14 @@ static bool WithMultipleAppearancesOmpException(
           symbol.test(Symbol::Flag::OmpFirstPrivate));
 }
 
+static bool IsFirstPrivateLastPrivatePair(
+    Symbol::Flag flag, Symbol::Flag prevFlag) {
+  return (flag == Symbol::Flag::OmpFirstPrivate &&
+             prevFlag == Symbol::Flag::OmpLastPrivate) ||
+      (flag == Symbol::Flag::OmpLastPrivate &&
+          prevFlag == Symbol::Flag::OmpFirstPrivate);
+}
+
 void OmpAttributeVisitor::CheckMultipleAppearances(
     const parser::Name &name, const Symbol &symbol, Symbol::Flag ompFlag) {
   const auto *target{&symbol};
@@ -3337,14 +3359,41 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
       target = &details->symbol();
     }
   }
-  if (HasDataSharingAttributeObject(target->GetUltimate()) &&
-      !WithMultipleAppearancesOmpException(symbol, ompFlag)) {
+  const Symbol &ultimate{target->GetUltimate()};
+  bool conflicts{HasDataSharingAttributeObject(ultimate)};
+  if (!conflicts) {
+    if (const Symbol *commonBlock{FindCommonBlockContaining(ultimate)}) {
+      conflicts = HasDataSharingAttributeObject(*commonBlock);
+    } else if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
+      for (const auto &object : details->objects()) {
+        const Symbol &member{object->GetUltimate()};
+        if (HasDataSharingAttributeObject(member)) {
+          bool allowed{WithMultipleAppearancesOmpException(member, ompFlag)};
+          if (!allowed) {
+            if (auto prevFlag{GetContext().FindExplicitDSAForMember(member)}) {
+              allowed = IsFirstPrivateLastPrivatePair(ompFlag, *prevFlag);
+            }
+          }
+          if (!allowed) {
+            conflicts = true;
+            break;
+          }
+        }
+      }
+    }
+  }
+  if (conflicts && !WithMultipleAppearancesOmpException(symbol, ompFlag)) {
     context_.Say(name.source,
         "'%s' appears in more than one data-sharing clause "
         "on the same OpenMP directive"_err_en_US,
         name.ToString());
   } else {
-    AddDataSharingAttributeObject(target->GetUltimate());
+    AddDataSharingAttributeObject(ultimate);
+    if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
+      for (const auto &object : details->objects()) {
+        AddDataSharingAttributeObject(object->GetUltimate());
+      }
+    }
   }
 }
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -3199,6 +3199,21 @@ void OmpAttributeVisitor::PropagateOmpFlagToEquivalenceSet(
   }
 }
 
+static bool WithMultipleAppearancesOmpException(const Symbol &symbol,
+    Symbol::Flag flag, std::optional<Symbol::Flag> prevFlag = std::nullopt) {
+  if (prevFlag &&
+      ((flag == Symbol::Flag::OmpFirstPrivate &&
+           *prevFlag == Symbol::Flag::OmpLastPrivate) ||
+          (flag == Symbol::Flag::OmpLastPrivate &&
+              *prevFlag == Symbol::Flag::OmpFirstPrivate))) {
+    return true;
+  }
+  return (flag == Symbol::Flag::OmpFirstPrivate &&
+             symbol.test(Symbol::Flag::OmpLastPrivate)) ||
+      (flag == Symbol::Flag::OmpLastPrivate &&
+          symbol.test(Symbol::Flag::OmpFirstPrivate));
+}
+
 void OmpAttributeVisitor::ResolveOmpCommonBlock(
     const parser::Name &name, Symbol::Flag ompFlag) {
   bool cbResolved{false};
@@ -3214,6 +3229,7 @@ void OmpAttributeVisitor::ResolveOmpCommonBlock(
   parser::Name cbName{name};
   Symbol *originalCB{ResolveOmpCommonBlockName(&cbName)};
   if (auto *symbol{cbResolved ? name.symbol : originalCB}) {
+    bool allowRepeatedAppearance{false};
     if (!dataCopyingAttributeFlags.test(ompFlag)) {
       const Symbol::Flags mapFlags{Symbol::Flag::OmpMapTo,
           Symbol::Flag::OmpMapFrom, Symbol::Flag::OmpMapToFrom,
@@ -3227,15 +3243,12 @@ void OmpAttributeVisitor::ResolveOmpCommonBlock(
       if (isTargetData) {
         allowedRepeatFlags.set(Symbol::Flag::OmpUseDeviceAddr);
       }
-      bool allowRepeatedAppearance{!inserted &&
+      allowRepeatedAppearance = !inserted &&
           (it->second & ~allowedRepeatFlags).none() &&
           (mapFlags.test(ompFlag) ||
               (isTargetData && ompFlag == Symbol::Flag::OmpUseDeviceAddr &&
-                  !it->second.test(Symbol::Flag::OmpUseDeviceAddr)))};
+                  !it->second.test(Symbol::Flag::OmpUseDeviceAddr)));
       it->second.set(ompFlag);
-      if (!allowRepeatedAppearance) {
-        CheckMultipleAppearances(name, *symbol, ompFlag);
-      }
     }
     // 2.15.3 When a named common block appears in a list, it has the
     // same meaning as if every explicit member of the common block
@@ -3244,11 +3257,23 @@ void OmpAttributeVisitor::ResolveOmpCommonBlock(
     bool cbCloned{cbResolved && name.symbol != originalCB};
     bool cloneCommonBlock{dataSharingAttributeFlags.test(ompFlag) && !cbCloned};
     CommonBlockDetails cloneDetails{symbol->name()};
+    bool memberConflict{false};
     for (auto [index, object] : llvm::enumerate(details.objects())) {
       if (auto *resolvedObject{ResolveOmp(*object, ompFlag, currScope())}) {
         if (dataCopyingAttributeFlags.test(ompFlag)) {
           CheckDataCopyingClause(name, *resolvedObject, ompFlag);
         } else {
+          // Check for member conflicts before recording this clause's DSA so
+          // that FindObjectWithDSAByUltimate only reflects prior clauses.
+          if (!memberConflict && !allowRepeatedAppearance &&
+              dataSharingAttributeFlags.test(ompFlag)) {
+            const Symbol &member{object->GetUltimate()};
+            if (HasDataSharingAttributeObject(member) &&
+                !WithMultipleAppearancesOmpException(member, ompFlag,
+                    GetContext().FindObjectWithDSAByUltimate(member))) {
+              memberConflict = true;
+            }
+          }
           AddToContextObjectWithExplicitDSA(*resolvedObject, ompFlag);
         }
         if (cloneCommonBlock) {
@@ -3260,6 +3285,22 @@ void OmpAttributeVisitor::ResolveOmpCommonBlock(
         // Propagate the flag to symbols in the equivalence set
         if (ompFlag == Symbol::Flag::OmpThreadprivate) {
           PropagateOmpFlagToEquivalenceSet(*resolvedObject, ompFlag);
+        }
+      }
+    }
+    if (!dataCopyingAttributeFlags.test(ompFlag) && !allowRepeatedAppearance) {
+      const Symbol &blockUltimate{symbol->GetUltimate()};
+      bool conflicts{
+          memberConflict || HasDataSharingAttributeObject(blockUltimate)};
+      if (conflicts && !WithMultipleAppearancesOmpException(*symbol, ompFlag)) {
+        context_.Say(name.source,
+            "'%s' appears in more than one data-sharing clause "
+            "on the same OpenMP directive"_err_en_US,
+            name.ToString());
+      } else {
+        AddDataSharingAttributeObject(blockUltimate);
+        for (const auto &object : details.objects()) {
+          AddDataSharingAttributeObject(*object);
         }
       }
     }
@@ -3336,21 +3377,6 @@ Symbol *OmpAttributeVisitor::DeclareOrMarkOtherAccessEntity(
   return &object;
 }
 
-static bool WithMultipleAppearancesOmpException(const Symbol &symbol,
-    Symbol::Flag flag, std::optional<Symbol::Flag> prevFlag = std::nullopt) {
-  if (prevFlag &&
-      ((flag == Symbol::Flag::OmpFirstPrivate &&
-           *prevFlag == Symbol::Flag::OmpLastPrivate) ||
-          (flag == Symbol::Flag::OmpLastPrivate &&
-              *prevFlag == Symbol::Flag::OmpFirstPrivate))) {
-    return true;
-  }
-  return (flag == Symbol::Flag::OmpFirstPrivate &&
-             symbol.test(Symbol::Flag::OmpLastPrivate)) ||
-      (flag == Symbol::Flag::OmpLastPrivate &&
-          symbol.test(Symbol::Flag::OmpFirstPrivate));
-}
-
 void OmpAttributeVisitor::CheckMultipleAppearances(
     const parser::Name &name, const Symbol &symbol, Symbol::Flag ompFlag) {
   const Symbol &ultimate{symbol.GetUltimate()};
@@ -3358,15 +3384,6 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
   if (!conflicts) {
     if (const Symbol *commonBlock{FindCommonBlockContaining(ultimate)}) {
       conflicts = HasDataSharingAttributeObject(*commonBlock);
-    } else if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
-      for (const auto &object : details->objects()) {
-        if (HasDataSharingAttributeObject(*object) &&
-            !WithMultipleAppearancesOmpException(*object, ompFlag,
-                GetContext().FindObjectWithDSAByUltimate(*object))) {
-          conflicts = true;
-          break;
-        }
-      }
     }
   }
   if (conflicts && !WithMultipleAppearancesOmpException(symbol, ompFlag)) {
@@ -3376,11 +3393,6 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
         name.ToString());
   } else {
     AddDataSharingAttributeObject(ultimate);
-    if (const auto *details{ultimate.detailsIf<CommonBlockDetails>()}) {
-      for (const auto &object : details->objects()) {
-        AddDataSharingAttributeObject(*object);
-      }
-    }
   }
 }
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -73,20 +73,6 @@ protected:
       return std::nullopt;
     }
 
-    std::optional<Symbol::Flag> FindObjectWithDSAByUltimate(
-        const Symbol &symbol) {
-      if (auto flag{FindSymbolWithDSA(symbol)}) {
-        return flag;
-      }
-      const Symbol &ultimate{symbol.GetUltimate()};
-      for (const auto &entry : objectWithDSA) {
-        if (entry.first->GetUltimate() == ultimate) {
-          return entry.second;
-        }
-      }
-      return std::nullopt;
-    }
-
     bool withinConstruct{false};
     std::int64_t associatedLoopLevel{0};
   };
@@ -3199,15 +3185,8 @@ void OmpAttributeVisitor::PropagateOmpFlagToEquivalenceSet(
   }
 }
 
-static bool WithMultipleAppearancesOmpException(const Symbol &symbol,
-    Symbol::Flag flag, std::optional<Symbol::Flag> prevFlag = std::nullopt) {
-  if (prevFlag &&
-      ((flag == Symbol::Flag::OmpFirstPrivate &&
-           *prevFlag == Symbol::Flag::OmpLastPrivate) ||
-          (flag == Symbol::Flag::OmpLastPrivate &&
-              *prevFlag == Symbol::Flag::OmpFirstPrivate))) {
-    return true;
-  }
+static bool WithMultipleAppearancesOmpException(
+    const Symbol &symbol, Symbol::Flag flag) {
   return (flag == Symbol::Flag::OmpFirstPrivate &&
              symbol.test(Symbol::Flag::OmpLastPrivate)) ||
       (flag == Symbol::Flag::OmpLastPrivate &&
@@ -3263,14 +3242,12 @@ void OmpAttributeVisitor::ResolveOmpCommonBlock(
         if (dataCopyingAttributeFlags.test(ompFlag)) {
           CheckDataCopyingClause(name, *resolvedObject, ompFlag);
         } else {
-          // Check for member conflicts before recording this clause's DSA so
-          // that FindObjectWithDSAByUltimate only reflects prior clauses.
           if (!memberConflict && !allowRepeatedAppearance &&
               dataSharingAttributeFlags.test(ompFlag)) {
             const Symbol &member{object->GetUltimate()};
             if (HasDataSharingAttributeObject(member) &&
-                !WithMultipleAppearancesOmpException(member, ompFlag,
-                    GetContext().FindObjectWithDSAByUltimate(member))) {
+                !WithMultipleAppearancesOmpException(
+                    *resolvedObject, ompFlag)) {
               memberConflict = true;
             }
           }

--- a/flang/test/Semantics/OpenMP/common-block-data-sharing.f90
+++ b/flang/test/Semantics/OpenMP/common-block-data-sharing.f90
@@ -1,0 +1,11 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+
+! a common block in a data-sharing clause is equivalent to
+! listing every explicit member of the common block.
+
+subroutine common_block_dsa()
+  common /c/ x, y
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenMP directive
+  !$omp parallel private(/c/) shared(x)
+  !$omp end parallel
+end subroutine


### PR DESCRIPTION
Fixes #205779

OpenMP treats a named common block in a data-sharing clause as equivalent to listing every explicit member. 

Extend CheckMultipleAppearances to detect conflicts between a common block and its members, and register all explicit members when a common block is listed. Added a regression test.