### PR TITLE
[CIR] Reject a global carrying a function type

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2076,6 +2076,11 @@ static void printConstant(OpAsmPrinter &p, Attribute value) {
 }
 
 mlir::LogicalResult cir::GlobalOp::verify() {
+  // A function is not an object, so it cannot be the type of a global.  A
+  // global that holds a function's address carries a pointer type instead.
+  if (mlir::isa<cir::FuncType>(getSymType()))
+    return emitOpError("global type cannot be a function type");
+
   // Verify that the initial value, if present, is either a unit attribute or
   // an attribute CIR supports.
   if (getInitialValue().has_value()) {

--- a/clang/test/CIR/IR/invalid-global.cir
+++ b/clang/test/CIR/IR/invalid-global.cir
@@ -40,3 +40,12 @@ cir.global external @bad_alias_with_dtor alias(@target) = #cir.int<7> : !s32i dt
 }
 
 }
+
+// -----
+
+module {
+
+// expected-error @below {{global type cannot be a function type}}
+cir.global "private" external @bad_func_type : !cir.func<()>
+
+}


### PR DESCRIPTION
The verifier was accepting a `cir.global` whose `sym_type` is a function.  The LLVM dialect global takes one too, so it survives to LLVM IR translation and crashes instead of reporting an error.  `GlobalOp::verify()` now rejects it.

Assisted-by: Cursor / claude-opus-5