### PR TITLE
[SelectionDAG] Split masked div/rem operands with illegal masks

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
@@ -979,6 +979,7 @@ private:
   // Vector Operand Splitting: <128 x ty> -> 2 x <64 x ty>.
   bool SplitVectorOperand(SDNode *N, unsigned OpNo);
   SDValue SplitVecOp_VSELECT(SDNode *N, unsigned OpNo);
+  SDValue SplitVecOp_MaskedBinOp(SDNode *N, unsigned OpNo);
   SDValue SplitVecOp_VECREDUCE(SDNode *N, unsigned OpNo);
   SDValue SplitVecOp_VECREDUCE_SEQ(SDNode *N);
   SDValue SplitVecOp_VP_REDUCE(SDNode *N, unsigned OpNo);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -3858,6 +3858,12 @@ bool DAGTypeLegalizer::SplitVectorOperand(SDNode *N, unsigned OpNo) {
   case ISD::VSELECT:
     Res = SplitVecOp_VSELECT(N, OpNo);
     break;
+  case ISD::MASKED_UDIV:
+  case ISD::MASKED_SDIV:
+  case ISD::MASKED_UREM:
+  case ISD::MASKED_SREM:
+    Res = SplitVecOp_MaskedBinOp(N, OpNo);
+    break;
   case ISD::VECTOR_COMPRESS:
     Res = SplitVecOp_VECTOR_COMPRESS(N, OpNo);
     break;
@@ -4051,6 +4057,22 @@ SDValue DAGTypeLegalizer::SplitVecOp_VSELECT(SDNode *N, unsigned OpNo) {
     DAG.getNode(ISD::VSELECT, DL, HiOpVT, HiMask, HiOp0, HiOp1);
 
   return DAG.getNode(ISD::CONCAT_VECTORS, DL, Src0VT, LoSelect, HiSelect);
+}
+
+SDValue DAGTypeLegalizer::SplitVecOp_MaskedBinOp(SDNode *N, unsigned OpNo) {
+  assert(OpNo == 2 && "Illegal operand must be mask");
+
+  SDLoc DL(N);
+  auto [LHSLo, LHSHi] = DAG.SplitVector(N->getOperand(0), DL);
+  auto [RHSLo, RHSHi] = DAG.SplitVector(N->getOperand(1), DL);
+  SDValue MaskLo, MaskHi;
+  GetSplitVector(N->getOperand(2), MaskLo, MaskHi);
+
+  SDValue Lo = DAG.getNode(N->getOpcode(), DL, LHSLo.getValueType(), LHSLo,
+                           RHSLo, MaskLo, N->getFlags());
+  SDValue Hi = DAG.getNode(N->getOpcode(), DL, LHSHi.getValueType(), LHSHi,
+                           RHSHi, MaskHi, N->getFlags());
+  return DAG.getNode(ISD::CONCAT_VECTORS, DL, N->getValueType(0), Lo, Hi);
 }
 
 SDValue DAGTypeLegalizer::SplitVecOp_VECTOR_COMPRESS(SDNode *N, unsigned OpNo) {

--- a/llvm/test/CodeGen/NVPTX/masked-divrem.ll
+++ b/llvm/test/CodeGen/NVPTX/masked-divrem.ll
@@ -1,0 +1,65 @@
+; RUN: llc -mtriple=nvptx64-nvidia-cuda -mcpu=sm_90a < %s | FileCheck %s
+; RUN: llc -mtriple=nvptx64-nvidia-cuda -mcpu=sm_100a < %s | FileCheck %s
+
+target triple = "nvptx64-nvidia-cuda"
+
+declare <2 x i32> @llvm.masked.sdiv.v2i32(<2 x i32>, <2 x i32>, <2 x i1>)
+declare <2 x i32> @llvm.masked.udiv.v2i32(<2 x i32>, <2 x i32>, <2 x i1>)
+declare <2 x i32> @llvm.masked.srem.v2i32(<2 x i32>, <2 x i32>, <2 x i1>)
+declare <2 x i32> @llvm.masked.urem.v2i32(<2 x i32>, <2 x i32>, <2 x i1>)
+declare <8 x i32> @llvm.masked.srem.v8i32(<8 x i32>, <8 x i32>, <8 x i1>)
+
+define <2 x i32> @masked_sdiv_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
+; CHECK-LABEL: masked_sdiv_v2i32(
+; CHECK: selp.b32
+; CHECK: div.s32
+; CHECK: ret;
+  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
+  %result = call <2 x i32> @llvm.masked.sdiv.v2i32(
+      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @masked_udiv_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
+; CHECK-LABEL: masked_udiv_v2i32(
+; CHECK: selp.b32
+; CHECK: div.u32
+; CHECK: ret;
+  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
+  %result = call <2 x i32> @llvm.masked.udiv.v2i32(
+      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @masked_srem_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
+; CHECK-LABEL: masked_srem_v2i32(
+; CHECK: selp.b32
+; CHECK: rem.s32
+; CHECK: ret;
+  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
+  %result = call <2 x i32> @llvm.masked.srem.v2i32(
+      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @masked_urem_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
+; CHECK-LABEL: masked_urem_v2i32(
+; CHECK: selp.b32
+; CHECK: rem.u32
+; CHECK: ret;
+  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
+  %result = call <2 x i32> @llvm.masked.urem.v2i32(
+      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
+  ret <2 x i32> %result
+}
+
+define <8 x i32> @masked_srem_v8i32(<8 x i32> %lhs, <8 x i32> %rhs) {
+; CHECK-LABEL: masked_srem_v8i32(
+; CHECK-COUNT-5: rem.s32
+; CHECK: ret;
+  %result = call <8 x i32> @llvm.masked.srem.v8i32(
+      <8 x i32> %lhs, <8 x i32> %rhs,
+      <8 x i1> <i1 true, i1 true, i1 true, i1 true,
+                  i1 true, i1 false, i1 false, i1 false>)
+  ret <8 x i32> %result
+}

--- a/llvm/test/CodeGen/NVPTX/masked-divrem.ll
+++ b/llvm/test/CodeGen/NVPTX/masked-divrem.ll
@@ -9,47 +9,28 @@ declare <2 x i32> @llvm.masked.srem.v2i32(<2 x i32>, <2 x i32>, <2 x i1>)
 declare <2 x i32> @llvm.masked.urem.v2i32(<2 x i32>, <2 x i32>, <2 x i1>)
 declare <8 x i32> @llvm.masked.srem.v8i32(<8 x i32>, <8 x i32>, <8 x i1>)
 
-define <2 x i32> @masked_sdiv_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
-; CHECK-LABEL: masked_sdiv_v2i32(
-; CHECK: selp.b32
-; CHECK: div.s32
+define <2 x i32> @masked_divrem_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
+; CHECK-LABEL: masked_divrem_v2i32(
+; CHECK-DAG: selp.b32
+; CHECK-DAG: div.s32
+; CHECK-DAG: div.u32
+; CHECK-DAG: rem.s32
+; CHECK-DAG: rem.u32
 ; CHECK: ret;
   %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
-  %result = call <2 x i32> @llvm.masked.sdiv.v2i32(
+  %lhs2 = add <2 x i32> %lhs, <i32 1, i32 1>
+  %rhs2 = add <2 x i32> %rhs, <i32 1, i32 1>
+  %sdiv = call <2 x i32> @llvm.masked.sdiv.v2i32(
       <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @masked_udiv_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
-; CHECK-LABEL: masked_udiv_v2i32(
-; CHECK: selp.b32
-; CHECK: div.u32
-; CHECK: ret;
-  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
-  %result = call <2 x i32> @llvm.masked.udiv.v2i32(
-      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @masked_srem_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
-; CHECK-LABEL: masked_srem_v2i32(
-; CHECK: selp.b32
-; CHECK: rem.s32
-; CHECK: ret;
-  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
-  %result = call <2 x i32> @llvm.masked.srem.v2i32(
-      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @masked_urem_v2i32(<2 x i32> %lhs, <2 x i32> %rhs) {
-; CHECK-LABEL: masked_urem_v2i32(
-; CHECK: selp.b32
-; CHECK: rem.u32
-; CHECK: ret;
-  %mask = icmp sgt <2 x i32> %lhs, zeroinitializer
-  %result = call <2 x i32> @llvm.masked.urem.v2i32(
-      <2 x i32> %lhs, <2 x i32> %rhs, <2 x i1> %mask)
+  %udiv = call <2 x i32> @llvm.masked.udiv.v2i32(
+      <2 x i32> %lhs, <2 x i32> %rhs2, <2 x i1> %mask)
+  %srem = call <2 x i32> @llvm.masked.srem.v2i32(
+      <2 x i32> %lhs2, <2 x i32> %rhs, <2 x i1> %mask)
+  %urem = call <2 x i32> @llvm.masked.urem.v2i32(
+      <2 x i32> %lhs2, <2 x i32> %rhs2, <2 x i1> %mask)
+  %div = add <2 x i32> %sdiv, %udiv
+  %rem = add <2 x i32> %srem, %urem
+  %result = add <2 x i32> %div, %rem
   ret <2 x i32> %result
 }
 


### PR DESCRIPTION
PR description written by Codex

Split masked signed and unsigned division/remainder alongside illegal vector masks to fix NVPTX SelectionDAG crashes. Covers all four intrinsics and the original eight-lane reproducer; five focused LLVM tests pass.