### PR TITLE
[libc++] Add dry-run coverage for the LNT tooling to the test-tools builder

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -317,6 +317,26 @@ test-tools)
 
     step "Compare benchmark results" # perform a no-op comparison, just to run the tool
     "${MONOREPO_ROOT}/libcxx/utils/compare-benchmarks" "${BUILD_DIR}/results.lnt" "${BUILD_DIR}/results.lnt"
+
+    # Exercise LNT tooling with --dry-run. Doing a real run is time consuming and would
+    # submit to a LNT instance, which we obviously don't want.
+    step "Run benchmarks using the LNT flow (dry-run)"
+    "${MONOREPO_ROOT}/libcxx/utils/ci/lnt/run-benchmarks" \
+        --dry-run -vv \
+        --git-repo "${MONOREPO_ROOT}" \
+        --benchmark-commit HEAD \
+        --test-suite-commit HEAD \
+        --machine test-tools \
+        --compiler "${CXX}" \
+        --filter hash.bench.cpp \
+        --output "${BUILD_DIR}/report.json"
+
+    step "Submit a LNT report (dry-run)"
+    "${MONOREPO_ROOT}/libcxx/utils/ci/lnt/submit-benchmarks" \
+        --dry-run -vv \
+        --lnt-url http://localhost:8000 \
+        --test-suite libcxx \
+        "${BUILD_DIR}/results.lnt"
 ;;
 #
 # Various Standard modes

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -336,7 +336,7 @@ test-tools)
         --dry-run -vv \
         --lnt-url http://localhost:8000 \
         --test-suite libcxx \
-        "${BUILD_DIR}/results.lnt"
+        "${BUILD_DIR}/report.json"
 ;;
 #
 # Various Standard modes


### PR DESCRIPTION
This provides better-than-nothing coverage at a low cost.