### PR TITLE
[Clang] Make exact dynamic_cast optimization AS aware

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1785,12 +1785,12 @@ llvm::Value *ItaniumCXXABI::emitExactDynamicCast(
     PerformPostCastAuthentication = CGF.getLangOpts().PointerAuthCalls;
     CGPointerAuthInfo StrippingAuthInfo(0, PointerAuthenticationMode::Strip,
                                         false, false, nullptr);
-    Address VTablePtrPtr = ThisAddr.withElementType(CGF.VoidPtrPtrTy);
+    Address VTablePtrPtr = ThisAddr.withElementType(CGM.GlobalsInt8PtrTy);
     VTable = CGF.Builder.CreateLoad(VTablePtrPtr, "vtable");
     if (PerformPostCastAuthentication)
       VTable = CGF.EmitPointerAuthAuth(StrippingAuthInfo, VTable);
   } else
-    VTable = CGF.GetVTablePtr(ThisAddr, CGF.DefaultPtrTy, SrcDecl);
+    VTable = CGF.GetVTablePtr(ThisAddr, CGM.GlobalsInt8PtrTy, SrcDecl);
 
   // Compare the vptr against the expected vptr for the destination type at
   // this offset.

--- a/clang/test/CodeGenCXX/dynamic-cast-exact-address-space.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast-exact-address-space.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 %s -triple amdgpu-amd-amdhsa -emit-llvm -std=c++11 -O1 -o - | FileCheck %s \
+// RUN:   --implicit-check-not='call {{.*}} @__dynamic_cast'
+
+struct A {
+  virtual ~A();
+};
+struct B final : A {};
+
+// CHECK-LABEL: define {{.*}} ptr @_Z4castP1A(
+// CHECK: %[[VTABLE:.*]] = load ptr addrspace(1), ptr %{{.*}}
+// CHECK: %[[MATCH:.*]] = icmp eq ptr addrspace(1) %[[VTABLE]], getelementptr {{.*}} ptr addrspace(1) @_ZTV1B
+B *cast(A *a) {
+  return dynamic_cast<B *>(a);
+}
+
+struct Left : A {};
+struct Right : A {};
+struct Repeated final : Left, Right {};
+
+// CHECK-LABEL: define {{.*}} ptr @_Z13cast_repeatedP1A(
+// CHECK: %[[PRIMARY:.*]] = getelementptr inbounds i8, ptr %{{.*}}, i64 %{{.*}}
+// CHECK: %[[VTABLE:.*]] = load ptr addrspace(1), ptr %[[PRIMARY]]
+// CHECK: %[[MATCH:.*]] = icmp eq ptr addrspace(1) %[[VTABLE]], getelementptr {{.*}} ptr addrspace(1) @_ZTV8Repeated
+Repeated *cast_repeated(A *a) {
+  return dynamic_cast<Repeated *>(a);
+}


### PR DESCRIPTION
PR https://github.com/llvm/llvm-project/pull/213253 exposed a problem in AMDGPU where exact dynamic_cast optimization would generate compare operands for the compare instruction that live in different address spaces.
The culprit appears to have been the introduction of the `final` keyword in the derived struct definition.

This patch uses CGF.GetVTablePtr and uses CGM.GlobalsInt8PtrTy in the code for emitExactDynamicCast, following the pattern that is used in EmitTypeid.

A test case that was reduced from the above PR is added as test.
AI-assisted (edit, forgot to mention in first version of PR description)