### PR TITLE
[libc] Skip the RPC doorbell interrupt when the mailbox is uninitialized

### DIFF
--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -158,11 +158,16 @@ template <bool Invert> struct Process {
     if (rpc::is_first_lane(lane_mask)) {
       if (!__scoped_atomic_fetch_add(doorbell->value, 1UL, __ATOMIC_RELAXED,
                                      __MEMORY_SCOPE_SYSTEM)) {
-        __scoped_atomic_store_n(doorbell->mailbox,
-                                static_cast<uint64_t>(doorbell->event_id),
-                                __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
-        __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
-        signal_interrupt(event_id);
+        // A doorbell that is not interrupt-backed has no mailbox. The counter
+        // incremented above already publishes the work, so skipping the
+        // interrupt is safe.
+        if (doorbell->mailbox) {
+          __scoped_atomic_store_n(doorbell->mailbox,
+                                  static_cast<uint64_t>(doorbell->event_id),
+                                  __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+          __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
+          signal_interrupt(event_id);
+        }
       }
     }
 #endif

--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -156,18 +156,15 @@ template <bool Invert> struct Process {
 
     uint32_t event_id = rpc::broadcast_value(lane_mask, doorbell->event_id);
     if (rpc::is_first_lane(lane_mask)) {
+      // The interrupt is optional and is skipped if there is no mailbox.
       if (!__scoped_atomic_fetch_add(doorbell->value, 1UL, __ATOMIC_RELAXED,
-                                     __MEMORY_SCOPE_SYSTEM)) {
-        // A doorbell that is not interrupt-backed has no mailbox. The counter
-        // incremented above already publishes the work, so skipping the
-        // interrupt is safe.
-        if (doorbell->mailbox) {
-          __scoped_atomic_store_n(doorbell->mailbox,
-                                  static_cast<uint64_t>(doorbell->event_id),
-                                  __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
-          __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
-          signal_interrupt(event_id);
-        }
+                                     __MEMORY_SCOPE_SYSTEM) &&
+          doorbell->mailbox) {
+        __scoped_atomic_store_n(doorbell->mailbox,
+                                static_cast<uint64_t>(doorbell->event_id),
+                                __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+        __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
+        signal_interrupt(event_id);
       }
     }
 #endif

--- a/libc/test/src/__support/RPC/CMakeLists.txt
+++ b/libc/test/src/__support/RPC/CMakeLists.txt
@@ -9,3 +9,13 @@ add_libc_test(
   DEPENDS
    libc.src.__support.RPC.rpc
 )
+
+add_libc_test(
+  rpc_doorbell_test
+  SUITE
+    libc-rpc-tests
+  SRCS
+    rpc_doorbell_test.cpp
+  DEPENDS
+   libc.src.__support.RPC.rpc
+)

--- a/libc/test/src/__support/RPC/rpc_doorbell_test.cpp
+++ b/libc/test/src/__support/RPC/rpc_doorbell_test.cpp
@@ -19,16 +19,10 @@ enum { alloc_size = ProcType::allocation_size(port_count, 1) };
 
 alignas(64) char buffer[alloc_size] = {0};
 
-// At namespace scope so the doorbell never refers to a dead local.
 uint64_t pending = 0;
 } // namespace
 
-// A doorbell can be only partially initialized. The AMDGPU offload plugin sets
-// 'value' to the address of a field inside its HSA signal, so it is never null,
-// while 'mailbox' is that signal's event mailbox pointer, which is null unless
-// the signal is backed by an interrupt. Ringing such a doorbell must not
-// dereference the null mailbox, and must still publish the pending work so a
-// polling server makes progress.
+// A null mailbox is ignored, but the work is still published.
 TEST(LlvmLibcRPCDoorbell, NotifyWithoutMailbox) {
   ProcType Proc(port_count, buffer);
 
@@ -39,13 +33,13 @@ TEST(LlvmLibcRPCDoorbell, NotifyWithoutMailbox) {
 
   Proc.notify(/*lane_mask=*/1);
 
-  // notify() has no effect when built with MSVC.
+  // notify() is a no-op on MSVC.
 #ifndef _MSC_VER
   EXPECT_EQ(pending, static_cast<uint64_t>(1));
 #endif
 }
 
-// A doorbell that was never configured at all is ignored entirely.
+// An unconfigured doorbell is ignored entirely.
 TEST(LlvmLibcRPCDoorbell, NotifyWithoutDoorbell) {
   ProcType Proc(port_count, buffer);
 

--- a/libc/test/src/__support/RPC/rpc_doorbell_test.cpp
+++ b/libc/test/src/__support/RPC/rpc_doorbell_test.cpp
@@ -1,0 +1,57 @@
+//===-- tests for the RPC doorbell ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/RPC/rpc.h"
+
+#include "test/UnitTest/Test.h"
+
+namespace {
+enum { port_count = 4 };
+
+using ProcType = LIBC_NAMESPACE::rpc::Process<false>;
+
+enum { alloc_size = ProcType::allocation_size(port_count, 1) };
+
+alignas(64) char buffer[alloc_size] = {0};
+
+// At namespace scope so the doorbell never refers to a dead local.
+uint64_t pending = 0;
+} // namespace
+
+// A doorbell can be only partially initialized. The AMDGPU offload plugin sets
+// 'value' to the address of a field inside its HSA signal, so it is never null,
+// while 'mailbox' is that signal's event mailbox pointer, which is null unless
+// the signal is backed by an interrupt. Ringing such a doorbell must not
+// dereference the null mailbox, and must still publish the pending work so a
+// polling server makes progress.
+TEST(LlvmLibcRPCDoorbell, NotifyWithoutMailbox) {
+  ProcType Proc(port_count, buffer);
+
+  pending = 0;
+  Proc.doorbell->value = &pending;
+  Proc.doorbell->mailbox = nullptr;
+  Proc.doorbell->event_id = 0;
+
+  Proc.notify(/*lane_mask=*/1);
+
+  // notify() has no effect when built with MSVC.
+#ifndef _MSC_VER
+  EXPECT_EQ(pending, static_cast<uint64_t>(1));
+#endif
+}
+
+// A doorbell that was never configured at all is ignored entirely.
+TEST(LlvmLibcRPCDoorbell, NotifyWithoutDoorbell) {
+  ProcType Proc(port_count, buffer);
+
+  Proc.doorbell->value = nullptr;
+  Proc.doorbell->mailbox = nullptr;
+  Proc.doorbell->event_id = 0;
+
+  Proc.notify(/*lane_mask=*/1);
+}


### PR DESCRIPTION
## Overview

`rpc::Process::notify()` guards `doorbell->value` but then unconditionally
dereferences `doorbell->mailbox`. The two are not initialized together. The
AMDGPU offload plugin sets `value` to the address of a field in its HSA signal,
so it is never null, while `mailbox` is that signal's `event_mailbox_ptr`, which
is zero unless the signal is interrupt-backed:

```c++
Value   = reinterpret_cast<uint64_t *>(&Doorbell->value);
Mailbox = reinterpret_cast<uint64_t *>(Doorbell->event_mailbox_ptr);
```

The existing guard can therefore never fire on AMDGPU, and `notify()` stores to
a null address. Guard the mailbox store instead, which matches the intent stated
in 4961700c1004 that the interrupt is "completely optional, as it is ignored if
uninitialized".

The check is inside the block rather than in the outer condition because `value`
is the pending-work counter the server observes; skipping the increment starves
a polling server instead of fixing anything.

## Testing - (AI assisted)

New unit test covering a partially initialized doorbell and an unconfigured one;
the former segfaults without this change.

Also verified end to end on MI350X (gfx950, ROCm 7.14, clang 23) by rebuilding
both consumers of this header, `libc.a` and the OpenMP DeviceRTL, with and
without the change. In-kernel `malloc`, in-kernel `printf`, and a Fortran
array-section assignment all fault before it and complete with correct results
after.