### PR TITLE
[LLVM][CodeGen][AArch64] Increase opportunities to fold shift-of-extend into sshll/ushll.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -17,6 +17,7 @@
 #include "MCTargetDesc/AArch64AddressingModes.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
+#include "llvm/CodeGen/SDPatternMatch.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
 #include "llvm/IR/Function.h" // To access function attributes.
 #include "llvm/IR/GlobalValue.h"
@@ -29,6 +30,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
+using namespace llvm::SDPatternMatch;
 
 #define DEBUG_TYPE "aarch64-isel"
 #define PASS_NAME "AArch64 Instruction Selection"
@@ -8298,6 +8300,24 @@ void AArch64DAGToDAGISel::PreprocessISelDAG() {
           ScalarTy == N.getOperand(0).getValueType())
         Result = addBitcastHints(*CurDAG, N);
 
+      break;
+    }
+    case AArch64ISD::VSHL: {
+      // Undo mul(shl(A,C),B) -> shl(mul(A,B),C) canonicalisation when A is an
+      // extend that can be folded into the shift.
+      EVT VT = N.getValueType(0);
+      SDValue A, B, C = N.getOperand(1);
+      if (sd_match(N.getOperand(0),
+                   m_OneUse(m_Mul(m_Value(A, m_AnyOf(m_ZExt(m_Value()),
+                                                     m_SExt(m_Value()))),
+                                  m_Value(B))))) {
+        // If both mul operands are extended, preserve the smull/umull idiom.
+        if (B.getOpcode() == A.getOpcode())
+          break;
+        SDLoc DL(&N);
+        SDValue SHL = CurDAG->getNode(AArch64ISD::VSHL, DL, VT, A, C);
+        Result = CurDAG->getNode(ISD::MUL, DL, VT, SHL, B);
+      }
       break;
     }
     default:

--- a/llvm/test/CodeGen/AArch64/neon-shift-left-long.ll
+++ b/llvm/test/CodeGen/AArch64/neon-shift-left-long.ll
@@ -672,3 +672,142 @@ define <8 x i16> @test_ushll_cmp(<8 x i8> %a, <8 x i8> %b) #0 {
   %vmovl.i.i.i = zext <8 x i8> %vcgtz.i.i to <8 x i16>
   ret <8 x i16> %vmovl.i.i.i
 }
+
+define  <8 x i16> @mul_of_shl_zext(<8 x i8> %a, <8 x i16> %b) {
+; CHECK-SD-LABEL: mul_of_shl_zext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: mul_of_shl_zext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    ushll v0.8h, v0.8b, #1
+; CHECK-GI-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-GI-NEXT:    ret
+  %a.ext = zext <8 x i8> %a to <8 x i16>
+  %shl = shl <8 x i16> %a.ext, splat (i16 1)
+  %mul = mul <8 x i16> %shl, %b
+  ret <8 x i16> %mul
+}
+
+define  <8 x i16> @shl_of_mul_zext(<8 x i8> %a, <8 x i16> %b) {
+; CHECK-SD-LABEL: shl_of_mul_zext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shl_of_mul_zext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-GI-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #1
+; CHECK-GI-NEXT:    ret
+  %a.ext = zext <8 x i8> %a to <8 x i16>
+  %mul = mul <8 x i16> %a.ext, %b
+  %shl = shl <8 x i16> %mul, splat (i16 1)
+  ret <8 x i16> %shl
+}
+
+define  <8 x i16> @shl_of_mul_zext_zext(<8 x i8> %a, <8 x i8> %b) {
+; CHECK-SD-LABEL: shl_of_mul_zext_zext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    umull v0.8h, v0.8b, v1.8b
+; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shl_of_mul_zext_zext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    umull v0.8h, v0.8b, v1.8b
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #1
+; CHECK-GI-NEXT:    ret
+  %a.ext = zext <8 x i8> %a to <8 x i16>
+  %b.ext = zext <8 x i8> %b to <8 x i16>
+  %mul = mul <8 x i16> %a.ext, %b.ext
+  %shl = shl <8 x i16> %mul, splat (i16 1)
+  ret <8 x i16> %shl
+}
+
+define  <8 x i16> @mul_of_shl_sext(<8 x i8> %a, <8 x i16> %b) {
+; CHECK-SD-LABEL: mul_of_shl_sext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    sshll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: mul_of_shl_sext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    sshll v0.8h, v0.8b, #1
+; CHECK-GI-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-GI-NEXT:    ret
+  %a.ext = sext <8 x i8> %a to <8 x i16>
+  %shl = shl <8 x i16> %a.ext, splat (i16 1)
+  %mul = mul <8 x i16> %shl, %b
+  ret <8 x i16> %mul
+}
+
+define  <8 x i16> @shl_of_mul_sext(<8 x i8> %a, <8 x i16> %b) {
+; CHECK-SD-LABEL: shl_of_mul_sext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    sshll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shl_of_mul_sext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    sshll v0.8h, v0.8b, #0
+; CHECK-GI-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #1
+; CHECK-GI-NEXT:    ret
+  %a.ext = sext <8 x i8> %a to <8 x i16>
+  %mul = mul <8 x i16> %a.ext, %b
+  %shl = shl <8 x i16> %mul, splat (i16 1)
+  ret <8 x i16> %shl
+}
+
+define  <8 x i16> @shl_of_mul_sext_sext(<8 x i8> %a, <8 x i8> %b) {
+; CHECK-SD-LABEL: shl_of_mul_sext_sext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    smull v0.8h, v0.8b, v1.8b
+; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shl_of_mul_sext_sext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    smull v0.8h, v0.8b, v1.8b
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #1
+; CHECK-GI-NEXT:    ret
+  %a.ext = sext <8 x i8> %a to <8 x i16>
+  %b.ext = sext <8 x i8> %b to <8 x i16>
+  %mul = mul <8 x i16> %a.ext, %b.ext
+  %shl = shl <8 x i16> %mul, splat (i16 1)
+  ret <8 x i16> %shl
+}
+
+define  <8 x i16> @shl_of_multi_use_mul_sext(<8 x i8> %a, <8 x i16> %b) {
+; CHECK-SD-LABEL: shl_of_multi_use_mul_sext:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    sshll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    mul v1.8h, v0.8h, v1.8h
+; CHECK-SD-NEXT:    add v0.8h, v1.8h, v1.8h
+; CHECK-SD-NEXT:    // fake_use: $q1
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shl_of_multi_use_mul_sext:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    sshll v0.8h, v0.8b, #0
+; CHECK-GI-NEXT:    mul v1.8h, v0.8h, v1.8h
+; CHECK-GI-NEXT:    shl v0.8h, v1.8h, #1
+; CHECK-GI-NEXT:    // fake_use: $q1
+; CHECK-GI-NEXT:    ret
+  %a.ext = sext <8 x i8> %a to <8 x i16>
+  %mul = mul <8 x i16> %a.ext, %b
+  %shl = shl <8 x i16> %mul, splat (i16 1)
+  call void (...) @llvm.fake.use(<8 x i16> %mul)
+  ret <8 x i16> %shl
+}

--- a/llvm/test/CodeGen/AArch64/neon-shift-left-long.ll
+++ b/llvm/test/CodeGen/AArch64/neon-shift-left-long.ll
@@ -674,18 +674,11 @@ define <8 x i16> @test_ushll_cmp(<8 x i8> %a, <8 x i8> %b) #0 {
 }
 
 define  <8 x i16> @mul_of_shl_zext(<8 x i8> %a, <8 x i16> %b) {
-; CHECK-SD-LABEL: mul_of_shl_zext:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
-; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
-; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: mul_of_shl_zext:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    ushll v0.8h, v0.8b, #1
-; CHECK-GI-NEXT:    mul v0.8h, v0.8h, v1.8h
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: mul_of_shl_zext:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ushll v0.8h, v0.8b, #1
+; CHECK-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-NEXT:    ret
   %a.ext = zext <8 x i8> %a to <8 x i16>
   %shl = shl <8 x i16> %a.ext, splat (i16 1)
   %mul = mul <8 x i16> %shl, %b
@@ -695,9 +688,8 @@ define  <8 x i16> @mul_of_shl_zext(<8 x i8> %a, <8 x i16> %b) {
 define  <8 x i16> @shl_of_mul_zext(<8 x i8> %a, <8 x i16> %b) {
 ; CHECK-SD-LABEL: shl_of_mul_zext:
 ; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #1
 ; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
-; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: shl_of_mul_zext:
@@ -732,18 +724,11 @@ define  <8 x i16> @shl_of_mul_zext_zext(<8 x i8> %a, <8 x i8> %b) {
 }
 
 define  <8 x i16> @mul_of_shl_sext(<8 x i8> %a, <8 x i16> %b) {
-; CHECK-SD-LABEL: mul_of_shl_sext:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    sshll v0.8h, v0.8b, #0
-; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
-; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: mul_of_shl_sext:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    sshll v0.8h, v0.8b, #1
-; CHECK-GI-NEXT:    mul v0.8h, v0.8h, v1.8h
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: mul_of_shl_sext:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sshll v0.8h, v0.8b, #1
+; CHECK-NEXT:    mul v0.8h, v0.8h, v1.8h
+; CHECK-NEXT:    ret
   %a.ext = sext <8 x i8> %a to <8 x i16>
   %shl = shl <8 x i16> %a.ext, splat (i16 1)
   %mul = mul <8 x i16> %shl, %b
@@ -753,9 +738,8 @@ define  <8 x i16> @mul_of_shl_sext(<8 x i8> %a, <8 x i16> %b) {
 define  <8 x i16> @shl_of_mul_sext(<8 x i8> %a, <8 x i16> %b) {
 ; CHECK-SD-LABEL: shl_of_mul_sext:
 ; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    sshll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    sshll v0.8h, v0.8b, #1
 ; CHECK-SD-NEXT:    mul v0.8h, v0.8h, v1.8h
-; CHECK-SD-NEXT:    add v0.8h, v0.8h, v0.8h
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: shl_of_mul_sext:


### PR DESCRIPTION
Add PreprocessISelDAG logic to undo mul-of-shl to shl-of-mul canonicalisation when either operand is sign/zero extended because the extension can be folded into the shift.

I've gone the PreprocessISelDAG rather than DAGCombine route because the transformation only exists to aid ISel. I also have a long time desire to remove AArch64ISD::VSHL, after which PreprocessISelDAG will be the only option to break the canonical form anyway.