### PR TITLE
[libc++] Try fixing flaky fs.op.space test on FreeBSD

### DIFF
--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.space/space.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.space/space.pass.cpp
@@ -106,7 +106,7 @@ static void basic_space_test()
         space_info info = space(p, ec);
         assert(!ec);
         assert(info.capacity != bad_value);
-        assert(expect_capacity == info.capacity);
+        assert(EqualDelta(expect_capacity, info.capacity, delta));
         assert(info.free != bad_value);
         assert(EqualDelta(expect_free, info.free, delta));
         assert(info.available != bad_value);


### PR DESCRIPTION
As part of this test, we check the capacity available on the filesystem and compare it against an expected capacity. However, on some filesystems, the capacity is actually computed and may change depending on filesystem usage. This creates a race condition since the disk may be filling up (by e.g. other running tests) between the two calls.

For that same reason, other checks for the available size were using an approximate equality up to a delta. Use the same approach for the capacity here.