### PR TITLE
[Flang][test] Account for FLANG_TEST_Fortran_FLAGS

### DIFF
--- a/flang/test/Driver/compiler-options.f90
+++ b/flang/test/Driver/compiler-options.f90
@@ -1,6 +1,10 @@
 ! RUN: %flang -S -emit-llvm -o - %s | FileCheck %s
 ! Test communication of COMPILER_OPTIONS from flang to flang -fc1.
-! CHECK: [[OPTSVAR:@_QQclX[0-9A-Fa-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"-S -emit-llvm -o -"
+! In a Flang-standalone build, the driver also injects its own implicit
+! search-path options (e.g. -fintrinsic-modules-path=...) ahead of the
+! options given on the command line above, so allow (and ignore) an
+! arbitrary prefix before the flags under test here.
+! CHECK: [[OPTSVAR:@_QQclX[0-9A-Fa-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}-S -emit-llvm -o -"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Driver/compiler-options.f90
+++ b/flang/test/Driver/compiler-options.f90
@@ -1,10 +1,8 @@
 ! RUN: %flang -S -emit-llvm -o - %s | FileCheck %s
+! REQUIRES: flang-authentic-cmdline
+
 ! Test communication of COMPILER_OPTIONS from flang to flang -fc1.
-! In a Flang-standalone build, the driver also injects its own implicit
-! search-path options (e.g. -fintrinsic-modules-path=...) ahead of the
-! options given on the command line above, so allow (and ignore) an
-! arbitrary prefix before the flags under test here.
-! CHECK: [[OPTSVAR:@_QQclX[0-9A-Fa-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}-S -emit-llvm -o -"
+! CHECK: [[OPTSVAR:@_QQclX[0-9A-Fa-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"-S -emit-llvm -o -"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Driver/intrinsic-module-path_per_target.f90
+++ b/flang/test/Driver/intrinsic-module-path_per_target.f90
@@ -42,7 +42,7 @@
 !-----------------------------------------
 
 ! DEFAULTPATH:      "-fc1"
-! DEFAULTPATH-SAME: "-fintrinsic-modules-path" "{{.*(\\\\|/)}}finclude{{(\\\\|/)}}flang{{(\\\\|/)}}{{[^/\]+}}"
+! DEFAULTPATH-SAME: "-fintrinsic-modules-path" "{{.*(\\\\|/)}}finclude{{(\\\\|/)}}flang{{(\\\\|/)}}{{[^/\]+[/\]?}}"
 
 ! NOINPUTONE: Source file 'basictestmoduleone.mod' was not found
 ! NOINPUTTWO: Source file 'basictestmoduletwo.mod' was not found

--- a/flang/test/Semantics/bug2236.f90
+++ b/flang/test/Semantics/bug2236.f90
@@ -1,4 +1,4 @@
-!RUN: flang -c -Xflang -fdisable-real-10 %s 2>&1 | FileCheck --allow-empty %s
+!RUN: %flang -c -Xflang -fdisable-real-10 %s 2>&1 | FileCheck --allow-empty %s
 !REQUIRES: x86-registered-target
 !CHECK-NOT: error
 !Ensure ieee_arithmetic.mod can be used even when REAL(10) is disabled.

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -220,7 +220,7 @@ tools = [
 # Some tests expect the command line to be verbatim what is specified on the
 # RUN: line.
 if not flang_extra_search_args:
-  config.available_features.add("flang-authentic-cmdline")
+    config.available_features.add("flang-authentic-cmdline")
 
 # Flang has several unimplemented features. TODO messages are used to mark
 # and fail if these features are exercised. Some TODOs exit with a non-zero

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -217,6 +217,11 @@ tools = [
     ),
 ]
 
+# Some tests expect the command line to be verbatim what is specified on the
+# RUN: line.
+if not flang_extra_search_args:
+  config.available_features.add("flang-authentic-cmdline")
+
 # Flang has several unimplemented features. TODO messages are used to mark
 # and fail if these features are exercised. Some TODOs exit with a non-zero
 # exit code, but others abort the execution in assert builds.


### PR DESCRIPTION
FLANG_TEST_Fortran_FLAGS allows adding additional flags when running Flang's test. It is typically used for standalone builds of Flang where the intrinsic modules are not (and cannot be) built using LLVM_ENABLE_RUNTIMES=flang-rt, but an external location can be specified using `-fintrinsic-modules-path`. FLANG_TEST_Fortran_FLAGS was not accounted for in #201278. In this PR, accept (and ignore) any additional command line arguments in the test.

Also change `flang` -> `%flang` which is what inserts the FLANG_TEST_Fortran_FLAGS.