### PR TITLE
[docs] Fix two stale file paths

### DIFF
--- a/llvm/docs/HowToSubmitABug.rst
+++ b/llvm/docs/HowToSubmitABug.rst
@@ -78,7 +78,7 @@ The `creduce <https://github.com/csmith-project/creduce>`_ tool helps to
 reduce the preprocessed file down to the smallest amount of code that still
 replicates the problem. You're encouraged to use creduce to reduce the code
 to make the developers' lives easier. The
-``clang/utils/creduce-clang-crash.py`` script can be used on the files
+``clang/utils/reduce-clang-crash.py`` script can be used on the files
 that clang dumps to help with automating creating a test to check for the
 compiler crash.
 

--- a/llvm/docs/PDB/PdbStream.md
+++ b/llvm/docs/PDB/PdbStream.md
@@ -139,7 +139,7 @@ directory". The exact format of a debug directory is described by the
 [IMAGE_DEBUG_DIRECTORY structure](<https://msdn.microsoft.com/en-us/library/windows/desktop/ms680307(v=vs.85).aspx>).
 For this particular case, the linker emits a debug directory of type
 `IMAGE_DEBUG_TYPE_CODEVIEW`. The format of this record is defined in
-`llvm/DebugInfo/CodeView/CVDebugRecord.h`, but it suffices to say here only
+`llvm/include/llvm/Object/CVDebugRecord.h`, but it suffices to say here only
 that it includes the same `Guid` and `Age` fields. At runtime, a
 debugger or tool can scan the COFF executable image for the presence of
 a debug directory of the correct type and verify that the Guid and Age match.


### PR DESCRIPTION
Two documentation paths point at files that are not there.

- `HowToSubmitABug.rst` tells readers to run `clang/utils/creduce-clang-crash.py`. The script was renamed to `reduce-clang-crash.py` in 59cee030f and the doc was not updated with it.
- `PDB/PdbStream.rst` gives `llvm/DebugInfo/CodeView/CVDebugRecord.h`. That header moved to `llvm/include/llvm/Object/CVDebugRecord.h` in 211c67cdb.

Neither old path resolves at `main`; both replacements do.

## AI disclosure

AI-assisted (Claude Code), per the AI Tool Use Policy. A sweep resolved the repo-internal paths written in `llvm/docs`, `clang/docs`, `mlir/docs`, `lld/docs`, `libcxx/docs` and `flang/docs` against the tree; only these two failed to resolve anywhere. Before opening I checked both replacements in the tree and found the commits that renamed and moved them, and went through the rest of the sweep's output — the remaining candidates are correct in context and were left alone. I have reviewed and understood the change and take responsibility for it.