### PR TITLE
[MIR] Quote basic block names that are not plain identifiers

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MILexer.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.cpp
@@ -341,6 +341,23 @@ static Cursor maybeLexMachineBasicBlock(Cursor C, MIToken &Token,
   if (C.peek() == '.') {
     C.advance(); // Skip '.'
     ++StringOffset;
+    // The name is quoted if it is not a plain identifier.
+    if (C.peek() == '"') {
+      Cursor R = lexStringConstant(C, ErrorCallback);
+      if (!R) {
+        ErrorCallback(C.location(),
+                      "unable to parse quoted string from opening quote");
+        Token.reset(MIToken::Error, Range.remaining());
+        return Range;
+      }
+      MIToken::TokenKind Kind = IsReference ? MIToken::MachineBasicBlock
+                                            : MIToken::MachineBasicBlockLabel;
+      Token.reset(Kind, Range.upto(R))
+          .setIntegerValue(APSInt(Number))
+          .setOwnedStringValue(
+              unescapeQuotedString(Range.upto(R).drop_front(StringOffset)));
+      return R;
+    }
     while (isIdentifierChar(C.peek()))
       C.advance();
   }

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -30,6 +30,7 @@
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
@@ -495,7 +496,7 @@ void MachineBasicBlock::printName(raw_ostream &os, unsigned printNameFlags,
   auto PrintBBRef = [&](const BasicBlock *bb) {
     os << "%ir-block.";
     if (bb->hasName()) {
-      os << bb->getName();
+      printLLVMNameWithoutPrefix(os, bb->getName());
     } else {
       int slot = -1;
 
@@ -517,7 +518,9 @@ void MachineBasicBlock::printName(raw_ostream &os, unsigned printNameFlags,
   if (printNameFlags & PrintNameIr) {
     if (const auto *bb = getBasicBlock()) {
       if (bb->hasName()) {
-        os << '.' << bb->getName();
+        // Quote if not a plain identifier, or the MIR cannot be parsed back.
+        os << '.';
+        printLLVMNameWithoutPrefix(os, bb->getName());
       } else {
         hasAttributes = true;
         os << " (";

--- a/llvm/test/CodeGen/MIR/AMDGPU/bb-name-needs-quotes.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/bb-name-needs-quotes.ll
@@ -1,0 +1,27 @@
+; Basic block names that are not plain identifiers must be quoted when printed,
+; otherwise the MIR that llc emits cannot be parsed back by llc. The names here
+; contain commas and spaces, which is the shape a Fortran front end emits.
+;
+; Check both that the name is quoted on the way out and that the result parses.
+
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -stop-before=greedy -o %t.mir %s
+; RUN: FileCheck %s < %t.mir
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -x mir -start-before=greedy -o /dev/null %t.mir
+
+; CHECK: bb.0.entry:
+; CHECK: bb.1.", bb71":
+; CHECK: bb.2."file f.f90, line 12, bb99":
+
+define amdgpu_kernel void @k(ptr addrspace(1) %o, i32 %n) {
+entry:
+  %c = icmp sgt i32 %n, 0
+  br i1 %c, label %", bb71", label %"file f.f90, line 12, bb99"
+
+", bb71":
+  store i32 1, ptr addrspace(1) %o, align 4
+  br label %"file f.f90, line 12, bb99"
+
+"file f.f90, line 12, bb99":
+  store i32 2, ptr addrspace(1) %o, align 4
+  ret void
+}


### PR DESCRIPTION
`MachineBasicBlock::printName` writes the IR basic-block name after `bb.<N>.` unquoted, and the
MIR lexer reads it back with `isIdentifierChar` only. If the name contains anything else -- a
comma, say -- the name is cut short on the way in and the remainder is treated as syntax, so `llc`
cannot parse the MIR that `llc` just wrote:

```console
$ llc -mcpu=gfx90a -stop-before=greedy bb-comma-name.ll -o out.mir
$ llc -mcpu=gfx90a -x mir -start-before=greedy out.mir -o /dev/null
error: out.mir:170:8: expected ':'
```

because the printer emitted

```
  bb.1., bb71:
```

This breaks the `-stop-before` / `-start-before` round-trip normally used to reduce a backend bug
to a MIR test. Fortran front ends emit such names routinely, which is where I hit it. Fixes #212785.

Both sides need the change:

* `MachineBasicBlock::printName` now uses `printLLVMNameWithoutPrefix`, which quotes and escapes
  only when the name is not a plain identifier. Names that already round-tripped are printed
  exactly as before, so existing MIR output is unchanged.
* `maybeLexMachineBasicBlock` accepts a quoted name after `bb.<id>.`, via the same
  `lexStringConstant` / `unescapeQuotedString` pair that `lexName` already uses for `%ir-block.`
  and that the printer's `printEscapedString` output matches.

The `%ir-block.` reference printed by `PrintBBRef` had the same hole and is fixed the same way.
The parse side there was already correct, since `maybeLexIRBlock` goes through `lexName`.

### Testing

New test round-trips a module whose block names contain commas and spaces, checking both that the
name is quoted on the way out and that the result parses back.

Verified the test fails without the patch: the unpatched `llc` emits `bb.1., bb71:` and then
rejects it with `expected ':'`.

`llvm/test/CodeGen/X86`, `llvm/test/CodeGen/AMDGPU` and `llvm/test/CodeGen/MIR` are clean, 10902
tests, no failures. Those are the targets my build enables; I have not run the other backends.

---

Parts of this change were written or audited with Claude Code. I have reviewed all of it and take
full responsibility for the contribution. See `llvm/docs/AIToolPolicy.md`.
