### PR TITLE
[NFC][AMDGPU] Fix exit code mismatch with EXPENSIVE_CHECK in schedule…

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/schedule-amdgpu-tracker-physreg-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-amdgpu-tracker-physreg-crash.ll
@@ -1,4 +1,4 @@
-; RUN: not llc -mtriple=amdgpu9.00-amd-amdhsa --amdgpu-xnack=true -amdgpu-use-amdgpu-trackers=1  2>&1  < %s | FileCheck -check-prefixes=ERR-GCNTRACKERS %s
+; RUN: not --crash llc -mtriple=amdgpu9.00-amd-amdhsa --amdgpu-xnack=true -amdgpu-use-amdgpu-trackers=1 -verify-machineinstrs  2>&1  < %s | FileCheck -check-prefixes=ERR-GCNTRACKERS %s
 ; RUN: llc -mtriple=amdgpu9.00-amd-amdhsa --amdgpu-xnack=true 2>&1  < %s | FileCheck -check-prefixes=GCN %s
 
 %asm.output = type { <16 x i32>, <16 x i32>, <16 x i32>, <8 x i32>, <2 x i32>, i32, ; sgprs


### PR DESCRIPTION
…-amdgpu-tracker-physreg-crash.ll

Observed in https://ci.swift.org/job/llvm.org/job/clang-stage1-RA-expensive/job/main/1155 with LLVM_ENABLE_EXPENSIVE_CHECKS enabled, `CodeGen/AMDGPU/schedule-amdgpu-tracker-physreg-crash.ll` fails due to MachineVerifier running, causing an exit 1. 

Modified to always run the `-verify-machineinstrs`. 