### PR TITLE
[CodeLayout] Avoid repeated full scans in ExtTSP merging

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -18,6 +18,8 @@ add_benchmark(PointerUnionBM PointerUnionBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(ImmutableSetIteratorBM ImmutableSetIteratorBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(ImmutableSetBuildBM ImmutableSetBuildBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(ImmutableMergeBM ImmutableMergeBM.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(CodeLayoutBench CodeLayout.cpp PARTIAL_SOURCES_INTENDED)
+target_link_libraries(CodeLayoutBench PRIVATE LLVMTransformUtils)
 
 add_benchmark(RuntimeLibcallsBench RuntimeLibcalls.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(writeToOutputInParallelBench writeToOutputInParallel.cpp PARTIAL_SOURCES_INTENDED)

--- a/llvm/benchmarks/CodeLayout.cpp
+++ b/llvm/benchmarks/CodeLayout.cpp
@@ -1,0 +1,46 @@
+//===- CodeLayout.cpp - Code layout benchmarks ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Utils/CodeLayout.h"
+#include "benchmark/benchmark.h"
+
+#include <cstdint>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::codelayout;
+
+namespace {
+
+static void BM_ExtTSP(benchmark::State &State) {
+  const size_t NumNodes = State.range(0);
+  const std::vector<uint64_t> NodeSizes(NumNodes, 16);
+  const std::vector<uint64_t> NodeCounts(NumNodes, 100);
+  std::vector<EdgeCount> EdgeCounts;
+  EdgeCounts.reserve(2 * NumNodes);
+
+  // Use two successors and two predecessors for each node to prevent the
+  // forced-pair pass from collapsing the graph before mergeChainPairs runs.
+  for (size_t I = 0; I < NumNodes; ++I) {
+    EdgeCounts.push_back({I, (I + 1) % NumNodes, 60});
+    EdgeCounts.push_back({I, (I + 2) % NumNodes, 40});
+  }
+
+  for (auto _ : State) {
+    auto Order = computeExtTspLayout(NodeSizes, NodeCounts, EdgeCounts);
+    benchmark::DoNotOptimize(Order);
+  }
+
+  State.SetComplexityN(NumNodes);
+}
+
+} // namespace
+
+BENCHMARK(BM_ExtTSP)->RangeMultiplier(2)->Range(1 << 10, 1 << 14)->Complexity();
+
+BENCHMARK_MAIN();

--- a/llvm/lib/Transforms/Utils/CodeLayout.cpp
+++ b/llvm/lib/Transforms/Utils/CodeLayout.cpp
@@ -657,13 +657,10 @@ private:
 
     // Initialize chains.
     AllChains.reserve(NumNodes);
-    HotChains.reserve(NumNodes);
     for (NodeT &Node : AllNodes) {
       // Create a chain.
       AllChains.emplace_back(Node.Index, &Node);
       Node.CurChain = &AllChains.back();
-      if (Node.ExecutionCount > 0)
-        HotChains.push_back(&AllChains.back());
     }
 
     // Initialize chain edges.
@@ -739,64 +736,91 @@ private:
 
   /// Merge pairs of chains while improving the ExtTSP objective.
   void mergeChainPairs() {
-    /// Deterministically compare pairs of chains.
-    auto compareChainPairs = [](const ChainT *A1, const ChainT *B1,
-                                const ChainT *A2, const ChainT *B2) {
-      return std::make_tuple(A1->Id, B1->Id) < std::make_tuple(A2->Id, B2->Id);
+    struct ChainPair {
+      ChainT *Pred;
+      ChainT *Succ;
+      ChainEdge *Edge;
+      MergeGainT Gain;
+      uint64_t PredId;
+      uint64_t SuccId;
     };
 
-    while (HotChains.size() > 1) {
-      ChainT *BestChainPred = nullptr;
-      ChainT *BestChainSucc = nullptr;
-      MergeGainT BestGain;
-      // Iterate over all pairs of chains.
-      for (ChainT *ChainPred : HotChains) {
-        // Get candidates for merging with the current chain.
-        for (const auto &[ChainSucc, Edge] : ChainPred->Edges) {
-          // Ignore loop edges.
+    // Keep all profitable merges ordered by gain. Chain identifiers make the
+    // choice deterministic when gains are equal.
+    auto CompareChainPairs = [](const ChainPair &L, const ChainPair &R) {
+      return std::make_tuple(-L.Gain.score(), L.PredId, L.SuccId) <
+             std::make_tuple(-R.Gain.score(), R.PredId, R.SuccId);
+    };
+    std::set<ChainPair, decltype(CompareChainPairs)> Queue(CompareChainPairs);
+
+    auto MakeChainPair = [](ChainT *Pred, ChainT *Succ, ChainEdge *Edge,
+                            MergeGainT Gain) {
+      return ChainPair{Pred, Succ, Edge, Gain, Pred->Id, Succ->Id};
+    };
+
+    auto InsertChainPair = [&](ChainT *Pred, ChainT *Succ, ChainEdge *Edge) {
+      if (Edge->isSelfEdge())
+        return;
+      if (Pred->numBlocks() + Succ->numBlocks() >= MaxChainSize)
+        return;
+
+      // Don't merge chains whose densities differ too much.
+      const double PredDensity = Pred->density();
+      const double SuccDensity = Succ->density();
+      assert(PredDensity > 0.0 && SuccDensity > 0.0 &&
+             "incorrectly computed chain densities");
+      auto [MinDensity, MaxDensity] = std::minmax(PredDensity, SuccDensity);
+      if (MaxDensity / MinDensity > MaxMergeDensityRatio)
+        return;
+
+      MergeGainT Gain = getBestMergeGain(Pred, Succ, Edge);
+      if (Gain.score() > EPS)
+        Queue.insert(MakeChainPair(Pred, Succ, Edge, Gain));
+    };
+
+    auto RemoveChainPair = [&](ChainT *Pred, ChainT *Succ, ChainEdge *Edge) {
+      if (!Edge->hasCachedMergeGain(Pred, Succ))
+        return;
+      MergeGainT Gain = Edge->getCachedMergeGain(Pred, Succ);
+      if (Gain.score() > EPS)
+        Queue.erase(MakeChainPair(Pred, Succ, Edge, Gain));
+    };
+
+    // Initialize the queue with both directions of every active edge.
+    for (ChainT &Chain : AllChains) {
+      if (Chain.Nodes.empty() || Chain.isCold())
+        continue;
+      for (const auto &[Succ, Edge] : Chain.Edges)
+        InsertChainPair(&Chain, Succ, Edge);
+    }
+
+    while (!Queue.empty()) {
+      ChainPair BestPair = *Queue.begin();
+      Queue.erase(Queue.begin());
+
+      // Only pairs adjacent to the merged chains can have their gain changed.
+      // Remove them before mutating chain identifiers or cached gains.
+      auto RemoveAdjacentPairs = [&](ChainT *Chain) {
+        for (const auto &[Adjacent, Edge] : Chain->Edges) {
           if (Edge->isSelfEdge())
             continue;
-          // Skip the merge if the combined chain violates the maximum specified
-          // size.
-          if (ChainPred->numBlocks() + ChainSucc->numBlocks() >= MaxChainSize)
-            continue;
-          // Don't merge the chains if they have vastly different densities.
-          // Skip the merge if the ratio between the densities exceeds
-          // MaxMergeDensityRatio. Smaller values of the option result in fewer
-          // merges, and hence, more chains.
-          const double ChainPredDensity = ChainPred->density();
-          const double ChainSuccDensity = ChainSucc->density();
-          assert(ChainPredDensity > 0.0 && ChainSuccDensity > 0.0 &&
-                 "incorrectly computed chain densities");
-          auto [MinDensity, MaxDensity] =
-              std::minmax(ChainPredDensity, ChainSuccDensity);
-          const double Ratio = MaxDensity / MinDensity;
-          if (Ratio > MaxMergeDensityRatio)
-            continue;
-
-          // Compute the gain of merging the two chains.
-          MergeGainT CurGain = getBestMergeGain(ChainPred, ChainSucc, Edge);
-          if (CurGain.score() <= EPS)
-            continue;
-
-          if (BestGain < CurGain ||
-              (std::abs(CurGain.score() - BestGain.score()) < EPS &&
-               compareChainPairs(ChainPred, ChainSucc, BestChainPred,
-                                 BestChainSucc))) {
-            BestGain = CurGain;
-            BestChainPred = ChainPred;
-            BestChainSucc = ChainSucc;
-          }
+          RemoveChainPair(Chain, Adjacent, Edge);
+          RemoveChainPair(Adjacent, Chain, Edge);
         }
+      };
+      RemoveAdjacentPairs(BestPair.Pred);
+      RemoveAdjacentPairs(BestPair.Succ);
+
+      mergeChains(BestPair.Pred, BestPair.Succ, BestPair.Gain.mergeOffset(),
+                  BestPair.Gain.mergeType());
+
+      // Recompute the candidates adjacent to the newly formed chain.
+      for (const auto &[Adjacent, Edge] : BestPair.Pred->Edges) {
+        if (Edge->isSelfEdge())
+          continue;
+        InsertChainPair(BestPair.Pred, Adjacent, Edge);
+        InsertChainPair(Adjacent, BestPair.Pred, Edge);
       }
-
-      // Stop merging when there is no improvement.
-      if (BestGain.score() <= EPS)
-        break;
-
-      // Merge the best pair of chains.
-      mergeChains(BestChainPred, BestChainSucc, BestGain.mergeOffset(),
-                  BestGain.mergeType());
     }
   }
 
@@ -945,8 +969,8 @@ private:
     return MergeGainT(NewScore - CurScore, MergeOffset, MergeType);
   }
 
-  /// Merge chain From into chain Into, update the list of active chains,
-  /// adjacency information, and the corresponding cached values.
+  /// Merge chain From into chain Into and update its adjacency information and
+  /// cached values.
   void mergeChains(ChainT *Into, ChainT *From, size_t MergeOffset,
                    MergeTypeT MergeType) {
     assert(Into != From && "a chain cannot be merged with itself");
@@ -967,9 +991,6 @@ private:
       MergedJumpsT MergedJumps(&SelfEdge->jumps());
       Into->Score = extTSPScore(MergedNodes, MergedJumps);
     }
-
-    // Remove the chain from the list of active chains.
-    llvm::erase(HotChains, From);
 
     // Invalidate caches.
     for (auto EdgeIt : Into->Edges)
@@ -1027,9 +1048,6 @@ private:
 
   /// All edges between the chains.
   std::vector<ChainEdge> AllEdges;
-
-  /// Active chains. The vector gets updated at runtime when chains are merged.
-  std::vector<ChainT *> HotChains;
 };
 
 /// The implementation of the Cache-Directed Sort (CDSort) algorithm for

--- a/llvm/unittests/Transforms/Utils/CodeLayoutTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CodeLayoutTest.cpp
@@ -68,4 +68,17 @@ TEST(CodeLayout, BreakLoop) {
   Order = computeCacheDirectedLayout(Sizes, Counts, Edges, CallOffsets);
   EXPECT_THAT(Order, ElementsAreArray({0, 4, 1, 2, 3, 5}));
 }
+
+TEST(CodeLayout, ExtTSP) {
+  const uint64_t Sizes[] = {16, 16, 16, 16, 16, 16, 16, 16};
+  const uint64_t Counts[] = {100, 100, 100, 100, 100, 100, 100, 100};
+  const EdgeCount Edges[] = {
+      {0, 1, 60}, {0, 2, 40}, {1, 2, 60}, {1, 3, 40}, {2, 3, 60}, {2, 4, 40},
+      {3, 4, 60}, {3, 5, 40}, {4, 5, 60}, {4, 6, 40}, {5, 6, 60}, {5, 7, 40},
+      {6, 7, 60}, {6, 0, 40}, {7, 0, 60}, {7, 1, 40},
+  };
+
+  auto Order = computeExtTspLayout(Sizes, Counts, Edges);
+  EXPECT_THAT(Order, ElementsAreArray({0, 1, 2, 3, 4, 5, 6, 7}));
+}
 } // namespace


### PR DESCRIPTION
## Motivation

We were linking a very large shared-library at Meta and it was very slow. Looking at the stack continously pointed to ` ExtTSPImpl::mergeChainPairs` as the culprit.

I avoided the problem for now internally with ` -mllvm -ext-tsp-block-placement-max-blocks=10000` or disabling the pass completely via ` -mllvm -enable-ext-tsp-block-placement=false`

To understand the size we are hitting for this performance penalty:
 - libA.so: 3.45 GiB
 - functionA is 13.56MiB code and ~~678K blocks
- functionB is ~10MiB code and ~533k blocks

| Blocks | Old | New | Speedup |
| :---   | :---          | :---          | :---    |
| (A) 678K   | 106 min       | 5.4 sec       | ~1,168× |
| (B) 533K   | 65 min        | 4.3 sec       | ~918×   |


## Change

ExtTSP currently examines every edge between active chains after each merge, even though only edges incident to the merged chains can have changed gains. These repeated scans make mergeChainPairs quadratic on sparse CFGs and can dominate block placement for very large functions.

Keep profitable directional chain pairs in an ordered worklist. Before merging, remove pairs incident to either chain; afterward, recompute only pairs incident to the resulting chain. This also removes the linear erase from HotChains.

Add a direct computeExtTspLayout unit test and a benchmark whose nodes have two successors and two predecessors, preventing forced-pair preprocessing from collapsing the graph.

Built with `LLVM_INCLUDE_BENCHMARKS=ON` and measured median CPU time over three repetitions:

| Nodes | Before | After | Speedup |
| --- | --- | --- | --- |
| 1024 | 22.64 ms | 9.04 ms | 2.5x |
| 2048 | 77.10 ms | 15.55 ms | 5.0x |
| 4096 | 280.81 ms | 31.34 ms | 9.0x |
| 8192 | 944.15 ms | 65.04 ms | 14.5x |
| 16384 | 3699.29 ms | 131.14 ms | 28.2x |

Google Benchmark fits the workload as O(N^2) before and O(N) after. Reproduce with:

  ninja CodeLayoutBench
  ./benchmarks/CodeLayoutBench --benchmark_min_time=0.05s \
    --benchmark_repetitions=3 --benchmark_report_aggregates_only=true

Assisted-by: Codex