### PR TITLE
[flang][OpenMP] Diagnose failed construct decomposition instead of falling through

### DIFF
--- a/flang/lib/Lower/OpenMP/Decomposer.cpp
+++ b/flang/lib/Lower/OpenMP/Decomposer.cpp
@@ -15,6 +15,8 @@
 #include "Utils.h"
 #include "flang/Lower/OpenMP/Clauses.h"
 #include "flang/Lower/PFTBuilder.h"
+#include "flang/Optimizer/Support/FatalError.h"
+#include "flang/Parser/provenance.h"
 #include "flang/Semantics/semantics.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -82,7 +84,31 @@ ConstructQueue buildConstructQueue(
     llvm::omp::Directive compound, const List<Clause> &clauses) {
 
   ConstructDecomposition decompose(modOp, semaCtx, eval, compound, clauses);
-  assert(!decompose.output.empty() && "Construct decomposition failed");
+  // Decomposition produces no output when a clause on a compound directive
+  // cannot be assigned to any of its leaf constructs. Semantics is expected to
+  // have rejected such a directive already, but it does not catch every case,
+  // and continuing here consumes an empty queue and reads uninitialized state.
+  // Fail deterministically instead: in a release build the fall-through is
+  // undefined behaviour, which shows up as an intermittent crash rather than a
+  // diagnostic. See https://github.com/llvm/llvm-project/issues/211430.
+  if (decompose.output.empty()) {
+    mlir::Location loc = modOp.getLoc();
+    parser::AllCookedSources &cooked = semaCtx.allCookedSources();
+    if (std::optional<parser::ProvenanceRange> provenance =
+            cooked.GetProvenanceRange(source)) {
+      if (std::optional<parser::SourcePosition> pos =
+              cooked.allSources().GetSourcePosition(provenance->start()))
+        loc = mlir::FileLineColLoc::get(modOp.getContext(), pos->path.get(),
+                                        pos->line, pos->column);
+    }
+    fir::emitFatalError(
+        loc,
+        llvm::Twine("OpenMP construct decomposition failed: a clause on '") +
+            llvm::omp::getOpenMPDirectiveName(compound,
+                                              llvm::omp::FallbackVersion) +
+            "' cannot be applied to any of its leaf constructs",
+        /*genCrashDiag=*/false);
+  }
 
   for (UnitConstruct &uc : decompose.output) {
     assert(getLeafConstructs(uc.id).empty() && "unexpected compound directive");


### PR DESCRIPTION
`buildConstructQueue` asserts that decomposition produced output:

```cpp
ConstructDecomposition decompose(modOp, semaCtx, eval, compound, clauses);
assert(!decompose.output.empty() && "Construct decomposition failed");
```

Release builds have no check, so the empty queue falls through to the loop below and out to the
caller. That is undefined behaviour, and it is reachable — semantics does not catch every
directive/clause combination that cannot be decomposed. The result is an intermittent segfault
rather than a diagnostic.

#211430 is one way in: `allocate` is an OpenMP 5.0 clause, but most directives declare it in
`OMP.td` without a minimum version, so semantics accepts it below 5.0 and decomposition then
correctly refuses it. flang defaults to OpenMP 3.1, so no unusual flags are needed. The
intermittency is what made that report hard to pin down — 40 trials at `-fopenmp-version=31`:

| | segfaults |
|---|---|
| ASLR on | 25/40 |
| ASLR off (`setarch -R`) | 0/40 |

which is an uninitialized read.

After this patch the same input fails deterministically with a located diagnostic, 40/40:

```
error: loc("repro.f90":6:11): OpenMP construct decomposition failed: a clause on
       'target teams distribute parallel do' cannot be applied to any of its leaf constructs
```

`genCrashDiag=false` so it exits non-zero without a backtrace, rather than presenting as a compiler
crash.

This is a hardening fix for the lowering path and is independent of any particular clause: it covers
every combination that decomposes empty. It does not make the `allocate` case a *good* diagnostic —
that belongs in semantics, and #213980 is the separate change for it.

`check-flang` is clean (4808 tests). No test is added: the only in-tree way to reach this path is
through the `OMP.td` gap that #213980 fixes, so a test here would encode that gap as expected
behaviour and have to be removed when it lands. Happy to add one if you'd prefer.


---

Parts of this change were written or audited with Claude Code. I have reviewed all of it and take
full responsibility for the contribution. See `llvm/docs/AIToolPolicy.md`.
