### PR TITLE
[analyzer] Generalize MemRegion::getDescriptiveName

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -213,11 +213,18 @@ public:
   /// the variable/field declaration retrieved from the memory region.
   /// Regions that point to an element of an array are returned as: "arr[0]".
   /// Regions that point to a struct are returned as: "st.var".
+  /// Returns an empty string for regions that don't have a clear descriptive
+  /// name (e.g. a heap are allocated by 'malloc').
   //
   /// \param UseQuotes Set if the name should be quoted.
   ///
+  /// \param AllowFallback When true, always retursn a non-empty string, using
+  /// vague descriptions like "the heap area", "the string literal" (or "the
+  /// region" as a catch-all) when there is nothing better.
+  ///
   /// \returns variable name for memory region
-  std::string getDescriptiveName(bool UseQuotes = true) const;
+  std::string getDescriptiveName(bool UseQuotes = true,
+                                 bool AllowFallback = false) const;
 
   /// Retrieve source range from memory region. The range retrieval
   /// is based on the decl obtained from the memory region.

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
@@ -455,31 +455,6 @@ compareValueToThreshold(ProgramStateRef State, NonLoc Value, NonLoc Threshold,
   return {nullptr, nullptr};
 }
 
-static std::string getRegionName(const MemSpaceRegion *Space,
-                                 const SubRegion *Region) {
-  if (std::string RegName = Region->getDescriptiveName(); !RegName.empty())
-    return RegName;
-
-  // Field regions only have descriptive names when their parent has a
-  // descriptive name; so we provide a fallback representation for them:
-  if (const auto *FR = Region->getAs<FieldRegion>()) {
-    if (StringRef Name = FR->getDecl()->getName(); !Name.empty())
-      return formatv("the field '{0}'", Name);
-    return "the unnamed field";
-  }
-
-  if (isa<AllocaRegion>(Region))
-    return "the memory returned by 'alloca'";
-
-  if (isa<SymbolicRegion>(Region) && isa<HeapSpaceRegion>(Space))
-    return "the heap area";
-
-  if (isa<StringRegion>(Region))
-    return "the string literal";
-
-  return "the region";
-}
-
 static std::optional<int64_t> getConcreteValue(NonLoc SV) {
   if (auto ConcreteVal = SV.getAs<nonloc::ConcreteInt>()) {
     return ConcreteVal->getValue()->tryExtValue();
@@ -681,7 +656,8 @@ void ArrayBoundChecker::handleAccessExpr(const Expr *E,
     return;
   }
 
-  std::string RegName = getRegionName(Space, Reg);
+  std::string RegName =
+      Reg->getDescriptiveName(/*UseQuotes=*/true, /*AllowFallback=*/true);
 
   const NoteTag *T = nullptr;
   if (Res.mayBeInvalid()) {

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -722,8 +722,8 @@ void CXXDerivedObjectRegion::printPrettyAsExpr(raw_ostream &os) const {
   superRegion->printPrettyAsExpr(os);
 }
 
-std::string MemRegion::getDescriptiveName(bool UseQuotes) const {
-  std::string VariableName;
+std::string MemRegion::getDescriptiveName(bool UseQuotes,
+                                          bool AllowFallback) const {
   std::string ArrayIndices;
   const MemRegion *R = this;
   SmallString<50> buf;
@@ -734,6 +734,28 @@ std::string MemRegion::getDescriptiveName(bool UseQuotes) const {
     if (UseQuotes)
       return ("'" + Subject + "'").str();
     return Subject.str();
+  };
+
+  auto FallbackName = [this, AllowFallback]() -> std::string {
+    if (!AllowFallback)
+      return "";
+
+    if (const auto *FR = getAs<FieldRegion>()) {
+      if (StringRef Name = FR->getDecl()->getName(); !Name.empty())
+        return (llvm::Twine("the field '") + Name + "'").str();
+      return "the unnamed field";
+    }
+
+    if (isa<AllocaRegion>(this))
+      return "the memory returned by 'alloca'";
+
+    if (isa<SymbolicRegion>(this) && isa<HeapSpaceRegion>(getRawMemorySpace()))
+      return "the heap area";
+
+    if (isa<StringRegion>(this))
+      return "the string literal";
+
+    return "the region";
   };
 
   // Obtain array indices to add them to the variable name.
@@ -749,15 +771,15 @@ std::string MemRegion::getDescriptiveName(bool UseQuotes) const {
     else {
       auto SI = ER->getIndex().getAs<nonloc::SymbolVal>();
       if (!SI)
-        return "";
+        return FallbackName();
 
       const MemRegion *OR = SI->getAsSymbol()->getOriginRegion();
       if (!OR)
-        return "";
+        return FallbackName();
 
       std::string Idx = OR->getDescriptiveName(false);
       if (Idx.empty())
-        return "";
+        return FallbackName();
 
       ArrayIndices = (llvm::Twine("[") + Idx + "]" + ArrayIndices).str();
     }
@@ -776,12 +798,12 @@ std::string MemRegion::getDescriptiveName(bool UseQuotes) const {
     if (const auto *FR = R->getAs<FieldRegion>()) {
       std::string Super = FR->getSuperRegion()->getDescriptiveName(false);
       if (Super.empty())
-        return "";
+        return FallbackName();
       return QuoteIfNeeded(Super + "." + FR->getDecl()->getName());
     }
   }
 
-  return VariableName;
+  return FallbackName();
 }
 
 SourceRange MemRegion::sourceRange() const {


### PR DESCRIPTION
Previously `ArrayBoundChecker` had a utility function called `getRegionName` that acted as a wrapper around
`MemRegion::getDescriptiveName` and provided fallback descriptions like "the heap area" or "the string literal" in cases when there was no exact name and `Memregion::getDescriptiveName` just returned an empty string.

As this functionality may be useful for other checkers in the future, this commit moves it to `getDescriptiveName`, which now gains a second optional parameter called `AllowFallback` (which defaults to false).

Calling `getDescriptiveName` with `AllowFallback == true` is almost equivalent to the utility function `getRegionName`: the only difference is that `getDescriptiveName` uses `getRawMemorySpace()` to remain independent of the current `State` -- while `getRegionName` took the `Space` (calculated with `Reg->getMemorySpace(State)`) as an argument.

This introduces a very minor functional change in
`security.ArrayBoundChecker`: if a symbolic region was originally created in the Unknown memory space but later we deduced that it is on the heap, then before this commit it was described as "the heap area" but now it is referred to as "the region".

As this is a very rare situation and the new, less specific message is also completely acceptable, I don't think that we need to complicate the code to preserve the old behavior.

This commit eliminates the useless variable `VariableName` from `getDescriptiveName`, other technical debt is left unchanged.