### PR TITLE
[compiler-rt][ORC][COFF] Run atexit callbacks in LIFO order

### DIFF
--- a/compiler-rt/lib/orc/coff_platform.cpp
+++ b/compiler-rt/lib/orc/coff_platform.cpp
@@ -483,10 +483,13 @@ Error COFFPlatformRuntimeState::dlcloseDeinitialize(JITDylibState &JDS) {
              JDS.Name.c_str());
   });
 
-  // Run atexits
-  for (auto AtExit : JDS.AtExits)
+  // Run atexits in reverse registration order.
+  auto AtExits = std::move(JDS.AtExits);
+  while (!AtExits.empty()) {
+    auto AtExit = AtExits.back();
+    AtExits.pop_back();
     AtExit();
-  JDS.AtExits.clear();
+  }
 
   // Run static terminators.
   JDS.CPreTermSection.RunAllNewAndFlush();

--- a/compiler-rt/test/orc/TestCases/Windows/x86-64/atexit-order.c
+++ b/compiler-rt/test/orc/TestCases/Windows/x86-64/atexit-order.c
@@ -1,0 +1,25 @@
+// RUN: %clang_cl -MD -c -o %t %s
+// RUN: %llvm_jitlink %t 2>&1 | FileCheck %s
+// CHECK: Entering main
+// CHECK-NEXT: Second
+// CHECK-NEXT: First
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void first(void) {
+  printf("First\n");
+  fflush(stdout);
+}
+
+void second(void) {
+  printf("Second\n");
+  fflush(stdout);
+}
+
+int main(int argc, char *argv[]) {
+  atexit(first);
+  atexit(second);
+  printf("Entering main\n");
+  return 0;
+}


### PR DESCRIPTION
The COFF runtime stores atexit callbacks in registration order, but executes them in the same order during JITDylib deinitialization.

Run callbacks from the back of the vector so that they execute in reverse registration order, and add a regression test.

This was found while investigating #213568.

Assisted-by: OpenAI Codex