### PR TITLE
AMDGPU/GlobalISel: Fix G_PTR_ADD handling in getBaseWithConstantOffset

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
@@ -64,8 +64,13 @@ AMDGPU::getBaseWithConstantOffset(MachineRegisterInfo &MRI, Register Reg,
   // Handle G_PTRTOINT (G_PTR_ADD base, const) case
   if (Def->getOpcode() == TargetOpcode::G_PTRTOINT) {
     MachineInstr *Base;
-    if (mi_match(Def->getOperand(1).getReg(), MRI,
-                 m_GPtrAdd(m_MInstr(Base), m_ICst(Offset)))) {
+    Register PtrAdd = Def->getOperand(1).getReg();
+    if (mi_match(PtrAdd, MRI, m_GPtrAdd(m_MInstr(Base), m_ICst(Offset)))) {
+      // Same check as for G_ADD; nuw comes from getelementptr inbounds.
+      if (CheckNUW && !MRI.getVRegDef(PtrAdd)->getFlag(MachineInstr::NoUWrap)) {
+        assert(MRI.getType(Reg).getScalarSizeInBits() == 32);
+        return std::pair(Reg, 0);
+      }
       // If Base was int converted to pointer, simply return int and offset.
       if (Base->getOpcode() == TargetOpcode::G_INTTOPTR)
         return std::pair(Base->getOperand(1).getReg(), Offset);

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.buffer.load.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.buffer.load.ll
@@ -2188,7 +2188,8 @@ define amdgpu_ps i32 @s_buffer_load_ptr_soffset(<4 x i32> inreg %desc, ptr addrs
 ; GFX1250-GISEL:       ; %bb.0:
 ; GFX1250-GISEL-NEXT:    global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
 ; GFX1250-GISEL-NEXT:    v_nop
-; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x34 nv
+; GFX1250-GISEL-NEXT:    s_add_co_u32 s4, s4, 52
+; GFX1250-GISEL-NEXT:    s_buffer_load_b32 s0, s[0:3], s4 offset:0x0 nv
 ; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-GISEL-NEXT:    ; return to shader part epilog
   %gep = getelementptr i8, ptr addrspace(6) %p, i32 52


### PR DESCRIPTION
There was a discrepancy compared to SDAG when G_PTR_ADD was being matched
and there was no nuw flag check. In case of G_PTR_ADD, nuw flag comes
from inbounds flag on getelementptr. For reference, SDAG does not have
pointers so PTR_ADD is integer ADD in SDAG.