### PR TITLE
[flang][openmp] Write to clause to modfile

### DIFF
--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -78,8 +78,13 @@ void WithOmpDeclarative::printClauseSet(llvm::raw_ostream &os,
   size_t idx{0}, size{clauses.count()};
 
   for (llvm::omp::Clause c : clauses) {
-    os << toLower(llvm::omp::getOpenMPClauseName(c, version_));
-    switch (c) {
+    llvm::omp::Clause clause = c;
+    // Write to as enter when writing a mod file
+    if (clause == llvm::omp::Clause::OMPC_to && !name.empty()) {
+      clause = llvm::omp::Clause::OMPC_enter;
+    }
+    os << toLower(llvm::omp::getOpenMPClauseName(clause, version_));
+    switch (clause) {
     case llvm::omp::Clause::OMPC_atomic_default_mem_order:
       os << '(' << toLower(EnumToString(*ompAtomicDefaultMemOrder())) << ')';
       break;

--- a/flang/test/Semantics/OpenMP/declare-target-modfile.f90
+++ b/flang/test/Semantics/OpenMP/declare-target-modfile.f90
@@ -3,6 +3,8 @@
 module m
 integer :: x
 !$omp declare_target link(x) device_type(nohost)
+integer :: y
+!$omp declare target to(y)
 real :: w(10), u(10)
 common /named_block/ w, u
 !$omp declare_target link(/named_block/)
@@ -28,6 +30,7 @@ end module
 !Expect: m.mod
 !module m
 !integer(4)::x
+!integer(4)::y
 !real(4)::w(1_8:10_8)
 !real(4)::u(1_8:10_8)
 !interface
@@ -38,6 +41,7 @@ end module
 !end interface
 !common/named_block/w,u
 !!$omp declare_target device_type(nohost) link(x)
+!!$omp declare_target enter(y)
 !!$omp declare_target enter(g)
 !!$omp declare_target enter(f)
 !!$omp declare_target enter(h)


### PR DESCRIPTION
Fix bug where the list of variables would be ignored when writing the
to clause of a declare target directive to a modfile.