### PR TITLE
[AArch64] Improve AES clustering tests(NFC)

### DIFF
--- a/llvm/test/CodeGen/AArch64/misched-fusion-aes-post-ra.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-aes-post-ra.mir
@@ -1,73 +1,79 @@
 # REQUIRES: asserts
 
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=+fuse-aes,+crypto -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=generic -mattr=+crypto -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a53 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a57 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a65 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a72 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a73 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a76 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a77 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78c -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-x1 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-e1 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-n1 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-v1 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-512tvb -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m3 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m4 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m5 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1 -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1a -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1b -misched-print-dags 2>&1 | FileCheck %s
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -misched-print-dags 2>&1 | FileCheck %s
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=+fuse-aes,+crypto -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=generic -mattr=+crypto -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a53 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a57 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a65 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a72 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a73 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a76 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a77 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78c -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-x1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-e1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-n1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-v1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-512tvb -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m3 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m4 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m5 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1a -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1b -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
 
-## Verify that only tied AES pairs (both instructions write to the same register)
-## are being fused post-RA.
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=-fuse-aes,+crypto -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -mattr=-fuse-aes -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
 
 ---
-name: encode_physregs_tied
+name: encode_waw
 body: |
   bb.0:
     ; CHECK: SU(0): $q0 = AESErr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
-    ; CHECK: SU(1): Ord  Latency=0 Cluster
-    ; CHECK: SU(1): $q0 = AESMCrr $q0
+    ; FUSE: SU(2): Ord  Latency=0 Cluster
+    ; NOFUSE-NOT: SU(2): Ord  Latency=0 Cluster
+    ; CHECK: SU(2): $q0 = AESMCrr $q0
     $q0 = AESErr undef $q0, undef $q1
+    $q3 = ADDv16i8 undef $q4, undef $q5
     $q0 = AESMCrr $q0
 ...
 ---
-name: decode_physregs_tied
-body: |
-  bb.0:
-    ; CHECK: SU(0): $q0 = AESDrr undef $q0(tied-def 0), undef $q1
-    ; CHECK: Successors:
-    ; CHECK: SU(1): Ord  Latency=0 Cluster
-    ; CHECK: SU(1): $q0 = AESIMCrr $q0
-    $q0 = AESDrr undef $q0, undef $q1
-    $q0 = AESIMCrr $q0
-...
----
-name: encode_physregs_untied
+name: encode_nowaw
 body: |
   bb.0:
     ; CHECK: SU(0): $q0 = AESErr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
     ; CHECK-NOT: SU({{.*}}): Ord  Latency=0 Cluster
-    ; CHECK: SU(1): $q2 = AESMCrr $q0
+    ; CHECK: SU(2): $q2 = AESMCrr $q0
     $q0 = AESErr undef $q0, undef $q1
+    $q3 = ADDv16i8 undef $q4, undef $q5
     $q2 = AESMCrr $q0
 ...
 ---
-name: decode_physregs_untied
+name: decode_waw
+body: |
+  bb.0:
+    ; CHECK: SU(0): $q0 = AESDrr undef $q0(tied-def 0), undef $q1
+    ; CHECK: Successors:
+    ; FUSE: SU(2): Ord  Latency=0 Cluster
+    ; NOFUSE-NOT: SU(2): Ord  Latency=0 Cluster
+    ; CHECK: SU(2): $q0 = AESIMCrr $q0
+    $q0 = AESDrr undef $q0, undef $q1
+    $q3 = ADDv16i8 undef $q4, undef $q5
+    $q0 = AESIMCrr $q0
+...
+---
+name: decode_nowaw
 body: |
   bb.0:
     ; CHECK: SU(0): $q0 = AESDrr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
     ; CHECK-NOT: SU({{.*}}): Ord  Latency=0 Cluster
-    ; CHECK: SU(1): $q2 = AESIMCrr $q0
+    ; CHECK: SU(2): $q2 = AESIMCrr $q0
     $q0 = AESDrr undef $q0, undef $q1
+    $q3 = ADDv16i8 undef $q4, undef $q5
     $q2 = AESIMCrr $q0
 ...

--- a/llvm/test/CodeGen/AArch64/misched-fusion-aes-post-ra.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-aes-post-ra.mir
@@ -1,36 +1,37 @@
 # REQUIRES: asserts
 
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=+fuse-aes,+crypto -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=generic -mattr=+crypto -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a53 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a57 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a65 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a72 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a73 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a76 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a77 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78c -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-x1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-e1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-n1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-v1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-512tvb -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m3 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m4 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m5 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1a -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1b -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=+fuse-aes,+crypto -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=generic -mattr=+crypto -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a53 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a57 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a65 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a72 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a73 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a76 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a77 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-a78c -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=cortex-x1 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-e1 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-n1 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-v1 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=neoverse-512tvb -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m3 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m4 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=exynos-m5 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1a -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=ampere1b -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
 
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=-fuse-aes,+crypto -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
-# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -mattr=-fuse-aes -misched-print-dags 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mattr=-fuse-aes,+crypto -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
+# RUN: llc -o /dev/null %s -run-pass=machine-scheduler -mtriple aarch64-unknown -mcpu=apple-m5 -mattr=-fuse-aes -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
 
 ---
 name: encode_waw
 body: |
   bb.0:
+    ; CHECK-LABEL: encode_waw
     ; CHECK: SU(0): $q0 = AESErr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
     ; FUSE: SU(2): Ord  Latency=0 Cluster
@@ -44,6 +45,7 @@ body: |
 name: encode_nowaw
 body: |
   bb.0:
+    ; CHECK-LABEL: encode_nowaw
     ; CHECK: SU(0): $q0 = AESErr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
     ; CHECK-NOT: SU({{.*}}): Ord  Latency=0 Cluster
@@ -56,6 +58,7 @@ body: |
 name: decode_waw
 body: |
   bb.0:
+    ; CHECK-LABEL: decode_waw
     ; CHECK: SU(0): $q0 = AESDrr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
     ; FUSE: SU(2): Ord  Latency=0 Cluster
@@ -69,6 +72,7 @@ body: |
 name: decode_nowaw
 body: |
   bb.0:
+    ; CHECK-LABEL: decode_nowaw
     ; CHECK: SU(0): $q0 = AESDrr undef $q0(tied-def 0), undef $q1
     ; CHECK: Successors:
     ; CHECK-NOT: SU({{.*}}): Ord  Latency=0 Cluster

--- a/llvm/test/CodeGen/AArch64/misched-fusion-aes-pre-ra.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-aes-pre-ra.mir
@@ -1,0 +1,85 @@
+# REQUIRES: asserts
+
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mattr=+fuse-aes,+crypto -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=generic -mattr=+crypto -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a53 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a57 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a65 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a72 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a73 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a76 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a77 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a78 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-a78c -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=cortex-x1 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=neoverse-e1 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=neoverse-n1 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=neoverse-v1 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=neoverse-512tvb -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=exynos-m3 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=exynos-m4 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=exynos-m5 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=ampere1 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=ampere1a -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=ampere1b -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=apple-m5 -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,FUSE
+
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mattr=-fuse-aes,+crypto -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
+# RUN: llc -o /dev/null %s -mtriple=aarch64-unknown -mcpu=apple-m5 -mattr=-fuse-aes -passes=machine-scheduler -misched-print-dags -print-before=machine-scheduler 2>&1 | FileCheck %s --check-prefixes=CHECK,NOFUSE
+
+---
+name: encode_tied
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK: SU(0): %0:fpr128 = AESErr
+    ; CHECK: Successors:
+    ; FUSE: SU(2): Ord  Latency=0 Cluster
+    ; NOFUSE-NOT: SU(2): Ord  Latency=0 Cluster
+    ; CHECK: SU(2): dead %6:fpr128 = AESMCrrTied
+    %0:fpr128 = AESErr undef %1:fpr128, undef %2:fpr128
+    %3:fpr128 = ADDv16i8 undef %4:fpr128, undef %5:fpr128
+    %6:fpr128 = AESMCrrTied %0
+...
+---
+name: encode_untied
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK: SU(0): %0:fpr128 = AESErr
+    ; CHECK: Successors:
+    ; FUSE: SU(2): Ord  Latency=0 Cluster
+    ; NOFUSE-NOT: SU(2): Ord  Latency=0 Cluster
+    ; CHECK: SU(2): dead %6:fpr128 = AESMCrr
+    %0:fpr128 = AESErr undef %1:fpr128, undef %2:fpr128
+    %3:fpr128 = ADDv16i8 undef %4:fpr128, undef %5:fpr128
+    %6:fpr128 = AESMCrr %0
+...
+---
+name: decode_tied
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK: SU(0): %0:fpr128 = AESDrr
+    ; CHECK: Successors:
+    ; FUSE: SU(2): Ord  Latency=0 Cluster
+    ; NOFUSE-NOT: SU(2): Ord  Latency=0 Cluster
+    ; CHECK: SU(2): dead %6:fpr128 = AESIMCrrTied
+    %0:fpr128 = AESDrr undef %1:fpr128, undef %2:fpr128
+    %3:fpr128 = ADDv16i8 undef %4:fpr128, undef %5:fpr128
+    %6:fpr128 = AESIMCrrTied %0
+...
+---
+name: decode_untied
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK: SU(0): %0:fpr128 = AESDrr
+    ; CHECK: Successors:
+    ; FUSE: SU(2): Ord  Latency=0 Cluster
+    ; NOFUSE-NOT: SU(2): Ord  Latency=0 Cluster
+    ; CHECK: SU(2): dead %6:fpr128 = AESIMCrr
+    %0:fpr128 = AESDrr undef %1:fpr128, undef %2:fpr128
+    %3:fpr128 = ADDv16i8 undef %4:fpr128, undef %5:fpr128
+    %6:fpr128 = AESIMCrr %0
+...

--- a/llvm/test/CodeGen/AArch64/misched-fusion-aes-pre-ra.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-aes-pre-ra.mir
@@ -32,6 +32,7 @@ name: encode_tied
 tracksRegLiveness: true
 body: |
   bb.0:
+    ; CHECK-LABEL: encode_tied
     ; CHECK: SU(0): %0:fpr128 = AESErr
     ; CHECK: Successors:
     ; FUSE: SU(2): Ord  Latency=0 Cluster
@@ -46,6 +47,7 @@ name: encode_untied
 tracksRegLiveness: true
 body: |
   bb.0:
+    ; CHECK-LABEL: encode_untied
     ; CHECK: SU(0): %0:fpr128 = AESErr
     ; CHECK: Successors:
     ; FUSE: SU(2): Ord  Latency=0 Cluster
@@ -60,6 +62,7 @@ name: decode_tied
 tracksRegLiveness: true
 body: |
   bb.0:
+    ; CHECK-LABEL: decode_tied
     ; CHECK: SU(0): %0:fpr128 = AESDrr
     ; CHECK: Successors:
     ; FUSE: SU(2): Ord  Latency=0 Cluster
@@ -74,6 +77,7 @@ name: decode_untied
 tracksRegLiveness: true
 body: |
   bb.0:
+    ; CHECK-LABEL: decode_untied
     ; CHECK: SU(0): %0:fpr128 = AESDrr
     ; CHECK: Successors:
     ; FUSE: SU(2): Ord  Latency=0 Cluster


### PR DESCRIPTION
- post-RA: rename test cases, reorder them, add artificially interfering instruction in between pairs, add negative runlines
- add pre-RA test
- add missing label boundaries checks