### PR TITLE
AMDGPU/GlobalISel: Fix assert in selectSMRDBufferSgprImm

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -7181,7 +7181,7 @@ AMDGPUInstructionSelector::selectSMRDBufferSgprImm(MachineOperand &Root) const {
   if (!EncodedOffset)
     return std::nullopt;
 
-  assert(MRI->getType(SOffset) == LLT::scalar(32));
+  assert(MRI->getType(SOffset).getSizeInBits() == 32);
   return {{[=](MachineInstrBuilder &MIB) { MIB.addReg(SOffset); },
            [=](MachineInstrBuilder &MIB) { MIB.addImm(*EncodedOffset); }}};
 }

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.buffer.load.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.buffer.load.ll
@@ -7,6 +7,7 @@
 ; RUN: llc < %s -mtriple=amdgpu11.00 -amdgpu-enable-vopd=0 | FileCheck %s -check-prefixes=GFX11
 ; RUN: llc < %s -mtriple=amdgpu12.00 -amdgpu-enable-vopd=0 | FileCheck %s -check-prefixes=GFX1200_GFX1250,GFX1200
 ; RUN: llc < %s -mtriple=amdgpu12.50 -amdgpu-enable-vopd=0 -mattr=-wait-xcnt | FileCheck %s -check-prefixes=GFX1200_GFX1250,GFX1250
+; RUN: llc < %s -global-isel -mtriple=amdgpu12.50 -amdgpu-enable-vopd=0 -mattr=-wait-xcnt | FileCheck %s -check-prefixes=GFX1250-GISEL
 
 define amdgpu_ps i32 @s_buffer_load_imm(<4 x i32> inreg %desc) {
 ; GFX67-LABEL: s_buffer_load_imm:
@@ -40,6 +41,14 @@ define amdgpu_ps i32 @s_buffer_load_imm(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x4 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x4 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 4, i32 0)
   ret i32 %load
@@ -77,6 +86,14 @@ define amdgpu_ps i32 @s_buffer_load_index(<4 x i32> inreg %desc, i32 inreg %inde
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_index:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 %index, i32 0)
   ret i32 %load
@@ -112,6 +129,15 @@ define amdgpu_ps i32 @s_buffer_load_index_divergent(<4 x i32> inreg %desc, i32 %
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_index_divergent:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    buffer_load_b32 v0, v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 %index, i32 0)
   ret i32 %load
@@ -148,6 +174,16 @@ define amdgpu_ps i32 @s_buffer_load_index_divergent_offset(<4 x i32> inreg %desc
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_index_divergent_offset:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    v_add_nc_u32_e32 v0, 32, v0
+; GFX1250-GISEL-NEXT:    buffer_load_b32 v0, v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %offset.index = add i32 %index, 32
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 %offset.index, i32 0)
@@ -184,6 +220,15 @@ define amdgpu_ps i32 @s_buffer_load_index_divergent_offset_nuw(<4 x i32> inreg %
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_index_divergent_offset_nuw:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    buffer_load_b32 v0, v0, s[0:3], null offen offset:32 nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %offset.index = add nuw i32 %index, 32
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 %offset.index, i32 0)
@@ -222,6 +267,14 @@ define amdgpu_ps <2 x i32> @s_buffer_loadx2_imm(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b64 s[0:1], s[0:3], 0x40 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx2_imm:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b64 s[0:1], s[0:3], 0x40 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32> %desc, i32 64, i32 0)
   ret <2 x i32> %load
@@ -277,6 +330,17 @@ define amdgpu_ps float @s_buffer_loadx2_index(<4 x i32> inreg %desc, i32 inreg %
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx2_index:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b64 s[0:1], s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    s_add_f32 s0, s0, s1
+; GFX1250-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
+; GFX1250-GISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32> %desc, i32 %index, i32 0)
   %bitcast = bitcast <2 x i32> %load to <2 x float>
@@ -320,6 +384,16 @@ define amdgpu_ps <2 x i32> @s_buffer_loadx2_index_divergent(<4 x i32> inreg %des
 ; GFX1250-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1250-NEXT:    v_readfirstlane_b32 s1, v1
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx2_index_divergent:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    buffer_load_b64 v[0:1], v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32> %desc, i32 %index, i32 0)
   ret <2 x i32> %load
@@ -357,6 +431,14 @@ define amdgpu_ps <3 x i32> @s_buffer_loadx3_imm(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b96 s[0:2], s[0:3], 0x40 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx3_imm:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b96 s[0:2], s[0:3], 0x40 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <3 x i32> @llvm.amdgcn.s.buffer.load.v3i32(<4 x i32> %desc, i32 64, i32 0)
   ret <3 x i32> %load
@@ -394,6 +476,14 @@ define amdgpu_ps <3 x i32> @s_buffer_loadx3_index(<4 x i32> inreg %desc, i32 inr
 ; GFX1250-NEXT:    s_buffer_load_b96 s[0:2], s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx3_index:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b96 s[0:2], s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <3 x i32> @llvm.amdgcn.s.buffer.load.v3i32(<4 x i32> %desc, i32 %index, i32 0)
   ret <3 x i32> %load
@@ -446,6 +536,17 @@ define amdgpu_ps <3 x i32> @s_buffer_loadx3_index_divergent(<4 x i32> inreg %des
 ; GFX1250-NEXT:    v_readfirstlane_b32 s1, v1
 ; GFX1250-NEXT:    v_readfirstlane_b32 s2, v2
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx3_index_divergent:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    buffer_load_b96 v[0:2], v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <3 x i32> @llvm.amdgcn.s.buffer.load.v3i32(<4 x i32> %desc, i32 %index, i32 0)
   ret <3 x i32> %load
@@ -483,6 +584,14 @@ define amdgpu_ps <4 x i32> @s_buffer_loadx4_imm(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b128 s[0:3], s[0:3], 0xc8 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx4_imm:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b128 s[0:3], s[0:3], 0xc8 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %desc, i32 200, i32 0)
   ret <4 x i32> %load
@@ -520,6 +629,14 @@ define amdgpu_ps <4 x i32> @s_buffer_loadx4_index(<4 x i32> inreg %desc, i32 inr
 ; GFX1250-NEXT:    s_buffer_load_b128 s[0:3], s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx4_index:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b128 s[0:3], s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %desc, i32 %index, i32 0)
   ret <4 x i32> %load
@@ -567,6 +684,18 @@ define amdgpu_ps <4 x i32> @s_buffer_loadx4_index_divergent(<4 x i32> inreg %des
 ; GFX1250-NEXT:    v_readfirstlane_b32 s2, v2
 ; GFX1250-NEXT:    v_readfirstlane_b32 s3, v3
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_loadx4_index_divergent:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    buffer_load_b128 v[0:3], v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s3, v3
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load = call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %desc, i32 %index, i32 0)
   ret <4 x i32> %load
@@ -614,6 +743,16 @@ define amdgpu_ps <2 x i32> @s_buffer_load_imm_mergex2(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_mov_b32 s0, s4
 ; GFX1250-NEXT:    s_mov_b32 s1, s5
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_mergex2:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b64 s[4:5], s[0:3], 0x4 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    s_mov_b32 s0, s4
+; GFX1250-GISEL-NEXT:    s_mov_b32 s1, s5
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load0 = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 4, i32 0)
   %load1 = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 8, i32 0)
@@ -668,6 +807,18 @@ define amdgpu_ps <4 x i32> @s_buffer_load_imm_mergex4(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_mov_b32 s2, s6
 ; GFX1250-NEXT:    s_mov_b32 s3, s7
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_mergex4:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b128 s[4:7], s[0:3], 0x8 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    s_mov_b32 s0, s4
+; GFX1250-GISEL-NEXT:    s_mov_b32 s1, s5
+; GFX1250-GISEL-NEXT:    s_mov_b32 s2, s6
+; GFX1250-GISEL-NEXT:    s_mov_b32 s3, s7
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %load0 = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 8, i32 0)
   %load1 = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 12, i32 0)
@@ -816,6 +967,23 @@ define amdgpu_ps i32 @s_buffer_load_index_across_bb(<4 x i32> inreg %desc, i32 %
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_index_across_bb:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_get_pc_i64 s[4:5]
+; GFX1250-GISEL-NEXT:    s_add_nc_u64 s[4:5], s[4:5], gv@gotpcrel+4
+; GFX1250-GISEL-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
+; GFX1250-GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x0 nv
+; GFX1250-GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    global_store_b32 v1, v0, s[4:5]
+; GFX1250-GISEL-NEXT:    v_or_b32_e32 v0, 8, v0
+; GFX1250-GISEL-NEXT:    buffer_load_b32 v0, v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %tmp = shl i32 %index, 4
   store i32 %tmp, ptr addrspace(1) @gv
@@ -865,6 +1033,22 @@ define amdgpu_ps <2 x i32> @s_buffer_load_index_across_bb_merged(<4 x i32> inreg
 ; GFX1250-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1250-NEXT:    v_readfirstlane_b32 s1, v1
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_index_across_bb_merged:
+; GFX1250-GISEL:       ; %bb.0: ; %main_body
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    v_lshl_or_b32 v0, v0, 4, 8
+; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-GISEL-NEXT:    v_or_b32_e32 v1, 4, v0
+; GFX1250-GISEL-NEXT:    s_clause 0x1
+; GFX1250-GISEL-NEXT:    buffer_load_b32 v2, v0, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    buffer_load_b32 v3, v1, s[0:3], null offen nv
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x1
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s0, v2
+; GFX1250-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-GISEL-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
 main_body:
   %tmp = shl i32 %index, 4
   br label %bb1
@@ -924,6 +1108,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_neg1(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_neg1:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_mov_b32 s4, -1
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 -1, i32 0)
   ret i32 %load
 }
@@ -979,6 +1172,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_neg4(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_neg4:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_mov_b32 s4, -4
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 -4, i32 0)
   ret i32 %load
 }
@@ -1034,6 +1236,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_neg8(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_neg8:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_mov_b32 s4, -8
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 -8, i32 0)
   ret i32 %load
 }
@@ -1089,6 +1300,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_bit31(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_bit31:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_brev_b32 s4, 1
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 -2147483648, i32 0)
   ret i32 %load
 }
@@ -1144,6 +1364,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_bit30(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_bit30:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_mov_b32 s4, 2.0
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1073741824, i32 0)
   ret i32 %load
 }
@@ -1199,6 +1428,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_bit29(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_bit29:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_brev_b32 s4, 4
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 536870912, i32 0)
   ret i32 %load
 }
@@ -1252,6 +1490,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_bit21(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x200000 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_bit21:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x200000 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 2097152, i32 0)
   ret i32 %load
 }
@@ -1305,6 +1551,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_bit20(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x100000 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_bit20:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x100000 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1048576, i32 0)
   ret i32 %load
 }
@@ -1360,6 +1614,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_neg_bit20(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_neg_bit20:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_mov_b32 s4, 0xfff00000
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32  -1048576, i32 0)
   ret i32 %load
 }
@@ -1404,6 +1667,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_bit19(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x80000 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_bit19:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x80000 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 524288, i32 0)
   ret i32 %load
 }
@@ -1459,6 +1730,15 @@ define amdgpu_ps i32 @s_buffer_load_imm_neg_bit19(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_neg_bit19:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_mov_b32 s4, 0xfff80000
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 -524288, i32 0)
   ret i32 %load
 }
@@ -1504,6 +1784,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_255(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0xff nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_255:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0xff nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 255, i32 0)
   ret i32 %load
 }
@@ -1540,6 +1828,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_256(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x100 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_256:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x100 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 256, i32 0)
   ret i32 %load
 }
@@ -1576,6 +1872,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_1016(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x3f8 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_1016:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x3f8 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1016, i32 0)
   ret i32 %load
 }
@@ -1612,6 +1916,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_1020(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x3fc nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_1020:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x3fc nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1020, i32 0)
   ret i32 %load
 }
@@ -1657,6 +1969,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_1021(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x3fd nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_1021:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x3fd nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1021, i32 0)
   ret i32 %load
 }
@@ -1701,6 +2021,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_1024(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x400 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_1024:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x400 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1024, i32 0)
   ret i32 %load
 }
@@ -1746,6 +2074,14 @@ define amdgpu_ps i32 @s_buffer_load_imm_1025(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x401 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_1025:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x401 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1025, i32 0)
   ret i32 %load
 }
@@ -1790,7 +2126,129 @@ define amdgpu_ps i32 @s_buffer_load_imm_1028(<4 x i32> inreg %desc) {
 ; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x400 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_imm_1028:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], 0x400 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 1024, i32 0)
+  ret i32 %load
+}
+
+define amdgpu_ps i32 @s_buffer_load_ptr_soffset(<4 x i32> inreg %desc, ptr addrspace(6) inreg %p) {
+; GFX6-LABEL: s_buffer_load_ptr_soffset:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_add_i32 s4, s4, 52
+; GFX6-NEXT:    s_nop 3
+; GFX6-NEXT:    s_buffer_load_dword s0, s[0:3], s4
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    ; return to shader part epilog
+;
+; GFX78-LABEL: s_buffer_load_ptr_soffset:
+; GFX78:       ; %bb.0:
+; GFX78-NEXT:    s_add_i32 s4, s4, 52
+; GFX78-NEXT:    s_buffer_load_dword s0, s[0:3], s4
+; GFX78-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX78-NEXT:    ; return to shader part epilog
+;
+; GFX910-LABEL: s_buffer_load_ptr_soffset:
+; GFX910:       ; %bb.0:
+; GFX910-NEXT:    s_add_i32 s4, s4, 52
+; GFX910-NEXT:    s_buffer_load_dword s0, s[0:3], s4 offset:0x0
+; GFX910-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX910-NEXT:    ; return to shader part epilog
+;
+; GFX11-LABEL: s_buffer_load_ptr_soffset:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_add_i32 s4, s4, 52
+; GFX11-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-NEXT:    ; return to shader part epilog
+;
+; GFX1200-LABEL: s_buffer_load_ptr_soffset:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_add_co_i32 s4, s4, 52
+; GFX1200-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    ; return to shader part epilog
+;
+; GFX1250-LABEL: s_buffer_load_ptr_soffset:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-NEXT:    v_nop
+; GFX1250-NEXT:    s_add_co_i32 s4, s4, 52
+; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_ptr_soffset:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x34 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
+  %gep = getelementptr i8, ptr addrspace(6) %p, i32 52
+  %soffset = ptrtoint ptr addrspace(6) %gep to i32
+  %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 %soffset, i32 0)
+  ret i32 %load
+}
+
+define amdgpu_ps i32 @s_buffer_load_ptr_soffset_inbounds(<4 x i32> inreg %desc, ptr addrspace(6) inreg %p) {
+; GFX6-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX6:       ; %bb.0:
+; GFX6-NEXT:    s_add_i32 s4, s4, 52
+; GFX6-NEXT:    s_nop 3
+; GFX6-NEXT:    s_buffer_load_dword s0, s[0:3], s4
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    ; return to shader part epilog
+;
+; GFX78-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX78:       ; %bb.0:
+; GFX78-NEXT:    s_add_i32 s4, s4, 52
+; GFX78-NEXT:    s_buffer_load_dword s0, s[0:3], s4
+; GFX78-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX78-NEXT:    ; return to shader part epilog
+;
+; GFX910-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX910:       ; %bb.0:
+; GFX910-NEXT:    s_buffer_load_dword s0, s[0:3], s4 offset:0x34
+; GFX910-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX910-NEXT:    ; return to shader part epilog
+;
+; GFX11-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x34
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-NEXT:    ; return to shader part epilog
+;
+; GFX1200-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX1200:       ; %bb.0:
+; GFX1200-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x34
+; GFX1200-NEXT:    s_wait_kmcnt 0x0
+; GFX1200-NEXT:    ; return to shader part epilog
+;
+; GFX1250-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX1250:       ; %bb.0:
+; GFX1250-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-NEXT:    v_nop
+; GFX1250-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x34 nv
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    ; return to shader part epilog
+;
+; GFX1250-GISEL-LABEL: s_buffer_load_ptr_soffset_inbounds:
+; GFX1250-GISEL:       ; %bb.0:
+; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+; GFX1250-GISEL-NEXT:    v_nop
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x34 nv
+; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-GISEL-NEXT:    ; return to shader part epilog
+  %gep = getelementptr inbounds i8, ptr addrspace(6) %p, i32 52
+  %soffset = ptrtoint ptr addrspace(6) %gep to i32
+  %load = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %desc, i32 %soffset, i32 0)
   ret i32 %load
 }
 


### PR DESCRIPTION
Soffset can come in as a pointer (converted to int);
the common case is a constant addrspace(6) pointer.