### PR TITLE
[mlir][linalg] Support subtracting accumulation in partial reduction …

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -534,6 +534,36 @@ static InitSliceInfo getInitSliceInfo(MLIRContext *context,
       partialReductionMap, initOperandShape);
 }
 
+/// Returns true if `combinerOp` accumulates into `accumulator` by subtracting
+/// the reduced value from it, i.e. it reduces the negated inputs.
+///
+/// Subtraction is not commutative, so this is a reduction only when the
+/// accumulator is the left-hand side. Such a reduction starts from the additive
+/// neutral element, but its partial results have to be combined with an
+/// addition instead of with the combiner itself: each of the `N` partial
+/// results `p_i` holds the negated sum of its own tile, so the reduced value
+/// `init - sum(x)` is `init + p_0 + ... + p_N-1` and not
+/// `init - p_0 - ... - p_N-1`.
+static bool isSubtractingAccumulation(Operation *combinerOp,
+                                      Value accumulator) {
+  if (!isa<arith::SubFOp, arith::SubIOp>(combinerOp))
+    return false;
+  return combinerOp->getOperand(0) == accumulator;
+}
+
+/// Creates the operation combining two partial results of the subtracting
+/// accumulation performed by `combinerOp`, preserving its fast-math flags and
+/// rounding mode. Integer overflow flags are dropped, since the flags of the
+/// subtraction do not carry over to the addition.
+static Value createSubtractingAccumulationMerge(OpBuilder &b, Location loc,
+                                                Operation *combinerOp,
+                                                Value lhs, Value rhs) {
+  if (auto subFOp = dyn_cast<arith::SubFOp>(combinerOp))
+    return arith::AddFOp::create(b, loc, lhs, rhs, subFOp.getFastmathAttr(),
+                                 subFOp.getRoundingmodeAttr());
+  return arith::AddIOp::create(b, loc, lhs, rhs);
+}
+
 /// External model implementation of PartialReductionInterface for
 /// LinalgOps.
 template <typename LinalgOpTy>
@@ -562,7 +592,12 @@ struct LinalgOpPartialReductionInterface
         return op->emitOpError("Failed to anaysis the reduction operation.");
 
       Operation *reductionOp = combinerOps[0];
-      std::optional<TypedAttr> identity = arith::getNeutralElement(reductionOp);
+      std::optional<TypedAttr> identity;
+      if (isSubtractingAccumulation(reductionOp,
+                                    linalgOp.getRegionOutputArgs()[initIdx]))
+        identity = b.getZeroAttr(reductionOp->getResult(0).getType());
+      else
+        identity = arith::getNeutralElement(reductionOp);
       if (!identity.has_value())
         return op->emitOpError(
             "Failed to get an identity value for the reduction operation.");
@@ -730,11 +765,20 @@ struct LinalgOpPartialReductionInterface
             SmallVector<Operation *, 4> combinerOps;
             matchReduction(linalgOp.getRegionOutputArgs(), initIdx,
                            combinerOps);
-            Operation *clonedReductionOp = b.clone(*combinerOps[0]);
-            // Combine the input at idx and output at numInits + idx.
-            clonedReductionOp->setOperand(0, inputs[0]);
-            clonedReductionOp->setOperand(1, inputs[1]);
-            linalg::YieldOp::create(b, loc, clonedReductionOp->getResult(0));
+            Operation *reductionOp = combinerOps[0];
+            Value merged;
+            if (isSubtractingAccumulation(
+                    reductionOp, linalgOp.getRegionOutputArgs()[initIdx])) {
+              merged = createSubtractingAccumulationMerge(b, loc, reductionOp,
+                                                          inputs[0], inputs[1]);
+            } else {
+              Operation *clonedReductionOp = b.clone(*reductionOp);
+              // Combine the input at idx and output at numInits + idx.
+              clonedReductionOp->setOperand(0, inputs[0]);
+              clonedReductionOp->setOperand(1, inputs[1]);
+              merged = clonedReductionOp->getResult(0);
+            }
+            linalg::YieldOp::create(b, loc, merged);
           });
 
       mergeOperations.push_back(reduction);

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -552,11 +552,12 @@ static bool isSubtractingAccumulation(Operation *combinerOp,
 /// accumulation performed by `combinerOp`, preserving its fast-math flags,
 /// rounding mode and integer overflow flags.
 ///
-/// Note that the overflow flags assert that the original accumulation does not
-/// wrap, which may not hold for partial results since they are subtractions
-/// from zero. The flags are propagated nonetheless, for consistency with the
-/// other combiners, which are cloned with their flags. This behaviour should
-/// be revisited.
+/// TODO: see issue https://github.com/llvm/llvm-project/issues/218538
+/// The overflow flags assert that the original accumulation does not wrap,
+/// which may not hold for partial results since they are subtractions from
+/// zero. The flags are propagated nonetheless, for consistency with the other
+/// combiners, which are cloned with their flags. This behaviour should be
+/// revisited.
 static Value createSubtractingAccumulationMerge(OpBuilder &b, Location loc,
                                                 Operation *combinerOp,
                                                 Value lhs, Value rhs) {

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -545,31 +545,27 @@ static bool isSubtractingAccumulation(Operation *combinerOp,
                                       Value accumulator) {
   if (!isa<arith::SubFOp, arith::SubIOp>(combinerOp))
     return false;
-  // Do not tile when the subtraction carries overflow flags: they assert that
-  // the original accumulation does not wrap, which no longer holds once the
-  // partial results accumulate from the neutral element instead.
-  //   `nuw`: `0 - x` wraps for every non-zero `x`, the result being negative.
-  //   `nsw`: `0 - x` wraps for the minimum signed `x`, as `-x` is then not
-  //          representable.
-  auto subIOp = dyn_cast<arith::SubIOp>(combinerOp);
-  if (subIOp && subIOp.getOverflowFlags() != arith::IntegerOverflowFlags::none)
-    return false;
   return combinerOp->getOperand(0) == accumulator;
 }
 
 /// Creates the operation combining two partial results of the subtracting
-/// accumulation performed by `combinerOp`, preserving its fast-math flags and
-/// rounding mode. The integer addition carries no overflow flags, since
-/// `isSubtractingAccumulation` only accepts subtractions that have none.
+/// accumulation performed by `combinerOp`, preserving its fast-math flags,
+/// rounding mode and integer overflow flags.
+///
+/// Note that the overflow flags assert that the original accumulation does not
+/// wrap, which may not hold for partial results since they are subtractions
+/// from zero. The flags are propagated nonetheless, for consistency with the
+/// other combiners, which are cloned with their flags. This behaviour should
+/// be revisited.
 static Value createSubtractingAccumulationMerge(OpBuilder &b, Location loc,
                                                 Operation *combinerOp,
                                                 Value lhs, Value rhs) {
   if (auto subFOp = dyn_cast<arith::SubFOp>(combinerOp))
     return arith::AddFOp::create(b, loc, lhs, rhs, subFOp.getFastmathAttr(),
                                  subFOp.getRoundingmodeAttr());
-  assert(isa<arith::SubIOp>(combinerOp) &&
-         "expected a subtracting accumulation combiner");
-  return arith::AddIOp::create(b, loc, lhs, rhs);
+  auto subIOp = dyn_cast<arith::SubIOp>(combinerOp);
+  assert(subIOp && "expected a subtracting accumulation combiner");
+  return arith::AddIOp::create(b, loc, lhs, rhs, subIOp.getOverflowFlags());
 }
 
 /// Describes how a reduction is split into partial results.

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -536,14 +536,6 @@ static InitSliceInfo getInitSliceInfo(MLIRContext *context,
 
 /// Returns true if `combinerOp` accumulates into `accumulator` by subtracting
 /// the reduced value from it, i.e. it reduces the negated inputs.
-///
-/// Subtraction is not commutative, so this is a reduction only when the
-/// accumulator is the left-hand side. Such a reduction starts from the additive
-/// neutral element, but its partial results have to be combined with an
-/// addition instead of with the combiner itself: each of the `N` partial
-/// results `p_i` holds the negated sum of its own tile, so the reduced value
-/// `init - sum(x)` is `init + p_0 + ... + p_N-1` and not
-/// `init - p_0 - ... - p_N-1`.
 static bool isSubtractingAccumulation(Operation *combinerOp,
                                       Value accumulator) {
   if (!isa<arith::SubFOp, arith::SubIOp>(combinerOp))

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -536,23 +536,38 @@ static InitSliceInfo getInitSliceInfo(MLIRContext *context,
 
 /// Returns true if `combinerOp` accumulates into `accumulator` by subtracting
 /// the reduced value from it, i.e. it reduces the negated inputs.
+///
+/// Subtraction is not commutative, so the accumulator has to be the left-hand
+/// side: `x - acc` computes an alternating sum instead of accumulating every
+/// input with the same sign, and cannot be split into partial results.
 static bool isSubtractingAccumulation(Operation *combinerOp,
                                       Value accumulator) {
   if (!isa<arith::SubFOp, arith::SubIOp>(combinerOp))
+    return false;
+  // Overflow flags assert that the original accumulation does not wrap. Each
+  // partial result accumulates a different subset of the inputs starting from
+  // the neutral element, so that assertion does not carry over: `0 - x` wraps
+  // for every non-zero `x` under `nuw`, and for the minimum signed value under
+  // `nsw`. Leave such reductions untiled rather than propagating an assumption
+  // that no longer holds.
+  auto subIOp = dyn_cast<arith::SubIOp>(combinerOp);
+  if (subIOp && subIOp.getOverflowFlags() != arith::IntegerOverflowFlags::none)
     return false;
   return combinerOp->getOperand(0) == accumulator;
 }
 
 /// Creates the operation combining two partial results of the subtracting
 /// accumulation performed by `combinerOp`, preserving its fast-math flags and
-/// rounding mode. Integer overflow flags are dropped, since the flags of the
-/// subtraction do not carry over to the addition.
+/// rounding mode. The integer addition carries no overflow flags, since
+/// `isSubtractingAccumulation` only accepts subtractions that have none.
 static Value createSubtractingAccumulationMerge(OpBuilder &b, Location loc,
                                                 Operation *combinerOp,
                                                 Value lhs, Value rhs) {
   if (auto subFOp = dyn_cast<arith::SubFOp>(combinerOp))
     return arith::AddFOp::create(b, loc, lhs, rhs, subFOp.getFastmathAttr(),
                                  subFOp.getRoundingmodeAttr());
+  assert(isa<arith::SubIOp>(combinerOp) &&
+         "expected a subtracting accumulation combiner");
   return arith::AddIOp::create(b, loc, lhs, rhs);
 }
 

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/Debug.h"
+#include <functional>
 #include <optional>
 
 #define DEBUG_TYPE "linalg-tiling-interface-impl"
@@ -571,6 +572,45 @@ static Value createSubtractingAccumulationMerge(OpBuilder &b, Location loc,
   return arith::AddIOp::create(b, loc, lhs, rhs);
 }
 
+/// Describes how a reduction is split into partial results.
+struct SplitReductionCombiner {
+  /// Value each partial result is initialized with.
+  TypedAttr identity;
+  /// Builds the operation combining two partial results.
+  std::function<Value(OpBuilder &, Location, Value, Value)> merge;
+};
+
+/// Returns how the reduction implemented by `combinerOp`, accumulating into
+/// `accumulator`, is split into partial results, or `std::nullopt` if it cannot
+/// be split. The identity and the merge operation have to agree, so they are
+/// determined together.
+static std::optional<SplitReductionCombiner>
+getSplitReductionCombiner(Operation *combinerOp, Value accumulator) {
+  if (isSubtractingAccumulation(combinerOp, accumulator)) {
+    // Each partial result holds the negated sum of its own tile, so they are
+    // combined with an addition rather than with the subtraction itself.
+    Builder builder(combinerOp->getContext());
+    return SplitReductionCombiner{
+        builder.getZeroAttr(combinerOp->getResult(0).getType()),
+        [combinerOp](OpBuilder &b, Location loc, Value lhs, Value rhs) {
+          return createSubtractingAccumulationMerge(b, loc, combinerOp, lhs,
+                                                    rhs);
+        }};
+  }
+
+  std::optional<TypedAttr> identity = arith::getNeutralElement(combinerOp);
+  if (!identity.has_value())
+    return std::nullopt;
+  return SplitReductionCombiner{
+      *identity,
+      [combinerOp](OpBuilder &b, Location loc, Value lhs, Value rhs) {
+        Operation *clonedCombinerOp = b.clone(*combinerOp);
+        clonedCombinerOp->setOperand(0, lhs);
+        clonedCombinerOp->setOperand(1, rhs);
+        return clonedCombinerOp->getResult(0);
+      }};
+}
+
 /// External model implementation of PartialReductionInterface for
 /// LinalgOps.
 template <typename LinalgOpTy>
@@ -598,16 +638,12 @@ struct LinalgOpPartialReductionInterface
           combinerOps.size() != 1)
         return op->emitOpError("Failed to anaysis the reduction operation.");
 
-      Operation *reductionOp = combinerOps[0];
-      std::optional<TypedAttr> identity;
-      if (isSubtractingAccumulation(reductionOp,
-                                    linalgOp.getRegionOutputArgs()[initIdx]))
-        identity = b.getZeroAttr(reductionOp->getResult(0).getType());
-      else
-        identity = arith::getNeutralElement(reductionOp);
-      if (!identity.has_value())
+      std::optional<SplitReductionCombiner> combiner =
+          getSplitReductionCombiner(combinerOps[0],
+                                    linalgOp.getRegionOutputArgs()[initIdx]);
+      if (!combiner.has_value())
         return op->emitOpError(
-            "Failed to get an identity value for the reduction operation.");
+            "failed to determine how to split the reduction operation");
 
       // Append the new partial result dimensions.
       SmallVector<OpFoldResult> partialResultShape;
@@ -629,7 +665,7 @@ struct LinalgOpPartialReductionInterface
       Type elType = getElementTypeOrSelf(result.getType());
       Value emptyTensor =
           tensor::EmptyOp::create(b, loc, partialResultShape, elType);
-      Value constantOp = arith::ConstantOp::create(b, loc, *identity);
+      Value constantOp = arith::ConstantOp::create(b, loc, combiner->identity);
       auto identityTensor =
           linalg::FillOp::create(b, loc, constantOp, emptyTensor);
       inits.push_back(identityTensor.getResult(0));
@@ -765,27 +801,24 @@ struct LinalgOpPartialReductionInterface
         }
       }
 
+      // Get the combiner op. This has to happen before the merge operation is
+      // built, since the region builder below cannot report a failure.
+      SmallVector<Operation *, 4> combinerOps;
+      if (!matchReduction(linalgOp.getRegionOutputArgs(), initIdx, combinerOps))
+        return op->emitOpError("failed to match the reduction operation");
+      std::optional<SplitReductionCombiner> combiner =
+          getSplitReductionCombiner(combinerOps[0],
+                                    linalgOp.getRegionOutputArgs()[initIdx]);
+      if (!combiner.has_value())
+        return op->emitOpError(
+            "failed to determine how to split the reduction operation");
+
       auto reduction = linalg::ReduceOp::create(
           b, loc, partialResult, init, partialReductionDims,
-          [&linalgOp, &initIdx](OpBuilder &b, Location loc, ValueRange inputs) {
-            // Get the combiner op.
-            SmallVector<Operation *, 4> combinerOps;
-            matchReduction(linalgOp.getRegionOutputArgs(), initIdx,
-                           combinerOps);
-            Operation *reductionOp = combinerOps[0];
-            Value merged;
-            if (isSubtractingAccumulation(
-                    reductionOp, linalgOp.getRegionOutputArgs()[initIdx])) {
-              merged = createSubtractingAccumulationMerge(b, loc, reductionOp,
-                                                          inputs[0], inputs[1]);
-            } else {
-              Operation *clonedReductionOp = b.clone(*reductionOp);
-              // Combine the input at idx and output at numInits + idx.
-              clonedReductionOp->setOperand(0, inputs[0]);
-              clonedReductionOp->setOperand(1, inputs[1]);
-              merged = clonedReductionOp->getResult(0);
-            }
-            linalg::YieldOp::create(b, loc, merged);
+          [&combiner](OpBuilder &b, Location loc, ValueRange inputs) {
+            // Combine the input at idx and output at numInits + idx.
+            linalg::YieldOp::create(
+                b, loc, combiner->merge(b, loc, inputs[0], inputs[1]));
           });
 
       mergeOperations.push_back(reduction);

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -544,12 +544,12 @@ static bool isSubtractingAccumulation(Operation *combinerOp,
                                       Value accumulator) {
   if (!isa<arith::SubFOp, arith::SubIOp>(combinerOp))
     return false;
-  // Overflow flags assert that the original accumulation does not wrap. Each
-  // partial result accumulates a different subset of the inputs starting from
-  // the neutral element, so that assertion does not carry over: `0 - x` wraps
-  // for every non-zero `x` under `nuw`, and for the minimum signed value under
-  // `nsw`. Leave such reductions untiled rather than propagating an assumption
-  // that no longer holds.
+  // Do not tile when the subtraction carries overflow flags: they assert that
+  // the original accumulation does not wrap, which no longer holds once the
+  // partial results accumulate from the neutral element instead.
+  //   `nuw`: `0 - x` wraps for every non-zero `x`, the result being negative.
+  //   `nsw`: `0 - x` wraps for the minimum signed `x`, as `-x` is then not
+  //          representable.
   auto subIOp = dyn_cast<arith::SubIOp>(combinerOp);
   if (subIOp && subIOp.getOverflowFlags() != arith::IntegerOverflowFlags::none)
     return false;

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1125,7 +1125,7 @@ module attributes {transform.with_named_sequence} {
 #map1 = affine_map<(d0, d1) -> (d0)>
 
 module {
-  func.func @fail_for_rhs_accumulator(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  func.func @negative_reduction_tile_rhs_accumulator_f32(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
     // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
     %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%arg1 : tensor<?xf32>) {
     ^bb0(%in: f32, %acc: f32):
@@ -1133,6 +1133,31 @@ module {
       linalg.yield %sub : f32
     } -> tensor<?xf32>
     return %0 : tensor<?xf32>
+  }
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+      %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+      // expected-error @below {{failed to tile using partial reduction}}
+      %fill_op, %split_linalg_op, %combining_linalg_op, %for_op = transform.structured.tile_reduction_using_for %0 by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+    }
+  }
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+
+module {
+  func.func @negative_reduction_tile_rhs_accumulator_i32(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
+    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
+    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
+    ^bb0(%in: i32, %acc: i32):
+      %sub = arith.subi %in, %acc : i32
+      linalg.yield %sub : i32
+    } -> tensor<?xi32>
+    return %0 : tensor<?xi32>
   }
   module attributes {transform.with_named_sequence} {
     transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1029,3 +1029,104 @@ module attributes {transform.with_named_sequence} {
 //       CHECK:   }
 //       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x3x?x4xf32>) outs(%arg1 : tensor<?x3x?xf32>) dimensions = [3]
 //       CHECK:   return %{{.*}}
+
+// -----
+
+// A subtracting accumulation (`acc - x`) reduces the negated inputs. It is
+// tiled starting from the additive neutral element, and its partial results are
+// merged with an addition rather than with the subtraction itself.
+
+func.func @reduction_tile_negated_sum(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
+  %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                          affine_map<(d0, d1) -> (d0)>],
+   iterator_types = ["parallel", "reduction"]}
+   ins(%arg0 : tensor<?x?xf32>)
+   outs(%out : tensor<?xf32>) {
+    ^bb0(%arg7: f32, %arg9: f32):
+      %1 = arith.subf %arg9, %arg7 : f32
+      linalg.yield %1 : f32
+    } -> tensor<?xf32>
+  return %red : tensor<?xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1, %2, %3, %loop = transform.structured.tile_reduction_using_for %0
+      by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduction_tile_negated_sum
+//   CHECK-DAG:   %[[I:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : f32) outs(%{{.*}} : tensor<?x5xf32>) -> tensor<?x5xf32>
+//       CHECK:   %[[L:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[F]]) -> (tensor<?x5xf32>) {
+//       CHECK:     linalg.generic
+//       CHECK:       arith.subf
+//       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xf32>) outs(%{{.*}} : tensor<?xf32>) dimensions = [1]
+//       CHECK:     arith.addf
+//       CHECK:   return
+
+// -----
+
+// Same for integers, and for the `scf.forall` tiling strategy.
+
+func.func @reduction_tile_negated_sum_int(%arg0: tensor<?x?xi32>, %out: tensor<?xi32>) -> tensor<?xi32> {
+  %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                          affine_map<(d0, d1) -> (d0)>],
+   iterator_types = ["parallel", "reduction"]}
+   ins(%arg0 : tensor<?x?xi32>)
+   outs(%out : tensor<?xi32>) {
+    ^bb0(%arg7: i32, %arg9: i32):
+      %1 = arith.subi %arg9, %arg7 : i32
+      linalg.yield %1 : i32
+    } -> tensor<?xi32>
+  return %red : tensor<?xi32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1, %2, %3, %loop = transform.structured.tile_reduction_using_forall %0
+      by num_threads = [0, 5] tile_sizes = [] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduction_tile_negated_sum_int
+//   CHECK-DAG:   %[[I:.*]] = arith.constant 0 : i32
+//       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : i32) outs(%{{.*}} : tensor<?x5xi32>) -> tensor<?x5xi32>
+//       CHECK:   %[[L:.*]] = scf.forall
+//       CHECK:       arith.subi
+//       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xi32>) outs(%{{.*}} : tensor<?xi32>) dimensions = [1]
+//       CHECK:     arith.addi
+//       CHECK:   return
+
+// -----
+
+// `x - acc` is not a splittable reduction: the accumulator has to be the
+// left-hand side of the subtraction, so no neutral element applies.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+
+module {
+  func.func @fail_for_rhs_accumulator(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%arg1 : tensor<?xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %1 = arith.subf %in, %out : f32
+      linalg.yield %1 : f32
+    } -> tensor<?xf32>
+    return %0 : tensor<?xf32>
+  }
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+      %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+      // expected-error @below {{failed to tile using partial reduction}}
+      %fill_op, %split_linalg_op, %combining_linalg_op, %for_op = transform.structured.tile_reduction_using_for %0 by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+    }
+  }
+}

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1118,6 +1118,55 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// A reduction written as `acc + (-x)` is canonicalized into the subtracting
+// accumulation `acc - x` before any tiling happens, giving the same result as
+// reduction_tile_negated_sum_f32_for above.
+
+func.func @reduction_tile_negated_sum_f32_canonicalized_for(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
+  %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                          affine_map<(d0, d1) -> (d0)>],
+   iterator_types = ["parallel", "reduction"]}
+   ins(%arg0 : tensor<?x?xf32>)
+   outs(%out : tensor<?xf32>) {
+    ^bb0(%in: f32, %acc: f32):
+      %neg = arith.negf %in : f32
+      %add = arith.addf %acc, %neg : f32
+      linalg.yield %add : f32
+    } -> tensor<?xf32>
+  return %red : tensor<?xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1, %2, %3, %loop = transform.structured.tile_reduction_using_for %0
+      by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduction_tile_negated_sum_f32_canonicalized_for
+//   CHECK-DAG:   %[[I:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : f32) outs(%{{.*}} : tensor<?x5xf32>) -> tensor<?x5xf32>
+//       CHECK:   %[[L:.*]] = scf.for {{.*}} iter_args(%[[ITER:.+]] = %[[F]]) -> (tensor<?x5xf32>) {
+//       CHECK:     %[[TILE:.+]] = linalg.generic
+//       CHECK:     ^bb0(%[[IN:.+]]: f32, %[[ACC:.+]]: f32):
+//       CHECK:       %[[SUB:.+]] = arith.subf %[[ACC]], %[[IN]] : f32
+//       CHECK:       linalg.yield %[[SUB]] : f32
+//       CHECK:     %[[INSERTED:.+]] = tensor.insert_slice %[[TILE]] into %[[ITER]]
+//       CHECK:     scf.yield %[[INSERTED]] : tensor<?x5xf32>
+//       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xf32>) outs(%{{.*}} : tensor<?xf32>) dimensions = [1]
+//       CHECK:     (%[[PARTIAL:.+]]: f32, %[[INIT:.+]]: f32) {
+//       CHECK:       %[[ADD:.+]] = arith.addf %[[PARTIAL]], %[[INIT]] : f32
+//       CHECK:       linalg.yield %[[ADD]] : f32
+//       CHECK:   return
+
+// -----
+
 // `x - acc` is not a splittable reduction: the accumulator has to be the
 // left-hand side of the subtraction, so no neutral element applies.
 

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1141,61 +1141,42 @@ module {
 
 // -----
 
-// A subtracting accumulation carrying integer overflow flags is not tiled: the
-// flags assert that the original accumulation does not wrap, which does not
-// hold for partial results accumulated from the neutral element. `0 - x`
-// already wraps for the minimum signed value under `nsw`.
+// The integer overflow flags of the subtraction carry over to the addition
+// combining the partial results, matching how the other combiners are cloned
+// with their flags.
 
-#map = affine_map<(d0, d1) -> (d0, d1)>
-#map1 = affine_map<(d0, d1) -> (d0)>
-
-module {
-  func.func @fail_for_nsw_overflow_flag(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
-    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
-    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
-    ^bb0(%in: i32, %out: i32):
-      %1 = arith.subi %out, %in overflow<nsw> : i32
+func.func @reduction_tile_negated_sum_overflow_flags(%arg0: tensor<?x?xi32>, %out: tensor<?xi32>) -> tensor<?xi32> {
+  %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                          affine_map<(d0, d1) -> (d0)>],
+   iterator_types = ["parallel", "reduction"]}
+   ins(%arg0 : tensor<?x?xi32>)
+   outs(%out : tensor<?xi32>) {
+    ^bb0(%arg7: i32, %arg9: i32):
+      %1 = arith.subi %arg9, %arg7 overflow<nsw, nuw> : i32
       linalg.yield %1 : i32
     } -> tensor<?xi32>
-    return %0 : tensor<?xi32>
-  }
-  module attributes {transform.with_named_sequence} {
-    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-      %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-      // expected-error @below {{failed to tile using partial reduction}}
-      %fill_op, %split_linalg_op, %combining_linalg_op, %for_op = transform.structured.tile_reduction_using_for %0 by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+  return %red : tensor<?xi32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1, %2, %3, %loop = transform.structured.tile_reduction_using_for %0
+      by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
       transform.yield
-    }
   }
 }
 
-// -----
-
-// Same for `nuw`, where the assertion is broken even more readily: `0 - x`
-// wraps for every non-zero `x`.
-
-#map = affine_map<(d0, d1) -> (d0, d1)>
-#map1 = affine_map<(d0, d1) -> (d0)>
-
-module {
-  func.func @fail_for_nuw_overflow_flag(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
-    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
-    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
-    ^bb0(%in: i32, %out: i32):
-      %1 = arith.subi %out, %in overflow<nuw> : i32
-      linalg.yield %1 : i32
-    } -> tensor<?xi32>
-    return %0 : tensor<?xi32>
-  }
-  module attributes {transform.with_named_sequence} {
-    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-      %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
-      // expected-error @below {{failed to tile using partial reduction}}
-      %fill_op, %split_linalg_op, %combining_linalg_op, %for_op = transform.structured.tile_reduction_using_for %0 by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
-      transform.yield
-    }
-  }
-}
+// CHECK-LABEL: func @reduction_tile_negated_sum_overflow_flags
+//       CHECK:   linalg.generic
+//       CHECK:   ^bb0(%[[IN:.+]]: i32, %[[ACC:.+]]: i32):
+//       CHECK:     %[[SUB:.+]] = arith.subi %[[ACC]], %[[IN]] overflow<nsw, nuw> : i32
+//       CHECK:     linalg.yield %[[SUB]] : i32
+//       CHECK:   linalg.reduce
+//       CHECK:     (%[[PARTIAL:.+]]: i32, %[[INIT:.+]]: i32) {
+//       CHECK:       %[[ADD:.+]] = arith.addi %[[PARTIAL]], %[[INIT]] overflow<nsw, nuw> : i32
+//       CHECK:       linalg.yield %[[ADD]] : i32
+//       CHECK:   return
 
 // -----
 

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1036,15 +1036,15 @@ module attributes {transform.with_named_sequence} {
 // tiled starting from the additive neutral element, and its partial results are
 // merged with an addition rather than with the subtraction itself.
 
-func.func @reduction_tile_negated_sum(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
+func.func @reduction_tile_negated_sum_f32_for(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
   %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                                           affine_map<(d0, d1) -> (d0)>],
    iterator_types = ["parallel", "reduction"]}
    ins(%arg0 : tensor<?x?xf32>)
    outs(%out : tensor<?xf32>) {
-    ^bb0(%arg7: f32, %arg9: f32):
-      %1 = arith.subf %arg9, %arg7 : f32
-      linalg.yield %1 : f32
+    ^bb0(%in: f32, %acc: f32):
+      %sub = arith.subf %acc, %in : f32
+      linalg.yield %sub : f32
     } -> tensor<?xf32>
   return %red : tensor<?xf32>
 }
@@ -1058,14 +1058,16 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-// CHECK-LABEL: func @reduction_tile_negated_sum
+// CHECK-LABEL: func @reduction_tile_negated_sum_f32_for
 //   CHECK-DAG:   %[[I:.*]] = arith.constant 0.000000e+00 : f32
 //       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : f32) outs(%{{.*}} : tensor<?x5xf32>) -> tensor<?x5xf32>
-//       CHECK:   %[[L:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[F]]) -> (tensor<?x5xf32>) {
-//       CHECK:     linalg.generic
+//       CHECK:   %[[L:.*]] = scf.for {{.*}} iter_args(%[[ITER:.+]] = %[[F]]) -> (tensor<?x5xf32>) {
+//       CHECK:     %[[TILE:.+]] = linalg.generic
 //       CHECK:     ^bb0(%[[IN:.+]]: f32, %[[ACC:.+]]: f32):
 //       CHECK:       %[[SUB:.+]] = arith.subf %[[ACC]], %[[IN]] : f32
 //       CHECK:       linalg.yield %[[SUB]] : f32
+//       CHECK:     %[[INSERTED:.+]] = tensor.insert_slice %[[TILE]] into %[[ITER]]
+//       CHECK:     scf.yield %[[INSERTED]] : tensor<?x5xf32>
 //       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xf32>) outs(%{{.*}} : tensor<?xf32>) dimensions = [1]
 //       CHECK:     (%[[PARTIAL:.+]]: f32, %[[INIT:.+]]: f32) {
 //       CHECK:       %[[ADD:.+]] = arith.addf %[[PARTIAL]], %[[INIT]] : f32
@@ -1076,15 +1078,15 @@ module attributes {transform.with_named_sequence} {
 
 // Same for integers, and for the `scf.forall` tiling strategy.
 
-func.func @reduction_tile_negated_sum_int(%arg0: tensor<?x?xi32>, %out: tensor<?xi32>) -> tensor<?xi32> {
+func.func @reduction_tile_negated_sum_i32_forall(%arg0: tensor<?x?xi32>, %out: tensor<?xi32>) -> tensor<?xi32> {
   %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                                           affine_map<(d0, d1) -> (d0)>],
    iterator_types = ["parallel", "reduction"]}
    ins(%arg0 : tensor<?x?xi32>)
    outs(%out : tensor<?xi32>) {
-    ^bb0(%arg7: i32, %arg9: i32):
-      %1 = arith.subi %arg9, %arg7 : i32
-      linalg.yield %1 : i32
+    ^bb0(%in: i32, %acc: i32):
+      %sub = arith.subi %acc, %in : i32
+      linalg.yield %sub : i32
     } -> tensor<?xi32>
   return %red : tensor<?xi32>
 }
@@ -1098,13 +1100,16 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-// CHECK-LABEL: func @reduction_tile_negated_sum_int
+// CHECK-LABEL: func @reduction_tile_negated_sum_i32_forall
 //   CHECK-DAG:   %[[I:.*]] = arith.constant 0 : i32
 //       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : i32) outs(%{{.*}} : tensor<?x5xi32>) -> tensor<?x5xi32>
-//       CHECK:   %[[L:.*]] = scf.forall
+//       CHECK:   %[[L:.*]] = scf.forall {{.*}} shared_outs(%[[ITER:.+]] = %[[F]]) -> (tensor<?x5xi32>) {
+//       CHECK:     %[[TILE:.+]] = linalg.generic
 //       CHECK:     ^bb0(%[[IN:.+]]: i32, %[[ACC:.+]]: i32):
 //       CHECK:       %[[SUB:.+]] = arith.subi %[[ACC]], %[[IN]] : i32
 //       CHECK:       linalg.yield %[[SUB]] : i32
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[TILE]] into %[[ITER]]
 //       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xi32>) outs(%{{.*}} : tensor<?xi32>) dimensions = [1]
 //       CHECK:     (%[[PARTIAL:.+]]: i32, %[[INIT:.+]]: i32) {
 //       CHECK:       %[[ADD:.+]] = arith.addi %[[PARTIAL]], %[[INIT]] : i32
@@ -1123,9 +1128,9 @@ module {
   func.func @fail_for_rhs_accumulator(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
     // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
     %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%arg1 : tensor<?xf32>) {
-    ^bb0(%in: f32, %out: f32):
-      %1 = arith.subf %in, %out : f32
-      linalg.yield %1 : f32
+    ^bb0(%in: f32, %acc: f32):
+      %sub = arith.subf %in, %acc : f32
+      linalg.yield %sub : f32
     } -> tensor<?xf32>
     return %0 : tensor<?xf32>
   }
@@ -1145,15 +1150,15 @@ module {
 // combining the partial results, matching how the other combiners are cloned
 // with their flags.
 
-func.func @reduction_tile_negated_sum_overflow_flags(%arg0: tensor<?x?xi32>, %out: tensor<?xi32>) -> tensor<?xi32> {
+func.func @reduction_tile_negated_sum_i32_overflow_flags(%arg0: tensor<?x?xi32>, %out: tensor<?xi32>) -> tensor<?xi32> {
   %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                                           affine_map<(d0, d1) -> (d0)>],
    iterator_types = ["parallel", "reduction"]}
    ins(%arg0 : tensor<?x?xi32>)
    outs(%out : tensor<?xi32>) {
-    ^bb0(%arg7: i32, %arg9: i32):
-      %1 = arith.subi %arg9, %arg7 overflow<nsw, nuw> : i32
-      linalg.yield %1 : i32
+    ^bb0(%in: i32, %acc: i32):
+      %sub = arith.subi %acc, %in overflow<nsw, nuw> : i32
+      linalg.yield %sub : i32
     } -> tensor<?xi32>
   return %red : tensor<?xi32>
 }
@@ -1167,11 +1172,12 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-// CHECK-LABEL: func @reduction_tile_negated_sum_overflow_flags
-//       CHECK:   linalg.generic
+// CHECK-LABEL: func @reduction_tile_negated_sum_i32_overflow_flags
+//       CHECK:   %[[TILE:.+]] = linalg.generic
 //       CHECK:   ^bb0(%[[IN:.+]]: i32, %[[ACC:.+]]: i32):
 //       CHECK:     %[[SUB:.+]] = arith.subi %[[ACC]], %[[IN]] overflow<nsw, nuw> : i32
 //       CHECK:     linalg.yield %[[SUB]] : i32
+//       CHECK:   tensor.insert_slice %[[TILE]]
 //       CHECK:   linalg.reduce
 //       CHECK:     (%[[PARTIAL:.+]]: i32, %[[INIT:.+]]: i32) {
 //       CHECK:       %[[ADD:.+]] = arith.addi %[[PARTIAL]], %[[INIT]] overflow<nsw, nuw> : i32
@@ -1183,15 +1189,15 @@ module attributes {transform.with_named_sequence} {
 // The fast-math flags and the rounding mode of the subtraction carry over to
 // the addition combining the partial results.
 
-func.func @reduction_tile_negated_sum_flags(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
+func.func @reduction_tile_negated_sum_f32_fastmath_rounding(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
   %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                                           affine_map<(d0, d1) -> (d0)>],
    iterator_types = ["parallel", "reduction"]}
    ins(%arg0 : tensor<?x?xf32>)
    outs(%out : tensor<?xf32>) {
-    ^bb0(%arg7: f32, %arg9: f32):
-      %1 = arith.subf %arg9, %arg7 to_nearest_even fastmath<nnan,ninf> : f32
-      linalg.yield %1 : f32
+    ^bb0(%in: f32, %acc: f32):
+      %sub = arith.subf %acc, %in to_nearest_even fastmath<nnan,ninf> : f32
+      linalg.yield %sub : f32
     } -> tensor<?xf32>
   return %red : tensor<?xf32>
 }
@@ -1205,11 +1211,12 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-// CHECK-LABEL: func @reduction_tile_negated_sum_flags
-//       CHECK:   linalg.generic
+// CHECK-LABEL: func @reduction_tile_negated_sum_f32_fastmath_rounding
+//       CHECK:   %[[TILE:.+]] = linalg.generic
 //       CHECK:   ^bb0(%[[IN:.+]]: f32, %[[ACC:.+]]: f32):
 //       CHECK:     %[[SUB:.+]] = arith.subf %[[ACC]], %[[IN]] to_nearest_even fastmath<nnan,ninf> : f32
 //       CHECK:     linalg.yield %[[SUB]] : f32
+//       CHECK:   tensor.insert_slice %[[TILE]]
 //       CHECK:   linalg.reduce
 //       CHECK:     (%[[PARTIAL:.+]]: f32, %[[INIT:.+]]: f32) {
 //       CHECK:       %[[ADD:.+]] = arith.addf %[[PARTIAL]], %[[INIT]] to_nearest_even fastmath<nnan,ninf> : f32

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1130,3 +1130,95 @@ module {
     }
   }
 }
+
+// -----
+
+// A subtracting accumulation carrying integer overflow flags is not tiled: the
+// flags assert that the original accumulation does not wrap, which does not
+// hold for partial results accumulated from the neutral element. `0 - x`
+// already wraps for the minimum signed value under `nsw`.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+
+module {
+  func.func @fail_for_nsw_overflow_flag(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
+    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
+    ^bb0(%in: i32, %out: i32):
+      %1 = arith.subi %out, %in overflow<nsw> : i32
+      linalg.yield %1 : i32
+    } -> tensor<?xi32>
+    return %0 : tensor<?xi32>
+  }
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+      %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+      // expected-error @below {{failed to tile using partial reduction}}
+      %fill_op, %split_linalg_op, %combining_linalg_op, %for_op = transform.structured.tile_reduction_using_for %0 by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+    }
+  }
+}
+
+// -----
+
+// Same for `nuw`, where the assertion is broken even more readily: `0 - x`
+// wraps for every non-zero `x`.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+
+module {
+  func.func @fail_for_nuw_overflow_flag(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
+    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
+    ^bb0(%in: i32, %out: i32):
+      %1 = arith.subi %out, %in overflow<nuw> : i32
+      linalg.yield %1 : i32
+    } -> tensor<?xi32>
+    return %0 : tensor<?xi32>
+  }
+  module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+      %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+      // expected-error @below {{failed to tile using partial reduction}}
+      %fill_op, %split_linalg_op, %combining_linalg_op, %for_op = transform.structured.tile_reduction_using_for %0 by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+    }
+  }
+}
+
+// -----
+
+// The fast-math flags and the rounding mode of the subtraction carry over to
+// the addition combining the partial results.
+
+func.func @reduction_tile_negated_sum_flags(%arg0: tensor<?x?xf32>, %out: tensor<?xf32>) -> tensor<?xf32> {
+  %red = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                          affine_map<(d0, d1) -> (d0)>],
+   iterator_types = ["parallel", "reduction"]}
+   ins(%arg0 : tensor<?x?xf32>)
+   outs(%out : tensor<?xf32>) {
+    ^bb0(%arg7: f32, %arg9: f32):
+      %1 = arith.subf %arg9, %arg7 to_nearest_even fastmath<nnan,ninf> : f32
+      linalg.yield %1 : f32
+    } -> tensor<?xf32>
+  return %red : tensor<?xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1, %2, %3, %loop = transform.structured.tile_reduction_using_for %0
+      by tile_sizes = [0, 5] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduction_tile_negated_sum_flags
+//       CHECK:   linalg.generic
+//       CHECK:     arith.subf %{{.*}}, %{{.*}} to_nearest_even fastmath<nnan,ninf> : f32
+//       CHECK:   linalg.reduce
+//       CHECK:     arith.addf %{{.*}}, %{{.*}} to_nearest_even fastmath<nnan,ninf> : f32
+//       CHECK:   return

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -1063,9 +1063,13 @@ module attributes {transform.with_named_sequence} {
 //       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : f32) outs(%{{.*}} : tensor<?x5xf32>) -> tensor<?x5xf32>
 //       CHECK:   %[[L:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[F]]) -> (tensor<?x5xf32>) {
 //       CHECK:     linalg.generic
-//       CHECK:       arith.subf
+//       CHECK:     ^bb0(%[[IN:.+]]: f32, %[[ACC:.+]]: f32):
+//       CHECK:       %[[SUB:.+]] = arith.subf %[[ACC]], %[[IN]] : f32
+//       CHECK:       linalg.yield %[[SUB]] : f32
 //       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xf32>) outs(%{{.*}} : tensor<?xf32>) dimensions = [1]
-//       CHECK:     arith.addf
+//       CHECK:     (%[[PARTIAL:.+]]: f32, %[[INIT:.+]]: f32) {
+//       CHECK:       %[[ADD:.+]] = arith.addf %[[PARTIAL]], %[[INIT]] : f32
+//       CHECK:       linalg.yield %[[ADD]] : f32
 //       CHECK:   return
 
 // -----
@@ -1098,9 +1102,13 @@ module attributes {transform.with_named_sequence} {
 //   CHECK-DAG:   %[[I:.*]] = arith.constant 0 : i32
 //       CHECK:   %[[F:.*]] = linalg.fill ins(%[[I]] : i32) outs(%{{.*}} : tensor<?x5xi32>) -> tensor<?x5xi32>
 //       CHECK:   %[[L:.*]] = scf.forall
-//       CHECK:       arith.subi
+//       CHECK:     ^bb0(%[[IN:.+]]: i32, %[[ACC:.+]]: i32):
+//       CHECK:       %[[SUB:.+]] = arith.subi %[[ACC]], %[[IN]] : i32
+//       CHECK:       linalg.yield %[[SUB]] : i32
 //       CHECK:   linalg.reduce ins(%[[L]] : tensor<?x5xi32>) outs(%{{.*}} : tensor<?xi32>) dimensions = [1]
-//       CHECK:     arith.addi
+//       CHECK:     (%[[PARTIAL:.+]]: i32, %[[INIT:.+]]: i32) {
+//       CHECK:       %[[ADD:.+]] = arith.addi %[[PARTIAL]], %[[INIT]] : i32
+//       CHECK:       linalg.yield %[[ADD]] : i32
 //       CHECK:   return
 
 // -----
@@ -1218,7 +1226,11 @@ module attributes {transform.with_named_sequence} {
 
 // CHECK-LABEL: func @reduction_tile_negated_sum_flags
 //       CHECK:   linalg.generic
-//       CHECK:     arith.subf %{{.*}}, %{{.*}} to_nearest_even fastmath<nnan,ninf> : f32
+//       CHECK:   ^bb0(%[[IN:.+]]: f32, %[[ACC:.+]]: f32):
+//       CHECK:     %[[SUB:.+]] = arith.subf %[[ACC]], %[[IN]] to_nearest_even fastmath<nnan,ninf> : f32
+//       CHECK:     linalg.yield %[[SUB]] : f32
 //       CHECK:   linalg.reduce
-//       CHECK:     arith.addf %{{.*}}, %{{.*}} to_nearest_even fastmath<nnan,ninf> : f32
+//       CHECK:     (%[[PARTIAL:.+]]: f32, %[[INIT:.+]]: f32) {
+//       CHECK:       %[[ADD:.+]] = arith.addf %[[PARTIAL]], %[[INIT]] to_nearest_even fastmath<nnan,ninf> : f32
+//       CHECK:       linalg.yield %[[ADD]] : f32
 //       CHECK:   return

--- a/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir
@@ -235,7 +235,7 @@ module attributes {transform.with_named_sequence} {
 
 module {
   func.func @fail_for_float_neutral(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
-    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
     %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%arg1 : tensor<?xf32>) {
     ^bb0(%in: f32, %out: f32):
       %1 = llvm.fmul %in, %in  : f32
@@ -1113,7 +1113,7 @@ module attributes {transform.with_named_sequence} {
 
 module {
   func.func @fail_for_rhs_accumulator(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
-    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
     %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%arg1 : tensor<?xf32>) {
     ^bb0(%in: f32, %out: f32):
       %1 = arith.subf %in, %out : f32
@@ -1143,7 +1143,7 @@ module {
 
 module {
   func.func @fail_for_nsw_overflow_flag(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
-    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
     %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
     ^bb0(%in: i32, %out: i32):
       %1 = arith.subi %out, %in overflow<nsw> : i32
@@ -1171,7 +1171,7 @@ module {
 
 module {
   func.func @fail_for_nuw_overflow_flag(%arg0: tensor<?x?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
-    // expected-error @below {{'linalg.generic' op Failed to get an identity value for the reduction operation.}}
+    // expected-error @below {{'linalg.generic' op failed to determine how to split the reduction operation}}
     %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xi32>) outs(%arg1 : tensor<?xi32>) {
     ^bb0(%in: i32, %out: i32):
       %1 = arith.subi %out, %in overflow<nuw> : i32

--- a/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
@@ -1,0 +1,62 @@
+// Checks that tiling a subtracting accumulation (`acc - x`) computes the same
+// result as the untiled reduction. The first RUN line runs the untiled
+// reduction, the second one tiles it first; both have to print the same values.
+
+// RUN: mlir-opt %s -test-transform-dialect-erase-schedule \
+// RUN: -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries" \
+// RUN: -buffer-deallocation-pipeline -convert-bufferization-to-memref -convert-linalg-to-loops -convert-scf-to-cf \
+// RUN: -expand-strided-metadata -lower-affine -convert-arith-to-llvm --finalize-memref-to-llvm -convert-func-to-llvm -convert-cf-to-llvm -reconcile-unrealized-casts | \
+// RUN: mlir-runner -e main -entry-point-result=void \
+// RUN:   -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils \
+// RUN: | FileCheck %s
+
+// RUN: mlir-opt %s -transform-interpreter -test-transform-dialect-erase-schedule \
+// RUN: -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries" \
+// RUN: -buffer-deallocation-pipeline -convert-bufferization-to-memref -convert-linalg-to-loops -convert-scf-to-cf \
+// RUN: -expand-strided-metadata -lower-affine -convert-arith-to-llvm --finalize-memref-to-llvm -convert-func-to-llvm -convert-cf-to-llvm -reconcile-unrealized-casts | \
+// RUN: mlir-runner -e main -entry-point-result=void \
+// RUN:   -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils \
+// RUN: | FileCheck %s
+
+func.func private @printMemrefF32(memref<*xf32>)
+
+func.func @main() {
+  %input = arith.constant dense<[[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+                                 [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]]>
+      : tensor<2x8xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<2xf32>
+  %init = linalg.fill ins(%cst : f32) outs(%empty : tensor<2xf32>) -> tensor<2xf32>
+  %res = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                          affine_map<(d0, d1) -> (d0)>],
+                         iterator_types = ["parallel", "reduction"]}
+      ins(%input : tensor<2x8xf32>) outs(%init : tensor<2xf32>) {
+  ^bb0(%in: f32, %acc: f32):
+    %sub = arith.subf %acc, %in : f32
+    linalg.yield %sub : f32
+  } -> tensor<2xf32>
+
+  %buffer = bufferization.to_buffer %res : tensor<2xf32> to memref<2xf32>
+  %cast = memref.cast %buffer : memref<2xf32> to memref<*xf32>
+  call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg0
+        : (!transform.any_op) -> !transform.any_op
+    // A tile size that does not divide the reduction dimension, so that the
+    // partial results are unevenly sized.
+    %1, %2, %3, %loop = transform.structured.tile_reduction_using_for %0
+        by tile_sizes = [0, 3]
+        : (!transform.any_op) -> (!transform.any_op, !transform.any_op,
+                                  !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+
+// Both rows reduce to the negated sum of their elements. Merging the partial
+// results with a subtraction instead of an addition would print [36, 360].
+// CHECK: Unranked Memref base@ = {{.*}} rank = 1 offset = 0 sizes = [2] strides = [1] data =
+// CHECK-NEXT: [-36,  -360]

--- a/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
@@ -2,18 +2,17 @@
 // result as the untiled reduction. The first RUN line runs the untiled
 // reduction, the second one tiles it first; both have to print the same values.
 
-// DEFINE: %{mlir_options} = -test-transform-dialect-erase-schedule \
+// DEFINE: %{lower_to_llvm} = mlir-opt -test-transform-dialect-erase-schedule \
 // DEFINE: -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries" \
-// DEFINE: -buffer-deallocation-pipeline -convert-bufferization-to-memref -convert-linalg-to-loops -convert-scf-to-cf \
-// DEFINE: -expand-strided-metadata -lower-affine -convert-arith-to-llvm --finalize-memref-to-llvm -convert-func-to-llvm -convert-cf-to-llvm -reconcile-unrealized-casts
+// DEFINE: -buffer-deallocation-pipeline -convert-bufferization-to-memref -test-lower-to-llvm
 
 // DEFINE: %{run} = mlir-runner -e main -entry-point-result=void \
 // DEFINE:   -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils \
 // DEFINE: | FileCheck %s
 
-// RUN: mlir-opt %s %{mlir_options} | %{run}
+// RUN: %{lower_to_llvm} %s | %{run}
 
-// RUN: mlir-opt %s -transform-interpreter %{mlir_options} | %{run}
+// RUN: mlir-opt %s -transform-interpreter | %{lower_to_llvm} | %{run}
 
 func.func private @printMemrefF32(memref<*xf32>)
 

--- a/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
@@ -53,7 +53,6 @@ module attributes {transform.with_named_sequence} {
   }
 }
 
-// Both rows reduce to the negated sum of their elements. Merging the partial
-// results with a subtraction instead of an addition would print [36, 360].
+// Both rows reduce to the negated sum of their elements.
 // CHECK: Unranked Memref base@ = {{.*}} rank = 1 offset = 0 sizes = [2] strides = [1] data =
 // CHECK-NEXT: [-36,  -360]

--- a/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir
@@ -2,21 +2,18 @@
 // result as the untiled reduction. The first RUN line runs the untiled
 // reduction, the second one tiles it first; both have to print the same values.
 
-// RUN: mlir-opt %s -test-transform-dialect-erase-schedule \
-// RUN: -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries" \
-// RUN: -buffer-deallocation-pipeline -convert-bufferization-to-memref -convert-linalg-to-loops -convert-scf-to-cf \
-// RUN: -expand-strided-metadata -lower-affine -convert-arith-to-llvm --finalize-memref-to-llvm -convert-func-to-llvm -convert-cf-to-llvm -reconcile-unrealized-casts | \
-// RUN: mlir-runner -e main -entry-point-result=void \
-// RUN:   -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils \
-// RUN: | FileCheck %s
+// DEFINE: %{mlir_options} = -test-transform-dialect-erase-schedule \
+// DEFINE: -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries" \
+// DEFINE: -buffer-deallocation-pipeline -convert-bufferization-to-memref -convert-linalg-to-loops -convert-scf-to-cf \
+// DEFINE: -expand-strided-metadata -lower-affine -convert-arith-to-llvm --finalize-memref-to-llvm -convert-func-to-llvm -convert-cf-to-llvm -reconcile-unrealized-casts
 
-// RUN: mlir-opt %s -transform-interpreter -test-transform-dialect-erase-schedule \
-// RUN: -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries" \
-// RUN: -buffer-deallocation-pipeline -convert-bufferization-to-memref -convert-linalg-to-loops -convert-scf-to-cf \
-// RUN: -expand-strided-metadata -lower-affine -convert-arith-to-llvm --finalize-memref-to-llvm -convert-func-to-llvm -convert-cf-to-llvm -reconcile-unrealized-casts | \
-// RUN: mlir-runner -e main -entry-point-result=void \
-// RUN:   -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils \
-// RUN: | FileCheck %s
+// DEFINE: %{run} = mlir-runner -e main -entry-point-result=void \
+// DEFINE:   -shared-libs=%mlir_c_runner_utils,%mlir_runner_utils \
+// DEFINE: | FileCheck %s
+
+// RUN: mlir-opt %s %{mlir_options} | %{run}
+
+// RUN: mlir-opt %s -transform-interpreter %{mlir_options} | %{run}
 
 func.func private @printMemrefF32(memref<*xf32>)
 


### PR DESCRIPTION
# [mlir][linalg] Support subtracting accumulation in partial reduction tiling

## Summary

A `linalg` reduction whose combiner is `arith.subf`/`arith.subi` cannot be tiled. `PartialReductionOpInterface` looks the combiner up with `arith::getNeutralElement`, which has no entry for subtraction, and fails with a hard error:

```
error: 'linalg.generic' op Failed to get an identity value for the reduction operation.
```

`matchReduction` already accepts such a body, so the reduction is recognized and then rejected one step later.

## Motivation

Since https://github.com/llvm/llvm-project/commit/dccdacc2dc49c708a8fde04b04ae76b552aaf122 added the first `arith.addf` canonicalizations, a reduction of a sum of negated values is now rewritten from

```mlir
^bb0(%in: f32, %acc: f32):
  %neg = arith.negf %in : f32
  %sum = arith.addf %acc, %neg : f32
  linalg.yield %sum : f32
```

to

```mlir
^bb0(%in: f32, %acc: f32):
  %sum = arith.subf %acc, %in : f32
  linalg.yield %sum : f32
```

This causes a regression since the new form fails to compile where the old form worked okay. I think that this form would have always failed, but it didn't come up until the new canonicalization. Now `mlir-opt --canonicalize --transform-interpreter` fails to tile a reduction that `mlir-opt --transform-interpreter` tiles fine.

Found downstream in IREE, where a GPU reduction-tiling pass hits the error and aborts compilation.

## Repro case

```mlir
// Canonicalizing `addf(%acc, negf(%in))` into `subf(%acc, %in)` inside a
// linalg reduction body makes the reduction untileable: `arith.subf` has no
// neutral element, so PartialReductionOpInterface bails out with a hard error.
//
// RUN: mlir-opt %s --canonicalize --transform-interpreter
//
// Expected: tiling succeeds (as it does without --canonicalize).
// Actual:   error: 'linalg.generic' op Failed to get an identity value for the
//           reduction operation.

func.func @negated_sum(%arg0: tensor<8x64xf32>) -> tensor<8xf32> {
  %cst = arith.constant 0.000000e+00 : f32
  %empty = tensor.empty() : tensor<8xf32>
  %init = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
  %red = linalg.generic {
      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                       affine_map<(d0, d1) -> (d0)>],
      iterator_types = ["parallel", "reduction"]}
      ins(%arg0 : tensor<8x64xf32>)
      outs(%init : tensor<8xf32>) {
    ^bb0(%in: f32, %acc: f32):
      %neg = arith.negf %in : f32
      %sum = arith.addf %acc, %neg : f32
      linalg.yield %sum : f32
  } -> tensor<8xf32>
  return %red : tensor<8xf32>
}

module attributes {transform.with_named_sequence} {
  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
    %0 = transform.structured.match ops{["linalg.generic"]} in %arg0
        : (!transform.any_op) -> !transform.any_op
    %1, %2, %3, %loop = transform.structured.tile_reduction_using_for %0
        by tile_sizes = [0, 16]
        : (!transform.any_op) -> (!transform.any_op, !transform.any_op,
                                  !transform.any_op, !transform.any_op)
    transform.yield
  }
}
```

## The change

In mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp:

- A new `getSplitReductionCombiner` returns how a reduction is split into partial results: the identity each partial is initialized with, and the operation combining two partials. The two have to agree, so they are determined together rather than derived independently in `generateInitialTensorForPartialReduction` and `mergeReductions`. The existing combiners keep their behaviour: `arith::getNeutralElement` plus a clone of the combiner op.
- A subtracting combiner is recognized as such and split with the additive neutral element, but only when the accumulator is the left-hand side. Subtraction is not commutative, so `subf(%in, %acc)` is still rejected since it is not a splittable reduction. Every combiner supported so far is commutative, which is why the operand position never mattered before.
- Its partial results are merged with `arith.addf`/`arith.addi` instead of a clone of the `subf`/`subi`, carrying over the fast-math flags, the rounding mode and the integer overflow flags.

With `N` tiles the partials hold `p_i = 0 - sum_i(x)`, and the reduced value `init - sum(x) is init + p_0 + ... + p_N-1`. Emitting a real `arith.addf` (as opposed to the equally correct `subf(acc, negf(p))`) also keeps the merge a recognizable `ADD` reduction, so it retains a neutral element and stays vectorizable.

### Why not just add `subf` to `arith::getNeutralElement`

That is the one-line fix, and it would silently miscompile. `mergeReductions` clones the *combiner op* to combine partial results:

```cpp
Operation *clonedReductionOp = b.clone(*combinerOps[0]);
```

so a cloned `subf` merge computes `((p_0 - p_1) - p_2) - ...` where the correct result is `p_0 + p_1 + p_2 + ...`. No identity value alone makes subtraction work here; the merge operation has to change with it. Keeping the special case in Linalg also avoids handing `getNeutralElement` (a pure op-to-attribute map) a result that is only valid for one operand ordering.

## Tests

- `mlir/test/Dialect/Linalg/transform-tile-reduction.mlir` gains test cases covering the new combiner: subtracting accumulations tiled with `tile_reduction_using_for` and `tile_reduction_using_forall`, the propagation of the fast-math flags, rounding mode and integer overflow flags onto the merge, and a negative case checking that `x - acc` is rejected as unsplittable.
- `mlir/test/Integration/Dialect/Linalg/CPU/test-tile-reduction-subf.mlir` is a new end-to-end test: it runs the same `subf` reduction untiled and tiled and requires both to print the same values, with a tile size that does not divide the reduction dimension so the partials are unevenly sized.

## Follow-ups

Claude has identified `linalg::splitReduction` (`SplitReduction.cpp`) and the mesh `ShardingInterfaceImpl` as other code that looks the combiner up the same way and merges by cloning it, so they may have similar issues. I didn't run into these cases or verify that there are issues here since I think that they are outside the scope of this PR, but am pointing them our as potential bugs.

Assisted By: Claude Opus 5