### PR TITLE
[clang][Driver] Remove support for legacy -pthreads option

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6674,7 +6674,6 @@ def print_diagnostic_options : Flag<["-", "--"], "print-diagnostic-options">,
   HelpText<"Print all of Clang's warning options">,
   Visibility<[ClangOption, CLOption]>;
 def private__bundle : Flag<["-"], "private_bundle">;
-def pthreads : Flag<["-"], "pthreads">;
 defm pthread : BoolOption<"", "pthread",
   LangOpts<"POSIXThreads">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption], "Support POSIX threads in generated code">,

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -312,8 +312,8 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-lpthreads");
       }
 
-      // Support POSIX threads if "-pthreads" or "-pthread" is present.
-      if (Args.hasArg(options::OPT_pthreads, options::OPT_pthread))
+      // Support POSIX threads if "-pthread" is present.
+      if (Args.hasArg(options::OPT_pthread))
         CmdArgs.push_back("-lpthreads");
 
       if (D.CCCIsCXX())

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -807,7 +807,6 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
       // No need to do anything for pthreads. Claim argument to avoid warning.
       Args.ClaimAllArgs(options::OPT_pthread);
-      Args.ClaimAllArgs(options::OPT_pthreads);
     }
   }
 

--- a/clang/lib/Driver/ToolChains/Fuchsia.cpp
+++ b/clang/lib/Driver/ToolChains/Fuchsia.cpp
@@ -149,7 +149,7 @@ void fuchsia::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   bool NoLibc = Args.hasArg(options::OPT_nolibc);
   bool OnlyLibstdcxxStatic = Args.hasArg(options::OPT_static_libstdcxx) &&
                              !Args.hasArg(options::OPT_static);
-  bool Pthreads = Args.hasArg(options::OPT_pthread, options::OPT_pthreads);
+  bool Pthreads = Args.hasArg(options::OPT_pthread);
   bool SplitStack = Args.hasArg(options::OPT_fsplit_stack);
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
                    options::OPT_r)) {

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -494,8 +494,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       if (NeedsXRayDeps)
         linkXRayRuntimeDeps(ToolChain, Args, CmdArgs);
 
-      bool WantPthread = Args.hasArg(options::OPT_pthread) ||
-                         Args.hasArg(options::OPT_pthreads);
+      bool WantPthread = Args.hasArg(options::OPT_pthread);
 
       // Use the static OpenMP runtime with -static-openmp
       bool StaticOpenMP = Args.hasArg(options::OPT_static_openmp) &&

--- a/clang/lib/Driver/ToolChains/Haiku.cpp
+++ b/clang/lib/Driver/ToolChains/Haiku.cpp
@@ -139,7 +139,7 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // No need to do anything for pthreads. Claim argument to avoid warning.
-  Args.claimAllArgs(options::OPT_pthread, options::OPT_pthreads);
+  Args.claimAllArgs(options::OPT_pthread);
 
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
                    options::OPT_r)) {

--- a/clang/lib/Driver/ToolChains/Solaris.cpp
+++ b/clang/lib/Driver/ToolChains/Solaris.cpp
@@ -119,7 +119,6 @@ void solaris::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // libpthread has been folded into libc since Solaris 10, no need to do
     // anything for pthreads. Claim argument to avoid warning.
     Args.ClaimAllArgs(options::OPT_pthread);
-    Args.ClaimAllArgs(options::OPT_pthreads);
   }
 
   if (LinkerIsGnuLd) {

--- a/clang/test/Driver/aix-ld.c
+++ b/clang/test/Driver/aix-ld.c
@@ -81,10 +81,10 @@
 // CHECK-LD32-PTHREAD-NOT: "-lm"
 // CHECK-LD32-PTHREAD:     "-lc"
 
-// Check powerpc64-ibm-aix7.1.0.0, 64-bit. POSIX thread alias.
+// Check powerpc64-ibm-aix7.1.0.0, 64-bit. POSIX thread support.
 // RUN: %clang %s -### 2>&1 \
 // RUN:        -resource-dir=%S/Inputs/resource_dir \
-// RUN:        -pthreads \
+// RUN:        -pthread \
 // RUN:        --target=powerpc64-ibm-aix7.1.0.0 \
 // RUN:        --sysroot %S/Inputs/aix_ppc_tree \
 // RUN:        --unwindlib=libunwind \


### PR DESCRIPTION
Remove support for `-pthreads`. `-pthread` (singular) is the standard option supported across Clang and GCC on most platforms.

`-pthreads` was originally added in c800391fb9 as a distinct flag, likely for GCC compatibility where `-pthreads` on Solaris 2.

In LLVM, `-pthreads` was only checked by a subset of toolchains during linking and was never checked during compilation (`-c`), causing `argument unused during compilation: '-pthreads'` (and failing to set `_REENTRANT`).

Removing `-pthreads` completely simplifies option parsing and removes the broken and obsolete `-pthreads` form.

Alternative to #213749.