### PR TITLE
[clang] Mark P2686R5 as partial implemented

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -348,8 +348,8 @@ C++23, informally referred to as C++26.</p>
   <td class="partial" align="center">
     <details>
       <summary>Clang 22 (Partial)</summary>
-      References to constexpr variables and decomposition of tuple-like types are not yet
-      supported; arrays and aggregates are supported.
+      References to constexpr variables are not yet
+      supported; arrays, aggregates, and tuple-like decompositions are supported.
     </details>
   </td>
  </tr>

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -345,7 +345,13 @@ C++23, informally referred to as C++26.</p>
  <tr>
   <td>constexpr structured bindings</td>
   <td><a href="https://wg21.link/P2686R5">P2686R5</a></td>
-  <td class="none" align="center">No</td>
+  <td class="partial" align="center">
+    <details>
+      <summary>Clang 22 (Partial)</summary>
+      References to constexpr variables and decomposition of tuple-like types are not yet
+      supported; arrays and aggregates are supported.
+    </details>
+  </td>
  </tr>
  <tr>
   <td>Allowing exception throwing in constant-evaluation</td>


### PR DESCRIPTION
Partially implemented since https://github.com/llvm/llvm-project/pull/160337.