### PR TITLE
[CIR] Update get_global type for rewritten callees

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -691,17 +691,35 @@ void CallConvLoweringPass::runOnOperation() {
     return;
   }
 
-  // Rewrite each function together with every direct call to it.  By the
-  // time we move on to function F+1, F's signature and every direct call to
-  // F have already been brought into alignment, and F+1..FN are still in
-  // their original (mutually consistent) form, so the IR is verifier-clean
-  // at every outer-iteration boundary.
+  // A cir.get_global holding a function's address carries the signature the
+  // source wrote, which the verifier ties to the callee, so it goes stale when
+  // that callee is rewritten.  A function address in a global initializer is a
+  // GlobalViewAttr instead, whose recorded type the verifier does not tie to
+  // the callee and which is dropped at opaque-pointer lowering, so it needs no
+  // counterpart.
+  llvm::DenseMap<cir::FuncOp, SmallVector<cir::GetGlobalOp>> addressTakers;
+  moduleOp.walk([&](cir::GetGlobalOp getGlobal) {
+    auto ptrTy = cast<cir::PointerType>(getGlobal.getAddr().getType());
+    if (!isa<cir::FuncType>(ptrTy.getPointee()))
+      return;
+    // A get_global's pointee must equal the named symbol's type, and the
+    // GlobalOp verifier rejects a function type there, so this names a
+    // cir.func.
+    auto callee = cast<cir::FuncOp>(symbolTable.lookup(getGlobal.getName()));
+    addressTakers[callee].push_back(getGlobal);
+  });
+
+  // Rewrite each function together with every direct call to it and every op
+  // holding its address.  By the time we move on to function F+1, F's
+  // signature and every reference to F have already been brought into
+  // alignment, and F+1..FN are still in their original (mutually consistent)
+  // form, so the IR is verifier-clean at every outer-iteration boundary.
   //
   // There is still a brief inner window where F's signature has been
-  // rewritten but its callers have not yet caught up -- we have no way to
+  // rewritten but its references have not yet caught up -- we have no way to
   // mutate both sides of a call atomically.  No verifier runs inside the
   // pass, and at pass exit the module is verifier-clean.  Fusing the inner
-  // loop here keeps the invalid window per-function rather than module-wide.
+  // loops here keeps the invalid window per-function rather than module-wide.
   OpBuilder builder(ctx);
   for (auto &kv : classifications) {
     cir::FuncOp func = kv.first;
@@ -724,6 +742,8 @@ void CallConvLoweringPass::runOnOperation() {
         return;
       }
     }
+    for (cir::GetGlobalOp addrOp : addressTakers.lookup(func))
+      rewriteCtx.rewriteFunctionAddress(addrOp, func, builder);
   }
 
   // Rewrite indirect call sites.  The callee is opaque, so classify from the

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -1293,3 +1293,29 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
 
   return mlir::success();
 }
+
+void CIRABIRewriteContext::rewriteFunctionAddress(cir::GetGlobalOp addrOp,
+                                                  cir::FuncOp funcOp,
+                                                  mlir::OpBuilder &builder) {
+  auto oldPtrTy = mlir::cast<cir::PointerType>(addrOp.getAddr().getType());
+  cir::FuncType newFuncTy = funcOp.getFunctionType();
+  // An extension rides on an argument attribute and leaves the signature
+  // alone, so such a callee still matches the written type.
+  if (newFuncTy == oldPtrTy.getPointee())
+    return;
+
+  // The verifier requires the retype even when nothing reads the address.
+  addrOp.getAddr().setType(cir::PointerType::get(newFuncTy));
+  if (addrOp.getAddr().use_empty())
+    return;
+
+  // A later indirect call through the written type stays correct, since it
+  // reclassifies from that type and coerces to the signature funcOp was
+  // rewritten to.  Ellipsis arguments are the exception the indirect-call
+  // path reports rather than lowers.
+  mlir::OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointAfter(addrOp);
+  auto bitcast = cir::CastOp::create(builder, addrOp.getLoc(), oldPtrTy,
+                                     cir::CastKind::bitcast, addrOp.getAddr());
+  addrOp.getAddr().replaceAllUsesExcept(bitcast.getResult(), bitcast);
+}

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -50,6 +50,14 @@ public:
                   const mlir::abi::FunctionClassification &fc,
                   mlir::OpBuilder &builder) override;
 
+  /// Retype \p addrOp, which holds the address of \p funcOp, to the signature
+  /// funcOp was rewritten to, and cast it back so existing uses keep the type
+  /// they were built for.  A no-op when the ABI left funcOp's type alone.
+  /// Call after funcOp has been rewritten.  Not an override, since taking a
+  /// function's address has no counterpart in the generic contract.
+  void rewriteFunctionAddress(cir::GetGlobalOp addrOp, cir::FuncOp funcOp,
+                              mlir::OpBuilder &builder);
+
   mlir::StringRef getDialectNamespace() const override { return "cir"; }
 
 private:

--- a/clang/test/CIR/CodeGen/call-conv-lowering-x86_64-fnptr.c
+++ b/clang/test/CIR/CodeGen/call-conv-lowering-x86_64-fnptr.c
@@ -1,0 +1,94 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -clangir-enable-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: FileCheck --check-prefix=CIRGLOBAL --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -clangir-enable-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-CIR --input-file=%t-cir.ll %s
+// RUN: FileCheck --check-prefix=DECL --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=DECL --input-file=%t.ll %s
+
+// Module-level items, which the two backends order differently against the
+// function definitions, so DECL has no label blocks to be constrained by.
+// DECL-DAG: declare void @make_big(ptr dead_on_unwind writable sret(%struct.Big) align 8, i32 noundef)
+// DECL-DAG: declare i64 @make_pair(i32 noundef)
+// DECL-DAG: @g_big = global ptr @make_big, align 8
+// DECL-DAG: @g_arr = global [1 x ptr] [ptr @make_big], align 8
+// DECL-DAG: @g_rec = global %struct.HolderS { ptr @make_big }, align 8
+
+typedef struct { long a, b, c, d; } Big;
+typedef struct { int x, y; } Pair2;
+
+Big make_big(int);
+Pair2 make_pair(int);
+
+typedef Big (*BigFP)(int);
+typedef Pair2 (*PairFP)(int);
+
+// Global initializers hold a GlobalViewAttr, not a cir.get_global.
+BigFP g_big = make_big;
+BigFP g_arr[1] = { make_big };
+struct HolderS { BigFP p; };
+struct HolderS g_rec = { make_big };
+
+// CIRGLOBAL-DAG: cir.global external @g_big = #cir.global_view<@make_big> : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+// CIRGLOBAL-DAG: cir.global external @g_arr = #cir.const_array<[#cir.global_view<@make_big> : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>]>
+// CIRGLOBAL-DAG: cir.global external @g_rec = #cir.const_record<{#cir.global_view<@make_big> : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>}>
+
+// A 32-byte return becomes an sret parameter.
+BigFP get_big(void) { return make_big; }
+
+// CIR-LABEL: cir.func{{.*}} @get_big() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+// CIR:         %[[G:[0-9]+]] = cir.get_global @make_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+// CIR-NEXT:    %[[C:[0-9]+]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+// CIR-NEXT:    cir.store %[[C]], %{{[0-9]+}} :
+
+// LLVM-LABEL: define dso_local ptr @get_big()
+// LLVM-CIR:     store ptr @make_big, ptr %[[SLOT:[a-zA-Z0-9._]+]], align 8
+// LLVM-CIR:     %[[FP:[a-zA-Z0-9._]+]] = load ptr, ptr %[[SLOT]], align 8
+// LLVM-CIR:     ret ptr %[[FP]]
+// LLVM-OGCG:    ret ptr @make_big{{$}}
+
+// An 8-byte return is coerced into a register, changing the return type.
+PairFP get_pair(void) { return make_pair; }
+
+// CIR-LABEL: cir.func{{.*}} @get_pair() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+// CIR:         %[[G:[0-9]+]] = cir.get_global @make_pair : !cir.ptr<!cir.func<(!s32i) -> !u64i>>
+// CIR-NEXT:    %[[C:[0-9]+]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!s32i) -> !u64i>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+
+// LLVM-LABEL: define dso_local ptr @get_pair()
+// LLVM-CIR:     store ptr @make_pair, ptr %{{[a-zA-Z0-9._]+}}, align 8
+// LLVM-OGCG:    ret ptr @make_pair{{$}}
+
+// The address of a definition, whose body the sret rewrite also rewires.
+Big make_big_def(int n) { Big b = {n, n, n, n}; return b; }
+BigFP get_def(void) { return make_big_def; }
+
+// CIR-LABEL: cir.func{{.*}} @make_big_def(%arg0: !cir.ptr<!rec_Big> {{{.*}}llvm.sret = !rec_Big{{.*}}, %arg1: !s32i {llvm.noundef}
+// CIR-LABEL: cir.func{{.*}} @get_def() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+// CIR:         %[[G:[0-9]+]] = cir.get_global @make_big_def : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+// CIR-NEXT:    %[[C:[0-9]+]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+
+// LLVM-LABEL: define dso_local void @make_big_def(ptr dead_on_unwind noalias writable sret(%struct.Big) align 8 %{{.+}}, i32 noundef %{{.+}})
+// LLVM-LABEL: define dso_local ptr @get_def()
+// LLVM-CIR:     store ptr @make_big_def, ptr %{{[a-zA-Z0-9._]+}}, align 8
+// LLVM-OGCG:    ret ptr @make_big_def{{$}}
+
+// Calling through the address reaches the callee at its rewritten signature.
+Big call_local(int n) {
+  BigFP f = make_big;
+  return f(n);
+}
+
+// CIR-LABEL: cir.func{{.*}} @call_local(%arg0: !cir.ptr<!rec_Big> {{{.*}}llvm.sret = !rec_Big{{.*}}, %arg1: !s32i {llvm.noundef}
+// CIR:         %[[G:[0-9]+]] = cir.get_global @make_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+// CIR-NEXT:    %[[C:[0-9]+]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+// CIR-NEXT:    cir.store align(8) %[[C]], %[[SLOT:[0-9]+]] :
+// CIR-NEXT:    %[[LOADED:[0-9]+]] = cir.load align(8) %[[SLOT]] :
+// CIR:         %[[BACK:[0-9]+]] = cir.cast bitcast %[[LOADED]] : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>> -> !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+// CIR-NEXT:    cir.call %[[BACK]](%arg0, %{{[0-9]+}}) : (!cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>, !cir.ptr<!rec_Big> {{{.*}}llvm.sret = !rec_Big{{.*}}, !s32i {llvm.noundef}) -> ()
+
+// LLVM-LABEL: define dso_local void @call_local(ptr dead_on_unwind noalias writable sret(%struct.Big) align 8 %{{.+}}, i32 noundef %{{.+}})
+// LLVM:         store ptr @make_big, ptr %[[SLOT:[a-zA-Z0-9._]+]], align 8
+// LLVM:         %[[FP:[a-zA-Z0-9._]+]] = load ptr, ptr %[[SLOT]], align 8
+// LLVM:         call void %[[FP]](ptr dead_on_unwind writable sret(%struct.Big) align 8 %{{.+}}, i32 noundef %{{.+}})

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-get-global.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-get-global.cir
@@ -1,0 +1,146 @@
+// RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!rec_Big = !cir.struct<"Big" {!s64i, !s64i, !s64i, !s64i}>
+!rec_Pair2 = !cir.struct<"Pair2" {!s32i, !s32i}>
+!rec_E0 = !cir.struct<"E0" {}>
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  cir.func private @make_big(!s32i) -> !rec_Big
+  cir.func private @make_pair(!s32i) -> !rec_Pair2
+  cir.func private @take_big(!rec_Big)
+  cir.func private @take_char(!s8i)
+  cir.func private @plain(!s32i) -> !s32i
+  cir.func private @take_empty(!rec_E0)
+  cir.global "private" external @data : !s32i
+
+  // A 32-byte return becomes an sret pointer parameter, so the address of the
+  // function has to be taken at the rewritten type and cast back for the use.
+  cir.func @addr_sret() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>> {
+    %0 = cir.get_global @make_big : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+    cir.return %0 : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_sret() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @make_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+  // CHECK-NEXT:    %[[C:.*]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  // CHECK-NEXT:    cir.return %[[C]] : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+
+  // An 8-byte return is coerced to a single register, which changes the return
+  // type rather than adding a parameter.
+  cir.func @addr_coerced_return() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>> {
+    %0 = cir.get_global @make_pair : !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+    cir.return %0 : !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_coerced_return() -> !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @make_pair : !cir.ptr<!cir.func<(!s32i) -> !u64i>>
+  // CHECK-NEXT:    %[[C:.*]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!s32i) -> !u64i>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+  // CHECK-NEXT:    cir.return %[[C]] : !cir.ptr<!cir.func<(!s32i) -> !rec_Pair2>>
+
+  // A rewrite on the argument side reaches the address the same way.
+  cir.func @addr_byval_arg() -> !cir.ptr<!cir.func<(!rec_Big)>> {
+    %0 = cir.get_global @take_big : !cir.ptr<!cir.func<(!rec_Big)>>
+    cir.return %0 : !cir.ptr<!cir.func<(!rec_Big)>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_byval_arg() -> !cir.ptr<!cir.func<(!rec_Big)>>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @take_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>)>>
+  // CHECK-NEXT:    %[[C:.*]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>)>> -> !cir.ptr<!cir.func<(!rec_Big)>>
+  // CHECK-NEXT:    cir.return %[[C]] : !cir.ptr<!cir.func<(!rec_Big)>>
+
+  // Extend is carried by an argument attribute and leaves the function type
+  // alone, so the address needs no cast.
+  cir.func @addr_extend_only() -> !cir.ptr<!cir.func<(!s8i)>> {
+    %0 = cir.get_global @take_char : !cir.ptr<!cir.func<(!s8i)>>
+    cir.return %0 : !cir.ptr<!cir.func<(!s8i)>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_extend_only() -> !cir.ptr<!cir.func<(!s8i)>>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @take_char : !cir.ptr<!cir.func<(!s8i)>>
+  // CHECK-NEXT:    cir.return %[[G]] : !cir.ptr<!cir.func<(!s8i)>>
+
+  // A signature the ABI passes as written keeps its address type.
+  cir.func @addr_unrewritten() -> !cir.ptr<!cir.func<(!s32i) -> !s32i>> {
+    %0 = cir.get_global @plain : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+    cir.return %0 : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_unrewritten() -> !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @plain : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  // CHECK-NEXT:    cir.return %[[G]] : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+
+  // The address of a data global names no function at all.
+  cir.func @addr_data() -> !cir.ptr<!s32i> {
+    %0 = cir.get_global @data : !cir.ptr<!s32i>
+    cir.return %0 : !cir.ptr<!s32i>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_data() -> !cir.ptr<!s32i>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @data : !cir.ptr<!s32i>
+  // CHECK-NEXT:    cir.return %[[G]] : !cir.ptr<!s32i>
+
+  // The address can also be the callee of an indirect call.  It is retyped
+  // with its callee's rewrite, and the indirect-call rewrite that runs later
+  // casts it back to the coerced signature it calls through.
+  cir.func @call_through_address(%arg0: !s32i, %arg1: !cir.ptr<!rec_Big>) {
+    %0 = cir.get_global @make_big : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+    %1 = cir.call %0(%arg0) : (!cir.ptr<!cir.func<(!s32i) -> !rec_Big>>, !s32i) -> !rec_Big
+    cir.store %1, %arg1 : !rec_Big, !cir.ptr<!rec_Big>
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @call_through_address(%arg0: !s32i, %arg1: !cir.ptr<!rec_Big>)
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @make_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+  // CHECK-NEXT:    %[[C:.*]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  // CHECK-NEXT:    %[[BACK:.*]] = cir.cast bitcast %[[C]] : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>> -> !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+  // CHECK-NEXT:    cir.call %[[BACK]](%arg1, %arg0) : (!cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>, !cir.ptr<!rec_Big> {{{.*}}llvm.sret = !rec_Big{{.*}}, !s32i) -> ()
+
+  // A direct call and an address of the same callee are rewritten in one
+  // iteration, the call first.  The sret path there reuses a dominating store
+  // and erases it, so the address must survive that.
+  cir.func @call_and_address(%arg0: !cir.ptr<!rec_Big>) -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>> {
+    %0 = cir.const #cir.int<7> : !s32i
+    %1 = cir.call @make_big(%0) : (!s32i) -> !rec_Big
+    cir.store %1, %arg0 : !rec_Big, !cir.ptr<!rec_Big>
+    %2 = cir.get_global @make_big : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+    cir.return %2 : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @call_and_address(%arg0: !cir.ptr<!rec_Big>) -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  // CHECK:         cir.call @make_big(%arg0, %{{.*}}) : (!cir.ptr<!rec_Big> {{{.*}}llvm.sret = !rec_Big{{.*}}, !s32i) -> ()
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @make_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+  // CHECK-NEXT:    %[[C:.*]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>> -> !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+  // CHECK-NEXT:    cir.return %[[C]] : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+
+  // An address nothing reads still has to be retyped, since the verifier ties
+  // it to the callee, but it needs no cast back.
+  cir.func @unused_address() {
+    %0 = cir.get_global @make_big : !cir.ptr<!cir.func<(!s32i) -> !rec_Big>>
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @unused_address()
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @make_big : !cir.ptr<!cir.func<(!cir.ptr<!rec_Big>, !s32i)>>
+  // CHECK-NEXT:    cir.return
+
+  // An empty record argument the ABI ignores leaves the signature shorter, so
+  // the address changes type by losing a parameter rather than coercing one.
+  cir.func @addr_ignored_arg() -> !cir.ptr<!cir.func<(!rec_E0)>> {
+    %0 = cir.get_global @take_empty : !cir.ptr<!cir.func<(!rec_E0)>>
+    cir.return %0 : !cir.ptr<!cir.func<(!rec_E0)>>
+  }
+
+  // CHECK-LABEL: cir.func{{.*}} @addr_ignored_arg() -> !cir.ptr<!cir.func<(!rec_E0)>>
+  // CHECK-NEXT:    %[[G:.*]] = cir.get_global @take_empty : !cir.ptr<!cir.func<()>>
+  // CHECK-NEXT:    %[[C:.*]] = cir.cast bitcast %[[G]] : !cir.ptr<!cir.func<()>> -> !cir.ptr<!cir.func<(!rec_E0)>>
+  // CHECK-NEXT:    cir.return %[[C]] : !cir.ptr<!cir.func<(!rec_E0)>>
+}


### PR DESCRIPTION
When the pass rewrites a callee's signature, any `cir.get_global` holding that function's address is left behind at the old type.  The verifier ties a get_global's pointee to the symbol it names, so the module stops verifying. Returning the address of a function that returns a 32-byte struct is enough to hit it.

Each address now gets retyped to whatever signature its callee ended up with, then cast back so the existing uses still see the type they were built for. That happens in the same iteration that rewrites the callee, so the module is
only ever inconsistent for one function at a time.

Assisted-by: Cursor / claude-opus-5

