### PR TITLE
[libc] Read multiple interfaces per netlink message in if_nameindex

### DIFF
--- a/libc/src/net/linux/if_nameindex_impl.h
+++ b/libc/src/net/linux/if_nameindex_impl.h
@@ -24,6 +24,7 @@
 #include "src/__support/CPP/scope.h"
 #include "src/__support/CPP/span.h"
 #include "src/__support/alloc-checker.h"
+#include "src/__support/blockstore.h"
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
 #include "src/string/memory_utils/inline_memcpy.h"
@@ -60,6 +61,100 @@ LIBC_INLINE ErrorOr<ssize_t> send_netlink_dump_request(int sockfd) {
 /// A reasonable buffer size for netlink messages (see NLMSG_GOODSIZE in the
 /// kernel).
 constexpr size_t NLMSG_BUFFER_SIZE = 8192;
+
+struct InterfaceEntry {
+  unsigned int index;
+  char name[IF_NAMESIZE];
+};
+
+// TODO: Use ErrorOr<void> when that's a thing.
+LIBC_INLINE ErrorOr<int>
+parse_netlink_messages(cpp::span<uint8_t> buf,
+                       BlockStore<InterfaceEntry, 16> &store) {
+  size_t len = buf.size();
+  for (auto *nh = reinterpret_cast<struct nlmsghdr *>(buf.data());
+       NLMSG_OK(nh, len); nh = NLMSG_NEXT(nh, len)) {
+    if (nh->nlmsg_type == NLMSG_DONE)
+      break;
+    if (nh->nlmsg_type == NLMSG_ERROR) {
+      if (nh->nlmsg_len < NLMSG_LENGTH(sizeof(struct nlmsgerr)))
+        return Error(EINVAL);
+      auto *err = reinterpret_cast<struct nlmsgerr *>(NLMSG_DATA(nh));
+      if (err->error == 0) {
+        // Zero means an ACK, which we shouldn't get because we didn't ask for
+        // it...
+        continue;
+      }
+      return Error(-err->error);
+    }
+    if (nh->nlmsg_type != RTM_NEWLINK)
+      continue;
+    if (nh->nlmsg_len < NLMSG_LENGTH(sizeof(struct ifinfomsg)))
+      continue;
+
+    auto *ifm = reinterpret_cast<struct ifinfomsg *>(NLMSG_DATA(nh));
+    size_t attrlen = nh->nlmsg_len - NLMSG_LENGTH(sizeof(struct ifinfomsg));
+    struct rtattr *rta = IFLA_RTA(ifm);
+    for (; RTA_OK(rta, attrlen); rta = RTA_NEXT(rta, attrlen)) {
+      if (rta->rta_type != IFLA_IFNAME)
+        continue;
+
+      size_t rta_payload_len = RTA_PAYLOAD(rta);
+      const char *name_data = reinterpret_cast<const char *>(RTA_DATA(rta));
+      size_t name_len = internal::strnlen(name_data, rta_payload_len);
+      // Defensive check: kernel should not be providing us with names that
+      // don't fit.
+      if (name_len >= IF_NAMESIZE)
+        name_len = IF_NAMESIZE - 1;
+
+      InterfaceEntry entry;
+      entry.index = static_cast<unsigned int>(ifm->ifi_index);
+      inline_memcpy(entry.name, name_data, name_len);
+      entry.name[name_len] = '\0';
+
+      if (!store.push_back(entry))
+        return Error(ENOBUFS);
+      break;
+    }
+  }
+  return 0;
+}
+
+LIBC_INLINE ErrorOr<struct if_nameindex *>
+build_if_nameindex_list(BlockStore<InterfaceEntry, 16> &store) {
+  size_t count = 0;
+  size_t strings_size = 0;
+  for (const InterfaceEntry &entry : store) {
+    ++count;
+    strings_size += internal::string_length(entry.name) + 1;
+  }
+
+  size_t total_size = (count + 1) * sizeof(struct if_nameindex) + strings_size;
+  AllocChecker ac;
+  uint8_t *buffer = new (ac) uint8_t[total_size];
+  if (!ac)
+    return Error(ENOBUFS);
+
+  cpp::span<struct if_nameindex> result(
+      reinterpret_cast<struct if_nameindex *>(buffer), count + 1);
+  char *str_ptr = reinterpret_cast<char *>(result.end());
+
+  size_t idx = 0;
+  for (const InterfaceEntry &entry : store) {
+    size_t name_len = internal::string_length(entry.name);
+    result[idx].if_index = entry.index;
+    result[idx].if_name = str_ptr;
+    inline_memcpy(str_ptr, entry.name, name_len + 1);
+    str_ptr += name_len + 1;
+    ++idx;
+  }
+
+  result[count].if_index = 0;
+  result[count].if_name = nullptr;
+
+  return result.data();
+}
+
 } // namespace detail
 
 template <typename Policy>
@@ -87,73 +182,18 @@ LIBC_INLINE ErrorOr<struct if_nameindex *> if_nameindex() {
     return Error(close_res.error());
 
   // TODO: Read more than one message.
-  // TODO: Read more than one interface per message.
   // TODO: Deduplicate interfaces to handle restarts.
-  auto len = static_cast<size_t>(*recv_res);
-  for (auto *nh = reinterpret_cast<struct nlmsghdr *>(buf); NLMSG_OK(nh, len);
-       nh = NLMSG_NEXT(nh, len)) {
-    if (nh->nlmsg_type == NLMSG_DONE)
-      break;
-    if (nh->nlmsg_type == NLMSG_ERROR) {
-      if (nh->nlmsg_len < NLMSG_LENGTH(sizeof(struct nlmsgerr)))
-        return Error(EINVAL);
-      auto *err = reinterpret_cast<struct nlmsgerr *>(NLMSG_DATA(nh));
-      if (err->error == 0) {
-        // Zero means an ACK, which we shouldn't get because we didn't ask for
-        // it...
-        continue;
-      }
-      return Error(-err->error);
-    }
-    if (nh->nlmsg_type != RTM_NEWLINK)
-      continue;
-    if (nh->nlmsg_len < NLMSG_LENGTH(sizeof(struct ifinfomsg)))
-      continue;
+  BlockStore<detail::InterfaceEntry, 16> store;
+  cpp::scope_exit destroy_store([&store]() {
+    BlockStore<detail::InterfaceEntry, 16>::destroy(&store);
+  });
 
-    auto *ifm = reinterpret_cast<struct ifinfomsg *>(NLMSG_DATA(nh));
-    size_t attrlen = nh->nlmsg_len - NLMSG_LENGTH(sizeof(struct ifinfomsg));
-    struct rtattr *rta = IFLA_RTA(ifm);
-    for (; RTA_OK(rta, attrlen); rta = RTA_NEXT(rta, attrlen)) {
-      if (rta->rta_type != IFLA_IFNAME)
-        continue;
+  if (ErrorOr<int> parse_res = detail::parse_netlink_messages(
+          {buf, static_cast<size_t>(*recv_res)}, store);
+      !parse_res.has_value())
+    return Error(parse_res.error());
 
-      size_t rta_payload_len = RTA_PAYLOAD(rta);
-      auto index = static_cast<unsigned int>(ifm->ifi_index);
-      const char *name_data = reinterpret_cast<const char *>(RTA_DATA(rta));
-      size_t name_len = internal::strnlen(name_data, rta_payload_len);
-
-      size_t total_size = 2 * sizeof(struct if_nameindex) + name_len + 1;
-      AllocChecker ac;
-      uint8_t *buffer = new (ac) uint8_t[total_size];
-      if (!ac)
-        return Error(ENOBUFS);
-
-      cpp::span<uint8_t> buffer_span(buffer, total_size);
-      cpp::span<struct if_nameindex> result(
-          reinterpret_cast<struct if_nameindex *>(buffer_span.data()), 2);
-      cpp::span<char> string_span(reinterpret_cast<char *>(result.end()),
-                                  reinterpret_cast<char *>(buffer_span.end()));
-
-      result[0].if_index = index;
-      result[0].if_name = string_span.data();
-      inline_memcpy(string_span.data(), name_data, name_len);
-      string_span[name_len] = '\0';
-
-      result[1].if_index = 0;
-      result[1].if_name = nullptr;
-
-      return result.data();
-    }
-  }
-
-  AllocChecker ac;
-  uint8_t *buffer = new (ac) uint8_t[sizeof(struct if_nameindex)];
-  if (!ac)
-    return Error(ENOBUFS);
-  cpp::span<struct if_nameindex> result(
-      reinterpret_cast<struct if_nameindex *>(buffer), 1);
-  result[0] = {};
-  return result.data();
+  return detail::build_if_nameindex_list(store);
 }
 
 } // namespace net

--- a/libc/src/net/linux/if_nameindex_impl.h
+++ b/libc/src/net/linux/if_nameindex_impl.h
@@ -64,7 +64,9 @@ constexpr size_t NLMSG_BUFFER_SIZE = 8192;
 
 struct InterfaceEntry {
   unsigned int index;
-  char name[IF_NAMESIZE];
+  uint8_t name_length;        // Length of next field.
+  char name[IF_NAMESIZE - 1]; // No null terminator.
+  static_assert(IF_NAMESIZE - 1 < (1u << 8));
 };
 
 // TODO: Use ErrorOr<void> when that's a thing.
@@ -109,8 +111,8 @@ parse_netlink_messages(cpp::span<uint8_t> buf,
 
       InterfaceEntry entry;
       entry.index = static_cast<unsigned int>(ifm->ifi_index);
+      entry.name_length = static_cast<uint8_t>(name_len);
       inline_memcpy(entry.name, name_data, name_len);
-      entry.name[name_len] = '\0';
 
       if (!store.push_back(entry))
         return Error(ENOBUFS);
@@ -126,7 +128,7 @@ build_if_nameindex_list(BlockStore<InterfaceEntry, 16> &store) {
   size_t strings_size = 0;
   for (const InterfaceEntry &entry : store) {
     ++count;
-    strings_size += internal::string_length(entry.name) + 1;
+    strings_size += entry.name_length + 1;
   }
 
   size_t total_size = (count + 1) * sizeof(struct if_nameindex) + strings_size;
@@ -141,11 +143,11 @@ build_if_nameindex_list(BlockStore<InterfaceEntry, 16> &store) {
 
   size_t idx = 0;
   for (const InterfaceEntry &entry : store) {
-    size_t name_len = internal::string_length(entry.name);
     result[idx].if_index = entry.index;
     result[idx].if_name = str_ptr;
-    inline_memcpy(str_ptr, entry.name, name_len + 1);
-    str_ptr += name_len + 1;
+    inline_memcpy(str_ptr, entry.name, entry.name_length);
+    str_ptr[entry.name_length] = '\0';
+    str_ptr += entry.name_length + 1;
     ++idx;
   }
 

--- a/libc/src/net/linux/if_nameindex_impl.h
+++ b/libc/src/net/linux/if_nameindex_impl.h
@@ -184,9 +184,8 @@ LIBC_INLINE ErrorOr<struct if_nameindex *> if_nameindex() {
   // TODO: Read more than one message.
   // TODO: Deduplicate interfaces to handle restarts.
   BlockStore<detail::InterfaceEntry, 16> store;
-  cpp::scope_exit destroy_store([&store]() {
-    BlockStore<detail::InterfaceEntry, 16>::destroy(&store);
-  });
+  cpp::scope_exit destroy_store(
+      [&store]() { BlockStore<detail::InterfaceEntry, 16>::destroy(&store); });
 
   if (ErrorOr<int> parse_res = detail::parse_netlink_messages(
           {buf, static_cast<size_t>(*recv_res)}, store);

--- a/libc/test/src/net/linux/if_nameindex_test.cpp
+++ b/libc/test/src/net/linux/if_nameindex_test.cpp
@@ -314,6 +314,39 @@ TEST_F(LlvmLibcIfNameIndexSocketTest, SingleInterface) {
   LIBC_NAMESPACE::if_freenameindex(list);
 }
 
+TEST_F(LlvmLibcIfNameIndexSocketTest, MultipleInterfaces) {
+  uint8_t pkt_buf[2048];
+  size_t len1 = build_ifinfomsg_packet(pkt_buf, 1, AttrName{"lo"});
+  size_t len2 = build_ifinfomsg_packet(pkt_buf + len1, 2, AttrName{"eth0"});
+  size_t len3 =
+      build_ifinfomsg_packet(pkt_buf + len1 + len2, 3, AttrName{"wlan0"});
+  size_t len4 = build_nlmsg_done_packet(pkt_buf + len1 + len2 + len3);
+
+  policy_data.recv_results.push_back(
+      span<const uint8_t>(pkt_buf, len1 + len2 + len3 + len4));
+
+  auto res = LIBC_NAMESPACE::net::if_nameindex<Policy>();
+  ASSERT_TRUE(res.has_value());
+  struct if_nameindex *list = res.value();
+  ASSERT_NE(list, static_cast<struct if_nameindex *>(nullptr));
+
+  ASSERT_EQ(list[0].if_index, 1u);
+  ASSERT_STREQ(list[0].if_name, "lo");
+  ASSERT_EQ(list[1].if_index, 2u);
+  ASSERT_STREQ(list[1].if_name, "eth0");
+  ASSERT_EQ(list[2].if_index, 3u);
+  ASSERT_STREQ(list[2].if_name, "wlan0");
+  ASSERT_EQ(list[3].if_index, 0u);
+  ASSERT_EQ(list[3].if_name, static_cast<char *>(nullptr));
+
+  validate_dump_request();
+
+  ASSERT_EQ(policy_data.recv_calls.size(), size_t(1));
+  ASSERT_EQ(get<0>(policy_data.recv_calls[0]), FAKE_SOCKET);
+
+  LIBC_NAMESPACE::if_freenameindex(list);
+}
+
 TEST_F(LlvmLibcIfNameIndexSocketTest, RecvFailure) {
   policy_data.recv_results.push_back(Error(ETIMEDOUT));
 
@@ -504,6 +537,29 @@ TEST_F(LlvmLibcIfNameIndexSocketTest, InterfaceNameWithoutNullTerminator) {
 
   ASSERT_EQ(list[0].if_index, 4u);
   ASSERT_STREQ(list[0].if_name, "docker0");
+  ASSERT_EQ(list[1].if_index, 0u);
+  ASSERT_EQ(list[1].if_name, static_cast<char *>(nullptr));
+
+  validate_dump_request();
+  LIBC_NAMESPACE::if_freenameindex(list);
+}
+
+TEST_F(LlvmLibcIfNameIndexSocketTest, InterfaceNameExceedingIfNamesize) {
+  uint8_t pkt_buf[1024];
+  size_t len1 = build_ifinfomsg_packet(
+      pkt_buf, 5,
+      AttrName{"this_interface_name_is_way_too_long_for_if_namesize"});
+  size_t len2 = build_nlmsg_done_packet(pkt_buf + len1);
+
+  policy_data.recv_results.push_back(span<const uint8_t>(pkt_buf, len1 + len2));
+
+  auto res = LIBC_NAMESPACE::net::if_nameindex<Policy>();
+  ASSERT_TRUE(res.has_value());
+  struct if_nameindex *list = res.value();
+  ASSERT_NE(list, static_cast<struct if_nameindex *>(nullptr));
+
+  ASSERT_EQ(list[0].if_index, 5u);
+  ASSERT_STREQ(list[0].if_name, "this_interface_");
   ASSERT_EQ(list[1].if_index, 0u);
   ASSERT_EQ(list[1].if_name, static_cast<char *>(nullptr));
 


### PR DESCRIPTION
This patch changes it to collect all interfaces in the buffer using BlockStore<InterfaceEntry, 16>. I'm storing interface names as a fixed char array (IF_NAMESIZE) in InterfaceEntry so that we're ready for the next step when we reuse the recvfrom buffer across multiple messages. Once all messages in the buffer are parsed, I allocate a single contiguous buffer containing all struct if_nameindex entries and strings.

To keep if_nameindex() readable, I've split the implementation into two helper functions: parse_netlink_messages() and build_if_nameindex_list().