### PR TITLE
[clang-format] Fix wrapping before ##__VA_ARGS__ macro arguments

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -6511,8 +6511,14 @@ bool TokenAnnotator::canBreakBefore(const AnnotatedLine &Line,
             !(Right.Next &&
               Right.Next->isOneOf(TT_FunctionDeclarationName, tok::kw_const)));
   }
-  if (Left.is(tok::hashhash) || Right.is(tok::hashhash))
+  // Keep pasted tokens together, except for the GNU comma elision extension,
+  // where the comma is also an argument separator and remains a useful break
+  // point before ##__VA_ARGS__.
+  if ((Left.is(tok::hashhash) || Right.is(tok::hashhash)) &&
+      !(Line.InMacroBody && Left.is(tok::comma) &&
+        Right.is(tok::hashhash))) {
     return false;
+  }
   if (Right.isOneOf(TT_StartOfName, TT_FunctionDeclarationName,
                     TT_ClassHeadName, TT_QtProperty, tok::kw_operator)) {
     return true;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -5995,6 +5995,78 @@ TEST_F(FormatTest, HashInMacroDefinition) {
       "  struct LongPrefix##Name##LongSuffix<VeryLongTemplateArgument> {};",
       Style);
 
+  Style = getLLVMStyle();
+  Style.IndentWidth = 4;
+  Style.ContinuationIndentWidth = 8;
+  Style.ColumnLimit = 80;
+  Style.AlignEscapedNewlines = FormatStyle::ENAS_Right;
+  verifyFormat(
+      "#define M(f, ...)                                                       "
+      "       \\\n"
+      "    auto f = "
+      "call(firstArgumentThatIsQuiteLongEnoughToForceAWrapHere11111111,  \\\n"
+      "                  ##__VA_ARGS__);",
+      "#define M(f, ...) \\\n"
+      "    auto f = "
+      "call(firstArgumentThatIsQuiteLongEnoughToForceAWrapHere11111111, "
+      "##__VA_ARGS__);",
+      Style);
+  verifyFormat(
+      "#define CHECK(flagName, expr, ...)                                      "
+      "       \\\n"
+      "    ({                                                                 "
+      "        \\\n"
+      "        if ((false)) {                                                 "
+      "        \\\n"
+      "            if (expr) {                                                "
+      "        \\\n"
+      "            }                                                          "
+      "        \\\n"
+      "        }                                                              "
+      "        \\\n"
+      "        if (unlikely(!(expr))) {                                       "
+      "        \\\n"
+      "            if "
+      "(someLongContainerName.contains(SomeEnumTypeName::flagName)) {  \\\n"
+      "                "
+      "someLongContainerName.add(SomeEnumTypeName::flagName);         \\\n"
+      "            } else {                                                   "
+      "        \\\n"
+      "                reportFunction(std::source_location::current(),        "
+      "        \\\n"
+      "                               \"some diagnostic message "
+      "string here \"          \\\n"
+      "                               \"(\" #flagName \"): \" "
+      "#expr,                      \\\n"
+      "                               ##__VA_ARGS__, extra);                  "
+      "        \\\n"
+      "            }                                                          "
+      "        \\\n"
+      "        }                                                              "
+      "        \\\n"
+      "        (void)0;                                                       "
+      "        \\\n"
+      "    })",
+      "#define CHECK(flagName, expr, ...) \\\n"
+      "    ({ \\\n"
+      "        if ((false)) { \\\n"
+      "            if (expr) {} \\\n"
+      "        } \\\n"
+      "        if (unlikely(!(expr))) { \\\n"
+      "            if "
+      "(someLongContainerName.contains(SomeEnumTypeName::flagName)) { \\\n"
+      "                "
+      "someLongContainerName.add(SomeEnumTypeName::flagName); \\\n"
+      "            } else { \\\n"
+      "                reportFunction(std::source_location::current(), \"some "
+      "diagnostic message string here \" \"(\" #flagName \"): \" #expr, "
+      "##__VA_ARGS__, extra); \\\n"
+      "            } \\\n"
+      "        } \\\n"
+      "        (void) 0; \\\n"
+      "    })",
+      Style);
+
   verifyFormat("{\n"
                "  {\n"
                "#define GEN_ID(_x) char *_x{#_x}\n"


### PR DESCRIPTION
Fixes #212835.

Commit 26ffc71afa7c prohibited line breaks on either side of the `##`
token-paste operator to keep pasted identifiers together. This also removed
the normal break opportunity after a comma in the GNU comma-elision pattern
`, ##__VA_ARGS__`, which can produce lines over the column limit and
misaligned escaped newlines.

Allow the comma before `##` in a macro body to use the normal comma-breaking
logic. Other `##` boundaries remain unbreakable, preserving the behavior for
concatenated identifiers fixed by #199775.

Add regression coverage for both a simple variadic macro call and a nested
call where `##__VA_ARGS__` is not the final argument. The tests also verify
stable escaped-newline alignment.

Tests:

- `FormatTests --gtest_filter=FormatTest.HashInMacroDefinition`
- `FormatTests` (1,275 tests passed)

Assisted-by: OpenAI Codex
