### PR TITLE
[flang] Add LLVM dialect dependency to VScaleAttr

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -426,6 +426,7 @@ def VScaleAttr : Pass<"vscale-attr", "mlir::func::FuncOp"> {
      Set an attribute for the vscale range on functions, to allow scalable
      vector operations to be used on processors with variable vector length.
   }];
+  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
   let options = [Option<"vscaleMin", "vscale-min", "unsigned", /*default=*/"1",
                         "vector scale minimum value. Defaults to \"1\"">,
                  Option<"vscaleMax", "vscale-max", "unsigned", /*default=*/"0",

--- a/flang/test/Transforms/vscale-attr.fir
+++ b/flang/test/Transforms/vscale-attr.fir
@@ -19,6 +19,6 @@
 // VSCALE-MIN-NO-PO2: VScaleAttr: vscaleMin has to be a power-of-two greater than 0
 // VSCALE-MAX-NO-PO2: VScaleAttr: vscaleMax has to be a power-of-two greater-than-or-equal to vscaleMin or 0 to signify an unbounded maximum
 // VSCALE-MIN-GREATER: VScaleAttr: vscaleMax has to be a power-of-two greater-than-or-equal to vscaleMin or 0 to signify an unbounded maximum
-func.func @_QPtest(%arg0: !fir.ref<i32> {fir.bindc_name = "x"}) {
+func.func @_QPtest() {
   return
 }


### PR DESCRIPTION
`VScaleAttr` creates an LLVM `VScaleRangeAttr`, but did not declare the LLVM dialect as a pass dependency. This aborts when the input does not otherwise load LLVM.

Declare the dependency and remove the unused FIR-typed argument from the existing test. Parsing `!fir.ref` loads `FIROpsDialect`, which loads `LLVMDialect` as a dependency and previously masked the missing pass dependency.