### PR TITLE
[flang][OpenMP] Fix DO SIMD LINEAR/LASTPRIVATE

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -26,6 +26,7 @@
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Support/Flags.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/OpenMP/OMP.h.inc"
@@ -2232,9 +2233,11 @@ void OmpAttributeVisitor::PrivatizeAssociatedLoopIndex(
     return;
   }
 
+  llvm::omp::Directive directive{GetContext().directive};
   int64_t level{*depth.value};
   Symbol::Flag ivDSA;
-  if (!llvm::omp::allSimdSet.test(GetContext().directive)) {
+  if (!llvm::omp::allSimdSet.test(directive) ||
+      llvm::omp::allDoSet.test(directive)) {
     ivDSA = Symbol::Flag::OmpPrivate;
   } else if (level == 1 && version < 60) {
     ivDSA = Symbol::Flag::OmpLinear;
@@ -2242,18 +2245,69 @@ void OmpAttributeVisitor::PrivatizeAssociatedLoopIndex(
     ivDSA = Symbol::Flag::OmpLastPrivate;
   }
 
-  Scope &scope{currScope()};
+  // Collect all symbols that appear in linear/lastprivate clauses
+  llvm::DenseSet<const Symbol *> linearObjs;
+  llvm::DenseSet<const Symbol *> lastprivateObjs;
+  bool explicitDSA{false};
+  auto getObjSymbols = [&](const parser::OmpObjectList &objs,
+                           llvm::DenseSet<const Symbol *> &syms) {
+    for (const parser::OmpObject &obj : objs.v) {
+      const parser::Name *objName{};
+      common::visit(common::visitors{
+                        [&](const parser::Designator &designator) {
+                          objName =
+                              parser::GetDesignatorNameIfDataRef(designator);
+                        },
+                        [&](const parser::Name &name) { objName = &name; },
+                        [&](const auto &other) {},
+                    },
+          obj.u);
+      if (objName && objName->symbol) {
+        syms.insert(&objName->symbol->GetUltimate());
+      }
+    }
+  };
+  for (const parser::OmpClause &clause : x.BeginDir().Clauses().v) {
+    if (auto *linear{std::get_if<parser::OmpClause::Linear>(&clause.u)}) {
+      getObjSymbols(std::get<parser::OmpObjectList>(linear->v.t), linearObjs);
+    } else if (auto *lastprivate{
+                   std::get_if<parser::OmpClause::Lastprivate>(&clause.u)}) {
+      getObjSymbols(
+          std::get<parser::OmpObjectList>(lastprivate->v.t), lastprivateObjs);
+    }
+  }
 
+  Scope &scope{currScope()};
   if (auto doLoops{omp::CollectAffectedDoLoops(x, version, &context_)}) {
     for (const parser::DoConstruct *loop : *doLoops) {
       const parser::Name *iv{GetLoopIndex(*loop)};
       if (!iv || (iv->symbol && IsLocalInsideScope(*iv->symbol, scope))) {
         continue;
       }
+      // Override explicitly set linear/lastprivate DSA on DO SIMD directives
+      if (auto *symbol{iv->symbol}) {
+        const Symbol *ult{&symbol->GetUltimate()};
+        std::optional<Symbol::Flag> dsa;
+        if (linearObjs.count(ult))
+          dsa = Symbol::Flag::OmpLinear;
+        else if (lastprivateObjs.count(ult))
+          dsa = Symbol::Flag::OmpLastPrivate;
+        if (dsa.has_value()) {
+          if (llvm::omp::allSimdSet.test(directive) &&
+              llvm::omp::allDoSet.test(directive)) {
+            explicitDSA = true;
+            ivDSA = Symbol::Flag::OmpPrivate;
+          }
+        }
+      }
       if (auto *symbol{ResolveOmp(*iv, ivDSA, scope)}) {
         SetSymbolDSA(*symbol, {Symbol::Flag::OmpPreDetermined, ivDSA});
         iv->symbol = symbol; // adjust the symbol within region
-        AddToContextObjectWithDSA(*symbol, ivDSA);
+        if (explicitDSA) {
+          AddToContextObjectWithExplicitDSA(*symbol, ivDSA);
+        } else {
+          AddToContextObjectWithDSA(*symbol, ivDSA);
+        }
       }
     }
   }
@@ -3047,7 +3101,31 @@ void OmpAttributeVisitor::ResolveOmpDesignator(
     return;
   }
 
-  if (auto *symbol{ResolveOmp(*name, ompFlag, currScope())}) {
+  // Explicit symbol flags for iteration variables in DO SIMD directives may
+  // have already been set by PrivatizeAssociatedLoopIndex().
+  Symbol::Flags prevFlags;
+  Symbol *symbol{};
+  if (name->symbol) {
+    auto it{currScope().find(name->source)};
+    if (it != currScope().end()) {
+      symbol = &*it->second;
+      prevFlags = symbol->flags();
+    }
+  }
+  bool doSimd{llvm::omp::allDoSet.test(directive) &&
+      llvm::omp::allSimdSet.test(directive)};
+  bool setDSA{!symbol || !doSimd ||
+      (ompFlag != Symbol::Flag::OmpLastPrivate &&
+          ompFlag != Symbol::Flag::OmpLinear) ||
+      !symbol->test(Symbol::Flag::OmpExplicit) ||
+      !symbol->test(Symbol::Flag::OmpPreDetermined) ||
+      (prevFlags.test(Symbol::Flag::OmpFirstPrivate) &&
+          ompFlag == Symbol::Flag::OmpLastPrivate)};
+  if (setDSA) {
+    symbol = ResolveOmp(*name, ompFlag, currScope());
+  }
+
+  if (symbol) {
     auto checkExclusivelists{//
         [&](const Symbol *symbol1, Symbol::Flag firstOmpFlag,
             const Symbol *symbol2, Symbol::Flag secondOmpFlag) {
@@ -3063,7 +3141,9 @@ void OmpAttributeVisitor::ResolveOmpDesignator(
     if (dataCopyingAttributeFlags.test(ompFlag)) {
       CheckDataCopyingClause(*name, *symbol, ompFlag);
     } else {
-      AddToContextObjectWithExplicitDSA(*symbol, ompFlag);
+      if (setDSA) {
+        AddToContextObjectWithExplicitDSA(*symbol, ompFlag);
+      }
       if (dataSharingAttributeFlags.test(ompFlag)) {
         CheckMultipleAppearances(*name, *symbol, ompFlag);
       }

--- a/flang/test/Lower/OpenMP/composite_simd_linear.f90
+++ b/flang/test/Lower/OpenMP/composite_simd_linear.f90
@@ -10,10 +10,9 @@ subroutine do_simd
 !CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
 !DEFAULT: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = {{.*}}) {
 !OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = {{.*}})) {
-!DEFAULT: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) {
-!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) {
+!CHECK: omp.simd private(@_QFdo_simdEi_private_i32 %[[I]]#0 -> %{{.*}} : !fir.ref<i32>) {
 !CHECK: }
-!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {omp.composite}
 !CHECK: } {linear_var_types = [i32], omp.composite}
     integer :: x
     !$omp do simd linear(x:1)
@@ -52,14 +51,13 @@ subroutine distribute_parallel_do
 !CHECK: omp.distribute {
 !DEFAULT: omp.wsloop linear(%[[I]]#0 : !fir.ref<i32> = %[[CONST]] : i32) {
 !OPENMP52: omp.wsloop linear(val(%[[I]]#0 : !fir.ref<i32> = %[[CONST]] : i32)) {
-!DEFAULT: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) {
-!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) {
+!CHECK: omp.simd private({{.*}} %[[I]]#0 -> %{{.*}}) {
     !$omp teams
     !$omp distribute parallel do simd linear(i:1)
     do i = 1, N
     end do
     !$omp end distribute parallel do simd
-!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {omp.composite}
 !CHECK: } {linear_var_types = [i32], omp.composite}
     !$omp end teams
 end subroutine distribute_parallel_do
@@ -73,14 +71,13 @@ subroutine parallel_do
 !CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
 !DEFAULT: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = %[[LINEAR_STEP]] : i32) {
 !OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = %[[LINEAR_STEP]] : i32)) {
-!DEFAULT: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) {
-!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) {
+!CHECK: omp.simd private(@_QFparallel_doEi_private_i32 %[[I]]#0 -> %{{.*}} : !fir.ref<i32>) {
     integer :: x
     !$omp parallel do simd linear(x:2)
     do i = 1, N
     end do
     !$omp end parallel do simd
-!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {omp.composite}
 !CHECK: } {linear_var_types = [i32], omp.composite}
 end subroutine parallel_do
 
@@ -113,13 +110,12 @@ subroutine teams_distribute_parallel_do
 !CHECK: omp.distribute {
 !DEFAULT: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = %[[LINEAR_STEP]] : i32) {
 !OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = %[[LINEAR_STEP]] : i32)) {
-!DEFAULT: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) {
-!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) {
+!CHECK: omp.simd private(@_QFteams_distribute_parallel_doEi_private_i32 %[[I]]#0 -> %{{.*}} : !fir.ref<i32>) {
     integer :: x
     !$omp teams distribute parallel do simd linear(x)
     do i = 1, N
     end do
     !$omp end teams distribute parallel do simd
-!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {omp.composite}
 !CHECK: } {linear_var_types = [i32], omp.composite}
 end subroutine teams_distribute_parallel_do

--- a/flang/test/Lower/OpenMP/distribute-parallel-do-simd.f90
+++ b/flang/test/Lower/OpenMP/distribute-parallel-do-simd.f90
@@ -1,10 +1,10 @@
 ! This test checks lowering of OpenMP DISTRIBUTE PARALLEL DO SIMD composite
 ! constructs.
 
-! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK,DEFAULT
-! RUN: %flang_fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK,DEFAULT
-! RUN: bbc -fopenmp -fopenmp-version=52 -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK,OPENMP52
-! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK,OPENMP52
+! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK
+! RUN: %flang_fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK
+! RUN: bbc -fopenmp -fopenmp-version=52 -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK
 
 ! CHECK-LABEL: func.func @_QPdistribute_parallel_do_simd_num_threads(
 subroutine distribute_parallel_do_simd_num_threads()
@@ -13,8 +13,7 @@ subroutine distribute_parallel_do_simd_num_threads()
   ! CHECK:      omp.parallel num_threads({{.*}}) {
   ! CHECK:      omp.distribute {
   ! CHECK-NEXT: omp.wsloop {
-  ! DEFAULT-NEXT: omp.simd linear({{.*}}) {
-  ! OPENMP52-NEXT: omp.simd linear(val({{.*}})) {
+  ! CHECK-NEXT: omp.simd private({{.*}}) {
   ! CHECK-NEXT: omp.loop_nest
   !$omp distribute parallel do simd num_threads(10)
   do index_ = 1, 10
@@ -31,8 +30,7 @@ subroutine distribute_parallel_do_simd_dist_schedule()
   ! CHECK:      omp.parallel  {
   ! CHECK:      omp.distribute dist_schedule_static dist_schedule_chunk_size({{.*}}) {
   ! CHECK-NEXT: omp.wsloop {
-  ! DEFAULT-NEXT: omp.simd linear({{.*}}) {
-  ! OPENMP52-NEXT: omp.simd linear(val({{.*}})) {
+  ! CHECK-NEXT: omp.simd private({{.*}}) {
   ! CHECK-NEXT: omp.loop_nest
   !$omp distribute parallel do simd dist_schedule(static, 4)
   do index_ = 1, 10
@@ -49,8 +47,7 @@ subroutine distribute_parallel_do_simd_schedule()
   ! CHECK:      omp.parallel {
   ! CHECK:      omp.distribute {
   ! CHECK-NEXT: omp.wsloop schedule(static = {{.*}}) {
-  ! DEFAULT-NEXT: omp.simd linear({{.*}}) {
-  ! OPENMP52-NEXT: omp.simd linear(val({{.*}})) {
+  ! CHECK-NEXT: omp.simd private({{.*}}) {
   ! CHECK-NEXT: omp.loop_nest
   !$omp distribute parallel do simd schedule(static, 4)
   do index_ = 1, 10
@@ -67,8 +64,7 @@ subroutine distribute_parallel_do_simd_simdlen()
   ! CHECK:      omp.parallel {
   ! CHECK:      omp.distribute {
   ! CHECK-NEXT: omp.wsloop {
-  ! DEFAULT-NEXT: omp.simd linear({{.*}}) simdlen(4) {
-  ! OPENMP52-NEXT: omp.simd linear(val({{.*}})) simdlen(4) {
+  ! CHECK-NEXT: omp.simd simdlen(4) private({{.*}}) {
   ! CHECK-NEXT: omp.loop_nest
   !$omp distribute parallel do simd simdlen(4)
   do index_ = 1, 10
@@ -92,10 +88,7 @@ subroutine distribute_parallel_do_simd_private()
   ! CHECK:      omp.parallel {
   ! CHECK:      omp.distribute {
   ! CHECK-NEXT: omp.wsloop {
-  ! DEFAULT-NEXT: omp.simd linear(%{{.*}}) private(@{{.*}} %[[X]]#0 -> %[[X_ARG:[^:]+]]
-  ! DEFAULT-SAME:                  : !fir.ref<i64>) {
-  ! OPENMP52-NEXT: omp.simd linear(val(%{{.*}})) private(@{{.*}} %[[X]]#0 -> %[[X_ARG:[^:]+]]
-  ! OPENMP52-SAME:                  : !fir.ref<i64>) {
+  ! CHECK-NEXT: omp.simd private(@{{.*}} %[[X]]#0 -> %[[X_ARG:[^:]+]], {{.*}}) {
   ! CHECK-NEXT: omp.loop_nest
   ! CHECK:      %[[X_PRIV:.*]]:2 = hlfir.declare %[[X_ARG]]
   !$omp distribute parallel do simd private(x)
@@ -120,29 +113,11 @@ integer :: i,j
 ! CHECK:                   omp.wsloop {
 ! CHECK:                     omp.simd private({{.*}}) {
 ! CHECK:                       omp.loop_nest (%[[I_IV:.*]], %[[J_IV:.*]]) : i32 = ({{.*}}) to ({{.*}}) inclusive step ({{.*}}) collapse(2) {
-! CHECK:                         %[[Y_MAX_PRIV:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "{{.*}}y_max"}
-
-! CHECK:                         %[[I_UB:.*]] = fir.load %[[X_MAX_MAPPED]]#0 : !fir.ref<i32>
-! CHECK:                         %[[I_STEP:.*]] = arith.constant 1 : i32
-! CHECK:                         %[[J_UB:.*]] = fir.load %[[Y_MAX_PRIV]]#0 : !fir.ref<i32>
-! CHECK:                         %[[J_STEP:.*]] = arith.constant 1 : i32
-
-! CHECK:                         %[[VAL_55:.*]] = arith.addi %[[I_IV]], %[[I_STEP]] : i32
-! CHECK:                         %[[VAL_56:.*]] = arith.constant 0 : i32
-! CHECK:                         %[[VAL_57:.*]] = arith.cmpi slt, %[[I_STEP]], %[[VAL_56]] : i32
-! CHECK:                         %[[VAL_58:.*]] = arith.cmpi slt, %[[VAL_55]], %[[I_UB]] : i32
-! CHECK:                         %[[VAL_59:.*]] = arith.cmpi sgt, %[[VAL_55]], %[[I_UB]] : i32
-! CHECK:                         %[[VAL_60:.*]] = arith.select %[[VAL_57]], %[[VAL_58]], %[[VAL_59]] : i1
-
-! CHECK:                         %[[VAL_61:.*]] = arith.addi %[[J_IV]], %[[J_STEP]] : i32
-! CHECK:                         %[[VAL_62:.*]] = arith.constant 0 : i32
-! CHECK:                         %[[VAL_63:.*]] = arith.cmpi slt, %[[J_STEP]], %[[VAL_62]] : i32
-! CHECK:                         %[[VAL_64:.*]] = arith.cmpi slt, %[[VAL_61]], %[[J_UB]] : i32
-! CHECK:                         %[[VAL_65:.*]] = arith.cmpi sgt, %[[VAL_61]], %[[J_UB]] : i32
-! CHECK:                         %[[VAL_66:.*]] = arith.select %[[VAL_63]], %[[VAL_64]], %[[VAL_65]] : i1
-
-! CHECK:                         %[[LASTPRIV_CMP:.*]] = arith.andi %[[VAL_60]], %[[VAL_66]] : i1
-! CHECK:                         fir.if %[[LASTPRIV_CMP]] {
+! CHECK:                        %[[I_IV_DECL:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFlastprivate_cond_in_composite_constructEi"} {{.*}})
+! CHECK:                        %[[J_IV_DECL:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFlastprivate_cond_in_composite_constructEj"} {{.*}})
+! CHECK:                        hlfir.assign %[[I_IV]] to %[[I_IV_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:                        hlfir.assign %[[J_IV]] to %[[J_IV_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:                        omp.yield
 
 !$omp target teams distribute parallel do simd collapse(2) private(y_max)
   do i=x_min,x_max

--- a/flang/test/Lower/OpenMP/linear_modifier.f90
+++ b/flang/test/Lower/OpenMP/linear_modifier.f90
@@ -43,13 +43,12 @@ subroutine do_simd_linear
 !CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
 !OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32)) {
 !OPENMP45: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32) {
-!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) {
-!OPENMP45: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) {
+!CHECK: omp.simd private({{.*}} %[[I]]#0 {{.*}}) {
     integer :: x
     !$omp do simd linear(x:1)
     do i = 1, 10
     end do
     !$omp end do simd
-!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {omp.composite}
 !CHECK: } {linear_var_types = [i32], omp.composite}
 end subroutine do_simd_linear

--- a/flang/test/Lower/OpenMP/ordered-simd.f90
+++ b/flang/test/Lower/OpenMP/ordered-simd.f90
@@ -34,14 +34,14 @@ subroutine ws_ordered_simd(n)
 
 ! CHECK-LABEL: func @_QPws_ordered_simd
 ! CHECK:         omp.wsloop ordered(0) {
-! CHECK:           omp.simd linear({{.*}}) {
+! CHECK:           omp.simd private({{.*}}) {
 ! CHECK:             omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
 ! CHECK:               omp.ordered.region par_level_simd {
 ! CHECK:                 omp.terminator
 ! CHECK:               }
 ! CHECK:               omp.yield
 ! CHECK:             }
-! CHECK:           } {linear_var_types = [i32], omp.composite}
+! CHECK:           } {omp.composite}
 ! CHECK:         } {omp.composite}
 
   !$omp do simd ordered

--- a/flang/test/Lower/OpenMP/wsloop-simd.f90
+++ b/flang/test/Lower/OpenMP/wsloop-simd.f90
@@ -89,14 +89,15 @@ end subroutine do_simd_array_reduction
 ! CHECK-LABEL: func.func @_QPdo_simd_private(
 subroutine do_simd_private()
   integer, allocatable :: tmp
-  ! CHECK:      %[[I_DECL:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFdo_simd_privateEi"}
   ! CHECK:      omp.wsloop
   ! CHECK-NEXT: omp.simd
-  ! CHECK-SAME: private(@[[PRIV_BOX_SYM:.*]] %{{.*}} -> %[[PRIV_BOX:.*]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
+  ! CHECK-SAME: private(@[[PRIV_BOX_SYM:.*]] %{{[^ ]*}} -> %[[PRIV_BOX:[A-Za-z0-9]*]],
+  ! CHECK-SAME:         {{.*}} -> %[[PRIV_I:.*]] : !fir.ref<!fir.box<!fir.heap<i32>>>, {{.*}})
   ! CHECK-NEXT: omp.loop_nest (%[[IVAR:.*]]) : i32
   !$omp do simd private(tmp)
   do i=1, 10
   ! CHECK:      %[[PRIV_BOX_DECL:.*]]:2 = hlfir.declare %[[PRIV_BOX]]
+  ! CHECK:      %[[I_DECL:.*]]:2 = hlfir.declare %[[PRIV_I]]
   ! CHECK:      hlfir.assign %[[IVAR]] to %[[I_DECL]]#0
   ! CHECK:      %[[PRIV_BOX_LOAD:.*]] = fir.load %[[PRIV_BOX_DECL]]
   ! CHECK:      hlfir.assign %{{.*}} to %[[PRIV_BOX_DECL]]#0
@@ -111,8 +112,7 @@ subroutine do_simd_lastprivate_firstprivate()
   ! CHECK:      omp.wsloop
   ! CHECK-SAME: private(@[[FIRSTPRIVATE_A_SYM:.*]] %{{.*}} -> %[[FIRSTPRIVATE_A:.*]] : !fir.ref<i32>)
   ! CHECK-NEXT: omp.simd
-  ! CHECK-SAME: linear({{.*}}#0 : !fir.ref<i32> = %{{[^:]*}} : i32)
-  ! CHECK-SAME: private(@[[PRIVATE_A_SYM:.*]] %{{.*}} -> %[[PRIVATE_A:.*]] : !fir.ref<i32>)
+  ! CHECK-SAME: private(@[[PRIVATE_A_SYM:.*]] %{{.*}} -> %[[PRIVATE_A:.*]], {{.*}} : !fir.ref<i32>, {{.*}})
   !$omp do simd lastprivate(a) firstprivate(a)
   do i = 1, 10
     ! CHECK: %[[FIRSTPRIVATE_A_DECL:.*]]:2 = hlfir.declare %[[FIRSTPRIVATE_A]]

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -51,7 +51,7 @@ program OMP_DO
   !$omp end target teams distribute parallel do
 
   !$omp target teams distribute parallel do simd
-  !DEF:/OMP_DO/OtherConstruct5/i (OmpLinear,OmpPreDetermined) HostAssoc INTEGER(4)
+  !DEF:/OMP_DO/OtherConstruct5/i (OmpPrivate,OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,100
     !REF:/OMP_DO/OtherConstruct5/i
     if(i<10) cycle

--- a/flang/test/Semantics/OpenMP/symbol08.f90
+++ b/flang/test/Semantics/OpenMP/symbol08.f90
@@ -168,7 +168,7 @@ subroutine test_simd
  !DEF: /test_simd/k ObjectEntity INTEGER(4)
  integer i, j, k
 !$omp parallel do simd
- !DEF: /test_simd/OtherConstruct1/i (OmpLinear, OmpPreDetermined) HostAssoc INTEGER(4)
+ !DEF: /test_simd/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
  do i=1,5
   !DEF: /test_simd/OtherConstruct1/j (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do j=6,10
@@ -195,11 +195,11 @@ subroutine test_simd_multi
  !DEF: /test_simd_multi/k ObjectEntity INTEGER(4)
  integer i, j, k
 !$omp parallel do simd  collapse(3)
- !DEF: /test_simd_multi/OtherConstruct1/i (OmpLastPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+ !DEF: /test_simd_multi/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
  do i=1,5
-  !DEF: /test_simd_multi/OtherConstruct1/j (OmpLastPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+  !DEF: /test_simd_multi/OtherConstruct1/j (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do j=6,10
-   !DEF: /test_simd_multi/OtherConstruct1/k (OmpLastPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+   !DEF: /test_simd_multi/OtherConstruct1/k (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
    do k=11,15
     !DEF: /test_simd_multi/OtherConstruct1/a (OmpShared) HostAssoc REAL(4)
     !REF: /test_simd_multi/OtherConstruct1/k


### PR DESCRIPTION
In compound constructs containing DO and SIMD, linear/lastprivate
iteration variables were incorrectly updating their original variables.
To avoid this, now their DSAs are changed to private in semantics.

This works for implicit DSAs, but there is an issue with explicit DSAs.
While the symbol is changed to private at the semantic level, in
lowering linear/lastprivate ends up being applied to the worksharing
loop, resulting in updates to the original variables.

Another downside is that linear clause arguments, such as step, are
discarded.

It seems like the correct fix would have to be done in lowering, by
keeping iteration variables in `omp.simd` as linear/lastprivate and
making them private in `omp.wsloop`.
