### PR TITLE
[mlir][ArmSVE] move transform entry points into arm_sve namespace (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/ArmSVE/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/ArmSVE/Transforms/Transforms.h
@@ -15,14 +15,15 @@ class LLVMConversionTarget;
 class LLVMTypeConverter;
 class RewritePatternSet;
 
+namespace arm_sve {
+void populateLowerContractionToSVEI8MMPatterns(RewritePatternSet &patterns);
+void populateLowerContractionToSVEBFMMLAPatterns(RewritePatternSet &patterns);
+} // namespace arm_sve
+
 /// Collect a set of patterns to lower ArmSVE ops to ops that map to LLVM
 /// intrinsics.
 void populateArmSVELegalizeForLLVMExportPatterns(
     const LLVMTypeConverter &converter, RewritePatternSet &patterns);
-
-void populateLowerContractionToSVEI8MMPatterns(RewritePatternSet &patterns);
-
-void populateLowerContractionToSVEBFMMLAPatterns(RewritePatternSet &patterns);
 
 /// Configure the target to support lowering ArmSVE ops to ops that map to LLVM
 /// intrinsics.

--- a/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp
+++ b/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp
@@ -95,13 +95,13 @@ void ConvertVectorToLLVMPass::runOnOperation() {
       if (armNeon)
         arm_neon::populateLowerContractionToNeonI8MMPatterns(patterns);
       if (armSVE)
-        populateLowerContractionToSVEI8MMPatterns(patterns);
+        arm_sve::populateLowerContractionToSVEI8MMPatterns(patterns);
     }
     if (armBF16) {
       if (armNeon)
         arm_neon::populateLowerContractionToNeonBFMMLAPatterns(patterns);
       if (armSVE)
-        populateLowerContractionToSVEBFMMLAPatterns(patterns);
+        arm_sve::populateLowerContractionToSVEBFMMLAPatterns(patterns);
     }
     (void)applyPatternsGreedily(getOperation(), std::move(patterns));
   }

--- a/mlir/lib/Dialect/ArmSVE/TransformOps/ArmSVEVectorTransformOps.cpp
+++ b/mlir/lib/Dialect/ArmSVE/TransformOps/ArmSVEVectorTransformOps.cpp
@@ -20,12 +20,12 @@ using namespace mlir;
 
 void transform::ApplyArmSVELowerContractionToI8MMPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
-  mlir::populateLowerContractionToSVEI8MMPatterns(patterns);
+  arm_sve::populateLowerContractionToSVEI8MMPatterns(patterns);
 }
 
 void transform::ApplyArmSVELowerContractionToBFMMLAPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
-  mlir::populateLowerContractionToSVEBFMMLAPatterns(patterns);
+  arm_sve::populateLowerContractionToSVEBFMMLAPatterns(patterns);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/ArmSVE/Transforms/LowerContractToSVEPatterns.cpp
+++ b/mlir/lib/Dialect/ArmSVE/Transforms/LowerContractToSVEPatterns.cpp
@@ -31,6 +31,7 @@
 #define DEBUG_TYPE "lower-contract-to-arm-sve-i8mm"
 
 using namespace mlir;
+using namespace mlir::arm_sve;
 
 namespace {
 // Get the operand of a `vector.contract`. This function is intended to abstract
@@ -581,13 +582,13 @@ public:
 
 } // namespace
 
-void mlir::populateLowerContractionToSVEI8MMPatterns(
+void mlir::arm_sve::populateLowerContractionToSVEI8MMPatterns(
     RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
   patterns.add<LowerContractionToSVEI8MMPattern>(context, /*benefit=*/2);
 }
 
-void mlir::populateLowerContractionToSVEBFMMLAPatterns(
+void mlir::arm_sve::populateLowerContractionToSVEBFMMLAPatterns(
     RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
   patterns.add<LowerContractionToSVEBFMMLAPattern>(context, /*benefit=*/2);


### PR DESCRIPTION
This PR moves `populateLowerContractionToSVE*` entry points into the `arm_sve` namespace for consistency with their Arm Neon counterparts.