### PR TITLE
[flang][openmp] Support importing module declare target globals

### DIFF
--- a/flang/include/flang/Lower/OpenMP.h
+++ b/flang/include/flang/Lower/OpenMP.h
@@ -106,6 +106,11 @@ void materializeOpenMPDeclareMappers(
     Fortran::lower::AbstractConverter &, Fortran::semantics::SemanticsContext &,
     const Fortran::semantics::Scope *scope = nullptr);
 
+// Attach declare target attributes to declare target global variables
+// imported from a module file.
+void attachOpenMPDeclareTargetAttributes(lower::AbstractConverter &converter,
+                                         const lower::pft::Variable &var);
+
 namespace omp {
 /// If \p base carries OpenMP DECLARE VARIANT entries, return the variant symbol
 /// that best matches the enclosing OpenMP context, or nullptr if none matches.

--- a/flang/include/flang/Lower/OpenMP.h
+++ b/flang/include/flang/Lower/OpenMP.h
@@ -106,6 +106,8 @@ void materializeOpenMPDeclareMappers(
     Fortran::lower::AbstractConverter &, Fortran::semantics::SemanticsContext &,
     const Fortran::semantics::Scope *scope = nullptr);
 
+// Mark declare target globals and functions that were imported from a
+// module file.
 void markOpenMPImportedDeclareTargets(
     Fortran::lower::AbstractConverter &converter,
     semantics::SemanticsContext &semaCtx);

--- a/flang/include/flang/Lower/OpenMP.h
+++ b/flang/include/flang/Lower/OpenMP.h
@@ -106,10 +106,9 @@ void materializeOpenMPDeclareMappers(
     Fortran::lower::AbstractConverter &, Fortran::semantics::SemanticsContext &,
     const Fortran::semantics::Scope *scope = nullptr);
 
-// Attach declare target attributes to declare target global variables
-// imported from a module file.
-void attachOpenMPDeclareTargetAttributes(lower::AbstractConverter &converter,
-                                         const lower::pft::Variable &var);
+void markOpenMPImportedDeclareTargets(
+    Fortran::lower::AbstractConverter &converter,
+    semantics::SemanticsContext &semaCtx);
 
 namespace omp {
 /// If \p base carries OpenMP DECLARE VARIANT entries, return the variant symbol

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -377,7 +377,7 @@ public:
   // Top-level ProgramTrees are owned by the SemanticsContext for persistence.
   ProgramTree &SaveProgramTree(ProgramTree &&);
 
-  std::list<parser::Program> &GetModFileParseTrees() {
+  const std::list<parser::Program> &GetModFileParseTrees() {
     return modFileParseTrees_;
   }
 

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -377,6 +377,10 @@ public:
   // Top-level ProgramTrees are owned by the SemanticsContext for persistence.
   ProgramTree &SaveProgramTree(ProgramTree &&);
 
+  std::list<parser::Program> &GetModFileParseTrees() {
+    return modFileParseTrees_;
+  }
+
   // Label analysis classifies every labeled statement, and only some of those
   // classifications may be named by a statement that branches.  Lowering needs
   // the same distinction when it records the targets of a branch, so the

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -626,6 +626,11 @@ public:
             bridge.getLoweringOptions().getFPExceptionTraps());
       });
 
+    createBuilderOutsideOfFuncOpAndDo([&]() {
+      Fortran::lower::markOpenMPImportedDeclareTargets(
+          *this, bridge.getSemanticsContext());
+    });
+
     finalizeOpenMPLowering(globalOmpRequiresSymbols);
   }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -626,6 +626,10 @@ public:
             bridge.getLoweringOptions().getFPExceptionTraps());
       });
 
+    // Marking of OpenMP declare target functions and globals imported
+    // from a module file needs to happen after the primary
+    // translation pass has run, because that is where the ops that
+    // need marking are created.
     createBuilderOutsideOfFuncOpAndDo([&]() {
       Fortran::lower::markOpenMPImportedDeclareTargets(
           *this, bridge.getSemanticsContext());

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -7830,8 +7830,12 @@ void Fortran::lower::genOpenMPSymbolProperties(
   if (sym.test(semantics::Symbol::Flag::OmpThreadprivate))
     lower::genThreadprivateOp(converter, var);
 
-  if (sym.test(semantics::Symbol::Flag::OmpDeclareTarget))
-    lower::genDeclareTargetIntGlobal(converter, var);
+  if (sym.test(semantics::Symbol::Flag::OmpDeclareTarget)) {
+    if (var.isGlobal())
+      lower::attachOpenMPDeclareTargetAttributes(converter, var);
+    else
+      lower::genDeclareTargetIntGlobal(converter, var);
+  }
 }
 
 void Fortran::lower::genGroupprivateOp(lower::AbstractConverter &converter,
@@ -7931,14 +7935,12 @@ void Fortran::lower::genThreadprivateOp(lower::AbstractConverter &converter,
 // generation.
 void Fortran::lower::genDeclareTargetIntGlobal(
     lower::AbstractConverter &converter, const lower::pft::Variable &var) {
-  if (!var.isGlobal()) {
-    // A non-global variable which can be in a declare target directive must
-    // be a variable in the main program, and it has the implicit SAVE
-    // attribute. We create a GlobalOp for it to simplify the translation to
-    // LLVM IR.
-    globalInitialization(converter, converter.getFirOpBuilder(),
-                         var.getSymbol(), var, converter.getCurrentLocation());
-  }
+  // A non-global variable which can be in a declare target directive must
+  // be a variable in the main program, and it has the implicit SAVE
+  // attribute. We create a GlobalOp for it to simplify the translation to
+  // LLVM IR.
+  globalInitialization(converter, converter.getFirOpBuilder(), var.getSymbol(),
+                       var, converter.getCurrentLocation());
 }
 
 bool Fortran::lower::isOpenMPTargetConstruct(
@@ -8093,3 +8095,38 @@ void Fortran::lower::materializeOpenMPDeclareMappers(
 // Walk scopes and materialize omp.declare_reduction ops for user-defined
 // operator reductions imported from modules (deleted: replaced by lazy,
 // clause-driven materialization).
+
+void Fortran::lower::attachOpenMPDeclareTargetAttributes(
+    lower::AbstractConverter &converter, const lower::pft::Variable &var) {
+  auto module = converter.getModuleOp();
+
+  mlir::Operation *globalOp =
+      module.lookupSymbol(converter.mangleName(var.getSymbol()));
+
+  auto ultimateSymbol = var.getSymbol().GetUltimate();
+
+  if (globalOp && ultimateSymbol.IsFromModFile()) {
+    auto declareTargetOp =
+        llvm::dyn_cast<mlir::omp::DeclareTargetInterface>(globalOp);
+    Fortran::common::visit(
+        [&](const auto &details) {
+          if constexpr (std::is_base_of_v<semantics::WithOmpDeclarative,
+                                          std::decay_t<decltype(details)>>) {
+            mlir::omp::DeclareTargetDeviceType deviceType =
+                toMLIRDeclareTargetDeviceType(
+                    details.ompDeclTargetDeviceType().value_or(
+                        Fortran::common::OmpDeviceType::Any));
+
+            mlir::omp::DeclareTargetCaptureClause clause;
+            if (details.ompDeclTarget().test(llvm::omp::Clause::OMPC_link))
+              clause = mlir::omp::DeclareTargetCaptureClause::link;
+            else
+              clause = mlir::omp::DeclareTargetCaptureClause::enter;
+
+            declareTargetOp.setDeclareTarget(deviceType, clause,
+                                             /*automap=*/false);
+          }
+        },
+        ultimateSymbol.details());
+  }
+}

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -18,6 +18,7 @@
 #include "Decomposer.h"
 #include "Utils.h"
 #include "flang/Common/idioms.h"
+#include "flang/Common/reference-wrapper.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/fold.h"
 #include "flang/Evaluate/tools.h"
@@ -1496,7 +1497,7 @@ static void promoteNonCPtrUseDevicePtrArgsToUseDeviceAddr(
 /// 'declare target' directive and return the intended device type for them.
 static void getDeclareTargetInfo(
     lower::AbstractConverter &converter, semantics::SemanticsContext &semaCtx,
-    lower::pft::Evaluation &eval,
+    std::optional<common::reference_wrapper<lower::pft::Evaluation>> eval,
     const parser::OmpDeclareTargetDirective &construct,
     mlir::omp::DeclareTargetOperands &clauseOps,
     llvm::SmallVectorImpl<DeclareTargetCaptureInfo> &symbolAndClause) {
@@ -1510,8 +1511,10 @@ static void getDeclareTargetInfo(
     List<Clause> clauses = makeClauses(construct.v.Clauses(), semaCtx);
     if (clauses.empty()) {
       // Case: implicit capture of the enclosing function/subroutine.
+      assert(eval.has_value() &&
+             "expected eval to have value when clauses is empty");
       Fortran::lower::pft::FunctionLikeUnit *owningProc =
-          eval.getOwningProcedure();
+          eval->get().getOwningProcedure();
       bool owningProcNotMainProgram =
           owningProc && !owningProc->isMainProgram();
 
@@ -7830,12 +7833,8 @@ void Fortran::lower::genOpenMPSymbolProperties(
   if (sym.test(semantics::Symbol::Flag::OmpThreadprivate))
     lower::genThreadprivateOp(converter, var);
 
-  if (sym.test(semantics::Symbol::Flag::OmpDeclareTarget)) {
-    if (var.isGlobal())
-      lower::attachOpenMPDeclareTargetAttributes(converter, var);
-    else
-      lower::genDeclareTargetIntGlobal(converter, var);
-  }
+  if (sym.test(semantics::Symbol::Flag::OmpDeclareTarget))
+    lower::genDeclareTargetIntGlobal(converter, var);
 }
 
 void Fortran::lower::genGroupprivateOp(lower::AbstractConverter &converter,
@@ -7935,12 +7934,14 @@ void Fortran::lower::genThreadprivateOp(lower::AbstractConverter &converter,
 // generation.
 void Fortran::lower::genDeclareTargetIntGlobal(
     lower::AbstractConverter &converter, const lower::pft::Variable &var) {
-  // A non-global variable which can be in a declare target directive must
-  // be a variable in the main program, and it has the implicit SAVE
-  // attribute. We create a GlobalOp for it to simplify the translation to
-  // LLVM IR.
-  globalInitialization(converter, converter.getFirOpBuilder(), var.getSymbol(),
-                       var, converter.getCurrentLocation());
+  if (!var.isGlobal()) {
+    // A non-global variable which can be in a declare target directive must
+    // be a variable in the main program, and it has the implicit SAVE
+    // attribute. We create a GlobalOp for it to simplify the translation to
+    // LLVM IR.
+    globalInitialization(converter, converter.getFirOpBuilder(),
+                         var.getSymbol(), var, converter.getCurrentLocation());
+  }
 }
 
 bool Fortran::lower::isOpenMPTargetConstruct(
@@ -8096,38 +8097,53 @@ void Fortran::lower::materializeOpenMPDeclareMappers(
 // operator reductions imported from modules (deleted: replaced by lazy,
 // clause-driven materialization).
 
-void Fortran::lower::attachOpenMPDeclareTargetAttributes(
-    lower::AbstractConverter &converter, const lower::pft::Variable &var) {
-  assert(var.isGlobal());
-  auto module = converter.getModuleOp();
+// Visitor used to mark declare target globals from imported modules.
+struct ModuleDeclareTargetVisitor {
+  Fortran::lower::AbstractConverter &converter;
+  semantics::SemanticsContext &semaCtx;
 
-  mlir::Operation *globalOp =
-      module.lookupSymbol(converter.mangleName(var.getSymbol()));
+  explicit ModuleDeclareTargetVisitor(
+      Fortran::lower::AbstractConverter &converter,
+      semantics::SemanticsContext &ctx)
+      : converter(converter), semaCtx(ctx) {}
 
-  auto ultimateSymbol = var.getSymbol().GetUltimate();
+  template <typename T>
+  bool Pre(const T &) {
+    return true;
+  }
+  template <typename T>
+  void Post(const T &) {}
 
-  if (globalOp && ultimateSymbol.IsFromModFile()) {
-    auto declareTargetOp =
-        llvm::cast<mlir::omp::DeclareTargetInterface>(globalOp);
-    Fortran::common::visit(
-        [&](const auto &details) {
-          if constexpr (std::is_base_of_v<semantics::WithOmpDeclarative,
-                                          std::decay_t<decltype(details)>>) {
-            mlir::omp::DeclareTargetDeviceType deviceType =
-                toMLIRDeclareTargetDeviceType(
-                    details.ompDeclTargetDeviceType().value_or(
-                        Fortran::common::OmpDeviceType::Any));
+  void Post(const parser::OmpDeclareTargetDirective &directive) {
+    mlir::omp::DeclareTargetOperands clauseOps;
+    llvm::SmallVector<DeclareTargetCaptureInfo> symbolAndClause;
+    mlir::ModuleOp mod = converter.getFirOpBuilder().getModule();
 
-            mlir::omp::DeclareTargetCaptureClause clause;
-            if (details.ompDeclTarget().test(llvm::omp::Clause::OMPC_link))
-              clause = mlir::omp::DeclareTargetCaptureClause::link;
-            else
-              clause = mlir::omp::DeclareTargetCaptureClause::enter;
+    getDeclareTargetInfo(converter, semaCtx, std::nullopt, directive, clauseOps,
+                         symbolAndClause);
 
-            declareTargetOp.setDeclareTarget(deviceType, clause,
-                                             /*automap=*/false);
-          }
-        },
-        ultimateSymbol.details());
+    for (const DeclareTargetCaptureInfo &symClause : symbolAndClause) {
+      mlir::Operation *op =
+          mod.lookupSymbol(converter.mangleName(symClause.symbol));
+
+      // op not found, so nothing to mark. This happens for variables
+      // and functions that are not actually used in the current
+      // translation unit.
+      if (!op)
+        continue;
+
+      markDeclareTarget(op, converter, symClause.clause, clauseOps.deviceType,
+                        symClause.automap);
+    }
+  }
+};
+
+void Fortran::lower::markOpenMPImportedDeclareTargets(
+    Fortran::lower::AbstractConverter &converter,
+    semantics::SemanticsContext &semaCtx) {
+  std::list<parser::Program> &modTrees = semaCtx.GetModFileParseTrees();
+  ModuleDeclareTargetVisitor visitor{converter, semaCtx};
+  for (auto &modTree : modTrees) {
+    parser::Walk(modTree, visitor);
   }
 }

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -8098,6 +8098,7 @@ void Fortran::lower::materializeOpenMPDeclareMappers(
 
 void Fortran::lower::attachOpenMPDeclareTargetAttributes(
     lower::AbstractConverter &converter, const lower::pft::Variable &var) {
+  assert(var.isGlobal());
   auto module = converter.getModuleOp();
 
   mlir::Operation *globalOp =
@@ -8107,7 +8108,7 @@ void Fortran::lower::attachOpenMPDeclareTargetAttributes(
 
   if (globalOp && ultimateSymbol.IsFromModFile()) {
     auto declareTargetOp =
-        llvm::dyn_cast<mlir::omp::DeclareTargetInterface>(globalOp);
+        llvm::cast<mlir::omp::DeclareTargetInterface>(globalOp);
     Fortran::common::visit(
         [&](const auto &details) {
           if constexpr (std::is_base_of_v<semantics::WithOmpDeclarative,

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1855,6 +1855,31 @@ markDeclareTarget(mlir::Operation *op, lower::AbstractConverter &converter,
                                    /*implicit=*/false);
 }
 
+// Take a declare target directive, and mark the globals and functions
+// named in its clauses.
+static void markDeclareTargetWithDirective(
+    lower::AbstractConverter &converter, semantics::SemanticsContext &semaCtx,
+    std::optional<common::reference_wrapper<lower::pft::Evaluation>> eval,
+    const parser::OmpDeclareTargetDirective &declareTargetConstruct) {
+  mlir::omp::DeclareTargetOperands clauseOps;
+  llvm::SmallVector<DeclareTargetCaptureInfo> symbolAndClause;
+  mlir::ModuleOp mod = converter.getFirOpBuilder().getModule();
+  getDeclareTargetInfo(converter, semaCtx, eval, declareTargetConstruct,
+                       clauseOps, symbolAndClause);
+
+  for (const DeclareTargetCaptureInfo &symClause : symbolAndClause) {
+    mlir::Operation *op =
+        mod.lookupSymbol(converter.mangleName(symClause.symbol));
+
+    // Do nothing if op is not found.
+    if (!op)
+      continue;
+
+    markDeclareTarget(op, converter, symClause.clause, clauseOps.deviceType,
+                      symClause.automap);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Op body generation helper structures and functions
 //===----------------------------------------------------------------------===//
@@ -6777,25 +6802,12 @@ static void
 genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
        semantics::SemanticsContext &semaCtx, lower::pft::Evaluation &eval,
        const parser::OmpDeclareTargetDirective &declareTargetConstruct) {
-  mlir::omp::DeclareTargetOperands clauseOps;
-  llvm::SmallVector<DeclareTargetCaptureInfo> symbolAndClause;
-  mlir::ModuleOp mod = converter.getFirOpBuilder().getModule();
-  getDeclareTargetInfo(converter, semaCtx, eval, declareTargetConstruct,
-                       clauseOps, symbolAndClause);
 
-  for (const DeclareTargetCaptureInfo &symClause : symbolAndClause) {
-    mlir::Operation *op =
-        mod.lookupSymbol(converter.mangleName(symClause.symbol));
-
-    // Some symbols are deferred until later in the module, these are handled
-    // upon finalization of the module for OpenMP inside of Bridge, so we simply
-    // skip for now.
-    if (!op)
-      continue;
-
-    markDeclareTarget(op, converter, symClause.clause, clauseOps.deviceType,
-                      symClause.automap);
-  }
+  // Some symbols are deferred until later. These are skipped in
+  // markDeclareTargetWithDirective at this stage and handled later in
+  // finalizeOpenMPLowering.
+  markDeclareTargetWithDirective(converter, semaCtx, eval,
+                                 declareTargetConstruct);
 }
 
 static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
@@ -8097,6 +8109,7 @@ void Fortran::lower::materializeOpenMPDeclareMappers(
 // operator reductions imported from modules (deleted: replaced by lazy,
 // clause-driven materialization).
 
+namespace {
 // Visitor used to mark declare target globals from imported modules.
 struct ModuleDeclareTargetVisitor {
   Fortran::lower::AbstractConverter &converter;
@@ -8115,33 +8128,19 @@ struct ModuleDeclareTargetVisitor {
   void Post(const T &) {}
 
   void Post(const parser::OmpDeclareTargetDirective &directive) {
-    mlir::omp::DeclareTargetOperands clauseOps;
-    llvm::SmallVector<DeclareTargetCaptureInfo> symbolAndClause;
-    mlir::ModuleOp mod = converter.getFirOpBuilder().getModule();
-
-    getDeclareTargetInfo(converter, semaCtx, std::nullopt, directive, clauseOps,
-                         symbolAndClause);
-
-    for (const DeclareTargetCaptureInfo &symClause : symbolAndClause) {
-      mlir::Operation *op =
-          mod.lookupSymbol(converter.mangleName(symClause.symbol));
-
-      // op not found, so nothing to mark. This happens for variables
-      // and functions that are not actually used in the current
-      // translation unit.
-      if (!op)
-        continue;
-
-      markDeclareTarget(op, converter, symClause.clause, clauseOps.deviceType,
-                        symClause.automap);
-    }
+    // The directive might mention symbols that are not used in the
+    // current translation unit. Such symbols are ignored in
+    // markDeclareTargetWithDirective, as there exists no Operation
+    // that needs marking.
+    markDeclareTargetWithDirective(converter, semaCtx, std::nullopt, directive);
   }
 };
+} // namespace
 
 void Fortran::lower::markOpenMPImportedDeclareTargets(
     Fortran::lower::AbstractConverter &converter,
     semantics::SemanticsContext &semaCtx) {
-  std::list<parser::Program> &modTrees = semaCtx.GetModFileParseTrees();
+  const std::list<parser::Program> &modTrees = semaCtx.GetModFileParseTrees();
   ModuleDeclareTargetVisitor visitor{converter, semaCtx};
   for (auto &modTree : modTrees) {
     parser::Walk(modTree, visitor);

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1871,7 +1871,12 @@ static void markDeclareTargetWithDirective(
     mlir::Operation *op =
         mod.lookupSymbol(converter.mangleName(symClause.symbol));
 
-    // Do nothing if op is not found.
+    // Skip if no op is found. This happens during module declaration
+    // scope lowering for symbols that are deferred to be handled
+    // later in finalizeOpenMPLowering. This is also expected when
+    // handling a directive imported from a module file and the symbol
+    // is not used in the current translation unit, because no op is
+    // created for unused imports.
     if (!op)
       continue;
 
@@ -6802,10 +6807,6 @@ static void
 genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
        semantics::SemanticsContext &semaCtx, lower::pft::Evaluation &eval,
        const parser::OmpDeclareTargetDirective &declareTargetConstruct) {
-
-  // Some symbols are deferred until later. These are skipped in
-  // markDeclareTargetWithDirective at this stage and handled later in
-  // finalizeOpenMPLowering.
   markDeclareTargetWithDirective(converter, semaCtx, eval,
                                  declareTargetConstruct);
 }
@@ -8128,10 +8129,6 @@ struct ModuleDeclareTargetVisitor {
   void Post(const T &) {}
 
   void Post(const parser::OmpDeclareTargetDirective &directive) {
-    // The directive might mention symbols that are not used in the
-    // current translation unit. Such symbols are ignored in
-    // markDeclareTargetWithDirective, as there exists no Operation
-    // that needs marking.
     markDeclareTargetWithDirective(converter, semaCtx, std::nullopt, directive);
   }
 };

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -78,8 +78,13 @@ void WithOmpDeclarative::printClauseSet(llvm::raw_ostream &os,
   size_t idx{0}, size{clauses.count()};
 
   for (llvm::omp::Clause c : clauses) {
-    os << toLower(llvm::omp::getOpenMPClauseName(c, version_));
-    switch (c) {
+    llvm::omp::Clause clause = c;
+    // Write to as enter when writing a mod file
+    if (clause == llvm::omp::Clause::OMPC_to && !name.empty()) {
+      clause = llvm::omp::Clause::OMPC_enter;
+    }
+    os << toLower(llvm::omp::getOpenMPClauseName(clause, version_));
+    switch (clause) {
     case llvm::omp::Clause::OMPC_atomic_default_mem_order:
       os << '(' << toLower(EnumToString(*ompAtomicDefaultMemOrder())) << ')';
       break;

--- a/flang/test/Lower/OpenMP/declare_target_module.f90
+++ b/flang/test/Lower/OpenMP/declare_target_module.f90
@@ -1,0 +1,37 @@
+! RUN: rm -rf %t && split-file %s %t
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -module-dir %t %t/declare_target_module.f90 -o - > /dev/null
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -J %t %t/use_declare_target_module.f90 -o - | FileCheck %s
+
+!--- declare_target_module.f90
+module declare_target_module
+  implicit none
+  integer, dimension(10) :: global_arr
+  !$omp declare target (global_arr)
+  real :: global_real
+  !$omp declare target link(global_real)
+  integer :: global_integer
+  !$omp declare target to(global_integer)
+  integer :: global_device_integer
+  !$omp declare target enter(global_device_integer) device_type(nohost)
+end module
+
+!--- use_declare_target_module.f90
+module use_declare_target_module
+use declare_target_module
+implicit none
+contains
+subroutine s()
+  !$omp declare target
+  global_arr(1) = 1
+  global_real = 1.0
+  global_integer = 1
+end subroutine
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_arr {alignment = 64 : i64, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter), automap = false>} : !fir.array<10xi32>
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_real {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link), automap = false>} : f32
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_integer {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter), automap = false>} : i32
+subroutine device_s()
+  !$omp declare target enter(device_s) device_type(nohost)
+  global_device_integer = 1
+end subroutine
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_device_integer {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter), automap = false>} : i32
+end module

--- a/flang/test/Lower/OpenMP/declare_target_module.f90
+++ b/flang/test/Lower/OpenMP/declare_target_module.f90
@@ -1,6 +1,7 @@
 ! RUN: rm -rf %t && split-file %s %t
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -module-dir %t %t/declare_target_module.f90 -o - > /dev/null
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -J %t %t/use_declare_target_module.f90 -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -fopenmp-is-target-device -J %t %t/use_declare_target_module.f90 -o - | FileCheck %s
 
 !--- declare_target_module.f90
 module declare_target_module

--- a/flang/test/Lower/OpenMP/declare_target_module.f90
+++ b/flang/test/Lower/OpenMP/declare_target_module.f90
@@ -13,6 +13,10 @@ module declare_target_module
   !$omp declare target to(global_integer)
   integer :: global_device_integer
   !$omp declare target enter(global_device_integer) device_type(nohost)
+  contains
+  subroutine module_s()
+    !$omp declare target
+  end subroutine
 end module
 
 !--- use_declare_target_module.f90
@@ -20,18 +24,25 @@ module use_declare_target_module
 use declare_target_module
 implicit none
 contains
+
 subroutine s()
   !$omp declare target
   global_arr(1) = 1
   global_real = 1.0
   global_integer = 1
 end subroutine
-!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_arr {alignment = 64 : i64, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter), automap = false>} : !fir.array<10xi32>
-!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_real {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link), automap = false>} : f32
-!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_integer {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter), automap = false>} : i32
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_arr {alignment = 64 : i64, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : !fir.array<10xi32>
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_real {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link)>} : f32
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_integer {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : i32
+
 subroutine device_s()
   !$omp declare target enter(device_s) device_type(nohost)
   global_device_integer = 1
 end subroutine
-!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_device_integer {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter), automap = false>} : i32
+!CHECK-DAG: fir.global @_QMdeclare_target_moduleEglobal_device_integer {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>} : i32
+
+subroutine call_module_s()
+call module_s()
+end subroutine
+!CHECK-DAG: func.func private @_QMdeclare_target_modulePmodule_s() attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>}
 end module

--- a/flang/test/Semantics/OpenMP/declare-target-modfile.f90
+++ b/flang/test/Semantics/OpenMP/declare-target-modfile.f90
@@ -25,6 +25,9 @@ subroutine h
   !$omp declare_target enter(h, a)
   continue
 end
+subroutine k
+  !$omp declare target
+end
 end module
 
 !Expect: m.mod
@@ -45,10 +48,13 @@ end module
 !!$omp declare_target enter(g)
 !!$omp declare_target enter(f)
 !!$omp declare_target enter(h)
+!!$omp declare_target enter(k)
 !!$omp declare_target link(named_block)
 !contains
 !subroutine f()
 !end
 !subroutine h()
+!end
+!subroutine k()
 !end
 !end

--- a/flang/test/Semantics/OpenMP/declare-target-modfile.f90
+++ b/flang/test/Semantics/OpenMP/declare-target-modfile.f90
@@ -3,6 +3,8 @@
 module m
 integer :: x
 !$omp declare_target link(x) device_type(nohost)
+integer :: y
+!$omp declare target to(y)
 real :: w(10), u(10)
 common /named_block/ w, u
 !$omp declare_target link(/named_block/)
@@ -28,6 +30,7 @@ end module
 !Expect: m.mod
 !module m
 !integer(4)::x
+!integer(4)::y
 !real(4)::w(1_8:10_8)
 !real(4)::u(1_8:10_8)
 !interface
@@ -38,6 +41,7 @@ end module
 !end interface
 !common/named_block/w,u
 !!$omp declare_target device_type(nohost) link(x)
+!!$omp declare_target enter(y)
 !!$omp declare_target enter(g)
 !!$omp declare_target enter(f)
 !!$omp declare_target enter(h)


### PR DESCRIPTION
Attach declare target attributes to declare target functions and
globals that have been imported from a module file.

Fixes https://github.com/llvm/llvm-project/issues/212333