### PR TITLE
[lldb][Python] Fix SBProcessInfoList subscript and iterator

### DIFF
--- a/lldb/bindings/interface/SBProcessInfoListExtensions.i
+++ b/lldb/bindings/interface/SBProcessInfoListExtensions.i
@@ -8,7 +8,9 @@
     def __iter__(self):
       '''Iterate over all the process info in a lldb.SBProcessInfoListExtensions object.'''
       for i in range(self.GetSize()):
-          yield self.GetProcessInfoAtIndex(i)
+          p = SBProcessInfo()
+          self.GetProcessInfoAtIndex(i, p)
+          yield p
 
     def __getitem__(self, idx):
       '''Get the process info at a given index in an lldb.SBProcessInfoList object.'''
@@ -18,7 +20,9 @@
       if not (-count <= idx < count):
         raise IndexError("list index out of range")
       idx %= count
-      return self.GetProcessInfoAtIndex(idx)
+      p = SBProcessInfo()
+      self.GetProcessInfoAtIndex(idx, p)
+      return p
     %}
 #endif
 }

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformListProcesses.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformListProcesses.py
@@ -46,9 +46,23 @@ class TestPlatformListProcesses(GDBRemoteTestBase):
         processes.GetProcessInfoAtIndex(0, process_info)
         self.assertEqual(process_info.GetProcessID(), 95117)
         self.assertEqual(process_info.GetName(), "foo")
+        self.assertEqual(processes[0].GetProcessID(), 95117)
 
         processes.GetProcessInfoAtIndex(1, process_info)
         self.assertEqual(process_info.GetProcessID(), 95126)
         self.assertEqual(process_info.GetName(), "foo")
+        self.assertEqual(processes[1].GetProcessID(), 95126)
+
+        any_process = False
+        for i, info in enumerate(processes):
+            any_process = True
+            if i == 0:
+                self.assertEqual(info.GetProcessID(), 95117)
+            elif i == 1:
+                self.assertEqual(info.GetProcessID(), 95126)
+            else:
+                self.fail("More than two processes returned")
+
+        self.assertTrue(any_process)
 
         platform.DisconnectRemote()


### PR DESCRIPTION
Found this in #214000 when looking through the generated `__init__.py`.

[`SBProcessInfo::GetProcessInfoAtIndex`](https://lldb.llvm.org/python_api/lldb.SBProcessInfoList.html#lldb.SBProcessInfoList.GetProcessInfoAtIndex) takes a reference to an info that it fills instead of returning one. So we need to pass that `ProcessInfo` to it.