### PR TITLE
[libc][__support] Remove inline_memset(0) from FixedVector::pop_back

### DIFF
--- a/libc/src/__support/fixedvector.h
+++ b/libc/src/__support/fixedvector.h
@@ -13,7 +13,6 @@
 #include "src/__support/CPP/iterator.h"
 #include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
-#include "src/string/memory_utils/inline_memset.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -70,7 +69,6 @@ public:
   LIBC_INLINE constexpr bool pop_back() {
     if (item_count == 0)
       return false;
-    inline_memset(&store[item_count - 1], 0, sizeof(T));
     --item_count;
     return true;
   }
@@ -90,10 +88,7 @@ public:
   LIBC_INLINE constexpr size_t size() const { return item_count; }
 
   // Empties the store for all practical purposes.
-  LIBC_INLINE constexpr void reset() {
-    inline_memset(store.data(), 0, sizeof(T) * item_count);
-    item_count = 0;
-  }
+  LIBC_INLINE constexpr void reset() { item_count = 0; }
 
   // This static method does not free up the resources held by |store|,
   // say by calling `free` or something similar. It just does the equivalent


### PR DESCRIPTION
If FixedVector would contain a non-trivial type then the memset could override some bits we shouldn't be touching (like a vtable). This could result in some eventual UB, and AFAICT no actual FixedVector users contain referenes to popped objects (users only check the size), so I think it should be safe to just remove the memset altogether.