### PR TITLE
[llvm][ABI][NFC] Name the required-argument boundary in FunctionInfo

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -321,62 +321,27 @@ convertABIArgInfo(const llvm::abi::ArgInfo &info, MLIRContext *ctx,
   return ArgClassification::getIgnore();
 }
 
-/// Whether a signature accepts arguments beyond its declared parameters, and
-/// where the declared ones end when it does.  An argument past the ellipsis is
-/// unnamed, and the x86_64 rules pass some unnamed types differently.
-///
-/// llvm::abi::FunctionInfo::create takes this boundary as an optional count,
-/// where an absent value means the signature accepts no optional arguments.
-/// Any value there makes FunctionInfo::isVariadic() answer true, so the
-/// non-variadic case has to be spelled as an absent one.  That encoding is
-/// applied where classifyX86_64Signature builds the FunctionInfo.
-///
-/// Mirrors classic CodeGen's `RequiredArgs` in `CGFunctionInfo.h`, and CIRGen's
-/// copy in `CIRGenFunctionInfo.h`.
-class RequiredArgs {
-  /// The number of leading arguments that are declared parameters, or ~0U if
-  /// the signature accepts no optional arguments.
-  unsigned numRequired;
-
-public:
-  enum All_t { All };
-
-  /// A signature with no ellipsis, where every argument is declared.
-  RequiredArgs(All_t) : numRequired(~0U) {}
-
-  /// A signature whose leading \p n arguments are declared and whose remaining
-  /// arguments pass through an ellipsis.
-  explicit RequiredArgs(unsigned n) : numRequired(n) { assert(n != ~0U); }
-
-  bool allowsOptionalArgs() const { return numRequired != ~0U; }
-
-  unsigned getNumRequiredArgs() const {
-    assert(allowsOptionalArgs() && "signature accepts no optional arguments");
-    return numRequired;
-  }
-};
-
 /// Where \p fnTy's declared parameters end and its ellipsis arguments begin.
 ///
-/// The only x86_64 rule that reads this boundary today sends an unnamed vector
-/// wider than 128 bits to memory, and isSupportedType rejects every vector, so
-/// no input that currently reaches classification can observe the difference.
-static RequiredArgs requiredArgs(cir::FuncType fnTy) {
+/// The only x86_64 rule that reads this boundary sends an unnamed vector wider
+/// than 128 bits to memory, and isSupportedType rejects every vector, so no
+/// input this bridge accepts can observe the difference.
+static llvm::abi::RequiredArgs requiredArgs(cir::FuncType fnTy) {
   if (!fnTy.isVarArg())
-    return RequiredArgs::All;
-  return RequiredArgs(fnTy.getNumInputs());
+    return llvm::abi::RequiredArgs::All;
+  return llvm::abi::RequiredArgs(fnTy.getNumInputs());
 }
 
 /// Classify an x86_64 SysV signature (return type + argument types) using the
 /// LLVM ABI library.  Shared by the cir.func path, the variadic-call path and
 /// the indirect-call path (the latter classifies from the callee function
-/// pointer's pointee FuncType).  \p required marks how many leading entries in
-/// \p inputs are declared parameters, the classifier treating the rest as
-/// arguments passed through an ellipsis.  Returns std::nullopt and emits an NYI
+/// pointer's pointee FuncType).  \p required marks where the declared
+/// parameters in \p inputs end.  The classifier treats every argument past that
+/// point as passed through an ellipsis.  Returns std::nullopt and emits an NYI
 /// error via \p emitError if the signature uses a type the bridge does not
 /// handle yet.
 static std::optional<FunctionClassification> classifyX86_64Signature(
-    mlir::Type retCIR, mlir::TypeRange inputs, RequiredArgs required,
+    mlir::Type retCIR, mlir::TypeRange inputs, llvm::abi::RequiredArgs required,
     MLIRContext *ctx, const DataLayout &dl,
     mlir::abi::ABITypeMapper &typeMapper,
     const llvm::abi::TargetInfo &targetInfo, ModuleOp modOp,
@@ -408,12 +373,8 @@ static std::optional<FunctionClassification> classifyX86_64Signature(
   for (mlir::Type a : inputs)
     argAbi.push_back(mapCIRType(a, typeMapper, dl, modOp));
 
-  std::optional<unsigned> numRequired;
-  if (required.allowsOptionalArgs())
-    numRequired = required.getNumRequiredArgs();
-
   std::unique_ptr<llvm::abi::FunctionInfo> fi = llvm::abi::FunctionInfo::create(
-      llvm::CallingConv::C, retAbi, argAbi, numRequired);
+      llvm::CallingConv::C, retAbi, argAbi, required);
   targetInfo.computeInfo(*fi);
 
   // convertABIArgInfo returns nullopt when the classifier picks a coercion

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -902,14 +902,14 @@ void CodeGenModule::computeABIInfoUsingLib(CGFunctionInfo &FI) {
   for (const auto &Arg : FI.arguments())
     MappedArgTypes.push_back(AbiMapper->convertType(Arg.type));
 
-  std::optional<unsigned> NumRequired;
   RequiredArgs Required = FI.getRequiredArgs();
+  llvm::abi::RequiredArgs AbiRequired = llvm::abi::RequiredArgs::All;
   if (Required.allowsOptionalArgs())
-    NumRequired = Required.getNumRequiredArgs();
+    AbiRequired = llvm::abi::RequiredArgs(Required.getNumRequiredArgs());
 
   auto AbiFI = llvm::abi::FunctionInfo::create(
       FI.getCallingConvention(), AbiMapper->convertType(FI.getReturnType()),
-      MappedArgTypes, NumRequired);
+      MappedArgTypes, AbiRequired);
 
   getLLVMABITargetInfo(AbiMapper->getTypeBuilder()).computeInfo(*AbiFI);
 

--- a/llvm/include/llvm/ABI/FunctionInfo.h
+++ b/llvm/include/llvm/ABI/FunctionInfo.h
@@ -207,18 +207,50 @@ struct ArgEntry {
   ArgEntry(const Type *T, ArgInfo A) : ABIType(T), Info(A) {}
 };
 
+/// Whether a signature accepts arguments beyond its declared parameters, and
+/// where the declared ones end when it does.  An argument past an ellipsis is
+/// unnamed, and some ABI rules pass an unnamed type differently.
+///
+/// A count and All are not interchangeable when the count equals the number of
+/// arguments.  FunctionInfo::isVariadic() is true whenever a count was given,
+/// so a signature with no ellipsis has to be spelled All.
+class RequiredArgs {
+  /// The number of leading arguments that are declared parameters, or ~0U if
+  /// the signature accepts no optional arguments.
+  unsigned NumRequired;
+
+public:
+  enum All_t { All };
+
+  /// A signature with no ellipsis, where every argument is declared.
+  RequiredArgs(All_t) : NumRequired(~0U) {}
+
+  /// A signature whose leading \p N arguments are declared and whose remaining
+  /// arguments pass through an ellipsis.
+  explicit RequiredArgs(unsigned N) : NumRequired(N) {
+    assert(N != ~0U && "~0U is reserved for a signature with no ellipsis");
+  }
+
+  bool allowsOptionalArgs() const { return NumRequired != ~0U; }
+
+  unsigned getNumRequiredArgs() const {
+    assert(allowsOptionalArgs() && "signature accepts no optional arguments");
+    return NumRequired;
+  }
+};
+
 class FunctionInfo final : private TrailingObjects<FunctionInfo, ArgEntry> {
 private:
   const Type *ReturnType;
   ArgInfo ReturnInfo;
   unsigned NumArgs;
   CallingConv::ID CC = CallingConv::C;
-  std::optional<unsigned> NumRequired;
+  RequiredArgs Required;
 
   FunctionInfo(CallingConv::ID CC, const Type *RetTy, unsigned NumArguments,
-               std::optional<unsigned> NumRequired)
+               RequiredArgs Required)
       : ReturnType(RetTy), ReturnInfo(ArgInfo::getDirect()),
-        NumArgs(NumArguments), CC(CC), NumRequired(NumRequired) {}
+        NumArgs(NumArguments), CC(CC), Required(Required) {}
 
   friend class TrailingObjects;
 
@@ -237,7 +269,7 @@ public:
   LLVM_ABI static std::unique_ptr<FunctionInfo>
   create(CallingConv::ID CC, const Type *ReturnType,
          ArrayRef<const Type *> ArgTypes,
-         std::optional<unsigned> NumRequired = std::nullopt);
+         RequiredArgs Required = RequiredArgs::All);
 
   const Type *getReturnType() const { return ReturnType; }
   ArgInfo &getReturnInfo() { return ReturnInfo; }
@@ -245,10 +277,10 @@ public:
 
   CallingConv::ID getCallingConvention() const { return CC; }
 
-  bool isVariadic() const { return NumRequired.has_value(); }
+  bool isVariadic() const { return Required.allowsOptionalArgs(); }
 
   unsigned getNumRequiredArgs() const {
-    return isVariadic() ? *NumRequired : arg_size();
+    return isVariadic() ? Required.getNumRequiredArgs() : arg_size();
   }
 
   ArrayRef<ArgEntry> arguments() const {

--- a/llvm/lib/ABI/FunctionInfo.cpp
+++ b/llvm/lib/ABI/FunctionInfo.cpp
@@ -7,24 +7,24 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ABI/FunctionInfo.h"
-#include <optional>
 
 using namespace llvm;
 using namespace llvm::abi;
 
 std::unique_ptr<FunctionInfo>
 FunctionInfo::create(CallingConv::ID CC, const Type *ReturnType,
-                     ArrayRef<const Type *> ArgTypes,
-                     std::optional<unsigned> NumRequired) {
+                     ArrayRef<const Type *> ArgTypes, RequiredArgs Required) {
 
-  assert(!NumRequired || *NumRequired <= ArgTypes.size());
+  assert((!Required.allowsOptionalArgs() ||
+          Required.getNumRequiredArgs() <= ArgTypes.size()) &&
+         "declared parameters cannot outnumber the arguments");
 
   void *Buffer = operator new(totalSizeToAlloc<ArgEntry>(ArgTypes.size()));
 
   // FunctionInfo overloads operator delete, so we can use std::unique_ptr
   // without worrying about sized deallocation of trailing objects.
   std::unique_ptr<FunctionInfo> FI(
-      new (Buffer) FunctionInfo(CC, ReturnType, ArgTypes.size(), NumRequired));
+      new (Buffer) FunctionInfo(CC, ReturnType, ArgTypes.size(), Required));
 
   ArgEntry *Args = FI->getTrailingObjects();
   for (unsigned I = 0; I < ArgTypes.size(); ++I)


### PR DESCRIPTION
`FunctionInfo::create` took the declared-parameter count as a bare `std::optional<unsigned>`, where an absent value meant the signature has no ellipsis, because `isVariadic()` was `NumRequired.has_value()`.  A caller who reads that parameter name and passes the real count for a non-variadic signature makes `isVariadic()` true even though there is no ellipsis.  A reviewer read the parameter that way on [#213315](https://github.com/llvm/llvm-project/pull/213315) and asked for this move as a follow-up.

`RequiredArgs` moves out of `CallConvLoweringPass` and into the library, so both producers name the case they mean instead of encoding it.  This is the same shape as clang's `RequiredArgs` in `CGFunctionInfo.h`, minus the members that would have no caller here.  The x86_64 classifier in `llvm/lib/ABI/Targets/X86.cpp` is untouched, since `getNumRequiredArgs()` keeps its signature.

Assisted-by: Cursor / claude-opus-5
