### PR TITLE
[CIR] Move array-ctor cleanup to properly cleanup temporaries

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -786,71 +786,70 @@ void CIRGenFunction::emitCXXAggrConstructorCall(
     dynamicElPtr =
         builder.createPtrBitcast(arrayBase.getPointer(), elementType);
 
-  // C++ [class.temporary]p4:
-  // There are two contexts in which temporaries are destroyed at a different
-  // point than the end of the full-expression. The first context is when a
-  // default constructor is called to initialize an element of an array.
-  // If the constructor has one or more default arguments, the destruction of
-  // every temporary created in a default argument expression is sequenced
-  // before the construction of the next array element, if any.
-  {
-    RunCleanupsScope scope(*this);
+  // When the caller has already pushed an irregular partial-array cleanup
+  // (signalled by a valid endOfInit), our loop body will keep that cleanup's
+  // upper bound up to date, so we don't need a separate per-element
+  // partial-destruction region on the cir::ArrayCtor op.
+  bool needsPartialArrayCleanup = getLangOpts().Exceptions &&
+                                  !ctor->getParent()->hasTrivialDestructor() &&
+                                  !endOfInit.isValid();
 
-    // When the caller has already pushed an irregular partial-array cleanup
-    // (signalled by a valid endOfInit), our loop body will keep that cleanup's
-    // upper bound up to date, so we don't need a separate per-element
-    // partial-destruction region on the cir::ArrayCtor op.
-    bool needsPartialArrayCleanup =
-        getLangOpts().Exceptions &&
-        !ctor->getParent()->hasTrivialDestructor() && !endOfInit.isValid();
-
-    auto emitCtorBody = [&](mlir::OpBuilder &b, mlir::Location l) {
-      mlir::BlockArgument arg =
-          b.getInsertionBlock()->addArgument(ptrToElmType, l);
-      Address curAddr = Address(arg, elementType, eltAlignment);
-      // Extend the caller's irregular partial-array cleanup to cover the
-      // element we're about to construct. If this constructor throws, the
-      // cleanup will destroy every element strictly below this one.
-      if (endOfInit.isValid())
-        builder.createStore(l, arg, endOfInit);
-      assert(!cir::MissingFeatures::sanitizers());
-      if (zeroInitialize)
-        emitNullInitialization(l, curAddr, type);
-      auto currAVS = AggValueSlot::forAddr(
-          curAddr, type.getQualifiers(), AggValueSlot::IsDestructed,
-          AggValueSlot::IsNotAliased, AggValueSlot::DoesNotOverlap,
-          AggValueSlot::IsNotZeroed);
+  auto emitCtorBody = [&](mlir::OpBuilder &b, mlir::Location l) {
+    mlir::BlockArgument arg =
+        b.getInsertionBlock()->addArgument(ptrToElmType, l);
+    Address curAddr = Address(arg, elementType, eltAlignment);
+    // Extend the caller's irregular partial-array cleanup to cover the
+    // element we're about to construct. If this constructor throws, the
+    // cleanup will destroy every element strictly below this one.
+    if (endOfInit.isValid())
+      builder.createStore(l, arg, endOfInit);
+    assert(!cir::MissingFeatures::sanitizers());
+    if (zeroInitialize)
+      emitNullInitialization(l, curAddr, type);
+    auto currAVS = AggValueSlot::forAddr(
+        curAddr, type.getQualifiers(), AggValueSlot::IsDestructed,
+        AggValueSlot::IsNotAliased, AggValueSlot::DoesNotOverlap,
+        AggValueSlot::IsNotZeroed);
+    // C++ [class.temporary]p4:
+    // There are two contexts in which temporaries are destroyed at a
+    // different point than the end of the full-expression. The first context
+    // is when a default constructor is called to initialize an element of an
+    // array. If the constructor has one or more default arguments, the
+    // destruction of every temporary created in a default argument expression
+    // is sequenced before the construction of the next array element, if any.
+    {
+      RunCleanupsScope scope(*this);
       emitCXXConstructorCall(ctor, Ctor_Complete,
                              /*ForVirtualBase=*/false,
                              /*Delegating=*/false, currAVS, e);
-      cir::YieldOp::create(b, l);
-    };
-
-    llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>
-        emitPartialDtorBody = nullptr;
-    auto partialDtorBuilder = [&](mlir::OpBuilder &b, mlir::Location l) {
-      mlir::BlockArgument arg =
-          b.getInsertionBlock()->addArgument(ptrToElmType, l);
-      Address curAddr = Address(arg, elementType, eltAlignment);
-      emitCXXDestructorCall(ctor->getParent()->getDestructor(), Dtor_Complete,
-                            /*forVirtualBase=*/false,
-                            /*delegating=*/false, curAddr, type);
-      cir::YieldOp::create(b, l);
-    };
-    if (needsPartialArrayCleanup)
-      emitPartialDtorBody = partialDtorBuilder;
-
-    if (useDynamicArrayCtor) {
-      cir::ArrayCtor::create(builder, loc, dynamicElPtr, numElements,
-                             emitCtorBody, emitPartialDtorBody);
-    } else {
-      cir::ArrayType arrayTy =
-          cir::ArrayType::get(elementType, constElementCount);
-      mlir::Value arrayOp =
-          builder.createPtrBitcast(arrayBase.getPointer(), arrayTy);
-      cir::ArrayCtor::create(builder, loc, arrayOp, emitCtorBody,
-                             emitPartialDtorBody);
     }
+    cir::YieldOp::create(b, l);
+  };
+
+  llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>
+      emitPartialDtorBody = nullptr;
+  auto partialDtorBuilder = [&](mlir::OpBuilder &b, mlir::Location l) {
+    mlir::BlockArgument arg =
+        b.getInsertionBlock()->addArgument(ptrToElmType, l);
+    Address curAddr = Address(arg, elementType, eltAlignment);
+    emitCXXDestructorCall(ctor->getParent()->getDestructor(), Dtor_Complete,
+                          /*forVirtualBase=*/false,
+                          /*delegating=*/false, curAddr, type);
+    cir::YieldOp::create(b, l);
+  };
+  if (needsPartialArrayCleanup)
+    emitPartialDtorBody = partialDtorBuilder;
+
+  if (useDynamicArrayCtor) {
+    cir::ArrayCtor::create(builder, loc, dynamicElPtr, numElements,
+                           emitCtorBody, emitPartialDtorBody);
+  } else {
+    cir::ArrayType arrayTy =
+        cir::ArrayType::get(elementType, constElementCount);
+    mlir::Value arrayOp =
+        builder.createPtrBitcast(arrayBase.getPointer(), arrayTy);
+    cir::ArrayCtor::create(builder, loc, arrayOp, emitCtorBody,
+                           emitPartialDtorBody);
   }
 }
 

--- a/clang/test/CIR/CodeGen/array-ctor.cpp
+++ b/clang/test/CIR/CodeGen/array-ctor.cpp
@@ -241,3 +241,111 @@ void TempInArray() {
 // OGCG:       %[[CURRENT:.*]] = phi ptr
 // OGCG:       call void @_ZN10CausesTempC1E4Temp(ptr {{.*}}%[[CURRENT]], ptr{{.*}}[[TMP]])
 // OGCG:       call void @_ZN4TempD1Ev({{.*}}[[TMP]])
+
+struct Temp2 {
+  Temp2();
+  ~Temp2();
+};
+
+struct CausesTemp2 {
+  CausesTemp2(Temp2 = Temp2());
+  ~CausesTemp2();
+};
+
+void Temp2InArray() {
+  CausesTemp2 ct2[42];
+}
+
+// CIR-BEFORE-LPP-LABEL: cir.func {{.*}} @_Z12Temp2InArrayv()
+// CIR-BEFORE-LPP-NEXT:   %[[ARRAY:.*]] = cir.alloca "ct2" {{.*}} init : !cir.ptr<!cir.array<!rec_CausesTemp2 x 42>>
+// CIR-BEFORE-LPP-NEXT:   %[[TMP:.*]] = cir.alloca "agg.tmp0" {{.*}} : !cir.ptr<!rec_Temp2>
+// CIR-BEFORE-LPP-NEXT:   cir.array.ctor %[[ARRAY]] : !cir.ptr<!cir.array<!rec_CausesTemp2 x 42>> {
+// CIR-BEFORE-LPP-NEXT:    ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_CausesTemp2>):
+// CIR-BEFORE-LPP-NEXT:      cir.call @_ZN5Temp2C1Ev(%[[TMP]])
+// CIR-BEFORE-LPP-NEXT:      cir.cleanup.scope {
+// CIR-BEFORE-LPP-NEXT:        %[[LOAD:.*]] = cir.load {{.*}} %[[TMP]] : !cir.ptr<!rec_Temp2>, !rec_Temp2
+// CIR-BEFORE-LPP-NEXT:        cir.call @_ZN11CausesTemp2C1E5Temp2(%[[ARG]], %[[LOAD]])
+// CIR-BEFORE-LPP-NEXT:        cir.yield
+// CIR-BEFORE-LPP-NEXT:      } cleanup normal {
+// CIR-BEFORE-LPP-NEXT:        cir.call @_ZN5Temp2D1Ev(%[[TMP]]) nothrow
+// CIR-BEFORE-LPP-NEXT:        cir.yield
+// CIR-BEFORE-LPP-NEXT:      }
+// CIR-BEFORE-LPP-NEXT:    }
+// CIR-BEFORE-LPP-NEXT:    cir.cleanup.scope {
+// CIR-BEFORE-LPP-NEXT:      cir.yield
+// CIR-BEFORE-LPP-NEXT:    } cleanup normal {
+// CIR-BEFORE-LPP-NEXT:      cir.array.dtor %[[ARRAY]] : !cir.ptr<!cir.array<!rec_CausesTemp2 x 42>> {
+// CIR-BEFORE-LPP-NEXT:      ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_CausesTemp2>):
+// CIR-BEFORE-LPP-NEXT:        cir.call @_ZN11CausesTemp2D1Ev(%[[ARG]]) nothrow : ({{.*}})
+// CIR-BEFORE-LPP-NEXT:      }
+// CIR-BEFORE-LPP-NEXT:      cir.yield
+// CIR-BEFORE-LPP-NEXT:    }
+// CIR-BEFORE-LPP-NEXT:   cir.return
+// CIR-BEFORE-LPP-NEXT: }
+
+// CIR-BEFORE-LPP: module @
+
+
+
+// CIR-LABEL: cir.func {{.*}} @_Z12Temp2InArrayv()
+// CIR:        %[[TMP:.*]] = cir.alloca "agg.tmp0" {{.*}} : !cir.ptr<!rec_Temp2>
+// CIR:        cir.do {
+// CIR-NEXT:     %[[CURRENT:.*]] = cir.load %[[ITER:.*]] : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>, !cir.ptr<!rec_CausesTemp2>
+// CIR-NEXT:     cir.call @_ZN5Temp2C1Ev(%[[TMP]])
+// CIR-NEXT:     cir.cleanup.scope {
+// CIR-NEXT:       %[[LOAD:.*]] = cir.load {{.*}} %[[TMP]] : !cir.ptr<!rec_Temp2>, !rec_Temp2
+// CIR-NEXT:         cir.call @_ZN11CausesTemp2C1E5Temp2(%[[CURRENT]], %[[LOAD]])
+// CIR-NEXT:         cir.yield
+// CIR-NEXT:       } cleanup normal {
+// CIR-NEXT:         cir.call @_ZN5Temp2D1Ev(%[[TMP]]) nothrow
+// CIR-NEXT:         cir.yield
+// CIR-NEXT:     }
+// CIR-NEXT:     %[[CONST1:.*]] = cir.const #cir.int<1> : !u64i
+// CIR-NEXT:     %[[NEXT:.*]] = cir.ptr_stride %[[CURRENT]], %[[CONST1]] : (!cir.ptr<!rec_CausesTemp2>, !u64i) -> !cir.ptr<!rec_CausesTemp2>
+// CIR-NEXT:     cir.store %[[NEXT]], %[[ITER]] : !cir.ptr<!rec_CausesTemp2>, !cir.ptr<!cir.ptr<!rec_CausesTemp2>>
+// CIR-NEXT:     cir.yield
+// CIR-NEXT:   } while {
+// CIR:        }
+// Array dtor:
+// CIR-NEXT:   cir.cleanup.scope {
+// CIR-NEXT:     cir.yield
+// CIR-NEXT:   } cleanup normal {
+// CIR:         %[[IDX:.*]] = cir.alloca "__array_idx" {{.*}} : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>
+// CIR:         cir.do {
+// CIR-NEXT:       %[[LOAD_IDX:.*]] = cir.load %[[IDX]] : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>, !cir.ptr<!rec_CausesTemp2>
+// CIR-NEXT:       %[[NEG_1:.*]] = cir.const #cir.int<-1> : !s64i
+// CIR-NEXT:       %[[STRIDE:.*]] = cir.ptr_stride %[[LOAD_IDX]], %[[NEG_1]]
+// CIR:            cir.call @_ZN11CausesTemp2D1Ev(%[[STRIDE]]) nothrow 
+// CIR-NEXT:       cir.yield
+// CIR-NEXT:     } while {
+// CIR:          }
+
+
+// LLVM-LABEL: define {{.*}}void @_Z12Temp2InArrayv()
+// LLVM:       %[[DTOR_ITR:.*]] = alloca ptr
+// LLVM:       %[[TMP:.*]] = alloca %struct.Temp2
+// LLVM:       %[[ITER:.*]] = alloca ptr
+// LLVM:       br label %[[DO_BR:.*]]
+// LLVM:       [[DO_BR]]:
+// LLVM:       %[[CURRENT:.*]] = load ptr, ptr %[[ITER]]
+// LLVM:       call void @_ZN5Temp2C1Ev({{.*}}%[[TMP]])
+// LLVM:       br label %[[CONSTRUCT_BR:.*]]
+// LLVM:       [[CONSTRUCT_BR]]:
+// LLVM:       %[[LOAD:.*]] = load %struct.Temp2, ptr %[[TMP]]
+// LLVM:       call void @_ZN11CausesTemp2C1E5Temp2(ptr {{.*}}%[[CURRENT]], %struct.Temp2 %[[LOAD]])
+// LLVM:       br label %[[CLEANUP_BR:.*]]
+// LLVM:       [[CLEANUP_BR]]:
+// LLVM:       call void @_ZN5Temp2D1Ev({{.*}}[[TMP]])
+// LLVM:       %[[DTOR_ELT:.*]] = getelementptr %struct.CausesTemp2, ptr %{{.*}}, i64 -1
+// LLVM:       call void @_ZN11CausesTemp2D1Ev(ptr {{.*}}%[[DTOR_ELT]])
+
+// OGCG-LABEL: define {{.*}}void @_Z12Temp2InArrayv()
+// OGCG:       %[[TMP:.*]] = alloca %struct.Temp
+// OGCG:       br label %[[LOOP:.*]]
+// OGCG:       [[LOOP]]:
+// OGCG:       %[[CURRENT:.*]] = phi ptr
+// OGCG:       call void @_ZN5Temp2C1Ev(ptr {{.*}}%[[TMP]])
+// OGCG-NEXT:  call void @_ZN11CausesTemp2C1E5Temp2(ptr {{.*}}%[[CURRENT]], ptr{{.*}}[[TMP]])
+// OGCG-NEXT:  call void @_ZN5Temp2D1Ev({{.*}}[[TMP]])
+// OGCG:       %[[DTOR_ELT:.*]] = getelementptr inbounds %struct.CausesTemp2, ptr %{{.*}}, i64 -1
+// OGCG-NEXT:  call void @_ZN11CausesTemp2D1Ev(ptr {{.*}}%[[DTOR_ELT]])

--- a/clang/test/CIR/CodeGen/array-ctor.cpp
+++ b/clang/test/CIR/CodeGen/array-ctor.cpp
@@ -171,3 +171,73 @@ void multi_dimensional() {
 // OGCG:       br i1 %[[DONE]], label %[[EXIT:.*]], label %[[LOOP]]
 // OGCG:     [[EXIT]]:
 // OGCG:       ret void
+
+struct Temp {
+  ~Temp();
+};
+
+struct CausesTemp {
+  CausesTemp(Temp = Temp());
+};
+
+void TempInArray() {
+  CausesTemp ct[42];
+}
+
+// CIR-BEFORE-LPP: cir.func {{.*}} @_Z11TempInArrayv()
+// CIR-BEFORE-LPP:   %[[ARRAY:.*]] = cir.alloca "ct" {{.*}} init : !cir.ptr<!cir.array<!rec_CausesTemp x 42>>
+// CIR-BEFORE-LPP:   %[[TMP:.*]] = cir.alloca "agg.tmp0" {{.*}} : !cir.ptr<!rec_Temp>
+// CIR-BEFORE-LPP:   cir.array.ctor %[[ARRAY]] : !cir.ptr<!cir.array<!rec_CausesTemp x 42>> {
+// CIR-BEFORE-LPP:    ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_CausesTemp>):
+// CIR-BEFORE-LPP:      cir.cleanup.scope {
+// CIR-BEFORE-LPP:        %[[LOAD:.*]] = cir.load {{.*}} %[[TMP]] : !cir.ptr<!rec_Temp>, !rec_Temp
+// CIR-BEFORE-LPP:        cir.call @_ZN10CausesTempC1E4Temp(%[[ARG]], %[[LOAD]])
+// CIR-BEFORE-LPP:        cir.yield
+// CIR-BEFORE-LPP:      } cleanup normal {
+// CIR-BEFORE-LPP:        cir.call @_ZN4TempD1Ev(%[[TMP]]) nothrow
+// CIR-BEFORE-LPP:        cir.yield
+// CIR-BEFORE-LPP:      }
+// CIR-BEFORE-LPP:    }
+// CIR-BEFORE-LPP:   cir.return
+// CIR-BEFORE-LPP: }
+
+// CIR-LABEL: cir.func {{.*}} @_Z11TempInArrayv()
+// CIR:        %[[TMP:.*]] = cir.alloca "agg.tmp0" {{.*}} : !cir.ptr<!rec_Temp>
+// CIR:        cir.do {
+// CIR-NEXT:     %[[CURRENT:.*]] = cir.load %[[ITER:.*]] : !cir.ptr<!cir.ptr<!rec_CausesTemp>>, !cir.ptr<!rec_CausesTemp>
+// CIR-NEXT:     cir.cleanup.scope {
+// CIR-NEXT:       %[[LOAD:.*]] = cir.load {{.*}} %[[TMP]] : !cir.ptr<!rec_Temp>, !rec_Temp
+// CIR-NEXT:       cir.call @_ZN10CausesTempC1E4Temp(%[[CURRENT]], %[[LOAD]])
+// CIR-NEXT:       cir.yield
+// CIR-NEXT:     } cleanup normal {
+// CIR-NEXT:       cir.call @_ZN4TempD1Ev(%[[TMP]]) nothrow
+// CIR-NEXT:       cir.yield
+// CIR-NEXT:     }
+// CIR-NEXT:     %[[CONST1:.*]] = cir.const #cir.int<1> : !u64i
+// CIR-NEXT:     %[[NEXT:.*]] = cir.ptr_stride %[[CURRENT]], %[[CONST1]] : (!cir.ptr<!rec_CausesTemp>, !u64i) -> !cir.ptr<!rec_CausesTemp>
+// CIR-NEXT:     cir.store %[[NEXT]], %[[ITER]] : !cir.ptr<!rec_CausesTemp>, !cir.ptr<!cir.ptr<!rec_CausesTemp>>
+// CIR-NEXT:     cir.yield
+// CIR-NEXT:   } while {
+// CIR:        }
+
+// LLVM-LABEL: define {{.*}}void @_Z11TempInArrayv()
+// LLVM:       %[[TMP:.*]] = alloca %struct.Temp
+// LLVM:       %[[ITER:.*]] = alloca ptr
+// LLVM:       br label %[[DO_BR:.*]]
+// LLVM:       [[DO_BR]]:
+// LLVM:       %[[CURRENT:.*]] = load ptr, ptr %[[ITER]]
+// LLVM:       br label %[[CONSTRUCT_BR:.*]]
+// LLVM:       [[CONSTRUCT_BR]]:
+// LLVM:       %[[LOAD:.*]] = load %struct.Temp, ptr %[[TMP]]
+// LLVM:       call void @_ZN10CausesTempC1E4Temp(ptr {{.*}}%[[CURRENT]], %struct.Temp %[[LOAD]])
+// LLVM:       br label %[[CLEANUP_BR:.*]]
+// LLVM:       [[CLEANUP_BR]]:
+// LLVM:       call void @_ZN4TempD1Ev({{.*}}[[TMP]])
+
+// OGCG-LABEL: define {{.*}}void @_Z11TempInArrayv()
+// OGCG:       %[[TMP:.*]] = alloca %struct.Temp
+// OGCG:       br label %[[LOOP:.*]]
+// OGCG:       [[LOOP]]:
+// OGCG:       %[[CURRENT:.*]] = phi ptr
+// OGCG:       call void @_ZN10CausesTempC1E4Temp(ptr {{.*}}%[[CURRENT]], ptr{{.*}}[[TMP]])
+// OGCG:       call void @_ZN4TempD1Ev({{.*}}[[TMP]])

--- a/clang/test/CIR/CodeGen/partial-array-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/partial-array-cleanup.cpp
@@ -820,3 +820,164 @@ void test_init_list_partial_array_cleanup() {
 //
 // OGCG:     [[EH_RESUME]]:
 // OGCG:       resume { ptr, i32 }
+
+struct Temp2 {
+  Temp2();
+  ~Temp2();
+};
+
+struct CausesTemp2 {
+  CausesTemp2(Temp2 = Temp2());
+  ~CausesTemp2();
+};
+
+void Temp2InArray() {
+  CausesTemp2 ct2[42];
+}
+// CIR-BEFORE-LPP-LABEL: cir.func {{.*}}@_Z12Temp2InArrayv()
+// CIR-BEFORE-LPP-NEXT:   %[[ARR:.*]] = cir.alloca "ct2" {{.*}}init : !cir.ptr<!cir.array<!rec_CausesTemp2 x 42>>
+// CIR-BEFORE-LPP-NEXT:   %[[TMP:.*]] = cir.alloca "agg.tmp0" {{.*}} : !cir.ptr<!rec_Temp2>
+// CIR-BEFORE-LPP-NEXT:   cir.array.ctor %[[ARR]] : !cir.ptr<!cir.array<!rec_CausesTemp2 x 42>> {
+// CIR-BEFORE-LPP-NEXT:   ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_CausesTemp2>):
+// CIR-BEFORE-LPP-NEXT:     cir.call @_ZN5Temp2C1Ev(%[[TMP]])
+// CIR-BEFORE-LPP-NEXT:     cir.cleanup.scope {
+// CIR-BEFORE-LPP-NEXT:       %[[CURRENT:.*]] = cir.load {{.*}}%[[TMP]] : !cir.ptr<!rec_Temp2>, !rec_Temp2
+// CIR-BEFORE-LPP-NEXT:       cir.call @_ZN11CausesTemp2C1E5Temp2(%[[ARG]], %[[CURRENT]])
+// CIR-BEFORE-LPP-NEXT:       cir.yield
+// CIR-BEFORE-LPP-NEXT:     } cleanup all {
+// CIR-BEFORE-LPP-NEXT:       cir.call @_ZN5Temp2D1Ev(%[[TMP]]) nothrow
+// CIR-BEFORE-LPP-NEXT:       cir.yield
+// CIR-BEFORE-LPP-NEXT:     }
+// CIR-BEFORE-LPP-NEXT:   } partial_dtor {
+// CIR-BEFORE-LPP-NEXT:   ^bb0(%[[ARG]]: !cir.ptr<!rec_CausesTemp2>):
+// CIR-BEFORE-LPP-NEXT:     cir.call @_ZN11CausesTemp2D1Ev(%[[ARG]]) nothrow : ({{.*}})
+// CIR-BEFORE-LPP-NEXT:   }
+// CIR-BEFORE-LPP-NEXT:   cir.cleanup.scope {
+// CIR-BEFORE-LPP-NEXT:     cir.yield
+// CIR-BEFORE-LPP-NEXT:   } cleanup all {
+// CIR-BEFORE-LPP-NEXT:     cir.array.dtor %[[ARR]] : !cir.ptr<!cir.array<!rec_CausesTemp2 x 42>> {
+// CIR-BEFORE-LPP-NEXT:     ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_CausesTemp2>):
+// CIR-BEFORE-LPP-NEXT:       cir.call @_ZN11CausesTemp2D1Ev(%[[ARG]]) nothrow : ({{.*}})
+// CIR-BEFORE-LPP-NEXT:     }
+// CIR-BEFORE-LPP-NEXT:     cir.yield
+// CIR-BEFORE-LPP-NEXT:   }
+// CIR-BEFORE-LPP-NEXT:   cir.return
+// CIR-BEFORE-LPP-NEXT: }
+
+// CIR-LABEL: cir.func {{.*}}@_Z12Temp2InArrayv()
+// CIR:       %[[TMP:.*]] = cir.alloca "agg.tmp0" {{.*}}: !cir.ptr<!rec_Temp2>
+// CIR:       %[[ARR_IDX:.*]] = cir.alloca "__array_idx" {{.*}}: !cir.ptr<!cir.ptr<!rec_CausesTemp2>>
+// CIR:       cir.cleanup.scope {
+// CIR-NEXT:    cir.do {
+// CIR-NEXT:      %[[CURRENT:.*]] = cir.load %[[ARR_IDX]] : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>, !cir.ptr<!rec_CausesTemp2>
+// CIR-NEXT:      cir.call @_ZN5Temp2C1Ev(%[[TMP]])
+// CIR-NEXT:      cir.cleanup.scope {
+// CIR-NEXT:        %[[LOAD_TMP:.*]] = cir.load {{.*}}%[[TMP]] : !cir.ptr<!rec_Temp2>, !rec_Temp2
+// CIR-NEXT:        cir.call @_ZN11CausesTemp2C1E5Temp2(%[[CURRENT]], %[[LOAD_TMP]])
+// CIR-NEXT:        cir.yield
+// CIR-NEXT:      } cleanup all {
+// CIR-NEXT:        cir.call @_ZN5Temp2D1Ev(%[[TMP]]) nothrow
+// CIR-NEXT:        cir.yield
+// CIR-NEXT:      }
+// CIR:           cir.yield
+// CIR-NEXT:    } while {
+// CIR:         }
+// CIR-NEXT:    cir.yield
+// CIR-NEXT:  } cleanup eh {
+// CIR:           cir.do {
+// CIR-NEXT:        %[[CURRENT:.*]] = cir.load %[[ARR_IDX]] : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>, !cir.ptr<!rec_CausesTemp2>
+// CIR-NEXT:        %[[NEG_1:.*]] = cir.const #cir.int<-1> : !s64i
+// CIR-NEXT:        %[[STRIDE:.*]] = cir.ptr_stride %[[CURRENT]], %[[NEG_1]] : (!cir.ptr<!rec_CausesTemp2>, !s64i) -> !cir.ptr<!rec_CausesTemp2>
+// CIR:             cir.call @_ZN11CausesTemp2D1Ev(%[[STRIDE]]) nothrow 
+// CIR-NEXT:        cir.yield
+// CIR-NEXT:      } while {
+// CIR:           }
+// CIR-NEXT:    }
+// CIR-NEXT:    cir.yield
+// CIR-NEXT:  }
+// CIR-NEXT:  cir.cleanup.scope {
+// CIR-NEXT:    cir.yield
+// CIR-NEXT:  } cleanup all {
+// CIR:         %[[ARR_IDX:.*]] = cir.alloca "__array_idx" {{.*}} : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>
+// CIR:         cir.do {
+// CIR-NEXT:      %[[ARR_LOAD:.*]] = cir.load %[[ARR_IDX]] : !cir.ptr<!cir.ptr<!rec_CausesTemp2>>, !cir.ptr<!rec_CausesTemp2>
+// CIR-NEXT:      %[[NEG_1:.*]] = cir.const #cir.int<-1> : !s64i
+// CIR-NEXT:      %[[STRIDE:.*]] = cir.ptr_stride %[[ARR_LOAD]], %[[NEG_1]] : (!cir.ptr<!rec_CausesTemp2>, !s64i) -> !cir.ptr<!rec_CausesTemp2>
+// CIR:           cir.call @_ZN11CausesTemp2D1Ev(%[[STRIDE]]) nothrow
+// CIR-NEXT:      cir.yield
+// CIR-NEXT:    } while {
+// CIR:         }
+// CIR-NEXT:    cir.yield
+// CIR-NEXT:  }
+// CIR-NEXT:  cir.return
+
+// LLVM: define {{.*}}@_Z12Temp2InArrayv()
+// LLVM: %[[TMP:.*]] = alloca %struct.Temp2
+// LLVM: %[[ARR_IDX:.*]] = alloca ptr
+// LLVM: br label %[[EMPTY:.*]]
+// LLVM: [[EMPTY]]:
+// LLVM: br label %[[CONSTRUCT_TEMP:.*]]
+// LLVM: [[CONSTRUCT_TEMP]]:
+// LLVM: invoke void @_ZN5Temp2C1Ev(ptr {{.*}}%[[TMP]])
+// LLVM-NEXT:        to label %[[EMPTY2:.*]] unwind label %[[EXCEPT_TEMP:.*]]
+// LLVM: [[EMPTY2]]:
+// LLVM: br label %[[CONSTRUCT_CT:.*]]
+// LLVM: [[CONSTRUCT_CT]]:
+// LLVM: %[[LOAD:.*]] = load %struct.Temp2, ptr %[[TMP]]
+// LLVM: invoke void @_ZN11CausesTemp2C1E5Temp2(ptr noundef nonnull align 1 dereferenceable(1) %12, %struct.Temp2 %15)
+// LLVM-NEXT:         to label %[[EMPTY3:.*]] unwind label %[[EXCEPT:.*]]
+// LLVM: [[EMPTY3]]:
+// LLVM: br label %[[DTOR_TEMP:.*]]
+// LLVM: [[DTOR_TEMP]]:
+// LLVM: call void @_ZN5Temp2D1Ev(ptr {{.*}} %[[TMP]])
+
+// LLVM: [[EXCEPT]]:
+// LLVM: br label %[[DO_DTOR:.*]]
+// LLVM: [[DO_DTOR]]:
+// LLVM: call void @_ZN5Temp2D1Ev(ptr {{.*}}%[[TMP]])
+
+// LLVM: [[EXCEPT_TEMP]]:
+// LLVM: br label %[[CHECK_TEMP:.*]]
+// LLVM: [[CHECK_TEMP]]:
+// LLVM: br i1 %37, label %[[EMPTY4:.*]], 
+// LLVM: [[EMPTY4]]:
+// LLVM: br label %[[DTOR_TMP:.*]]
+//
+// LLVM: [[DTOR_TMP]]:
+// LLVM: %[[DTOR_ELT:.*]] = getelementptr %struct.CausesTemp2, ptr %{{.*}}, i64 -1
+// LLVM: call void @_ZN11CausesTemp2D1Ev(ptr {{.*}}%[[DTOR_ELT]])
+//
+// Array destruction:
+// LLVM: %[[GET_ELT:.*]] = getelementptr %struct.CausesTemp2, ptr %{{.*}}, i64 -1
+// LLVM: call void @_ZN11CausesTemp2D1Ev(ptr {{.*}}%[[GET_ELT]])
+
+// OGCG-LABEL: define {{.*}}@_Z12Temp2InArrayv()
+// OGCG: %[[TMP:.*]] = alloca %struct.Temp2
+// OGCG: invoke void @_ZN5Temp2C1Ev(ptr {{.*}}%[[TMP]])
+// OGCG-NEXT:         to label %[[TMP_CTD:.*]] unwind label %[[TMP_UNWIND:.*]]
+
+// OGCG: [[TMP_CTD]]:
+// OGCG-NEXT: invoke void @_ZN11CausesTemp2C1E5Temp2(ptr {{.*}}%{{.*}}, ptr {{.*}}%[[TMP]])
+// OGCG-NEXT:      to label %[[CTD:.*]] unwind label %[[UNWIND:.*]]
+
+// OGCG: [[CTD]]:
+// OGCG-NEXT: call void @_ZN5Temp2D1Ev(ptr {{.*}}%[[TMP]])
+
+// Array destruction is before cleanups.
+// OGCG: %[[DTOR_ELT:.*]] = getelementptr inbounds %struct.CausesTemp2, ptr %{{.*}}, i64 -1
+// OGCG: call void @_ZN11CausesTemp2D1Ev(ptr {{.*}}%[[DTOR_ELT]])
+
+// OGCG: [[TMP_UNWIND]]:
+// OGCG: br label %[[EH_CLEANUP:.*]]
+
+// OGCG: [[UNWIND]]:
+// OGCG: call void @_ZN5Temp2D1Ev(ptr {{.*}} %[[TMP]])
+//
+// OGCG: [[EH_CLEANUP]]:
+// OGCG-NEXT: %[[IS_EMPTY:.*]] = icmp eq
+// OGCG-NEXT: br i1 %[[IS_EMPTY]], label %{{.*}}, label %[[CLEANUP_DTOR:.*]]
+//
+// OGCG: [[CLEANUP_DTOR]]:
+// OGCG: %[[DTOR_ELT:.*]] = getelementptr inbounds %struct.CausesTemp2, ptr %{{.*}}, i64 -1
+// OGCG: call void @_ZN11CausesTemp2D1Ev(ptr {{.*}}%[[DTOR_ELT]])
+


### PR DESCRIPTION
This patch came out of self-build, any constructor temporary called during the construction of an array element was being improperly cleaned up (actually, no terminator?).  This patch moves the RunCleanups RAII to do so immediately in the body.

The OGCG/LLVM check lines are effectively equal, except OGCG uses a PHI and we are doing so with an iterator loop, but the 'dtor called immediately' is still correct.