### PR TITLE
[AMDGPU] Skip s_delay_alu for WMMA C-reuse chains

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
@@ -397,8 +397,8 @@ public:
         // C-reuse: back-to-back WMMAs into the same C register forward the
         // accumulator in place, so the tied srcC read has no dependency. WMMA
         // implies GFX11+, so no explicit subtarget check is needed.
-        bool IsWMMACReuse = PrevWMMAVDst.isValid() &&
-                            (SII->isWMMA(MI) || SII->isSWMMAC(MI));
+        bool IsWMMACReuse =
+            PrevWMMAVDst.isValid() && (SII->isWMMA(MI) || SII->isSWMMAC(MI));
         // TODO: Scan implicit uses too?
         for (const auto &Op : MI.explicit_uses()) {
           if (Op.isReg()) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
@@ -360,6 +360,10 @@ public:
 
     // FIXME: 0 is a valid register unit.
     MCRegUnit LastSGPRFromVALU = static_cast<MCRegUnit>(0);
+
+    // Destination of the preceding XDL WMMA, for GFX1250 C-reuse detection.
+    Register PrevWMMAVDst;
+
     // Iterate over the contents of bundles, but don't emit any instructions
     // inside a bundle.
     for (auto &MI : MBB.instrs()) {
@@ -390,6 +394,10 @@ public:
         State = DelayState();
       } else if (Type != OTHER) {
         DelayInfo Delay;
+        // GFX1250 C-reuse: back-to-back WMMAs into the same C register forward
+        // the accumulator in place, so the tied srcC read has no dependency.
+        bool IsWMMACReuse = ST->hasGFX1250Insts() && PrevWMMAVDst.isValid() &&
+                            SII->isXDLWMMA(MI);
         // TODO: Scan implicit uses too?
         for (const auto &Op : MI.explicit_uses()) {
           if (Op.isReg()) {
@@ -397,6 +405,10 @@ public:
             // This creates the insertion of redundant delays. Hence, we have to
             // ignore this operand.
             if (MI.getOpcode() == AMDGPU::V_WRITELANE_B32 && Op.isTied())
+              continue;
+            // Skip the tied srcC of a GFX1250 C-reuse edge.
+            if (IsWMMACReuse && Op.isTied() &&
+                TRI->regsOverlap(Op.getReg(), PrevWMMAVDst))
               continue;
             for (MCRegUnit Unit : TRI->regunits(Op.getReg())) {
               auto It = State.find(Unit);
@@ -443,6 +455,17 @@ public:
       // instructions on the assumption that they will usually have to be issued
       // twice?
       State.advance(Type, Cycles);
+
+      // Track the preceding XDL WMMA's dst for C-reuse; reset on anything else.
+      if (ST->hasGFX1250Insts()) {
+        if (SII->isXDLWMMA(MI)) {
+          const MachineOperand *VDst =
+              SII->getNamedOperand(MI, AMDGPU::OpName::vdst);
+          PrevWMMAVDst = VDst ? VDst->getReg() : Register();
+        } else {
+          PrevWMMAVDst = Register();
+        }
+      }
 
       LLVM_DEBUG(dbgs() << "  State after " << MI; State.dump(TRI););
     }

--- a/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
@@ -361,7 +361,7 @@ public:
     // FIXME: 0 is a valid register unit.
     MCRegUnit LastSGPRFromVALU = static_cast<MCRegUnit>(0);
 
-    // Destination of the preceding WMMA, for GFX12+ C-reuse detection.
+    // Destination of the preceding WMMA, for C-reuse detection.
     Register PrevWMMAVDst;
 
     // Iterate over the contents of bundles, but don't emit any instructions
@@ -394,9 +394,10 @@ public:
         State = DelayState();
       } else if (Type != OTHER) {
         DelayInfo Delay;
-        // GFX12+ C-reuse: back-to-back WMMAs into the same C register forward
-        // the accumulator in place, so the tied srcC read has no dependency.
-        bool IsWMMACReuse = ST->hasGFX12Insts() && PrevWMMAVDst.isValid() &&
+        // C-reuse: back-to-back WMMAs into the same C register forward the
+        // accumulator in place, so the tied srcC read has no dependency. WMMA
+        // implies GFX11+, so no explicit subtarget check is needed.
+        bool IsWMMACReuse = PrevWMMAVDst.isValid() &&
                             (SII->isWMMA(MI) || SII->isSWMMAC(MI));
         // TODO: Scan implicit uses too?
         for (const auto &Op : MI.explicit_uses()) {
@@ -406,7 +407,7 @@ public:
             // ignore this operand.
             if (MI.getOpcode() == AMDGPU::V_WRITELANE_B32 && Op.isTied())
               continue;
-            // Skip the tied srcC of a GFX12+ C-reuse edge.
+            // Skip the tied srcC of a C-reuse edge.
             if (IsWMMACReuse && Op.isTied() && Op.getReg() == PrevWMMAVDst)
               continue;
             for (MCRegUnit Unit : TRI->regunits(Op.getReg())) {
@@ -456,14 +457,12 @@ public:
       State.advance(Type, Cycles);
 
       // Track the preceding WMMA's dst for C-reuse; reset on anything else.
-      if (ST->hasGFX12Insts()) {
-        if (SII->isWMMA(MI) || SII->isSWMMAC(MI)) {
-          const MachineOperand *VDst =
-              SII->getNamedOperand(MI, AMDGPU::OpName::vdst);
-          PrevWMMAVDst = VDst ? VDst->getReg() : Register();
-        } else {
-          PrevWMMAVDst = Register();
-        }
+      if (SII->isWMMA(MI) || SII->isSWMMAC(MI)) {
+        const MachineOperand *VDst =
+            SII->getNamedOperand(MI, AMDGPU::OpName::vdst);
+        PrevWMMAVDst = VDst ? VDst->getReg() : Register();
+      } else {
+        PrevWMMAVDst = Register();
       }
 
       LLVM_DEBUG(dbgs() << "  State after " << MI; State.dump(TRI););

--- a/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
@@ -361,7 +361,7 @@ public:
     // FIXME: 0 is a valid register unit.
     MCRegUnit LastSGPRFromVALU = static_cast<MCRegUnit>(0);
 
-    // Destination of the preceding XDL WMMA, for GFX1250 C-reuse detection.
+    // Destination of the preceding WMMA, for GFX12+ C-reuse detection.
     Register PrevWMMAVDst;
 
     // Iterate over the contents of bundles, but don't emit any instructions
@@ -394,10 +394,10 @@ public:
         State = DelayState();
       } else if (Type != OTHER) {
         DelayInfo Delay;
-        // GFX1250 C-reuse: back-to-back WMMAs into the same C register forward
+        // GFX12+ C-reuse: back-to-back WMMAs into the same C register forward
         // the accumulator in place, so the tied srcC read has no dependency.
-        bool IsWMMACReuse = ST->hasGFX1250Insts() && PrevWMMAVDst.isValid() &&
-                            SII->isXDLWMMA(MI);
+        bool IsWMMACReuse = ST->hasGFX12Insts() && PrevWMMAVDst.isValid() &&
+                            (SII->isWMMA(MI) || SII->isSWMMAC(MI));
         // TODO: Scan implicit uses too?
         for (const auto &Op : MI.explicit_uses()) {
           if (Op.isReg()) {
@@ -406,9 +406,8 @@ public:
             // ignore this operand.
             if (MI.getOpcode() == AMDGPU::V_WRITELANE_B32 && Op.isTied())
               continue;
-            // Skip the tied srcC of a GFX1250 C-reuse edge.
-            if (IsWMMACReuse && Op.isTied() &&
-                TRI->regsOverlap(Op.getReg(), PrevWMMAVDst))
+            // Skip the tied srcC of a GFX12+ C-reuse edge.
+            if (IsWMMACReuse && Op.isTied() && Op.getReg() == PrevWMMAVDst)
               continue;
             for (MCRegUnit Unit : TRI->regunits(Op.getReg())) {
               auto It = State.find(Unit);
@@ -456,9 +455,9 @@ public:
       // twice?
       State.advance(Type, Cycles);
 
-      // Track the preceding XDL WMMA's dst for C-reuse; reset on anything else.
-      if (ST->hasGFX1250Insts()) {
-        if (SII->isXDLWMMA(MI)) {
+      // Track the preceding WMMA's dst for C-reuse; reset on anything else.
+      if (ST->hasGFX12Insts()) {
+        if (SII->isWMMA(MI) || SII->isSWMMAC(MI)) {
           const MachineOperand *VDst =
               SII->getNamedOperand(MI, AMDGPU::OpName::vdst);
           PrevWMMAVDst = VDst ? VDst->getReg() : Register();

--- a/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-gfx12.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-gfx12.mir
@@ -1,0 +1,32 @@
+# RUN: llc -mtriple=amdgpu12.00 -start-before=amdgpu-insert-delay-alu %s -o - | FileCheck %s
+
+---
+name: wmma_c_reuse_no_delay_gfx12
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}wmma_c_reuse_no_delay_gfx12:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[8:11], v[12:15], v[0:7]
+    ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[16:19], v[20:23], v[0:7]
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15, $vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21_vgpr22_vgpr23
+    $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7 = V_WMMA_F32_16X16X16_F16_w32_twoaddr 8, $vgpr8_vgpr9_vgpr10_vgpr11, 8, $vgpr12_vgpr13_vgpr14_vgpr15, 8, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 0, 0, implicit $exec
+    $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7 = V_WMMA_F32_16X16X16_F16_w32_twoaddr 8, $vgpr16_vgpr17_vgpr18_vgpr19, 8, $vgpr20_vgpr21_vgpr22_vgpr23, 8, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 0, 0, implicit $exec
+...
+
+---
+name: wmma_no_c_reuse_when_interrupted_gfx12
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}wmma_no_c_reuse_when_interrupted_gfx12:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[8:11], v[12:15], v[0:7]
+    ; CHECK-NEXT: v_add_nc_u32_e32 v24, v24, v25
+    ; CHECK-NEXT: s_delay_alu instid0(VALU_DEP_2)
+    ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[16:19], v[20:23], v[0:7]
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15, $vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24, $vgpr25
+    $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7 = V_WMMA_F32_16X16X16_F16_w32_twoaddr 8, $vgpr8_vgpr9_vgpr10_vgpr11, 8, $vgpr12_vgpr13_vgpr14_vgpr15, 8, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 0, 0, implicit $exec
+    $vgpr24 = V_ADD_U32_e32 $vgpr24, $vgpr25, implicit $exec
+    $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7 = V_WMMA_F32_16X16X16_F16_w32_twoaddr 8, $vgpr16_vgpr17_vgpr18_vgpr19, 8, $vgpr20_vgpr21_vgpr22_vgpr23, 8, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 0, 0, implicit $exec
+...

--- a/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-xdl.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-xdl.mir
@@ -109,3 +109,29 @@ body: |
     $vgpr16 = V_ADD_U32_e32 $vgpr16, $vgpr17, implicit $exec
     $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
 ...
+
+name: wmma_non_xdl_c_reuse_no_delay
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}wmma_non_xdl_c_reuse_no_delay:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_wmma_f32_16x16x4_f32 v[4:11], v[0:1], v[2:3], v[4:11]
+    ; CHECK-NEXT: v_wmma_f32_16x16x4_f32 v[4:11], v[12:13], v[14:15], v[4:11]
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr12_vgpr13, $vgpr14_vgpr15, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11
+    $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr12_vgpr13, $vgpr14_vgpr15, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+...
+
+name: swmmac_c_reuse_no_delay
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}swmmac_c_reuse_no_delay:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_swmmac_f16_16x16x128_bf8_bf8 v[24:27], v[0:7], v[8:23], v[28:29]
+    ; CHECK-NEXT: v_swmmac_f16_16x16x128_bf8_bf8 v[24:27], v[0:7], v[8:23], v[30:31]
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24_vgpr25_vgpr26_vgpr27, $vgpr28_vgpr29, $vgpr30_vgpr31
+    $vgpr24_vgpr25_vgpr26_vgpr27 = V_SWMMAC_F16_16X16X128_BF8_BF8_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24_vgpr25_vgpr26_vgpr27, $vgpr28_vgpr29, 0, 0, 0, implicit $exec
+    $vgpr24_vgpr25_vgpr26_vgpr27 = V_SWMMAC_F16_16X16X128_BF8_BF8_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24_vgpr25_vgpr26_vgpr27, $vgpr30_vgpr31, 0, 0, 0, implicit $exec
+...

--- a/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-xdl.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-xdl.mir
@@ -65,3 +65,47 @@ body: |
     $vgpr12 = V_EXP_F32_e32 $vgpr12, implicit $exec, implicit $mode
     $vgpr13 = V_ADD_U32_e32 $vgpr13, $vgpr8, implicit $exec
 ...
+
+name: wmma_xdl_c_reuse_no_delay
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}wmma_xdl_c_reuse_no_delay:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[0:7], v[0:7], v[8:15]
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[16:23], v[16:23], v[8:15]
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+...
+
+name: wmma_xdl_c_reuse_chain_no_delay
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}wmma_xdl_c_reuse_chain_no_delay:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[0:7], v[0:7], v[8:15]
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[16:23], v[16:23], v[8:15]
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[24:31], v[24:31], v[8:15]
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+...
+
+name: wmma_xdl_no_c_reuse_when_interrupted
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: {{^}}wmma_xdl_no_c_reuse_when_interrupted:
+    ; CHECK: %bb.0:
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[0:7], v[0:7], v[8:15]
+    ; CHECK-NEXT: v_add_nc_u32_e32 v16, v16, v17
+    ; CHECK-NEXT: s_delay_alu instid0(TRANS32_DEP_1)
+    ; CHECK-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[8:15], v[24:31], v[24:31], v[8:15]
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, $vgpr16, $vgpr17
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+    $vgpr16 = V_ADD_U32_e32 $vgpr16, $vgpr17, implicit $exec
+    $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
+...

--- a/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma.mir
@@ -1,11 +1,12 @@
+# RUN: llc -mtriple=amdgpu11.70 -start-before=amdgpu-insert-delay-alu %s -o - | FileCheck %s
 # RUN: llc -mtriple=amdgpu12.00 -start-before=amdgpu-insert-delay-alu %s -o - | FileCheck %s
 
 ---
-name: wmma_c_reuse_no_delay_gfx12
+name: wmma_c_reuse_no_delay
 tracksRegLiveness: true
 body: |
   bb.0:
-    ; CHECK-LABEL: {{^}}wmma_c_reuse_no_delay_gfx12:
+    ; CHECK-LABEL: {{^}}wmma_c_reuse_no_delay:
     ; CHECK: %bb.0:
     ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[8:11], v[12:15], v[0:7]
     ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[16:19], v[20:23], v[0:7]
@@ -15,11 +16,11 @@ body: |
 ...
 
 ---
-name: wmma_no_c_reuse_when_interrupted_gfx12
+name: wmma_no_c_reuse_when_interrupted
 tracksRegLiveness: true
 body: |
   bb.0:
-    ; CHECK-LABEL: {{^}}wmma_no_c_reuse_when_interrupted_gfx12:
+    ; CHECK-LABEL: {{^}}wmma_no_c_reuse_when_interrupted:
     ; CHECK: %bb.0:
     ; CHECK-NEXT: v_wmma_f32_16x16x16_f16 v[0:7], v[8:11], v[12:15], v[0:7]
     ; CHECK-NEXT: v_add_nc_u32_e32 v24, v24, v25


### PR DESCRIPTION
Consecutive wmma/swmmac ops accumulating into the same matrix C register
reuse the accumulator in place, so the tied srcC read is omitted and no
delay is needed. AMDGPUInsertDelayAlu did not model this and emitted an
s_delay_alu that stalls the reuse chain.

Detect a C-reuse edge (tied srcC exactly matches the previous wmma/
swmmac dest, with no intervening instruction) and skip the delay for
that operand. This applies on all wmma-capable targets (gfx11+).