### PR TITLE
[lldb][Python] Inline `lldb_iter` for better type inference

### DIFF
--- a/lldb/bindings/interface/SBAddressRangeListExtensions.i
+++ b/lldb/bindings/interface/SBAddressRangeListExtensions.i
@@ -7,7 +7,8 @@
 
     def __iter__(self):
       '''Iterate over all the address ranges in a lldb.SBAddressRangeList object.'''
-      return lldb_iter(self, 'GetSize', 'GetAddressRangeAtIndex')
+      for i in range(self.GetSize()):
+        yield self.GetAddressRangeAtIndex(i)
 
     def __getitem__(self, idx):
       '''Get the address range at a given index in an lldb.SBAddressRangeList object.'''

--- a/lldb/bindings/interface/SBBreakpointExtensions.i
+++ b/lldb/bindings/interface/SBBreakpointExtensions.i
@@ -37,7 +37,8 @@ STRING_EXTENSION_OUTSIDE(SBBreakpoint)
         def __iter__(self):
             '''Iterate over all breakpoint locations in a lldb.SBBreakpoint
             object.'''
-            return lldb_iter(self, 'GetNumLocations', 'GetLocationAtIndex')
+            for i in range(self.GetNumLocations()):
+                yield self.GetLocationAtIndex(i)
 
         def __len__(self):
             '''Return the number of breakpoint locations in a lldb.SBBreakpoint

--- a/lldb/bindings/interface/SBBreakpointListExtensions.i
+++ b/lldb/bindings/interface/SBBreakpointListExtensions.i
@@ -7,7 +7,8 @@
 
     def __iter__(self):
         '''Iterate over all breakpoints in a lldb.SBBreakpointList object.'''
-        return lldb_iter(self, 'GetSize', 'GetBreakpointAtIndex')
+        for i in range(self.GetSize()):
+            yield self.GetBreakpointAtIndex(i)
 
     def __getitem__(self, idx):
         '''Get the breakpoint at a given index in an lldb.SBBreakpointList object.'''

--- a/lldb/bindings/interface/SBCompileUnitExtensions.i
+++ b/lldb/bindings/interface/SBCompileUnitExtensions.i
@@ -10,7 +10,8 @@ STRING_EXTENSION_OUTSIDE(SBCompileUnit)
 
         def __iter__(self):
             '''Iterate over all line entries in a lldb.SBCompileUnit object.'''
-            return lldb_iter(self, 'GetNumLineEntries', 'GetLineEntryAtIndex')
+            for i in range(self.GetNumLineEntries()):
+                yield self.GetLineEntryAtIndex(i)
 
         def __len__(self):
             '''Return the number of line entries in a lldb.SBCompileUnit

--- a/lldb/bindings/interface/SBDebuggerExtensions.i
+++ b/lldb/bindings/interface/SBDebuggerExtensions.i
@@ -26,7 +26,8 @@ STRING_EXTENSION_OUTSIDE(SBDebugger)
 
         def __iter__(self):
             '''Iterate over all targets in a lldb.SBDebugger object.'''
-            return lldb_iter(self, 'GetNumTargets', 'GetTargetAtIndex')
+            for i in range(self.GetNumTargets()):
+                yield self.GetTargetAtIndex(i)
 
         def __len__(self):
             '''Return the number of targets in a lldb.SBDebugger object.'''

--- a/lldb/bindings/interface/SBFileSpecListExtensions.i
+++ b/lldb/bindings/interface/SBFileSpecListExtensions.i
@@ -9,7 +9,8 @@ STRING_EXTENSION_OUTSIDE(SBFileSpecList)
 
     def __iter__(self):
       '''Iterate over all FileSpecs in a lldb.SBFileSpecList object.'''
-      return lldb_iter(self, 'GetSize', 'GetFileSpecAtIndex')
+      for i in range(self.GetSize()):
+          yield self.GetFileSpecAtIndex(i)
 
     def __getitem__(self, idx):
       '''Get the FileSpec at a given index in an lldb.SBFileSpecList object.'''

--- a/lldb/bindings/interface/SBFrameListExtensions.i
+++ b/lldb/bindings/interface/SBFrameListExtensions.i
@@ -21,7 +21,8 @@
     %pythoncode %{
         def __iter__(self):
             '''Iterate over all frames in a lldb.SBFrameList object.'''
-            return lldb_iter(self, 'GetSize', 'GetFrameAtIndex')
+            for i in range(self.GetSize()):
+                yield self.GetFrameAtIndex(i)
 
         def __len__(self):
             return int(self.GetSize())

--- a/lldb/bindings/interface/SBInstructionListExtensions.i
+++ b/lldb/bindings/interface/SBInstructionListExtensions.i
@@ -6,7 +6,8 @@ STRING_EXTENSION_OUTSIDE(SBInstructionList)
         def __iter__(self):
             '''Iterate over all instructions in a lldb.SBInstructionList
             object.'''
-            return lldb_iter(self, 'GetSize', 'GetInstructionAtIndex')
+            for i in range(self.GetSize()):
+                yield self.GetInstructionAtIndex(i)
 
         def __len__(self):
             '''Access len of the instruction list.'''

--- a/lldb/bindings/interface/SBModuleExtensions.i
+++ b/lldb/bindings/interface/SBModuleExtensions.i
@@ -39,15 +39,18 @@ STRING_EXTENSION_OUTSIDE(SBModule)
 
         def __iter__(self):
             '''Iterate over all symbols in a lldb.SBModule object.'''
-            return lldb_iter(self, 'GetNumSymbols', 'GetSymbolAtIndex')
+            for i in range(self.GetNumSymbols()):
+                yield self.GetSymbolAtIndex(i)
 
         def section_iter(self):
             '''Iterate over all sections in a lldb.SBModule object.'''
-            return lldb_iter(self, 'GetNumSections', 'GetSectionAtIndex')
+            for i in range(self.GetNumSections()):
+                yield self.GetSectionAtIndex(i)
 
         def compile_unit_iter(self):
             '''Iterate over all compile units in a lldb.SBModule object.'''
-            return lldb_iter(self, 'GetNumCompileUnits', 'GetCompileUnitAtIndex')
+            for i in range(self.GetNumCompileUnits()):
+                yield self.GetCompileUnitAtIndex(i)
 
         def symbol_in_section_iter(self, section):
             '''Given a module and its contained section, returns an iterator on the

--- a/lldb/bindings/interface/SBModuleSpecListExtensions.i
+++ b/lldb/bindings/interface/SBModuleSpecListExtensions.i
@@ -9,7 +9,8 @@ STRING_EXTENSION_OUTSIDE(SBModuleSpecList)
 
     def __iter__(self):
       '''Iterate over all ModuleSpecs in a lldb.SBModuleSpecList object.'''
-      return lldb_iter(self, 'GetSize', 'GetSpecAtIndex')
+      for i in range(self.GetSize()):
+          yield self.GetSpecAtIndex(i)
 
     def __getitem__(self, key):
       '''Access module specs by index or by file path.

--- a/lldb/bindings/interface/SBProcessExtensions.i
+++ b/lldb/bindings/interface/SBProcessExtensions.i
@@ -73,7 +73,8 @@ STRING_EXTENSION_OUTSIDE(SBProcess)
 
         def __iter__(self):
             '''Iterate over all threads in a lldb.SBProcess object.'''
-            return lldb_iter(self, 'GetNumThreads', 'GetThreadAtIndex')
+            for i in range(self.GetNumThreads()):
+                yield self.GetThreadAtIndex(i)
 
         def __len__(self):
             '''Return the number of threads in a lldb.SBProcess object.'''

--- a/lldb/bindings/interface/SBProcessInfoListExtensions.i
+++ b/lldb/bindings/interface/SBProcessInfoListExtensions.i
@@ -7,7 +7,8 @@
 
     def __iter__(self):
       '''Iterate over all the process info in a lldb.SBProcessInfoListExtensions object.'''
-      return lldb_iter(self, 'GetSize', 'GetProcessInfoAtIndex')
+      for i in range(self.GetSize()):
+          yield self.GetProcessInfoAtIndex(i)
 
     def __getitem__(self, idx):
       '''Get the process info at a given index in an lldb.SBProcessInfoList object.'''

--- a/lldb/bindings/interface/SBSectionExtensions.i
+++ b/lldb/bindings/interface/SBSectionExtensions.i
@@ -10,7 +10,8 @@ STRING_EXTENSION_OUTSIDE(SBSection)
 
         def __iter__(self):
             '''Iterate over all subsections in a lldb.SBSection object.'''
-            return lldb_iter(self, 'GetNumSubSections', 'GetSubSectionAtIndex')
+            for i in range(self.GetNumSubSections()):
+                yield self.GetSubSectionAtIndex(i)
 
         def __len__(self):
             '''Return the number of subsections in a lldb.SBSection object.'''

--- a/lldb/bindings/interface/SBStringListExtensions.i
+++ b/lldb/bindings/interface/SBStringListExtensions.i
@@ -3,7 +3,8 @@
     %pythoncode%{
     def __iter__(self):
         '''Iterate over all strings in a lldb.SBStringList object.'''
-        return lldb_iter(self, 'GetSize', 'GetStringAtIndex')
+        for i in range(self.GetSize()):
+            yield self.GetStringAtIndex(i)
 
     def __len__(self):
         '''Return the number of strings in a lldb.SBStringList object.'''

--- a/lldb/bindings/interface/SBSymbolContextListExtensions.i
+++ b/lldb/bindings/interface/SBSymbolContextListExtensions.i
@@ -6,7 +6,8 @@ STRING_EXTENSION_OUTSIDE(SBSymbolContextList)
         def __iter__(self):
             '''Iterate over all symbol contexts in a lldb.SBSymbolContextList
             object.'''
-            return lldb_iter(self, 'GetSize', 'GetContextAtIndex')
+            for i in range(self.GetSize()):
+                yield self.GetContextAtIndex(i)
 
         def __len__(self):
             return int(self.GetSize())

--- a/lldb/bindings/interface/SBTargetExtensions.i
+++ b/lldb/bindings/interface/SBTargetExtensions.i
@@ -105,12 +105,14 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTarget, lldb::eDescriptionLevelBrief)
         def module_iter(self):
             '''Returns an iterator over all modules in a lldb.SBTarget
             object.'''
-            return lldb_iter(self, 'GetNumModules', 'GetModuleAtIndex')
+            for i in range(self.GetNumModules()):
+                yield self.GetModuleAtIndex(i)
 
         def breakpoint_iter(self):
             '''Returns an iterator over all breakpoints in a lldb.SBTarget
             object.'''
-            return lldb_iter(self, 'GetNumBreakpoints', 'GetBreakpointAtIndex')
+            for i in range(self.GetNumBreakpoints()):
+                yield self.GetBreakpointAtIndex(i)
 
         class bkpts_access(object):
             '''A helper object that will lazily hand out bkpts for a target when supplied an index.'''
@@ -144,7 +146,8 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTarget, lldb::eDescriptionLevelBrief)
         def watchpoint_iter(self):
             '''Returns an iterator over all watchpoints in a lldb.SBTarget
             object.'''
-            return lldb_iter(self, 'GetNumWatchpoints', 'GetWatchpointAtIndex')
+            for i in range(self.GetNumWatchpoints()):
+                yield self.GetWatchpointAtIndex(i)
 
         class watchpoints_access(object):
             '''A helper object that will lazily hand out watchpoints for a target when supplied an index.'''

--- a/lldb/bindings/interface/SBThreadCollectionExtensions.i
+++ b/lldb/bindings/interface/SBThreadCollectionExtensions.i
@@ -4,7 +4,8 @@
 
     def __iter__(self):
         '''Iterate over all threads in a lldb.SBThreadCollection object.'''
-        return lldb_iter(self, 'GetSize', 'GetThreadAtIndex')
+        for i in range(self.GetSize()):
+            yield self.GetThreadAtIndex(i)
 
     def __len__(self):
         '''Return the number of threads in a lldb.SBThreadCollection object.'''

--- a/lldb/bindings/interface/SBThreadExtensions.i
+++ b/lldb/bindings/interface/SBThreadExtensions.i
@@ -10,7 +10,8 @@ STRING_EXTENSION_OUTSIDE(SBThread)
 
         def __iter__(self):
             '''Iterate over all frames in a lldb.SBThread object.'''
-            return lldb_iter(self, 'GetNumFrames', 'GetFrameAtIndex')
+            for i in range(self.GetNumFrames()):
+                yield self.GetFrameAtIndex(i)
 
         def __len__(self):
             '''Return the number of frames in a lldb.SBThread object.'''

--- a/lldb/bindings/interface/SBTypeEnumMemberExtensions.i
+++ b/lldb/bindings/interface/SBTypeEnumMemberExtensions.i
@@ -15,7 +15,8 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTypeEnumMember, lldb::eDescriptionLevelBrief)
     %pythoncode %{
         def __iter__(self):
             '''Iterate over all members in a lldb.SBTypeEnumMemberList object.'''
-            return lldb_iter(self, 'GetSize', 'GetTypeEnumMemberAtIndex')
+            for i in range(self.GetSize()):
+                yield self.GetTypeEnumMemberAtIndex(i)
 
         def __len__(self):
             '''Return the number of members in a lldb.SBTypeEnumMemberList object.'''

--- a/lldb/bindings/interface/SBTypeExtensions.i
+++ b/lldb/bindings/interface/SBTypeExtensions.i
@@ -153,7 +153,8 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBType, lldb::eDescriptionLevelBrief)
 
     def __iter__(self):
         '''Iterate over all types in a lldb.SBTypeList object.'''
-        return lldb_iter(self, 'GetSize', 'GetTypeAtIndex')
+        for i in range(self.GetSize()):
+            yield self.GetTypeAtIndex(i)
 
     def __len__(self):
         '''Return the number of types in a lldb.SBTypeList object.'''

--- a/lldb/bindings/interface/SBUnixSignalsExtensions.i
+++ b/lldb/bindings/interface/SBUnixSignalsExtensions.i
@@ -3,7 +3,8 @@
     %pythoncode %{
         def __iter__(self):
             '''Iterate over all signals in a lldb.SBUnixSignals object.'''
-            return lldb_iter(self, 'GetNumSignals', 'GetSignalAtIndex')
+            for i in range(self.GetNumSignals()):
+                yield self.GetSignalAtIndex(i)
 
         def __len__(self):
             return self.GetNumSignals()

--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -56,7 +56,8 @@ STRING_EXTENSION_OUTSIDE(SBValue)
 
         def __iter__(self):
             '''Iterate over all child values of a lldb.SBValue object.'''
-            return lldb_iter(self, 'GetNumChildren', 'GetChildAtIndex')
+            for i in range(self.GetNumChildren()):
+                yield self.GetChildAtIndex(i)
 
         def __len__(self):
             '''Return the number of child values of a lldb.SBValue object.'''

--- a/lldb/bindings/interface/SBValueListExtensions.i
+++ b/lldb/bindings/interface/SBValueListExtensions.i
@@ -29,7 +29,8 @@
     %pythoncode %{
         def __iter__(self):
             '''Iterate over all values in a lldb.SBValueList object.'''
-            return lldb_iter(self, 'GetSize', 'GetValueAtIndex')
+            for i in range(self.GetSize()):
+                yield self.GetValueAtIndex(i)
 
         def __len__(self):
             return int(self.GetSize())

--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -612,7 +612,8 @@ class SBSyntheticValueProvider(object):
 
     def __iter__(self):
       '''Iterate over all children in a lldb.SBSyntheticValueProvider object.'''
-      return lldb_iter(self, 'num_children', 'get_child_at_index')
+      for i in range(self.num_children()):
+          yield self.get_child_at_index(i)
 
 %}
 

--- a/lldb/bindings/python/python.swig
+++ b/lldb/bindings/python/python.swig
@@ -89,18 +89,6 @@ del _to_int
 %enddef
 EMBED_VERSION(SWIG_VERSION)
 
-%pythoncode%{
-# ===================================
-# Iterator for lldb container objects
-# ===================================
-def lldb_iter(obj, getsize, getelem):
-    """A generator adaptor to support iteration for lldb container objects."""
-    size = getattr(obj, getsize)
-    elem = getattr(obj, getelem)
-    for i in range(size()):
-        yield elem(i)
-%}
-
 %include <std_string.i>
 %include "python-typemaps.swig"
 %include "macros.swig"


### PR DESCRIPTION
Currently, the `lldb_iter` helper is used for providing `__iter__` in the Python bindings:
```python
def lldb_iter(obj, getsize, getelem):
    """A generator adaptor to support iteration for lldb container objects."""
    size = getattr(obj, getsize)
    elem = getattr(obj, getelem)
    for i in range(size()):
        yield elem(i)
```

A type checker or LSP can't see through this function. Currently, that's no problem, because it doesn't know the return type of any Swig wrapper, but when we add type annotations (hopefully with Swig 4.5 in #213463), `__iter__` remains untyped. So iterating through the wrappers won't show the correct type.

As the functionality is fairly simple, it's easier to inline it. That's what this PR does. Then a type checker can infer the return type.