### PR TITLE
[X86] Fix potential CSE issues in commuteSelect multi-use path

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -48594,8 +48594,7 @@ static SDValue commuteSelect(SDNode *N, SelectionDAG &DAG, const SDLoc &DL,
     return DAG.getSelect(DL, LHS.getValueType(), NewCond, RHS, LHS);
 
   // Invert the setcc for all users and commute all vselects.
-  SmallVector<SDNode *> UsersToUpdate(Cond->users());
-  for (SDNode *User : UsersToUpdate) {
+  for (SDNode *User : llvm::make_early_inc_range(Cond->users())) {
     SDValue UserLHS = User->getOperand(1);
     SDValue UserRHS = User->getOperand(2);
     [[maybe_unused]] SDNode *Updated =

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -48594,11 +48594,14 @@ static SDValue commuteSelect(SDNode *N, SelectionDAG &DAG, const SDLoc &DL,
     return DAG.getSelect(DL, LHS.getValueType(), NewCond, RHS, LHS);
 
   // Invert the setcc for all users and commute all vselects.
+  SmallVector<SDNode *> UsersToUpdate(Cond->users());
   DAG.ReplaceAllUsesOfValueWith(Cond, NewCond);
-  for (SDNode *User : NewCond->users()) {
+  for (SDNode *User : UsersToUpdate) {
     SDValue UserLHS = User->getOperand(1);
     SDValue UserRHS = User->getOperand(2);
-    DAG.UpdateNodeOperands(User, NewCond, UserRHS, UserLHS);
+    [[maybe_unused]] SDNode *Updated =
+        DAG.UpdateNodeOperands(User, NewCond, UserRHS, UserLHS);
+    assert(Updated == User && "Unexpected CSE in commuteSelect");
   }
   return SDValue(N, 0);
 }

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -48595,7 +48595,6 @@ static SDValue commuteSelect(SDNode *N, SelectionDAG &DAG, const SDLoc &DL,
 
   // Invert the setcc for all users and commute all vselects.
   SmallVector<SDNode *> UsersToUpdate(Cond->users());
-  DAG.ReplaceAllUsesOfValueWith(Cond, NewCond);
   for (SDNode *User : UsersToUpdate) {
     SDValue UserLHS = User->getOperand(1);
     SDValue UserRHS = User->getOperand(2);


### PR DESCRIPTION
Snapshot the validated user list before ReplaceAllUsesOfValueWith. If getSetCC returns a CSE'd node that already has users, iterating NewCond->users() would visit pre-existing unvalidated users and swap their operands incorrectly.

Also assert that UpdateNodeOperands does not CSE to an existing node, which would silently leave the original node unmodified with an inverted condition but unswapped operands.