### PR TITLE
[IR] Remove deprecated BasicBlock::getFirstNonPHI

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -280,21 +280,6 @@ public:
         static_cast<const BasicBlock *>(this)->getTerminatingMustTailCall());
   }
 
-  /// Returns a pointer to the first instruction in this block that is not a
-  /// PHINode instruction.
-  ///
-  /// When adding instructions to the beginning of the basic block, they should
-  /// be added before the returned value, not before the first instruction,
-  /// which might be PHI. Returns 0 is there's no non-PHI instruction.
-  ///
-  /// Deprecated in favour of getFirstNonPHIIt, which returns an iterator that
-  /// preserves some debugging information.
-  LLVM_ABI LLVM_DEPRECATED("Use iterators as instruction positions",
-                           "getFirstNonPHIIt") const
-      Instruction *getFirstNonPHI() const;
-  LLVM_ABI LLVM_DEPRECATED("Use iterators as instruction positions instead",
-                           "getFirstNonPHIIt") Instruction *getFirstNonPHI();
-
   /// Returns an iterator to the first instruction in this block that is not a
   /// PHINode instruction.
   ///

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -284,20 +284,6 @@ const Instruction *BasicBlock::getFirstMayFaultInst() const {
   return nullptr;
 }
 
-const Instruction* BasicBlock::getFirstNonPHI() const {
-  for (const Instruction &I : *this)
-    if (!isa<PHINode>(I))
-      return &I;
-  return nullptr;
-}
-
-Instruction *BasicBlock::getFirstNonPHI() {
-  for (Instruction &I : *this)
-    if (!isa<PHINode>(I))
-      return &I;
-  return nullptr;
-}
-
 BasicBlock::const_iterator BasicBlock::getFirstNonPHIIt() const {
   for (const Instruction &I : *this) {
     if (isa<PHINode>(I))


### PR DESCRIPTION
All in-tree callers already migrated to getFirstNonPHIIt(), which preserves debug-info placement. No remaining users of the deprecated overloads exist in the codebase.